### PR TITLE
fix(providers): add sendername field in mailgun config

### DIFF
--- a/libs/application-generic/src/factories/mail/handlers/mailgun.handler.ts
+++ b/libs/application-generic/src/factories/mail/handlers/mailgun.handler.ts
@@ -18,11 +18,13 @@ export class MailgunHandler extends BaseHandler {
       domain: string;
       from: string;
       baseUrl?: string;
+      senderName: string;
     } = {
       apiKey: credentials.apiKey,
       username: credentials.user,
       domain: credentials.domain,
       baseUrl: credentials.baseUrl,
+      senderName: credentials.senderName,
       from: from as string,
     };
 

--- a/packages/providers/src/lib/email/mailgun/mailgun.provider.spec.ts
+++ b/packages/providers/src/lib/email/mailgun/mailgun.provider.spec.ts
@@ -7,6 +7,7 @@ const mockConfig = {
   domain: 'test.com',
   username: 'api',
   from: 'test@test.com',
+  senderName: 'Novu Mailgun test',
 };
 
 const mockNovuMessage = {

--- a/packages/providers/src/lib/email/mailgun/mailgun.provider.ts
+++ b/packages/providers/src/lib/email/mailgun/mailgun.provider.ts
@@ -50,6 +50,7 @@ export class MailgunEmailProvider
       username: string;
       domain: string;
       from: string;
+      senderName: string;
     }
   ) {
     super();
@@ -66,8 +67,10 @@ export class MailgunEmailProvider
     emailOptions: IEmailOptions,
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ): Promise<ISendMessageSuccessResponse> {
+    const senderName = emailOptions.senderName || this.config.senderName;
+    const fromAddress = emailOptions.from || this.config.from;
     const data = {
-      from: emailOptions.from || this.config.from,
+      from: senderName ? `${senderName} <${fromAddress}>` : fromAddress,
       to: emailOptions.to,
       subject: emailOptions.subject,
       html: emailOptions.html,


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

Mailgun provider config was missing `senderName` field.
- Added `senderName` field in mailgun config and factory handler
- added `senderName` condition for `from` field

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
