### PR TITLE
Allow validator on IMessage level

### DIFF
--- a/packages/core/src/lib/template/template.interface.ts
+++ b/packages/core/src/lib/template/template.interface.ts
@@ -6,11 +6,16 @@ export interface ITemplate {
   messages: IMessage[];
 }
 
+export interface IMessageValidator {
+  validate(payload: ITriggerPayload): Promise<boolean> | boolean;
+}
+
 export interface IMessage {
   subject?: string;
   channel: ChannelTypeEnum;
   template: string | ((payload: ITriggerPayload) => Promise<string> | string);
   active?: boolean | ((payload: ITriggerPayload) => Promise<boolean> | boolean);
+  validator?: IMessageValidator;
 }
 
 export enum ChannelTypeEnum {

--- a/packages/core/src/lib/trigger/trigger.engine.spec.ts
+++ b/packages/core/src/lib/trigger/trigger.engine.spec.ts
@@ -133,3 +133,95 @@ test('variable protection should throw if missing variable provided with templat
     })
   ).rejects.toEqual(new Error('Missing variables passed. firstName'));
 });
+
+test('TriggerEngine should call validate if validator is provided', async () => {
+  const templateStore = new TemplateStore();
+  const providerStore = new ProviderStore();
+  const themeStore = new ThemeStore();
+  const ee = new EventEmitter();
+
+  await providerStore.addProvider({
+    channelType: ChannelTypeEnum.EMAIL,
+    id: 'email-provider',
+    sendMessage: () =>
+      Promise.resolve({ id: '1', date: new Date().toString() }),
+  });
+
+  const validate = jest.fn().mockImplementation(() => true);
+
+  await templateStore.addTemplate({
+    id: 'test-notification',
+    messages: [
+      {
+        subject: 'test',
+        channel: ChannelTypeEnum.EMAIL,
+        template: '<div>{{firstName}}</div>',
+        validator: {
+          validate,
+        },
+      },
+    ],
+  });
+
+  const triggerEngine = new TriggerEngine(
+    templateStore,
+    providerStore,
+    themeStore,
+    {},
+    ee
+  );
+
+  await triggerEngine.trigger('test-notification', {
+    $user_id: '12345',
+    $email: 'test@gmail.com',
+  });
+
+  expect(validate).toBeCalled();
+  expect(validate).toBeCalledWith({
+    $email: 'test@gmail.com',
+    $user_id: '12345',
+  });
+});
+
+test('Validation should throw error if validate method returns false', async () => {
+  const templateStore = new TemplateStore();
+  const providerStore = new ProviderStore();
+  const themeStore = new ThemeStore();
+  const ee = new EventEmitter();
+
+  await providerStore.addProvider({
+    channelType: ChannelTypeEnum.EMAIL,
+    id: 'email-provider',
+    sendMessage: () =>
+      Promise.resolve({ id: '1', date: new Date().toString() }),
+  });
+
+  await templateStore.addTemplate({
+    id: 'test-notification',
+    messages: [
+      {
+        subject: 'test',
+        channel: ChannelTypeEnum.EMAIL,
+        template: '<div>{{firstName}}</div>',
+        validator: {
+          validate: () => Promise.resolve(false),
+        },
+      },
+    ],
+  });
+
+  const triggerEngine = new TriggerEngine(
+    templateStore,
+    providerStore,
+    themeStore,
+    {},
+    ee
+  );
+
+  await expect(
+    triggerEngine.trigger('test-notification', {
+      $user_id: '12345',
+      $email: 'test@gmail.com',
+    })
+  ).rejects.toEqual(new Error('Payload for email is invalid'));
+});

--- a/packages/core/src/lib/trigger/trigger.engine.ts
+++ b/packages/core/src/lib/trigger/trigger.engine.ts
@@ -61,6 +61,8 @@ export class TriggerEngine {
       );
     }
 
+    await this.validate(message, data);
+
     this.eventEmitter.emit('pre:send', {
       id: template.id,
       channel: message.channel,
@@ -116,5 +118,15 @@ export class TriggerEngine {
 
     const deduplicatedResults = [...new Set(mergedResults)];
     return deduplicatedResults;
+  }
+
+  private async validate(message: IMessage, data: ITriggerPayload) {
+    if (!message.validator) {
+      return;
+    }
+    const valid = await message.validator?.validate(data);
+    if (!valid) {
+      throw new Error(`Payload for ${message.channel} is invalid`);
+    }
   }
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Small method to use validator inside of trigger engine.
- **What is the current behavior?** (You can also link to an open issue here)
No validator can be provided.
https://github.com/notifirehq/notifire/issues/4
- **What is the new behavior (if this is a feature change)?**
If a validator return false an error is thrown. A validator is optional to provide on a IMessage.