### PR TITLE
fix(ee-auth): onboarding check

### DIFF
--- a/apps/web/src/components/layout/components/EnsureOnboardingComplete.tsx
+++ b/apps/web/src/components/layout/components/EnsureOnboardingComplete.tsx
@@ -1,6 +1,7 @@
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../../hooks/useAuth';
 import { ROUTES } from '../../../constants/routes';
+import { IS_EE_AUTH_ENABLED } from '../../../config/index';
 import { useBlueprint, useRedirectURL } from '../../../hooks';
 
 export function EnsureOnboardingComplete({ children }: any) {
@@ -9,7 +10,15 @@ export function EnsureOnboardingComplete({ children }: any) {
   const { getRedirectURL } = useRedirectURL();
   const { currentOrganization, environmentId } = useAuth();
 
-  if ((!currentOrganization || !environmentId) && location.pathname !== ROUTES.AUTH_APPLICATION) {
+  function isOnboardingComplete() {
+    if (IS_EE_AUTH_ENABLED) {
+      return currentOrganization?.productUseCases !== undefined;
+    }
+
+    return currentOrganization && environmentId;
+  }
+
+  if (!isOnboardingComplete() && location.pathname !== ROUTES.AUTH_APPLICATION) {
     return <Navigate to={ROUTES.AUTH_APPLICATION} replace />;
   }
 

--- a/apps/web/src/components/layout/components/EnsureOnboardingComplete.tsx
+++ b/apps/web/src/components/layout/components/EnsureOnboardingComplete.tsx
@@ -3,19 +3,32 @@ import { useAuth } from '../../../hooks/useAuth';
 import { ROUTES } from '../../../constants/routes';
 import { IS_EE_AUTH_ENABLED } from '../../../config/index';
 import { useBlueprint, useRedirectURL } from '../../../hooks';
+import { useEffect, useState } from 'react';
 
 export function EnsureOnboardingComplete({ children }: any) {
   useBlueprint();
   const location = useLocation();
   const { getRedirectURL } = useRedirectURL();
   const { currentOrganization, environmentId } = useAuth();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (currentOrganization) {
+      setIsLoading(false);
+    }
+  }, [currentOrganization]);
 
   function isOnboardingComplete() {
     if (IS_EE_AUTH_ENABLED) {
+      // TODO: replace with actual check property (e.g. isOnboardingCompleted)
       return currentOrganization?.productUseCases !== undefined;
     }
 
     return currentOrganization && environmentId;
+  }
+
+  if (isLoading) {
+    return null;
   }
 
   if (!isOnboardingComplete() && location.pathname !== ROUTES.AUTH_APPLICATION) {


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixed onboarding check to work for both enterprise and community versions. The organization in the enterprise version exists before the questionnaire is filled therefore the original check was not sufficient.


The `currentOrganization?.productUseCases !== undefined` is temporary, because in Clerk we store just `domain` and `productUseCases` while `domain` being optional. 

We will need proper check by introducing new property to Clerk metadata, e.g. `isOnboardingCompeted: boolean` 

