### PR TITLE
feat(web): Novu Dashboard fix- After clearing the search a provider input selected tab list should be visible not to show list from begining

### DIFF
--- a/apps/web/src/pages/integrations/components/multi-provider/SelectProviderSidebar.tsx
+++ b/apps/web/src/pages/integrations/components/multi-provider/SelectProviderSidebar.tsx
@@ -181,6 +181,10 @@ export function SelectProviderSidebar({
           type={'search'}
           onChange={(e) => {
             debouncedSearchChange(e.target.value);
+            if (e.target.value === '') {
+              // added timeout of 1000ms so that scroll happens after provider list is rendered
+              setTimeout(() => scrollToElement(selectedTab), 1000);
+            }
           }}
           mb={20}
           placeholder={'Search a provider...'}


### PR DESCRIPTION
### What changed? Why was the change needed?
fixes #6385

Clearing the provider input text make the list render from beginning of the list irrespective of selected tab. 

calling **scrollToElement** on selected tab after getting empty string.

### Screenshots

https://github.com/user-attachments/assets/d1ed19a4-275d-4449-b4dd-a3fbf8e3958f

<details>
<summary><strong>Expand for optional sections</strong></summary>


### Special notes for your reviewer
I've added timeout of 1000ms so that providers list is first rendered and then scrolled to selected tab.

</details>
