### PR TITLE
chore(root): Set NOVU_ENTERPRISE to doppler

### DIFF
--- a/scripts/get-remote-env-files.sh
+++ b/scripts/get-remote-env-files.sh
@@ -8,4 +8,10 @@ doppler secrets download --project nx --config dev --no-file --format env > nx-c
 echo "Downloading secrets for the API..."
 doppler secrets download --project api --config dev --no-file --format env > apps/api/src/.env
 
+echo "Downloading secrets for the Worker..."
+doppler secrets download --project worker --config dev --no-file --format env > apps/worker/src/.env
+
+echo "Downloading secrets for the Web app..."
+doppler secrets download --project web --config dev --no-file --format env > apps/web/src/.env
+
 echo "All done! ✅"


### PR DESCRIPTION
### What changed? Why was the change needed?
Local development environment for novu-team should operate with NOVU_ENTERPRISE=true by default.