### PR TITLE
feat(worker): add topics fanout in batches by pagination

### DIFF
--- a/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
@@ -9,6 +9,9 @@ import { TopicSubscribers } from './topic-subscribers.schema';
 import { EnvironmentId, OrganizationId, TopicId, TopicKey } from './types';
 import { BaseRepository } from '../base-repository';
 import type { EnforceEnvOrOrgIds } from '../../types/enforce';
+import { FilterQuery } from 'mongoose';
+
+type TopicSubscribersQuery = FilterQuery<TopicSubscribersDBModel>;
 
 export class TopicSubscribersRepository extends BaseRepository<
   TopicSubscribersDBModel,
@@ -53,6 +56,22 @@ export class TopicSubscribersRepository extends BaseRepository<
     ])) {
       yield doc;
     }
+  }
+
+  async getDistinctSubscribers(
+    query: TopicSubscribersQuery & {
+      _environmentId: string;
+    },
+    options?: {
+      limit?: number;
+      skip?: number;
+    }
+  ) {
+    const data = await this.MongooseModel.distinct('externalSubscriberId', query)
+      .limit(options?.limit || 10)
+      .skip(options?.skip || 10);
+
+    return this.mapEntities(data);
   }
 
   async findOneByTopicKeyAndExternalSubscriberId(

--- a/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -156,7 +156,7 @@ export class TriggerMulticast {
         subscriberId: subscriber.externalSubscriberId,
       };
 
-      if (!actor || actor.subscriberId !== subscriberDefine.subscriberId) {
+      if (actor && actor.subscriberId !== subscriberDefine.subscriberId) {
         subscriberDefines.push(subscriberDefine);
       }
     }

--- a/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -120,8 +120,8 @@ export class TriggerMulticast {
             {
               _organizationId: organizationId,
               _environmentId: environmentId,
-              topicIds: topicIds,
-              excludeSubscribers: singleSubscriberIds,
+              _topicId: { $in: topicIds },
+              externalSubscriberId: { $nin: singleSubscriberIds },
             },
             {
               limit: subscriberFetchBatchSize,


### PR DESCRIPTION
### What change does this PR introduce?

Offspring of https://github.com/novuhq/novu/pull/5165, while we initially used batch creation via the mongo cursor, the resolution here involves pagination instead.

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
