### PR TITLE
fix(framework): Explicitly exit workflow evaluation early after evaluating specified `stepId`

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -241,7 +241,6 @@
     "cross-fetch": "^4.0.0",
     "json-schema-to-ts": "^3.0.0",
     "liquidjs": "^10.13.1",
-    "ora": "^5.4.1",
     "sanitize-html": "^2.13.0"
   },
   "nx": {

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -1287,6 +1287,43 @@ describe('Novu Client', () => {
       expect(mockFn).toHaveBeenCalledTimes(0);
     });
 
+    it.only('should NOT log anything after executing the provided stepId', async () => {
+      const mockFn = vi.fn();
+      const spyConsoleLog = vi.spyOn(console, 'log');
+      const newWorkflow = workflow('test-workflow', async ({ step }) => {
+        await step.email('active-step-id', async () => ({ body: 'Test Body', subject: 'Subject' }));
+        await step.email('inactive-step-id', async () => {
+          mockFn();
+
+          return { body: 'Test Body', subject: 'Subject' };
+        });
+      });
+
+      client.addWorkflows([newWorkflow]);
+
+      const event: Event = {
+        action: PostActionEnum.EXECUTE,
+        workflowId: 'test-workflow',
+        stepId: 'active-step-id',
+        subscriber: {},
+        state: [],
+        payload: {},
+        controls: {},
+      };
+
+      await client.executeWorkflow(event);
+
+      // Wait for the conclusion promise to resolve.
+      await new Promise((resolve) => {
+        setTimeout(resolve);
+      });
+      /*
+       * Not the most robust test, but ensures that the last log call contains the duration,
+       * which is the last expected log call.
+       */
+      expect(spyConsoleLog.mock.lastCall).toEqual([expect.stringContaining('duration:')]);
+    });
+
     it('should evaluate code in steps after a skipped step', async () => {
       const mockFn = vi.fn();
       const newWorkflow = workflow('test-workflow', async ({ step }) => {

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -1287,7 +1287,7 @@ describe('Novu Client', () => {
       expect(mockFn).toHaveBeenCalledTimes(0);
     });
 
-    it.only('should NOT log anything after executing the provided stepId', async () => {
+    it('should NOT log anything after executing the provided stepId', async () => {
       const mockFn = vi.fn();
       const spyConsoleLog = vi.spyOn(console, 'log');
       const newWorkflow = workflow('test-workflow', async ({ step }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3396,9 +3396,6 @@ importers:
       liquidjs:
         specifier: ^10.13.1
         version: 10.13.1
-      ora:
-        specifier: ^5.4.1
-        version: 5.4.1
       sanitize-html:
         specifier: ^2.13.0
         version: 2.13.0
@@ -26654,8 +26651,8 @@ packages:
     engines: {node: '>= 14.0.0'}
     hasBin: true
 
-  mocha@10.7.3:
-    resolution: {integrity: sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==}
+  mocha@10.8.2:
+    resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
     engines: {node: '>= 14.0.0'}
     hasBin: true
 
@@ -34989,8 +34986,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -35191,8 +35188,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.575.0
@@ -35418,11 +35415,11 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@aws-sdk/client-sso-oidc@3.575.0':
+  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -35461,6 +35458,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.7.0
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)':
@@ -35845,11 +35843,11 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
+  '@aws-sdk/client-sts@3.575.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -35888,7 +35886,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.7.0
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.637.0':
@@ -36118,7 +36115,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
       '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
@@ -36429,7 +36426,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
@@ -36950,7 +36947,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -36959,7 +36956,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -62105,7 +62102,7 @@ snapshots:
 
   cypress-intellij-reporter@0.0.7:
     dependencies:
-      mocha: 10.7.3
+      mocha: 10.8.2
 
   cypress-network-idle@1.14.2: {}
 
@@ -71266,7 +71263,7 @@ snapshots:
       yargs-parser: 20.2.4
       yargs-unparser: 2.0.0
 
-  mocha@10.7.3:
+  mocha@10.8.2:
     dependencies:
       ansi-colors: 4.1.3
       browser-stdout: 1.3.1


### PR DESCRIPTION
### What changed? Why was the change needed?
* For workflows with 2 or more steps, internal framework client code was being executed after the executing the specified `stepId` which resulted in a misleading log of `Failed to hydrate stepId`. This change adds an explicit check (a [Promise cancellation token](https://stackoverflow.com/a/30235261)) to exit step evaluation early when the workflow is expected to conclude, preventing any further code execution including the misleading log. This approach is necessary whilst Node.js doesn't provide a native Promise cancellation API (which is a planned feature).
* `chore`: remove `ora` dependency which provided a nice local Studio DX, but ultimately doesn't provide enough value for the size of an extra package. It's dependencies may also be incompatible with some serverless environments like Cloudflare. It also simplifies the test assertion.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_BEFORE - the misleading `Failed to hydrate stepId` log is present_
```bash
 POST /api/novu?action=trigger&workflowId=in-app-wf 200 in 343ms

Executing workflowId: 'in-app-wf'
 ✔ Executed stepId: `custom-step`
✔ Executed workflowId: `in-app-wf`

  ✔ Executed workflowId: 'in-app-wf'
  ├ σ stepId: 'custom-step'
  ├ α action: 'execute'
  └ Δ duration: '23.15ms'

 POST /api/novu?action=execute&workflowId=in-app-wf&stepId=custom-step 200 in 27ms
 ✗ Failed to hydrate stepId: `inbox` # 👈❌ MISLEADING LOG HERE ❌👈

Executing workflowId: 'in-app-wf'
 → Hydrated stepId: `custom-step`
 ✔ Executed stepId: `inbox`
✔ Executed workflowId: `in-app-wf`

  ✔ Executed workflowId: 'in-app-wf'
  ├ σ stepId: 'inbox'
  ├ α action: 'execute'
  └ Δ duration: '8.95ms'

 POST /api/novu?action=execute&workflowId=in-app-wf&stepId=inbox 200 in 13ms
```

_AFTER - no misleading logs present_

```bash
 POST /api/novu?action=trigger&workflowId=in-app-wf 200 in 290ms

Executing workflowId: 'in-app-wf'
  ✔ Executed stepId: `custom-step`
✔ Executed workflowId: `in-app-wf`

  ✔ Executed workflowId: 'in-app-wf'
  ├ σ stepId: 'custom-step'
  ├ α action: 'execute'
  └ Δ duration: '24.18ms'

 POST /api/novu?action=execute&workflowId=in-app-wf&stepId=custom-step 200 in 29ms

Executing workflowId: 'in-app-wf'
  → Hydrated stepId: `custom-step`
  ✔ Executed stepId: `inbox`
✔ Executed workflowId: `in-app-wf`

  ✔ Executed workflowId: 'in-app-wf'
  ├ σ stepId: 'inbox'
  ├ α action: 'execute'
  └ Δ duration: '31.45ms'

 POST /api/novu?action=execute&workflowId=in-app-wf&stepId=inbox 200 in 46ms
```

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
