### PR TITLE
fix(web): V2 minor fixes

### DIFF
--- a/apps/web/src/components/layout/components/LocalStudioSidebar/LocalStudioSidebarContent.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioSidebar/LocalStudioSidebarContent.tsx
@@ -6,7 +6,7 @@ import { IBridgeWorkflow } from '../../../../studio/types';
 import { NavMenu } from '../../../nav/NavMenu';
 import { NavMenuSection } from '../../../nav/NavMenuSection';
 import { LocalStudioSidebarOrganizationDisplay } from './LocalStudioSidebarOrganizationDisplay';
-import { LocalStudioSidebarToggleButton } from './LocalStudioSidebarToggleButtonProps';
+import { LocalStudioSidebarToggleButton } from './LocalStudioSidebarToggleButton';
 import { token } from '@novu/novui/tokens';
 import { css, cx } from '@novu/novui/css';
 import { useStudioState } from '../../../../studio/StudioStateProvider';

--- a/apps/web/src/components/layout/components/LocalStudioSidebar/LocalStudioSidebarToggleButton.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioSidebar/LocalStudioSidebarToggleButton.tsx
@@ -8,7 +8,7 @@ import {
   getStudioWorkflowStepLink,
   getStudioWorkflowTestLink,
 } from '../../../../studio/utils/routing';
-import { NavMenuLinkButton, NavMenuToggleButton } from '../../../nav/NavMenuButton/index';
+import { NavMenuLinkButton, NavMenuToggleButton } from '../../../nav/NavMenuButton';
 
 type LocalStudioSidebarToggleButtonProps = {
   workflow: IBridgeWorkflow;

--- a/apps/web/src/components/layout/components/LocalStudioSidebar/LocalStudioSidebarToggleButton.tsx
+++ b/apps/web/src/components/layout/components/LocalStudioSidebar/LocalStudioSidebarToggleButton.tsx
@@ -8,7 +8,7 @@ import {
   getStudioWorkflowStepLink,
   getStudioWorkflowTestLink,
 } from '../../../../studio/utils/routing';
-import { NavMenuLinkButton, NavMenuToggleButton } from '../../../nav/NavMenuButton';
+import { NavMenuLinkButton, NavMenuToggleButton } from '../../../nav/NavMenuButton/index';
 
 type LocalStudioSidebarToggleButtonProps = {
   workflow: IBridgeWorkflow;

--- a/apps/web/src/components/nav/NavMenuButton/NavMenuToggleButton.tsx
+++ b/apps/web/src/components/nav/NavMenuButton/NavMenuToggleButton.tsx
@@ -40,16 +40,10 @@ export const NavMenuToggleButton: FC<PropsWithChildren<INavMenuToggleButtonProps
         )}
         {...hoverProps}
       >
-        {({ isActive }) => {
-          setIsOpen(isActive);
-
-          return (
-            <HStack justifyContent={'space-between'} w="inherit" className={css(truncatedFlexTextCss)}>
-              <NavMenuButtonInner icon={icon}>{label}</NavMenuButtonInner>
-              {isOpen ? <IconKeyboardArrowUp /> : isHovered ? <IconKeyboardArrowDown /> : null}
-            </HStack>
-          );
-        }}
+        <HStack justifyContent={'space-between'} w="inherit" className={css(truncatedFlexTextCss)}>
+          <NavMenuButtonInner icon={icon}>{label}</NavMenuButtonInner>
+          {isOpen ? <IconKeyboardArrowUp /> : isHovered ? <IconKeyboardArrowDown /> : null}
+        </HStack>
       </NavLink>
       <Stack pl="100" gap="25">
         {!isOpen ? null : children}

--- a/apps/web/src/components/nav/NavMenuButton/NavMenuToggleButton.tsx
+++ b/apps/web/src/components/nav/NavMenuButton/NavMenuToggleButton.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@novu/novui/css';
 import { IconKeyboardArrowDown, IconKeyboardArrowUp } from '@novu/novui/icons';
 import { HStack, Stack } from '@novu/novui/jsx';
