### PR TITLE
fix(api): Fix 500 error in /identify

### DIFF
--- a/apps/api/src/app/analytics/analytics.controller.ts
+++ b/apps/api/src/app/analytics/analytics.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Headers } from '@nestjs/common';
+import { Body, Controller, Post, HttpCode, HttpStatus } from '@nestjs/common';
 import { SkipThrottle } from '@nestjs/throttler';
 import { AnalyticsService, ExternalApiAccessible, UserSession } from '@novu/application-generic';
 import { UserSessionData } from '@novu/shared';
@@ -35,8 +35,9 @@ export class AnalyticsController {
   @Post('/identify')
   @ExternalApiAccessible()
   @UserAuthentication()
-  async identifyUser(@Body() body: any, @UserSession() user: UserSessionData): Promise<any> {
-    return this.hubspotIdentifyFormUsecase.execute(
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async identifyUser(@Body() body: any, @UserSession() user: UserSessionData) {
+    await this.hubspotIdentifyFormUsecase.execute(
       HubspotIdentifyFormCommand.create({
         email: user.email as string,
         lastName: user.lastName,

--- a/apps/web/src/api/telemetry.ts
+++ b/apps/web/src/api/telemetry.ts
@@ -2,9 +2,7 @@ import { api } from './api.client';
 
 export const identifyUser = async (userData) => {
   try {
-    const response = await api.post('/v1/telemetry/identify', userData);
-
-    return response.data;
+    await api.post('/v1/telemetry/identify', userData);
   } catch (error) {
     console.error('Error identifying user:', error);
   }


### PR DESCRIPTION
### What changed? Why was the change needed?
Catch all 4XX and 5XX errors that might occur while communicating with Hubspot.

The Hubspot API response has been removed as it wasn't used in the API or the Dashboard.

### Screenshots

<img width="1241" alt="Screenshot 2024-10-31 at 12 25 32" src="https://github.com/user-attachments/assets/e0f781da-5a28-438d-82e6-ccbb226eed65">
