### PR TITLE
feat(echo): add support for Remix framework

### DIFF
--- a/packages/echo/package.json
+++ b/packages/echo/package.json
@@ -71,6 +71,11 @@
       "require": "./dist/sveltekit.js",
       "import": "./dist/sveltekit.mjs",
       "types": "./dist/sveltekit.d.ts"
+    },
+    "./remix": {
+      "require": "./dist/remix.js",
+      "import": "./dist/remix.mjs",
+      "types": "./dist/remix.d.ts"
     }
   },
   "devDependencies": {

--- a/packages/echo/src/remix.ts
+++ b/packages/echo/src/remix.ts
@@ -1,0 +1,41 @@
+import { EchoRequestHandler, ServeHandlerOptions } from './handler';
+import { type SupportedFrameworkName } from './types';
+
+export const frameworkName: SupportedFrameworkName = 'remix';
+
+export const serve = (
+  options: ServeHandlerOptions
+): ((ctx: { request: Request; context?: unknown }) => Promise<Response>) => {
+  const handler = new EchoRequestHandler({
+    frameworkName,
+    ...options,
+    handler: ({ request: req }: { request: Request }) => {
+      return {
+        body: () => req.json(),
+        headers: (key) => req.headers.get(key),
+        method: () => req.method,
+        url: () => new URL(req.url, `https://${req.headers.get('host') || ''}`),
+        transformResponse: ({ body, status, headers }): Response => {
+          // Handle Response polyfills
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          let Res: typeof Response;
+
+          if (typeof Response === 'undefined') {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-var-requires
+            Res = require('cross-fetch').Response;
+          } else {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            Res = Response;
+          }
+
+          return new Res(body, {
+            status,
+            headers,
+          });
+        },
+      };
+    },
+  });
+
+  return handler.createHandler();
+};

--- a/packages/echo/src/types/framework.types.ts
+++ b/packages/echo/src/types/framework.types.ts
@@ -1,1 +1,1 @@
-export type SupportedFrameworkName = 'next' | 'express' | 'nuxt' | 'h3' | 'sveltekit';
+export type SupportedFrameworkName = 'next' | 'express' | 'nuxt' | 'h3' | 'sveltekit' | 'remix';

--- a/packages/echo/tsup.config.ts
+++ b/packages/echo/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 import { type SupportedFrameworkName } from './src';
 
-const frameworks: SupportedFrameworkName[] = ['h3', 'express', 'next', 'nuxt', 'sveltekit'];
+const frameworks: SupportedFrameworkName[] = ['h3', 'express', 'next', 'nuxt', 'sveltekit', 'remix'];
 
 export default defineConfig({
   entry: ['src/index.ts', ...frameworks.map((framework) => `src/${framework}.ts`)],


### PR DESCRIPTION
### What changed? Why was the change needed?
* Remix is a modern web framework that is being used both internally for Dev Rel and externally requested by Novu platform developers.

### Screenshots
_Health-check test_
```bash
> curl -v http://localhost:5173/api/echo\?action\=health-check
*   Trying 127.0.0.1:5173...
* connect to 127.0.0.1 port 5173 failed: Connection refused
*   Trying [::1]:5173...
* Connected to localhost (::1) port 5173 (#0)
> GET /api/echo?action=health-check HTTP/1.1
> Host: localhost:5173
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/1.1 200 OK
< access-control-allow-origin: *
< access-control-allow-headers: *
< access-control-allow-methods: GET, POST
< content-type: application/json
< user-agent: novu-echo:v0.24.3-alpha.0
< x-echo-framework: remix
< x-echo-sdk: novu-echo:v0.24.3-alpha.0
< Date: Mon, 03 Jun 2024 14:32:56 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< Transfer-Encoding: chunked
< 
* Connection #0 to host localhost left intact
{"status":"ok","version":"0.24.3-alpha.0","discovered":{"workflows":1,"steps":3}}% 
```

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
