### PR TITLE
Nv 3230 auto remove deleted subscribers from topic

### DIFF
--- a/apps/api/migrations/topic-subscriber-normalize/topic-subscriber-normalize.migration.spec.ts
+++ b/apps/api/migrations/topic-subscriber-normalize/topic-subscriber-normalize.migration.spec.ts
@@ -1,0 +1,137 @@
+import axios from 'axios';
+import { beforeEach } from 'mocha';
+import { expect } from 'chai';
+
+import { ExternalSubscriberId, TopicId, TopicKey, TopicName } from '@novu/shared';
+import { SubscriberEntity, SubscriberRepository, TopicSubscribersRepository } from '@novu/dal';
+import { UserSession, SubscribersService } from '@novu/testing';
+
+import { topicSubscriberNormalize } from './topic-subscriber-normalize.migration';
+
+const axiosInstance = axios.create();
+const TOPIC_PATH = '/v1/topics';
+
+describe('Remove all the stale topic subscriber relations', () => {
+  let session: UserSession;
+  let subscriberService: SubscribersService;
+  const subscriberRepository = new SubscriberRepository();
+  const topicSubscribersRepository = new TopicSubscribersRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+    subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+  });
+
+  it('should remove topic subscriber relation record on removed subscribers', async () => {
+    const subscriberId = '123';
+    const createdSubscriber = await subscriberService.createSubscriber({ subscriberId: subscriberId });
+    const firstTopicKey = `topic-key-1-trigger-event`;
+    const firstTopicName = `topic-name-1-trigger-event`;
+    const newTopic = await createTopic(session, firstTopicKey, firstTopicName);
+    await addSubscribersToTopic(session, { _id: newTopic._id, key: newTopic.key }, [createdSubscriber]);
+
+    // create subscriber and its relation to topic
+    const subscriber = await subscriberRepository.findBySubscriberId(session.environment._id, subscriberId);
+    const topicSubscriber = await topicSubscribersRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      externalSubscriberId: subscriberId,
+    });
+
+    if (!subscriber) {
+      expect(subscriber).to.be.ok;
+      throw new Error('Subscriber not found');
+    }
+    if (!topicSubscriber) {
+      expect(topicSubscriber).to.be.ok;
+      throw new Error('topicSubscriber not found');
+    }
+
+    expect(subscriber.subscriberId).to.be.equal(subscriberId);
+    expect(topicSubscriber.externalSubscriberId).to.be.equal(subscriberId);
+    // END - create subscriber and its relation to topic
+
+    await subscriberRepository.delete({
+      _environmentId: subscriber._environmentId,
+      _organizationId: subscriber._organizationId,
+      subscriberId: subscriber.subscriberId,
+    });
+
+    const subscriberAfterDeletion = await subscriberRepository.findBySubscriberId(
+      session.environment._id,
+      subscriberId
+    );
+    const topicSubscriberAfterDeletion = await topicSubscribersRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      externalSubscriberId: subscriberId,
+    });
+
+    expect(subscriberAfterDeletion).to.not.be.ok;
+    expect(topicSubscriberAfterDeletion).to.be.ok;
+
+    await topicSubscriberNormalize();
+
+    const topicSubscriberAfterMigration = await topicSubscribersRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      externalSubscriberId: subscriberId,
+    });
+
+    expect(topicSubscriberAfterMigration).to.not.be.ok;
+  });
+});
+
+const createTopic = async (
+  session: UserSession,
+  key: TopicKey,
+  name: TopicName
+): Promise<{ _id: TopicId; key: TopicKey }> => {
+  const response = await axiosInstance.post(
+    `${session.serverUrl}${TOPIC_PATH}`,
+    {
+      key,
+      name,
+    },
+    {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    }
+  );
+
+  expect(response.status).to.eql(201);
+  const body = response.data;
+  expect(body.data._id).to.exist;
+  expect(body.data.key).to.eql(key);
+
+  return body.data;
+};
+
+const addSubscribersToTopic = async (
+  session: UserSession,
+  createdTopicDto: { _id: TopicId; key: TopicKey },
+  subscribers: SubscriberEntity[]
+) => {
+  const subscriberIds: ExternalSubscriberId[] = subscribers.map(
+    (subscriber: SubscriberEntity) => subscriber.subscriberId
+  );
+
+  const response = await axiosInstance.post(
+    `${session.serverUrl}${TOPIC_PATH}/${createdTopicDto.key}/subscribers`,
+    {
+      subscribers: subscriberIds,
+    },
+    {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    }
+  );
+
+  expect(response.status).to.be.eq(200);
+  expect(response.data.data).to.be.eql({
+    succeeded: subscriberIds,
+  });
+};