-import { FC, PropsWithChildren, useState } from 'react';
+import { FC, PropsWithChildren, useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { useHover } from '../../../hooks/useHover';
 import { truncatedFlexTextCss } from '../../../studio/utils/shared.styles';
@@ -40,10 +40,9 @@ export const NavMenuToggleButton: FC<PropsWithChildren<INavMenuToggleButtonProps
         )}
         {...hoverProps}
       >
-        <HStack justifyContent={'space-between'} w="inherit" className={css(truncatedFlexTextCss)}>
-          <NavMenuButtonInner icon={icon}>{label}</NavMenuButtonInner>
-          {isOpen ? <IconKeyboardArrowUp /> : isHovered ? <IconKeyboardArrowDown /> : null}
-        </HStack>
+        {({ isActive }) => (
+          <ToggleButtonInner isOpen={isOpen} setIsOpen={setIsOpen} icon={icon} label={label} isActive={isActive} />
+        )}
       </NavLink>
       <Stack pl="100" gap="25">
         {!isOpen ? null : children}
@@ -51,3 +50,24 @@ export const NavMenuToggleButton: FC<PropsWithChildren<INavMenuToggleButtonProps
     </>
   );
 };
+
+type ToggleButtonInnerProps = Pick<INavMenuToggleButtonProps, 'icon' | 'label'> & {
+  isActive: boolean;
+  isOpen: boolean;
+  setIsOpen: (val: boolean) => void;
+};
+
+function ToggleButtonInner({ isActive, isOpen, setIsOpen, icon, label }: ToggleButtonInnerProps) {
+  useEffect(() => {
+    if (!isActive) {
+      setIsOpen(false);
+    }
+  }, [setIsOpen, isActive]);
+
+  return (
+    <HStack justifyContent={'space-between'} w="inherit" className={css(truncatedFlexTextCss)}>
+      <NavMenuButtonInner icon={icon}>{label}</NavMenuButtonInner>
+      {isOpen && isActive ? <IconKeyboardArrowUp /> : <IconKeyboardArrowDown />}
+    </HStack>
+  );
+}

--- a/apps/web/src/components/workflow/preview/ErrorPrettyRender.tsx
+++ b/apps/web/src/components/workflow/preview/ErrorPrettyRender.tsx
@@ -1,37 +1,74 @@
 import { css } from '@novu/novui/css';
-import { Text } from '@novu/novui';
-import { Center } from '@novu/novui/jsx';
-import { IconErrorOutline } from '@novu/novui/icons';
+import { Button, Text, Title } from '@novu/novui';
+import { Center, Stack, VStack } from '@novu/novui/jsx';
+import { IconErrorOutline, IconExpandLess, IconExpandMore } from '@novu/novui/icons';
+import { useDisclosure } from '@mantine/hooks';
+import { hstack } from '@novu/novui/patterns';
 
-export function ErrorPrettyRender({ error }) {
+export function ErrorPrettyRender({ error: unparsedError }) {
+  const [isExpanded, { toggle }] = useDisclosure();
+  const error = 'response' in unparsedError ? unparsedError?.response?.data : unparsedError;
+
   return (
-    <div
+    <Stack
       className={css({
+        color: 'typography.text.feedback.alert',
         bg: 'input.border.error/20',
-        borderColor: 'input.border.error !important',
-        border: '1px solid !important',
+        border: 'solid',
+        borderColor: 'input.border.error',
         width: '100%',
-        borderRadius: 'input !important',
-        my: 'margins.layout.tabs.bottom !important',
+        borderRadius: 'input',
+        my: 'margins.layout.tabs.bottom',
         p: '125',
       })}
     >
-      <Center gap={10}>
-        <IconErrorOutline
-          className={css({ fill: 'input.border.error !important' })}
-          color={'input.border.error !important'}
-        />
-        <Text color={'input.border.error'} variant={'mono'}>
-          Error
-        </Text>
+      <Center>
+        <IconErrorOutline size="24" color={'inherit'} />
       </Center>
-      <h3 style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 10 }}>Error while rendering</h3>
-      <div>{error.message}</div> <br />
+
+      <Text textAlign={'center'} color={'inherit'}>
+        {error.message || 'Error while rendering'}
+      </Text>
+
       {error.data ? (
-        <pre style={{ overflow: 'auto', background: 'input.surface !important', padding: 15 }}>
-          {JSON.stringify(error.data, null, 2)}
-        </pre>
+        <Stack mt="100">
+          <Center>
+            <button
+              onClick={toggle}
+              className={hstack({
+                gap: '50',
+                cursor: 'pointer',
+                _hover: { opacity: 'hover' },
+              })}
+            >
+              <Text color="inherit">See more</Text>
+              <>
+                {isExpanded ? (
+                  <IconExpandLess title="expand-less-section-icon" color="inherit" />
+                ) : (
+                  <IconExpandMore title="expand-more-section-icon" color="inherit" />
+                )}
+              </>
+            </button>
+          </Center>
+          {isExpanded && (
+            <pre
+              className={css({
+                overflow: 'auto',
+                border: 'solid',
+                borderColor: 'input.border.error/40',
+                borderRadius: 'input',
+                p: '75',
+                mt: '25',
+                color: 'typography.text.main',
+                fontFamily: 'mono',
+              })}
+            >
+              {JSON.stringify(error.data, null, 2)}
+            </pre>
+          )}
+        </Stack>
       ) : null}
-    </div>
+    </Stack>
   );
 }

