### PR TITLE
fix(framework): Stop requiring default properties to be specified in outputs

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -633,6 +633,8 @@
     "unpublish",
     "unsub",
     "untracked",
+    "unvalidated",
+    "Unvalidated",
     "upsert",
     "upserted",
     "upstash",

--- a/libs/application-generic/src/utils/bridge.ts
+++ b/libs/application-generic/src/utils/bridge.ts
@@ -1,8 +1,8 @@
 import { DigestTypeEnum } from '@novu/shared';
 import {
   DigestOutput,
-  digestRegularOutput,
-  digestTimedOutput,
+  DigestRegularOutput,
+  DigestTimedOutput,
 } from '@novu/framework';
 
 export function getDigestType(outputs: DigestOutput): DigestTypeEnum {
@@ -17,21 +17,21 @@ export function getDigestType(outputs: DigestOutput): DigestTypeEnum {
 
 export const isTimedDigestOutput = (
   outputs: DigestOutput | undefined
-): outputs is digestTimedOutput => {
-  return (outputs as digestTimedOutput)?.cron != null;
+): outputs is DigestTimedOutput => {
+  return (outputs as DigestTimedOutput)?.cron != null;
 };
 
 export const isLookBackDigestOutput = (
   outputs: DigestOutput
-): outputs is digestRegularOutput => {
+): outputs is DigestRegularOutput => {
   return (
-    (outputs as digestRegularOutput)?.lookBackWindow?.amount != null &&
-    (outputs as digestRegularOutput)?.lookBackWindow?.unit != null
+    (outputs as DigestRegularOutput)?.lookBackWindow?.amount != null &&
+    (outputs as DigestRegularOutput)?.lookBackWindow?.unit != null
   );
 };
 
 export const isRegularDigestOutput = (
   outputs: DigestOutput
-): outputs is digestRegularOutput => {
+): outputs is DigestRegularOutput => {
   return !isTimedDigestOutput(outputs) && !isLookBackDigestOutput(outputs);
 };

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -8,9 +8,8 @@ import {
   WorkflowNotFoundError,
 } from './errors';
 import { workflow } from './resources';
-import { Event, Step, FromSchema } from './types';
-import { delayOutputSchema, channelStepSchemas } from './schemas';
-import { FRAMEWORK_VERSION, SDK_VERSION, ChannelStepEnum, PostActionEnum } from './constants';
+import { Event, Step } from './types';
+import { FRAMEWORK_VERSION, SDK_VERSION, PostActionEnum } from './constants';
 
 describe('Novu Client', () => {
   let client: Client;
@@ -444,11 +443,11 @@ describe('Novu Client', () => {
 
   describe('executeWorkflow method', () => {
     it('should execute workflow successfully when action is execute and payload is provided', async () => {
-      const delayConfiguration: FromSchema<typeof delayOutputSchema> = { type: 'regular', unit: 'seconds', amount: 1 };
-      const emailConfiguration: FromSchema<(typeof channelStepSchemas)[ChannelStepEnum.EMAIL]['output']> = {
+      const delayConfiguration = { unit: 'seconds', amount: 1 } as const;
+      const emailConfiguration = {
         body: 'Test Body',
         subject: 'Subject',
-      };
+      } as const;
       const newWorkflow = workflow('test-workflow', async ({ step }) => {
         await step.email('send-email', async () => emailConfiguration);
         await step.delay('delay', async () => delayConfiguration);
@@ -515,7 +514,7 @@ describe('Novu Client', () => {
       expect(amount).toBe(delayConfiguration.amount);
       expect(delayExecutionResult.providers).toEqual({});
       const type = delayExecutionResult.outputs.type;
-      expect(type).toBe(delayConfiguration.type);
+      expect(type).toBe('regular');
     });
 
     it('should compile default control variable', async () => {

--- a/packages/framework/src/resources/workflow.test.ts
+++ b/packages/framework/src/resources/workflow.test.ts
@@ -63,14 +63,38 @@ describe('workflow function', () => {
       });
     });
 
-    it('should compile when returning undefined for a result property that has a default value', async () => {
+    it('should compile when returning undefined for a built-in step property that has a default value', async () => {
       const delayType = undefined;
-      workflow('custom-test-something', async ({ step }) => {
+      workflow('built-in-default-test', async ({ step }) => {
         await step.delay('custom', async () => ({
           type: delayType,
           amount: 1,
           unit: 'seconds',
         }));
+      });
+    });
+
+    it('should compile when returning undefined for a custom step property that has a default value', async () => {
+      const delayType = undefined;
+      workflow('custom-default-test', async ({ step }) => {
+        const data = await step.custom(
+          'custom',
+          async () => ({
+            withDefault: undefined,
+            withoutDefault: 'bar',
+          }),
+          {
+            outputSchema: {
+              type: 'object',
+              properties: {
+                withDefault: { type: 'string', default: 'bar' },
+                withoutDefault: { type: 'string' },
+              },
+              required: ['withoutDefault'],
+              additionalProperties: false,
+            } as const,
+          }
+        );
       });
     });
   });
@@ -111,6 +135,38 @@ describe('workflow function', () => {
         testWorkflow.trigger({
           // @ts-expect-error - foo is missing from the payload
           payload: {},
+          to: 'test@test.com',
+        });
+    });
+
+    it('should compile when returning undefined for a payload property that has a default value', async () => {
+      const testWorkflow = workflow(
+        'test-workflow',
+        async ({ step }) => {
+          await step.custom('custom', async () => ({
+            foo: 'bar',
+          }));
+        },
+        {
+          payloadSchema: {
+            type: 'object',
+            properties: {
+              withDefault: { type: 'string', default: 'bar' },
+              withoutDefault: { type: 'string' },
+            },
+            required: ['withoutDefault'],
+            additionalProperties: false,
+          } as const,
+        }
+      );
+
+      // Capture in a test function to avoid throwing execution errors
+      const testFn = () =>
+        testWorkflow.trigger({
+          payload: {
+            withDefault: undefined,
+            withoutDefault: 'bar',
+          },
           to: 'test@test.com',
         });
     });

--- a/packages/framework/src/resources/workflow.test.ts
+++ b/packages/framework/src/resources/workflow.test.ts
@@ -62,6 +62,17 @@ describe('workflow function', () => {
         result?.foo === 'custom';
       });
     });
+
+    it('should compile when returning undefined for a result property that has a default value', async () => {
+      const delayType = undefined;
+      workflow('custom-test-something', async ({ step }) => {
+        await step.delay('custom', async () => ({
+          type: delayType,
+          amount: 1,
+          unit: 'seconds',
+        }));
+      });
+    });
   });
 
   describe('trigger', () => {

--- a/packages/framework/src/types/provider.types.ts
+++ b/packages/framework/src/types/provider.types.ts
@@ -1,5 +1,5 @@
 import { providerSchemas } from '../schemas';
-import type { FromSchema } from './schema.types';
+import type { FromSchemaUnvalidated } from './schema.types';
 import { Awaitable, Prettify } from './util.types';
 
 export type Passthrough = {
@@ -29,5 +29,5 @@ export type Providers<T_StepType extends keyof typeof providerSchemas, T_Control
     // eslint-disable-next-line multiline-comment-style
     // TODO: fix the typing for `type` to use the keyof providerSchema[channelType]
     // @ts-expect-error - Types of parameters 'options' and 'options' are incompatible.
-  }) => Awaitable<WithPassthrough<FromSchema<(typeof providerSchemas)[T_StepType][K]['output']>>>;
+  }) => Awaitable<WithPassthrough<FromSchemaUnvalidated<(typeof providerSchemas)[T_StepType][K]['output']>>>;
 };

--- a/packages/framework/src/types/schema.types.ts
+++ b/packages/framework/src/types/schema.types.ts
@@ -24,7 +24,20 @@ export type Schema = JsonSchema | zod.ZodSchema;
  * type MySchema = FromSchemaUnvalidated<typeof mySchema>;
  * ```
  */
-export type FromSchemaUnvalidated<T extends JsonSchema> = JsonSchemaInfer<T, { keepDefaultedPropertiesOptional: true }>;
+export type FromSchemaUnvalidated<T extends Schema> =
+  /*
+   * Handle each Schema's type inference individually until
+   * all Schema types are exhausted.
+   */
+
+  // JSONSchema
+  T extends JSONSchema
+    ? JsonSchemaInfer<T, { keepDefaultedPropertiesOptional: true }>
+    : // ZodSchema
+    T extends zod.ZodSchema
+    ? zod.input<T>
+    : // All schema types exhausted.
+      never;
 
 /**
  * Infer the type of a Schema for validated data.

--- a/packages/framework/src/types/schema.types.ts
+++ b/packages/framework/src/types/schema.types.ts
@@ -3,8 +3,37 @@ import zod from 'zod';
 
 export type JsonSchema = JSONSchema;
 
+/**
+ * A JSONSchema or a ZodSchema.
+ */
 export type Schema = JsonSchema | zod.ZodSchema;
 
+/**
+ * Infer the type of a Schema for unvalidated data.
+ *
+ * The resulting type has default properties set to optional,
+ * reflecting the fact that the data is unvalidated and has
+ * not had default properties set.
+ *
+ * @example
+ * ```ts
+ * type MySchema = FromSchemaUnvalidated<typeof mySchema>;
+ * ```
+ */
+export type FromSchemaUnvalidated<T extends JsonSchema> = JsonSchemaInfer<T, { keepDefaultedPropertiesOptional: true }>;
+
+/**
+ * Infer the type of a Schema for validated data.
+ *
+ * The resulting type has default properties set to required,
+ * reflecting the fact that the data has been validated and
+ * default properties have been set.
+ *
+ * @example
+ * ```ts
+ * type MySchema = FromSchema<typeof mySchema>;
+ * ```
+ */
 export type FromSchema<T extends Schema> =
   /*
    * Handle each Schema's type inference individually until

--- a/packages/framework/src/types/schema.types.ts
+++ b/packages/framework/src/types/schema.types.ts
@@ -4,7 +4,11 @@ import zod from 'zod';
 export type JsonSchema = JSONSchema;
 
 /**
- * A JSONSchema or a ZodSchema.
+ * A schema used to validate a JSON object.
+ *
+ * Supported schemas:
+ * - JSONSchema
+ * - ZodSchema
  */
 export type Schema = JsonSchema | zod.ZodSchema;
 

--- a/packages/framework/src/types/step.types.ts
+++ b/packages/framework/src/types/step.types.ts
@@ -101,8 +101,8 @@ export type CustomStep = <
    */
   T_Controls extends Record<string, unknown> = FromSchema<T_ControlSchema>,
   /*
-   * These intermediary types are needed to capture the types in a single location
-   * and stop Typescript from erroring with:
+   * These intermediary types are needed to capture the types in a single type instance
+   * to stop Typescript from erroring with:
    * `Type instantiation is excessively deep and possibly infinite.`
    */
   T_IntermediaryResult extends Record<string, unknown> = FromSchema<T_OutputsSchema>,

--- a/packages/framework/src/types/step.types.ts
+++ b/packages/framework/src/types/step.types.ts
@@ -100,19 +100,28 @@ export type CustomStep = <
    * The controls for the step.
    */
   T_Controls extends Record<string, unknown> = FromSchema<T_ControlSchema>,
+  /*
+   * These intermediary types are needed to capture the types in a single location
+   * and stop Typescript from erroring with:
+   * `Type instantiation is excessively deep and possibly infinite.`
+   */
+  T_IntermediaryResult extends Record<string, unknown> = FromSchema<T_OutputsSchema>,
+  T_IntermediaryOutput extends Record<string, unknown> = FromSchemaUnvalidated<T_OutputsSchema>,
+  /**
+   * The output for the step.
+   */
+  T_Outputs extends T_IntermediaryOutput = T_IntermediaryOutput,
   /**
    * The result for the step.
    */
-  T_Intermediary extends Record<string, unknown> = FromSchema<T_OutputsSchema>,
-  T_Outputs extends T_Intermediary = T_Intermediary,
-  T_Result extends T_Intermediary = T_Intermediary
+  T_Result extends T_IntermediaryResult = T_IntermediaryResult
 >(
   /**
    * The name of the step. This is used to identify the step in the workflow.
    */
   name: string,
   /**
-   * The function to resolve the step notification content for the step.
+   * The function to resolve the custom data for the step.
    *
    * @param controls The controls for the step.
    */

--- a/packages/framework/src/types/step.types.ts
+++ b/packages/framework/src/types/step.types.ts
@@ -200,10 +200,10 @@ export type DelayOutput = FromSchema<(typeof actionStepSchemas)[ActionStepEnum.D
 export type DelayOutputUnvalidated = FromSchemaUnvalidated<(typeof actionStepSchemas)[ActionStepEnum.DELAY]['output']>;
 export type DelayResult = FromSchema<(typeof actionStepSchemas)[ActionStepEnum.DELAY]['result']>;
 
-export type digestRegularOutput = FromSchema<typeof digestRegularOutputSchema>;
-export type digestRegularOutputUnvalidated = FromSchemaUnvalidated<typeof digestRegularOutputSchema>;
-export type digestTimedOutput = FromSchema<typeof digestTimedOutputSchema>;
-export type digestTimedOutputUnvalidated = FromSchemaUnvalidated<typeof digestTimedOutputSchema>;
+export type DigestRegularOutput = FromSchema<typeof digestRegularOutputSchema>;
+export type DigestRegularOutputUnvalidated = FromSchemaUnvalidated<typeof digestRegularOutputSchema>;
+export type DigestTimedOutput = FromSchema<typeof digestTimedOutputSchema>;
+export type DigestTimedOutputUnvalidated = FromSchemaUnvalidated<typeof digestTimedOutputSchema>;
 
 export type DigestOutput = FromSchema<(typeof actionStepSchemas)[ActionStepEnum.DIGEST]['output']>;
 export type DigestOutputUnvalidated = FromSchemaUnvalidated<

--- a/packages/framework/src/types/step.types.ts
+++ b/packages/framework/src/types/step.types.ts
@@ -3,7 +3,7 @@ import { digestRegularOutputSchema, digestTimedOutputSchema } from '../schemas';
 import { actionStepSchemas } from '../schemas/steps/actions';
 import { channelStepSchemas } from '../schemas/steps/channels';
 import type { Providers } from './provider.types';
-import type { FromSchema, Schema } from './schema.types';
+import type { FromSchema, FromSchemaUnvalidated, Schema } from './schema.types';
 import type { Skip } from './skip.types';
 import type { Awaitable, Prettify } from './util.types';
 
@@ -173,27 +173,42 @@ export type ChannelStep<
 ) => StepOutput<T_Result>;
 
 export type EmailOutput = FromSchema<(typeof channelStepSchemas)[ChannelStepEnum.EMAIL]['output']>;
+export type EmailOutputUnvalidated = FromSchemaUnvalidated<
+  (typeof channelStepSchemas)[ChannelStepEnum.EMAIL]['output']
+>;
 export type EmailResult = FromSchema<(typeof channelStepSchemas)[ChannelStepEnum.EMAIL]['result']>;
 
 export type SmsOutput = FromSchema<(typeof channelStepSchemas)[ChannelStepEnum.SMS]['output']>;
+export type SmsOutputUnvalidated = FromSchemaUnvalidated<(typeof channelStepSchemas)[ChannelStepEnum.SMS]['output']>;
 export type SmsResult = FromSchema<(typeof channelStepSchemas)[ChannelStepEnum.SMS]['result']>;
 
 export type PushOutput = FromSchema<(typeof channelStepSchemas)[ChannelStepEnum.PUSH]['output']>;
+export type PushOutputUnvalidated = FromSchemaUnvalidated<(typeof channelStepSchemas)[ChannelStepEnum.PUSH]['output']>;
 export type PushResult = FromSchema<(typeof channelStepSchemas)[ChannelStepEnum.PUSH]['result']>;
 
 export type ChatOutput = FromSchema<(typeof channelStepSchemas)[ChannelStepEnum.CHAT]['output']>;
+export type ChatOutputUnvalidated = FromSchemaUnvalidated<(typeof channelStepSchemas)[ChannelStepEnum.CHAT]['output']>;
 export type ChatResult = FromSchema<(typeof channelStepSchemas)[ChannelStepEnum.CHAT]['result']>;
 
 export type InAppOutput = FromSchema<(typeof channelStepSchemas)[ChannelStepEnum.IN_APP]['output']>;
+export type InAppOutputUnvalidated = FromSchemaUnvalidated<
+  (typeof channelStepSchemas)[ChannelStepEnum.IN_APP]['output']
+>;
 export type InAppResult = FromSchema<(typeof channelStepSchemas)[ChannelStepEnum.IN_APP]['result']>;
 
 export type DelayOutput = FromSchema<(typeof actionStepSchemas)[ActionStepEnum.DELAY]['output']>;
+export type DelayOutputUnvalidated = FromSchemaUnvalidated<(typeof actionStepSchemas)[ActionStepEnum.DELAY]['output']>;
 export type DelayResult = FromSchema<(typeof actionStepSchemas)[ActionStepEnum.DELAY]['result']>;
 
 export type digestRegularOutput = FromSchema<typeof digestRegularOutputSchema>;
+export type digestRegularOutputUnvalidated = FromSchemaUnvalidated<typeof digestRegularOutputSchema>;
 export type digestTimedOutput = FromSchema<typeof digestTimedOutputSchema>;
+export type digestTimedOutputUnvalidated = FromSchemaUnvalidated<typeof digestTimedOutputSchema>;
 
 export type DigestOutput = FromSchema<(typeof actionStepSchemas)[ActionStepEnum.DIGEST]['output']>;
+export type DigestOutputUnvalidated = FromSchemaUnvalidated<
+  (typeof actionStepSchemas)[ActionStepEnum.DIGEST]['output']
+>;
 export type DigestResult = FromSchema<(typeof actionStepSchemas)[ActionStepEnum.DIGEST]['result']>;
 
 /**
@@ -201,19 +216,19 @@ export type DigestResult = FromSchema<(typeof actionStepSchemas)[ActionStepEnum.
  */
 export type Step = {
   /** Send an email. */
-  email: ChannelStep<ChannelStepEnum.EMAIL, EmailOutput, EmailResult>;
+  email: ChannelStep<ChannelStepEnum.EMAIL, EmailOutputUnvalidated, EmailResult>;
   /** Send an SMS. */
-  sms: ChannelStep<ChannelStepEnum.SMS, SmsOutput, SmsResult>;
+  sms: ChannelStep<ChannelStepEnum.SMS, SmsOutputUnvalidated, SmsResult>;
   /** Send a push notification. */
-  push: ChannelStep<ChannelStepEnum.PUSH, PushOutput, PushResult>;
+  push: ChannelStep<ChannelStepEnum.PUSH, PushOutputUnvalidated, PushResult>;
   /** Send a chat message. */
-  chat: ChannelStep<ChannelStepEnum.CHAT, ChatOutput, ChatResult>;
+  chat: ChannelStep<ChannelStepEnum.CHAT, ChatOutputUnvalidated, ChatResult>;
   /** Send an in-app notification. */
-  inApp: ChannelStep<ChannelStepEnum.IN_APP, InAppOutput, InAppResult>;
+  inApp: ChannelStep<ChannelStepEnum.IN_APP, InAppOutputUnvalidated, InAppResult>;
   /** Aggregate events for a period of time. */
-  digest: ActionStep<DigestOutput, DigestResult>;
+  digest: ActionStep<DigestOutputUnvalidated, DigestResult>;
   /** Delay the workflow for a period of time. */
-  delay: ActionStep<DelayOutput, DelayResult>;
+  delay: ActionStep<DelayOutputUnvalidated, DelayResult>;
   /** Execute custom code */
   custom: CustomStep;
 };

--- a/packages/framework/src/types/validator.types.ts
+++ b/packages/framework/src/types/validator.types.ts
@@ -1,6 +1,6 @@
 import type { ValidateFunction as AjvValidateFunction } from 'ajv';
 import type { ParseReturnType } from 'zod';
-import type { Schema, JsonSchema } from './schema.types';
+import type { Schema, JsonSchema, FromSchema, FromSchemaUnvalidated } from './schema.types';
 
 export type ValidateFunction<T = unknown> = AjvValidateFunction<T> | ((data: T) => ParseReturnType<T>);
 
@@ -20,8 +20,14 @@ export type ValidateResult<T> =
     };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export interface Validator<T_Schema extends Schema> {
-  validate: <T_Data extends Record<string, unknown>>(data: T_Data, schema: T_Schema) => Promise<ValidateResult<T_Data>>;
-  isSchema: (schema: Schema) => schema is T_Schema;
+export interface Validator<T_Schema extends Schema = Schema> {
+  validate: <
+    T_Unvalidated extends Record<string, unknown> = FromSchemaUnvalidated<T_Schema>,
+    T_Validated extends Record<string, unknown> = FromSchema<T_Schema>
+  >(
+    data: T_Unvalidated,
+    schema: T_Schema
+  ) => Promise<ValidateResult<T_Validated>>;
+  canHandle: (schema: Schema) => schema is T_Schema;
   transformToJsonSchema: (schema: T_Schema) => JsonSchema;
 }

--- a/packages/framework/src/validators/base.validator.ts
+++ b/packages/framework/src/validators/base.validator.ts
@@ -1,32 +1,33 @@
-import type { JsonSchema, Schema } from '../types/schema.types';
+import type { FromSchema, FromSchemaUnvalidated, JsonSchema, Schema } from '../types/schema.types';
 import type { ValidateResult } from '../types/validator.types';
 import { JsonSchemaValidator } from './json-schema.validator';
 import { ZodValidator } from './zod.validator';
 
-const validators = [new ZodValidator(), new JsonSchemaValidator()];
+const zodValidator = new ZodValidator();
+const jsonSchemaValidator = new JsonSchemaValidator();
 
-export const validateData = async <T extends Record<string, unknown>>(
-  schema: Schema,
-  data: T
-): Promise<ValidateResult<T>> => {
-  for (const validator of validators) {
-    if (validator.isSchema(schema)) {
-      // TODO: fix validator type guards
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return validator.validate(data, schema as any);
-    }
+export const validateData = async <
+  T_Schema extends Schema = Schema,
+  T_Unvalidated extends Record<string, unknown> = FromSchemaUnvalidated<T_Schema>,
+  T_Validated extends Record<string, unknown> = FromSchema<T_Schema>
+>(
+  schema: T_Schema,
+  data: T_Unvalidated
+): Promise<ValidateResult<T_Validated>> => {
+  if (zodValidator.canHandle(schema)) {
+    return zodValidator.validate(data, schema);
+  } else if (jsonSchemaValidator.canHandle(schema)) {
+    return jsonSchemaValidator.validate(data, schema);
   }
 
   throw new Error('Invalid schema');
 };
 
 export const transformSchema = (schema: Schema): JsonSchema => {
-  for (const validator of validators) {
-    if (validator.isSchema(schema)) {
-      // TODO: fix validator type guards
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return validator.transformToJsonSchema(schema as any);
-    }
+  if (zodValidator.canHandle(schema)) {
+    return zodValidator.transformToJsonSchema(schema);
+  } else if (jsonSchemaValidator.canHandle(schema)) {
+    return jsonSchemaValidator.transformToJsonSchema(schema);
   }
 
   throw new Error('Invalid schema');

--- a/packages/framework/src/validators/json-schema.validator.ts
+++ b/packages/framework/src/validators/json-schema.validator.ts
@@ -1,7 +1,8 @@
-import Ajv, { type ErrorObject, type ValidateFunction as AjvValidateFunction } from 'ajv';
+import Ajv from 'ajv';
+import type { ErrorObject, ValidateFunction as AjvValidateFunction } from 'ajv';
 import addFormats from 'ajv-formats';
 import type { ValidateResult, Validator } from '../types/validator.types';
-import type { JsonSchema, Schema } from '../types/schema.types';
+import type { FromSchema, FromSchemaUnvalidated, JsonSchema, Schema } from '../types/schema.types';
 import { cloneData } from '../utils/clone.utils';
 
 export class JsonSchemaValidator implements Validator<JsonSchema> {
@@ -26,7 +27,7 @@ export class JsonSchemaValidator implements Validator<JsonSchema> {
     this.compiledSchemas = new Map();
   }
 
-  isSchema(schema: Schema): schema is JsonSchema {
+  canHandle(schema: Schema): schema is JsonSchema {
     if (typeof schema === 'boolean') return false;
 
     return (
@@ -37,7 +38,11 @@ export class JsonSchemaValidator implements Validator<JsonSchema> {
     );
   }
 
-  async validate<T extends Record<string, unknown>>(data: T, schema: JsonSchema): Promise<ValidateResult<T>> {
+  async validate<
+    T_Schema extends JsonSchema = JsonSchema,
+    T_Unvalidated = FromSchemaUnvalidated<T_Schema>,
+    T_Validated = FromSchema<T_Schema>
+  >(data: T_Unvalidated, schema: T_Schema): Promise<ValidateResult<T_Validated>> {
     let validateFn = this.compiledSchemas.get(schema);
 
     if (!validateFn) {
@@ -51,7 +56,7 @@ export class JsonSchemaValidator implements Validator<JsonSchema> {
     const valid = validateFn(clonedData);
 
     if (valid) {
-      return { success: true, data: clonedData };
+      return { success: true, data: clonedData as unknown as T_Validated };
     } else {
       return {
         success: false,

--- a/packages/framework/src/validators/zod.validator.ts
+++ b/packages/framework/src/validators/zod.validator.ts
@@ -1,18 +1,22 @@
 import { ZodSchema } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
-import type { JsonSchema, Schema } from '../types/schema.types';
+import type { FromSchema, FromSchemaUnvalidated, JsonSchema, Schema } from '../types/schema.types';
 import type { ValidateResult, Validator } from '../types/validator.types';
 
 export class ZodValidator implements Validator<ZodSchema> {
-  isSchema(schema: Schema): schema is ZodSchema {
+  canHandle(schema: Schema): schema is ZodSchema {
     return (schema as ZodSchema).safeParseAsync !== undefined;
   }
 
-  async validate<T extends Record<string, unknown>>(data: T, schema: ZodSchema): Promise<ValidateResult<T>> {
+  async validate<
+    T_Schema extends ZodSchema = ZodSchema,
+    T_Unvalidated = FromSchemaUnvalidated<T_Schema>,
+    T_Validated = FromSchema<T_Schema>
+  >(data: T_Unvalidated, schema: T_Schema): Promise<ValidateResult<T_Validated>> {
     const result = schema.safeParse(data);
     if (result.success) {
-      return { success: true, data: result.data };
+      return { success: true, data: result.data as T_Validated };
     } else {
       return {
         success: false,


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Stop requiring default properties to be specified in step outputs, provider outputs, and trigger payload
  * `json-schema-to-ts` supports `keepDefaultedPropertiesOptional` ([ref](https://github.com/ThomasAribart/json-schema-to-ts?tab=readme-ov-file#objects)) which is now set to `true` for unvalidated data (such as the return value of a `step.delay` step)
  * Add tests to verify the `undefined` properties can be specified for outputs with a `default` value set
* Fix schema validator types

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_BEFORE - properties with a `default` set are required to be specified in outputs_
![image](https://github.com/user-attachments/assets/cfa3467f-e8ac-48ca-a758-e5c376534b8a)

_AFTER - properties with a `default` set are NOT required to be specified in outputs_
![image](https://github.com/user-attachments/assets/87cdd2b5-c0e6-410d-8850-3aaf67f50c0f)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
