### PR TITLE
feat: add group by handlebar helper

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -485,7 +485,8 @@
     "orcid",
     "Barnea",
     "Tomer",
-    "codesandbox"
+    "codesandbox",
+    "GROUPBY"
   ],
   "flagWords": [],
   "patterns": [

--- a/libs/shared/src/consts/handlebar-helpers/handlebarHelpers.ts
+++ b/libs/shared/src/consts/handlebar-helpers/handlebarHelpers.ts
@@ -6,6 +6,7 @@ export enum HandlebarHelpersEnum {
   PLURALIZE = 'pluralize',
   DATEFORMAT = 'dateFormat',
   UNIQUE = 'unique',
+  GROUPBY = 'groupBy',
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -17,4 +18,5 @@ export const HandlebarHelpers = {
   [HandlebarHelpersEnum.PLURALIZE]: { description: 'pluralize if needed' },
   [HandlebarHelpersEnum.DATEFORMAT]: { description: 'format date' },
   [HandlebarHelpersEnum.UNIQUE]: { description: 'filter unique values in an array' },
+  [HandlebarHelpersEnum.GROUPBY]: { description: 'group by a property' },
 };

--- a/packages/application-generic/src/usecases/compile-template/compile-template.spec.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.spec.ts
@@ -68,6 +68,33 @@ describe('Compile Template', function () {
     expect(result).toEqual('<div>dog-cat-</div>');
   });
 
+  it('should render groupBy values of array', async function () {
+    const result = await useCase.execute(
+      CompileTemplateCommand.create({
+        data: {
+          names: [
+            {
+              name: 'Name 1',
+              age: '30',
+            },
+            {
+              name: 'Name 2',
+              age: '31',
+            },
+            {
+              name: 'Name 1',
+              age: '32',
+            },
+          ],
+        },
+        template:
+          '{{#each (unique names "name")}}<h1>{{key}}</h1>{{#each items}}{{age}}-{{/each}}{{/each}}>',
+      })
+    );
+
+    expect(result).toEqual('<h1>Name1</h1>30-32-<h1>Name2</h1>31-');
+  });
+
   it('should allow the user to specify handlebars helpers', async function () {
     const result = await useCase.execute(
       CompileTemplateCommand.create({

--- a/packages/application-generic/src/usecases/compile-template/compile-template.spec.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.spec.ts
@@ -30,7 +30,7 @@ describe('Compile Template', function () {
           name: 'Test Name',
         },
         template: '<div>{{name}}</div>',
-      })
+      }),
     );
 
     expect(result).toEqual('<div>Test Name</div>');
@@ -48,7 +48,7 @@ describe('Compile Template', function () {
         },
         template:
           '<div>{{dog_count}} {{pluralize dog_count "dog" "dogs"}} and {{sausage_count}} {{pluralize sausage_count "sausage" "sausages"}} for {{pluralize dog_count "him" "them"}}</div>',
-      })
+      }),
     );
 
     expect(result).toEqual('<div>1 dog and 2 sausages for him</div>');
@@ -62,7 +62,7 @@ describe('Compile Template', function () {
         },
         template:
           '<div>{{#each (unique names "name")}}{{this}}-{{/each}}</div>',
-      })
+      }),
     );
 
     expect(result).toEqual('<div>dog-cat-</div>');
@@ -89,7 +89,7 @@ describe('Compile Template', function () {
         },
         template:
           '{{#each (unique names "name")}}<h1>{{key}}</h1>{{#each items}}{{age}}-{{/each}}{{/each}}>',
-      })
+      }),
     );
 
     expect(result).toEqual('<h1>Name1</h1>30-32-<h1>Name2</h1>31-');
@@ -107,11 +107,11 @@ describe('Compile Template', function () {
         },
         template:
           '<div>{{titlecase message}} and {{lowercase messageTwo}} and {{uppercase message}}</div>',
-      })
+      }),
     );
 
     expect(result).toEqual(
-      '<div>Hello World and hello world and HELLO WORLD</div>'
+      '<div>Hello World and hello world and HELLO WORLD</div>',
     );
   });
 
