### PR TITLE
fix(api, web): More fixes on env and org switching

### DIFF
--- a/apps/api/src/app/auth/services/passport/jwt.strategy.ts
+++ b/apps/api/src/app/auth/services/passport/jwt.strategy.ts
@@ -4,22 +4,34 @@ import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ApiAuthSchemeEnum, HttpRequestHeaderKeysEnum, UserSessionData } from '@novu/shared';
 import { AuthService, Instrument } from '@novu/application-generic';
+import { EnvironmentRepository } from '@novu/dal';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(private readonly authService: AuthService) {
+  constructor(private readonly authService: AuthService, private environmentRepository: EnvironmentRepository) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: process.env.JWT_SECRET,
       passReqToCallback: true,
     });
   }
-
   @Instrument()
   async validate(req: http.IncomingMessage, session: UserSessionData) {
     // Set the scheme to Bearer, meaning the user is authenticated via a JWT coming from Dashboard
     session.scheme = ApiAuthSchemeEnum.BEARER;
 
+    const user = await this.authService.validateUser(session);
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+
+    await this.resolveEnvironmentId(req, session);
+
+    return session;
+  }
+
+  @Instrument()
+  async resolveEnvironmentId(req: http.IncomingMessage, session: UserSessionData) {
     // Fetch the environmentId from the request header
     const environmentIdFromHeader =
       (req.headers[HttpRequestHeaderKeysEnum.NOVU_ENVIRONMENT_ID.toLowerCase()] as string) || '';
@@ -29,13 +41,24 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
      * or cached SPA versions of Dashboard as there is no guarantee all current users
      * will have environmentId in localStorage instantly after the deployment.
      */
-    session.environmentId = session.environmentId || environmentIdFromHeader;
+    const environmentIdFromLegacyAuthToken = session.environmentId;
 
-    const user = await this.authService.validateUser(session);
-    if (!user) {
-      throw new UnauthorizedException();
+    let currentEnvironmentId = '';
+
+    if (environmentIdFromLegacyAuthToken) {
+      currentEnvironmentId = environmentIdFromLegacyAuthToken;
+    } else {
+      const environments = await this.environmentRepository.findOrganizationEnvironments(session.organizationId);
+      const environmentIds = environments.map((env) => env._id);
+      const developmentEnvironmentId = environments.find((env) => env.name === 'Development')?._id || '';
+
+      currentEnvironmentId = developmentEnvironmentId;
+
+      if (environmentIds.includes(environmentIdFromHeader)) {
+        currentEnvironmentId = environmentIdFromHeader;
+      }
     }
 
-    return session;
+    session.environmentId = currentEnvironmentId;
   }
 }

--- a/apps/web/src/components/providers/CommunityAuthProvider.tsx
+++ b/apps/web/src/components/providers/CommunityAuthProvider.tsx
@@ -134,6 +134,9 @@ export const CommunityAuthProvider = ({ children }: { children: React.ReactNode 
         return;
       }
 
+      // TODO: Revise storing environment id in local storage to avoid having to clear it during org or env switching
+      clearEnvironmentId();
+
       saveToken(newToken);
       await refetchOrganizations();
       /*
@@ -205,7 +208,7 @@ export const CommunityAuthProvider = ({ children }: { children: React.ReactNode 
   const switchOrganization = useCallback(
     async (orgId: string) => {
       if (!orgId) {
-        return;
+        throw new Error('Organization ID is required');
       }
 
       if (orgId === currentOrganization?._id) {
@@ -213,9 +216,7 @@ export const CommunityAuthProvider = ({ children }: { children: React.ReactNode 
       }
 
       // TODO: Revise storing environment id in local storage to avoid having to clear it during org or env switching
-      if (currentOrganization) {
-        clearEnvironmentId();
-      }
+      clearEnvironmentId();
 
       const token = await apiSwitchOrganization(orgId);
       await login(token);
@@ -225,11 +226,9 @@ export const CommunityAuthProvider = ({ children }: { children: React.ReactNode 
   );
 
   useEffect(() => {
-    (async () => {
-      if (organizations && !currentOrganization) {
-        await switchOrganization(getTokenClaims()?.organizationId || '');
-      }
-    })();
+    if (organizations) {
+      setCurrentOrganization(selectOrganization(organizations, getTokenClaims()?.organizationId));
+    }
   }, [organizations, currentOrganization, switchOrganization]);
 
   useEffect(() => {

--- a/apps/web/src/ee/billing/utils/hooks/useSubscription.ts
+++ b/apps/web/src/ee/billing/utils/hooks/useSubscription.ts
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { differenceInDays, isSameDay } from 'date-fns';
 import { ApiServiceLevelEnum } from '@novu/shared';
+import { useEnvironment } from '../../../../hooks/useEnvironment';
 
 export const useSubscription = () => {
   // TODO: Fix with a useMemo
@@ -14,6 +15,7 @@ export const useSubscription = () => {
     ['billing-subscription', currentOrganization?._id],
     () => api.get('/v1/billing/subscription'),
     {
+      enabled: !!currentOrganization,
       initialData: {
         trialStart: today.toISOString(),
         trialEnd: today.toISOString(),

--- a/libs/application-generic/src/services/auth/community.auth.service.ts
+++ b/libs/application-generic/src/services/auth/community.auth.service.ts
@@ -289,19 +289,7 @@ export class CommunityAuthService implements IAuthService {
       ? this.isAuthenticatedForOrganization(payload._id, payload.organizationId)
       : Promise.resolve(true);
 
-    const environmentPromise =
-      payload.organizationId && payload.environmentId
-        ? this.environmentRepository.findByIdAndOrganization(
-            payload.environmentId,
-            payload.organizationId
-          )
-        : Promise.resolve(true);
-
-    const [user, isMember, environment] = await Promise.all([
-      userPromise,
-      isMemberPromise,
-      environmentPromise,
-    ]);
+    const [user, isMember] = await Promise.all([userPromise, isMemberPromise]);
 
     if (!user) throw new UnauthorizedException('User not found');
     if (payload.organizationId && !isMember) {
@@ -309,10 +297,6 @@ export class CommunityAuthService implements IAuthService {
         `User ${payload._id} is not a member of organization ${payload.organizationId}`
       );
     }
-    if (payload.organizationId && payload.environmentId && !environment)
-      throw new UnauthorizedException(
-        `Environment ${payload.environmentId} doesn't belong to organization ${payload.organizationId}`
-      );
 
     return user;
   }


### PR DESCRIPTION
### What changed? Why was the change needed?
1. Always fallback to dev environment id on the server side if the environment sent from the client doesn't belong to the current organization or is stale.

This is hack until we revise all hooks to include environmentID in the request URL.

2. Ensure that org and environment switching work in all cases