### PR TITLE
refactor(web): simplify and break down auth providers 

### DIFF
--- a/apps/web/src/components/providers/AuthProvider.tsx
+++ b/apps/web/src/components/providers/AuthProvider.tsx
@@ -1,7 +1,8 @@
 import { IS_EE_AUTH_ENABLED } from '../../config/index';
 import { IOrganizationEntity, IUserEntity } from '@novu/shared';
 import { CommunityAuthCtx, CommunityAuthProvider } from './CommunityAuthProvider';
-import { EnterpriseAuthCtx, EnterpriseAuthProvider } from '../../ee/clerk/providers/EnterpriseAuthProvider';
+import EnterpriseAuthProvider, { EnterpriseAuthCtx } from '../../ee/clerk/providers/EnterpriseAuthProvider';
+import { useContext } from 'react';
 
 export type AuthContextValue = {
   inPublicRoute: boolean;
@@ -28,11 +29,12 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 };
 
 export const useAuth = () => {
-  const context = IS_EE_AUTH_ENABLED ? EnterpriseAuthCtx : CommunityAuthCtx;
+  const ctx = IS_EE_AUTH_ENABLED ? EnterpriseAuthCtx : CommunityAuthCtx;
+  const context = useContext(ctx);
   const value = (context as any).value as AuthContextValue;
 
   if (!value) {
-    throw new Error('useAuth must be used within ' + context.displayName);
+    throw new Error('useAuth must be used within ' + ctx.displayName);
   }
 
   return value;

--- a/apps/web/src/components/providers/AuthProvider.tsx
+++ b/apps/web/src/components/providers/AuthProvider.tsx
@@ -1,8 +1,7 @@
-import { Context, useContext } from 'react';
 import { IS_EE_AUTH_ENABLED } from '../../config/index';
 import { IOrganizationEntity, IUserEntity } from '@novu/shared';
-import { CommunityAuthContext, CommunityAuthProvider } from './CommunityAuthProvider';
-import { EnterpriseAuthContext, EnterpriseAuthProvider } from '../../ee/clerk/providers/EnterpriseAuthProvider';
+import { CommunityAuthCtx, CommunityAuthProvider } from './CommunityAuthProvider';
+import { EnterpriseAuthCtx, EnterpriseAuthProvider } from '../../ee/clerk/providers/EnterpriseAuthProvider';
 
 export type AuthContextValue = {
   inPublicRoute: boolean;
@@ -25,13 +24,12 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     return <EnterpriseAuthProvider>{children}</EnterpriseAuthProvider>;
   }
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   return <CommunityAuthProvider>{children}</CommunityAuthProvider>;
 };
 
 export const useAuth = () => {
-  const context = IS_EE_AUTH_ENABLED ? EnterpriseAuthContext : CommunityAuthContext;
-  const value = useContext(context);
+  const context = IS_EE_AUTH_ENABLED ? EnterpriseAuthCtx : CommunityAuthCtx;
+  const value = (context as any).value as AuthContextValue;
 
   if (!value) {
     throw new Error('useAuth must be used within ' + context.displayName);

--- a/apps/web/src/components/providers/CommunityAuthProvider.tsx
+++ b/apps/web/src/components/providers/CommunityAuthProvider.tsx
@@ -1,19 +1,17 @@
 import { createContext } from 'react';
 import { IOrganizationEntity, IUserEntity } from '@novu/shared';
-import { setUser as sentrySetUser, configureScope as sentryConfigureScope } from '@sentry/react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { HttpStatusCode } from 'axios';
-import { useLDClient } from 'launchdarkly-react-client-sdk';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { ROUTES, PUBLIC_ROUTES_PREFIXES } from '../../constants/routes';
-import { useSegment } from './SegmentProvider';
+import { useCallback, useEffect, useState } from 'react';
+import { ROUTES } from '../../constants/routes';
 import { clearEnvironmentId } from './EnvironmentProvider';
 import { getToken } from '../../auth/getToken';
 import { getTokenClaims } from '../../auth/getTokenClaims';
 import { getUser } from '../../api/user';
 import { switchOrganization as apiSwitchOrganization, getOrganizations } from '../../api/organization';
 import { type AuthContextValue } from './AuthProvider';
+import { useCommonAuth } from '../../hooks/useCommonAuth';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 // TODO: Add a novu prefix to the local storage key
 export const LOCAL_STORAGE_AUTH_TOKEN_KEY = 'auth_token';
@@ -26,8 +24,8 @@ export const CommunityAuthContext = createContext<AuthContextValue>({
   inPrivateRoute: false,
   isLoading: false,
   currentUser: null,
-  currentOrganization: null,
   organizations: [],
+  currentOrganization: null,
   login: asyncNoop,
   logout: noop,
   redirectToLogin: noop,
@@ -54,15 +52,15 @@ function inIframe() {
   }
 }
 
-function selectOrganization(organizations: IOrganizationEntity[] | null, selectedOrganizationId?: string) {
-  let org: IOrganizationEntity | null = null;
+function selectOrganization(organizations: IOrganizationEntity[] | undefined, selectedOrganizationId?: string) {
+  let org: IOrganizationEntity | undefined = undefined;
 
   if (!organizations) {
-    return null;
+    return;
   }
 
   if (selectedOrganizationId) {
-    org = organizations.find((currOrg) => currOrg._id === selectedOrganizationId) || null;
+    org = organizations.find((currOrg) => currOrg._id === selectedOrganizationId);
   }
 
   // Or pick the development environment
@@ -74,36 +72,14 @@ function selectOrganization(organizations: IOrganizationEntity[] | null, selecte
 }
 
 export const CommunityAuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const ldClient = useLDClient();
-  const segment = useSegment();
-  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
-  const inPublicRoute = !!Array.from(PUBLIC_ROUTES_PREFIXES.values()).find((prefix) =>
-    location.pathname.startsWith(prefix)
-  );
-  const inPrivateRoute = !inPublicRoute;
+
+  const [currentOrganization, setCurrentOrganization] = useState<IOrganizationEntity | undefined>(undefined);
   const hasToken = !!getToken();
 
-  useEffect(() => {
-    if (!getToken() && inPrivateRoute && !inIframe()) {
-      navigate(ROUTES.AUTH_LOGIN, { state: { redirectTo: location } });
-    }
-  }, [navigate, inPrivateRoute, location]);
-
-  const { data: user = null, isLoading: isUserLoading } = useQuery<IUserEntity>(['/v1/users/me'], getUser, {
-    enabled: hasToken,
-    retry: false,
-    staleTime: Infinity,
-    onError: (error: any) => {
-      if (error?.statusCode === HttpStatusCode.Unauthorized) {
-        logout();
-      }
-    },
-  });
-
   const {
-    data: organizations = null,
+    data: organizations,
     isLoading: isOrganizationLoading,
     refetch: refetchOrganizations,
   } = useQuery<IOrganizationEntity[]>(['/v1/organizations'], getOrganizations, {
@@ -117,16 +93,25 @@ export const CommunityAuthProvider = ({ children }: { children: React.ReactNode 
     },
   });
 
-  const reloadOrganization = async () => {
-    const { data } = await getOrganizations();
-    // we need to update all organizations so current org (data) and 'organizations' are not ouf of sync
-    await refetchOrganizations();
-    setCurrentOrganization(selectOrganization(data, currentOrganization?._id));
-  };
+  const { data: user, isLoading: isUserLoading } = useQuery<IUserEntity>(['/v1/users/me'], getUser, {
+    enabled: hasToken,
+    retry: false,
+    staleTime: Infinity,
+    onError: (error: any) => {
+      if (error?.statusCode === HttpStatusCode.Unauthorized) {
+        logout();
+      }
+    },
+  });
 
-  const [currentOrganization, setCurrentOrganization] = useState<IOrganizationEntity | null>(
-    selectOrganization(organizations)
-  );
+  const { inPublicRoute, inPrivateRoute, logout, redirectToLogin, redirectToSignUp } = useCommonAuth({
+    user,
+    organization: currentOrganization,
+    logoutCallback: async () => {
+      saveToken(null);
+      clearEnvironmentId();
+    },
+  });
 
   const login = useCallback(
     async (newToken: string, redirectUrl?: string) => {
@@ -146,63 +131,6 @@ export const CommunityAuthProvider = ({ children }: { children: React.ReactNode 
       redirectUrl ? navigate(redirectUrl) : void 0;
     },
     [navigate, refetchOrganizations]
-  );
-
-  const logout = useCallback(() => {
-    saveToken(null);
-    queryClient.clear();
-    segment.reset();
-    // TODO: Revise storing environment id in local storage to avoid having to clear it during org or env switching
-    clearEnvironmentId();
-    navigate(ROUTES.AUTH_LOGIN);
-    setCurrentOrganization(null);
-  }, [navigate, queryClient, segment]);
-
-  const redirectTo = useCallback(
-    ({
-      url,
-      redirectURL,
-      origin,
-      anonymousId,
-    }: {
-      url: string;
-      redirectURL?: string;
-      origin?: string;
-      anonymousId?: string | null;
-    }) => {
-      const finalURL = new URL(url, window.location.origin);
-
-      if (redirectURL) {
-        finalURL.searchParams.append('redirect_url', redirectURL);
-      }
-
-      if (origin) {
-        finalURL.searchParams.append('origin', origin);
-      }
-
-      if (anonymousId) {
-        finalURL.searchParams.append('anonymous_id', anonymousId);
-      }
-
-      // Note: Do not use react-router-dom. The version we have doesn't do instant cross origin redirects.
-      window.location.replace(finalURL.href);
-    },
-    []
-  );
-
-  const redirectToLogin = useCallback(
-    ({ redirectURL }: { redirectURL?: string } = {}) => redirectTo({ url: ROUTES.AUTH_LOGIN, redirectURL }),
-    [redirectTo]
-  );
-
-  const redirectToSignUp = useCallback(
-    ({
-      redirectURL,
-      origin,
-      anonymousId,
-    }: { redirectURL?: string; origin?: string; anonymousId?: string | null } = {}) =>
-      redirectTo({ url: ROUTES.AUTH_SIGNUP, redirectURL, origin, anonymousId }),
-    [redirectTo]
   );
 
   const switchOrganization = useCallback(
@@ -225,6 +153,13 @@ export const CommunityAuthProvider = ({ children }: { children: React.ReactNode 
     [organizations, currentOrganization, setCurrentOrganization, login]
   );
 
+  const reloadOrganization = async () => {
+    const { data } = await getOrganizations();
+    // we need to update all organizations so current org (data) and 'organizations' are not ouf of sync
+    await refetchOrganizations();
+    setCurrentOrganization(selectOrganization(data, currentOrganization?._id));
+  };
+
   useEffect(() => {
     if (organizations) {
       setCurrentOrganization(selectOrganization(organizations, getTokenClaims()?.organizationId));
@@ -232,40 +167,10 @@ export const CommunityAuthProvider = ({ children }: { children: React.ReactNode 
   }, [organizations, currentOrganization, switchOrganization]);
 
   useEffect(() => {
-    if (user && currentOrganization) {
-      segment.identify(user);
-
-      sentrySetUser({
-        email: user.email ?? '',
-        username: `${user.firstName} ${user.lastName}`,
-        id: user._id,
-        organizationId: currentOrganization._id,
-        organizationName: currentOrganization.name,
-      });
-    } else {
-      sentryConfigureScope((scope) => scope.setUser(null));
+    if (!getToken() && inPrivateRoute && !inIframe()) {
+      navigate(ROUTES.AUTH_LOGIN, { state: { redirectTo: location } });
     }
-  }, [user, currentOrganization, segment]);
-
-  useEffect(() => {
-    if (!ldClient) {
-      return;
-    }
-
-    if (currentOrganization) {
-      ldClient.identify({
-        kind: 'organization',
-        key: currentOrganization._id,
-        name: currentOrganization.name,
-        createdAt: currentOrganization.createdAt,
-      });
-    } else {
-      ldClient.identify({
-        kind: 'user',
-        anonymous: true,
-      });
-    }
-  }, [ldClient, currentOrganization]);
+  }, [navigate, inPrivateRoute, location]);
 
   const value = {
     inPublicRoute,

--- a/apps/web/src/components/providers/CommunityAuthProvider.tsx
+++ b/apps/web/src/components/providers/CommunityAuthProvider.tsx
@@ -1,4 +1,3 @@
-import { createContext } from 'react';
 import { IOrganizationEntity, IUserEntity } from '@novu/shared';
 import { useQuery } from '@tanstack/react-query';
 import { HttpStatusCode } from 'axios';
@@ -12,29 +11,10 @@ import { switchOrganization as apiSwitchOrganization, getOrganizations } from '.
 import { type AuthContextValue } from './AuthProvider';
 import { useCommonAuth } from '../../hooks/useCommonAuth';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { createContextAndHook } from './createContextAndHook';
 
 // TODO: Add a novu prefix to the local storage key
 export const LOCAL_STORAGE_AUTH_TOKEN_KEY = 'auth_token';
-
-const noop = () => {};
-const asyncNoop = async () => {};
-
-export const CommunityAuthContext = createContext<AuthContextValue>({
-  inPublicRoute: false,
-  inPrivateRoute: false,
-  isLoading: false,
-  currentUser: null,
-  organizations: [],
-  currentOrganization: null,
-  login: asyncNoop,
-  logout: noop,
-  redirectToLogin: noop,
-  redirectToSignUp: noop,
-  switchOrganization: asyncNoop,
-  reloadOrganization: asyncNoop,
-});
-
-CommunityAuthContext.displayName = 'CommunityAuthProvider';
 
 function saveToken(token: string | null) {
   if (token) {
@@ -70,6 +50,8 @@ function selectOrganization(organizations: IOrganizationEntity[] | undefined, se
 
   return org;
 }
+
+export const [CommunityAuthCtx] = createContextAndHook<AuthContextValue>('Community Auth Context');
 
 export const CommunityAuthProvider = ({ children }: { children: React.ReactNode }) => {
   const navigate = useNavigate();
@@ -187,5 +169,5 @@ export const CommunityAuthProvider = ({ children }: { children: React.ReactNode 
     reloadOrganization,
   };
 
-  return <CommunityAuthContext.Provider value={value}>{children}</CommunityAuthContext.Provider>;
+  return <CommunityAuthCtx.Provider value={{ value }}>{children}</CommunityAuthCtx.Provider>;
 };

--- a/apps/web/src/ee/clerk/providers/EnterpriseAuthProvider.tsx
+++ b/apps/web/src/ee/clerk/providers/EnterpriseAuthProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { type AuthContextValue } from '../../../components/providers/AuthProvider';
 import type { IOrganizationEntity, IUserEntity } from '@novu/shared';
 import { useAuth, useUser, useOrganization, useOrganizationList } from '@clerk/clerk-react';
@@ -8,26 +8,11 @@ import { ROUTES } from '../../../constants/routes';
 import { useCommonAuth } from '../../../hooks/useCommonAuth';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import { createContextAndHook } from '../../../components/providers/createContextAndHook';
 
-const noop = () => {};
 const asyncNoop = async () => {};
 
-// TODO: Replace with createContextAndHook
-export const EnterpriseAuthContext = createContext<AuthContextValue>({
-  inPublicRoute: false,
-  inPrivateRoute: false,
-  isLoading: false,
-  currentUser: null,
-  organizations: [],
-  currentOrganization: null,
-  login: asyncNoop,
-  logout: noop,
-  redirectToLogin: noop,
-  redirectToSignUp: noop,
-  switchOrganization: asyncNoop,
-  reloadOrganization: asyncNoop,
-});
-EnterpriseAuthContext.displayName = 'EnterpriseAuthProvider';
+export const [EnterpriseAuthCtx] = createContextAndHook<AuthContextValue>('Enterprise Auth Context');
 
 export const EnterpriseAuthProvider = ({ children }: { children: React.ReactNode }) => {
   const navigate = useNavigate();
@@ -124,7 +109,7 @@ export const EnterpriseAuthProvider = ({ children }: { children: React.ReactNode
     reloadOrganization,
   };
 
-  return <EnterpriseAuthContext.Provider value={value}>{children}</EnterpriseAuthContext.Provider>;
+  return <EnterpriseAuthCtx.Provider value={{ value }}>{children}</EnterpriseAuthCtx.Provider>;
 };
 
 const toUserEntity = (clerkUser: UserResource): IUserEntity => ({

--- a/apps/web/src/ee/clerk/providers/withOrganizationGuard.tsx
+++ b/apps/web/src/ee/clerk/providers/withOrganizationGuard.tsx
@@ -1,0 +1,30 @@
+import { useUser, useOrganizationList, useAuth } from '@clerk/clerk-react';
+import { ComponentType, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../../../constants/routes';
+
+export const withOrganizationGuard = <P extends Record<string, any>>(
+  WrappedComponent: ComponentType<P>
+): React.FC<P> => {
+  return (props: P) => {
+    const navigate = useNavigate();
+    const { orgId } = useAuth();
+    const { user: clerkUser } = useUser();
+    const { isLoaded: isOrgListLoaded, setActive } = useOrganizationList({ userMemberships: { infinite: true } });
+
+    useEffect(() => {
+      if (!orgId && isOrgListLoaded && clerkUser) {
+        const hasOrgs = clerkUser.organizationMemberships.length > 0;
+
+        if (hasOrgs) {
+          const firstOrg = clerkUser.organizationMemberships[0].organization;
+          setActive({ organization: firstOrg });
+        } else {
+          navigate(ROUTES.AUTH_SIGNUP_ORGANIZATION_LIST);
+        }
+      }
+    }, [navigate, setActive, isOrgListLoaded, clerkUser, orgId]);
+
+    return <WrappedComponent {...(props as P)} />;
+  };
+};

--- a/apps/web/src/hooks/useCommonAuth.ts
+++ b/apps/web/src/hooks/useCommonAuth.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { useLDClient } from 'launchdarkly-react-client-sdk';
+import { IOrganizationEntity, IUserEntity } from '@novu/shared';
+import { useSegment } from '../components/providers/SegmentProvider';
+import { PUBLIC_ROUTES_PREFIXES, ROUTES } from '../constants/routes';
+import { configureScope, setUser } from '@sentry/react';
+
+type CommonAuthProps = {
+  user?: IUserEntity;
+  organization?: IOrganizationEntity;
+  logoutCallback?: () => void;
+};
+
+export const useCommonAuth = ({ user, organization, logoutCallback }: CommonAuthProps) => {
+  const segment = useSegment();
+  const queryClient = useQueryClient();
+  const ldClient = useLDClient();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const inPublicRoute = Array.from(PUBLIC_ROUTES_PREFIXES).some((prefix) => location.pathname.startsWith(prefix));
+  const inPrivateRoute = !inPublicRoute;
+
+  const logout = useCallback(() => {
+    queryClient.clear();
+    segment.reset();
+    navigate(ROUTES.AUTH_LOGIN);
+    logoutCallback?.();
+  }, [logoutCallback, navigate, queryClient, segment]);
+
+  const redirectTo = useCallback(
+    ({
+      url,
+      redirectURL,
+      origin,
+      anonymousId,
+    }: {
+      url: string;
+      redirectURL?: string;
+      origin?: string;
+      anonymousId?: string | null;
+    }) => {
+      const finalURL = new URL(url, window.location.origin);
+
+      if (redirectURL) {
+        finalURL.searchParams.append('redirect_url', redirectURL);
+      }
+
+      if (origin) {
+        finalURL.searchParams.append('origin', origin);
+      }
+
+      if (anonymousId) {
+        finalURL.searchParams.append('anonymous_id', anonymousId);
+      }
+
+      window.location.replace(finalURL.href);
+    },
+    []
+  );
+
+  const redirectToLogin = useCallback(
+    ({ redirectURL }: { redirectURL?: string } = {}) => redirectTo({ url: ROUTES.AUTH_LOGIN, redirectURL }),
+    [redirectTo]
+  );
+
+  const redirectToSignUp = useCallback(
+    ({ redirectURL, origin, anonymousId }: { redirectURL?: string; origin?: string; anonymousId?: string } = {}) =>
+      redirectTo({ url: ROUTES.AUTH_SIGNUP, redirectURL, origin, anonymousId }),
+    [redirectTo]
+  );
+
+  useEffect(() => {
+    if (user && organization) {
+      segment.identify(user);
+
+      setUser({
+        email: user.email ?? '',
+        username: `${user.firstName} ${user.lastName}`,
+        id: user._id,
+        organizationId: organization._id,
+        organizationName: organization.name,
+      });
+    } else {
+      configureScope((scope) => scope.setUser(null));
+    }
+  }, [user, organization, segment]);
+
+  useEffect(() => {
+    if (!ldClient) return;
+
+    if (organization) {
+      ldClient.identify({
+        kind: 'organization',
+        key: organization._id,
+        name: organization.name,
+      });
+    } else {
+      ldClient.identify({
+        kind: 'user',
+        anonymous: true,
+      });
+    }
+  }, [ldClient, organization]);
+
+  return {
+    inPublicRoute,
+    inPrivateRoute,
+    logout,
+    redirectToLogin,
+    redirectToSignUp,
+  };
+};


### PR DESCRIPTION
### What changed? Why was the change needed?
Generally cleaned up the auth providers to increase the code readability, since they packed too much logic it was hard to navigate

* extracted shared auth logic to `useCommonAuth` hook (auth version specific side effects can be passed as arguments, e.g. logout)
* refactored some of the methods and constants
* moved EE organization guard useEffect to standalone `withOrganizationGuard` 
* used `createContextAndHook` utility for auth providers similarly as in `EnterpriseProvider`
