### PR TITLE
chore(web): target visual issues in the clerk menu integration

### DIFF
--- a/apps/web/src/components/nav/NavSelect.styles.ts
+++ b/apps/web/src/components/nav/NavSelect.styles.ts
@@ -3,7 +3,9 @@ import { css } from '@novu/novui/css';
 // TODO: these are ugly, but necessary for overriding Mantine + our design-system overrides
 export const navSelectStyles = css({
   fontWeight: 'strong !important',
-  '& input': { bg: 'transparent', border: 'none !important', pl: '3.25rem !important' },
+  marginLeft: '12px !important',
+
+  '& input': { bg: 'transparent', border: 'none !important', pl: '2.50rem !important' },
   '& .mantine-Select-icon': { width: 'inherit !important' },
   '& .mantine-Select-dropdown': { top: '50px !important' },
 });

--- a/apps/web/src/components/nav/NavSelect.styles.ts
+++ b/apps/web/src/components/nav/NavSelect.styles.ts
@@ -3,9 +3,9 @@ import { css } from '@novu/novui/css';
 // TODO: these are ugly, but necessary for overriding Mantine + our design-system overrides
 export const navSelectStyles = css({
   fontWeight: 'strong !important',
-  marginLeft: '12px !important',
+  marginLeft: '75 !important',
 
-  '& input': { bg: 'transparent', border: 'none !important', pl: '2.50rem !important' },
+  '& input': { bg: 'transparent', border: 'none !important', pl: '250 !important' },
   '& .mantine-Select-icon': { width: 'inherit !important' },
   '& .mantine-Select-dropdown': { top: '50px !important' },
 });

--- a/apps/web/src/ee/clerk/components/OrganizationSwitcher.tsx
+++ b/apps/web/src/ee/clerk/components/OrganizationSwitcher.tsx
@@ -1,5 +1,4 @@
 import { OrganizationSwitcher as ClerkOrganizationSwitcher } from '@clerk/clerk-react';
-import { ArrowDown } from '@novu/design-system';
 import { token } from '@novu/novui/tokens';
 import { ROUTES } from '../../../constants/routes';
 

--- a/apps/web/src/ee/clerk/components/OrganizationSwitcher.tsx
+++ b/apps/web/src/ee/clerk/components/OrganizationSwitcher.tsx
@@ -1,8 +1,8 @@
 import { OrganizationSwitcher as ClerkOrganizationSwitcher } from '@clerk/clerk-react';
+import { ArrowDown } from '@novu/design-system';
 import { token } from '@novu/novui/tokens';
 import { ROUTES } from '../../../constants/routes';
 
