### PR TITLE
fix(web): show organization verified domains

### DIFF
--- a/apps/web/src/ee/clerk/providers/ClerkProvider.tsx
+++ b/apps/web/src/ee/clerk/providers/ClerkProvider.tsx
@@ -197,9 +197,6 @@ const CLERK_MODAL_ELEMENT = {
   pageScrollBox: {
     padding: '0',
   },
-  profileSectionItemList__organizationDomains: {
-    display: 'none',
-  },
   userButtonPopoverMain: {
     backgroundColor: 'var(--nv-colors-surface-panel-subsection)',
     boxShadow: 'unset !important',


### PR DESCRIPTION
### What changed? Why was the change needed?
Not sure why it was hidden.

![image](https://github.com/user-attachments/assets/5c86c6d6-6251-4f0f-a2a4-a8de7bbb2d46)

![image](https://github.com/user-attachments/assets/be9ed56e-8302-4d6a-8287-fd8b7fe8250a)
