### PR TITLE
fix(framework): Default to health action

### DIFF
--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -132,7 +132,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
   private async handleAction({ actions }: { actions: HandlerResponse<Output> }): Promise<IActionResponse> {
     const url = await actions.url();
     const method = await actions.method();
-    const action = url.searchParams.get(HttpQueryKeysEnum.ACTION) || '';
+    const action = url.searchParams.get(HttpQueryKeysEnum.ACTION) || GetActionEnum.HEALTH_CHECK;
     const workflowId = url.searchParams.get(HttpQueryKeysEnum.WORKFLOW_ID) || '';
     const stepId = url.searchParams.get(HttpQueryKeysEnum.STEP_ID) || '';
     const signatureHeader =


### PR DESCRIPTION
### What changed? Why was the change needed?
Visiting `/api/novu` should return the health action response instead of an error.

### Screenshots
<img width="1512" alt="Screenshot 2024-09-02 at 15 06 36" src="https://github.com/user-attachments/assets/9982a699-5ae7-420d-8adc-ce5a507e64e1">
