### PR TITLE
fix(framework): Prevent adding duplicate workflows

### DIFF
--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -316,6 +316,14 @@ describe('Novu Client', () => {
       expect(stepChat.providers[0].code).toContain(`type: "plain_text"`);
       expect(stepChat.providers[0].code).toContain(`text: "Pretty Header"`);
     });
+
+    it('should not add duplicate workflows when adding the same workflow in parallel', async () => {
+      const newWorkflow = workflow('test-workflow', async () => {});
+      await Promise.all([client.addWorkflows([newWorkflow]), client.addWorkflows([newWorkflow])]);
+
+      const discovery = client.discover();
+      expect(discovery.workflows).toHaveLength(2);
+    });
   });
 
   describe('previewWorkflow method', () => {


### PR DESCRIPTION
### What changed? Why was the change needed?
* Add locking mechanism to prevent adding duplicate workflows in `Client.addWorkflows`
* Convert `discoveredWorkflows` internal `Client` attribute to a `Map` for more performant lookups of existing workflows

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
_Before - duplicate workflows could be added if more than 1 Local Studio tab is open in Browser during hot reload_
![image](https://github.com/user-attachments/assets/9fd24a34-4737-4756-8622-54bc5f375f8a)

_After - duplicate workflows are not added_
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/df662a40-ddf6-4647-a3ac-fc1b3b447d2e">

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
