### PR TITLE
fix(node): Remove bridge URL generation for Next.js preview deployments

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/node",
-  "version": "2.0.0-canary.0",
+  "version": "2.0.0-canary.1",
   "description": "Notification Management Framework",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/packages/node/src/lib/events/events.spec.ts
+++ b/packages/node/src/lib/events/events.spec.ts
@@ -37,32 +37,6 @@ describe('test use of novus node package - Events', () => {
     });
   });
 
-  test('should generate bridge URL correctly', async () => {
-    mockedAxios.post.mockResolvedValue({});
-    process.env.NEXT_PUBLIC_VERCEL_URL = 'example.com';
-    const expectedUrl = `https://${process.env.NEXT_PUBLIC_VERCEL_URL}/api/novu`;
-
-    await novu.events.trigger('test-template', {
-      to: 'test-user',
-      payload: {
-        email: 'test-user@sd.com',
-      },
-    });
-
-    expect(mockedAxios.post).toHaveBeenCalled();
-    expect(mockedAxios.post).toHaveBeenCalledWith('/events/trigger', {
-      name: 'test-template',
-      to: 'test-user',
-      overrides: {},
-      payload: {
-        email: 'test-user@sd.com',
-      },
-      bridgeUrl: expectedUrl,
-    });
-
-    delete process.env.NEXT_PUBLIC_VERCEL_URL;
-  });
-
   test('should broadcast correctly', async () => {
     mockedAxios.post.mockResolvedValue({});
 

--- a/packages/node/src/lib/events/events.ts
+++ b/packages/node/src/lib/events/events.ts
@@ -8,10 +8,6 @@ import { WithHttp } from '../novu.interface';
 
 export class Events extends WithHttp implements IEvents {
   async trigger(workflowIdentifier: string, data: ITriggerPayloadOptions) {
-    if (!data.bridgeUrl && process.env.NEXT_PUBLIC_VERCEL_URL) {
-      data.bridgeUrl = `https://${process.env.NEXT_PUBLIC_VERCEL_URL}/api/novu`;
-    }
-
     return await this.http.post(`/events/trigger`, {
       name: workflowIdentifier,
       to: data.to,


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Remove bridge URL generation for Next.js preview deployments. This internal helper was causing V1 workflows to be executed against the bridge endpoint. The recommendation is to use `@novu/framework` with the `myWorkflow.trigger(...)` syntax to target V2 workflows only

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
