### PR TITLE
fix(api): Remove double logging of Bridge errors

### DIFF
--- a/apps/api/src/app/bridge/bridge.controller.ts
+++ b/apps/api/src/app/bridge/bridge.controller.ts
@@ -50,13 +50,11 @@ export class BridgeController {
   @Get('/status')
   @UseGuards(UserAuthGuard)
   async health(@UserSession() user: UserSessionData) {
-    const result = await this.getBridgeStatus.execute(
+    return this.getBridgeStatus.execute(
       GetBridgeStatusCommand.create({
         environmentId: user.environmentId,
       })
     );
-
-    return result;
   }
 
   @Post('/preview/:workflowId/:stepId')

--- a/apps/api/src/app/bridge/usecases/get-bridge-status/get-bridge-status.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/get-bridge-status/get-bridge-status.usecase.ts
@@ -11,25 +11,14 @@ export class GetBridgeStatus {
   constructor(private executeBridgeRequest: ExecuteBridgeRequest) {}
 
   async execute(command: GetBridgeStatusCommand): Promise<HealthCheck> {
-    try {
-      const response = (await this.executeBridgeRequest.execute(
-        ExecuteBridgeRequestCommand.create({
-          environmentId: command.environmentId,
-          action: GetActionEnum.HEALTH_CHECK,
-          workflowOrigin: WorkflowOriginEnum.EXTERNAL,
-          statelessBridgeUrl: command.statelessBridgeUrl,
-          retriesLimit: 1,
-        })
-      )) as ExecuteBridgeRequestDto<GetActionEnum.HEALTH_CHECK>;
-
-      return response;
-    } catch (err: any) {
-      Logger.error(
-        `Failed to verify Bridge endpoint for environment ${command.environmentId} with error: ${(err as Error).message || err}`,
-        (err as Error).stack,
-        LOG_CONTEXT
-      );
-      throw err;
-    }
+    return (await this.executeBridgeRequest.execute(
+      ExecuteBridgeRequestCommand.create({
+        environmentId: command.environmentId,
+        action: GetActionEnum.HEALTH_CHECK,
+        workflowOrigin: WorkflowOriginEnum.EXTERNAL,
+        statelessBridgeUrl: command.statelessBridgeUrl,
+        retriesLimit: 1,
+      })
+    )) as ExecuteBridgeRequestDto<GetActionEnum.HEALTH_CHECK>;
   }
 }


### PR DESCRIPTION
### What changed? Why was the change needed?
We log once in ExecuteBridgeRequest, so there is no need to log the error again in `get-bridge-status.usecase.ts`

### Screenshots
The fix should remove the log entry in the red-dotted box
<img width="1232" alt="Screenshot 2024-11-05 at 23 34 27" src="https://github.com/user-attachments/assets/a17c13a7-43d2-4766-b8b5-71a5a1970338">

