### PR TITLE
fix(novu): Allow popups so we can open discord link

### DIFF
--- a/packages/cli/src/dev-server/http-server.ts
+++ b/packages/cli/src/dev-server/http-server.ts
@@ -78,7 +78,7 @@ export class DevServer {
 
           function injectIframe(src) {
             const iframe = window.document.createElement('iframe');
-            iframe.sandbox = 'allow-forms allow-scripts allow-modals allow-same-origin'
+            iframe.sandbox = 'allow-forms allow-scripts allow-modals allow-same-origin allow-popups'
             iframe.style = 'width: 100%; height: 100vh; border: none;';
             iframe.setAttribute('src', src);
             document.body.appendChild(iframe);


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

We currently get:

```
Blocked opening 'https://discord.gg/novu' in a new window because the request was made in a sandboxed frame whose 'allow-popups' permission is not set.
```

When clicking on the `?` button that opens the discord invite URL from local. This should address that!
