### PR TITLE
chore(web): enable redirect from legacy dashboard url in stage

### DIFF
--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -9,6 +9,18 @@
   command = "cd apps/web && pnpm run envsetup && cd ../../ && pnpm run build:web --skip-nx-cache"
 
 [[redirects]]
+  from = "https://dev.web.novu.co/*"
+  to = "https://dev.dashboard.novu.co/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "http://dev.web.novu.co/*"
+  to = "http://dev.dashboard.novu.co/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
setup netlify config to redirect legacy url to new dashboard location
