### PR TITLE
chore(js, react, nextjs): Release version `2.6.0`

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/js",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "repository": "https://github.com/novuhq/novu",
   "description": "Novu's JavaScript SDK for building custom inbox notification experiences",
   "author": "",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/nextjs",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "repository": "https://github.com/novuhq/novu",
   "description": "Novu's Next.js SDK for building custom inbox notification experiences",
   "author": "",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/react",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "repository": "https://github.com/novuhq/novu",
   "description": "Novu's React SDK for building custom inbox notification experiences",
   "author": "",


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Release version `2.6.0` for `<Inbox />` packages (`@novu/js`, `@novu/react`, `@novu/nextjs`)
  * 🚀 Global Preferences only displays channels that the Subscriber receives notifications on, ensuring the Subscriber only sees relevant channels, reducing UI noise
  * 🚀 Modifying the Subscriber's Global Preferences for a specified channel deletes their Workflow Preferences for that Channel, ensuring that Global Preferences take immediate priority. Subscriber's can modify their Workflow Preference again to take priority over the Global Preference

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
_Demonstrating that toggling Subscriber Global Preference removes the Workflow Preference, but Workflow Preference can later be updated to take priority. Global Preferences only shows relevant channels._

https://github.com/user-attachments/assets/20b25283-e8f2-478d-904a-d8b8d2fcdcce


<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