--- a/apps/api/migrations/topic-subscriber-normalize/topic-subscriber-normalize.migration.ts
+++ b/apps/api/migrations/topic-subscriber-normalize/topic-subscriber-normalize.migration.ts
@@ -1,0 +1,50 @@
+import '../../src/config';
+
+import { NestFactory } from '@nestjs/core';
+import { SubscriberRepository, TopicSubscribersRepository } from '@novu/dal';
+
+import { AppModule } from '../../src/app.module';
+
+/*
+ * topic subscriber normalize - will remove deleted subscribers from topic subscribers
+ */
+export async function topicSubscriberNormalize() {
+  // eslint-disable-next-line no-console
+  console.log('start migration - topic subscriber normalize - will remove deleted subscribers from topic subscribers');
+
+  const app = await NestFactory.create(AppModule, {
+    logger: false,
+  });
+  const topicSubscribersRepository = app.get(TopicSubscribersRepository);
+  const subscriberRepository = app.get(SubscriberRepository);
+
+  const cursor = await topicSubscribersRepository._model
+    .find({} as any)
+    .batchSize(1000)
+    .cursor();
+
+  for await (const topicSubscriber of cursor) {
+    const subscriber = await subscriberRepository.findBySubscriberId(
+      topicSubscriber._environmentId.toString(),
+      topicSubscriber.externalSubscriberId
+    );
+
+    if (!subscriber) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `remove relation topic subscriber ${topicSubscriber.externalSubscriberId} from topic ${topicSubscriber._topicId}`
+      );
+
+      await topicSubscribersRepository.delete({
+        _environmentId: topicSubscriber._environmentId.toString(),
+        _organizationId: topicSubscriber._organizationId,
+        externalSubscriberId: topicSubscriber.externalSubscriberId,
+      });
+    }
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('end migration- topic subscriber normalize');
+
+  app.close();
+}

--- a/apps/api/src/app/subscribers/e2e/remove-subscriber.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/remove-subscriber.e2e.ts
@@ -1,17 +1,22 @@
-import { UserSession } from '@novu/testing';
-import { SubscriberRepository } from '@novu/dal';
+import { SubscribersService, UserSession } from '@novu/testing';
+import { SubscriberEntity, SubscriberRepository, TopicSubscribersRepository } from '@novu/dal';
 import { expect } from 'chai';
 import axios from 'axios';
+import { ExternalSubscriberId, TopicId, TopicKey, TopicName } from '@novu/shared';
 
 const axiosInstance = axios.create();
+const TOPIC_PATH = '/v1/topics';
 
 describe('Delete Subscriber - /subscribers/:subscriberId (DELETE)', function () {
   let session: UserSession;
+  let subscriberService: SubscribersService;
   const subscriberRepository = new SubscriberRepository();
+  const topicSubscribersRepository = new TopicSubscribersRepository();
 
   beforeEach(async () => {
     session = new UserSession();
     await session.initialize();
+    subscriberService = new SubscribersService(session.organization._id, session.environment._id);
   });
 
   it('should delete an existing subscriber', async function () {
@@ -49,8 +54,95 @@ describe('Delete Subscriber - /subscribers/:subscriberId (DELETE)', function () 
         _environmentId: session.environment._id,
         subscriberId: '123',
       })
-    )[0];
+    )?.[0];
 
     expect(deletedSubscriber.deleted).to.equal(true);
   });
