### PR TITLE
feat(novui,web): V2 flow list

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -48,6 +48,7 @@ import { TenantsPage } from './pages/tenants/TenantsPage';
 import { UpdateTenantPage } from './pages/tenants/UpdateTenantPage';
 import { TranslationRoutes } from './pages/TranslationPages';
 import { useSettingsRoutes } from './SettingsRoutes';
+import { WorkflowsListPage } from './studio/components/workflows/WorkflowsListPage';
 
 export const AppRoutes = () => {
   const isImprovedOnboardingEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_IMPROVED_ONBOARDING_ENABLED);
@@ -140,7 +141,7 @@ export const AppRoutes = () => {
         )}
         <Route path={ROUTES.STUDIO}>
           <Route path="" element={<Navigate to={ROUTES.STUDIO_FLOWS} replace />} />
-          <Route path={ROUTES.STUDIO_FLOWS} element={<WorkflowListPage />} />
+          <Route path={ROUTES.STUDIO_FLOWS} element={<WorkflowsListPage />} />
         </Route>
 
         <Route path="/translations/*" element={<TranslationRoutes />} />

--- a/apps/web/src/studio/components/workflows/WorkflowsListPage.tsx
+++ b/apps/web/src/studio/components/workflows/WorkflowsListPage.tsx
@@ -1,5 +1,10 @@
+import { SettingsPageContainer } from '../../../pages/settings/SettingsPageContainer';
 import { WorkflowsTable } from './table';
 
 export const WorkflowsListPage = () => {
-  return <WorkflowsTable />;
+  return (
+    <SettingsPageContainer title="Workflows">
+      <WorkflowsTable />
+    </SettingsPageContainer>
+  );
 };

--- a/apps/web/src/studio/components/workflows/WorkflowsListPage.tsx
+++ b/apps/web/src/studio/components/workflows/WorkflowsListPage.tsx
@@ -1,10 +1,10 @@
-import { SettingsPageContainer } from '../../../pages/settings/SettingsPageContainer';
+import { PageContainer } from '../../layout';
 import { WorkflowsTable } from './table';
 
 export const WorkflowsListPage = () => {
   return (
-    <SettingsPageContainer title="Workflows">
+    <PageContainer title="Workflows">
       <WorkflowsTable />
-    </SettingsPageContainer>
+    </PageContainer>
   );
 };

--- a/apps/web/src/studio/components/workflows/WorkflowsListPage.tsx
+++ b/apps/web/src/studio/components/workflows/WorkflowsListPage.tsx
@@ -1,0 +1,5 @@
+import { WorkflowsTable } from './table';
+
+export const WorkflowsListPage = () => {
+  return <WorkflowsTable />;
+};

--- a/apps/web/src/studio/components/workflows/WorkflowsTable.tsx
+++ b/apps/web/src/studio/components/workflows/WorkflowsTable.tsx
@@ -1,9 +1,0 @@
-import { FC } from 'react';
-
-interface IWorkflowsTableProps {
-  temp?: string;
-}
-
-export const WorkflowsTable: FC<IWorkflowsTableProps> = (props) => {
-  return <div></div>;
-};

--- a/apps/web/src/studio/components/workflows/WorkflowsTable.tsx
+++ b/apps/web/src/studio/components/workflows/WorkflowsTable.tsx
@@ -1,0 +1,9 @@
+import { FC } from 'react';
+
+interface IWorkflowsTableProps {
+  temp?: string;
+}
+
+export const WorkflowsTable: FC<IWorkflowsTableProps> = (props) => {
+  return <div></div>;
+};

--- a/apps/web/src/studio/components/workflows/index.ts
+++ b/apps/web/src/studio/components/workflows/index.ts
@@ -1,0 +1,1 @@
+export * from './WorkflowsListPage';

--- a/apps/web/src/studio/components/workflows/table/WorkflowsTable.tsx
+++ b/apps/web/src/studio/components/workflows/table/WorkflowsTable.tsx
@@ -1,4 +1,5 @@
 import { createColumnHelper, Table } from '@novu/novui';
+import { css } from '@novu/novui/css';
 import format from 'date-fns/format';
 import { FC } from 'react';
 import { WorkflowTableRow } from './WorkflowsTable.types';
@@ -97,6 +98,10 @@ const WORKFLOW_COLUMNS = [
   }),
 ];
 
