### PR TITLE
Helmchart - add google bucket support

### DIFF
--- a/docker/kubernetes/helm/templates/api/deployment.yaml
+++ b/docker/kubernetes/helm/templates/api/deployment.yaml
@@ -130,6 +130,16 @@ spec:
                 secretKeyRef:
                   name: {{ include "novu.mongodb.secretName" .}}
                   key: mongoUrl
+            {{- if eq .Values.externalS3.storageService "GCS" }}
+            - name: STORAGE_SERVICE
+              value: {{ .Values.externalS3.storageService | quote }}
+            - name: GCS_DOMAIN
+              value: {{ .Values.externalS3.gcsDomain | quote }}
+            - name: GCS_BUCKET_NAME
+              value: {{ .Values.externalS3.gcsBucketName | quote }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: {{ .Values.externalS3.googleApplicationCredentials | quote }}
+            {{- else -}}
             - name: S3_BUCKET_NAME
               valueFrom :
                 secretKeyRef:
@@ -150,6 +160,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "novu.s3.secretName" . }}
                   key: secretKey
+            {{- end }}
             - name: JWT_SECRET
               valueFrom :
                 secretKeyRef:

--- a/docker/kubernetes/helm/templates/externals3-secrets.yaml
+++ b/docker/kubernetes/helm/templates/externals3-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.localstack.enabled) (not .Values.externalS3.existingSecret) (not .Values.localstack.existingSecret) }}
+{{- if and (not .Values.localstack.enabled) (not .Values.externalS3.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/docker/kubernetes/helm/templates/localstack-secrets.yaml
+++ b/docker/kubernetes/helm/templates/localstack-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Values.localstack.enabled) (not .Values.localstack.existingSecret) }}
+{{- if .Values.localstack.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/docker/kubernetes/helm/templates/worker/deployment.yaml
+++ b/docker/kubernetes/helm/templates/worker/deployment.yaml
@@ -124,6 +124,16 @@ spec:
                 secretKeyRef:
                   name: {{ include "novu.mongodb.secretName" .}}
                   key: mongoUrl
+            {{- if eq .Values.externalS3.storageService "GCS" }}
+            - name: STORAGE_SERVICE
+              value: {{ .Values.externalS3.storageService | quote }}
+            - name: GCS_DOMAIN
+              value: {{ .Values.externalS3.gcsDomain | quote }}
+            - name: GCS_BUCKET_NAME
+              value: {{ .Values.externalS3.gcsBucketName | quote }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: {{ .Values.externalS3.googleApplicationCredentials | quote }}
+            {{- else -}}
             - name: S3_BUCKET_NAME
               valueFrom :
                 secretKeyRef:
@@ -144,6 +154,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "novu.s3.secretName" . }}
                   key: secretKey
+            {{- end }}
             - name: STORE_ENCRYPTION_KEY
               valueFrom :
                 secretKeyRef:

--- a/docker/kubernetes/helm/values.yaml
+++ b/docker/kubernetes/helm/values.yaml
@@ -1794,8 +1794,15 @@ externalRedis:
 ## @param externalS3.accessKey access Key for external S3 storage access
 ## @param externalS3.secretKey secret Key for external S3 storage access
 externalS3:
+  ## S3, LOCALSTACK or GCS
+  storageService: s3
+  ## for storageService: s3 and localstack
   endpoint: http://localstack:4566
   bucketName: novu-local
   region: us-east-1
   accessKey: test
   secretKey: test
+  ## for storageService: gcs
+  gcsBucketName: ''
+  gcsDomain: 'https://storage.googleapis.com'
+  googleApplicationCredentials: ''


### PR DESCRIPTION
### What changed? Why was the change needed?
added possibility to use **GCS bucket** as an object storage

the app itself is capable of using those environment variables whilst the chart does not provide the option

see https://docs.novu.co/self-hosting-novu/object-storage

---
\+ cleanup - remove unnecessary conditions on `.Values.localstack.existingSecret`