### PR TITLE
chore(root): Production deployment fixes

### DIFF
--- a/.github/workflows/dev-deploy-ws.yml
+++ b/.github/workflows/dev-deploy-ws.yml
@@ -55,11 +55,6 @@ jobs:
               }
             }
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
-
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -13,7 +13,7 @@ jobs:
     environment: Production
     strategy:
       matrix:
-        name: [ 'novu/api-ee', 'novu/api' ]
+        name: [ 'novu/api-ee' ]
     outputs:
       docker_image: ${{ steps.build-image.outputs.IMAGE }}
     permissions:
@@ -42,11 +42,6 @@ jobs:
                 "containerd-snapshotter": true
               }
             }
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
 
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/prod-deploy-webhook.yml
+++ b/.github/workflows/prod-deploy-webhook.yml
@@ -6,11 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_webhook:
-    uses: ./.github/workflows/reusable-webhook-e2e.yml
-  
   publish_docker_image_webhook:
-    needs: test_webhook
     uses: ./.github/workflows/reusable-docker.yml
     with:
       environment: Production

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -6,21 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_worker:
-    strategy:
-      # The order is important for ee to be first, otherwise outputs not work correctly
-      matrix:
-        name: [ 'novu/worker-ee', 'novu/worker' ]
-    uses: ./.github/workflows/reusable-worker-e2e.yml
-    with:
-      ee: ${{ contains (matrix.name,'-ee') }}
-    secrets: inherit
-
   build_prod_image:
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    needs: test_worker
     timeout-minutes: 80
     environment: Production
     strategy:
@@ -55,11 +43,6 @@ jobs:
                 "containerd-snapshotter": true
               }
             }
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
 
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -6,26 +6,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_ws:
-    strategy:
-      matrix:
-        name: [ 'novu/ws-ee', 'novu/ws' ]
-    uses: ./.github/workflows/reusable-ws-e2e.yml
-    with:
-      ee: ${{ contains (matrix.name,'-ee') }}
-    secrets: inherit
-
   # This workflow contains a single job called "build"
   build_prod_image:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     timeout-minutes: 80
     environment: Production
-    needs:
-      - test_ws
     strategy:
       matrix:
-        name: [ 'novu/ws-ee', 'novu/ws' ]
+        name: [ 'novu/ws-ee' ]
     outputs:
       docker_image: ${{ steps.build-image.outputs.IMAGE }}
     steps:


### PR DESCRIPTION
### What changed? Why was the change needed?
1. Build only EE version for Cloud
2. Do not run test during production deployment, run them before
