### PR TITLE
fix(js): Use key prefix instead of id for alpha shades

### DIFF
--- a/packages/js/src/ui/helpers/utils.ts
+++ b/packages/js/src/ui/helpers/utils.ts
@@ -68,7 +68,7 @@ export function generatesAlphaShadesFromColor(props: { color: string; key: strin
   const rules = [];
   for (let i = 0; i < shades.length; i++) {
     const shade = shades[i];
-    const cssVariableAlphaRule = `.${props.id} { --nv-${props.id}-${shade}: oklch(from ${props.color} l c h / ${
+    const cssVariableAlphaRule = `.${props.id} { --nv-${props.key}-${shade}: oklch(from ${props.color} l c h / ${
       shade / 1000
     }); }`;
     rules.push(cssVariableAlphaRule);


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
Fixing a small bug, where the inbox ui id was used as the prefix instead of the key for the variable.
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
