### PR TITLE
feat(js): Implement the renderNotification prop

### DIFF
--- a/packages/js/src/ui/components/ExternalElementMounter.tsx
+++ b/packages/js/src/ui/components/ExternalElementMounter.tsx
@@ -1,0 +1,26 @@
+import { onCleanup, onMount, ParentProps } from 'solid-js';
+
+type ExternalElementMounterProps = ParentProps<{
+  mount: (el: HTMLDivElement) => () => void;
+}>;
+
+export const ExternalElementMounter = ({ mount, ...rest }: ExternalElementMounterProps) => {
+  let ref: HTMLDivElement;
+
+  onMount(() => {
+    const unmount = mount(ref);
+
+    onCleanup(() => {
+      unmount();
+    });
+  });
+
+  return (
+    <div
+      ref={(el) => {
+        ref = el;
+      }}
+      {...rest}
+    />
+  );
+};

--- a/packages/js/src/ui/components/Inbox.tsx
+++ b/packages/js/src/ui/components/Inbox.tsx
@@ -1,11 +1,13 @@
 import { Accessor, createSignal, JSX, Match, Switch } from 'solid-js';
 import { useStyle } from '../helpers';
+import { NotificationMounter } from '../types';
 import { Bell, Footer, Header, Settings, SettingsHeader } from './elements';
 import { NotificationList } from './Notification';
 import { Button, Popover } from './primitives';
 