-// TODO: this is tmp. styling
 const OrganizationSwitcherAppearance = {
   elements: {
     organizationSwitcherTrigger: {
@@ -10,9 +10,18 @@ const OrganizationSwitcherAppearance = {
       width: '240px',
       height: '52px',
       justifyContent: 'space-between',
+      color: 'var(--nv-colors-typography-text-secondary) !important',
+      '&:hover, &:focus, &:active': {
+        color: 'var(--nv-colors-typography-text-main) !important',
+      },
     },
     organizationSwitcherPopoverActionButton__manageOrganization: {
       display: 'none',
+    },
+    organizationPreviewMainIdentifier: {
+      fontFamily: 'var(--nv-fonts-system)',
+      fontWeight: 'var(--nv-font-weights-strong)',
+      fontSize: 'var(--nv-font-sizes-88)',
     },
   },
 };

--- a/apps/web/src/ee/clerk/components/UserProfileButton.tsx
+++ b/apps/web/src/ee/clerk/components/UserProfileButton.tsx
@@ -13,19 +13,22 @@ export function UserProfileButton() {
   return (
     <UserButton afterSignOutUrl={ROUTES.AUTH_LOGIN}>
       <UserButton.UserProfilePage label="account" />
+      <UserButton.UserProfilePage label="security" />
       <UserButton.UserProfilePage label="Organization" url={ROUTES.ORGANIZATION} labelIcon={<IconRoomPreferences />}>
         <CustomOrganizationProfile firstItem="general" />
       </UserButton.UserProfilePage>
-      <UserButton.UserProfilePage label="security" />
+
       <UserButton.UserProfilePage label="Team members" url={ROUTES.TEAM} labelIcon={<IconGroup />}>
         <CustomOrganizationProfile firstItem="members" />
       </UserButton.UserProfilePage>
+
       {!isV2Enabled && (
         <UserButton.UserProfilePage label="Branding" url={ROUTES.BRAND_SETTINGS} labelIcon={<IconWorkspacePremium />}>
           <BrandingPage />
         </UserButton.UserProfilePage>
       )}
-      <UserButton.UserProfilePage label="Billing" url={ROUTES.BILLING} labelIcon={<IconCreditCard />}>
+
+      <UserButton.UserProfilePage label="Billing plans" url={ROUTES.BILLING} labelIcon={<IconCreditCard />}>
         <BillingPage />
       </UserButton.UserProfilePage>
     </UserButton>

--- a/apps/web/src/ee/clerk/providers/ClerkProvider.tsx
+++ b/apps/web/src/ee/clerk/providers/ClerkProvider.tsx
@@ -21,15 +21,16 @@ const ClerkModalElement = {
     fontFamily: 'var(--nv-fonts-system)',
     fontWeight: 'var(--nv-font-weights-strong)',
     fontSize: 'var(--nv-font-sizes-88)',
-    margin: '10px 10px 10px 10px important!',
+    paddingTop: 'var(--nv-spacing-50) !important',
+    paddingBottom: 'var(--nv-spacing-50) !important',
     color: 'var(--nv-colors-typography-text-secondary) !important',
     '&:hover, &:focus, &:active': {
       color: 'var(--nv-colors-typography-text-main) !important',
     },
   },
   navbarButtonIcon: {
-    height: '20px',
-    width: '20px',
+    height: 'var(--nv-sizes-125)',
+    width: 'var(--nv-sizes-125)',
   },
 };
 

--- a/apps/web/src/ee/clerk/providers/ClerkProvider.tsx
+++ b/apps/web/src/ee/clerk/providers/ClerkProvider.tsx
@@ -17,13 +17,27 @@ const ClerkModalElement = {
   rootBox: {
     width: 'auto',
   },
+  navbarButton: {
+    fontFamily: 'var(--nv-fonts-system)',
+    fontWeight: 'var(--nv-font-weights-strong)',
+    fontSize: 'var(--nv-font-sizes-88)',
+    margin: '10px 10px 10px 10px important!',
+    color: 'var(--nv-colors-typography-text-secondary) !important',
+    '&:hover, &:focus, &:active': {
+      color: 'var(--nv-colors-typography-text-main) !important',
+    },
+  },
+  navbarButtonIcon: {
+    height: '20px',
+    width: '20px',
+  },
 };
 
 const localization = {
   userProfile: {
     navbar: {
       title: 'Settings',
-      description: 'Manage your account settings',
+      description: '',
     },
   },
 };


### PR DESCRIPTION
### What changed? Why was the change needed?
Targeted comments raised in the channel about design flaws:
- align environment icon/text with rest of the sidebar
- align font face and size in organization drop down to rest of the sidebar
- align font face and size in profile modal to rest of the app

### Screenshots
Sidebar (org dropdown and environment picker):
![image](https://github.com/user-attachments/assets/210b8d3c-01af-429d-b0e1-8bd225acf200)

Profile menu (font size and face):
![image](https://github.com/user-attachments/assets/ef66f897-574f-4395-b677-8711079d4f26)

### Issues
- not known how to change some system icons and labels in clerk profile modal
- default selected element in profile not respecting focused colors until re selected
- org switcher arrow not in line with style from environment switcher