### PR TITLE
fix(framework): Ensure all steps are logged during discovery and add step connector

### DIFF
--- a/packages/framework/src/resources/workflow.ts
+++ b/packages/framework/src/resources/workflow.ts
@@ -166,9 +166,10 @@ export function workflow<
       ),
       custom: discoverCustomStepFactory(newWorkflow, ActionStepEnum.CUSTOM),
     } as never,
+    // eslint-disable-next-line promise/always-return
+  }).then(() => {
+    prettyPrintDiscovery(newWorkflow);
   });
-
-  prettyPrintDiscovery(newWorkflow);
 
   return {
     trigger,
@@ -366,13 +367,16 @@ function prettyPrintDiscovery(discoveredWorkflow: DiscoverWorkflowOutput): void 
   // eslint-disable-next-line no-console
   console.log(`\n${log.bold(log.underline('Discovered workflowId:'))} '${discoveredWorkflow.workflowId}'`);
   discoveredWorkflow.steps.forEach((step, i) => {
-    const prefix = i === discoveredWorkflow.steps.length - 1 ? '└' : '├';
+    const isLastStep = i === discoveredWorkflow.steps.length - 1;
+    const prefix = isLastStep ? '└' : '├';
     // eslint-disable-next-line no-console
     console.log(`${prefix} ${EMOJI.STEP} Discovered stepId: '${step.stepId}'\tType: '${step.type}'`);
     step.providers.forEach((provider, providerIndex) => {
-      const providerPrefix = providerIndex === step.providers.length - 1 ? '└' : '├';
+      const isLastProvider = providerIndex === step.providers.length - 1;
+      const stepPrefix = isLastStep ? ' ' : '│';
+      const providerPrefix = isLastProvider ? '└' : '├';
       // eslint-disable-next-line no-console
-      console.log(`  ${providerPrefix} ${EMOJI.PROVIDER} Discovered provider: '${provider.type}'`);
+      console.log(`${stepPrefix} ${providerPrefix} ${EMOJI.PROVIDER} Discovered provider: '${provider.type}'`);
     });
   });
 }


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Ensure all steps are logged during discovery
  * Due to the async nature of the `execute` function, it's necessary to await the promise with a thenable to ensure all steps are discovered prior to logging the discovery results

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_BEFORE (only the first step was logged)_
<img width="378" alt="image" src="https://github.com/user-attachments/assets/5a4d9cda-6029-4178-bcca-b7c42b35603d">

_AFTER (all steps are now logged with a connector when more than 1 exists)_
<img width="378" alt="image" src="https://github.com/user-attachments/assets/e36f4923-0326-44cd-9154-5b6ebb395125">

_the sample workflow used for the screenshots_
```typescript
export const allTypedProvidersWorkflow = workflow('all-providers-workflow', async ({ step }) => {
  await step.email('email-step', () => ({
    subject: 'Test email',
    body: 'Hello there',
  }), {
    providers: {
      mailgun: async () => ({ 'to': 'rifont@gmail.com' }),
      mailjet: async () => ({ 'to': [{ 'email': 'rifont@gmail.com' }] }),
      nodemailer: async () => ({ 'to': 'rifont@gmail.com' }),
      'novu-email': async () => ({}),
      sendgrid: async () => ({ 'replyTo': { 'email': 'rifont@gmail.com' } }),
    }
  });

  await step.chat('chat-step', () => ({
    body: 'Hello there',
  }), {
    providers: {
      slack: async () => ({ 'text': 'Hello there' }),
    }
  });

  await step.push('push-step', () => ({
    subject: 'Test push',
    body: 'Hello there',
  }), {
    providers: {
      apns: async () => ({ 'badge': 1 }),
      fcm: async () => ({ 'to': 'rifont@gmail.com' }),
      expo: async () => ({ 'to': 'rifont@gmail.com' }),
      "one-signal": async () => ({ 'aggregation': 'count' }),
    }
  });

  await step.sms('sms-step', () => ({
    body: 'Hello there',
  }), {
    providers: {
      twilio: async () => ({ to: '+1234567890' }),
    }
  });
});
```

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