@@ -122,7 +122,7 @@ describe('Compile Template', function () {
           message: "hello' world",
         },
         template: '<div>{{message}}</div>',
-      })
+      }),
     );
 
     expect(result).toEqual("<div>hello' world</div>");
@@ -136,7 +136,7 @@ describe('Compile Template', function () {
             date: '2020-01-01',
           },
           template: "<div>{{dateFormat date 'EEEE, MMMM Do yyyy'}}</div>",
-        })
+        }),
       );
       expect(result).toEqual('<div>Wednesday, January 1st 2020</div>');
     });
@@ -148,7 +148,7 @@ describe('Compile Template', function () {
             date: 'ABCD',
           },
           template: "<div>{{dateFormat date 'EEEE, MMMM Do yyyy'}}</div>",
-        })
+        }),
       );
       expect(result).toEqual('<div>ABCD</div>');
     });

--- a/packages/application-generic/src/usecases/compile-template/compile-template.spec.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.spec.ts
@@ -88,7 +88,7 @@ describe('Compile Template', function () {
           ],
         },
         template:
-          '{{#each (unique names "name")}}<h1>{{key}}</h1>{{#each items}}{{age}}-{{/each}}{{/each}}>',
+          '{{#each (groupby names "name")}}<h1>{{key}}</h1>{{#each items}}{{age}}-{{/each}}{{/each}}>',
       }),
     );
 

--- a/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
@@ -65,6 +65,46 @@ Handlebars.registerHelper(
   }
 );
 
+Handlebars.registerHelper(
+  HandlebarHelpersEnum.UNIQUE,
+  function (array, property) {
+    if (!Array.isArray(array)) return '';
+
+    return array
+      .map((item) => {
+        if (item[property]) {
+          return item[property];
+        }
+      })
+      .filter((value, index, self) => self.indexOf(value) === index);
+  }
+);
+
+Handlebars.registerHelper(
+  HandlebarHelpersEnum.GROUPBY,
+  function (array, property) {
+    if (!Array.isArray(array)) return [];
+    const map = {};
+    array.forEach((item) => {
+      if (item[property]) {
+        const key = item[property];
+        if (!map[key]) {
+          map[key] = [item];
+        } else {
+          map[key].push(item);
+        }
+      }
+    });
+
+    const result = [];
+    for (const [key, value] of Object.entries(map)) {
+      result.push({ key: key, items: value });
+    }
+
+    return result;
+  }
+);
+
 @Injectable()
 export class CompileTemplate {
   async execute(command: CompileTemplateCommand): Promise<string> {

--- a/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
@@ -11,15 +11,14 @@ Handlebars.registerHelper(
     // eslint-disable-next-line
     // @ts-expect-error
     return arg1 == arg2 ? options.fn(this) : options.inverse(this);
-  },
+  }
 );
 
 Handlebars.registerHelper(HandlebarHelpersEnum.TITLECASE, function (value) {
   return value
     ?.split(' ')
     .map(
-      (letter) =>
-        letter.charAt(0).toUpperCase() + letter.slice(1).toLowerCase(),
+      (letter) => letter.charAt(0).toUpperCase() + letter.slice(1).toLowerCase()
     )
     .join(' ');
 });
@@ -36,7 +35,7 @@ Handlebars.registerHelper(
   HandlebarHelpersEnum.PLURALIZE,
   function (number, single, plural) {
     return number === 1 ? single : plural;
-  },
+  }
 );
 
 Handlebars.registerHelper(
@@ -48,7 +47,7 @@ Handlebars.registerHelper(
     }
 
     return date;
-  },
+  }
 );
 
 Handlebars.registerHelper(
@@ -63,22 +62,7 @@ Handlebars.registerHelper(
         }
       })
       .filter((value, index, self) => self.indexOf(value) === index);
-  },
-);
-
-Handlebars.registerHelper(
-  HandlebarHelpersEnum.UNIQUE,
-  function (array, property) {
-    if (!Array.isArray(array)) return '';
-
-    return array
-      .map((item) => {
-        if (item[property]) {
-          return item[property];
-        }
-      })
-      .filter((value, index, self) => self.indexOf(value) === index);
-  },
+  }
 );
 
 Handlebars.registerHelper(
@@ -103,7 +87,7 @@ Handlebars.registerHelper(
     }
 
     return result;
-  },
+  }
 );
 
 @Injectable()

