### PR TITLE
build(echo): Bundle only cjs and remove esm build

### DIFF
--- a/packages/echo/package.json
+++ b/packages/echo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/echo",
-  "version": "0.24.3-alpha.2",
+  "version": "0.24.3-alpha.3",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -47,37 +47,37 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
     "./express": {
       "require": "./dist/express.js",
-      "import": "./dist/express.mjs",
+      "import": "./dist/express.js",
       "types": "./dist/express.d.ts"
     },
     "./next": {
       "require": "./dist/next.js",
-      "import": "./dist/next.mjs",
+      "import": "./dist/next.js",
       "types": "./dist/next.d.ts"
     },
     "./nuxt": {
       "require": "./dist/nuxt.js",
-      "import": "./dist/nuxt.mjs",
+      "import": "./dist/nuxt.js",
       "types": "./dist/nuxt.d.ts"
     },
     "./h3": {
       "require": "./dist/h3.js",
-      "import": "./dist/h3.mjs",
+      "import": "./dist/h3.js",
       "types": "./dist/h3.d.ts"
     },
     "./sveltekit": {
       "require": "./dist/sveltekit.js",
-      "import": "./dist/sveltekit.mjs",
+      "import": "./dist/sveltekit.js",
       "types": "./dist/sveltekit.d.ts"
     },
     "./remix": {
       "require": "./dist/remix.js",
-      "import": "./dist/remix.mjs",
+      "import": "./dist/remix.js",
       "types": "./dist/remix.d.ts"
     }
   },

--- a/packages/echo/tsup.config.ts
+++ b/packages/echo/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   clean: true,
   treeshake: true,
   dts: true,
-  format: ['cjs', 'esm'],
+  format: ['cjs'],
   minify: true,
   minifyWhitespace: true,
   minifyIdentifiers: true,


### PR DESCRIPTION
### What changed? Why was the change needed?
* Remove ESM bundling as it is causing Next.js hot-reload issues. Defer to using CJS for all module environments. See error below. Both with/without chunking, ESM still has hot-reload issues. We will need to address the addition of ESM bundling at a later date.

### Details
<!-- If the changes are visual, include screenshots or screencasts. -->

**Testing**
_Next.js_
```bash
> curl -v http://localhost:4000/api/echo\?action\=health-check
*   Trying 127.0.0.1:4000...
* Connected to localhost (127.0.0.1) port 4000 (#0)
> GET /api/echo?action=health-check HTTP/1.1
> Host: localhost:4000
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< vary: RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Url
< access-control-allow-headers: *
< access-control-allow-methods: GET, POST
< access-control-allow-origin: *
< content-type: application/json
< user-agent: novu-echo:v0.24.3-alpha.3
< x-echo-framework: next
< x-echo-sdk: novu-echo:v0.24.3-alpha.3
< Date: Thu, 13 Jun 2024 15:01:32 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< Transfer-Encoding: chunked
<
* Connection #0 to host localhost left intact
{"status":"ok","version":"0.24.3-alpha.3","discovered":{"workflows":1,"steps":2}}%
```

_Remix_
```bash
> curl -v http://localhost:5173/api/echo\?action\=health-check
*   Trying 127.0.0.1:5173...
* connect to 127.0.0.1 port 5173 failed: Connection refused
*   Trying [::1]:5173...
* Connected to localhost (::1) port 5173 (#0)
> GET /api/echo?action=health-check HTTP/1.1
> Host: localhost:5173
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< access-control-allow-origin: *
< access-control-allow-headers: *
< access-control-allow-methods: GET, POST
< content-type: application/json
< user-agent: novu-echo:v0.24.3-alpha.3
< x-echo-framework: remix
< x-echo-sdk: novu-echo:v0.24.3-alpha.3
< Date: Thu, 13 Jun 2024 14:58:37 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< Transfer-Encoding: chunked
<
* Connection #0 to host localhost left intact
{"status":"ok","version":"0.24.3-alpha.3","discovered":{"workflows":1,"steps":3}}%
```

