### PR TITLE
refactor(api): config path definition

### DIFF
--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -4,15 +4,16 @@ import { str, url, port, ValidatorSpec } from 'envalid';
 
 dotenv.config();
 
-const path =
-  `${__dirname}/../` +
-  ({
-    prod: '.env.production',
-    test: '.env.test',
-    ci: '.env.ci',
-    local: '.env.local',
-    dev: '.env.development',
-  }[process.env.NODE_ENV] || '.env.local');
+const envFileMapper = {
+  prod: '.env.production',
+  test: '.env.test',
+  ci: '.env.ci',
+  local: '.env.local',
+  dev: '.env.development',
+};
+const selectedEnvFile = envFileMapper[process.env.NODE_ENV] || '.env.local';
+
+const path = `${__dirname}/../${selectedEnvFile}`;
 
 const { error } = dotenv.config({ path });
 if (error && !process.env.LAMBDA_TASK_ROOT) throw error;

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -4,26 +4,15 @@ import { str, url, port, ValidatorSpec } from 'envalid';
 
 dotenv.config();
 
-let path;
-switch (process.env.NODE_ENV) {
-  case 'prod':
-    path = `${__dirname}/../.env.production`;
-    break;
-  case 'test':
-    path = `${__dirname}/../.env.test`;
-    break;
-  case 'ci':
-    path = `${__dirname}/../.env.ci`;
-    break;
-  case 'local':
-    path = `${__dirname}/../.env.local`;
-    break;
-  case 'dev':
-    path = `${__dirname}/../.env.development`;
-    break;
-  default:
-    path = `${__dirname}/../.env.local`;
-}
-//
+const path =
+  `${__dirname}/../` +
+  ({
+    prod: '.env.production',
+    test: '.env.test',
+    ci: '.env.ci',
+    local: '.env.local',
+    dev: '.env.development',
+  }[process.env.NODE_ENV] || '.env.local');
+
 const { error } = dotenv.config({ path });
 if (error && !process.env.LAMBDA_TASK_ROOT) throw error;


### PR DESCRIPTION
It's much better to use a one-liner code to avoid string duplication.

Instead of declaring an empty `path` variable
And using the switch case to determine its value.