### PR TITLE
fix(web): Automatically switch to dev env when navigating to local studio

### DIFF
--- a/apps/web/src/components/layout/components/LocalStudioSidebar/SidebarFooter.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioSidebar/SidebarFooter.tsx
@@ -18,7 +18,7 @@ export const SidebarFooter: FC<SidebarFooterProps> = ({ children, className }) =
         gradientTo={'surface.panel/100'}
         gradientToPosition={'80%'}
       />
-      <Stack bg="surface.panel" gap="100">
+      <Stack bg="surface.panel" gap="0">
         {children}
       </Stack>
     </NavMenuFooter>

--- a/apps/web/src/studio/LocalStudioAuthenticator.tsx
+++ b/apps/web/src/studio/LocalStudioAuthenticator.tsx
@@ -83,8 +83,6 @@ export function LocalStudioAuthenticator() {
       }
 
       if (environment.name.toLowerCase() !== 'development') {
-        // throw new Error('Local Studio works only with development api keys');
-        console.warn('Local Studio works only with development');
         await setEnvironment(EnvironmentEnum.DEVELOPMENT);
 
         return;


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

https://linear.app/novu/issue/NV-4074/error-local-studio-works-only-with-development-api-keys

- Automatically switch to dev env when navigating to local studio -- opted for two prong approach:
  - Set env on "Open Local Studio" button as this should handle majority of use cases and avoids the "Cloud Dashboard" env select from getting out of sync
  - Set env during redirect -- this works (and will catch the occasional direct access, but causes the original "Cloud Dashboard" tab to not properly reflect the environment
- Fixed spacing on Sidebar between Free Trial widget and button 

### Questions for Reviewers

- Are there any risks associated with this?
- Do we need to handle the 2nd case when the env change happens during redirect and the original tab is (visually -- but not actually) out of sync?

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

https://www.loom.com/share/c5295bbb1ef94b7ea094c72af3c0db2a?sid=e370930c-06b7-4bfe-b09a-a9091491910d