--- a/apps/web/src/studio/components/workflows/step-editor/WorkflowStepEditorControlsPanel.tsx
+++ b/apps/web/src/studio/components/workflows/step-editor/WorkflowStepEditorControlsPanel.tsx
@@ -1,11 +1,11 @@
-import { Button, JsonSchemaForm, Tabs } from '@novu/novui';
+import { Button, JsonSchemaForm, Tabs, Title } from '@novu/novui';
 import { IconOutlineEditNote, IconOutlineTune, IconOutlineSave } from '@novu/novui/icons';
 import { FC, useMemo } from 'react';
 import { useDocsModal } from '../../../../components/docs/useDocsModal';
 import { When } from '../../../../components/utils/When';
 import { ControlsEmptyPanel } from './ControlsEmptyPanel';
 import { css } from '@novu/novui/css';
-import { Container } from '@novu/novui/jsx';
+import { Container, Flex } from '@novu/novui/jsx';
 import { useDebouncedCallback } from '@novu/novui';
 import { useTelemetry } from '../../../../hooks/useNovuAPI';
 
@@ -64,11 +64,12 @@ export const WorkflowStepEditorControlsPanel: FC<IWorkflowStepEditorControlsPane
               <Container className={formContainerClassName}>
                 <When truthy={haveControlProperties}>
                   {onSave && (
-                    <div style={{ display: 'flex', justifyContent: 'end' }}>
+                    <Flex justifyContent="space-between" alignItems={'center'} marginBottom="50">
+                      <Title variant="subsection">Email step controls</Title>
                       <Button
                         loading={isLoadingSave}
                         variant={'filled'}
-                        size={'sm'}
+                        size={'xs'}
                         Icon={IconOutlineSave}
                         onClick={() => {
                           track('Step controls saved - [Workflows Step Page]', {
@@ -79,7 +80,7 @@ export const WorkflowStepEditorControlsPanel: FC<IWorkflowStepEditorControlsPane
                       >
                         Save
                       </Button>
-                    </div>
+                    </Flex>
                   )}
 
                   <JsonSchemaForm

--- a/packages/cli/src/commands/init/templates/github/workflows/novu.yml
+++ b/packages/cli/src/commands/init/templates/github/workflows/novu.yml
@@ -12,7 +12,7 @@ jobs:
         uses: novuhq/actions-novu-sync@v2
         with:
           # The secret key used to authenticate with Novu Cloud
-          # To get the secret key, go to https://web.novu.co/api-keys.
+          # To get the secret key, go to https://dashboard.novu.co/api-keys.
           # Required.
           secret-key: ${{ secrets.NOVU_SECRET_KEY }}
 


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

- Make Studio nav buttons collapsible, but only the active one open ([ticket](https://linear.app/novu/issue/NV-4130/arrow-on-workflows-list-doesnt-collapse-when-clicked-should-have-a))
- Fix Step Preview error display to include relevant information and change the aesthetic
- Fix cli reference to `web` (--> `dashboard`)

https://www.loom.com/share/68ac81703ecf4d269bca71793a7d39f2?sid=c5e00b28-dd9f-493f-82dd-63149e2d4e62