### PR TITLE
feat(web,novui): Loading tweaks

### DIFF
--- a/apps/web/src/components/layout/components/AppShell.tsx
+++ b/apps/web/src/components/layout/components/AppShell.tsx
@@ -1,0 +1,14 @@
+import { styled } from '@novu/novui/jsx';
+import { cva } from '@novu/novui/css';
+
+export const AppShell = styled(
+  'div',
+  cva({
+    base: {
+      display: 'flex',
+      width: '[100vw]',
+      height: '[100vh]',
+      minWidth: '[1024px]',
+    },
+  })
+);

--- a/apps/web/src/components/layout/components/ContentShell.tsx
+++ b/apps/web/src/components/layout/components/ContentShell.tsx
@@ -1,0 +1,15 @@
+import { styled } from '@novu/novui/jsx';
+import { cva } from '@novu/novui/css';
+
+export const ContentShell = styled(
+  'div',
+  cva({
+    base: {
+      display: 'flex',
+      flexDirection: 'column',
+      flex: '[1 1 0%]',
+      // for appropriate scroll
+      overflow: 'hidden',
+    },
+  })
+);

--- a/apps/web/src/components/layout/components/LocalStudioPageLayout.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioPageLayout.tsx
@@ -8,6 +8,7 @@ import { AppShell } from './AppShell';
 import { ContentShell } from './ContentShell';
 import { WithLoadingSkeleton } from '@novu/novui';
 import { WorkflowsDetailPage } from '../../../studio/components/workflows/index';
