### PR TITLE
fix(web): Styling of SMS bubble

### DIFF
--- a/apps/web/src/components/workflow/preview/sms/SmsBubble.styles.tsx
+++ b/apps/web/src/components/workflow/preview/sms/SmsBubble.styles.tsx
@@ -52,6 +52,7 @@ export const BubbleText = styled(Text)`
   overflow: hidden;
   margin: 0;
   color: ${colors.white};
+  word-break: break-word;
 `;
 
 export const Delivered = styled.span`


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

https://linear.app/novu/issue/NV-4154/sms-preview-screen-overflows-with-long-url

- Fix styling of extra long strings

### Screenshots

<img width="431" alt="Screenshot 2024-08-12 at 4 32 23 PM" src="https://github.com/user-attachments/assets/5bea9825-acd2-4a7c-882b-f819ba568df9">
