### PR TITLE
feat: add support for optional types in Hygen provider script generator (SMS/EMAIL)

### DIFF
--- a/_templates/provider/new/.eslintrc.json.ejs.t
+++ b/_templates/provider/new/.eslintrc.json.ejs.t
@@ -1,7 +1,7 @@
 ---
-    to: providers/<%= name %>/.eslintrc.json
+    to: providers/<%= name %>/.eslintrc.js
 ---
 
 {
-  "extends": "../../.eslintrc.json"
+  "extends": "../../.eslintrc.js"
 }

--- a/_templates/provider/new/README.ejs.t
+++ b/_templates/provider/new/README.ejs.t
@@ -1,10 +1,11 @@
 ---
     to: providers/<%= name %>/README.md
 ---
-
+<% LowerType = h.changeCase.lower(type) -%>
+<% PascalName = h.changeCase.pascal(name) -%>
 # Notifire <%= h.changeCase.pascal(name) %> Provider
 
-A <%= h.changeCase.pascal(name) %> email provider library for [@notifire/core](https://github.com/notifirehq/notifire)
+A <%= PascalName %> <%= LowerType %> provider library for [@notifire/core](https://github.com/notifirehq/notifire)
 
 ## Usage
 

--- a/_templates/provider/new/prompt.js
+++ b/_templates/provider/new/prompt.js
@@ -1,7 +1,13 @@
 module.exports = [
-    {
-        type: 'input',
-        name: 'name',
-        message: "Write the provider name camelCased:"
-    }
-]
+  {
+    type: 'select',
+    name: 'type',
+    message: 'What type of provider is this?',
+    choices: ['EMAIL', 'SMS'],
+  },
+  {
+    type: 'input',
+    name: 'name',
+    message: 'Write the provider name camelCased:',
+  },
+];

--- a/_templates/provider/new/src/lib/provider.ejs.t
+++ b/_templates/provider/new/src/lib/provider.ejs.t
@@ -2,25 +2,28 @@
     to: providers/<%= name %>/src/lib/<%= name %>.provider.ts
 ---
 
+<% PascalType = h.changeCase.pascal(type) -%>
+<% UpperType = h.changeCase.upper(type) -%>
+<% PascalName = h.changeCase.pascal(name) -%>
 import {
   ChannelTypeEnum,
-  IEmailOptions,
-  IEmailProvider,
   ISendMessageSuccessResponse,
+  I<%= PascalType %>Options,
+  I<%= PascalType %>Provider,
 } from '@notifire/core';
 
-export class <%= h.changeCase.pascal(name) %>EmailProvider implements IEmailProvider {
-  channelType = ChannelTypeEnum.EMAIL as ChannelTypeEnum.EMAIL;
+export class <%= PascalName %><%= PascalType %>Provider implements I<%= PascalType %>Provider {
+  channelType = ChannelTypeEnum.<%= UpperType %> as ChannelTypeEnum.<%= UpperType %>;
 
   constructor(
     private config: {
-      apiKey: string;
+      <%= UpperType === 'EMAIL' ? 'apiKey: string;' : null %>
     }
   ) {
   }
 
   async sendMessage(
-    options: IEmailOptions
+    options: I<%= PascalType %>Options
   ): Promise<ISendMessageSuccessResponse> {
 
 

--- a/_templates/provider/new/src/lib/test.provider.spec.ejs.t
+++ b/_templates/provider/new/src/lib/test.provider.spec.ejs.t
@@ -2,7 +2,9 @@
     to: providers/<%= name %>/src/lib/<%= name %>.provider.spec.ts
 ---
 
-import { <%= h.changeCase.pascal(name) %>EmailProvider } from './<%= name %>.provider';
+<% PascalName = h.changeCase.pascal(name) -%>
+<% PascalType = h.changeCase.pascal(type) -%>
+import { <%= PascalName %><%= PascalType %>Provider } from './<%= name %>.provider';
 
 test('should trigger <%= name %> library correctly', async () => {
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add support for optional types in Hygen script generator (SMS/EMAIL)

- **What is the current behavior?** (You can also link to an open issue here)
Hygen script support is now only available in the email generator

- **What is the new behavior (if this is a feature change)?**
Add a new SMS provider generator for Hygen script

- **Other information**:
There was no open issue