### PR TITLE
fix(ee): Move nestjs deps to peer deps

### DIFF
--- a/enterprise/packages/billing/package.json
+++ b/enterprise/packages/billing/package.json
@@ -13,9 +13,6 @@
     "start:proxy": "ngrok http http://localhost:3000"
   },
   "dependencies": {
-    "@nestjs/core": "^10.2.2",
-    "@nestjs/swagger": "^7.1.8",
-    "@nestjs/throttler": "^5.0.1",
     "@novu/application-generic": "^0.24.2",
     "@novu/ee-dal": "^0.24.2",
     "@novu/shared": "^0.24.2",
@@ -44,8 +41,11 @@
   },
   "peerDependencies": {
     "@nestjs/common": "10.2.2",
+    "@nestjs/core": "^10.2.2",
     "@nestjs/jwt": "10.2.0",
     "@nestjs/platform-express": "^10.2.2",
+    "@nestjs/swagger": "^7.1.8",
+    "@nestjs/throttler": "^5.0.1",
     "@novu/dal": "^0.24.1"
   }
 }

--- a/enterprise/packages/translation/package.json
+++ b/enterprise/packages/translation/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@handlebars/parser": "^2.1.0",
-    "@nestjs/swagger": "^7.1.8",
     "@novu/application-generic": "^0.24.2",
     "@novu/ee-dal": "^0.24.2",
     "@novu/ee-shared-services": "^0.24.2",
@@ -41,6 +40,7 @@
   "peerDependencies": {
     "@nestjs/common": "10.2.2",
     "@nestjs/jwt": "10.2.0",
+    "@nestjs/swagger": "^7.1.8",
     "@nestjs/platform-express": "^10.2.2",
     "@novu/dal": "^0.24.1"
   }


### PR DESCRIPTION
### What changed? Why was the change needed?
Nestjs couldn't resolve singleton dependencies whilst using `dependencies`. We need to move all Nestjs dependencies for Enteprise packages under `peerDependencies`.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
