### PR TITLE
Fix TypeError: Cannot read properties of null (reading '_id') issue #365 Draft PR

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -48,6 +48,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.12.2",
     "compression": "^1.7.4",
+    "cross-env": "^7.0.3",
     "dotenv": "^8.2.0",
     "envalid": "^6.0.1",
     "handlebars": "^4.7.7",

--- a/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
@@ -2,7 +2,7 @@ import { UserSession } from '@notifire/testing';
 import * as jwt from 'jsonwebtoken';
 import { expect } from 'chai';
 
-describe('Initialize Session - /widgets/session/initialize (POST)', async () => {
+describe.only('Initialize Session - /widgets/session/initialize (POST)', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
@@ -29,4 +29,17 @@ describe('Initialize Session - /widgets/session/initialize (POST)', async () => 
     expect(body.data.profile.phone).to.equal('054777777');
     expect(body.data.profile.lastName).to.equal('User');
   });
+
+  it('should throw an error when an invalid application Id passed', async function () {
+    const { body } = await session.testAgent.post('/v1/widgets/session/initialize').send({
+      applicationIdentifier: 'some-not-existing-id',
+      $user_id: '12345',
+      $first_name: 'Test',
+      $last_name: 'User',
+      $email: 'test@example.com',
+      $phone: '054777777',
+    });
+
+    expect(body.message).to.contain('Please provide a valid app identifier');
+  });
 });

--- a/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/initialize-widget-session.e2e.ts
@@ -2,7 +2,7 @@ import { UserSession } from '@notifire/testing';
 import * as jwt from 'jsonwebtoken';
 import { expect } from 'chai';
 
