### PR TITLE
feat(api,application-generic): Handle readOnly for preferences

### DIFF
--- a/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.usecase.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import {
   AnalyticsService,
   GetSubscriberGlobalPreference,

--- a/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.usecase.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import {
   AnalyticsService,
   GetSubscriberGlobalPreference,
@@ -71,7 +71,7 @@ export class GetPreferences {
             id: workflow._id,
             identifier: workflow.triggers[0].identifier,
             name: workflow.name,
-            critical: workflow.critical,
+            critical: workflow.critical || workflowPreference.template.critical,
             tags: workflow.tags,
           },
         } satisfies InboxPreference;

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -140,6 +140,13 @@ export class UpdatePreferences {
         })
       );
 
+      /*
+       * Backwards compatible storage of new Preferences DTO.
+       *
+       * Currently, this is a side-effect due to the way that Preferences are stored
+       * and resolved with overrides in cascading order, necessitating a lookup against
+       * the old preferences structure before we can store the new Preferences DTO.
+       */
       await this.storePreferences({
         enabled: preference.enabled,
         channels: preference.channels,

--- a/apps/api/src/app/preferences/preferences.spec.ts
+++ b/apps/api/src/app/preferences/preferences.spec.ts
@@ -462,7 +462,7 @@ describe('Preferences', function () {
             channels: {
               in_app: {
                 defaultValue: false,
-                readOnly: true,
+                readOnly: false,
               },
               sms: {
                 defaultValue: false,
@@ -503,7 +503,7 @@ describe('Preferences', function () {
         channels: {
           in_app: {
             defaultValue: false,
-            readOnly: true,
+            readOnly: false,
           },
           sms: {
             defaultValue: false,
@@ -577,11 +577,11 @@ describe('Preferences', function () {
         channels: {
           in_app: {
             defaultValue: false,
-            readOnly: true,
+            readOnly: false,
           },
           sms: {
             defaultValue: false,
-            readOnly: true,
+            readOnly: false,
           },
           email: {
             defaultValue: false,

--- a/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
@@ -1,36 +1,23 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import {
-  PreferencesActorEnum,
-  PreferencesEntity,
-  PreferencesRepository,
-  PreferencesTypeEnum,
-} from '@novu/dal';
-import {
-  FeatureFlagsKeysEnum,
-  IPreferenceChannels,
-  WorkflowChannelPreferences,
-} from '@novu/shared';
+import { PreferencesActorEnum, PreferencesEntity, PreferencesRepository, PreferencesTypeEnum } from '@novu/dal';
+import { WorkflowOptionsPreferences } from '@novu/framework';
+import { FeatureFlagsKeysEnum, IPreferenceChannels, WorkflowChannelPreferences } from '@novu/shared';
 import { deepMerge } from '../../utils';
 import { GetFeatureFlag, GetFeatureFlagCommand } from '../get-feature-flag';
 import { GetPreferencesCommand } from './get-preferences.command';
 
 @Injectable()
 export class GetPreferences {
-  constructor(
-    private preferencesRepository: PreferencesRepository,
-    private getFeatureFlag: GetFeatureFlag,
-  ) {}
+  constructor(private preferencesRepository: PreferencesRepository, private getFeatureFlag: GetFeatureFlag) {}
 
-  async execute(
-    command: GetPreferencesCommand,
-  ): Promise<WorkflowChannelPreferences> {
+  async execute(command: GetPreferencesCommand): Promise<WorkflowOptionsPreferences> {
     const isEnabled = await this.getFeatureFlag.execute(
       GetFeatureFlagCommand.create({
         userId: 'system',
         environmentId: command.environmentId,
         organizationId: command.organizationId,
         key: FeatureFlagsKeysEnum.IS_WORKFLOW_PREFERENCES_ENABLED,
-      }),
+      })
     );
 
     if (!isEnabled) {
@@ -43,19 +30,91 @@ export class GetPreferences {
       throw new NotFoundException('We could not find any preferences');
     }
 
+    const mergedPreferences = this.mergePreferences(items, command.templateId);
+
+    if (!mergedPreferences) {
+      throw new NotFoundException('We could not find any preferences');
+    }
+
+    return mergedPreferences;
+  }
+
+  /** Get only simple, channel-level enablement flags */
+  public async getPreferenceChannels(command: {
+    environmentId: string;
+    organizationId: string;
+    subscriberId: string;
+    templateId?: string;
+  }): Promise<IPreferenceChannels | undefined> {
+    const result = await this.getWorkflowOptionsPreferences(command);
+
+    return GetPreferences.mapWorkflowOptionsPreferencesToChannels(result);
+  }
+
+  /** Safely get WorkflowOptionsPreferences by returning undefined if none are found */
+  public async getWorkflowOptionsPreferences(command: {
+    environmentId: string;
+    organizationId: string;
+    subscriberId: string;
+    templateId?: string;
+  }): Promise<WorkflowOptionsPreferences | undefined> {
+    try {
+      return await this.execute(
+        GetPreferencesCommand.create({
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+          subscriberId: command.subscriberId,
+          templateId: command.templateId,
+        })
+      );
+    } catch (e) {
+      // If we cant find preferences lets return undefined instead of throwing it up to caller to make it easier for caller to handle.
+      if ((e as Error).name === NotFoundException.name) {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
+  /** Transform WorkflowOptionsPreferences into IPreferenceChannels */
+  public static mapWorkflowOptionsPreferencesToChannels(
+    workflowPreferences: WorkflowOptionsPreferences
+  ): IPreferenceChannels | undefined {
+    if (!workflowPreferences) {
+      return undefined;
+    }
+
+    return {
+      in_app: workflowPreferences.channels.in_app.defaultValue || workflowPreferences.workflow.defaultValue,
+      sms: workflowPreferences.channels.sms.defaultValue || workflowPreferences.workflow.defaultValue,
+      email: workflowPreferences.channels.email.defaultValue || workflowPreferences.workflow.defaultValue,
+      push: workflowPreferences.channels.push.defaultValue || workflowPreferences.workflow.defaultValue,
+      chat: workflowPreferences.channels.chat.defaultValue || workflowPreferences.workflow.defaultValue,
+    };
+  }
+
+  /** Determine if Workflow Preferences should be marked as critical / readOnly at the top level */
+  public static checkIfWorkflowPreferencesIsReadOnly(workflowPreferences?: WorkflowOptionsPreferences): boolean {
+    if (!workflowPreferences) {
+      return false;
+    }
+
+    return (
+      workflowPreferences.workflow.readOnly ||
+      Object.values(workflowPreferences.channels).some(({ readOnly }) => readOnly)
+    );
+  }
+
+  private mergePreferences(items: PreferencesEntity[], workflowId?: string): WorkflowChannelPreferences | undefined {
     const workflowPreferences = this.getWorkflowPreferences(items);
 
     const userPreferences = this.getUserPreferences(items);
 
-    const subscriberGlobalPreferences =
-      this.getSubscriberGlobalPreferences(items);
+    const subscriberGlobalPreferences = this.getSubscriberGlobalPreferences(items);
 
-    const subscriberWorkflowPreferences = this.getSubscriberWorkflowPreferences(
-      items,
-      command.templateId,
-    );
+    const subscriberWorkflowPreferences = this.getSubscriberWorkflowPreferences(items, workflowId);
 
-    /*
+    /**
      * Order is important here because we like the workflowPreferences (that comes from the bridge)
      * to be overridden by any other preferences and then we have preferences defined in dashboard and
      * then subscribers global preferences and the once that should be used if it says other then anything before it
@@ -72,73 +131,53 @@ export class GetPreferences {
 
     // ensure we don't merge on an empty list
     if (preferences.length === 0) {
-      throw new NotFoundException('We could not find any preferences');
+      return;
     }
 
-    return deepMerge(preferences);
+    /**
+     * Order is (almost exactly) reversed of that above because 'readOnly' should be prioritized
+     * by the Dashboard (userPreferences) the most.
+     */
+    const orderedPreferencesForReadOnly = [
+      subscriberWorkflowPreferences,
+      subscriberGlobalPreferences,
+      workflowPreferences,
+      userPreferences,
+    ]
+      .filter((preference) => preference !== undefined)
+      .map((item) => item.preferences);
+
+    const readOnlyPreferences = orderedPreferencesForReadOnly.map(({ workflow, channels }) => ({
+      workflow: { readOnly: workflow.readOnly },
+      channels: {
+        in_app: { readOnly: channels['in_app'].readOnly },
+        email: { readOnly: channels['email'].readOnly },
+        sms: { readOnly: channels['sms'].readOnly },
+        chat: { readOnly: channels['chat'].readOnly },
+        push: { readOnly: channels['push'].readOnly },
+      },
+    })) as WorkflowChannelPreferences[];
+
+    // by merging only the read-only values after the full objects, we ensure that only the readOnly field is affected.
+    return deepMerge([...preferences, ...readOnlyPreferences]);
   }
 
-  public async getPreferenceChannels(command: {
-    environmentId: string;
-    organizationId: string;
-    subscriberId: string;
-    templateId?: string;
-  }): Promise<IPreferenceChannels | undefined> {
-    try {
-      const result = await this.execute(
-        GetPreferencesCommand.create({
-          environmentId: command.environmentId,
-          organizationId: command.organizationId,
-          subscriberId: command.subscriberId,
-          templateId: command.templateId,
-        }),
-      );
-
-      return {
-        in_app:
-          result.channels.in_app.defaultValue || result.workflow.defaultValue,
-        sms: result.channels.sms.defaultValue || result.workflow.defaultValue,
-        email:
-          result.channels.email.defaultValue || result.workflow.defaultValue,
-        push: result.channels.push.defaultValue || result.workflow.defaultValue,
-        chat: result.channels.chat.defaultValue || result.workflow.defaultValue,
-      };
-    } catch (e) {
-      // If we cant find preferences lets return undefined instead of throwing it up to caller to make it easier for caller to handle.
-      if ((e as Error).name === NotFoundException.name) {
-        return undefined;
-      }
-      throw e;
-    }
-  }
-
-  private getSubscriberWorkflowPreferences(
-    items: PreferencesEntity[],
-    templateId: string,
-  ) {
+  private getSubscriberWorkflowPreferences(items: PreferencesEntity[], templateId: string) {
     return items.find(
-      (item) =>
-        item.type === PreferencesTypeEnum.SUBSCRIBER_WORKFLOW &&
-        item._templateId === templateId,
+      (item) => item.type === PreferencesTypeEnum.SUBSCRIBER_WORKFLOW && item._templateId == templateId
     );
   }
 
   private getSubscriberGlobalPreferences(items: PreferencesEntity[]) {
-    return items.find(
-      (item) => item.type === PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
-    );
+    return items.find((item) => item.type === PreferencesTypeEnum.SUBSCRIBER_GLOBAL);
   }
 
   private getUserPreferences(items: PreferencesEntity[]) {
-    return items.find(
-      (item) => item.type === PreferencesTypeEnum.USER_WORKFLOW,
-    );
+    return items.find((item) => item.type === PreferencesTypeEnum.USER_WORKFLOW);
   }
 
   private getWorkflowPreferences(items: PreferencesEntity[]) {
-    return items.find(
-      (item) => item.type === PreferencesTypeEnum.WORKFLOW_RESOURCE,
-    );
+    return items.find((item) => item.type === PreferencesTypeEnum.WORKFLOW_RESOURCE);
   }
 
   private async getPreferencesFromDb(command: GetPreferencesCommand) {

--- a/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
@@ -59,13 +59,15 @@ export class GetPreferences {
     subscriberId: string;
     templateId?: string;
   }): Promise<IPreferenceChannels | undefined> {
-    const result = await this.getWorkflowOptionsPreferences(command);
+    const result = await this.getWorkflowChannelPreferences(command);
 
-    return GetPreferences.mapWorkflowOptionsPreferencesToChannels(result);
+    return GetPreferences.mapWorkflowChannelPreferencesToChannelPreferences(
+      result,
+    );
   }
 
   /** Safely get WorkflowChannelPreferences by returning undefined if none are found */
-  public async getWorkflowOptionsPreferences(command: {
+  public async getWorkflowChannelPreferences(command: {
     environmentId: string;
     organizationId: string;
     subscriberId: string;
@@ -90,7 +92,7 @@ export class GetPreferences {
   }
 
   /** Transform WorkflowChannelPreferences into IPreferenceChannels */
-  public static mapWorkflowOptionsPreferencesToChannels(
+  public static mapWorkflowChannelPreferencesToChannelPreferences(
     workflowPreferences: WorkflowChannelPreferences,
   ): IPreferenceChannels | undefined {
     if (!workflowPreferences) {

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -79,7 +79,10 @@ export class GetSubscriberTemplatePreference {
         templateId: command.template._id,
       });
 
-    const subscriberPreferenceChannels = subscriberPreference?.channels;
+    const subscriberPreferenceChannels =
+      GetPreferences.mapWorkflowChannelPreferencesToChannelPreferences(
+        subscriberWorkflowPreferences,
+      ) || subscriberPreference?.channels;
     const workflowOverrideChannelPreference =
       workflowOverride?.preferenceSettings;
 

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -23,7 +23,7 @@ import { GetSubscriberTemplatePreferenceCommand } from './get-subscriber-templat
 
 import { ApiException } from '../../utils/exceptions';
 import { CachedEntity, buildSubscriberKey } from '../../services/cache';
-import { GetPreferences, GetPreferencesCommand } from '../get-preferences';
+import { GetPreferences } from '../get-preferences';
 
 const PRIORITY_ORDER = [
   PreferenceOverrideSourceEnum.TEMPLATE,
@@ -72,17 +72,14 @@ export class GetSubscriberTemplatePreference {
     const templateChannelPreference = command.template.preferenceSettings;
 
     const subscriberWorkflowPreferences =
-      await this.getPreferences.getWorkflowOptionsPreferences({
+      await this.getPreferences.getWorkflowChannelPreferences({
         environmentId: command.environmentId,
         organizationId: command.organizationId,
         subscriberId: subscriber._id,
         templateId: command.template._id,
       });
 
-    const subscriberPreferenceChannels =
-      GetPreferences.mapWorkflowOptionsPreferencesToChannels(
-        subscriberWorkflowPreferences,
-      ) || subscriberPreference?.channels;
+    const subscriberPreferenceChannels = subscriberPreference?.channels;
     const workflowOverrideChannelPreference =
       workflowOverride?.preferenceSettings;
 

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -97,6 +97,7 @@ export class GetSubscriberTemplatePreference {
 
     const template = mapTemplateConfiguration({
       ...command.template,
+      // determine if any readOnly constraints have been set by the Workflow owner
       critical: GetPreferences.checkIfWorkflowPreferencesIsReadOnly(
         subscriberWorkflowPreferences,
       ),


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

https://linear.app/novu/issue/NV-4295/implement-inbox-changes-for-readonly-property-handling

- Surface the `readOnly` properties of channels through backwards-compatible change using `critical` field.
  - **Note:** for now, a workflow with new preferences is considered 'critical' if its top-level `workflow.readOnly` is true, or if any of the channels are true. This is because we lack the granularity in our response to disable switches individually.
- When "merging" preferences, `defaultValue` (enablement) and `readOnly` need to be handled in different orders because different scenarios take precedence. I.e. when determining if a workflow should be enabled, the subscriber's selection has the topmost priority; however, for `readOnly`, the preference set in the Dashboard should be the highest priority.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

![Screenshot 2024-09-12 at 12 05 43 AM](https://github.com/user-attachments/assets/e3042389-5ffd-4d40-ade6-7ba13f176a41)
