### PR TITLE
fix(ci): Workflow_dispatch for the Testing Pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ concurrency:
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   dependency-review:


### PR DESCRIPTION
On trigger for the test.yml workflow to include workflow_dispatch , so we can trigger a test run against a specified branch from Github Actions in the interim. Will save the headache of getting Cypress working locally