### PR TITLE
chore(ci): remove the api docker image build job from the test pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,30 +108,6 @@ jobs:
     if: ${{ contains(fromJson(needs.get-affected.outputs.test-cypress), '@novu/widget') || contains(fromJson(needs.get-affected.outputs.test-unit), '@novu/notification-center') || contains(fromJson(needs.get-affected.outputs.test-unit), '@novu/ws') }}
     secrets: inherit
 
-  build_docker_api:
-    name: Build Docker API
-    runs-on: ubuntu-latest
-    timeout-minutes: 80
-    needs: [get-affected]
-    if: ${{ contains(fromJson(needs.get-affected.outputs.test-e2e), '@novu/api') }}
-    permissions:
-      contents: read
-      packages: write
-      deployments: write
-      id-token: write
-    strategy:
-      matrix:
-        name: ['novu/api', 'novu/api-ee']
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-project
-      - uses: ./.github/actions/setup-redis-cluster
-      - uses: ./.github/actions/docker/build-api
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          fork: ${{ github.event.pull_request.head.repo.fork }}
-          docker_name: ${{ matrix.name }}
-
   test_providers:
     name: Unit Test Providers
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What changed? Why was the change needed?
Remove the API Docker image build job from the tests pipeline. Ref: https://novu.slack.com/archives/C06DU7A7BPV/p1713193888348909

It takes ages until the API image and EE images are built for different architectures and there is no need to do that during the tests pipeline execution. We build the API docker image when the PR is merged to `next` and everything gets deployed to the dev environment. If the code is broken in the API then the `Test API` job in the `Test` pipeline will catch that and cover.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
