### PR TITLE
fix(api): Log exception traits

### DIFF
--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -44,7 +44,13 @@ export class AllExceptionsFilter implements ExceptionFilter {
     this.logger.error(
       {
         errorId: uuid,
-        err: exception, // important to use `err` as the key, New Relic will log an empty object if the key is not `err`
+        /**
+         * It's important to use `err` as the key, pino (the logger we use) will
+         * log an empty object if the key is not `err`
+         *
+         * @see https://github.com/pinojs/pino/issues/819#issuecomment-611995074
+         */
+        err: exception,
       },
       `Unexpected exception thrown`,
       'Exception'

--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -41,11 +41,10 @@ export class AllExceptionsFilter implements ExceptionFilter {
     }
   ) {
     const uuid = this.getUuid(exception);
-    const error = exception as Error;
     this.logger.error(
       {
         errorId: uuid,
-        err: exception,
+        err: exception, // important to use `err` as the key, New Relic will log an empty object if the key is not `err`
       },
       `Unexpected exception thrown`,
       'Exception'

--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -41,8 +41,14 @@ export class AllExceptionsFilter implements ExceptionFilter {
     }
   ) {
     const uuid = this.getUuid(exception);
+    const error = exception as Error;
     this.logger.error(
-      { exception, errorId: uuid, stack: (exception as Error)?.stack },
+      {
+        errorId: uuid,
+        name: error?.name,
+        message: error?.message,
+        stack: error?.stack,
+      },
       `Unexpected exception thrown`,
       'Exception'
     );

--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -45,9 +45,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
     this.logger.error(
       {
         errorId: uuid,
-        name: error?.name,
-        message: error?.message,
-        stack: error?.stack,
+        err: exception,
       },
       `Unexpected exception thrown`,
       'Exception'

--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -41,7 +41,11 @@ export class AllExceptionsFilter implements ExceptionFilter {
     }
   ) {
     const uuid = this.getUuid(exception);
-    this.logger.error({ exception, errorId: uuid }, `unexpected exception thrown`, 'Exception');
+    this.logger.error(
+      { exception, errorId: uuid, stack: (exception as Error)?.stack },
+      `Unexpected exception thrown`,
+      'Exception'
+    );
 
     return { ...responseBody, errorId: uuid };
   }


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* The current exception logging garbles the error due to the `Error.toString()` method not working as expected. This change explicitly logs out the error traits

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Before_
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/43fd44be-2274-4c0d-97ce-d6bd1047502f">

_After_
<img width="1249" alt="image" src="https://github.com/user-attachments/assets/743a80f8-edb7-41f9-a07c-90161c402976">

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
