### PR TITLE
fix(api): get organizations e2e

### DIFF
--- a/apps/api/src/app/organization/e2e/get-organizations.e2e.ts
+++ b/apps/api/src/app/organization/e2e/get-organizations.e2e.ts
@@ -40,9 +40,6 @@ describe('Get organizations - /organizations (GET) @skip-in-ee', async () => {
     thirdOldOrganization = thirdSession.organization;
 
     await thirdSession.testAgent.post(`/v1/invites/${invitee.invite.token}/accept`).expect(201);
-
-    thirdSession.organization = session.organization;
-    await thirdSession.fetchJWT();
   });
 
   it('should see all organizations that you are a part of', async () => {

--- a/libs/testing/src/user.session.ts
+++ b/libs/testing/src/user.session.ts
@@ -233,9 +233,7 @@ export class UserSession {
 
   private async fetchJwtCommunity() {
     const response = await request(this.requestEndpoint).get(
-      `/v1/auth/test/token/${this.user._id}?environmentId=${
-        this.environment ? this.environment._id : ''
-      }&organizationId=${this.organization ? this.organization._id : ''}`
+      `/v1/auth/test/token/${this.user._id}?organizationId=${this.organization ? this.organization._id : ''}`
     );
 
     this.token = `Bearer ${response.body.data}`;


### PR DESCRIPTION
### What changed? Why was the change needed?
Remove redundant steps from the `get-organizations` e2e test