-export const WorkflowsTable: FC<IWorkflowsTableProps> = (props) => {
-  return <Table<typeof TEST_FLOW> columns={WORKFLOW_COLUMNS} data={[TEST_FLOW]} />;
+export const WorkflowsTable: FC<IWorkflowsTableProps> = () => {
+  return (
+    <div className={css({ display: 'flex', flex: '1' })}>
+      <Table<typeof TEST_FLOW> columns={WORKFLOW_COLUMNS} data={[TEST_FLOW]} className={css({ w: '100%' })} />
+    </div>
+  );
 };

--- a/apps/web/src/studio/components/workflows/table/WorkflowsTable.tsx
+++ b/apps/web/src/studio/components/workflows/table/WorkflowsTable.tsx
@@ -1,3 +1,5 @@
+/* cspell:disable */
+
 import { createColumnHelper, Table } from '@novu/novui';
 import { css } from '@novu/novui/css';
 import format from 'date-fns/format';
@@ -5,6 +7,7 @@ import { FC } from 'react';
 import { WorkflowTableRow } from './WorkflowsTable.types';
 import { GroupCell, NameCell, StatusCell } from './WorkflowsTableCellRenderers';
 
+// TODO: remove this test data
 const TEST_FLOW = {
   _id: 'adaewr',
   name: 'test naming',

--- a/apps/web/src/studio/components/workflows/table/WorkflowsTable.tsx
+++ b/apps/web/src/studio/components/workflows/table/WorkflowsTable.tsx
@@ -104,7 +104,11 @@ const WORKFLOW_COLUMNS = [
 export const WorkflowsTable: FC<IWorkflowsTableProps> = () => {
   return (
     <div className={css({ display: 'flex', flex: '1' })}>
-      <Table<typeof TEST_FLOW> columns={WORKFLOW_COLUMNS} data={[TEST_FLOW]} className={css({ w: '100%' })} />
+      <Table<typeof TEST_FLOW>
+        columns={WORKFLOW_COLUMNS}
+        data={[TEST_FLOW, { ...TEST_FLOW, active: true }]}
+        className={css({ w: '100%' })}
+      />
     </div>
   );
 };

--- a/apps/web/src/studio/components/workflows/table/WorkflowsTable.tsx
+++ b/apps/web/src/studio/components/workflows/table/WorkflowsTable.tsx
@@ -1,0 +1,102 @@
+import { createColumnHelper, Table } from '@novu/novui';
+import format from 'date-fns/format';
+import { FC } from 'react';
+import { WorkflowTableRow } from './WorkflowsTable.types';
+import { GroupCell, NameCell, StatusCell } from './WorkflowsTableCellRenderers';
+
+const TEST_FLOW = {
+  _id: 'adaewr',
+  name: 'test naming',
+  active: false,
+  type: 'REGULAR',
+  draft: true,
+  critical: false,
+  isBlueprint: false,
+  _notificationGroupId: 'dsasdfasdf',
+  tags: [],
+  triggers: [
+    {
+      type: 'event',
+      identifier: 'test-naming',
+      variables: [],
+      reservedVariables: [],
+      subscriberVariables: [],
+      _id: 'sdfsdf',
+    },
+  ],
+  steps: [],
+  preferenceSettings: {
+    email: true,
+    sms: true,
+    in_app: true,
+    chat: true,
+    push: true,
+  },
+  _environmentId: 'sdfsdf',
+  _organizationId: 'sdf',
+  _creatorId: 'sdfsdfsdf',
+  deleted: false,
+  createdAt: '2024-06-04T19:11:11.600Z',
+  updatedAt: '2024-06-05T17:55:39.022Z',
+  __v: 0,
+  notificationGroup: {
+    _id: 'sdfsdf',
+    name: 'General',
+    _organizationId: 'sdfsdf',
+    _environmentId: 'sdfdfsdfsf',
+    createdAt: '2024-05-17T22:26:08.177Z',
+    updatedAt: '2024-05-17T22:26:08.177Z',
+    __v: 0,
+  },
+  workflowIntegrationStatus: {
+    hasActiveIntegrations: true,
+    channels: {
+      in_app: {
+        hasActiveIntegrations: false,
+      },
+      email: {
+        hasActiveIntegrations: true,
+        hasPrimaryIntegrations: true,
+      },
+      sms: {
+        hasActiveIntegrations: true,
+        hasPrimaryIntegrations: true,
+      },
+      chat: {
+        hasActiveIntegrations: false,
+      },
+      push: {
+        hasActiveIntegrations: false,
+      },
+    },
+  },
+};
+
+interface IWorkflowsTableProps {
+  temp?: string;
+}
+
+const columnHelper = createColumnHelper<WorkflowTableRow>();
+
+const WORKFLOW_COLUMNS = [
+  columnHelper.accessor('name', {
+    header: 'Name & Trigger ID',
+    cell: NameCell,
+  }),
+  columnHelper.accessor('notificationGroup.name', {
+    header: 'Group',
+    cell: GroupCell,
+  }),
+  columnHelper.accessor('createdAt', {
+    header: 'Created at',
+    cell: ({ getValue }) => format(new Date(getValue() ?? ''), 'dd/MM/yyyy HH:mm'),
+  }),
+  columnHelper.accessor('active', {
+    header: 'Status',
+    cell: StatusCell,
+  }),
+];
+
+export const WorkflowsTable: FC<IWorkflowsTableProps> = (props) => {
+  return <Table<typeof TEST_FLOW> columns={WORKFLOW_COLUMNS} data={[TEST_FLOW]} />;
+};

--- a/apps/web/src/studio/components/workflows/table/WorkflowsTable.types.ts
+++ b/apps/web/src/studio/components/workflows/table/WorkflowsTable.types.ts
@@ -1,0 +1,3 @@
+import { INotificationTemplateExtended } from '../../../../hooks/useTemplates';
+
+export type WorkflowTableRow = INotificationTemplateExtended;

--- a/apps/web/src/studio/components/workflows/table/WorkflowsTableCellRenderers.tsx
+++ b/apps/web/src/studio/components/workflows/table/WorkflowsTableCellRenderers.tsx
@@ -1,0 +1,64 @@
+import { CellRendererComponent } from '@novu/novui';
+import { css } from '@novu/novui/css';
+import { IconBolt, IconCable, IconFlashOff } from '@novu/novui/icons';
+import { Center, Flex, HStack, styled } from '@novu/novui/jsx';
+import { text } from '@novu/novui/recipes';
+import { ColorToken } from '@novu/novui/tokens';
+import { WorkflowTableRow } from './WorkflowsTable.types';
+
+export const GroupCell: CellRendererComponent<WorkflowTableRow, string> = (props) => {
+  return (
+    <Center
+      className={css({
+        color: 'typography.text.main',
+        rounded: '50',
+        border: 'solid',
+        py: '25',
+        px: '75',
+        borderColor: 'badge.border',
+        width: '[fit-content]',
+        bg: '[transparent]',
+      })}
+    >
+      {props.getValue()}
+    </Center>
+  );
+};
+
+const Text = styled('p', text);
+
+export const NameCell: CellRendererComponent<WorkflowTableRow, string> = ({ getValue, row: { original } }) => {
+  return (
+    <HStack gap="50">
+      {
+        <IconCable
+          className={css({ width: '200', height: '200', color: 'icon.secondary' })}
+          title="workflow-row-label"
+        />
+      }
+      <Flex direction={'column'}>
+        <Text variant={'main'}>{getValue()}</Text>
+        <Text variant={'secondary'}>{original.triggers ? original.triggers[0].identifier : 'Unknown'}</Text>
+      </Flex>
+    </HStack>
+  );
+};
+
+export const StatusCell: CellRendererComponent<WorkflowTableRow, boolean> = ({ getValue }) => {
+  const isActive = getValue();
+  getValue();
+  const color: ColorToken = isActive ? 'status.active' : 'status.inactive';
+
+  return (
+    <HStack gap="0">
+      {isActive ? (
+        <IconBolt size="16" className={css({ color })} title="workflow-status-indicator" />
+      ) : (
+        <IconFlashOff size="16" className={css({ color })} title="workflow-status-indicator" />
+      )}
+      <Text variant={'main'} color={color}>
+        {isActive ? 'Active' : 'Inactive'}
+      </Text>
+    </HStack>
+  );
+};

--- a/apps/web/src/studio/components/workflows/table/index.ts
+++ b/apps/web/src/studio/components/workflows/table/index.ts
@@ -1,0 +1,1 @@
+export * from './WorkflowsTable';

--- a/apps/web/src/studio/layout/PageContainer.tsx
+++ b/apps/web/src/studio/layout/PageContainer.tsx
@@ -1,0 +1,44 @@
+import { FC, PropsWithChildren, ReactNode } from 'react';
+import { css, cx } from '@novu/novui/css';
+import { PageHeader } from './PageHeader';
+import { PageMeta } from './PageMeta';
+import { Container } from '@novu/novui/jsx';
+import { CoreProps } from '@novu/novui';
+
+export interface IPageContainerProps extends CoreProps {
+  // TODO: this should be LocalizedMessage, but PageContainer and PageHeader don't accept it
+  title: string;
+  header?: ReactNode;
+}
+
+export const PageContainer: FC<PropsWithChildren<IPageContainerProps>> = ({ title, children, header, className }) => {
+  return (
+    <Container
+      className={cx(
+        css({
+          overflowY: 'auto !important',
+          borderRadius: '0',
+          px: 'paddings.page.horizontal',
+          py: 'paddings.page.vertical',
+          m: '0',
+          h: '100%',
+          bg: 'surface.page',
+        }),
+        className
+      )}
+    >
+      <PageMeta title={title} />
+      <PageHeader title={title} className={css({ mb: 'margins.layout.page.titleBottom' })} />
+      {!!header && (
+        <section
+          className={css({
+            mx: 'paddings.page.horizontal',
+          })}
+        >
+          {header}
+        </section>
+      )}
+      <section>{children}</section>
+    </Container>
+  );
+};

--- a/apps/web/src/studio/layout/PageHeader.tsx
+++ b/apps/web/src/studio/layout/PageHeader.tsx
@@ -1,0 +1,20 @@
+import { CoreProps } from '@novu/novui';
+import { styled, Flex } from '@novu/novui/jsx';
+import { title as titleRecipe } from '@novu/novui/recipes';
+import { LocalizedMessage } from '@novu/shared-web';
+
+const Title = styled('h1', titleRecipe);
+
+export interface IPageHeaderProps extends CoreProps {
+  actions?: JSX.Element;
+  title: LocalizedMessage;
+}
+
+export const PageHeader: React.FC<IPageHeaderProps> = ({ title, actions, className }) => {
+  return (
+    <Flex direction={'row'} justifyContent="space-between" className={className}>
+      <Title variant={'page'}>{title}</Title>
+      {actions && <div>{actions}</div>}
+    </Flex>
+  );
+};

--- a/apps/web/src/studio/layout/PageMeta.tsx
+++ b/apps/web/src/studio/layout/PageMeta.tsx
@@ -1,0 +1,13 @@
+import { Helmet } from 'react-helmet-async';
+
+interface IPageMetaProps {
+  title?: string;
+}
+
+export const PageMeta: React.FC<IPageMetaProps> = ({ title }) => {
+  return (
+    <Helmet>
+      <title>{title ? `${title} | ` : ``}Novu</title>
+    </Helmet>
+  );
+};

--- a/apps/web/src/studio/layout/index.ts
+++ b/apps/web/src/studio/layout/index.ts
@@ -1,0 +1,1 @@
+export * from './PageContainer';

--- a/libs/novui/package.json
+++ b/libs/novui/package.json
@@ -129,6 +129,7 @@
   "dependencies": {
     "@mantine/core": "^7.10.0",
     "@mantine/hooks": "^7.10.0",
+    "@tanstack/react-table": "^8.17.3",
     "react-icons": "^5.0.1"
   }
 }

--- a/libs/novui/panda.config.ts
+++ b/libs/novui/panda.config.ts
@@ -40,4 +40,6 @@ export default defineConfig({
 
   // Enables JSX util generation!
   jsxFramework: 'react',
+
+  validation: 'error',
 });

--- a/libs/novui/src/components/index.ts
+++ b/libs/novui/src/components/index.ts
@@ -1,2 +1,3 @@
-export * from './Test';
 export * from './NovuiProvider';
+export * from './table';
+export * from './Test';

--- a/libs/novui/src/components/table/Table.stories.tsx
+++ b/libs/novui/src/components/table/Table.stories.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { StoryFn, Meta } from '@storybook/react';
+import { Badge, Switch } from '@mantine/core';
+
+import { Table } from './Table';
+import { ColumnDef } from '@tanstack/react-table';
+
+export default {
+  title: 'Components/Table',
+  component: Table,
+  argTypes: {
+    data: {
+      control: false,
+    },
+    columns: {
+      control: false,
+    },
+  },
+} as Meta<typeof Table>;
+
+const SwitchCell = (props) => {
+  const [status, setStatus] = useState(props.status);
+  const switchHandler = () => {
+    setStatus((prev) => (prev === 'Enabled' ? 'Disabled' : 'Enabled'));
+  };
+
+  return <Switch label={status} onChange={switchHandler} checked={status === 'Enabled'} />;
+};
+
+const BadgeCell = (props) => {
+  return (
+    <Badge variant="outline" size="md" radius="xs">
+      {props.getValue()}
+    </Badge>
+  );
+};
+
+interface IExampleData {
+  name: string;
+  category: string;
+  creationDate: string;
+  status: string;
+}
+
+const columns: ColumnDef<IExampleData>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'category', header: 'Category', cell: BadgeCell },
+  { accessorKey: 'creationDate', header: 'Date Created' },
+  { accessorKey: 'status', header: 'Status', cell: SwitchCell },
+];
+
+const data: IExampleData[] = [
+  { name: 'Great', category: 'Fun', status: 'Disabled', creationDate: '01/01/2021 16:36' },
+  { name: 'Whats up?', category: 'Done', status: 'Enabled', creationDate: '01/01/2021 16:36' },
+];
+
+const Template: StoryFn<typeof Table> = ({ ...args }) => <Table columns={columns} data={data} {...args} />;
+
+export const PrimaryUse = Template.bind({});
+PrimaryUse.args = {};

