### PR TITLE
fix: sentry error options.inverse is not a function

### DIFF
--- a/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
@@ -6,6 +6,12 @@ import { HandlebarHelpersEnum } from '@novu/shared';
 import { CompileTemplateCommand } from './compile-template.command';
 import * as i18next from 'i18next';
 
+const assertResult = (condition: boolean, options) => {
+  const fn = condition ? options.fn : options.inverse;
+
+  return typeof fn === 'function' ? fn(this) : condition;
+};
+
 Handlebars.registerHelper(
   HandlebarHelpersEnum.I18N,
   function (key, { hash, data, fn }) {
@@ -36,9 +42,7 @@ Handlebars.registerHelper(
 Handlebars.registerHelper(
   HandlebarHelpersEnum.EQUALS,
   function (arg1, arg2, options) {
-    // eslint-disable-next-line
-    // @ts-expect-error
-    return arg1 == arg2 ? options.fn(this) : options.inverse(this);
+    return assertResult(arg1 == arg2, options);
   }
 );
 
@@ -161,54 +165,42 @@ Handlebars.registerHelper(
 Handlebars.registerHelper(
   HandlebarHelpersEnum.GT,
   function (arg1, arg2, options) {
-    // eslint-disable-next-line
-    // @ts-expect-error
-    return arg1 > arg2 ? options.fn(this) : options.inverse(this);
+    return assertResult(arg1 > arg2, options);
   }
 );
 
 Handlebars.registerHelper(
   HandlebarHelpersEnum.GTE,
   function (arg1, arg2, options) {
-    // eslint-disable-next-line
-    // @ts-expect-error
-    return arg1 >= arg2 ? options.fn(this) : options.inverse(this);
+    return assertResult(arg1 >= arg2, options);
   }
 );
 
 Handlebars.registerHelper(
   HandlebarHelpersEnum.LT,
   function (arg1, arg2, options) {
-    // eslint-disable-next-line
-    // @ts-expect-error
-    return arg1 < arg2 ? options.fn(this) : options.inverse(this);
+    return assertResult(arg1 < arg2, options);
   }
 );
 
 Handlebars.registerHelper(
   HandlebarHelpersEnum.LTE,
   function (arg1, arg2, options) {
-    // eslint-disable-next-line
-    // @ts-expect-error
-    return arg1 <= arg2 ? options.fn(this) : options.inverse(this);
+    return assertResult(arg1 <= arg2, options);
   }
 );
 
 Handlebars.registerHelper(
   HandlebarHelpersEnum.EQ,
   function (arg1, arg2, options) {
-    // eslint-disable-next-line
-    // @ts-expect-error
-    return arg1 === arg2 ? options.fn(this) : options.inverse(this);
+    return assertResult(arg1 === arg2, options);
   }
 );
 
 Handlebars.registerHelper(
   HandlebarHelpersEnum.NE,
   function (arg1, arg2, options) {
-    // eslint-disable-next-line
-    // @ts-expect-error
-    return arg1 !== arg2 ? options.fn(this) : options.inverse(this);
+    return assertResult(arg1 !== arg2, options);
   }
 );
 


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
Fix for sentry errors that are coming from an incorrect use of our handlebar helpers that are expected to be in the syntax of if - else. Like equal, gt, lt etc.
There seems to be a misunderstanding with how people use it vs how we planned people will use it.
We treat it as a condition that encapsulates the if condition and its structure, while people use it under the assumption it will return a boolean value.
For example:
a user does this:
`{{#if (gte step.total_count 3)}}true{{else}}false{{/if}}`
but the correct use would be:
`{{#gte step.total_count 3}}true{{else}}false{{/gte}}`

In this PR, we change it to allow both uses, we check if the user gave a function (the if else block content) and if he didn't then return a boolean value.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
