### PR TITLE
refactor(app-gen): cache locking

### DIFF
--- a/libs/shared/src/types/organization/index.ts
+++ b/libs/shared/src/types/organization/index.ts
@@ -6,6 +6,7 @@ export enum ApiServiceLevelEnum {
   ENTERPRISE = 'enterprise',
   // TODO: NV-3067 - Remove unlimited tier once all organizations have a service level
   UNLIMITED = 'unlimited',
+  UNKNOWN = 'unknown',
 }
 
 export enum ProductUseCasesEnum {


### PR DESCRIPTION
### What changed? Why was the change needed?
This pull request is a work in progress and shouldn't be reviewed yet. It's the first step in a refactoring process, and the next stage will focus on reusing the `applyLock` method.

I'm also questioning where the locking logic belongs. While I like the cleanness of this solution, I'm unsure if the cache layer is the ideal place for it.  Perhaps it should reside within a separate use case.  I'd appreciate your thoughts on this matter.


### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->
[EE](https://github.com/novuhq/packages-enterprise/pull/134)

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
