### PR TITLE
feat(web): display 'Remove Novu branding' toggle in In-App integration panel

### DIFF
--- a/apps/web/src/pages/integrations/UpdateProviderPage.tsx
+++ b/apps/web/src/pages/integrations/UpdateProviderPage.tsx
@@ -8,7 +8,9 @@ import { UpdateProviderSidebar as UpdateProviderSidebarOld } from './components/
 export function UpdateProviderPage() {
   const { integrationId } = useParams();
   const navigate = useNavigate();
-  const isV2Enabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_V2_ENABLED);
+  let isV2Enabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_V2_ENABLED);
+
+  isV2Enabled = false;
 
   const onClose = () => {
     navigate(ROUTES.INTEGRATIONS);

--- a/apps/web/src/pages/integrations/UpdateProviderPage.tsx
+++ b/apps/web/src/pages/integrations/UpdateProviderPage.tsx
@@ -8,9 +8,7 @@ import { UpdateProviderSidebar as UpdateProviderSidebarOld } from './components/
 export function UpdateProviderPage() {
   const { integrationId } = useParams();
   const navigate = useNavigate();
-  let isV2Enabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_V2_ENABLED);
-
-  isV2Enabled = false;
+  const isV2Enabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_V2_ENABLED);
 
   const onClose = () => {
     navigate(ROUTES.INTEGRATIONS);

--- a/apps/web/src/pages/integrations/components/NovuInAppRemoveBranding.tsx
+++ b/apps/web/src/pages/integrations/components/NovuInAppRemoveBranding.tsx
@@ -1,0 +1,79 @@
+import styled from '@emotion/styled';
+import { Controller } from 'react-hook-form';
+import { Switch, Tooltip } from '@novu/design-system';
+import { useSubscription } from '../../../ee/billing/hooks/useSubscription';
+import { ApiServiceLevelEnum, FeatureFlagsKeysEnum } from '@novu/shared';
+import { useFeatureFlag } from '../../../hooks';
+
+const InputWrapper = styled.div`
+  > div {
+    width: 100%;
+  }
+`;
+
+const SwitchWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const SwitchDescription = styled.div`
+  color: ${({ theme }) => `${theme.colorScheme === 'dark' ? theme.colors.dark[3] : theme.colors.gray[6]}`};
+  font-size: 14px !important;
+  font-weight: 400;
+  margin-top: '0px';
+  margin-bottom: '10px';
+  line-height: '17px';
+`;
+
+const SwitchLabel = styled.div`
+  color: ${({ theme }) => `${theme.colorScheme === 'dark' ? theme.white : theme.colors.gray[8]}`};
+  font-size: 14px !important;
+  font-weight: 700;
+  margin: 5px auto 5px 0px;
+  line-height: 17px;
+`;
+
+export const NovuInAppRemoveBranding = ({ control }: { control: any }) => {
+  const { apiServiceLevel } = useSubscription();
+  const isImprovedBillingEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_IMPROVED_BILLING_ENABLED);
+
+  if (!isImprovedBillingEnabled) {
+    return null;
+  }
+
+  return (
+    <InputWrapper key="removeNovuBranding">
+      <Controller
+        name="removeNovuBranding"
+        control={control}
+        defaultValue={false}
+        render={({ field }) => (
+          <>
+            <SwitchWrapper>
+              <SwitchLabel>Remove Novu branding</SwitchLabel>
+              <Tooltip
+                disabled={apiServiceLevel !== ApiServiceLevelEnum.FREE}
+                withinPortal={false}
+                position="bottom"
+                width={250}
+                multiline
+                label="Please upgrade your plan to enable this feature"
+              >
+                <span>
+                  <Switch
+                    label={field.value ? 'Active' : 'Disabled'}
+                    data-test-id="remove-novu-branding"
+                    disabled={apiServiceLevel === ApiServiceLevelEnum.FREE}
+                    checked={field.value}
+                    onChange={field.onChange}
+                  />
+                </span>
+              </Tooltip>
+            </SwitchWrapper>
+            <SwitchDescription>Removes Novu branding from the Inbox when active</SwitchDescription>
+          </>
+        )}
+      />
+    </InputWrapper>
+  );
+};

--- a/apps/web/src/pages/integrations/components/multi-provider/UpdateProviderSidebar.tsx
+++ b/apps/web/src/pages/integrations/components/multi-provider/UpdateProviderSidebar.tsx
@@ -37,6 +37,7 @@ import { ShareableUrl } from '../Modal/ConnectIntegrationForm';
 import { Conditions, IConditions } from '../../../../components/conditions';
 import { useWebhookSupportStatus } from '../../../../api/hooks';
 import { defaultIntegrationConditionsProps } from '../../constants';
