### PR TITLE
feat(echo): introduce options method for cors config with nextjs

### DIFF
--- a/packages/echo/src/constants/http-methods.constants.ts
+++ b/packages/echo/src/constants/http-methods.constants.ts
@@ -1,4 +1,5 @@
 export enum HttpMethodEnum {
   POST = 'POST',
   GET = 'GET',
+  OPTIONS = 'OPTIONS',
 }

--- a/packages/echo/src/handler.ts
+++ b/packages/echo/src/handler.ts
@@ -156,6 +156,16 @@ export class EchoRequestHandler<Input extends any[] = any[], Output = any> {
       if (method === HttpMethodEnum.GET) {
         return await this.handleGetAction(action, getActionMap);
       }
+
+      if (method === HttpMethodEnum.OPTIONS) {
+        return this.createResponse(
+          HttpStatusEnum.OK,
+          {},
+          {
+            ...this.getStaticHeaders(),
+          }
+        );
+      }
     } catch (error) {
       return this.handleError(error);
     }

--- a/packages/echo/src/next.ts
+++ b/packages/echo/src/next.ts
@@ -180,10 +180,12 @@ export const serve = (options: ServeHandlerOptions): any => {
     GET: { value: baseHandler.bind(null, 'GET') },
     POST: { value: baseHandler.bind(null, 'POST') },
     PUT: { value: baseHandler.bind(null, 'PUT') },
+    OPTIONS: { value: baseHandler.bind(null, 'OPTIONS') },
   }) as HandlerFunction & {
     GET: HandlerFunction;
     POST: HandlerFunction;
     PUT: HandlerFunction;
+    OPTIONS: HandlerFunction;
   };
 
   return handlerFunctions;


### PR DESCRIPTION
## Why?
This is needed to support CORS config with Next.js, and other frameworks when the v2 studio attempts to communicate with the handler. 