### PR TITLE
chore(api): retire legacy v1 front base url

### DIFF
--- a/apps/api/src/config/cors.config.spec.ts
+++ b/apps/api/src/config/cors.config.spec.ts
@@ -30,7 +30,6 @@ describe('CORS Configuration', () => {
         process.env.NODE_ENV = environment;
 
         process.env.FRONT_BASE_URL = 'https://test.com';
-        process.env.LEGACY_V1_FRONT_BASE_URL = 'https://test-legacy.com';
         process.env.LEGACY_STAGING_DASHBOARD_URL = 'https://test-legacy-staging-dashboard.com';
         process.env.WIDGET_BASE_URL = 'https://widget.com';
         process.env.PR_PREVIEW_ROOT_URL = 'https://pr-preview.com';

--- a/apps/api/src/config/cors.config.ts
+++ b/apps/api/src/config/cors.config.ts
@@ -20,9 +20,6 @@ export const corsOptionsDelegate: Parameters<INestApplication['enableCors']>[0] 
     if (process.env.FRONT_BASE_URL) {
       corsOptions.origin.push(process.env.FRONT_BASE_URL);
     }
-    if (process.env.LEGACY_V1_FRONT_BASE_URL) {
-      corsOptions.origin.push(process.env.LEGACY_V1_FRONT_BASE_URL);
-    }
     if (process.env.LEGACY_STAGING_DASHBOARD_URL) {
       corsOptions.origin.push(process.env.LEGACY_STAGING_DASHBOARD_URL);
     }

--- a/apps/api/src/config/env.validators.ts
+++ b/apps/api/src/config/env.validators.ts
@@ -47,7 +47,6 @@ export const envValidators = {
   NOTIFICATION_RETENTION_DAYS: num({ default: DEFAULT_NOTIFICATION_RETENTION_DAYS }),
   MESSAGE_GENERIC_RETENTION_DAYS: num({ default: DEFAULT_MESSAGE_GENERIC_RETENTION_DAYS }),
   MESSAGE_IN_APP_RETENTION_DAYS: num({ default: DEFAULT_MESSAGE_IN_APP_RETENTION_DAYS }),
-  LEGACY_V1_FRONT_BASE_URL: url({ default: undefined }),
   LEGACY_STAGING_DASHBOARD_URL: url({ default: undefined }),
   API_ROOT_URL: url({ default: undefined }),
   NOVU_INVITE_TEAM_MEMBER_NUDGE_TRIGGER_IDENTIFIER: str({ default: undefined }),


### PR DESCRIPTION
### What changed? Why was the change needed?
it is no longer used after we moved all dashboards with a permanent move code in netlify

Related PR: https://github.com/novuhq/cloud-infra/pull/143
