### PR TITLE
feat(js): Introduce baseTheme prop and theme merging

### DIFF
--- a/packages/js/src/ui/Inbox.tsx
+++ b/packages/js/src/ui/Inbox.tsx
@@ -16,7 +16,7 @@ export const Inbox = (props: InboxProps) => {
   return (
     <NovuProvider options={props.options}>
       <LocalizationProvider localization={props.localization}>
-        <AppearanceProvider id={props.id} elements={props.appearance?.elements} variables={props.appearance?.variables}>
+        <AppearanceProvider id={props.id} appearance={props.appearance}>
           <InternalInbox />
         </AppearanceProvider>
       </LocalizationProvider>

--- a/packages/js/src/ui/themes/dark.ts
+++ b/packages/js/src/ui/themes/dark.ts
@@ -1,0 +1,11 @@
+import { Theme } from '../context';
+
+export const dark: Theme = {
+  variables: {
+    colorNeutral: 'white',
+    colorBackground: '#161618',
+    colorForeground: '#EDEDEF',
+    colorSecondary: '#7E7D86',
+    colorSecondaryForeground: '#EDEDEF',
+  },
+};

--- a/packages/js/src/ui/themes/index.ts
+++ b/packages/js/src/ui/themes/index.ts
@@ -1,0 +1,1 @@
+export * from './dark';


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
Allow passsing a `baseTheme` on `appearance`. The `baseTheme` can be a single `Theme` (meaning `elements` and `variables`) or an array. All the base themes and `elements`, `variables` are merged in the order they are provided (in the case of `baseTheme` array and the `elements`, `variables` are added last, meaning they override.

Also created a dark theme that can be used like so:
```
<Inbox 
  appearance={{
    baseTheme: dark, //or [dark, ...moreThemes]
    variables: {...} //overrides base theme variables
    elements: {...} //overrides base theme elements
  }}
/>
```
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
