### PR TITLE
fix(web): Suppress missing key or JWT error.

### DIFF
--- a/apps/web/src/api/api.client.ts
+++ b/apps/web/src/api/api.client.ts
@@ -104,7 +104,10 @@ export function buildApiHttpClient({
   environmentId?: string;
 }) {
   if (!secretKey && !jwt) {
-    throw new Error('A secretKey or jwt is required to create a Novu API client.');
+    // eslint-disable-next-line no-console
+    console.error('A secretKey or jwt is required to create a Novu API client.');
+
+    return;
   }
 
   const authHeader = jwt ? `Bearer ${jwt}` : `ApiKey ${secretKey}`;


### PR DESCRIPTION
### What changed? Why was the change needed?

This error is reported every time the laptop lid closes or when it loses internet connectivity. Then as soon as internet is resumed the Dashboard starts functioning again. 

Until we fully investigate it, suppressing it will prevent Dashboard from being deadlocked in its error page.

The hypothesis about the root cause is that it should be due to an extra render that happens on tab-focus fetching data before the environment resolution.