-type InboxProps = {
+export type InboxProps = {
   open?: boolean;
+  mountNotification?: NotificationMounter;
   renderBell?: ({ unreadCount }: { unreadCount: Accessor<number> }) => JSX.Element;
 };
 
@@ -13,7 +15,11 @@ enum Screen {
   Inbox = 'inbox',
   Settings = 'settings',
 }
-const InboxContent = () => {
+
+type InboxContentProps = {
+  mountNotification?: NotificationMounter;
+};
+const InboxContent = (props: InboxContentProps) => {
   const [currentScreen, setCurrentScreen] = createSignal<Screen>(Screen.Inbox);
 
   return (
@@ -21,7 +27,7 @@ const InboxContent = () => {
       <Switch>
         <Match when={currentScreen() === Screen.Inbox}>
           <Header updateScreen={setCurrentScreen} />
-          <NotificationList />
+          <NotificationList mountNotification={props.mountNotification} />
         </Match>
         <Match when={currentScreen() === Screen.Settings}>
           <SettingsHeader backAction={() => setCurrentScreen(Screen.Inbox)} />
@@ -46,7 +52,7 @@ export const Inbox = (props: InboxProps) => {
         )}
       />
       <Popover.Content appearanceKey="inbox__popoverContent">
-        <InboxContent />
+        <InboxContent mountNotification={props.mountNotification} />
       </Popover.Content>
     </Popover.Root>
   );

--- a/packages/js/src/ui/components/Notification/DefaultNotification.tsx
+++ b/packages/js/src/ui/components/Notification/DefaultNotification.tsx
@@ -1,0 +1,30 @@
+import { Show } from 'solid-js';
+import { InboxNotification } from '../../../types';
+import { useStyle } from '../../helpers';
+
+type DefaultNotificationProps = {
+  notification: InboxNotification;
+};
+
+//TODO: Complete the implementation
+export const DefaultNotification = (props: DefaultNotificationProps) => {
+  const style = useStyle();
+
+  return (
+    <div class={style('notificationContainer', 'nt-w-full nt-p-6')}>
+      <div class={style('notificationSubjectContainer', 'nt-flex nt-items-center nt-gap-2 nt-relative')}>
+        <span
+          class={style(
+            'notificationDot',
+            'nt-absolute -nt-left-3 nt-top-0 -nt-translate-x-1/2 nt-translate-y-1/2 nt-size-3 nt-bg-primary nt-rounded-full nt-border'
+          )}
+        />
+        <Show when={props.notification.subject}>
+          <span class={style('notificationSubject', 'nt-w-full nt-font-semibold')}>{props.notification.subject}</span>
+        </Show>
+        <span>{props.notification.createdAt}</span>
+      </div>
+      {props.notification.body}
+    </div>
+  );
+};

--- a/packages/js/src/ui/components/Notification/Notification.tsx
+++ b/packages/js/src/ui/components/Notification/Notification.tsx
@@ -1,0 +1,18 @@
+import { Show } from 'solid-js';
+import { InboxNotification } from '../../../types';
+import { NotificationMounter } from '../../types';
+import { ExternalElementMounter } from '../ExternalElementMounter';
+import { DefaultNotification } from './DefaultNotification';
+
+type NotificationProps = {
+  notification: InboxNotification;
+  mountNotification?: NotificationMounter;
+};
+
+export const Notification = (props: NotificationProps) => {
+  return (
+    <Show when={props.mountNotification} fallback={<DefaultNotification notification={props.notification} />}>
+      <ExternalElementMounter mount={(el) => props.mountNotification!(el, { notification: props.notification })} />
+    </Show>
+  );
+};

--- a/packages/js/src/ui/components/Notification/NotificationList.tsx
+++ b/packages/js/src/ui/components/Notification/NotificationList.tsx
@@ -4,6 +4,8 @@ import { useFeedInfiniteScroll } from '../../api';
 import { useLocalization } from '../../context';
 import { useStyle } from '../../helpers';
 import { EmptyIcon } from '../../icons/EmptyIcon';
+import { NotificationMounter } from '../../types';
+import { Notification } from './Notification';
 import { NotificationListSkeleton, NotificationSkeleton } from './NotificationListSkeleton';
 
 export const NotificationListContainer = (props: ParentProps) => {
@@ -38,8 +40,10 @@ const EmptyNotificationList = () => {
 };
 
 type NotificationListProps = {
+  mountNotification?: NotificationMounter;
   options?: FetchFeedArgs;
 };
+/* This is also going to be exported as a separate component. Keep it pure. */
 export const NotificationList = (props: NotificationListProps) => {
   const [data, { initialLoading, setEl, end }] = useFeedInfiniteScroll({ options: props.options });
 
@@ -47,8 +51,9 @@ export const NotificationList = (props: NotificationListProps) => {
     <Show when={!initialLoading()} fallback={<NotificationListSkeleton count={8} />}>
       <Show when={data().length > 0} fallback={<EmptyNotificationList />}>
         <NotificationListContainer>
-          {/* eslint-disable-next-line local-rules/no-class-without-style */}
-          <For each={data()}>{(notification) => <p class="nt-my-10">{notification.body}</p>}</For>
+          <For each={data()}>
+            {(notification) => <Notification notification={notification} mountNotification={props.mountNotification} />}
+          </For>
           <Show when={!end()}>
             <div ref={setEl}>
               <For each={Array.from({ length: 3 })}>{() => <NotificationSkeleton />}</For>

--- a/packages/js/src/ui/components/Notification/index.ts
+++ b/packages/js/src/ui/components/Notification/index.ts
@@ -1,1 +1,2 @@
+export * from './Notification';
 export { NotificationList } from './NotificationList';

--- a/packages/js/src/ui/components/Renderer.tsx
+++ b/packages/js/src/ui/components/Renderer.tsx
@@ -1,4 +1,4 @@
-import { onCleanup, onMount } from 'solid-js';
+import { For, onCleanup, onMount } from 'solid-js';
 import { MountableElement, Portal } from 'solid-js/web';
 import { NovuUI } from '..';
 import { NovuOptions } from '../../novu';
@@ -15,7 +15,7 @@ import { UnreadCountProvider } from '../context/UnreadCountContext';
 import { Bell, Root } from './elements';
 import { Inbox } from './Inbox';
 
-const NovuComponents = {
+export const novuComponents = {
   Inbox,
   Bell,
 };
@@ -24,7 +24,7 @@ export type NovuComponent = { name: NovuComponentName; props?: unknown };
 
 export type NovuMounterProps = NovuComponent & { element: MountableElement };
 
-export type NovuComponentName = keyof typeof NovuComponents;
+export type NovuComponentName = keyof typeof novuComponents;
 
 export type NovuComponentControls = {
   mount: (params: NovuMounterProps) => void;
@@ -67,11 +67,13 @@ export const Renderer = (props: RendererProps) => {
           <AppearanceProvider id={props.novuUI.id} appearance={props.appearance}>
             <FocusManagerProvider>
               <InboxNotificationStatusProvider>
-                {[...props.nodes].map(([node, component]) => (
-                  <Portal mount={node}>
-                    <Root>{NovuComponents[component.name](component.props || {})}</Root>
-                  </Portal>
-                ))}
+                <For each={[...props.nodes]}>
+                  {([node, component]) => (
+                    <Portal mount={node}>
+                      <Root>{novuComponents[component.name](component.props || {})}</Root>
+                    </Portal>
+                  )}
+                </For>
               </InboxNotificationStatusProvider>
             </FocusManagerProvider>
           </AppearanceProvider>

--- a/packages/js/src/ui/components/elements/Bell/Bell.tsx
+++ b/packages/js/src/ui/components/elements/Bell/Bell.tsx
@@ -1,10 +1,12 @@
 import { Accessor, JSX } from 'solid-js';
-import { BellContainer } from './DefaultBellContainer';
 import { useUnreadCount } from '../../../context/UnreadCountContext';
+import { BellContainer } from './DefaultBellContainer';
 
 type BellProps = {
+  //TODO: convert this in a `mountBell` prop like we do for notifications.
   children?: ({ unreadCount }: { unreadCount: Accessor<number> }) => JSX.Element;
 };
+/* This is also going to be exported as a separate component. Keep it pure. */
 export function Bell(props: BellProps) {
   const { unreadCount } = useUnreadCount();
 

--- a/packages/js/src/ui/components/elements/Bell/DefaultBellContainer.tsx
+++ b/packages/js/src/ui/components/elements/Bell/DefaultBellContainer.tsx
@@ -21,7 +21,7 @@ export const BellContainer = (props: DefaultBellContainerProps) => {
         <span
           class={style(
             'bellDot',
-            'nt-absolute nt-top-2 nt-right-2 nt-block nt-w-2 nt-h-2 nt-transform nt-translate-x-1/2 -nt-translate-y-1/2 nt-bg-primary nt-rounded-full nt-border nt-border-background'
+            'nt-absolute nt-top-2 nt-right-2 nt-block nt-size-2 nt-transform nt-translate-x-1/2 -nt-translate-y-1/2 nt-bg-primary nt-rounded-full nt-border nt-border-background'
           )}
         />
       </Show>

--- a/packages/js/src/ui/components/elements/Settings/Settings.tsx
+++ b/packages/js/src/ui/components/elements/Settings/Settings.tsx
@@ -6,6 +6,7 @@ import { ArrowDropDown } from '../../../icons';
 import { ChannelRow, getLabel } from './ChannelRow';
 import { LoadingScreen } from './LoadingScreen';
 
+/* This is also going to be exported as a separate component. Keep it pure. */
 export const Settings = () => {
   const style = useStyle();
 

--- a/packages/js/src/ui/context/AppearanceContext.tsx
+++ b/packages/js/src/ui/context/AppearanceContext.tsx
@@ -58,6 +58,10 @@ export const appearanceKeys = [
   'notificationListEmptyNoticeContainer',
   'notificationListEmptyNotice',
   'notificationListEmptyNoticeIcon',
+  'notificationContainer',
+  'notificationDot',
+  'notificationSubject',
+  'notificationSubjectContainer',
 
   //Inbox status
   'inboxStatus__title',

--- a/packages/js/src/ui/index.ts
+++ b/packages/js/src/ui/index.ts
@@ -1,2 +1,2 @@
 export { NovuUI } from './novuUI';
-export type { NovuUIOptions } from './novuUI';
+export type { BaseNovuUIOptions, NovuUIOptions } from './novuUI';

--- a/packages/js/src/ui/novuUI.tsx
+++ b/packages/js/src/ui/novuUI.tsx
@@ -1,15 +1,17 @@
-import { createSignal } from 'solid-js';
+import { ComponentProps, createSignal } from 'solid-js';
 import { MountableElement, render } from 'solid-js/web';
 import type { NovuOptions } from '../novu';
-import { NovuComponent, NovuComponentName, Renderer } from './components/Renderer';
+import { NovuComponent, novuComponents, Renderer } from './components/Renderer';
 import { Appearance } from './context';
 import { Localization } from './context/LocalizationContext';
 import { generateRandomString } from './helpers';
-import { NovuProviderProps } from './types';
+import { BaseNovuProviderProps, NovuProviderProps } from './types';
 //@ts-expect-error inline import esbuild syntax
 import css from 'directcss:./index.directcss';
+import { InboxProps } from './components';
 
 export type NovuUIOptions = NovuProviderProps;
+export type BaseNovuUIOptions = BaseNovuProviderProps;
 export class NovuUI {
   #dispose: { (): void } | null = null;
   #rootElement: HTMLElement;
@@ -73,15 +75,31 @@ export class NovuUI {
     this.#rootElement?.remove();
   }
 
-  #mountComponent({
+  #updateComponentProps(element: MountableElement, props: unknown) {
+    this.#setMountedElements((oldMountedElements) => {
+      const newMountedElements = new Map(oldMountedElements);
+      const mountedElement = newMountedElements.get(element);
+      if (mountedElement) {
+        newMountedElements.set(element, { ...mountedElement, props });
+      }
+
+      return newMountedElements;
+    });
+  }
+
+  mountComponent<T extends keyof typeof novuComponents>({
     name,
     element,
     props: componentProps,
   }: {
-    name: NovuComponentName;
+    name: T;
     element: MountableElement;
-    props?: unknown;
+    props?: ComponentProps<(typeof novuComponents)[T]>;
   }) {
+    if (this.#mountedElements().has(element)) {
+      return this.#updateComponentProps(element, componentProps);
+    }
+
     this.#setMountedElements((oldNodes) => {
       const newNodes = new Map(oldNodes);
       newNodes.set(element, { name, props: componentProps });
@@ -91,28 +109,16 @@ export class NovuUI {
   }
 
   //All in one <Inbox />
-  mountInbox(element: MountableElement) {
-    this.#mountComponent({ name: 'Inbox', element });
+  mountInbox(element: MountableElement, props?: InboxProps) {
+    this.mountComponent({ name: 'Inbox', element, props });
   }
 
   unmountComponent(element: MountableElement) {
-    this.#setMountedElements((oldNodes) => {
-      const newNodes = new Map(oldNodes);
-      newNodes.delete(element);
+    this.#setMountedElements((oldMountedElements) => {
+      const newMountedElements = new Map(oldMountedElements);
+      newMountedElements.delete(element);
 
-      return newNodes;
-    });
-  }
-
-  updateComponentProps({ element, props }: { element: MountableElement; props: unknown }) {
-    this.#setMountedElements((oldNodes) => {
-      const newNodes = new Map(oldNodes);
-      const node = newNodes.get(element);
-      if (node) {
-        newNodes.set(element, { ...node, props });
-      }
-
-      return newNodes;
+      return newMountedElements;
     });
   }
 

--- a/packages/js/src/ui/types.ts
+++ b/packages/js/src/ui/types.ts
@@ -1,10 +1,17 @@
 import { NovuOptions } from '../novu';
+import { InboxNotification } from '../types';
 import { Appearance, Localization } from './context';
 
-export type NovuProviderProps = {
+export type NotificationMounter = (el: HTMLDivElement, options: { notification: InboxNotification }) => () => void;
+
+export type BaseNovuProviderProps = {
   appearance?: Appearance;
   localization?: Localization;
   options: NovuOptions;
+};
+
+export type NovuProviderProps = BaseNovuProviderProps & {
+  mountNotification?: NotificationMounter;
 };
 
 export enum NotificationStatus {

--- a/playground/nextjs/src/components/Inbox.tsx
+++ b/playground/nextjs/src/components/Inbox.tsx
@@ -1,0 +1,57 @@
+import { Mounter } from '@/components/Mounter';
+import { useRenderer } from '@/context/RendererContext';
+import { InboxNotification } from '@novu/js/dist/types/types';
+import type { BaseNovuUIOptions } from '@novu/js/ui';
+import { ReactNode, useCallback } from 'react';
+import { Renderer } from './Renderer';
+
+type AllInOneInboxProps = {
+  renderNotification?: (notification: InboxNotification) => ReactNode;
+};
+const AllInOneInbox = (props: AllInOneInboxProps) => {
+  const { renderNotification, ...rest } = props;
+  const { novuUI, mountElement } = useRenderer();
+
+  const mount = useCallback(
+    (element: HTMLElement) => {
+      return novuUI.mountComponent({
+        name: 'Inbox',
+        props: {
+          ...rest,
+          mountNotification: renderNotification
+            ? (element, { notification }) => {
+                return mountElement(element, renderNotification(notification));
+              }
+            : undefined,
+        },
+        element,
+      });
+    },
+    [renderNotification]
+  );
+
+  return <Mounter mount={mount} />;
+};
+
+type InboxProps = BaseNovuUIOptions &
+  (
+    | ({
+        children?: never;
+      } & AllInOneInboxProps)
+    | {
+        children: ReactNode;
+      }
+  );
+
+export const Inbox = (props: InboxProps) => {
+  if (props.children) {
+    return <Renderer options={props} />;
+  }
+
+  const { renderNotification, ...options } = props as BaseNovuUIOptions & AllInOneInboxProps;
+  return (
+    <Renderer options={options}>
+      <AllInOneInbox renderNotification={renderNotification} />
+    </Renderer>
+  );
+};

--- a/playground/nextjs/src/components/Mounter.tsx
+++ b/playground/nextjs/src/components/Mounter.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 type MounterProps = {
-  mount: (node: HTMLDivElement) => ((node: HTMLDivElement) => void) | void;
+  mount: (node: HTMLElement) => ((node: HTMLElement) => void) | void;
 };
 
 export function Mounter({ mount }: MounterProps) {

--- a/playground/nextjs/src/components/Renderer.tsx
+++ b/playground/nextjs/src/components/Renderer.tsx
@@ -1,0 +1,55 @@
+import { MountedElement, RendererProvider } from '@/context/RendererContext';
+import type { NovuUI, NovuUIOptions } from '@novu/js/ui';
+import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type RendererProps = PropsWithChildren<{
+  options: NovuUIOptions;
+}>;
+export const Renderer = (props: RendererProps) => {
+  const { options, children } = props;
+  const [novuUI, setNovuUI] = useState<NovuUI | undefined>();
+  const [mountedElements, setMountedElements] = useState(new Map<HTMLElement, MountedElement>());
+
+  const mountElement = useCallback(
+    (el: HTMLElement, mountedElement: MountedElement) => {
+      setMountedElements((mountedElements) => {
+        const newMountedElements = new Map(mountedElements);
+        newMountedElements.set(el, mountedElement);
+        return newMountedElements;
+      });
+
+      return () => {
+        setMountedElements((mountedElements) => {
+          const newMountedElements = new Map(mountedElements);
+          newMountedElements.delete(el);
+          return newMountedElements;
+        });
+      };
+    },
+    [setMountedElements]
+  );
+
+  useEffect(() => {
+    //require here as it won't work in SSR.
+    const { NovuUI } = require('@novu/js/ui');
+    // we could import above and have types here but `mount` can't be async, since the unmount method is
+    // returned and couldn't be used as a cleanup successfully.
+    const ui = new (NovuUI as new (options: NovuUIOptions) => NovuUI)(options) as NovuUI;
+    setNovuUI(ui);
+  }, []);
+
+  if (!novuUI) {
+    return null;
+  }
+
+  return (
+    <RendererProvider value={{ mountElement, novuUI }}>
+      {[...mountedElements].map(([element, mountedElement]) => {
+        return createPortal(mountedElement, element);
+      })}
+
+      {children}
+    </RendererProvider>
+  );
+};

--- a/playground/nextjs/src/context/RendererContext.tsx
+++ b/playground/nextjs/src/context/RendererContext.tsx
@@ -1,0 +1,19 @@
+import { createContextAndHook } from '@/utils/createContextAndHook';
+import { ReactNode } from 'react';
+import type { NovuUI } from '@novu/js/ui';
+
+export type MountedElement = ReactNode;
+export type MountedElements = Map<HTMLElement, MountedElement>;
+
+type RendererContextValue = {
+  mountElement: (el: HTMLElement, mountedElement: MountedElement) => () => void;
+  novuUI: NovuUI;
+};
+
+const [RendererContext, useRendererContext] = createContextAndHook<RendererContextValue>('RendererContext');
+
+const RendererProvider = (props: React.PropsWithChildren<{ value: RendererContextValue }>) => {
+  return <RendererContext.Provider value={{ value: props.value }}>{props.children}</RendererContext.Provider>;
+};
+
+export { useRendererContext as useRenderer, RendererProvider };

--- a/playground/nextjs/src/pages/index.tsx
+++ b/playground/nextjs/src/pages/index.tsx
@@ -1,29 +1,17 @@
-import { Mounter } from '@/components/Mounter';
-import type { NovuUI, NovuUIOptions } from '@novu/js/ui';
+import { Inbox } from '@/components/Inbox';
 
 export default function Home() {
   return (
     <div className="h-screen w-full bg-white">
-      <Mounter
-        mount={(el) => {
-          //require here as it won't work in SSR.
-          const { NovuUI } = require('@novu/js/ui');
-          // we could import above and have types here but `mount` can't be async, since the unmount method is
-          // returned and couldn't be used as a cleanup successfully.
-          const ui = new (NovuUI as new (options: NovuUIOptions) => NovuUI)({
-            options: {
-              applicationIdentifier: process.env.NEXT_PUBLIC_NOVU_APP_ID ?? '',
-              subscriberId: process.env.NEXT_PUBLIC_NOVU_SUBSCRIBER_ID ?? '',
-              backendUrl: process.env.NEXT_PUBLIC_NOVU_BACKEND_URL ?? 'http://localhost:3000',
-              socketUrl: process.env.NEXT_PUBLIC_NOVU_SOCKET_URL ?? 'http://localhost:3002',
-            },
-            appearance: {},
-          }) as NovuUI;
-          ui.mountInbox(el);
-
-          return () => {
-            ui.unmountComponent(el);
-          };
+      <Inbox
+        options={{
+          applicationIdentifier: process.env.NEXT_PUBLIC_NOVU_APP_ID ?? '',
+          subscriberId: process.env.NEXT_PUBLIC_NOVU_SUBSCRIBER_ID ?? '',
+          backendUrl: process.env.NEXT_PUBLIC_NOVU_BACKEND_URL ?? 'http://localhost:3000',
+          socketUrl: process.env.NEXT_PUBLIC_NOVU_SOCKET_URL ?? 'http://localhost:3002',
+        }}
+        renderNotification={(notification) => {
+          return <button className="p-10 bg-red-300 w-full">{notification.body}</button>;
         }}
       />
     </div>

--- a/playground/nextjs/src/utils/createContextAndHook.ts
+++ b/playground/nextjs/src/utils/createContextAndHook.ts
@@ -1,0 +1,40 @@
+'use client';
+import React from 'react';
+
+export function assertContextExists(contextVal: unknown, msgOrCtx: string | React.Context<any>): asserts contextVal {
+  if (!contextVal) {
+    throw typeof msgOrCtx === 'string' ? new Error(msgOrCtx) : new Error(`${msgOrCtx.displayName} not found`);
+  }
+}
+
+type Options = { assertCtxFn?: (v: unknown, msg: string) => void };
+type ContextOf<T> = React.Context<{ value: T } | undefined>;
+type UseCtxFn<T> = () => T;
+
+/**
+ * Creates and returns a Context and two hooks that return the context value.
+ * The Context type is derived from the type passed in by the user.
+ * The first hook returned guarantees that the context exists so the returned value is always CtxValue
+ * The second hook makes no guarantees, so the returned value can be CtxValue | undefined
+ */
+export const createContextAndHook = <CtxVal>(
+  displayName: string,
+  options?: Options
+): [ContextOf<CtxVal>, UseCtxFn<CtxVal>, UseCtxFn<CtxVal | Partial<CtxVal>>] => {
+  const { assertCtxFn = assertContextExists } = options || {};
+  const Ctx = React.createContext<{ value: CtxVal } | undefined>(undefined);
+  Ctx.displayName = displayName;
+
+  const useCtx = () => {
+    const ctx = React.useContext(Ctx);
+    assertCtxFn(ctx, `${displayName} not found`);
+    return (ctx as any).value as CtxVal;
+  };
+
+  const useCtxWithoutGuarantee = () => {
+    const ctx = React.useContext(Ctx);
+    return ctx ? ctx.value : {};
+  };
+
+  return [Ctx, useCtx, useCtxWithoutGuarantee];
+};

--- a/playground/nextjs/tsconfig.json
+++ b/playground/nextjs/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "ES6",
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -17,18 +14,10 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
     "forceConsistentCasingInFileNames": true
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
We need a way to allow for the react package to render custom elements in the `@novu/js` package. A way to do this, is to have a renderer component in the react package, that is responsible for rendering all these elements. This includes a map of all elements that are rendered.

A render prop is defined in the react package. This needs to be transformed to a `mount` prop for `@novu/js` to be able to use it as it has no way to render JSX from react. The transformation is as simple as appending a new element to the renderer's map, with the render prop as the data (the key is the `HTMLElement`). This triggers a rerender for the `<Renderer />` in `@novu/react` and the component will be mounted. In this case, the components that are mounted are the notifications, using the `renderNotification` prop.

We will need to make some performance improvements here around the mounts/unmounts that happen.

Essentially the flow is:
* `@novu/react` wraps everything with a `<Renderer />` component. This is also a context, so our custom components are able to mutate it's state.
* Developer uses our `<Inbox />` component and defines a `renderNotification` prop.
* This `renderNotification` prop is converted to a function that mutates the `<Renderer />` state and adds a new element (a custom notification).
* This `mountNotification` function that was created is passed to `@novu/js` as a prop for the Inbox.
* Every time a notification is rendered by `@novu/js`, this function is triggered, given an `HTMLElement` that we render on `@novu/js`(this is the element that the custom notification will be portaled onto).
* `@novu/react`'s `<Renderer />` is rerendered and portals the custom notifications on the `div`s that `@novu/js` placed in the DOM.

An example would be :
```
      <Inbox
        options={{
          ...
        }}
        renderNotification={(notification) => {
          return <button className="p-10 bg-red-300 w-full">{notification.body}</button>;
        }}
      />
```
that results in: 

<img width="431" alt="Screenshot 2024-07-21 at 1 35 52 PM" src="https://github.com/user-attachments/assets/feff3238-c28d-4e79-af9a-3876557c31a5">

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
