### PR TITLE
WIP - Fix Nested Validation

### DIFF
--- a/apps/api/src/app/shared/commands/base.command.ts
+++ b/apps/api/src/app/shared/commands/base.command.ts
@@ -1,8 +1,30 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { plainToInstance } from 'class-transformer';
-import { validateSync } from 'class-validator';
+import { validateSync, ValidationError } from 'class-validator';
 import * as Sentry from '@sentry/node';
-import { BadRequestException, flatten } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
+
+interface IConstraint {
+  path: string[];
+  constraint: string[];
+}
+
+function extractConstraints(obj: any, path: string[] = []): IConstraint[] {
+  const constraints: IConstraint[] = [];
+
+  for (const key in obj) {
+    if (obj[key] && typeof obj[key] === 'object') {
+      const currentLocation = obj[key]?.property;
+      const newPath = [...path, currentLocation];
+      if (obj[key].constraints) {
+        constraints.push({ path: [...newPath, key], constraint: Object.values(obj[key].constraints) });
+      }
+      constraints.push(...extractConstraints(obj[key].children, newPath));
+    }
+  }
+
+  return constraints;
+}
 
 export abstract class BaseCommand {
   static create<T extends BaseCommand>(this: new (...args: any[]) => T, data: T): T {
@@ -12,7 +34,7 @@ export abstract class BaseCommand {
 
     const errors = validateSync(convertedObject as unknown as object);
     if (errors?.length) {
-      const mappedErrors = flatten(errors.map((item) => Object.values(item.constraints ?? {})));
+      const mappedErrors = extractConstraints(errors);
 
       Sentry.addBreadcrumb({
         category: 'BaseCommand',

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.command.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.command.ts
@@ -1,36 +1,6 @@
-import { BaseCommand } from '@novu/application-generic';
-import {
-  IsEnum,
-  IsMongoId,
-  IsOptional,
-  IsString,
-  registerDecorator,
-  ValidationArguments,
-  ValidationOptions,
-} from 'class-validator';
+import { BaseCommand, IsNotEmpty } from '@novu/application-generic';
+import { IsEnum, IsMongoId, IsOptional, IsString } from 'class-validator';
 import { ChatProviderIdEnum } from '@novu/shared';
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function IsNotEmpty(validationOptions?: ValidationOptions) {
-  return function (object: object, propertyName: string) {
-    registerDecorator({
-      name: 'isNotEmpty',
-      target: object.constructor,
-      propertyName: propertyName,
-      options: validationOptions,
-      validator: {
-        validate(value: any, args: ValidationArguments) {
-          return ![null, undefined, 'null', 'undefined', ''].some((invalidValue) => invalidValue === value);
-        },
-        defaultMessage: function (data) {
-          const value = data?.value === '' ? 'empty string' : data?.value;
-
-          return `${data?.property} should not be ${value}`;
-        },
-      },
-    });
-  };
-}
 
 export class ChatOauthCallbackCommand extends BaseCommand {
   @IsMongoId()

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/is-not-empty.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/is-not-empty.spec.ts
@@ -1,5 +1,4 @@
-import { BaseCommand } from '@novu/application-generic';
-import { IsNotEmpty } from './chat-oauth-callback.command';
+import { BaseCommand, IsNotEmpty } from '@novu/application-generic';
 import { expect } from 'chai';
 
 describe('@IsNotEmpty() validator', function () {

--- a/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.command.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth/chat-oauth.command.ts
@@ -1,8 +1,6 @@
 import { IsEnum, IsMongoId, IsOptional, IsString } from 'class-validator';
-import { BaseCommand } from '@novu/application-generic';
+import { BaseCommand, IsNotEmpty } from '@novu/application-generic';
 import { ChatProviderIdEnum } from '@novu/shared';
-
-import { IsNotEmpty } from '../chat-oauth-callback/chat-oauth-callback.command';
 
 export class ChatOauthCommand extends BaseCommand {
   @IsMongoId()

--- a/apps/api/src/app/workflows/usecases/create-notification-template/create-notification-template.command.ts
+++ b/apps/api/src/app/workflows/usecases/create-notification-template/create-notification-template.command.ts
@@ -21,6 +21,8 @@ import {
 
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { MessageTemplate } from '../../../shared/dtos/message-template';
+import { Type } from 'class-transformer';
+import { VariantWithFilter } from '@novu/application-generic';
 
 /**
  * DEPRECATED:
@@ -46,7 +48,8 @@ export class CreateNotificationTemplateCommand extends EnvironmentWithUserComman
 
   @IsDefined()
   @IsArray()
-  @ValidateNested()
+  @ValidateNested({ each: true })
+  @Type(() => NotificationStep)
   steps: NotificationStep[];
 
   @IsBoolean()
@@ -88,8 +91,8 @@ export class ChannelCTACommand {
 }
 
 export class NotificationStepVariant {
-  @IsString()
   @IsOptional()
+  @IsString()
   _templateId?: string;
 
   @ValidateNested()
@@ -97,15 +100,19 @@ export class NotificationStepVariant {
   template?: MessageTemplate;
 
   @IsOptional()
+  @IsString()
   uuid?: string;
 
   @IsOptional()
+  @IsBoolean()
   name?: string;
 
+  @IsOptional()
   @IsBoolean()
   active?: boolean;
 
   @IsBoolean()
+  @IsOptional()
   shouldStopOnFail?: boolean;
 
   @ValidateNested()
@@ -131,7 +138,9 @@ export class NotificationStepVariant {
 export class NotificationStep extends NotificationStepVariant {
   @IsOptional()
   @IsArray()
-  @ValidateNested()
+  @ValidateNested({ each: true })
+  @Type(() => NotificationStepVariant)
+  @VariantWithFilter()
   variants?: NotificationStepVariant[];
 }
 

--- a/packages/application-generic/src/index.ts
+++ b/packages/application-generic/src/index.ts
@@ -14,3 +14,4 @@ export * from './utils/filter-processing-details';
 export * from './resilience';
 export * from './utils/exceptions';
 export * from './utils/email-normalization';
+export * from './utils/validation';

--- a/packages/application-generic/src/utils/validation.ts
+++ b/packages/application-generic/src/utils/validation.ts
@@ -1,0 +1,52 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+import { StepVariantDto } from '@novu/shared';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function IsNotEmpty(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isNotEmpty',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any, args: ValidationArguments) {
+          return ![null, undefined, 'null', 'undefined', ''].some(
+            (invalidValue) => invalidValue === value
+          );
+        },
+        defaultMessage: function (data) {
+          const value = data?.value === '' ? 'empty string' : data?.value;
+
+          return `${data?.property} should not be ${value}`;
+        },
+      },
+    });
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function VariantWithFilter(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'variantWithFilter',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: any, args: ValidationArguments) {
+          const invalid = value.some((variant) => !variant.filters?.length);
+
+          return !invalid;
+        },
+        defaultMessage: function (data) {
+          return `Variant conditions are required, by providing a variant please make sure to add at least one condition.`;
+        },
+      },
+    });
+  };
+}


### PR DESCRIPTION
### What change does this PR introduce?

The PR introduces WIP of what we need to do in order to fix the nested validation that currently is broken. In order to add nested validation to the variants we will need to do the following: 
* Create a custom validation decorator. 
* Fix the nested validation that does not work at the moment. In order to fix it we need to do the following add ValidateNested decorator, if it is an array we should add each as well (`@ValidateNested({ each: true })`), then add `@Type(() => NotificationStepVariant)` decorator from `class-transformer` in order to map the type implicitly.
* The hardest part IMO will be to return the nested errors that we will get, at the moment we throw an exception on the first layer, but it an error is not thrown we do flat on the first layer on BaseComman which won't return us the nested `constrains`.

### Why was this change needed?

So we could validate nested objects and return a valid error if validations had errors.

### Other information

In this PR I am adding nested validation only for variants as POC, once we merge this PR we most definitely need to validate all of the rest `ValidateNested` decorators.

### DOD
* Add unit tests for the extractConstraints function.
* Add tests of command in order to check that the new logic works with it as expected.
* Add max validation depth in order to not over-compute extractConstraints if the input is unexpectedly long or infinite.

