### PR TITLE
feat(web): billing page revamp

### DIFF
--- a/apps/web/src/ee/billing/components/Plan.tsx
+++ b/apps/web/src/ee/billing/components/Plan.tsx
@@ -8,15 +8,11 @@ import { planList } from '../utils/planList';
 import { PlanFooter } from './PlanFooter';
 import { FreeTrialPlanWidget } from './FreeTrialPlanWidget';
 import { useSubscriptionContext } from './SubscriptionProvider';
-import { ActivePlanBanner } from './billingV2/ActivePlanBanner';
-import { useFeatureFlag } from '../../../hooks';
-import { FeatureFlagsKeysEnum } from '@novu/shared';
 
 export const Plan = () => {
   const { colorScheme } = useMantineTheme();
   const isDark = colorScheme === 'dark';
   const { isLoading, trial } = useSubscriptionContext();
-  const isImprovedBillingEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_IMPROVED_BILLING_ENABLED);
 
   if (isLoading || trial.daysLeft === null) {
     return (
@@ -28,8 +24,7 @@ export const Plan = () => {
 
   return (
     <>
-      {!isImprovedBillingEnabled && <FreeTrialPlanWidget isDark={isDark} />}
-      {isImprovedBillingEnabled && <ActivePlanBanner />}
+      <FreeTrialPlanWidget isDark={isDark} />
       <PlanWrapper isDark={isDark}>
         <PlanHeader />
         {planList.map((row, index) => (

--- a/apps/web/src/ee/billing/components/UpgradeSubmitButton.tsx
+++ b/apps/web/src/ee/billing/components/UpgradeSubmitButton.tsx
@@ -3,8 +3,6 @@ import { useStripe, useElements } from '@stripe/react-stripe-js';
 import { errorMessage, Button, When } from '@novu/design-system';
 import { useSegment } from '../../../components/providers/SegmentProvider';
 import { useSubscription } from '../hooks/useSubscription';
-import { useFeatureFlag } from '../../../hooks';
-import { FeatureFlagsKeysEnum } from '@novu/shared';
 
 export const UpgradeSubmitButton = ({ intervalChanging }: { intervalChanging: boolean }) => {
   const segment = useSegment();
@@ -12,7 +10,6 @@ export const UpgradeSubmitButton = ({ intervalChanging }: { intervalChanging: bo
   const elements = useElements();
   const [loading, setLoading] = useState(false);
   const { trial } = useSubscription();
-  const isImprovedBillingEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_IMPROVED_BILLING_ENABLED);
 
   const handleSubmit = async (event) => {
     segment.track('Submit Payment Checkout Clicked - Billing');
@@ -39,11 +36,8 @@ export const UpgradeSubmitButton = ({ intervalChanging }: { intervalChanging: bo
 
   return (
     <Button loading={loading} disabled={intervalChanging} onClick={handleSubmit} fullWidth>
-      <When truthy={isImprovedBillingEnabled}>Upgrade now</When>
-      <When truthy={!isImprovedBillingEnabled}>
-        <When truthy={!trial.isActive}>Upgrade now</When>
-        <When truthy={trial.isActive}>Save payment method</When>
-      </When>
+      <When truthy={!trial.isActive}>Upgrade now</When>
+      <When truthy={trial.isActive}>Save payment method</When>
     </Button>
   );
 };

--- a/apps/web/src/ee/billing/components/billingV2/Badge.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/Badge.tsx
@@ -1,0 +1,23 @@
+import { BadgeProps, Badge as MantineBadge, MantineTheme, useMantineTheme } from '@mantine/core';
+import { css } from '@novu/novui/css';
+
+export const Badge = ({ label, ...props }: BadgeProps & { label?: React.ReactNode }) => {
+  const theme = useMantineTheme();
+
+  return (
+    <MantineBadge className={styles.badge(theme)} {...props}>
+      {label}
+    </MantineBadge>
+  );
+};
+
+const styles = {
+  badge: (theme: MantineTheme) =>
+    css({
+      // TODO: replace with 'mauve.80' color token when legacy tokens are removed
+      background: theme.colorScheme === 'dark' ? '#2E2E32 !important' : '#e4e2e4ff !important',
+      padding: '2px 8px !important',
+      color: theme.colorScheme === 'dark' ? '#7E7D86' : '#86848dff',
+      borderRadius: '24px !important',
+    }),
+};

--- a/apps/web/src/ee/billing/components/billingV2/ContactUsButton.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/ContactUsButton.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@novu/novui';
+import { css } from '@novu/novui/css';
+import { ApiServiceLevelEnum } from '@novu/shared';
+import { useState } from 'react';
+import { ContactSalesModal } from '../ContactSalesModal';
+
+export const ContactUsButton = () => {
+  const [isContactSalesModalOpen, setIsContactSalesModalOpen] = useState(false);
+
+  return (
+    <>
+      <Button className={styles.contactButton} onClick={() => setIsContactSalesModalOpen(true)}>
+        Contact us
+      </Button>
+      <ContactSalesModal
+        isOpen={isContactSalesModalOpen}
+        onClose={() => {
+          setIsContactSalesModalOpen(false);
+        }}
+        intendedApiServiceLevel={ApiServiceLevelEnum.ENTERPRISE}
+      />
+    </>
+  );
+};
+
+const styles = {
+  contactButton: css({
+    background: '#34343A !important',
+    fontWeight: '400 !important',
+  }),
+};

--- a/apps/web/src/ee/billing/components/billingV2/Features.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/Features.tsx
@@ -59,35 +59,54 @@ type Feature = {
 
 const features: Feature[] = [
   {
-    label: 'Geographic data residency',
+    label: 'Platform',
     isContrast: false,
+    isTitle: true,
     values: {
-      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
-      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
-      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.FREE]: { value: '' },
+      [SupportedPlansEnum.BUSINESS]: { value: '' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '' },
     },
   },
   {
     label: 'Monthly events',
-    isContrast: true,
+    isContrast: false,
     values: {
       [SupportedPlansEnum.FREE]: { value: 'Up to 30,000' },
       [SupportedPlansEnum.BUSINESS]: { value: 'Up to 250,000' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '5,000,000' },
     },
   },
   {
-    label: 'Trigger rate limit',
-    isContrast: false,
+    label: 'Additional Events',
+    isContrast: true,
     values: {
-      [SupportedPlansEnum.FREE]: { value: '60RPS' },
-      [SupportedPlansEnum.BUSINESS]: { value: '600RPS' },
+      [SupportedPlansEnum.FREE]: { value: '-' },
+      [SupportedPlansEnum.BUSINESS]: { value: '$0.0012 per event' },
       [SupportedPlansEnum.ENTERPRISE]: { value: 'Custom' },
     },
   },
   {
-    label: 'Content',
+    label: 'Email, InApp, SMS, Chat, Push Channels',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+    },
+  },
+  {
+    label: 'Notification subscribers',
     isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: 'Unlimited' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Unlimited' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+    },
+  },
+  {
+    label: 'Framework',
+    isContrast: false,
     isTitle: true,
     values: {
       [SupportedPlansEnum.FREE]: { value: '' },
@@ -96,7 +115,7 @@ const features: Feature[] = [
     },
   },
   {
-    label: 'Workflows',
+    label: 'Total workflows',
     isContrast: false,
     values: {
       [SupportedPlansEnum.FREE]: { value: 'Unlimited' },
@@ -105,7 +124,7 @@ const features: Feature[] = [
     },
   },
   {
-    label: 'Providers',
+    label: 'Provider integrations',
     isContrast: true,
     values: {
       [SupportedPlansEnum.FREE]: { value: 'Unlimited' },
@@ -114,71 +133,34 @@ const features: Feature[] = [
     },
   },
   {
-    label: 'Subscribers',
+    label: 'Activity retention',
     isContrast: false,
     values: {
-      [SupportedPlansEnum.FREE]: { value: 'Unlimited' },
-      [SupportedPlansEnum.BUSINESS]: { value: 'Unlimited' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+      [SupportedPlansEnum.FREE]: { value: <Badge label="Coming soon" /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <Badge label="Coming soon" /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <Badge label="Coming soon" /> },
     },
   },
   {
-    label: 'Team size',
+    label: 'Digests',
     isContrast: true,
     values: {
-      [SupportedPlansEnum.FREE]: { value: 'Up to 2 members' },
-      [SupportedPlansEnum.BUSINESS]: { value: 'Up to 15 members' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
     },
   },
   {
-    label: 'Topics',
+    label: 'Step controls',
     isContrast: false,
     values: {
-      [SupportedPlansEnum.FREE]: { value: 'Unlimited' },
-      [SupportedPlansEnum.BUSINESS]: { value: 'Unlimited' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
     },
   },
   {
     label: 'Inbox',
-    isTitle: true,
-    isContrast: true,
-    values: {
-      [SupportedPlansEnum.FREE]: { value: '' },
-      [SupportedPlansEnum.BUSINESS]: { value: '' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: '' },
-    },
-  },
-  {
-    label: 'Topics',
-    isContrast: false,
-    values: {
-      [SupportedPlansEnum.FREE]: { value: '-' },
-      [SupportedPlansEnum.BUSINESS]: { value: 'Unlimited' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
-    },
-  },
-  {
-    label: 'Remove branding',
-    isContrast: true,
-    values: {
-      [SupportedPlansEnum.FREE]: { value: '-' },
-      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
-      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
-    },
-  },
-  {
-    label: 'Feed retention',
-    isContrast: false,
-    values: {
-      [SupportedPlansEnum.FREE]: { value: '90 days' },
-      [SupportedPlansEnum.BUSINESS]: { value: '1 year' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: 'Custom' },
-    },
-  },
-  {
-    label: 'Features',
     isContrast: true,
     isTitle: true,
     values: {
@@ -188,7 +170,7 @@ const features: Feature[] = [
     },
   },
   {
-    label: 'Subscriber Preference API',
+    label: 'Inbox component',
     isContrast: false,
     values: {
       [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
@@ -197,7 +179,7 @@ const features: Feature[] = [
     },
   },
   {
-    label: 'Digest Engine',
+    label: 'User preferences component',
     isContrast: true,
     values: {
       [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
@@ -206,7 +188,7 @@ const features: Feature[] = [
     },
   },
   {
-    label: 'Translation management',
+    label: 'Remove Novu branding',
     isContrast: false,
     values: {
       [SupportedPlansEnum.FREE]: { value: '-' },
@@ -215,7 +197,7 @@ const features: Feature[] = [
     },
   },
   {
-    label: 'Role-based access control',
+    label: 'Notifications retention',
     isContrast: true,
     values: {
       [SupportedPlansEnum.FREE]: { value: <Badge label="Coming soon" /> },
@@ -224,7 +206,26 @@ const features: Feature[] = [
     },
   },
   {
-    label: 'Inbound reply email',
+    label: 'Account administration and security',
+    isContrast: false,
+    isTitle: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '' },
+      [SupportedPlansEnum.BUSINESS]: { value: '' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '' },
+    },
+  },
+  {
+    label: 'Team members',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: <Badge label="Coming soon" /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <Badge label="Coming soon" /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <Badge label="Coming soon" /> },
+    },
+  },
+  {
+    label: 'RBAC',
     isContrast: false,
     values: {
       [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
@@ -233,7 +234,7 @@ const features: Feature[] = [
     },
   },
   {
-    label: 'Google and Github OAuth',
+    label: 'GDPR compliance',
     isContrast: true,
     values: {
       [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
@@ -247,79 +248,81 @@ const features: Feature[] = [
     values: {
       [SupportedPlansEnum.FREE]: { value: '-' },
       [SupportedPlansEnum.BUSINESS]: { value: '-' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: '-' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
     },
   },
   {
-    label: 'Support',
+    label: 'Support and account management',
     isContrast: true,
+    isTitle: true,
     values: {
-      [SupportedPlansEnum.FREE]: { value: 'Chat' },
-      [SupportedPlansEnum.BUSINESS]: { value: 'Chat and Email' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: 'Dedicated support' },
+      [SupportedPlansEnum.FREE]: { value: '' },
+      [SupportedPlansEnum.BUSINESS]: { value: '' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '' },
     },
   },
   {
     label: 'Support SLA',
     isContrast: false,
     values: {
-      [SupportedPlansEnum.FREE]: { value: '5 business days' },
-      [SupportedPlansEnum.BUSINESS]: { value: '2 business days' },
+      [SupportedPlansEnum.FREE]: { value: 'Community & Intercom' },
+      [SupportedPlansEnum.BUSINESS]: { value: '48 hours' },
       [SupportedPlansEnum.ENTERPRISE]: { value: '24 hours' },
     },
   },
   {
-    label: 'Uptime SLA',
+    label: 'Support channels',
     isContrast: true,
     values: {
-      [SupportedPlansEnum.FREE]: { value: '99.9%' },
-      [SupportedPlansEnum.BUSINESS]: { value: '99.9%' },
+      [SupportedPlansEnum.FREE]: { value: 'Community & Intercom' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Chat and Email' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Dedicated support' },
+    },
+  },
+  {
+    label: 'Legal & Vendor management',
+    isContrast: false,
+    isTitle: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '' },
+      [SupportedPlansEnum.BUSINESS]: { value: '' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '' },
+    },
+  },
+  {
+    label: 'Payment method',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: 'N/A' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Credit card only' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'PO and Invoicing' },
+    },
+  },
+  {
+    label: 'Terms of service',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: 'Standard' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Standard' },
       [SupportedPlansEnum.ENTERPRISE]: { value: 'Custom' },
     },
   },
   {
-    label: 'Audit logs',
-    isContrast: false,
-    values: {
-      [SupportedPlansEnum.FREE]: { value: '-' },
-      [SupportedPlansEnum.BUSINESS]: { value: '-' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: '-' },
-    },
-  },
-  {
-    label: 'SOC II, ISO27001, GDPR',
+    label: 'DPA',
     isContrast: true,
     values: {
-      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
-      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
-      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.FREE]: { value: 'Standard' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Standard' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Custom' },
     },
   },
   {
-    label: 'Data warehouse connections',
+    label: 'Security review',
     isContrast: false,
     values: {
-      [SupportedPlansEnum.FREE]: { value: '-' },
-      [SupportedPlansEnum.BUSINESS]: { value: '-' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
-    },
-  },
-  {
-    label: 'Data processing agreement',
-    isContrast: true,
-    values: {
-      [SupportedPlansEnum.FREE]: { value: '-' },
-      [SupportedPlansEnum.BUSINESS]: { value: '-' },
-      [SupportedPlansEnum.ENTERPRISE]: { value: '-' },
-    },
-  },
-  {
-    label: 'Provider webhook integration',
-    isContrast: false,
-    values: {
-      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
-      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
-      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.FREE]: { value: 'SOC 2 and ISO 27001 upon request' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Custom' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Custom' },
     },
   },
 ];

--- a/apps/web/src/ee/billing/components/billingV2/Features.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/Features.tsx
@@ -1,0 +1,370 @@
+import { css } from '@novu/novui/css';
+import { Text } from '@novu/novui';
+import styled from '@emotion/styled';
+import { ApiServiceLevelEnum } from '@novu/shared';
+import { IconCheck as _IconCheck } from '@novu/novui/icons';
+import { Badge } from './Badge';
+
+const TitleCell = styled.div`
+  display: flex;
+  padding: 16px 24px;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  flex: 1 0 0;
+`;
+
+const Cell = styled.div`
+  display: flex;
+  padding: 16px;
+  flex: 1 0 0;
+  align-self: stretch;
+  flex-direction: column;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
+`;
+
+const IconCheck = () => (
+  <_IconCheck
+    className={css({
+      color: {
+        base: 'typography.text.primary !important',
+        _dark: 'typography.text.main !important',
+      },
+    })}
+  />
+);
+
+enum SupportedPlansEnum {
+  FREE = ApiServiceLevelEnum.FREE,
+  BUSINESS = ApiServiceLevelEnum.BUSINESS,
+  ENTERPRISE = ApiServiceLevelEnum.ENTERPRISE,
+}
+
+type FeatureValue = {
+  value: React.ReactNode;
+};
+
+type Feature = {
+  label: string;
+  isTitle?: boolean;
+  isContrast?: boolean;
+  values: {
+    [SupportedPlansEnum.FREE]: FeatureValue;
+    [SupportedPlansEnum.BUSINESS]: FeatureValue;
+    [SupportedPlansEnum.ENTERPRISE]: FeatureValue;
+  };
+};
+
+const features: Feature[] = [
+  {
+    label: 'Geographic data residency',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+    },
+  },
+  {
+    label: 'Monthly events',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: 'Up to 30,000' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Up to 250,000' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+    },
+  },
+  {
+    label: 'Trigger rate limit',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '60RPS' },
+      [SupportedPlansEnum.BUSINESS]: { value: '600RPS' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Custom' },
+    },
+  },
+  {
+    label: 'Content',
+    isContrast: true,
+    isTitle: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '' },
+      [SupportedPlansEnum.BUSINESS]: { value: '' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '' },
+    },
+  },
+  {
+    label: 'Workflows',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: 'Unlimited' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Unlimited' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+    },
+  },
+  {
+    label: 'Providers',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: 'Unlimited' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Unlimited' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+    },
+  },
+  {
+    label: 'Subscribers',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: 'Unlimited' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Unlimited' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+    },
+  },
+  {
+    label: 'Team size',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: 'Up to 2 members' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Up to 15 members' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+    },
+  },
+  {
+    label: 'Topics',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: 'Unlimited' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Unlimited' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+    },
+  },
+  {
+    label: 'Inbox',
+    isTitle: true,
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '' },
+      [SupportedPlansEnum.BUSINESS]: { value: '' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '' },
+    },
+  },
+  {
+    label: 'Topics',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '-' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Unlimited' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Unlimited' },
+    },
+  },
+  {
+    label: 'Remove branding',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '-' },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+    },
+  },
+  {
+    label: 'Feed retention',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '90 days' },
+      [SupportedPlansEnum.BUSINESS]: { value: '1 year' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Custom' },
+    },
+  },
+  {
+    label: 'Features',
+    isContrast: true,
+    isTitle: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '' },
+      [SupportedPlansEnum.BUSINESS]: { value: '' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '' },
+    },
+  },
+  {
+    label: 'Subscriber Preference API',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+    },
+  },
+  {
+    label: 'Digest Engine',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+    },
+  },
+  {
+    label: 'Translation management',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '-' },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+    },
+  },
+  {
+    label: 'Role-based access control',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: <Badge label="Coming soon" /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <Badge label="Coming soon" /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <Badge label="Coming soon" /> },
+    },
+  },
+  {
+    label: 'Inbound reply email',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+    },
+  },
+  {
+    label: 'Google and Github OAuth',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+    },
+  },
+  {
+    label: 'SAML SSO and Enterprise SSO providers',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '-' },
+      [SupportedPlansEnum.BUSINESS]: { value: '-' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '-' },
+    },
+  },
+  {
+    label: 'Support',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: 'Chat' },
+      [SupportedPlansEnum.BUSINESS]: { value: 'Chat and Email' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Dedicated support' },
+    },
+  },
+  {
+    label: 'Support SLA',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '5 business days' },
+      [SupportedPlansEnum.BUSINESS]: { value: '2 business days' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '24 hours' },
+    },
+  },
+  {
+    label: 'Uptime SLA',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '99.9%' },
+      [SupportedPlansEnum.BUSINESS]: { value: '99.9%' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: 'Custom' },
+    },
+  },
+  {
+    label: 'Audit logs',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '-' },
+      [SupportedPlansEnum.BUSINESS]: { value: '-' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '-' },
+    },
+  },
+  {
+    label: 'SOC II, ISO27001, GDPR',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+    },
+  },
+  {
+    label: 'Data warehouse connections',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '-' },
+      [SupportedPlansEnum.BUSINESS]: { value: '-' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+    },
+  },
+  {
+    label: 'Data processing agreement',
+    isContrast: true,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: '-' },
+      [SupportedPlansEnum.BUSINESS]: { value: '-' },
+      [SupportedPlansEnum.ENTERPRISE]: { value: '-' },
+    },
+  },
+  {
+    label: 'Provider webhook integration',
+    isContrast: false,
+    values: {
+      [SupportedPlansEnum.FREE]: { value: <IconCheck /> },
+      [SupportedPlansEnum.BUSINESS]: { value: <IconCheck /> },
+      [SupportedPlansEnum.ENTERPRISE]: { value: <IconCheck /> },
+    },
+  },
+];
+
+export const Features = () => {
+  return (
+    <div className={styles.featureList}>
+      {features.map((feature, index) => (
+        <FeatureRow key={index} feature={feature} />
+      ))}
+    </div>
+  );
+};
+
+const FeatureRow = ({ feature }: { feature: Feature }) => (
+  <div className={styles.rowContainer(feature.isContrast, feature.isTitle)}>
+    <TitleCell>
+      <Text
+        variant={feature.isTitle ? 'strong' : undefined}
+        color={feature.isTitle ? 'typography.text.primary' : 'typography.text.secondary'}
+      >
+        {feature.label}
+      </Text>
+    </TitleCell>
+
+    {Object.entries(feature.values).map(([plan, value]) => {
+      return <Cell key={plan}>{value.value}</Cell>;
+    })}
+  </div>
+);
+
+const styles = {
+  featureList: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    alignSelf: 'stretch',
+  }),
+  rowContainer: (isContrast: boolean | undefined, isHeader: boolean | undefined) =>
+    css({
+      display: 'flex',
+      alignItems: 'flex-start',
+      alignSelf: 'stretch',
+      background: isContrast ? 'surface.panel' : undefined,
+      borderTop: isHeader ? '1px solid #34343A !important' : undefined,
+      borderBottom: isHeader ? '1px solid #34343A !important' : undefined,
+    }),
+};

