### PR TITLE
fix(web): Display billing cycle dates in event usage.

### DIFF
--- a/apps/web/src/ee/billing/components/SubscriptionProvider.tsx
+++ b/apps/web/src/ee/billing/components/SubscriptionProvider.tsx
@@ -1,6 +1,8 @@
 import React, { useContext } from 'react';
-import { useSubscription, UseSubscriptionType } from '../hooks/useSubscription';
 import { ApiServiceLevelEnum } from '@novu/shared';
+import { useSubscription, UseSubscriptionType } from '../hooks/useSubscription';
+
+export type { UseSubscriptionType } from '../hooks/useSubscription';
 
 const SubscriptionContext = React.createContext<UseSubscriptionType>({
   isLoading: false,


### PR DESCRIPTION
### What changed? Why was the change needed?
Display billing cycle dates

### Screenshots
<img width="1061" alt="Screenshot 2024-11-05 at 22 52 49" src="https://github.com/user-attachments/assets/3f0fb661-d53b-4d19-bf57-7973f031f004">
