### PR TITLE
feat(api): add option to remove Novu branding in the inbox

### DIFF
--- a/apps/api/src/app/inbox/dtos/subscriber-session-response.dto.ts
+++ b/apps/api/src/app/inbox/dtos/subscriber-session-response.dto.ts
@@ -1,4 +1,5 @@
 export class SubscriberSessionResponseDto {
   readonly token: string;
   readonly totalUnreadCount: number;
+  readonly removeNovuBranding: boolean;
 }

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -86,9 +86,12 @@ export class Session {
 
     const token = await this.authService.getSubscriberWidgetToken(subscriber);
 
+    const removeNovuBranding = inAppIntegration.removeNovuBranding || false;
+
     return {
       token,
       totalUnreadCount,
+      removeNovuBranding,
     };
   }
 }

--- a/apps/api/src/app/integrations/dtos/update-integration.dto.ts
+++ b/apps/api/src/app/integrations/dtos/update-integration.dto.ts
@@ -37,6 +37,14 @@ export class UpdateIntegrationRequestDto implements IUpdateIntegrationBodyDto {
   @ValidateNested()
   credentials?: CredentialsDto;
 
+  @ApiPropertyOptional({
+    type: Boolean,
+    description: 'If true, the Novu branding will be removed from the Inbox component',
+  })
+  @IsOptional()
+  @IsBoolean()
+  removeNovuBranding?: boolean;
+
   @ApiPropertyOptional({ type: Boolean })
   @IsOptional()
   @IsBoolean()

--- a/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
@@ -1,7 +1,8 @@
-import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { EnvironmentRepository, IntegrationRepository, CommunityOrganizationRepository } from '@novu/dal';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 import {
+  ApiServiceLevelEnum,
   ChannelTypeEnum,
   ChatProviderIdEnum,
   EmailProviderIdEnum,
@@ -15,6 +16,7 @@ describe('Update Integration - /integrations/:integrationId (PUT)', function () 
   let session: UserSession;
   const integrationRepository = new IntegrationRepository();
   const envRepository = new EnvironmentRepository();
+  const communityOrganizationRepository = new CommunityOrganizationRepository();
 
   beforeEach(async () => {
     session = new UserSession();
@@ -961,5 +963,91 @@ describe('Update Integration - /integrations/:integrationId (PUT)', function () 
     expect(second.primary).to.equal(false);
     expect(second.active).to.equal(true);
     expect(second.priority).to.equal(1);
+  });
+
+  it('should update removeNovuBranding when organization is not on free tier', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    process.env.IS_IMPROVED_BILLING_ENABLED = 'true';
+
+    await communityOrganizationRepository.update(
+      { _id: session.organization._id },
+      { $set: { apiServiceLevel: ApiServiceLevelEnum.BUSINESS } }
+    );
+
+    const inAppIntegration = await integrationRepository.create({
+      name: 'Novu In-App',
+      identifier: 'identifier1',
+      providerId: InAppProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.IN_APP,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      removeNovuBranding: true,
+      check: false,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${inAppIntegration._id}`).send(payload);
+
+    expect(data.removeNovuBranding).to.equal(true);
+
+    const updatedIntegration = await integrationRepository.findOne({
+      _id: inAppIntegration._id,
+      _organizationId: session.organization._id,
+    });
+
+    expect(updatedIntegration?.removeNovuBranding).to.equal(true);
+  });
+
+  it('should not update removeNovuBranding when organization is on free tier', async function () {
+    await integrationRepository.deleteMany({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    process.env.IS_IMPROVED_BILLING_ENABLED = 'true';
+
+    await communityOrganizationRepository.update(
+      { _id: session.organization._id },
+      { $set: { apiServiceLevel: ApiServiceLevelEnum.FREE } }
+    );
+
+    const inAppIntegration = await integrationRepository.create({
+      name: 'Novu In-App',
+      identifier: 'identifier1',
+      providerId: InAppProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.IN_APP,
+      active: false,
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+    });
+
+    const payload = {
+      removeNovuBranding: true,
+      check: false,
+      active: true,
+    };
+
+    const {
+      body: { data },
+    } = await session.testAgent.put(`/v1/integrations/${inAppIntegration._id}`).send(payload);
+
+    console.log('data', data);
+    expect(data.removeNovuBranding).to.be.undefined;
+
+    const updatedIntegration = await integrationRepository.findOne({
+      _id: inAppIntegration._id,
+      _organizationId: session.organization._id,
+    });
+
+    expect(updatedIntegration?.removeNovuBranding).to.be.undefined;
   });
 });

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -198,6 +198,7 @@ export class IntegrationsController {
           organizationId: user.organizationId,
           integrationId,
           credentials: body.credentials,
+          removeNovuBranding: body.removeNovuBranding,
           active: body.active,
           check: body.check ?? true,
           conditions: body.conditions,

--- a/apps/api/src/app/integrations/integrations.module.ts
+++ b/apps/api/src/app/integrations/integrations.module.ts
@@ -1,16 +1,16 @@
 import { forwardRef, Module } from '@nestjs/common';
 
-import { CompileTemplate, CreateExecutionDetails, QueuesModule } from '@novu/application-generic';
-import { JobTopicNameEnum } from '@novu/shared';
+import { CompileTemplate, CreateExecutionDetails } from '@novu/application-generic';
 import { SharedModule } from '../shared/shared.module';
 import { USE_CASES } from './usecases';
 import { IntegrationsController } from './integrations.controller';
 import { AuthModule } from '../auth/auth.module';
+import { CommunityOrganizationRepository } from '@novu/dal';
 
 @Module({
   imports: [SharedModule, forwardRef(() => AuthModule)],
   controllers: [IntegrationsController],
-  providers: [...USE_CASES, CompileTemplate, CreateExecutionDetails],
+  providers: [...USE_CASES, CompileTemplate, CreateExecutionDetails, CommunityOrganizationRepository],
   exports: [...USE_CASES],
 })
 export class IntegrationModule {}

--- a/apps/api/src/app/integrations/integrations.module.ts
+++ b/apps/api/src/app/integrations/integrations.module.ts
@@ -1,11 +1,10 @@
 import { forwardRef, Module } from '@nestjs/common';
-
+import { CommunityOrganizationRepository } from '@novu/dal';
 import { CompileTemplate, CreateExecutionDetails } from '@novu/application-generic';
 import { SharedModule } from '../shared/shared.module';
 import { USE_CASES } from './usecases';
 import { IntegrationsController } from './integrations.controller';
 import { AuthModule } from '../auth/auth.module';
-import { CommunityOrganizationRepository } from '@novu/dal';
 
 @Module({
   imports: [SharedModule, forwardRef(() => AuthModule)],

--- a/apps/api/src/app/integrations/usecases/update-integration/update-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/update-integration/update-integration.command.ts
@@ -28,6 +28,9 @@ export class UpdateIntegrationCommand extends OrganizationCommand {
   credentials?: ICredentialsDto;
 
   @IsOptional()
+  removeNovuBranding?: boolean;
+
+  @IsOptional()
   active?: boolean;
 
   @IsOptional()

--- a/apps/api/src/app/testing/billing/upsert-subscription.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/upsert-subscription.e2e-ee.ts
@@ -1,6 +1,6 @@
 /* eslint-disable global-require */
 import sinon from 'sinon';
-import { CommunityOrganizationRepository } from '@novu/dal';
+import { CommunityOrganizationRepository, IntegrationRepository } from '@novu/dal';
 import { expect } from 'chai';
 import { ApiServiceLevelEnum } from '@novu/shared';
 import { StripeBillingIntervalEnum, StripeUsageTypeEnum } from '@novu/ee-billing/src/stripe/types';
@@ -69,6 +69,7 @@ describe('UpsertSubscription', () => {
       ],
     } as any);
     updateOrgStub = sinon.stub(repo, 'update').resolves({ matched: 1, modified: 1 });
+    (repo as any).integrationRepository = sinon.createStubInstance(IntegrationRepository);
     createSubscriptionStub = sinon.stub(stripeStub.subscriptions, 'create');
     updateSubscriptionStub = sinon.stub(stripeStub.subscriptions, 'update');
     deleteSubscriptionStub = sinon.stub(stripeStub.subscriptions, 'del');

--- a/libs/dal/src/repositories/integration/integration.entity.ts
+++ b/libs/dal/src/repositories/integration/integration.entity.ts
@@ -35,6 +35,8 @@ export class IntegrationEntity {
   deletedBy: string;
 
   conditions?: StepFilter[];
+
+  removeNovuBranding?: boolean;
 }
 
 export type ICredentialsEntity = ICredentials;

--- a/libs/dal/src/repositories/integration/integration.repository.ts
+++ b/libs/dal/src/repositories/integration/integration.repository.ts
@@ -1,6 +1,6 @@
 import { FilterQuery } from 'mongoose';
 import { SoftDeleteModel } from 'mongoose-delete';
-import { NOVU_PROVIDERS } from '@novu/shared';
+import { ApiServiceLevelEnum, ChannelTypeEnum, NOVU_PROVIDERS } from '@novu/shared';
 
 import { IntegrationEntity, IntegrationDBModel } from './integration.entity';
 import { Integration } from './integration.schema';
@@ -31,6 +31,16 @@ export class IntegrationRepository extends BaseRepository<IntegrationDBModel, In
     return await this.find({
       _environmentId: environmentId,
     });
+  }
+
+  async setRemoveNovuBranding(organizationId: string, value: boolean) {
+    return await this.update(
+      {
+        _organizationId: organizationId,
+        channel: ChannelTypeEnum.IN_APP,
+      },
+      { removeNovuBranding: value }
+    );
   }
 
   async findHighestPriorityIntegration({

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -76,10 +76,7 @@ const integrationSchema = new Schema<IntegrationDBModel>(
       type: Schema.Types.Boolean,
       default: false,
     },
-    removeNovuBranding: {
-      type: Schema.Types.Boolean,
-      default: false,
-    },
+    removeNovuBranding: Schema.Types.Boolean,
     conditions: [
       {
         isNegated: Schema.Types.Boolean,

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -76,6 +76,10 @@ const integrationSchema = new Schema<IntegrationDBModel>(
       type: Schema.Types.Boolean,
       default: false,
     },
+    removeNovuBranding: {
+      type: Schema.Types.Boolean,
+      default: false,
+    },
     conditions: [
       {
         isNegated: Schema.Types.Boolean,

--- a/libs/dal/src/repositories/organization/community.organization.repository.ts
+++ b/libs/dal/src/repositories/organization/community.organization.repository.ts
@@ -4,12 +4,14 @@ import { BaseRepository } from '../base-repository';
 import { Organization } from './organization.schema';
 import { CommunityMemberRepository } from '../member';
 import { IOrganizationRepository } from './organization-repository.interface';
+import { IntegrationRepository } from '../integration';
 
 export class CommunityOrganizationRepository
   extends BaseRepository<OrganizationDBModel, OrganizationEntity, object>
   implements IOrganizationRepository
 {
   private memberRepository = new CommunityMemberRepository();
+  private integrationRepository = new IntegrationRepository();
 
   constructor() {
     super(Organization, OrganizationEntity);
@@ -63,6 +65,10 @@ export class CommunityOrganizationRepository
   }
 
   async updateServiceLevel(organizationId: string, apiServiceLevel: ApiServiceLevelEnum) {
+    if (apiServiceLevel === ApiServiceLevelEnum.FREE) {
+      await this.integrationRepository.setRemoveNovuBranding(organizationId, false);
+    }
+
     return this.update(
       {
         _id: organizationId,

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -59,6 +59,7 @@ export enum ActionTypeEnum {
 export type Session = {
   token: string;
   totalUnreadCount: number;
+  removeNovuBranding: boolean;
 };
 
 export type MessageButton = {

--- a/packages/shared/src/dto/integration/construct-integration.interface.ts
+++ b/packages/shared/src/dto/integration/construct-integration.interface.ts
@@ -11,6 +11,7 @@ export interface IConstructIntegrationDto {
   credentials?: ICredentialsDto;
   active?: boolean;
   check?: boolean;
+  removeNovuBranding?: boolean;
   conditions?: {
     isNegated?: boolean;
     type?: BuilderFieldType;


### PR DESCRIPTION
### What changed? Why was the change needed?
Added option to remove Novu branding from Inbox component for paid customers. 

- Only non-free tiers are able to update this setting
- After customer is set back to `free`, this setting is set back to `false`
- Value will be always `false` unless explicitly set to `true` on integration entity
- This setting is exposed for Inbox component inside session
- This feature is under a feature flag `IS_IMPROVED_BILLING_ENABLED`

**Related PRs:**
https://github.com/novuhq/novu/pull/6500
https://github.com/novuhq/packages-enterprise/pull/218