### PR TITLE
fix(client): handle empty or no content responses

### DIFF
--- a/packages/client/src/http-client/http-client.ts
+++ b/packages/client/src/http-client/http-client.ts
@@ -58,9 +58,10 @@ export class HttpClient {
       method: 'POST',
       body: JSON.stringify(body),
     });
-    const data = await response.json();
+    const data = await response.text();
+    const parsedData = data ? JSON.parse(data) : null;
 
-    return data.data;
+    return parsedData?.data;
   }
 
   async patch(url: string, body = {}) {
@@ -68,9 +69,10 @@ export class HttpClient {
       method: 'PATCH',
       body: JSON.stringify(body),
     });
-    const data = await response.json();
+    const data = await response.text();
+    const parsedData = data ? JSON.parse(data) : null;
 
-    return data.data;
+    return parsedData?.data;
   }
 
   async delete(url: string, body = {}) {
@@ -78,9 +80,10 @@ export class HttpClient {
       method: 'DELETE',
       body: JSON.stringify(body),
     });
-    const data = await response.json();
+    const data = await response.text();
+    const parsedData = data ? JSON.parse(data) : null;
 
-    return data.data;
+    return parsedData?.data;
   }
 
   private getQueryString(params?: CustomDataType) {

--- a/packages/client/src/http-client/http-client.ts
+++ b/packages/client/src/http-client/http-client.ts
@@ -58,8 +58,8 @@ export class HttpClient {
       method: 'POST',
       body: JSON.stringify(body),
     });
-    const hasEmptyContent = this.checkEmptyResponse(response);
-    if (hasEmptyContent) {
+    const hasEmptyResponse = this.checkEmptyResponse(response);
+    if (hasEmptyResponse) {
       return;
     }
 
@@ -88,8 +88,8 @@ export class HttpClient {
       method: 'DELETE',
       body: JSON.stringify(body),
     });
-    const hasEmptyContent = this.checkEmptyResponse(response);
-    if (hasEmptyContent) {
+    const hasEmptyResponse = this.checkEmptyResponse(response);
+    if (hasEmptyResponse) {
       return;
     }
 

--- a/packages/client/src/http-client/http-client.ts
+++ b/packages/client/src/http-client/http-client.ts
@@ -58,10 +58,14 @@ export class HttpClient {
       method: 'POST',
       body: JSON.stringify(body),
     });
-    const data = await response.text();
-    const parsedData = data ? JSON.parse(data) : null;
+    const hasEmptyContent = this.checkEmptyResponse(response);
+    if (hasEmptyContent) {
+      return;
+    }
 
-    return parsedData?.data;
+    const data = await response.json();
+
+    return data.data;
   }
 
   async patch(url: string, body = {}) {
@@ -69,10 +73,14 @@ export class HttpClient {
       method: 'PATCH',
       body: JSON.stringify(body),
     });
-    const data = await response.text();
-    const parsedData = data ? JSON.parse(data) : null;
+    const hasEmptyResponse = this.checkEmptyResponse(response);
+    if (hasEmptyResponse) {
+      return;
+    }
 
-    return parsedData?.data;
+    const data = await response.json();
+
+    return data.data;
   }
 
   async delete(url: string, body = {}) {
@@ -80,10 +88,14 @@ export class HttpClient {
       method: 'DELETE',
       body: JSON.stringify(body),
     });
-    const data = await response.text();
-    const parsedData = data ? JSON.parse(data) : null;
+    const hasEmptyContent = this.checkEmptyResponse(response);
+    if (hasEmptyContent) {
+      return;
+    }
 
-    return parsedData?.data;
+    const data = await response.json();
+
+    return data.data;
   }
 
   private getQueryString(params?: CustomDataType) {
@@ -111,5 +123,13 @@ export class HttpClient {
         `HTTP error! Status: ${response.status}, Message: ${errorData.message}`,
       );
     }
+  }
+
+  private checkEmptyResponse(response: Response) {
+    if (response.status === 204) {
+      return true;
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
- updated client to use `response.text()` to handle empty responses
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