--- a/libs/novui/src/components/table/Table.styles.ts
+++ b/libs/novui/src/components/table/Table.styles.ts
@@ -1,0 +1,69 @@
+import { type TableStylesNames } from '@mantine/core';
+import { css } from '../../../styled-system/css';
+
+const tableStyles: Partial<Record<TableStylesNames, string>> = {
+  tr: css({
+    '& td': {
+      textOverflow: 'ellipsis',
+    },
+  }),
+  table: css({
+    borderCollapse: 'collapse',
+    borderSpacingX: '125',
+    textStyle: 'text.main',
+    '& tr td:first-of-type': {
+      pl: '200',
+      pr: '200',
+    },
+    '& tr th:first-of-type': {
+      pl: '200',
+      pr: '200',
+    },
+    '& tr td:last-child': {
+      pr: '200',
+    },
+    '& tr th:last-child': {
+      pr: '200',
+    },
+    '& thead tr': {
+      borderBottom: 'solid',
+      borderColor: 'table.header.border',
+    },
+    '& thead tr th': {
+      fontWeight: 'regular',
+      // height: '17px',
+      textAlign: 'left',
+      color: 'typography.text.tertiary',
+      borderBottom: 'none',
+      borderSpacing: '0',
+      pb: '100',
+    },
+    '& tbody tr td': {
+      // TODO: replace with token value
+      maxWidth: '[100px]',
+      // TODO: replace with token value
+      height: '[80px]',
+
+      color: 'typography.text.main',
+      borderBottom: 'solid',
+      borderColor: 'table.row.border',
+    },
+    '& tbody tr[data-disabled="true"]:hover': {
+      cursor: 'default',
+    },
+    '& tbody tr[data-disabled="false"]:hover': {
+      cursor: 'pointer',
+    },
+    '& tbody tr:last-of-type td': {
+      borderBottom: 'solid',
+      borderColor: 'table.bottom.border',
+    },
+    _hover: {
+      '& tbody tr:hover': {
+        bg: 'table.row.surface.hover',
+      },
+    },
+  }),
+};
+
+export default tableStyles;

--- a/libs/novui/src/components/table/Table.styles.ts
+++ b/libs/novui/src/components/table/Table.styles.ts
@@ -12,11 +12,9 @@ const tableStyles: Partial<Record<TableStylesNames, string>> = {
     borderSpacingX: '125',
     textStyle: 'text.main',
     '& tr td:first-of-type': {
-      pl: '200',
       pr: '200',
     },
     '& tr th:first-of-type': {
-      pl: '200',
       pr: '200',
     },
     '& tr td:last-child': {

--- a/libs/novui/src/components/table/Table.tsx
+++ b/libs/novui/src/components/table/Table.tsx
@@ -1,0 +1,93 @@
+import { Table as ExternalTable } from '@mantine/core';
+import { flexRender, getCoreRowModel, Row, useReactTable } from '@tanstack/react-table';
+import React, { useMemo } from 'react';
+import { CoreProps } from 'src/types';
+
+import classes from './Table.styles';
+
+export type IRow<T extends object = {}> = Row<T>;
+
+export interface ITableProps<T extends object> extends CoreProps {
+  columns?: any[];
+  data?: T[];
+  isLoading?: boolean;
+  pagination?: any;
+  noDataPlaceholder?: React.ReactNode;
+  loadingItems?: number;
+  hasMore?: boolean;
+  onRowClick?: (row: Row<T>) => void;
+  onRowSelect?: (row: Row<T>) => void;
+}
+
+/**
+ * Table component
+ *
+ */
+export function Table<T extends object>({
+  columns: userColumns,
+  data: userData,
+  isLoading = false,
+  noDataPlaceholder,
+  loadingItems = 10,
+  onRowClick,
+  onRowSelect,
+  ...props
+}: ITableProps<T>) {
+  const columns = useMemo(() => userColumns?.map((col) => ({ ...col })), [userColumns]);
+  const data = useMemo(() => (userData || [])?.map((row) => ({ ...row })), [userData]);
+  const fakeData = useMemo(() => Array.from({ length: loadingItems }).map((_, index) => ({ index })), [loadingItems]);
+
+  const table = useReactTable<T>({
+    columns,
+    data: isLoading ? (fakeData as T[]) : data,
+    getCoreRowModel: getCoreRowModel(),
+    // FIXME: remove this
+    debugTable: true,
+  });
+
+  return (
+    <ExternalTable classNames={classes} highlightOnHover {...props}>
+      <thead>
+        {table.getHeaderGroups().map((headerGroup, i) => {
+          return (
+            <tr key={headerGroup.id} {...headerGroup}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <th key={header.id} {...header}>
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                  </th>
+                );
+              })}
+            </tr>
+          );
+        })}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map((row) => {
+          return (
+            <tr
+              key={row.id}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!isLoading && onRowClick) {
+                  onRowClick(row);
+                }
+              }}
+              {...row}
+              className={classes.tr}
+              data-disabled={isLoading || !onRowClick}
+            >
+              {row.getVisibleCells().map((cell) => {
+                return (
+                  <td key={cell.id} {...cell}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                );
+              })}
+            </tr>
+          );
+        })}
+      </tbody>
+    </ExternalTable>
+  );
+}

--- a/libs/novui/src/components/table/Table.tsx
+++ b/libs/novui/src/components/table/Table.tsx
@@ -8,12 +8,12 @@ import {
   createColumnHelper as _createColumnHelper,
   ColumnDefTemplate,
 } from '@tanstack/react-table';
-import React, { ComponentType, useMemo } from 'react';
-import { CoreProps } from 'src/types';
+import React, { useMemo } from 'react';
+import { CoreProps } from '../../types';
 
 import classes from './Table.styles';
 
