### PR TITLE
feat: add daily bot using Novu

### DIFF
--- a/.github/workflows/daily-updates.yml
+++ b/.github/workflows/daily-updates.yml
@@ -1,0 +1,23 @@
+name: Daily Updates on Discord
+on:
+  schedule:
+    # Runs daily from Sunday to Friday on 8:00AM UTC
+    - cron: '0 8 * * 1-5'
+  workflow_dispatch:
+
+jobs:
+  daily_updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send a curl post command to https://api.novu.co with payload
+        run: |
+          curl --location --request POST 'https://api.novu.co/v1/events/trigger' \
+            --header 'Authorization: ApiKey ${{secrets.NOVU_API_KEY}}' \
+            --header 'Content-Type: application/json' \
+            --data-raw '{
+              "name": "daily-updates",
+              "to": "engineering-team",
+              "payload": {
+              }
+            }'
+  


### PR DESCRIPTION
### What change does this PR introduce?

Add a Daily Bot to notify our Discord channel about a "Daily updates" thread we can all participate in. 

### Why was this change needed?

To help us with organizing and reminding to post daily updates on the "Daily" channel on Discod. 

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