--- a/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
@@ -11,14 +11,15 @@ Handlebars.registerHelper(
     // eslint-disable-next-line
     // @ts-expect-error
     return arg1 == arg2 ? options.fn(this) : options.inverse(this);
-  }
+  },
 );
 
 Handlebars.registerHelper(HandlebarHelpersEnum.TITLECASE, function (value) {
   return value
     ?.split(' ')
     .map(
-      (letter) => letter.charAt(0).toUpperCase() + letter.slice(1).toLowerCase()
+      (letter) =>
+        letter.charAt(0).toUpperCase() + letter.slice(1).toLowerCase(),
     )
     .join(' ');
 });
@@ -35,7 +36,7 @@ Handlebars.registerHelper(
   HandlebarHelpersEnum.PLURALIZE,
   function (number, single, plural) {
     return number === 1 ? single : plural;
-  }
+  },
 );
 
 Handlebars.registerHelper(
@@ -47,7 +48,7 @@ Handlebars.registerHelper(
     }
 
     return date;
-  }
+  },
 );
 
 Handlebars.registerHelper(
@@ -62,7 +63,7 @@ Handlebars.registerHelper(
         }
       })
       .filter((value, index, self) => self.indexOf(value) === index);
-  }
+  },
 );
 
 Handlebars.registerHelper(
@@ -77,7 +78,7 @@ Handlebars.registerHelper(
         }
       })
       .filter((value, index, self) => self.indexOf(value) === index);
-  }
+  },
 );
 
 Handlebars.registerHelper(
@@ -102,7 +103,7 @@ Handlebars.registerHelper(
     }
 
     return result;
-  }
+  },
 );
 
 @Injectable()

--- a/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
@@ -11,14 +11,15 @@ Handlebars.registerHelper(
     // eslint-disable-next-line
     // @ts-expect-error
     return arg1 == arg2 ? options.fn(this) : options.inverse(this);
-  }
+  },
 );
 
 Handlebars.registerHelper(HandlebarHelpersEnum.TITLECASE, function (value) {
   return value
     ?.split(' ')
     .map(
-      (letter) => letter.charAt(0).toUpperCase() + letter.slice(1).toLowerCase()
+      (letter) =>
+        letter.charAt(0).toUpperCase() + letter.slice(1).toLowerCase(),
     )
     .join(' ');
 });
@@ -35,7 +36,7 @@ Handlebars.registerHelper(
   HandlebarHelpersEnum.PLURALIZE,
   function (number, single, plural) {
     return number === 1 ? single : plural;
-  }
+  },
 );
 
 Handlebars.registerHelper(
@@ -47,7 +48,7 @@ Handlebars.registerHelper(
     }
 
     return date;
-  }
+  },
 );
 
 Handlebars.registerHelper(
@@ -62,7 +63,7 @@ Handlebars.registerHelper(
         }
       })
       .filter((value, index, self) => self.indexOf(value) === index);
-  }
+  },
 );
 
 Handlebars.registerHelper(
@@ -87,7 +88,7 @@ Handlebars.registerHelper(
     }
 
     return result;
-  }
+  },
 );
 
 @Injectable()


### PR DESCRIPTION
### What change does this PR introduce?
Add new `groupBy` handlebar helper to group array values by property

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->

**Context**:- 
```
{{#each (groupBy names "name")}}
 <h1>{{key}}<h1>
 {{#each items}}
   {{age}}-
 {{/each}}
{{/each}}
```

`Input`

```
{
	"names": [{
		"name": "Name 1",
		"age": "30"
	}, {
		"name": "Name 2",
    "age": "31"
	}, {
		"name": "Name 1",
    "age": "32"
	}]
}

```

Output:- 

```
<h1>Name 1<h1>
   30-
   32-
 <h1>Name 2<h1>
   31-
```