--- a/apps/web/src/ee/billing/components/billingV2/HighlightsRow.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/HighlightsRow.tsx
@@ -28,20 +28,19 @@ const highlights: PlanHighlights = {
   [ApiServiceLevelEnum.FREE]: [
     { text: 'Up to 30,000 events per month' },
     { text: '7 days activity feed' },
-    { text: '2 teammates' },
-    { text: 'RBAC' },
+    { text: '3 teammates', badgeLabel: 'Coming soon' },
   ],
   [ApiServiceLevelEnum.BUSINESS]: [
-    { text: 'Unlimited events per month' },
-    { text: '30 days activity feed' },
-    { text: '15 teammates' },
+    { text: 'Up to 250,000 events per month' },
+    { text: '90 days activity feed', badgeLabel: 'Coming soon' },
+    { text: '50 teammates', badgeLabel: 'Coming soon' },
     { text: 'RBAC', badgeLabel: 'Coming soon' },
   ],
   [ApiServiceLevelEnum.ENTERPRISE]: [
-    { text: 'Unlimited events per month' },
-    { text: 'Custom time activity feed' },
-    { text: 'Unlimited teammates' },
-    { text: 'Workspace analytics' },
+    { text: 'Up to 5,000,000 events per month' },
+    { text: 'Custom time activity feed', badgeLabel: 'Coming soon' },
+    { text: 'Unlimited teammates', badgeLabel: 'Coming soon' },
+    { text: 'SAML SSO' },
     { text: 'RBAC', badgeLabel: 'Coming soon' },
   ],
 };

--- a/apps/web/src/ee/billing/components/billingV2/HighlightsRow.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/HighlightsRow.tsx
@@ -1,0 +1,93 @@
+import { css } from '@novu/novui/css';
+import { Text } from '@novu/novui';
+import styled from '@emotion/styled';
+import { List } from '@mantine/core';
+import { ApiServiceLevelEnum } from '@novu/shared';
+import { Badge } from './Badge';
+
+const Cell = styled.div`
+  display: flex;
+  padding: 24px;
+  align-items: flex-start;
+  flex: 1 0 0;
+  align-self: stretch;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+type Highlight = {
+  text: string;
+  badgeLabel?: string;
+};
+
+type PlanHighlights = {
+  [key in ApiServiceLevelEnum]?: Highlight[];
+};
+
+const highlights: PlanHighlights = {
+  [ApiServiceLevelEnum.FREE]: [
+    { text: 'Up to 30,000 events per month' },
+    { text: '7 days activity feed' },
+    { text: '2 teammates' },
+    { text: 'RBAC' },
+  ],
+  [ApiServiceLevelEnum.BUSINESS]: [
+    { text: 'Unlimited events per month' },
+    { text: '30 days activity feed' },
+    { text: '15 teammates' },
+    { text: 'RBAC', badgeLabel: 'Coming soon' },
+  ],
+  [ApiServiceLevelEnum.ENTERPRISE]: [
+    { text: 'Unlimited events per month' },
+    { text: 'Custom time activity feed' },
+    { text: 'Unlimited teammates' },
+    { text: 'Workspace analytics' },
+    { text: 'RBAC', badgeLabel: 'Coming soon' },
+  ],
+};
+
+const PlanHighlights = ({ planHighlights }: { planHighlights: Highlight[] }) => (
+  <Cell>
+    <List classNames={styles.list} listStyleType="disc">
+      {planHighlights.map((item, index) => (
+        <List.Item key={index}>
+          <span className={styles.listBadgeItem}>
+            {item.text} {item.badgeLabel && <Badge size="xs" label={item.badgeLabel} />}
+          </span>
+        </List.Item>
+      ))}
+    </List>
+  </Cell>
+);
+
+export const HighlightsRow = () => {
+  return (
+    <div className={styles.container}>
+      <Cell>
+        <Text color="typography.text.secondary">Highlights</Text>
+      </Cell>
+      {Object.entries(highlights).map(([planName, planHighlights]) => (
+        <PlanHighlights key={planName} planHighlights={planHighlights} />
+      ))}
+    </div>
+  );
+};
+
+const styles = {
+  container: css({
+    display: 'flex',
+    alignItems: 'flex-start',
+    alignSelf: 'stretch',
+    background: 'surface.panel',
+  }),
+  list: {
+    item: css({
+      lineHeight: '24px !important',
+    }),
+  },
+  listBadgeItem: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+  }),
+};

--- a/apps/web/src/ee/billing/components/billingV2/Plan.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/Plan.tsx
@@ -1,0 +1,51 @@
+import { Center, Loader, useMantineTheme } from '@mantine/core';
+import { colors, errorMessage, successMessage } from '@novu/design-system';
+import { useEffect, useState } from 'react';
+import { PlanSwitcher } from './PlanSwitcher';
+import { useSubscriptionContext } from '../SubscriptionProvider';
+import { ActivePlanBanner } from './ActivePlanBanner';
+import { PlansRow } from './PlansRow';
+import { HighlightsRow } from './HighlightsRow';
+import { Features } from './Features';
+
+export const Plan = () => {
+  const theme = useMantineTheme();
+  const { isLoading, billingInterval: subscriptionBillingInterval } = useSubscriptionContext();
+  const [selectedBillingInterval, setSelectedBillingInterval] = useState<'month' | 'year'>(
+    subscriptionBillingInterval || 'month'
+  );
+
+  useEffect(() => {
+    const checkoutResult = new URLSearchParams(window.location.search).get('result');
+
+    if (checkoutResult === 'success') {
+      successMessage('Payment was successful.');
+    }
+
+    if (checkoutResult === 'canceled') {
+      errorMessage('Order canceled.');
+    }
+  }, []);
+
+  if (isLoading) {
+    return (
+      <Center>
+        <Loader color={colors.error} size={32} />
+      </Center>
+    );
+  }
+
+  return (
+    <>
+      <ActivePlanBanner selectedBillingInterval={selectedBillingInterval} />
+      <PlanSwitcher
+        theme={theme}
+        selectedBillingInterval={selectedBillingInterval}
+        setSelectedBillingInterval={setSelectedBillingInterval}
+      />
+      <PlansRow theme={theme} selectedBillingInterval={selectedBillingInterval} />
+      <HighlightsRow />
+      <Features />
+    </>
+  );
+};

--- a/apps/web/src/ee/billing/components/billingV2/PlanActionButton.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/PlanActionButton.tsx
@@ -1,0 +1,80 @@
+import { Button } from '@novu/novui';
+import { css } from '@novu/novui/css';
+import { ApiServiceLevelEnum } from '@novu/shared';
+import { useMutation } from '@tanstack/react-query';
+import { errorMessage, When } from '@novu/design-system';
+import { api } from '../../../../api';
+import { useSubscriptionContext } from '../SubscriptionProvider';
+import { useSegment } from '../../../../components/providers/SegmentProvider';
+
+const checkoutUrl = '/v1/billing/checkout-session';
+const billingPortalUrl = '/v1/billing/portal';
+
+export const PlanActionButton = ({ selectedBillingInterval }: { selectedBillingInterval: 'month' | 'year' }) => {
+  const segment = useSegment();
+  const { isActive, trial, apiServiceLevel } = useSubscriptionContext();
+  const isPaidSubscriptionActive = isActive && !trial.isActive && apiServiceLevel !== ApiServiceLevelEnum.FREE;
+
+  const { mutateAsync: checkout, isLoading: isCheckingOut } = useMutation<{ stripeCheckoutUrl: string }, Error>(
+    () =>
+      api.post(checkoutUrl, {
+        billingInterval: selectedBillingInterval,
+        apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
+      }),
+    {
+      onSuccess: (data) => {
+        window.location.href = data.stripeCheckoutUrl;
+      },
+      onError: (e: Error) => {
+        errorMessage(e.message || 'Unexpected error');
+      },
+    }
+  );
+
+  const { mutateAsync: goToPortal, isLoading: isGoingToPortal } = useMutation<string, Error>(
+    () => api.get(billingPortalUrl),
+    {
+      onSuccess: (url) => {
+        window.location.href = url;
+      },
+      onError: (e: Error) => {
+        errorMessage(e.message || 'Unexpected error');
+      },
+    }
+  );
+
+  return (
+    <>
+      <When truthy={isPaidSubscriptionActive}>
+        <Button
+          className={styles.planActionButton}
+          loading={isGoingToPortal}
+          data-test-id={`plan-${apiServiceLevel}-manage`}
+          onClick={() => {
+            segment.track(`Manage Subscription Clicked - Plans List`);
+            goToPortal();
+          }}
+        >
+          Manage subscription
+        </Button>
+      </When>
+      <When truthy={!isPaidSubscriptionActive}>
+        <Button
+          className={styles.planActionButton}
+          loading={isCheckingOut}
+          data-test-id="plan-business-upgrade"
+          onClick={() => checkout()}
+        >
+          Upgrade plan
+        </Button>
+      </When>
+    </>
+  );
+};
+
+const styles = {
+  planActionButton: css({
+    background: '#2A92E7 !important',
+    fontWeight: '400 !important',
+  }),
+};

--- a/apps/web/src/ee/billing/components/billingV2/PlanSwitcher.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/PlanSwitcher.tsx
@@ -1,0 +1,93 @@
+import { MantineTheme, Tabs, useMantineTheme } from '@mantine/core';
+import { Title } from '@novu/novui';
+import { css } from '@novu/novui/css';
+
+export const PlanSwitcher = ({
+  theme,
+  selectedBillingInterval,
+  setSelectedBillingInterval,
+}: {
+  theme: MantineTheme;
+  selectedBillingInterval: 'month' | 'year';
+  setSelectedBillingInterval: (value: 'month' | 'year') => void;
+}) => (
+  <div className={styles.planSwitcherContainer(theme)}>
+    <Title variant="section" className={styles.planHeaderTitle}>
+      All plans
+    </Title>
+    <div className={styles.tabsWrapper}>
+      <Tabs classNames={styles.tabs} onTabChange={setSelectedBillingInterval} value={selectedBillingInterval}>
+        <Tabs.List>
+          <Tabs.Tab className={styles.tab(theme)} value="month">
+            Monthly
+          </Tabs.Tab>
+          <Tabs.Tab className={styles.tab(theme)} value="year">
+            Anually <span>10% off</span>
+          </Tabs.Tab>
+        </Tabs.List>
+      </Tabs>
+    </div>
+  </div>
+);
+
+const styles = {
+  planSwitcherContainer: (theme: MantineTheme) =>
+    css({
+      position: 'relative',
+      display: 'flex',
+      height: '40px',
+      justifyContent: 'space-between',
+      alignItems: 'flex-end',
+      alignSelf: 'stretch',
+      borderBottom: theme.colorScheme === 'dark' ? '1px solid #34343A' : '1px solid #e4e2e4ff',
+    }),
+  planHeaderTitle: css({
+    position: 'absolute',
+    left: '0',
+    top: '0',
+  }),
+  tabsWrapper: css({
+    flex: 1,
+    display: 'flex',
+    justifyContent: 'center',
+  }),
+  tabs: {
+    tabsList: css({
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'flex-end',
+      flex: '1 0 0',
+      borderBottom: 'none !important',
+    }),
+  },
+  tab: (theme: MantineTheme) =>
+    css({
+      padding: '12px !important',
+      gap: '8px !important',
+      color: 'typography.text.secondary !important',
+      fontSize: '14px !important',
+      lineHeight: '16px !important',
+      '& span': {
+        color: 'mode.local.middle',
+      },
+      '&[data-active="true"]': {
+        color: 'typography.text.main !important',
+        borderBottom: theme.colorScheme === 'dark' ? '1px solid #FFF !important' : '1px solid #e4e2e4ff !important',
+        fontWeight: '600 !important',
+
+        '& span': {
+          color: 'mode.local.middle',
+          fontWeight: '600',
+        },
+      },
+      '&:hover': {
+        color: 'typography.text.main !important',
+        backgroundColor: 'transparent !important',
+
+        '& span': {
+          color: 'mode.local.middle',
+          fontWeight: '600',
+        },
+      },
+    }),
+};

--- a/apps/web/src/ee/billing/components/billingV2/PlanSwitcher.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/PlanSwitcher.tsx
@@ -22,7 +22,7 @@ export const PlanSwitcher = ({
             Monthly
           </Tabs.Tab>
           <Tabs.Tab className={styles.tab(theme)} value="year">
-            Anually <span>10% off</span>
+            Annually <span>10% off</span>
           </Tabs.Tab>
         </Tabs.List>
       </Tabs>

--- a/apps/web/src/ee/billing/components/billingV2/PlansRow.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/PlansRow.tsx
@@ -1,0 +1,91 @@
+import { css } from '@novu/novui/css';
+import { Title, Text } from '@novu/novui';
+import styled from '@emotion/styled';
+import { MantineTheme } from '@mantine/core';
+import { Badge } from './Badge';
+import { PlanActionButton } from './PlanActionButton';
+import { ContactUsButton } from './ContactUsButton';
+
+const Cell = styled.div`
+  display: flex;
+  padding: 24px;
+  align-items: flex-start;
+  flex: 1 0 0;
+  align-self: stretch;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const PriceDisplay = ({ price, subtitle, events }) => (
+  <div>
+    <div className={styles.priceDisplay}>
+      <Title>{price}</Title>
+      <Text style={{ paddingBottom: '2px' }}>{subtitle}</Text>
+    </div>
+    <Text color="typography.text.secondary">{events}</Text>
+  </div>
+);
+
+export const PlansRow = ({
+  theme,
+  selectedBillingInterval,
+}: {
+  theme: MantineTheme;
+  selectedBillingInterval: 'month' | 'year';
+}) => {
+  const businessPlanPrice = selectedBillingInterval === 'year' ? '$2,700' : '$250';
+
+  return (
+    <div className={styles.container(theme)}>
+      <Cell>
+        <Title variant="subsection" color="typography.text.secondary">
+          Plans
+        </Title>
+      </Cell>
+      <Cell>
+        <Title variant="subsection" color="typography.text.primary">
+          Free
+        </Title>
+        <PriceDisplay price="$0" subtitle="free forever" events="30,000 events per month" />
+      </Cell>
+      <Cell>
+        <Title
+          variant="subsection"
+          color="typography.text.primary"
+          style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
+        >
+          Business <Badge label="Popular" />
+        </Title>
+        <PriceDisplay
+          price={businessPlanPrice}
+          subtitle={`billed ${selectedBillingInterval === 'year' ? 'annually' : 'monthly'}`}
+          events="250,000 events per month"
+        />
+        <PlanActionButton selectedBillingInterval={selectedBillingInterval} />
+      </Cell>
+      <Cell style={{ justifyContent: 'space-between' }}>
+        <Title variant="subsection" color="typography.text.primary">
+          Enterprise
+        </Title>
+        <Text color="typography.text.secondary">Custom pricing, billing, and extended services.</Text>
+        <ContactUsButton />
+      </Cell>
+    </div>
+  );
+};
+
+const styles = {
+  container: (theme: MantineTheme) =>
+    css({
+      display: 'flex',
+      alignItems: 'flex-start',
+      alignSelf: 'stretch',
+      borderBottom: theme.colorScheme === 'dark' ? '1px solid #34343A' : '1px solid #e4e2e4ff',
+    }),
+
+  priceDisplay: css({
+    display: 'flex',
+    alignItems: 'flex-end',
+    gap: '4px',
+  }),
+};

--- a/apps/web/src/ee/billing/pages/BillingPage.tsx
+++ b/apps/web/src/ee/billing/pages/BillingPage.tsx
@@ -1,19 +1,19 @@
 import React, { useEffect } from 'react';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { Plan } from '../components/Plan';
+import { Plan as PlanV2 } from '../components/billingV2/Plan';
 import { SubscriptionProvider } from '../components/SubscriptionProvider';
 import { useSegment } from '../../../components/providers/SegmentProvider';
+import { useFeatureFlag } from '../../../hooks/useFeatureFlag';
 
 export const BillingPage = () => {
   const segment = useSegment();
+  const isImprovedBillingEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_IMPROVED_BILLING_ENABLED);
 
   useEffect(() => {
     segment.track('Billing Page Viewed');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return (
-    <SubscriptionProvider>
-      <Plan />
-    </SubscriptionProvider>
-  );
+  return <SubscriptionProvider>{isImprovedBillingEnabled ? <PlanV2 /> : <Plan />}</SubscriptionProvider>;
 };

--- a/apps/web/src/ee/clerk/pages/ManageAccountPage.styles.ts
+++ b/apps/web/src/ee/clerk/pages/ManageAccountPage.styles.ts
@@ -80,7 +80,7 @@ export const tabsStyles = {
   panel: css({
     padding: '150',
     borderRadius: 'l',
-    backgroundColor: 'surface.panelSubsection',
+    backgroundColor: 'surface.page',
     overflowY: 'auto',
   }),
   tabsList: css({

--- a/apps/web/src/ee/clerk/providers/ClerkProvider.tsx
+++ b/apps/web/src/ee/clerk/providers/ClerkProvider.tsx
@@ -190,7 +190,7 @@ const CLERK_MODAL_ELEMENT = {
     width: '100%',
   },
   scrollBox: {
-    backgroundColor: 'var(--nv-colors-surface-panel-subsection)',
+    backgroundColor: 'surface.page',
     padding: '0',
   },
   pageScrollBox: {


### PR DESCRIPTION
### What changed? Why was the change needed?
- Revamp of the billing page
- The design is not pixel perfect since we currently don't have a consistent design system that would match the intended designs in Figma, so I had to use some hardcoded variables and quite a lot of custom styling. 
- Currently, there are 2 variants in the code, the new one (behind FF) + the legacy one
- Looking at the existing code, it seems we are yet not consistent in which styling/css codestyle we are following (`novu/design-system`, `mantine v5`, `mantine v7`, `styled()`, `css()`, `inline styles`, etc.) so I was aiming to use the least amount of external imports and used mostly `@novu/novui` and basic styled classes

### Screenshots
![image](https://github.com/user-attachments/assets/e70630aa-4222-4548-89bd-6506ad009663)