+import { NovuInAppRemoveBranding } from '../NovuInAppRemoveBranding';
 
 interface IProviderForm {
   name: string;
@@ -44,6 +45,7 @@ interface IProviderForm {
   active: boolean;
   identifier: string;
   conditions: IConditions[];
+  removeNovuBranding?: boolean;
 }
 
 enum SidebarStateEnum {
@@ -154,6 +156,7 @@ export function UpdateProviderSidebar({
       }, {} as any),
       conditions: foundProvider.conditions,
       active: foundProvider.active,
+      removeNovuBranding: foundProvider.removeNovuBranding,
     });
   }, [reset, integrationId, providers]);
 
@@ -382,7 +385,12 @@ export function UpdateProviderSidebar({
             </InputWrapper>
           )}
           <ShareableUrl provider={selectedProvider?.providerId} hmacEnabled={!!hmacEnabled} />
-          {isNovuInAppProvider && <NovuInAppFrameworks onFrameworkClick={onFrameworkClickCallback} />}
+          {isNovuInAppProvider && (
+            <>
+              <NovuInAppFrameworks onFrameworkClick={onFrameworkClickCallback} />
+              <NovuInAppRemoveBranding control={control} />
+            </>
+          )}
         </When>
         <When truthy={isNovuInAppProvider && sidebarState === SidebarStateEnum.EXPANDED}>
           <SetupTimeline

--- a/apps/web/src/pages/integrations/components/multi-provider/v2/UpdateProviderSidebarV2.tsx
+++ b/apps/web/src/pages/integrations/components/multi-provider/v2/UpdateProviderSidebarV2.tsx
@@ -30,6 +30,7 @@ import { useProviders } from '../../../useProviders';
 import { IntegrationInput } from '../../IntegrationInput';
 import { ShareableUrl } from '../../Modal/ConnectIntegrationForm';
 import { NovuInAppFrameworkHeader } from '../../NovuInAppFrameworkHeader';
+import { NovuInAppRemoveBranding } from '../../NovuInAppRemoveBranding';
 import { SetupWarning } from '../../SetupWarning';
 import { UpdateIntegrationCommonFields } from '../../UpdateIntegrationCommonFields';
 import { UpdateIntegrationSidebarHeader } from '../../UpdateIntegrationSidebarHeader';
@@ -43,6 +44,7 @@ interface IProviderForm {
   active: boolean;
   identifier: string;
   conditions: IConditions[];
+  removeNovuBranding?: boolean;
 }
 
 enum SidebarStateEnum {
@@ -153,6 +155,7 @@ export function UpdateProviderSidebar({
       }, {} as any),
       conditions: foundProvider.conditions,
       active: foundProvider.active,
+      removeNovuBranding: foundProvider.removeNovuBranding,
     });
   }, [reset, integrationId, providers]);
 
@@ -380,7 +383,12 @@ export function UpdateProviderSidebar({
             </InputWrapper>
           )}
           <ShareableUrl provider={selectedProvider?.providerId} hmacEnabled={!!hmacEnabled} />
-          {isNovuInAppProvider && <NovuInAppFrameworks onFrameworkClick={onFrameworkClickCallback} />}
+          {isNovuInAppProvider && (
+            <>
+              <NovuInAppFrameworks onFrameworkClick={onFrameworkClickCallback} />
+              <NovuInAppRemoveBranding control={control} />
+            </>
+          )}
         </When>
         <When truthy={isNovuInAppProvider && sidebarState === SidebarStateEnum.EXPANDED}>
           <SetupTimeline

--- a/apps/web/src/pages/integrations/types.ts
+++ b/apps/web/src/pages/integrations/types.ts
@@ -34,6 +34,7 @@ export interface IIntegratedProvider {
   docReference: string;
   comingSoon: boolean;
   active: boolean;
+  removeNovuBranding?: boolean;
   connected: boolean;
   conditions?: IConditions[];
   logoFileName: ILogoFileName;
@@ -56,6 +57,7 @@ export interface IntegrationEntity {
   credentials: ICredentials;
   conditions?: IConditions[];
   active: boolean;
+  removeNovuBranding?: boolean;
   deleted: boolean;
   order: number;
   primary: boolean;

--- a/apps/web/src/pages/integrations/useProviders.ts
+++ b/apps/web/src/pages/integrations/useProviders.ts
@@ -86,6 +86,7 @@ function initializeProvidersByIntegration(integrations: IntegrationEntity[]): II
         identifier: integrationItem?.identifier,
         primary: integrationItem?.primary ?? false,
         conditions: integrationItem?.conditions ?? [],
+        removeNovuBranding: integrationItem?.removeNovuBranding ?? false,
       };
     });
 }


### PR DESCRIPTION
### What changed? Why was the change needed?
Displays "Remove Novu branding" toggle on the In-App integration panel, which removes Novu branding from Inbox component.  This setting available only for paid plans.

Related PRs: 
https://github.com/novuhq/novu/pull/6498

### Screenshots
![image](https://github.com/user-attachments/assets/16328973-71b1-4064-956a-6c233edefd68)

![image](https://github.com/user-attachments/assets/c7a72023-b20a-4350-a30a-c7b79c66056c)

![image](https://github.com/user-attachments/assets/b3030aaf-bda1-4302-8b53-758170fd1676)
