### PR TITLE
ci(root): Check of EE files within community docker images

### DIFF
--- a/.github/workflows/prepare-self-hosted-release.yml
+++ b/.github/workflows/prepare-self-hosted-release.yml
@@ -125,7 +125,7 @@ jobs:
           )
           for pattern in "${patterns[@]}"; do
             if docker run --rm novu-$SERVICE_COMMON_NAME sh -c "ls $pattern 2>/dev/null"; then
-              echo "Error: '$pattern'  files were detected in ${{ matrix.name }}."
+              echo "::error::'$pattern' files were detected in ${{ matrix.name }}."
               exit 1
             fi
           done

--- a/.github/workflows/prepare-self-hosted-release.yml
+++ b/.github/workflows/prepare-self-hosted-release.yml
@@ -115,6 +115,23 @@ jobs:
           pnpm run docker:build
           docker images
 
+      - name: Check for EE files
+        if: "!contains(matrix.name, '-ee')"
+        id: check-ee-files
+        run: |
+          patterns=(
+            './node_modules/@novu/ee-**/dist/index.js'
+            './node_modules/@taskforcesh/bullmq-pro'  # Add more patterns as needed
+          )
+          for pattern in "${patterns[@]}"; do
+            if docker run --rm novu-$SERVICE_COMMON_NAME sh -c "ls $pattern 2>/dev/null"; then
+              echo "File matching pattern '$pattern' exists in ${{ matrix.name }}"
+              echo "Error: EE files should not be present in ${{ matrix.name }}"
+              exit 1
+            fi
+          done
+          echo "No matching EE files found in the Docker image ${{ matrix.name }}"
+
       - name: Tag and Push docker image
         shell: bash
         run: |

--- a/.github/workflows/prepare-self-hosted-release.yml
+++ b/.github/workflows/prepare-self-hosted-release.yml
@@ -125,7 +125,6 @@ jobs:
           )
           for pattern in "${patterns[@]}"; do
             if docker run --rm novu-$SERVICE_COMMON_NAME sh -c "ls $pattern 2>/dev/null"; then
-              echo "File matching pattern '$pattern' exists in ${{ matrix.name }}"
               echo "Error: '$pattern'  files were detected in ${{ matrix.name }}."
               exit 1
             fi

--- a/.github/workflows/prepare-self-hosted-release.yml
+++ b/.github/workflows/prepare-self-hosted-release.yml
@@ -126,7 +126,7 @@ jobs:
           for pattern in "${patterns[@]}"; do
             if docker run --rm novu-$SERVICE_COMMON_NAME sh -c "ls $pattern 2>/dev/null"; then
               echo "File matching pattern '$pattern' exists in ${{ matrix.name }}"
-              echo "Error: EE files should not be present in ${{ matrix.name }}"
+              echo "Error: '$pattern'  files were detected in ${{ matrix.name }}."
               exit 1
             fi
           done


### PR DESCRIPTION
It's needed to make sure that the docker images for community do not contain EE packages.
@LetItRock @rifont @SokratisVidros please take a look at the patterns here because I'm not sure that I know all of them:
```
patterns=(
  './node_modules/@novu/ee-**/dist/index.js'
  './node_modules/@taskforcesh/bullmq-pro'  # Add more patterns as needed
)
```
Each image that doesn't contain `-ee` in the name will be passed through this step. By using a simple tool ls we check existing files. If we find at least one file equal to the pattern, then a workflow will be stopped with an error before pushing images to the GitHub Registry.