### PR TITLE
fix(web): Fix component type for `VariableManagement`

### DIFF
--- a/apps/web/src/components/layout/components/UpgradePlanBanner.tsx
+++ b/apps/web/src/components/layout/components/UpgradePlanBanner.tsx
@@ -1,7 +1,8 @@
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { IS_DOCKER_HOSTED, useFeatureFlag } from '@novu/shared-web';
+import { ComponentType } from 'react';
 
-export function UpgradePlanBanner({ FeatureActivatedBanner }: { FeatureActivatedBanner: React.ReactNode }) {
+export function UpgradePlanBanner({ FeatureActivatedBanner }: { FeatureActivatedBanner: ComponentType }) {
   const isEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_BILLING_REVERSE_TRIAL_ENABLED);
 
   if (IS_DOCKER_HOSTED) {

--- a/apps/web/src/components/layout/components/UpgradePlanBanner.tsx
+++ b/apps/web/src/components/layout/components/UpgradePlanBanner.tsx
@@ -1,8 +1,8 @@
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { IS_DOCKER_HOSTED, useFeatureFlag } from '@novu/shared-web';
-import { ComponentType } from 'react';
+import { FC } from 'react';
 
-export function UpgradePlanBanner({ FeatureActivatedBanner }: { FeatureActivatedBanner: ComponentType }) {
+export function UpgradePlanBanner({ FeatureActivatedBanner }: { FeatureActivatedBanner: FC }) {
   const isEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_BILLING_REVERSE_TRIAL_ENABLED);
 
   if (IS_DOCKER_HOSTED) {

--- a/apps/web/src/pages/templates/components/email-editor/variables-management/VariablesManagement.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/variables-management/VariablesManagement.tsx
@@ -288,7 +288,7 @@ export const TranslationSectionItem = ({
       />
       <When truthy={!keys?.length && !search.length}>
         <VarLabel label={sectionName} Icon={Translation}>
-          <UpgradePlanBanner FeatureActivatedBanner={<TranslationsGetStartedText />} />
+          <UpgradePlanBanner FeatureActivatedBanner={TranslationsGetStartedText} />
         </VarLabel>
       </When>
     </>


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

- Fixes bug with editing `in-app` and `email` workflow steps described [here](https://novu.slack.com/archives/C06GS20SPE0/p1717523370932029?thread_ts=1717521227.183549&cid=C06GS20SPE0)
- This occurred after my changes in #5641:
  1. There were numerous build errors that required manual fixing: one of which involved a function component being passed as a `ReactNode`
  2. I assumed the expected type (`ReactNode`) was correct, and used the component as a JSX Element
  3. This was incorrect though, and the type should've been changed to `FC` as the consuming component was expecting a function component

_I did an additional review of #5461 just now to ensure that this was the only place I made a change like this -- everything else was more straight-forward_

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

Email and In-app editing opens properly with no errors in the console

<img width="1449" alt="Screenshot 2024-06-04 at 10 27 54 PM" src="https://github.com/novuhq/novu/assets/47441786/11a90bbf-0949-4b8d-a2c8-11349d91b07f">

