### PR TITLE
fix(api): response interceptor

### DIFF
--- a/apps/api/src/app/shared/framework/response.interceptor.ts
+++ b/apps/api/src/app/shared/framework/response.interceptor.ts
@@ -39,7 +39,7 @@ export class ResponseInterceptor<T> implements NestInterceptor<T, Response<T>> {
    */
   private returnWholeObject(data) {
     const isPaginatedResult = data?.data;
-    const isEntityObject = data?._id;
+    const isEntityObject = data?._id || data?.id;
 
     return isPaginatedResult && !isEntityObject;
   }


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
- It is breaking now because we added the data property in the DSL
So when it returns the Notification object
our response.interceptor.ts intercepts it as a pagination response due to the presence of data key and doesnt adds the data to the response

- adding `data?.id` condition to test for isEntityObject works.
### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