+
+  it('should dispose subscriber relations to topic once he was removed', async () => {
+    const subscriberId = '123';
+
+    const subscriber = await subscriberService.createSubscriber({ subscriberId: subscriberId });
+    for (let i = 0; i < 50; i++) {
+      const firstTopicKey = `topic-key-${i}-trigger-event`;
+      const firstTopicName = `topic-name-${i}-trigger-event`;
+      const newTopic = await createTopic(session, firstTopicKey, firstTopicName);
+      await addSubscribersToTopic(session, { _id: newTopic._id, key: newTopic.key }, [subscriber]);
+    }
+
+    const createdRelations = await topicSubscribersRepository.find({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      externalSubscriberId: subscriberId,
+    });
+
+    expect(createdRelations.length).to.equal(50);
+
+    await axiosInstance.delete(`${session.serverUrl}/v1/subscribers/${subscriberId}`, {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    });
+
+    const deletedRelations = await topicSubscribersRepository.find({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      externalSubscriberId: subscriberId,
+    });
+
+    expect(deletedRelations.length).to.equal(0);
+  });
 });
+
+const createTopic = async (
+  session: UserSession,
+  key: TopicKey,
+  name: TopicName
+): Promise<{ _id: TopicId; key: TopicKey }> => {
+  const response = await axiosInstance.post(
+    `${session.serverUrl}${TOPIC_PATH}`,
+    {
+      key,
+      name,
+    },
+    {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    }
+  );
+
+  expect(response.status).to.eql(201);
+  const body = response.data;
+  expect(body.data._id).to.exist;
+  expect(body.data.key).to.eql(key);
+
+  return body.data;
+};
+
+const addSubscribersToTopic = async (
+  session: UserSession,
+  createdTopicDto: { _id: TopicId; key: TopicKey },
+  subscribers: SubscriberEntity[]
+) => {
+  const subscriberIds: ExternalSubscriberId[] = subscribers.map(
+    (subscriber: SubscriberEntity) => subscriber.subscriberId
+  );
+
+  const response = await axiosInstance.post(
+    `${session.serverUrl}${TOPIC_PATH}/${createdTopicDto.key}/subscribers`,
+    {
+      subscribers: subscriberIds,
+    },
+    {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    }
+  );
+
+  expect(response.status).to.be.eq(200);
+  expect(response.data.data).to.be.eql({
+    succeeded: subscriberIds,
+  });
+};

--- a/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/remove-subscriber/remove-subscriber.usecase.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { SubscriberRepository, DalException } from '@novu/dal';
+import { SubscriberRepository, DalException, TopicSubscribersRepository } from '@novu/dal';
 import { buildSubscriberKey, InvalidateCacheService } from '@novu/application-generic';
 
 import { RemoveSubscriberCommand } from './remove-subscriber.command';
@@ -11,7 +11,8 @@ export class RemoveSubscriber {
   constructor(
     private invalidateCache: InvalidateCacheService,
     private subscriberRepository: SubscriberRepository,
-    private getSubscriber: GetSubscriber
+    private getSubscriber: GetSubscriber,
+    private topicSubscribersRepository: TopicSubscribersRepository
   ) {}
 
   async execute(command: RemoveSubscriberCommand) {
@@ -34,6 +35,12 @@ export class RemoveSubscriber {
         _environmentId: subscriber._environmentId,
         _organizationId: subscriber._organizationId,
         subscriberId: subscriber.subscriberId,
+      });
+
+      await this.topicSubscribersRepository.delete({
+        _environmentId: subscriber._environmentId,
+        _organizationId: subscriber._organizationId,
+        externalSubscriberId: subscriber.subscriberId,
       });
     } catch (e) {
       if (e instanceof DalException) {

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -92,6 +92,19 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
     }
   }
 
+  async *aggregateBatch(
+    query: any,
+    select = '',
+    options: { limit?: number; sort?: any; skip?: number } = {},
+    batchSize = 500
+  ) {
+    for await (const doc of this._model
+      .aggregate<FilterQuery<T_DBModel> & T_Enforcement>(query, { batchSize: batchSize })
+      .cursor()) {
+      yield this.mapEntity(doc);
+    }
+  }
+
   private calcExpireDate(modelName: string, data: FilterQuery<T_DBModel> & T_Enforcement) {
     let startDate: Date = new Date();
     if (data.expireAt) {

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -92,19 +92,6 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
     }
   }
 
