### PR TITLE
[POC] -  offload execution logs to queue

### DIFF
--- a/apps/worker/src/app/workflow/services/execution-details-archive/execution-details-archive-consumer.service.ts
+++ b/apps/worker/src/app/workflow/services/execution-details-archive/execution-details-archive-consumer.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { BullMqService, CreateExecutionDetails, CreateExecutionDetailsCommand } from '@novu/application-generic';
+import { JobTopicNameEnum } from '@novu/shared';
+
+@Injectable()
+export class ExecutionDetailsArchiveConsumer {
+  private readonly LOG_CONTEXT = 'ExecutionDetailsArchiveConsumerService';
+  private readonly name = JobTopicNameEnum.EXECUTION_DETAIL_ARCHIVE;
+
+  constructor(private createExecutionDetails: CreateExecutionDetails, private bullMqService: BullMqService) {
+    this.bullMqService.createWorker(this.name, this.getWorkerProcessor(), this.getWorkerOpts());
+  }
+
+  private getWorkerProcessor() {
+    return async ({ data }) => {
+      try {
+        await this.createExecutionDetails.execute(CreateExecutionDetailsCommand.create({ ...data }));
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        Logger.error(
+          'Unexpected exception occurred while execution details archive consumer services route ',
+          e,
+          this.LOG_CONTEXT
+        );
+
+        throw e;
+      }
+    };
+  }
+
+  private getWorkerOpts() {
+    return {
+      lockDuration: 90000,
+      concurrency: 5,
+    };
+  }
+}

--- a/apps/worker/src/app/workflow/services/execution-details-archive/execution-details-archive-producer.service.ts
+++ b/apps/worker/src/app/workflow/services/execution-details-archive/execution-details-archive-producer.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { BullMqService } from '@novu/application-generic';
+import { JobTopicNameEnum } from '@novu/shared';
+
+@Injectable()
+export class ExecutionDetailsArchiveProducer {
+  private readonly LOG_CONTEXT = 'ExecutionDetailsArchiveProducerService';
+  public readonly name = JobTopicNameEnum.EXECUTION_DETAIL_ARCHIVE;
+
+  constructor(private bullMqService: BullMqService) {
+    this.bullMqService.createQueue(this.name, {
+      defaultJobOptions: {
+        removeOnComplete: true,
+      },
+    });
+  }
+
+  public add(id: string, data: any, organizationId: string) {
+    Logger.log(`${this.LOG_CONTEXT}.add: ${id} Group: ${organizationId}`, this.LOG_CONTEXT);
+
+    this.bullMqService.add(
+      id,
+      data,
+      {
+        removeOnComplete: true,
+        removeOnFail: true,
+      },
+      organizationId
+    );
+  }
+
+  public async gracefulShutdown(): Promise<void> {
+    Logger.log('Shutting the execution details archive producer service down', this.LOG_CONTEXT);
+
+    await this.bullMqService.gracefulShutdown();
+
+    Logger.log('Shutting down the execution details archive producer service has finished', this.LOG_CONTEXT);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.gracefulShutdown();
+  }
+}

--- a/libs/shared/src/config/job-queue.ts
+++ b/libs/shared/src/config/job-queue.ts
@@ -4,6 +4,7 @@ export enum JobTopicNameEnum {
   STANDARD = 'standard',
   WEB_SOCKETS = 'ws_socket_queue',
   WORKFLOW = 'trigger-handler',
+  EXECUTION_DETAIL_ARCHIVE = 'execution-details-archive',
 }
 
 export enum ObservabilityBackgroundTransactionEnum {


### PR DESCRIPTION
### What change does this PR introduce?

Offload execution logs to a queue. This PR is a POC, only to show how it could look like. In the first stage, we could use just the queue, this way we offload the DB query, and the response time of the trigger flow will be faster. 
Due to the reason that the execution details are not time sensitive and are meant only for debugging the possible latency is bearable.

### Why was this change needed?

Currently, we create a lot of execution detail requests in our trigger flow and they will probably increase in the future, which could cause a load in the DB.

### Other information (Screenshots)

Addition things that needed to be done + next steps:
* initialize Date time of the queued execution detail to the command and store it as createdAt. 
* refactor all of the execution detail requests to use the queue.
* refactor the worker to WorkerPro in order to get the execution details in batches and reduce the number of requests to the DB.  REF https://docs.bullmq.io/bullmq-pro/batches
