### PR TITLE
fix(worker, application-generic): Remove In-App message lookup for stateless Workflows

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
@@ -169,6 +169,7 @@ export class SendMessageInApp extends SendMessageBase {
       oldMessage = await this.messageRepository.findOne({
         _notificationId: command.notificationId,
         _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
         _subscriberId: command._subscriberId,
         _templateId: command._templateId,
         _messageTemplateId: step.template._id,
@@ -212,6 +213,7 @@ export class SendMessageInApp extends SendMessageBase {
     if (!oldMessage) {
       message = await this.messageRepository.create({
         _notificationId: command.notificationId,
+        _organizationId: command.organizationId,
         _environmentId: command.environmentId,
         _subscriberId: command._subscriberId,
         _templateId: command._templateId,

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.command.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.command.ts
@@ -28,7 +28,7 @@ export class SendMessageCommand extends EnvironmentWithUserCommand {
   notificationId: string;
 
   @IsOptional()
-  _templateId: string;
+  _templateId?: string;
 
   @IsDefined()
   subscriberId: string;

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
@@ -120,7 +120,9 @@ export class ExecuteBridgeRequest {
         } else {
           // Handle unknown bridge request errors
           Logger.error(
-            `Unknown bridge request error calling \`${url}\`: \`${body}\``,
+            `Unknown bridge request error calling \`${url}\`: \`${JSON.stringify(
+              body
+            )}\``,
             LOG_CONTEXT
           );
           throw error;


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Remove In-App message lookup for stateless Workflows
  * In-app messages support edit after delivery by modifying the message entity if it already exists in the database. Stateless Workflows do not persist Workflow (formerly Template) and Step (formerly NotificationTemplate) entities and therefore have undefined identifiers. During in-app message delivery, Stateless Workflows with multiple in-app steps were retrieving the Message entity of the previous in-app step in the same Workflow due to the Workflow and Step identifiers being undefined. This retrieved Message entity meant the logic to create a new message was never executed, the effect being that Stateless Workflow executions with multiple in-app steps only ever had 1 in-app message delivered.
  * This issue didn't surface at compile because the database repository typings are broken, allowing for `any | undefined` attributes to be passed in
* Add tests for double in-app Workflows

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_TDD (before)_
```bash
    1) should store 2 in-app messages for a single notification event [stateless]


  1 passing (3s)
  1 failing

  1) Bridge Trigger
       should store 2 in-app messages for a single notification event [stateless]:

      AssertionError: expected 1 to equal 2
      + expected - actual

      -1
      +2
      
      at /Users/rifont/git/novu/apps/api/src/app/events/e2e/bridge-trigger.e2e.ts:707:41
      at Generator.next (<anonymous>)
      at fulfilled (src/app/events/e2e/bridge-trigger.e2e.ts:5:58)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

_TDD (after)_
```bash
    ✔ should store 2 in-app messages for a single notification event [stateless] (149ms)


  2 passing (2s)
```

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
