### PR TITLE
fix(web, novu): Onboarding flow authentication and iFrame popups

### DIFF
--- a/apps/web/src/bridgeApi/bridgeApi.client.ts
+++ b/apps/web/src/bridgeApi/bridgeApi.client.ts
@@ -24,8 +24,6 @@ export function buildBridgeHTTPClient(baseURL: string) {
     baseURL,
     headers: {
       'Content-Type': 'application/json',
-      // Required for localtunnel.it
-      'Bypass-Tunnel-Reminder': true,
     },
   });
 

--- a/apps/web/src/components/docs/DocsModal.tsx
+++ b/apps/web/src/components/docs/DocsModal.tsx
@@ -1,12 +1,13 @@
-import { IconOpenInNew, IconOutlineClose, Modal, ActionButton } from '@novu/design-system';
+import { Modal } from '@novu/design-system';
 import { useSegment } from '../providers/SegmentProvider';
 import { useEffect, useState } from 'react';
 import { css } from '@novu/novui/css';
 import { Flex } from '@novu/novui/jsx';
-import { openInNewTab } from '../../utils';
+import { IconOpenInNew, IconClose } from '@novu/novui/icons';
 import { Docs } from './Docs';
 import { DOCS_URL } from './docs.const';
 import { Voting, VotingWidget } from './VotingWidget';
+import { IconButton } from '@novu/novui';
 
 export const DocsModal = ({ open, toggle, path }) => {
   const [voted, setVoted] = useState<Voting | undefined>(undefined);
@@ -77,18 +78,18 @@ export const DocsModal = ({ open, toggle, path }) => {
             })}
             gap="75"
           >
-            <ActionButton
-              tooltip="Open docs website"
-              onClick={() => {
-                openInNewTab(`${DOCS_URL}/${path}`);
-              }}
-              Icon={() => <IconOpenInNew />}
+            <IconButton
+              as="a"
+              href={`${DOCS_URL}/${path}`}
+              target="_blank"
+              rel="noreferrer noopener"
+              Icon={IconOpenInNew}
             />
-            <ActionButton
+            <IconButton
               onClick={() => {
                 toggle();
               }}
-              Icon={() => <IconOutlineClose />}
+              Icon={IconClose}
             />
           </Flex>
         }

--- a/apps/web/src/components/layout/components/LocalStudioHeader/LocalStudioHeader.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioHeader/LocalStudioHeader.tsx
@@ -30,6 +30,8 @@ export const LocalStudioHeader: FC = () => {
         <HStack gap="100">
           <BridgeMenuItems />
           <DocsButton />
+          {/* This doesn't work because of Discord's popup blocker via the response header:
+          Cross-Origin-Opener-Policy: same-origin-allow-popups. We will likely need a Javascript workaround for Discord's popup blocker. */}
           <IconButton Icon={IconHelpOutline} as="a" href={discordInviteUrl} target="_blank" rel="noopener noreferrer" />
         </HStack>
       </HStack>

--- a/apps/web/src/components/layout/components/LocalStudioHeader/LocalStudioHeader.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioHeader/LocalStudioHeader.tsx
@@ -30,8 +30,6 @@ export const LocalStudioHeader: FC = () => {
         <HStack gap="100">
           <BridgeMenuItems />
           <DocsButton />
-          {/** TODO: this currently fails with Blocked opening in a new window
-           * because the request was made in a sandboxed frame whose 'allow-popups' permission is not set. */}
           <IconButton Icon={IconHelpOutline} as="a" href={discordInviteUrl} target="_blank" rel="noopener noreferrer" />
         </HStack>
       </HStack>

--- a/apps/web/src/components/layout/components/v2/SyncInfoModal.tsx
+++ b/apps/web/src/components/layout/components/v2/SyncInfoModal.tsx
@@ -12,10 +12,10 @@ export type SyncInfoModalProps = {
   toggleOpen: () => void;
 };
 
-const novuEndpointPlaceholder = '<YOUR_NOVU_ENDPOINT_URL>';
+const BRIDGE_ENDPOINT_PLACEHOLDER = '<YOUR_BRIDGE_URL>';
 
 export const SyncInfoModal: FC<SyncInfoModalProps> = ({ isOpen, toggleOpen }) => {
-  const { apiKey } = useApiKeysPage();
+  const { secretKey } = useApiKeysPage();
   const bridgeUrl = useBridgeURL();
 
   const tabs = [
@@ -24,7 +24,7 @@ export const SyncInfoModal: FC<SyncInfoModalProps> = ({ isOpen, toggleOpen }) =>
       label: 'GitHub Actions',
       content: (
         <Prism withLineNumbers language="yaml">
-          {getGithubYamlContent({ apiKey, bridgeUrl })}
+          {getGithubYamlContent({ secretKey, bridgeUrl })}
         </Prism>
       ),
     },
@@ -33,7 +33,7 @@ export const SyncInfoModal: FC<SyncInfoModalProps> = ({ isOpen, toggleOpen }) =>
       label: 'CLI',
       content: (
         <Prism withLineNumbers language="bash">
-          {getOtherCodeContent({ apiKey, bridgeUrl })}
+          {getOtherCodeContent({ secretKey, bridgeUrl })}
         </Prism>
       ),
     },
@@ -55,7 +55,7 @@ export const SyncInfoModal: FC<SyncInfoModalProps> = ({ isOpen, toggleOpen }) =>
   );
 };
 