_Svelte_
```bash
> curl -v http://localhost:5173/api/echo\?action\=health-check
*   Trying 127.0.0.1:5173...
* connect to 127.0.0.1 port 5173 failed: Connection refused
*   Trying [::1]:5173...
* Connected to localhost (::1) port 5173 (#0)
> GET /api/echo?action=health-check HTTP/1.1
> Host: localhost:5173
> User-Agent: curl/8.1.2
> Accept: */*
>
< HTTP/1.1 200 OK
< access-control-allow-origin: *
< access-control-allow-headers: *
< access-control-allow-methods: GET, POST
< content-type: application/json
< user-agent: novu-echo:v0.24.3-alpha.3
< x-echo-framework: sveltekit
< x-echo-sdk: novu-echo:v0.24.3-alpha.3
< Date: Thu, 13 Jun 2024 14:59:54 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< Transfer-Encoding: chunked
<
* Connection #0 to host localhost left intact
{"status":"ok","version":"0.24.3-alpha.3","discovered":{"workflows":1,"steps":3}}%
```

**Bug**
_Observed Next.js hot-reload error_
The following stacktrace was observed when using ESM bundled `@novu/echo` with `next@14.2.3`:
```bash
GET /favicon.ico 200 in 3ms
⨯ TypeError: Cannot read properties of undefined (reading 'length')
   at installChunk (/Users/rifont/git/my-novu-bun-app/.next/server/webpack-runtime.js:188:41)
   at __webpack_require__.f.require (/Users/rifont/git/my-novu-bun-app/.next/server/webpack-runtime.js:198:15)
   at /Users/rifont/git/my-novu-bun-app/.next/server/webpack-runtime.js:116:40
   at Array.reduce (<anonymous>)
   at __webpack_require__.e (/Users/rifont/git/my-novu-bun-app/.next/server/webpack-runtime.js:115:67)
   at Array.map (<anonymous>)
   at __webpack_require__.X (/Users/rifont/git/my-novu-bun-app/.next/server/webpack-runtime.js:162:22)
   at /Users/rifont/git/my-novu-bun-app/.next/server/app/api/echo/route.js:260:47
   at Object.<anonymous> (/Users/rifont/git/my-novu-bun-app/.next/server/app/api/echo/route.js:263:3)
   at Module._compile (node:internal/modules/cjs/loader:1358:14)
   at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
   at Module.load (node:internal/modules/cjs/loader:1208:32)
   at Module._load (node:internal/modules/cjs/loader:1024:12)
   at Module.require (node:internal/modules/cjs/loader:1233:19)
   at mod.require (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/require-hook.js:65:28)
   at require (node:internal/modules/helpers:179:18)
   at requirePage (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/require.js:109:84)
   at /Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/load-components.js:98:84
   at async loadComponentsImpl (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/load-components.js:98:26)
   at async DevServer.findPageComponentsImpl (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/next-server.js:710:36)
   at async DevServer.findPageComponents (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/dev/next-dev-server.js:577:20)
   at async DevServer.renderPageComponent (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/base-server.js:1910:24)
   at async DevServer.renderToResponseImpl (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/base-server.js:1962:32)
   at async DevServer.pipeImpl (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/base-server.js:920:25)
   at async NextNodeServer.handleCatchallRenderRequest (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/next-server.js:272:17)
   at async DevServer.handleRequestImpl (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/base-server.js:816:17)
   at async /Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/dev/next-dev-server.js:339:20
   at async Span.traceAsyncFn (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/trace/trace.js:154:20)
   at async DevServer.handleRequest (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/dev/next-dev-server.js:336:24)
   at async invokeRender (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/lib/router-server.js:174:21)
   at async handleRequest (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/lib/router-server.js:353:24)
   at async requestHandlerImpl (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/lib/router-server.js:377:13)
   at async Server.requestListener (/Users/rifont/git/my-novu-bun-app/node_modules/next/dist/server/lib/start-server.js:141:13) {
 page: '/api/echo'
```
Expand below for the responsible hot-reload script that is failing, line 188 with code `for(var i = 0; i < chunkIds.length; i++)` (`chunkIds` is undefined)
<details>
<summary><strong>Expand for optional sections</strong></summary>

