### PR TITLE
fix(web): translation e2e tests

### DIFF
--- a/apps/web/src/components/providers/CommunityAuthProvider.tsx
+++ b/apps/web/src/components/providers/CommunityAuthProvider.tsx
@@ -117,6 +117,13 @@ export const CommunityAuthProvider = ({ children }: { children: React.ReactNode 
     },
   });
 
+  const reloadOrganization = async () => {
+    const { data } = await getOrganizations();
+    // we need to update all organizations so current org (data) and 'organizations' are not ouf of sync
+    await refetchOrganizations();
+    setCurrentOrganization(selectOrganization(data, currentOrganization?._id));
+  };
+
   const [currentOrganization, setCurrentOrganization] = useState<IOrganizationEntity | null>(
     selectOrganization(organizations)
   );
@@ -273,7 +280,7 @@ export const CommunityAuthProvider = ({ children }: { children: React.ReactNode 
     redirectToLogin,
     redirectToSignUp,
     switchOrganization,
-    reloadOrganization: asyncNoop,
+    reloadOrganization,
   };
 
   return <CommunityAuthContext.Provider value={value}>{children}</CommunityAuthContext.Provider>;

--- a/apps/web/src/ee/translations/components/DefaultLocaleModal/index.tsx
+++ b/apps/web/src/ee/translations/components/DefaultLocaleModal/index.tsx
@@ -38,8 +38,8 @@ export const DefaultLocaleModal = ({
   const { mutateAsync: saveDefaultLocale, isLoading: isSaving } = useMutation<any, any, any>(
     (args) => api.patch('/v1/translations/language', args),
     {
-      onSuccess: () => {
-        reloadOrganization();
+      onSuccess: async () => {
+        await reloadOrganization();
         queryClient.refetchQueries([`translationGroups`]);
         queryClient.refetchQueries(['changesCount']);
 

--- a/apps/web/src/ee/translations/components/DefaultLocaleModal/index.tsx
+++ b/apps/web/src/ee/translations/components/DefaultLocaleModal/index.tsx
@@ -33,13 +33,13 @@ export const DefaultLocaleModal = ({
 }) => {
   const queryClient = useQueryClient();
   const { locales, isLoading } = useFetchLocales();
-  const { currentOrganization } = useAuth();
+  const { currentOrganization, reloadOrganization } = useAuth();
 
   const { mutateAsync: saveDefaultLocale, isLoading: isSaving } = useMutation<any, any, any>(
     (args) => api.patch('/v1/translations/language', args),
     {
       onSuccess: () => {
-        queryClient.refetchQueries([`/v1/organizations`]);
+        reloadOrganization();
         queryClient.refetchQueries([`translationGroups`]);
         queryClient.refetchQueries(['changesCount']);
 


### PR DESCRIPTION
### What changed? Why was the change needed?
`currentOrganization` object is not being properly refreshed when running tests PW when `useQuery` is used - replaced with specific `reloadOrganization` to match EE implementation.