### PR TITLE
[RLD-108] - Persist JWT token in the users CLI storage

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@notifire/shared": "^0.3.5",
+    "configstore": "^5.0.0",
     "axios": "^0.25.0",
     "inquirer": "^8.2.0",
     "open": "^8.4.0",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,5 +1,6 @@
 import * as open from 'open';
 import { Answers } from 'inquirer';
+import * as Configstore from 'configstore';
 import { prompt } from '../client';
 import { promptIntroArray } from './init.consts';
 import { HttpServer } from '../server';
@@ -8,10 +9,13 @@ import { SERVER_PORT, SERVER_HOST, REDIRECT_ROUTH, API_OAUTH_URL } from '../cons
 let answers: Answers;
 
 export async function initCommand() {
+  const config = new Configstore('notu-cli');
   try {
     answers = await prompt(promptIntroArray);
 
-    await gitHubOAuth();
+    const userJwt = await gitHubOAuth();
+
+    config.set('token', userJwt);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.log(error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -864,6 +864,7 @@ importers:
       '@notifire/shared': ^0.3.5
       '@types/inquirer': ^8.2.0
       axios: ^0.25.0
+      configstore: ^5.0.0
       inquirer: ^8.2.0
       nodemon: ^2.0.15
       open: ^8.4.0
@@ -872,6 +873,7 @@ importers:
     dependencies:
       '@notifire/shared': link:../../libs/shared
       axios: 0.25.0
+      configstore: 5.0.1
       inquirer: 8.2.0
       open: 8.4.0
       ts-node: 10.5.0_f6d7dbfa47c058bf494b37a3e2e17d5a


### PR DESCRIPTION
## Why?

Easily load and persist config without having to think about where and how.

## How?

Saving the token on disk on the machine.

## ref:

Config store for saving API key and credentials locally: [https://www.npmjs.com/package/configstore](https://www.npmjs.com/package/configstore)