### PR TITLE
fix(api,web): Align segment traits payload

### DIFF
--- a/apps/web/src/utils/segment.ts
+++ b/apps/web/src/utils/segment.ts
@@ -60,6 +60,7 @@ export class SegmentService {
       firstName: user.firstName,
       lastName: user.lastName,
       avatar: user.profilePicture,
+      createdAt: user.createdAt,
     });
   }
 

--- a/packages/cli/src/services/analytics.service.ts
+++ b/packages/cli/src/services/analytics.service.ts
@@ -53,7 +53,7 @@ export class AnalyticService {
       userId: user._id,
       traits: {
         email: user.email,
-        name: user.firstName + ' ' + user.lastName,
+        name: `${user.firstName || ''} ${user.lastName || ''}`.trim(),
         firstName: user.firstName,
         lastName: user.lastName,
         avatar: user.profilePicture,

--- a/packages/cli/src/services/analytics.service.ts
+++ b/packages/cli/src/services/analytics.service.ts
@@ -52,10 +52,12 @@ export class AnalyticService {
     this._analytics.identify({
       userId: user._id,
       traits: {
+        email: user.email,
+        name: user.firstName + ' ' + user.lastName,
         firstName: user.firstName,
         lastName: user.lastName,
-        email: user.email,
-        created: user.createdAt,
+        avatar: user.profilePicture,
+        createdAt: user.createdAt,
       },
     });
   }


### PR DESCRIPTION
### What changed? Why was the change needed?
Send the same payload during Segment Identify call from the API and the web app. This is a test to see if sometimes user data are lost on Segment's side when the traits sent from different apps differ.

It will be surprising to figure out that Segment doesn't merge traits based on user_id.