-export type IRow<T extends object = {}> = Row<T>;
+export type IRow<TRow extends object = {}> = Row<TRow>;
 
 /** Component used to render the contents of a cell */
 export type CellRendererComponent<TRow, TCellValue> = ColumnDefTemplate<CellContext<TRow, TCellValue>>;
@@ -21,23 +21,23 @@ export type CellRendererComponent<TRow, TCellValue> = ColumnDefTemplate<CellCont
 /** Helper for type-safe column definitions */
 export const createColumnHelper = _createColumnHelper;
 
-export interface ITableProps<T extends object> extends CoreProps {
+export interface ITableProps<TRow extends object> extends CoreProps {
   columns?: any[];
-  data?: T[];
+  data?: TRow[];
   isLoading?: boolean;
   pagination?: any;
   noDataPlaceholder?: React.ReactNode;
   loadingItems?: number;
   hasMore?: boolean;
-  onRowClick?: (row: Row<T>) => void;
-  onRowSelect?: (row: Row<T>) => void;
+  onRowClick?: (row: Row<TRow>) => void;
+  onRowSelect?: (row: Row<TRow>) => void;
 }
 
 /**
  * Table component
  *
  */
-export function Table<T extends object>({
+export function Table<TRow extends object>({
   columns: userColumns,
   data: userData,
   isLoading = false,
@@ -46,14 +46,14 @@ export function Table<T extends object>({
   onRowClick,
   onRowSelect,
   ...props
-}: ITableProps<T>) {
+}: ITableProps<TRow>) {
   const columns = useMemo(() => userColumns?.map((col) => ({ ...col })), [userColumns]);
   const data = useMemo(() => (userData || [])?.map((row) => ({ ...row })), [userData]);
   const fakeData = useMemo(() => Array.from({ length: loadingItems }).map((_, index) => ({ index })), [loadingItems]);
 
-  const table = useReactTable<T>({
+  const table = useReactTable<TRow>({
     columns,
-    data: isLoading ? (fakeData as T[]) : data,
+    data: isLoading ? (fakeData as TRow[]) : data,
     getCoreRowModel: getCoreRowModel(),
     // FIXME: remove this
     debugTable: true,

--- a/libs/novui/src/components/table/Table.tsx
+++ b/libs/novui/src/components/table/Table.tsx
@@ -55,8 +55,6 @@ export function Table<TRow extends object>({
     columns,
     data: isLoading ? (fakeData as TRow[]) : data,
     getCoreRowModel: getCoreRowModel(),
-    // FIXME: remove this
-    debugTable: true,
   });
 
   return (

--- a/libs/novui/src/components/table/Table.tsx
+++ b/libs/novui/src/components/table/Table.tsx
@@ -1,11 +1,25 @@
 import { Table as ExternalTable } from '@mantine/core';
-import { flexRender, getCoreRowModel, Row, useReactTable } from '@tanstack/react-table';
-import React, { useMemo } from 'react';
+import {
+  CellContext,
+  flexRender,
+  getCoreRowModel,
+  Row,
+  useReactTable,
+  createColumnHelper as _createColumnHelper,
+  ColumnDefTemplate,
+} from '@tanstack/react-table';
+import React, { ComponentType, useMemo } from 'react';
 import { CoreProps } from 'src/types';
 
 import classes from './Table.styles';
 
 export type IRow<T extends object = {}> = Row<T>;
+
+/** Component used to render the contents of a cell */
+export type CellRendererComponent<TRow, TCellValue> = ColumnDefTemplate<CellContext<TRow, TCellValue>>;
+
+/** Helper for type-safe column definitions */
+export const createColumnHelper = _createColumnHelper;
 
 export interface ITableProps<T extends object> extends CoreProps {
   columns?: any[];

--- a/libs/novui/src/components/table/index.ts
+++ b/libs/novui/src/components/table/index.ts
@@ -1,0 +1,2 @@
+export { Table } from './Table';
+export type { IRow, ITableProps } from './Table';

--- a/libs/novui/src/components/table/index.ts
+++ b/libs/novui/src/components/table/index.ts
@@ -1,2 +1,1 @@
-export { Table } from './Table';
-export type { IRow, ITableProps } from './Table';
+export * from './Table';

--- a/libs/novui/src/panda-preset.ts
+++ b/libs/novui/src/panda-preset.ts
@@ -21,6 +21,7 @@ import {
 import { Z_INDEX_TOKENS } from './tokens/zIndex.tokens';
 import { SEMANTIC_SIZES_TOKENS } from './tokens/semanticSizes.tokens';
 import { SEMANTIC_SPACING_TOKENS } from './tokens/semanticSpacing.tokens';
+import { SEMANTIC_RADIUS_TOKENS } from './tokens/semanticRadius.tokens';
 
 /**
  * This defines all Novu tokens into a single preset to be used in our various apps (and design-system).
@@ -63,6 +64,7 @@ export const novuPandaPreset = definePreset({
         ...COLOR_SEMANTIC_TOKENS,
         ...LEGACY_COLOR_SEMANTIC_TOKENS,
       },
+      radii: SEMANTIC_RADIUS_TOKENS,
       shadows: LEGACY_SHADOW_TOKENS,
       gradients: {
         ...GRADIENT_TOKENS,

--- a/libs/novui/src/tokens/semanticColors.tokens.ts
+++ b/libs/novui/src/tokens/semanticColors.tokens.ts
@@ -85,9 +85,29 @@ export const LEGACY_COLOR_SEMANTIC_TOKENS = defineSemanticTokens.colors({
       },
     },
   },
+  badge: {
+    border: {
+      value: { base: '{colors.legacy.B80}', _dark: '{colors.legacy.B30}' },
+      type: 'color',
+    },
+  },
   icon: {
     main: {
       value: { base: '{colors.legacy.B60}', _dark: '{colors.legacy.B60}' },
+      type: 'color',
+    },
+    secondary: {
+      value: { base: '{colors.legacy.B70}', _dark: '{colors.legacy.B40}' },
+      type: 'color',
+    },
+  },
+  status: {
+    active: {
+      value: { base: '{colors.legacy.success}', _dark: '{colors.legacy.success}' },
+      type: 'color',
+    },
+    inactive: {
+      value: { base: '{colors.legacy.B40}', _dark: '{colors.legacy.B40}' },
       type: 'color',
     },
   },

--- a/libs/novui/src/tokens/semanticColors.tokens.ts
+++ b/libs/novui/src/tokens/semanticColors.tokens.ts
@@ -59,6 +59,32 @@ export const LEGACY_COLOR_SEMANTIC_TOKENS = defineSemanticTokens.colors({
       },
     },
   },
+  table: {
+    header: {
+      border: {
+        value: { base: '{colors.legacy.B98}', _dark: '{colors.legacy.B30}' },
+        type: 'color',
+      },
+    },
+    row: {
+      border: {
+        value: { base: '{colors.legacy.B98}', _dark: '{colors.legacy.B20}' },
+        type: 'color',
+      },
+      surface: {
+        hover: {
+          value: { base: '{colors.legacy.B98}', _dark: '{colors.legacy.B20}' },
+          type: 'color',
+        },
+      },
+    },
+    bottom: {
+      border: {
+        value: { base: '{colors.legacy.B98}', _dark: '{colors.legacy.B30}' },
+        type: 'color',
+      },
+    },
+  },
   icon: {
     main: {
       value: { base: '{colors.legacy.B60}', _dark: '{colors.legacy.B60}' },

--- a/libs/novui/src/tokens/semanticRadius.tokens.ts
+++ b/libs/novui/src/tokens/semanticRadius.tokens.ts
@@ -1,0 +1,25 @@
+import { defineSemanticTokens } from '@pandacss/dev';
+
+/**
+ * Represents the size of an element.
+ *
+ * Used for properties like width and height.
+ */
+export const SEMANTIC_RADIUS_TOKENS = defineSemanticTokens.radii({
+  xs: {
+    value: '{radii.50}',
+    type: 'radius',
+  },
+  s: {
+    value: '{radii.75}',
+    type: 'radius',
+  },
+  m: {
+    value: '{radii.100}',
+    type: 'radius',
+  },
+  l: {
+    value: '{radii.150}',
+    type: 'radius',
+  },
+});

--- a/libs/novui/src/tokens/semanticSizes.tokens.ts
+++ b/libs/novui/src/tokens/semanticSizes.tokens.ts
@@ -29,4 +29,17 @@ export const SEMANTIC_SIZES_TOKENS = defineSemanticTokens.sizes({
       type: 'sizes',
     },
   },
+  // From Figma
+  s: {
+    value: '{sizes.200}',
+    type: 'sizes',
+  },
+  m: {
+    value: '{sizes.250}',
+    type: 'sizes',
+  },
+  l: {
+    value: '{sizes.300}',
+    type: 'sizes',
+  },
 });

--- a/libs/novui/src/tokens/semanticSpacing.tokens.ts
+++ b/libs/novui/src/tokens/semanticSpacing.tokens.ts
@@ -15,16 +15,282 @@ export const SEMANTIC_SPACING_TOKENS = defineSemanticTokens.spacing({
       },
     },
   },
-  page: {
-    padding: {
-      value: `{spacing.150}`,
-      description: 'The space around page content',
-      type: 'spacing',
+  paddings: {
+    page: {
+      horizontal: {
+        type: 'spacing',
+        value: '{spacing.150}',
+      },
+      vertical: {
+        type: 'spacing',
+        value: '{spacing.150}',
+      },
     },
-    majorElements: {
-      value: `{spacing.150}`,
-      description: 'The spacing between major elements in a page',
-      type: 'spacing',
+    panel: {
+      horizontal: {
+        type: 'spacing',
+        value: '{spacing.150}',
+      },
+      vertical: {
+        type: 'spacing',
+        value: '{spacing.150}',
+      },
+    },
+    popover: {
+      horizontal: {
+        type: 'spacing',
+        value: '{spacing.150}',
+      },
+      vertical: {
+        type: 'spacing',
+        value: '{spacing.150}',
+      },
+    },
+    node: {
+      horizontal: {
+        type: 'spacing',
+        value: '{spacing.150}',
+      },
+      vertical: {
+        type: 'spacing',
+        value: '{spacing.150}',
+      },
+    },
+    nav: {
+      menu: {
+        horizontal: {
+          type: 'spacing',
+          value: '{spacing.100}',
+        },
+        vertical: {
+          type: 'spacing',
+          value: '{spacing.100}',
+        },
+      },
+      header: {
+        horizontal: {
+          type: 'spacing',
+          value: '{spacing.50}',
+        },
+        vertical: {
+          type: 'spacing',
+          value: '{spacing.50}',
+        },
+      },
+      futer: {
+        top: {
+          type: 'spacing',
+          value: '{spacing.50}',
+        },
+        bottom: {
+          type: 'spacing',
+          value: '{spacing.100}',
+        },
+      },
+    },
+    WF: {
+      WFtop: {
+        type: 'spacing',
+        value: '{spacing.375}',
+      },
+      WFheaderHorizontal: {
+        type: 'spacing',
+        value: '{spacing.100}',
+      },
+      WFhorizontal: {
+        type: 'spacing',
+        value: '{spacing.50}',
+      },
+      MobPreviewTop: {
+        type: 'spacing',
+        value: '{spacing.250}',
+      },
+    },
+    components: {
+      code: {
+        horizontal: {
+          type: 'spacing',
+          value: '{spacing.100}',
+        },
+        vertical: {
+          type: 'spacing',
+          value: '{spacing.25}',
+        },
+      },
+      button: {
+        horizontal: {
+          l: {
+            type: 'spacing',
+            value: '{spacing.125}',
+          },
+          m: {
+            type: 'spacing',
+            value: '{spacing.100}',
+          },
+          s: {
+            type: 'spacing',
+            value: '{spacing.75}',
+          },
+          xs: {
+            type: 'spacing',
+            value: '{spacing.50}',
+          },
+        },
+      },
+      info: {
+        spotlight: {
+          horizontal: {
+            type: 'spacing',
+            value: '{spacing.75}',
+          },
+          vertical: {
+            type: 'spacing',
+            value: '{spacing.75}',
+          },
+        },
+        hint: {
+          horizontal: {
+            type: 'spacing',
+            value: '{spacing.100}',
+          },
+          vertical: {
+            type: 'spacing',
+            value: '{spacing.100}',
+          },
+        },
+      },
+      txtInput: {
+        horizontal: {
+          type: 'spacing',
+          value: '{spacing.75}',
+        },
+      },
+    },
+  },
+  margins: {
+    icons: {
+      'Icon40-txt': {
+        type: 'spacing',
+        value: '{spacing.50}',
+      },
+      'Icon32-txt': {
+        type: 'spacing',
+        value: '{spacing.50}',
+      },
+      'Icon20-txt': {
+        type: 'spacing',
+        value: '{spacing.50}',
+      },
+      'Icon16-txt': {
+        type: 'spacing',
+        value: '{spacing.25}',
+      },
+      'icon20-icon20': {
+        type: 'spacing',
+        value: '{spacing.50}',
+      },
+    },
+    buttons: {
+      'XS-XS': {
+        type: 'spacing',
+        value: '{spacing.25}',
+      },
+      WFchannels: {
+        type: 'spacing',
+        value: '{spacing.50}',
+      },
+      'XS-status': {
+        type: 'spacing',
+        value: '{spacing.100}',
+      },
+      'S-S': {
+        type: 'spacing',
+        value: '{spacing.100}',
+      },
+      'M-M': {
+        type: 'spacing',
+        value: '{spacing.125}',
+      },
+    },
+    layout: {
+      tabs: {
+        'tab-tab': {
+          type: 'spacing',
+          value: '{spacing.150}',
+        },
+        bottom: {
+          type: 'spacing',
+          value: '{spacing.150}',
+        },
+      },
+      text: {
+        'title-body': {
+          type: 'spacing',
+          value: '{spacing.100}',
+        },
+        'sub-title-body': {
+          type: 'spacing',
+          value: '{spacing.50}',
+        },
+        paragraph: {
+          type: 'spacing',
+          value: '{spacing.100}',
+        },
+      },
+      Input: {
+        titleBottom: {
+          type: 'spacing',
+          value: '{spacing.50}',
+        },
+        'input-input': {
+          type: 'spacing',
+          value: '{spacing.200}',
+        },
+      },
+      guideSteps: {
+        type: 'spacing',
+        value: '{spacing.200}',
+      },
+      page: {
+        titleBottom: {
+          type: 'spacing',
+          value: '{spacing.150}',
+        },
+        horizontal: {
+          type: 'spacing',
+          value: '{spacing.250}',
+        },
+        vertical: {
+          type: 'spacing',
+          value: '{spacing.200}',
+        },
+        section: {
+          titleBottom: {
+            type: 'spacing',
+            value: '{spacing.150}',
+          },
+        },
+        'sub-section': {
+          titleBottom: {
+            type: 'spacing',
+            value: '{spacing.100}',
+          },
+        },
+        'content-buttons': {
+          type: 'spacing',
+          value: '{spacing.150}',
+        },
+      },
+    },
+    menu: {
+      'item-item': {
+        type: 'spacing',
+        value: '{spacing.25}',
+      },
+      'sec-sec': {
+        type: 'spacing',
+        value: '{spacing.100}',
+      },
     },
   },
 });

--- a/libs/novui/src/tokens/semanticSpacing.tokens.ts
+++ b/libs/novui/src/tokens/semanticSpacing.tokens.ts
@@ -77,7 +77,7 @@ export const SEMANTIC_SPACING_TOKENS = defineSemanticTokens.spacing({
           value: '{spacing.50}',
         },
       },
-      futer: {
+      footer: {
         top: {
           type: 'spacing',
           value: '{spacing.50}',

--- a/libs/novui/src/tokens/semanticSpacing.tokens.ts
+++ b/libs/novui/src/tokens/semanticSpacing.tokens.ts
@@ -15,4 +15,16 @@ export const SEMANTIC_SPACING_TOKENS = defineSemanticTokens.spacing({
       },
     },
   },
+  page: {
+    padding: {
+      value: `{spacing.150}`,
+      description: 'The space around page content',
+      type: 'spacing',
+    },
+    majorElements: {
+      value: `{spacing.150}`,
+      description: 'The spacing between major elements in a page',
+      type: 'spacing',
+    },
+  },
 });

--- a/libs/novui/src/tokens/sizes.tokens.ts
+++ b/libs/novui/src/tokens/sizes.tokens.ts
@@ -50,8 +50,24 @@ export const SIZES_TOKENS = defineTokens.sizes({
     value: '2.5rem',
     type: 'sizes',
   },
+  '275': {
+    value: '2.75rem',
+    type: 'sizes',
+  },
   '300': {
     value: '3rem',
+    type: 'sizes',
+  },
+  '325': {
+    value: '3.25rem',
+    type: 'sizes',
+  },
+  '350': {
+    value: '3.5rem',
+    type: 'sizes',
+  },
+  '375': {
+    value: '3.75rem',
     type: 'sizes',
   },
 });

--- a/libs/novui/src/tokens/spacing.tokens.ts
+++ b/libs/novui/src/tokens/spacing.tokens.ts
@@ -50,8 +50,24 @@ export const SPACING_TOKENS = defineTokens.spacing({
     value: '2.5rem',
     type: 'spacing',
   },
+  '275': {
+    value: '2.75rem',
+    type: 'spacing',
+  },
   '300': {
     value: '3rem',
+    type: 'spacing',
+  },
+  '325': {
+    value: '3.25rem',
+    type: 'spacing',
+  },
+  '350': {
+    value: '3.5rem',
+    type: 'spacing',
+  },
+  '375': {
+    value: '3.75rem',
     type: 'spacing',
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3192,6 +3192,9 @@ importers:
       '@mantine/hooks':
         specifier: ^7.10.0
         version: 7.10.1(react@18.3.1)
+      '@tanstack/react-table':
+        specifier: ^8.17.3
+        version: 8.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-icons:
         specifier: ^5.0.1
         version: 5.0.1(react@18.3.1)
@@ -4246,7 +4249,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^16.2.5
-        version: 16.2.8(@angular/compiler-cli@16.2.11(@angular/compiler@16.2.11(@angular/core@16.2.11(rxjs@7.8.1)(zone.js@0.13.3)))(typescript@4.9.5))(@swc/core@1.3.107)(@types/node@20.12.12)(html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)))(jest-environment-jsdom@29.5.0)(jest@29.7.0(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(karma@6.4.1)(lightningcss@1.23.0)(ng-packagr@16.2.3(@angular/compiler-cli@16.2.11(@angular/compiler@16.2.11(@angular/core@16.2.11(rxjs@7.8.1)(zone.js@0.13.3)))(typescript@4.9.5))(tailwindcss@3.3.1(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(tslib@2.5.0)(typescript@4.9.5))(sugarss@4.0.1(postcss@8.4.38))(tailwindcss@3.3.1(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(typescript@4.9.5)
+        version: 16.2.8(@angular/compiler-cli@16.2.11(@angular/compiler@16.2.11(@angular/core@16.2.11(rxjs@7.8.1)(zone.js@0.13.3)))(typescript@4.9.5))(@swc/core@1.3.107)(@types/node@20.12.12)(html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.107)))(jest-environment-jsdom@29.5.0)(jest@29.7.0(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(karma@6.4.1)(lightningcss@1.23.0)(ng-packagr@16.2.3(@angular/compiler-cli@16.2.11(@angular/compiler@16.2.11(@angular/core@16.2.11(rxjs@7.8.1)(zone.js@0.13.3)))(typescript@4.9.5))(tailwindcss@3.3.1(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(tslib@2.5.0)(typescript@4.9.5))(sugarss@4.0.1(postcss@8.4.38))(tailwindcss@3.3.1(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(typescript@4.9.5)
       '@angular/cli':
         specifier: ^16.2.5
         version: 16.2.8(chokidar@3.5.3)
@@ -14589,6 +14592,17 @@ packages:
     resolution: {integrity: sha512-BATvtM0rohwg7pRHUnxgeDiwLWRGZ8OM/4y8LImHVpecQWoH6Uhytu3Z8YV6V7hQ1sMQBFcUrGE1/e4MxR6YiA==}
     peerDependencies:
       react: ^18.0.0
+
+  '@tanstack/react-table@8.17.3':
+    resolution: {integrity: sha512-5gwg5SvPD3lNAXPuJJz1fOCEZYk9/GeBFH3w/hCgnfyszOIzwkwgp5I7Q4MJtn0WECp84b5STQUDdmvGi8m3nA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.17.3':
+    resolution: {integrity: sha512-mPBodDGVL+fl6d90wUREepHa/7lhsghg2A3vFpakEhrhtbIlgNAZiMr7ccTgak5qbHqF14Fwy+W1yFWQt+WmYQ==}
+    engines: {node: '>=12'}
 
   '@taskforcesh/bullmq-pro@5.1.14':
     resolution: {integrity: sha512-J/83Q1GTFWbUWn1bpsiX+CcQXktp7ADg/d1oID+wQ8ZwSB2W5l/1FV4yR1BEi3sO+UFEo+rK3qfXQuDml7aBYA==, tarball: https://npm.taskforce.sh/@taskforcesh/bullmq-pro/-/@taskforcesh/bullmq-pro-5.1.14.tgz}
@@ -31476,11 +31490,11 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@16.2.8(@angular/compiler-cli@16.2.11(@angular/compiler@16.2.11(@angular/core@16.2.11(rxjs@7.8.1)(zone.js@0.13.3)))(typescript@4.9.5))(@swc/core@1.3.107)(@types/node@20.12.12)(html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)))(jest-environment-jsdom@29.5.0)(jest@29.7.0(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(karma@6.4.1)(lightningcss@1.23.0)(ng-packagr@16.2.3(@angular/compiler-cli@16.2.11(@angular/compiler@16.2.11(@angular/core@16.2.11(rxjs@7.8.1)(zone.js@0.13.3)))(typescript@4.9.5))(tailwindcss@3.3.1(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(tslib@2.5.0)(typescript@4.9.5))(sugarss@4.0.1(postcss@8.4.38))(tailwindcss@3.3.1(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(typescript@4.9.5)':
+  '@angular-devkit/build-angular@16.2.8(@angular/compiler-cli@16.2.11(@angular/compiler@16.2.11(@angular/core@16.2.11(rxjs@7.8.1)(zone.js@0.13.3)))(typescript@4.9.5))(@swc/core@1.3.107)(@types/node@20.12.12)(html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.107)))(jest-environment-jsdom@29.5.0)(jest@29.7.0(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(karma@6.4.1)(lightningcss@1.23.0)(ng-packagr@16.2.3(@angular/compiler-cli@16.2.11(@angular/compiler@16.2.11(@angular/core@16.2.11(rxjs@7.8.1)(zone.js@0.13.3)))(typescript@4.9.5))(tailwindcss@3.3.1(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(tslib@2.5.0)(typescript@4.9.5))(sugarss@4.0.1(postcss@8.4.38))(tailwindcss@3.3.1(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5)))(typescript@4.9.5)':
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@angular-devkit/architect': 0.1602.8(chokidar@3.5.3)
-      '@angular-devkit/build-webpack': 0.1602.8(chokidar@3.5.3)(webpack-dev-server@4.15.1(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)))(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))
+      '@angular-devkit/build-webpack': 0.1602.8(chokidar@3.5.3)(webpack-dev-server@4.15.1(webpack@5.88.2(@swc/core@1.3.107)))(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))
       '@angular-devkit/core': 16.2.8(chokidar@3.5.3)
       '@angular/compiler-cli': 16.2.11(@angular/compiler@16.2.11(@angular/core@16.2.11(rxjs@7.8.1)(zone.js@0.13.3)))(typescript@4.9.5)
       '@babel/core': 7.22.9
@@ -31541,9 +31555,9 @@ snapshots:
       vite: 4.4.7(@types/node@20.12.12)(less@4.1.3)(lightningcss@1.23.0)(sass@1.64.1)(sugarss@4.0.1(postcss@8.4.38))(terser@5.19.2)
       webpack: 5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)
       webpack-dev-middleware: 6.1.1(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))
-      webpack-dev-server: 4.15.1(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))
+      webpack-dev-server: 4.15.1(webpack@5.88.2(@swc/core@1.3.107))
       webpack-merge: 5.9.0
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)))(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.107)))(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))
     optionalDependencies:
       esbuild: 0.18.17
       jest: 29.7.0(@types/node@20.12.12)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.107)(@types/node@16.11.7)(typescript@4.9.5))
@@ -31569,12 +31583,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1602.8(chokidar@3.5.3)(webpack-dev-server@4.15.1(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)))(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))':
+  '@angular-devkit/build-webpack@0.1602.8(chokidar@3.5.3)(webpack-dev-server@4.15.1(webpack@5.88.2(@swc/core@1.3.107)))(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))':
     dependencies:
       '@angular-devkit/architect': 0.1602.8(chokidar@3.5.3)
       rxjs: 7.8.1
       webpack: 5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)
-      webpack-dev-server: 4.15.1(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))
+      webpack-dev-server: 4.15.1(webpack@5.88.2(@swc/core@1.3.107))
     transitivePeerDependencies:
       - chokidar
 
@@ -32063,8 +32077,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -32490,52 +32504,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0
-      '@aws-sdk/core': 3.575.0
-      '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0))(@aws-sdk/client-sts@3.575.0)
-      '@aws-sdk/middleware-host-header': 3.575.0
-      '@aws-sdk/middleware-logger': 3.575.0
-      '@aws-sdk/middleware-recursion-detection': 3.575.0
-      '@aws-sdk/middleware-user-agent': 3.575.0
-      '@aws-sdk/region-config-resolver': 3.575.0
-      '@aws-sdk/types': 3.575.0
-      '@aws-sdk/util-endpoints': 3.575.0
-      '@aws-sdk/util-user-agent-browser': 3.575.0
-      '@aws-sdk/util-user-agent-node': 3.575.0
-      '@smithy/config-resolver': 3.0.0
-      '@smithy/core': 2.0.0
-      '@smithy/fetch-http-handler': 3.0.0
-      '@smithy/hash-node': 3.0.0
-      '@smithy/invalid-dependency': 3.0.0
-      '@smithy/middleware-content-length': 3.0.0
-      '@smithy/middleware-endpoint': 3.0.0
-      '@smithy/middleware-retry': 3.0.0
-      '@smithy/middleware-serde': 3.0.0
-      '@smithy/middleware-stack': 3.0.0
-      '@smithy/node-config-provider': 3.0.0
-      '@smithy/node-http-handler': 3.0.0
-      '@smithy/protocol-http': 4.0.0
-      '@smithy/smithy-client': 3.0.0
-      '@smithy/types': 3.0.0
-      '@smithy/url-parser': 3.0.0
-      '@smithy/util-base64': 3.0.0
-      '@smithy/util-body-length-browser': 3.0.0
-      '@smithy/util-body-length-node': 3.0.0
-      '@smithy/util-defaults-mode-browser': 3.0.0
-      '@smithy/util-defaults-mode-node': 3.0.0
-      '@smithy/util-endpoints': 2.0.0
-      '@smithy/util-middleware': 3.0.0
-      '@smithy/util-retry': 3.0.0
-      '@smithy/util-utf8': 3.0.0
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sts'
-      - aws-crt
-
   '@aws-sdk/client-sso@3.382.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
@@ -32834,7 +32802,7 @@ snapshots:
       '@aws-crypto/sha256-js': 3.0.0
       '@aws-sdk/client-sso-oidc': 3.575.0
       '@aws-sdk/core': 3.575.0
-      '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0))(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
       '@aws-sdk/middleware-logger': 3.575.0
       '@aws-sdk/middleware-recursion-detection': 3.575.0
@@ -32871,6 +32839,52 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.2
     transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/core': 3.575.0
+      '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0))
+      '@aws-sdk/middleware-host-header': 3.575.0
+      '@aws-sdk/middleware-logger': 3.575.0
+      '@aws-sdk/middleware-recursion-detection': 3.575.0
+      '@aws-sdk/middleware-user-agent': 3.575.0
+      '@aws-sdk/region-config-resolver': 3.575.0
+      '@aws-sdk/types': 3.575.0
+      '@aws-sdk/util-endpoints': 3.575.0
+      '@aws-sdk/util-user-agent-browser': 3.575.0
+      '@aws-sdk/util-user-agent-node': 3.575.0
+      '@smithy/config-resolver': 3.0.0
+      '@smithy/core': 2.0.0
+      '@smithy/fetch-http-handler': 3.0.0
+      '@smithy/hash-node': 3.0.0
+      '@smithy/invalid-dependency': 3.0.0
+      '@smithy/middleware-content-length': 3.0.0
+      '@smithy/middleware-endpoint': 3.0.0
+      '@smithy/middleware-retry': 3.0.0
+      '@smithy/middleware-serde': 3.0.0
+      '@smithy/middleware-stack': 3.0.0
+      '@smithy/node-config-provider': 3.0.0
+      '@smithy/node-http-handler': 3.0.0
+      '@smithy/protocol-http': 4.0.0
+      '@smithy/smithy-client': 3.0.0
+      '@smithy/types': 3.0.0
+      '@smithy/url-parser': 3.0.0
+      '@smithy/util-base64': 3.0.0
+      '@smithy/util-body-length-browser': 3.0.0
+      '@smithy/util-body-length-node': 3.0.0
+      '@smithy/util-defaults-mode-browser': 3.0.0
+      '@smithy/util-defaults-mode-node': 3.0.0
+      '@smithy/util-endpoints': 2.0.0
+      '@smithy/util-middleware': 3.0.0
+      '@smithy/util-retry': 3.0.0
+      '@smithy/util-utf8': 3.0.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.496.0':
@@ -33006,13 +33020,13 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0))(@aws-sdk/client-sts@3.575.0)':
+  '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0))':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
-      '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0))
-      '@aws-sdk/credential-provider-web-identity': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/credential-provider-web-identity': 3.575.0(@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0))
       '@aws-sdk/types': 3.575.0
       '@smithy/credential-provider-imds': 3.0.0
       '@smithy/property-provider': 3.0.0
@@ -33090,14 +33104,14 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@aws-sdk/credential-provider-node@3.575.0(@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0))(@aws-sdk/client-sts@3.575.0)':
+  '@aws-sdk/credential-provider-node@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0))':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-http': 3.575.0
-      '@aws-sdk/credential-provider-ini': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0))(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/credential-provider-ini': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0))
       '@aws-sdk/credential-provider-process': 3.575.0
-      '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0))
-      '@aws-sdk/credential-provider-web-identity': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/credential-provider-web-identity': 3.575.0(@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0))
       '@aws-sdk/types': 3.575.0
       '@smithy/credential-provider-imds': 3.0.0
       '@smithy/property-provider': 3.0.0
@@ -33199,19 +33213,6 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@aws-sdk/credential-provider-sso@3.575.0(@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0))':
-    dependencies:
-      '@aws-sdk/client-sso': 3.575.0
-      '@aws-sdk/token-providers': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0))
-      '@aws-sdk/types': 3.575.0
-      '@smithy/property-provider': 3.0.0
-      '@smithy/shared-ini-file-loader': 3.0.0
-      '@smithy/types': 3.0.0
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
-
   '@aws-sdk/credential-provider-sso@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
       '@aws-sdk/client-sso': 3.575.0
