### PR TITLE
feat(api): inbox api filter preferences by workflow tags

### DIFF
--- a/apps/api/src/app/inbox/dtos/get-preferences-request.dto.ts
+++ b/apps/api/src/app/inbox/dtos/get-preferences-request.dto.ts
@@ -1,0 +1,8 @@
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+export class GetPreferencesRequestDto {
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+}

--- a/apps/api/src/app/inbox/e2e/get-preferences.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/get-preferences.e2e.ts
@@ -49,4 +49,33 @@ describe('Get all preferences - /inbox/preferences (GET)', function () {
 
     expect(response.status).to.equal(401);
   });
+
+  it('should allow filtering preferences by tags', async function () {
+    const newsletterTag = 'newsletter';
+    const securityTag = 'security';
+    await session.createTemplate({
+      noFeedId: true,
+      tags: [newsletterTag],
+    });
+    await session.createTemplate({
+      noFeedId: true,
+      tags: [securityTag],
+    });
+
+    const response = await session.testAgent
+      .get(`/v1/inbox/preferences?tags[]=${newsletterTag}&tags[]=${securityTag}`)
+      .set('Authorization', `Bearer ${session.subscriberToken}`);
+
+    expect(response.body.data.length).to.equal(3);
+
+    const globalPreference = response.body.data[0];
+    expect(globalPreference.channels.email).to.equal(true);
+    expect(globalPreference.channels.in_app).to.equal(true);
+    expect(globalPreference.level).to.equal('global');
+
+    const workflowPreferences = response.body.data.slice(1);
+    workflowPreferences.forEach((workflowPreference) => {
+      expect(workflowPreference.workflow.tags[0]).to.be.oneOf([newsletterTag, securityTag]);
+    });
+  });
 });

--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -33,6 +33,7 @@ import { GetPreferencesResponseDto } from './dtos/get-preferences-response.dto';
 import { UpdatePreferencesRequestDto } from './dtos/update-preferences-request.dto';
 import { UpdatePreferences } from './usecases/update-preferences/update-preferences.usecase';
 import { UpdatePreferencesCommand } from './usecases/update-preferences/update-preferences.command';
+import { GetPreferencesRequestDto } from './dtos/get-preferences-request.dto';
 
 @ApiCommonResponses()
 @Controller('/inbox')
