### PR TITLE
chore(js): blank line before return statement

### DIFF
--- a/packages/js/src/ui/components/Notification/NotificationList.tsx
+++ b/packages/js/src/ui/components/Notification/NotificationList.tsx
@@ -71,6 +71,7 @@ export const NotificationList = (props: NotificationListProps) => {
             <For each={ids()}>
               {(_, index) => {
                 const notification = () => data()[index()];
+
                 return (
                   <Notification
                     notification={notification()}


### PR DESCRIPTION
### What changed? Why was the change needed?
There seems to be a linting error here: https://cloud.nx.app/runs/o6LQZa3Uij

![image](https://github.com/user-attachments/assets/d0b9b4b0-d5fb-4932-b03f-543c36bc4db7)