-  async *aggregateBatch(
-    query: any,
-    select = '',
-    options: { limit?: number; sort?: any; skip?: number } = {},
-    batchSize = 500
-  ) {
-    for await (const doc of this._model
-      .aggregate<FilterQuery<T_DBModel> & T_Enforcement>(query, { batchSize: batchSize })
-      .cursor()) {
-      yield this.mapEntity(doc);
-    }
-  }
-
   private calcExpireDate(modelName: string, data: FilterQuery<T_DBModel> & T_Enforcement) {
     let startDate: Date = new Date();
     if (data.expireAt) {

--- a/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
@@ -23,7 +23,7 @@ export class TopicSubscribersRepository extends BaseRepository<
     await this.upsertMany(subscribers);
   }
 
-  async getTopicDistinctSubscribersCursor({
+  async *getTopicDistinctSubscribers({
     query,
     batchSize = 500,
   }: {
@@ -54,7 +54,9 @@ export class TopicSubscribersRepository extends BaseRepository<
       },
     ];
 
-    return this._model.aggregate(aggregatePipeline, { batchSize: batchSize }).cursor();
+    for await (const doc of this._model.aggregate(aggregatePipeline, { batchSize: batchSize }).cursor()) {
+      yield this.mapEntity(doc);
+    }
   }
 
   async findOneByTopicKeyAndExternalSubscriberId(

--- a/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import * as _ from 'lodash';
 
 import {
@@ -6,31 +6,42 @@ import {
   JobRepository,
   NotificationTemplateRepository,
   SubscriberRepository,
+  TopicEntity,
+  TopicRepository,
+  TopicSubscribersRepository,
 } from '@novu/dal';
 import {
-  ChannelTypeEnum,
+  FeatureFlagsKeysEnum,
   ISubscribersDefine,
-  ISubscribersSource,
-  ProvidersIdEnum,
+  ITopic,
+  SubscriberSourceEnum,
+  TriggerRecipient,
+  TriggerRecipientsTypeEnum,
+  TriggerRecipientSubscriber,
 } from '@novu/shared';
 
 import { ProcessSubscriber } from '../process-subscriber';
 import { PinoLogger } from '../../logging';
-import { Instrument, InstrumentUsecase } from '../../instrumentation';
-import {
-  buildNotificationTemplateIdentifierKey,
-  CachedEntity,
-} from '../../services/cache';
+import { InstrumentUsecase } from '../../instrumentation';
 import { ApiException } from '../../utils/exceptions';
 import { ProcessTenant } from '../process-tenant';
 import { MapTriggerRecipients } from '../map-trigger-recipients/map-trigger-recipients.use-case';
 import { SubscriberProcessQueueService } from '../../services/queues/subscriber-process-queue.service';
 import { TriggerMulticastCommand } from './trigger-multicast.command';
-import { MapTriggerRecipientsCommand } from '../map-trigger-recipients';
 import { IProcessSubscriberBulkJobDto } from '../../dtos';
+import { GetFeatureFlag, GetFeatureFlagCommand } from '../get-feature-flag';
+import { GetTopicSubscribersUseCase } from '../get-topic-subscribers';
 
 const LOG_CONTEXT = 'TriggerMulticastUseCase';
 const QUEUE_CHUNK_SIZE = Number(process.env.MULTICAST_QUEUE_CHUNK_SIZE) || 100;
+
+const isNotTopic = (
+  recipient: TriggerRecipient
+): recipient is TriggerRecipientSubscriber => !isTopic(recipient);
+
+const isTopic = (recipient: TriggerRecipient): recipient is ITopic =>
+  (recipient as ITopic).type &&
+  (recipient as ITopic).type === TriggerRecipientsTypeEnum.TOPIC;
 
 @Injectable()
 export class TriggerMulticast {
@@ -43,97 +54,159 @@ export class TriggerMulticast {
     private processTenant: ProcessTenant,
     private logger: PinoLogger,
     private mapTriggerRecipients: MapTriggerRecipients,
-    private subscriberProcessQueueService: SubscriberProcessQueueService
+    private subscriberProcessQueueService: SubscriberProcessQueueService,
+    private getTopicSubscribers: GetTopicSubscribersUseCase,
+    private topicSubscribersRepository: TopicSubscribersRepository,
+    private topicRepository: TopicRepository,
+    private getFeatureFlag: GetFeatureFlag
   ) {}
 
   @InstrumentUsecase()
   async execute(command: TriggerMulticastCommand) {
     {
-      const mappedRecipients = await this.mapTriggerRecipients.execute(
-        MapTriggerRecipientsCommand.create({
-          environmentId: command.environmentId,
-          organizationId: command.organizationId,
-          recipients: command.to,
-          transactionId: command.transactionId,
-          userId: command.userId,
-          actor: command.actor,
+      const {
+        environmentId,
+        organizationId,
+        to: recipients,
+        actor,
+        userId,
+      } = command;
+
+      const mappedRecipients = Array.isArray(recipients)
+        ? recipients
+        : [recipients];
+
+      const { singleSubscribers, topicKeys } =
+        this.splitByRecipientType(mappedRecipients);
+
+      await this.sendToProcessSubscriberService(
+        command,
+        Array.from(singleSubscribers.values()),
+        SubscriberSourceEnum.SINGLE
+      );
+
+      const isEnabled = await this.getFeatureFlag.execute(
+        GetFeatureFlagCommand.create({
+          environmentId,
+          organizationId,
+          userId,
+          key: FeatureFlagsKeysEnum.IS_TOPIC_NOTIFICATION_ENABLED,
         })
       );
 
-      await this.validateSubscriberIdProperty(mappedRecipients);
+      if (!isEnabled) {
+        return;
+      }
 
-      const jobs = this.mapSubscribersToJobs(mappedRecipients, command);
+      const topics = await this.getTopicsByTopicKeys(
+        organizationId,
+        environmentId,
+        topicKeys
+      );
 
-      await this.subscriberProcessQueueAddBulk(jobs);
+      this.validateTopicExist(topics, topicKeys);
+
+      const topicIds = topics.map((topic) => topic._id);
+      const singleSubscriberIds = Array.from(singleSubscribers.keys());
+      const subscriberFetchBatchSize = 500;
+      let subscribersList: ISubscribersDefine[] = [];
+
+      for await (const topicSubscriber of this.topicSubscribersRepository.getTopicDistinctSubscribers(
+        {
+          _organizationId: organizationId,
+          _environmentId: environmentId,
+          topicIds: topicIds,
+          excludeSubscribers: singleSubscriberIds,
+        }
+      )) {
+        const externalSubscriberId = topicSubscriber._id;
+
+        if (actor && actor.subscriberId === externalSubscriberId) {
+          continue;
+        }
+
+        subscribersList.push({ subscriberId: externalSubscriberId });
+
+        if (subscribersList.length === subscriberFetchBatchSize) {
+          await this.sendToProcessSubscriberService(
+            command,
+            subscribersList,
+            SubscriberSourceEnum.TOPIC
+          );
+
+          subscribersList = [];
+        }
+      }
+
+      if (subscribersList.length > 0) {
+        await this.sendToProcessSubscriberService(
+          command,
+          subscribersList,
+          SubscriberSourceEnum.TOPIC
+        );
+      }
     }
   }
 
-  @CachedEntity({
-    builder: (command: { triggerIdentifier: string; environmentId: string }) =>
-      buildNotificationTemplateIdentifierKey({
-        _environmentId: command.environmentId,
-        templateIdentifier: command.triggerIdentifier,
-      }),
-  })
-  private async getNotificationTemplateByTriggerIdentifier(command: {
-    triggerIdentifier: string;
-    environmentId: string;
-  }) {
-    return await this.notificationTemplateRepository.findByTriggerIdentifier(
-      command.environmentId,
-      command.triggerIdentifier
-    );
-  }
-
-  @Instrument()
-  private async validateSubscriberIdProperty(
-    to: ISubscribersSource[]
-  ): Promise<boolean> {
-    for (const subscriber of to) {
-      const subscriberIdExists =
-        typeof subscriber === 'string' ? subscriber : subscriber.subscriberId;
-
-      if (Array.isArray(subscriberIdExists)) {
-        throw new ApiException(
-          'subscriberId under property to is type array, which is not allowed please make sure all subscribers ids are strings'
-        );
-      }
-
-      if (!subscriberIdExists) {
-        throw new ApiException(
-          'subscriberId under property to is not configured, please make sure all subscribers contains subscriberId property'
-        );
-      }
-    }
-
-    return true;
-  }
-
-  @Instrument()
-  private async getProviderId(
+  private async getTopicsByTopicKeys(
+    organizationId: string,
     environmentId: string,
-    channelType: ChannelTypeEnum
-  ): Promise<ProvidersIdEnum> {
-    const integration = await this.integrationRepository.findOne(
+    topicKeys: Set<string>
+  ): Promise<TopicEntity[]> {
+    return await this.topicRepository.find(
       {
+        _organizationId: organizationId,
         _environmentId: environmentId,
-        active: true,
-        channel: channelType,
+        key: { $in: Array.from(topicKeys) },
       },
-      'providerId'
+      '_id'
     );
+  }
 
-    return integration?.providerId as ProvidersIdEnum;
+  private validateTopicExist(topics: TopicEntity[], topicKeys: Set<string>) {
+    if (topics.length !== topicKeys.size) {
+      topicKeys.forEach((topicKey) => {
+        if (!topics.find((topic) => topic.key === topicKey)) {
+          throw new NotFoundException(
+            `Topic with key ${topicKey} not found in current environment`
+          );
+        }
+      });
+    }
+  }
+
+  private splitByRecipientType(mappedRecipients: TriggerRecipient[]): {
+    singleSubscribers: Map<string, ISubscribersDefine>;
+    topicKeys: Set<string>;
+  } {
+    return mappedRecipients.reduce(
+      (acc, recipient) => {
+        if (isTopic(recipient)) {
+          acc.topicKeys.add(recipient.topicKey);
+        } else {
+          const subscribersDefine = this.buildSubscriberDefine(recipient);
+
+          acc.singleSubscribers.set(
+            subscribersDefine.subscriberId,
+            subscribersDefine
+          );
+        }
+
+        return acc;
+      },
+      {
+        singleSubscribers: new Map<string, ISubscribersDefine>(),
+        topicKeys: new Set<string>(),
+      }
+    );
   }
 
   private mapSubscribersToJobs(
-    subscribers: ISubscribersSource[],
+    _subscriberSource: SubscriberSourceEnum,
+    subscribers: ISubscribersDefine[],
     command: TriggerMulticastCommand
   ): IProcessSubscriberBulkJobDto[] {
     return subscribers.map((subscriber) => {
-      const { _subscriberSource, ...subscribersDefineParams } = subscriber;
-      const subscribersDefine: ISubscribersDefine = subscribersDefineParams;
-
       const job: IProcessSubscriberBulkJobDto = {
         name: command.transactionId + subscriber.subscriberId,
         data: {
@@ -144,7 +217,7 @@ export class TriggerMulticast {
           identifier: command.identifier,
           payload: command.payload,
           overrides: command.overrides,
-          subscriber: subscribersDefine,
+          subscriber: subscriber,
           templateId: command.template._id,
           _subscriberSource: _subscriberSource,
           requestCategory: command.requestCategory,
@@ -163,6 +236,32 @@ export class TriggerMulticast {
     });
   }
 
+  private buildSubscriberDefine(
+    recipient: TriggerRecipientSubscriber
+  ): ISubscribersDefine {
+    if (typeof recipient === 'string') {
+      return { subscriberId: recipient };
+    } else {
+      this.validateSubscriberDefine(recipient);
+
+      return recipient;
+    }
+  }
+
+  private validateSubscriberDefine(recipient: ISubscribersDefine) {
+    if (Array.isArray(recipient)) {
+      throw new ApiException(
+        'subscriberId under property to is type array, which is not allowed please make sure all subscribers ids are strings'
+      );
+    }
+
+    if (!recipient) {
+      throw new ApiException(
+        'subscriberId under property to is not configured, please make sure all subscribers contains subscriberId property'
+      );
+    }
+  }
+
   private async subscriberProcessQueueAddBulk(
     jobs: IProcessSubscriberBulkJobDto[]
   ) {
@@ -172,5 +271,23 @@ export class TriggerMulticast {
           this.subscriberProcessQueueService.addBulk(chunk)
       )
     );
+  }
+
+  private async sendToProcessSubscriberService(
+    command: TriggerMulticastCommand,
+    subscribers: ISubscribersDefine[],
+    _subscriberSource: SubscriberSourceEnum
+  ) {
+    if (subscribers.length === 0) {
+      return;
+    }
+
+    const jobs = this.mapSubscribersToJobs(
+      _subscriberSource,
+      subscribers,
+      command
+    );
+
+    return await this.subscriberProcessQueueAddBulk(jobs);
   }
 }

--- a/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -102,20 +102,18 @@ export class TriggerMulticast {
       const singleSubscriberIds = Array.from(singleSubscribers.keys());
       const subscriberFetchBatchSize = 500;
       let subscribersList: ISubscribersDefine[] = [];
-      const cursor =
-        await this.topicSubscribersRepository.getTopicDistinctSubscribersCursor(
-          {
-            query: {
-              _organizationId: organizationId,
-              _environmentId: environmentId,
-              topicIds: topicIds,
-              excludeSubscribers: singleSubscriberIds,
-            },
-            batchSize: subscriberFetchBatchSize,
-          }
-        );
+      const getTopicDistinctSubscribersGenerator =
+        await this.topicSubscribersRepository.getTopicDistinctSubscribers({
+          query: {
+            _organizationId: organizationId,
+            _environmentId: environmentId,
+            topicIds: topicIds,
+            excludeSubscribers: singleSubscriberIds,
+          },
+          batchSize: subscriberFetchBatchSize,
+        });
 
-      for await (const topicSubscriber of cursor) {
+      for await (const topicSubscriber of getTopicDistinctSubscribersGenerator) {
         const externalSubscriberId = topicSubscriber._id;
 
         if (actor && actor.subscriberId === externalSubscriberId) {

--- a/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -110,15 +110,20 @@ export class TriggerMulticast {
       const singleSubscriberIds = Array.from(singleSubscribers.keys());
       const subscriberFetchBatchSize = 500;
       let subscribersList: ISubscribersDefine[] = [];
+      const cursor =
+        await this.topicSubscribersRepository.getTopicDistinctSubscribersCursor(
+          {
+            query: {
+              _organizationId: organizationId,
+              _environmentId: environmentId,
+              topicIds: topicIds,
+              excludeSubscribers: singleSubscriberIds,
+            },
+            batchSize: subscriberFetchBatchSize,
+          }
+        );
 
-      for await (const topicSubscriber of this.topicSubscribersRepository.getTopicDistinctSubscribers(
-        {
-          _organizationId: organizationId,
-          _environmentId: environmentId,
-          topicIds: topicIds,
-          excludeSubscribers: singleSubscriberIds,
-        }
-      )) {
+      for await (const topicSubscriber of cursor) {
         const externalSubscriberId = topicSubscriber._id;
 
         if (actor && actor.subscriberId === externalSubscriberId) {

--- a/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/packages/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -46,16 +46,8 @@ const isTopic = (recipient: TriggerRecipient): recipient is ITopic =>
 @Injectable()
 export class TriggerMulticast {
   constructor(
-    private processSubscriber: ProcessSubscriber,
-    private integrationRepository: IntegrationRepository,
-    private subscriberRepository: SubscriberRepository,
-    private jobRepository: JobRepository,
-    private notificationTemplateRepository: NotificationTemplateRepository,
-    private processTenant: ProcessTenant,
     private logger: PinoLogger,
-    private mapTriggerRecipients: MapTriggerRecipients,
     private subscriberProcessQueueService: SubscriberProcessQueueService,
-    private getTopicSubscribers: GetTopicSubscribersUseCase,
     private topicSubscribersRepository: TopicSubscribersRepository,
     private topicRepository: TopicRepository,
     private getFeatureFlag: GetFeatureFlag


### PR DESCRIPTION
### What change does this PR introduce?

Subscribers can be added in topic using subscriberId. 
Subscriber can be deleted later using API or SDK, however a user manually also has to delete them from every topic they where apart of.

### Why was this change needed?

If subscriber is deleted, it is still part of topic
Currently user had to call API to first check if subscriber is part of any topic then remove that subscriber from topic.

### Definition of Done
* Novu should automatically handle this usecase
* The migration script to remove not existing subscribers from the topics
