### PR TITLE
feat(framework,js): expose the data property on the in-app step and notification object

### DIFF
--- a/apps/api/src/app/inbox/utils/notification-mapper.ts
+++ b/apps/api/src/app/inbox/utils/notification-mapper.ts
@@ -17,6 +17,7 @@ const mapSingleItem = ({
   avatar,
   cta,
   tags,
+  data,
 }: MessageEntity): InboxNotification => {
   const to: Subscriber = {
     id: subscriber?._id ?? '',
@@ -56,6 +57,7 @@ const mapSingleItem = ({
           url: cta.data.url,
         }
       : undefined,
+    data,
   };
 };
 

--- a/apps/api/src/app/inbox/utils/types.ts
+++ b/apps/api/src/app/inbox/utils/types.ts
@@ -31,6 +31,7 @@ export type InboxNotification = {
   redirect?: {
     url: string;
   };
+  data?: Record<string, unknown>;
 };
 
 export type NotificationFilter = {

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
@@ -201,12 +201,15 @@ export class SendMessageInApp extends SendMessageBase {
     const bridgeOutputs = command.bridgeData?.outputs as InAppOutput;
     const inAppMessage = inAppMessageFromBridgeOutputs(bridgeOutputs);
 
-    const channelData: Partial<Pick<MessageEntity, 'content' | 'subject' | 'avatar' | 'payload' | 'cta' | 'tags'>> = {
+    const channelData: Partial<
+      Pick<MessageEntity, 'content' | 'subject' | 'avatar' | 'payload' | 'cta' | 'tags' | 'data'>
+    > = {
       content: (this.storeContent() ? inAppMessage.content || content : null) as string,
       cta: bridgeOutputs ? inAppMessage.cta : step.template.cta,
       subject: inAppMessage.subject,
       avatar: inAppMessage.avatar,
       payload: messagePayload,
+      data: inAppMessage.data,
       tags: command.tags,
     };
 

--- a/libs/dal/src/repositories/message/message.entity.ts
+++ b/libs/dal/src/repositories/message/message.entity.ts
@@ -90,6 +90,8 @@ export class MessageEntity {
 
   payload: Record<string, unknown>;
 
+  data?: Record<string, unknown>;
+
   overrides: Record<string, unknown>;
 
   identifier?: string;

--- a/libs/dal/src/repositories/message/message.schema.ts
+++ b/libs/dal/src/repositories/message/message.schema.ts
@@ -102,6 +102,7 @@ const messageSchema = new Schema<MessageDBModel>(
     },
     identifier: Schema.Types.String,
     payload: Schema.Types.Mixed,
+    data: Schema.Types.Mixed,
     overrides: Schema.Types.Mixed,
     actor: {
       type: {

--- a/libs/shared/src/entities/messages/messages.interface.ts
+++ b/libs/shared/src/entities/messages/messages.interface.ts
@@ -23,6 +23,7 @@ export interface IMessage {
   _feedId?: string | null;
   _layoutId?: string;
   payload: Record<string, unknown>;
+  data?: Record<string, unknown>;
   actor?: IActor;
   avatar?: string;
   subject?: string;

--- a/libs/shared/src/utils/bridge.utils.ts
+++ b/libs/shared/src/utils/bridge.utils.ts
@@ -25,9 +25,10 @@ type InAppOutput = {
     label: string;
     url?: string;
   };
+  data?: Record<string, unknown>;
 };
 
-type InAppMessage = Pick<IMessage, 'subject' | 'content' | 'cta' | 'avatar'>;
+type InAppMessage = Pick<IMessage, 'subject' | 'content' | 'cta' | 'avatar' | 'data'>;
 
 /**
  * This function maps the V2 InAppOutput to the V1 MessageEntity.
@@ -66,5 +67,6 @@ export const inAppMessageFromBridgeOutputs = (outputs?: InAppOutput) => {
     content: outputs?.body || '',
     cta,
     avatar: outputs?.avatar,
+    data: outputs?.data,
   } satisfies InAppMessage;
 };

--- a/packages/framework/src/schemas/steps/channels/in-app.schema.ts
+++ b/packages/framework/src/schemas/steps/channels/in-app.schema.ts
@@ -18,6 +18,7 @@ const inAppOutputSchema = {
     avatar: { type: 'string', format: 'uri' },
     primaryAction: actionSchema,
     secondaryAction: actionSchema,
+    data: { type: 'object', additionalProperties: true },
   },
   required: ['body'],
   additionalProperties: false,

--- a/packages/js/src/notifications/notification.ts
+++ b/packages/js/src/notifications/notification.ts
@@ -23,6 +23,7 @@ export class Notification implements Pick<NovuEventEmitter, 'on' | 'off'>, Inbox
   readonly channelType: InboxNotification['channelType'];
   readonly tags: InboxNotification['tags'];
   readonly redirect: InboxNotification['redirect'];
+  readonly data?: InboxNotification['data'];
 
   constructor(notification: InboxNotification) {
     this.#emitter = NovuEventEmitter.getInstance();
@@ -43,6 +44,7 @@ export class Notification implements Pick<NovuEventEmitter, 'on' | 'off'>, Inbox
     this.channelType = notification.channelType;
     this.tags = notification.tags;
     this.redirect = notification.redirect;
+    this.data = notification.data;
   }
 
   read(): Result<Notification> {

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -102,6 +102,7 @@ export type InboxNotification = {
   redirect?: {
     url: string;
   };
+  data?: Record<string, unknown>;
 };
 
 export type NotificationFilter = {

--- a/packages/js/src/ws/socket.ts
+++ b/packages/js/src/ws/socket.ts
@@ -38,6 +38,7 @@ const mapToNotification = ({
   avatar,
   cta,
   tags,
+  data,
 }: TODO): InboxNotification => {
   const to: Subscriber = {
     id: subscriber?._id ?? '',
@@ -77,6 +78,7 @@ const mapToNotification = ({
           url: cta.data.url,
         }
       : undefined,
+    data,
   };
 };
 


### PR DESCRIPTION
### What changed? Why was the change needed?
Expose the `data` property on the framework `in-app` step output. The `data` value is stored on the `message` document and will be read by the Inbox API.

**This PR doesn't include any changes to the Studio UI.**

### Screenshots

![Screenshot 2024-08-26 at 13 56 52](https://github.com/user-attachments/assets/89ea268d-4391-42fe-9356-3ac8a8f56644)

![Screenshot 2024-08-26 at 13 57 04](https://github.com/user-attachments/assets/3f07a241-7f6b-4806-8366-ce17ba360ceb)
