### PR TITLE
feat(js): inbox - single websocket connection across tabs

### DIFF
--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -51,7 +51,7 @@ export enum ActionTypeEnum {
 
 export type Session = {
   token: string;
-  unreadCount: number;
+  totalUnreadCount: number;
 };
 
 export type MessageButton = {

--- a/packages/js/src/ui/api/hooks/useFetchUnreadCount.ts
+++ b/packages/js/src/ui/api/hooks/useFetchUnreadCount.ts
@@ -1,0 +1,28 @@
+import { createResource } from 'solid-js';
+import type { FetchCountArgs } from '../../../feeds';
+import { useNovu } from '../../context';
+
+type UseUnreadCountOptions = {
+  filters?: Pick<FetchCountArgs, 'archived' | 'tags'>;
+  onSuccess?: (count: number) => void;
+  onError?: (error: unknown) => void;
+};
+
+export const useFetchUnreadCount = ({ filters, onSuccess, onError }: UseUnreadCountOptions = { filters: {} }) => {
+  const novu = useNovu();
+
+  const [unreadCount, { refetch }] = createResource({ ...filters, read: false }, async (payload?: FetchCountArgs) => {
+    try {
+      const response = await novu.feeds.fetchCount(payload);
+      const count = response.data.count;
+      onSuccess?.(count);
+
+      return count;
+    } catch (error) {
+      console.warn('Error fetching unread count:', error);
+      onError?.(error);
+    }
+  });
+
+  return { unreadCount, refetch };
+};

--- a/packages/js/src/ui/components/Inbox.tsx
+++ b/packages/js/src/ui/components/Inbox.tsx
@@ -1,4 +1,4 @@
-import { createSignal, JSX, Match, Switch } from 'solid-js';
+import { Accessor, createSignal, JSX, Match, Switch } from 'solid-js';
 import { useStyle } from '../helpers';
 import { Bell, Footer, Header, Settings, SettingsHeader } from './elements';
 import { NotificationList } from './Notification';
@@ -6,7 +6,7 @@ import { Button, Popover } from './primitives';
 
 type InboxProps = {
   open?: boolean;
-  renderBell?: ({ unreadCount }: { unreadCount: number }) => JSX.Element;
+  renderBell?: ({ unreadCount }: { unreadCount: Accessor<number> }) => JSX.Element;
 };
 
 enum Screen {

--- a/packages/js/src/ui/components/Renderer.tsx
+++ b/packages/js/src/ui/components/Renderer.tsx
@@ -11,6 +11,7 @@ import {
   LocalizationProvider,
   NovuProvider,
 } from '../context';
+import { UnreadCountProvider } from '../context/UnreadCountContext';
 import { Bell, Root } from './elements';
 import { Inbox } from './Inbox';
 
@@ -61,19 +62,21 @@ export const Renderer = (props: RendererProps) => {
 
   return (
     <NovuProvider options={props.options}>
-      <LocalizationProvider localization={props.localization}>
-        <AppearanceProvider id={props.novuUI.id} appearance={props.appearance}>
-          <FocusManagerProvider>
-            <InboxNotificationStatusProvider>
-              {[...props.nodes].map(([node, component]) => (
-                <Portal mount={node}>
-                  <Root>{NovuComponents[component.name](component.props || {})}</Root>
-                </Portal>
-              ))}
-            </InboxNotificationStatusProvider>
-          </FocusManagerProvider>
-        </AppearanceProvider>
-      </LocalizationProvider>
+      <UnreadCountProvider>
+        <LocalizationProvider localization={props.localization}>
+          <AppearanceProvider id={props.novuUI.id} appearance={props.appearance}>
+            <FocusManagerProvider>
+              <InboxNotificationStatusProvider>
+                {[...props.nodes].map(([node, component]) => (
+                  <Portal mount={node}>
+                    <Root>{NovuComponents[component.name](component.props || {})}</Root>
+                  </Portal>
+                ))}
+              </InboxNotificationStatusProvider>
+            </FocusManagerProvider>
+          </AppearanceProvider>
+        </LocalizationProvider>
+      </UnreadCountProvider>
     </NovuProvider>
   );
 };

--- a/packages/js/src/ui/components/elements/Bell/Bell.tsx
+++ b/packages/js/src/ui/components/elements/Bell/Bell.tsx
@@ -1,4 +1,6 @@
 import { createSignal, JSX, onCleanup, onMount } from 'solid-js';
+import { requestLock } from '../../../helpers/browser';
+import { NV_INBOX_WEBSOCKET } from '../../../helpers/constants';
 import { useNovu } from '../../../context';
 import { BellContainer } from './DefaultBellContainer';
 
@@ -14,11 +16,14 @@ export function Bell(props: BellProps) {
   };
 
   onMount(() => {
-    novu.on('notifications.unread_count_changed', updateReadCount);
-  });
+    const resolveLock = requestLock(NV_INBOX_WEBSOCKET, () => {
+      novu.on('notifications.unread_count_changed', updateReadCount);
+    });
 
-  onCleanup(() => {
-    novu.off('notifications.unread_count_changed', updateReadCount);
+    onCleanup(() => {
+      novu.off('notifications.unread_count_changed', updateReadCount);
+      resolveLock();
+    });
   });
 
   if (props.children) {

--- a/packages/js/src/ui/components/elements/Bell/Bell.tsx
+++ b/packages/js/src/ui/components/elements/Bell/Bell.tsx
@@ -1,8 +1,9 @@
 import { createSignal, JSX, onCleanup, onMount } from 'solid-js';
 import { requestLock } from '../../../helpers/browser';
-import { NV_INBOX_WEBSOCKET } from '../../../helpers/constants';
+import { NV_INBOX_WEBSOCKET_LOCK } from '../../../helpers/constants';
 import { useNovu } from '../../../context';
 import { BellContainer } from './DefaultBellContainer';
+import { useTabsChannel } from '../../../helpers/useTabsChannel';
 
 type BellProps = {
   children?: ({ unreadCount }: { unreadCount: number }) => JSX.Element;
@@ -10,13 +11,15 @@ type BellProps = {
 export function Bell(props: BellProps) {
   const [unreadCount, setUnreadCount] = createSignal(0);
   const novu = useNovu();
+  const { postMessage } = useTabsChannel<number>({ onMessage: setUnreadCount });
 
   const updateReadCount = (data: { result: number }) => {
     setUnreadCount(data.result);
+    postMessage(data.result);
   };
 
   onMount(() => {
-    const resolveLock = requestLock(NV_INBOX_WEBSOCKET, () => {
+    const resolveLock = requestLock(NV_INBOX_WEBSOCKET_LOCK, () => {
       novu.on('notifications.unread_count_changed', updateReadCount);
     });
 

--- a/packages/js/src/ui/components/elements/Bell/DefaultBellContainer.tsx
+++ b/packages/js/src/ui/components/elements/Bell/DefaultBellContainer.tsx
@@ -1,9 +1,9 @@
-import { Show } from 'solid-js';
+import { Accessor, Show } from 'solid-js';
 import { useStyle } from '../../../helpers';
 import { BellIcon } from '../../../icons';
 
 type DefaultBellContainerProps = {
-  unreadCount: number;
+  unreadCount: Accessor<number>;
 };
 
 export const BellContainer = (props: DefaultBellContainerProps) => {
@@ -17,11 +17,13 @@ export const BellContainer = (props: DefaultBellContainerProps) => {
       )}
     >
       <BellIcon />
-      <Show when={props.unreadCount > 0}>
-        {/* <span
-          class="nt-absolute nt-top-2 nt-right-2 nt-block nt-w-2 nt-h-2 nt-transform nt-translate-x-1/2
-        -nt-translate-y-1/2 nt-bg-primary nt-rounded-full"
-        /> */}
+      <Show when={props.unreadCount() > 0}>
+        <span
+          class={style(
+            'bellDot',
+            'nt-absolute nt-top-2 nt-right-2 nt-block nt-w-2 nt-h-2 nt-transform nt-translate-x-1/2 -nt-translate-y-1/2 nt-bg-primary nt-rounded-full nt-border nt-border-background'
+          )}
+        />
       </Show>
     </span>
   );

--- a/packages/js/src/ui/context/AppearanceContext.tsx
+++ b/packages/js/src/ui/context/AppearanceContext.tsx
@@ -43,6 +43,7 @@ export const appearanceKeys = [
   'root',
   'bellIcon',
   'bellContainer',
+  'bellDot',
   'settings__button',
   'settingsContainer',
   'inboxHeader',

--- a/packages/js/src/ui/context/UnreadCountContext.tsx
+++ b/packages/js/src/ui/context/UnreadCountContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, createSignal, Accessor, ParentProps } from 'solid-js';
+import { useNovuEvent } from '../helpers/useNovuEvent';
+import { useWebSocketEvent } from '../helpers/useWebSocketEvent';
+
+type UnreadCountContextValue = {
+  unreadCount: Accessor<number>;
+};
+
+const UnreadCountContext = createContext<UnreadCountContextValue>(undefined);
+
+export const UnreadCountProvider = (props: ParentProps) => {
+  const [unreadCount, setUnreadCount] = createSignal(0);
+  useWebSocketEvent({
+    event: 'notifications.unread_count_changed',
+    eventHandler: (data) => setUnreadCount(data.result),
+  });
+  useNovuEvent({
+    event: 'session.initialize.success',
+    eventHandler: (data) => setUnreadCount(data.result.totalUnreadCount),
+  });
+
+  return <UnreadCountContext.Provider value={{ unreadCount }}>{props.children}</UnreadCountContext.Provider>;
+};
+
+export function useUnreadCount() {
+  const context = useContext(UnreadCountContext);
+  if (!context) {
+    throw new Error('useUnreadCount must be used within a UnreadCountProvider');
+  }
+
+  return context;
+}

--- a/packages/js/src/ui/helpers/browser.ts
+++ b/packages/js/src/ui/helpers/browser.ts
@@ -1,13 +1,13 @@
 export function requestLock(id: string, cb: (id: string) => void) {
-  let isFullfilled = false;
-  let resolve: () => void;
+  let isFulfilled = false;
+  let promiseResolve: () => void;
 
-  const promise = new Promise<void>((res) => {
-    resolve = res;
+  const promise = new Promise<void>((resolve) => {
+    promiseResolve = resolve;
   });
 
   navigator.locks.request(id, () => {
-    if (!isFullfilled) {
+    if (!isFulfilled) {
       cb(id);
     }
 
@@ -15,7 +15,7 @@ export function requestLock(id: string, cb: (id: string) => void) {
   });
 
   return () => {
-    isFullfilled = true;
-    resolve();
+    isFulfilled = true;
+    promiseResolve();
   };
 }

--- a/packages/js/src/ui/helpers/browser.ts
+++ b/packages/js/src/ui/helpers/browser.ts
@@ -1,4 +1,5 @@
 export function requestLock(id: string, cb: (id: string) => void) {
+  let isFullfilled = false;
   let resolve: () => void;
 
   const promise = new Promise<void>((res) => {
@@ -6,9 +7,15 @@ export function requestLock(id: string, cb: (id: string) => void) {
   });
 
   navigator.locks.request(id, () => {
-    cb(id);
+    if (!isFullfilled) {
+      cb(id);
+    }
+
     return promise;
   });
 
-  return () => resolve();
+  return () => {
+    isFullfilled = true;
+    resolve();
+  };
 }

--- a/packages/js/src/ui/helpers/browser.ts
+++ b/packages/js/src/ui/helpers/browser.ts
@@ -1,0 +1,14 @@
+export function requestLock(id: string, cb: (id: string) => void) {
+  let resolve: () => void;
+
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+
+  navigator.locks.request(id, () => {
+    cb(id);
+    return promise;
+  });
+
+  return () => resolve();
+}

--- a/packages/js/src/ui/helpers/constants.ts
+++ b/packages/js/src/ui/helpers/constants.ts
@@ -1,0 +1,1 @@
+export const NV_INBOX_WEBSOCKET = 'nv-inbox-websocket';

--- a/packages/js/src/ui/helpers/constants.ts
+++ b/packages/js/src/ui/helpers/constants.ts
@@ -1,1 +1,2 @@
-export const NV_INBOX_WEBSOCKET = 'nv-inbox-websocket';
+export const NV_INBOX_TABS_CHANNEL = 'nv-inbox-tabs-channel';
+export const NV_INBOX_WEBSOCKET_LOCK = 'nv-inbox-websocket-lock';

--- a/packages/js/src/ui/helpers/useBrowserTabsChannel.ts
+++ b/packages/js/src/ui/helpers/useBrowserTabsChannel.ts
@@ -1,7 +1,7 @@
 import { createSignal, onCleanup, onMount } from 'solid-js';
 import { NV_INBOX_TABS_CHANNEL } from './constants';
 
-export const useTabsChannel = <T = unknown>({ onMessage }: { onMessage: (args: T) => void }) => {
+export const useBrowserTabsChannel = <T = unknown>({ onMessage }: { onMessage: (args: T) => void }) => {
   const [tabsChannel] = createSignal(new BroadcastChannel(NV_INBOX_TABS_CHANNEL));
 
   const postMessage = (data: T) => {

--- a/packages/js/src/ui/helpers/useNovuEvent.ts
+++ b/packages/js/src/ui/helpers/useNovuEvent.ts
@@ -1,0 +1,21 @@
+import { onCleanup, onMount } from 'solid-js';
+import type { EventHandler, Events, EventNames } from '../../event-emitter';
+import { useNovu } from '../context';
+
+export const useNovuEvent = <E extends EventNames>({
+  event,
+  eventHandler,
+}: {
+  event: E;
+  eventHandler: EventHandler<Events[E]>;
+}) => {
+  const novu = useNovu();
+
+  onMount(() => {
+    novu.on(event, eventHandler);
+
+    onCleanup(() => {
+      novu.off(event, eventHandler);
+    });
+  });
+};

--- a/packages/js/src/ui/helpers/useTabsChannel.ts
+++ b/packages/js/src/ui/helpers/useTabsChannel.ts
@@ -1,0 +1,26 @@
+import { createSignal, onCleanup, onMount } from 'solid-js';
+import { NV_INBOX_TABS_CHANNEL } from './constants';
+
+export const useTabsChannel = <T = unknown>({ onMessage }: { onMessage: (args: T) => void }) => {
+  const [tabsChannel] = createSignal(new BroadcastChannel(NV_INBOX_TABS_CHANNEL));
+
+  const postMessage = (data: T) => {
+    const channel = tabsChannel();
+    channel.postMessage(data);
+  };
+
+  onMount(() => {
+    const listener = (event: MessageEvent<T>) => {
+      onMessage(event.data);
+    };
+
+    const channel = tabsChannel();
+    channel.addEventListener('message', listener);
+
+    onCleanup(() => {
+      channel.removeEventListener('message', listener);
+    });
+  });
+
+  return { postMessage };
+};

--- a/packages/js/src/ui/helpers/useWebSocketEvent.ts
+++ b/packages/js/src/ui/helpers/useWebSocketEvent.ts
@@ -1,0 +1,33 @@
+import { onCleanup, onMount } from 'solid-js';
+import type { SocketEventNames, EventHandler, Events } from '../../event-emitter';
+import { useNovu } from '../context';
+import { requestLock } from './browser';
+import { NV_INBOX_WEBSOCKET_LOCK } from './constants';
+import { useBrowserTabsChannel } from './useBrowserTabsChannel';
+
+export const useWebSocketEvent = <E extends SocketEventNames>({
+  event: webSocketEvent,
+  eventHandler: onMessage,
+}: {
+  event: E;
+  eventHandler: (args: Events[E]) => void;
+}) => {
+  const novu = useNovu();
+  const { postMessage } = useBrowserTabsChannel({ onMessage });
+
+  const updateReadCount: EventHandler<Events[E]> = (data) => {
+    onMessage(data);
+    postMessage(data);
+  };
+
+  onMount(() => {
+    const resolveLock = requestLock(NV_INBOX_WEBSOCKET_LOCK, () => {
+      novu.on(webSocketEvent, updateReadCount);
+    });
+
+    onCleanup(() => {
+      novu.off(webSocketEvent, updateReadCount);
+      resolveLock();
+    });
+  });
+};

--- a/packages/js/src/ws/socket.ts
+++ b/packages/js/src/ws/socket.ts
@@ -87,13 +87,17 @@ export class Socket extends BaseModule {
 
   initialize(): void {
     if (this.#token) {
-      this.#initializeSocket().then((error) => console.error(error));
+      this.#initializeSocket().catch((error) => {
+        console.error(error);
+      });
 
       return;
     }
 
     this.callWithSession(async () => {
-      this.#initializeSocket().then((error) => console.error(error));
+      this.#initializeSocket().catch((error) => {
+        console.error(error);
+      });
     });
   }
 }


### PR DESCRIPTION
### What changed? Why was the change needed?
In this PR:
- Implemented the locking mechanism across multiple tabs with `Web Locks API`. The locking mechanism establishes the single WebSocket connection across multiple tabs.
- Single WebSocket event broadcasting with `BroadcastChannel`

### Screenshots

https://github.com/user-attachments/assets/af95955d-1abc-4f31-bb82-ee0612ccbc7e


