### PR TITLE
`subject` now accepts a `Function` on `trigger` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ const passwordResetTemplate = await notifire.registerTemplate({
   id: 'password-reset',
   messages: [
     {
+      // you can pass here a function as well:
+      // subject: (message: IMessage) => getTranslation('common.users')
       subject: 'Your password reset request',
       channel: ChannelTypeEnum.EMAIL,
       template: `

--- a/docs/docs/recipes/using-translations.md
+++ b/docs/docs/recipes/using-translations.md
@@ -1,0 +1,163 @@
+---
+sidebar_position: 4
+---
+
+# Using translations
+
+Be able to localize your notifications is extremely important in apps where people from all over the world is using it.
+
+In this recipe we will use [i18n-node](https://github.com/mashpie/i18n-node), but it is applicable
+to many other translation frameworks.
+
+```typescript
+import { Notifire, ChannelTypeEnum } from "@notifire/core";
+import { SendgridEmailProvider } from "@notifire/sendgrid";
+// We will use i18n as a singleton and not as an instance in this recipe
+import i18n from 'i18n';
+
+i18n.configure({
+  locales: ['en', 'de'],
+  directory: path.join(__dirname, '/locales')
+})
+
+const notifire = new Notifire();
+
+await notifire.registerProvider(
+  new SendgridEmailProvider({
+    apiKey: process.env.SENDGRID_API_KEY,
+  })
+);
+
+// Defined in a file or folder responsible for managing templates
+const inviteToOrganizationTemplate = await notifire.registerTemplate({
+  id: "invite-to-organization",
+  messages: [
+    {
+      // It is important to pass a function here as the template will be stored
+      // as soon as you pass it. Passing a function will allow Notifire to
+      // dynamic fetch the actual value of the translation key, specially
+      // if you have changed the locale of i18n dynamicly after
+      // registering the template
+      subject: () => i18n.__('templates.emails.invite-to-organization.subject'),
+      channel: ChannelTypeEnum.EMAIL,
+      template: `
+          Hi {{firstName}}!
+          
+          You've been invited by <b>{{inviterName}}</b> to join  <b>{{organizationName}}</b>.
+          
+          Click <a href="{{inviteLink}}">here</a> to join
+      `,
+    },
+  ],
+});
+
+// Triggered in the relevant part of the business logic of your code
+await notifire.trigger("invite-to-organization", {
+  $user_id: "<USER IDENTIFIER>",
+  $email: "<USER EMAIL>",
+  firstName: "John",
+  lastName: "Doe",
+  inviterName: "Jannie Doe",
+  inviteLink: "https://example.com/invitation?token=123",
+  organizationName: "My Org",
+});
+```
+
+# How to translate my templates?
+
+There are two approaches to translating your templates:
+
+## 1. Store it in a separate folder with each template already translated
+
+You can store the templates in a separte folder with each template already translated:
+
+*templates/inviteOrganization/en.html*
+```html
+...
+<body>
+    You have been invited to {{ organizationName }} by {{ inviterName }} 
+</body>
+...
+```
+
+Then just pass the variables to `trigger`:
+
+```js
+await notifire.trigger("invite-to-organization", {
+  $user_id: "<USER IDENTIFIER>",
+  $email: "<USER EMAIL>",
+  organizationName: "Organization Cool",
+  inviterName: "John Doe"
+});
+```
+
+The advantages of this is that each template can be customized to each language. Imagine you would like to add
+`Thank you very much` in the end of the email to every English emails, you are free to do so.
+
+The great disadvantage is that you will duplicate the contents of each template.
+
+## 2. Store a single template
+
+Assuming you have a translation file `en.json`:
+
+```json
+{
+  "templates.emails.invite-to-organization.title": "You have been invited to {{ organizationName }} by {{ inviterName }} ",
+  "templates.emails.invite-to-organization.subject": "You have been invited"
+}
+```
+
+You can store a single template of your email and pass the translations by key:
+
+*templates/inviteOrganization.html*
+```handlebars
+<body>
+    {{ title }}
+</body>
+...
+```
+
+Then you pass the template directly to Notifire:
+
+```js
+const inviteOrganizationTemplate = loadFile('templates/inviteOrganization.html');
+
+const inviteToOrganizationTemplate = await notifire.registerTemplate({
+  id: "invite-to-organization",
+  messages: [
+    {
+      // It is important to pass a function here as the template will be stored
+      // as soon as you pass it. Passing a function will allow Notifire to
+      // dynamic fetch the actual value of the translation key, specially
+      // if you have changed the locale of i18n dynamicly after
+      // registering the template
+      subject: () => i18n.__('templates.emails.invite-to-organization.subject'),
+      channel: ChannelTypeEnum.EMAIL,
+      template: inviteOrganizationTemplate,
+    },
+  ],
+});
+```
+
+and now when you trigger the email you can pass the variables:
+
+```js
+// At this time `title` will be the translated string without any mustaches (`{{` or `}}`).
+// Notifire will still pass your template to handlebars and it will still process
+// any leftover mustaches
+const titleTranslated = i18n.__n('templates.emails.invite-to-organization.title', {
+  organizationName: "Organization Cool",
+  inviterName: "John Doe"
+})
+
+// Triggered in the relevant part of the business logic of your code
+await notifire.trigger("invite-to-organization", {
+  $user_id: "<USER IDENTIFIER>",
+  $email: "<USER EMAIL>",
+  title: titleTranslated,
+});
+```
+
+The advantages of this method is that you only need to manage one template.
+
+The disadvantages of this is that you won't be able to customize a template to a single language.

--- a/docs/docs/templates/messages.md
+++ b/docs/docs/templates/messages.md
@@ -13,6 +13,8 @@ const passwordResetTemplate = await notifire.registerTemplate({
   id: "password-reset",
   messages: [
     {
+      // you can pass here a function as well:
+      // subject: (message: IMessage) => getTranslation('common.users')
       subject: "Your password reset request",
       channel: ChannelTypeEnum.EMAIL,
       template: `

--- a/packages/core/src/lib/handler/email.handler.spec.ts
+++ b/packages/core/src/lib/handler/email.handler.spec.ts
@@ -1,5 +1,8 @@
 import { IEmailProvider } from '../provider/provider.interface';
-import { ChannelTypeEnum, IMessage } from '../template/template.interface';
+import {
+  ChannelTypeEnum,
+  ITriggerPayload,
+} from '../template/template.interface';
 import { IEmailTemplate, ITheme } from '../theme/theme.interface';
 import { EmailHandler } from './email.handler';
 
@@ -18,10 +21,8 @@ test('it should be able to accept subject as a function and read message configu
     emailTemplate: new EmailTemplate('logo-url'),
   };
 
-  const subjectCallback = (message: IMessage) =>
-    (message.active as typeof emailHandlerMessage['active'])
-      ? 'should pass'
-      : 'should fail';
+  const subjectCallback = (message: ITriggerPayload) =>
+    message.$email === 'test@email.com' ? 'should pass' : 'should fail';
 
   const emailHandlerMessage = {
     subject: subjectCallback,

--- a/packages/core/src/lib/handler/email.handler.spec.ts
+++ b/packages/core/src/lib/handler/email.handler.spec.ts
@@ -19,19 +19,19 @@ test('it should be able to accept subject as a function and read message configu
   };
 
   const subjectCallback = (message: IMessage) =>
-    (message.active as boolean) ? 'should pass' : 'should fail';
+    (message.active as typeof emailHandlerMessage['active'])
+      ? 'should pass'
+      : 'should fail';
+
+  const emailHandlerMessage = {
+    subject: subjectCallback,
+    channel: ChannelTypeEnum.EMAIL as ChannelTypeEnum,
+    template: `<div><h1>Test Header</div> Name: {{firstName}}</div>`,
+    active: true,
+  };
 
   const spy = jest.spyOn(provider, 'sendMessage');
-  const emailHandler = new EmailHandler(
-    {
-      subject: subjectCallback,
-      channel: ChannelTypeEnum.EMAIL as ChannelTypeEnum,
-      template: `<div><h1>Test Header</div> Name: {{firstName}}</div>`,
-      active: true,
-    },
-    provider,
-    theme
-  );
+  const emailHandler = new EmailHandler(emailHandlerMessage, provider, theme);
 
   await emailHandler.send({
     $email: 'test@email.com',

--- a/packages/core/src/lib/handler/email.handler.ts
+++ b/packages/core/src/lib/handler/email.handler.ts
@@ -36,7 +36,21 @@ export class EmailHandler {
     } else {
       html = await this.message.template(templatePayload);
     }
-    const subject = compileTemplate(this.message.subject || '', data);
+
+    let subjectParsed;
+
+    if (typeof this.message.subject === 'string') {
+      subjectParsed = this.message.subject || '';
+    } else if (typeof this.message.subject === 'function') {
+      subjectParsed = this.message.subject(this.message);
+    } else {
+      throw new Error(
+        `Subject must be either of 'string' or 'function' type. Type ${typeof this
+          .message.subject} passed`
+      );
+    }
+
+    const subject = compileTemplate(subjectParsed, data);
 
     if (this.theme?.emailTemplate?.getEmailLayout()) {
       const themeVariables =

--- a/packages/core/src/lib/handler/email.handler.ts
+++ b/packages/core/src/lib/handler/email.handler.ts
@@ -42,7 +42,7 @@ export class EmailHandler {
     if (typeof this.message.subject === 'string') {
       subjectParsed = this.message.subject || '';
     } else if (typeof this.message.subject === 'function') {
-      subjectParsed = this.message.subject(this.message);
+      subjectParsed = this.message.subject(data);
     } else {
       throw new Error(
         `Subject must be either of 'string' or 'function' type. Type ${typeof this

--- a/packages/core/src/lib/handler/email.handler.ts
+++ b/packages/core/src/lib/handler/email.handler.ts
@@ -34,7 +34,10 @@ export class EmailHandler {
     if (typeof this.message.template === 'string') {
       html = compileTemplate(this.message.template, templatePayload);
     } else {
-      html = await this.message.template(templatePayload);
+      html = compileTemplate(
+        await this.message.template(templatePayload),
+        templatePayload
+      );
     }
 
     let subjectParsed;

--- a/packages/core/src/lib/template/template.interface.ts
+++ b/packages/core/src/lib/template/template.interface.ts
@@ -11,7 +11,7 @@ export interface IMessageValidator {
 }
 
 export interface IMessage {
-  subject?: string;
+  subject?: string | ((config: IMessage) => string);
   channel: ChannelTypeEnum;
   template: string | ((payload: ITriggerPayload) => Promise<string> | string);
   active?: boolean | ((payload: ITriggerPayload) => Promise<boolean> | boolean);

--- a/packages/core/src/lib/template/template.interface.ts
+++ b/packages/core/src/lib/template/template.interface.ts
@@ -11,7 +11,7 @@ export interface IMessageValidator {
 }
 
 export interface IMessage {
-  subject?: string | ((config: IMessage) => string);
+  subject?: string | ((config: ITriggerPayload) => string);
   channel: ChannelTypeEnum;
   template: string | ((payload: ITriggerPayload) => Promise<string> | string);
   active?: boolean | ((payload: ITriggerPayload) => Promise<boolean> | boolean);

--- a/packages/core/src/lib/trigger/trigger.engine.ts
+++ b/packages/core/src/lib/trigger/trigger.engine.ts
@@ -116,8 +116,17 @@ export class TriggerEngine {
     if (message.template && typeof message.template === 'string') {
       mergedResults.push(...getHandlebarsVariables(message.template));
     }
+
     if (message.subject) {
-      mergedResults.push(...getHandlebarsVariables(message.subject));
+      if (typeof message.subject === 'string') {
+        mergedResults.push(...getHandlebarsVariables(message.subject));
+      } else if (typeof message.subject === 'function') {
+        mergedResults.push(...getHandlebarsVariables(message.subject(message)));
+      } else {
+        throw new Error(
+          "Subject must be either of 'string' or 'function' type"
+        );
+      }
     }
 
     const deduplicatedResults = [...new Set(mergedResults)];

--- a/packages/core/src/lib/trigger/trigger.engine.ts
+++ b/packages/core/src/lib/trigger/trigger.engine.ts
@@ -98,7 +98,7 @@ export class TriggerEngine {
   }
 
   private getMissingVariables(message: IMessage, data: ITriggerPayload) {
-    const variables = this.extractMessageVariables(message);
+    const variables = this.extractMessageVariables(message, data);
 
     const missingVariables: string[] = [];
     for (const variable of variables) {
@@ -110,7 +110,7 @@ export class TriggerEngine {
     return missingVariables;
   }
 
-  private extractMessageVariables(message: IMessage) {
+  private extractMessageVariables(message: IMessage, data: ITriggerPayload) {
     const mergedResults: string[] = [];
 
     if (message.template && typeof message.template === 'string') {
@@ -121,7 +121,7 @@ export class TriggerEngine {
       if (typeof message.subject === 'string') {
         mergedResults.push(...getHandlebarsVariables(message.subject));
       } else if (typeof message.subject === 'function') {
-        mergedResults.push(...getHandlebarsVariables(message.subject(message)));
+        mergedResults.push(...getHandlebarsVariables(message.subject(data)));
       } else {
         throw new Error(
           "Subject must be either of 'string' or 'function' type"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces the option of passing a `function` to `subject` property when invoking the `trigger method`

- **What is the current behavior?** (You can also link to an open issue here)
The `subject` property only accepts strings.  [Issue here](https://github.com/notifirehq/notifire/issues/152)

- **What is the new behavior (if this is a feature change)?**
The `subject` now accepts `functions` as well as `string`
