### PR TITLE
Create direct message interface

### DIFF
--- a/packages/core/src/lib/content/content.engine.ts
+++ b/packages/core/src/lib/content/content.engine.ts
@@ -3,7 +3,7 @@ import { IAttachmentOptions } from '../template/template.interface';
 
 Handlebars.registerHelper(
   'equals',
-  function (this: typeof Handlebars, arg1, arg2, options) {
+  function helper(this: typeof Handlebars, arg1, arg2, options) {
     // eslint-disable-next-line eqeqeq
     return arg1 == arg2 ? options.fn(this) : options.inverse(this);
   }

--- a/packages/core/src/lib/content/content.engine.ts
+++ b/packages/core/src/lib/content/content.engine.ts
@@ -2,7 +2,7 @@ import * as Handlebars from 'handlebars';
 
 Handlebars.registerHelper(
   'equals',
-  function (this: typeof Handlebars, arg1, arg2, options) {
+  function helper(this: typeof Handlebars, arg1, arg2, options) {
     return arg1 === arg2 ? options.fn(this) : options.inverse(this);
   }
 );

--- a/packages/core/src/lib/handler/direct.handler.spec.ts
+++ b/packages/core/src/lib/handler/direct.handler.spec.ts
@@ -1,0 +1,70 @@
+import { IDirectProvider } from '../provider/provider.interface';
+import { ChannelTypeEnum } from '../template/template.interface';
+import { DirectHandler } from './direct.handler';
+
+test('send direct should call the provider method correctly', async () => {
+  const provider: IDirectProvider = {
+    id: 'direct-provider',
+    channelType: ChannelTypeEnum.DIRECT,
+    sendMessage: () =>
+      Promise.resolve({ id: '1', date: new Date().toString() }),
+  };
+
+  const spy = jest.spyOn(provider, 'sendMessage');
+  const directHandler = new DirectHandler(
+    {
+      subject: 'test',
+      channel: ChannelTypeEnum.DIRECT,
+      template: `Name: {{firstName}}`,
+    },
+    provider
+  );
+
+  await directHandler.send({
+    $channel_id: '+1333322214',
+    $user_id: '1234',
+    firstName: 'test name',
+  });
+
+  expect(spy).toHaveBeenCalled();
+  expect(spy).toHaveBeenCalledWith({
+    content: 'Name: test name',
+    channelId: '+1333322214',
+  });
+  spy.mockRestore();
+});
+
+test('send direct should template method correctly', async () => {
+  const provider: IDirectProvider = {
+    id: 'direct-provider',
+    channelType: ChannelTypeEnum.DIRECT,
+    sendMessage: () =>
+      Promise.resolve({ id: '1', date: new Date().toString() }),
+  };
+
+  const spyTemplateFunction = jest
+    .fn()
+    .mockImplementation(() => Promise.resolve('test'));
+
+  const directHandler = new DirectHandler(
+    {
+      subject: 'test',
+      channel: ChannelTypeEnum.DIRECT,
+      template: spyTemplateFunction,
+    },
+    provider
+  );
+
+  await directHandler.send({
+    $channel_id: '+1333322214',
+    $user_id: '1234',
+    firstName: 'test name',
+  });
+
+  expect(spyTemplateFunction).toHaveBeenCalled();
+  expect(spyTemplateFunction).toBeCalledWith({
+    $channel_id: '+1333322214',
+    $user_id: '1234',
+    firstName: 'test name',
+  });
+});

--- a/packages/core/src/lib/handler/direct.handler.ts
+++ b/packages/core/src/lib/handler/direct.handler.ts
@@ -1,9 +1,9 @@
 import { compileTemplate } from '../content/content.engine';
-import { ISmsProvider } from '../provider/provider.interface';
+import { IDirectProvider } from '../provider/provider.interface';
 import { IMessage, ITriggerPayload } from '../template/template.interface';
 
-export class SmsHandler {
-  constructor(private message: IMessage, private provider: ISmsProvider) {}
+export class DirectHandler {
+  constructor(private message: IMessage, private provider: IDirectProvider) {}
 
   async send(data: ITriggerPayload) {
     let content = '';
@@ -13,14 +13,14 @@ export class SmsHandler {
       content = await this.message.template(data);
     }
 
-    if (!data.$phone) {
+    if (!data.$channel_id) {
       throw new Error(
-        '$phone is missing in trigger payload. To send an SMS You must specify a $phone property.'
+        '$channel_id is missing in trigger payload. To send an SMS You must specify a $phone property.'
       );
     }
 
     return await this.provider.sendMessage({
-      to: data.$phone,
+      channelId: data.$channel_id,
       content,
     });
   }

--- a/packages/core/src/lib/handler/direct.handler.ts
+++ b/packages/core/src/lib/handler/direct.handler.ts
@@ -15,7 +15,7 @@ export class DirectHandler {
 
     if (!data.$channel_id) {
       throw new Error(
-        '$channel_id is missing in trigger payload. To send an SMS You must specify a $phone property.'
+        '$channel_id is missing in trigger payload. To send an a direct message you must specify a $channel_id property.'
       );
     }
 

--- a/packages/core/src/lib/handler/email.handler.ts
+++ b/packages/core/src/lib/handler/email.handler.ts
@@ -45,7 +45,7 @@ export class EmailHandler {
       );
     }
 
-    await this.provider.sendMessage({
+    return await this.provider.sendMessage({
       to: data.$email,
       subject,
       html,

--- a/packages/core/src/lib/handler/sms.handler.ts
+++ b/packages/core/src/lib/handler/sms.handler.ts
@@ -32,7 +32,7 @@ export class SmsHandler {
     return await this.provider.sendMessage({
       to: data.$phone,
       content,
-      attachments: attachments,
+      attachments,
     });
   }
 }

--- a/packages/core/src/lib/notifire.spec.ts
+++ b/packages/core/src/lib/notifire.spec.ts
@@ -23,7 +23,7 @@ test('should call 2 hooks', async () => {
 
   const template = {
     id: 'test',
-    channelType: ChannelTypeEnum.SMS,
+    channelType: ChannelTypeEnum.SMS as ChannelTypeEnum,
     sendMessage: () =>
       Promise.resolve({ id: '1', date: new Date().toString() }),
   };

--- a/packages/core/src/lib/notifire.ts
+++ b/packages/core/src/lib/notifire.ts
@@ -1,7 +1,11 @@
 import merge from 'lodash.merge';
 import { EventEmitter } from 'events';
 import { INotifireConfig } from './notifire.interface';
-import { IEmailProvider, ISmsProvider } from './provider/provider.interface';
+import {
+  IEmailProvider,
+  ISmsProvider,
+  IDirectProvider,
+} from './provider/provider.interface';
 import { ProviderStore } from './provider/provider.store';
 import { ITemplate, ITriggerPayload } from './template/template.interface';
 import { TemplateStore } from './template/template.store';
@@ -46,7 +50,9 @@ export class Notifire extends EventEmitter {
     return await this.templateStore.getTemplateById(template.id);
   }
 
-  async registerProvider(provider: IEmailProvider | ISmsProvider) {
+  async registerProvider(
+    provider: IEmailProvider | ISmsProvider | IDirectProvider
+  ) {
     await this.providerStore.addProvider(provider);
   }
 

--- a/packages/core/src/lib/provider/provider.interface.ts
+++ b/packages/core/src/lib/provider/provider.interface.ts
@@ -19,6 +19,11 @@ export interface ISmsOptions {
   from?: string;
 }
 
+export interface IDirectOptions {
+  channelId: string;
+  content: string;
+}
+
 export interface ISendMessageSuccessResponse {
   id?: string;
   date?: string;
@@ -31,8 +36,13 @@ export interface IEmailProvider extends IProvider {
 }
 
 export interface ISmsProvider extends IProvider {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  sendMessage(options: ISmsOptions): Promise<any>;
+  sendMessage(options: ISmsOptions): Promise<ISendMessageSuccessResponse>;
 
   channelType: ChannelTypeEnum.SMS;
+}
+
+export interface IDirectProvider extends IProvider {
+  sendMessage(options: IDirectOptions): Promise<ISendMessageSuccessResponse>;
+
+  channelType: ChannelTypeEnum.DIRECT;
 }

--- a/packages/core/src/lib/provider/provider.store.ts
+++ b/packages/core/src/lib/provider/provider.store.ts
@@ -1,11 +1,16 @@
 import { ChannelTypeEnum } from '../template/template.interface';
 
-import { IEmailProvider, ISmsProvider } from './provider.interface';
+import {
+  IEmailProvider,
+  ISmsProvider,
+  IDirectProvider,
+} from './provider.interface';
 
 export class ProviderStore {
-  private providers: Array<ISmsProvider | IEmailProvider> = [];
+  private providers: Array<ISmsProvider | IEmailProvider | IDirectProvider> =
+    [];
 
-  async addProvider(provider: IEmailProvider | ISmsProvider) {
+  async addProvider(provider: IEmailProvider | ISmsProvider | IDirectProvider) {
     this.providers.push(provider);
   }
 

--- a/packages/core/src/lib/template/template.interface.ts
+++ b/packages/core/src/lib/template/template.interface.ts
@@ -21,6 +21,7 @@ export interface IMessage {
 export enum ChannelTypeEnum {
   EMAIL = 'email',
   SMS = 'sms',
+  DIRECT = 'direct',
 }
 
 export interface ITriggerPayload {
@@ -28,5 +29,6 @@ export interface ITriggerPayload {
   $phone?: string;
   $user_id: string;
   $theme_id?: string;
+  $channel_id?: string;
   [key: string]: string | boolean | number | undefined;
 }

--- a/packages/core/src/lib/trigger/trigger.engine.ts
+++ b/packages/core/src/lib/trigger/trigger.engine.ts
@@ -15,6 +15,7 @@ import {
 } from '../template/template.interface';
 import { TemplateStore } from '../template/template.store';
 import { ThemeStore } from '../theme/theme.store';
+import { DirectHandler } from '../handler/direct.handler';
 
 export class TriggerEngine {
   constructor(
@@ -83,6 +84,9 @@ export class TriggerEngine {
     } else if (provider.channelType === ChannelTypeEnum.SMS) {
       const smsHandler = new SmsHandler(message, provider);
       await smsHandler.send(data);
+    } else if (provider.channelType === ChannelTypeEnum.DIRECT) {
+      const directHandler = new DirectHandler(message, provider);
+      await directHandler.send(data);
     }
 
     this.eventEmitter.emit('post:send', {


### PR DESCRIPTION
Adds the ability to create direct providers that allow sending a message to a specific `$channel_id`. In a later point, we can add support for private messages and thread replies.

Closes #108