### PR TITLE
fix(worker): Build stateless preferences for bridge-sourced definition

### DIFF
--- a/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
@@ -137,7 +137,14 @@ export class SubscriberJobBound {
       userId,
       tenant,
       bridgeUrl: command.bridge?.url,
-      ...(command.bridge?.workflow?.preferences && {
+      /*
+       * Only populate preferences if the command contains a `bridge` property,
+       * indicating that the execution is stateless.
+       *
+       * TODO: refactor the Worker execution to handle both stateless and stateful workflows
+       * transparently.
+       */
+      ...(command.bridge?.workflow && {
         preferences: buildWorkflowPreferences(command.bridge?.workflow?.preferences),
       }),
     };


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Ensure that old bridge-sourced Workflow definitions without `preferences` can execute statelessly
  * Rather than check for existence of `preferences` before populating the `statelessPreferences`, we instead check for presence of a `bridge.workflow` to indicate whether the execution is stateless, ensuring backward compatiblity for old Framework versions

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_BEFORE - failing test case when `preferences` doesn't exist_
<img width="693" alt="image" src="https://github.com/user-attachments/assets/8f6c6012-50bf-4307-8db3-bd0818c39cd9">

_AFTER - passing test case when `preferences` doesn't exist_
<img width="751" alt="image" src="https://github.com/user-attachments/assets/d7f9eccc-b921-4fcd-ba24-60700bc12165">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
