### PR TITLE
fix(api): Update .source and quota-throttler tests

### DIFF
--- a/apps/api/src/app/shared/interceptors/product-feature.interceptor.ts
+++ b/apps/api/src/app/shared/interceptors/product-feature.interceptor.ts
@@ -51,6 +51,7 @@ export class ProductFeatureInterceptor implements NestInterceptor {
     );
 
     if (!enabled) {
+      // TODO: Reuse PaymentRequiredException from EE billing module.
       throw new HttpException('Payment Required', 402);
     }
 

--- a/apps/api/src/app/testing/billing/quota-throttler.guard.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/quota-throttler.guard.e2e-ee.ts
@@ -52,8 +52,8 @@ describe('Resource Limiting', () => {
 
           expect(response.status).to.equal(402);
           expect(response.body.status).to.equal(402);
-          expect(response.body.message).to.equal('Payment required');
-          expect(response.body.error).to.match(
+          expect(response.body.error).to.equal('Payment required');
+          expect(response.body.message).to.match(
             /You have exceeded the number of allowed requests for this resource\. Please visit http.+ to upgrade your subscription./
           );
         });

--- a/apps/api/src/app/testing/billing/quota-throttler.guard.e2e-ee.ts
+++ b/apps/api/src/app/testing/billing/quota-throttler.guard.e2e-ee.ts
@@ -51,6 +51,11 @@ describe('Resource Limiting', () => {
           const response = await request(pathEvent);
 
           expect(response.status).to.equal(402);
+          expect(response.body.status).to.equal(402);
+          expect(response.body.message).to.equal('Payment required');
+          expect(response.body.error).to.match(
+            /You have exceeded the number of allowed requests for this resource\. Please visit http.+ to upgrade your subscription./
+          );
         });
       });
 


### PR DESCRIPTION
### What changed? Why was the change needed?
Add "error" key to payload so that all published `@novu/framework` versions treat it as a platform error and prints it nicely in Bridge Endpoint logs.

See:
https://github.com/novuhq/novu/blob/2acea62f906c180fc8503449b803af36ce23f1c6/packages/shared/src/utils/checkIsResponseError.ts#L7
https://github.com/novuhq/novu/blob/a305ec690cbdd7b89e636379cbfd36657d55a662/packages/framework/src/utils/http.utils.ts#L22

Before the fix, 402 was convert to a 500 error:

```➜  my-novu-app git:(main) ✗ npm run dev
...
 GET /api/novu?action=discover 200 in 4ms
y [Error]: Something went wrong. Please try again later.
    at Object.post (webpack-internal:///(rsc)/./node_modules/@novu/framework/dist/servers/next.js:23:5386)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async eval (webpack-internal:///(rsc)/./node_modules/@novu/framework/dist/servers/next.js:27:4757)
    at async Re.handleAction (webpack-internal:///(rsc)/./node_modules/@novu/framework/dist/servers/next.js:27:3949)
    at async eval (webpack-internal:///(rsc)/./node_modules/@novu/framework/dist/servers/next.js:27:2841)
    at async /Users/foo/my-novu-app/node_modules/next/dist/compiled/next-server/app-route.runtime.dev.js:6:55759
    at async eO.execute (/Users/foo/my-novu-app/node_modules/next/dist/compiled/next-server/app-route.runtime.dev.js:6:46527)
    at async eO.handle (/Users/foo/my-novu-app/node_modules/next/dist/compiled/next-server/app-route.runtime.dev.js:6:57093)
    at async doRender (/Users/foo/my-novu-app/node_modules/next/dist/server/base-server.js:1345:42)
    at async cacheEntry.responseCache.get.routeKind (/Users/foo/my-novu-app/node_modules/next/dist/server/base-server.js:1567:28)
    at async DevServer.renderToResponseWithComponentsImpl (/Users/foo/my-novu-app/node_modules/next/dist/server/base-server.js:1475:28)
    at async DevServer.renderPageComponent (/Users/foo/my-novu-app/node_modules/next/dist/server/base-server.js:1901:24)
    at async DevServer.renderToResponseImpl (/Users/foo/my-novu-app/node_modules/next/dist/server/base-server.js:1939:32)
    at async DevServer.pipeImpl (/Users/foo/my-novu-app/node_modules/next/dist/server/base-server.js:914:25)
    at async NextNodeServer.handleCatchallRenderRequest (/Users/foo/my-novu-app/node_modules/next/dist/server/next-server.js:272:17)
    at async DevServer.handleRequestImpl (/Users/foo/my-novu-app/node_modules/next/dist/server/base-server.js:810:17)
    at async /Users/foo/my-novu-app/node_modules/next/dist/server/dev/next-dev-server.js:339:20
    at async Span.traceAsyncFn (/Users/foo/my-novu-app/node_modules/next/dist/trace/trace.js:154:20)
    at async DevServer.handleRequest (/Users/foo/my-novu-app/node_modules/next/dist/server/dev/next-dev-server.js:336:24)
    at async invokeRender (/Users/foo/my-novu-app/node_modules/next/dist/server/lib/router-server.js:173:21)
    at async handleRequest (/Users/foo/my-novu-app/node_modules/next/dist/server/lib/router-server.js:350:24)
    at async requestHandlerImpl (/Users/foo/my-novu-app/node_modules/next/dist/server/lib/router-server.js:374:13)
    at async Server.requestListener (/Users/foo/my-novu-app/node_modules/next/dist/server/lib/start-server.js:141:13) {
  data: undefined,
  statusCode: 500,
  code: 'BridgeError'
}
...
```