### PR TITLE
helmchart secret store-encryption-key lenght 32

### DIFF
--- a/docker/kubernetes/helm/templates/secret.yaml
+++ b/docker/kubernetes/helm/templates/secret.yaml
@@ -14,5 +14,5 @@ metadata:
 type: Opaque
 data:
   jwt-secret: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "jwt-secret" "providedValues" (list "jwt.secret") "context" $) }}
-  store-encryption-key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "store-encryption-key" "providedValues" (list "store.encryption-key") "context" $) }}
+  store-encryption-key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "store-encryption-key" "providedValues" (list "store.encryption-key")  "length" 32 "context" $) }}
 {{- end }}


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
when STORE_ENCRYPTION_KEY is not provided through values or an existing secret, helmchart will generate it

this mr is changing the length of the generated key
without this change the key won't have valid length (32)

see https://docs.novu.co/self-hosting-novu/deploy-with-docker#required-variables

> STORE_ENCRYPTION_KEY: Used to encrypt/decrypt the provider credentials. It must be 32 characters long.