-describe.only('Initialize Session - /widgets/session/initialize (POST)', async () => {
+describe('Initialize Session - /widgets/session/initialize (POST)', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ApplicationRepository, SubscriberEntity } from '@notifire/dal';
 import { AuthService } from '../../../auth/services/auth.service';
+import { ApiException } from '../../../shared/exceptions/api.exception';
 import { CreateSubscriber, CreateSubscriberCommand } from '../../../subscribers/usecases/create-subscriber';
 import { InitializeSessionCommand } from './initialize-session.command';
 
@@ -27,6 +28,10 @@ export class InitializeSession {
       email: command.email,
       phone: command.phone,
     });
+
+    if (!application) {
+      throw new ApiException('Please provide a valid app identifier');
+    }
 
     const subscriber = await this.createSubscriber.execute(commandos);
 

--- a/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
@@ -19,6 +19,10 @@ export class InitializeSession {
   }> {
     const application = await this.applicationRepository.findApplicationByIdentifier(command.applicationIdentifier);
 
+    if (!application) {
+      throw new ApiException('Please provide a valid app identifier');
+    }
+
     const commandos = CreateSubscriberCommand.create({
       applicationId: application._id,
       organizationId: application._organizationId,
@@ -28,10 +32,6 @@ export class InitializeSession {
       email: command.email,
       phone: command.phone,
     });
-
-    if (!application) {
-      throw new ApiException('Please provide a valid app identifier');
-    }
 
     const subscriber = await this.createSubscriber.execute(commandos);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,7 @@ importers:
       class-transformer: ^0.5.1
       class-validator: ^0.12.2
       compression: ^1.7.4
+      cross-env: ^7.0.3
       dotenv: ^8.2.0
       envalid: ^6.0.1
       faker: ^5.5.3
@@ -190,6 +191,7 @@ importers:
       class-transformer: 0.5.1
       class-validator: 0.12.2
       compression: 1.7.4
+      cross-env: 7.0.3
       dotenv: 8.6.0
       envalid: 6.0.2
       handlebars: 4.7.7
@@ -9003,8 +9005,8 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.11.7
-      chalk: 4.1.0
+      '@types/node': 17.0.5
+      chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
       slash: 3.0.0
@@ -9221,7 +9223,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.7
+      '@types/node': 17.0.5
       jest-mock: 27.5.1
     dev: true
 
@@ -9255,7 +9257,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 16.11.7
+      '@types/node': 17.0.5
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -9345,10 +9347,10 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      chalk: 4.1.0
+      chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
-      glob: 7.1.4
+      glob: 7.2.0
       graceful-fs: 4.2.9
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 4.0.3
@@ -9637,7 +9639,7 @@ packages:
       '@babel/core': 7.17.5
       '@jest/types': 27.5.1
       babel-plugin-istanbul: 6.1.1
-      chalk: 4.1.0
+      chalk: 4.1.2
       convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.9
@@ -9680,9 +9682,9 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.11.7
+      '@types/node': 17.0.5
       '@types/yargs': 16.0.4
-      chalk: 4.1.0
+      chalk: 4.1.2
     dev: true
 
   /@josephg/resolvable/1.0.1:
@@ -11491,7 +11493,7 @@ packages:
   /@octokit/types/2.16.2:
     resolution: {integrity: sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==}
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 17.0.5
     dev: true
 
   /@octokit/types/6.34.0:
@@ -15337,7 +15339,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 16.11.7
+      '@types/node': 17.0.5
 
   /@types/got/9.6.12:
     resolution: {integrity: sha512-X4pj/HGHbXVLqTpKjA2ahI4rV/nNBc9mGO2I/0CgAra+F2dKgMXnENv2SRpemScBzBAI4vMelIVYViQxlSE6xA==}
@@ -15572,6 +15574,7 @@ packages:
 
   /@types/node/16.11.7:
     resolution: {integrity: sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==}
+    dev: true
 
   /@types/node/17.0.5:
     resolution: {integrity: sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==}
@@ -18044,7 +18047,7 @@ packages:
       '@types/babel__core': 7.1.18
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 27.5.1_@babel+core@7.17.5
-      chalk: 4.1.0
+      chalk: 4.1.2
       graceful-fs: 4.2.9
       slash: 3.0.0
     transitivePeerDependencies:
@@ -20903,7 +20906,6 @@ packages:
     hasBin: true
     dependencies:
       cross-spawn: 7.0.3
-    dev: true
 
   /cross-fetch/3.1.4:
     resolution: {integrity: sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==}
@@ -27358,8 +27360,8 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.7
-      chalk: 4.1.0
+      '@types/node': 17.0.5
+      chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
       expect: 27.5.1
@@ -27542,9 +27544,9 @@ packages:
       '@jest/test-sequencer': 27.5.1
       '@jest/types': 27.5.1
       babel-jest: 27.5.1_@babel+core@7.17.5
-      chalk: 4.1.0
+      chalk: 4.1.2
       deepmerge: 4.2.2
-      glob: 7.1.4
+      glob: 7.2.0
       graceful-fs: 4.2.9
       is-ci: 3.0.1
       jest-circus: 27.5.1
@@ -27668,7 +27670,7 @@ packages:
     resolution: {integrity: sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      chalk: 4.1.0
+      chalk: 4.1.2
       diff-sequences: 27.5.1
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
@@ -27722,7 +27724,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      chalk: 4.1.0
+      chalk: 4.1.2
       jest-get-type: 27.5.1
       jest-util: 27.5.1
       pretty-format: 27.5.1
@@ -27771,7 +27773,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.7
+      '@types/node': 17.0.5
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -27813,7 +27815,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.7
+      '@types/node': 17.0.5
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -27898,7 +27900,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.5
-      '@types/node': 16.11.7
+      '@types/node': 17.0.5
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.9
@@ -27975,8 +27977,8 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.7
-      chalk: 4.1.0
+      '@types/node': 17.0.5
+      chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
       is-generator-fn: 2.1.0
@@ -28058,7 +28060,7 @@ packages:
     resolution: {integrity: sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      chalk: 4.1.0
+      chalk: 4.1.2
       jest-diff: 27.5.1
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
@@ -28116,7 +28118,7 @@ packages:
       '@babel/code-frame': 7.16.7
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.1
-      chalk: 4.1.0
+      chalk: 4.1.2
       graceful-fs: 4.2.9
       micromatch: 4.0.4
       pretty-format: 27.5.1
@@ -28153,7 +28155,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.11.7
+      '@types/node': 17.0.5
     dev: true
 
   /jest-pnp-resolver/1.2.2_jest-resolve@26.6.0:
@@ -28306,7 +28308,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      chalk: 4.1.0
+      chalk: 4.1.2
       escalade: 3.1.1
       graceful-fs: 4.2.9
       jest-haste-map: 27.5.1
@@ -28354,7 +28356,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      chalk: 4.1.0
+      chalk: 4.1.2
       graceful-fs: 4.2.9
       jest-haste-map: 27.5.1
       jest-pnp-resolver: 1.2.2_jest-resolve@27.5.1
@@ -28472,8 +28474,8 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.11.7
-      chalk: 4.1.0
+      '@types/node': 17.0.5
+      chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.9
       jest-docblock: 27.5.1
@@ -28610,11 +28612,11 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      chalk: 4.1.0
+      chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
       execa: 5.1.1
-      glob: 7.1.4
+      glob: 7.2.0
       graceful-fs: 4.2.9
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
@@ -28648,7 +28650,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 17.0.5
       graceful-fs: 4.2.9
     dev: true
 
@@ -28750,7 +28752,7 @@ packages:
       '@types/babel__traverse': 7.14.2
       '@types/prettier': 2.4.4
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.17.5
-      chalk: 4.1.0
+      chalk: 4.1.2
       expect: 27.5.1
       graceful-fs: 4.2.9
       jest-diff: 27.5.1
@@ -28783,7 +28785,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/node': 16.11.7
-      chalk: 4.1.0
+      chalk: 4.1.2
       graceful-fs: 4.2.9
       is-ci: 3.0.1
       picomatch: 2.3.1
@@ -28806,8 +28808,8 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.11.7
-      chalk: 4.1.0
+      '@types/node': 17.0.5
+      chalk: 4.1.2
       ci-info: 3.3.0
       graceful-fs: 4.2.9
       picomatch: 2.3.1
@@ -28855,7 +28857,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       camelcase: 6.3.0
-      chalk: 4.1.0
+      chalk: 4.1.2
       jest-get-type: 27.5.1
       leven: 3.1.0
       pretty-format: 27.5.1


### PR DESCRIPTION
Added new e2e test on line 33 in apps/api/src/app/widgets/e2e/intialize-widget-session.e2s.ts and a new ApiException on line 32 of apps/api/src/app/widgets/usecases/initialize-session/intialize-session.usecase.ts.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Right now one e2e test is failing. Dima suggested I draft a PR so we can try and see what's causing that to happen. It is supposed to fix the error described in the title.

- **What is the current behavior?** (You can also link to an open issue here)
https://github.com/notifirehq/notifire/issues/365
Right now the new test I wrote is failing, but I'm not sure why.

- **What is the new behavior (if this is a feature change)?**
No just trying to stop the error from happening and almost there but not just yet.