### PR TITLE
chore(api, worker): Remove redundant trigger `state` for Bridge API requests

### DIFF
--- a/apps/api/src/app/bridge/usecases/preview-step/preview-step.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/preview-step/preview-step.usecase.ts
@@ -35,13 +35,7 @@ export class PreviewStep {
     return {
       controls: command.controls || {},
       payload: command.payload || {},
-      state: [
-        {
-          stepId: 'trigger',
-          outputs: {},
-          state: { status: JobStatusEnum.COMPLETED },
-        },
-      ],
+      state: [],
       subscriber: command.subscriber || {},
       stepId: command.stepId,
       workflowId: command.workflowId,


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Remove redundant trigger `state` for Bridge API requests
  * The manual `'trigger'` step state has been deprecated since before canary releases and is no longer needed by Framework

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
