### PR TITLE
fix(api, application-generic): Don't slugify workflow identifier for bridge workflows

### DIFF
--- a/apps/widget/cypress/e2e/initialization.spec.ts
+++ b/apps/widget/cypress/e2e/initialization.spec.ts
@@ -17,12 +17,8 @@ describe('Initialization', function () {
 describe('Initialization with enabled HMAC encryption', function () {
   it('should initialize encrypted session with the help of HMAC hash', function () {
     cy.intercept('**/widgets/session/initialize**').as('sessionInitialize');
-    cy.initializeSession({ hmacEncryption: true }).then(() => {
-      cy.wait(500);
-    });
-    cy.wait('@sessionInitialize', {
-      timeout: 60000,
-    });
+    cy.initializeSession({ hmacEncryption: true });
+    cy.wait('@sessionInitialize');
     cy.window().then((w) => {
       expect(w.localStorage.getItem('widget_user_auth_token')).to.be.ok;
       return null;

--- a/apps/widget/cypress/e2e/initialization.spec.ts
+++ b/apps/widget/cypress/e2e/initialization.spec.ts
@@ -17,8 +17,12 @@ describe('Initialization', function () {
 describe('Initialization with enabled HMAC encryption', function () {
   it('should initialize encrypted session with the help of HMAC hash', function () {
     cy.intercept('**/widgets/session/initialize**').as('sessionInitialize');
-    cy.initializeSession({ hmacEncryption: true });
-    cy.wait('@sessionInitialize');
+    cy.initializeSession({ hmacEncryption: true }).then(() => {
+      cy.wait(500);
+    });
+    cy.wait('@sessionInitialize', {
+      timeout: 60000,
+    });
     cy.window().then((w) => {
       expect(w.localStorage.getItem('widget_user_auth_token')).to.be.ok;
       return null;

--- a/libs/application-generic/src/usecases/create-workflow/create-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/create-workflow/create-workflow.usecase.ts
@@ -60,10 +60,24 @@ export class CreateWorkflow {
 
     this.validatePayload(command);
 
-    const triggerIdentifier = `${slugify(command.name, {
-      lower: true,
-      strict: true,
-    })}`;
+    let triggerIdentifier: string;
+    if (command.type === WorkflowTypeEnum.BRIDGE)
+      /*
+       * Bridge workflows need to have the identifier preserved to ensure that
+       * the Framework-defined identifier is the source of truth.
+       */
+      triggerIdentifier = command.name;
+    else {
+      /**
+       * For non-bridge workflows, we use a slugified version of the workflow name
+       * as the trigger identifier to provide a better trigger DX.
+       */
+      triggerIdentifier = `${slugify(command.name, {
+        lower: true,
+        strict: true,
+      })}`;
+    }
+
     const parentChangeId: string =
       NotificationTemplateRepository.createObjectId();
 


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Don't slugify workflow identifier for bridge workflows, ensuring the Framework workflows define the source of truth for the identifier.
  * Previously, this slugification resulted in a failure to execute the Workflow with a 404 response from the Bridge application, because the UI always sent the slugified identifier whilst the Bridge app expected the untransformed identifier.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Triggering a space-separated identifier **BEFORE** fix_
<img width="1525" alt="image" src="https://github.com/user-attachments/assets/d33ea74b-598c-45e7-bd4d-a2da8b62e481">

_Triggering a space-separated identifier **AFTER** fix_
```typescript
export const spaceSeparatedIdWorkflow = workflow('My Workflow', async ({ step }) => {
  await step.email('send-email', () => ({
    subject: 'Welcome!',
    body: 'Hello there',
  }));
});
```

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/ea7fb5ae-eb81-4759-9b12-9c59cdf4d96c">


<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
