### PR TITLE
feat(js,react): inbox preferences cache

### DIFF
--- a/apps/api/src/app/inbox/e2e/update-preferences.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/update-preferences.e2e.ts
@@ -1,4 +1,4 @@
-import { PreferenceLevelEnum } from '@novu/shared';
+import { EmailBlockTypeEnum, PreferenceLevelEnum, StepTypeEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
@@ -175,7 +175,7 @@ describe('Update workflow preferences - /inbox/preferences/:workflowId (PATCH)',
       .patch(`/v1/inbox/preferences/${workflow._id}`)
       .send({
         email: true,
-        in_app: true,
+        in_app: false,
         sms: false,
         push: false,
         chat: true,
@@ -183,17 +183,42 @@ describe('Update workflow preferences - /inbox/preferences/:workflowId (PATCH)',
       .set('Authorization', `Bearer ${session.subscriberToken}`);
 
     expect(response.status).to.equal(200);
+    expect(Object.keys(response.body.data.channels).length).to.equal(2);
     expect(response.body.data.channels.email).to.equal(true);
-    expect(response.body.data.channels.in_app).to.equal(true);
-    expect(response.body.data.channels.sms).to.equal(false);
-    expect(response.body.data.channels.push).to.equal(false);
-    expect(response.body.data.channels.chat).to.equal(true);
+    expect(response.body.data.channels.in_app).to.equal(false);
     expect(response.body.data.level).to.equal(PreferenceLevelEnum.TEMPLATE);
   });
 
   it('should update the particular channel sent in the body and return all channels', async function () {
     const workflow = await session.createTemplate({
       noFeedId: true,
+      steps: [
+        {
+          type: StepTypeEnum.SMS,
+          content: 'Welcome to {{organizationName}}' as string,
+        },
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Hello {{subscriber.lastName}}, Welcome to {{organizationName}}' as string,
+        },
+        {
+          type: StepTypeEnum.EMAIL,
+          content: [
+            {
+              type: EmailBlockTypeEnum.TEXT,
+              content: 'Hello {{subscriber.lastName}}, Welcome to {{organizationName}}' as string,
+            },
+          ],
+        },
+        {
+          type: StepTypeEnum.CHAT,
+          content: 'Hello {{subscriber.lastName}}, Welcome to {{organizationName}}' as string,
+        },
+        {
+          type: StepTypeEnum.PUSH,
+          content: 'Hello {{subscriber.lastName}}, Welcome to {{organizationName}}' as string,
+        },
+      ],
     });
 
     const response = await session.testAgent

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.spec.ts
@@ -1,4 +1,9 @@
-import { AnalyticsService } from '@novu/application-generic';
+import {
+  AnalyticsService,
+  GetSubscriberGlobalPreference,
+  GetSubscriberTemplatePreference,
+  GetSubscriberGlobalPreferenceCommand,
+} from '@novu/application-generic';
 import { NotificationTemplateRepository, SubscriberPreferenceRepository, SubscriberRepository } from '@novu/dal';
 import { PreferenceLevelEnum } from '@novu/shared';
 import { expect } from 'chai';
@@ -8,7 +13,7 @@ import { UpdatePreferences } from './update-preferences.usecase';
 
 const mockedSubscriber: any = { _id: '123', subscriberId: 'test-mockSubscriber', firstName: 'test', lastName: 'test' };
 
-const mockedPreference: any = {
+const mockedSubscriberPreference: any = {
   _id: '123',
   subscriberId: 'test-mockSubscriber',
   level: 'global',
@@ -22,27 +27,51 @@ const mockedPreference: any = {
   },
 };
 
-const mockedWorkflow: any = [{}];
+const mockedGlobalPreference: any = {
+  preference: {
+    enabled: true,
+    channels: {
+      email: true,
+      in_app: true,
+      sms: false,
+      push: false,
+      chat: true,
+    },
+  },
+};
+
+const mockedWorkflow: any = {
+  _id: 'workflow-1',
+  name: 'test-workflow',
+  critical: false,
+  triggers: [{ identifier: 'test-trigger' }],
+  tags: [],
+};
 
 describe('UpdatePreferences', () => {
   let updatePreferences: UpdatePreferences;
   let subscriberRepositoryMock: sinon.SinonStubbedInstance<SubscriberRepository>;
   let analyticsServiceMock: sinon.SinonStubbedInstance<AnalyticsService>;
-
   let notificationTemplateRepositoryMock: sinon.SinonStubbedInstance<NotificationTemplateRepository>;
   let subscriberPreferenceRepositoryMock: sinon.SinonStubbedInstance<SubscriberPreferenceRepository>;
+  let getSubscriberGlobalPreferenceMock: sinon.SinonStubbedInstance<GetSubscriberGlobalPreference>;
+  let getSubscriberTemplatePreferenceUsecase: sinon.SinonStubbedInstance<GetSubscriberTemplatePreference>;
 
   beforeEach(() => {
     subscriberRepositoryMock = sinon.createStubInstance(SubscriberRepository);
     analyticsServiceMock = sinon.createStubInstance(AnalyticsService);
     notificationTemplateRepositoryMock = sinon.createStubInstance(NotificationTemplateRepository);
     subscriberPreferenceRepositoryMock = sinon.createStubInstance(SubscriberPreferenceRepository);
+    getSubscriberGlobalPreferenceMock = sinon.createStubInstance(GetSubscriberGlobalPreference);
+    getSubscriberTemplatePreferenceUsecase = sinon.createStubInstance(GetSubscriberTemplatePreference);
 
     updatePreferences = new UpdatePreferences(
       subscriberPreferenceRepositoryMock as any,
       notificationTemplateRepositoryMock as any,
       subscriberRepositoryMock as any,
-      analyticsServiceMock as any
+      analyticsServiceMock as any,
+      getSubscriberGlobalPreferenceMock as any,
+      getSubscriberTemplatePreferenceUsecase as any
     );
   });
 
@@ -100,27 +129,18 @@ describe('UpdatePreferences', () => {
     };
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
-    subscriberPreferenceRepositoryMock.findOne.onFirstCall().resolves(undefined);
-    subscriberPreferenceRepositoryMock.findOne.onSecondCall().resolves(mockedPreference);
+    subscriberPreferenceRepositoryMock.findOne.resolves(undefined);
+    getSubscriberGlobalPreferenceMock.execute.resolves(mockedGlobalPreference);
 
-    await updatePreferences.execute(command);
+    const result = await updatePreferences.execute(command);
 
-    expect(subscriberPreferenceRepositoryMock.create.calledOnce).to.be.true;
-    expect(subscriberPreferenceRepositoryMock.create.firstCall.args).to.deep.equal([
-      {
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-        _subscriberId: mockedSubscriber._id,
-        enabled: true,
-        channels: {
-          chat: command.chat,
-          email: undefined,
-          sms: undefined,
-          in_app: undefined,
-          push: undefined,
-        },
-        level: command.level,
-      },
+    expect(getSubscriberGlobalPreferenceMock.execute.called).to.be.true;
+    expect(getSubscriberGlobalPreferenceMock.execute.lastCall.args).to.deep.equal([
+      GetSubscriberGlobalPreferenceCommand.create({
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        subscriberId: mockedSubscriber.subscriberId,
+      }),
     ]);
 
     expect(analyticsServiceMock.mixpanelTrack.firstCall.args).to.deep.equal([
@@ -138,9 +158,13 @@ describe('UpdatePreferences', () => {
           in_app: undefined,
           push: undefined,
         },
-        __source: 'UpdatePreferences',
       },
     ]);
+
+    expect(result).to.deep.equal({
+      level: command.level,
+      ...mockedGlobalPreference.preference,
+    });
   });
 
   it('should update user preference if preference exists', async () => {
@@ -153,25 +177,42 @@ describe('UpdatePreferences', () => {
     };
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
-    subscriberPreferenceRepositoryMock.findOne.resolves(mockedPreference);
+    subscriberPreferenceRepositoryMock.findOne.resolves(mockedSubscriberPreference);
+    getSubscriberGlobalPreferenceMock.execute.resolves(mockedGlobalPreference);
 
-    await updatePreferences.execute(command);
+    const result = await updatePreferences.execute(command);
 
-    expect(subscriberPreferenceRepositoryMock.create.calledOnce).to.be.false;
-    expect(subscriberPreferenceRepositoryMock.update.calledOnce).to.be.true;
-    expect(subscriberPreferenceRepositoryMock.update.firstCall.args).to.deep.equal([
+    expect(getSubscriberGlobalPreferenceMock.execute.called).to.be.true;
+    expect(getSubscriberGlobalPreferenceMock.execute.lastCall.args).to.deep.equal([
+      GetSubscriberGlobalPreferenceCommand.create({
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        subscriberId: mockedSubscriber.subscriberId,
+      }),
+    ]);
+
+    expect(analyticsServiceMock.mixpanelTrack.firstCall.args).to.deep.equal([
+      AnalyticsEventsEnum.UPDATE_PREFERENCES,
+      '',
       {
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-        _subscriberId: mockedSubscriber._id,
+        _organization: command.organizationId,
+        _subscriber: mockedSubscriber._id,
         level: command.level,
-      },
-      {
-        $set: {
-          'channels.chat': true,
+        _workflowId: undefined,
+        channels: {
+          chat: true,
+          email: undefined,
+          sms: undefined,
+          in_app: undefined,
+          push: undefined,
         },
       },
     ]);
+
+    expect(result).to.deep.equal({
+      level: command.level,
+      ...mockedGlobalPreference.preference,
+    });
   });
 
   it('should update user preference if preference exists and level is template', async () => {
@@ -186,10 +227,11 @@ describe('UpdatePreferences', () => {
     };
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
-    subscriberPreferenceRepositoryMock.findOne.resolves(mockedPreference);
+    subscriberPreferenceRepositoryMock.findOne.resolves(mockedSubscriberPreference);
+    getSubscriberTemplatePreferenceUsecase.execute.resolves({ ...mockedGlobalPreference });
     notificationTemplateRepositoryMock.findById.resolves(mockedWorkflow);
 
-    await updatePreferences.execute(command);
+    const result = await updatePreferences.execute(command);
 
     expect(subscriberPreferenceRepositoryMock.create.calledOnce).to.be.false;
     expect(subscriberPreferenceRepositoryMock.update.calledOnce).to.be.true;
@@ -227,5 +269,17 @@ describe('UpdatePreferences', () => {
         },
       },
     ]);
+
+    expect(result).to.deep.equal({
+      level: command.level,
+      ...mockedGlobalPreference.preference,
+      workflow: {
+        id: mockedWorkflow._id,
+        identifier: mockedWorkflow.triggers[0].identifier,
+        name: mockedWorkflow.name,
+        critical: mockedWorkflow.critical,
+        tags: mockedWorkflow.tags,
+      },
+    });
   });
 });

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -1,5 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { AnalyticsService } from '@novu/application-generic';
+import {
+  AnalyticsService,
+  GetSubscriberGlobalPreference,
+  GetSubscriberGlobalPreferenceCommand,
+  GetSubscriberTemplatePreference,
+  GetSubscriberTemplatePreferenceCommand,
+} from '@novu/application-generic';
 import {
   ChannelTypeEnum,
   NotificationTemplateEntity,
@@ -20,7 +26,9 @@ export class UpdatePreferences {
     private subscriberPreferenceRepository: SubscriberPreferenceRepository,
     private notificationTemplateRepository: NotificationTemplateRepository,
     private subscriberRepository: SubscriberRepository,
-    private analyticsService: AnalyticsService
+    private analyticsService: AnalyticsService,
+    private getSubscriberGlobalPreference: GetSubscriberGlobalPreference,
+    private getSubscriberTemplatePreferenceUsecase: GetSubscriberTemplatePreference
   ) {}
 
   async execute(command: UpdatePreferencesCommand): Promise<InboxPreference> {
@@ -48,27 +56,7 @@ export class UpdatePreferences {
       await this.updateUserPreference(command, subscriber);
     }
 
-    const updatedPreference = await this.findPreference(command, subscriber);
-
-    if (!updatedPreference) {
-      throw new NotFoundException(`Preference not found`);
-    }
-
-    return {
-      level: updatedPreference.level,
-      enabled: updatedPreference.enabled,
-      channels: updatedPreference.channels,
-      ...(workflow &&
-        updatedPreference.level === PreferenceLevelEnum.TEMPLATE && {
-          workflow: {
-            id: workflow._id,
-            identifier: workflow.triggers[0].identifier,
-            name: workflow.name,
-            critical: workflow.critical,
-            tags: workflow.tags,
-          },
-        }),
-    };
+    return await this.findPreference(command, subscriber);
   }
 
   private async createUserPreference(command: UpdatePreferencesCommand, subscriber: SubscriberEntity): Promise<void> {
@@ -127,10 +115,53 @@ export class UpdatePreferences {
     });
   }
 
-  private async findPreference(command: UpdatePreferencesCommand, subscriber: SubscriberEntity) {
-    const query = this.commonQuery(command, subscriber);
+  private async findPreference(
+    command: UpdatePreferencesCommand,
+    subscriber: SubscriberEntity
+  ): Promise<InboxPreference> {
+    if (command.level === PreferenceLevelEnum.TEMPLATE && command.workflowId) {
+      const workflow = await this.notificationTemplateRepository.findById(command.workflowId, command.environmentId);
+      if (!workflow) {
+        throw new NotFoundException(`Workflow with id: ${command.workflowId} is not found`);
+      }
 
-    return await this.subscriberPreferenceRepository.findOne(query);
+      const { preference } = await this.getSubscriberTemplatePreferenceUsecase.execute(
+        GetSubscriberTemplatePreferenceCommand.create({
+          organizationId: command.organizationId,
+          subscriberId: command.subscriberId,
+          environmentId: command.environmentId,
+          template: workflow,
+          subscriber,
+        })
+      );
+
+      return {
+        level: PreferenceLevelEnum.TEMPLATE,
+        enabled: preference.enabled,
+        channels: preference.channels,
+        workflow: {
+          id: workflow._id,
+          identifier: workflow.triggers[0].identifier,
+          name: workflow.name,
+          critical: workflow.critical,
+          tags: workflow.tags,
+        },
+      };
+    }
+
+    const { preference } = await this.getSubscriberGlobalPreference.execute(
+      GetSubscriberGlobalPreferenceCommand.create({
+        organizationId: command.organizationId,
+        environmentId: command.environmentId,
+        subscriberId: command.subscriberId,
+      })
+    );
+
+    return {
+      level: PreferenceLevelEnum.GLOBAL,
+      enabled: preference.enabled,
+      channels: preference.channels,
+    };
   }
 
   private commonQuery(command: UpdatePreferencesCommand, subscriber: SubscriberEntity) {

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -48,8 +48,7 @@ export class UpdatePreferences {
       }
     }
 
-    const userPreference = await this.findPreference(command, subscriber);
-
+    const userPreference = await this.subscriberPreferenceRepository.findOne(this.commonQuery(command, subscriber));
     if (!userPreference) {
       await this.createUserPreference(command, subscriber);
     } else {
@@ -74,7 +73,6 @@ export class UpdatePreferences {
       _workflowId: command.workflowId,
       level: command.level,
       channels: channelObj,
-      __source: 'UpdatePreferences',
     });
 
     const query = this.commonQuery(command, subscriber);

--- a/packages/js/src/cache/notifications-cache.ts
+++ b/packages/js/src/cache/notifications-cache.ts
@@ -173,6 +173,14 @@ export class NotificationsCache {
     this.#cache.set(getCacheKey(args), data);
   }
 
+  update(args: ListNotificationsArgs, data: ListNotificationsResponse): void {
+    this.set(args, data);
+    const notificationsResponse = this.getAggregated(getFilter(getCacheKey(args)));
+    this.#emitter.emit('notifications.list.updated', {
+      data: notificationsResponse,
+    });
+  }
+
   getAll(args: ListNotificationsArgs): ListNotificationsResponse | undefined {
     if (this.has(args)) {
       return this.getAggregated({ tags: args.tags, read: args.read, archived: args.archived });

--- a/packages/js/src/cache/preferences-cache.ts
+++ b/packages/js/src/cache/preferences-cache.ts
@@ -1,0 +1,76 @@
+import { InMemoryCache } from './in-memory-cache';
+import type { Cache } from './types';
+import { NovuEventEmitter, PreferenceEvents } from '../event-emitter';
+import { PreferenceLevel } from '../types';
+import { Preference } from '../preferences/preference';
+
+// these events should update the preferences in the cache
+const updateEvents: PreferenceEvents[] = ['preference.update.pending', 'preference.update.resolved'];
+
+const DEFAULT_KEY = 'default';
+
+export class PreferencesCache {
+  #emitter: NovuEventEmitter;
+  #cache: Cache<Preference[]>;
+
+  constructor() {
+    this.#emitter = NovuEventEmitter.getInstance();
+    updateEvents.forEach((event) => {
+      this.#emitter.on(event, this.handlePreferenceEvent);
+    });
+    this.#cache = new InMemoryCache();
+  }
+
+  private updatePreference = (key: string, data: Preference): boolean => {
+    const preferences = this.#cache.get(key);
+    if (!preferences) {
+      return false;
+    }
+
+    const index = preferences.findIndex(
+      (el) =>
+        el.workflow?.id === data.workflow?.id || (el.level === data.level && data.level === PreferenceLevel.GLOBAL)
+    );
+    if (index === -1) {
+      return false;
+    }
+
+    const updatedPreferences = [...preferences];
+    updatedPreferences[index] = data;
+
+    this.#cache.set(key, updatedPreferences);
+
+    return true;
+  };
+
+  private handlePreferenceEvent = ({ data }: { data?: Preference }): void => {
+    if (!data) {
+      return;
+    }
+
+    this.#cache.keys().forEach((key) => {
+      const hasUpdatedPreference = this.updatePreference(key, data);
+
+      const updatedPreference = this.#cache.get(key);
+      if (!hasUpdatedPreference || !updatedPreference) {
+        return;
+      }
+
+      this.#emitter.emit('preferences.list.updated', {
+        data: updatedPreference,
+      });
+    });
+  };
+
+  set(data: Preference[]): void {
+    this.#cache.set(DEFAULT_KEY, data);
+  }
+
+  getAll(): Preference[] | undefined {
+    return this.#cache.get(DEFAULT_KEY);
+  }
+
+  clearAll(): void {
+    this.#cache.clear();
+  }
+}

--- a/packages/js/src/event-emitter/types.ts
+++ b/packages/js/src/event-emitter/types.ts
@@ -53,7 +53,7 @@ type NotificationsReadArchivedAllEvents = BaseEvents<
   Notification[]
 >;
 type PreferencesFetchEvents = BaseEvents<'preferences.list', undefined, Preference[]>;
-type PreferencesUpdateEvents = BaseEvents<'preferences.update', UpdatePreferencesArgs, Preference>;
+type PreferenceUpdateEvents = BaseEvents<'preference.update', UpdatePreferencesArgs, Preference>;
 type SocketConnectEvents = BaseEvents<'socket.connect', { socketUrl: string }, undefined>;
 export type NotificationReceivedEvent = `notifications.${WebSocketEvent.RECEIVED}`;
 export type NotificationUnseenEvent = `notifications.${WebSocketEvent.UNSEEN}`;
@@ -82,8 +82,9 @@ export type Events = SessionInitializeEvents &
   NotificationsFetchEvents & {
     'notifications.list.updated': { data: ListNotificationsResponse };
   } & NotificationsFetchCountEvents &
-  PreferencesFetchEvents &
-  PreferencesUpdateEvents &
+  PreferencesFetchEvents & {
+    'preferences.list.updated': { data: Preference[] };
+  } & PreferenceUpdateEvents &
   SocketConnectEvents &
   SocketEvents &
   NotificationReadEvents &
@@ -107,5 +108,6 @@ export type NotificationEvents = keyof (NotificationReadEvents &
   NotificationsReadAllEvents &
   NotificationsArchivedAllEvents &
   NotificationsReadArchivedAllEvents);
+export type PreferenceEvents = keyof PreferenceUpdateEvents;
 
 export type EventHandler<T = unknown> = (event: T) => void;

--- a/packages/js/src/notifications/notifications.ts
+++ b/packages/js/src/notifications/notifications.ts
@@ -49,6 +49,7 @@ export class Notifications extends BaseModule {
       const args = { limit, ...restOptions };
       try {
         let data: ListNotificationsResponse | undefined = this.#useCache ? this.cache.getAll(args) : undefined;
+        this._emitter.emit('notifications.list.pending', { args, data });
 
         if (!data) {
           const response = await this._inboxService.fetchNotifications({

--- a/packages/js/src/notifications/notifications.ts
+++ b/packages/js/src/notifications/notifications.ts
@@ -36,11 +36,11 @@ import { NotificationsCache } from '../cache';
 export class Notifications extends BaseModule {
   #useCache: boolean;
 
-  readonly #notificationsCache: NotificationsCache;
+  readonly cache: NotificationsCache;
 
   constructor({ useCache }: { useCache: boolean }) {
     super();
-    this.#notificationsCache = new NotificationsCache();
+    this.cache = new NotificationsCache();
     this.#useCache = useCache;
   }
 
@@ -48,9 +48,7 @@ export class Notifications extends BaseModule {
     return this.callWithSession(async () => {
       const args = { limit, ...restOptions };
       try {
-        let data: ListNotificationsResponse | undefined = this.#useCache
-          ? this.#notificationsCache.getAll(args)
-          : undefined;
+        let data: ListNotificationsResponse | undefined = this.#useCache ? this.cache.getAll(args) : undefined;
 
         if (!data) {
           const response = await this._inboxService.fetchNotifications({
@@ -65,8 +63,8 @@ export class Notifications extends BaseModule {
           };
 
           if (this.#useCache) {
-            this.#notificationsCache.set(args, data);
-            data = this.#notificationsCache.getAll(args);
+            this.cache.set(args, data);
+            data = this.cache.getAll(args);
           }
         }
 
@@ -215,7 +213,7 @@ export class Notifications extends BaseModule {
       readAll({
         emitter: this._emitter,
         inboxService: this._inboxService,
-        notificationsCache: this.#notificationsCache,
+        notificationsCache: this.cache,
         tags,
       })
     );
@@ -226,7 +224,7 @@ export class Notifications extends BaseModule {
       archiveAll({
         emitter: this._emitter,
         inboxService: this._inboxService,
-        notificationsCache: this.#notificationsCache,
+        notificationsCache: this.cache,
         tags,
       })
     );
@@ -237,7 +235,7 @@ export class Notifications extends BaseModule {
       archiveAllRead({
         emitter: this._emitter,
         inboxService: this._inboxService,
-        notificationsCache: this.#notificationsCache,
+        notificationsCache: this.cache,
         tags,
       })
     );
@@ -245,9 +243,9 @@ export class Notifications extends BaseModule {
 
   clearCache({ filter }: { filter?: NotificationFilter } = {}): void {
     if (filter) {
-      return this.#notificationsCache.clear(filter ?? {});
+      return this.cache.clear(filter ?? {});
     }
 
-    return this.#notificationsCache.clearAll();
+    return this.cache.clearAll();
   }
 }

--- a/packages/js/src/novu.ts
+++ b/packages/js/src/novu.ts
@@ -26,7 +26,7 @@ export class Novu implements Pick<NovuEventEmitter, 'on' | 'off'> {
     });
     this.#session.initialize();
     this.notifications = new Notifications({ useCache: options.useCache ?? true });
-    this.preferences = new Preferences();
+    this.preferences = new Preferences({ useCache: options.useCache ?? true });
     this.#socket = new Socket({ socketUrl: options.socketUrl });
   }
 

--- a/packages/js/src/preferences/helpers.ts
+++ b/packages/js/src/preferences/helpers.ts
@@ -16,7 +16,7 @@ export const updatePreference = async ({
 }): Result<Preference> => {
   const { workflowId, channelPreferences } = args;
   try {
-    emitter.emit('preferences.update.pending', {
+    emitter.emit('preference.update.pending', {
       args,
       data: args.preference
         ? new Preference({
@@ -37,11 +37,11 @@ export const updatePreference = async ({
     }
 
     const preference = new Preference(response);
-    emitter.emit('preferences.update.resolved', { args, data: preference });
+    emitter.emit('preference.update.resolved', { args, data: preference });
 
     return { data: preference };
   } catch (error) {
-    emitter.emit('preferences.update.resolved', { args, error });
+    emitter.emit('preference.update.resolved', { args, error });
 
     return { error: new NovuError('Failed to fetch notifications', error) };
   }

--- a/packages/js/src/ui/components/Notification/NotificationList.tsx
+++ b/packages/js/src/ui/components/Notification/NotificationList.tsx
@@ -1,7 +1,7 @@
-import { createMemo, For, JSX, Show } from 'solid-js';
+import { createEffect, createMemo, For, JSX, Show } from 'solid-js';
 import type { NotificationFilter } from '../../../types';
 import { useNotificationsInfiniteScroll } from '../../api';
-import { useLocalization, useNewMessagesCount } from '../../context';
+import { DEFAULT_LIMIT, useInboxContext, useLocalization, useNewMessagesCount } from '../../context';
 import { useStyle } from '../../helpers';
 import { EmptyIcon } from '../../icons/EmptyIcon';
 import type { NotificationActionClickHandler, NotificationClickHandler, NotificationRenderer } from '../../types';
@@ -42,7 +42,12 @@ export const NotificationList = (props: NotificationListProps) => {
   const style = useStyle();
   const { data, setEl, end, refetch, initialLoading } = useNotificationsInfiniteScroll({ options });
   const { count, reset: resetNewMessagesCount } = useNewMessagesCount({ filter: { tags: props.filter?.tags ?? [] } });
+  const { setLimit } = useInboxContext();
   let notificationListElement: HTMLDivElement;
+
+  createEffect(() => {
+    setLimit(props.limit || DEFAULT_LIMIT);
+  });
 
   const handleOnNewMessagesClick: JSX.EventHandlerUnion<HTMLButtonElement, MouseEvent> = async (e) => {
     e.stopPropagation();

--- a/packages/js/src/ui/components/elements/Preferences/ChannelRow.tsx
+++ b/packages/js/src/ui/components/elements/Preferences/ChannelRow.tsx
@@ -1,6 +1,5 @@
 import { JSX } from 'solid-js';
 import { ChannelType } from '../../../../types';
-import { useNovu } from '../../../context';
 import { useStyle } from '../../../helpers';
 import { Chat, Email, InApp, Push, Sms } from '../../../icons';
 import { Switch } from './Switch';
@@ -15,7 +14,6 @@ type ChannelRowProps = {
 };
 
 export const ChannelRow = (props: ChannelRowProps) => {
-  const novu = useNovu();
   const style = useStyle();
 
   const updatePreference = async (enabled: boolean) => {
@@ -23,16 +21,7 @@ export const ChannelRow = (props: ChannelRowProps) => {
       return;
     }
 
-    try {
-      await novu.preferences.update({
-        workflowId: props.workflowId,
-        channelPreferences: { [props.channel]: enabled },
-      });
-
-      props.onChange({ channel: props.channel, enabled, workflowId: props.workflowId });
-    } catch (error) {
-      console.error(error);
-    }
+    props.onChange({ channel: props.channel, enabled, workflowId: props.workflowId });
   };
 
   const onChange = (checked: boolean) => {

--- a/packages/js/src/ui/context/CountContext.tsx
+++ b/packages/js/src/ui/context/CountContext.tsx
@@ -1,5 +1,5 @@
 import { Accessor, createContext, createMemo, createSignal, onMount, ParentProps, useContext } from 'solid-js';
-import { NotificationFilter } from '../../types';
+import { NotificationFilter, Notification } from '../../types';
 import { useNovuEvent } from '../helpers/useNovuEvent';
 import { useWebSocketEvent } from '../helpers/useWebSocketEvent';
 import { useInboxContext } from './InboxContext';
@@ -16,7 +16,7 @@ const CountContext = createContext<CountContextValue>(undefined);
 
 export const CountProvider = (props: ParentProps) => {
   const novu = useNovu();
-  const { tabs } = useInboxContext();
+  const { tabs, filter, limit } = useInboxContext();
   const [totalUnreadCount, setTotalUnreadCount] = createSignal(0);
   const [unreadCounts, setUnreadCounts] = createSignal(new Map<string, number>());
   const [newNotificationCounts, setNewNotificationCounts] = createSignal(new Map<string, number>());
@@ -64,37 +64,52 @@ export const CountProvider = (props: ParentProps) => {
     },
   });
 
+  const updateNewNotificationCountsOrCache = (notification: Notification, tags: string[]) => {
+    const notificationsCache = novu.notifications.cache;
+    const limitValue = limit();
+    const tabFilter = { ...filter(), tags, offset: 0, limit: limitValue };
+    const cachedData = notificationsCache.getAll(tabFilter) || { hasMore: false, filter: tabFilter, notifications: [] };
+    const hasLessThenTenItems = (cachedData?.notifications.length || 0) < limitValue;
+    if (hasLessThenTenItems) {
+      notificationsCache.update(tabFilter, {
+        ...cachedData,
+        notifications: [notification, ...cachedData.notifications],
+      });
+
+      return;
+    }
+
+    setNewNotificationCounts((oldMap) => {
+      const tagsKey = createKey(tags);
+      const newMap = new Map(oldMap);
+      newMap.set(tagsKey, (oldMap.get(tagsKey) || 0) + 1);
+
+      return newMap;
+    });
+  };
+
   useWebSocketEvent({
     event: 'notifications.notification_received',
-    eventHandler: async (data) => {
-      const notification = data.result;
-      const allTabs = tabs();
+    eventHandler: async ({ result: notification }) => {
+      if (filter().archived) {
+        return;
+      }
 
+      const allTabs = tabs();
       if (allTabs.length > 0) {
         for (let i = 0; i < allTabs.length; i++) {
           const tab = allTabs[i];
           const tags = tab.value;
           const allNotifications = tags.length === 0;
-          const includeTags = notification.tags?.every((tag) => tags.includes(tag));
-          if (!allNotifications && !includeTags) {
+          const includesAtLeastOneTag = tags.some((tag) => notification.tags?.includes(tag));
+          if (!allNotifications && !includesAtLeastOneTag) {
             continue;
           }
-          setNewNotificationCounts((oldMap) => {
-            const tagsKey = createKey(tags);
-            const newMap = new Map(oldMap);
-            newMap.set(tagsKey, (oldMap.get(tagsKey) || 0) + 1);
 
-            return newMap;
-          });
+          updateNewNotificationCountsOrCache(notification, tags);
         }
       } else {
-        setNewNotificationCounts((oldMap) => {
-          const tagsKey = createKey([]);
-          const newMap = new Map(oldMap);
-          newMap.set(tagsKey, (oldMap.get(tagsKey) || 0) + 1);
-
-          return newMap;
-        });
+        updateNewNotificationCountsOrCache(notification, []);
       }
     },
   });

--- a/packages/js/src/ui/context/InboxContext.tsx
+++ b/packages/js/src/ui/context/InboxContext.tsx
@@ -6,6 +6,8 @@ type InboxContextType = {
   setStatus: (status: NotificationStatus) => void;
   status: Accessor<NotificationStatus>;
   filter: Accessor<NotificationFilter>;
+  limit: Accessor<number>;
+  setLimit: (tab: number) => void;
   tabs: Accessor<Array<Tab>>;
   activeTab: Accessor<string>;
   setActiveTab: (tab: string) => void;
@@ -19,6 +21,8 @@ const STATUS_TO_FILTER: Record<NotificationStatus, NotificationFilter> = {
   [NotificationStatus.ARCHIVED]: { archived: true },
 };
 
+export const DEFAULT_LIMIT = 10;
+
 type InboxProviderProps = ParentProps<{
   tabs: Array<Tab>;
 }>;
@@ -27,6 +31,7 @@ export const InboxProvider = (props: InboxProviderProps) => {
   const [tabs, setTabs] = createSignal<Array<Tab>>(props.tabs);
   const [activeTab, setActiveTab] = createSignal<string>((props.tabs[0] && props.tabs[0].label) ?? '');
   const [status, setStatus] = createSignal<NotificationStatus>(NotificationStatus.UNREAD_READ);
+  const [limit, setLimit] = createSignal<number>(DEFAULT_LIMIT);
   const [filter, setFilter] = createSignal<NotificationFilter>({
     ...STATUS_TO_FILTER[NotificationStatus.UNREAD_READ],
     tags: props.tabs.length > 0 ? props.tabs[0].value : [],
@@ -63,6 +68,8 @@ export const InboxProvider = (props: InboxProviderProps) => {
         tabs,
         activeTab,
         setActiveTab: setNewActiveTab,
+        limit,
+        setLimit,
       }}
     >
       {props.children}


### PR DESCRIPTION
### What changed? Why was the change needed?
Inbox preferences cache. Storing in the cache and handling the optimistic updates will simplify the work required to implement the react hooks as we won't need to duplicate the storing/optimistic updates logic.

### Screenshots

