### PR TITLE
feat(js): Include headers and tabs in separate components

### DIFF
--- a/novu.code-workspace
+++ b/novu.code-workspace
@@ -97,6 +97,10 @@
       "path": "packages/js"
     },
     {
+      "name": "📦 @novu/react",
+      "path": "packages/react"
+    },
+    {
       "name": "🎮 @novu/nextjs-playground",
       "path": "playground/nextjs"
     }

--- a/packages/js/src/ui/components/Renderer.tsx
+++ b/packages/js/src/ui/components/Renderer.tsx
@@ -11,15 +11,19 @@ import {
   NovuProvider,
 } from '../context';
 import type { Appearance, Localization, Tab } from '../types';
-import { Bell, Preferences, Root } from './elements';
-import { Inbox } from './Inbox';
-import { NotificationList as Notifications } from './Notification';
+import { Bell, Root } from './elements';
+import { Inbox, InboxContent, InboxContentProps, InboxPage } from './Inbox';
 
 export const novuComponents = {
   Inbox,
+  // InboxContent, //enable this to also allow the whole inbox content as a component
   Bell,
-  Preferences,
-  Notifications,
+  Notifications: (props: Omit<InboxContentProps, 'hideNav' | 'initialPage'>) => (
+    <InboxContent {...props} hideNav={true} initialPage={InboxPage.Notifications} />
+  ),
+  Preferences: (props: Omit<InboxContentProps, 'hideNav' | 'initialPage'>) => (
+    <InboxContent {...props} hideNav={true} initialPage={InboxPage.Preferences} />
+  ),
 };
 
 export type NovuComponent = { name: NovuComponentName; props?: any };

--- a/packages/js/src/ui/components/elements/Header/ActionsContainer.tsx
+++ b/packages/js/src/ui/components/elements/Header/ActionsContainer.tsx
@@ -1,10 +1,11 @@
+import { Show } from 'solid-js';
 import { useStyle } from '../../../helpers';
 import { Settings } from '../../../icons';
 import { Button } from '../../primitives';
 import { MoreActionsDropdown } from './MoreActionsDropdown';
 
 type ActionsContainerProps = {
-  showPreferences: () => void;
+  showPreferences?: () => void;
 };
 
 export const ActionsContainer = (props: ActionsContainerProps) => {
@@ -13,9 +14,13 @@ export const ActionsContainer = (props: ActionsContainerProps) => {
   return (
     <div class={style('moreActionsContainer', 'nt-flex nt-gap-2')}>
       <MoreActionsDropdown />
-      <Button appearanceKey="preferences__button" variant="icon" size="icon" onClick={props.showPreferences}>
-        <Settings />
-      </Button>
+      <Show when={props.showPreferences}>
+        {(showPreferences) => (
+          <Button appearanceKey="preferences__button" variant="icon" size="icon" onClick={showPreferences()}>
+            <Settings />
+          </Button>
+        )}
+      </Show>
     </div>
   );
 };

--- a/packages/js/src/ui/components/elements/Header/Header.tsx
+++ b/packages/js/src/ui/components/elements/Header/Header.tsx
@@ -3,7 +3,7 @@ import { StatusDropdown } from '../InboxStatus/InboxStatusDropdown';
 import { ActionsContainer } from './ActionsContainer';
 
 type HeaderProps = {
-  updateScreen: (screen: 'inbox' | 'preferences') => void;
+  navigateToPreferences?: () => void;
 };
 
 export const Header = (props: HeaderProps) => {
@@ -17,7 +17,7 @@ export const Header = (props: HeaderProps) => {
       )}
     >
       <StatusDropdown />
-      <ActionsContainer showPreferences={() => props.updateScreen('preferences')} />
+      <ActionsContainer showPreferences={props.navigateToPreferences} />
     </div>
   );
 };

