### PR TITLE
chore(dashboard): use step slug in the url

### DIFF
--- a/apps/dashboard/src/api/workflows.ts
+++ b/apps/dashboard/src/api/workflows.ts
@@ -55,14 +55,14 @@ export const updateWorkflow = async ({
 export const previewStep = async ({
   workflowSlug,
   payload,
-  stepId,
+  stepSlug,
 }: {
   workflowSlug: string;
-  stepId: string;
+  stepSlug: string;
   payload?: Record<string, unknown>;
 }): Promise<GeneratePreviewResponseDto> => {
   const { data } = await postV2<{ data: GeneratePreviewResponseDto }>(
-    `/workflows/${workflowSlug}/step/${stepId}/preview`,
+    `/workflows/${workflowSlug}/step/${stepSlug}/preview`,
     payload
   );
 

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -13,7 +13,7 @@ export type NodeData = {
   name?: string;
   content?: string;
   addStepIndex?: number;
-  stepId?: string;
+  stepSlug?: string;
   error?: string;
 };
 
@@ -45,7 +45,7 @@ export const EmailNode = ({ data }: NodeProps<NodeType>) => {
   const Icon = STEP_TYPE_TO_ICON[StepTypeEnum.EMAIL];
 
   return (
-    <Link to={`step/${data.stepId}`}>
+    <Link to={`step/${data.stepSlug}`}>
       <Node>
         <NodeHeader type={StepTypeEnum.EMAIL}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.EMAIL]}>
@@ -66,7 +66,7 @@ export const SmsNode = ({ data }: NodeProps<NodeType>) => {
   const Icon = STEP_TYPE_TO_ICON[StepTypeEnum.SMS];
 
   return (
-    <Link to={`step/${data.stepId}`}>
+    <Link to={`step/${data.stepSlug}`}>
       <Node>
         <NodeHeader type={StepTypeEnum.SMS}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.SMS]}>
@@ -87,7 +87,7 @@ export const InAppNode = ({ data }: NodeProps<NodeType>) => {
   const Icon = STEP_TYPE_TO_ICON[StepTypeEnum.IN_APP];
 
   return (
-    <Link to={buildRoute(ROUTES.CONFIGURE_STEP, { stepId: data.stepId ?? '' })}>
+    <Link to={buildRoute(ROUTES.CONFIGURE_STEP, { stepSlug: data.stepSlug ?? '' })}>
       <Node>
         <NodeHeader type={StepTypeEnum.IN_APP}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.IN_APP]}>
@@ -108,7 +108,7 @@ export const PushNode = ({ data }: NodeProps<NodeType>) => {
   const Icon = STEP_TYPE_TO_ICON[StepTypeEnum.PUSH];
 
   return (
-    <Link to={`step/${data.stepId}`}>
+    <Link to={`step/${data.stepSlug}`}>
       <Node>
         <NodeHeader type={StepTypeEnum.PUSH}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.PUSH]}>
@@ -129,7 +129,7 @@ export const ChatNode = ({ data }: NodeProps<NodeType>) => {
   const Icon = STEP_TYPE_TO_ICON[StepTypeEnum.CHAT];
 
   return (
-    <Link to={`step/${data.stepId}`}>
+    <Link to={`step/${data.stepSlug}`}>
       <Node>
         <NodeHeader type={StepTypeEnum.CHAT}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.CHAT]}>

--- a/apps/dashboard/src/components/workflow-editor/schema.ts
+++ b/apps/dashboard/src/components/workflow-editor/schema.ts
@@ -1,5 +1,5 @@
 import * as z from 'zod';
-import type { WorkflowTestDataResponseDto } from '@novu/shared';
+import type { StepResponseDto, WorkflowTestDataResponseDto } from '@novu/shared';
 import { StepTypeEnum } from '@/utils/enums';
 import { capitalize } from '@/utils/string';
 
@@ -30,6 +30,7 @@ export const workflowSchema = z.object({
         type: z.nativeEnum(StepTypeEnum),
         _id: z.string(),
         stepId: z.string(),
+        slug: z.literal<StepResponseDto['slug']>('_stp_'),
       })
       .passthrough()
   ),

--- a/apps/dashboard/src/components/workflow-editor/steps/edit-step-sidebar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/edit-step-sidebar.tsx
@@ -14,7 +14,7 @@ import { StepEditor } from './step-editor';
 const transitionSetting = { ease: [0.29, 0.83, 0.57, 0.99], duration: 0.4 };
 
 export const EditStepSidebar = () => {
-  const { workflowSlug = '', stepId = '' } = useParams<{ workflowSlug: string; stepId: string }>();
+  const { workflowSlug = '', stepSlug = '' } = useParams<{ workflowSlug: string; stepSlug: string }>();
   const navigate = useNavigate();
   const form = useForm<z.infer<typeof workflowSchema>>({ mode: 'onSubmit', resolver: zodResolver(workflowSchema) });
   const { reset, setError } = form;
@@ -23,7 +23,7 @@ export const EditStepSidebar = () => {
     workflowSlug,
   });
 
-  const step = useMemo(() => workflow?.steps.find((el) => el._id === stepId), [stepId, workflow]);
+  const step = useMemo(() => workflow?.steps.find((el) => el.slug === stepSlug), [stepSlug, workflow]);
 
   useLayoutEffect(() => {
     if (!workflow) {

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-preview.tsx
@@ -7,16 +7,16 @@ import { InAppRenderOutput } from '@novu/shared';
 
 export function InAppPreview() {
   const { previewStep, data } = usePreviewStep();
-  const { workflowSlug, stepId } = useParams<{
+  const { workflowSlug, stepSlug } = useParams<{
     workflowSlug: string;
-    stepId: string;
+    stepSlug: string;
   }>();
 
   useEffect(() => {
-    if (workflowSlug && stepId) {
-      previewStep({ workflowSlug, stepId });
+    if (workflowSlug && stepSlug) {
+      previewStep({ workflowSlug, stepSlug });
     }
-  }, [workflowSlug, stepId, previewStep]);
+  }, [workflowSlug, stepSlug, previewStep]);
 
   return (
     <div className="border-foreground-200 to-background/90 pointer-events-none relative left-0 top-0 flex h-full w-full flex-col gap-2 rounded-xl border border-dashed px-2">

--- a/apps/dashboard/src/components/workflow-editor/steps/use-step.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/use-step.tsx
@@ -5,8 +5,8 @@ import * as z from 'zod';
 import { workflowSchema } from '../schema';
 
 export const useStep = () => {
-  const { stepId = '' } = useParams<{
-    stepId: string;
+  const { stepSlug = '' } = useParams<{
+    stepSlug: string;
   }>();
 
   const { watch, control } = useFormContext<z.infer<typeof workflowSchema>>();
@@ -14,17 +14,17 @@ export const useStep = () => {
 
   const step = useMemo(() => {
     if (Array.isArray(steps)) {
-      return steps.find((message) => message._id === stepId);
+      return steps.find((el) => el.slug === stepSlug);
     }
     return undefined;
-  }, [stepId, steps]);
+  }, [stepSlug, steps]);
 
   const stepIndex = useMemo(() => {
     if (Array.isArray(steps)) {
-      return steps.findIndex((message) => message._id === stepId);
+      return steps.findIndex((el) => el.slug === stepSlug);
     }
     return -1;
-  }, [stepId, steps]);
+  }, [stepSlug, steps]);
 
   return {
     step,

--- a/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
@@ -70,7 +70,7 @@ const mapStepToNode = (
       name: step.name,
       content,
       addStepIndex,
-      stepId: step._id,
+      stepSlug: step.slug,
       error,
     },
     type: step.type,

--- a/apps/dashboard/src/components/workflow-editor/workflow-editor-provider.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-editor-provider.tsx
@@ -34,6 +34,7 @@ const STEP_NAME_BY_TYPE: Record<StepTypeEnum, string> = {
 const createStep = (type: StepTypeEnum): Step => ({
   name: STEP_NAME_BY_TYPE[type],
   stepId: '',
+  slug: '_stp_',
   type,
   _id: crypto.randomUUID(),
 });

--- a/apps/dashboard/src/context/environment/environment-provider.tsx
+++ b/apps/dashboard/src/context/environment/environment-provider.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-
-import { EnvironmentEnum, type IEnvironment } from '@novu/shared';
+import { type IEnvironment } from '@novu/shared';
 
 import { getEnvironmentId, saveEnvironmentId } from '@/utils/environment';
 import { buildRoute, ROUTES } from '@/utils/routes';
@@ -22,7 +21,7 @@ function selectEnvironment(environments: IEnvironment[], selectedEnvironmentSlug
 
   // Or pick the development environment
   if (!environment) {
-    environment = environments.find((env) => env.name === EnvironmentEnum.DEVELOPMENT);
+    environment = environments.find((env) => env.name === DEVELOPMENT_ENVIRONMENT);
   }
 
   if (!environment) {

--- a/apps/dashboard/src/hooks/use-preview-step.ts
+++ b/apps/dashboard/src/hooks/use-preview-step.ts
@@ -5,14 +5,14 @@ import { previewStep } from '@/api/workflows';
 export const usePreviewStep = ({ onSuccess }: { onSuccess?: (data: GeneratePreviewResponseDto) => void } = {}) => {
   const { mutateAsync, isPending, error, data } = useMutation({
     mutationFn: async ({
-      stepId,
+      stepSlug,
       workflowSlug,
       payload,
     }: {
-      stepId: string;
+      stepSlug: string;
       workflowSlug: string;
       payload?: Record<string, unknown>;
-    }) => previewStep({ stepId, workflowSlug, payload }),
+    }) => previewStep({ stepSlug, workflowSlug, payload }),
     onSuccess,
   });
 

--- a/apps/dashboard/src/utils/routes.ts
+++ b/apps/dashboard/src/utils/routes.ts
@@ -7,8 +7,8 @@ export const ROUTES = {
   WORKFLOWS: '/env/:environmentSlug/workflows',
   EDIT_WORKFLOW: '/env/:environmentSlug/workflows/:workflowSlug',
   TEST_WORKFLOW: '/env/:environmentSlug/workflows/:workflowSlug/test',
-  CONFIGURE_STEP: 'steps/:stepId',
-  EDIT_STEP: 'steps/:stepId/edit',
+  CONFIGURE_STEP: 'steps/:stepSlug',
+  EDIT_STEP: 'steps/:stepSlug/edit',
 };
 
 export const buildRoute = (route: string, params: Record<string, string>) => {

--- a/apps/dashboard/src/utils/types.ts
+++ b/apps/dashboard/src/utils/types.ts
@@ -29,7 +29,7 @@ export type RuntimeIssue = {
 };
 
 // TODO: update this when the API types are updated
-export type Step = Pick<StepResponseDto, 'name' | 'type' | '_id' | 'stepId'> & {
+export type Step = Pick<StepResponseDto, 'name' | 'type' | '_id' | 'stepId' | 'slug'> & {
   issues?: {
     body: Record<string, RuntimeIssue[]>;
     control: Record<string, RuntimeIssue[]>;


### PR DESCRIPTION
### What changed? Why was the change needed?
Dashboard: use the step slug in the URL.

### Screenshots


https://github.com/user-attachments/assets/137eb6aa-587f-4fe8-94ba-6c1abc9071dc

