### PR TITLE
feat(js): inbox sdk manage pagination state in cache

### DIFF
--- a/packages/js/src/cache/in-memory-cache.ts
+++ b/packages/js/src/cache/in-memory-cache.ts
@@ -15,7 +15,7 @@ export class InMemoryCache<T> implements Cache<T> {
     return Array.from(this.#cache.values());
   }
 
-  pairs(): [string, T][] {
+  entries(): [string, T][] {
     return Array.from(this.#cache.entries());
   }
 

--- a/packages/js/src/cache/in-memory-cache.ts
+++ b/packages/js/src/cache/in-memory-cache.ts
@@ -1,0 +1,37 @@
+import type { Cache } from './types';
+
+export class InMemoryCache<T> implements Cache<T> {
+  #cache: Map<string, T>;
+
+  constructor() {
+    this.#cache = new Map();
+  }
+
+  get(key: string): T | undefined {
+    return this.#cache.get(key);
+  }
+
+  getValues(): T[] {
+    return Array.from(this.#cache.values());
+  }
+
+  pairs(): [string, T][] {
+    return Array.from(this.#cache.entries());
+  }
+
+  keys(): string[] {
+    return Array.from(this.#cache.keys());
+  }
+
+  set(key: string, value: T): void {
+    this.#cache.set(key, value);
+  }
+
+  remove(key: string): void {
+    this.#cache.delete(key);
+  }
+
+  clear(): void {
+    this.#cache.clear();
+  }
+}

--- a/packages/js/src/cache/index.ts
+++ b/packages/js/src/cache/index.ts
@@ -1,0 +1,1 @@
+export { NotificationsCache } from './notifications-cache';

--- a/packages/js/src/cache/notifications-cache.test.ts
+++ b/packages/js/src/cache/notifications-cache.test.ts
@@ -2,9 +2,26 @@
 import { NovuEventEmitter } from '../event-emitter';
 import { ListNotificationsArgs, ListNotificationsResponse, Notification } from '../notifications';
 import { NotificationsCache } from './notifications-cache';
+import { ChannelType } from '../types';
 
-const notification1 = { id: '1', body: 'test1' } as Notification;
-const notification2 = { id: '2', body: 'test2' } as Notification;
+const notification1 = new Notification({
+  id: '1',
+  body: 'test1',
+  isRead: false,
+  isArchived: false,
+  to: { id: '1', subscriberId: '1' },
+  createdAt: new Date().toISOString(),
+  channelType: ChannelType.IN_APP,
+});
+const notification2 = new Notification({
+  id: '2',
+  body: 'test2',
+  isRead: false,
+  isArchived: false,
+  to: { id: '2', subscriberId: '2' },
+  createdAt: new Date().toISOString(),
+  channelType: ChannelType.IN_APP,
+});
 
 describe('NotificationsCache', () => {
   let notificationsCache: NotificationsCache;
@@ -122,13 +139,50 @@ describe('NotificationsCache', () => {
     expect(result).toEqual([notification1, notification2]);
   });
 
-  it('should update single notifications and emit single event', () => {
+  it('should get unique read notifications based on tags', () => {
+    const updated1 = new Notification({ ...notification1, isRead: true });
+    const updated2 = new Notification({ ...notification2, isRead: true });
+    const updated3 = new Notification({ ...notification2, id: '3' });
+
+    const args1 = { tags: ['tag1'], limit: 10, offset: 0 };
+    const data1: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [updated1, updated2],
+    };
+
+    const args2 = { tags: ['tag1'], limit: 10, offset: 1 };
+    const data2: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [updated3],
+    };
+
+    const args3 = { tags: ['tag2'], limit: 10, offset: 0 };
+    const data3: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification2],
+    };
+
+    notificationsCache.set(args1, data1);
+    notificationsCache.set(args2, data2);
+    notificationsCache.set(args3, data3);
+
+    let result = notificationsCache.getUniqueNotifications({ tags: ['tag1'], read: true });
+    expect(result).toEqual([updated1, updated2]);
+
+    result = notificationsCache.getUniqueNotifications({ tags: ['tag2'] });
+    expect(result).toEqual([notification2]);
+  });
+
+  it('should update notification and emit single event', () => {
     const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
-    const updatedNotification = { id: '1', body: 'Updated Notification' } as Notification;
+    const updatedNotification = new Notification({ ...notification1, body: 'Updated Notification' });
     const data: ListNotificationsResponse = { hasMore: false, filter: {}, notifications: [notification1] };
 
     notificationsCache.set(args, data);
-    (notificationsCache as any).handleSingleNotificationEvent({ data: updatedNotification });
+    (notificationsCache as any).handleNotificationEvent()({ data: updatedNotification });
 
     expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
       data: {
@@ -139,38 +193,83 @@ describe('NotificationsCache', () => {
     });
   });
 
-  it('should update single notifications for different filters and emit two events', () => {
+  it('should remove notification and emit single event', () => {
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const updatedNotification = new Notification({ ...notification1, body: 'Updated Notification' });
+    const data: ListNotificationsResponse = { hasMore: false, filter: {}, notifications: [notification1] };
+
+    notificationsCache.set(args, data);
+    (notificationsCache as any).handleNotificationEvent({ remove: true })({ data: updatedNotification });
+
+    expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: {},
+        notifications: [],
+      },
+    });
+  });
+
+  it('should update notification for different filters and emit two events', () => {
     const filter1 = { tags: ['tag1'], read: false, archived: false };
     const filter2 = { tags: ['tag2'], read: false, archived: false };
     const args1: ListNotificationsArgs = { limit: 10, offset: 0, ...filter1 };
     const args2: ListNotificationsArgs = { limit: 10, offset: 0, ...filter2 };
-    const updatedNotification = { id: '1', body: 'Updated Notification' } as Notification;
+    const updatedNotification = new Notification({ ...notification1, body: 'Updated Notification' });
 
-    notificationsCache.set(args1, { hasMore: false, filter: filter1, notifications: [notification1] });
-    notificationsCache.set(args2, { hasMore: false, filter: filter2, notifications: [notification1] });
-    (notificationsCache as any).handleSingleNotificationEvent({ data: updatedNotification });
+    notificationsCache.set(args1, { hasMore: false, filter: filter1, notifications: [notification1, notification2] });
+    notificationsCache.set(args2, { hasMore: false, filter: filter2, notifications: [notification1, notification2] });
+    (notificationsCache as any).handleNotificationEvent()({ data: updatedNotification });
 
     expect(mockEmitter.emit).toHaveBeenCalledTimes(2);
     expect(mockEmitter.emit).toHaveBeenNthCalledWith(1, 'notifications.list.updated', {
       data: {
         hasMore: false,
         filter: filter1,
-        notifications: [updatedNotification],
+        notifications: [updatedNotification, notification2],
       },
     });
     expect(mockEmitter.emit).toHaveBeenNthCalledWith(2, 'notifications.list.updated', {
       data: {
         hasMore: false,
         filter: filter2,
-        notifications: [updatedNotification],
+        notifications: [updatedNotification, notification2],
+      },
+    });
+  });
+
+  it('should remove notification for different filters and emit two events', () => {
+    const filter1 = { tags: ['tag1'], read: false, archived: false };
+    const filter2 = { tags: ['tag2'], read: false, archived: false };
+    const args1: ListNotificationsArgs = { limit: 10, offset: 0, ...filter1 };
+    const args2: ListNotificationsArgs = { limit: 10, offset: 0, ...filter2 };
+    const updatedNotification = new Notification({ ...notification1, body: 'Updated Notification' });
+
+    notificationsCache.set(args1, { hasMore: false, filter: filter1, notifications: [notification1, notification2] });
+    notificationsCache.set(args2, { hasMore: false, filter: filter2, notifications: [notification1, notification2] });
+    (notificationsCache as any).handleNotificationEvent({ remove: true })({ data: updatedNotification });
+
+    expect(mockEmitter.emit).toHaveBeenCalledTimes(2);
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(1, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter1,
+        notifications: [notification2],
+      },
+    });
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(2, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter2,
+        notifications: [notification2],
       },
     });
   });
 
   it('should update multiple notifications and emit single event', () => {
     const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
-    const updatedNotification1 = { id: '1', body: 'Updated Notification' } as Notification;
-    const updatedNotification2 = { id: '2', body: 'Updated Notification' } as Notification;
+    const updatedNotification1 = new Notification({ ...notification1, body: 'Updated Notification' });
+    const updatedNotification2 = new Notification({ ...notification2, body: 'Updated Notification' });
     const data: ListNotificationsResponse = {
       hasMore: false,
       filter: {},
@@ -178,7 +277,7 @@ describe('NotificationsCache', () => {
     };
 
     notificationsCache.set(args, data);
-    (notificationsCache as any).handleMultipleNotificationsEvent({
+    (notificationsCache as any).handleNotificationsEvent()({
       data: [updatedNotification1, updatedNotification2],
     });
 
@@ -191,13 +290,38 @@ describe('NotificationsCache', () => {
     });
   });
 
+  it('should remove multiple notifications and emit single event', () => {
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const updatedNotification1 = new Notification({ ...notification1, body: 'Updated Notification' });
+    const updatedNotification2 = new Notification({ ...notification2, body: 'Updated Notification' });
+    const notification3 = new Notification({ ...notification1, id: '3' });
+    const data: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1, notification2, notification3],
+    };
+
+    notificationsCache.set(args, data);
+    (notificationsCache as any).handleNotificationsEvent({ remove: true })({
+      data: [updatedNotification1, updatedNotification2],
+    });
+
+    expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: {},
+        notifications: [notification3],
+      },
+    });
+  });
+
   it('should update multiple notifications for different filters and emit two events', () => {
     const filter1 = { tags: ['tag1'], read: false, archived: false };
     const filter2 = { tags: ['tag2'], read: false, archived: false };
     const args1: ListNotificationsArgs = { limit: 10, offset: 0, ...filter1 };
     const args2: ListNotificationsArgs = { limit: 10, offset: 0, ...filter2 };
-    const updatedNotification1 = { id: '1', body: 'Updated Notification' } as Notification;
-    const updatedNotification2 = { id: '2', body: 'Updated Notification' } as Notification;
+    const updatedNotification1 = new Notification({ ...notification1, body: 'Updated Notification' });
+    const updatedNotification2 = new Notification({ ...notification2, body: 'Updated Notification' });
 
     notificationsCache.set(args1, {
       hasMore: false,
@@ -209,7 +333,7 @@ describe('NotificationsCache', () => {
       filter: filter2,
       notifications: [notification2],
     });
-    (notificationsCache as any).handleMultipleNotificationsEvent({
+    (notificationsCache as any).handleNotificationsEvent()({
       data: [updatedNotification1, updatedNotification2],
     });
 
@@ -226,6 +350,46 @@ describe('NotificationsCache', () => {
         hasMore: false,
         filter: filter2,
         notifications: [updatedNotification2],
+      },
+    });
+  });
+
+  it('should remove multiple notifications for different filters and emit two events', () => {
+    const filter1 = { tags: ['tag1'], read: false, archived: false };
+    const filter2 = { tags: ['tag2'], read: false, archived: false };
+    const args1: ListNotificationsArgs = { limit: 10, offset: 0, ...filter1 };
+    const args2: ListNotificationsArgs = { limit: 10, offset: 0, ...filter2 };
+    const updatedNotification1 = new Notification({ ...notification1, body: 'Updated Notification' });
+    const updatedNotification2 = new Notification({ ...notification2, body: 'Updated Notification' });
+    const notification3 = new Notification({ ...notification1, id: '3' });
+
+    notificationsCache.set(args1, {
+      hasMore: false,
+      filter: filter1,
+      notifications: [notification1, notification3],
+    });
+    notificationsCache.set(args2, {
+      hasMore: false,
+      filter: filter2,
+      notifications: [notification2, notification3],
+    });
+    (notificationsCache as any).handleNotificationsEvent({ remove: true })({
+      data: [updatedNotification1, updatedNotification2],
+    });
+
+    expect(mockEmitter.emit).toHaveBeenCalledTimes(2);
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(1, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter1,
+        notifications: [notification3],
+      },
+    });
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(2, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter2,
+        notifications: [notification3],
       },
     });
   });

--- a/packages/js/src/cache/notifications-cache.test.ts
+++ b/packages/js/src/cache/notifications-cache.test.ts
@@ -1,0 +1,232 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NovuEventEmitter } from '../event-emitter';
+import { ListNotificationsArgs, ListNotificationsResponse, Notification } from '../notifications';
+import { NotificationsCache } from './notifications-cache';
+
+const notification1 = { id: '1', body: 'test1' } as Notification;
+const notification2 = { id: '2', body: 'test2' } as Notification;
+
+describe('NotificationsCache', () => {
+  let notificationsCache: NotificationsCache;
+  let mockEmitter: NovuEventEmitter;
+
+  beforeEach(() => {
+    mockEmitter = {
+      on: jest.fn(),
+      emit: jest.fn(),
+    } as unknown as NovuEventEmitter;
+    jest.spyOn(NovuEventEmitter, 'getInstance').mockReturnValue(mockEmitter);
+    notificationsCache = new NotificationsCache();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should set and get notifications from the cache', () => {
+    const args = { tags: ['tag1'], limit: 10, offset: 0 };
+    const data = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    };
+
+    notificationsCache.set(args, data);
+    const result = notificationsCache.getAll(args);
+
+    expect(result).toEqual(data);
+  });
+
+  it('should clear specific filter from the cache', () => {
+    const args = { tags: ['tag1'], limit: 10, offset: 0 };
+    const data = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    };
+    notificationsCache.set(args, data);
+
+    const filter = { tags: args.tags };
+    notificationsCache.clear(filter);
+
+    const result = notificationsCache.getAll(args);
+    expect(result).toBeUndefined();
+  });
+
+  it('should clear specific filter from the cache but leave the others', () => {
+    const args1 = { tags: ['tag1'], limit: 10, offset: 0 };
+    const args2 = { tags: ['newsletter'], limit: 10, offset: 0 };
+    const data = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    };
+    notificationsCache.set(args1, data);
+    notificationsCache.set(args2, data);
+
+    const filter = { tags: args1.tags };
+    notificationsCache.clear(filter);
+
+    const result1 = notificationsCache.getAll(args1);
+    expect(result1).toBeUndefined();
+    const result2 = notificationsCache.getAll(args2);
+    expect(result2).toEqual(data);
+  });
+
+  it('should clear all caches', () => {
+    const args1 = { tags: ['tag1'], limit: 10, offset: 0 };
+    const args2 = { tags: ['newsletter'], limit: 10, offset: 0 };
+    const data = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    };
+    notificationsCache.set(args1, data);
+    notificationsCache.set(args2, data);
+
+    notificationsCache.clearAll();
+
+    const result1 = notificationsCache.getAll(args1);
+    expect(result1).toBeUndefined();
+    const result2 = notificationsCache.getAll(args2);
+    expect(result2).toBeUndefined();
+  });
+
+  it('should get unique notifications based on tags', () => {
+    const args1 = { tags: ['tag1'], limit: 10, offset: 0 };
+    const data1: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    };
+
+    const args2 = { tags: ['tag1'], limit: 10, offset: 1 };
+    const data2: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification2],
+    };
+
+    const args3 = { tags: ['tag2'], limit: 10, offset: 1 };
+    const data3: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification2],
+    };
+
+    notificationsCache.set(args1, data1);
+    notificationsCache.set(args2, data2);
+    notificationsCache.set(args3, data3);
+
+    const result = notificationsCache.getUniqueNotifications({ tags: ['tag1'] });
+    expect(result).toEqual([notification1, notification2]);
+  });
+
+  it('should update single notifications and emit single event', () => {
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const updatedNotification = { id: '1', body: 'Updated Notification' } as Notification;
+    const data: ListNotificationsResponse = { hasMore: false, filter: {}, notifications: [notification1] };
+
+    notificationsCache.set(args, data);
+    (notificationsCache as any).handleSingleNotificationEvent({ data: updatedNotification });
+
+    expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: {},
+        notifications: [updatedNotification],
+      },
+    });
+  });
+
+  it('should update single notifications for different filters and emit two events', () => {
+    const filter1 = { tags: ['tag1'], read: false, archived: false };
+    const filter2 = { tags: ['tag2'], read: false, archived: false };
+    const args1: ListNotificationsArgs = { limit: 10, offset: 0, ...filter1 };
+    const args2: ListNotificationsArgs = { limit: 10, offset: 0, ...filter2 };
+    const updatedNotification = { id: '1', body: 'Updated Notification' } as Notification;
+
+    notificationsCache.set(args1, { hasMore: false, filter: filter1, notifications: [notification1] });
+    notificationsCache.set(args2, { hasMore: false, filter: filter2, notifications: [notification1] });
+    (notificationsCache as any).handleSingleNotificationEvent({ data: updatedNotification });
+
+    expect(mockEmitter.emit).toHaveBeenCalledTimes(2);
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(1, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter1,
+        notifications: [updatedNotification],
+      },
+    });
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(2, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter2,
+        notifications: [updatedNotification],
+      },
+    });
+  });
+
+  it('should update multiple notifications and emit single event', () => {
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const updatedNotification1 = { id: '1', body: 'Updated Notification' } as Notification;
+    const updatedNotification2 = { id: '2', body: 'Updated Notification' } as Notification;
+    const data: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1, notification2],
+    };
+
+    notificationsCache.set(args, data);
+    (notificationsCache as any).handleMultipleNotificationsEvent({
+      data: [updatedNotification1, updatedNotification2],
+    });
+
+    expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: {},
+        notifications: [updatedNotification1, updatedNotification2],
+      },
+    });
+  });
+
+  it('should update multiple notifications for different filters and emit two events', () => {
+    const filter1 = { tags: ['tag1'], read: false, archived: false };
+    const filter2 = { tags: ['tag2'], read: false, archived: false };
+    const args1: ListNotificationsArgs = { limit: 10, offset: 0, ...filter1 };
+    const args2: ListNotificationsArgs = { limit: 10, offset: 0, ...filter2 };
+    const updatedNotification1 = { id: '1', body: 'Updated Notification' } as Notification;
+    const updatedNotification2 = { id: '2', body: 'Updated Notification' } as Notification;
+
+    notificationsCache.set(args1, {
+      hasMore: false,
+      filter: filter1,
+      notifications: [notification1],
+    });
+    notificationsCache.set(args2, {
+      hasMore: false,
+      filter: filter2,
+      notifications: [notification2],
+    });
+    (notificationsCache as any).handleMultipleNotificationsEvent({
+      data: [updatedNotification1, updatedNotification2],
+    });
+
+    expect(mockEmitter.emit).toHaveBeenCalledTimes(2);
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(1, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter1,
+        notifications: [updatedNotification1],
+      },
+    });
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(2, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter2,
+        notifications: [updatedNotification2],
+      },
+    });
+  });
+});

