### PR TITLE
fix(app-gen): Fix ts directive

### DIFF
--- a/packages/application-generic/src/services/distributed-lock/distributed-lock.service.ts
+++ b/packages/application-generic/src/services/distributed-lock/distributed-lock.service.ts
@@ -45,8 +45,8 @@ export class DistributedLockService {
 
     if (client) {
       this.instances = [client];
-      // @ts-expect-error - Redlock does not have the correct (latest) client typings
-      this.distributedLock = new Redlock(this.instances, settings);
+      // TODO: remove any - Redlock does not have the correct (latest) client typings
+      this.distributedLock = new Redlock(this.instances as any, settings);
       Logger.verbose('Redlock started', LOG_CONTEXT);
 
       /**


### PR DESCRIPTION
### What changed? Why was the change needed?
Some [services](https://github.com/novuhq/novu/actions/runs/9092157947/job/24988466708#step:11:269) were complaining about an unused ts-expect-error directive. This change falls back to any and adds a TODO directive to address the typings later.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
