### PR TITLE
fix(framework): Stop validating controls for non previewed step

### DIFF
--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -1350,7 +1350,15 @@ describe('Novu Client', () => {
         workflowId: 'test-workflow',
         stepId: 'active-step-id',
         subscriber: {},
-        state: [],
+        state: [
+          {
+            stepId: 'skipped-step-id',
+            outputs: {},
+            state: {
+              status: 'success',
+            },
+          },
+        ],
         payload: {},
         controls: {},
       };
@@ -1399,6 +1407,65 @@ describe('Novu Client', () => {
     it('should preview workflow successfully when action is preview', async () => {
       const newWorkflow = workflow('test-workflow', async ({ step }) => {
         await step.email('send-email', async () => ({ body: 'Test Body', subject: 'Subject' }));
+      });
+
+      client.addWorkflows([newWorkflow]);
+
+      const event: Event = {
+        action: PostActionEnum.PREVIEW,
+        workflowId: 'test-workflow',
+        stepId: 'send-email',
+        subscriber: {},
+        state: [],
+        payload: {},
+        controls: {},
+      };
+
+      const executionResult = await client.executeWorkflow(event);
+
+      expect(executionResult).toBeDefined();
+      expect(executionResult.outputs).toBeDefined();
+      if (!executionResult.outputs) throw new Error('executionResult.outputs is undefined');
+
+      const { body } = executionResult.outputs;
+      expect(body).toBe('Test Body');
+
+      const { subject } = executionResult.outputs;
+      expect(subject).toBe('Subject');
+
+      expect(executionResult.providers).toEqual({});
+
+      const { metadata } = executionResult;
+      expect(metadata.status).toBe('success');
+      expect(metadata.error).toBe(false);
+      expect(metadata.duration).toEqual(expect.any(Number));
+    });
+
+    it('should preview workflow successfully when action is preview and a non-first step is targeted', async () => {
+      const newWorkflow = workflow('test-workflow', async ({ step }) => {
+        await step.delay(
+          'delay-step',
+          async (controls) => ({
+            amount: controls.amount,
+            unit: controls.unit,
+          }),
+          {
+            controlSchema: {
+              type: 'object',
+              properties: {
+                amount: { type: 'number' },
+                unit: {
+                  type: 'string',
+                  enum: ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months'],
+                },
+              },
+              required: ['amount', 'unit'],
+              additionalProperties: false,
+            } as const,
+          }
+        );
+
+        await step.inApp('send-email', async () => ({ body: 'Test Body', subject: 'Subject' }));
       });
 
       client.addWorkflows([newWorkflow]);

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -1441,7 +1441,7 @@ describe('Novu Client', () => {
       expect(metadata.duration).toEqual(expect.any(Number));
     });
 
-    it('should preview workflow successfully when action is preview and a non-first step is targeted', async () => {
+    it('should preview a non-first step in a workflow successfully when action is preview', async () => {
       const newWorkflow = workflow('test-workflow', async ({ step }) => {
         await step.delay(
           'delay-step',
@@ -1465,7 +1465,7 @@ describe('Novu Client', () => {
           }
         );
 
-        await step.inApp('send-email', async () => ({ body: 'Test Body', subject: 'Subject' }));
+        await step.inApp('send-in-app', async () => ({ body: 'Test Body', subject: 'Subject' }));
       });
 
       client.addWorkflows([newWorkflow]);
@@ -1473,7 +1473,7 @@ describe('Novu Client', () => {
       const event: Event = {
         action: PostActionEnum.PREVIEW,
         workflowId: 'test-workflow',
-        stepId: 'send-email',
+        stepId: 'send-in-app',
         subscriber: {},
         state: [],
         payload: {},

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -31,6 +31,7 @@ import type {
   HealthCheck,
   Schema,
   Skip,
+  State,
   ValidationError,
   Workflow,
 } from './types';
@@ -277,25 +278,27 @@ export class Client {
       }
 
       const step = this.getStep(event.workflowId, stepId);
-      const controls = await this.createStepControls(step, event);
       const isPreview = event.action === PostActionEnum.PREVIEW;
 
-      if (!isPreview && (await this.shouldSkip(options?.skip as typeof step.options.skip, controls))) {
-        if (stepId === event.stepId) {
-          // Only set the result when the step is the current step.
+      // Only evaluate a skip condition when the step is the current step and not in preview mode.
+      if (!isPreview && stepId === event.stepId) {
+        const controls = await this.createStepControls(step, event);
+        const shouldSkip = await this.shouldSkip(options?.skip as typeof step.options.skip, controls);
+
+        if (shouldSkip) {
           setResult({
             options: { skip: true },
             outputs: {},
             providers: {},
           });
-        }
 
-        /*
-         * Return an empty object for results when a step is skipped.
-         * TODO: fix typings when `skip` is specified to return `Partial<T_Result>`
-         */
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return {} as any;
+          /*
+           * Return an empty object for results when a step is skipped.
+           * TODO: fix typings when `skip` is specified to return `Partial<T_Result>`
+           */
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return {} as any;
+        }
       }
 
       const previewStepHandler = this.previewStep.bind(this);

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -31,7 +31,6 @@ import type {
   HealthCheck,
   Schema,
   Skip,
-  State,
   ValidationError,
   Workflow,
 } from './types';


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Due to some code misconfiguration for `skip` step logical execution, non-previewed steps were having controls validated. This was a bug as no controls are ever supplied to the non-executed step. This change removes controls validation for non-previewed steps

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
