### PR TITLE
feat(js): Use render props universally with a single argument

### DIFF
--- a/packages/js/src/ui/components/Notification/DefaultNotification.tsx
+++ b/packages/js/src/ui/components/Notification/DefaultNotification.tsx
@@ -44,7 +44,7 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
       props.notification.read();
     }
 
-    props.onNotificationClick?.({ notification: props.notification });
+    props.onNotificationClick?.(props.notification);
     if (props.notification.redirect?.url) {
       window.open(props.notification.redirect?.url, '_blank', 'noreferrer noopener');
     }
@@ -55,10 +55,10 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
 
     if (action === ActionTypeEnum.PRIMARY) {
       props.notification.completePrimary();
-      props.onPrimaryActionClick?.({ notification: props.notification });
+      props.onPrimaryActionClick?.(props.notification);
     } else {
       props.notification.completeSecondary();
-      props.onSecondaryActionClick?.({ notification: props.notification });
+      props.onSecondaryActionClick?.(props.notification);
     }
   };
 

--- a/packages/js/src/ui/components/Notification/Notification.tsx
+++ b/packages/js/src/ui/components/Notification/Notification.tsx
@@ -25,13 +25,7 @@ export const Notification = (props: NotificationProps) => {
         />
       }
     >
-      <ExternalElementMounter
-        mount={(el) =>
-          props.mountNotification!(el, {
-            notification: props.notification,
-          })
-        }
-      />
+      <ExternalElementMounter mount={(el) => props.mountNotification!(el, props.notification)} />
     </Show>
   );
 };

--- a/packages/js/src/ui/components/elements/Bell/Bell.tsx
+++ b/packages/js/src/ui/components/elements/Bell/Bell.tsx
@@ -13,7 +13,7 @@ export const Bell: Component<BellProps> = (props) => {
 
   return (
     <Show when={props.mountBell} fallback={<BellContainer unreadCount={totalUnreadCount()} />}>
-      <ExternalElementMounter mount={(el) => props.mountBell!(el, { unreadCount: totalUnreadCount() })} />
+      <ExternalElementMounter mount={(el) => props.mountBell!(el, totalUnreadCount())} />
     </Show>
   );
 };

--- a/packages/js/src/ui/types.ts
+++ b/packages/js/src/ui/types.ts
@@ -1,17 +1,12 @@
 import type { Notification } from '../notifications';
 import type { NovuOptions } from '../types';
-import { defaultLocalization, appearanceKeys } from './config';
+import { appearanceKeys, defaultLocalization } from './config';
 
-export type NotificationClickHandler = (args: { notification: Notification }) => void;
-export type NotificationActionClickHandler = (args: { notification: Notification }) => void;
+export type NotificationClickHandler = (notification: Notification) => void;
+export type NotificationActionClickHandler = (notification: Notification) => void;
 
-export type NotificationMounter = (
-  el: HTMLDivElement,
-  options: {
-    notification: Notification;
-  }
-) => () => void;
-export type BellMounter = (el: HTMLDivElement, options: { unreadCount: number }) => () => void;
+export type NotificationMounter = (el: HTMLDivElement, notification: Notification) => () => void;
+export type BellMounter = (el: HTMLDivElement, unreadCount: number) => () => void;
 
 export type Tab = { label: string; value: Array<string> };
 

--- a/packages/react/src/components/Bell.tsx
+++ b/packages/react/src/components/Bell.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { useRenderer } from '../context/RenderContext';
 import { Mounter } from './Mounter';
