### PR TITLE
fix(application-generic): handle lock acquisition conflicts

### DIFF
--- a/libs/application-generic/src/services/cache/interceptors/cached-entity.interceptor.ts
+++ b/libs/application-generic/src/services/cache/interceptors/cached-entity.interceptor.ts
@@ -1,4 +1,4 @@
-import { Inject, Logger } from '@nestjs/common';
+import { ConflictException, Inject, Logger } from '@nestjs/common';
 import { DistributedLockService } from '../../distributed-lock';
 import { CacheService, CachingConfig } from '../cache.service';
 
@@ -89,7 +89,9 @@ export function CachedEntity<T_Output = any>({
             `Failed to acquire lock for key: ${cacheKey} in "method: ${methodName}"`,
             LOG_CONTEXT,
           );
-          throw new Error(`Failed to acquire lock for key: ${cacheKey}`);
+          throw new ConflictException(
+            `Failed to acquire cache lock. Please try again.`,
+          );
         }
       }
 

--- a/libs/application-generic/src/services/cache/interceptors/cached-entity.interceptor.ts
+++ b/libs/application-generic/src/services/cache/interceptors/cached-entity.interceptor.ts
@@ -90,7 +90,7 @@ export function CachedEntity<T_Output = any>({
             LOG_CONTEXT,
           );
           throw new ConflictException(
-            `Failed to acquire cache lock. Please try again.`,
+            `Failed to acquire cache lock. Please try again later.`,
           );
         }
       }


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Throw a `409 Conflict Error` when a cache lock cannot be acquired. `409` is commonly understood to be a retryable 4xx error, so this change is semantic.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
