### PR TITLE
fix(api): Ensure that environment switching endpoints is backwards compatible

### DIFF
--- a/apps/api/src/app/auth/e2e/switch-environment.e2e.ts
+++ b/apps/api/src/app/auth/e2e/switch-environment.e2e.ts
@@ -19,10 +19,6 @@ describe('Switch Environment - /auth/environments/:id/switch (POST) @skip-in-ee'
     });
 
     it('should switch to second environment', async () => {
-      const content = jwt.decode(session.token.split(' ')[1]) as UserSessionData;
-
-      expect(content.environmentId).to.equal(firstEnvironment._id);
-
       const { body } = await session.testAgent
         .post(`/v1/auth/environments/${secondEnvironment._id}/switch`)
         .expect(200);

--- a/libs/application-generic/src/services/auth/auth.service.interface.ts
+++ b/libs/application-generic/src/services/auth/auth.service.interface.ts
@@ -32,7 +32,8 @@ export interface IAuthService {
   getSignedToken(
     user: UserEntity,
     organizationId?: string,
-    member?: MemberEntity
+    member?: MemberEntity,
+    environmentId?: string
   ): Promise<string>;
 
   validateUser(payload: UserSessionData): Promise<UserEntity>;

--- a/libs/application-generic/src/services/auth/auth.service.ts
+++ b/libs/application-generic/src/services/auth/auth.service.ts
@@ -65,9 +65,15 @@ export class AuthService implements IAuthService {
   getSignedToken(
     user: UserEntity,
     organizationId?: string,
-    member?: MemberEntity
+    member?: MemberEntity,
+    environmentId?: string
   ): Promise<string> {
-    return this.authService.getSignedToken(user, organizationId, member);
+    return this.authService.getSignedToken(
+      user,
+      organizationId,
+      member,
+      environmentId
+    );
   }
 
   validateUser(payload: UserSessionData): Promise<UserEntity> {

--- a/libs/application-generic/src/services/auth/community.auth.service.ts
+++ b/libs/application-generic/src/services/auth/community.auth.service.ts
@@ -32,10 +32,6 @@ import { ApiException } from '../../utils/exceptions';
 import { Instrument } from '../../instrumentation';
 import { CreateUser, CreateUserCommand } from '../../usecases/create-user';
 import {
-  SwitchEnvironment,
-  SwitchEnvironmentCommand,
-} from '../../usecases/switch-environment';
-import {
   SwitchOrganization,
   SwitchOrganizationCommand,
 } from '../../usecases/switch-organization';
@@ -60,9 +56,7 @@ export class CommunityAuthService implements IAuthService {
     private environmentRepository: EnvironmentRepository,
     private memberRepository: MemberRepository,
     @Inject(forwardRef(() => SwitchOrganization))
-    private switchOrganizationUsecase: SwitchOrganization,
-    @Inject(forwardRef(() => SwitchEnvironment))
-    private switchEnvironmentUsecase: SwitchEnvironment
+    private switchOrganizationUsecase: SwitchOrganization
   ) {}
 
   public async authenticate(

--- a/libs/application-generic/src/usecases/switch-environment/switch-environment.usecase.ts
+++ b/libs/application-generic/src/usecases/switch-environment/switch-environment.usecase.ts
@@ -23,11 +23,11 @@ export class SwitchEnvironment {
   ) {}
 
   async execute(command: SwitchEnvironmentCommand) {
-    const project = await this.environmentRepository.findOne({
+    const environment = await this.environmentRepository.findOne({
       _id: command.newEnvironmentId,
     });
-    if (!project) throw new NotFoundException('Environment not found');
-    if (project._organizationId !== command.organizationId) {
+    if (!environment) throw new NotFoundException('Environment not found');
+    if (environment._organizationId !== command.organizationId) {
       throw new UnauthorizedException('Not authorized for organization');
     }
 
@@ -43,7 +43,8 @@ export class SwitchEnvironment {
     const token = await this.authService.getSignedToken(
       user,
       command.organizationId,
-      member
+      member,
+      command.newEnvironmentId
     );
 
     return token;

--- a/libs/application-generic/src/utils/inject-repositories.ts
+++ b/libs/application-generic/src/utils/inject-repositories.ts
@@ -16,7 +16,7 @@ import {
   CommunityAuthService,
   CommunityUserAuthGuard,
 } from '../services';
-import { CreateUser, SwitchOrganization, SwitchEnvironment } from '../usecases';
+import { CreateUser, SwitchOrganization } from '../usecases';
 
 class PlatformException extends Error {}
 
@@ -60,8 +60,7 @@ export function injectRepositories(
         organizationRepository: OrganizationRepository,
         environmentRepository: EnvironmentRepository,
         memberRepository: MemberRepository,
-        switchOrganizationUsecase: SwitchOrganization,
-        switchEnvironmentUsecase: SwitchEnvironment
+        switchOrganizationUsecase: SwitchOrganization
       ) => {
         return new CommunityAuthService(
           userRepository,
@@ -72,8 +71,7 @@ export function injectRepositories(
           organizationRepository,
           environmentRepository,
           memberRepository,
-          switchOrganizationUsecase,
-          switchEnvironmentUsecase
+          switchOrganizationUsecase
         );
       },
       inject: [
@@ -86,7 +84,6 @@ export function injectRepositories(
         EnvironmentRepository,
         MemberRepository,
         SwitchOrganization,
-        SwitchEnvironment,
       ],
     };
 


### PR DESCRIPTION
### What changed? Why was the change needed?

This is necessary for old Dashboard SPAs that will still rely on this endpoint for environment switching until the new SPA code is deployed and loaded on full page reload.