### PR TITLE
fix: workflow override build

### DIFF
--- a/apps/api/src/app/workflow-overrides/e2e/delete-workflow-override.e2e.ts
+++ b/apps/api/src/app/workflow-overrides/e2e/delete-workflow-override.e2e.ts
@@ -19,18 +19,13 @@ describe('Delete workflow override - /workflow-overrides/:overrideId (Delete)', 
       environmentId: session.environment._id,
     });
 
-    const createdWorkflowOverride = await workflowOverrideService.createWorkflowOverride();
-
-    const tenant = await tenantRepository.findOne({
-      _environmentId: session.environment._id,
-      _id: createdWorkflowOverride._tenantId,
-    });
+    const { tenant, workflowOverride } = await workflowOverrideService.createWorkflowOverride();
 
     if (!tenant) throw new Error('Tenant not found');
 
     const validatedCreationWorkflowOverride = await workflowOverrideRepository.findOne({
       _environmentId: session.environment._id,
-      _id: createdWorkflowOverride._id,
+      _id: workflowOverride._id,
     });
 
     if (!validatedCreationWorkflowOverride) throw new Error('WorkflowOverride not found');
@@ -45,7 +40,7 @@ describe('Delete workflow override - /workflow-overrides/:overrideId (Delete)', 
 
     const findDeleted = await workflowOverrideRepository.findOne({
       _environmentId: session.environment._id,
-      _id: createdWorkflowOverride._id,
+      _id: workflowOverride._id,
     });
 
     expect(findDeleted).to.be.null;

--- a/apps/api/src/app/workflow-overrides/e2e/get-workflow-override-by-id.e2e.ts
+++ b/apps/api/src/app/workflow-overrides/e2e/get-workflow-override-by-id.e2e.ts
@@ -18,26 +18,26 @@ describe('Get workflow override by ID - /workflow-overrides/:overrideId (GET)', 
       organizationId: session.organization._id,
       environmentId: session.environment._id,
     });
-    const createdWorkflowOverride = await workflowOverrideService.createWorkflowOverride();
+    const { workflowOverride } = await workflowOverrideService.createWorkflowOverride();
 
     const tenant = await tenantRepository.findOne({
       _environmentId: session.environment._id,
-      _id: createdWorkflowOverride._tenantId,
+      _id: workflowOverride._tenantId,
     });
 
     if (!tenant) throw new Error('Tenant not found');
 
-    const res = await session.testAgent.get(`/v1/workflow-overrides/${createdWorkflowOverride._id}`);
+    const res = await session.testAgent.get(`/v1/workflow-overrides/${workflowOverride._id}`);
 
     const foundWorkflowOverride: IWorkflowOverride = res.body.data;
 
-    expect(foundWorkflowOverride._workflowId).to.equal(createdWorkflowOverride._workflowId);
-    expect(foundWorkflowOverride._tenantId).to.equal(createdWorkflowOverride._tenantId);
-    expect(foundWorkflowOverride.active).to.equal(createdWorkflowOverride.active);
-    expect(foundWorkflowOverride.preferenceSettings.chat).to.equal(createdWorkflowOverride.preferenceSettings.chat);
-    expect(foundWorkflowOverride.preferenceSettings.sms).to.equal(createdWorkflowOverride.preferenceSettings.sms);
-    expect(foundWorkflowOverride.preferenceSettings.in_app).to.equal(createdWorkflowOverride.preferenceSettings.in_app);
-    expect(foundWorkflowOverride.preferenceSettings.email).to.equal(createdWorkflowOverride.preferenceSettings.email);
-    expect(foundWorkflowOverride.preferenceSettings.push).to.equal(createdWorkflowOverride.preferenceSettings.push);
+    expect(foundWorkflowOverride._workflowId).to.equal(workflowOverride._workflowId);
+    expect(foundWorkflowOverride._tenantId).to.equal(workflowOverride._tenantId);
+    expect(foundWorkflowOverride.active).to.equal(workflowOverride.active);
+    expect(foundWorkflowOverride.preferenceSettings.chat).to.equal(workflowOverride.preferenceSettings.chat);
+    expect(foundWorkflowOverride.preferenceSettings.sms).to.equal(workflowOverride.preferenceSettings.sms);
+    expect(foundWorkflowOverride.preferenceSettings.in_app).to.equal(workflowOverride.preferenceSettings.in_app);
+    expect(foundWorkflowOverride.preferenceSettings.email).to.equal(workflowOverride.preferenceSettings.email);
+    expect(foundWorkflowOverride.preferenceSettings.push).to.equal(workflowOverride.preferenceSettings.push);
   });
 });

--- a/apps/api/src/app/workflow-overrides/e2e/get-workflow-override.e2e.ts
+++ b/apps/api/src/app/workflow-overrides/e2e/get-workflow-override.e2e.ts
@@ -18,28 +18,28 @@ describe('Get workflow override - /workflow-overrides/workflows/:workflowId/tena
       organizationId: session.organization._id,
       environmentId: session.environment._id,
     });
