### PR TITLE
Add `emailjs` to list of providers in `readme.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Notifire provides a single API to manage providers across multiple channels with
 - [x] [Mailjet](https://github.com/notifirehq/notifire/tree/master/providers/mailjet)
 - [x] [Mandrill](https://github.com/notifirehq/notifire/tree/master/providers/mandrill)
 - [x] [SendinBlue](https://github.com/notifirehq/notifire/tree/master/providers/sendinblue)
+- [x] [EmailJS](https://github.com/notifirehq/notifire/tree/master/providers/emailjs)
 - [ ] SparkPost
 
 #### 📞 SMS


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs

- **What is the current behavior?** (You can also link to an open issue here)
The `emailjs` was missing from `readme.md`

- **What is the new behavior (if this is a feature change)?**
`readme.md` now is showing `emailjs` as a provider and the link to it

- **Other information**:
