### PR TITLE
fix(web): dedicated billing page for ee (tmp)

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -66,6 +66,7 @@ import { novuOnboardedCookie } from './utils/cookies';
 import { EnterprisePrivatePageLayout } from './ee/clerk/components/EnterprisePrivatePageLayout';
 import { OnboardingPage } from './pages/auth/onboarding/Onboarding';
 import { GetStartedPageV2 } from './studio/components/GetStartedPageV2/index';
+import { BillingRoutes } from './pages/BillingPages';
 
 const AuthRoutes = () => {
   const CommunityAuthRoutes = () => (
@@ -148,7 +149,9 @@ export const AppRoutes = () => {
             <Route path={ROUTES.PROFILE} element={<UserProfilePage />} />
             <Route path={`${ROUTES.SETTINGS}/*`} element={<Navigate to={ROUTES.SETTINGS} replace />} />
           </Route>
-        ) : null}
+        ) : (
+          <Route path="/billing" element={<BillingRoutes />} />
+        )}
         <Route path={ROUTES.INTEGRATIONS} element={<IntegrationsListPage />}>
           <Route path="create" element={<SelectProviderPage />} />
           <Route path="create/:channel/:providerId" element={<CreateProviderPage />} />

--- a/apps/web/src/components/layout/components/FreeTrialSidebarWidget.tsx
+++ b/apps/web/src/components/layout/components/FreeTrialSidebarWidget.tsx
@@ -1,8 +1,8 @@
 import { FreeTrialSidebarWidget as Component } from '../../../ee/billing';
-import { IS_DOCKER_HOSTED } from '../../../config';
+import { IS_DOCKER_HOSTED, IS_EE_AUTH_ENABLED } from '../../../config';
 
 export const FreeTrialSidebarWidget = () => {
-  if (IS_DOCKER_HOSTED) {
+  if (IS_DOCKER_HOSTED || IS_EE_AUTH_ENABLED) {
     return null;
   }
 

--- a/apps/web/src/components/layout/components/FreeTrialSidebarWidget.tsx
+++ b/apps/web/src/components/layout/components/FreeTrialSidebarWidget.tsx
@@ -2,7 +2,7 @@ import { FreeTrialSidebarWidget as Component } from '../../../ee/billing';
 import { IS_DOCKER_HOSTED, IS_EE_AUTH_ENABLED } from '../../../config';
 
 export const FreeTrialSidebarWidget = () => {
-  if (IS_DOCKER_HOSTED || IS_EE_AUTH_ENABLED) {
+  if (IS_DOCKER_HOSTED) {
     return null;
   }
 

--- a/apps/web/src/ee/billing/components/FreeTrialSidebarWidget.tsx
+++ b/apps/web/src/ee/billing/components/FreeTrialSidebarWidget.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import React from 'react';
 import { useSubscription } from '../utils/hooks/useSubscription';
 import { pluralizeDaysLeft, WARNING_LIMIT_DAYS, COLOR_WARNING } from '../utils/freeTrial.constants';
+import { IS_EE_AUTH_ENABLED } from '../../../config/index';
 
 export const FreeTrialSidebarWidget = () => {
   const { isFreeTrialActive, daysLeft, daysTotal, hasPaymentMethod } = useSubscription();
@@ -44,7 +45,7 @@ export const FreeTrialSidebarWidget = () => {
       />
       <Button
         onClick={() => {
-          navigate('/settings/billing');
+          navigate(IS_EE_AUTH_ENABLED ? '/billing' : '/settings/billing');
         }}
         data-test-id="free-trial-widget-button"
         mt={12}


### PR DESCRIPTION
### What changed? Why was the change needed?
Quick solution to render the original billing page upon clicking "Upgrade button"