--- a/packages/js/src/cache/notifications-cache.test.ts
+++ b/packages/js/src/cache/notifications-cache.test.ts
@@ -277,7 +277,7 @@ describe('NotificationsCache', () => {
     };
 
     notificationsCache.set(args, data);
-    (notificationsCache as any).handleNotificationsEvent()({
+    (notificationsCache as any).handleNotificationEvent()({
       data: [updatedNotification1, updatedNotification2],
     });
 
@@ -302,7 +302,7 @@ describe('NotificationsCache', () => {
     };
 
     notificationsCache.set(args, data);
-    (notificationsCache as any).handleNotificationsEvent({ remove: true })({
+    (notificationsCache as any).handleNotificationEvent({ remove: true })({
       data: [updatedNotification1, updatedNotification2],
     });
 
@@ -333,7 +333,7 @@ describe('NotificationsCache', () => {
       filter: filter2,
       notifications: [notification2],
     });
-    (notificationsCache as any).handleNotificationsEvent()({
+    (notificationsCache as any).handleNotificationEvent()({
       data: [updatedNotification1, updatedNotification2],
     });
 
@@ -373,7 +373,7 @@ describe('NotificationsCache', () => {
       filter: filter2,
       notifications: [notification2, notification3],
     });
-    (notificationsCache as any).handleNotificationsEvent({ remove: true })({
+    (notificationsCache as any).handleNotificationEvent({ remove: true })({
       data: [updatedNotification1, updatedNotification2],
     });
 

--- a/packages/js/src/cache/notifications-cache.ts
+++ b/packages/js/src/cache/notifications-cache.ts
@@ -5,8 +5,8 @@ import { NotificationEvents, NotificationsEvents, NovuEventEmitter } from '../ev
 import type { NotificationFilter } from '../types';
 import { areTagsEqual, isSameFilter } from '../utils/notification-utils';
 
-const getCacheKey = (args: ListNotificationsArgs): string => {
-  return JSON.stringify(args);
+const getCacheKey = ({ tags, read, archived, limit, offset, after }: ListNotificationsArgs): string => {
+  return JSON.stringify({ tags, read, archived, limit, offset, after });
 };
 
 const getFilterKey = ({ tags, read, archived }: Pick<ListNotificationsArgs, 'tags' | 'read' | 'archived'>): string => {

--- a/packages/js/src/cache/notifications-cache.ts
+++ b/packages/js/src/cache/notifications-cache.ts
@@ -1,0 +1,212 @@
+import { InMemoryCache } from './in-memory-cache';
+import type { Cache } from './types';
+import type { ListNotificationsArgs, ListNotificationsResponse, Notification } from '../notifications';
+import { NotificationEvents, NotificationsEvents, NovuEventEmitter } from '../event-emitter';
+import type { NotificationFilter } from '../types';
+
+const getFilterKey = ({ tags, read, archived }: Pick<ListNotificationsArgs, 'tags' | 'read' | 'archived'>): string => {
+  return JSON.stringify({ tags, read, archived });
+};
+
+const getPageKey = ({ limit, offset, after }: Pick<ListNotificationsArgs, 'limit' | 'offset' | 'after'>): string => {
+  return JSON.stringify({ limit, offset, after });
+};
+
+const singleNotificationEvents: NotificationEvents[] = [
+  'notification.read.pending',
+  'notification.read.resolved',
+  'notification.unread.pending',
+  'notification.unread.resolved',
+  'notification.archive.pending',
+  'notification.archive.resolved',
+  'notification.unarchive.pending',
+  'notification.unarchive.resolved',
+  'notification.complete_action.pending',
+  'notification.complete_action.resolved',
+  'notification.revert_action.pending',
+  'notification.revert_action.resolved',
+];
+
+const multipleNotificationEvents: NotificationsEvents[] = [
+  'notifications.read_all.pending',
+  'notifications.read_all.resolved',
+  'notifications.archive_all.pending',
+  'notifications.archive_all.resolved',
+  'notifications.archive_all_read.pending',
+  'notifications.archive_all_read.resolved',
+];
+
+export class NotificationsCache {
+  #emitter: NovuEventEmitter;
+  /**
+   * The key is the stringified notifications filter, the value is the pagination cache
+   * where the key is pagination arguments and the value is the list of notifications.
+   */
+  #cache: Cache<Cache<ListNotificationsResponse>>;
+  /**
+   * The key is the stringified notifications filter, the value is the set of unique notification ids.
+   */
+  #idsCache: Cache<Set<string>>;
+
+  constructor() {
+    this.#emitter = NovuEventEmitter.getInstance();
+    singleNotificationEvents.forEach((event) => {
+      this.#emitter.on(event, this.handleSingleNotificationEvent);
+    });
+    multipleNotificationEvents.forEach((event) => {
+      this.#emitter.on(event, this.handleMultipleNotificationsEvent);
+    });
+    this.#cache = new InMemoryCache();
+    this.#idsCache = new InMemoryCache();
+  }
+
+  private getFilterCache = (args: ListNotificationsArgs): Cache<ListNotificationsResponse> | undefined => {
+    return this.#cache.get(getFilterKey(args));
+  };
+
+  private updateNotificationInCache = (cache: Cache<ListNotificationsResponse>, data: Notification): void => {
+    const allCache = cache.pairs();
+
+    allCache.forEach(([key, el]) => {
+      const index = el.notifications.findIndex((notification) => notification.id === data.id);
+      if (index === -1) {
+        return;
+      }
+
+      const updatedNotifications = [...el.notifications];
+      updatedNotifications[index] = data;
+
+      cache.set(key, { ...el, notifications: updatedNotifications });
+    });
+  };
+
+  private handleSingleNotificationEvent = ({ data }: { data?: Notification }): void => {
+    if (!data) {
+      return;
+    }
+
+    const filterKeysToUpdate = this.#idsCache.keys().filter((key) => {
+      const cache = this.#idsCache.get(key);
+
+      return cache?.has(data.id);
+    });
+
+    filterKeysToUpdate.forEach((key) => {
+      const filterCache = this.#cache.get(key);
+      if (!filterCache) {
+        return;
+      }
+
+      this.updateNotificationInCache(filterCache, data);
+
+      const notificationsResponse = this.getReducedNotifications(filterCache);
+      this.#emitter.emit('notifications.list.updated', {
+        data: notificationsResponse,
+      });
+    });
+  };
+
+  private handleMultipleNotificationsEvent = ({ data }: { data?: Notification[] }): void => {
+    if (!data) {
+      return;
+    }
+
+    const notificationIds = data.map((notification) => notification.id);
+    const filterKeysToUpdate = this.#idsCache.keys().filter((key) => {
+      const idsSet = this.#idsCache.get(key);
+
+      return notificationIds.some((id) => idsSet?.has(id));
+    });
+
+    filterKeysToUpdate.forEach((key) => {
+      const filterCache = this.#cache.get(key);
+      if (!filterCache) {
+        return;
+      }
+
+      data.forEach((notification) => this.updateNotificationInCache(filterCache, notification));
+
+      const notificationsResponse = this.getReducedNotifications(filterCache);
+      this.#emitter.emit('notifications.list.updated', {
+        data: notificationsResponse,
+      });
+    });
+  };
+
+  private has(args: ListNotificationsArgs): boolean {
+    const pageKey = getPageKey(args);
+    const filterCache = this.getFilterCache(args);
+
+    return filterCache?.get(pageKey) !== undefined;
+  }
+
+  private getReducedNotifications(filterCache: Cache<ListNotificationsResponse>): ListNotificationsResponse {
+    const values = filterCache.getValues();
+
+    return values.reduce<ListNotificationsResponse>(
+      (acc, el) => {
+        return {
+          hasMore: el.hasMore,
+          filter: el.filter,
+          notifications: [...acc.notifications, ...el.notifications],
+        };
+      },
+      { hasMore: false, filter: {}, notifications: [] }
+    );
+  }
+
+  set(args: ListNotificationsArgs, data: ListNotificationsResponse): void {
+    const filterKey = getFilterKey(args);
+    const pageKey = getPageKey(args);
+    const filterCache = this.getFilterCache(args) ?? new InMemoryCache();
+    filterCache.set(pageKey, data);
+    this.#cache.set(filterKey, filterCache);
+
+    const uniqueIds = this.#idsCache.get(filterKey) ?? new Set();
+    data.notifications.forEach((el) => uniqueIds.add(el.id));
+    this.#idsCache.set(filterKey, uniqueIds);
+  }
+
+  getAll(args: ListNotificationsArgs): ListNotificationsResponse | undefined {
+    const filterCache = this.getFilterCache(args);
+    if (this.has(args) && filterCache) {
+      return this.getReducedNotifications(filterCache);
+    }
+
+    return;
+  }
+
+  getUniqueNotifications({ tags }: Pick<ListNotificationsArgs, 'tags'>): Array<Notification> {
+    const keys = this.#cache.keys();
+
+    const uniqueNotifications = new Map<string, Notification>();
+    keys.forEach((key) => {
+      const filter: NotificationFilter = JSON.parse(key);
+      if (!tags || tags?.every((tag) => filter.tags?.includes(tag))) {
+        const filterCache = this.#cache.get(key);
+        if (!filterCache) {
+          return;
+        }
+
+        filterCache
+          .getValues()
+          .map((el) => el.notifications)
+          .flat()
+          .forEach((notification) => uniqueNotifications.set(notification.id, notification));
+      }
+    });
+
+    return Array.from(uniqueNotifications.values());
+  }
+
+  clear(filter: NotificationFilter): void {
+    const filterKey = getFilterKey(filter);
+    this.#cache.remove(filterKey);
+    this.#idsCache.remove(filterKey);
+  }
+
+  clearAll(): void {
+    this.#cache.clear();
+    this.#idsCache.clear();
+  }
+}

--- a/packages/js/src/cache/types.ts
+++ b/packages/js/src/cache/types.ts
@@ -1,7 +1,7 @@
 export type Cache<T = unknown> = {
   get: (key: string) => T | undefined;
   getValues: () => T[];
-  pairs: () => [string, T][];
+  entries: () => [string, T][];
   keys: () => string[];
   set: (key: string, value: T) => void;
   remove: (key: string) => void;

--- a/packages/js/src/cache/types.ts
+++ b/packages/js/src/cache/types.ts
@@ -1,0 +1,9 @@
+export type Cache<T = unknown> = {
+  get: (key: string) => T | undefined;
+  getValues: () => T[];
+  pairs: () => [string, T][];
+  keys: () => string[];
+  set: (key: string, value: T) => void;
+  remove: (key: string) => void;
+  clear: () => void;
+};

--- a/packages/js/src/event-emitter/types.ts
+++ b/packages/js/src/event-emitter/types.ts
@@ -103,8 +103,8 @@ export type NotificationEvents = keyof (NotificationReadEvents &
   NotificationArchiveEvents &
   NotificationUnarchiveEvents &
   NotificationCompleteActionEvents &
-  NotificationRevertActionEvents);
-export type NotificationsEvents = keyof (NotificationsReadAllEvents &
+  NotificationRevertActionEvents &
+  NotificationsReadAllEvents &
   NotificationsArchivedAllEvents &
   NotificationsReadArchivedAllEvents);
 

--- a/packages/js/src/notifications/helpers.ts
+++ b/packages/js/src/notifications/helpers.ts
@@ -347,14 +347,10 @@ export const archiveAllRead = async ({
   tags?: NotificationFilter['tags'];
 }): Result<void> => {
   try {
-    const notifications = notificationsCache.getUniqueNotifications({ tags });
-    const optimisticNotifications = notifications.map((notification) => {
-      if (notification.isRead) {
-        return new Notification({ ...notification, isArchived: true, archivedAt: new Date().toISOString() });
-      }
-
-      return notification;
-    });
+    const notifications = notificationsCache.getUniqueNotifications({ tags, read: true });
+    const optimisticNotifications = notifications.map(
+      (notification) => new Notification({ ...notification, isArchived: true, archivedAt: new Date().toISOString() })
+    );
     emitter.emit('notifications.archive_all_read.pending', { args: { tags }, data: optimisticNotifications });
 
     await inboxService.archiveAllRead({ tags });

--- a/packages/js/src/notifications/helpers.ts
+++ b/packages/js/src/notifications/helpers.ts
@@ -1,9 +1,10 @@
-import { Action, ActionTypeEnum, Result } from '../types';
-import { InboxService } from '../api';
+import { Action, ActionTypeEnum, NotificationFilter, Result } from '../types';
+import type { InboxService } from '../api';
 import type { NovuEventEmitter } from '../event-emitter';
 import { Notification } from './notification';
-import { ArchivedArgs, CompleteArgs, ReadArgs, RevertArgs, UnarchivedArgs, UnreadArgs } from './types';
+import type { ArchivedArgs, CompleteArgs, ReadArgs, RevertArgs, UnarchivedArgs, UnreadArgs } from './types';
 import { NovuError } from '../utils/errors';
+import type { NotificationsCache } from '../cache';
 
 export const read = async ({
   emitter,
@@ -257,5 +258,113 @@ const getNotificationDetails = (
     return {
       notificationId: args.notificationId,
     };
+  }
+};
+
+export const readAll = async ({
+  emitter,
+  inboxService,
+  notificationsCache,
+  tags,
+}: {
+  emitter: NovuEventEmitter;
+  inboxService: InboxService;
+  notificationsCache: NotificationsCache;
+  tags?: NotificationFilter['tags'];
+}): Result<void> => {
+  try {
+    const notifications = notificationsCache.getUniqueNotifications({ tags });
+    const optimisticNotifications = notifications.map(
+      (notification) =>
+        new Notification({
+          ...notification,
+          isRead: true,
+          readAt: new Date().toISOString(),
+          isArchived: false,
+          archivedAt: undefined,
+        })
+    );
+    emitter.emit('notifications.read_all.pending', { args: { tags }, data: optimisticNotifications });
+
+    await inboxService.readAll({ tags });
+
+    emitter.emit('notifications.read_all.resolved', { args: { tags }, data: optimisticNotifications });
+
+    return {};
+  } catch (error) {
+    emitter.emit('notifications.read_all.resolved', { args: { tags }, error });
+
+    return { error: new NovuError('Failed to read all notifications', error) };
+  }
+};
+
+export const archiveAll = async ({
+  emitter,
+  inboxService,
+  notificationsCache,
+  tags,
+}: {
+  emitter: NovuEventEmitter;
+  inboxService: InboxService;
+  notificationsCache: NotificationsCache;
+  tags?: NotificationFilter['tags'];
+}): Result<void> => {
+  try {
+    const notifications = notificationsCache.getUniqueNotifications({ tags });
+    const optimisticNotifications = notifications.map(
+      (notification) =>
+        new Notification({
+          ...notification,
+          isRead: true,
+          readAt: new Date().toISOString(),
+          isArchived: true,
+          archivedAt: new Date().toISOString(),
+        })
+    );
+    emitter.emit('notifications.archive_all.pending', { args: { tags }, data: optimisticNotifications });
+
+    await inboxService.archiveAll({ tags });
+
+    emitter.emit('notifications.archive_all.resolved', { args: { tags }, data: optimisticNotifications });
+
+    return {};
+  } catch (error) {
+    emitter.emit('notifications.archive_all.resolved', { args: { tags }, error });
+
+    return { error: new NovuError('Failed to archive all notifications', error) };
+  }
+};
+
+export const archiveAllRead = async ({
+  emitter,
+  inboxService,
+  notificationsCache,
+  tags,
+}: {
+  emitter: NovuEventEmitter;
+  inboxService: InboxService;
+  notificationsCache: NotificationsCache;
+  tags?: NotificationFilter['tags'];
+}): Result<void> => {
+  try {
+    const notifications = notificationsCache.getUniqueNotifications({ tags });
+    const optimisticNotifications = notifications.map((notification) => {
+      if (notification.isRead) {
+        return new Notification({ ...notification, isArchived: true, archivedAt: new Date().toISOString() });
+      }
+
+      return notification;
+    });
+    emitter.emit('notifications.archive_all_read.pending', { args: { tags }, data: optimisticNotifications });
+
+    await inboxService.archiveAllRead({ tags });
+
+    emitter.emit('notifications.archive_all_read.resolved', { args: { tags }, data: optimisticNotifications });
+
+    return {};
+  } catch (error) {
+    emitter.emit('notifications.archive_all_read.resolved', { args: { tags }, error });
+
+    return { error: new NovuError('Failed to archive all read notifications', error) };
   }
 };

--- a/packages/js/src/notifications/notifications.ts
+++ b/packages/js/src/notifications/notifications.ts
@@ -34,21 +34,21 @@ import { NovuError } from '../utils/errors';
 import { NotificationsCache } from '../cache';
 
 export class Notifications extends BaseModule {
+  #useCache: boolean;
+
   readonly #notificationsCache: NotificationsCache;
 
-  constructor() {
+  constructor({ useCache }: { useCache: boolean }) {
     super();
     this.#notificationsCache = new NotificationsCache();
+    this.#useCache = useCache;
   }
 
-  async list(
-    { limit = 10, ...restOptions }: ListNotificationsArgs = {},
-    options: { cache: boolean } = { cache: true }
-  ): Result<ListNotificationsResponse> {
+  async list({ limit = 10, ...restOptions }: ListNotificationsArgs = {}): Result<ListNotificationsResponse> {
     return this.callWithSession(async () => {
       const args = { limit, ...restOptions };
       try {
-        let data: ListNotificationsResponse | undefined = options.cache
+        let data: ListNotificationsResponse | undefined = this.#useCache
           ? this.#notificationsCache.getAll(args)
           : undefined;
 
@@ -64,7 +64,7 @@ export class Notifications extends BaseModule {
             notifications: response.data.map((el) => new Notification(el)),
           };
 
-          if (options.cache) {
+          if (this.#useCache) {
             this.#notificationsCache.set(args, data);
             data = this.#notificationsCache.getAll(args);
           }

--- a/packages/js/src/notifications/notifications.ts
+++ b/packages/js/src/notifications/notifications.ts
@@ -1,6 +1,16 @@
 import { BaseModule } from '../base-module';
 import { ActionTypeEnum, NotificationFilter, Result } from '../types';
-import { archive, completeAction, read, revertAction, unarchive, unread } from './helpers';
+import {
+  archive,
+  archiveAll,
+  archiveAllRead,
+  completeAction,
+  read,
+  readAll,
+  revertAction,
+  unarchive,
+  unread,
+} from './helpers';
 import { Notification } from './notification';
 import type {
   ArchivedArgs,
@@ -21,28 +31,48 @@ import type {
   BaseArgs,
 } from './types';
 import { NovuError } from '../utils/errors';
+import { NotificationsCache } from '../cache';
 
 export class Notifications extends BaseModule {
-  async list({ limit = 10, ...restOptions }: ListNotificationsArgs = {}): Result<ListNotificationsResponse> {
+  readonly #notificationsCache: NotificationsCache;
+
+  constructor() {
+    super();
+    this.#notificationsCache = new NotificationsCache();
+  }
+
+  async list(
+    { limit = 10, ...restOptions }: ListNotificationsArgs = {},
+    options: { cache: boolean } = { cache: true }
+  ): Result<ListNotificationsResponse> {
     return this.callWithSession(async () => {
       const args = { limit, ...restOptions };
       try {
-        this._emitter.emit('notifications.list.pending', { args });
+        let data: ListNotificationsResponse | undefined = options.cache
+          ? this.#notificationsCache.getAll(args)
+          : undefined;
 
-        const response = await this._inboxService.fetchNotifications({
-          limit,
-          ...restOptions,
-        });
+        if (!data) {
+          const response = await this._inboxService.fetchNotifications({
+            limit,
+            ...restOptions,
+          });
 
-        const modifiedResponse: ListNotificationsResponse = {
-          hasMore: response.hasMore,
-          filter: response.filter,
-          notifications: response.data.map((el) => new Notification(el)),
-        };
+          data = {
+            hasMore: response.hasMore,
+            filter: response.filter,
+            notifications: response.data.map((el) => new Notification(el)),
+          };
 
-        this._emitter.emit('notifications.list.resolved', { args, data: modifiedResponse });
+          if (options.cache) {
+            this.#notificationsCache.set(args, data);
+            data = this.#notificationsCache.getAll(args);
+          }
+        }
 
-        return { data: modifiedResponse };
+        this._emitter.emit('notifications.list.resolved', { args, data });
+
+        return { data };
       } catch (error) {
         this._emitter.emit('notifications.list.resolved', { args, error });
 
@@ -181,56 +211,35 @@ export class Notifications extends BaseModule {
   }
 
   async readAll({ tags }: { tags?: NotificationFilter['tags'] } = {}): Result<void> {
-    return this.callWithSession(async () => {
-      try {
-        this._emitter.emit('notifications.read_all.pending', { args: { tags } });
-
-        await this._inboxService.readAll({ tags });
-
-        this._emitter.emit('notifications.read_all.resolved', { args: { tags } });
-
-        return {};
-      } catch (error) {
-        this._emitter.emit('notifications.read_all.resolved', { args: { tags }, error });
-
-        return { error: new NovuError('Failed to read all notifications', error) };
-      }
-    });
+    return this.callWithSession(async () =>
+      readAll({
+        emitter: this._emitter,
+        inboxService: this._inboxService,
+        notificationsCache: this.#notificationsCache,
+        tags,
+      })
+    );
   }
 
   async archiveAll({ tags }: { tags?: NotificationFilter['tags'] } = {}): Result<void> {
-    return this.callWithSession(async () => {
-      try {
-        this._emitter.emit('notifications.archive_all.pending', { args: { tags } });
-
-        await this._inboxService.archiveAll({ tags });
-
-        this._emitter.emit('notifications.archive_all.resolved', { args: { tags } });
-
-        return {};
-      } catch (error) {
-        this._emitter.emit('notifications.archive_all.resolved', { args: { tags }, error });
-
-        return { error: new NovuError('Failed to archive all notifications', error) };
-      }
-    });
+    return this.callWithSession(async () =>
+      archiveAll({
+        emitter: this._emitter,
+        inboxService: this._inboxService,
+        notificationsCache: this.#notificationsCache,
+        tags,
+      })
+    );
   }
 
   async archiveAllRead({ tags }: { tags?: NotificationFilter['tags'] } = {}): Result<void> {
-    return this.callWithSession(async () => {
-      try {
-        this._emitter.emit('notifications.archive_all_read.pending', { args: { tags } });
-
-        await this._inboxService.archiveAllRead({ tags });
-
-        this._emitter.emit('notifications.archive_all_read.resolved', { args: { tags } });
-
-        return {};
-      } catch (error) {
-        this._emitter.emit('notifications.archive_all_read.resolved', { args: { tags }, error });
-
-        return { error: new NovuError('Failed to archive all read notifications', error) };
-      }
-    });
+    return this.callWithSession(async () =>
+      archiveAllRead({
+        emitter: this._emitter,
+        inboxService: this._inboxService,
+        notificationsCache: this.#notificationsCache,
+        tags,
+      })
+    );
   }
 }

--- a/packages/js/src/novu.ts
+++ b/packages/js/src/novu.ts
@@ -13,6 +13,7 @@ export type NovuOptions = {
   subscriberHash?: string;
   backendUrl?: string;
   socketUrl?: string;
+  useCache?: boolean;
 };
 
 export class Novu implements Pick<NovuEventEmitter, 'on' | 'off'> {
@@ -32,7 +33,7 @@ export class Novu implements Pick<NovuEventEmitter, 'on' | 'off'> {
       subscriberHash: options.subscriberHash,
     });
     this.#session.initialize();
-    this.notifications = new Notifications();
+    this.notifications = new Notifications({ useCache: options.useCache ?? true });
     this.preferences = new Preferences();
     this.#socket = new Socket({ socketUrl: options.socketUrl });
   }

--- a/packages/js/src/ui/components/Inbox.tsx
+++ b/packages/js/src/ui/components/Inbox.tsx
@@ -50,6 +50,7 @@ const InboxContent = (props: InboxContentProps) => {
                 onNotificationClick={props.onNotificationClick}
                 onPrimaryActionClick={props.onPrimaryActionClick}
                 onSecondaryActionClick={props.onSecondaryActionClick}
+                options={{ archived: false }}
               />
             }
           >

--- a/packages/js/src/ui/components/InboxTabs/InboxTabs.tsx
+++ b/packages/js/src/ui/components/InboxTabs/InboxTabs.tsx
@@ -103,7 +103,7 @@ export const InboxTabs = (props: InboxTabsProps) => {
             cn(activeTab() === tab.label ? 'nt-block' : 'nt-hidden', 'nt-flex-1 nt-overflow-hidden')
           )}
         >
-          <NotificationList options={{ tags: tab.value }} />
+          <NotificationList options={{ tags: tab.value, archived: false }} />
         </Tabs.Content>
       ))}
     </Tabs.Root>

--- a/packages/js/src/ui/components/Notification/DefaultNotification.tsx
+++ b/packages/js/src/ui/components/Notification/DefaultNotification.tsx
@@ -95,12 +95,12 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
             fallback={
               <Tooltip.Root>
                 <Tooltip.Trigger
-                  asChild={(props) => (
+                  asChild={(childProps) => (
                     <Button
                       appearanceKey="notificationRead__button"
                       size="icon"
                       variant="icon"
-                      {...props}
+                      {...childProps}
                       onClick={() => {
                         props.notification.read();
                       }}
@@ -115,12 +115,12 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
           >
             <Tooltip.Root>
               <Tooltip.Trigger
-                asChild={(props) => (
+                asChild={(childProps) => (
                   <Button
                     appearanceKey="notificationUnread__button"
                     size="icon"
                     variant="icon"
-                    {...props}
+                    {...childProps}
                     onClick={() => {
                       props.notification.unread();
                     }}
@@ -137,12 +137,12 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
             fallback={
               <Tooltip.Root>
                 <Tooltip.Trigger
-                  asChild={(props) => (
+                  asChild={(childProps) => (
                     <Button
                       appearanceKey="notificationArchive__button"
                       size="icon"
                       variant="icon"
-                      {...props}
+                      {...childProps}
                       onClick={() => {
                         props.notification.archive();
                       }}
@@ -157,12 +157,12 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
           >
             <Tooltip.Root>
               <Tooltip.Trigger
-                asChild={(props) => (
+                asChild={(childProps) => (
                   <Button
                     appearanceKey="notificationUnarchive__button"
                     size="icon"
                     variant="icon"
-                    {...props}
+                    {...childProps}
                     onClick={() => {
                       props.notification.unarchive();
                     }}

--- a/packages/js/src/ui/components/Notification/DefaultNotification.tsx
+++ b/packages/js/src/ui/components/Notification/DefaultNotification.tsx
@@ -96,7 +96,15 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
               <Tooltip.Root>
                 <Tooltip.Trigger
                   asChild={(props) => (
-                    <Button appearanceKey="notificationRead__button" size="icon" variant="icon" {...props}>
+                    <Button
+                      appearanceKey="notificationRead__button"
+                      size="icon"
+                      variant="icon"
+                      {...props}
+                      onClick={() => {
+                        props.notification.read();
+                      }}
+                    >
                       <ReadAll />
                     </Button>
                   )}
@@ -108,7 +116,15 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
             <Tooltip.Root>
               <Tooltip.Trigger
                 asChild={(props) => (
-                  <Button appearanceKey="notificationUnread__button" size="icon" variant="icon" {...props}>
+                  <Button
+                    appearanceKey="notificationUnread__button"
+                    size="icon"
+                    variant="icon"
+                    {...props}
+                    onClick={() => {
+                      props.notification.unread();
+                    }}
+                  >
                     <Unread />
                   </Button>
                 )}
@@ -122,7 +138,15 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
               <Tooltip.Root>
                 <Tooltip.Trigger
                   asChild={(props) => (
-                    <Button appearanceKey="notificationArchive__button" size="icon" variant="icon" {...props}>
+                    <Button
+                      appearanceKey="notificationArchive__button"
+                      size="icon"
+                      variant="icon"
+                      {...props}
+                      onClick={() => {
+                        props.notification.archive();
+                      }}
+                    >
                       <Archive />
                     </Button>
                   )}
@@ -134,7 +158,15 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
             <Tooltip.Root>
               <Tooltip.Trigger
                 asChild={(props) => (
-                  <Button appearanceKey="notificationUnarchive__button" size="icon" variant="icon" {...props}>
+                  <Button
+                    appearanceKey="notificationUnarchive__button"
+                    size="icon"
+                    variant="icon"
+                    {...props}
+                    onClick={() => {
+                      props.notification.unarchive();
+                    }}
+                  >
                     <Unarchive />
                   </Button>
                 )}

--- a/packages/js/src/ui/components/Notification/NotificationList.tsx
+++ b/packages/js/src/ui/components/Notification/NotificationList.tsx
@@ -46,7 +46,7 @@ type NotificationListProps = {
 };
 /* This is also going to be exported as a separate component. Keep it pure. */
 export const NotificationList = (props: NotificationListProps) => {
-  const [data, { initialLoading, setEl, end }] = useNotificationsInfiniteScroll({ options: props.options });
+  const { data, initialLoading, setEl, end } = useNotificationsInfiniteScroll({ options: props.options });
 
   return (
     <Show when={!initialLoading()} fallback={<NotificationListSkeleton count={8} />}>

--- a/packages/js/src/ui/helpers/createInfiniteScroll.ts
+++ b/packages/js/src/ui/helpers/createInfiniteScroll.ts
@@ -1,4 +1,4 @@
-import { Accessor, batch, createComputed, createResource, createSignal, onCleanup } from 'solid-js';
+import { Accessor, batch, createComputed, createResource, createSignal, onCleanup, Setter } from 'solid-js';
 import { isServer } from 'solid-js/web';
 
 export function createInfiniteScroll<T>(fetcher: (page: number) => Promise<{ data: T[]; hasMore: boolean }>): [
@@ -8,13 +8,20 @@ export function createInfiniteScroll<T>(fetcher: (page: number) => Promise<{ dat
     setEl: (el: Element) => void;
     offset: Accessor<number>;
     end: Accessor<boolean>;
+    mutate: Setter<
+      | {
+          data: T[];
+          hasMore: boolean;
+        }
+      | undefined
+    >;
   }
 ] {
   const [data, setData] = createSignal<T[]>([]);
   const [initialLoading, setInitialLoading] = createSignal(true);
   const [offset, setOffset] = createSignal(0);
   const [end, setEnd] = createSignal(false);
-  const [contents] = createResource(offset, fetcher);
+  const [contents, { mutate }] = createResource(offset, fetcher);
 
   let setEl: (el: Element) => void = () => {};
   if (!isServer) {
@@ -33,10 +40,11 @@ export function createInfiniteScroll<T>(fetcher: (page: number) => Promise<{ dat
   createComputed(() => {
     const content = contents.latest;
     if (!content) return;
+
     setInitialLoading(false);
     batch(() => {
       if (!content.hasMore) setEnd(true);
-      setData((p) => [...p, ...content.data]);
+      setData(content.data);
     });
   });
 
@@ -47,6 +55,7 @@ export function createInfiniteScroll<T>(fetcher: (page: number) => Promise<{ dat
       setEl,
       offset: offset,
       end: end,
+      mutate,
     },
   ];
 }

--- a/packages/js/src/utils/arrays.ts
+++ b/packages/js/src/utils/arrays.ts
@@ -1,0 +1,15 @@
+export const arrayValuesEqual = (arr1?: Array<unknown>, arr2?: Array<unknown>) => {
+  if (arr1 === arr2) {
+    return true;
+  }
+
+  if (!arr1 || !arr2) {
+    return false;
+  }
+
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+
+  return arr1.every((value, index) => value === arr2[index]);
+};

--- a/packages/js/src/utils/notification-utils.ts
+++ b/packages/js/src/utils/notification-utils.ts
@@ -1,4 +1,13 @@
-import { NotificationStatus } from '../types';
+import { NotificationFilter, NotificationStatus } from '../types';
+import { arrayValuesEqual } from './arrays';
 
 export const SEEN_OR_UNSEEN = [NotificationStatus.SEEN, NotificationStatus.UNSEEN];
 export const READ_OR_UNREAD = [NotificationStatus.READ, NotificationStatus.UNREAD];
+
+export const isSameFilter = (filter1: NotificationFilter, filter2: NotificationFilter) => {
+  return (
+    arrayValuesEqual(filter1.tags, filter2.tags) &&
+    filter1.read === filter2.read &&
+    filter1.archived === filter2.archived
+  );
+};

--- a/packages/js/src/utils/notification-utils.ts
+++ b/packages/js/src/utils/notification-utils.ts
@@ -4,10 +4,12 @@ import { arrayValuesEqual } from './arrays';
 export const SEEN_OR_UNSEEN = [NotificationStatus.SEEN, NotificationStatus.UNSEEN];
 export const READ_OR_UNREAD = [NotificationStatus.READ, NotificationStatus.UNREAD];
 
+export const areTagsEqual = (tags1?: string[], tags2?: string[]) => {
+  return arrayValuesEqual(tags1, tags2) || (!tags1 && tags2?.length === 0) || (tags1?.length === 0 && !tags2);
+};
+
 export const isSameFilter = (filter1: NotificationFilter, filter2: NotificationFilter) => {
   return (
-    arrayValuesEqual(filter1.tags, filter2.tags) &&
-    filter1.read === filter2.read &&
-    filter1.archived === filter2.archived
+    areTagsEqual(filter1.tags, filter2.tags) && filter1.read === filter2.read && filter1.archived === filter2.archived
   );
 };


### PR DESCRIPTION
### What changed? Why was the change needed?

The notifications in-memory cache:
- stores data in memory
- supports multiple filters aka tabs
- is listening to the notification events like mark as read/unread/archive/unarchive, action button events, and mark all events and updates optimistically data in the cache for any/all filters
- emits events for all updated filters whenever a notification is updated
- updates or removes notifications in the cache depending on the "action"

The cache structure:
```
{
  `${JSON.stringify(filter1 + page1)}`: { ..., notification: [] },
  `${JSON.stringify(filter1 + page2)}`: { ..., notification: [] },
  `${JSON.stringify(filter2 + page1)}`: { ..., notification: [] },
  `${JSON.stringify(filter2 + page1)}`: { ..., notification: [] },
}
```

UI changes:
- the infinite scroll updates to listen to the emitted events
- mark as actions assigned

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
