### PR TITLE
fix(framework): add locale to subscriber

### DIFF
--- a/packages/framework/src/types/subscriber.types.ts
+++ b/packages/framework/src/types/subscriber.types.ts
@@ -5,4 +5,5 @@ export type Subscriber = {
   email?: string;
   phone?: string;
   avatar?: string;
+  locale?: string;
 };


### PR DESCRIPTION
### What changed? Why was the change needed?
I would like to access the locale of a subscriber within a workflow.

I have tested it on my computer and with a locale set, I am successfully able to access it.
This is basically a type update.

---

Not sure if related, but I saw that the following files also have a subscriber type, where it could be added.
For my use-case, within the framework is already enough and working.

`apps/api/src/app/inbox/utils/types.ts`
`packages/js/src/types.ts`

### Screenshots


<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
