### PR TITLE
fix(novu): Set `maxRetries` to `Infinity` for tunnel connection

### DIFF
--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -150,7 +150,7 @@ async function connectToTunnel(parsedUrl: URL, parsedOrigin: URL) {
     {
       WebSocket: ws,
       connectionTimeout: 2000,
-      maxRetries: 10,
+      maxRetries: Infinity,
     },
     { verbose: false }
   );


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Set `maxRetries` to `Infinity` for tunnel connection
  * Ensures that the connection will always be retried (with backoff) when a connection failure occurs (e.g. Wifi connection)

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
https://www.loom.com/share/f294877f650247ad96d33de285ea4ce0?sid=b067d5fa-3c8f-4e1a-8a17-17374a27eb82

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
