### PR TITLE
style(web, novui): Add custom scrollbar styling and remove workflow preview overflow

### DIFF
--- a/apps/web/src/pages/get-started/GetStartedPage.tsx
+++ b/apps/web/src/pages/get-started/GetStartedPage.tsx
@@ -31,7 +31,7 @@ export function GetStartedPage() {
   };
 
   return (
-    <PageContainer>
+    <PageContainer className={css({ overflowY: 'auto' })}>
       <div
         className={css({
           maxWidth: '1000px',

--- a/apps/web/src/pages/templates/editor_v2/TemplateDetailsPageV2.tsx
+++ b/apps/web/src/pages/templates/editor_v2/TemplateDetailsPageV2.tsx
@@ -39,7 +39,7 @@ export const TemplateDetailsPageV2 = () => {
 
   return (
     <WorkflowsPageTemplate
-      className={css({ p: 0, paddingBlockStart: 0, overflowY: 'hidden' })}
+      className={css({ p: 0, paddingBlockStart: 0, overflowY: 'auto' })}
       icon={<IconCable size="32" />}
       title={title}
       actions={

--- a/apps/web/src/studio/components/workflows/node-view/WorkflowsDetailPage.tsx
+++ b/apps/web/src/studio/components/workflows/node-view/WorkflowsDetailPage.tsx
@@ -37,7 +37,7 @@ export const WorkflowsDetailPage = () => {
 
   return (
     <WorkflowsPageTemplate
-      className={css({ p: 0, paddingBlockStart: 0, overflowY: 'hidden' })}
+      className={css({ p: 0, paddingBlockStart: 0, overflowY: 'auto' })}
       icon={<IconCable size="32" />}
       title={title}
       actions={

--- a/apps/web/src/studio/components/workflows/step-editor/WorkflowStepEditorControlsPanel.tsx
+++ b/apps/web/src/studio/components/workflows/step-editor/WorkflowStepEditorControlsPanel.tsx
@@ -142,7 +142,7 @@ export const WorkflowStepEditorControlsPanel: FC<IWorkflowStepEditorControlsPane
 };
 
 export const formContainerClassName = css({
-  h: '80vh',
-  overflowY: 'auto !important',
+  h: '72vh',
+  overflowY: 'auto',
   scrollbar: 'hidden',
 });

--- a/apps/web/src/studio/layout/PageContainer.tsx
+++ b/apps/web/src/studio/layout/PageContainer.tsx
@@ -10,7 +10,6 @@ export const PageContainer: FC<PropsWithChildren<IPageContainerProps>> = ({ chil
     <Container
       className={cx(
         css({
-          overflowY: 'auto !important',
           borderRadius: '0',
           px: 'paddings.page.horizontal',
           py: 'paddings.page.vertical',

--- a/apps/web/src/studio/layout/PageContainer.tsx
+++ b/apps/web/src/studio/layout/PageContainer.tsx
@@ -10,6 +10,7 @@ export const PageContainer: FC<PropsWithChildren<IPageContainerProps>> = ({ chil
     <Container
       className={cx(
         css({
+          overflowX: 'hidden',
           borderRadius: '0',
           px: 'paddings.page.horizontal',
           py: 'paddings.page.vertical',

--- a/libs/novui/src/global.styles.ts
+++ b/libs/novui/src/global.styles.ts
@@ -1,4 +1,5 @@
 import { defineGlobalStyles } from '@pandacss/dev';
+import { LEGACY_COLOR_TOKENS } from './tokens/colors.tokens';
 
 export const GLOBAL_CSS = defineGlobalStyles({
   body: {
@@ -14,6 +15,11 @@ export const GLOBAL_CSS = defineGlobalStyles({
 
     backgroundColor: 'surface.page',
     overflow: 'hidden',
+    scrollbarWidth: 'thin',
+    scrollbarColor: {
+      base: `${LEGACY_COLOR_TOKENS.legacy.B80.value} transparent`,
+      _dark: `${LEGACY_COLOR_TOKENS.legacy.B30.value} transparent`,
+    },
   },
   a: {
     textDecoration: 'none',

--- a/libs/novui/src/global.styles.ts
+++ b/libs/novui/src/global.styles.ts
@@ -1,6 +1,4 @@
 import { defineGlobalStyles } from '@pandacss/dev';
-import { LEGACY_COLOR_TOKENS } from './tokens/colors.tokens';
-import { token } from '../styled-system/tokens';
 
 export const GLOBAL_CSS = defineGlobalStyles({
   body: {
@@ -16,30 +14,27 @@ export const GLOBAL_CSS = defineGlobalStyles({
 
     backgroundColor: 'surface.page',
     overflow: 'hidden',
-    scrollbarWidth: 'thin',
-    scrollbarColor: {
-      base: `${token('colors.legacy.B80')} transparent`,
-      _dark: `${token('colors.legacy.B30')} transparent`,
-    },
+    scrollbarWidth: '{sizes.scrollbar.width}',
+    scrollbarColor: '{colors.scrollbar.color}',
+    /* SAFARI SCROLLBAR SUPPORT - remove after Safari supports `scrollbar-width` and `scrollbar-color` */
     '::-webkit-scrollbar': {
-      width: '14px',
-      height: '14px',
+      width: '{sizes.scrollbar.track}',
+      height: '{sizes.scrollbar.track}',
     },
     '::-webkit-scrollbar-thumb': {
-      border: '3px solid transparent',
+      // For this calculation, see: https://stackoverflow.com/questions/11691718/css-webkit-scrollbar-and-safari
+      border: `calc(({sizes.scrollbar.track} - {sizes.scrollbar.thumb}) / 2) solid {colors.scrollbar.track}`,
+      borderRadius: '{sizes.scrollbar.thumb}',
       backgroundClip: 'padding-box',
-      borderRadius: '8px',
-      backgroundColor: {
-        base: `${token('colors.legacy.B80')}`,
-        _dark: `${token('colors.legacy.B30')}`,
-      },
+      backgroundColor: '{colors.scrollbar.thumb}',
     },
     '::-webkit-scrollbar-track': {
-      backgroundColor: 'transparent',
+      backgroundColor: '{colors.scrollbar.track}',
     },
     '::-webkit-scrollbar-corner': {
-      backgroundColor: 'transparent',
+      backgroundColor: '{colors.scrollbar.track}',
     },
+    /* END SAFARI SCROLLBAR SUPPORT */
   },
   a: {
     textDecoration: 'none',

--- a/libs/novui/src/global.styles.ts
+++ b/libs/novui/src/global.styles.ts
@@ -21,6 +21,25 @@ export const GLOBAL_CSS = defineGlobalStyles({
       base: `${token('colors.legacy.B80')} transparent`,
       _dark: `${token('colors.legacy.B30')} transparent`,
     },
+    '::-webkit-scrollbar': {
+      width: '14px',
+      height: '14px',
+    },
+    '::-webkit-scrollbar-thumb': {
+      border: '3px solid transparent',
+      backgroundClip: 'padding-box',
+      borderRadius: '8px',
+      backgroundColor: {
+        base: `${token('colors.legacy.B80')}`,
+        _dark: `${token('colors.legacy.B30')}`,
+      },
+    },
+    '::-webkit-scrollbar-track': {
+      backgroundColor: 'transparent',
+    },
+    '::-webkit-scrollbar-corner': {
+      backgroundColor: 'transparent',
+    },
   },
   a: {
     textDecoration: 'none',

--- a/libs/novui/src/global.styles.ts
+++ b/libs/novui/src/global.styles.ts
@@ -1,5 +1,6 @@
 import { defineGlobalStyles } from '@pandacss/dev';
 import { LEGACY_COLOR_TOKENS } from './tokens/colors.tokens';
+import { token } from '../styled-system/tokens';
 
 export const GLOBAL_CSS = defineGlobalStyles({
   body: {
@@ -17,8 +18,8 @@ export const GLOBAL_CSS = defineGlobalStyles({
     overflow: 'hidden',
     scrollbarWidth: 'thin',
     scrollbarColor: {
-      base: `${LEGACY_COLOR_TOKENS.legacy.B80.value} transparent`,
-      _dark: `${LEGACY_COLOR_TOKENS.legacy.B30.value} transparent`,
+      base: `${token('colors.legacy.B80')} transparent`,
+      _dark: `${token('colors.legacy.B30')} transparent`,
     },
   },
   a: {

--- a/libs/novui/src/tokens/semanticColors.tokens.ts
+++ b/libs/novui/src/tokens/semanticColors.tokens.ts
@@ -358,4 +358,18 @@ export const COLOR_SEMANTIC_TOKENS = defineSemanticTokens.colors({
       type: 'color',
     },
   },
+  scrollbar: {
+    color: {
+      value: '{colors.scrollbar.thumb} {colors.scrollbar.track}',
+      type: 'color',
+    },
+    track: {
+      value: { base: '{colors.transparent}', _dark: '{colors.transparent}' },
+      type: 'color',
+    },
+    thumb: {
+      value: { base: '{colors.legacy.B80}', _dark: '{colors.legacy.B30}' },
+      type: 'color',
+    },
+  },
 });

--- a/libs/novui/src/tokens/semanticSizes.tokens.ts
+++ b/libs/novui/src/tokens/semanticSizes.tokens.ts
@@ -46,4 +46,18 @@ export const SEMANTIC_SIZES_TOKENS = defineSemanticTokens.sizes({
     value: '{sizes.300}',
     type: 'sizes',
   },
+  scrollbar: {
+    width: {
+      value: 'thin',
+      type: 'sizes',
+    },
+    track: {
+      value: '14px', // equivalent to `thin` scrollbar width
+      type: 'sizes',
+    },
+    thumb: {
+      value: '8px', // equivalent to `thin` scrollbar width
+      type: 'sizes',
+    },
+  },
 });


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Remove overflow from `PageContainer` to remove scrolling by default
  * Add `overflowY: auto` to pages requiring scrollable content
* Add Panda Global CSS for scrollbar styling

### Screenshots
_Dark Mode_
![image](https://github.com/user-attachments/assets/54a5d887-4ff1-4252-a0fa-b0608d7194ca)

_Light Mode_
![image](https://github.com/user-attachments/assets/b033a38c-47b0-4383-85ce-ebe5f8f66d77)

_Recording demonstrating correct scrolling across the application_
https://www.loom.com/share/01e3c4e328cc42c489f7ca31343c70eb?sid=416b7fce-083c-4d61-a284-eefbb016cefa

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
