### PR TITLE
fix mongodb secret condition and helper

### DIFF
--- a/docker/kubernetes/helm/templates/_helpers.tpl
+++ b/docker/kubernetes/helm/templates/_helpers.tpl
@@ -245,12 +245,12 @@ Return mongodb username
 Return mongodb secretName
 */}}
 {{- define "novu.mongodb.secretName" -}}
-{{- if .Values.mongodb.enabled -}}
+{{- if and (not .Values.externalDatabase.existingSecret) (not .Values.mongodb.auth.existingSecret) }}
     {{- printf "%s-url-mongodb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- else if .Values.externalDatabase.existingSecret -}}
     {{- printf "%s" .Values.externalDatabase.existingSecret -}}
-{{- else -}}
-     {{- printf "%s-externaldb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- else if .Values.mongodb.auth.existingSecret -}}
+    {{- printf "%s" .Values.mongodb.auth.existingSecret -}}
 {{- end -}}
 {{- end -}}
 

--- a/docker/kubernetes/helm/templates/db-secrets.yaml
+++ b/docker/kubernetes/helm/templates/db-secrets.yaml
@@ -1,8 +1,7 @@
-{{- if and (not .Values.externalDatabase.existingSecret) (not .Values.mongodb.existingSecret) }}
+{{- if and (not .Values.externalDatabase.existingSecret) (not .Values.mongodb.auth.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  
   name: {{ include "novu.mongodb.secretName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}


### PR DESCRIPTION
### What changed? Why was the change needed?

condition in mongodb secret was changed to use `.Values.mongodb.auth.existingSecret` (added `.auth`)
as this is the proper  path to configure bitnami mongodb subchart to use existingSecret

also the `novu.mongodb.secretName` was changed accordingly