-function getGithubYamlContent({ apiKey, bridgeUrl }: { apiKey: string; bridgeUrl: string }) {
+function getGithubYamlContent({ secretKey, bridgeUrl }: { secretKey: string; bridgeUrl: string }) {
   return `name: Deploy Workflow State to Novu
 
 on:
@@ -71,12 +71,12 @@ jobs:
       - name: Sync State to Novu
         uses: novuhq/actions-novu-sync@v0.0.4
         with:
-          novu-api-key: ${apiKey}
-          bridge-url: ${bridgeUrl || novuEndpointPlaceholder}`;
+          secret-key: ${secretKey}
+          bridge-url: ${bridgeUrl || BRIDGE_ENDPOINT_PLACEHOLDER}`;
 }
 
-function getOtherCodeContent({ apiKey, bridgeUrl }: { apiKey: string; bridgeUrl: string }) {
-  return `npx novu-labs@latest sync \\
-  --echo-url ${bridgeUrl || novuEndpointPlaceholder} \\
-  --api-key ${apiKey}`;
+function getOtherCodeContent({ secretKey, bridgeUrl }: { secretKey: string; bridgeUrl: string }) {
+  return `npx novu@latest sync \\
+  --bridge-url ${bridgeUrl || BRIDGE_ENDPOINT_PLACEHOLDER} \\
+  --secret-key ${secretKey}`;
 }

--- a/apps/web/src/pages/settings/ApiKeysPage/ApiKeysPage.tsx
+++ b/apps/web/src/pages/settings/ApiKeysPage/ApiKeysPage.tsx
@@ -7,17 +7,17 @@ import { ConfirmRegenerationModal } from '../tabs/components/ConfirmRegeneration
 import { useSettingsEnvRedirect } from '../useSettingsEnvRedirect';
 import { useApiKeysPage } from './useApiKeysPage';
 
-type ApiKeysRendererProps = ReturnType<typeof useApiKeysPage>;
+type SecretKeysRendererProps = ReturnType<typeof useApiKeysPage>;
 
 const INPUT_ICON_SIZE: IconSize = '16';
 
-const ApiKeysRenderer: FC<ApiKeysRendererProps> = ({
-  apiKey,
+const ApiKeysRenderer: FC<SecretKeysRendererProps> = ({
+  secretKey,
   environmentIdentifier,
   environmentId,
-  isApiKeyMasked,
-  toggleApiKeyVisibility,
-  clipboardApiKey,
+  isSecretKeyMasked,
+  toggleSecretKeyVisibility,
+  clipboardSecretKey,
   clipboardEnvironmentIdentifier,
   clipboardEnvironmentId,
   regenerationModalProps,
@@ -29,7 +29,7 @@ const ApiKeysRenderer: FC<ApiKeysRendererProps> = ({
       <Flex direction={'column'} gap={'200'} maxW="37.5rem">
         <Input
           readOnly
-          type={isApiKeyMasked ? 'password' : 'text'}
+          type={isSecretKeyMasked ? 'password' : 'text'}
           label="Secret Key"
           description="The secret key to interact with the Novu API"
           rightSection={
@@ -43,25 +43,25 @@ const ApiKeysRenderer: FC<ApiKeysRendererProps> = ({
                 <IconRefresh size={INPUT_ICON_SIZE} />
               </IconButton>
               <IconButton
-                onClick={toggleApiKeyVisibility}
-                tooltipProps={{ label: isApiKeyMasked ? 'Show API Key' : 'Hide API Key' }}
+                onClick={toggleSecretKeyVisibility}
+                tooltipProps={{ label: isSecretKeyMasked ? 'Show API Key' : 'Hide API Key' }}
                 id={'api-key-toggle-visibility-btn'}
               >
-                {isApiKeyMasked ? (
+                {isSecretKeyMasked ? (
                   <IconOutlineVisibility size={INPUT_ICON_SIZE} />
                 ) : (
                   <IconOutlineVisibilityOff size={INPUT_ICON_SIZE} />
                 )}
               </IconButton>
               <ClipboardIconButton
-                isCopied={clipboardApiKey.copied}
-                handleCopy={() => clipboardApiKey.copy(apiKey)}
+                isCopied={clipboardSecretKey.copied}
+                handleCopy={() => clipboardSecretKey.copy(secretKey)}
                 testId={'api-key-copy'}
                 size={INPUT_ICON_SIZE}
               />
             </Flex>
           }
-          value={apiKey}
+          value={secretKey}
           data-test-id="api-key"
         />
         <Input

--- a/apps/web/src/pages/settings/ApiKeysPage/ApiKeysPage.tsx
+++ b/apps/web/src/pages/settings/ApiKeysPage/ApiKeysPage.tsx
@@ -7,11 +7,11 @@ import { ConfirmRegenerationModal } from '../tabs/components/ConfirmRegeneration
 import { useSettingsEnvRedirect } from '../useSettingsEnvRedirect';
 import { useApiKeysPage } from './useApiKeysPage';
 
-type SecretKeysRendererProps = ReturnType<typeof useApiKeysPage>;
+type ApiKeysRendererProps = ReturnType<typeof useApiKeysPage>;
 
 const INPUT_ICON_SIZE: IconSize = '16';
 
-const ApiKeysRenderer: FC<SecretKeysRendererProps> = ({
+const ApiKeysRenderer: FC<ApiKeysRendererProps> = ({
   secretKey,
   environmentIdentifier,
   environmentId,

--- a/apps/web/src/pages/settings/ApiKeysPage/useApiKeysPage.ts
+++ b/apps/web/src/pages/settings/ApiKeysPage/useApiKeysPage.ts
@@ -4,7 +4,7 @@ import { useClipboard } from '@mantine/hooks';
 
 import { getApiKeys } from '../../../api/environment';
 import { useEnvironment } from '../../../hooks';
-import { useRegenerateApiKeyModal } from './useRegenerateApiKeyModal';
+import { useRegenerateSecretKeyModal } from './useRegenerateApiKeyModal';
 
 const CLIPBOARD_TIMEOUT_MS = 2000;
 
@@ -16,29 +16,29 @@ export const useApiKeysPage = () => {
    * const { env } = useParams<'env'>();
    */
 
-  const clipboardApiKey = useClipboard({ timeout: CLIPBOARD_TIMEOUT_MS });
+  const clipboardSecretKey = useClipboard({ timeout: CLIPBOARD_TIMEOUT_MS });
   const clipboardEnvironmentIdentifier = useClipboard({ timeout: CLIPBOARD_TIMEOUT_MS });
   const clipboardEnvironmentId = useClipboard({ timeout: CLIPBOARD_TIMEOUT_MS });
-  const { data: apiKeys } = useQuery<{ key: string }[]>(['getApiKeys'], getApiKeys);
+  const { data: secretKeys } = useQuery<{ key: string }[]>(['getApiKeys'], getApiKeys);
   const { environment } = useEnvironment();
 
-  const apiKey = apiKeys?.length ? apiKeys[0].key : '';
+  const secretKey = secretKeys?.length ? secretKeys[0].key : '';
   const environmentIdentifier = environment?.identifier ? environment.identifier : '';
   const environmentId = environment?._id ? environment._id : '';
 
-  const [isApiKeyMasked, setIsApiKeyMasked] = useState<boolean>(true);
+  const [isSecretKeyMasked, setIsSecretKeyMasked] = useState<boolean>(true);
 
-  const toggleApiKeyVisibility = () => setIsApiKeyMasked((prevHidden) => !prevHidden);
+  const toggleSecretKeyVisibility = () => setIsSecretKeyMasked((prevHidden) => !prevHidden);
 
-  const regenerationModalProps = useRegenerateApiKeyModal();
+  const regenerationModalProps = useRegenerateSecretKeyModal();
 
   return {
-    apiKey,
+    secretKey,
     environmentIdentifier,
     environmentId,
-    isApiKeyMasked,
-    toggleApiKeyVisibility,
-    clipboardApiKey,
+    isSecretKeyMasked,
+    toggleSecretKeyVisibility,
+    clipboardSecretKey,
     clipboardEnvironmentIdentifier,
     clipboardEnvironmentId,
     pageEnv: environment?.name ?? '',

--- a/apps/web/src/pages/settings/ApiKeysPage/useRegenerateApiKeyModal.ts
+++ b/apps/web/src/pages/settings/ApiKeysPage/useRegenerateApiKeyModal.ts
@@ -5,10 +5,10 @@ import { useState } from 'react';
 
 import { showNotification } from '@mantine/notifications';
 
-export const useRegenerateApiKeyModal = () => {
+export const useRegenerateSecretKeyModal = () => {
   const [isOpen, setModalIsOpen] = useState(false);
 
-  const { refetch: refetchApiKeys } = useQuery<{ key: string }[]>(['getApiKeys'], getApiKeys);
+  const { refetch: refetchSecretKeys } = useQuery<{ key: string }[]>(['getApiKeys'], getApiKeys);
 
   const { mutateAsync: regenerateApiKeysMutation } = useMutation<{ key: string }[], IResponseError>(regenerateApiKeys);
 
@@ -22,7 +22,7 @@ export const useRegenerateApiKeyModal = () => {
 
   async function confirmAction() {
     await regenerateApiKeysMutation();
-    await refetchApiKeys();
+    await refetchSecretKeys();
     setModalIsOpen(false);
     showNotification({
       message: `Successfully regenerated API keys!`,

--- a/apps/web/src/pages/settings/tabs/components/Regenerate.tsx
+++ b/apps/web/src/pages/settings/tabs/components/Regenerate.tsx
@@ -1,11 +1,11 @@
 import { Group } from '@mantine/core';
 import { Button } from '@novu/design-system';
 
-import { useRegenerateApiKeyModal } from '../../ApiKeysPage/useRegenerateApiKeyModal';
+import { useRegenerateSecretKeyModal } from '../../ApiKeysPage/useRegenerateApiKeyModal';
 import { ConfirmRegenerationModal } from './ConfirmRegenerationModal';
 
 export const Regenerate = () => {
-  const { isOpen, cancelAction, confirmAction, openModal } = useRegenerateApiKeyModal();
+  const { isOpen, cancelAction, confirmAction, openModal } = useRegenerateSecretKeyModal();
 
   return (
     <>

--- a/apps/web/src/pages/studio-onboarding/components/SetupTimeline.tsx
+++ b/apps/web/src/pages/studio-onboarding/components/SetupTimeline.tsx
@@ -9,6 +9,7 @@ import { Timeline } from '../../../components/Timeline/index';
 import { css } from '@novu/novui/css';
 import { BridgeStatus } from '../../../bridgeApi/bridgeApi.client';
 import { useColorScheme } from '@novu/design-system';
+import { useStudioState } from '../../../studio/StudioStateProvider';
 
 const Icon = () => (
   <IconCheck
@@ -19,8 +20,11 @@ const Icon = () => (
 );
 
 export const SetupTimeline = ({ testResponse }: { testResponse: { isLoading: boolean; data: BridgeStatus } }) => {
+  // TODO: revisit with consolidation of API fetching via single hook entry point
   const { data: apiKeys = [] } = useQuery<{ key: string }[]>(['getApiKeys'], getApiKeys);
   const key = useMemo(() => apiKeys[0]?.key, [apiKeys]);
+
+  const { devSecretKey } = useStudioState();
   const [active, setActive] = useState(0);
   const { colorScheme } = useColorScheme();
 
@@ -55,7 +59,7 @@ export const SetupTimeline = ({ testResponse }: { testResponse: { isLoading: boo
           This will create a new Next.js sample app with React-Email
         </Text>
         <CodeSnippet
-          command={`npx create-novu-app --api-key=${key}`}
+          command={`npx create-novu-app --api-key=${devSecretKey}`}
           onClick={() => {
             setActive((old) => (old > 1 ? old : 1));
           }}
@@ -81,7 +85,9 @@ export const SetupTimeline = ({ testResponse }: { testResponse: { isLoading: boo
         active={active >= 3}
       >
         <Text variant="main" color="typography.text.secondary">
-          {active < 3 ? 'Waiting for you to start the application' : 'Succefully connected to the Novu Bridge Endpoint'}
+          {active < 3
+            ? 'Waiting for you to start the application'
+            : 'Successfully connected to the Novu Bridge Endpoint'}
         </Text>
       </MantineTimeline.Item>
     </Timeline>

--- a/apps/web/src/pages/studio-onboarding/components/SetupTimeline.tsx
+++ b/apps/web/src/pages/studio-onboarding/components/SetupTimeline.tsx
@@ -59,7 +59,7 @@ export const SetupTimeline = ({ testResponse }: { testResponse: { isLoading: boo
           This will create a new Next.js sample app with React-Email
         </Text>
         <CodeSnippet
-          command={`npx create-novu-app --api-key=${devSecretKey}`}
+          command={`npx create-novu-app --secret-key=${devSecretKey}`}
           onClick={() => {
             setActive((old) => (old > 1 ? old : 1));
           }}

--- a/apps/web/src/utils/url.ts
+++ b/apps/web/src/utils/url.ts
@@ -1,5 +1,5 @@
 export function openInNewTab(url: string) {
-  return window.open(url, '_blank', 'noreferrer noopener');
+  window.open('https://google.com', '_blank', 'noreferrer noopener');
 }
 
 export function validateURL(url: string, msg = 'The provided URL is invalid'): asserts url {

--- a/apps/web/src/utils/url.ts
+++ b/apps/web/src/utils/url.ts
@@ -1,5 +1,5 @@
 export function openInNewTab(url: string) {
-  window.open('https://google.com', '_blank', 'noreferrer noopener');
+  return window.open(url, '_blank', 'noreferrer noopener');
 }
 
 export function validateURL(url: string, msg = 'The provided URL is invalid'): asserts url {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "0.24.3-alpha.4",
+  "version": "0.24.3-alpha.5",
   "description": "Novu CLI. Used to sign-up, sync with Novu Cloud, and run Novu Studio.",
   "main": "index.js",
   "scripts": {
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@novu/ntfr-client": "^0.0.3",
-    "@novu/shared": "workspace:*",
+    "@novu/shared": "^0.24.2",
     "@segment/analytics-node": "^1.1.4",
     "axios": "^1.6.2",
     "chalk": "4.1.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@novu/ntfr-client": "^0.0.3",
-    "@novu/shared": "^0.24.2",
+    "@novu/shared": "workspace:*",
     "@segment/analytics-node": "^1.1.4",
     "axios": "^1.6.2",
     "chalk": "4.1.2",

--- a/packages/cli/src/dev-server/http-server.ts
+++ b/packages/cli/src/dev-server/http-server.ts
@@ -78,7 +78,7 @@ export class DevServer {
 
           function injectIframe(src) {
             const iframe = window.document.createElement('iframe');
-            iframe.sandbox = 'allow-forms allow-scripts allow-modals allow-same-origin'
+            iframe.sandbox = 'allow-forms allow-scripts allow-modals allow-same-origin allow-popups'
             iframe.style = 'width: 100%; height: 100vh; border: none;';
             iframe.setAttribute('src', src);
             document.body.appendChild(iframe);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,7 @@ program
   Sync with Novu Cloud in Europe:
   (e.g., novu sync -b https://acme.org/api/novu -s NOVU_SECRET_KEY -a https://eu.api.novu.co)`
   )
-  .usage('[-b <url>] [-s <secret-key>] [-a <url>]')
+  .usage('-b <url> -s <secret-key> [-a <url>]')
   .option('-a, --api-url <url>', 'The Novu Cloud API URL', 'https://api.novu.co')
   .requiredOption(
     '-b, --bridge-url <url>',

--- a/packages/create-novu-app/index.ts
+++ b/packages/create-novu-app/index.ts
@@ -36,54 +36,29 @@ const onPromptState = (state: { value: InitialReturnValue; aborted: boolean; exi
 
 const program = new Commander.Command(packageJson.name)
   .version(packageJson.version)
+  .description(
+    `Create a new Novu app
+
+  Using PNPM
+  (e.g., create-novu-app --use-pnpm)
+
+  Specifying the secret key:
+  (e.g., create-novu-app -s NOVU_SECRET_KEY)`
+  )
   .arguments('<project-directory>')
-  .usage(`${green('<project-directory>')} [options]`)
+  .usage(`${green('<project-directory>')} [-s <secret-key>] [options]`)
   .action((name) => {
     projectPath = name;
   })
   .option(
-    '-k, --secret-key [secretKey]',
-    `
-
-  Your Novu development environment secret key. Note that your novu app won't
-  work outside of local mode without it.
-`
+    '-s, --secret-key <secret-key>',
+    `Your Novu development environment secret key. Note that your novu app won't work outside of local mode without it.`
   )
-  .option(
-    '--react-email',
-    `
-
-  Initialize with React Email config. (default)
-`
-  )
-  .option(
-    '--use-npm',
-    `
-
-  Explicitly tell the CLI to bootstrap the application using npm
-`
-  )
-  .option(
-    '--use-pnpm',
-    `
-
-  Explicitly tell the CLI to bootstrap the application using pnpm
-`
-  )
-  .option(
-    '--use-yarn',
-    `
-
-  Explicitly tell the CLI to bootstrap the application using Yarn
-`
-  )
-  .option(
-    '--use-bun',
-    `
-
-  Explicitly tell the CLI to bootstrap the application using Bun
-`
-  )
+  .option('--react-email', `Initialize with React Email config. (default)`)
+  .option('--use-npm', `Explicitly tell the CLI to bootstrap the application using npm`)
+  .option('--use-pnpm', `Explicitly tell the CLI to bootstrap the application using pnpm`)
+  .option('--use-yarn', `Explicitly tell the CLI to bootstrap the application using Yarn`)
+  .option('--use-bun', `Explicitly tell the CLI to bootstrap the application using Bun`)
   .allowUnknownOption()
   .parse(process.argv);
 

--- a/packages/create-novu-app/package.json
+++ b/packages/create-novu-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-novu-app",
-  "version": "0.24.3-alpha.8",
+  "version": "0.24.3-alpha.9",
   "keywords": [
     "novu",
     "create",


### PR DESCRIPTION
### What changed? Why was the change needed?
* Onboarding flow now shows api key in all environments
* Clicking the open docs button now works
* Pull in echo -> bridge rename from https://github.com/novuhq/packages-enterprise/pull/157

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->
https://github.com/novuhq/packages-enterprise/pull/157

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
