### PR TITLE
feat(js): Dynamic localization keys and data-localization attribute

### DIFF
--- a/packages/js/src/ui/components/Notification/DefaultNotification.tsx
+++ b/packages/js/src/ui/components/Notification/DefaultNotification.tsx
@@ -127,7 +127,9 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
                         </Button>
                       )}
                     />
-                    <Tooltip.Content>{t('notification.actions.read.toolTip')}</Tooltip.Content>
+                    <Tooltip.Content data-localization="notification.actions.read.tooltip">
+                      {t('notification.actions.read.tooltip')}
+                    </Tooltip.Content>
                   </Tooltip.Root>
                 }
               >
@@ -149,7 +151,9 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
                       </Button>
                     )}
                   />
-                  <Tooltip.Content>{t('notification.actions.unread.toolTip')}</Tooltip.Content>
+                  <Tooltip.Content data-localization="notification.actions.unread.tooltip">
+                    {t('notification.actions.unread.tooltip')}
+                  </Tooltip.Content>
                 </Tooltip.Root>
               </Show>
             </Show>
@@ -174,7 +178,9 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
                       </Button>
                     )}
                   />
-                  <Tooltip.Content>{t('notification.actions.archive.toolTip')}</Tooltip.Content>
+                  <Tooltip.Content data-localization="notification.actions.archive.tooltip">
+                    {t('notification.actions.archive.tooltip')}
+                  </Tooltip.Content>
                 </Tooltip.Root>
               }
             >
@@ -196,7 +202,9 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
                     </Button>
                   )}
                 />
-                <Tooltip.Content>{t('notification.actions.unarchive.toolTip')}</Tooltip.Content>
+                <Tooltip.Content data-localization="notification.actions.unarchive.tooltip">
+                  {t('notification.actions.unarchive.tooltip')}
+                </Tooltip.Content>
               </Tooltip.Root>
             </Show>
           </div>

--- a/packages/js/src/ui/components/Notification/NewMessagesCta.tsx
+++ b/packages/js/src/ui/components/Notification/NewMessagesCta.tsx
@@ -6,8 +6,8 @@ export const NewMessagesCta: Component<{
   onClick?: JSX.EventHandlerUnion<HTMLButtonElement, MouseEvent>;
   count: number;
 }> = (props) => {
-  const { t } = useLocalization();
   const shouldRender = createMemo(() => !!props.count);
+  const { t } = useLocalization();
 
   return (
     <Show when={shouldRender()}>
@@ -15,6 +15,7 @@ export const NewMessagesCta: Component<{
         appearanceKey="notificationListNewNotificationsNotice__button"
         class="nt-absolute nt-w-fit nt-top-0 nt-mx-auto nt-inset-2 nt-z-10 nt-rounded-full hover:nt-bg-primary-600 nt-animate-in nt-slide-in-from-top-2 nt-fade-in"
         onClick={props.onClick}
+        data-localization="notifications.newNotifications"
       >
         {t('notifications.newNotifications', { notificationCount: props.count })}
       </Button>

--- a/packages/js/src/ui/components/Notification/NotificationList.tsx
+++ b/packages/js/src/ui/components/Notification/NotificationList.tsx
@@ -21,7 +21,9 @@ const EmptyNotificationList = () => {
       )}
     >
       <EmptyIcon class={style('notificationListEmptyNoticeIcon')} />
-      <p class={style('notificationListEmptyNotice')}>{t('notifications.emptyNotice')}</p>
+      <p class={style('notificationListEmptyNotice')} data-localization="notifications.emptyNotice">
+        {t('notifications.emptyNotice')}
+      </p>
     </div>
   );
 };

--- a/packages/js/src/ui/components/elements/Header/MoreActionsOptions.tsx
+++ b/packages/js/src/ui/components/elements/Header/MoreActionsOptions.tsx
@@ -1,12 +1,11 @@
 import { JSX } from 'solid-js';
 import { useArchiveAll, useArchiveAllRead, useReadAll } from '../../../api';
