### PR TITLE
fix(headless): dont refetch notifications

### DIFF
--- a/packages/headless/src/lib/headless.service.test.ts
+++ b/packages/headless/src/lib/headless.service.test.ts
@@ -577,7 +577,7 @@ describe('headless.service', () => {
       });
       await promiseResolveTimeout(0);
 
-      expect(mockServiceInstance.getNotificationsList).toBeCalledTimes(3);
+      expect(mockServiceInstance.getNotificationsList).toBeCalledTimes(2);
       expect(notificationsListener).toHaveBeenCalledTimes(8);
       expect(notificationsListener).toHaveBeenNthCalledWith(
         4,

--- a/packages/headless/src/lib/headless.service.test.ts
+++ b/packages/headless/src/lib/headless.service.test.ts
@@ -578,7 +578,7 @@ describe('headless.service', () => {
       await promiseResolveTimeout(0);
 
       expect(mockServiceInstance.getNotificationsList).toBeCalledTimes(2);
-      expect(notificationsListener).toHaveBeenCalledTimes(8);
+      expect(notificationsListener).toHaveBeenCalledTimes(6);
       expect(notificationsListener).toHaveBeenNthCalledWith(
         4,
         expect.objectContaining({

--- a/packages/headless/src/lib/headless.service.ts
+++ b/packages/headless/src/lib/headless.service.ts
@@ -337,9 +337,6 @@ export class HeadlessService {
         WebSocketEventEnum.RECEIVED,
         (data?: { message: IMessage }) => {
           if (data?.message) {
-            this.queryClient.refetchQueries(NOTIFICATIONS_QUERY_KEY, {
-              exact: false,
-            });
             listener(data.message);
           }
         }


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
- remove auto fetch for notifications when new notification received event is triggered
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
