### PR TITLE
fix(web): http api client missing env and memoizing jwt

### DIFF
--- a/apps/web/src/api/api.client.ts
+++ b/apps/web/src/api/api.client.ts
@@ -102,10 +102,12 @@ export function buildApiHttpClient({
   baseURL = API_ROOT || 'https://api.novu.co',
   secretKey,
   jwt,
+  environmentId,
 }: {
   baseURL?: string;
   secretKey?: string;
   jwt?: string;
+  environmentId?: string;
 }) {
   if (!secretKey && !jwt) {
     throw new Error('A secretKey or jwt is required to create a Novu API client.');
@@ -118,6 +120,7 @@ export function buildApiHttpClient({
     headers: {
       Authorization: authHeader,
       'Content-Type': 'application/json',
+      'Novu-Environment-Id': environmentId,
     },
   });
 

--- a/apps/web/src/hooks/useNovuAPI.ts
+++ b/apps/web/src/hooks/useNovuAPI.ts
@@ -5,12 +5,17 @@ import { buildApiHttpClient } from '../api/api.client';
 import * as mixpanel from 'mixpanel-browser';
 import { useStudioState } from '../studio/StudioStateProvider';
 import { getToken } from '../components/providers/AuthProvider';
+import { useEnvironment } from './useEnvironment';
 
 function useNovuAPI() {
   const { devSecretKey } = useStudioState();
+  const { currentEnvironment } = useEnvironment();
+  const token = getToken();
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useMemo(() => buildApiHttpClient({ secretKey: devSecretKey, jwt: getToken() }), []);
+  return useMemo(
+    () => buildApiHttpClient({ secretKey: devSecretKey, jwt: token, environmentId: currentEnvironment?._id }),
+    [currentEnvironment?._id, devSecretKey, token]
+  );
 }
 
 // WIP: This method should accept more parameters, not just transactionId


### PR DESCRIPTION
### What changed? Why was the change needed?
* `environmentId` was missing in header therefore API was defaulting to development env
* we can't memoize the entire `useNovuAPI` for 2 reasons:
  1) when JWT changes due to expiration and we are on notification modal which makes refetch every second - the api client will still use the old jwt for all the requests resulting in 401
  2) same applies for environmentId

