### PR TITLE
fix(application-generic): Use V2 Preferences `critical` flag only if it exists

### DIFF
--- a/apps/api/src/app/step-schemas/e2e/get-default-schema.e2e.ts
+++ b/apps/api/src/app/step-schemas/e2e/get-default-schema.e2e.ts
@@ -15,7 +15,7 @@ describe('Get Control Schema - /step-schemas/:stepType (GET)', async () => {
   it('should get control schema for email step', async function () {
     const { body } = await session.testAgent.get(`/v1/step-schemas/${StepTypeEnum.EMAIL}`);
 
-    const schema = body.data.schema;
+    const { schema } = body.data;
 
     expect(schema.type).to.equal('object');
     expect(schema.properties).to.have.property('subject');

--- a/apps/api/src/app/step-schemas/step-schemas.controller.ts
+++ b/apps/api/src/app/step-schemas/step-schemas.controller.ts
@@ -4,6 +4,7 @@ import { UserSessionData } from '@novu/shared';
 import { ExternalApiAccessible, UserSession } from '@novu/application-generic';
 import { StepType } from '@novu/framework';
 
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
 import { GetStepSchemaCommand } from './usecases/get-step-schema/get-step-schema.command';
 import { UserAuthentication } from '../shared/framework/swagger/api.key.security';
 import { GetStepSchema } from './usecases/get-step-schema/get-step-schema.usecase';
@@ -16,6 +17,15 @@ export class StepSchemasController {
   constructor(private getStepDefaultSchemaUsecase: GetStepSchema) {}
 
   @Get('/:stepType')
+  @ApiOperation({
+    summary: 'Get step schema',
+    description: 'Get the schema for a step type',
+  })
+  @ApiParam({
+    name: 'stepType',
+    type: String,
+    description: 'The type of step to get the schema for.',
+  })
   @ExternalApiAccessible()
   async getStepSchema(
     @UserSession() user: UserSessionData,

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -105,10 +105,12 @@ export class GetSubscriberTemplatePreference {
 
     const template = mapTemplateConfiguration({
       ...command.template,
-      // determine if any readOnly constraints have been set by the Workflow owner
-      critical: GetPreferences.checkIfWorkflowPreferencesIsReadOnly(
-        subscriberWorkflowPreferences,
-      ),
+      // Use the critical flag from the V2 Preference object if it exists
+      ...(subscriberWorkflowPreferences && {
+        critical: GetPreferences.checkIfWorkflowPreferencesIsReadOnly(
+          subscriberWorkflowPreferences,
+        ),
+      }),
     });
 
     return {


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Use V2 Preferences `critical` flag only if it exists

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Critical marked Workflow_
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/f9a63a10-9504-4f70-8be4-60cb039297cb">

_Critical Workflow doesn't appear in Preferences_
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/249480ba-cfea-4d24-bad2-90c5894f54c6">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
