### PR TITLE
fix(notification-center): Translation error in french

### DIFF
--- a/packages/notification-center/src/i18n/languages/fr.ts
+++ b/packages/notification-center/src/i18n/languages/fr.ts
@@ -3,7 +3,7 @@ import { ITranslationEntry } from '../lang';
 export const FR: ITranslationEntry = {
   translations: {
     notifications: 'Notifications',
-    markAllAsRead: 'Tout marquer comme lus',
+    markAllAsRead: 'Tout marquer comme lu',
     poweredBy: 'Propulsé par',
     settings: 'Paramètres',
     noNewNotification: 'Rien de nouveau à voir ici pour le moment',


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR fixe a small translation error in the notification center introduce by a previous PR. 

The phrase "tout marquer comme lu" translates to "mark all as read" in English, where "lu" is the correct singular past participle of "lire" (to read) used in this context. The use of "lus" is grammatically incorrect here because:

"Tout" (all) is singular, and it modifies "marquer" (to mark) and "lu" (read), which should remain in singular form.
The correct usage emphasizes marking all individual items collectively as "read" (lu), not "reads" (lus).
