### PR TITLE
chore(root): Fix for prepare-cloud-release checkout

### DIFF
--- a/.github/workflows/prepare-cloud-release.yaml
+++ b/.github/workflows/prepare-cloud-release.yaml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set output variables
         id: output-variables


### PR DESCRIPTION
### What changed? Why was the change needed?
Checkout only the last commit.  0 indicates all history for all branches and tags creating the wrong prod history.