### PR TITLE
fix(application-generic, api, worker): Throw client timeout exception for Bridge timeout errors

### DIFF
--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
@@ -49,7 +49,7 @@ export const RETRYABLE_HTTP_CODES: number[] = [
   504, // Gateway Timeout
   521, // CloudFlare TCP Error
   522, // CloudFlare Web Server Connection Error
-  524, // CloudFlate Timeout Error
+  524, // CloudFlare Timeout Error
 ];
 const RETRYABLE_ERROR_CODES: string[] = [
   'EAI_AGAIN', //    DNS resolution failed, retry

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
@@ -47,6 +47,7 @@ export const RETRYABLE_HTTP_CODES: number[] = [
   500, // Internal Server Error
   503, // Service Unavailable
   504, // Gateway Timeout
+  // https://developers.cloudflare.com/support/troubleshooting/cloudflare-errors/troubleshooting-cloudflare-5xx-errors/
   521, // CloudFlare web server is down
   522, // CloudFlare connection timed out
   524, // CloudFlare a timeout occurred

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
@@ -4,7 +4,7 @@ import {
   NotFoundException,
   BadRequestException,
   HttpException,
-  GatewayTimeoutException,
+  RequestTimeoutException,
 } from '@nestjs/common';
 import got, {
   CacheError,
@@ -39,10 +39,17 @@ import {
 } from '../get-decrypted-secret-key';
 import { BRIDGE_EXECUTION_ERROR } from '../../utils';
 
-export const DEFAULT_TIMEOUT = 15_000; // 15 seconds
+export const DEFAULT_TIMEOUT = 5_000; // 5 seconds
 export const DEFAULT_RETRIES_LIMIT = 3;
 export const RETRYABLE_HTTP_CODES: number[] = [
-  408, 413, 429, 500, 502, 503, 504, 521, 522, 524,
+  408, // Request Timeout
+  429, // Too Many Requests
+  500, // Internal Server Error
+  503, // Service Unavailable
+  504, // Gateway Timeout
+  521, // CloudFlare TCP Error
+  522, // CloudFlare Web Server Connection Error
+  524, // CloudFlate Timeout Error
 ];
 const RETRYABLE_ERROR_CODES: string[] = [
   'EAI_AGAIN', //    DNS resolution failed, retry
@@ -267,7 +274,7 @@ export class ExecuteBridgeRequest {
 
       if (error instanceof TimeoutError) {
         Logger.error(`Bridge request timeout for \`${url}\``, LOG_CONTEXT);
-        throw new GatewayTimeoutException({
+        throw new RequestTimeoutException({
           message: BRIDGE_EXECUTION_ERROR.BRIDGE_REQUEST_TIMEOUT.message(url),
           code: BRIDGE_EXECUTION_ERROR.BRIDGE_REQUEST_TIMEOUT.code,
         });

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
@@ -47,9 +47,9 @@ export const RETRYABLE_HTTP_CODES: number[] = [
   500, // Internal Server Error
   503, // Service Unavailable
   504, // Gateway Timeout
-  521, // CloudFlare TCP Error
-  522, // CloudFlare Web Server Connection Error
-  524, // CloudFlare Timeout Error
+  521, // CloudFlare web server is down
+  522, // CloudFlare connection timed out
+  524, // CloudFlare a timeout occurred
 ];
 const RETRYABLE_ERROR_CODES: string[] = [
   'EAI_AGAIN', //    DNS resolution failed, retry


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Throw client timeout exception for Bridge timeout errors
  * Previously, a `504 GatewayTimeout` exception was thrown, which was inaccurate as the server was not at fault. This is replaced by a more accurate `408 Request Timeout`, indicating the client was unable to fulfil the request within the time the server was prepared to wait.
* Reduce bridge maximum timeout to 5 seconds
* Add comments and refine retryable status codes

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
