### PR TITLE
fix(ee-auth): update session when org metadata are updated

### DIFF
--- a/apps/web/src/auth/useCreateAuthCommunity.ts
+++ b/apps/web/src/auth/useCreateAuthCommunity.ts
@@ -224,6 +224,7 @@ export function useCreateAuthCommunity() {
     currentUser: user,
     organizations,
     currentOrganization,
+    session: undefined,
     login,
     logout,
     environmentId,

--- a/apps/web/src/auth/useCreateAuthCommunity.ts
+++ b/apps/web/src/auth/useCreateAuthCommunity.ts
@@ -224,7 +224,7 @@ export function useCreateAuthCommunity() {
     currentUser: user,
     organizations,
     currentOrganization,
-    session: undefined,
+    reloadOrganization: () => {},
     login,
     logout,
     environmentId,

--- a/apps/web/src/components/providers/CommunityAuthProvider.tsx
+++ b/apps/web/src/components/providers/CommunityAuthProvider.tsx
@@ -8,6 +8,7 @@ export const CommunityAuthContext = createContext<ReturnType<typeof useCreateAut
   currentUser: undefined,
   organizations: [],
   currentOrganization: undefined,
+  session: undefined,
   login: () => Promise.resolve(),
   logout: () => {},
   environmentId: undefined,

--- a/apps/web/src/components/providers/CommunityAuthProvider.tsx
+++ b/apps/web/src/components/providers/CommunityAuthProvider.tsx
@@ -8,7 +8,7 @@ export const CommunityAuthContext = createContext<ReturnType<typeof useCreateAut
   currentUser: undefined,
   organizations: [],
   currentOrganization: undefined,
-  session: undefined,
+  reloadOrganization: () => {},
   login: () => Promise.resolve(),
   logout: () => {},
   environmentId: undefined,

--- a/apps/web/src/ee/clerk/components/QuestionnaireForm.tsx
+++ b/apps/web/src/ee/clerk/components/QuestionnaireForm.tsx
@@ -45,7 +45,7 @@ export function QuestionnaireForm() {
     control,
   } = useForm<UpdateExternalOrganizationDto>({});
   const navigate = useNavigate();
-  const { currentUser, currentOrganization, environmentId } = useAuth();
+  const { currentUser, currentOrganization, environmentId, session } = useAuth();
   const { startVercelSetup } = useVercelIntegration();
   const { isFromVercel } = useVercelParams();
   const { parse } = useDomainParser();
@@ -71,6 +71,8 @@ export function QuestionnaireForm() {
       productUseCases: data.productUseCases,
     };
     await updateOrganizationMutation(updateClerkOrgDto);
+    // get updated organization data in session
+    await session?.reload();
   }
 
   const onUpdateOrganization = async (data: UpdateExternalOrganizationDto) => {

--- a/apps/web/src/ee/clerk/components/QuestionnaireForm.tsx
+++ b/apps/web/src/ee/clerk/components/QuestionnaireForm.tsx
@@ -45,7 +45,7 @@ export function QuestionnaireForm() {
     control,
   } = useForm<UpdateExternalOrganizationDto>({});
   const navigate = useNavigate();
-  const { currentUser, currentOrganization, environmentId, session } = useAuth();
+  const { currentUser, currentOrganization, environmentId, reloadOrganization } = useAuth();
   const { startVercelSetup } = useVercelIntegration();
   const { isFromVercel } = useVercelParams();
   const { parse } = useDomainParser();
@@ -72,7 +72,7 @@ export function QuestionnaireForm() {
     };
     await updateOrganizationMutation(updateClerkOrgDto);
     // get updated organization data in session
-    await session?.reload();
+    await reloadOrganization();
   }
 
   const onUpdateOrganization = async (data: UpdateExternalOrganizationDto) => {

--- a/apps/web/src/ee/clerk/providers/EnterpriseAuthProvider.tsx
+++ b/apps/web/src/ee/clerk/providers/EnterpriseAuthProvider.tsx
@@ -8,6 +8,7 @@ export const EnterpriseAuthContext = createContext<ReturnType<typeof useCreateAu
   currentUser: undefined,
   organizations: [],
   currentOrganization: undefined,
+  session: undefined,
   logout: () => {},
   login: (...args: any[]) => {},
   redirectToLogin: () => {},

--- a/apps/web/src/ee/clerk/providers/EnterpriseAuthProvider.tsx
+++ b/apps/web/src/ee/clerk/providers/EnterpriseAuthProvider.tsx
@@ -8,7 +8,7 @@ export const EnterpriseAuthContext = createContext<ReturnType<typeof useCreateAu
   currentUser: undefined,
   organizations: [],
   currentOrganization: undefined,
-  session: undefined,
+  reloadOrganization: () => Promise.resolve(),
   logout: () => {},
   login: (...args: any[]) => {},
   redirectToLogin: () => {},

--- a/apps/web/src/ee/clerk/providers/useCreateAuthEnterprise.ts
+++ b/apps/web/src/ee/clerk/providers/useCreateAuthEnterprise.ts
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { setUser as setSentryUser, configureScope } from '@sentry/react';
 import type { IOrganizationEntity, IUserEntity } from '@novu/shared';
-import { useAuth, useUser, useOrganization, useOrganizationList } from '@clerk/clerk-react';
+import { useAuth, useUser, useOrganization, useOrganizationList, useSession } from '@clerk/clerk-react';
 import { OrganizationResource, UserResource } from '@clerk/types';
 import { useSegment } from '../../../components/providers/SegmentProvider';
 import { PUBLIC_ROUTES_PREFIXES, ROUTES } from '../../../constants/routes';
@@ -36,6 +36,7 @@ const toOrganizationEntity = (clerkOrganization: OrganizationResource): IOrganiz
 
 export function useCreateAuthEnterprise() {
   const { signOut, orgId } = useAuth();
+  const { session } = useSession();
   const { user: clerkUser, isLoaded: isUserLoaded } = useUser();
   const { organization: clerkOrganization, isLoaded: isOrganizationLoaded } = useOrganization();
   const { setActive, isLoaded: isOrgListLoaded } = useOrganizationList();
@@ -194,6 +195,7 @@ export function useCreateAuthEnterprise() {
     // TODO: (to decide) either remove/rework places where "organizations" is used or fetch from Clerk
     organizations: isOrganizationLoaded && organization ? [organization] : undefined,
     currentOrganization: organization,
+    session,
     logout,
     login: (...args: any[]) => {},
     // TODO: implement proper environment switch

--- a/apps/web/src/ee/clerk/providers/useCreateAuthEnterprise.ts
+++ b/apps/web/src/ee/clerk/providers/useCreateAuthEnterprise.ts
@@ -36,7 +36,6 @@ const toOrganizationEntity = (clerkOrganization: OrganizationResource): IOrganiz
 
 export function useCreateAuthEnterprise() {
   const { signOut, orgId } = useAuth();
-  const { session } = useSession();
   const { user: clerkUser, isLoaded: isUserLoaded } = useUser();
   const { organization: clerkOrganization, isLoaded: isOrganizationLoaded } = useOrganization();
   const { setActive, isLoaded: isOrgListLoaded } = useOrganizationList();
@@ -112,6 +111,10 @@ export function useCreateAuthEnterprise() {
   const switchOrgCallback = useCallback(async () => {
     await queryClient.refetchQueries();
   }, [queryClient]);
+
+  const reloadOrganization = useCallback(async () => {
+    await clerkOrganization?.reload();
+  }, [clerkOrganization]);
 
   // check if user has active organization
   useEffect(() => {
@@ -195,7 +198,7 @@ export function useCreateAuthEnterprise() {
     // TODO: (to decide) either remove/rework places where "organizations" is used or fetch from Clerk
     organizations: isOrganizationLoaded && organization ? [organization] : undefined,
     currentOrganization: organization,
-    session,
+    reloadOrganization,
     logout,
     login: (...args: any[]) => {},
     // TODO: implement proper environment switch


### PR DESCRIPTION
### What changed? Why was the change needed?

When Clerk organization metadata are updated after questionnaire is submitted, we need to reload session in order to get these new data, otherwise we wouldn't be able to check if the onboarding is complete. 