### PR TITLE
chore(api): Move `triggerBulk`, `triggerBroadcast` and `cancel` Event API methods to the top-level of the sdk

### DIFF
--- a/apps/api/src/app/events/events.controller.ts
+++ b/apps/api/src/app/events/events.controller.ts
@@ -94,6 +94,8 @@ export class EventsController {
   @ThrottlerCost(ApiRateLimitCostEnum.BULK)
   @Post('/trigger/bulk')
   @SdkMethodName('triggerBulk')
+  @SdkUsageExample('Trigger Notification Events in Bulk')
+  @SdkGroupName('')
   @ApiResponse(TriggerEventResponseDto, 201, true)
   @ApiOperation({
     summary: 'Bulk trigger event',
@@ -122,6 +124,8 @@ export class EventsController {
   @Post('/trigger/broadcast')
   @ApiResponse(TriggerEventResponseDto)
   @SdkMethodName('triggerBroadcast')
+  @SdkUsageExample('Broadcast Event to All')
+  @SdkGroupName('')
   @ApiOperation({
     summary: 'Broadcast event to all',
     description: `Trigger a broadcast event to all existing subscribers, could be used to send announcements, etc.
@@ -187,6 +191,8 @@ export class EventsController {
     `,
   })
   @SdkMethodName('cancel')
+  @SdkUsageExample('Cancel Triggered Event')
+  @SdkGroupName('')
   async cancel(@UserSession() user: UserSessionData, @Param('transactionId') transactionId: string): Promise<boolean> {
     return await this.cancelDelayedUsecase.execute(
       CancelDelayedCommand.create({


### PR DESCRIPTION
### What changed? Why was the change needed?
* Move the `triggerBulk`, `triggerBroadcast` and `cancel` methods to the top-level of the sdk (previously under `novu.events`) to maintain consistency with `novu.trigger`

### Screenshots
_Before, there is separation of `.trigger` and other methods:_
<img width="456" alt="image" src="https://github.com/novuhq/novu/assets/32132657/9787bb67-b0fa-4ded-a87b-dbd637c2e661">


<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
