### PR TITLE
fix(web): pre-login email denormalization when using pass manager

### DIFF
--- a/apps/web/src/ee/clerk/providers/clerk-singleton.ts
+++ b/apps/web/src/ee/clerk/providers/clerk-singleton.ts
@@ -19,9 +19,10 @@ export async function buildClerk({ publishableKey }: BuildClerkOptions): Promise
   clerk.__unstable__onBeforeRequest(async (requestInit) => {
     const { path, method, body } = requestInit;
     const isSignIn = path === '/client/sign_ins' && method === 'POST';
-    const isRegularSignIn = isSignIn && !getParamFromQuery(body as string, 'strategy');
+    const isPasswordStrategy =
+      getParamFromQuery(body as string, 'strategy') === 'password' || !getParamFromQuery(body as string, 'strategy');
 
-    if (isRegularSignIn) {
+    if (isSignIn && isPasswordStrategy) {
       const email = getParamFromQuery(body as string, 'identifier');
       if (email && email !== normalizeEmail(email)) {
         await normalizeEmailData(email);


### PR DESCRIPTION
### What changed? Why was the change needed?
Intercepted Clerk request contains also `strategy=password` when using login via password manager. In regular email -> password 2-step login, it does not.