### PR TITLE
fix(web): Restore Local Studio opening

### DIFF
--- a/apps/web/src/ApplicationReadyGuard.tsx
+++ b/apps/web/src/ApplicationReadyGuard.tsx
@@ -1,11 +1,14 @@
+import { Navigate, useLocation } from 'react-router-dom';
 import { type PropsWithChildren, useLayoutEffect } from 'react';
 import { useAuth, useEnvironment } from './hooks';
+import { isStudioRoute } from './studio/utils/routing';
 
 export function ApplicationReadyGuard({ children }: PropsWithChildren<{}>) {
+  const location = useLocation();
   const { isLoading: isLoadingAuth, inPublicRoute } = useAuth();
   const { isLoading: isLoadingEnvironment } = useEnvironment();
 
-  const isLoading = isLoadingAuth || isLoadingEnvironment;
+  const isLoading = isLoadingAuth || (isStudioRoute(location.pathname) && isLoadingEnvironment);
 
   // Clean up the skeleton loader when the app is ready
   useLayoutEffect(() => {


### PR DESCRIPTION
### What changed? Why was the change needed?
Teach the Dashboard to wait for environments only when not in local studio paths.