+import { Box } from '@novu/novui/jsx';
 
 export const LocalStudioPageLayout: WithLoadingSkeleton = () => {
   const { pathname } = useLocation();
@@ -47,6 +48,7 @@ function LoadingDisplay() {
     <AppShell>
       <LocalStudioSidebar.LoadingDisplay />
       <ContentShell>
+        <Box bg="surface.page" h="250" />
         <WorkflowsDetailPage.LoadingDisplay />
       </ContentShell>
     </AppShell>

--- a/apps/web/src/components/layout/components/LocalStudioPageLayout.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioPageLayout.tsx
@@ -1,26 +1,15 @@
 import * as Sentry from '@sentry/react';
 import { Outlet, useLocation } from 'react-router-dom';
-import styled from '@emotion/styled';
 import { css } from '@novu/novui/css';
 import { LocalStudioHeader } from './LocalStudioHeader/LocalStudioHeader';
 import { LocalStudioSidebar } from './LocalStudioSidebar';
 import { isStudioOnboardingRoute } from '../../../studio/utils/routing';
+import { AppShell } from './AppShell';
+import { ContentShell } from './ContentShell';
+import { WithLoadingSkeleton } from '@novu/novui';
+import { WorkflowsDetailPage } from '../../../studio/components/workflows/index';
 
-const AppShell = styled.div`
-  display: flex;
-  width: 100vw;
-  height: 100vh;
-  min-width: 1024px;
-`;
-
-const ContentShell = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 0%;
-  overflow: hidden; // for appropriate scroll
-`;
-
-export function LocalStudioPageLayout() {
+export const LocalStudioPageLayout: WithLoadingSkeleton = () => {
   const { pathname } = useLocation();
 
   return (
@@ -48,5 +37,18 @@ export function LocalStudioPageLayout() {
         </ContentShell>
       </AppShell>
     </Sentry.ErrorBoundary>
+  );
+};
+
+LocalStudioPageLayout.LoadingDisplay = LoadingDisplay;
+
+function LoadingDisplay() {
+  return (
+    <AppShell>
+      <LocalStudioSidebar.LoadingDisplay />
+      <ContentShell>
+        <WorkflowsDetailPage.LoadingDisplay />
+      </ContentShell>
+    </AppShell>
   );
 }

--- a/apps/web/src/components/layout/components/LocalStudioSidebar/LocalStudioSidebar.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioSidebar/LocalStudioSidebar.tsx
@@ -1,27 +1,39 @@
-import { css } from '@novu/novui/css';
-import { FC } from 'react';
+import { WithLoadingSkeleton } from '@novu/novui';
+import { css, cva } from '@novu/novui/css';
+import { styled } from '@novu/novui/jsx';
 import { useDiscover } from '../../../../studio/hooks/useBridgeAPI';
 import { LocalStudioSidebarContent } from './LocalStudioSidebarContent';
 
-export const LocalStudioSidebar: FC = () => {
+const Aside = styled(
+  'aside',
+  cva({
+    base: {
+      position: 'sticky',
+      top: '0',
+      zIndex: 'auto',
+      backgroundColor: 'transparent',
+      borderRight: 'none',
+      width: '[272px]',
+      height: 'full',
+      p: '50',
+      bg: 'surface.panel',
+      overflowY: 'auto',
+    },
+  })
+);
+
+export const LocalStudioSidebar: WithLoadingSkeleton = () => {
   const { isLoading, data } = useDiscover();
 
   return (
-    <aside
-      className={css({
-        position: 'sticky',
-        top: 0,
-        zIndex: 'auto',
-        backgroundColor: 'transparent',
-        borderRight: 'none',
-        width: '272px',
-        height: '100%',
-        p: '50',
-        bg: 'surface.panel',
-        overflowY: 'auto',
-      })}
-    >
+    <Aside>
       <LocalStudioSidebarContent workflows={data?.workflows ?? []} isLoading={isLoading} />
-    </aside>
+    </Aside>
   );
 };
+
+LocalStudioSidebar.LoadingDisplay = () => (
+  <Aside>
+    <LocalStudioSidebarContent.LoadingDisplay />
+  </Aside>
+);

--- a/apps/web/src/components/layout/components/LocalStudioSidebar/LocalStudioSidebarContent.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioSidebar/LocalStudioSidebarContent.tsx
@@ -12,17 +12,21 @@ import { DocsButton } from '../../../docs/DocsButton';
 import { css, cx } from '@novu/novui/css';
 import { NavMenuButtonInner, rawButtonBaseStyles } from '../../../nav/NavMenuButton/NavMenuButton.shared';
 import { useStudioState } from '../../../../studio/StudioStateProvider';
+import { WithLoadingSkeleton } from '@novu/novui';
 
 type LocalStudioSidebarContentProps = {
   workflows: IBridgeWorkflow[];
   isLoading?: boolean;
 };
 
-export const LocalStudioSidebarContent: FC<LocalStudioSidebarContentProps> = ({ workflows, isLoading }) => {
+export const LocalStudioSidebarContent: WithLoadingSkeleton<FC<LocalStudioSidebarContentProps>> = ({
+  workflows,
+  isLoading,
+}) => {
   const { organizationName } = useStudioState();
 
   if (isLoading) {
-    return <SidebarContentLoading />;
+    return <LoadingDisplay />;
   }
 
   return (
@@ -50,7 +54,9 @@ export const LocalStudioSidebarContent: FC<LocalStudioSidebarContentProps> = ({ 
   );
 };
 
-function SidebarContentLoading() {
+LocalStudioSidebarContent.LoadingDisplay = LoadingDisplay;
+
+function LoadingDisplay() {
   return (
     <Stack gap="300" p="75">
       <Flex gap="75">

--- a/apps/web/src/studio/LocalStudioAuthenticator.tsx
+++ b/apps/web/src/studio/LocalStudioAuthenticator.tsx
@@ -1,8 +1,4 @@
 import { useEffect } from 'react';
-import { Center } from '@novu/novui/jsx';
-import { Loader } from '@mantine/core';
-import { colors } from '@novu/design-system';
-import { css } from '@novu/novui/css';
 import { useAuth, useAPIKeys, useEnvironment } from '../hooks';
 import { ROUTES } from '../constants/routes';
 import { assertProtocol } from '../utils/url';
@@ -10,6 +6,7 @@ import { encodeBase64 } from './utils/base64';
 import { StudioState } from './types';
 import { useLocation } from 'react-router-dom';
 import { novuOnboardedCookie } from '../utils/cookies';
+import { LocalStudioPageLayout } from '../components/layout/components/LocalStudioPageLayout';
 
 function buildBridgeURL(origin: string | null, tunnelPath: string) {
   if (!origin) {
@@ -140,13 +137,5 @@ export function LocalStudioAuthenticator() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUser, environment, apiKey]);
 
-  return (
-    <Center
-      className={css({
-        marginTop: '[4rem]',
-      })}
-    >
-      <Loader color={colors.error} size={32} />
-    </Center>
-  );
+  return <LocalStudioPageLayout.LoadingDisplay />;
 }

--- a/apps/web/src/studio/components/workflows/node-view/StepNode.tsx
+++ b/apps/web/src/studio/components/workflows/node-view/StepNode.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from '@mantine/core';
-import { Title, type LocalizedMessage } from '@novu/novui';
+import { Title, type WithLoadingSkeleton, type LocalizedMessage } from '@novu/novui';
 import { css, cx } from '@novu/novui/css';
 import { hstack } from '@novu/novui/patterns';
 import { token } from '@novu/novui/tokens';
@@ -12,9 +12,7 @@ interface IStepNodeProps {
   onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-type StepNodeComponent = FC<IStepNodeProps> & { LoadingDisplay: FC };
-
-export const StepNode: StepNodeComponent = ({ icon, title, onClick }) => {
+export const StepNode: WithLoadingSkeleton<FC<IStepNodeProps>> = ({ icon, title, onClick }) => {
   return (
     <button
       className={cx(

--- a/apps/web/src/studio/components/workflows/test-workflow/WorkflowsTestPage.tsx
+++ b/apps/web/src/studio/components/workflows/test-workflow/WorkflowsTestPage.tsx
@@ -140,8 +140,8 @@ export const WorkflowsTestPage = () => {
       description="Trigger a test run for this workflow"
       icon={<IconOutlineCable size="32" />}
       actions={
-        <Button loading={isTestLoading} Icon={IconPlayArrow} variant="filled" onClick={handleTestClick}>
-          Run a test
+        <Button loading={isTestLoading} Icon={IconPlayArrow} variant="outline" onClick={handleTestClick}>
+          Test workflow
         </Button>
       }
     >

--- a/libs/novui/src/types/WithLoadingSkeleton.ts
+++ b/libs/novui/src/types/WithLoadingSkeleton.ts
@@ -1,0 +1,6 @@
+import { FC } from 'react';
+
+// TODO: consider props that may be universal for loading skeletons
+export type LoadingDisplayComponent<TProps = object> = FC<TProps>;
+export type LoadingDisplayProps<TProps = object> = { LoadingDisplay: LoadingDisplayComponent<TProps> };
+export type WithLoadingSkeleton<T extends FC<any> = FC> = T & LoadingDisplayProps;

--- a/libs/novui/src/types/WithLoadingSkeleton.ts
+++ b/libs/novui/src/types/WithLoadingSkeleton.ts
@@ -1,6 +1,7 @@
 import { FC } from 'react';
+import { CoreProps } from './CoreProps';
 
 // TODO: consider props that may be universal for loading skeletons
-export type LoadingDisplayComponent<TProps = object> = FC<TProps>;
-export type LoadingDisplayProps<TProps = object> = { LoadingDisplay: LoadingDisplayComponent<TProps> };
+export type LoadingDisplayComponent<TProps = CoreProps> = FC<TProps>;
+export type LoadingDisplayProps<TProps = CoreProps> = { LoadingDisplay: LoadingDisplayComponent<TProps> };
 export type WithLoadingSkeleton<T extends FC<any> = FC> = T & LoadingDisplayProps;

--- a/libs/novui/src/types/index.ts
+++ b/libs/novui/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './CoreProps';
 export { type ExtractGeneric } from './ExtractGeneric';
 export * from './LocalizedMessage';
+export * from './WithLoadingSkeleton';


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

- Replace initial studio loader with a full-page skeleton loader
- Styling fix for test workflow button

_Note: the loading is still not ideal due to what happens with the redirect + multiple sequences of our `index.html` loader. _. This is a follow-up ticket: https://linear.app/novu/issue/NV-3984/improve-loaders-for-studio

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

https://github.com/novuhq/novu/assets/47441786/d89c97b2-83d2-42b9-872d-2433174db52c


