### PR TITLE
feat: catch errors of wrong use of handlebars

### DIFF
--- a/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
@@ -5,6 +5,7 @@ import { HandlebarHelpersEnum } from '@novu/shared';
 
 import { CompileTemplateCommand } from './compile-template.command';
 import * as i18next from 'i18next';
+import { ApiException } from '../../utils/exceptions';
 
 const assertResult = (condition: boolean, options) => {
   const fn = condition ? options.fn : options.inverse;
@@ -208,10 +209,16 @@ Handlebars.registerHelper(
 export class CompileTemplate {
   async execute(command: CompileTemplateCommand): Promise<string> {
     const templateContent = command.template;
+    let result = '';
+    try {
+      const template = Handlebars.compile(templateContent);
 
-    const template = Handlebars.compile(templateContent);
-
-    const result = template(command.data, {});
+      result = template(command.data, {});
+    } catch (e: any) {
+      throw new ApiException(
+        e?.message || `Message content could not be generated`
+      );
+    }
 
     return result.replace(/&#x27;/g, "'");
   }

--- a/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import * as Handlebars from 'handlebars';
 import { format } from 'date-fns';
-import { HandlebarHelpersEnum } from '@novu/shared';
+import { checkIsResponseError, HandlebarHelpersEnum } from '@novu/shared';
 
 import { CompileTemplateCommand } from './compile-template.command';
 import * as i18next from 'i18next';
@@ -214,10 +214,12 @@ export class CompileTemplate {
       const template = Handlebars.compile(templateContent);
 
       result = template(command.data, {});
-    } catch (e: any) {
-      throw new ApiException(
-        e?.message || `Message content could not be generated`
-      );
+    } catch (e: unknown) {
+      let errorMessage = `Message content could not be generated`;
+      if (checkIsResponseError(e)) {
+        errorMessage = e.message;
+      }
+      throw new ApiException(errorMessage);
     }
 
     return result.replace(/&#x27;/g, "'");


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

For compile email template, there was no catch block for wrong use of handlebars syntax which resulted in
1.  A lot of sentry errors that only creates clutter 
2. Uninformative message for the  user (showed Internal server error)

I added the try-catch on the actual template compilation - so we won't miss adding it in each place we are using that usecase.

Sentry links:
[1](https://novu-r9.sentry.io/issues/4380720667/), [2](https://novu-r9.sentry.io/issues/4765198103/), [3](https://novu-r9.sentry.io/issues/4109348362/), [4](https://novu-r9.sentry.io/issues/4837740604/), [5](https://novu-r9.sentry.io/issues/5310239789/), [6](https://novu-r9.sentry.io/issues/5310189560/)
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
