### PR TITLE
fix(ci): checkout submodules and install enterprise packages

### DIFF
--- a/.github/workflows/dev-deploy-api.yml
+++ b/.github/workflows/dev-deploy-api.yml
@@ -49,6 +49,9 @@ jobs:
           submodules: ${{ contains (matrix.name,'-ee') }}
           token: ${{ secrets.SUBMODULES_TOKEN }}
       - uses: ./.github/actions/setup-project
+        with:
+          submodules: ${{ contains (matrix.name,'-ee') }}
+          slim: 'true'
       - uses: ./.github/actions/docker/build-api
         id: docker_build
         with:
@@ -142,7 +145,7 @@ jobs:
           sourcemaps: apps/api/dist
           ignore_empty: true
           ignore_missing: true
-          url_prefix: "~"
+          url_prefix: '~'
 
   newrelic:
     runs-on: ubuntu-latest
@@ -159,6 +162,6 @@ jobs:
         with:
           region: EU
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          guid: "MzgxMjQwOHxBUE18QVBQTElDQVRJT058NDk3NjQzODIy"
-          version: "${{ env.RELEASE_VERSION }}"
-          user: "${{ github.actor }}"
+          guid: 'MzgxMjQwOHxBUE18QVBQTElDQVRJT058NDk3NjQzODIy'
+          version: '${{ env.RELEASE_VERSION }}'
+          user: '${{ github.actor }}'

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       # The order is important for ee to be first, otherwise outputs not work correctly
       matrix:
-        name: [ 'novu/api-ee', 'novu/api' ]
+        name: ['novu/api-ee', 'novu/api']
     uses: ./.github/workflows/reusable-api-e2e.yml
     with:
       ee: ${{ contains (matrix.name,'-ee') }}
@@ -26,7 +26,7 @@ jobs:
     environment: Production
     strategy:
       matrix:
-        name: [ 'novu/api-ee', 'novu/api' ]
+        name: ['novu/api-ee', 'novu/api']
     outputs:
       docker_image: ${{ steps.build-image.outputs.IMAGE }}
     permissions:
@@ -36,7 +36,12 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: ${{ contains (matrix.name,'-ee') }}
+          token: ${{ secrets.SUBMODULES_TOKEN }}
       - uses: ./.github/actions/setup-project
+        with:
+          submodules: ${{ contains (matrix.name,'-ee') }}
 
       - name: build api
         run: pnpm build:api
@@ -128,6 +133,6 @@ jobs:
         with:
           region: EU
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
-          guid: "MzgxMjQwOHxBUE18QVBQTElDQVRJT058NDk3NzA2ODk2"
-          version: "${{ env.RELEASE_VERSION }}"
-          user: "${{ github.actor }}"
+          guid: 'MzgxMjQwOHxBUE18QVBQTElDQVRJT058NDk3NzA2ODk2'
+          version: '${{ env.RELEASE_VERSION }}'
+          user: '${{ github.actor }}'


### PR DESCRIPTION
### What change does this PR introduce?

Fixes the issue with docker enterprise images not having the enterprise packages bundled.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
