### PR TITLE
refactor(framework): Add env-var for strict authentication

### DIFF
--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -31,18 +31,18 @@ describe('Novu Client', () => {
 
   describe('client constructor', () => {
     it('should set secretKey to process.env.NOVU_SECRET_KEY by default', () => {
-      const originalsecretKey = process.env.NOVU_SECRET_KEY;
-      const testsecretKey = 'test-env-secret-key';
-      process.env = { ...process.env, NOVU_SECRET_KEY: testsecretKey };
+      const originalSecretKey = process.env.NOVU_SECRET_KEY;
+      const testSecretKey = 'test-env-secret-key';
+      process.env = { ...process.env, NOVU_SECRET_KEY: testSecretKey };
       const newClient = new Client();
       expect(newClient.secretKey).toBe(process.env.NOVU_SECRET_KEY);
-      process.env = { ...process.env, NOVU_SECRET_KEY: originalsecretKey };
+      process.env = { ...process.env, NOVU_SECRET_KEY: originalSecretKey };
     });
 
     it('should set secretKey to provided secretKey', () => {
-      const testsecretKey = 'test-provided-secret-key';
-      const newClient = new Client({ secretKey: testsecretKey });
-      expect(newClient.secretKey).toBe(testsecretKey);
+      const testSecretKey = 'test-provided-secret-key';
+      const newClient = new Client({ secretKey: testSecretKey });
+      expect(newClient.secretKey).toBe(testSecretKey);
     });
 
     it('should throw an error when secretKey is not provided', () => {

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -45,6 +45,12 @@ describe('Novu Client', () => {
       expect(newClient.secretKey).toBe(testsecretKey);
     });
 
+    it('should throw an error when secretKey is not provided', () => {
+      expect(() => new Client({ secretKey: undefined })).toThrow(
+        'Missing secret key. Set the NOVU_SECRET_KEY environment variable or pass `secretKey` to the client options.'
+      );
+    });
+
     it('should set strictAuthentication to false when NODE_ENV is development', () => {
       const originalEnv = process.env.NODE_ENV;
       process.env = { ...process.env, NODE_ENV: 'development' };
@@ -65,6 +71,22 @@ describe('Novu Client', () => {
       const testStrictAuthentication = false;
       const newClient = new Client({ secretKey: 'some-secret-key', strictAuthentication: testStrictAuthentication });
       expect(newClient.strictAuthentication).toBe(testStrictAuthentication);
+    });
+
+    it('should set strictAuthentication to false when NOVU_STRICT_AUTHENTICATION_ENABLED is false', () => {
+      const originalEnv = process.env.NOVU_STRICT_AUTHENTICATION_ENABLED;
+      process.env = { ...process.env, NOVU_STRICT_AUTHENTICATION_ENABLED: 'false' };
+      const newClient = new Client({ secretKey: 'some-secret-key' });
+      expect(newClient.strictAuthentication).toBe(false);
+      process.env = { ...process.env, NOVU_STRICT_AUTHENTICATION_ENABLED: originalEnv };
+    });
+
+    it('should set strictAuthentication to true when NOVU_STRICT_AUTHENTICATION_ENABLED is true', () => {
+      const originalEnv = process.env.NOVU_STRICT_AUTHENTICATION_ENABLED;
+      process.env = { ...process.env, NOVU_STRICT_AUTHENTICATION_ENABLED: 'true' };
+      const newClient = new Client({ secretKey: 'some-secret-key' });
+      expect(newClient.strictAuthentication).toBe(true);
+      process.env = { ...process.env, NOVU_STRICT_AUTHENTICATION_ENABLED: originalEnv };
     });
   });
 

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -71,7 +71,7 @@ export class Client {
   private buildOptions(providedOptions?: ClientOptions) {
     const builtConfiguration: { secretKey?: string; strictAuthentication: boolean } = {
       secretKey: undefined,
-      strictAuthentication: true,
+      strictAuthentication: isRuntimeInDevelopment() ? false : true,
     };
 
     builtConfiguration.secretKey =
@@ -79,14 +79,14 @@ export class Client {
 
     if (!isRuntimeInDevelopment() && !builtConfiguration.secretKey) {
       throw new Error(
-        'Missing secret key. Set the NOVU_SECRET_KEY environment variable or pass secretKey to the client options.'
+        'Missing secret key. Set the NOVU_SECRET_KEY environment variable or pass `secretKey` to the client options.'
       );
     }
 
     if (providedOptions?.strictAuthentication !== undefined) {
       builtConfiguration.strictAuthentication = providedOptions.strictAuthentication;
-    } else if (isRuntimeInDevelopment()) {
-      builtConfiguration.strictAuthentication = false;
+    } else if (process.env.NOVU_STRICT_AUTHENTICATION_ENABLED !== undefined) {
+      builtConfiguration.strictAuthentication = process.env.NOVU_STRICT_AUTHENTICATION_ENABLED === 'true';
     }
 
     return builtConfiguration;


### PR DESCRIPTION
### What changed? Why was the change needed?
* Add `NOVU_STRICT_AUTHENTICATION_ENABLED` env-var for strict authentication config via environment
* Add tests for strict authentication and secret key error

### Screenshots
_Tests_
<img width="499" alt="image" src="https://github.com/novuhq/novu/assets/32132657/20ec8015-abf8-4520-a72c-d6b69b341124">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