```javascript
/*
 * ATTENTION: An "eval-source-map" devtool has been used.
 * This devtool is neither made for production nor for readable output files.
 * It uses "eval()" calls to create a separate source file with attached SourceMaps in the browser devtools.
 * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
 * or disable the default devtool with "devtool: false".
 * If you are looking for production-ready output files, see mode: "production" (https://webpack.js.org/configuration/mode/).
 */
/******/ (() => { // webpackBootstrap
/******/ 	"use strict";
/******/ 	var __webpack_modules__ = ({});
/************************************************************************/
/******/ 	// The module cache
/******/ 	var __webpack_module_cache__ = {};
/******/ 	
/******/ 	// The require function
/******/ 	function __webpack_require__(moduleId) {
/******/ 		// Check if module is in cache
/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
/******/ 		if (cachedModule !== undefined) {
/******/ 			return cachedModule.exports;
/******/ 		}
/******/ 		// Create a new module (and put it into the cache)
/******/ 		var module = __webpack_module_cache__[moduleId] = {
/******/ 			id: moduleId,
/******/ 			loaded: false,
/******/ 			exports: {}
/******/ 		};
/******/ 	
/******/ 		// Execute the module function
/******/ 		var threw = true;
/******/ 		try {
/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __webpack_require__);
/******/ 			threw = false;
/******/ 		} finally {
/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
/******/ 		}
/******/ 	
/******/ 		// Flag the module as loaded
/******/ 		module.loaded = true;
/******/ 	
/******/ 		// Return the exports of the module
/******/ 		return module.exports;
/******/ 	}
/******/ 	
/******/ 	// expose the modules object (__webpack_modules__)
/******/ 	__webpack_require__.m = __webpack_modules__;
/******/ 	
/************************************************************************/
/******/ 	/* webpack/runtime/amd options */
/******/ 	(() => {
/******/ 		__webpack_require__.amdO = {};
/******/ 	})();
/******/ 	
/******/ 	/* webpack/runtime/compat get default export */
/******/ 	(() => {
/******/ 		// getDefaultExport function for compatibility with non-harmony modules
/******/ 		__webpack_require__.n = (module) => {
/******/ 			var getter = module && module.__esModule ?
/******/ 				() => (module['default']) :
/******/ 				() => (module);
/******/ 			__webpack_require__.d(getter, { a: getter });
/******/ 			return getter;
/******/ 		};
/******/ 	})();
/******/ 	
/******/ 	/* webpack/runtime/create fake namespace object */
/******/ 	(() => {
/******/ 		var getProto = Object.getPrototypeOf ? (obj) => (Object.getPrototypeOf(obj)) : (obj) => (obj.__proto__);
/******/ 		var leafPrototypes;
/******/ 		// create a fake namespace object
/******/ 		// mode & 1: value is a module id, require it
/******/ 		// mode & 2: merge all properties of value into the ns
/******/ 		// mode & 4: return value when already ns object
/******/ 		// mode & 16: return value when it's Promise-like
/******/ 		// mode & 8|1: behave like require
/******/ 		__webpack_require__.t = function(value, mode) {
/******/ 			if(mode & 1) value = this(value);
/******/ 			if(mode & 8) return value;
/******/ 			if(typeof value === 'object' && value) {
/******/ 				if((mode & 4) && value.__esModule) return value;
/******/ 				if((mode & 16) && typeof value.then === 'function') return value;
/******/ 			}
/******/ 			var ns = Object.create(null);
/******/ 			__webpack_require__.r(ns);
/******/ 			var def = {};
/******/ 			leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
/******/ 			for(var current = mode & 2 && value; typeof current == 'object' && !~leafPrototypes.indexOf(current); current = getProto(current)) {
/******/ 				Object.getOwnPropertyNames(current).forEach((key) => (def[key] = () => (value[key])));
/******/ 			}
/******/ 			def['default'] = () => (value);
/******/ 			__webpack_require__.d(ns, def);
/******/ 			return ns;
/******/ 		};
/******/ 	})();
/******/ 	
/******/ 	/* webpack/runtime/define property getters */
/******/ 	(() => {
/******/ 		// define getter functions for harmony exports
/******/ 		__webpack_require__.d = (exports, definition) => {
/******/ 			for(var key in definition) {
/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
/******/ 				}
/******/ 			}
/******/ 		};
/******/ 	})();
/******/ 	
/******/ 	/* webpack/runtime/ensure chunk */
/******/ 	(() => {
/******/ 		__webpack_require__.f = {};
/******/ 		// This file contains only the entry chunk.
/******/ 		// The chunk loading function for additional chunks
/******/ 		__webpack_require__.e = (chunkId) => {
/******/ 			return Promise.all(Object.keys(__webpack_require__.f).reduce((promises, key) => {
/******/ 				__webpack_require__.f[key](chunkId, promises);
/******/ 				return promises;
/******/ 			}, []));
/******/ 		};
/******/ 	})();
/******/ 	
/******/ 	/* webpack/runtime/get javascript chunk filename */
/******/ 	(() => {
/******/ 		// This function allow to reference async chunks and sibling chunks for the entrypoint
/******/ 		__webpack_require__.u = (chunkId) => {
/******/ 			// return url for filenames based on template
/******/ 			return "" + chunkId + ".js";
/******/ 		};
/******/ 	})();
/******/ 	
/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
/******/ 	(() => {
/******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
/******/ 	})();
/******/ 	
/******/ 	/* webpack/runtime/make namespace object */
/******/ 	(() => {
/******/ 		// define __esModule on exports
/******/ 		__webpack_require__.r = (exports) => {
/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
/******/ 			}
/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
/******/ 		};
/******/ 	})();
/******/ 	
/******/ 	/* webpack/runtime/node module decorator */
/******/ 	(() => {
/******/ 		__webpack_require__.nmd = (module) => {
/******/ 			module.paths = [];
/******/ 			if (!module.children) module.children = [];
/******/ 			return module;
/******/ 		};
/******/ 	})();
/******/ 	
/******/ 	/* webpack/runtime/startup entrypoint */
/******/ 	(() => {
/******/ 		__webpack_require__.X = (result, chunkIds, fn) => {
/******/ 			// arguments: chunkIds, moduleId are deprecated
/******/ 			var moduleId = chunkIds;
/******/ 			if(!fn) chunkIds = result, fn = () => (__webpack_require__(__webpack_require__.s = moduleId));
/******/ 			chunkIds.map(__webpack_require__.e, __webpack_require__)
/******/ 			var r = fn();
/******/ 			return r === undefined ? result : r;
/******/ 		}
/******/ 	})();
/******/ 	
/******/ 	/* webpack/runtime/require chunk loading */
/******/ 	(() => {
/******/ 		// no baseURI
/******/ 		
/******/ 		// object to store loaded chunks
/******/ 		// "1" means "loaded", otherwise not loaded yet
/******/ 		var installedChunks = {
/******/ 			"webpack-runtime": 1
/******/ 		};
/******/ 		
/******/ 		// no on chunks loaded
/******/ 		
/******/ 		var installChunk = (chunk) => {
/******/ 			var moreModules = chunk.modules, chunkIds = chunk.ids, runtime = chunk.runtime;
/******/ 			for(var moduleId in moreModules) {
/******/ 				if(__webpack_require__.o(moreModules, moduleId)) {
/******/ 					__webpack_require__.m[moduleId] = moreModules[moduleId];
/******/ 				}
/******/ 			}
/******/ 			if(runtime) runtime(__webpack_require__);
/******/ 			for(var i = 0; i < chunkIds.length; i++)
/******/ 				installedChunks[chunkIds[i]] = 1;
/******/ 		
/******/ 		};
/******/ 		
/******/ 		// require() chunk loading for javascript
/******/ 		__webpack_require__.f.require = (chunkId, promises) => {
/******/ 			// "1" is the signal for "already loaded"
/******/ 			if(!installedChunks[chunkId]) {
/******/ 				if("webpack-runtime" != chunkId) {
/******/ 					installChunk(require("./" + __webpack_require__.u(chunkId)));
/******/ 				} else installedChunks[chunkId] = 1;
/******/ 			}
/******/ 		};
/******/ 		
/******/ 		module.exports = __webpack_require__;
/******/ 		__webpack_require__.C = installChunk;
/******/ 		
/******/ 		// no HMR
/******/ 		
/******/ 		// no HMR manifest
/******/ 	})();
/******/ 	
/************************************************************************/
/******/ 	
/******/ 	
/******/ })()
;
```

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
