### PR TITLE
chore(root): Fix workspace resolution during preview releases

### DIFF
--- a/.github/workflows/release-packages-preview.yml
+++ b/.github/workflows/release-packages-preview.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Teach Novu preview packages to work with latest dependencies
-        run: pnpm run packages:set-latest
-
       - name: Build
         run: pnpm run build:affected
         if: ${{ success() }}

--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "get-affected": "node scripts/print-affected-array.mjs",
     "symlink:submodules": "pnpm --filter \"@novu/ee-*\" exec node \"$(pwd)/scripts/symlink-ee.mjs\"",
     "install:with-ee": "pnpm install && pnpm symlink:submodules",
-    "packages:set-workspace-protocol": "node scripts/set-package-dependencies.mjs workspace:*",
-    "packages:set-latest": "node scripts/set-package-dependencies.mjs latest"
+    "packages:set-workspace-protocol": "node scripts/set-package-dependencies.mjs workspace:*"
   },
   "devDependencies": {
     "@auto-it/npm": "^10.36.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
     "start:test": "cross-env NODE_ENV=test PORT=1336 nodemon init",
     "start:debug": "cross-env nodemon --config nodemon-debug.json",
     "start:prod": "cross-env node dist/src/index.js",
-    "release:preview": "pnpx pkg-pr-new publish"
+    "release:preview": "pnpx pkg-pr-new --compact --pnpm publish"
   },
   "keywords": [
     "novu",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -36,7 +36,7 @@
     "doc:publish": "gh-pages -m \"[ci skip] Updates\" -d build/docs",
     "reset-hard": "git clean -dfx && git reset --hard && pnpm install",
     "prepare-release": "run-s reset-hard test",
-    "release:preview": "pnpx pkg-pr-new publish"
+    "release:preview": "pnpx pkg-pr-new --compact --pnpm publish"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -30,7 +30,7 @@
     "bump:prerelease": "npm version prerelease --preid=alpha & PID=$!; (sleep 1 && kill -9 $PID) & wait $PID",
     "release:alpha": "pnpm bump:prerelease || pnpm build && npm publish",
     "devtool": "tsx ./scripts/devtool.ts",
-    "release:preview": "pnpx pkg-pr-new publish"
+    "release:preview": "pnpx pkg-pr-new --compact --pnpm publish"
   },
   "keywords": [
     "novu",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "eslint src --fix",
     "test": "jest",
     "test:watch": "jest --watch",
-    "release:preview": "pnpx pkg-pr-new publish"
+    "release:preview": "pnpx pkg-pr-new --compact --pnpm publish"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -55,7 +55,7 @@
     "lint": "eslint src",
     "lint:fix": "pnpm lint -- --fix",
     "test": "jest",
-    "release:preview": "pnpx pkg-pr-new publish"
+    "release:preview": "pnpx pkg-pr-new --compact --pnpm publish"
   },
   "browserslist": {
     "production": [

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -27,7 +27,7 @@
     "watch:test": "jest src --watch",
     "reset-hard": "git clean -dfx && git reset --hard && pnpm install",
     "prepare-release": "run-s reset-hard test",
-    "release:preview": "pnpx pkg-pr-new publish"
+    "release:preview": "pnpx pkg-pr-new --compact --pnpm publish"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -34,7 +34,7 @@
     "doc:publish": "gh-pages -m \"[ci skip] Updates\" -d build/docs",
     "reset-hard": "git clean -dfx && git reset --hard && pnpm install",
     "prepare-release": "run-s reset-hard test",
-    "release:preview": "pnpx pkg-pr-new publish"
+    "release:preview": "pnpx pkg-pr-new --compact --pnpm publish"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -24,7 +24,7 @@
     "watch:test": "vitest",
     "reset-hard": "git clean -dfx && git reset --hard && yarn",
     "prepare-release": "run-s reset-hard test",
-    "release:preview": "pnpx pkg-pr-new publish"
+    "release:preview": "pnpx pkg-pr-new --compact --pnpm publish"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,7 +51,7 @@
     "build": "tsup && pnpm run check-exports",
     "lint": "eslint src",
     "check-exports": "attw --pack .",
-    "release:preview": "pnpx pkg-pr-new publish"
+    "release:preview": "pnpx pkg-pr-new --compact --pnpm publish"
   },
   "browserslist": {
     "production": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "pnpm lint -- --fix",
     "test": "jest src",
     "watch:test": "jest src --watch",
-    "release:preview": "pnpx pkg-pr-new publish"
+    "release:preview": "pnpx pkg-pr-new --compact --pnpm publish"
   },
   "author": "",
   "license": "ISC",

--- a/packages/stateless/package.json
+++ b/packages/stateless/package.json
@@ -34,7 +34,7 @@
     "doc:publish": "gh-pages -m \"[ci skip] Updates\" -d build/docs",
     "reset-hard": "git clean -dfx && git reset --hard && pnpm install",
     "prepare-release": "run-s reset-hard test",
-    "release:preview": "pnpx pkg-pr-new publish"
+    "release:preview": "pnpx pkg-pr-new --compact --pnpm publish"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### What changed? Why was the change needed?
Based on the following comment, using `pnpm` should resolve the workspace:*protocol correctly. Let's try it.

https://github.com/stackblitz-labs/pkg.pr.new/issues/204#issuecomment-2315256680