### PR TITLE
feat(web): mark trigger as loading for until playground init

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -85,9 +85,7 @@
       },
       "dependsOn": [
         "SHARED",
-        "API",
-        "DESIGN SYSTEM",
-        "NOVUI"
+        "API"
       ]
     },
     {

--- a/apps/web/src/pages/playground/onboarding/PlaygroundHeader.tsx
+++ b/apps/web/src/pages/playground/onboarding/PlaygroundHeader.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Button } from '@novu/novui';
 import { useSegment } from '../../../components/providers/SegmentProvider';
 import { css } from '@novu/novui/css';
-import { navigateToWorkflows } from '../../../utils/playground-navigation';
+import { navigateToGetStarted } from '../../../utils/playground-navigation';
 import { HStack } from '@novu/novui/jsx';
 import { useStudioState } from '../../../studio/StudioStateProvider';
 import { useDisclosure } from '@mantine/hooks';
@@ -15,7 +15,7 @@ export function Header({ handleTestClick }: { handleTestClick: () => Promise<any
   const [isTestRan, setTestTestRan] = useState(false);
 
   const handleContinue = () => {
-    navigateToWorkflows();
+    navigateToGetStarted();
 
     if (isTestRan) {
       segment.track('Playground Continue Clicked - [Playground]', {

--- a/apps/web/src/pages/playground/onboarding/PlaygroundHeader.tsx
+++ b/apps/web/src/pages/playground/onboarding/PlaygroundHeader.tsx
@@ -8,6 +8,7 @@ import { useStudioState } from '../../../studio/StudioStateProvider';
 import { useDisclosure } from '@mantine/hooks';
 import { IconPlayArrow, successMessage, errorMessage, Tooltip } from '@novu/design-system';
 import { ExecutionDetailsModalWrapper } from '../../templates/components/ExecutionDetailsModalWrapper';
+import { useContainer } from '../../../hooks/useContainer';
 
 export function Header({ handleTestClick }: { handleTestClick: () => Promise<any> }) {
   const segment = useSegment();
@@ -91,6 +92,7 @@ const TriggerActionModal = ({
   handleTestClick: () => Promise<any>;
   onTestRun: () => void;
 }) => {
+  const { isBridgeAppLoading } = useContainer();
   const studioState = useStudioState() || {};
   const [transactionId, setTransactionId] = useState<string>('');
   const [executionModalOpened, { close: closeExecutionModal, open: openExecutionModal }] = useDisclosure(false);
@@ -129,9 +131,9 @@ const TriggerActionModal = ({
           size="sm"
           Icon={IconPlayArrow}
           onClick={handleOnRunTestClick}
-          loading={isLoading}
+          loading={isLoading || isBridgeAppLoading}
         >
-          Run a test
+          Trigger Workflow
         </Button>
       </Tooltip>
       <ExecutionDetailsModalWrapper

--- a/apps/web/src/utils/playground-navigation.ts
+++ b/apps/web/src/utils/playground-navigation.ts
@@ -19,6 +19,14 @@ export const navigateToWorkflows = () => {
 
 /**
  * Note: Do not use client-side navigation (react-router-dom),
+ * because we need to create new default headers for the dashboard.
+ */
+export const navigateToGetStarted = () => {
+  window.location.replace(window.location.origin + ROUTES.GET_STARTED);
+};
+
+/**
+ * Note: Do not use client-side navigation (react-router-dom),
  * because we need to create new default headers for the onboarding playground.
  */
 export const navigatePlayground = () => {


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

Add a loader state for trigger button during playground init.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
