### PR TITLE
fix(web): Workflow trigger on-click sidebar render loop

### DIFF
--- a/apps/web/src/pages/templates/components/TestWorkflow.tsx
+++ b/apps/web/src/pages/templates/components/TestWorkflow.tsx
@@ -59,6 +59,13 @@ export function TestWorkflow({ trigger }) {
 
     return [{ name: 'subscriberId' }, ...(trigger?.subscriberVariables || [])];
   }, [trigger]);
+
+  const currentUserDependencies = subscriberVariables.map((variable) =>
+    currentUser ? currentUser[variable.name === 'subscriberId' ? '_id' : variable.name] : null
+  );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const memoizedCurrentUser = useMemo(() => currentUser, [...currentUserDependencies]);
+
   const variables = useMemo(() => [...(trigger?.variables || [])], [trigger]);
   const reservedVariables = useMemo(() => [...(trigger?.reservedVariables || [])], [trigger]);
 
@@ -90,8 +97,8 @@ export function TestWorkflow({ trigger }) {
   const { setValues } = form;
 
   useEffect(() => {
-    setValues({ toValue: makeToValue(subscriberVariables, currentUser) });
-  }, [setValues, subscriberVariables, currentUser]);
+    setValues({ toValue: makeToValue(subscriberVariables, memoizedCurrentUser) });
+  }, [setValues, subscriberVariables, memoizedCurrentUser]);
 
   const onTrigger = async ({ toValue, payloadValue, overridesValue, snippetValue }) => {
     const to = JSON.parse(toValue);


### PR DESCRIPTION
### What changed? Why was the change needed?
*  since `currentUser` is an object, its likely creating a new reference on every render, causing the useEffect to trigger continuously
* memoized `currentUser` with `subscriberVariables` as deps, since only those are being used/extracted from the `currentUser` object in this component

Related function that does the extraction for reference:

```typescript
const makeToValue = (subscriberVariables: INotificationTriggerVariable[], currentUser?: IUserEntity) => {
  const subsVars = getSubscriberValue(
    subscriberVariables,
    (variable) =>
      (currentUser && currentUser[variable.name === 'subscriberId' ? '_id' : variable.name]) || '<REPLACE_WITH_DATA>'
  );

  return JSON.stringify(subsVars, null, 2);
};
```

### Screenshots

Before:

https://github.com/novuhq/novu/assets/32128755/30074511-e398-4c3b-a577-b26d7ab9a94f

After:

https://github.com/novuhq/novu/assets/32128755/6b658df7-1a03-421b-9cbe-29a9adc9298a




