### PR TITLE
fix(framework): Experiement with importing json-schema-faker

### DIFF
--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -39,6 +39,10 @@ import { WithPassthrough } from './types/provider.types';
 import { EMOJI, log, sanitizeHtmlInObject, stringifyDataStructureWithSingleQuotes } from './utils';
 import { transformSchema, validateData } from './validators';
 
+/*
+ * JSONSchemaFaker needs to be imported as CJS to avoid HMR and Webpack issues when importing @novu/framework
+ * in Next.js. See https://github.com/json-schema-faker/json-schema-faker/issues/796#issuecomment-2433335751
+ */
 const { JSONSchemaFaker } = require('json-schema-faker');
 
 /**

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -1,4 +1,3 @@
-import JSONSchemaFaker from 'json-schema-faker';
 import { Liquid } from 'liquidjs';
 import ora from 'ora';
 
@@ -39,6 +38,8 @@ import type {
 import { WithPassthrough } from './types/provider.types';
 import { EMOJI, log, sanitizeHtmlInObject, stringifyDataStructureWithSingleQuotes } from './utils';
 import { transformSchema, validateData } from './validators';
+
+const { JSONSchemaFaker } = require('json-schema-faker');
 
 /**
  * We want to respond with a consistent string value for preview


### PR DESCRIPTION
### What changed? Why was the change needed?

This dependency is causing issues when @novu/framework is used in Next.js while webpack is trying to load it via ESM.

See [here](https://github.com/json-schema-faker/json-schema-faker/issues/796#issuecomment-2433335751) and [here](https://github.com/json-schema-faker/json-schema-faker/blob/master/docs/DEPRECATED.md#deprecation-notice).