### PR TITLE
fix(web): ee modals overlapping

### DIFF
--- a/apps/web/src/components/layout/components/v2/HeaderNav.tsx
+++ b/apps/web/src/components/layout/components/v2/HeaderNav.tsx
@@ -37,7 +37,7 @@ export function HeaderNav() {
         position: 'sticky',
         top: 0,
         borderBottom: 'none !important',
-        zIndex: 'sticky',
+        zIndex: '200 !important',
         padding: '50',
       })}
     >

--- a/apps/web/src/ee/clerk/providers/ClerkProvider.tsx
+++ b/apps/web/src/ee/clerk/providers/ClerkProvider.tsx
@@ -11,6 +11,9 @@ const ClerkModalElement = {
     width: '80rem',
     display: 'block',
   },
+  modalBackdrop: {
+    zIndex: 200,
+  },
   cardBox: {
     width: '100%',
   },


### PR DESCRIPTION
### What changed? Why was the change needed?
Billing modals were overlapping with Clerk settings modal.

Action item: create a technical debt task to properly handle all z-indexes in the app, so we don't use seemingly random magic values
