### PR TITLE
chore(dashboard): InApp /docs redirect fix

### DIFF
--- a/apps/web/src/studio/components/workflows/node-view/WorkflowFloatingMenu.tsx
+++ b/apps/web/src/studio/components/workflows/node-view/WorkflowFloatingMenu.tsx
@@ -47,7 +47,7 @@ export const WorkflowFloatingMenu: FC<IWorkflowFloatingMenuProps> = ({ className
           <WorkflowFloatingMenuButton
             Icon={IconOutlineNotifications}
             tooltipLabel="View the In-app step documentation"
-            onClick={handleClick('inbox')}
+            onClick={handleClick('inApp')}
           />
           <WorkflowFloatingMenuButton
             Icon={IconOutlineEmail}


### PR DESCRIPTION
### What changed? Why was the change needed?
currently clicking on the in-app step takes to docs homepage, instead of inApp step page, this PR fixes it. 

