### PR TITLE
ci(root): remove redundant API unit test

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -244,6 +244,7 @@ jobs:
       test-e2e-affected: ${{ contains(fromJson(needs.get-affected.outputs.test-e2e), '@novu/api') || contains(fromJson(needs.get-affected.outputs.test-e2e), '@novu/worker') }}
       test-e2e-ee-affected: ${{ contains(fromJson(needs.get-affected.outputs.test-e2e-ee), '@novu/api') || contains(fromJson(needs.get-affected.outputs.test-e2e-ee), '@novu/worker') }}
       job-name: ${{ matrix.name }}
+      test-unit: false
     secrets: inherit    
 
   test_e2e_web:

--- a/.github/workflows/reusable-api-e2e.yml
+++ b/.github/workflows/reusable-api-e2e.yml
@@ -116,10 +116,6 @@ jobs:
       - name: Kill port for worker 1342 for unit tests
         run: sudo kill -9 $(sudo lsof -t -i:1342)
 
-      - name: Run unit tests
-        run: |
-          cd apps/api && pnpm test
-
       - name: Send Slack notifications
         uses: ./.github/actions/slack-notify-on-failure
         if: failure()

--- a/.github/workflows/reusable-api-e2e.yml
+++ b/.github/workflows/reusable-api-e2e.yml
@@ -14,6 +14,11 @@ on:
         required: false
         default: true
         type: boolean
+      test-unit:
+        description: 'detect if we should run unit tests'
+        required: false
+        default: true
+        type: boolean
       ee:
         description: 'use the ee version of api'
         required: false
@@ -115,6 +120,11 @@ jobs:
 
       - name: Kill port for worker 1342 for unit tests
         run: sudo kill -9 $(sudo lsof -t -i:1342)
+
+      - name: Run unit tests
+        if: inputs.test-unit
+        run: |
+          cd apps/api && pnpm test
 
       - name: Send Slack notifications
         uses: ./.github/actions/slack-notify-on-failure


### PR DESCRIPTION
### What changed? Why was the change needed?
On PR we are running this workflow: https://github.com/novuhq/novu/blob/next/.github/workflows/on-pr.yml
which already has a step called `test_unit_services` which runs API unit tests.

We don't need another 2x runs of API unit tests inside e2e test workflow (2x runs because the e2e runs twice for enterprise and regular API)/ 

