### PR TITLE
fix(worker): Report Push notification specific errors in logs

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
@@ -294,7 +294,7 @@ export class SendMessagePush extends SendMessageBase {
     content: string,
     overrides: object,
     step: IPushOptions['step']
-  ): Promise<{ success: false; error: Error } | { success: true }> {
+  ): Promise<{ success: false; error: Error } | { success: true; error: undefined }> {
     try {
       const pushHandler = this.getIntegrationHandler(integration);
       const bridgeOutputs = command.bridgeData?.outputs;
@@ -324,7 +324,7 @@ export class SendMessagePush extends SendMessageBase {
         })
       );
 
-      return { success: true };
+      return { success: true, error: undefined };
     } catch (e) {
       await this.sendErrorStatus(
         message,

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
@@ -168,18 +168,22 @@ export class SendMessagePush extends SendMessageBase {
           stepData
         );
 
-        if (!result) {
+        if (!result.success) {
           integrationsWithErrors++;
+
+          Logger.error(
+            { jobId: command.jobId },
+            [
+              `Error sending push notification for jobId ${command.jobId}`,
+              result.error.message || result.error.toString(),
+            ].join(' '),
+            LOG_CONTEXT
+          );
         }
       }
     }
 
     if (integrationsWithErrors > 0) {
-      Logger.error(
-        { jobId: command.jobId },
-        `There was an error sending the push notification(s) for the jobId ${command.jobId}`,
-        LOG_CONTEXT
-      );
       await this.sendNotificationError(command.job);
     }
   }
@@ -290,7 +294,7 @@ export class SendMessagePush extends SendMessageBase {
     content: string,
     overrides: object,
     step: IPushOptions['step']
-  ): Promise<boolean> {
+  ): Promise<{ success: false; error: Error } | { success: true }> {
     try {
       const pushHandler = this.getIntegrationHandler(integration);
       const bridgeOutputs = command.bridgeData?.outputs;
@@ -320,7 +324,7 @@ export class SendMessagePush extends SendMessageBase {
         })
       );
 
-      return true;
+      return { success: true };
     } catch (e) {
       await this.sendErrorStatus(
         message,
@@ -335,7 +339,7 @@ export class SendMessagePush extends SendMessageBase {
 
       await this.sendProviderError(command.job, message._id, raw);
 
-      return false;
+      return { success: false, error: e };
     }
   }
 


### PR DESCRIPTION
### What changed? Why was the change needed?
Report the specific third party error to the logs, instead of a generic error for easier debugging.