### PR TITLE
test(api): Remove create-usage-records feature flag tests

### DIFF
--- a/apps/api/src/app/testing/billing/create-usage-records.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/create-usage-records.e2e-ee.ts
@@ -39,7 +39,6 @@ describe('CreateUsageRecords', () => {
   const upsertSubscriptionUsecase = { execute: () => Promise.resolve() };
   const getCustomerUsecase = { execute: () => Promise.resolve() };
   const getPlatformNotificationUsageUsecase = { execute: () => Promise.resolve() };
-  const getFeatureFlagUsecase = { execute: () => true };
 
   let createUsageRecordStub: sinon.SinonStub;
   const getOrganizationAdminUserStub = {
@@ -50,7 +49,6 @@ describe('CreateUsageRecords', () => {
     },
   };
   let getPlatformNotificationUsageStub: sinon.SinonStub;
-  let getFeatureFlagStub: sinon.SinonStub;
   let upsertSubscriptionStub: sinon.SinonStub;
   let getCustomerStub: sinon.SinonStub;
 
@@ -66,7 +64,6 @@ describe('CreateUsageRecords', () => {
         notificationsCount: 100,
       },
     ] as any);
-    getFeatureFlagStub = sinon.stub(getFeatureFlagUsecase, 'execute').resolves(true);
     upsertSubscriptionStub = sinon.stub(upsertSubscriptionUsecase, 'execute').resolves({
       licensed: mockMonthlyBusinessSubscription,
       metered: mockMonthlyBusinessSubscription,
@@ -88,7 +85,6 @@ describe('CreateUsageRecords', () => {
     getCustomerStub.reset();
     upsertSubscriptionStub.reset();
     getPlatformNotificationUsageStub.reset();
-    getFeatureFlagStub.reset();
     analyticsServiceStub.track.reset();
   });
 
@@ -98,7 +94,6 @@ describe('CreateUsageRecords', () => {
       getCustomerUsecase,
       upsertSubscriptionUsecase,
       getPlatformNotificationUsageUsecase,
-      getFeatureFlagUsecase,
       analyticsServiceStub,
       getOrganizationAdminUserStub
     );
@@ -125,19 +120,6 @@ describe('CreateUsageRecords', () => {
         endDate: expectedEndDate,
       },
     ]);
-  });
-
-  it('should not get the customer if the feature flag is disabled', async () => {
-    getFeatureFlagStub.resolves(false);
-    const useCase = createUseCase();
-
-    await useCase.execute(
-      CreateUsageRecordsCommand.create({
-        startDate: new Date(),
-      })
-    );
-
-    expect(getCustomerStub.callCount).to.equal(0);
   });
 
   it('should upsert a free-tier subscription if the customer has no subscriptions', async () => {


### PR DESCRIPTION
### What changed? Why was the change needed?
* The tests were failing due to removal of the feature flag logic. This change removes those tests which validated the feature flag off logic.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
