### PR TITLE
fix: helm chart  

### DIFF
--- a/docker/kubernetes/helm/templates/api/deployment.yaml
+++ b/docker/kubernetes/helm/templates/api/deployment.yaml
@@ -208,7 +208,7 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.api.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.api.extraVolumeMounts }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.api.extraVolumeMounts "context" $) | nindent 12 }}
+          volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.api.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         {{- if .Values.api.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.api.sidecars "context" $) | nindent 8 }}


### PR DESCRIPTION
### What changed? Why was the change needed?
`volumeMounts` key was missing in deployment template file. have added it.


Associated Error on executing `helm template`:
```
Error: YAML parse error on novu/templates/api/deployment.yaml: error converting YAML to JSON: yaml: line 155: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 155: did not find expected key
YAML parse error on novu/templates/api/deployment.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
        helm.sh/helm/v3/pkg/action/action.go:168
helm.sh/helm/v3/pkg/action.(*Install).RunWithContext
        helm.sh/helm/v3/pkg/action/install.go:304
main.runInstall
        helm.sh/helm/v3/cmd/helm/install.go:306
main.newTemplateCmd.func2
        helm.sh/helm/v3/cmd/helm/template.go:95
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.8.0/command.go:983
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.8.0/command.go:1115
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.8.0/command.go:1039
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
        runtime/proc.go:267
runtime.goexit
        runtime/asm_amd64.s:1650
```