-import { useInboxContext, useLocalization } from '../../../context';
+import { StringLocalizationKey, useInboxContext, useLocalization } from '../../../context';
 import { cn, useStyle } from '../../../helpers';
 import { Archive, ArchiveRead, ReadAll } from '../../../icons';
 import { Dropdown, dropdownItemVariants } from '../../primitives';
 
 export const MoreActionsOptions = () => {
-  const { t } = useLocalization();
   const { filter } = useInboxContext();
   const { readAll } = useReadAll();
   const { archiveAll } = useArchiveAll();
@@ -15,17 +14,17 @@ export const MoreActionsOptions = () => {
   return (
     <>
       <ActionsItem
-        label={t('notifications.actions.readAll')}
+        localizationKey="notifications.actions.readAll"
         onClick={() => readAll({ tags: filter().tags })}
         icon={ReadAll}
       />
       <ActionsItem
-        label={t('notifications.actions.archiveAll')}
+        localizationKey="notifications.actions.archiveAll"
         onClick={() => archiveAll({ tags: filter().tags })}
         icon={Archive}
       />
       <ActionsItem
-        label={t('notifications.actions.archiveRead')}
+        localizationKey="notifications.actions.archiveRead"
         onClick={() => archiveAllRead({ tags: filter().tags })}
         icon={ArchiveRead}
       />
@@ -33,8 +32,13 @@ export const MoreActionsOptions = () => {
   );
 };
 
-export const ActionsItem = (props: { label: string; onClick: () => void; icon: () => JSX.Element }) => {
+export const ActionsItem = (props: {
+  localizationKey: StringLocalizationKey;
+  onClick: () => void;
+  icon: () => JSX.Element;
+}) => {
   const style = useStyle();
+  const { t } = useLocalization();
 
   return (
     <Dropdown.Item
@@ -42,7 +46,9 @@ export const ActionsItem = (props: { label: string; onClick: () => void; icon: (
       onClick={props.onClick}
     >
       <span class={style('moreActions__dropdownItemLeft__icon', 'nt-text-foreground-alpha-600')}>{props.icon()}</span>
-      <span class={style('moreActions__dropdownItemLabel')}>{props.label}</span>
+      <span data-localization={props.localizationKey} class={style('moreActions__dropdownItemLabel')}>
+        {t(props.localizationKey)}
+      </span>
     </Dropdown.Item>
   );
 };

--- a/packages/js/src/ui/components/elements/Header/PreferencesHeader.tsx
+++ b/packages/js/src/ui/components/elements/Header/PreferencesHeader.tsx
@@ -1,5 +1,5 @@
 import { Show } from 'solid-js';
-import { useLocalization } from 'src/ui/context';
+import { useLocalization } from '../../../context';
 import { useStyle } from '../../../helpers';
 import { ArrowLeft } from '../../../icons';
 
@@ -26,7 +26,12 @@ export const PreferencesHeader = (props: PreferencesHeaderProps) => {
           </button>
         )}
       </Show>
-      <div class={style('preferencesHeader__title', 'nt-text-xl nt-font-semibold')}>{t('preferences.title')}</div>
+      <div
+        data-localization="preferences.title"
+        class={style('preferencesHeader__title', 'nt-text-xl nt-font-semibold')}
+      >
+        {t('preferences.title')}
+      </div>
     </div>
   );
 };

--- a/packages/js/src/ui/components/elements/InboxStatus/InboxStatusDropdown.tsx
+++ b/packages/js/src/ui/components/elements/InboxStatus/InboxStatusDropdown.tsx
@@ -19,7 +19,10 @@ export const StatusDropdown = () => {
         )}
         asChild={(triggerProps) => (
           <Button variant="unstyled" size="none" {...triggerProps}>
-            <span class={style('inboxStatus__title', 'nt-text-xl nt-font-semibold')}>
+            <span
+              data-localization={inboxStatusLocalizationKeys[status()]}
+              class={style('inboxStatus__title', 'nt-text-xl nt-font-semibold')}
+            >
               {t(inboxStatusLocalizationKeys[status()])}
             </span>
             <span class={style('inboxStatus__dropdownItemRight__icon', 'nt-text-foreground-alpha-600')}>

--- a/packages/js/src/ui/components/elements/InboxStatus/InboxStatusOptions.tsx
+++ b/packages/js/src/ui/components/elements/InboxStatus/InboxStatusOptions.tsx
@@ -1,6 +1,6 @@
 import { For, Show } from 'solid-js';
 import { JSX } from 'solid-js/jsx-runtime';
-import { useLocalization } from '../../../context';
+import { StringLocalizationKey, useLocalization } from '../../../context';
 import { cn, useStyle } from '../../../helpers';
 import { Archive, Check, Inbox, Unread } from '../../../icons';
 import { NotificationStatus } from '../../../types';
@@ -26,13 +26,11 @@ export const StatusOptions = (props: {
   setStatus: (status: NotificationStatus) => void;
   status: NotificationStatus;
 }) => {
-  const { t } = useLocalization();
-
   return (
     <For each={cases}>
       {(c) => (
         <StatusItem
-          label={t(notificationStatusOptionsLocalizationKeys[c.status])}
+          localizationKey={notificationStatusOptionsLocalizationKeys[c.status]}
           onClick={() => {
             props.setStatus(c.status);
           }}
@@ -45,12 +43,13 @@ export const StatusOptions = (props: {
 };
 
 export const StatusItem = (props: {
-  label: string;
+  localizationKey: StringLocalizationKey;
   onClick: () => void;
   isSelected?: boolean;
   icon: () => JSX.Element;
 }) => {
   const style = useStyle();
+  const { t } = useLocalization();
 
   return (
     <Dropdown.Item
@@ -59,7 +58,9 @@ export const StatusItem = (props: {
     >
       <span class={style('inboxStatus__dropdownItemLabelContainer', 'nt-flex nt-gap-2 nt-items-center')}>
         <span class={style('inboxStatus__dropdownItemLeft__icon')}>{props.icon()}</span>
-        <span class={style('inboxStatus__dropdownItemLabel')}>{props.label}</span>
+        <span data-localization={props.localizationKey} class={style('inboxStatus__dropdownItemLabel')}>
+          {t(props.localizationKey)}
+        </span>
       </span>
       <Show when={props.isSelected}>
         <span class={style('inboxStatus__dropdownItemRight__icon')}>

--- a/packages/js/src/ui/config/defaultLocalization.ts
+++ b/packages/js/src/ui/config/defaultLocalization.ts
@@ -1,3 +1,5 @@
+import { createSignal } from 'solid-js';
+
 export const defaultLocalization = {
   locale: 'en-US',
   'inbox.status.options.unread': 'Unread only',
@@ -14,13 +16,15 @@ export const defaultLocalization = {
     `${notificationCount > 99 ? '99+' : notificationCount} new ${
       notificationCount === 1 ? 'notification' : 'notifications'
     }`,
-  'notification.actions.read.toolTip': 'Mark as read',
-  'notification.actions.unread.toolTip': 'Mark as unread',
-  'notification.actions.archive.toolTip': 'Archive',
-  'notification.actions.unarchive.toolTip': 'Unarchive',
+  'notification.actions.read.tooltip': 'Mark as read',
+  'notification.actions.unread.tooltip': 'Mark as unread',
+  'notification.actions.archive.tooltip': 'Archive',
+  'notification.actions.unarchive.tooltip': 'Unarchive',
   'preferences.title': 'Notification Preferences',
   'preferences.global': 'Global Preferences',
   'preferences.workflow.disabled.notice':
     'Contact admin to enable subscription management for this critical notification.',
   'preferences.workflow.disabled.tooltip': 'Contact admin to edit',
 } as const;
+
+export const [dynamicLocalization, setDynamicLocalization] = createSignal<Record<string, string>>({});

--- a/packages/js/src/ui/context/LocalizationContext.tsx
+++ b/packages/js/src/ui/context/LocalizationContext.tsx
@@ -1,17 +1,35 @@
 import { Accessor, createContext, createMemo, ParentProps, useContext } from 'solid-js';
-import { defaultLocalization } from '../config/defaultLocalization';
-import type { Localization, LocalizationKey } from '../types';
+import { defaultLocalization, dynamicLocalization } from '../config/defaultLocalization';
 
-type LocalizationValue<K extends LocalizationKey> = (typeof defaultLocalization)[K];
-type LocalizationParams<K extends LocalizationKey> = LocalizationValue<K> extends (args: infer P) => any
-  ? P
+export type LocalizationKey = keyof typeof defaultLocalization;
+
+export type StringLocalizationKey = {
+  [K in LocalizationKey]: (typeof defaultLocalization)[K] extends string ? K : never;
+}[LocalizationKey];
+
+export type Localization = {
+  [K in LocalizationKey]?: (typeof defaultLocalization)[K] extends (...args: infer P) => any
+    ? ((...args: P) => ReturnType<(typeof defaultLocalization)[K]>) | string
+    : string;
+} & {
+  dynamic?: Record<string, string>;
+};
+
+export type TranslateFunctionArg<K extends LocalizationKey> = K extends keyof typeof defaultLocalization
+  ? (typeof defaultLocalization)[K] extends (arg: infer A) => any
+    ? A
+    : undefined
   : undefined;
 
+export type TranslateFunction = <K extends LocalizationKey>(
+  key: K,
+  ...args: TranslateFunctionArg<K> extends undefined
+    ? [undefined?] // No arguments needed if TranslateFunctionArg<K> is undefined
+    : [TranslateFunctionArg<K>] // A single argument is required if TranslateFunctionArg<K> is defined
+) => string;
+
 type LocalizationContextType = {
-  t: <K extends LocalizationKey>(
-    key: K,
-    ...args: LocalizationParams<K> extends undefined ? [] : [LocalizationParams<K>]
-  ) => string;
+  t: TranslateFunction;
   locale: Accessor<string>;
 };
 
@@ -20,18 +38,28 @@ const LocalizationContext = createContext<LocalizationContextType | undefined>(u
 type LocalizationProviderProps = ParentProps & { localization?: Localization };
 
 export const LocalizationProvider = (props: LocalizationProviderProps) => {
-  const localization = createMemo(() => ({ ...defaultLocalization, ...(props.localization || {}) }));
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  const localization = createMemo<Record<string, string | Function>>(() => {
+    const { dynamic, ...localizationObject } = props.localization || {};
+
+    return {
+      ...defaultLocalization,
+      ...dynamicLocalization(),
+      ...(dynamic || {}),
+      ...localizationObject,
+    };
+  });
 
   const t: LocalizationContextType['t'] = (key, ...args) => {
     const value = localization()[key];
     if (typeof value === 'function') {
-      return (value as (args: LocalizationParams<typeof key>) => string)(args[0]!);
+      return value(args[0]);
     }
 
     return value as string;
   };
 
-  const locale = createMemo(() => localization().locale);
+  const locale = createMemo(() => localization().locale as string);
 
   return (
     <LocalizationContext.Provider

--- a/packages/js/src/ui/types.ts
+++ b/packages/js/src/ui/types.ts
@@ -1,6 +1,7 @@
 import type { Notification } from '../notifications';
 import type { NovuOptions } from '../types';
-import { appearanceKeys, defaultLocalization } from './config';
+import { appearanceKeys } from './config';
+import { Localization } from './context/LocalizationContext';
 
 export type NotificationClickHandler = (notification: Notification) => void;
 export type NotificationActionClickHandler = (notification: Notification) => void;
@@ -39,9 +40,6 @@ export type Theme = {
 };
 export type Appearance = Theme & { baseTheme?: Theme | Theme[] };
 
-export type LocalizationKey = keyof typeof defaultLocalization;
-export type Localization = Partial<Record<LocalizationKey, string>>;
-
 export type BaseNovuProviderProps = {
   appearance?: Appearance;
   localization?: Localization;
@@ -59,3 +57,5 @@ export enum NotificationStatus {
   UNREAD = 'unread',
   ARCHIVED = 'archived',
 }
+
+export { Localization, LocalizationKey } from './context/LocalizationContext';

--- a/playground/nextjs/src/pages/index.tsx
+++ b/playground/nextjs/src/pages/index.tsx
@@ -6,7 +6,15 @@ export default function Home() {
   return (
     <>
       <Title title="Default Inbox" />
-      <Inbox {...novuConfig} />
+      <Inbox
+        {...novuConfig}
+        localization={{
+          'notifications.newNotifications': ({ notificationCount }) => `${notificationCount} new notifications`,
+          dynamic: {
+            '6697c185607852e9104daf33': 'My workflow in other language', // key is workflow id
+          },
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Fixed the localization prop type. It now correctly allows typed function or strings in the corresponding keys.|
* Added the `<Localized />` component which renders a span with the localized value of the key provided to it (along with any data in the data prop if necessary, data is used in the values that are functions). This component also adds the `data-localization` attrubute to the span element.
* Allow dynamic keys to be used in the `dynamic` field. For now, these are the workflow names which have a key of their respective id.
Doing this 
```
        localization={{
          'notifications.newNotifications': ({ notificationCount }) => `new : ${notificationCount}`,
          dynamic: {
            '6697c185607852e9104daf33': 'My workflow in other language',
          },
        }}
 ``` 
 will result in
![image](https://github.com/user-attachments/assets/e816dbfa-0bbb-416d-9007-89bf180da266)

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
