### PR TITLE
Leverage PNPM deploy

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -130,5 +130,10 @@
     "*.{js,jsx,ts,tsx}": [
       "eslint"
     ]
-  }
+  },
+  "files": [
+    "dist",
+    "nest-cli.json",
+    "package.json"
+  ]
 }

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "declaration": true,
     "noImplicitAny": false,
     "removeComments": true,
     "allowSyntheticDefaultImports": true,
@@ -15,7 +14,9 @@
     "skipLibCheck": true,
     "outDir": "./dist",
     "baseUrl": "./src",
-    "types": ["node", "mocha"]
+    "types": ["node", "mocha"],
+    "declarationMap": false,
+    "declaration": false
   },
   "include": [".eslintrc.js", "src/**/*", "src/**/*.d.ts"],
   "exclude": ["node_modules", "**/*.spec.ts", "**/*.e2e.ts", "**/*.e2e-ee.ts"]

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -10,7 +10,8 @@
     "target": "es2017",
     "allowJs": false,
     "esModuleInterop": false,
-    "declarationMap": true,
+    "declarationMap": false,
+    "declaration": false,
     "skipLibCheck": true
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
### What changed? Why was the change needed?
After building apps, use [PNPM deploy](https://pnpm.io/cli/deploy) to generate much smaller docker images and simplify the CICD pipeline.

The idea is that all libs and apps should be built once in a single Docker build image, then `pnpm deploy` should be invoked for all the apps, and the output folder should be copied into separate Docker runners as part of a multi-stage build setup. For example, `pnpm --filter @novu/api --prod deploy deployed_api`

Benefits:
1. Smaller docker images. Currently, the generated docker images are ~1.5GB; this should reduce their size by 30-40%.
2. Simpler CICD, as there is no need to replicate the mono repo structure inside the docker running container. No more `pnpm-content`!


### Next steps
- [ ] Remove all dev dependencies from node_modules (see screenshot below)
- [ ] Consolidate duplicate node_modules versions (see screenshot below)
- [ ] See if leveraging [Nest.js libraries](https://docs.nestjs.com/cli/libraries) on application-generic helps further - We already do this with @novu/dal.
- [ ] Remove all .env files from dist and replace them with default values in the code.
- [ ] Repeat for all Nest.js apps

### Screenshots

#### Total node_module folder size
<img width="269" alt="Screenshot 2024-06-10 at 23 35 59" src="https://github.com/novuhq/novu/assets/1352422/eb7464bf-1f64-40aa-8698-84d487cceb24">

#### Further low hanging fruit improvements to further reduce the folder size
<img width="1050" alt="Screenshot 2024-06-10 at 23 53 06" src="https://github.com/novuhq/novu/assets/1352422/28a5bae6-d76c-469c-994a-c7d637150064">
