### PR TITLE
fix(novu): Upgrade react-email dependencies to fix headers in example app

### DIFF
--- a/packages/cli/src/commands/init/templates/app-react-email/ts/.env.example
+++ b/packages/cli/src/commands/init/templates/app-react-email/ts/.env.example
@@ -1,3 +1,0 @@
-# Rename this file to `.env.local` to use environment variables locally with `next dev`
-# https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
-MY_HOST="example.com"

--- a/packages/cli/src/commands/init/templates/app-react-email/ts/app/novu/emails/novu-onboarding-email.tsx
+++ b/packages/cli/src/commands/init/templates/app-react-email/ts/app/novu/emails/novu-onboarding-email.tsx
@@ -141,7 +141,7 @@ export const NovuWelcomeEmail = ({
 
           <Container className="mt-20">
             <Text className="text-center text-gray-400 mb-45">
-              Novu, Emek Dotan 109, Apt 2, Modiin, Israel
+              Powered by Novu, the Code-First Notification Infrastructure
             </Text>
           </Container>
         </Body>

--- a/packages/cli/src/commands/init/templates/app-react-email/ts/app/novu/emails/novu-onboarding-email.tsx
+++ b/packages/cli/src/commands/init/templates/app-react-email/ts/app/novu/emails/novu-onboarding-email.tsx
@@ -1,20 +1,22 @@
+import React from "react";
 import {
   Body,
   Button,
+  CodeInline,
   Column,
   Container,
   Head,
+  Heading,
   Html,
   Img,
   Preview,
+  render,
   Row,
   Section,
-  Text,
   Tailwind,
-  render,
-  CodeInline,
+  Text,
 } from "@react-email/components";
-import React from "react";
+
 import { ControlSchema, PayloadSchema } from "../workflows";
 
 type NovuWelcomeEmailProps = ControlSchema & PayloadSchema;
@@ -54,7 +56,7 @@ export const NovuWelcomeEmail = ({
               src={`https://images.spr.so/cdn-cgi/imagedelivery/j42No7y-dcokJuNgXeA0ig/dca73b36-cf39-4e28-9bc7-8a0d0cd8ac70/standalone-gradient2x_2/w=128,quality=90,fit=scale-down`}
               width="56"
               height="56"
-              alt="Netlify"
+              alt="Novu"
               className="mx-auto my-20"
             />
           ) : null}
@@ -64,22 +66,22 @@ export const NovuWelcomeEmail = ({
               return (
                 <Section key={componentIndex}>
                   {component.type === "heading" ? (
-                    <Column>
-                      <h1 className={`text-${component.align}`}>
+                    <Section>
+                      <Heading as="h1" className={`text-${component.align}`}>
                         {component.text}
-                      </h1>
-                    </Column>
+                      </Heading>
+                    </Section>
                   ) : null}
 
                   {component.type === "button" ? (
-                    <Column className={`text-${component.align}`}>
+                    <Section className={`text-${component.align}`}>
                       <Button
                         href={"http://localhost:2022"}
                         className="bg-[#000000] rounded text-white text-[12px] font-semibold no-underline text-center px-5 py-3"
                       >
                         {component.text}
                       </Button>
-                    </Column>
+                    </Section>
                   ) : null}
 
                   {component.type === "text" ? (
@@ -128,9 +130,9 @@ export const NovuWelcomeEmail = ({
                     </Section>
                   ) : null}
                   {component.type === "code" ? (
-                    <Column>
+                    <Section>
                       <CodeInline>{component.text}</CodeInline>;
-                    </Column>
+                    </Section>
                   ) : null}
                 </Section>
               );
@@ -149,13 +151,6 @@ export const NovuWelcomeEmail = ({
 };
 
 export default NovuWelcomeEmail;
-
-const heading = {
-  fontSize: "30px",
-  lineHeight: "1.1",
-  fontWeight: "700",
-  color: "#000000",
-};
 
 export function renderEmail(controls: ControlSchema, payload: PayloadSchema) {
   return render(<NovuWelcomeEmail {...controls} {...payload} />);

--- a/packages/cli/src/commands/init/templates/index.ts
+++ b/packages/cli/src/commands/init/templates/index.ts
@@ -235,9 +235,8 @@ export const installTemplate = async ({
 
     packageJson.dependencies = {
       ...packageJson.dependencies,
-      "@react-email/components": "0.0.17",
-      "@react-email/tailwind": "0.0.16",
-      "react-email": "2.1.2",
+      "@react-email/components": "0.0.18",
+      "@react-email/tailwind": "0.0.18",
     };
 
     /* Zod dependencies used in react email example */


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Upgrade `@react-email/components` and `@react-email/tailwind` to fix header rendering issue ([downstream ref](https://github.com/resend/react-email/issues/1420#issuecomment-2130452320)). This issue became apparent after introducing the html-sanitization feature in https://github.com/novuhq/novu/pull/6082
* Tidy up imports
* Remove redundant `.env.example` file
* Replace redundant address in onboarding email with "Powered by Novu" statement to assist in delivering message of the ease & pace of first notification delivery and the platform that delivered it

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
Correctly formatted onboarding example
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/4a5fcf37-c8b5-4768-a710-0b2ec03ae2a7">


<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
