### PR TITLE
fix(web): so skeleton for preview web takes full width

### DIFF
--- a/apps/web/src/components/workflow/preview/email/PreviewWeb.tsx
+++ b/apps/web/src/components/workflow/preview/email/PreviewWeb.tsx
@@ -111,6 +111,7 @@ export const PreviewWeb = ({
     frame?: string;
     content?: string;
     contentContainer?: string;
+    skeleton?: string;
   };
   bridge?: boolean;
 }) => {
@@ -188,7 +189,7 @@ export const PreviewWeb = ({
             </When>
             <div className={cx(classes.content, classNames.content)}>
               <When truthy={loading}>
-                <ContentSkeleton />
+                <ContentSkeleton className={classNames.skeleton} />
               </When>
               <When truthy={!loading}>
                 <ErrorBoundary

--- a/apps/web/src/components/workflow/preview/email/Skeleton/ContentSkeleton.tsx
+++ b/apps/web/src/components/workflow/preview/email/Skeleton/ContentSkeleton.tsx
@@ -1,8 +1,8 @@
 import { Group, Skeleton, Stack } from '@mantine/core';
 
-export function ContentSkeleton() {
+export function ContentSkeleton({ className }: { className?: string }) {
   return (
-    <Stack spacing={40} py={40} px={30} h="100%">
+    <Stack className={className} spacing={40} py={40} px={30} h="100%">
       <Group position="center" noWrap>
         <Skeleton height={40} width={80} radius="sm" />
       </Group>

--- a/apps/web/src/studio/components/workflows/step-editor/WorkflowStepEditorContentPanel.tsx
+++ b/apps/web/src/studio/components/workflows/step-editor/WorkflowStepEditorContentPanel.tsx
@@ -93,6 +93,9 @@ export const PreviewStep = ({
               minHeight: '72vh',
               flex: '1',
             }),
+            skeleton: css({
+              width: '100%',
+            }),
           }}
           {...props}
         />


### PR DESCRIPTION
<img width="1512" alt="Screenshot 2024-07-03 at 15 45 02" src="https://github.com/novuhq/novu/assets/2233092/1f0382df-6daf-4c93-aeb4-6257d44d16d8">
