### PR TITLE
fix(framework): Allow trigger without `payloadSchema` and require Vercel preview flag for preview `bridgeUrl`

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "0.24.3-alpha.16",
+  "version": "0.24.3-alpha.18",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/framework/src/utils/env.utils.test.ts
+++ b/packages/framework/src/utils/env.utils.test.ts
@@ -22,6 +22,7 @@ describe('env.utils', () => {
     beforeEach(() => {
       delete process.env.NOVU_BRIDGE_ORIGIN;
       delete process.env.NEXT_PUBLIC_VERCEL_URL;
+      delete process.env.NEXT_PUBLIC_VERCEL_ENV;
       // @ts-expect-error - overriding read-only property
       process.env.NODE_ENV = 'development';
     });
@@ -32,8 +33,10 @@ describe('env.utils', () => {
       expect(url).toBe('http://example.com/api/novu');
     });
 
-    it('should return NEXT_PUBLIC_VERCEL_URL if NOVU_BRIDGE_ORIGIN is not defined', async () => {
+    it('should return NEXT_PUBLIC_VERCEL_URL if NEXT_PUBLIC_VERCEL_ENV is preview', async () => {
       process.env.NEXT_PUBLIC_VERCEL_URL = 'vercel.example.com';
+      process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview';
+
       const url = await getBridgeUrl();
       expect(url).toBe('https://vercel.example.com/api/novu');
     });

--- a/packages/framework/src/utils/env.utils.ts
+++ b/packages/framework/src/utils/env.utils.ts
@@ -18,7 +18,7 @@ export const getBridgeUrl = async (): Promise<string> => {
   }
 
   // Vercel preview deployments
-  if (process.env.NEXT_PUBLIC_VERCEL_URL) {
+  if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' && process.env.NEXT_PUBLIC_VERCEL_URL) {
     return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}/api/novu`;
   }
 

--- a/packages/framework/src/workflow.ts
+++ b/packages/framework/src/workflow.ts
@@ -41,7 +41,7 @@ export function workflow<
       throw new MissingSecretKeyError();
     }
 
-    let validatedData: T_Payload;
+    let validatedData: T_Payload = event.payload;
     if (options.payloadSchema) {
       const validationResult = await validateData(options.payloadSchema, event.payload);
       if (validationResult.success === false) {


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Allow trigger without `payloadSchema`
* require Vercel `NEXT_PUBLIC_VERCEL_URL` env var presence for preview `bridgeUrl= NEXT_PUBLIC_VERCEL_URL `
* Publish https://www.npmjs.com/package/@novu/framework/v/0.24.3-alpha.18

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
