### PR TITLE
chore(root): Add repo to scopes

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -6,11 +6,13 @@ on:
       - opened
       - edited
       - synchronize
-  pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
+
+  # Use the following event if you want edit and test setting regarding conventional commits
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - edited
+  #     - synchronize
 
 permissions:
   pull-requests: write
@@ -29,7 +31,7 @@ jobs:
       - name: Generate scopes
         id: generate_scopes
         run: |
-          scopes=$(pnpm m ls --json --depth=-1 | grep "name" | cut -d":" -f2 | grep "@novu" | cut -d"/" -f2 | grep "\"" | cut -d"\"" -f1)
+          scopes=$(pnpm m ls --json --depth=-1 | grep "name" | sed -e 's/.*\: \(.*\)/\1/' -e 's/@novu\///g' -e 's/[",]//g')
           echo 'SCOPES<<EOF' >> $GITHUB_ENV
           echo "$scopes" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
@@ -41,6 +43,8 @@ jobs:
         with:
           scopes: |
             ${{ env.SCOPES }}
+            requireScope: true
+
 
       - uses: marocchino/sticky-pull-request-comment@v2
         # When the previous steps fails, the workflow would stop. By adding this
@@ -50,14 +54,14 @@ jobs:
           header: pr-title-lint-error
           message: |
             Hey there and thank you for opening this pull request! 👋
-            
+
             We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
 
             Your PR title is: `${{ github.event.pull_request.title }}`
             It should be something like: `feat(scope): Add fancy new feature`
 
             Details:
-            
+
             ```
             ${{ steps.lint_pr_title.outputs.error_message }}
             ```
@@ -65,6 +69,6 @@ jobs:
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
         uses: marocchino/sticky-pull-request-comment@v2
-        with:   
+        with:
           header: pr-title-lint-error
           delete: true

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "novuhq",
+  "name": "root",
   "private": true,
   "packageManager": "pnpm@9.1.1",
   "scripts": {


### PR DESCRIPTION
### What changed? Why was the change needed?
This scope is required for global repo-level changes, not directly linked to a single package.