### PR TITLE
fix(api): replace axios instance with test agent in events e2e

### DIFF
--- a/apps/api/src/app/events/e2e/test-email.e2e.ts
+++ b/apps/api/src/app/events/e2e/test-email.e2e.ts
@@ -1,12 +1,9 @@
 import { expect } from 'chai';
-import axios from 'axios';
 import { UserSession } from '@novu/testing';
 import { MessageRepository, IntegrationRepository } from '@novu/dal';
 import { ChannelTypeEnum, EmailProviderIdEnum } from '@novu/shared';
 
 import { TestSendEmailRequestDto } from '../dtos';
-
-const axiosInstance = axios.create();
 
 describe('Events - Test email - /v1/events/test/email (POST)', function () {
   const requestDto: TestSendEmailRequestDto = {
@@ -29,12 +26,8 @@ describe('Events - Test email - /v1/events/test/email (POST)', function () {
     integrationRepository = new IntegrationRepository();
   });
 
-  const sendTestEmail = async (body: TestSendEmailRequestDto) => {
-    return await axiosInstance.post(`${session.serverUrl}/v1/events/test/email`, body, {
-      headers: {
-        authorization: session.token,
-      },
-    });
+  const sendTestEmail = (body: TestSendEmailRequestDto) => {
+    return session.testAgent.post('/v1/events/test/email').send(body);
   };
 
   const deleteEmailIntegration = async () => {


### PR DESCRIPTION
### What changed? Why was the change needed?
In some tests we are creating a new `axiosInstance` and in some tests we are using `session.testAgent` - this leads to various issues and weird behaviour - we should probably use `session.testAgent` everywhere since thats being initialized in the testing session.  
