### PR TITLE
fix(api): clerk e2e ee tests

### DIFF
--- a/libs/testing/src/user.session.ts
+++ b/libs/testing/src/user.session.ts
@@ -263,7 +263,9 @@ export class UserSession {
 
     this.token = `Bearer ${encoded}`;
 
-    this.testAgent = superAgentDefaults(request(this.requestEndpoint)).set('Authorization', this.token);
+    this.testAgent = superAgentDefaults(request(this.requestEndpoint))
+      .set('Authorization', this.token)
+      .set('Novu-Environment-Id', this.environment ? this.environment._id : '');
   }
 
   private async decodeClerkJWT(token: string) {


### PR DESCRIPTION
### What changed? Why was the change needed?
Add missing `novu-environment-id` to the superagent requests when Clerk is enabled