### PR TITLE
fix(web): Use `refetch` in dependency array for discovery refetch

### DIFF
--- a/apps/web/src/studio/components/workflows/landing-page/LocalStudioWorkflowLandingPage.tsx
+++ b/apps/web/src/studio/components/workflows/landing-page/LocalStudioWorkflowLandingPage.tsx
@@ -18,7 +18,7 @@ export const LocalStudioWorkflowLandingPage = () => {
       <WorkflowPlaceholderPage title={'Studio Disconnected'} docsButtonLabel="See our troubleshooting guide">
         Local environment disconnected from Novu Bridge URL.
         <br />
-        Likely because your application is not running or `npx novu dev` is not running.
+        This usually happens when your Bridge app is not running or <code>npx novu dev</code> is not running.
       </WorkflowPlaceholderPage>
     );
   }

--- a/apps/web/src/studio/hooks/useBridgeAPI.ts
+++ b/apps/web/src/studio/hooks/useBridgeAPI.ts
@@ -31,10 +31,11 @@ export const useDiscover = (options?: any) => {
       ...(options || {}),
     }
   );
+  const { refetch } = discoverQuery;
 
   useEffect(() => {
-    discoverQuery.refetch();
-  }, [bridgeURL, setBridgeURL, discoverQuery]);
+    refetch();
+  }, [bridgeURL, setBridgeURL, refetch]);
 
   return discoverQuery;
 };


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Use `refetch` in dependency array for discovery refetch. This ensures that refetches only occur during changes to the `refetch` function and not to the entire query hook

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_No infinite refetching when disconnecting a Bridge app_
https://github.com/novuhq/novu/assets/32132657/516a2218-c6ce-44eb-9fc5-5fc95e94fe65

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
