### PR TITLE
fix(framework): Remove compile time secret key check

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "0.24.3-alpha.14",
+  "version": "0.24.3-alpha.15",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "0.24.3-alpha.15",
+  "version": "0.24.3-alpha.16",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -45,12 +45,6 @@ describe('Novu Client', () => {
       expect(newClient.secretKey).toBe(testSecretKey);
     });
 
-    it('should throw an error when secretKey is not provided', () => {
-      expect(() => new Client({ secretKey: undefined })).toThrow(
-        'Missing secret key. Set the `NOVU_SECRET_KEY` environment variable or pass `secretKey` to the client options.'
-      );
-    });
-
     it('should set strictAuthentication to false when NODE_ENV is development', () => {
       const originalEnv = process.env.NODE_ENV;
       process.env = { ...process.env, NODE_ENV: 'development' };

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -10,7 +10,6 @@ import {
   ExecutionStateCorruptError,
   ExecutionStateOutputInvalidError,
   ExecutionStateResultInvalidError,
-  MissingSecretKeyError,
   ProviderExecutionFailedError,
   ProviderNotFoundError,
   StepNotFoundError,
@@ -78,10 +77,6 @@ export class Client {
 
     builtConfiguration.secretKey =
       providedOptions?.secretKey || process.env.NOVU_SECRET_KEY || process.env.NOVU_API_KEY;
-
-    if (!isRuntimeInDevelopment() && !builtConfiguration.secretKey) {
-      throw new MissingSecretKeyError();
-    }
 
     if (providedOptions?.strictAuthentication !== undefined) {
       builtConfiguration.strictAuthentication = providedOptions.strictAuthentication;

--- a/packages/framework/src/h3.ts
+++ b/packages/framework/src/h3.ts
@@ -1,6 +1,6 @@
 import { getHeader, getQuery, type H3Event, readBody, send, setHeaders } from 'h3';
 
-import { NovuRequestHandler, ServeHandlerOptions } from './handler';
+import { NovuRequestHandler, type ServeHandlerOptions } from './handler';
 import { type SupportedFrameworkName } from './types';
 
 export const frameworkName: SupportedFrameworkName = 'h3';

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -22,22 +22,22 @@ import {
   SignatureNotFoundError,
   SigningKeyNotFoundError,
 } from './errors';
-import { FRAMEWORK_VERSION, SDK_VERSION } from './version';
-import { Awaitable, EventTriggerParams, Workflow } from './types';
+import type { Awaitable, EventTriggerParams, Workflow } from './types';
 import { initApiClient } from './utils';
+import { FRAMEWORK_VERSION, SDK_VERSION } from './version';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export interface ServeHandlerOptions {
+export type ServeHandlerOptions = {
   client?: Client;
   workflows: Array<Workflow>;
-}
+};
 
-interface INovuRequestHandlerOptions<Input extends any[] = any[], Output = any> extends ServeHandlerOptions {
+export type INovuRequestHandlerOptions<Input extends any[] = any[], Output = any> = ServeHandlerOptions & {
   frameworkName: string;
   client?: Client;
   workflows: Array<Workflow>;
   handler: Handler<Input, Output>;
-}
+};
 
 type Handler<Input extends any[] = any[], Output = any> = (...args: Input) => HandlerResponse<Output>;
 
@@ -50,11 +50,11 @@ type HandlerResponse<Output = any> = {
   transformResponse: (res: IActionResponse<string>) => Output;
 };
 
-interface IActionResponse<TBody extends string = string> {
+export type IActionResponse<TBody extends string = string> = {
   status: number;
   headers: Record<string, string>;
   body: TBody;
-}
+};
 
 export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
   public readonly frameworkName: string;

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -1,5 +1,5 @@
 export { Client } from './client';
 export * from './types';
 export * from './constants';
-export { NovuRequestHandler, ServeHandlerOptions } from './handler';
+export { NovuRequestHandler, type ServeHandlerOptions } from './handler';
 export { workflow } from './workflow';

--- a/packages/framework/src/next.ts
+++ b/packages/framework/src/next.ts
@@ -1,8 +1,8 @@
 import { type NextApiRequest, type NextApiResponse } from 'next';
 import { type NextRequest } from 'next/server';
 
-import { NovuRequestHandler, ServeHandlerOptions } from './handler';
-import { Either } from './types';
+import { NovuRequestHandler, type ServeHandlerOptions } from './handler';
+import { type Either } from './types';
 import { type SupportedFrameworkName } from './types';
 import { getResponse } from './utils';
 

--- a/packages/framework/src/nuxt.ts
+++ b/packages/framework/src/nuxt.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { getHeader, getQuery, H3Event, readBody, send, setHeaders } from 'h3';
 
-import { NovuRequestHandler, ServeHandlerOptions } from './handler';
+import { NovuRequestHandler, type ServeHandlerOptions } from './handler';
 import { type SupportedFrameworkName } from './types';
 
 export const frameworkName: SupportedFrameworkName = 'nuxt';

--- a/packages/framework/src/remix.ts
+++ b/packages/framework/src/remix.ts
@@ -1,4 +1,4 @@
-import { NovuRequestHandler, ServeHandlerOptions } from './handler';
+import { NovuRequestHandler, type ServeHandlerOptions } from './handler';
 import { type SupportedFrameworkName } from './types';
 import { getResponse } from './utils';
 

--- a/packages/framework/src/sveltekit.ts
+++ b/packages/framework/src/sveltekit.ts
@@ -1,5 +1,5 @@
 import { RequestEvent } from '@sveltejs/kit';
-import { NovuRequestHandler, ServeHandlerOptions } from './handler';
+import { NovuRequestHandler, type ServeHandlerOptions } from './handler';
 import { type SupportedFrameworkName } from './types';
 import { getResponse } from './utils';
 

--- a/packages/framework/src/types/discover.types.ts
+++ b/packages/framework/src/types/discover.types.ts
@@ -1,9 +1,9 @@
 import { ActionStepEnum, ChannelStepEnum } from '../constants';
-import { JsonSchema, Schema } from './schema.types';
-import { StepOptions } from './step.types';
-import { Execute, WorkflowOptions } from './workflow.types';
-import { Awaitable, Prettify } from './util.types';
-import { EventTriggerParams, EventTriggerResult } from './event.types';
+import type { JsonSchema, Schema } from './schema.types';
+import type { StepOptions } from './step.types';
+import type { Execute, WorkflowOptions } from './workflow.types';
+import type { Awaitable, Prettify } from './util.types';
+import type { EventTriggerParams, EventTriggerResult } from './event.types';
 
 export type StepType = `${ChannelStepEnum | ActionStepEnum}`;
 

--- a/packages/framework/src/types/execution.types.ts
+++ b/packages/framework/src/types/execution.types.ts
@@ -1,4 +1,4 @@
-import { Subscriber } from './subscriber.types';
+import type { Subscriber } from './subscriber.types';
 
 export type Event = {
   /** @deprecated */

--- a/packages/framework/src/types/provider.types.ts
+++ b/packages/framework/src/types/provider.types.ts
@@ -1,5 +1,5 @@
 import { providerSchemas } from '../schemas';
-import { FromSchema } from './schema.types';
+import type { FromSchema } from './schema.types';
 
 export type Providers<T_StepType extends keyof typeof providerSchemas, T_Control, T_Output> = {
   [K in keyof (typeof providerSchemas)[T_StepType]]: (step: {

--- a/packages/framework/src/types/schema.types.ts
+++ b/packages/framework/src/types/schema.types.ts
@@ -1,4 +1,4 @@
-import { JSONSchema, FromSchema as JsonSchemaInfer } from 'json-schema-to-ts';
+import type { JSONSchema, FromSchema as JsonSchemaInfer } from 'json-schema-to-ts';
 import * as z from 'zod';
 
 export type Schema = JSONSchema | z.ZodSchema;

--- a/packages/framework/src/types/skip.types.ts
+++ b/packages/framework/src/types/skip.types.ts
@@ -1,3 +1,3 @@
-import { Awaitable } from './util.types';
+import type { Awaitable } from './util.types';
 
 export type Skip<T> = (controls: T) => Awaitable<boolean>;

--- a/packages/framework/src/types/step.types.ts
+++ b/packages/framework/src/types/step.types.ts
@@ -7,12 +7,12 @@ import {
   digestResultSchema,
   digestTimedOutputSchema,
 } from '../schemas';
-import { channelStepSchemas } from '../schemas/steps/channels';
-import { Providers } from './provider.types';
-import { Schema, FromSchema } from './schema.types';
-import { Skip } from './skip.types';
-import { Awaitable } from './util.types';
 import { actionStepSchemas } from '../schemas/steps/actions';
+import { channelStepSchemas } from '../schemas/steps/channels';
+import type { Providers } from './provider.types';
+import type { FromSchema, Schema } from './schema.types';
+import type { Skip } from './skip.types';
+import type { Awaitable } from './util.types';
 
 // @TODO: remove the credentials, providers, and preferences from the ActionStepOptions (fix the client typings)
 export type StepOptions = {

--- a/packages/framework/src/types/subscriber.types.ts
+++ b/packages/framework/src/types/subscriber.types.ts
@@ -1,4 +1,8 @@
 export type Subscriber = {
+  subscriberId?: string;
   firstName?: string;
   lastName?: string;
+  email?: string;
+  phone?: string;
+  avatar?: string;
 };

--- a/packages/framework/src/types/validator.types.ts
+++ b/packages/framework/src/types/validator.types.ts
@@ -1,6 +1,6 @@
-import { ValidateFunction as AjvValidateFunction } from 'ajv';
-import { ParseReturnType } from 'zod';
-import { Schema, JsonSchema } from './schema.types';
+import type { ValidateFunction as AjvValidateFunction } from 'ajv';
+import type { ParseReturnType } from 'zod';
+import type { Schema, JsonSchema } from './schema.types';
 
 export type ValidateFunction<T = unknown> = AjvValidateFunction<T> | ((data: T) => ParseReturnType<T>);
 

--- a/packages/framework/src/types/workflow.types.ts
+++ b/packages/framework/src/types/workflow.types.ts
@@ -1,5 +1,5 @@
-import { Step } from './step.types';
-import { Subscriber } from './subscriber.types';
+import type { Step } from './step.types';
+import type { Subscriber } from './subscriber.types';
 
 /**
  * The parameters for the workflow function.

--- a/packages/framework/src/utils/env.utils.ts
+++ b/packages/framework/src/utils/env.utils.ts
@@ -31,6 +31,7 @@ export const getBridgeUrl = async (): Promise<string> => {
       return `${data.tunnelOrigin}${data.route}`;
     }
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error(error);
   }
 

--- a/packages/framework/src/validators/base.validator.ts
+++ b/packages/framework/src/validators/base.validator.ts
@@ -1,5 +1,5 @@
-import { JsonSchema, Schema } from '../types/schema.types';
-import { ValidateResult } from '../types/validator.types';
+import type { JsonSchema, Schema } from '../types/schema.types';
+import type { ValidateResult } from '../types/validator.types';
 import { JsonSchemaValidator } from './json-schema.validator';
 import { ZodValidator } from './zod.validator';
 

--- a/packages/framework/src/validators/json-schema.validator.ts
+++ b/packages/framework/src/validators/json-schema.validator.ts
@@ -1,7 +1,7 @@
-import Ajv, { ErrorObject, ValidateFunction as AjvValidateFunction } from 'ajv';
+import Ajv, { type ErrorObject, type ValidateFunction as AjvValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
-import { ValidateResult, Validator } from '../types/validator.types';
-import { JsonSchema, Schema } from '../types/schema.types';
+import type { ValidateResult, Validator } from '../types/validator.types';
+import type { JsonSchema, Schema } from '../types/schema.types';
 
 export class JsonSchemaValidator implements Validator<JsonSchema> {
   private readonly ajv: Ajv;

--- a/packages/framework/src/validators/zod.validator.ts
+++ b/packages/framework/src/validators/zod.validator.ts
@@ -1,8 +1,8 @@
 import { ZodSchema } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
-import { JsonSchema, Schema } from '../types/schema.types';
-import { ValidateResult, Validator } from '../types/validator.types';
+import type { JsonSchema, Schema } from '../types/schema.types';
+import type { ValidateResult, Validator } from '../types/validator.types';
 
 export class ZodValidator implements Validator<ZodSchema> {
   isSchema(schema: Schema): schema is ZodSchema {

--- a/packages/framework/src/workflow.test.ts
+++ b/packages/framework/src/workflow.test.ts
@@ -1,5 +1,5 @@
 import { it, describe, beforeEach, expect, vi, afterEach } from 'vitest';
-import { MissingSecretKeyError, WorkflowPayloadInvalidError } from './errors';
+import { MissingSecretKeyError } from './errors';
 import { workflow } from './workflow';
 
 describe('workflow function', () => {

--- a/packages/framework/src/workflow.ts
+++ b/packages/framework/src/workflow.ts
@@ -1,7 +1,7 @@
 import { ChannelStepEnum } from './constants';
 import { MissingSecretKeyError, StepAlreadyExistsError, WorkflowPayloadInvalidError } from './errors';
 import { channelStepSchemas, delayChannelSchemas, digestChannelSchemas, emptySchema, providerSchemas } from './schemas';
-import {
+import type {
   ActionStep,
   Awaitable,
   CancelEventTriggerResponse,


### PR DESCRIPTION
### What changed? Why was the change needed?
* Remove compile time secret key check. This is necessary to ensure that the application can still build without a secret key being present in the environment
* Add missing `type` import directives to further reduce bundle size
* Convert remaining `interface`s to `type`s
* Publish @novu/framework@[0.24.3-alpha.16](https://www.npmjs.com/package/@novu/framework/v/0.24.3-alpha.16)

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_No critical dep issue during Next.js app startup `npm run dev`_
<img width="299" alt="image" src="https://github.com/novuhq/novu/assets/32132657/1ee3aa07-c690-4fd8-939d-15a0a235fb03">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
