### PR TITLE
fix(api): Remove admin check and track always

### DIFF
--- a/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/update-subscriber-preference/update-subscriber-preference.usecase.ts
@@ -40,16 +40,13 @@ export class UpdateSubscriberPreference {
       _templateId: command.templateId,
     });
 
-    const admin = await this.memberRepository.getOrganizationAdminAccount(command.organizationId);
-    if (admin) {
-      this.analyticsService.mixpanelTrack('Update User Preference - [Notification Center]', '', {
-        _organization: command.organizationId,
-        _subscriber: subscriber._id,
-        _template: command.templateId,
-        channel: command.channel?.type,
-        enabled: command.channel?.enabled,
-      });
-    }
+    this.analyticsService.mixpanelTrack('Update User Preference - [Notification Center]', '', {
+      _organization: command.organizationId,
+      _subscriber: subscriber._id,
+      _template: command.templateId,
+      channel: command.channel?.type,
+      enabled: command.channel?.enabled,
+    });
 
     if (!userPreference) {
       await this.createUserPreference(command, subscriber);


### PR DESCRIPTION
### What changed? Why was the change needed?

Every organization should have at least one admin, so the check shouldn't be necessary.