### PR TITLE
feat(framework): Set `strictAuthentication` to false when `process.env.NODE_ENV==='development'`

### DIFF
--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, describe, beforeEach, vi } from 'vitest';
+import { expect, it, describe, beforeEach } from 'vitest';
 
 import { Client } from './client';
 import {

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, describe, beforeEach } from 'vitest';
+import { expect, it, describe, beforeEach, vi } from 'vitest';
 
 import { Client } from './client';
 import {
@@ -28,9 +28,43 @@ describe('Novu Client', () => {
     client.addWorkflows([newWorkflow]);
   });
 
-  it('should discover 1 workflow', () => {
-    const discovery = client.discover();
-    expect(discovery.workflows).toHaveLength(1);
+  describe('client constructor', () => {
+    it('should set apiKey to process.env.NOVU_API_KEY by default', () => {
+      const originalApiKey = process.env.NOVU_API_KEY;
+      const testApiKey = 'test-env-api-key';
+      process.env = { ...process.env, NOVU_API_KEY: testApiKey };
+      const newClient = new Client();
+      expect(newClient.apiKey).toBe(process.env.NOVU_API_KEY);
+      process.env = { ...process.env, NOVU_API_KEY: originalApiKey };
+    });
+
+    it('should set apiKey to provided apiKey', () => {
+      const testApiKey = 'test-provided-api-key';
+      const newClient = new Client({ apiKey: testApiKey });
+      expect(newClient.apiKey).toBe(testApiKey);
+    });
+
+    it('should set strictAuthentication to false when NODE_ENV is development', () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env = { ...process.env, NODE_ENV: 'development' };
+      const newClient = new Client();
+      expect(newClient.strictAuthentication).toBe(false);
+      process.env = { ...process.env, NODE_ENV: originalEnv };
+    });
+
+    it('should set strictAuthentication to true when NODE_ENV is production', () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env = { ...process.env, NODE_ENV: 'production' };
+      const newClient = new Client();
+      expect(newClient.strictAuthentication).toBe(true);
+      process.env = { ...process.env, NODE_ENV: originalEnv };
+    });
+
+    it('should set strictAuthentication to provided strictAuthentication', () => {
+      const testStrictAuthentication = false;
+      const newClient = new Client({ strictAuthentication: testStrictAuthentication });
+      expect(newClient.strictAuthentication).toBe(testStrictAuthentication);
+    });
   });
 
   describe('discover method', () => {

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -81,8 +81,8 @@ export class Client {
 
     if (providedOptions?.strictAuthentication !== undefined) {
       builtConfiguration.strictAuthentication = providedOptions.strictAuthentication;
-    } else if (process.env.NOVU_STRICT_AUTHENTICATION !== undefined) {
-      builtConfiguration.strictAuthentication = process.env.NOVU_STRICT_AUTHENTICATION === 'true';
+    } else if (process.env.NODE_ENV === 'development') {
+      builtConfiguration.strictAuthentication = false;
     }
 
     return builtConfiguration;


### PR DESCRIPTION
### What changed? Why was the change needed?
* Set `strictAuthentication` to false when `process.env.NODE_ENV==='development'

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
