### PR TITLE
fix(ci): Cypress E2E has been disabled for PR temporary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,8 @@ jobs:
   test_web:
     name: Test Web Cypress
     needs: [get-affected]
-    if: ${{ contains(fromJson(needs.get-affected.outputs.test-cypress), '@novu/web') }}
+#    if: ${{ contains(fromJson(needs.get-affected.outputs.test-cypress), '@novu/web') }}
+    if: false
     uses: ./.github/workflows/reusable-web-e2e.yml
     secrets: inherit
     with:
@@ -105,7 +106,8 @@ jobs:
     uses: ./.github/workflows/reusable-widget-e2e.yml
     with:
       ee: true
-    if: ${{ contains(fromJson(needs.get-affected.outputs.test-cypress), '@novu/widget') || contains(fromJson(needs.get-affected.outputs.test-unit), '@novu/notification-center') || contains(fromJson(needs.get-affected.outputs.test-unit), '@novu/ws') }}
+    if: false
+#    if: ${{ contains(fromJson(needs.get-affected.outputs.test-cypress), '@novu/widget') || contains(fromJson(needs.get-affected.outputs.test-unit), '@novu/notification-center') || contains(fromJson(needs.get-affected.outputs.test-unit), '@novu/ws') }}
     secrets: inherit
 
   test_providers:


### PR DESCRIPTION
We decided to disable E2E tests on PR request, when E2E is fast and stable, we will restore it
