### PR TITLE
feat(api): send rate limit headers in response while in dry run

### DIFF
--- a/apps/api/src/app/rate-limiting/guards/throttler.guard.ts
+++ b/apps/api/src/app/rate-limiting/guards/throttler.guard.ts
@@ -154,14 +154,6 @@ export class ApiRateLimitInterceptor extends ThrottlerGuard implements NestInter
       })
     );
 
-    if (isDryRun) {
-      if (!success) {
-        Logger.warn(`[Dry run] ${THROTTLED_EXCEPTION_MESSAGE}`, 'ApiRateLimitInterceptor');
-      }
-
-      return true;
-    }
-
     res.header(HttpResponseHeaderKeysEnum.RATELIMIT_REMAINING, remaining);
     res.header(HttpResponseHeaderKeysEnum.RATELIMIT_LIMIT, limit);
     res.header(HttpResponseHeaderKeysEnum.RATELIMIT_RESET, secondsToReset);
@@ -177,6 +169,14 @@ export class ApiRateLimitInterceptor extends ThrottlerGuard implements NestInter
         apiServiceLevel
       )
     );
+
+    if (isDryRun) {
+      if (!success) {
+        Logger.warn(`[Dry run] ${THROTTLED_EXCEPTION_MESSAGE}`, 'ApiRateLimitInterceptor');
+      }
+
+      return true;
+    }
 
     if (success) {
       return true;

--- a/apps/api/src/app/rate-limiting/guards/throttler.guard.ts
+++ b/apps/api/src/app/rate-limiting/guards/throttler.guard.ts
@@ -10,7 +10,7 @@ import {
 import { CallHandler, ExecutionContext, Injectable, Logger, NestInterceptor } from '@nestjs/common';
 import { EvaluateApiRateLimit, EvaluateApiRateLimitCommand } from '../usecases/evaluate-api-rate-limit';
 import { Reflector } from '@nestjs/core';
-import { GetFeatureFlag, GetFeatureFlagCommand, Instrument, PinoLogger } from '@novu/application-generic';
+import { GetFeatureFlag, GetFeatureFlagCommand, Instrument } from '@novu/application-generic';
 import {
   ApiAuthSchemeEnum,
   ApiRateLimitCategoryEnum,
@@ -40,8 +40,7 @@ export class ApiRateLimitInterceptor extends ThrottlerGuard implements NestInter
     @InjectThrottlerStorage() protected readonly storageService: ThrottlerStorage,
     reflector: Reflector,
     private evaluateApiRateLimit: EvaluateApiRateLimit,
-    private getFeatureFlag: GetFeatureFlag,
-    private logger: PinoLogger
+    private getFeatureFlag: GetFeatureFlag
   ) {
     super(options, storageService, reflector);
   }
@@ -128,18 +127,6 @@ export class ApiRateLimitInterceptor extends ThrottlerGuard implements NestInter
       );
 
     const secondsToReset = Math.max(Math.ceil((reset - Date.now()) / 1e3), 0);
-
-    const rateLimitPolicy = {
-      limit,
-      windowDuration,
-      burstLimit,
-      algorithm,
-      apiRateLimitCategory,
-      apiRateLimitCost,
-      apiServiceLevel,
-    };
-
-    this.logger.assign({ rateLimitPolicy });
 
     /**
      * The purpose of the dry run is to allow us to observe how


### PR DESCRIPTION
### What changed? Why was the change needed?
This sets rate limit headers in dry run mode:
1. users can observe their usage and adjust accordingly until its enforced
2. we are able to observe the usage better in dashboards - before this, we logged once just when the rate limit was hit which prevents us to use more advanced dashboards that rely on the headers in every request
3. we can see rate limit utilisation per org (e.g. 90% utilisation reached), before we can see only how many requests were throttled
