### PR TITLE
fix(web): Restore all variants specs

### DIFF
--- a/apps/web/tests/navbar-sidebar.spec.ts
+++ b/apps/web/tests/navbar-sidebar.spec.ts
@@ -4,36 +4,34 @@ import { test } from './utils/baseTest';
 import { SidebarPage } from './page-models/sidebarPage';
 
 test.describe('Main Nav (Sidebar)', () => {
-  test.describe('Information Architecture enabled', () => {
-    test.beforeEach(async ({ page, context }) => {
-      await initializeSession(page, { noTemplates: false });
-    });
+  test.beforeEach(async ({ page, context }) => {
+    await initializeSession(page, { noTemplates: false });
+  });
 
-    test('should render all navigation links', async ({ page }) => {
-      // Check if all expected navigation links are present
-      const sidebarPage = await SidebarPage.goTo(page);
-      await expect(sidebarPage.getQuickStartLingLocator()).toBeVisible();
-      await expect(sidebarPage.getIntegrationLinkLocator()).toBeVisible();
-      await expect(sidebarPage.getSettingsLinkLocator()).toBeVisible();
-      await expect(sidebarPage.getTemplatesLinkLocator()).toBeVisible();
-      await expect(sidebarPage.getActivitiesLinkLocator()).toBeVisible();
-      await expect(sidebarPage.getChangesLinkLocator()).toBeVisible();
-      await expect(sidebarPage.getSubscribersLinkLocator()).toBeVisible();
-      await expect(sidebarPage.getTenantsLinkLocator()).toBeVisible();
-      await expect(sidebarPage.getTranslationsLinkLocator()).toBeVisible();
-    });
+  test('should render all navigation links', async ({ page }) => {
+    // Check if all expected navigation links are present
+    const sidebarPage = await SidebarPage.goTo(page);
+    await expect(sidebarPage.getQuickStartLingLocator()).toBeVisible();
+    await expect(sidebarPage.getIntegrationLinkLocator()).toBeVisible();
+    await expect(sidebarPage.getSettingsLinkLocator()).toBeVisible();
+    await expect(sidebarPage.getTemplatesLinkLocator()).toBeVisible();
+    await expect(sidebarPage.getActivitiesLinkLocator()).toBeVisible();
+    await expect(sidebarPage.getChangesLinkLocator()).toBeVisible();
+    await expect(sidebarPage.getSubscribersLinkLocator()).toBeVisible();
+    await expect(sidebarPage.getTenantsLinkLocator()).toBeVisible();
+    await expect(sidebarPage.getTranslationsLinkLocator()).toBeVisible();
+  });
 
-    test('should navigate to correct routes when clicking links', async ({ page }) => {
-      // Check if clicking on a navigation link navigates to the correct route
-      const sidebarPage = await SidebarPage.goTo(page);
-      await sidebarPage.getQuickStartLingLocator().click();
-      expect(page.url()).toContain('/get-started');
+  test('should navigate to correct routes when clicking links', async ({ page }) => {
+    // Check if clicking on a navigation link navigates to the correct route
+    const sidebarPage = await SidebarPage.goTo(page);
+    await sidebarPage.getQuickStartLingLocator().click();
+    expect(page.url()).toContain('/get-started');
 
-      await sidebarPage.getIntegrationLinkLocator().click();
-      expect(page.url()).toContain('/integrations');
+    await sidebarPage.getIntegrationLinkLocator().click();
+    expect(page.url()).toContain('/integrations');
 
-      await sidebarPage.getSettingsLinkLocator().click();
-      expect(page.url()).toContain('/settings');
-    });
+    await sidebarPage.getSettingsLinkLocator().click();
+    expect(page.url()).toContain('/settings');
   });
 });

--- a/apps/web/tests/page-models/sidebarPage.ts
+++ b/apps/web/tests/page-models/sidebarPage.ts
@@ -10,8 +10,8 @@ export enum Environment {
 export class SidebarPage {
   constructor(private page: Page) {}
 
-  public async getTemplatesLink() {
-    return await getAttByTestId(this.page, 'side-nav-templates-link', 'href');
+  public getTemplatesLink() {
+    return this.page.getByTestId('side-nav-templates-link');
   }
 
   public getOrganizationSwitch() {

--- a/apps/web/tests/variants.spec.ts
+++ b/apps/web/tests/variants.spec.ts
@@ -195,8 +195,8 @@ test('should show only edit step in production for simple node', async ({ page }
   const sidebarPage = await SidebarPage.goTo(page);
   await sidebarPage.toggleToProduction();
 
-  const workflowsPage = await WorkflowsPage.goTo(page);
-  workflowEditorPage = await workflowsPage.getFirstWorkflowEditor();
+  await sidebarPage.getTemplatesLink().click();
+  workflowEditorPage = await new WorkflowsPage(page).getFirstWorkflowEditor();
   const relevantNode = workflowEditorPage.getNode(ChannelType.SMS, 0);
 
   await relevantNode.hover();
@@ -206,7 +206,7 @@ test('should show only edit step in production for simple node', async ({ page }
   expect(relevantNode.getByTestId('step-actions-menu')).toHaveCount(0);
 });
 
-test.skip('should show edit step and conditions in production for node with conditions', async ({ page }) => {
+test('should show edit step and conditions in production for node with conditions', async ({ page }) => {
   let workflowEditorPage = await WorkflowEditorPage.goToNewWorkflow(page);
   await workflowEditorPage.addAndFillSmsNode('this is a test paragraph', 'Test Add Variant Flow for SMS');
 
@@ -218,8 +218,8 @@ test.skip('should show edit step and conditions in production for node with cond
   const sidebarPage = await SidebarPage.goTo(page);
   await sidebarPage.toggleToProduction();
 
-  const workflowsPage = await WorkflowsPage.goTo(page);
-  workflowEditorPage = await workflowsPage.getFirstWorkflowEditor();
+  await sidebarPage.getTemplatesLink().click();
+  workflowEditorPage = await new WorkflowsPage(page).getFirstWorkflowEditor();
   const relevantNode = workflowEditorPage.getNode(ChannelType.SMS, 0);
 
   await relevantNode.hover();
@@ -251,7 +251,7 @@ test('ensure the variant step editor has expected actions', async ({ page }) => 
   await assertHasExpectedVariantEditorButtons(page);
 });
 
-test.skip('ensure production node editor only shows close button for simple case', async ({ page }) => {
+test('ensure production node editor only shows close button for simple case', async ({ page }) => {
   let workflowEditorPage = await WorkflowEditorPage.goToNewWorkflow(page);
   await workflowEditorPage.addAndFillSmsNode('this is a test paragraph', 'Test Add Flow for SMS');
 
@@ -260,9 +260,8 @@ test.skip('ensure production node editor only shows close button for simple case
   const sidebarPage = await SidebarPage.goTo(page);
   await sidebarPage.toggleToProduction();
 
-  const workflowsPage = await WorkflowsPage.goTo(page);
-  workflowEditorPage = await workflowsPage.getFirstWorkflowEditor();
-
+  await sidebarPage.getTemplatesLink().click();
+  workflowEditorPage = await new WorkflowsPage(page).getFirstWorkflowEditor();
   const smsNodeEditorPage = await workflowEditorPage.getFirstSmsNodeEditor();
 
   expect(smsNodeEditorPage.getEditorAddVariantButton()).toHaveCount(0);
@@ -272,7 +271,7 @@ test.skip('ensure production node editor only shows close button for simple case
   expect(smsNodeEditorPage.getCloseSidebarLocator()).toHaveCount(1);
 });
 
-test.skip('ensure production shows close and edit conditions button for conditioned node', async ({ page }) => {
+test('ensure production shows close and edit conditions button for conditioned node', async ({ page }) => {
   let workflowEditorPage = await WorkflowEditorPage.goToNewWorkflow(page);
   await workflowEditorPage.addAndFillSmsNode('this is a test paragraph', 'Test Add Flow for SMS');
   await workflowEditorPage.addConditionToNode(ChannelType.SMS);
@@ -283,8 +282,8 @@ test.skip('ensure production shows close and edit conditions button for conditio
   const sidebarPage = await SidebarPage.goTo(page);
   await sidebarPage.toggleToProduction();
 
-  const workflowsPage = await WorkflowsPage.goTo(page);
-  workflowEditorPage = await workflowsPage.getFirstWorkflowEditor();
+  await sidebarPage.getTemplatesLink().click();
+  workflowEditorPage = await new WorkflowsPage(page).getFirstWorkflowEditor();
 
   const smsNodeEditorPage = await workflowEditorPage.getFirstSmsNodeEditor();
 
@@ -327,7 +326,7 @@ test('Allows adding second variant condition from the variants overview modal he
   await expect(variantOverview.getVariantAtIndex(0)).toContainText('2');
 });
 
-test.skip('Allows adding second condition from the in step editor', async ({ page }) => {
+test('Allows adding second condition from the in step editor', async ({ page }) => {
   const workflowEditorPage = await WorkflowEditorPage.goToNewWorkflow(page);
   const inAppEditor = await workflowEditorPage.addAndEditInAppNode();
   await inAppEditor.fillNotificationBody('some content');


### PR DESCRIPTION
### What changed? Why was the change needed?
Remove all flakiness and make them run in a predictable, fast way without goTo invocations that trigger full page reloads.