### PR TITLE
fix(web): Show how often usage metrics update

### DIFF
--- a/apps/web/src/ee/billing/components/billingV2/ActivePlanBanner.tsx
+++ b/apps/web/src/ee/billing/components/billingV2/ActivePlanBanner.tsx
@@ -61,8 +61,10 @@ const PlanInfo = ({ apiServiceLevel, currentEvents, maxEvents }) => {
         </div>
         <Text className={styles.usageText}>used this month</Text>
       </div>
-
       <UsageProgress apiServiceLevel={apiServiceLevel} currentEvents={currentEvents} maxEvents={maxEvents} />
+      <Text variant="secondary" fontSize="12px" color="typography.text.secondary">
+        Updates every hour
+      </Text>
     </div>
   );
 };
@@ -72,7 +74,7 @@ const PlanActions = ({ trialEnd, status, selectedBillingInterval }) => {
     <div className={styles.actions}>
       <PlanActionButton selectedBillingInterval={selectedBillingInterval} />
       {status === 'trialing' ? (
-        <Text variant="secondary" fontSize="14px" color="typography.text.secondary">
+        <Text variant="secondary" fontSize="12px" color="typography.text.secondary">
           Trial ends on {formatDate(trialEnd)}
         </Text>
       ) : null}
@@ -191,6 +193,12 @@ const styles = {
     fontSize: '14px',
     fontWeight: '400',
     lineHeight: '20px',
+  }),
+  usageFootnote: css({
+    color: 'typography.text.secondary',
+    fontSize: '12px',
+    fontWeight: '400',
+    lineHeight: '12px',
   }),
   actions: css({
     display: 'flex',

--- a/apps/web/src/ee/billing/pages/BillingPage.tsx
+++ b/apps/web/src/ee/billing/pages/BillingPage.tsx
@@ -15,5 +15,5 @@ export const BillingPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return <SubscriptionProvider>{isImprovedBillingEnabled ? <PlanV2 /> : <Plan />}</SubscriptionProvider>;
+  return <SubscriptionProvider>{isImprovedBillingEnabled ? <PlanV2 /> : <PlanV2 />}</SubscriptionProvider>;
 };

--- a/apps/web/src/ee/billing/pages/BillingPage.tsx
+++ b/apps/web/src/ee/billing/pages/BillingPage.tsx
@@ -15,5 +15,5 @@ export const BillingPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return <SubscriptionProvider>{isImprovedBillingEnabled ? <PlanV2 /> : <PlanV2 />}</SubscriptionProvider>;
+  return <SubscriptionProvider>{isImprovedBillingEnabled ? <PlanV2 /> : <Plan />}</SubscriptionProvider>;
 };


### PR DESCRIPTION
### What changed? Why was the change needed?
Show how often usage metrics update

### Screenshots
<img width="1319" alt="Screenshot 2024-10-08 at 17 44 08" src="https://github.com/user-attachments/assets/c1182d01-3b66-4ed6-98d1-1bce8555ead2">