### PR TITLE
fix(api,js): inbox api send workflow identifier

### DIFF
--- a/apps/api/src/app/inbox/dtos/get-preferences-response.dto.ts
+++ b/apps/api/src/app/inbox/dtos/get-preferences-response.dto.ts
@@ -1,5 +1,6 @@
-import { IPreferenceChannels, IPreferenceOverride, IWorkflow, PreferenceLevelEnum } from '@novu/shared';
+import { IPreferenceChannels, PreferenceLevelEnum } from '@novu/shared';
 import { IsDefined, IsEnum, IsOptional } from 'class-validator';
+import type { Workflow } from '../utils/types';
 
 export class GetPreferencesResponseDto {
   @IsDefined()
@@ -9,14 +10,11 @@ export class GetPreferencesResponseDto {
   level: PreferenceLevelEnum;
 
   @IsOptional()
-  workflow?: IWorkflow;
+  workflow?: Workflow;
 
   @IsDefined()
   enabled: boolean;
 
   @IsDefined()
   channels: IPreferenceChannels;
-
-  @IsOptional()
-  overrides?: IPreferenceOverride[];
 }

--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Get, HttpCode, HttpStatus, Post, Patch, Query, UseGua
 import { ApiExcludeController } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { SubscriberEntity } from '@novu/dal';
-import { ISubscriberPreferences, MessageActionStatusEnum, PreferenceLevelEnum } from '@novu/shared';
+import { MessageActionStatusEnum, PreferenceLevelEnum } from '@novu/shared';
 
 import { SubscriberSessionRequestDto } from './dtos/subscriber-session-request.dto';
 import { SubscriberSessionResponseDto } from './dtos/subscriber-session-response.dto';
@@ -18,7 +18,7 @@ import { GetNotificationsCountRequestDto } from './dtos/get-notifications-count-
 import { GetNotificationsCountResponseDto } from './dtos/get-notifications-count-response.dto';
 import { NotificationsCount } from './usecases/notifications-count/notifications-count.usecase';
 import { NotificationsCountCommand } from './usecases/notifications-count/notifications-count.command';
-import { InboxNotification } from './utils/types';
+import type { InboxNotification, InboxPreference } from './utils/types';
 import { MarkNotificationAsCommand } from './usecases/mark-notification-as/mark-notification-as.command';
 import { MarkNotificationAs } from './usecases/mark-notification-as/mark-notification-as.usecase';
 import { ActionTypeRequestDto } from './dtos/action-type-request.dto';
@@ -225,7 +225,7 @@ export class InboxController {
   async updateGlobalPreference(
     @SubscriberSession() subscriberSession: SubscriberEntity,
     @Body() body: UpdatePreferencesRequestDto
-  ): Promise<ISubscriberPreferences> {
+  ): Promise<InboxPreference> {
     return await this.updatePreferencesUsecase.execute(
       UpdatePreferencesCommand.create({
         organizationId: subscriberSession._organizationId,
@@ -247,7 +247,7 @@ export class InboxController {
     @SubscriberSession() subscriberSession: SubscriberEntity,
     @Param('workflowId') workflowId: string,
     @Body() body: UpdatePreferencesRequestDto
-  ): Promise<ISubscriberPreferences> {
+  ): Promise<InboxPreference> {
     return await this.updatePreferencesUsecase.execute(
       UpdatePreferencesCommand.create({
         organizationId: subscriberSession._organizationId,

--- a/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.spec.ts
@@ -11,6 +11,13 @@ import { AnalyticsEventsEnum } from '../../utils';
 import { GetPreferences } from './get-preferences.usecase';
 
 const mockedSubscriber: any = { _id: '123', subscriberId: 'test-mockSubscriber', firstName: 'test', lastName: 'test' };
+const mockedWorkflow = {
+  _id: '123',
+  name: 'workflow',
+  triggers: [{ identifier: '123' }],
+  critical: false,
+  tags: [],
+};
 const mockedWorkflowPreference: any = {
   template: {},
 
@@ -46,17 +53,25 @@ const mockedPreferencesResponse: any = [
   {
     level: PreferenceLevelEnum.TEMPLATE,
     workflow: {
-      critical: undefined,
-      id: undefined,
-      name: undefined,
-      tags: undefined,
-      triggers: undefined,
+      id: mockedWorkflow._id,
+      identifier: mockedWorkflow.triggers[0].identifier,
+      name: mockedWorkflow.name,
+      critical: mockedWorkflow.critical,
+      tags: mockedWorkflow.tags,
     },
     ...mockedWorkflowPreference.preference,
   },
 ];
 
-const mockedWorkflow: any = [{}];
+const mockedWorkflows: any = [
+  {
+    _id: '123',
+    name: 'workflow',
+    triggers: [{ identifier: '123' }],
+    critical: false,
+    tags: [],
+  },
+];
 
 describe('GetPreferences', () => {
   let getPreferences: GetPreferences;
@@ -112,7 +127,7 @@ describe('GetPreferences', () => {
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
     getSubscriberGlobalPreferenceMock.execute.resolves(mockedGlobalPreferences);
-    notificationTemplateRepositoryMock.getActiveList.resolves(mockedWorkflow);
+    notificationTemplateRepositoryMock.getActiveList.resolves(mockedWorkflows);
     getSubscriberWorkflowMock.execute.resolves(mockedWorkflowPreference);
 
     const result = await getPreferences.execute(command);
@@ -136,7 +151,7 @@ describe('GetPreferences', () => {
         organizationId: command.organizationId,
         subscriberId: command.subscriberId,
         environmentId: command.environmentId,
-        template: mockedWorkflow[0],
+        template: mockedWorkflow,
         subscriber: mockedSubscriber,
       },
     ]);

--- a/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.usecase.ts
@@ -7,8 +7,9 @@ import {
   GetSubscriberTemplatePreferenceCommand,
 } from '@novu/application-generic';
 import { NotificationTemplateRepository, SubscriberRepository } from '@novu/dal';
-import { ISubscriberPreferences, PreferenceLevelEnum } from '@novu/shared';
+import { PreferenceLevelEnum } from '@novu/shared';
 import { AnalyticsEventsEnum } from '../../utils';
+import { InboxPreference } from '../../utils/types';
 import { GetPreferencesCommand } from './get-preferences.command';
 
 @Injectable()
@@ -21,7 +22,7 @@ export class GetPreferences {
     private analyticsService: AnalyticsService
   ) {}
 
-  async execute(command: GetPreferencesCommand): Promise<ISubscriberPreferences[]> {
+  async execute(command: GetPreferencesCommand): Promise<InboxPreference[]> {
     const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
 
     if (!subscriber) {
@@ -68,12 +69,12 @@ export class GetPreferences {
           level: PreferenceLevelEnum.TEMPLATE,
           workflow: {
             id: workflow._id,
+            identifier: workflow.triggers[0].identifier,
             name: workflow.name,
             critical: workflow.critical,
             tags: workflow.tags,
-            triggers: workflow.triggers,
           },
-        };
+        } satisfies InboxPreference;
       })
     );
 

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -9,9 +9,9 @@ import {
   SubscriberPreferenceRepository,
   SubscriberRepository,
 } from '@novu/dal';
-import { ISubscriberPreferences } from '@novu/shared';
 import { ApiException } from '../../../shared/exceptions/api.exception';
 import { AnalyticsEventsEnum } from '../../utils';
+import { InboxPreference } from '../../utils/types';
 import { UpdatePreferencesCommand } from './update-preferences.command';
 
 @Injectable()
@@ -23,7 +23,7 @@ export class UpdatePreferences {
     private analyticsService: AnalyticsService
   ) {}
 
-  async execute(command: UpdatePreferencesCommand): Promise<ISubscriberPreferences> {
+  async execute(command: UpdatePreferencesCommand): Promise<InboxPreference> {
     const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
     if (!subscriber) throw new NotFoundException(`Subscriber with id: ${command.subscriberId} is not found`);
 
@@ -61,11 +61,11 @@ export class UpdatePreferences {
       ...(workflow &&
         updatedPreference.level === PreferenceLevelEnum.TEMPLATE && {
           workflow: {
-            critical: workflow.critical,
             id: workflow._id,
+            identifier: workflow.triggers[0].identifier,
             name: workflow.name,
+            critical: workflow.critical,
             tags: workflow.tags,
-            triggers: workflow.triggers,
           },
         }),
     };

--- a/apps/api/src/app/inbox/utils/types.ts
+++ b/apps/api/src/app/inbox/utils/types.ts
@@ -1,4 +1,4 @@
-import type { ChannelTypeEnum } from '@novu/shared';
+import type { ChannelTypeEnum, IPreferenceChannels, PreferenceLevelEnum } from '@novu/shared';
 
 export type Subscriber = {
   id: string;
@@ -38,4 +38,19 @@ export type NotificationFilter = {
   tags?: string[];
   read?: boolean;
   archived?: boolean;
+};
+
+export type Workflow = {
+  id: string;
+  identifier: string;
+  name: string;
+  critical: boolean;
+  tags?: string[];
+};
+
+export type InboxPreference = {
+  level: PreferenceLevelEnum;
+  enabled: boolean;
+  channels: IPreferenceChannels;
+  workflow?: Workflow;
 };

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -117,11 +117,10 @@ export type NotificationFilter = {
 
 export type Workflow = {
   id: string;
+  identifier: string;
   name: string;
   critical: boolean;
-  identifier: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: Record<string, any>;
+  tags?: string[];
 };
 
 export type ChannelPreference = {

--- a/packages/js/src/ui/components/elements/Preferences/Preferences.tsx
+++ b/packages/js/src/ui/components/elements/Preferences/Preferences.tsx
@@ -45,10 +45,7 @@ export const Preferences = () => {
   }) => {
     mutate((prev) =>
       prev?.map((preference) => {
-        if (
-          preference.workflow?.identifier === workflowId ||
-          (!workflowId && preference.level === PreferenceLevel.GLOBAL)
-        ) {
+        if (preference.workflow?.id === workflowId || (!workflowId && preference.level === PreferenceLevel.GLOBAL)) {
           preference.channels[channel] = enabled;
         }
 
@@ -79,7 +76,7 @@ export const Preferences = () => {
             <PreferencesRow
               localizationKey={preference.workflow!.identifier as StringLocalizationKey}
               channels={preference.channels}
-              workflowId={preference.workflow?.identifier}
+              workflowId={preference.workflow?.id}
               onChange={optimisticUpdate}
               isCritical={preference.workflow?.critical}
             />


### PR DESCRIPTION
### What changed? Why was the change needed?
We've been missing sending the workflow identifier with the preferences response, this field is useful for the localization of the preferences.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