@@ -103,13 +104,15 @@ export class InboxController {
   @UseGuards(AuthGuard('subscriberJwt'))
   @Get('/preferences')
   async getAllPreferences(
-    @SubscriberSession() subscriberSession: SubscriberEntity
+    @SubscriberSession() subscriberSession: SubscriberEntity,
+    @Query() query: GetPreferencesRequestDto
   ): Promise<GetPreferencesResponseDto[]> {
     return await this.getPreferencesUsecase.execute(
       GetPreferencesCommand.create({
         organizationId: subscriberSession._organizationId,
         subscriberId: subscriberSession.subscriberId,
         environmentId: subscriberSession._environmentId,
+        tags: query.tags,
       })
     );
   }

--- a/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.command.ts
+++ b/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.command.ts
@@ -1,3 +1,9 @@
+import { IsArray, IsOptional, IsString } from 'class-validator';
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
 
-export class GetPreferencesCommand extends EnvironmentWithSubscriber {}
+export class GetPreferencesCommand extends EnvironmentWithSubscriber {
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  readonly tags?: string[];
+}

--- a/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.spec.ts
@@ -127,7 +127,7 @@ describe('GetPreferences', () => {
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
     getSubscriberGlobalPreferenceMock.execute.resolves(mockedGlobalPreferences);
-    notificationTemplateRepositoryMock.getActiveList.resolves(mockedWorkflows);
+    notificationTemplateRepositoryMock.filterActive.resolves(mockedWorkflows);
     getSubscriberWorkflowMock.execute.resolves(mockedWorkflowPreference);
 
     const result = await getPreferences.execute(command);
@@ -139,11 +139,13 @@ describe('GetPreferences', () => {
     ]);
     expect(getSubscriberGlobalPreferenceMock.execute.calledOnce).to.be.true;
     expect(getSubscriberGlobalPreferenceMock.execute.firstCall.args).to.deep.equal([command]);
-    expect(notificationTemplateRepositoryMock.getActiveList.calledOnce).to.be.true;
-    expect(notificationTemplateRepositoryMock.getActiveList.firstCall.args).to.deep.equal([
-      command.organizationId,
-      command.environmentId,
-      true,
+    expect(notificationTemplateRepositoryMock.filterActive.calledOnce).to.be.true;
+    expect(notificationTemplateRepositoryMock.filterActive.firstCall.args).to.deep.equal([
+      {
+        organizationId: command.organizationId,
+        environmentId: command.environmentId,
+        tags: undefined,
+      },
     ]);
     expect(getSubscriberWorkflowMock.execute.calledOnce).to.be.true;
     expect(getSubscriberWorkflowMock.execute.firstCall.args).to.deep.equal([
@@ -168,5 +170,116 @@ describe('GetPreferences', () => {
     ]);
 
     expect(result).to.deep.equal(mockedPreferencesResponse);
+  });
+
+  it('it should return subscriber preferences filtered by tags', async () => {
+    const workflowsWithTags: any = [
+      {
+        _id: '111',
+        name: 'workflow',
+        triggers: [{ identifier: '111' }],
+        critical: false,
+        tags: ['newsletter'],
+      },
+      {
+        _id: '222',
+        name: 'workflow',
+        triggers: [{ identifier: '222' }],
+        critical: false,
+        tags: ['security'],
+      },
+    ];
+    const response: any = [
+      { level: PreferenceLevelEnum.GLOBAL, ...mockedGlobalPreferences.preference },
+      {
+        level: PreferenceLevelEnum.TEMPLATE,
+        workflow: {
+          id: workflowsWithTags[0]._id,
+          identifier: workflowsWithTags[0].triggers[0].identifier,
+          name: workflowsWithTags[0].name,
+          critical: workflowsWithTags[0].critical,
+          tags: workflowsWithTags[0].tags,
+        },
+        ...mockedWorkflowPreference.preference,
+      },
+      {
+        level: PreferenceLevelEnum.TEMPLATE,
+        workflow: {
+          id: workflowsWithTags[1]._id,
+          identifier: workflowsWithTags[1].triggers[0].identifier,
+          name: workflowsWithTags[1].name,
+          critical: workflowsWithTags[1].critical,
+          tags: workflowsWithTags[1].tags,
+        },
+        ...mockedWorkflowPreference.preference,
+      },
+    ];
+    const command = {
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      tags: ['newsletter', 'security'],
+    };
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+    getSubscriberGlobalPreferenceMock.execute.resolves(mockedGlobalPreferences);
+    notificationTemplateRepositoryMock.filterActive.resolves(workflowsWithTags);
+    getSubscriberWorkflowMock.execute.resolves(mockedWorkflowPreference);
+
+    const result = await getPreferences.execute(command);
+
+    expect(subscriberRepositoryMock.findBySubscriberId.calledOnce).to.be.true;
+    expect(subscriberRepositoryMock.findBySubscriberId.firstCall.args).to.deep.equal([
+      command.environmentId,
+      command.subscriberId,
+    ]);
+    expect(getSubscriberGlobalPreferenceMock.execute.calledOnce).to.be.true;
+    expect(getSubscriberGlobalPreferenceMock.execute.firstCall.args).to.deep.equal([
+      {
+        organizationId: command.organizationId,
+        environmentId: command.environmentId,
+        subscriberId: command.subscriberId,
+      },
+    ]);
+    expect(notificationTemplateRepositoryMock.filterActive.calledOnce).to.be.true;
+    expect(notificationTemplateRepositoryMock.filterActive.firstCall.args).to.deep.equal([
+      {
+        organizationId: command.organizationId,
+        environmentId: command.environmentId,
+        tags: command.tags,
+      },
+    ]);
+    expect(getSubscriberWorkflowMock.execute.calledTwice).to.be.true;
+    expect(getSubscriberWorkflowMock.execute.firstCall.args).to.deep.equal([
+      {
+        organizationId: command.organizationId,
+        subscriberId: command.subscriberId,
+        environmentId: command.environmentId,
+        template: workflowsWithTags[0],
+        subscriber: mockedSubscriber,
+      },
+    ]);
+    expect(getSubscriberWorkflowMock.execute.secondCall.args).to.deep.equal([
+      {
+        organizationId: command.organizationId,
+        subscriberId: command.subscriberId,
+        environmentId: command.environmentId,
+        template: workflowsWithTags[1],
+        subscriber: mockedSubscriber,
+      },
+    ]);
+
+    expect(analyticsServiceMock.mixpanelTrack.calledOnce).to.be.true;
+    expect(analyticsServiceMock.mixpanelTrack.firstCall.args).to.deep.equal([
+      AnalyticsEventsEnum.FETCH_PREFERENCES,
+      '',
+      {
+        _organization: command.organizationId,
+        subscriberId: command.subscriberId,
+        workflowSize: 2,
+      },
+    ]);
+
+    expect(result).to.deep.equal(response);
   });
 });

--- a/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/get-preferences/get-preferences.usecase.ts
@@ -43,8 +43,11 @@ export class GetPreferences {
     };
 
     const workflowList =
-      (await this.notificationTemplateRepository.getActiveList(command.organizationId, command.environmentId, true)) ||
-      [];
+      (await this.notificationTemplateRepository.filterActive({
+        organizationId: command.organizationId,
+        environmentId: command.environmentId,
+        tags: command.tags,
+      })) || [];
 
     this.analyticsService.mixpanelTrack(AnalyticsEventsEnum.FETCH_PREFERENCES, '', {
       _organization: command.organizationId,
@@ -71,7 +74,7 @@ export class GetPreferences {
             id: workflow._id,
             identifier: workflow.triggers[0].identifier,
             name: workflow.name,
-            critical: workflow.critical || workflowPreference.template.critical,
+            critical: workflow.critical ?? workflowPreference.template.critical,
             tags: workflow.tags,
           },
         } satisfies InboxPreference;

--- a/libs/application-generic/src/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
@@ -29,12 +29,12 @@ export class GetSubscriberPreference {
       command.subscriberId,
     );
 
-    const templateList =
-      await this.notificationTemplateRepository.getActiveList(
-        command.organizationId,
-        command.environmentId,
-        true,
-      );
+    const templateList = await this.notificationTemplateRepository.filterActive(
+      {
+        organizationId: command.organizationId,
+        environmentId: command.environmentId,
+      },
+    );
 
     this.analyticsService.mixpanelTrack(
       'Fetch User Preferences - [Notification Center]',

--- a/libs/dal/src/repositories/notification-template/notification-template.repository.ts
+++ b/libs/dal/src/repositories/notification-template/notification-template.repository.ts
@@ -207,12 +207,24 @@ export class NotificationTemplateRepository extends BaseRepository<
     return { totalCount: totalItemsCount, data: this.mapEntities(items) };
   }
 
-  async getActiveList(organizationId: string, environmentId: string, active?: boolean) {
+  async filterActive({
+    organizationId,
+    environmentId,
+    tags,
+  }: {
+    organizationId: string;
+    environmentId: string;
+    tags?: string[];
+  }) {
     const requestQuery: NotificationTemplateQuery = {
       _environmentId: environmentId,
       _organizationId: organizationId,
-      active,
+      active: true,
     };
+
+    if (tags && tags?.length > 0) {
+      requestQuery.tags = { $in: tags };
+    }
 
     const items = await this.MongooseModel.find(requestQuery)
       .populate('steps.template', { type: 1 })


### PR DESCRIPTION
### What changed? Why was the change needed?
Updated the Inbox API to allow filtering preferences by workflow tags.

### Screenshots

![Screenshot 2024-09-17 at 13 59 52](https://github.com/user-attachments/assets/fdfd623d-50bd-48d6-9b75-cd09f7a868f2)
![Screenshot 2024-09-17 at 14 04 04](https://github.com/user-attachments/assets/8418420b-c87f-45b5-808c-62ffafdaadbb)
