### PR TITLE
fix(web): Use web url for sync confirmation toast

### DIFF
--- a/apps/web/src/components/layout/components/v2/SyncInfoModal.tsx
+++ b/apps/web/src/components/layout/components/v2/SyncInfoModal.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useState } from 'react';
 import { QueryObserverResult } from '@tanstack/react-query';
 import { showNotification } from '@mantine/notifications';
 // TODO: replace with Novui Code Block when available
@@ -53,7 +53,19 @@ export const SyncInfoModal: FC<SyncInfoModalProps> = ({ isOpen, toggleOpen, refe
 
       showNotification({
         color: 'green',
-        message: `Synced successfully. Visit https://dashboard.novu.co`,
+        message: (
+          <>
+            Successfully synced. Visit{' '}
+            <a
+              href={`${process.env.PUBLIC_URL}/workflows`}
+              target="_blank"
+              className={css({ textDecoration: 'underline' })}
+            >
+              Dashboard
+            </a>{' '}
+            to see your workflows.
+          </>
+        ),
       });
     } catch (error: any) {
       showNotification({

--- a/apps/web/src/components/layout/components/v2/SyncInfoModal.tsx
+++ b/apps/web/src/components/layout/components/v2/SyncInfoModal.tsx
@@ -55,7 +55,7 @@ export const SyncInfoModal: FC<SyncInfoModalProps> = ({ isOpen, toggleOpen, refe
         color: 'green',
         message: (
           <>
-            Successfully synced. Visit{' '}
+            Successfully synced. Visit the{' '}
             <a
               href={`${process.env.PUBLIC_URL}/workflows`}
               target="_blank"


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Use web url for sync confirmation toast
* Make the Dashboard link clickable

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Toast showing after successful sync_
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/c587dcc7-558f-4a71-9636-bd82494fef24">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
