### PR TITLE
Index Cleanup - Changes

### DIFF
--- a/apps/api/src/app/change/usecases/apply-change/apply-change.usecase.ts
+++ b/apps/api/src/app/change/usecases/apply-change/apply-change.usecase.ts
@@ -15,7 +15,6 @@ export class ApplyChange {
     const parentChange = await this.changeRepository.findOne({
       _id: command.changeId,
       _environmentId: command.environmentId,
-      _organizationId: command.organizationId,
     });
 
     if (!parentChange) throw new NotFoundException('Parent Change not found');
@@ -46,7 +45,6 @@ export class ApplyChange {
       {
         _id: change._id,
         _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
       },
       {
         enabled: true,

--- a/apps/api/src/app/change/usecases/bulk-apply-change/bulk-apply-change.usecase.ts
+++ b/apps/api/src/app/change/usecases/bulk-apply-change/bulk-apply-change.usecase.ts
@@ -16,7 +16,6 @@ export class BulkApplyChange {
           $in: command.changeIds,
         },
         _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
       },
       '',
       { sort: { createdAt: 1 } }

--- a/apps/api/src/app/change/usecases/count-changes/count-changes.usecase.ts
+++ b/apps/api/src/app/change/usecases/count-changes/count-changes.usecase.ts
@@ -8,7 +8,6 @@ export class CountChanges {
 
   async execute(command: CountChangesCommand): Promise<number> {
     return await this.changeRepository.count({
-      _organizationId: command.organizationId,
       _environmentId: command.environmentId,
       enabled: false,
       _parentId: { $exists: false, $eq: null },

--- a/apps/api/src/app/change/usecases/create-change/create-change.usecase.ts
+++ b/apps/api/src/app/change/usecases/create-change/create-change.usecase.ts
@@ -9,11 +9,7 @@ export class CreateChange {
   constructor(private changeRepository: ChangeRepository) {}
 
   async execute(command: CreateChangeCommand) {
-    const changes = await this.changeRepository.getEntityChanges(
-      command.organizationId,
-      command.type,
-      command.item._id
-    );
+    const changes = await this.changeRepository.getEntityChanges(command.environmentId, command.type, command.item._id);
     const aggregatedItem = changes
       .filter((change) => change.enabled)
       .reduce((prev, change) => {

--- a/apps/api/src/app/change/usecases/promote-change-to-environment/promote-change-to-environment.usecase.ts
+++ b/apps/api/src/app/change/usecases/promote-change-to-environment/promote-change-to-environment.usecase.ts
@@ -25,7 +25,7 @@ export class PromoteChangeToEnvironment {
   ) {}
 
   async execute(command: PromoteChangeToEnvironmentCommand) {
-    const changes = await this.changeRepository.getEntityChanges(command.organizationId, command.type, command.itemId);
+    const changes = await this.changeRepository.getEntityChanges(command.environmentId, command.type, command.itemId);
     const aggregatedItem = changes
       .filter((change) => change.enabled)
       .reduce((prev, change) => {

--- a/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.usecase.ts
+++ b/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.usecase.ts
@@ -75,7 +75,7 @@ export class PromoteNotificationTemplateChange {
 
     if (!notificationGroup) {
       const changes = await this.changeRepository.getEntityChanges(
-        command.organizationId,
+        command.environmentId,
         ChangeEntityTypeEnum.NOTIFICATION_GROUP,
         newItem._notificationGroupId
       );

--- a/libs/dal/src/repositories/change/change.repository.ts
+++ b/libs/dal/src/repositories/change/change.repository.ts
@@ -1,23 +1,23 @@
 import { ChangeEntityTypeEnum } from '@novu/shared';
 
-import { EnforceEnvOrOrgIds } from '../../types/enforce';
+import { EnforceEnvId } from '../../types/enforce';
 import { BaseRepository } from '../base-repository';
 import { ChangeEntity, ChangeDBModel } from './change.entity';
 import { Change } from './change.schema';
 
-export class ChangeRepository extends BaseRepository<ChangeDBModel, ChangeEntity, EnforceEnvOrOrgIds> {
+export class ChangeRepository extends BaseRepository<ChangeDBModel, ChangeEntity, EnforceEnvId> {
   constructor() {
     super(Change, ChangeEntity);
   }
 
   public async getEntityChanges(
-    organizationId: string,
+    environmentId: string,
     entityType: ChangeEntityTypeEnum,
     entityId: string
   ): Promise<ChangeEntity[]> {
     return await this.find(
       {
-        _organizationId: organizationId,
+        _environmentId: environmentId,
         _entityId: entityId,
         type: entityType,
       },

--- a/libs/dal/src/repositories/change/change.schema.ts
+++ b/libs/dal/src/repositories/change/change.schema.ts
@@ -43,13 +43,10 @@ changeSchema.virtual('user', {
 });
 
 changeSchema.index({
-  _environmentId: 1,
   _parentId: 1,
   _entityId: 1,
+  _environmentId: 1,
   createdAt: 1,
-  type: 1,
-  enabled: 1,
-  _creatorId: 1,
 });
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/libs/dal/src/repositories/change/change.schema.ts
+++ b/libs/dal/src/repositories/change/change.schema.ts
@@ -17,7 +17,6 @@ const changeSchema = new Schema<ChangeDBModel>(
     _environmentId: {
       type: Schema.Types.ObjectId,
       ref: 'Environment',
-      index: true,
     },
     _organizationId: {
       type: Schema.Types.ObjectId,
@@ -27,7 +26,6 @@ const changeSchema = new Schema<ChangeDBModel>(
     _creatorId: {
       type: Schema.Types.ObjectId,
       ref: 'User',
-      index: true,
     },
     _parentId: {
       type: Schema.Types.ObjectId,
@@ -42,6 +40,16 @@ changeSchema.virtual('user', {
   localField: '_creatorId',
   foreignField: '_id',
   justOne: true,
+});
+
+changeSchema.index({
+  _environmentId: 1,
+  _parentId: 1,
+  _entityId: 1,
+  createdAt: 1,
+  type: 1,
+  enabled: 1,
+  _creatorId: 1,
 });
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/libs/dal/src/types/enforce.ts
+++ b/libs/dal/src/types/enforce.ts
@@ -2,4 +2,5 @@ import type { EnvironmentId } from '../repositories/environment';
 import type { OrganizationId } from '../repositories/organization';
 
 export type EnforceOrgId = { _organizationId: OrganizationId };
-export type EnforceEnvOrOrgIds = { _environmentId: EnvironmentId } | EnforceOrgId;
+export type EnforceEnvId = { _environmentId: EnvironmentId };
+export type EnforceEnvOrOrgIds = EnforceEnvId | EnforceOrgId;

--- a/libs/testing/src/user.session.ts
+++ b/libs/testing/src/user.session.ts
@@ -359,7 +359,6 @@ export class UserSession {
     const changes = await this.changeRepository.find(
       {
         _environmentId: this.environment._id,
-        _organizationId: this.organization._id,
         _parentId: { $exists: false, $eq: null },
         ...where,
       },


### PR DESCRIPTION
### What change does this PR introduce?

Why? (Context)

We want to remove as many inefficient indexs and queries as possible.

### Why was this change needed?

Stop using single indexes on the mongoose key implementation
Add compound indexes for common queries and patterns using MongoDB index best practices
Remove unused indexes from MongoDB atlas after implementing the new compound indexes

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
