### PR TITLE
fix(js): Fix notification skeleton padding and action wrap

### DIFF
--- a/packages/js/src/ui/components/Notification/DefaultNotification.tsx
+++ b/packages/js/src/ui/components/Notification/DefaultNotification.tsx
@@ -227,7 +227,7 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
         <Markdown class={style('notificationBody', 'nt-text-start')} strongAppearanceKey="notificationBody__strong">
           {props.notification.body}
         </Markdown>
-        <div class={style('notificationCustomActions', 'nt-flex nt-gap-4 nt-mt-4')}>
+        <div class={style('notificationCustomActions', 'nt-flex nt-flex-wrap nt-gap-4 nt-mt-4')}>
           <Show when={props.notification.primaryAction} keyed>
             {(primaryAction) => (
               <Button

--- a/packages/js/src/ui/components/Notification/NotificationListSkeleton.tsx
+++ b/packages/js/src/ui/components/Notification/NotificationListSkeleton.tsx
@@ -5,7 +5,7 @@ export const NotificationSkeleton = () => {
   return (
     <>
       {/* eslint-disable-next-line local-rules/no-class-without-style */}
-      <div class="nt-flex nt-gap-2 nt-p-4 nt-w-full">
+      <div class="nt-flex nt-gap-2 nt-px-6 nt-py-4 nt-w-full">
         <SkeletonAvatar appearanceKey="skeletonAvatar" />
         {/* eslint-disable-next-line local-rules/no-class-without-style */}
         <div class={'nt-flex nt-flex-col nt-self-stretch nt-gap-3 nt-flex-1'}>


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
Align the left padding of the notification skeleton with the default notification padding.
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
