### PR TITLE
chore(root): Temporarily disable web e2e tests in dev environment

### DIFF
--- a/.github/workflows/dev-deploy-web.yml
+++ b/.github/workflows/dev-deploy-web.yml
@@ -16,14 +16,15 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  test_web:
-    uses: ./.github/workflows/reusable-web-e2e.yml
-    with:
-      ee: true
-    secrets: inherit
+  # Temporarily disabled until 2024-07-01 or when the new EnvironmentSelect flakiness is addressed
+  # test_web:
+  #   uses: ./.github/workflows/reusable-web-e2e.yml
+  #   with:
+  #     ee: true
+  #   secrets: inherit
 
   deploy_web:
-    needs: test_web
+    # needs: test_web
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     uses: ./.github/workflows/reusable-web-deploy.yml
     with:


### PR DESCRIPTION
### What changed? Why was the change needed?
- Temporarily disabled until 2024-07-01 or when the new EnvironmentSelect flakiness is addressed. 
- Allow CI deployments to Netlify staging environment
