### PR TITLE
docs(nextjs): Add backticks to readme `<Inbox />` usage

### DIFF
--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -1,6 +1,6 @@
-# Novu's NextJS SDK for <Inbox />.
+# Novu's NextJS SDK for `<Inbox />`.
 
-Novu provides the `@novu/nextjs` library that helps to add a fully functioning <Inbox /> to your web application in minutes.
+Novu provides the `@novu/nextjs` library that helps to add a fully functioning `<Inbox />` to your web application in minutes.
 See full documentation [here](https://docs.novu.co/inbox/react/get-started).
 
 ## Installation


### PR DESCRIPTION
### What changed? Why was the change needed?
* Add backticks to readme `<Inbox />` usage to fix formatting on NPM readme
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
_Fixed rendering of `<Inbox />`_
<img width="696" alt="image" src="https://github.com/user-attachments/assets/c1679ed4-c735-42e5-97c2-43642117f3a9">


<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