@@ -33250,6 +33251,14 @@ snapshots:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
     optional: true
+
+  '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0))':
+    dependencies:
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/types': 3.575.0
+      '@smithy/property-provider': 3.0.0
+      '@smithy/types': 3.0.0
+      tslib: 2.6.2
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
@@ -33674,15 +33683,6 @@ snapshots:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
     optional: true
-
-  '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0))':
-    dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
-      '@aws-sdk/types': 3.575.0
-      '@smithy/property-provider': 3.0.0
-      '@smithy/shared-ini-file-loader': 3.0.0
-      '@smithy/types': 3.0.0
-      tslib: 2.6.2
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
@@ -41863,7 +41863,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.1.0
       typescript: 5.1.6
-      webpack: 5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)
+      webpack: 5.88.2(@swc/core@1.3.107)
       webpack-node-externals: 3.0.0
     optionalDependencies:
       '@swc/core': 1.3.107(@swc/helpers@0.5.2)
@@ -46169,7 +46169,7 @@ snapshots:
       rollup: 2.78.0
       stacktrace-parser: 0.1.10
     optionalDependencies:
-      webpack: 5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)
+      webpack: 5.88.2(@swc/core@1.3.107)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -50227,6 +50227,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.36.0
       react: 18.2.0
+
+  '@tanstack/react-table@8.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/table-core': 8.17.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/table-core@8.17.3': {}
 
   '@taskforcesh/bullmq-pro@5.1.14':
     dependencies:
