### PR TITLE
fix(web): Always pick the secret key from development environment

### DIFF
--- a/apps/web/src/studio/LocalStudioAuthenticator.tsx
+++ b/apps/web/src/studio/LocalStudioAuthenticator.tsx
@@ -105,6 +105,9 @@ export function LocalStudioAuthenticator() {
     const localBridgeURL = buildBridgeURL(parsedApplicationOrigin.origin, tunnelPath);
     const tunnelBridgeURL = buildBridgeURL(tunnelOrigin, tunnelPath);
 
+    // TODO: Add apiKeys to the IEnvironment interface as they exist in the response
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
     const devSecretKey = environments.find((env) => env.name.toLowerCase() === 'development')?.apiKey;
 
     const state: StudioState = {


### PR DESCRIPTION
### What changed? Why was the change needed?
Always pick the secret key from development environment

This way, users won't get an error during their local studio authentication if they work on production environment in the cloud.
