### PR TITLE
feat(api): change sync org request scope to default (singleton)

### DIFF
--- a/apps/api/src/app/organization/usecases/create-organization/sync-external-organization/sync-external-organization.usecase.ts
+++ b/apps/api/src/app/organization/usecases/create-organization/sync-external-organization/sync-external-organization.usecase.ts
@@ -14,9 +14,7 @@ import { ModuleRef } from '@nestjs/core';
 import { SyncExternalOrganizationCommand } from './sync-external-organization.command';
 
 // TODO: eventually move to @novu/ee-auth
-@Injectable({
-  scope: Scope.REQUEST,
-})
+@Injectable()
 export class SyncExternalOrganization {
   constructor(
     private readonly organizationRepository: OrganizationRepository,


### PR DESCRIPTION
### What changed? Why was the change needed?
- there is no need for this to be request scoped since it doesn't hold any state
- this change is also required because we need to inject this usecase to passport strategy which can inject only singletons 

> Websocket Gateways should not use request-scoped providers because they must act as singletons. Each gateway encapsulates a real socket and cannot be instantiated multiple times. The limitation also applies to some other providers, like [Passport strategies](https://docs.nestjs.com/security/authentication#request-scoped-strategies) or Cron controllers.

https://github.com/novuhq/packages-enterprise/pull/173
