### PR TITLE
feat(web): Add autocomplete example to Playground

### DIFF
--- a/apps/web/src/pages/playground/web-container-configuration/sandbox-vite/src/workflow.ts
+++ b/apps/web/src/pages/playground/web-container-configuration/sandbox-vite/src/workflow.ts
@@ -22,7 +22,7 @@ const helloWorld = workflow('hello-world', async ({ step, payload }) => {
        */
       controlSchema: z.object({
         subject: z.string().default('Welcome to Novu'),
-        title: z.string().default('Welcome to Novu'),
+        title: z.string().default('Welcome to Novu, {{payload.name}}'),
         text: z.string()
           .default(
             'This email is generated using Tailwind and React Email. ' +

--- a/apps/web/src/pages/playground/web-container-configuration/sandbox-vite/workflow.ts
+++ b/apps/web/src/pages/playground/web-container-configuration/sandbox-vite/workflow.ts
@@ -22,7 +22,7 @@ const helloWorld = workflow('hello-world', async ({ step, payload }) => {
        */
       controlSchema: z.object({
         subject: z.string().default('Welcome to Novu'),
-        title: z.string().default('Welcome to Novu'),
+        title: z.string().default('Welcome to Novu, {{payload.name}}'),
         text: z.string()
           .default(
             'This email is generated using Tailwind and React Email. ' +


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Add autocomplete example to Playground to demonstrate LiquidJS syntax during onboarding

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Demonstration of autocomplete syntax in the Playground example_
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/0a4310f2-f6ea-48ec-ab74-17fb637aa1fc">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