-    const createdWorkflowOverride = await workflowOverrideService.createWorkflowOverride();
+    const { workflowOverride } = await workflowOverrideService.createWorkflowOverride();
 
     const tenant = await tenantRepository.findOne({
       _environmentId: session.environment._id,
-      _id: createdWorkflowOverride._tenantId,
+      _id: workflowOverride._tenantId,
     });
 
     if (!tenant) throw new Error('Tenant not found');
 
     const res = await session.testAgent.get(
-      `/v1/workflow-overrides/workflows/${createdWorkflowOverride._workflowId}/tenants/${tenant._id}`
+      `/v1/workflow-overrides/workflows/${workflowOverride._workflowId}/tenants/${tenant._id}`
     );
 
     const foundWorkflowOverride: IWorkflowOverride = res.body.data;
 
-    expect(foundWorkflowOverride._workflowId).to.equal(createdWorkflowOverride._workflowId);
-    expect(foundWorkflowOverride._tenantId).to.equal(createdWorkflowOverride._tenantId);
-    expect(foundWorkflowOverride.active).to.equal(createdWorkflowOverride.active);
-    expect(foundWorkflowOverride.preferenceSettings.chat).to.equal(createdWorkflowOverride.preferenceSettings.chat);
-    expect(foundWorkflowOverride.preferenceSettings.sms).to.equal(createdWorkflowOverride.preferenceSettings.sms);
-    expect(foundWorkflowOverride.preferenceSettings.in_app).to.equal(createdWorkflowOverride.preferenceSettings.in_app);
-    expect(foundWorkflowOverride.preferenceSettings.email).to.equal(createdWorkflowOverride.preferenceSettings.email);
-    expect(foundWorkflowOverride.preferenceSettings.push).to.equal(createdWorkflowOverride.preferenceSettings.push);
+    expect(foundWorkflowOverride._workflowId).to.equal(workflowOverride._workflowId);
+    expect(foundWorkflowOverride._tenantId).to.equal(workflowOverride._tenantId);
+    expect(foundWorkflowOverride.active).to.equal(workflowOverride.active);
+    expect(foundWorkflowOverride.preferenceSettings.chat).to.equal(workflowOverride.preferenceSettings.chat);
+    expect(foundWorkflowOverride.preferenceSettings.sms).to.equal(workflowOverride.preferenceSettings.sms);
+    expect(foundWorkflowOverride.preferenceSettings.in_app).to.equal(workflowOverride.preferenceSettings.in_app);
+    expect(foundWorkflowOverride.preferenceSettings.email).to.equal(workflowOverride.preferenceSettings.email);
+    expect(foundWorkflowOverride.preferenceSettings.push).to.equal(workflowOverride.preferenceSettings.push);
   });
 });

--- a/apps/api/src/app/workflow-overrides/e2e/update-workflow-override-by-id.e2e.ts
+++ b/apps/api/src/app/workflow-overrides/e2e/update-workflow-override-by-id.e2e.ts
@@ -17,7 +17,7 @@ describe('Update Workflow Override By ID - /workflow-overrides/:overrideId (PUT)
       environmentId: session.environment._id,
     });
 
-    const overrides = await workflowOverrideService.createWorkflowOverride({
+    const { workflowOverride } = await workflowOverrideService.createWorkflowOverride({
       preferenceSettings: {
         email: false,
         sms: true,
@@ -27,14 +27,14 @@ describe('Update Workflow Override By ID - /workflow-overrides/:overrideId (PUT)
       },
     });
 
-    expect(overrides.preferenceSettings).to.deep.equal({
+    expect(workflowOverride.preferenceSettings).to.deep.equal({
       email: false,
       sms: true,
       in_app: true,
       chat: true,
       push: true,
     });
-    expect(overrides.active).to.equal(false);
+    expect(workflowOverride.active).to.equal(false);
 
     const updatePayload: IUpdateWorkflowOverrideRequestDto = {
       preferenceSettings: { email: true, sms: false },
@@ -42,7 +42,7 @@ describe('Update Workflow Override By ID - /workflow-overrides/:overrideId (PUT)
     };
 
     const updatedOverrides = (
-      await session.testAgent.put(`/v1/workflow-overrides/${overrides._id}`).send(updatePayload)
+      await session.testAgent.put(`/v1/workflow-overrides/${workflowOverride._id}`).send(updatePayload)
     ).body.data;
 
     expect(updatedOverrides.preferenceSettings).to.deep.equal({


### PR DESCRIPTION
### What change does this PR introduce?

Apologies I am not sure how this was missed locally and in the ci.
 
### Why was this change needed?

the use of the updated function `workflowOverrideService.createWorkflowOverride` interface, which will cause build failure. 

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
