### PR TITLE
fix(web): get new envs directly instead of via usequery update

### DIFF
--- a/apps/web/src/pages/auth/components/QuestionnaireForm.tsx
+++ b/apps/web/src/pages/auth/components/QuestionnaireForm.tsx
@@ -20,7 +20,7 @@ import {
 
 import { api } from '../../../api/api.client';
 import { useAuth } from '../../../hooks/useAuth';
-import { useFeatureFlag, useVercelIntegration, useVercelParams } from '../../../hooks';
+import { useEnvironment, useFeatureFlag, useVercelIntegration, useVercelParams } from '../../../hooks';
 import { ROUTES } from '../../../constants/routes';
 import { DynamicCheckBox } from './dynamic-checkbox/DynamicCheckBox';
 import styled from '@emotion/styled/macro';
@@ -37,6 +37,7 @@ export function QuestionnaireForm() {
   } = useForm<IOrganizationCreateForm>({});
   const navigate = useNavigate();
   const { login, currentOrganization } = useAuth();
+  const { refetchEnvironments } = useEnvironment();
   const { startVercelSetup } = useVercelIntegration();
   const { isFromVercel } = useVercelParams();
   const { parse } = useDomainParser();
@@ -72,6 +73,7 @@ export function QuestionnaireForm() {
 
     const organizationResponseToken = await api.post(`/v1/auth/organizations/${organization._id}/switch`, {});
     await login(organizationResponseToken);
+    await refetchEnvironments();
 
     segment.track('Create Organization Form Submitted', {
       location: (location.state as any)?.origin || 'web',


### PR DESCRIPTION
### What changed? Why was the change needed?
If we call `refetchEnvironments` from `useQuery` we can't guarantee the env-id will be in localStorage since its being set as side effect.

If we get the env and also set the localStorage env id inside single function, we are able to await both.

Ideal case would be if `useQuery` could both `getEnvironments()` and  `selectEnvironment()` inside single `refetchEnvironments()` call, but that doesn't seem to work even when trying to call `selectEnvironment` inside useQuery's `onSuccess`.
