### PR TITLE
feat(novu): custom tunnel support

### DIFF
--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -24,10 +24,16 @@ export async function devCommand(options: DevCommandOptions, anonymousId?: strin
   await showWelcomeScreen();
 
   const parsedOptions = parseOptions(options);
-  const devSpinner = ora('Creating a development local tunnel').start();
   const NOVU_ENDPOINT_PATH = options.route;
-  const tunnelOrigin = await createTunnel(parsedOptions.origin, NOVU_ENDPOINT_PATH);
+  let tunnelOrigin: string;
 
+  const devSpinner = ora('Creating a development local tunnel').start();
+
+  if (parsedOptions.tunnel) {
+    tunnelOrigin = parsedOptions.tunnel;
+  } else {
+    tunnelOrigin = await createTunnel(parsedOptions.origin, NOVU_ENDPOINT_PATH);
+  }
   devSpinner.succeed(`🛣️  Tunnel    → ${tunnelOrigin}${NOVU_ENDPOINT_PATH}`);
 
   const opts = {

--- a/packages/cli/src/commands/dev/types.ts
+++ b/packages/cli/src/commands/dev/types.ts
@@ -7,6 +7,7 @@ export type DevCommandOptions = {
   studioPort: string;
   dashboardUrl: string;
   route: string;
+  tunnel: string;
 };
 
 export type LocalTunnelResponse = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -60,7 +60,10 @@ program
   (e.g., npx novu@latest dev -p 4000)
 
   Running the Bridge application on a different route: 
-  (e.g., npx novu@latest dev -r /v1/api/novu)`
+  (e.g., npx novu@latest dev -r /v1/api/novu)
+  
+  Running with a custom tunnel:
+  (e.g., npx novu@latest dev --tunnel https://my-tunnel.ngrok.app)`
   )
   .usage('[-p <port>] [-r <route>] [-o <origin>] [-d <dashboard-url>] [-sp <studio-port>]')
   .option('-p, --port <port>', 'The local Bridge endpoint port', '4000')
@@ -68,6 +71,7 @@ program
   .option('-o, --origin <origin>', 'The Bridge endpoint origin')
   .option('-d, --dashboard-url <url>', 'The Novu Cloud Dashboard URL', 'https://dashboard.novu.co')
   .option('-sp, --studio-port <port>', 'The Local Studio server port', '2022')
+  .option('-t, --tunnel <url>', 'Self hosted tunnel. e.g. https://my-tunnel.ngrok.app')
   .action(async (options: DevCommandOptions) => {
     analytics.track({
       identity: {


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

This pull request introduces a new feature to support custom tunnels in the development command of the CLI. The key changes include adding a new `tunnel` option to the `DevCommandOptions` type, updating the `devCommand` function to handle this new option, and updating the CLI usage instructions to reflect the new feature.

This resolves #6709 

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
![2024-10-17 at 00 20 08@2x](https://github.com/user-attachments/assets/f90e3a83-7e38-483c-aaef-af9a1a1331cd)


<details>
<summary><strong>Expand for optional sections</strong></summary>

* [`packages/cli/src/commands/dev/dev.ts`](diffhunk://#diff-62fa8379d71ff88e5aab41363cbfaa9592933067aadbb22a764759a8859ca20aL27-R36): Modified the `devCommand` function to check for a custom tunnel URL in the options and use it if provided, otherwise, it creates a new tunnel as before.
* [`packages/cli/src/commands/dev/types.ts`](diffhunk://#diff-6023f4b19b52307d6dd173b0a6aee33857b9746a8bf84c862a13f44918134fbfR10): Added a new `tunnel` property to the `DevCommandOptions` type to store the custom tunnel URL.
* [`packages/cli/src/index.ts`](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cL63-R74): Updated the CLI usage instructions to include an example of running the command with a custom tunnel and added the `--tunnel` option to the command definition.

### Related enterprise PR


### Special notes for your reviewer
This was done after a conversation with Dima. I have verified that when you provide the custom tunnel, it operates the same as if one was created by `novu.sh`.

</details>
