### PR TITLE
chore(root): Only build and deploy in production

### DIFF
--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -6,22 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_api:
-    strategy:
-      # The order is important for ee to be first, otherwise outputs not work correctly
-      matrix:
-        name: [ 'novu/api-ee', 'novu/api' ]
-    uses: ./.github/workflows/reusable-api-e2e.yml
-    with:
-      ee: ${{ contains (matrix.name,'-ee') }}
-      job-name: ${{ matrix.name }}
-    secrets: inherit
-
   build_prod_image:
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    needs: test_api
     timeout-minutes: 80
     environment: Production
     strategy:

--- a/.github/workflows/prod-deploy-web.yml
+++ b/.github/workflows/prod-deploy-web.yml
@@ -9,14 +9,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  test_web:
-    uses: ./.github/workflows/reusable-web-e2e.yml
-    with:
-      ee: true
-    secrets: inherit
-
   deploy_web_eu:
-    needs: test_web
     uses: ./.github/workflows/reusable-web-deploy.yml
     with:
       environment: Production
@@ -35,9 +28,6 @@ jobs:
     secrets: inherit
 
   deploy_web_us:
-    needs:
-      - test_web
-      - deploy_web_eu
     uses: ./.github/workflows/reusable-web-deploy.yml
     with:
       environment: Production
@@ -53,17 +43,4 @@ jobs:
       netlify_alias: prod
       netlify_gh_env: Production
       netlify_site_id: 8639d8b9-81f9-44c3-b885-585a7fd2b5ff
-    secrets: inherit
-
-  deploy_docker:
-    needs:
-      - deploy_web_us
-      - deploy_web_eu
-    uses: ./.github/workflows/reusable-docker.yml
-    with:
-      environment: Production
-      package_name: novu/web
-      project_path: apps/web
-      local_tag: novu-web
-      env_tag: prod
     secrets: inherit


### PR DESCRIPTION
### What changed? Why was the change needed?

Tests run on every PR in prod and next branches. To speed up release time, we removed them from production deployment github actions.