-
-export type BellRenderProps = ({ unreadCount }: { unreadCount: number }) => React.ReactNode;
+import { BellRenderer } from '../utils/types';
 
 export type BellProps = {
-  children?: never | BellRenderProps;
+  renderBell?: BellRenderer;
 };
 
 export const Bell = React.memo((props: BellProps) => {
+  const { renderBell } = props;
   const { novuUI, mountElement } = useRenderer();
 
   const mount = React.useCallback(
@@ -16,12 +16,10 @@ export const Bell = React.memo((props: BellProps) => {
       return novuUI.mountComponent({
         name: 'Bell',
         element,
-        props: props.children
-          ? { mountBell: (el, { unreadCount }) => mountElement(el, props.children?.({ unreadCount })) }
-          : undefined,
+        props: renderBell ? { mountBell: (el, unreadCount) => mountElement(el, renderBell(unreadCount)) } : undefined,
       });
     },
-    [props.children]
+    [renderBell]
   );
 
   return <Mounter mount={mount} />;

--- a/packages/react/src/components/Inbox.tsx
+++ b/packages/react/src/components/Inbox.tsx
@@ -23,9 +23,9 @@ const DefaultInbox = ({
         props: {
           open,
           mountNotification: renderNotification
-            ? (el, { notification }) => mountElement(el, renderNotification({ notification }))
+            ? (el, notification) => mountElement(el, renderNotification(notification))
             : undefined,
-          mountBell: renderBell ? (el, { unreadCount }) => mountElement(el, renderBell({ unreadCount })) : undefined,
+          mountBell: renderBell ? (el, unreadCount) => mountElement(el, renderBell(unreadCount)) : undefined,
           onNotificationClick,
           onPrimaryActionClick,
           onSecondaryActionClick,

--- a/packages/react/src/components/Notifications.tsx
+++ b/packages/react/src/components/Notifications.tsx
@@ -1,38 +1,37 @@
 import React from 'react';
 import { useRenderer } from '../context/RenderContext';
-import { NotificationsRenderProps } from '../utils/types';
 import { Mounter } from './Mounter';
 import type { NotificationClickHandler, NotificationActionClickHandler } from '@novu/js/ui';
+import { NotificationsRenderer } from '../utils/types';
 
 export type NotificationProps = {
-  children?: never | NotificationsRenderProps;
+  renderNotification?: NotificationsRenderer;
   onNotificationClick?: NotificationClickHandler;
   onPrimaryActionClick?: NotificationActionClickHandler;
   onSecondaryActionClick?: NotificationActionClickHandler;
 };
 
-export const Notifications = React.memo(
-  ({ children, onNotificationClick, onPrimaryActionClick, onSecondaryActionClick }: NotificationProps) => {
-    const { novuUI, mountElement } = useRenderer();
+export const Notifications = React.memo((props: NotificationProps) => {
+  const { onNotificationClick, onPrimaryActionClick, renderNotification, onSecondaryActionClick } = props;
+  const { novuUI, mountElement } = useRenderer();
 
-    const mount = React.useCallback(
-      (element: HTMLElement) => {
-        return novuUI.mountComponent({
-          name: 'Notifications',
-          element,
-          props: children
-            ? {
-                mountNotification: (el, { notification }) => mountElement(el, children?.({ notification })),
-                onNotificationClick,
-                onPrimaryActionClick,
-                onSecondaryActionClick,
-              }
-            : { onNotificationClick, onPrimaryActionClick, onSecondaryActionClick },
-        });
-      },
-      [children, onNotificationClick, onPrimaryActionClick, onSecondaryActionClick]
-    );
+  const mount = React.useCallback(
+    (element: HTMLElement) => {
+      return novuUI.mountComponent({
+        name: 'Notifications',
+        element,
+        props: {
+          mountNotification: renderNotification
+            ? (el, notification) => mountElement(el, renderNotification(notification))
+            : undefined,
+          onNotificationClick,
+          onPrimaryActionClick,
+          onSecondaryActionClick,
+        },
+      });
+    },
+    [renderNotification, onNotificationClick, onPrimaryActionClick, onSecondaryActionClick]
+  );
 
-    return <Mounter mount={mount} />;
-  }
-);
+  return <Mounter mount={mount} />;
+});

--- a/packages/react/src/utils/types.ts
+++ b/packages/react/src/utils/types.ts
@@ -7,12 +7,13 @@ import type {
   Localization,
 } from '@novu/js/ui';
 
-export type NotificationsRenderProps = (args: { notification: Notification }) => React.ReactNode;
+export type NotificationsRenderer = (notification: Notification) => React.ReactNode;
+export type BellRenderer = (unreadCount: number) => React.ReactNode;
 
 export type DefaultInboxProps = {
   open?: boolean;
-  renderNotification?: (args: { notification: Notification }) => React.ReactNode;
-  renderBell?: ({ unreadCount }: { unreadCount: number }) => React.ReactNode;
+  renderNotification?: NotificationsRenderer;
+  renderBell?: BellRenderer;
   onNotificationClick?: NotificationClickHandler;
   onPrimaryActionClick?: NotificationActionClickHandler;
   onSecondaryActionClick?: NotificationActionClickHandler;

--- a/playground/nextjs/src/pages/render-bell/index.tsx
+++ b/playground/nextjs/src/pages/render-bell/index.tsx
@@ -8,7 +8,7 @@ export default function Home() {
       <Title title="Render Bell props" />
       <Inbox
         {...novuConfig}
-        renderBell={({ unreadCount }) => {
+        renderBell={(unreadCount) => {
           return (
             <button className="p-1 w-full">
               <div className="relative">

--- a/playground/nextjs/src/pages/render-notification/index.tsx
+++ b/playground/nextjs/src/pages/render-notification/index.tsx
@@ -8,7 +8,7 @@ export default function Home() {
       <Title title="Render Notification Props" />
       <Inbox
         {...novuConfig}
-        renderNotification={({ notification }) => {
+        renderNotification={(notification) => {
           return (
             <div className="flex gap-2 flex-nowrap items-start self-stretch my-1 p-2 hover:bg-slate-200">
               <div className="rounded-full w-8 h-8 overflow-hidden border border-cyan-200">Avatar</div>


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
```
<Inbox renderNotification={notification => {}} ... />

<Inbox>
  <Notifications renderNotification={notification => ...} ... />
</Inbox>

<Inbox>
  <Bell renderBell={unreadCount => ...} ... />
</Inbox>

<Inbox 
  onNotificationClick={notification => {}}
  onPrimaryActionClick={notification => {}}
  onSecondaryActionClick={notification => {}}
/>
```

I've also updated the js types to reflect the same pattern.
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