@@ -57394,7 +57402,7 @@ snapshots:
       lodash: 4.17.21
       resolve: 2.0.0-next.4
       semver: 5.7.2
-      webpack: 5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)
+      webpack: 5.88.2(@swc/core@1.3.107)
     transitivePeerDependencies:
       - supports-color
 
@@ -58590,7 +58598,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)
+      webpack: 5.88.2(@swc/core@1.3.107)
     optional: true
 
   file-selector@0.6.0:
@@ -58921,7 +58929,7 @@ snapshots:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 5.1.6
-      webpack: 5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)
+      webpack: 5.88.2(@swc/core@1.3.107)
 
   form-data@2.3.3:
     dependencies:
@@ -60112,7 +60120,7 @@ snapshots:
       tapable: 2.2.1
       webpack: 5.78.0(@swc/core@1.3.107)
 
-  html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)):
+  html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.107)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -72589,7 +72597,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.3.107(@swc/helpers@0.5.2)
 
-  terser-webpack-plugin@5.3.9(@swc/core@1.3.107)(esbuild@0.18.17)(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)):
+  terser-webpack-plugin@5.3.9(@swc/core@1.3.107)(esbuild@0.18.17)(webpack@5.88.2(@swc/core@1.3.107)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.18
       jest-worker: 27.5.1
@@ -72631,6 +72639,17 @@ snapshots:
       serialize-javascript: 6.0.1
       terser: 5.16.9
       webpack: 5.82.1(@swc/core@1.3.107)(webpack-cli@5.1.4)
+    optionalDependencies:
+      '@swc/core': 1.3.107(@swc/helpers@0.5.2)
+
+  terser-webpack-plugin@5.3.9(@swc/core@1.3.107)(webpack@5.88.2(@swc/core@1.3.107)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.18
+      jest-worker: 27.5.1
+      schema-utils: 3.1.2
+      serialize-javascript: 6.0.1
+      terser: 5.16.9
+      webpack: 5.88.2(@swc/core@1.3.107)
     optionalDependencies:
       '@swc/core': 1.3.107(@swc/helpers@0.5.2)
 
@@ -73155,7 +73174,7 @@ snapshots:
       micromatch: 4.0.5
       semver: 7.5.2
       typescript: 4.9.5
-      webpack: 5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)
+      webpack: 5.88.2(@swc/core@1.3.107)
 
   ts-morph@12.0.0:
     dependencies:
@@ -74043,7 +74062,7 @@ snapshots:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)
+      webpack: 5.88.2(@swc/core@1.3.107)
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.88.2(@swc/core@1.3.107))
 
