### PR TITLE
docs: Fix a few typos

### DIFF
--- a/apps/widget/public/iframeResizer.contentWindow.js
+++ b/apps/widget/public/iframeResizer.contentWindow.js
@@ -1261,7 +1261,7 @@
 
     function isInitMsg() {
       // Test if this message is from a child below us. This is an ugly test, however, updating
-      // the message format would break backwards compatibity.
+      // the message format would break backwards compatibility.
       return event.data.split(':')[2] in { true: 1, false: 1 }
     }
 

--- a/docs/docs/templates/messages.md
+++ b/docs/docs/templates/messages.md
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # Messages
 
-Messages are part of the notificaton template configuration. Each message is tied to a specific channel but not to specific provider. You customize the channel experience by adding channel related metadata (like subject in email, and CTA buttons in Direct messaging).
+Messages are part of the notification template configuration. Each message is tied to a specific channel but not to specific provider. You customize the channel experience by adding channel related metadata (like subject in email, and CTA buttons in Direct messaging).
 
 Here's an example of a template with a single message:
 
@@ -52,5 +52,5 @@ The template is the main content area of the notification. In case of other chan
 
 ## Active
 
-A switch to indicate wether this message should be sent or not. This can be a simple boolean, function or a promise that returns a boolean.
+A switch to indicate whether this message should be sent or not. This can be a simple boolean, function or a promise that returns a boolean.
 You can use it to conditionally send a message based on the trigger inputs.


### PR DESCRIPTION
There are small typos in:
- apps/widget/public/iframeResizer.contentWindow.js
- docs/docs/templates/messages.md

Fixes:
- Should read `whether` rather than `wether`.
- Should read `notification` rather than `notificaton`.
- Should read `compatibility` rather than `compatibity`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md