### PR TITLE
feat(web): launch darkly load the sdk in async

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { HelmetProvider } from 'react-helmet-async';
 import { Route, Routes, BrowserRouter } from 'react-router-dom';
-import { withLDProvider } from 'launchdarkly-react-client-sdk';
 import LogRocket from 'logrocket';
 import setupLogRocketReact from 'logrocket-react';
 import { Integrations } from '@sentry/tracing';
@@ -28,7 +27,7 @@ import { AppLayout } from './components/layout/AppLayout';
 import { MembersInvitePage } from './pages/invites/MembersInvitePage';
 import { IntegrationsStore } from './pages/integrations/IntegrationsStorePage';
 import CreateOrganizationPage from './pages/auth/CreateOrganizationPage';
-import { ENV, LAUNCH_DARKLY_CLIENT_SIDE_ID, SENTRY_DSN, CONTEXT_PATH, LOGROCKET_ID } from './config';
+import { ENV, SENTRY_DSN, CONTEXT_PATH, LOGROCKET_ID } from './config';
 import { PromoteChangesPage } from './pages/changes/PromoteChangesPage';
 import { LinkVercelProjectPage } from './pages/partner-integrations/LinkVercelProjectPage';
 import { ROUTES } from './constants/routes.enum';
@@ -220,11 +219,4 @@ function App() {
   );
 }
 
-export default Sentry.withProfiler(
-  withLDProvider({
-    clientSideID: LAUNCH_DARKLY_CLIENT_SIDE_ID,
-    reactOptions: {
-      useCamelCaseFlagKeys: false,
-    },
-  })(App)
-);
+export default Sentry.withProfiler(App);

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -1,14 +1,28 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
+
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { LAUNCH_DARKLY_CLIENT_SIDE_ID } from './config';
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById('root')
-);
+(async () => {
+  const LDProvider = await asyncWithLDProvider({
+    clientSideID: LAUNCH_DARKLY_CLIENT_SIDE_ID,
+    reactOptions: {
+      useCamelCaseFlagKeys: false,
+    },
+  });
+
+  ReactDOM.render(
+    <React.StrictMode>
+      <LDProvider>
+        <App />
+      </LDProvider>
+    </React.StrictMode>,
+    document.getElementById('root')
+  );
+})();
 
 /*
  * If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
### What change does this PR introduce?

Load the Launch Darkly SDK async and then render the application. Otherwise, if we do render the app first and then load the SDK then the feature flags are not initialized at the beginning and do fallback to the fallback values, which creates the blink on the UI when the flag fallback is `false` and the remote fetched flag value is `true`.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)


