### PR TITLE
fix(root): rebuild env on container start for web

### DIFF
--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -173,6 +173,7 @@ services:
       REACT_APP_WS_URL: ${REACT_APP_WS_URL}
     ports:
       - 4200:4200
+    command: ["/bin/sh", "-c", "pnpm run envsetup:docker && pnpm run start:static:build"]
     healthcheck:
       test: ['CMD-SHELL', 'curl --silent --fail http://localhost:4200 || exit 1'] 
       interval: 30s


### PR DESCRIPTION
fixes #6649 

With help from @ArjixWasTaken @bledar 

### What changed? Why was the change needed?
The environment-config is not being rebuilt when providing custom `.env` files.
Requests are always going to localhost.

### Screenshots
![image](https://github.com/user-attachments/assets/cdfafc57-91ab-4214-9217-57f34d5409fa)
