### PR TITLE
chore(api): Remove Sentry profiling from all apps

### DIFF
--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -1,24 +1,11 @@
-import { nodeProfilingIntegration } from '@sentry/profiling-node';
-import { init } from '@sentry/nestjs';
+import { init } from '@sentry/node';
+import { version } from '../package.json';
 
 if (process.env.SENTRY_DSN) {
   init({
     dsn: process.env.SENTRY_DSN,
-    integrations: [
-      // Add our Profiling integration
-      nodeProfilingIntegration(),
-    ],
-
-    /*
-     * Add Tracing by setting tracesSampleRate
-     * We recommend adjusting this value in production
-     */
-    tracesSampleRate: 1.0,
-
-    /*
-     * Set sampling rate for profiling
-     * This is relative to tracesSampleRate
-     */
-    profilesSampleRate: 1.0,
+    environment: process.env.NODE_ENV,
+    release: `v${version}`,
+    ignoreErrors: ['Non-Error exception captured'],
   });
 }

--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -1,4 +1,4 @@
-import { init } from '@sentry/node';
+import { init } from '@sentry/nestjs';
 import { version } from '../package.json';
 
 if (process.env.SENTRY_DSN) {

--- a/apps/inbound-mail/src/instrument.ts
+++ b/apps/inbound-mail/src/instrument.ts
@@ -1,28 +1,11 @@
-import { init } from '@sentry/nestjs';
-import { nodeProfilingIntegration } from '@sentry/profiling-node';
-import version from '../package.json';
+import { init } from '@sentry/node';
+import { version } from '../package.json';
 
 if (process.env.SENTRY_DSN) {
   init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.NODE_ENV,
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
     release: `v${version}`,
-    integrations: [
-      // Add our Profiling integration
-      nodeProfilingIntegration(),
-    ],
-
-    /*
-     * Add Tracing by setting tracesSampleRate
-     * We recommend adjusting this value in production
-     */
-    tracesSampleRate: 1.0,
-
-    /*
-     * Set sampling rate for profiling
-     * This is relative to tracesSampleRate
-     */
-    profilesSampleRate: 1.0,
+    ignoreErrors: ['Non-Error exception captured'],
   });
 }

--- a/apps/inbound-mail/src/instrument.ts
+++ b/apps/inbound-mail/src/instrument.ts
@@ -1,4 +1,4 @@
-import { init } from '@sentry/node';
+import { init } from '@sentry/nestjs';
 import { version } from '../package.json';
 
 if (process.env.SENTRY_DSN) {

--- a/apps/webhook/src/instrument.ts
+++ b/apps/webhook/src/instrument.ts
@@ -1,27 +1,11 @@
 import { init } from '@sentry/node';
-import packageJson from '../package.json';
-import { nodeProfilingIntegration } from '@sentry/profiling-node';
+import { version } from '../package.json';
 
 if (process.env.SENTRY_DSN) {
   init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.NODE_ENV,
-    release: `v${packageJson.version}`,
-    integrations: [
-      // Add our Profiling integration
-      nodeProfilingIntegration(),
-    ],
-
-    /*
-     * Add Tracing by setting tracesSampleRate
-     * We recommend adjusting this value in production
-     */
-    tracesSampleRate: 1.0,
-
-    /*
-     * Set sampling rate for profiling
-     * This is relative to tracesSampleRate
-     */
-    profilesSampleRate: 1.0,
+    release: `v${version}`,
+    ignoreErrors: ['Non-Error exception captured'],
   });
 }

--- a/apps/webhook/src/instrument.ts
+++ b/apps/webhook/src/instrument.ts
@@ -1,4 +1,4 @@
-import { init } from '@sentry/node';
+import { init } from '@sentry/nestjs';
 import { version } from '../package.json';
 
 if (process.env.SENTRY_DSN) {

--- a/apps/worker/src/instrument.ts
+++ b/apps/worker/src/instrument.ts
@@ -1,13 +1,11 @@
-import { nodeProfilingIntegration } from '@sentry/profiling-node';
-import { init } from '@sentry/nestjs';
-import packageJson from '../package.json';
+import { init } from '@sentry/node';
+import { version } from '../package.json';
 
 if (process.env.SENTRY_DSN) {
   init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.NODE_ENV,
-    release: `v${packageJson.version}`,
+    release: `v${version}`,
     ignoreErrors: ['Non-Error exception captured'],
-    integrations: [nodeProfilingIntegration()],
   });
 }

--- a/apps/worker/src/instrument.ts
+++ b/apps/worker/src/instrument.ts
@@ -1,4 +1,4 @@
-import { init } from '@sentry/node';
+import { init } from '@sentry/nestjs';
 import { version } from '../package.json';
 
 if (process.env.SENTRY_DSN) {

--- a/apps/ws/src/instrument.ts
+++ b/apps/ws/src/instrument.ts
@@ -1,5 +1,4 @@
-import { init } from '@sentry/nestjs';
-import { nodeProfilingIntegration } from '@sentry/profiling-node';
+import { init } from '@sentry/node';
 import { version } from '../package.json';
 
 if (process.env.SENTRY_DSN) {
@@ -7,21 +6,6 @@ if (process.env.SENTRY_DSN) {
     dsn: process.env.SENTRY_DSN,
     environment: process.env.NODE_ENV,
     release: `v${version}`,
-    integrations: [
-      // Add our Profiling integration
-      nodeProfilingIntegration(),
-    ],
-
-    /*
-     * Add Tracing by setting tracesSampleRate
-     * We recommend adjusting this value in production
-     */
-    tracesSampleRate: 1.0,
-
-    /*
-     * Set sampling rate for profiling
-     * This is relative to tracesSampleRate
-     */
-    profilesSampleRate: 1.0,
+    ignoreErrors: ['Non-Error exception captured'],
   });
 }

--- a/apps/ws/src/instrument.ts
+++ b/apps/ws/src/instrument.ts
@@ -1,4 +1,4 @@
-import { init } from '@sentry/node';
+import { init } from '@sentry/nestjs';
 import { version } from '../package.json';
 
 if (process.env.SENTRY_DSN) {


### PR DESCRIPTION
### What changed? Why was the change needed?
The hypothesis is that using Sentry profiler with a rate of 1.0, sends everything to Sentry, stressing the containers and the AWS tasks