### PR TITLE
helmchart fix extraEnvVars

### DIFF
--- a/docker/kubernetes/helm/templates/worker/deployment.yaml
+++ b/docker/kubernetes/helm/templates/worker/deployment.yaml
@@ -149,8 +149,8 @@ spec:
                secretKeyRef:
                   name: {{ include "common.names.fullname" . }}
                   key: store-encryption-key
-            {{- if .Values.api.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.api.extraEnvVars "context" $) | nindent 12 }}
+            {{- if .Values.worker.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
             {{- if .Values.worker.extraEnvVarsCM }}

--- a/docker/kubernetes/helm/templates/ws/deployment.yaml
+++ b/docker/kubernetes/helm/templates/ws/deployment.yaml
@@ -119,7 +119,7 @@ spec:
                   name: {{ include "common.names.fullname" . }}
                   key: jwt-secret
             {{- if .Values.ws.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.api.extraEnvVars "context" $) | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.ws.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           envFrom:
             {{- if .Values.ws.extraEnvVarsCM }}


### PR DESCRIPTION
### What changed? Why was the change needed?

`extraEnvVars` was fixed for multiple deployments

currently wrong `extraEnvVars` are taken from values for worker and ws deployments