@@ -74470,7 +74489,7 @@ snapshots:
       less: 4.1.3
       lightningcss: 1.23.0
       sass: 1.64.1
-      sugarss: 4.0.1(postcss@8.4.38)
+      sugarss: 4.0.1(postcss@8.4.31)
       terser: 5.22.0
 
   vite@4.5.2(@types/node@18.16.9)(less@4.1.3)(lightningcss@1.23.0)(sass@1.64.1)(sugarss@4.0.1(postcss@8.4.38))(terser@5.22.0):
@@ -74498,7 +74517,7 @@ snapshots:
       less: 4.1.3
       lightningcss: 1.23.0
       sass: 1.64.1
-      sugarss: 4.0.1(postcss@8.4.38)
+      sugarss: 4.0.1(postcss@8.4.31)
       terser: 5.22.0
 
   vite@5.1.7(@types/node@12.20.55)(less@4.1.3)(lightningcss@1.23.0)(sass@1.64.1)(sugarss@4.0.1(postcss@8.4.31))(terser@5.22.0):
@@ -74540,7 +74559,7 @@ snapshots:
       less: 4.1.3
       lightningcss: 1.23.0
       sass: 1.64.1
-      sugarss: 4.0.1(postcss@8.4.38)
+      sugarss: 4.0.1(postcss@8.4.31)
       terser: 5.22.0
 
   vite@5.1.7(@types/node@20.12.12)(less@4.1.3)(lightningcss@1.23.0)(sass@1.64.1)(sugarss@4.0.1(postcss@8.4.38))(terser@5.22.0):
