### PR TITLE
feat(web): Refactor docs to hide voting widget on error or load

### DIFF
--- a/apps/web/src/components/docs/Docs.tsx
+++ b/apps/web/src/components/docs/Docs.tsx
@@ -1,8 +1,10 @@
 import { Accordion, Alert, Code, Loader, Paper } from '@mantine/core';
-import { colors, IconInfoOutline, IconOutlineWarning, Tabs, Tooltip } from '@novu/design-system';
+import { Tabs, Tooltip } from '@novu/design-system';
+import { IconInfoOutline, IconOutlineWarning } from '@novu/novui/icons';
 import { css } from '@novu/novui/css';
-import { Center, Flex, Grid, GridItem, styled, VStack } from '@novu/novui/jsx';
+import { Flex, Grid, GridItem, styled, VStack } from '@novu/novui/jsx';
 import { text, title as RTitle } from '@novu/novui/recipes';
+import { token } from '@novu/novui/tokens';
 import * as mdxBundler from 'mdx-bundler/client';
 import { PropsWithChildren, ReactNode, useEffect, useMemo } from 'react';
 import { DOCS_URL, MINTLIFY_IMAGE_URL } from './docs.const';
@@ -65,13 +67,9 @@ export const Docs = ({ code = '', description = '', title = '', isLoading, child
 
   if (isLoading) {
     return (
-      <Center
-        className={css({
-          marginTop: '[4rem]',
-        })}
-      >
-        <Loader color={colors.error} size={32} />
-      </Center>
+      <Grid placeContent={'center'} h="full">
+        <Loader color={token('colors.mode.cloud.middle')} size={32} />
+      </Grid>
     );
   }
 

--- a/apps/web/src/components/docs/Docs.tsx
+++ b/apps/web/src/components/docs/Docs.tsx
@@ -1,14 +1,13 @@
-import { colors, IconInfoOutline, IconOutlineWarning, Tabs, Tooltip } from '@novu/design-system';
 import { Accordion, Alert, Code, Loader, Paper } from '@mantine/core';
-import { PropsWithChildren, ReactNode, useEffect, useMemo } from 'react';
-import * as mdxBundler from 'mdx-bundler/client';
-import { Highlight } from './Highlight';
-import { useQuery } from '@tanstack/react-query';
-import { useSegment } from '../providers/SegmentProvider';
-import { Center, Flex, Grid, GridItem, styled, VStack } from '@novu/novui/jsx';
+import { colors, IconInfoOutline, IconOutlineWarning, Tabs, Tooltip } from '@novu/design-system';
 import { css } from '@novu/novui/css';
+import { Center, Flex, Grid, GridItem, styled, VStack } from '@novu/novui/jsx';
 import { text, title as RTitle } from '@novu/novui/recipes';
-import { DOCS_URL, MDX_URL, MINTLIFY_IMAGE_URL } from './docs.const';
+import * as mdxBundler from 'mdx-bundler/client';
+import { PropsWithChildren, ReactNode, useEffect, useMemo } from 'react';
+import { DOCS_URL, MINTLIFY_IMAGE_URL } from './docs.const';
+import { Highlight } from './Highlight';
+import { DocsQueryResults } from './useLoadDocs';
 
 const Text = styled('p', text);
 const LiText = styled('span', text);
@@ -20,31 +19,18 @@ const getMDXComponent = mdxBundler.getMDXComponent;
 
 const DOCS_WRAPPER_ELEMENT_ID = 'embedded-docs';
 
+type DocsProps = PropsWithChildren<
+  DocsQueryResults & {
+    isLoading?: boolean;
+    actions: ReactNode;
+  }
+>;
+
 /*
- *Render the mdx for our mintlify docs inside of the web.
- *Fetching the compiled mdx from another service and then try to map the markdown to react components.
+ * Render the mdx for our mintlify docs inside of the web.
+ * Fetching the compiled mdx from another service and then try to map the markdown to react components.
  */
-export const Docs = ({ path = '', children, actions }: PropsWithChildren<{ path?: string; actions: ReactNode }>) => {
-  const segment = useSegment();
-
-  const { isLoading, data: { code, title, description } = { code: '', title: '', description: '' } } = useQuery<{
-    code: string;
-    title: string;
-    description: string;
-  }>(['docs', path], async () => {
-    const response = await fetch(MDX_URL + path);
-    const json = await response.json();
-
-    return json;
-  });
-
-  useEffect(() => {
-    segment.track('Inline docs opened', {
-      documentationPage: path,
-      pageURL: window.location.href,
-    });
-  }, [path, segment]);
-
+export const Docs = ({ code = '', description = '', title = '', isLoading, children, actions }: DocsProps) => {
   const Component = useMemo(() => {
     if (code.length === 0) {
       return null;

--- a/apps/web/src/components/docs/DocsButton.tsx
+++ b/apps/web/src/components/docs/DocsButton.tsx
@@ -154,7 +154,7 @@ export const DocsButton = ({
         </div>
       </Tooltip>
       {/* TODO: extract the Modal root out when modal management is improved */}
-      <DocsModal open={docsOpen} toggle={toggle} path={path} />
+      {docsOpen && <DocsModal open={docsOpen} toggle={toggle} path={path} />}
     </>
   );
 };

--- a/apps/web/src/components/docs/DocsModal.tsx
+++ b/apps/web/src/components/docs/DocsModal.tsx
@@ -7,9 +7,11 @@ import { openInNewTab } from '../../utils';
 import { Docs } from './Docs';
 import { DOCS_URL } from './docs.const';
 import { Voting, VotingWidget } from './VotingWidget';
+import { useLoadDocs } from './useLoadDocs';
 
 export const DocsModal = ({ open, toggle, path }) => {
   const [voted, setVoted] = useState<Voting | undefined>(undefined);
+  const { isLoading, data, isError } = useLoadDocs({ path });
   const segment = useSegment();
 
   useEffect(() => {
@@ -62,7 +64,8 @@ export const DocsModal = ({ open, toggle, path }) => {
       withCloseButton={false}
     >
       <Docs
-        path={path}
+        isLoading={isLoading}
+        {...data}
         actions={
           <Flex
             className={css({
@@ -93,7 +96,7 @@ export const DocsModal = ({ open, toggle, path }) => {
           </Flex>
         }
       >
-        <VotingWidget onVoteClick={onVoteClick} voted={voted} />
+        {isLoading || isError ? null : <VotingWidget onVoteClick={onVoteClick} voted={voted} />}
       </Docs>
     </Modal>
   );

--- a/apps/web/src/components/docs/DocsModal.tsx
+++ b/apps/web/src/components/docs/DocsModal.tsx
@@ -11,7 +11,7 @@ import { useLoadDocs } from './useLoadDocs';
 
 export const DocsModal = ({ open, toggle, path }) => {
   const [voted, setVoted] = useState<Voting | undefined>(undefined);
-  const { isLoading, data, isError } = useLoadDocs({ path });
+  const { isLoading, data, hasLoadedSuccessfully } = useLoadDocs({ path, isEnabled: open });
   const segment = useSegment();
 
   useEffect(() => {
@@ -96,7 +96,7 @@ export const DocsModal = ({ open, toggle, path }) => {
           </Flex>
         }
       >
-        {isLoading || isError ? null : <VotingWidget onVoteClick={onVoteClick} voted={voted} />}
+        {hasLoadedSuccessfully ? <VotingWidget onVoteClick={onVoteClick} voted={voted} /> : null}
       </Docs>
     </Modal>
   );

--- a/apps/web/src/components/docs/useLoadDocs.tsx
+++ b/apps/web/src/components/docs/useLoadDocs.tsx
@@ -1,0 +1,37 @@
+import { useSegment } from '../providers/SegmentProvider';
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { MDX_URL } from './docs.const';
+
+export type DocsQueryResults = {
+  code: string;
+  title: string;
+  description: string;
+};
+
+type UseLoadDocsProps = {
+  path: string;
+};
+
+export const useLoadDocs = ({ path }: UseLoadDocsProps) => {
+  const segment = useSegment();
+
+  const queryResults = useQuery<DocsQueryResults>(['docs', path], async () => {
+    const response = await fetch(MDX_URL + path);
+    const json = await response.json();
+
+    return json;
+  });
+
+  useEffect(() => {
+    segment.track('Inline docs opened', {
+      documentationPage: path,
+      pageURL: window.location.href,
+    });
+  }, [path, segment]);
+
+  return {
+    ...queryResults,
+    data: queryResults.data ?? { code: '', title: '', description: '' },
+  };
+};

--- a/apps/web/src/components/layout/components/LocalStudioHeader/LocalStudioHeader.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioHeader/LocalStudioHeader.tsx
@@ -32,7 +32,12 @@ export const LocalStudioHeader: FC = () => {
           <DocsButton />
           {/** TODO: this currently fails with Blocked opening in a new window
            * because the request was made in a sandboxed frame whose 'allow-popups' permission is not set. */}
-          <IconButton Icon={IconHelpOutline} as="a" href={discordInviteUrl} target="_blank" rel="noopener noreferrer" />
+          <IconButton
+            Icon={IconHelpOutline}
+            onClick={() => {
+              window.open(discordInviteUrl, '_blank', 'popup');
+            }}
+          />
         </HStack>
       </HStack>
     </Header>


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

- Refactor Docs such that we hide the voting widget while docs are loading or on error
- Also improved loader

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

https://github.com/novuhq/novu/assets/47441786/aa3bffbe-b227-4015-b8a0-27f30cd46bce

