### PR TITLE
fix(web): Remove double-quotes from Segment identifiers

### DIFF
--- a/apps/web/src/hooks/useNovuAPI.ts
+++ b/apps/web/src/hooks/useNovuAPI.ts
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { getToken } from './useAuth';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { buildApiHttpClient } from '../api/api.client';
 import * as mixpanel from 'mixpanel-browser';
 import { useStudioState } from '../studio/StudioStateProvider';
+import { cleanDoubleQuotedString } from '../utils/utils';
 
 function useNovuAPI() {
   const { devSecretKey } = useStudioState();
@@ -42,24 +43,27 @@ export const useTelemetry = () => {
     api.postTelemetry(event, data)
   );
 
-  return (event: string, data?: Record<string, unknown>) => {
-    const mixpanelEnabled = !!process.env.REACT_APP_MIXPANEL_KEY;
+  return useCallback(
+    (event: string, data?: Record<string, unknown>) => {
+      const mixpanelEnabled = !!process.env.REACT_APP_MIXPANEL_KEY;
 
-    if (mixpanelEnabled) {
-      const segmentDeviceId = localStorage.getItem('ajs_anonymous_id');
-      const userId = localStorage.getItem('ajs_user_id');
-      if (userId) {
-        mixpanel.identify(userId);
+      if (mixpanelEnabled) {
+        const segmentDeviceId = cleanDoubleQuotedString(localStorage.getItem('ajs_anonymous_id'));
+        const userId = cleanDoubleQuotedString(localStorage.getItem('ajs_user_id'));
+        if (userId) {
+          mixpanel.identify(userId);
+        }
+        mixpanel.register({ $device_id: segmentDeviceId });
+        const sessionReplayProperties = mixpanel.get_session_recording_properties();
+
+        data = {
+          ...(data || {}),
+          ...sessionReplayProperties,
+        };
       }
-      mixpanel.register({ $device_id: segmentDeviceId });
-      const sessionReplayProperties = mixpanel.get_session_recording_properties();
 
-      data = {
-        ...(data || {}),
-        ...sessionReplayProperties,
-      };
-    }
-
-    return mutate({ event: event + ' - [WEB]', data });
-  };
+      return mutate({ event: event + ' - [WEB]', data });
+    },
+    [mutate]
+  );
 };

--- a/apps/web/src/utils/segment.ts
+++ b/apps/web/src/utils/segment.ts
@@ -16,7 +16,6 @@ export class SegmentService {
     if (this._mixpanelEnabled) {
       mixpanel.init(process.env.REACT_APP_MIXPANEL_KEY as string, {
         record_sessions_percent: 100,
-        debug: true,
       });
     }
 

--- a/apps/web/src/utils/segment.ts
+++ b/apps/web/src/utils/segment.ts
@@ -2,6 +2,7 @@ import { AnalyticsBrowser } from '@segment/analytics-next';
 import { IUserEntity } from '@novu/shared';
 import * as mixpanel from 'mixpanel-browser';
 import { api } from '../api';
+import { cleanDoubleQuotedString } from './utils';
 
 export class SegmentService {
   private _segment: AnalyticsBrowser | null = null;
@@ -15,6 +16,7 @@ export class SegmentService {
     if (this._mixpanelEnabled) {
       mixpanel.init(process.env.REACT_APP_MIXPANEL_KEY as string, {
         record_sessions_percent: 100,
+        debug: true,
       });
     }
 
@@ -58,8 +60,8 @@ export class SegmentService {
     }
 
     if (this._mixpanelEnabled) {
-      const segmentDeviceId = localStorage.getItem('ajs_anonymous_id');
-      const userId = localStorage.getItem('ajs_user_id');
+      const segmentDeviceId = cleanDoubleQuotedString(localStorage.getItem('ajs_anonymous_id'));
+      const userId = cleanDoubleQuotedString(localStorage.getItem('ajs_user_id'));
       if (userId) {
         mixpanel.identify(userId);
       }

--- a/apps/web/src/utils/utils.ts
+++ b/apps/web/src/utils/utils.ts
@@ -26,3 +26,13 @@ export function parsePayload(payload: string) {
     return {};
   }
 }
+
+const DOUBLE_QUOTE_REGEX = /^\"(.*)\"$/;
+export function cleanDoubleQuotedString(str?: string | null) {
+  if (!str) {
+    return str;
+  }
+  const match = DOUBLE_QUOTE_REGEX.exec(str);
+
+  return match ? match[1] : str;
+}


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

- Write util for removing double-quotes on strings
- Use util for retrieval of segment identifiers from local storage

https://novu.slack.com/archives/C06UMR2M5U5/p1720029539611939?thread_ts=1720029289.379419&cid=C06UMR2M5U5
