### PR TITLE
guard does not fit handlebar error, revert to show informative error message

### DIFF
--- a/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import * as Handlebars from 'handlebars';
 import { format } from 'date-fns';
-import { checkIsResponseError, HandlebarHelpersEnum } from '@novu/shared';
+import { HandlebarHelpersEnum } from '@novu/shared';
 
 import { CompileTemplateCommand } from './compile-template.command';
 import * as i18next from 'i18next';

--- a/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
+++ b/packages/application-generic/src/usecases/compile-template/compile-template.usecase.ts
@@ -214,12 +214,10 @@ export class CompileTemplate {
       const template = Handlebars.compile(templateContent);
 
       result = template(command.data, {});
-    } catch (e: unknown) {
-      let errorMessage = `Message content could not be generated`;
-      if (checkIsResponseError(e)) {
-        errorMessage = e.message;
-      }
-      throw new ApiException(errorMessage);
+    } catch (e: any) {
+      throw new ApiException(
+        e?.message || `Message content could not be generated`
+      );
     }
 
     return result.replace(/&#x27;/g, "'");


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
 The guard `checkIsResponseError` does not satisfy the error returned by the handlebar compile. So, the message shown to user is general, and not specific to their action. 
 
Context [here](https://github.com/novuhq/novu/pull/5527#discussion_r1594298599)
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
