### PR TITLE
feat: reduce job stored object size

### DIFF
--- a/apps/api/src/app/events/e2e/digest-events.e2e.ts
+++ b/apps/api/src/app/events/e2e/digest-events.e2e.ts
@@ -112,7 +112,7 @@ describe('Trigger event - Digest triggered events - /v1/events/trigger (POST)', 
       },
     });
 
-    const digestJob = jobs.find((job) => job.step?.template?.type === StepTypeEnum.DIGEST);
+    const digestJob = jobs.find((job) => job.type === StepTypeEnum.DIGEST);
     expect((digestJob && (digestJob?.digest as IDigestRegularMetadata))?.amount).to.equal(digestAmount);
     expect((digestJob && (digestJob?.digest as IDigestRegularMetadata))?.unit).to.equal(digestUnit);
     const job = jobs.find((item) => item.digest?.events?.length && item.digest.events.length > 0);

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -86,7 +86,7 @@ export class SendMessage {
       this.filterPreferredChannels(command.job),
     ]);
 
-    const stepType = command.step?.template?.type;
+    const stepType = command.job?.type;
 
     const chimeraResponse = await this.chimeraConnector.execute<
       SendMessageCommand & { variables: IFilterVariables },

--- a/libs/dal/src/repositories/job/job.entity.ts
+++ b/libs/dal/src/repositories/job/job.entity.ts
@@ -15,7 +15,7 @@ export class JobEntity {
   payload: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   overrides: Record<string, Record<string, unknown>>;
-  step: NotificationStepEntity;
+  step: Pick<NotificationStepEntity, '_id' | 'stepId' | 'uuid' | 'shouldStopOnFail' | 'filters' | 'metadata'>;
   tenant?: ITenantDefine;
   transactionId: string;
   _notificationId: string;

--- a/libs/dal/src/repositories/job/job.repository.ts
+++ b/libs/dal/src/repositories/job/job.repository.ts
@@ -30,7 +30,7 @@ export class JobRepository extends BaseRepository<JobDBModel, JobEntity, Enforce
     super(Job, JobEntity);
   }
 
-  public async storeJobs(jobs: Omit<JobEntity, '_id' | 'createdAt' | 'updatedAt'>[]): Promise<JobEntity[]> {
+  public async storeJobs(jobs: Omit<JobEntity, '_id' | 'createdAt' | 'updatedAt' | 'step'>[]): Promise<JobEntity[]> {
     const stored: JobEntity[] = [];
     for (let index = 0; index < jobs.length; index++) {
       if (index > 0) {

--- a/packages/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
+++ b/packages/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
@@ -106,6 +106,8 @@ export class CreateNotificationJobs {
           stepId: step.stepId,
           uuid: step.uuid,
           shouldStopOnFail: step.shouldStopOnFail,
+          metadata: step.metadata,
+          replyCallback: step.replyCallback,
         },
         type: step.template.type,
         providerId: providerId,

--- a/packages/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
+++ b/packages/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
@@ -23,7 +23,10 @@ import { PlatformException } from '../../utils/exceptions';
 import { CalculateDelayService } from '../../services';
 
 const LOG_CONTEXT = 'CreateNotificationUseCase';
-type NotificationJob = Omit<JobEntity, '_id' | 'createdAt' | 'updatedAt'>;
+type NotificationJob = Omit<
+  JobEntity,
+  '_id' | 'createdAt' | 'updatedAt' | 'step'
+>;
 
 @Injectable()
 export class CreateNotificationJobs {
@@ -87,7 +90,6 @@ export class CreateNotificationJobs {
         payload: command.payload,
         overrides: command.overrides,
         tenant: command.tenant,
-        step,
         transactionId: command.transactionId,
         _notificationId: notification._id,
         _environmentId: command.environmentId,
@@ -98,6 +100,13 @@ export class CreateNotificationJobs {
         status: JobStatusEnum.PENDING,
         _templateId: notification._templateId,
         digest: step.metadata,
+        step: {
+          _id: step._id,
+          filters: step.filters,
+          stepId: step.stepId,
+          uuid: step.uuid,
+          shouldStopOnFail: step.shouldStopOnFail,
+        },
         type: step.template.type,
         providerId: providerId,
         expireAt: notification.expireAt,

--- a/packages/application-generic/src/usecases/store-subscriber-jobs/store-subscriber-jobs.command.ts
+++ b/packages/application-generic/src/usecases/store-subscriber-jobs/store-subscriber-jobs.command.ts
@@ -6,5 +6,5 @@ import { EnvironmentCommand } from '../../commands';
 
 export class StoreSubscriberJobsCommand extends EnvironmentCommand {
   @IsDefined()
-  jobs: Omit<JobEntity, '_id' | 'createdAt' | 'updatedAt'>[];
+  jobs: Omit<JobEntity, '_id' | 'createdAt' | 'updatedAt' | 'step'>[];
 }


### PR DESCRIPTION
### What change does this PR introduce?

Scopes down the stored `step` field on the job to only required fields

### Why was this change needed?

Reduce the object size stored in MongoDB with unneeded information

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
