### PR TITLE
fix(js): Bypass cache during novu.notifications.list()

### DIFF
--- a/packages/js/src/notifications/notifications.ts
+++ b/packages/js/src/notifications/notifications.ts
@@ -63,7 +63,8 @@ export class Notifications extends BaseModule {
     return this.callWithSession(async () => {
       const args = { limit, ...restOptions };
       try {
-        let data: ListNotificationsResponse | undefined = this.#useCache ? this.cache.getAll(args) : undefined;
+        const shouldUseCache = 'useCache' in args ? args.useCache : this.#useCache;
+        let data: ListNotificationsResponse | undefined = shouldUseCache ? this.cache.getAll(args) : undefined;
         this._emitter.emit('notifications.list.pending', { args, data });
 
         if (!data) {
@@ -78,7 +79,7 @@ export class Notifications extends BaseModule {
             notifications: response.data.map((el) => new Notification(el, this._emitter, this._inboxService)),
           };
 
-          if (this.#useCache) {
+          if (shouldUseCache) {
             this.cache.set(args, data);
             data = this.cache.getAll(args);
           }

--- a/packages/js/src/notifications/types.ts
+++ b/packages/js/src/notifications/types.ts
@@ -8,6 +8,7 @@ export type ListNotificationsArgs = {
   limit?: number;
   after?: string;
   offset?: number;
+  useCache?: boolean;
 };
 
 export type ListNotificationsResponse = { notifications: Notification[]; hasMore: boolean; filter: NotificationFilter };


### PR DESCRIPTION

### What changed? Why was the change needed?
Introduce `novu.notifications.list({ useCache: true | false })` option to always fetch the latest notifications and bypass the cache. This should give the ability to build an Inbox UI that auto-refreshes when a new notification is available.

The `useCache` option of the list function defaults to true.