### PR TITLE
feat(api): improve typescript compilation to avoid reindexing in webs…

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,15 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "outDir": "../../dist/libs/api",
+    "rootDir": ".",
     "allowJs": false,
-    "allowSyntheticDefaultImports": true,
-    "emitDecoratorMetadata": true,
-    "esModuleInterop": true,
     "module": "commonjs",
     "skipLibCheck": true,
     "sourceMap": true,
     "strictNullChecks": true,
     "target": "es6"
   },
-  "exclude": ["node_modules"]
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "lib": ["es2015", "dom"],
+    "sourceMap": true,
     "moduleResolution": "node",
     "noImplicitAny": false,
     "removeComments": true,
@@ -15,6 +16,7 @@
     "skipLibCheck": true,
     "strictNullChecks": false,
     "strictPropertyInitialization": false,
-    "target": "es5",
+    "target": "es6",
+    "module": "commonjs"
   }
 }


### PR DESCRIPTION
due to multiple freezing issues in webstorm I went to understrand why .js files are being created in place by my ide, the research results ended up with typescript as the culprit, I believe our project is not configured correctly, there is more work to be done, but the project typescript definitions are not aligned between modules, this alone made a huge change and for 48 hours i havent had anymore webstorm issues
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