--- a/packages/js/src/ui/components/elements/Header/MoreActionsOptions.tsx
+++ b/packages/js/src/ui/components/elements/Header/MoreActionsOptions.tsx
@@ -41,7 +41,7 @@ export const ActionsItem = (props: { label: string; onClick: () => void; icon: (
       class={style('moreActions__dropdownItem', cn(dropdownItemVariants(), 'nt-flex nt-gap-2'))}
       onClick={props.onClick}
     >
-      <span class={style('moreActions__dropdownItemLeftIcon', 'nt-text-foreground-alpha-500')}>{props.icon()}</span>
+      <span class={style('moreActions__dropdownItemLeftIcon')}>{props.icon()}</span>
       <span class={style('moreActions__dropdownItemLabel')}>{props.label}</span>
     </Dropdown.Item>
   );

--- a/packages/js/src/ui/components/elements/Header/PreferencesHeader.tsx
+++ b/packages/js/src/ui/components/elements/Header/PreferencesHeader.tsx
@@ -1,9 +1,10 @@
+import { Show } from 'solid-js';
 import { useLocalization } from 'src/ui/context';
 import { useStyle } from '../../../helpers';
 import { ArrowLeft } from '../../../icons';
 
 type PreferencesHeaderProps = {
-  backAction: () => void;
+  navigateToNotifications?: () => void;
 };
 
 export const PreferencesHeader = (props: PreferencesHeaderProps) => {
@@ -12,15 +13,19 @@ export const PreferencesHeader = (props: PreferencesHeaderProps) => {
 
   return (
     <div class={style('preferencesHeader', 'nt-flex nt-items-center nt-py-5 nt-px-6 nt-gap-2')}>
-      <button
-        class={style(
-          'preferencesHeader__back__button',
-          'nt-h-6 nt-w-6 nt-flex nt-justify-center nt-items-center nt-rounded-md nt-relative hover:nt-bg-foreground-alpha-50 focus:nt-bg-foreground-alpha-50 nt-text-foreground-alpha-600'
+      <Show when={props.navigateToNotifications}>
+        {(navigateToNotifications) => (
+          <button
+            class={style(
+              'preferencesHeader__back__button',
+              'nt-h-6 nt-w-6 nt-flex nt-justify-center nt-items-center nt-rounded-md nt-relative hover:nt-bg-foreground-alpha-50 focus:nt-bg-foreground-alpha-50 nt-text-foreground-alpha-600'
+            )}
+            onClick={navigateToNotifications()}
+          >
+            <ArrowLeft />
+          </button>
         )}
-        onClick={props.backAction}
-      >
-        <ArrowLeft />
-      </button>
+      </Show>
       <div class={style('preferencesHeader__title', 'nt-text-xl nt-font-semibold')}>{t('preferences.title')}</div>
     </div>
   );

--- a/packages/js/src/ui/components/elements/InboxStatus/InboxStatusOptions.tsx
+++ b/packages/js/src/ui/components/elements/InboxStatus/InboxStatusOptions.tsx
@@ -58,11 +58,11 @@ export const StatusItem = (props: {
       onClick={props.onClick}
     >
       <span class={style('inboxStatus__dropdownItemLabelContainer', 'nt-flex nt-gap-2 nt-items-center')}>
-        <span class={style('inboxStatus__dropdownItemLeftIcon')}>{props.icon()}</span>
+        <span class={style('inboxStatus__dropdownItemLeftIcon', 'nt-text-foreground-alpha-600')}>{props.icon()}</span>
         <span class={style('inboxStatus__dropdownItemLabel')}>{props.label}</span>
       </span>
       <Show when={props.isSelected}>
-        <span class={style('inboxStatus__dropdownItemRightIcon', 'nt-justify-self-end')}>
+        <span class={style('inboxStatus__dropdownItemRightIcon', 'nt-justify-self-end nt-text-foreground-alpha-600')}>
           <Check />
         </span>
       </Show>

--- a/packages/js/src/ui/index.ts
+++ b/packages/js/src/ui/index.ts
@@ -1,5 +1,5 @@
-export { NovuUI } from './novuUI';
-export type { InboxProps } from './components';
-export type { BaseNovuUIOptions, NovuUIOptions } from './novuUI';
 export type { Notification } from '../notifications';
+export type { InboxPage, InboxProps } from './components';
+export { NovuUI } from './novuUI';
+export type { BaseNovuUIOptions, NovuUIOptions } from './novuUI';
 export * from './types';

--- a/packages/js/src/ui/novuUI.tsx
+++ b/packages/js/src/ui/novuUI.tsx
@@ -3,7 +3,7 @@ import { MountableElement, render } from 'solid-js/web';
 import type { NovuOptions } from '../types';
 import { NovuComponent, NovuComponentName, novuComponents, Renderer } from './components/Renderer';
 import { generateRandomString } from './helpers';
-import type { BaseNovuProviderProps, NovuProviderProps, Tab, Appearance, Localization } from './types';
+import type { Appearance, BaseNovuProviderProps, Localization, NovuProviderProps, Tab } from './types';
 
 // eslint-disable-next-line
 // @ts-ignore

--- a/packages/react/src/components/Inbox.tsx
+++ b/packages/react/src/components/Inbox.tsx
@@ -6,14 +6,9 @@ import { Renderer } from './Renderer';
 
 export type InboxProps = DefaultProps | WithChildrenProps;
 
-const DefaultInbox = ({
-  open,
-  renderNotification,
-  renderBell,
-  onNotificationClick,
-  onPrimaryActionClick,
-  onSecondaryActionClick,
-}: DefaultInboxProps) => {
+const DefaultInbox = (props: DefaultInboxProps) => {
+  const { open, renderNotification, renderBell, onNotificationClick, onPrimaryActionClick, onSecondaryActionClick } =
+    props;
   const { novuUI, mountElement } = useRenderer();
 
   const mount = React.useCallback(


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
We decided to include the whole content of the pages shown in the inbox for the separate components. Also a one line change is possible by uncommenting `InboxContent` to allow mounting the whole content (with routing) for usage in custom popover.
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
<img width="499" alt="Screenshot 2024-08-14 at 5 17 51 PM" src="https://github.com/user-attachments/assets/dda449f5-d7b8-433f-b61c-707b76080f7e">
<img width="552" alt="Screenshot 2024-08-14 at 5 18 08 PM" src="https://github.com/user-attachments/assets/d8c13d4a-71c7-401b-b3ed-3452a1ee2f8d">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
