### PR TITLE
fix(web): Update api keys on regeneration

### DIFF
--- a/apps/web/src/pages/settings/ApiKeysPage/useApiKeysPage.ts
+++ b/apps/web/src/pages/settings/ApiKeysPage/useApiKeysPage.ts
@@ -1,8 +1,6 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { useClipboard } from '@mantine/hooks';
-import { getApiKeys } from '../../../api/environment';
-import { useEnvironment } from '../../../hooks';
+import { useEnvironment, useApiKeys } from '../../../hooks';
 import { useRegenerateSecretKeyModal } from './useRegenerateApiKeyModal';
 
 const CLIPBOARD_TIMEOUT_MS = 2000;
@@ -21,8 +19,7 @@ export const useApiKeysPage = () => {
   const { environment } = useEnvironment();
 
   const environmentIdentifier = environment?.identifier ? environment.identifier : '';
-
-  const { data: secretKeys } = useQuery<{ key: string }[]>(['getApiKeys', environment?._id], getApiKeys);
+  const { data: secretKeys } = useApiKeys();
 
   const secretKey = secretKeys?.length ? secretKeys[0].key : '';
 

--- a/apps/web/src/pages/settings/ApiKeysPage/useRegenerateApiKeyModal.ts
+++ b/apps/web/src/pages/settings/ApiKeysPage/useRegenerateApiKeyModal.ts
@@ -1,15 +1,14 @@
 import { IResponseError } from '@novu/shared';
-import { getApiKeys, regenerateApiKeys } from '../../../api';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { regenerateApiKeys } from '../../../api';
+import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useApiKeys } from '../../../hooks';
 
 import { showNotification } from '@mantine/notifications';
 
 export const useRegenerateSecretKeyModal = () => {
   const [isOpen, setModalIsOpen] = useState(false);
-
-  const { refetch: refetchSecretKeys } = useQuery<{ key: string }[]>(['getApiKeys'], getApiKeys);
-
+  const { refetch: refetchSecretKeys } = useApiKeys();
   const { mutateAsync: regenerateApiKeysMutation } = useMutation<{ key: string }[], IResponseError>(regenerateApiKeys);
 
   async function openModal() {


### PR DESCRIPTION
### What changed? Why was the change needed?
https://linear.app/novu/issue/PLAT-47/api-key-not-updating-until-page-is-refreshed-possibly-a-known-issue-on