### PR TITLE
fix(worker): Use susbcriber locale for in-app and email steps

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -53,7 +53,6 @@ export class SendMessageEmail extends SendMessageBase {
 
   constructor(
     protected environmentRepository: EnvironmentRepository,
-    protected organizationRepository: OrganizationRepository,
     protected subscriberRepository: SubscriberRepository,
     protected messageRepository: MessageRepository,
     protected layoutRepository: LayoutRepository,
@@ -212,12 +211,10 @@ export class SendMessageEmail extends SendMessageBase {
     }
 
     try {
-      const organization = await this.getOrganization(command.organizationId);
-
       const i18nInstance = await this.initiateTranslations(
         command.environmentId,
         command.organizationId,
-        command.payload.subscriber?.locale || organization?.defaultLocale
+        subscriber.locale
       );
 
       if (!command.bridgeData) {
@@ -546,16 +543,6 @@ export class SendMessageEmail extends SendMessageBase {
 
       return layoutOverride?._id;
     }
-  }
-
-  protected async getOrganization(organizationId: string): Promise<OrganizationEntity | undefined> {
-    const organization = await this.organizationRepository.findById(organizationId, 'branding defaultLocale');
-
-    if (!organization) {
-      throw new NotFoundException(`Organization ${organizationId} not found`);
-    }
-
-    return organization;
   }
 
   public buildFactoryIntegration(integration: IntegrationEntity, senderName?: string) {


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* In-App and Email steps were not using the Subscriber's locale and were always falling back to using the Organization's default locale. This fix ensures that the Organization's default locale resolution remains with the Translations service and the Subscribers locale is used for translations of In-App and Email channel, aligning with the SMS, Push, and Chat channel implementation.

### Screenshots
_Email received using Susbcriber locale_
![german-email-fix](https://github.com/user-attachments/assets/ad65fbc1-7437-4f05-95c9-2876c76fd7a5)

_In-App received using Susbcriber locale_
![image](https://github.com/user-attachments/assets/b2d272cf-560f-42b9-821c-b86aa7ec5518)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
