### PR TITLE
fix(root): Build only public packages during preview deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "release:preminor": "nx release version preminor --no-push",
     "release:prerelease": "nx release version prerelease --no-push",
     "release:submodules": "ts-node scripts/release-with-submodules.ts",
-    "preview:pkg:build": "nx affected -t build --base=origin/next --head=HEAD --exclude=nextjs",
+    "preview:pkg:build": "nx affected -t build --base=origin/next --head=HEAD --exclude='*,!tag:package:public'",
     "preview:pkg:publish": "node scripts/publish-preview-packages.mjs",
     "start:integration:api": "cd apps/api && pnpm run test",
     "start:e2e:api": "cd apps/api && pnpm run test:e2e",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -90,5 +90,8 @@
     "cross-spawn": "7.0.3",
     "fast-glob": "3.3.1",
     "async-sema": "3.0.1"
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -59,5 +59,8 @@
   },
   "prettier": {
     "singleQuote": true
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -163,5 +163,8 @@
     "liquidjs": "^10.13.1",
     "ora": "^5.4.1",
     "sanitize-html": "^2.13.0"
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -46,5 +46,8 @@
   },
   "prettier": {
     "singleQuote": true
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -124,5 +124,8 @@
     "solid-js": "^1.8.11",
     "solid-motionone": "^1.0.1",
     "tailwind-merge": "^2.4.0"
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -84,5 +84,8 @@
     "exclude": [
       "**/*.spec.js"
     ]
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -78,5 +78,8 @@
   ],
   "prettier": {
     "singleQuote": true
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/notification-center-angular/package.json
+++ b/packages/notification-center-angular/package.json
@@ -37,5 +37,8 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "ng-packagr": "^16.2.0",
     "typescript": "5.6.2"
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/notification-center-vue/package.json
+++ b/packages/notification-center-vue/package.json
@@ -50,5 +50,8 @@
       "node_modules",
       "dist"
     ]
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/notification-center/package.json
+++ b/packages/notification-center/package.json
@@ -92,5 +92,8 @@
     "socket.io-client": "4.7.2",
     "tslib": "^2.3.1",
     "webfontloader": "^1.6.28"
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -112,5 +112,8 @@
     "exclude": [
       "**/*.spec.js"
     ]
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -95,5 +95,8 @@
   },
   "dependencies": {
     "@novu/js": "workspace:*"
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -49,5 +49,8 @@
     "rimraf": "^3.0.2",
     "typescript": "5.6.2",
     "vitest": "^2.0.5"
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }

--- a/packages/stateless/package.json
+++ b/packages/stateless/package.json
@@ -72,5 +72,8 @@
   ],
   "prettier": {
     "singleQuote": true
+  },
+  "nx": {
+    "tags": ["package:public"]
   }
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

Prevent building all Novu-affected packages, including apps. Reduce the possibility of an error and increase the speed of the workflow.