### PR TITLE
fix(web): form issues for new settings sidebar

### DIFF
--- a/apps/api/src/app/workflows/e2e/update-notification-template.e2e.ts
+++ b/apps/api/src/app/workflows/e2e/update-notification-template.e2e.ts
@@ -132,9 +132,7 @@ describe('Update workflow by id - /workflows/:workflowId (PUT)', async () => {
     const { body } = await session.testAgent.put(`/v1/workflows/${template2._id}`).send(update);
 
     expect(body.statusCode).to.equal(400);
-    expect(body.message).to.equal(
-      `Notification template with identifier ${template1.triggers[0].identifier} already exists`
-    );
+    expect(body.message).to.equal(`Workflow with identifier ${template1.triggers[0].identifier} already exists`);
     expect(body.error).to.equal('Bad Request');
   });
 

--- a/apps/web/src/pages/templates/editor_v2/TemplateDetailsPageV2.tsx
+++ b/apps/web/src/pages/templates/editor_v2/TemplateDetailsPageV2.tsx
@@ -24,7 +24,7 @@ export const TemplateDetailsPageV2 = () => {
   const { template: workflow } = useTemplateController(templateId);
   const areWorkflowPreferencesEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_WORKFLOW_PREFERENCES_ENABLED);
 
-  const { submitWorkflow, isSubmitting, hasChanges, workflowName } = useWorkflowDetailPageForm({
+  const { submitWorkflow, isSubmitting, hasChanges, workflowName, isValid } = useWorkflowDetailPageForm({
     templateId,
     workflow,
   });
@@ -59,7 +59,7 @@ export const TemplateDetailsPageV2 = () => {
         actions={
           <HStack gap="75">
             {areWorkflowPreferencesEnabled && (
-              <Button type={'submit'} disabled={!hasChanges} Icon={IconSave} loading={isSubmitting}>
+              <Button type={'submit'} disabled={!hasChanges || !isValid} Icon={IconSave} loading={isSubmitting}>
                 Save
               </Button>
             )}

--- a/apps/web/src/studio/components/workflows/preferences/WorkflowDetailFormContextProvider.tsx
+++ b/apps/web/src/studio/components/workflows/preferences/WorkflowDetailFormContextProvider.tsx
@@ -26,14 +26,6 @@ export const WorkflowDetailFormContextProvider: FC<PropsWithChildren<IWorkflowDe
   const formValues = useForm<WorkflowDetailFormContext>({
     mode: 'onChange',
     defaultValues: DEFAULT_FORM_VALUES,
-    values: {
-      general: {
-        workflowId: '',
-        name: '',
-        description: undefined,
-      },
-      preferences: DEFAULT_WORKFLOW_PREFERENCES,
-    },
   });
 
   return <FormProvider {...formValues}>{children}</FormProvider>;

--- a/apps/web/src/studio/components/workflows/preferences/WorkflowGeneralSettingsForm.tsx
+++ b/apps/web/src/studio/components/workflows/preferences/WorkflowGeneralSettingsForm.tsx
@@ -2,45 +2,76 @@ import { useClipboard } from '@mantine/hooks';
 import { IconButton, Input, Textarea } from '@novu/novui';
 import { IconCheck, IconCopyAll } from '@novu/novui/icons';
 import { Stack } from '@novu/novui/jsx';
-import { ChangeEvent, FC } from 'react';
-import { WorkflowGeneralSettings } from './types';
+import { FC } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { WorkflowDetailFormContext } from './WorkflowDetailFormContextProvider';
 
 export type WorkflowGeneralSettingsProps = {
-  settings: WorkflowGeneralSettings;
-  updateSettings: (settings: WorkflowGeneralSettings) => void;
   areSettingsDisabled?: boolean;
 };
 
-export const WorkflowGeneralSettingsForm: FC<WorkflowGeneralSettingsProps> = ({
-  settings,
-  updateSettings,
-  areSettingsDisabled,
-}) => {
+export const WorkflowGeneralSettingsForm: FC<WorkflowGeneralSettingsProps> = ({ areSettingsDisabled }) => {
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<WorkflowDetailFormContext>();
+
   const { copied, copy } = useClipboard();
-  const onChange =
-    (fieldKey: keyof WorkflowGeneralSettings) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      const value = event.target.value;
-      updateSettings({ ...settings, [fieldKey]: value });
-    };
 
   return (
     <Stack gap="150">
-      <Input label="Workflow name" value={settings.name} onChange={onChange('name')} disabled={areSettingsDisabled} />
-      <Input
-        label="Identifier"
-        description="Must be unique and all lowercase, using - only"
-        rightSection={<IconButton Icon={copied ? IconCheck : IconCopyAll} onClick={() => copy(settings.workflowId)} />}
-        value={settings.workflowId}
-        onChange={onChange('workflowId')}
-        disabled={areSettingsDisabled}
-      />
       {!areSettingsDisabled && (
-        <Textarea
-          label="Description"
-          maxLines={2}
-          value={settings.description}
-          onChange={onChange('description')}
-          disabled={areSettingsDisabled}
+        <Controller
+          name="general.name"
+          control={control}
+          rules={{ required: 'Workflow name is required' }}
+          render={({ field }) => {
+            return (
+              <Input
+                {...field}
+                label="Workflow name"
+                value={field.value || ''}
+                disabled={areSettingsDisabled}
+                error={errors?.general?.name?.message}
+              />
+            );
+          }}
+        />
+      )}
+      <Controller
+        name="general.workflowId"
+        control={control}
+        rules={{ required: 'Workflow identifier is required' }}
+        render={({ field }) => {
+          return (
+            <Input
+              {...field}
+              label="Identifier"
+              description="Must be unique and all lowercase, using - only"
+              rightSection={<IconButton Icon={copied ? IconCheck : IconCopyAll} onClick={() => copy(field.value)} />}
+              error={errors?.general?.workflowId?.message}
+              value={field.value || ''}
+              disabled={areSettingsDisabled}
+            />
+          );
+        }}
+      />
+
+      {!areSettingsDisabled && (
+        <Controller
+          name="general.description"
+          control={control}
+          render={({ field }) => {
+            return (
+              <Textarea
+                {...field}
+                label="Description"
+                maxLines={2}
+                value={field.value || ''}
+                disabled={areSettingsDisabled}
+              />
+            );
+          }}
         />
       )}
     </Stack>

--- a/apps/web/src/studio/components/workflows/preferences/WorkflowGeneralSettingsForm.tsx
+++ b/apps/web/src/studio/components/workflows/preferences/WorkflowGeneralSettingsForm.tsx
@@ -24,7 +24,7 @@ export const WorkflowGeneralSettingsForm: FC<WorkflowGeneralSettingsProps> = ({ 
         <Controller
           name="general.name"
           control={control}
-          rules={{ required: 'Workflow name is required' }}
+          rules={{ required: 'Required - Workflow name' }}
           render={({ field }) => {
             return (
               <Input
@@ -41,7 +41,13 @@ export const WorkflowGeneralSettingsForm: FC<WorkflowGeneralSettingsProps> = ({ 
       <Controller
         name="general.workflowId"
         control={control}
-        rules={{ required: 'Workflow identifier is required' }}
+        rules={{
+          required: 'Required - Workflow identifier',
+          pattern: {
+            value: /^[a-z0-9-]+$/,
+            message: 'Identifier must contain only lowercase, numeric or dash characters',
+          },
+        }}
         render={({ field }) => {
           return (
             <Input

--- a/apps/web/src/studio/components/workflows/preferences/WorkflowSettingsSidePanelContent.tsx
+++ b/apps/web/src/studio/components/workflows/preferences/WorkflowSettingsSidePanelContent.tsx
@@ -33,23 +33,7 @@ export const WorkflowSettingsSidePanelContent: FC<WorkflowSettingsSidePanelConte
           value: WorkflowSettingsPanelTab.GENERAL,
           label: 'General',
           icon: <IconDynamicFeed />,
-          content: isLoading ? (
-            <CenteredLoader />
-          ) : (
-            <Controller
-              name="general"
-              control={control}
-              render={({ field }) => {
-                return (
-                  <WorkflowGeneralSettingsForm
-                    settings={field.value}
-                    updateSettings={field.onChange}
-                    areSettingsDisabled={isLocalStudio}
-                  />
-                );
-              }}
-            />
-          ),
+          content: isLoading ? <CenteredLoader /> : <WorkflowGeneralSettingsForm areSettingsDisabled={isLocalStudio} />,
         },
         {
           value: WorkflowSettingsPanelTab.PREFERENCES,

--- a/libs/application-generic/src/usecases/workflow/update-workflow/update-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/workflow/update-workflow/update-workflow.usecase.ts
@@ -102,7 +102,7 @@ export class UpdateWorkflow {
 
       if (isExistingIdentifier && isExistingIdentifier._id !== command.id) {
         throw new BadRequestException(
-          `Notification template with identifier ${command.identifier} already exists`,
+          `Workflow with identifier ${command.identifier} already exists`,
         );
       } else {
         updatePayload['triggers.0.identifier'] = command.identifier;


### PR DESCRIPTION

### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

Fixes the following issues:
- Upon changing the Workflow name in the sidebar, the new name only appears in the "main page" as the title after closing the sidebar
- Not showing errors on the setting input fields
- Clicking save after changing only preferences, the settings input fields are empty 
- No success/error message on saving 


### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
