### PR TITLE
feat(ci): E2E API tests have been disabled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
           targets: lint,build,test
           projects: ${{join(fromJson(needs.get-affected.outputs.test-libs), ',')}}
 
-  test_api:
+  test_unit_api:
     name: Test API
     needs: [get-affected]
     if: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,6 +181,7 @@ jobs:
   test_api:
     name: Test API
     needs: [get-affected]
+    if: false
     strategy:
       # The order is important for ee to be first, otherwise outputs not work correctly
       matrix:


### PR DESCRIPTION
We decided to disable E2E tests on PR requests, when E2E is fast and stable, we will restore it
