### PR TITLE
refactor(shared, api): Simplify Workflow API Resource DTO

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -41,7 +41,7 @@ import { StepUpsertMechanismFailedMissingIdException } from '../../exceptions/st
 import { toResponseWorkflowDto } from '../../mappers/notification-template-mapper';
 
 const workflowResponseDto: WorkflowResponseDto = {
-  id: 'my-workflow-{base62(6661fe983370d0542e4a096c)}', // `slug` + `-{base62(ObjectId)}`
+  id: 'my-workflow-FtfjFHJ9j11gGfds', // `slug` + `-{base62(ObjectId)}`
   slug: 'my-workflow', // previously, this was `workflow.triggers[0].identifier`
   name: 'My Workflow',
   description: 'My Workflow Description',
@@ -50,7 +50,7 @@ const workflowResponseDto: WorkflowResponseDto = {
   origin: WorkflowOriginEnum.NOVU_CLOUD,
   steps: [
     {
-      id: 'my-step-{base62(6661fe983370d0542e4a096c)}', // `slug` + `-{base62(ObjectId)}`
+      id: 'my-step-FtfjFHJ9j11gGfds', // `slug` + `-{base62(ObjectId)}`
       slug: 'my-step', // previously, this was `step.stepId`
       name: 'My Step',
       type: StepTypeEnum.IN_APP,

--- a/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -42,7 +42,7 @@ import { toResponseWorkflowDto } from '../../mappers/notification-template-mappe
 
 const workflowResponseDto: WorkflowResponseDto = {
   id: 'my-workflow-{base62(6661fe983370d0542e4a096c)}', // `slug` + `-{base62(ObjectId)}`
-  slug: 'my-workflow',
+  slug: 'my-workflow', // previously, this was `workflow.triggers[0].identifier`
   name: 'My Workflow',
   description: 'My Workflow Description',
   active: true,
@@ -51,10 +51,11 @@ const workflowResponseDto: WorkflowResponseDto = {
   steps: [
     {
       id: 'my-step-{base62(6661fe983370d0542e4a096c)}', // `slug` + `-{base62(ObjectId)}`
-      slug: 'my-step',
+      slug: 'my-step', // previously, this was `step.stepId`
       name: 'My Step',
       type: StepTypeEnum.IN_APP,
       controlSchema: {
+        // previously, this was `step.template.controls.schema`
         type: 'object',
         properties: {
           body: {

--- a/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -25,17 +25,57 @@ import {
 } from '@novu/application-generic';
 import {
   CreateWorkflowDto,
+  DEFAULT_WORKFLOW_PREFERENCES,
   StepCreateDto,
   StepDto,
+  StepTypeEnum,
   StepUpdateDto,
   WorkflowCreationSourceEnum,
   WorkflowOriginEnum,
   WorkflowResponseDto,
+  WorkflowStatusEnum,
   WorkflowTypeEnum,
 } from '@novu/shared';
 import { UpsertWorkflowCommand } from './upsert-workflow.command';
 import { StepUpsertMechanismFailedMissingIdException } from '../../exceptions/step-upsert-mechanism-failed-missing-id.exception';
 import { toResponseWorkflowDto } from '../../mappers/notification-template-mapper';
+
+const workflowResponseDto: WorkflowResponseDto = {
+  id: 'my-workflow-{base62(6661fe983370d0542e4a096c)}', // `slug` + `-{base62(ObjectId)}`
+  slug: 'my-workflow',
+  name: 'My Workflow',
+  description: 'My Workflow Description',
+  active: true,
+  type: WorkflowTypeEnum.BRIDGE,
+  origin: WorkflowOriginEnum.NOVU_CLOUD,
+  steps: [
+    {
+      id: 'my-step-{base62(6661fe983370d0542e4a096c)}', // `slug` + `-{base62(ObjectId)}`
+      slug: 'my-step',
+      name: 'My Step',
+      type: StepTypeEnum.IN_APP,
+      controlSchema: {
+        type: 'object',
+        properties: {
+          body: {
+            type: 'string',
+          },
+        },
+        required: ['body'],
+      },
+      controlValues: {
+        body: 'Hello, world!',
+      },
+    },
+  ],
+  updatedAt: '2024-04-01T00:00:00.000Z',
+  createdAt: '2024-04-01T00:00:00.000Z',
+  status: WorkflowStatusEnum.ACTIVE,
+  preferences: {
+    user: null,
+    default: DEFAULT_WORKFLOW_PREFERENCES,
+  },
+};
 
 function buildUpsertControlValuesCommand(
   command: UpsertWorkflowCommand,

--- a/packages/shared/src/dto/workflows/workflow-commons-fields.ts
+++ b/packages/shared/src/dto/workflows/workflow-commons-fields.ts
@@ -8,16 +8,6 @@ export class ControlsSchema {
   schema: JSONSchema;
 }
 
-export type StepResponseDto = StepDto & {
-  stepUuid: string;
-};
-
-export type StepUpdateDto = StepDto & {
-  stepUuid: string;
-};
-
-export type StepCreateDto = StepDto;
-
 export type ListWorkflowResponse = {
   workflows: WorkflowListResponseDto[];
   totalCount: number;
@@ -25,7 +15,7 @@ export type ListWorkflowResponse = {
 
 export type WorkflowListResponseDto = Pick<
   WorkflowResponseDto,
-  'name' | 'tags' | 'updatedAt' | 'createdAt' | '_id' | 'status' | 'type' | 'origin'
+  'name' | 'tags' | 'updatedAt' | 'createdAt' | 'id' | 'status' | 'type' | 'origin'
 > & {
   stepTypeOverviews: StepTypeEnum[];
 };
@@ -40,7 +30,7 @@ export class StepDto {
   type: StepTypeEnum;
 
   @IsObject()
-  controls: ControlsSchema;
+  controlSchema: JSONSchema;
 
   @IsObject()
   controlValues: Record<string, unknown>;
@@ -49,7 +39,11 @@ export class StepDto {
 export class WorkflowCommonsFields {
   @IsString()
   @IsDefined()
-  _id: string;
+  id: string;
+
+  @IsString()
+  @IsDefined()
+  slug: string;
 
   @IsOptional()
   @IsArray()
@@ -65,13 +59,27 @@ export class WorkflowCommonsFields {
   name: string;
 
   @IsString()
-  @IsDefined()
-  workflowId: string;
-
-  @IsString()
   @IsOptional()
   description?: string;
 }
+
+export class StepResponseDto extends StepDto {
+  @IsString()
+  @IsDefined()
+  id: string;
+
+  @IsString()
+  @IsDefined()
+  slug: string;
+}
+
+export class StepUpdateDto extends StepDto {
+  @IsString()
+  @IsDefined()
+  slug: string;
+}
+
+export class StepCreateDto extends StepDto {}
 
 export type PreferencesResponseDto = {
   user: WorkflowPreferences | null;


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
This is a draft PR for discussing conventions around the identifiers and slugs in API Resource DTOs. The proposal follows that:
* all resources will use a common `id` property to uniquely identify the resource for API Resource Parameter usage
  * This provides a strong DX for consumers of API SDKs as they will always know to access the `id` property, regardless of the resource type. The same logic follows for `slug`
* resources that allow for customizable, client-provided identifiers will use a common `slug` property to unique identify resources in a human-readable manner

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Address bar for the following DTO:_
_Workflow:_
`https://dashboard.novu.co/dev-FtfjFHJ9j11gGfds/workflows/my-workflow-FtfjFHJ9j11gGfds`
_Step:_
`https://dashboard.novu.co/dev-FtfjFHJ9j11gGfds/workflows/my-workflow-FtfjFHJ9j11gGfds/steps/my-step-FtfjFHJ9j11gGfds`

_Example Workflow DTO:_
```typescript
const workflowResponseDto: WorkflowResponseDto = {
  id: 'my-workflow-FtfjFHJ9j11gGfds', // `slug` + `-{base62(ObjectId)}`
  slug: 'my-workflow', // previously, this was `workflow.triggers[0].identifier`
  name: 'My Workflow',
  description: 'My Workflow Description',
  active: true,
  type: WorkflowTypeEnum.BRIDGE,
  origin: WorkflowOriginEnum.NOVU_CLOUD,
  steps: [
    {
      id: 'my-step-FtfjFHJ9j11gGfds', // `slug` + `-{base62(ObjectId)}`
      slug: 'my-step', // previously, this was `step.stepId`
      name: 'My Step',
      type: StepTypeEnum.IN_APP,
      controlSchema: {
        // previously, this was `step.template.controls.schema`
        type: 'object',
        properties: {
          body: {
            type: 'string',
          },
        },
        required: ['body'],
      },
      controlValues: {
        body: 'Hello, world!',
      },
    },
  ],
  updatedAt: '2024-04-01T00:00:00.000Z',
  createdAt: '2024-04-01T00:00:00.000Z',
  status: WorkflowStatusEnum.ACTIVE,
  preferences: {
    user: null,
    default: DEFAULT_WORKFLOW_PREFERENCES,
  },
};
```

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
