### PR TITLE
feat: Pass customData asm parameters to SendGrid

### DIFF
--- a/providers/sendgrid/src/lib/sendgrid.provider.spec.ts
+++ b/providers/sendgrid/src/lib/sendgrid.provider.spec.ts
@@ -16,6 +16,12 @@ const mockNovuMessage = {
     { mime: 'text/plain', file: Buffer.from('dGVzdA=='), name: 'test.txt' },
   ],
   id: 'message_id',
+  customData: {
+    asm: {
+      groupId: 12345,
+      groupsToDisplay: [12345],
+    },
+  },
 };
 
 test('should trigger sendgrid correctly', async () => {
@@ -71,6 +77,10 @@ test('should trigger sendgrid correctly', async () => {
       },
     ],
     templateId: undefined,
+    asm: {
+      groupId: 12345,
+      groupsToDisplay: [12345],
+    },
   });
 });
 

--- a/providers/sendgrid/src/lib/sendgrid.provider.ts
+++ b/providers/sendgrid/src/lib/sendgrid.provider.ts
@@ -13,6 +13,10 @@ import {
 import { MailDataRequired, MailService } from '@sendgrid/mail';
 
 type AttachmentJSON = MailDataRequired['attachments'][0];
+type ASMConfig = {
+  groupId: number;
+  groupsToDisplay: number[];
+};
 
 export class SendgridEmailProvider implements IEmailProvider {
   id = 'sendgrid';
@@ -70,12 +74,14 @@ export class SendgridEmailProvider implements IEmailProvider {
   private createMailData(options: IEmailOptions) {
     const dynamicTemplateData = options.customData?.dynamicTemplateData;
     const templateId = options.customData?.templateId as unknown as string;
+    const asm = options.customData?.asm as ASMConfig;
     /*
      * deleted below values from customData to avoid passing them
      * in customArgs because customArgs has max limit of 10,000 bytes
      */
     delete options.customData?.dynamicTemplateData;
     delete options.customData?.templateId;
+    delete options.customData?.asm;
 
     const attachments = options.attachments?.map(
       (attachment: IAttachmentOptions) => {
@@ -128,6 +134,7 @@ export class SendgridEmailProvider implements IEmailProvider {
         },
       ],
       templateId: templateId,
+      asm: asm,
     };
 
     if (options.replyTo) {

--- a/providers/sendgrid/src/lib/sendgrid.provider.ts
+++ b/providers/sendgrid/src/lib/sendgrid.provider.ts
@@ -75,6 +75,14 @@ export class SendgridEmailProvider implements IEmailProvider {
     const dynamicTemplateData = options.customData?.dynamicTemplateData;
     const templateId = options.customData?.templateId as unknown as string;
     const asm = options.customData?.asm as ASMConfig;
+    if (asm?.groupId) {
+      asm.groupId = parseInt(asm.groupId as any); // Sendgrid expects groupId to be a number
+    }
+    if (asm?.groupsToDisplay) {
+      asm.groupsToDisplay = asm.groupsToDisplay.map((group) =>
+        parseInt(group as any)
+      ); // Sendgrid expects groupsToDisplay to be an array of numbers
+    }
     /*
      * deleted below values from customData to avoid passing them
      * in customArgs because customArgs has max limit of 10,000 bytes


### PR DESCRIPTION
### What change does this PR introduce?

Looks for an optional `asm` parameter in `customData` that is passed through to the SendGrid API. 

### Why was this change needed?

Addresses #5402 


