### PR TITLE
fix(web): Display bridgeUrl on cURL command, refactor code snippets

### DIFF
--- a/apps/web/src/components/execution-detail/ExecutionDetailTrigger.tsx
+++ b/apps/web/src/components/execution-detail/ExecutionDetailTrigger.tsx
@@ -11,13 +11,14 @@ const TriggerTitle = styled(Text)`
 `;
 
 export const ExecutionDetailTrigger = ({ identifier, step, subscriberVariables }) => {
-  const { payload, tenant, actorId } = step || {};
+  const { payload, overrides, tenant, actorId } = step || {};
 
   const curlSnippet = getCurlTriggerSnippet({
     identifier,
     to: subscriberVariables,
     payload,
-    overrides: {
+    overrides,
+    snippet: {
       ...(tenant && { tenant }),
       ...(actorId && { actor: { subscriberId: actorId } }),
     },

--- a/apps/web/src/components/execution-detail/ExecutionDetailTrigger.tsx
+++ b/apps/web/src/components/execution-detail/ExecutionDetailTrigger.tsx
@@ -11,11 +11,16 @@ const TriggerTitle = styled(Text)`
 `;
 
 export const ExecutionDetailTrigger = ({ identifier, step, subscriberVariables }) => {
-  const { payload, overrides, tenant, actorId } = step || {};
+  const { payload, tenant, actorId } = step || {};
 
-  const curlSnippet = getCurlTriggerSnippet(identifier, subscriberVariables, payload, overrides, {
-    ...(tenant && { tenant }),
-    ...(actorId && { actor: { subscriberId: actorId } }),
+  const curlSnippet = getCurlTriggerSnippet({
+    identifier,
+    to: subscriberVariables,
+    payload,
+    overrides: {
+      ...(tenant && { tenant }),
+      ...(actorId && { actor: { subscriberId: actorId } }),
+    },
   });
 
   return (

--- a/apps/web/src/pages/templates/components/TriggerSnippetTabs.tsx
+++ b/apps/web/src/pages/templates/components/TriggerSnippetTabs.tsx
@@ -33,11 +33,21 @@ export function TriggerSnippetTabs({ trigger }: { trigger: INotificationTrigger 
   const prismTabs = [
     {
       value: NODE_JS,
-      content: getNodeTriggerSnippet({ identifier: trigger.identifier, to: toValue, payload: payloadValue }),
+      content: getNodeTriggerSnippet({
+        identifier: trigger.identifier,
+        to: toValue,
+        payload: payloadValue,
+        snippet: reservedValue,
+      }),
     },
     {
       value: CURL,
-      content: getCurlTriggerSnippet({ identifier: trigger.identifier, to: toValue, payload: payloadValue }),
+      content: getCurlTriggerSnippet({
+        identifier: trigger.identifier,
+        to: toValue,
+        payload: payloadValue,
+        snippet: reservedValue,
+      }),
     },
   ];
 
@@ -45,21 +55,17 @@ export function TriggerSnippetTabs({ trigger }: { trigger: INotificationTrigger 
 }
 
 export const getNodeTriggerSnippet = (props: CodeSnippetProps) => {
-  const triggerCodeSnippet = createNodeSnippet(props);
-
   return (
     <Prism mt={5} styles={prismStyles} data-test-id="trigger-code-snippet" language="javascript">
-      {triggerCodeSnippet}
+      {createNodeSnippet(props)}
     </Prism>
   );
 };
 
 export const getCurlTriggerSnippet = (props: CodeSnippetProps) => {
-  const curlSnippet = createCurlSnippet(props);
-
   return (
     <Prism mt={5} styles={prismStyles} language="bash" key="2" data-test-id="trigger-curl-snippet">
-      {curlSnippet}
+      {createCurlSnippet(props)}
     </Prism>
   );
 };

--- a/apps/web/src/pages/templates/components/TriggerSnippetTabs.tsx
+++ b/apps/web/src/pages/templates/components/TriggerSnippetTabs.tsx
@@ -6,7 +6,7 @@ import * as get from 'lodash.get';
 import { INotificationTrigger, INotificationTriggerVariable, TemplateVariableTypeEnum } from '@novu/shared';
 
 import { colors, Tabs } from '@novu/design-system';
-import { createCurlSnippet, createNodeSnippet } from '../../../utils/codeSnippets';
+import { CodeSnippetProps, createCurlSnippet, createNodeSnippet } from '../../../utils/codeSnippets';
 
 const NODE_JS = 'Node.js';
 const CURL = 'Curl';
@@ -33,26 +33,19 @@ export function TriggerSnippetTabs({ trigger }: { trigger: INotificationTrigger 
   const prismTabs = [
     {
       value: NODE_JS,
-      content: getNodeTriggerSnippet(trigger.identifier, toValue, payloadValue, undefined, reservedValue),
+      content: getNodeTriggerSnippet({ identifier: trigger.identifier, to: toValue, payload: payloadValue }),
     },
     {
       value: CURL,
-      content: getCurlTriggerSnippet(trigger.identifier, toValue, payloadValue, undefined, reservedValue),
+      content: getCurlTriggerSnippet({ identifier: trigger.identifier, to: toValue, payload: payloadValue }),
     },
   ];
 
   return <Tabs defaultValue={NODE_JS} data-test-id="trigger-code-snippet" menuTabs={prismTabs} />;
 }
 
-export const getNodeTriggerSnippet = (
-  identifier: string,
-  to: Record<string, unknown>,
-  payload: Record<string, unknown>,
-  overrides?: Record<string, unknown>,
-  snippet?: Record<string, unknown>,
-  apiKey = '<API_KEY>'
-) => {
-  const triggerCodeSnippet = createNodeSnippet(identifier, to, payload, overrides, snippet, apiKey);
+export const getNodeTriggerSnippet = (props: CodeSnippetProps) => {
+  const triggerCodeSnippet = createNodeSnippet(props);
 
   return (
     <Prism mt={5} styles={prismStyles} data-test-id="trigger-code-snippet" language="javascript">
@@ -61,15 +54,8 @@ export const getNodeTriggerSnippet = (
   );
 };
 
-export const getCurlTriggerSnippet = (
-  identifier: string,
-  to: Record<string, any>,
-  payload: Record<string, any>,
-  overrides?: Record<string, any>,
-  snippet?: Record<string, unknown>,
-  apiKey = '<REPLACE_WITH_API_KEY>'
-) => {
-  const curlSnippet = createCurlSnippet(identifier, to, payload, overrides, snippet, apiKey);
+export const getCurlTriggerSnippet = (props: CodeSnippetProps) => {
+  const curlSnippet = createCurlSnippet(props);
 
   return (
     <Prism mt={5} styles={prismStyles} language="bash" key="2" data-test-id="trigger-curl-snippet">

--- a/apps/web/src/studio/components/workflows/test-workflow/WorkflowTestTriggerPanel.tsx
+++ b/apps/web/src/studio/components/workflows/test-workflow/WorkflowTestTriggerPanel.tsx
@@ -10,16 +10,47 @@ import {
   createPhpSnippet,
   createGoSnippet,
   createPythonSnippet,
+  CodeSnippetProps,
 } from '../../../../utils/codeSnippets';
+import { Language } from 'prism-react-renderer';
 
-interface IWorkflowTestTriggerPanelProps {
-  identifier: string;
-  to: Record<string, unknown>;
-  payload: Record<string, unknown>;
-  apiKey: string;
-}
+type Snippet = {
+  languageLabel: string;
+  language: Language;
+  create: (props: CodeSnippetProps) => string;
+};
 
-export const WorkflowTestTriggerPanel: FC<IWorkflowTestTriggerPanelProps> = ({ identifier, to, payload, apiKey }) => {
+const snippets: Snippet[] = [
+  {
+    languageLabel: 'Node.js',
+    language: 'javascript',
+    create: createNodeSnippet,
+  },
+  {
+    languageLabel: 'Curl',
+    language: 'bash',
+    create: createCurlSnippet,
+  },
+  {
+    languageLabel: 'PHP',
+    language: 'c', // PHP is not supported
+    create: createPhpSnippet,
+  },
+  {
+    languageLabel: 'GOlang',
+    language: 'go',
+    create: createGoSnippet,
+  },
+  {
+    languageLabel: 'Python',
+    language: 'python',
+    create: createPythonSnippet,
+  },
+];
+
+const DEFAULT_LANGUAGE: Language = 'javascript';
+
+export const WorkflowTestTriggerPanel: FC<CodeSnippetProps> = (props) => {
   return (
     <Box>
       <HStack gap="50" mb="margins.layout.page.section.titleBottom">
@@ -28,54 +59,16 @@ export const WorkflowTestTriggerPanel: FC<IWorkflowTestTriggerPanelProps> = ({ i
       </HStack>
       <Tabs
         height={'[100% !important]'}
-        defaultValue="node"
-        tabConfigs={[
-          {
-            value: 'node',
-            label: 'Node.js',
-            content: (
-              <Prism withLineNumbers={true} language="javascript" h="100%">
-                {createNodeSnippet(identifier, to, payload, undefined, undefined, apiKey) as any}
-              </Prism>
-            ),
-          },
-          {
-            value: 'curl',
-            label: 'Curl',
-            content: (
-              <Prism withLineNumbers={true} language="bash" h="100%">
-                {createCurlSnippet(identifier, to, payload, undefined, undefined, apiKey) as any}
-              </Prism>
-            ),
-          },
-          {
-            value: 'php',
-            label: 'PHP',
-            content: (
-              <Prism withLineNumbers={true} language="markdown" h="100%">
-                {createPhpSnippet(identifier, to, payload, apiKey) as any}
-              </Prism>
-            ),
-          },
-          {
-            value: 'golang',
-            label: 'GOlang',
-            content: (
-              <Prism withLineNumbers={true} language="go" h="100%">
-                {createGoSnippet(identifier, to, payload, apiKey) as any}
-              </Prism>
-            ),
-          },
-          {
-            value: 'python',
-            label: 'Python',
-            content: (
-              <Prism withLineNumbers={true} language="python" h="100%">
-                {createPythonSnippet(identifier, to, payload, apiKey) as any}
-              </Prism>
-            ),
-          },
-        ]}
+        defaultValue={DEFAULT_LANGUAGE}
+        tabConfigs={snippets.map((snippet) => ({
+          value: snippet.language,
+          label: snippet.languageLabel,
+          content: (
+            <Prism withLineNumbers={true} language={snippet.language} h="100%">
+              {snippet.create(props)}
+            </Prism>
+          ),
+        }))}
       />
     </Box>
   );

--- a/apps/web/src/studio/components/workflows/test-workflow/WorkflowsTestPage.tsx
+++ b/apps/web/src/studio/components/workflows/test-workflow/WorkflowsTestPage.tsx
@@ -18,11 +18,11 @@ import { useTemplateFetcher } from '../../../../api/hooks/index';
 import { useSegment } from '../../../../components/providers/SegmentProvider';
 import { useStudioState } from '../../../StudioStateProvider';
 import { testTrigger } from '../../../../api/notification-templates';
-import { useApiKeys } from '../../../../hooks/useNovuAPI';
 
 export const WorkflowsTestPage = () => {
   const segment = useSegment();
-  const { isLocalStudio: local, testUser } = useStudioState() || {};
+  const studioState = useStudioState() || {};
+  const { isLocalStudio, testUser, devSecretKey } = studioState;
   const { templateId = '' } = useParams<{ templateId: string }>();
   const [payload, setPayload] = useState<Record<string, any>>({});
   const [to, setTo] = useState<ToSubscriber>({
@@ -30,19 +30,16 @@ export const WorkflowsTestPage = () => {
     email: '',
   });
 
-  const { data: apiKeys = [] } = useApiKeys();
-  const key = useMemo(() => apiKeys[0]?.key, [apiKeys]);
-
   const { template, isLoading: isTemplateLoading } = useTemplateFetcher({
-    templateId: local ? undefined : templateId,
+    templateId: isLocalStudio ? undefined : templateId,
   });
-  const { mutateAsync: triggerCloudTestEvent, isLoading: isCloudTestLoading } = useMutation(testTrigger);
-  const { data: workflow, isLoading: isWorkflowLoading } = useWorkflow(templateId, { enabled: local });
+  const { mutateAsync: triggerCloudTestEvent } = useMutation(testTrigger);
+  const { data: workflow, isLoading: isWorkflowLoading } = useWorkflow(templateId, { enabled: isLocalStudio });
   const { trigger, isLoading: isTestLoading } = useWorkflowTrigger();
 
   const isLoading = useMemo(
-    () => (local ? isWorkflowLoading : isTemplateLoading),
-    [isWorkflowLoading, isTemplateLoading, local]
+    () => (isLocalStudio ? isWorkflowLoading : isTemplateLoading),
+    [isWorkflowLoading, isTemplateLoading, isLocalStudio]
   );
 
   useEffect(() => {
@@ -55,7 +52,7 @@ export const WorkflowsTestPage = () => {
   }, [testUser]);
 
   const stepTypes = useMemo(() => {
-    if (local) {
+    if (isLocalStudio) {
       if (!workflow) {
         return [];
       }
@@ -68,25 +65,25 @@ export const WorkflowsTestPage = () => {
     }
 
     return template.steps.map((step) => step.template.type);
-  }, [workflow, local, template]);
+  }, [workflow, isLocalStudio, template]);
 
   const [transactionId, setTransactionId] = useState<string>('');
   const [executionModalOpened, { close: closeExecutionModal, open: openExecutionModal }] = useDisclosure(false);
   const workflowId = useMemo(
-    () => (local ? workflow?.workflowId : template?.triggers[0].identifier),
-    [local, template?.triggers, workflow?.workflowId]
+    () => (isLocalStudio ? workflow?.workflowId : template?.triggers[0].identifier),
+    [isLocalStudio, template?.triggers, workflow?.workflowId]
   );
 
   const handleTestClick = async () => {
     segment.track('Workflow test ran - [Workflows Test Page]', {
-      env: local ? 'local' : 'cloud',
+      env: isLocalStudio ? 'local' : 'cloud',
     });
 
     try {
       payload.__source = 'studio-test-workflow';
 
       let response;
-      if (local) {
+      if (isLocalStudio) {
         const bridgeResponse = await trigger({
           workflowId: workflowId,
           to,
@@ -123,7 +120,7 @@ export const WorkflowsTestPage = () => {
     }
   };
 
-  if (local ? isWorkflowLoading : isTemplateLoading) {
+  if (isLocalStudio ? isWorkflowLoading : isTemplateLoading) {
     return (
       <Center
         className={css({
@@ -147,7 +144,13 @@ export const WorkflowsTestPage = () => {
       }
     >
       <WorkflowsPanelLayout>
-        <WorkflowTestTriggerPanel identifier={workflowId} to={to} payload={payload} apiKey={key} />
+        <WorkflowTestTriggerPanel
+          identifier={workflowId}
+          to={to}
+          payload={payload}
+          secretKey={devSecretKey}
+          bridgeUrl={isLocalStudio ? studioState.tunnelBridgeURL : undefined}
+        />
         <When truthy={!isLoading}>
           <WorkflowTestControlsPanel
             onChange={onChange}

--- a/apps/web/src/utils/codeSnippets.ts
+++ b/apps/web/src/utils/codeSnippets.ts
@@ -12,7 +12,7 @@ export type CodeSnippetProps = {
 
 const SECRET_KEY_ENV_KEY = 'NOVU_SECRET_KEY';
 
-export const createNodeSnippet = ({ identifier, to, payload, snippet, secretKey }: CodeSnippetProps) => {
+export const createNodeSnippet = ({ identifier, to, payload, overrides, snippet, secretKey }: CodeSnippetProps) => {
   const renderedSecretKey = secretKey ? `'${secretKey}'` : `process.env['${SECRET_KEY_ENV_KEY}']`;
 
   return `import { Novu } from '@novu/node'; 
@@ -23,6 +23,7 @@ novu.trigger('${identifier}', ${JSON.stringify(
     {
       to,
       payload,
+      overrides,
       ...snippet,
     },
     null,
@@ -37,6 +38,7 @@ export const createCurlSnippet = ({
   identifier,
   to,
   payload,
+  overrides,
   snippet,
   bridgeUrl,
   secretKey = SECRET_KEY_ENV_KEY,
@@ -49,6 +51,7 @@ export const createCurlSnippet = ({
       name: identifier,
       to,
       payload,
+      overrides,
       bridgeUrl,
       ...snippet,
     },

--- a/apps/web/tests/create-notification.spec.ts
+++ b/apps/web/tests/create-notification.spec.ts
@@ -405,7 +405,7 @@ async function createWorkflow(page: Page) {
 }
 async function assertCurlSnippet(snippetModal: CodeSnippetSidePanelPageModel) {
   const curlSnippetText = await snippetModal.getCurlSnippet();
-  expect(curlSnippetText).toContain("--header 'Authorization: ApiKey");
+  expect(curlSnippetText).toContain("-H 'Authorization: ApiKey");
   expect(curlSnippetText).toContain('taskName');
 }
 interface DigestTestData {

--- a/packages/create-novu-app/templates/github/workflows/novu.yml
+++ b/packages/create-novu-app/templates/github/workflows/novu.yml
@@ -7,11 +7,21 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
+      # https://github.com/novuhq/actions-novu-sync
       - name: Sync State to Novu
         uses: novuhq/actions-novu-sync@v2
         with:
+          # The secret key used to authenticate with Novu Cloud
+          # To get the secret key, go to https://web.novu.co/api-keys.
+          # Required.
           secret-key: ${{ secrets.NOVU_SECRET_KEY }}
+
+          # The publicly available endpoint hosting the bridge application
+          # where notification entities (eg. workflows, topics) are defined.
+          # Required.
           bridge-url: ${{ secrets.NOVU_BRIDGE_URL }}
+
+          # The Novu Cloud API URL to sync with.
+          # Optional.
+          # Defaults to https://api.novu.co
+          api-url: https://api.novu.co


### PR DESCRIPTION
### What changed? Why was the change needed?
* Display `bridgeUrl` for cURL snippet when `isLocalStudio===true` (not needed for other languages as the resolution algorithm is built-in to the SDK)
* Refactor code snippets to use common props
* Use idiomatic process.env access for Cloud environment secret key
* Fix formatting on code snippets following best practices

### Screenshots
**All snippets screenshots follow a pattern of:**
1. Before (Cloud)
2. After (Local)
3. After (Cloud)

<!-- If the changes are visual, include screenshots or screencasts. -->
_Node_
![image](https://github.com/novuhq/novu/assets/32132657/505b612d-fa3d-4d2c-baf5-2b666571ce34)

_cURL - note, the new `bridgeUrl` shown_
![image](https://github.com/novuhq/novu/assets/32132657/5c7fff7e-10ec-4e4e-832d-aea2ebb87a8d)

_PHP_
![image](https://github.com/novuhq/novu/assets/32132657/f4e56360-6edc-406f-b465-dbbbf5903095)

_goLang_
![image](https://github.com/novuhq/novu/assets/32132657/852f50c0-11c7-44f9-8530-782b01a5c866)

_Python_
![image](https://github.com/novuhq/novu/assets/32132657/5d3a41ac-716f-4e4b-be55-1cc4852caf0b)

_Legacy Trigger payload_
<img width="460" alt="image" src="https://github.com/novuhq/novu/assets/32132657/7d9a249b-09a4-4319-902b-b78097be0d75">

_Execution details_
<img width="1532" alt="image" src="https://github.com/novuhq/novu/assets/32132657/195d505e-0516-47d6-90e6-94b85988a51c">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
