### PR TITLE
feat(framework): Add support for specifying mock results

### DIFF
--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -728,7 +728,14 @@ export class Client {
         const suppliedResult = this.getStepState(event, step.stepId);
 
         if (suppliedResult) {
-          mockResult = suppliedResult.outputs;
+          mockResult = await this.validate(
+            suppliedResult.outputs,
+            step.results.unknownSchema,
+            'step',
+            'result',
+            event.workflowId,
+            step.stepId
+          );
         } else {
           mockResult = this.mock(step.results.schema);
         }

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -31,6 +31,7 @@ import type {
   HealthCheck,
   Schema,
   Skip,
+  State,
   ValidationError,
   Workflow,
 } from './types';
@@ -634,7 +635,7 @@ export class Client {
       }
     } else {
       try {
-        const result = event.state.find((state) => state.stepId === step.stepId);
+        const result = this.getStepState(event, step.stepId);
 
         if (result) {
           const validatedOutput = await this.validate(
@@ -723,7 +724,14 @@ export class Client {
           providers: await this.executeProviders(event, step, validatedOutput),
         };
       } else {
-        const mockResult = this.mock(step.results.schema);
+        let mockResult: Record<string, unknown>;
+        const suppliedResult = this.getStepState(event, step.stepId);
+
+        if (suppliedResult) {
+          mockResult = suppliedResult.outputs;
+        } else {
+          mockResult = this.mock(step.results.schema);
+        }
 
         console.log(`  ${EMOJI.MOCK} Mocked stepId: \`${step.stepId}\``);
 
@@ -741,6 +749,10 @@ export class Client {
         throw new StepExecutionFailedError(step.stepId, event.action, error);
       }
     }
+  }
+
+  private getStepState(event: Event, stepId: string): State | undefined {
+    return event.state.find((state) => state.stepId === stepId);
   }
 
   private getStepCode(workflowId: string, stepId: string): CodeResult {


### PR DESCRIPTION
### What changed? Why was the change needed?
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
* Add support for specifying mock results during `action=preview`
  * Previously, mock results were only generated from the JSON schema for the step type. This change allows for specification of a state object to flexibly and accurately display preview content that depends on other step results

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->
N/A, see new tests in PR

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
