### PR TITLE
feat(web): update ee questionnaire

### DIFF
--- a/apps/api/src/app/organization/e2e/sync-organization.e2e-ee.ts
+++ b/apps/api/src/app/organization/e2e/sync-organization.e2e-ee.ts
@@ -26,10 +26,6 @@ describe.skip('Sync Organization - /organizations (POST)', async () => {
   const testOrganization: UpdateExternalOrganizationDto = {
     jobTitle: JobTitleEnum.ENGINEER,
     domain: 'example.com',
-    productUseCases: {
-      in_app: true,
-      delay: true,
-    },
   };
 
   function getRequest(payload: UpdateExternalOrganizationDto, origin: string = process.env.FRONT_BASE_URL) {
@@ -97,13 +93,6 @@ describe.skip('Sync Organization - /organizations (POST)', async () => {
     // these are stored in the Clerk organization only and then concatenated with the response
     expect(internalOrganization.name).to.equal(updatedClerkOrganization.name);
     expect(internalOrganization.logo).to.equal(updatedClerkOrganization.imageUrl);
-  });
-
-  it('should have all internal attributes set correctly', async () => {
-    expect(internalOrganization.domain).to.equal(testOrganization.domain);
-    expect(internalOrganization.productUseCases?.in_app).to.eq(testOrganization.productUseCases?.in_app);
-    expect(internalOrganization.productUseCases?.delay).to.eq(testOrganization.productUseCases?.delay);
-    expect(internalOrganization.apiServiceLevel).to.eq(ApiServiceLevelEnum.FREE);
   });
 
   it('should update user job title on organization creation', async () => {

--- a/apps/web/src/ApplicationReadyGuard.tsx
+++ b/apps/web/src/ApplicationReadyGuard.tsx
@@ -34,7 +34,7 @@ export function ApplicationReadyGuard({ children }: PropsWithChildren<{}>) {
   function isOnboardingComplete() {
     if (IS_EE_AUTH_ENABLED) {
       // TODO: replace with actual check property (e.g. isOnboardingCompleted)
-      return currentOrganization?.productUseCases !== undefined;
+      return currentOrganization?.productUseCases !== undefined || currentOrganization?.language !== undefined;
     }
 
     return currentOrganization;

--- a/apps/web/src/ee/clerk/components/QuestionnaireForm.tsx
+++ b/apps/web/src/ee/clerk/components/QuestionnaireForm.tsx
@@ -28,7 +28,7 @@ export function QuestionnaireForm() {
     handleSubmit,
     formState: { errors },
     control,
-  } = useForm<IOrganizationUpdateForm>({});
+  } = useForm<OrganizationUpdateForm>({});
   const navigate = useNavigate();
   const { reloadOrganization } = useAuth();
   const { startVercelSetup } = useVercelIntegration();
@@ -60,7 +60,7 @@ export function QuestionnaireForm() {
     await reloadOrganization();
   }
 
-  const onUpdateOrganization = async (data: IOrganizationUpdateForm) => {
+  const onUpdateOrganization = async (data: OrganizationUpdateForm) => {
     setLoading(true);
     await updateOrganization({ ...data });
     setLoading(false);
@@ -210,7 +210,7 @@ const frontendFrameworks = [
   { label: 'Other' },
 ];
 
-interface IOrganizationUpdateForm {
+interface OrganizationUpdateForm {
   jobTitle: JobTitleEnum;
   domain?: string;
   language?: string[];

--- a/apps/web/src/ee/clerk/providers/EnterpriseAuthProvider.tsx
+++ b/apps/web/src/ee/clerk/providers/EnterpriseAuthProvider.tsx
@@ -200,5 +200,6 @@ const toOrganizationEntity = (clerkOrganization: OrganizationResource): IOrganiz
     defaultLocale: clerkOrganization.publicMetadata.defaultLocale,
     domain: clerkOrganization.publicMetadata.domain,
     productUseCases: clerkOrganization.publicMetadata.productUseCases,
+    language: clerkOrganization.publicMetadata.language,
   };
 };

--- a/libs/shared/src/dto/organization/update-external-organization.dto.ts
+++ b/libs/shared/src/dto/organization/update-external-organization.dto.ts
@@ -12,5 +12,8 @@ export class UpdateExternalOrganizationDto {
   domain?: string;
 
   @IsOptional()
-  productUseCases?: ProductUseCases;
+  language?: string[];
+
+  @IsOptional()
+  frontendStack?: string[];
 }

--- a/libs/shared/src/entities/organization/organization.interface.ts
+++ b/libs/shared/src/entities/organization/organization.interface.ts
@@ -16,6 +16,7 @@ export interface IOrganizationEntity {
   defaultLocale?: string;
   domain?: string;
   productUseCases?: ProductUseCases;
+  language?: string[];
   createdAt: string;
   updatedAt: string;
   externalId?: string;

--- a/libs/shared/src/types/clerk/clerk.organization.types.ts
+++ b/libs/shared/src/types/clerk/clerk.organization.types.ts
@@ -25,6 +25,7 @@ export type OrganizationPublicMetadata = {
   apiServiceLevel?: ApiServiceLevelEnum;
   domain?: string;
   productUseCases?: ProductUseCases;
+  language?: string[];
   defaultLocale?: string;
 };
 


### PR DESCRIPTION
### What changed? Why was the change needed?
* added language property to Clerk organization metadata to reflect community questionnaire fields
* removed `name` fields from questionnaire form, since name is filled in step before when org is created
* removed unnecessary refetches and reloads in `onUpdateOrganization` - compared to community version, we don't create organization at this point, we are just updating existing one so the reloads shouldn't be needed  

Related PR: https://github.com/novuhq/packages-enterprise/pull/177