### PR TITLE
feat(api): implement feature flag generic use case

### DIFF
--- a/apps/api/src/app/feature-flags/services/feature-flags.service.ts
+++ b/apps/api/src/app/feature-flags/services/feature-flags.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { LaunchDarklyService } from './launch-darkly.service';
 
-import { IFeatureFlagsService } from '../types';
+import { FeatureFlagKey, IFeatureFlagContext, IFeatureFlagsService } from '../types';
 
 const LOG_CONTEXT = 'FeatureFlagsService';
 
@@ -47,5 +47,9 @@ export class FeatureFlagsService {
         Logger.error('Feature Flags service has failed when shutted down', LOG_CONTEXT, error);
       }
     }
+  }
+
+  public async get<T>(key: FeatureFlagKey, context: IFeatureFlagContext, defaultValue: T): Promise<T> {
+    return await this.service.get(key, context, defaultValue);
   }
 }

--- a/apps/api/src/app/feature-flags/types/index.ts
+++ b/apps/api/src/app/feature-flags/types/index.ts
@@ -1,4 +1,16 @@
+import { EnvironmentId, OrganizationId, UserId } from '@novu/shared';
+
+// This will become an enum with the keys.
+export type FeatureFlagKey = string;
+
+export interface IFeatureFlagContext {
+  environmentId: EnvironmentId;
+  organizationId: OrganizationId;
+  userId: UserId;
+}
+
 export interface IFeatureFlagsService {
   initialize: () => Promise<void>;
+  get: <T>(key: FeatureFlagKey, context: IFeatureFlagContext, defaultValue: T) => Promise<T>;
   gracefullyShutdown: () => Promise<void>;
 }

--- a/apps/api/src/app/feature-flags/use-cases/get-feature-flag/get-feature-flag.command.ts
+++ b/apps/api/src/app/feature-flags/use-cases/get-feature-flag/get-feature-flag.command.ts
@@ -1,0 +1,9 @@
+import { EnvironmentWithUserCommand } from '@novu/application-generic';
+import { IsDefined } from 'class-validator';
+
+import { FeatureFlagKey } from '../../types';
+
+export class GetFeatureFlagCommand extends EnvironmentWithUserCommand {
+  @IsDefined()
+  key: FeatureFlagKey;
+}

--- a/apps/api/src/app/feature-flags/use-cases/get-feature-flag/get-feature-flag.use-case.ts
+++ b/apps/api/src/app/feature-flags/use-cases/get-feature-flag/get-feature-flag.use-case.ts
@@ -1,0 +1,23 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { GetFeatureFlagCommand } from './get-feature-flag.command';
+
+import { FeatureFlagsService } from '../../services';
+
+@Injectable()
+export class GetFeatureFlag {
+  constructor(private featureFlagsService: FeatureFlagsService) {}
+
+  async execute(command: GetFeatureFlagCommand): Promise<void> {
+    const { key, environmentId, organizationId, userId } = command;
+
+    const context = {
+      environmentId,
+      organizationId,
+      userId,
+    };
+
+    // TODO: The type needs to be dynamic. String so far by default
+    await this.featureFlagsService.get(key, context, '');
+  }
+}

--- a/apps/api/src/app/feature-flags/use-cases/get-feature-flag/index.ts
+++ b/apps/api/src/app/feature-flags/use-cases/get-feature-flag/index.ts
@@ -1,0 +1,2 @@
+export { GetFeatureFlagCommand } from './get-feature-flag.command';
+export { GetFeatureFlag } from './get-feature-flag.use-case';

--- a/apps/api/src/app/feature-flags/use-cases/index.ts
+++ b/apps/api/src/app/feature-flags/use-cases/index.ts
@@ -1,0 +1,1 @@
+export { GetFeatureFlag, GetFeatureFlagCommand } from './get-feature-flag';


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
Implements a generic use case to retrieve a feature flag using the feature flag service and under the hood, Launch Darkly.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
This use case can be reused across our system once the feature flags are set and tested.

### Other information (Screenshots)

Missing tests. If I don't do them for this PR while it is reviewed I will do them when implementing https://linear.app/novu/issue/NV-2325/create-template-store-feature-flag
<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