@@ -74847,7 +74866,7 @@ snapshots:
       schema-utils: 4.0.0
       webpack: 5.78.0(@swc/core@1.3.107)
 
-  webpack-dev-middleware@5.3.3(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)):
+  webpack-dev-middleware@5.3.3(webpack@5.88.2(@swc/core@1.3.107)):
     dependencies:
       colorette: 2.0.19
       memfs: 3.5.0
@@ -74972,7 +74991,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@4.15.1(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)):
+  webpack-dev-server@4.15.1(webpack@5.88.2(@swc/core@1.3.107)):
     dependencies:
       '@types/bonjour': 3.5.10
       '@types/connect-history-api-fallback': 1.3.5
@@ -75002,7 +75021,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))
+      webpack-dev-middleware: 5.3.3(webpack@5.88.2(@swc/core@1.3.107))
       ws: 8.13.0
     optionalDependencies:
       webpack: 5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)
@@ -75054,12 +75073,12 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)))(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.5.3(webpack@5.88.2(@swc/core@1.3.107)))(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.88.2(@swc/core@1.3.107)(esbuild@0.18.17)
     optionalDependencies:
-      html-webpack-plugin: 5.5.3(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))
+      html-webpack-plugin: 5.5.3(webpack@5.88.2(@swc/core@1.3.107))
 
   webpack-virtual-modules@0.5.0: {}
 
@@ -75255,6 +75274,37 @@ snapshots:
       - esbuild
       - uglify-js
 
+  webpack@5.88.2(@swc/core@1.3.107):
+    dependencies:
+      '@types/eslint-scope': 3.7.4
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.11.5
+      '@webassemblyjs/wasm-edit': 1.11.5
+      '@webassemblyjs/wasm-parser': 1.11.5
+      acorn: 8.11.3
+      acorn-import-assertions: 1.9.0(acorn@8.11.3)
+      browserslist: 4.23.0
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.2.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.107)(webpack@5.88.2(@swc/core@1.3.107))
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
   webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17):
     dependencies:
       '@types/eslint-scope': 3.7.4
@@ -75278,7 +75328,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.107)(esbuild@0.18.17)(webpack@5.88.2(@swc/core@1.3.107)(esbuild@0.18.17))
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.107)(esbuild@0.18.17)(webpack@5.88.2(@swc/core@1.3.107))
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

- Create table in `novui` with newest version of react-table
  - Add stories
- Add design tokens from Figma
  - _Note: I'm not thrilled with how some of them are done, but I've kept them as-is to match Figma for the time being_
- Setup test example of new Workflows page in `web`

### Validation

1. Run `pnpm storybook` in `novui` and look for Table
2. Visit https://deploy-preview-5682--dev-web-novu.netlify.app/studio/flows to see in web

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

![Screenshot 2024-06-06 at 11 22 56 AM](https://github.com/novuhq/novu/assets/47441786/fb32bff9-fdcc-4f62-8be5-686aa97e0073)
![Screenshot 2024-06-06 at 11 25 47 AM](https://github.com/novuhq/novu/assets/47441786/8fcc1b7f-aad8-4089-870f-1303cb0588d0)
