### PR TITLE
fix(api): Use _subscriberId

### DIFF
--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -145,7 +145,7 @@ export class UpdatePreferences {
         channels: preference.channels,
         organizationId: command.organizationId,
         environmentId: command.environmentId,
-        subscriberId: command.subscriberId,
+        _subscriberId: subscriber._id,
         templateId: workflow._id,
       });
 
@@ -176,7 +176,7 @@ export class UpdatePreferences {
       channels: preference.channels,
       organizationId: command.organizationId,
       environmentId: command.environmentId,
-      subscriberId: command.subscriberId,
+      _subscriberId: subscriber._id,
     });
 
     return {
@@ -200,7 +200,7 @@ export class UpdatePreferences {
     enabled: boolean;
     channels: IPreferenceChannels;
     organizationId: string;
-    subscriberId: string;
+    _subscriberId: string;
     environmentId: string;
     templateId?: string;
   }) {
@@ -238,7 +238,7 @@ export class UpdatePreferences {
         UpsertSubscriberWorkflowPreferencesCommand.create({
           environmentId: item.environmentId,
           organizationId: item.organizationId,
-          subscriberId: item.subscriberId,
+          _subscriberId: item._subscriberId,
           templateId: item.templateId,
           preferences,
         })
@@ -250,7 +250,7 @@ export class UpdatePreferences {
         preferences,
         environmentId: item.environmentId,
         organizationId: item.organizationId,
-        subscriberId: item.subscriberId,
+        _subscriberId: item._subscriberId,
       })
     );
   }

--- a/apps/api/src/app/preferences/preferences.spec.ts
+++ b/apps/api/src/app/preferences/preferences.spec.ts
@@ -7,16 +7,17 @@ import {
   UpsertUserWorkflowPreferencesCommand,
   UpsertWorkflowPreferencesCommand,
 } from '@novu/application-generic';
-import { PreferencesActorEnum, PreferencesRepository } from '@novu/dal';
+import { PreferencesActorEnum, PreferencesRepository, SubscriberRepository } from '@novu/dal';
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
+
 import { AuthModule } from '../auth/auth.module';
 import { PreferencesModule } from './preferences.module';
 
 describe('Preferences', function () {
   let getPreferences: GetPreferences;
-  let subscriberId: string;
+  const subscriberId = SubscriberRepository.createObjectId();
   const workflowId = PreferencesRepository.createObjectId();
   let upsertPreferences: UpsertPreferences;
   let session: UserSession;
@@ -31,8 +32,6 @@ describe('Preferences', function () {
 
     session = new UserSession();
     await session.initialize();
-
-    subscriberId = session.subscriberId;
 
     getPreferences = moduleRef.get<GetPreferences>(GetPreferences);
     upsertPreferences = moduleRef.get<UpsertPreferences>(UpsertPreferences);

--- a/apps/api/src/app/preferences/preferences.spec.ts
+++ b/apps/api/src/app/preferences/preferences.spec.ts
@@ -163,7 +163,7 @@ describe('Preferences', function () {
           },
           environmentId: session.environment._id,
           organizationId: session.organization._id,
-          subscriberId,
+          _subscriberId: subscriberId,
         })
       );
 
@@ -209,7 +209,7 @@ describe('Preferences', function () {
           environmentId: session.environment._id,
           organizationId: session.organization._id,
           templateId: workflowId,
-          subscriberId,
+          _subscriberId: subscriberId,
         })
       );
 
@@ -485,7 +485,7 @@ describe('Preferences', function () {
           },
           environmentId: session.environment._id,
           organizationId: session.organization._id,
-          subscriberId,
+          _subscriberId: subscriberId,
         })
       );
 
@@ -559,7 +559,7 @@ describe('Preferences', function () {
           environmentId: session.environment._id,
           organizationId: session.organization._id,
           templateId: workflowId,
-          subscriberId,
+          _subscriberId: subscriberId,
         })
       );
 

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.command.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.command.ts
@@ -1,13 +1,13 @@
 import { IsDefined, IsEnum } from 'class-validator';
-import { EnvironmentCommand } from '../../commands';
 import { PreferencesActorEnum, PreferencesTypeEnum } from '@novu/dal';
 import { WorkflowChannelPreferences } from '@novu/shared';
+import { EnvironmentCommand } from '../../commands';
 
 export class UpsertPreferencesCommand extends EnvironmentCommand {
   @IsDefined()
   readonly preferences: WorkflowChannelPreferences;
 
-  subscriberId?: string;
+  _subscriberId?: string;
 
   userId?: string;
 

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
@@ -32,7 +32,7 @@ export class UpsertPreferences {
     command: UpsertSubscriberGlobalPreferencesCommand,
   ) {
     return this.upsert({
-      subscriberId: command.subscriberId,
+      _subscriberId: command._subscriberId,
       environmentId: command.environmentId,
       organizationId: command.organizationId,
       actor: PreferencesActorEnum.SUBSCRIBER,
@@ -45,7 +45,7 @@ export class UpsertPreferences {
     command: UpsertSubscriberWorkflowPreferencesCommand,
   ) {
     return this.upsert({
-      subscriberId: command.subscriberId,
+      _subscriberId: command._subscriberId,
       environmentId: command.environmentId,
       organizationId: command.organizationId,
       actor: PreferencesActorEnum.SUBSCRIBER,
@@ -85,7 +85,7 @@ export class UpsertPreferences {
     command: UpsertPreferencesCommand,
   ): Promise<PreferencesEntity> {
     return await this.preferencesRepository.create({
-      _subscriberId: command.subscriberId,
+      _subscriberId: command._subscriberId,
       _userId: command.userId,
       _environmentId: command.environmentId,
       _organizationId: command.organizationId,
@@ -124,7 +124,7 @@ export class UpsertPreferences {
   ): Promise<string | undefined> {
     const found = await this.preferencesRepository.findOne(
       {
-        _subscriberId: command.subscriberId,
+        _subscriberId: command._subscriberId,
         _environmentId: command.environmentId,
         _organizationId: command.organizationId,
         _templateId: command.templateId,

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-global-preferences.command.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-global-preferences.command.ts
@@ -1,4 +1,4 @@
-import { IsDefined, IsNotEmpty } from 'class-validator';
+import { IsDefined, IsMongoId, IsNotEmpty } from 'class-validator';
 import { WorkflowChannelPreferences } from '@novu/shared';
 import { EnvironmentCommand } from '../../commands';
 
@@ -7,5 +7,6 @@ export class UpsertSubscriberGlobalPreferencesCommand extends EnvironmentCommand
   readonly preferences: WorkflowChannelPreferences;
 
   @IsNotEmpty()
+  @IsMongoId()
   _subscriberId: string;
 }

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-global-preferences.command.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-global-preferences.command.ts
@@ -1,11 +1,11 @@
-import { EnvironmentCommand } from '../../commands';
 import { IsDefined, IsNotEmpty } from 'class-validator';
 import { WorkflowChannelPreferences } from '@novu/shared';
+import { EnvironmentCommand } from '../../commands';
 
 export class UpsertSubscriberGlobalPreferencesCommand extends EnvironmentCommand {
   @IsDefined()
   readonly preferences: WorkflowChannelPreferences;
 
   @IsNotEmpty()
-  subscriberId: string;
+  _subscriberId: string;
 }


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
- Fixed the usecase to use `_subscriberId` instead of `subscriberId`
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
[COM-224](https://linear.app/novu/issue/COM-224/use-subscriberid-instead-of-subscriberid-in-preferences)
<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
