### PR TITLE
ci(root): add ee clerk e2e tests to dev deploy

### DIFF
--- a/.github/workflows/dev-deploy-api.yml
+++ b/.github/workflows/dev-deploy-api.yml
@@ -22,10 +22,11 @@ jobs:
   test_api:
     strategy:
       matrix:
-        name: ['novu/api-ee', 'novu/api']
+        name: ['novu/api-ee', 'novu/api', 'novu/api-ee-clerk']
     uses: ./.github/workflows/reusable-api-e2e.yml
     with:
       ee: ${{ contains (matrix.name,'-ee') }}
+      ee-clerk: ${{ contains (matrix.name,'-ee-clerk') }}
       job-name: ${{ matrix.name }}
     secrets: inherit
 


### PR DESCRIPTION
### What changed? Why was the change needed?
Add missing clerk e2e api tests to `dev-deploy-api` workflow (same as in `on-pr` workflow)

Eventually, 'novu/api-ee' will get replaced by `novu/api-ee-clerk` when we remove the clerk feature flag. 