### PR TITLE
fix(worker): Remove custom Slack provider handling in send-message-chat

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
@@ -31,7 +31,7 @@ import {
   ExecutionLogRoute,
   ExecutionLogRouteCommand,
 } from '@novu/application-generic';
-import { ExecuteOutput } from '@novu/framework';
+import { ChatOutput, ExecuteOutput } from '@novu/framework';
 
 import { CreateLog } from '../../../shared/logs';
 import { SendMessageCommand } from './send-message.command';
@@ -88,7 +88,8 @@ export class SendMessageChat extends SendMessageBase {
       step.template = template;
     }
 
-    let content = '';
+    const bridgeOutput = command.bridgeData?.outputs as ChatOutput | undefined;
+    let content: string = bridgeOutput?.body || '';
 
     try {
       if (!command.bridgeData) {
@@ -392,7 +393,6 @@ export class SendMessageChat extends SendMessageBase {
         throw new PlatformException(`Chat handler for provider ${integration.providerId} is  not found`);
       }
 
-      const bridgeContent = this.getOverrideContent(command.bridgeData, integration);
       const overrides = {
         ...(command.overrides[integration?.channel] || {}),
         ...(command.overrides[integration?.providerId] || {}),
@@ -405,7 +405,7 @@ export class SendMessageChat extends SendMessageBase {
         customData: overrides,
         webhookUrl: chatWebhookUrl,
         channel: channelSpecification,
-        ...(bridgeContent?.content ? bridgeContent : { content }),
+        content,
       });
 
       await this.executionLogRoute.execute(
@@ -444,22 +444,5 @@ export class SendMessageChat extends SendMessageBase {
         })
       );
     }
-  }
-
-  private getOverrideContent(
-    bridgeData: ExecuteOutput | undefined | null,
-    integration: IntegrationEntity
-  ): Record<string, unknown> & { content: string } {
-    const bridgeProviderOverride = this.getBridgeOverride(bridgeData?.providers, integration);
-
-    // TODO: make this generic to handle all providers.
-    let bridgeContent: Record<string, unknown> & { content: string };
-    if (bridgeProviderOverride) {
-      bridgeContent = { content: bridgeProviderOverride.text as string, blocks: bridgeProviderOverride.blocks };
-    } else {
-      bridgeContent = { content: bridgeData?.outputs.body as string };
-    }
-
-    return bridgeContent;
   }
 }


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Remove custom Slack provider handling in sned-message-chat
  * This custom handling was causing Slack block content to duplicate due to the Providers merging feature that was recently introduced. The recent Providers update in https://github.com/novuhq/novu/pull/6062 means that we no longer need to handle Slack in a custom way, leveraging the transform feature instead
  * The updated code aligns with Bridge provider data handling in send-message-sms and other channels

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Before - duplicate Slack blocks content due to `blocks` mapping to "trigger data"_
<img width="661" alt="image" src="https://github.com/user-attachments/assets/a3931d62-3668-4bd4-b533-2a59a96ad5df">

_After - no more duplicate messages_
<img width="658" alt="image" src="https://github.com/user-attachments/assets/c8369489-4b8e-443b-b769-ba8b0b7e94e2">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
