### PR TITLE
Add Code Owners To Folders for Default PR reviewers

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -480,7 +480,8 @@
     "Dima",
     "orcid",
     "Barnea",
-    "Tomer"
+    "Tomer",
+    "devs"
   ],
   "flagWords": [],
   "patterns": [

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+
+# By default we assume that the novu-devs should review most changes
+# Remove for now until consensus is assured
+@novuhq/novu-devs
+
+# Except for the following exceptions
+# Novu infra team ownership
+.github @novuhq/novu-infra
+.husky @novuhq/novu-infra
+docker @novuhq/novu-infra
+
+# Novu community team ownership
+docs @novuhq/novu-community


### PR DESCRIPTION
### What change does this PR introduce?

This PR is the initial work to add novu's github team to prs by default based on which folder code was changed.

### Other information (Screenshots)

Moved to its own thing from #3651
