### PR TITLE
:sparkles: ISendMessageSuccessResponse to sms providers

### DIFF
--- a/providers/plivo/src/lib/plivo.provider.ts
+++ b/providers/plivo/src/lib/plivo.provider.ts
@@ -1,4 +1,9 @@
-import { ChannelTypeEnum, ISmsOptions, ISmsProvider } from '@notifire/core';
+import {
+  ChannelTypeEnum,
+  ISendMessageSuccessResponse,
+  ISmsOptions,
+  ISmsProvider,
+} from '@notifire/core';
 
 import * as plivo from 'plivo';
 
@@ -17,12 +22,18 @@ export class PlivoSmsProvider implements ISmsProvider {
     this.plivoClient = new plivo.Client(config.accountSid, config.authToken);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async sendMessage(options: ISmsOptions): Promise<any> {
-    return await this.plivoClient.messages.create(
+  async sendMessage(
+    options: ISmsOptions
+  ): Promise<ISendMessageSuccessResponse> {
+    const plivoResponse = await this.plivoClient.messages.create(
       this.config.from,
       options.to,
       options.content
     );
+
+    return {
+      id: plivoResponse.apiId,
+      date: new Date().toISOString(),
+    };
   }
 }

--- a/providers/twilio/src/lib/twilio.provider.ts
+++ b/providers/twilio/src/lib/twilio.provider.ts
@@ -1,4 +1,9 @@
-import { ChannelTypeEnum, ISmsOptions, ISmsProvider } from '@notifire/core';
+import {
+  ChannelTypeEnum,
+  ISendMessageSuccessResponse,
+  ISmsOptions,
+  ISmsProvider,
+} from '@notifire/core';
 
 import { Twilio } from 'twilio';
 
@@ -17,12 +22,18 @@ export class TwilioSmsProvider implements ISmsProvider {
     this.twilioClient = new Twilio(config.accountSid, config.authToken);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async sendMessage(options: ISmsOptions): Promise<any> {
-    return await this.twilioClient.messages.create({
+  async sendMessage(
+    options: ISmsOptions
+  ): Promise<ISendMessageSuccessResponse> {
+    const twilioResponse = await this.twilioClient.messages.create({
       body: options.content,
       to: options.to,
       from: this.config.from,
     });
+
+    return {
+      id: twilioResponse.sid,
+      date: twilioResponse.dateCreated.toISOString(),
+    };
   }
 }


### PR DESCRIPTION
:sparkles: add to Plivo sms provider
:sparkles: add to Twilio sms provider

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New feature, closes #16 
- **What is the current behavior?** (You can also link to an open issue here)
every provider pass said provider response, lacking consistent API in responses
- **What is the new behavior (if this is a feature change)?**
add new SMS providers output interface, so all SMS providers answer with the same API

- **Other information**:
