### PR TITLE
fix(node): add the missing integration override to sms

### DIFF
--- a/packages/node/src/lib/events/events.interface.ts
+++ b/packages/node/src/lib/events/events.interface.ts
@@ -139,7 +139,7 @@ export type ITriggerOverrideSMS = {
   content?: string;
   from?: string;
   customData?: Record<string, any>;
-};
+} & IIntegrationOverride;
 
 export type ITriggerOverrideExpo = {
   to?: string | string[];


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
fix: node sdk is missing `integrationIdentifier` field for sms overrides. It seems to have been removed accidentally in a previous refactor
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
