### PR TITLE
refactor: bootstrap worker as part of e2e setup

### DIFF
--- a/.github/workflows/reusable-api-e2e.yml
+++ b/.github/workflows/reusable-api-e2e.yml
@@ -60,17 +60,6 @@ jobs:
       - name: Install wait-on plugin
         run: npm i -g wait-on
 
-      - name: Build worker
-        run: CI='' pnpm build:worker
-
-      - name: Start worker
-        env:
-          IN_MEMORY_CLUSTER_MODE_ENABLED: true
-        run: cd apps/worker && pnpm start:test &
-
-      - name: Wait on worker
-        run: wait-on --timeout=180000 http://localhost:1342/v1/health-check
-
         # Runs a single command using the runners shell
       - name: Build API
         run: CI='' pnpm build:api

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,11 +209,6 @@ jobs:
 
       - uses: ./.github/actions/start-localstack
 
-      - uses: ./.github/actions/run-worker
-        if: ${{matrix.projectName == '@novu/api' }}
-        with:
-          launch_darkly_sdk_key: ${{ secrets.LAUNCH_DARKLY_SDK_KEY }}
-
       - uses: mansagroup/nrwl-nx-action@v3
         env:
           IN_MEMORY_CLUSTER_MODE_ENABLED: true

--- a/apps/api/e2e/setup.ts
+++ b/apps/api/e2e/setup.ts
@@ -3,10 +3,15 @@ import { testServer } from '@novu/testing';
 import * as sinon from 'sinon';
 
 import { bootstrap } from '../src/bootstrap';
+import { bootstrap as bootstrapWorker } from '../../worker/src/bootstrap';
 
 const dalService = new DalService();
 
 before(async () => {
+  process.env.PORT = '1342';
+  await bootstrapWorker();
+
+  process.env.PORT = '1337';
   await testServer.create(await bootstrap());
   await dalService.connect(process.env.MONGO_URL);
 });

--- a/apps/api/src/app/messages/e2e/get-messages.e2e.ts
+++ b/apps/api/src/app/messages/e2e/get-messages.e2e.ts
@@ -72,10 +72,11 @@ describe('Get Message - /messages (GET)', function () {
 
     const transactionId1 = '1566f9d0-6037-48c1-b356-42667921cadd';
     const transactionId2 = 'd2d9f9b5-4a96-403a-927f-1f8f40c6c7a9';
+    const transactionId3 = 'd2d9f9b5-4a96-403a-927f-1f8f40c6c71122';
 
     await triggerEventWithTransactionId(template.triggers[0].identifier, subscriber3.subscriberId, transactionId1);
     await triggerEventWithTransactionId(template.triggers[0].identifier, subscriber3.subscriberId, transactionId2);
-    await triggerEventWithTransactionId(template.triggers[0].identifier, subscriber3.subscriberId, transactionId1);
+    await triggerEventWithTransactionId(template.triggers[0].identifier, subscriber3.subscriberId, transactionId3);
 
     await session.awaitRunningJobs(template._id);
 
@@ -93,7 +94,7 @@ describe('Get Message - /messages (GET)', function () {
         authorization: `ApiKey ${session.apiKey}`,
       },
     });
-    expect(body.data.data.length).to.be.equal(4);
+    expect(body.data.data.length).to.be.equal(2);
 
     body = await axiosInstance.get(
       `${session.serverUrl}/v1/messages?transactionId=${transactionId1}&transactionId=${transactionId2}`,
@@ -103,7 +104,7 @@ describe('Get Message - /messages (GET)', function () {
         },
       }
     );
-    expect(body.data.data.length).to.be.equal(6);
+    expect(body.data.data.length).to.be.equal(4);
 
     body = await axiosInstance.get(`${session.serverUrl}/v1/messages?transactionId=${transactionId2}`, {
       headers: {


### PR DESCRIPTION
### What change does this PR introduce?

Instead of running the worker in a separate process, we can reuse the same running process of the tests for both service. 

### Why was this change needed?

When modifying the feature flags in the API tests, we are not able to modify the feature flags on the worker service.

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
