### PR TITLE
Handle undefined attachments

### DIFF
--- a/providers/emailjs/src/lib/emailjs.provider.ts
+++ b/providers/emailjs/src/lib/emailjs.provider.ts
@@ -31,7 +31,7 @@ export class EmailJsProvider implements IEmailProvider {
     html,
     attachments,
   }: IEmailOptions): Promise<ISendMessageSuccessResponse> {
-    const attachmentsModel: MessageAttachment[] = attachments?.map(
+    const attachmentsModel: MessageAttachment[] = attachments ? attachments.map(
       (attachment) => {
         return {
           name: attachment.name,
@@ -39,7 +39,7 @@ export class EmailJsProvider implements IEmailProvider {
           type: attachment.mime,
         };
       }
-    );
+    ) : [];
 
     attachmentsModel?.push({ data: html, alternative: true });
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
`providers/emailjs/src/lib/emailjs.provider.ts` is returning `undefined` if `attachments` is not present, when it should be returning empty array

- **What is the new behavior (if this is a feature change)?**
Returns new empty array in case attachment is not defined

- **Other information**:
