### PR TITLE
fix(web): subscription with no events included

### DIFF
--- a/apps/web/src/ee/billing/components/billingV2/ActivePlanBanner.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/ActivePlanBanner.tsx
@@ -60,7 +60,7 @@ const PlanInfo = ({ apiServiceLevel, currentEvents, maxEvents }) => {
       <div className={styles.eventsUsage}>
         <div className={styles.eventsCount}>
           <Text className={styles.eventsNumber} style={{ color }}>
-            {currentEvents.toLocaleString()}
+            {currentEvents?.toLocaleString()}
           </Text>
           <Text className={styles.eventsLabel}>events</Text>
         </div>

--- a/apps/web/src/ee/billing/components/billingV2/UsageProgress.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/UsageProgress.tsx
@@ -14,7 +14,7 @@ export const UsageProgress = ({ apiServiceLevel, currentEvents, maxEvents }) => 
       <Progress size="xs" value={usagePercentage} color={color} className={styles.progressBar} />
       <div className={styles.progressLegend}>
         <Text className={styles.legendItem}>0</Text>
-        <Text className={styles.legendItem}>{maxEvents.toLocaleString()}</Text>
+        <Text className={styles.legendItem}>{maxEvents?.toLocaleString()}</Text>
       </div>
     </div>
   );

--- a/apps/web/src/ee/billing/hooks/useSubscription.ts
+++ b/apps/web/src/ee/billing/hooks/useSubscription.ts
@@ -41,7 +41,7 @@ export const useSubscription = () => {
           ...data,
           events: {
             ...data.events,
-            // if included is null, customer doesn't have a valid metered subcription, default to 0
+            // if included is null, customer doesn't have a valid metered subscription, default to 0
             included: data.events.included ?? 0,
           },
         };

--- a/apps/web/src/ee/billing/hooks/useSubscription.ts
+++ b/apps/web/src/ee/billing/hooks/useSubscription.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { differenceInDays, isSameDay } from 'date-fns';
+import { ApiServiceLevelEnum, GetSubscriptionDto } from '@novu/shared';
 import { useAuth } from '../../../hooks/useAuth';
 import { api } from '../../../api';
-import { ApiServiceLevelEnum, GetSubscriptionDto } from '@novu/shared';
 
 const today = new Date();
 
@@ -35,6 +35,16 @@ export const useSubscription = () => {
           end: today.toISOString(),
           daysTotal: 0,
         },
+      },
+      select: (data) => {
+        return {
+          ...data,
+          events: {
+            ...data.events,
+            // if included is null, customer doesn't have a valid metered subcription, default to 0
+            included: data.events.included ?? 0,
+          },
+        };
       },
     }
   );


### PR DESCRIPTION
### What changed? Why was the change needed?
This handles a case where user doesn't have any metered subscription active and `includedEvents` is `null`. 