### PR TITLE
chore(root): update application-generic path in code workspace

### DIFF
--- a/novu.code-workspace
+++ b/novu.code-workspace
@@ -65,6 +65,10 @@
       "path": "libs/testing"
     },
     {
+      "name": "📦 @novu/application-generic",
+      "path": "libs/application-generic"
+    },
+    {
       "name": "📦 @novu/stateless",
       "path": "packages/stateless"
     },
@@ -87,10 +91,6 @@
     {
       "name": "📦 @novu/react-native",
       "path": "packages/react-native"
-    },
-    {
-      "name": "📦 @novu/application-generic",
-      "path": "packages/application-generic"
     },
     {
       "name": "📦 @novu/js",


### PR DESCRIPTION
### What changed? Why was the change needed?
the `@novu/application-generic` folder in vscode workspace is broken because it resides in `libs` not in `packages`  

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
