### PR TITLE
fix(framework): Add `OPTIONS` endpoint for Sveltekit, improve `serve` typedoc

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "2.0.0-canary.0",
+  "version": "2.0.0-canary.1",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "2.0.0-canary.1",
+  "version": "2.0.0-canary.2",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/framework/src/express.ts
+++ b/packages/framework/src/express.ts
@@ -8,7 +8,7 @@ import { type SupportedFrameworkName } from './types';
 export const frameworkName: SupportedFrameworkName = 'express';
 
 /**
- * Serve and register any declared functions with Inngest, making them available
+ * Serve and register any declared workflows with Novu, making them available
  * to be triggered by events.
  *
  * The return type is currently `any` to ensure there's no required type matches

--- a/packages/framework/src/express.ts
+++ b/packages/framework/src/express.ts
@@ -7,6 +7,28 @@ import { type SupportedFrameworkName } from './types';
 
 export const frameworkName: SupportedFrameworkName = 'express';
 
+/**
+ * Serve and register any declared functions with Inngest, making them available
+ * to be triggered by events.
+ *
+ * The return type is currently `any` to ensure there's no required type matches
+ * between the `express` and `vercel` packages. This may change in the future to
+ * appropriately infer.
+ *
+ * @example
+ * ```ts
+ * import { serve } from "@novu/framework/express";
+ * import { myWorkflow } from "./src/novu/workflows"; // Your workflows
+ *
+ * // Important:  ensure you add JSON middleware to process incoming JSON POST payloads.
+ * app.use(express.json());
+ * app.use(
+ *   // Expose the middleware on our recommended path at `/api/novu`.
+ *   "/api/novu",
+ *   serve({ workflows: [myWorkflow] })
+ * );
+ * ```
+ */
 export const serve = (options: ServeHandlerOptions): any => {
   const novuHandler = new NovuRequestHandler({
     frameworkName,

--- a/packages/framework/src/h3.ts
+++ b/packages/framework/src/h3.ts
@@ -6,7 +6,7 @@ import { type SupportedFrameworkName } from './types';
 export const frameworkName: SupportedFrameworkName = 'h3';
 
 /**
- * In h3, serve and register any declared functions with Inngest, making
+ * In h3, serve and register any declared workflows with Novu, making
  * them available to be triggered by events.
  *
  * @example

--- a/packages/framework/src/h3.ts
+++ b/packages/framework/src/h3.ts
@@ -1,33 +1,60 @@
-import { getHeader, getQuery, type H3Event, readBody, send, setHeaders } from 'h3';
+import { getHeader, getQuery, type H3Event, readBody, send, setHeaders, type EventHandlerRequest } from 'h3';
 
 import { NovuRequestHandler, type ServeHandlerOptions } from './handler';
 import { type SupportedFrameworkName } from './types';
 
 export const frameworkName: SupportedFrameworkName = 'h3';
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+/**
+ * In h3, serve and register any declared functions with Inngest, making
+ * them available to be triggered by events.
+ *
+ * @example
+ * ```ts
+ * import { createApp, eventHandler, toNodeListener } from "h3";
+ * import { serve } from "@novu/framework/h3";
+ * import { createServer } from "node:http";
+ * import { myWorkflow } from "./src/novu/workflows";
+ *
+ * const app = createApp();
+ * app.use(
+ *   "/api/novu",
+ *   eventHandler(
+ *     serve({
+ *       workflows: [myWorkflow],
+ *     })
+ *   )
+ * );
+ *
+ * createServer(toNodeListener(app)).listen(process.env.PORT || 4000);
+ * ```
+ *
+ * @public
+ */
 export const serve = (options: ServeHandlerOptions) => {
   const handler = new NovuRequestHandler({
     frameworkName,
     ...options,
-    handler: (event: H3Event) => ({
-      body: () => readBody(event),
-      headers: (key) => getHeader(event, key),
-      method: () => event.method,
-      url: () =>
-        new URL(
-          String(event.path),
-          `${process.env.NODE_ENV === 'development' ? 'http' : 'https'}://${String(getHeader(event, 'host'))}`
-        ),
-      queryString: (key) => String(getQuery(event)[key]),
-      transformResponse: (actionRes) => {
-        const { res } = event.node;
-        res.statusCode = actionRes.status;
-        setHeaders(event, actionRes.headers);
+    handler: (event: H3Event<EventHandlerRequest>) => {
+      return {
+        body: () => readBody(event),
+        headers: (key) => getHeader(event, key),
+        method: () => event.method,
+        url: () =>
+          new URL(
+            String(event.path),
+            `${process.env.NODE_ENV === 'development' ? 'http' : 'https'}://${String(getHeader(event, 'host'))}`
+          ),
+        queryString: (key) => String(getQuery(event)[key]),
+        transformResponse: (actionRes) => {
+          const { res } = event.node;
+          res.statusCode = actionRes.status;
+          setHeaders(event, actionRes.headers);
 
-        return send(event, actionRes.body);
-      },
-    }),
+          return send(event, actionRes.body);
+        },
+      };
+    },
   });
 
   return handler.createHandler();

--- a/packages/framework/src/next.ts
+++ b/packages/framework/src/next.ts
@@ -16,12 +16,18 @@ export const frameworkName: SupportedFrameworkName = 'next';
  *
  * @example Next.js <=12 or the pages router can export the handler directly
  * ```ts
- * export default serve({ workflows: [yourWorkflow] });
+ * import { serve } from "@novu/framework/next";
+ * import { myWorkflow } from "./src/novu/workflows"; // Your workflows
+ *
+ * export default serve({ workflows: [myWorkflow] });
  * ```
  *
  * @example Next.js >=13 with the `app` dir must export individual methods
  * ```ts
- * export const { GET, POST, OPTIONS } = serve({ workflows: [yourWorkflow] });
+ * import { serve } from "@novu/framework/next";
+ * import { myWorkflow } from "./src/novu/workflows";
+ *
+ * export const { GET, POST, OPTIONS } = serve({ workflows: [myWorkflow] });
  * ```
  */
 export const serve = (
@@ -35,7 +41,7 @@ export const serve = (
     frameworkName,
     ...options,
     handler: (
-      requestMethod: 'GET' | 'POST' | 'PUT' | 'OPTIONS' | undefined,
+      requestMethod: 'GET' | 'POST' | 'OPTIONS' | undefined,
       incomingRequest: NextRequest,
       response: NextApiResponse
     ) => {
@@ -163,7 +169,7 @@ export const serve = (
    *
    * This means that users must now export a function for each method supported
    * by the endpoint. For us, this means requiring a user explicitly exports
-   * `GET`, `POST`, and `PUT` functions.
+   * `GET`, `POST`, and `OPTIONS` functions.
    *
    * Because of this, we'll add circular references to those property names of
    * the returned handler, meaning we can write some succinct code to export

--- a/packages/framework/src/remix.ts
+++ b/packages/framework/src/remix.ts
@@ -4,6 +4,27 @@ import { getResponse } from './utils';
 
 export const frameworkName: SupportedFrameworkName = 'remix';
 
+/**
+ * In Remix, serve and register any declared workflows with Novu, making them
+ * available to be triggered by events.
+ *
+ * Remix requires that you export both a "loader" for serving `GET` requests,
+ * and an "action" for serving other requests, therefore exporting both is
+ * required.
+ *
+ * See {@link https://remix.run/docs/en/v1/guides/resource-routes}
+ *
+ * @example
+ * ```ts
+ * import { serve } from "@novu/framework/remix";
+ * import { myWorkflow } from "./src/novu/workflows";
+ *
+ * const handler = serve({ workflows: [myWorkflow] });
+ *
+ * export { handler as loader, handler as action };
+ * ```
+ */
+// Has explicit return type to avoid JSR-defined "slow types"
 export const serve = (
   options: ServeHandlerOptions
 ): ((ctx: { request: Request; context?: unknown }) => Promise<Response>) => {

--- a/packages/framework/src/sveltekit.ts
+++ b/packages/framework/src/sveltekit.ts
@@ -5,17 +5,32 @@ import { getResponse } from './utils';
 
 export const frameworkName: SupportedFrameworkName = 'sveltekit';
 
+/**
+ * Using SvelteKit, serve and register any declared workflows with Novu,
+ * making them available to be triggered by events.
+ *
+ * @example
+ * ```ts
+ * // app/routes/api/novu/+server.ts
+ * import { serve } from "@novu/framework/sveltekit";
+ * import { myWorkflow } from "./src/novu/workflows"; // Your workflows
+ *
+ * const handler = serve({ workflows: [myWorkflow] });
+ *
+ * export { handler as action, handler as loader };
+ * ```
+ */
 export const serve = (
   options: ServeHandlerOptions
 ): ((event: RequestEvent) => Promise<Response>) & {
   GET: (event: RequestEvent) => Promise<Response>;
   POST: (event: RequestEvent) => Promise<Response>;
-  PUT: (event: RequestEvent) => Promise<Response>;
+  OPTIONS: (event: RequestEvent) => Promise<Response>;
 } => {
   const handler = new NovuRequestHandler({
     frameworkName,
     ...options,
-    handler: (reqMethod: 'GET' | 'POST' | 'PUT' | undefined, event: RequestEvent) => {
+    handler: (reqMethod: 'GET' | 'POST' | 'OPTIONS' | undefined, event: RequestEvent) => {
       return {
         method: () => reqMethod || event.request.method || '',
         body: () => event.request.json(),
@@ -44,11 +59,11 @@ export const serve = (
   const handlerFn = Object.defineProperties(fn, {
     GET: { value: baseFn.bind(null, 'GET') },
     POST: { value: baseFn.bind(null, 'POST') },
-    PUT: { value: baseFn.bind(null, 'PUT') },
+    OPTIONS: { value: baseFn.bind(null, 'OPTIONS') },
   }) as Fn & {
     GET: Fn;
     POST: Fn;
-    PUT: Fn;
+    OPTIONS: Fn;
   };
 
   return handlerFn;


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Add `OPTIONS` endpoint for Sveltekit
* improve `serve` function typedoc for all supported frameworks
* Publish `@novu/framework` canary version

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Sveltekit successfully serving workflows in Local Studio_
![image](https://github.com/novuhq/novu/assets/32132657/10db2cbc-68a3-4f56-ab27-ca9212c2268b)


<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
