### PR TITLE
chore(repo): Bump AWS Github actions

### DIFF
--- a/.github/workflows/dev-deploy-api.yml
+++ b/.github/workflows/dev-deploy-api.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Render Amazon ECS task definition
         if: ${{ contains (matrix.name,'-ee') }}
         id: render-web-container
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@39c13cf530718ffeb524ec8ee0c15882bcb13842
         with:
           task-definition: task-definition.json
           container-name: ${{ env.api_ecs_container_name }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: Deploy to Amazon ECS service
         if: ${{ contains (matrix.name,'-ee') }}
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@3e7310352de91b71a906e60c22af629577546002
         with:
           task-definition: ${{ steps.render-web-container.outputs.task-definition }}
           service: ${{ env.api_ecs_service }}

--- a/.github/workflows/dev-deploy-inbound-mail.yml
+++ b/.github/workflows/dev-deploy-inbound-mail.yml
@@ -145,14 +145,14 @@ jobs:
 
       - name: Render Amazon ECS task definition
         id: render-web-container
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@39c13cf530718ffeb524ec8ee0c15882bcb13842
         with:
           task-definition: task-definition.json
           container-name: ${{ env.inbound_mail_ecs_container_name }}
           image: ${{ steps.build-image.outputs.IMAGE }}
 
       - name: Deploy to Amazon ECS service
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@39c13cf530718ffeb524ec8ee0c15882bcb13842
         with:
           task-definition: ${{ steps.render-web-container.outputs.task-definition }}
           service: ${{ env.inbound_mail_ecs_service }}

--- a/.github/workflows/dev-deploy-ws.yml
+++ b/.github/workflows/dev-deploy-ws.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Render Amazon ECS task definition
         id: render-container
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@39c13cf530718ffeb524ec8ee0c15882bcb13842
         with:
           task-definition: task-definition.json
           container-name: ${{ env.ws_ecs_container_name }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Deploy to Amazon ECS service
         if: ${{contains(matrix.name, 'ee')}}
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@3e7310352de91b71a906e60c22af629577546002
         with:
           task-definition: ${{ steps.render-container.outputs.task-definition }}
           service: ${{ env.ws_ecs_service }}

--- a/.github/workflows/reusable-app-service-deploy.yml
+++ b/.github/workflows/reusable-app-service-deploy.yml
@@ -81,14 +81,14 @@ jobs:
 
       - name: Render Amazon ECS task definition
         id: render-web-container
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@39c13cf530718ffeb524ec8ee0c15882bcb13842
         with:
           task-definition: task-definition.json
           container-name: ${{ env.ecs_container_name }}
           image: ${{ inputs.docker_image }}
 
       - name: Deploy to Amazon ECS service
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@3e7310352de91b71a906e60c22af629577546002
         with:
           task-definition: ${{ steps.render-web-container.outputs.task-definition }}
           service: ${{ env.ecs_service }}

--- a/.github/workflows/reusable-workers-service-deploy.yml
+++ b/.github/workflows/reusable-workers-service-deploy.yml
@@ -95,14 +95,14 @@ jobs:
 
       - name: Render Amazon ECS task definition
         id: render-web-container
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@39c13cf530718ffeb524ec8ee0c15882bcb13842
         with:
           task-definition: task-definition.json
           container-name: ${{ matrix.worker.container_name }}
           image: ${{ inputs.docker_image }}
 
       - name: Deploy to Amazon ECS service
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@3e7310352de91b71a906e60c22af629577546002
         with:
           task-definition: ${{ steps.render-web-container.outputs.task-definition }}
           service: ${{ matrix.worker.service }}


### PR DESCRIPTION
### What changed? Why was the change needed?
The AWS SDK for JavaScript (v2) will enter maintenance mode on September 8, 2024, and reach end-of-support on September 8, 2025.

More info at:

- https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-javascript-v2/
- https://docs.github.com/en/actions/deployment/deploying-to-your-cloud-provider/deploying-to-amazon-elastic-container-service


### Screenshots
<img width="1509" alt="Screenshot 2024-07-09 at 09 56 12" src="https://github.com/novuhq/novu/assets/1352422/4d9619b8-564d-4deb-8166-3b8dd07f86d6">