### PR TITLE
chore(root): move source of clerk config data to workflow params for all envs

### DIFF
--- a/.github/workflows/dev-deploy-web.yml
+++ b/.github/workflows/dev-deploy-web.yml
@@ -40,6 +40,8 @@ jobs:
       netlify_alias: dev
       netlify_gh_env: development
       netlify_site_id: 45396446-dc86-4ad6-81e4-86d3eb78d06f
+      clerk_publishable_key: {{ secrets.CLERK_PUBLISHABLE_KEY }}
+      clerk_is_ee_auth_enabled: {{ secrets.IS_EE_AUTH_ENABLED }}
     secrets: inherit
 
   publish_docker_image_web:

--- a/.github/workflows/prod-deploy-web.yml
+++ b/.github/workflows/prod-deploy-web.yml
@@ -25,6 +25,8 @@ jobs:
       netlify_alias: prod
       netlify_gh_env: Production
       netlify_site_id: d2e8b860-7016-4202-9256-ebca0f13259a
+      clerk_publishable_key: {{ secrets.CLERK_PUBLISHABLE_KEY_EU }}
+      clerk_is_ee_auth_enabled: {{ secrets.IS_EE_AUTH_ENABLED_EU }}
     secrets: inherit
 
   deploy_web_us:
@@ -43,4 +45,6 @@ jobs:
       netlify_alias: prod
       netlify_gh_env: Production
       netlify_site_id: 8639d8b9-81f9-44c3-b885-585a7fd2b5ff
+      clerk_publishable_key: {{ secrets.CLERK_PUBLISHABLE_KEY_US }}
+      clerk_is_ee_auth_enabled: {{ secrets.IS_EE_AUTH_ENABLED_US }}
     secrets: inherit

--- a/.github/workflows/reusable-web-deploy.yml
+++ b/.github/workflows/reusable-web-deploy.yml
@@ -44,6 +44,12 @@ on:
       netlify_site_id:
         required: true
         type: string
+      clerk_publishable_key:
+        required: true
+        type: string
+      clerk_is_ee_auth_enabled:
+        required: true
+        type: string
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -87,8 +93,8 @@ jobs:
           echo REACT_APP_STRIPE_CLIENT_KEY=${{ secrets.STRIPE_CLIENT_KEY }} >> .env
           echo REACT_APP_NOVU_GTM_ID=${{ secrets.REACT_APP_NOVU_GTM_ID }} >> .env
           echo REACT_APP_MIXPANEL_KEY=${{ secrets.MIXPANEL_TOKEN }} >> .env
-          echo REACT_APP_CLERK_PUBLISHABLE_KEY=${{ secrets.CLERK_PUBLISHABLE_KEY }} >> .env
-          echo REACT_APP_IS_EE_AUTH_ENABLED=${{ secrets.IS_EE_AUTH_ENABLED }} >> .env
+          echo REACT_APP_CLERK_PUBLISHABLE_KEY=${{ inputs.clerk_publishable_key }} >> .env
+          echo REACT_APP_IS_EE_AUTH_ENABLED=${{ inputs.clerk_is_ee_auth_enabled }} >> .env
       - name: Envsetup
         working-directory: apps/web
         run: npm run envsetup


### PR DESCRIPTION
secrets in 'Development' environment weren't touched and should work as is
4 new secrets added in 'Production' environment, names visible in the PR and **[here](https://github.com/novuhq/novu/settings/environments/303839906/edit)**