### PR TITLE
feat(api): make name required

### DIFF
--- a/apps/dashboard/src/components/create-workflow-button.tsx
+++ b/apps/dashboard/src/components/create-workflow-button.tsx
@@ -30,6 +30,7 @@ import { buildRoute, ROUTES } from '@/utils/routes';
 
 const formSchema = z.object({
   name: z.string().min(1, { message: 'Name is required' }),
+  workflowId: z.string(),
   tags: z
     .array(z.string().min(1))
     .max(8)
@@ -68,7 +69,7 @@ export const CreateWorkflowButton = (props: CreateWorkflowButtonProps) => {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: { description: '', name: '', tags: [] },
+    defaultValues: { description: '', workflowId: '', name: '', tags: [] },
   });
 
   return (
@@ -135,6 +136,22 @@ export const CreateWorkflowButton = (props: CreateWorkflowButtonProps) => {
                       </InputField>
                     </FormControl>
                     <FormMessage>Name is required</FormMessage>
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="workflowId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Identifier</FormLabel>
+                    <FormControl>
+                      <InputField>
+                        <Input placeholder="untitled" {...field} readOnly />
+                      </InputField>
+                    </FormControl>
+                    <FormMessage />
                   </FormItem>
                 )}
               />

--- a/apps/dashboard/src/components/create-workflow-button.tsx
+++ b/apps/dashboard/src/components/create-workflow-button.tsx
@@ -126,7 +126,6 @@ export const CreateWorkflowButton = (props: CreateWorkflowButtonProps) => {
                     <FormControl>
                       <InputField>
                         <Input
-                          placeholder="Untitled"
                           {...field}
                           onChange={(e) => {
                             field.onChange(e);
@@ -148,7 +147,7 @@ export const CreateWorkflowButton = (props: CreateWorkflowButtonProps) => {
                     <FormLabel>Identifier</FormLabel>
                     <FormControl>
                       <InputField>
-                        <Input placeholder="untitled" {...field} readOnly />
+                        <Input {...field} readOnly />
                       </InputField>
                     </FormControl>
                     <FormMessage />

--- a/apps/dashboard/src/components/create-workflow-button.tsx
+++ b/apps/dashboard/src/components/create-workflow-button.tsx
@@ -29,8 +29,7 @@ import { QueryKeys } from '@/utils/query-keys';
 import { buildRoute, ROUTES } from '@/utils/routes';
 
 const formSchema = z.object({
-  name: z.string(),
-  workflowId: z.string().regex(/^[a-z0-9-]+$/, 'Invalid identifier format. Must follow ^[a-z0-9-]+$'),
+  name: z.string().min(1, { message: 'Name is required' }),
   tags: z
     .array(z.string().min(1))
     .max(8)
@@ -69,7 +68,7 @@ export const CreateWorkflowButton = (props: CreateWorkflowButtonProps) => {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: { description: '', workflowId: '', name: '', tags: [] },
+    defaultValues: { description: '', name: '', tags: [] },
   });
 
   return (
@@ -135,23 +134,7 @@ export const CreateWorkflowButton = (props: CreateWorkflowButtonProps) => {
                         />
                       </InputField>
                     </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="workflowId"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Identifier</FormLabel>
-                    <FormControl>
-                      <InputField>
-                        <Input placeholder="untitled" {...field} />
-                      </InputField>
-                    </FormControl>
-                    <FormMessage>Must be unique and all lowercase ^[a-z0-9\-]+$</FormMessage>
+                    <FormMessage>Name is required</FormMessage>
                   </FormItem>
                 )}
               />

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow.tsx
@@ -74,7 +74,7 @@ export function ConfigureWorkflow() {
               <FormLabel>Workflow Identifier</FormLabel>
               <FormControl>
                 <InputField className="flex overflow-hidden pr-0">
-                  <Input placeholder="Untitled" {...field} />
+                  <Input placeholder="Untitled" {...field} readOnly />
                   <CopyButton
                     content={field.value}
                     className="rounded-md rounded-s-none border-b-0 border-r-0 border-t-0 text-neutral-400"

--- a/apps/dashboard/src/components/workflow-editor/steps/edit-step-sidebar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/edit-step-sidebar.tsx
@@ -20,7 +20,7 @@ export const EditStepSidebar = () => {
   const { reset, setError } = form;
 
   const { workflow, error } = useFetchWorkflow({
-    workflowId,
+    workflowSlug: workflowId,
   });
 
   const step = useMemo(() => workflow?.steps.find((el) => el._id === stepId), [stepId, workflow]);


### PR DESCRIPTION
### What changed? Why was the change needed?
Following our task to make the workflow name editable and keep the workflowId non-editable ([NV-4538](https://linear.app/novu/issue/NV-4538/treat-workflow-name-as-editable-non-unique-values)), we had two main changes to implement:

1. Make the workflow identifier read-only during creation.
2. Resolve a poor DX where, due to new auto-save and error handling in the client, meaningless workflowIds (like `untitled` or `untitled-asd8`) could be created if the workflow name was empty.

Here's how we addressed these issues:

1. After a quick sync with Pawel, we decided to remove the identifier field from the creation form altogether, since users don’t currently need to set it themselves.
2. To avoid storing meaningless identifiers like `untitled` or `untitled-asd8`, we now require users to provide a unique and meaningful workflow name during creation.

[Loom video overview](https://www.loom.com/share/a4d428543de849e38083a045f9c1cee3)

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
