### PR TITLE
typo: Notifire is and Open-source library

### DIFF
--- a/docs/docs/overview/introduction.md
+++ b/docs/docs/overview/introduction.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Introduction
 
-Notifire is and Open-source library for managing multi-channel transactional notifications with a single API.
+Notifire is an Open-source library for managing multi-channel transactional notifications with a single API.
 
 ## Why?
 


### PR DESCRIPTION
Notifire is and Open-source library > Notifire is an Open-source library

- **What kind of change does this PR introduce?** Fix typo

- **What is the current behavior?** In the doc, the first sentence is `Notifire is and Open-source library for managing multi-channel transactional notifications with a single API.` 

- **What is the new behavior (if this is a feature change)?** Fixed the typo : `Notifire is an Open-source`
