### PR TITLE
feat(web): Remove description, disable BRIDGE fields

### DIFF
--- a/apps/web/src/pages/templates/editor_v2/CloudWorkflowSettingsSidePanel.tsx
+++ b/apps/web/src/pages/templates/editor_v2/CloudWorkflowSettingsSidePanel.tsx
@@ -4,15 +4,17 @@ import { Sidebar } from '@novu/design-system';
 import { Title } from '@novu/novui';
 import { css } from '@novu/novui/css';
 import { useFormContext } from 'react-hook-form';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { useCloudWorkflowChannelPreferences } from '../../../hooks/workflowChannelPreferences/useCloudWorkflowChannelPreferences';
 import { WorkflowDetailFormContext } from '../../../studio/components/workflows/preferences/WorkflowDetailFormContextProvider';
 import { WorkflowSettingsSidePanelContent } from '../../../studio/components/workflows/preferences/WorkflowSettingsSidePanelContent';
+import { WorkflowTypeEnum } from '@novu/shared';
 
 type CloudWorkflowSettingsSidePanelProps = { onClose: () => void };
 
 export const CloudWorkflowSettingsSidePanel: FC<CloudWorkflowSettingsSidePanelProps> = ({ onClose }) => {
   const { templateId: workflowId = '' } = useParams<{ templateId: string }>();
+  const [searchParams] = useSearchParams();
   const { isLoading, workflowChannelPreferences } = useCloudWorkflowChannelPreferences(workflowId);
   const { setValue } = useFormContext<WorkflowDetailFormContext>();
 
@@ -25,7 +27,10 @@ export const CloudWorkflowSettingsSidePanel: FC<CloudWorkflowSettingsSidePanelPr
   return (
     <Sidebar customHeader={<Title variant="section">Workflow settings</Title>} isOpened onClose={onClose}>
       <div className={css({ colorPalette: 'mode.local' })}>
-        <WorkflowSettingsSidePanelContent isLoading={isLoading} />
+        <WorkflowSettingsSidePanelContent
+          isLoading={isLoading}
+          workflowType={searchParams.get('type') as WorkflowTypeEnum}
+        />
       </div>
     </Sidebar>
   );

--- a/apps/web/src/studio/components/workflows/preferences/WorkflowDetailFormContextProvider.tsx
+++ b/apps/web/src/studio/components/workflows/preferences/WorkflowDetailFormContextProvider.tsx
@@ -14,7 +14,6 @@ export type WorkflowDetailFormContext = {
 const DEFAULT_FORM_VALUES: WorkflowDetailFormContext = {
   general: {
     workflowId: '',
-    description: '',
     name: '',
   },
   preferences: DEFAULT_WORKFLOW_PREFERENCES,

--- a/apps/web/src/studio/components/workflows/preferences/WorkflowGeneralSettingsForm.tsx
+++ b/apps/web/src/studio/components/workflows/preferences/WorkflowGeneralSettingsForm.tsx
@@ -1,16 +1,25 @@
 import { useClipboard } from '@mantine/hooks';
-import { IconButton, Input, Textarea } from '@novu/novui';
+import { IconButton, Input } from '@novu/novui';
 import { IconCheck, IconCopyAll } from '@novu/novui/icons';
 import { Stack } from '@novu/novui/jsx';
 import { FC } from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, FieldPath, useFormContext } from 'react-hook-form';
 import { WorkflowDetailFormContext } from './WorkflowDetailFormContextProvider';
 
+export type WorkflowGeneralSettingsFieldName = Extract<
+  FieldPath<WorkflowDetailFormContext>,
+  'general.workflowId' | 'general.name'
+>;
+
 export type WorkflowGeneralSettingsProps = {
-  areSettingsDisabled?: boolean;
+  checkShouldDisableField?: (fieldName: WorkflowGeneralSettingsFieldName, fieldValue: string) => boolean;
+  checkShouldHideField?: (fieldName: WorkflowGeneralSettingsFieldName) => boolean;
 };
 
-export const WorkflowGeneralSettingsForm: FC<WorkflowGeneralSettingsProps> = ({ areSettingsDisabled }) => {
+export const WorkflowGeneralSettingsForm: FC<WorkflowGeneralSettingsProps> = ({
+  checkShouldDisableField,
+  checkShouldHideField,
+}) => {
   const {
     control,
     formState: { errors },
@@ -20,7 +29,7 @@ export const WorkflowGeneralSettingsForm: FC<WorkflowGeneralSettingsProps> = ({ 
 
   return (
     <Stack gap="150">
-      {!areSettingsDisabled && (
+      {!checkShouldHideField?.('general.name') && (
         <Controller
           name="general.name"
           control={control}
@@ -31,50 +40,34 @@ export const WorkflowGeneralSettingsForm: FC<WorkflowGeneralSettingsProps> = ({ 
                 {...field}
                 label="Workflow name"
                 value={field.value || ''}
-                disabled={areSettingsDisabled}
+                disabled={checkShouldDisableField?.(field.name, field.value)}
                 error={errors?.general?.name?.message}
               />
             );
           }}
         />
       )}
-      <Controller
-        name="general.workflowId"
-        control={control}
-        rules={{
-          required: 'Required - Workflow identifier',
-          pattern: {
-            value: /^[a-z0-9-]+$/,
-            message: 'Identifier must contain only lowercase, numeric or dash characters',
-          },
-        }}
-        render={({ field }) => {
-          return (
-            <Input
-              {...field}
-              label="Identifier"
-              description="Must be unique and all lowercase, using - only"
-              rightSection={<IconButton Icon={copied ? IconCheck : IconCopyAll} onClick={() => copy(field.value)} />}
-              error={errors?.general?.workflowId?.message}
-              value={field.value || ''}
-              disabled={areSettingsDisabled}
-            />
-          );
-        }}
-      />
-
-      {!areSettingsDisabled && (
+      {!checkShouldHideField?.('general.workflowId') && (
         <Controller
-          name="general.description"
+          name="general.workflowId"
           control={control}
+          rules={{
+            required: 'Required - Workflow identifier',
+            pattern: {
+              value: /^[a-z0-9-]+$/,
+              message: 'Identifier must contain only lowercase, numeric or dash characters',
+            },
+          }}
           render={({ field }) => {
             return (
-              <Textarea
+              <Input
                 {...field}
-                label="Description"
-                maxLines={2}
+                label="Identifier"
+                description="Must be unique and all lowercase, using - only"
+                rightSection={<IconButton Icon={copied ? IconCheck : IconCopyAll} onClick={() => copy(field.value)} />}
+                error={errors?.general?.workflowId?.message}
                 value={field.value || ''}
-                disabled={areSettingsDisabled}
+                disabled={checkShouldDisableField?.(field.name, field.value)}
               />
             );
           }}

--- a/apps/web/src/studio/components/workflows/preferences/WorkflowSettingsSidePanelContent.tsx
+++ b/apps/web/src/studio/components/workflows/preferences/WorkflowSettingsSidePanelContent.tsx
@@ -8,8 +8,9 @@ import { token } from '@novu/novui/tokens';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useStudioState } from '../../../StudioStateProvider';
 import { WorkflowDetailFormContext } from './WorkflowDetailFormContextProvider';
-import { WorkflowGeneralSettingsForm } from './WorkflowGeneralSettingsForm';
+import { WorkflowGeneralSettingsFieldName, WorkflowGeneralSettingsForm } from './WorkflowGeneralSettingsForm';
 import { WorkflowSubscriptionPreferences } from './WorkflowSubscriptionPreferences';
+import { isBridgeWorkflow, WorkflowTypeEnum } from '@novu/shared';
 
 enum WorkflowSettingsPanelTab {
   GENERAL = 'general',
@@ -18,11 +19,36 @@ enum WorkflowSettingsPanelTab {
 
 type WorkflowSettingsSidePanelContentProps = {
   isLoading?: boolean;
+  workflowType?: WorkflowTypeEnum;
 };
 
-export const WorkflowSettingsSidePanelContent: FC<WorkflowSettingsSidePanelContentProps> = ({ isLoading }) => {
+export const WorkflowSettingsSidePanelContent: FC<WorkflowSettingsSidePanelContentProps> = ({
+  isLoading,
+  workflowType,
+}) => {
   const { isLocalStudio } = useStudioState() || {};
   const { control } = useFormContext<WorkflowDetailFormContext>();
+
+  const checkShouldHideField = (fieldName: WorkflowGeneralSettingsFieldName) => {
+    switch (fieldName) {
+      case 'general.name':
+        return isLocalStudio;
+      case 'general.workflowId':
+        return false;
+      default:
+        return false;
+    }
+  };
+
+  const checkShouldDisableField = (fieldName: WorkflowGeneralSettingsFieldName) => {
+    switch (fieldName) {
+      case 'general.name':
+      case 'general.workflowId':
+        return isLocalStudio || isBridgeWorkflow(workflowType);
+      default:
+        return false;
+    }
+  };
 
   return (
     <Tabs
@@ -33,7 +59,14 @@ export const WorkflowSettingsSidePanelContent: FC<WorkflowSettingsSidePanelConte
           value: WorkflowSettingsPanelTab.GENERAL,
           label: 'General',
           icon: <IconDynamicFeed />,
-          content: isLoading ? <CenteredLoader /> : <WorkflowGeneralSettingsForm areSettingsDisabled={isLocalStudio} />,
+          content: isLoading ? (
+            <CenteredLoader />
+          ) : (
+            <WorkflowGeneralSettingsForm
+              checkShouldHideField={checkShouldHideField}
+              checkShouldDisableField={checkShouldDisableField}
+            />
+          ),
         },
         {
           value: WorkflowSettingsPanelTab.PREFERENCES,

--- a/apps/web/src/studio/components/workflows/preferences/types.ts
+++ b/apps/web/src/studio/components/workflows/preferences/types.ts
@@ -10,5 +10,4 @@ export type SubscriptionPreferenceRow = {
 export type WorkflowGeneralSettings = {
   workflowId: string;
   name: string;
-  description?: string;
 };


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
https://linear.app/novu/issue/NV-4286/disable-editing-workflow-fields-for-type-bridge-and-remove-description

- Remove Description from form
- Disable fields for "BRIDGE" type workflows

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

REGULAR

<img width="1158" alt="Screenshot 2024-09-09 at 10 24 53 PM" src="https://github.com/user-attachments/assets/acbab10e-b09c-46b2-9f18-b7302597d7fa">

BRIDGE
<img width="1158" alt="Screenshot 2024-09-09 at 10 25 43 PM" src="https://github.com/user-attachments/assets/edfa7b6b-808d-4a7a-93c4-926e128b536f">


