### PR TITLE
build(root): Fix deployment.yaml indent error after adding google bucket support

### DIFF
--- a/docker/kubernetes/helm/templates/api/deployment.yaml
+++ b/docker/kubernetes/helm/templates/api/deployment.yaml
@@ -139,7 +139,7 @@ spec:
               value: {{ .Values.externalS3.gcsBucketName | quote }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: {{ .Values.externalS3.googleApplicationCredentials | quote }}
-            {{- else -}}
+            {{- else }}
             - name: S3_BUCKET_NAME
               valueFrom :
                 secretKeyRef:

--- a/docker/kubernetes/helm/templates/worker/deployment.yaml
+++ b/docker/kubernetes/helm/templates/worker/deployment.yaml
@@ -133,7 +133,7 @@ spec:
               value: {{ .Values.externalS3.gcsBucketName | quote }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: {{ .Values.externalS3.googleApplicationCredentials | quote }}
-            {{- else -}}
+            {{- else }}
             - name: S3_BUCKET_NAME
               valueFrom :
                 secretKeyRef:


### PR DESCRIPTION
### What changed? Why was the change needed?
After implementing Google Bucket support in Helm Chart YAML templates, the installation started showing the following error:

```
Error: INSTALLATION FAILED: YAML parse error on novu/templates/api/deployment.yaml: error converting YAML to JSON: yaml: line 92: mapping values are not allowed in this context
```

This occurs because of the misuse of `{{- else -}}` instead of `{{- else }}`. The main difference between them is that one removes only the white space on the left and the other on both sides. Below is what the template looked like:

```
           name: novu-externalredis
                   key: redis-password
             - name: MONGO_URL
               valueFrom:
                 secretKeyRef:
                   name: novu-url-mongodb
                   key: mongoUrl- name: S3_BUCKET_NAME
               valueFrom:
                 secretKeyRef:
                   name: novu-externals3
                   key: bucketName
```

Therefore, I corrected this problem by removing the `-` after *else*, leaving only `{{ else }}`. Below is what was changed:

```
    {{- if eq .Values.externalS3.storageService "GCS" }}
             - name: STORAGE_SERVICE
               value: {{ .Values.externalS3.storageService | quote }}
             - name: GCS_DOMAIN
               value: {{ .Values.externalS3.gcsDomain | quote }}
             - name: GCS_BUCKET_NAME
               value: {{ .Values.externalS3.gcsBucketName | quote }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: {{ .Values.externalS3.googleApplicationCredentials | quote }}
    {{ else }}
             - name: S3_BUCKET_NAME
               valueFrom:
                 secretKeyRef:
                   name: {{ include "novu.s3.secretName" . }}
                   key: bucketName
```

### Screenshots

<img width="1107" alt="Screenshot 2024-05-27 at 12 52 21" src="https://github.com/novuhq/novu/assets/18234370/c90b58c2-26b1-4d05-96bb-3519316e28ce">
