### PR TITLE
fix(web): Remove faulty cross-iframe link for Discord invite

### DIFF
--- a/apps/web/src/components/layout/components/LocalStudioHeader/LocalStudioHeader.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioHeader/LocalStudioHeader.tsx
@@ -1,10 +1,9 @@
 import { Header } from '@mantine/core';
 import { IconButton } from '@novu/novui';
 import { css } from '@novu/novui/css';
-import { IconHelpOutline, IconOutlineMenuBook } from '@novu/novui/icons';
+import { IconOutlineMenuBook } from '@novu/novui/icons';
 import { HStack } from '@novu/novui/jsx';
 import { FC } from 'react';
-import { discordInviteUrl } from '../../../../pages/quick-start/consts';
 import { useStudioWorkflowsNavigation } from '../../../../studio/hooks';
 import { HEADER_NAV_HEIGHT } from '../../constants';
 import { BridgeMenuItems } from '../v2/BridgeMenuItems';

--- a/apps/web/src/components/layout/components/LocalStudioHeader/LocalStudioHeader.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioHeader/LocalStudioHeader.tsx
@@ -35,10 +35,6 @@ export const LocalStudioHeader: FC = () => {
             target="_blank"
             rel="noopener noreferrer"
           />
-
-          {/* This doesn't work because of Discord's popup blocker via the response header:
-          Cross-Origin-Opener-Policy: same-origin-allow-popups. We will likely need a Javascript workaround for Discord's popup blocker. */}
-          <IconButton Icon={IconHelpOutline} as="a" href={discordInviteUrl} target="_blank" rel="noopener noreferrer" />
         </HStack>
       </HStack>
     </Header>


### PR DESCRIPTION
### What changed? Why was the change needed?
* Remove faulty cross-iframe link for Discord invite (we will come back to address support via Local Studio later)

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Help button gone_
<img width="1727" alt="image" src="https://github.com/novuhq/novu/assets/32132657/8e0c3ea8-f51d-4e60-8881-ab348118b4ec">


<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
