### PR TITLE
fix(actions): Exclude prod branch from community labels

### DIFF
--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -3,6 +3,8 @@ name: Add Community Label
 on:
   pull_request_target:
     types: [opened]
+    branches:
+      - '!prod'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 20.8.1
       - name: Install Octokit
-        run: npm --prefix .github/workflows/scripts install @octokit/action
+        run: npm --prefix .github/workflows/scripts install @octokit/action@6
 
       - name: Check if user is a community contributor
         id: check

--- a/.github/workflows/issue-label.yml
+++ b/.github/workflows/issue-label.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 20.8.1
       - name: Install Octokit
-        run: npm --prefix .github/workflows/scripts install @octokit/action
+        run: npm --prefix .github/workflows/scripts install @octokit/action@6
 
       - name: Check if user is a community contributor
         id: check


### PR DESCRIPTION
### What changed? Why was the change needed?
The prod branch monitors the latest deployed code in Novu Cloud.