### PR TITLE
fix(api): connect parameter to level path param bug fix

### DIFF
--- a/apps/api/src/app/subscribers/params/get-subscriber-preferences-by-level.params.ts
+++ b/apps/api/src/app/subscribers/params/get-subscriber-preferences-by-level.params.ts
@@ -3,7 +3,7 @@ import { PreferenceLevelEnum } from '@novu/dal';
 
 export class GetSubscriberPreferencesByLevelParams {
   @IsEnum(PreferenceLevelEnum)
-  level: PreferenceLevelEnum;
+  parameter: PreferenceLevelEnum;
 
   @IsString()
   subscriberId: string;

--- a/apps/api/src/app/subscribers/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers/subscribers.controller.ts
@@ -29,6 +29,7 @@ import {
   ApiRateLimitCostEnum,
   ButtonTypeEnum,
   ChatProviderIdEnum,
+  TriggerRecipientsTypeEnum,
   UserSessionData,
 } from '@novu/shared';
 import { MessageEntity, PreferenceLevelEnum } from '@novu/dal';
@@ -417,7 +418,13 @@ export class SubscribersController {
     summary: 'Get subscriber preferences by level',
   })
   @ApiParam({ name: 'subscriberId', type: String, required: true })
-  @ApiParam({ name: 'parameter', type: String, required: true })
+  @ApiParam({
+    name: 'parameter',
+    type: String,
+    enum: TriggerRecipientsTypeEnum,
+    required: true,
+    description: 'the preferences level to be retrieved( Subscriber / Topic) ',
+  })
   @SdkGroupName('Subscribers.Preferences')
   @SdkMethodName('retrieveByLevel')
   async getSubscriberPreferenceByLevel(

--- a/apps/api/src/app/subscribers/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers/subscribers.controller.ts
@@ -422,13 +422,13 @@ export class SubscribersController {
   @SdkMethodName('retrieveByLevel')
   async getSubscriberPreferenceByLevel(
     @UserSession() user: UserSessionData,
-    @Param() { level, subscriberId }: GetSubscriberPreferencesByLevelParams
+    @Param() { parameter, subscriberId }: GetSubscriberPreferencesByLevelParams
   ): Promise<GetSubscriberPreferencesResponseDto[]> {
     const command = GetPreferencesByLevelCommand.create({
       organizationId: user.organizationId,
       subscriberId: subscriberId,
       environmentId: user.environmentId,
-      level: level,
+      level: parameter,
     });
 
     return await this.getPreferenceUsecase.execute(command);


### PR DESCRIPTION
### What changed? Why was the change needed?
we changed the path name in order to be openApi complaint, it broke the internal logic, aligning the logic now 
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
