### PR TITLE
chore: Do not lint during e2e run

### DIFF
--- a/.github/workflows/reusable-api-e2e.yml
+++ b/.github/workflows/reusable-api-e2e.yml
@@ -80,12 +80,6 @@ jobs:
       - uses: ./.github/actions/setup-redis-cluster
         name: Setup redis cluster
 
-      - uses: mansagroup/nrwl-nx-action@v3
-        name: Run Lint
-        with:
-          targets: lint
-          projects: '@novu/api'
-
       - uses: ./.github/actions/start-localstack
         name: Start localstack
 

--- a/.github/workflows/reusable-inbound-mail-e2e.yml
+++ b/.github/workflows/reusable-inbound-mail-e2e.yml
@@ -44,10 +44,6 @@ jobs:
         if: steps.setup.outputs.has_token != 'true'
       - uses: ./.github/actions/setup-project
       - uses: ./.github/actions/setup-redis-cluster
-      - uses: mansagroup/nrwl-nx-action@v3
-        with:
-          targets: lint
-          projects: "@novu/inbound-mail"
 
         # Runs a single command using the runners shell
       - name: Build Inbound Mail

--- a/.github/workflows/reusable-web-e2e.yml
+++ b/.github/workflows/reusable-web-e2e.yml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: mansagroup/nrwl-nx-action@v3
         with:
-          targets: lint,build
+          targets: build
           projects: '@novu/web,@novu/api,@novu/worker'
           args: --skip-nx-cache
 

--- a/.github/workflows/reusable-webhook-e2e.yml
+++ b/.github/workflows/reusable-webhook-e2e.yml
@@ -18,11 +18,6 @@ jobs:
 
     - uses: ./.github/actions/setup-project
 
-    - uses: mansagroup/nrwl-nx-action@v3
-      with:
-        targets: lint
-        projects: '@novu/webhook'
-
     - uses: ./.github/actions/start-localstack
 
       # Runs a single command using the runners shell
@@ -31,6 +26,6 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run a test
-      run: | 
+      run: |
         cd apps/webhook && pnpm test:e2e
         pnpm test

--- a/.github/workflows/reusable-widget-e2e.yml
+++ b/.github/workflows/reusable-widget-e2e.yml
@@ -54,11 +54,6 @@ jobs:
 
       - uses: mansagroup/nrwl-nx-action@v3
         with:
-          targets: lint
-          projects: '@novu/widget'
-
-      - uses: mansagroup/nrwl-nx-action@v3
-        with:
           targets: build
           args: --skip-nx-cache
           projects: '@novu/widget,@novu/embed,@novu/api,@novu/worker,@novu/ws'

--- a/.github/workflows/reusable-worker-e2e.yml
+++ b/.github/workflows/reusable-worker-e2e.yml
@@ -46,10 +46,6 @@ jobs:
     - uses: ./.github/actions/setup-project
 
     - uses: ./.github/actions/setup-redis-cluster
-    - uses: mansagroup/nrwl-nx-action@v3
-      with:
-        targets: lint
-        projects: '@novu/worker'
 
     - uses: ./.github/actions/start-localstack
 
@@ -59,6 +55,6 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Run a test
-      run: | 
+      run: |
         cd apps/worker && pnpm test:e2e
         pnpm test

--- a/.github/workflows/reusable-ws-e2e.yml
+++ b/.github/workflows/reusable-ws-e2e.yml
@@ -43,10 +43,6 @@ jobs:
       - uses: actions/checkout@v3
         if: steps.setup.outputs.has_token != 'true'
       - uses: ./.github/actions/setup-project
-      - uses: mansagroup/nrwl-nx-action@v3
-        with:
-          targets: lint
-          projects: "@novu/ws"
 
         # Runs a single command using the runners shell
       - name: Build WS


### PR DESCRIPTION
### What changed? Why was the change needed?
Linting should run on a PR before merged into next or main. It's already in there, [for example](https://github.com/novuhq/novu/blob/d9a7096b3a9af9af7427b2981fecc8a6e9216651/.github/workflows/test.yml#L149).