### PR TITLE
feat(api): create default activities feed

### DIFF
--- a/apps/api/src/app/feeds/e2e/get-feeds.e2e.ts
+++ b/apps/api/src/app/feeds/e2e/get-feeds.e2e.ts
@@ -20,9 +20,28 @@ describe('Get Feeds - /feeds (GET)', async () => {
     const { body } = await session.testAgent.get(`/v1/feeds`);
 
     expect(body.data.length).to.equal(2);
-    const group = body.data.find((i) => i.name === 'Test name');
+    const feed = body.data.find((i) => i.name === 'Test name');
 
-    expect(group.name).to.equal(`Test name`);
-    expect(group._environmentId).to.equal(session.environment._id);
+    expect(feed.name).to.equal(`Test name`);
+    expect(feed._environmentId).to.equal(session.environment._id);
+  });
+
+  it('should create default feed if none exists', async function () {
+    const { body } = await session.testAgent.get(`/v1/feeds`);
+    expect(body.data.length).to.equal(1);
+    const defaultFeed = body.data[0];
+
+    expect(defaultFeed.name).to.equal(`Activities`);
+
+    await session.testAgent.post(`/v1/feeds`).send({
+      name: 'Feed 2',
+    });
+    const { body: newBody } = await session.testAgent.get(`/v1/feeds`);
+
+    expect(newBody.data.length).to.equal(2);
+    const feed = newBody.data.find((i) => i.name === 'Feed 2');
+
+    expect(feed.name).to.equal(`Feed 2`);
+    expect(feed._environmentId).to.equal(session.environment._id);
   });
 });

--- a/apps/api/src/app/feeds/usecases/get-feeds/get-feeds.usecase.ts
+++ b/apps/api/src/app/feeds/usecases/get-feeds/get-feeds.usecase.ts
@@ -1,14 +1,32 @@
 import { Injectable } from '@nestjs/common';
 import { FeedRepository, FeedEntity } from '@novu/dal';
 import { GetFeedsCommand } from './get-feeds.command';
+import { CreateFeed } from '../create-feed/create-feed.usecase';
+import { CreateFeedCommand } from '../create-feed/create-feed.command';
 
 @Injectable()
 export class GetFeeds {
-  constructor(private feedsRepository: FeedRepository) {}
+  constructor(private feedsRepository: FeedRepository, private createFeed: CreateFeed) {}
 
   async execute(command: GetFeedsCommand): Promise<FeedEntity[]> {
-    return await this.feedsRepository.find({
+    let feeds = await this.feedsRepository.find({
       _environmentId: command.environmentId,
     });
+
+    if (!feeds.length) {
+      await this.createFeed.execute(
+        CreateFeedCommand.create({
+          organizationId: command.organizationId,
+          environmentId: command.environmentId,
+          userId: command.userId,
+          name: 'Activities',
+        })
+      );
+      feeds = await this.feedsRepository.find({
+        _environmentId: command.environmentId,
+      });
+    }
+
+    return feeds;
   }
 }


### PR DESCRIPTION
When getting the feeds, if none are created- create the default feed. That way, a user that doesn't have any in-app messages will not have a feed (and it would not show on his changes page)