### PR TITLE
ci(root): Better readability of PR title linting comment

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -1,11 +1,11 @@
 name: "Lint PR title"
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+  # pull_request_target:
+  #   types:
+  #     - opened
+  #     - edited
+  #     - synchronize
 
   # Use the following event if you want edit and test setting regarding conventional commits
   pull_request:

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -62,9 +62,7 @@ jobs:
 
             Details:
 
-            ```
             ${{ steps.lint_pr_title.outputs.error_message }}
-            ```
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -60,7 +60,7 @@ jobs:
             Your PR title is: `${{ github.event.pull_request.title }}`
             It should be something like: `feat(scope): Add fancy new feature`
 
-            Details:
+            **Details:**
 
             ${{ steps.lint_pr_title.outputs.error_message }}
 

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -1,18 +1,18 @@
 name: "Lint PR title"
 
 on:
-  # pull_request_target:
-  #   types:
-  #     - opened
-  #     - edited
-  #     - synchronize
-
-  # Use the following event if you want edit and test setting regarding conventional commits
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited
       - synchronize
+
+  # Use the following event if you want edit and test setting regarding conventional commits
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - edited
+  #     - synchronize
 
 permissions:
   pull-requests: write

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -8,11 +8,11 @@ on:
       - synchronize
 
   # Use the following event if you want edit and test setting regarding conventional commits
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - edited
-  #     - synchronize
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
### What changed? Why was the change needed?
* Remove code blocks from the PR title linting comment description section for better readability
* Add bold to "Details" text

### Screenshots
_Bad release type:_
<img width="773" alt="image" src="https://github.com/novuhq/novu/assets/32132657/72910949-6bcd-4d7f-936c-86c032149661">

_Bad scope:_
<img width="825" alt="image" src="https://github.com/novuhq/novu/assets/32132657/b9034377-f1b4-43a4-801f-cb156e92a280">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
