### PR TITLE
Fixes for scheduled e2e

### DIFF
--- a/.github/workflows/scheduled_e2e.yml
+++ b/.github/workflows/scheduled_e2e.yml
@@ -12,9 +12,9 @@ permissions:
   actions: write
 
 env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   OWNER: ${{ github.repository_owner }}
   REPO: ${{ github.event.repository.name }}
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   test_web:
@@ -49,7 +49,8 @@ jobs:
 
   release_decision:
     name: Release Decision
-    if: always()
+    # TODO: Remove the conditional for next when we fully switch to main/prod branching model
+    if: github.ref_name == 'next' || github.ref_name == 'prod' || github.ref_name == 'main'
     runs-on: ubuntu-latest
     needs:
       - test_widget

--- a/.github/workflows/scheduled_e2e.yml
+++ b/.github/workflows/scheduled_e2e.yml
@@ -65,9 +65,13 @@ jobs:
           widget_status=$(echo "$needs_json" | jq -r '.test_widget.result')
           api_status=$(echo "$needs_json" | jq -r '.test_unit_api.result')
           workflows_map=$(cat << EOF
+          prod-deploy-embed.yml: $widget_status
           prod-deploy-widget.yml: $widget_status
           prod-deploy-web.yml: $web_status
           prod-deploy-api.yml: $api_status
+          prod-deploy-webhook.yml: $api_status
+          prod-deploy-worker.yml: $api_status
+          prod-deploy-ws.yml: $api_status
           EOF
           )
           while IFS= read -r line; do


### PR DESCRIPTION
### What changed? Why was the change needed?

1. Scheduled E2E should disable deployment only if the failure happens on prod, next or main branches.
2. Scheduled E2E should disable all affected workflows per E2E suite.