### PR TITLE
fix(correct docker readme): remove docker cluster references execpt in the devlopment readme

### DIFF
--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: 'Whether this is being triggered from a forked repo'
     required: false
     default: 'false'
-  docker_name: 
+  docker_name:
     description: 'Name for docker image'
     required: true
 
@@ -89,7 +89,7 @@ runs:
         GH_PASSWORD: ${{ inputs.github_token }}
       run: |
         echo "Built image"
-        docker tag novu-api ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
+        docker tag nodvu-api ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
 
         docker run --network=host --name api -dit --env NODE_ENV=test ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
         docker run --network=host appropriate/curl --retry 10 --retry-delay 5 --retry-connrefused http://localhost:1337/v1/health-check | grep 'ok'

--- a/.github/actions/docker/build-api/action.yml
+++ b/.github/actions/docker/build-api/action.yml
@@ -89,7 +89,7 @@ runs:
         GH_PASSWORD: ${{ inputs.github_token }}
       run: |
         echo "Built image"
-        docker tag nodvu-api ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
+        docker tag novu-api ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
 
         docker run --network=host --name api -dit --env NODE_ENV=test ghcr.io/$REGISTRY_OWNER/$DOCKER_NAME:$IMAGE_TAG
         docker run --network=host appropriate/curl --retry 10 --retry-delay 5 --retry-connrefused http://localhost:1337/v1/health-check | grep 'ok'

--- a/.github/workflows/dev-deploy-api.yml
+++ b/.github/workflows/dev-deploy-api.yml
@@ -19,12 +19,12 @@ env:
 
 jobs:
   test_api:
-    strategy:
-      matrix:
-        name: ['novu/api', 'novu/api-ee']
     uses: ./.github/workflows/reusable-api-e2e.yml
+<<<<<<< HEAD
     with:
       ee: ${{ contains (matrix.name,'ee') }}
+=======
+>>>>>>> parent of 6ad53b858 (feat: add matrix for dev deploy api)
 
   deploy_dev_api:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
@@ -38,15 +38,15 @@ jobs:
       packages: write
       deployments: write
       id-token: write
+<<<<<<< HEAD
     strategy:
       matrix:
         # Only should be deploying api-ee to dev
         # name: ['novu/api', 'novu/api-ee']
         name: ['novu/api-ee']
+=======
+>>>>>>> parent of 6ad53b858 (feat: add matrix for dev deploy api)
     steps:
-      - name: echo
-        run: echo ${{ matrix.name }} container
-
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-project
       - uses: ./.github/actions/docker/build-api
@@ -55,7 +55,14 @@ jobs:
           tag: dev
           push: 'true'
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: ${{ matrix.name }}
+      
+      - uses: ./.github/actions/docker/build-api
+        id: docker_build
+        with:
+          tag: dev
+          push: 'true'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          docker_name: 'novu/api-ee'
 
       - name: Checkout cloud infra
         uses: actions/checkout@master

--- a/.github/workflows/reusable-api-e2e.yml
+++ b/.github/workflows/reusable-api-e2e.yml
@@ -4,13 +4,6 @@ name: E2E API Tests
 on:
   workflow_call:
 
-    inputs:
-      ee:
-        description: 'use the ee version of api'
-        required: false
-        default: false
-        type: boolean
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -22,11 +15,6 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v3
-
-      - if: ${{ inputs.ee }}
-        run: |
-          rm -f .npmrc
-          cp .npmrc-cloud .npmrc
 
       - uses: ./.github/actions/setup-project
 

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -26,7 +26,7 @@ cd novu/docker
 cp .env.example ./local/deployment/.env
 
 # Start Novu
-docker-compose -f ./local/deployment/docker-compose.redis-cluster.yml up
+docker-compose -f ./local/deployment/docker-compose.yml up
 ```
 
 Now visit [http://localhost:4200](http://localhost:4200) to start using Novu.

--- a/docker/local/Readme.md
+++ b/docker/local/Readme.md
@@ -7,7 +7,6 @@ For a full guide on running novu locally for development needs, please read our 
 Novu has support for redis cluster, however you must set the following env variables to enable it:
 // To be determined
 
-
 In the local development example in the docker-compose.redis-cluster.yml file, the primary nodes are hard coded to 6391 through 6393 and
 the secondary (read) node to 6394 through 6396 on localhost.
 In addition, for the queue service there is a redis sentinel cluster that has ones primary and two read nodes

--- a/docker/local/Readme.md
+++ b/docker/local/Readme.md
@@ -2,11 +2,14 @@
 
 For a full guide on running novu locally for development needs, please read our guide here: https://docs.novu.co/community/run-locally
 
-### Redis Cluster
+### Advanced - Running with a Redis Cluster
 
-Novu has support for redis cluster, however you must set the following env variables to:
-// FIXME
+Novu has support for redis cluster, however you must set the following env variables to enable it:
+// To be determined
 
-In the local development example, the primary nodes are hard coded to 6391 through 6393 and
-the secondary (read) node to 6381 through 6383 on localhost.
+
+In the local development example in the docker-compose.redis-cluster.yml file, the primary nodes are hard coded to 6391 through 6393 and
+the secondary (read) node to 6394 through 6396 on localhost.
+In addition, for the queue service there is a redis sentinel cluster that has ones primary and two read nodes
+with append-only file enabled that run on ports 6381 through 6383 on localhost.
 We have also set up redis commander on 5001 for you to be able to see the keys and statistics of the cluster.


### PR DESCRIPTION
### What change does this PR introduce?

Reverting accidental reference to redis cluster in the get starting readme. 
