### PR TITLE
fix(api): Return correct workflow.origin

### DIFF
--- a/apps/api/src/app/workflows-v2/mappers/notification-template-mapper.ts
+++ b/apps/api/src/app/workflows-v2/mappers/notification-template-mapper.ts
@@ -33,8 +33,7 @@ export function toResponseWorkflowDto(
     name: template.name,
     workflowId: template.triggers[0].identifier,
     description: template.description,
-    origin: template.origin || WorkflowOriginEnum.EXTERNAL,
-    type: template.type || ('MISSING-TYPE-ISSUE' as unknown as WorkflowTypeEnum),
+    origin: computeOrigin(template),
     updatedAt: template.updatedAt || 'Missing Updated At',
     createdAt: template.createdAt || 'Missing Create At',
     status: WorkflowStatusEnum.ACTIVE,
@@ -57,8 +56,7 @@ function getSteps(template: NotificationTemplateEntity, controlValuesMap: { [p: 
 
 function toMinifiedWorkflowDto(template: NotificationTemplateEntity): WorkflowListResponseDto {
   return {
-    origin: template.origin || WorkflowOriginEnum.EXTERNAL,
-    type: template.type || ('MISSING-TYPE-ISSUE' as unknown as WorkflowTypeEnum),
+    origin: computeOrigin(template),
     _id: template._id,
     name: template.name,
     tags: template.tags,
@@ -95,4 +93,11 @@ function convertControls(step: NotificationStepEntity): ControlsSchema {
 
 function buildStepTypeOverview(step: NotificationStepEntity): StepTypeEnum | undefined {
   return step.template?.type;
+}
+
+function computeOrigin(template: NotificationTemplateEntity): WorkflowOriginEnum {
+  // Required to differentiate between old V1 and new workflows in an attempt to eliminate the need for type field
+  return template?.type === WorkflowTypeEnum.REGULAR
+    ? WorkflowOriginEnum.NOVU_CLOUD_V1
+    : template.origin || WorkflowOriginEnum.EXTERNAL;
 }

--- a/apps/dashboard/src/utils/enums.ts
+++ b/apps/dashboard/src/utils/enums.ts
@@ -18,6 +18,7 @@ export enum WorkflowTypeEnum {
 
 export enum WorkflowOriginEnum {
   NOVU_CLOUD = 'novu-cloud',
+  NOVU_CLOUD_V1 = 'novu-cloud-v1',
   EXTERNAL = 'external',
 }
 

--- a/packages/shared/src/dto/workflows/workflow-commons-fields.ts
+++ b/packages/shared/src/dto/workflows/workflow-commons-fields.ts
@@ -28,7 +28,7 @@ export type ListWorkflowResponse = {
 
 export type WorkflowListResponseDto = Pick<
   WorkflowResponseDto,
-  'name' | 'tags' | 'updatedAt' | 'createdAt' | '_id' | 'status' | 'type' | 'origin'
+  'name' | 'tags' | 'updatedAt' | 'createdAt' | '_id' | 'status' | 'origin'
 > & {
   stepTypeOverviews: StepTypeEnum[];
 };

--- a/packages/shared/src/dto/workflows/workflow-response-dto.ts
+++ b/packages/shared/src/dto/workflows/workflow-response-dto.ts
@@ -14,6 +14,4 @@ export class WorkflowResponseDto extends WorkflowCommonsFields {
   preferences: PreferencesResponseDto;
 
   status: WorkflowStatusEnum;
-
-  type: WorkflowTypeEnum;
 }

--- a/packages/shared/src/types/notification-templates/index.ts
+++ b/packages/shared/src/types/notification-templates/index.ts
@@ -48,6 +48,7 @@ export enum WorkflowTypeEnum {
  */
 export enum WorkflowOriginEnum {
   NOVU_CLOUD = 'novu-cloud',
+  NOVU_CLOUD_V1 = 'novu-cloud-v1',
   EXTERNAL = 'external',
 }
 export * from './workflow-creation-source.enum';


### PR DESCRIPTION
### What changed? Why was the change needed?
There are three origins:
1. V1 Workflows defined in Novu Cloud (will be deprecated soon)
2. V2 Workflows defined in Novu Cloud
3. V2 Workflows defined in code via @novu/framework

The Dashboard will redirect to the appropriate workflow editor according to its origin.