### PR TITLE
fix(web): Simplify enterprise sign up

### DIFF
--- a/apps/web/src/ee/clerk/pages/OrganizationListPage.tsx
+++ b/apps/web/src/ee/clerk/pages/OrganizationListPage.tsx
@@ -9,7 +9,15 @@ export default function OrganizationListPage() {
       description="Please select or create an organization to continue."
     >
       <OrganizationList
+        appearance={{
+          elements: {
+            organizationAvatarUploaderContainer: {
+              display: 'none',
+            },
+          },
+        }}
         hidePersonal
+        skipInvitationScreen
         afterSelectOrganizationUrl={ROUTES.GET_STARTED}
         afterCreateOrganizationUrl={ROUTES.AUTH_APPLICATION}
       />


### PR DESCRIPTION
### What changed? Why was the change needed?
Skip organization invitation screen and logo upload during sign up

### Screenshots
<img width="1472" alt="Screenshot 2024-07-23 at 18 48 17" src="https://github.com/user-attachments/assets/018586f1-80d0-462a-887a-78a7182d154e">
