### PR TITLE
fix(web): Make "Edit endpoint" button look more clickable

### DIFF
--- a/apps/web/src/components/layout/components/v2/BridgeMenuItems.tsx
+++ b/apps/web/src/components/layout/components/v2/BridgeMenuItems.tsx
@@ -1,11 +1,17 @@
+import { useStudioState } from '../../../../studio/StudioStateProvider';
+import { When } from '../../../utils/When';
 import { BridgeUpdateModalTrigger } from './BridgeUpdateModalTrigger';
 import { SyncInfoModalTrigger } from './SyncInfoModalTrigger';
 
 export function BridgeMenuItems() {
+  const { isLocalStudio } = useStudioState();
+
   return (
     <>
       <BridgeUpdateModalTrigger />
-      <SyncInfoModalTrigger />
+      <When truthy={isLocalStudio}>
+        <SyncInfoModalTrigger />
+      </When>
     </>
   );
 }

--- a/apps/web/src/components/layout/components/v2/BridgeUpdateModal.tsx
+++ b/apps/web/src/components/layout/components/v2/BridgeUpdateModal.tsx
@@ -20,7 +20,7 @@ export type BridgeUpdateModalProps = {
 
 export const BridgeUpdateModal: FC<BridgeUpdateModalProps> = ({ isOpen, toggleOpen }) => {
   const segment = useSegment();
-  const { local, bridgeURL, setBridgeURL } = useStudioState();
+  const { isLocalStudio, bridgeURL, setBridgeURL } = useStudioState();
   const [urlError, setUrlError] = useState<string>('');
   const [url, setUrl] = useState(bridgeURL);
   const [isUpdating, setIsUpdating] = useState(false);
@@ -60,7 +60,7 @@ export const BridgeUpdateModal: FC<BridgeUpdateModalProps> = ({ isOpen, toggleOp
 
   const storeInProperLocation = async (newUrl: string) => {
     setBridgeURL(newUrl);
-    if (!local) {
+    if (!isLocalStudio) {
       await updateBridgeUrl({ url: newUrl }, environment?._id ?? '');
     }
   };

--- a/apps/web/src/components/layout/components/v2/BridgeUpdateModalTrigger.tsx
+++ b/apps/web/src/components/layout/components/v2/BridgeUpdateModalTrigger.tsx
@@ -33,7 +33,7 @@ function BridgeUpdateModalTriggerControl({ onClick }: { onClick: () => void }) {
 
   const trigger = isHovered ? (
     <Button {...hoverProps} variant="outline" size="xs" Icon={IconEdit} onClick={onClick}>
-      <Text>Edit endpoint</Text>
+      Edit endpoint
     </Button>
   ) : (
     <ConnectionStatusIndicator status={status} {...hoverProps} onClick={onClick} />

--- a/apps/web/src/components/layout/components/v2/BridgeUpdateModalTrigger.tsx
+++ b/apps/web/src/components/layout/components/v2/BridgeUpdateModalTrigger.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from 'react';
 import { Tooltip } from '@novu/design-system';
-import { Text } from '@novu/novui';
+import { Text, Button } from '@novu/novui';
 import { css } from '@novu/novui/css';
 import { IconEdit, IconLink, IconLinkOff } from '@novu/novui/icons';
 import { HStack } from '@novu/novui/jsx';
@@ -32,16 +32,9 @@ function BridgeUpdateModalTriggerControl({ onClick }: { onClick: () => void }) {
   const { status, bridgeURL } = useBridgeConnectionStatus();
 
   const trigger = isHovered ? (
-    <button
-      {...hoverProps}
-      onClick={onClick}
-      className={css({ '&, & svg': { color: 'typography.text.main !important' } })}
-    >
-      <HStack gap="25">
-        <IconEdit className={css({ color: 'icon.main' })} size="16" />
-        <Text>Edit endpoint</Text>
-      </HStack>
-    </button>
+    <Button {...hoverProps} variant="outline" size="xs" Icon={IconEdit} onClick={onClick}>
+      <Text>Edit endpoint</Text>
+    </Button>
   ) : (
     <ConnectionStatusIndicator status={status} {...hoverProps} onClick={onClick} />
   );

--- a/apps/web/src/studio/LocalStudioAuthenticator.tsx
+++ b/apps/web/src/studio/LocalStudioAuthenticator.tsx
@@ -111,7 +111,7 @@ export function LocalStudioAuthenticator() {
     const tunnelBridgeURL = buildBridgeURL(tunnelOrigin, tunnelPath);
 
     const state: StudioState = {
-      local: true,
+      isLocalStudio: true,
       devSecretKey: apiKey,
       testUser: {
         id: currentUser._id,

--- a/apps/web/src/studio/StudioPageLayout.tsx
+++ b/apps/web/src/studio/StudioPageLayout.tsx
@@ -12,7 +12,7 @@ export function StudioPageLayout() {
     return <Outlet />;
   }
 
-  if (state?.local) {
+  if (state?.isLocalStudio) {
     return <LocalStudioPageLayout />;
   }
 

--- a/apps/web/src/studio/StudioStateProvider.tsx
+++ b/apps/web/src/studio/StudioStateProvider.tsx
@@ -11,7 +11,7 @@ type BridgeURLGetterSetter = { bridgeURL: string; setBridgeURL: (url: string) =>
 const StudioStateContext = React.createContext<(StudioState & BridgeURLGetterSetter) | undefined>(undefined);
 
 function computeBridgeURL(state: StudioState) {
-  return state.local ? state.localBridgeURL || state.tunnelBridgeURL : state.storedBridgeURL;
+  return state.isLocalStudio ? state.localBridgeURL || state.tunnelBridgeURL : state.storedBridgeURL;
 }
 
 function convertToTestUser(currentUser?: IUserEntity) {
@@ -36,7 +36,7 @@ export const StudioStateProvider = ({ children }: { children: React.ReactNode })
     }
 
     return {
-      local: false,
+      isLocalStudio: false,
       storedBridgeURL: environment?.echo?.url || '',
       testUser: convertToTestUser(currentUser),
       organizationName: currentOrganization?.name || '',
@@ -46,15 +46,15 @@ export const StudioStateProvider = ({ children }: { children: React.ReactNode })
   const [bridgeURL, setBridgeURL] = useState(computeBridgeURL(state));
 
   useEffect(() => {
-    if (!state.local) {
+    if (!state.isLocalStudio) {
       setState({
-        local: false,
+        isLocalStudio: false,
         storedBridgeURL: environment?.echo?.url || '',
         testUser: convertToTestUser(currentUser),
         organizationName: currentOrganization?.name || '',
       });
     }
-  }, [environment, state?.local, currentUser, currentOrganization]);
+  }, [environment, state?.isLocalStudio, currentUser, currentOrganization]);
 
   useEffect(() => {
     setBridgeURL(computeBridgeURL(state));

--- a/apps/web/src/studio/components/workflows/step-editor/WorkflowTestStepButton.tsx
+++ b/apps/web/src/studio/components/workflows/step-editor/WorkflowTestStepButton.tsx
@@ -21,7 +21,7 @@ export const WorkflowTestStepButton = ({
   stepType: ChannelTypeEnum;
 }) => {
   const segment = useSegment();
-  const { local, testUser } = useStudioState();
+  const { isLocalStudio: local, testUser } = useStudioState();
   const { mutateAsync: testSendEmailEvent, isLoading: isTestingEmail } = useMutation(testSendEmailMessage);
 
   const handleTestClick = async () => {

--- a/apps/web/src/studio/components/workflows/test-workflow/WorkflowsTestPage.tsx
+++ b/apps/web/src/studio/components/workflows/test-workflow/WorkflowsTestPage.tsx
@@ -22,7 +22,7 @@ import { useApiKeys } from '../../../../hooks/useNovuAPI';
 
 export const WorkflowsTestPage = () => {
   const segment = useSegment();
-  const { local, testUser } = useStudioState() || {};
+  const { isLocalStudio: local, testUser } = useStudioState() || {};
   const { templateId = '' } = useParams<{ templateId: string }>();
   const [payload, setPayload] = useState<Record<string, any>>({});
   const [to, setTo] = useState<ToSubscriber>({

--- a/apps/web/src/studio/hooks/useBridgeAPI.ts
+++ b/apps/web/src/studio/hooks/useBridgeAPI.ts
@@ -89,7 +89,7 @@ export const useWorkflowTrigger = () => {
 
   const { mutateAsync, ...rest } = useMutation(api.trigger);
 
-  const bridgeUrl = state.local ? state.tunnelBridgeURL : state.storedBridgeURL;
+  const bridgeUrl = state.isLocalStudio ? state.tunnelBridgeURL : state.storedBridgeURL;
 
   async function trigger(params: TriggerParams): Promise<{ data: { transactionId: string } }> {
     return mutateAsync({ ...params, bridgeUrl });

--- a/apps/web/src/studio/hooks/useBridgeURL.ts
+++ b/apps/web/src/studio/hooks/useBridgeURL.ts
@@ -5,7 +5,7 @@ export function useBridgeURL(tunnel = false) {
 
   let bridgeURL;
 
-  if (studioState.local) {
+  if (studioState.isLocalStudio) {
     /*
      * Local studio mode.
      * Prefer local host for bridge discovery as it's faster

--- a/apps/web/src/studio/types.ts
+++ b/apps/web/src/studio/types.ts
@@ -32,12 +32,12 @@ type BaseStudioState = {
 };
 
 type CloudStudioState = BaseStudioState & {
-  local: false;
+  isLocalStudio: false;
   storedBridgeURL: string;
 };
 
 type LocalStudioState = BaseStudioState & {
-  local: true;
+  isLocalStudio: true;
   localBridgeURL: string;
   tunnelBridgeURL: string;
 };


### PR DESCRIPTION
### What changed? Why was the change needed?
* Modify the clickable "Edit endpoint" button to include an outline to better signify that it is clickable
* Remove the "Sync" button from Cloud mode, as this button is not relevant to Cloud and only relevant to Local Studio
* rename `local` in Studio state to a more descriptive `isLocalStudio`

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Local Studio mode_
<img width="319" alt="image" src="https://github.com/novuhq/novu/assets/32132657/f88d467a-90ce-497d-9741-196314362da2">

_Cloud Studio mode (note: sync button is removed per requirements)_
<img width="462" alt="image" src="https://github.com/novuhq/novu/assets/32132657/5c6e2f50-e519-41ae-add3-e79581ebe5b1">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
