### PR TITLE
fix(provider): allow legacy SSL renegotiation for Gupshup Integration

### DIFF
--- a/packages/providers/src/lib/gupshup/gupshup.provider.ts
+++ b/packages/providers/src/lib/gupshup/gupshup.provider.ts
@@ -5,6 +5,8 @@ import {
   ISmsProvider,
 } from '@novu/stateless';
 import axios from 'axios';
+import { constants } from "crypto";
+import { Agent } from "https";
 
 if (!globalThis.fetch) {
   // eslint-disable-next-line global-require
@@ -44,7 +46,12 @@ export class GupshupSmsProvider implements ISmsProvider {
       }),
     };
 
-    const response = await axios.post(GupshupSmsProvider.BASE_URL, params);
+    const response = await axios.post(GupshupSmsProvider.BASE_URL, params, {
+      httpsAgent: new Agent({
+        rejectUnauthorized: false,
+        secureOptions: constants.SSL_OP_LEGACY_SERVER_CONNECT,
+      }),
+    });
 
     const body = response.data;
     const result = body.split(' | ');


### PR DESCRIPTION
### What changed? Why was the change needed?
Added httpsAgent for allowing legacy SSL renegoation in Gupshup API integration

### Screenshots

<details>

### Related enterprise PR

### Special notes for your reviewer

</details>
@SokratisVidros Any chance this could be added as a hotfix to the docker package?
