### PR TITLE
fix(api,application-generic): assign user to logger context

### DIFF
--- a/apps/api/src/app/auth/framework/subscriber-route.guard.ts
+++ b/apps/api/src/app/auth/framework/subscriber-route.guard.ts
@@ -2,10 +2,11 @@ import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { ISubscriberJwt } from '@novu/shared';
 import jwt from 'jsonwebtoken';
+import { PinoLogger } from '@novu/application-generic';
 
 @Injectable()
 export class SubscriberRouteGuard implements CanActivate {
-  constructor(private readonly reflector: Reflector) {}
+  constructor(private readonly reflector: Reflector, private readonly logger: PinoLogger) {}
 
   canActivate(context: ExecutionContext): boolean {
     const subscriberRouteGuard = this.reflector.get<string[]>('subscriberRouteGuard', context.getHandler());
@@ -23,6 +24,8 @@ export class SubscriberRouteGuard implements CanActivate {
     if (!tokenContent) return false;
     if (tokenContent.aud !== 'widget_user') return false;
     if (!tokenContent.environmentId) return false;
+
+    this.logger.assign({ user: tokenContent });
 
     return true;
   }

--- a/apps/api/src/app/rate-limiting/guards/throttler.guard.ts
+++ b/apps/api/src/app/rate-limiting/guards/throttler.guard.ts
@@ -177,7 +177,6 @@ export class ApiRateLimitInterceptor extends ThrottlerGuard implements NestInter
         apiServiceLevel
       )
     );
-    res.rateLimitPolicy = rateLimitPolicy;
 
     if (success) {
       return true;

--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -105,7 +105,7 @@ export async function bootstrap(expressApp?): Promise<INestApplication> {
   app.useGlobalInterceptors(getErrorInterceptor());
 
   app.useGlobalGuards(new RolesGuard(app.get(Reflector)));
-  app.useGlobalGuards(new SubscriberRouteGuard(app.get(Reflector)));
+  app.useGlobalGuards(new SubscriberRouteGuard(app.get(Reflector), app.get(PinoLogger)));
 
   app.use(extendedBodySizeRoutes, bodyParser.json({ limit: '20mb' }));
   app.use(extendedBodySizeRoutes, bodyParser.urlencoded({ limit: '20mb', extended: true }));

--- a/libs/application-generic/src/logging/index.ts
+++ b/libs/application-generic/src/logging/index.ts
@@ -128,15 +128,6 @@ export function createNestLoggingModuleOptions(
       },
       transport: transport,
       autoLogging: !['test', 'local'].includes(process.env.NODE_ENV),
-      customProps: (req: any, res: any) => ({
-        user: {
-          userId: req?.user?._id || null,
-          environmentId: req?.user?.environmentId || null,
-          organizationId: req?.user?.organizationId || null,
-        },
-        authScheme: req?.authScheme,
-        rateLimitPolicy: res?.rateLimitPolicy,
-      }),
     },
   };
 }

--- a/libs/application-generic/src/services/auth/community.user.auth.guard.ts
+++ b/libs/application-generic/src/services/auth/community.user.auth.guard.ts
@@ -12,13 +12,17 @@ import {
   HandledUser,
   NONE_AUTH_SCHEME,
 } from '@novu/shared';
+import { PinoLogger } from '../../logging';
 
 @Injectable()
 export class CommunityUserAuthGuard extends AuthGuard([
   PassportStrategyEnum.JWT,
   PassportStrategyEnum.HEADER_API_KEY,
 ]) {
-  constructor(private readonly reflector: Reflector) {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly logger: PinoLogger
+  ) {
     super();
   }
 
@@ -28,6 +32,8 @@ export class CommunityUserAuthGuard extends AuthGuard([
 
     const authScheme = authorizationHeader?.split(' ')[0] || NONE_AUTH_SCHEME;
     request.authScheme = authScheme;
+
+    this.logger.assign({ authScheme });
 
     switch (authScheme) {
       case ApiAuthSchemeEnum.BEARER:
@@ -77,6 +83,8 @@ export class CommunityUserAuthGuard extends AuthGuard([
     } else {
       handledUser = user;
     }
+
+    this.logger.assign({ user: handledUser });
 
     return super.handleRequest(err, handledUser, info, context, status);
   }

--- a/libs/application-generic/src/utils/inject-auth-providers.ts
+++ b/libs/application-generic/src/utils/inject-auth-providers.ts
@@ -10,6 +10,7 @@ import {
   MemberRepository,
   OrganizationRepository,
 } from '@novu/dal';
+import { PinoLogger } from '../logging';
 import {
   AnalyticsService,
   CommunityAuthService,
@@ -84,10 +85,10 @@ export function injectCommunityAuthProviders(
 
   const userAuthGuardProvider = {
     provide: 'USER_AUTH_GUARD',
-    useFactory: (reflector: Reflector) => {
-      return new CommunityUserAuthGuard(reflector);
+    useFactory: (reflector: Reflector, logger: PinoLogger) => {
+      return new CommunityUserAuthGuard(reflector, logger);
     },
-    inject: [Reflector],
+    inject: [Reflector, PinoLogger],
   };
 
   if (repositoriesOnly) {


### PR DESCRIPTION
### What changed? Why was the change needed?
Currently, when we try to log something before the request completes, we don't have the user object and other properties present in the log because they're not yet available in the `customProps` context:

![image](https://github.com/user-attachments/assets/506e2d05-6a53-40ce-b650-5ecf3e715686)


To assign custom properties and have them available for the entire request duration. we need to call `assign()` on a PinoLogger instance: https://github.com/iamolegga/nestjs-pino?tab=readme-ov-file#assign-extra-fields-for-future-calls  

![image](https://github.com/user-attachments/assets/0b357d9b-4189-4be7-bca9-66e3228cb1a6)

Related EE PR: https://github.com/novuhq/packages-enterprise/pull/201
