### PR TITLE
refactor(api): Set new integrations as `active` & first integration as `primary`

### DIFF
--- a/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
@@ -306,7 +306,7 @@ describe('Create Integration - /integration (POST)', function () {
     expect(data.active).to.equal(true);
   });
 
-  it('should not set the integration as primary when its active and there are no other active integrations', async function () {
+  it('should set the integration as primary when its active and there are no other active integrations', async function () {
     await integrationRepository.deleteMany({
       _organizationId: session.organization._id,
       _environmentId: session.environment._id,
@@ -324,7 +324,7 @@ describe('Create Integration - /integration (POST)', function () {
     } = await session.testAgent.post('/v1/integrations').send(payload);
 
     expect(data.priority).to.equal(1);
-    expect(data.primary).to.equal(false);
+    expect(data.primary).to.equal(true);
     expect(data.active).to.equal(true);
   });
 
@@ -452,7 +452,7 @@ describe('Create Integration - /integration (POST)', function () {
       providerId: EmailProviderIdEnum.SendGrid,
       channel: ChannelTypeEnum.EMAIL,
       active: true,
-      primary: false,
+      primary: true,
       priority: 1,
       _organizationId: session.organization._id,
       _environmentId: session.environment._id,
@@ -469,7 +469,7 @@ describe('Create Integration - /integration (POST)', function () {
       body: { data },
     } = await session.testAgent.post('/v1/integrations').send(payload);
 
-    expect(data.priority).to.equal(2);
+    expect(data.priority).to.equal(1);
     expect(data.primary).to.equal(false);
     expect(data.active).to.equal(true);
 
@@ -483,12 +483,12 @@ describe('Create Integration - /integration (POST)', function () {
       { sort: { priority: -1 } }
     );
 
-    expect(first._id).to.equal(data._id);
-    expect(first.primary).to.equal(false);
+    expect(first._id).to.equal(activeIntegration._id);
+    expect(first.primary).to.equal(true);
     expect(first.active).to.equal(true);
     expect(first.priority).to.equal(2);
 
-    expect(second._id).to.equal(activeIntegration._id);
+    expect(second._id).to.equal(data._id);
     expect(second.primary).to.equal(false);
     expect(second.active).to.equal(true);
     expect(second.priority).to.equal(1);

--- a/apps/api/src/app/integrations/usecases/create-integration/create-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/create-integration/create-integration.usecase.ts
@@ -62,6 +62,7 @@ export class CreateIntegration {
       );
     } else {
       result.priority = highestPriorityIntegration ? highestPriorityIntegration.priority + 1 : 1;
+      result.primary = true;
     }
 
     return result;

--- a/apps/web/src/pages/integrations/components/UpdateIntegrationSidebarHeader.tsx
+++ b/apps/web/src/pages/integrations/components/UpdateIntegrationSidebarHeader.tsx
@@ -14,6 +14,7 @@ import {
   DotsHorizontal,
   StarEmpty,
   Trash,
+  When,
 } from '@novu/design-system';
 
 import { useEnvironment } from '../../../hooks';
@@ -132,13 +133,15 @@ export const UpdateIntegrationSidebarHeader = ({
         />
         <Group spacing={12} noWrap ml="auto">
           {children}
-          <PrimaryIconButton
-            primary={provider.primary}
-            onClick={() => {
-              makePrimaryIntegration({ id: provider.integrationId });
-            }}
-            conditions={numOfConditions}
-          />
+          <When truthy={canMarkAsPrimary}>
+            <PrimaryIconButton
+              primary={provider.primary}
+              onClick={() => {
+                makePrimaryIntegration({ id: provider.integrationId });
+              }}
+              conditions={numOfConditions}
+            />
+          </When>
           <ConditionIconButton primary={provider.primary} onClick={openConditions} conditions={numOfConditions} />
           <div>
             <Dropdown

--- a/apps/web/src/pages/integrations/components/multi-provider/CreateProviderInstanceSidebar.tsx
+++ b/apps/web/src/pages/integrations/components/multi-provider/CreateProviderInstanceSidebar.tsx
@@ -118,7 +118,7 @@ export function CreateProviderInstanceSidebar({
         channel: selectedChannel,
         name: data.name,
         credentials: {},
-        active: provider.channel === ChannelTypeEnum.IN_APP ? true : false,
+        active: true,
         check: false,
         conditions,
         _environmentId: environmentId,

--- a/apps/web/tests/integrations-list-modal.spec.ts
+++ b/apps/web/tests/integrations-list-modal.spec.ts
@@ -447,8 +447,6 @@ test('should update the mailjet integration', async ({ page }) => {
   await providerName.clear();
   await providerName.fill('Mailjet Integration Updated');
 
-  await isActive.locator('~ label').click();
-
   const apiKey = page.getByTestId('apiKey');
   await apiKey.fill('fake-api-key');
 
@@ -461,11 +459,13 @@ test('should update the mailjet integration', async ({ page }) => {
   const senderName = page.getByTestId('senderName');
   await senderName.fill('Novu');
 
+  const toastClose = page.locator('.mantine-Notification-closeButton');
+  await toastClose.click();
+
   await expect(updateButton).toBeEnabled();
   await updateButton.click();
+  await expect(updateButton).toBeEnabled();
 
-  const modalClose = page.locator('.mantine-Modal-close');
-  await modalClose.click();
   const sidebarClose = page.getByTestId('sidebar-close');
   await sidebarClose.click();
 
@@ -528,8 +528,6 @@ test('should update the mailjet integration from the list', async ({ page }) => 
   await providerName.clear();
   await providerName.fill('Mailjet Integration Updated');
 
-  await isActive.locator('~ label').click();
-
   const apiKey = page.getByTestId('apiKey');
   await apiKey.fill('fake-api-key');
 
@@ -542,11 +540,13 @@ test('should update the mailjet integration from the list', async ({ page }) => 
   const senderName = page.getByTestId('senderName');
   await senderName.fill('Novu');
 
+  const toastClose = page.locator('.mantine-Notification-closeButton');
+  await toastClose.click();
+
   await expect(updateButton).toBeEnabled();
   await updateButton.click();
+  await expect(updateButton).toBeEnabled();
 
-  const modalClose = page.locator('.mantine-Modal-close');
-  await modalClose.click();
   sidebarClose = page.getByTestId('sidebar-close');
   await sidebarClose.click();
 

--- a/apps/web/tests/integrations-list-modal.spec.ts
+++ b/apps/web/tests/integrations-list-modal.spec.ts
@@ -395,7 +395,7 @@ test('should create a new mailjet integration', async ({ page }) => {
     provider: 'Mailjet',
     channel: 'Email',
     environment: 'Development',
-    status: 'Disabled',
+    status: 'Active',
   });
 });
 
@@ -433,7 +433,7 @@ test('should update the mailjet integration', async ({ page }) => {
   await expect(integrationEnvironment).toContainText('Development');
 
   const isActive = page.getByTestId('is_active_id');
-  await expect(isActive).toHaveValue('false');
+  await expect(isActive).toHaveValue('true');
 
   providerName = updateProviderSidebar.getByPlaceholder('Enter instance name');
   await expect(providerName).toHaveValue('Mailjet Integration');
@@ -513,7 +513,7 @@ test('should update the mailjet integration from the list', async ({ page }) => 
   await expect(updateProviderSidebar).toBeVisible();
 
   const isActive = page.getByTestId('is_active_id');
-  await expect(isActive).toHaveValue('false');
+  await expect(isActive).toHaveValue('true');
 
   providerName = updateProviderSidebar.getByPlaceholder('Enter instance name');
   await expect(providerName).toHaveValue('Mailjet Integration');

--- a/apps/web/tests/integrations-list-page.spec.ts
+++ b/apps/web/tests/integrations-list-page.spec.ts
@@ -709,8 +709,6 @@ test('should update the mailjet integration', async ({ page }) => {
   await providerName.clear();
   await providerName.fill('Mailjet Integration Updated');
 
-  await isActive.locator('~ label').click();
-
   const apiKey = page.getByTestId('apiKey');
   await apiKey.fill('fake-api-key');
 
@@ -723,11 +721,13 @@ test('should update the mailjet integration', async ({ page }) => {
   const senderName = page.getByTestId('senderName');
   await senderName.fill('Novu');
 
+  const toastClose = page.locator('.mantine-Notification-closeButton');
+  await toastClose.click();
+
   await expect(updateButton).toBeEnabled();
   await updateButton.click();
+  await expect(updateButton).toBeEnabled();
 
-  const modalClose = page.locator('.mantine-Modal-close');
-  await modalClose.click();
   const sidebarClose = page.getByTestId('sidebar-close');
   await sidebarClose.click();
 
@@ -795,8 +795,6 @@ test('should update the mailjet integration from the list', async ({ page }) => 
   await providerName.clear();
   await providerName.fill('Mailjet Integration Updated');
 
-  await isActive.locator('~ label').click();
-
   const apiKey = page.getByTestId('apiKey');
   await apiKey.fill('fake-api-key');
 
@@ -809,11 +807,13 @@ test('should update the mailjet integration from the list', async ({ page }) => 
   const senderName = page.getByTestId('senderName');
   await senderName.fill('Novu');
 
+  const toastClose = page.locator('.mantine-Notification-closeButton');
+  await toastClose.click();
+
   await expect(updateButton).toBeEnabled();
   await updateButton.click();
+  await expect(updateButton).toBeEnabled();
 
-  const modalClose = page.locator('.mantine-Modal-close');
-  await modalClose.click();
   sidebarClose = page.getByTestId('sidebar-close');
   await sidebarClose.click();
 

--- a/apps/web/tests/integrations-list-page.spec.ts
+++ b/apps/web/tests/integrations-list-page.spec.ts
@@ -408,7 +408,7 @@ test('should create a new mailjet integration', async ({ page }) => {
     provider: 'Mailjet',
     channel: 'Email',
     environment: 'Development',
-    status: 'Disabled',
+    status: 'Active',
   });
 });
 
@@ -499,7 +499,7 @@ test('should create a new mailjet integration with conditions', async ({ page })
     provider: 'Mailjet',
     channel: 'Email',
     environment: 'Development',
-    status: 'Disabled',
+    status: 'Active',
   });
 });
 
@@ -692,7 +692,7 @@ test('should update the mailjet integration', async ({ page }) => {
   await expect(integrationEnvironment).toContainText('Development');
 
   const isActive = page.getByTestId('is_active_id');
-  await expect(isActive).toHaveValue('false');
+  await expect(isActive).toHaveValue('true');
 
   providerName = updateProviderSidebar.getByPlaceholder('Enter instance name');
   await expect(providerName).toHaveValue('Mailjet Integration');
@@ -777,7 +777,7 @@ test('should update the mailjet integration from the list', async ({ page }) => 
   await expect(updateProviderSidebar).toBeVisible();
 
   const isActive = page.getByTestId('is_active_id');
-  await expect(isActive).toHaveValue('false');
+  await expect(isActive).toHaveValue('true');
 
   providerName = updateProviderSidebar.getByPlaceholder('Enter instance name');
   await expect(providerName).toHaveValue('Mailjet Integration');

--- a/apps/web/tests/integrations-list-page.spec.ts
+++ b/apps/web/tests/integrations-list-page.spec.ts
@@ -1,10 +1,13 @@
 import {
   ChannelTypeEnum,
+  ChatProviderIdEnum,
   chatProviders,
   EmailProviderIdEnum,
   emailProviders,
   InAppProviderIdEnum,
   inAppProviders,
+  ProvidersIdEnum,
+  PushProviderIdEnum,
   pushProviders,
   SmsProviderIdEnum,
   smsProviders,
@@ -1088,4 +1091,73 @@ test('should show the Novu SMS integration sidebar', async ({ page }) => {
   const limitbarLimit = page.getByTestId('limitbar-limit');
   const limitbarText = await limitbarLimit.innerText();
   await expect(limitbarText).toEqual('20 messages per month');
+});
+
+type PrimaryToggleButtonTest = {
+  channelType: ChannelTypeEnum;
+  providerId: ProvidersIdEnum;
+  providerName: string;
+  enabled: boolean;
+};
+
+const testCases: PrimaryToggleButtonTest[] = [
+  {
+    channelType: ChannelTypeEnum.SMS,
+    providerId: SmsProviderIdEnum.Twilio,
+    providerName: 'Twilio',
+    enabled: true,
+  },
+  {
+    channelType: ChannelTypeEnum.EMAIL,
+    providerId: EmailProviderIdEnum.Mailjet,
+    providerName: 'Mailjet',
+    enabled: true,
+  },
+  {
+    channelType: ChannelTypeEnum.CHAT,
+    providerId: ChatProviderIdEnum.Discord,
+    providerName: 'Discord',
+    enabled: false,
+  },
+  {
+    channelType: ChannelTypeEnum.PUSH,
+    providerId: PushProviderIdEnum.FCM,
+    providerName: 'Firebase',
+    enabled: false,
+  },
+];
+
+testCases.forEach((testCase) => {
+  test(`should ${testCase.enabled ? 'show' : 'NOT show'} the primary toggle button for ${
+    testCase.providerName
+  }`, async ({ page }) => {
+    await page.goto('/integrations');
+    await expect(page).toHaveURL(/\/integrations/);
+
+    const addProvider = page.getByTestId('add-provider');
+    await expect(addProvider).toBeEnabled();
+    await addProvider.click();
+
+    const selectProviderSidebar = page.getByTestId('select-provider-sidebar');
+    await expect(selectProviderSidebar).toBeVisible();
+
+    const mailjet = page.getByTestId(`provider-${testCase.providerId}`);
+    await expect(mailjet).toContainText(testCase.providerName);
+    await mailjet.click();
+
+    const next = page.getByTestId('select-provider-sidebar-next');
+    await expect(next).toContainText('Next');
+    await next.click();
+
+    const providerName = page.getByTestId('provider-instance-name');
+    await providerName.clear();
+    await providerName.fill(`${testCase.providerName} Integration`);
+
+    const create = page.getByTestId('create-provider-instance-sidebar-create');
+    await expect(create).toContainText('Create');
+    await expect(create).toBeEnabled();
+    await create.click();
+
+    await expect(page.getByTestId('header-make-primary-btn')).toBeVisible({ visible: testCase.enabled });
+  });
 });


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Set new integrations as active to ensure that integrations can be used immediately after adding provider credentials.
  * This reduces confusion when creating new integrations but not being able to use them immediately for triggering notification worklfows
* Set the first non-primary integration to be primary
  * As above, ensures that SMS and Email have a primary integration ready for immediate trigger

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Dashboard walkthrough demonstrating new active and primary integrations_
https://www.loom.com/share/324f1ae3b03942b794e97ffc9a8cfe37?sid=6107ccb0-3f3a-4355-badf-52c0081e61cd

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
