### PR TITLE
fix(dashboard): promote toast env name

### DIFF
--- a/apps/dashboard/src/components/promote-workflow/promote-success-toast.tsx
+++ b/apps/dashboard/src/components/promote-workflow/promote-success-toast.tsx
@@ -1,20 +1,21 @@
 import { Button } from '@/components/primitives/button';
 import { ToastClose, ToastIcon } from '@/components/primitives/sonner';
 import { useEnvironment } from '@/context/environment/hooks';
-import { WorkflowListResponseDto } from '@novu/shared';
+import { IEnvironment, WorkflowResponseDto } from '@novu/shared';
 import { RiArrowRightSLine } from 'react-icons/ri';
 
 interface PromoteSuccessToastProps {
-  workflow: WorkflowListResponseDto;
+  workflow: WorkflowResponseDto;
+  environment?: IEnvironment;
   onClose: () => void;
 }
 
-export function PromoteSuccessToast({ workflow, onClose }: PromoteSuccessToastProps) {
-  const { switchEnvironment, oppositeEnvironment } = useEnvironment();
+export function PromoteSuccessToast({ workflow, environment, onClose }: PromoteSuccessToastProps) {
+  const { switchEnvironment } = useEnvironment();
 
   function onSwitchEnvironmentClick() {
     onClose();
-    switchEnvironment(oppositeEnvironment?.slug || '');
+    switchEnvironment(environment?.slug || '');
   }
 
   return (
@@ -22,14 +23,14 @@ export function PromoteSuccessToast({ workflow, onClose }: PromoteSuccessToastPr
       <ToastIcon variant="default" />
       <div className="flex flex-1 flex-col items-start gap-2.5">
         <div className="flex flex-col items-start justify-center gap-1 self-stretch">
-          <div className="text-foreground-950 text-sm font-medium">Workflow synced to {oppositeEnvironment?.name}</div>
+          <div className="text-foreground-950 text-sm font-medium">Workflow synced to {environment?.name}</div>
           <div className="text-foreground-600 text-sm">
-            Workflow '{workflow.name}' has been successfully synced to {oppositeEnvironment?.name}.
+            Workflow '{workflow.name}' has been successfully synced to {environment?.name}.
           </div>
         </div>
         <div className="flex items-center justify-end gap-2 self-stretch">
           <Button variant="ghost" size="sm" className="text-destructive gap-1" onClick={onSwitchEnvironmentClick}>
-            Switch to production
+            Switch to {environment?.name}
             <RiArrowRightSLine />
           </Button>
         </div>

--- a/apps/dashboard/src/hooks/use-sync-workflow.tsx
+++ b/apps/dashboard/src/hooks/use-sync-workflow.tsx
@@ -4,7 +4,13 @@ import { ConfirmationModal } from '@/components/confirmation-modal';
 import { showToast } from '@/components/primitives/sonner-helpers';
 import { PromoteSuccessToast } from '@/components/promote-workflow/promote-success-toast';
 import { useEnvironment } from '@/context/environment/hooks';
-import { WorkflowListResponseDto, WorkflowOriginEnum, WorkflowResponseDto, WorkflowStatusEnum } from '@novu/shared';
+import {
+  IEnvironment,
+  WorkflowListResponseDto,
+  WorkflowOriginEnum,
+  WorkflowResponseDto,
+  WorkflowStatusEnum,
+} from '@novu/shared';
 import { useMutation } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
@@ -55,14 +61,14 @@ export function useSyncWorkflow(workflow: WorkflowListResponseDto) {
     }
   };
 
-  const onSyncSuccess = () => {
+  const onSyncSuccess = (workflow: WorkflowResponseDto, environment?: IEnvironment) => {
     toast.dismiss(loadingToast);
     setIsLoading(false);
 
     return showToast({
       variant: 'lg',
       className: 'gap-3',
-      children: ({ close }) => <PromoteSuccessToast workflow={workflow} onClose={close} />,
+      children: ({ close }) => <PromoteSuccessToast workflow={workflow} environment={environment} onClose={close} />,
       options: {
         position: 'bottom-right',
       },
@@ -82,12 +88,12 @@ export function useSyncWorkflow(workflow: WorkflowListResponseDto) {
     mutationFn: async () =>
       syncWorkflow(workflow._id, {
         targetEnvironmentId: oppositeEnvironment?._id || '',
-      }).then((res) => res.data),
+      }).then((res) => ({ workflow: res.data, environment: oppositeEnvironment || undefined })),
     onMutate: () => {
       setIsLoading(true);
       loadingToast = toast.loading('Syncing workflow...');
     },
-    onSuccess: onSyncSuccess,
+    onSuccess: ({ workflow, environment }) => onSyncSuccess(workflow, environment),
     onError: onSyncError,
   });
 

--- a/apps/dashboard/src/hooks/use-sync-workflow.tsx
+++ b/apps/dashboard/src/hooks/use-sync-workflow.tsx
@@ -4,13 +4,8 @@ import { ConfirmationModal } from '@/components/confirmation-modal';
 import { showToast } from '@/components/primitives/sonner-helpers';
 import { PromoteSuccessToast } from '@/components/promote-workflow/promote-success-toast';
 import { useEnvironment } from '@/context/environment/hooks';
-import {
-  IEnvironment,
-  WorkflowListResponseDto,
-  WorkflowOriginEnum,
-  WorkflowResponseDto,
-  WorkflowStatusEnum,
-} from '@novu/shared';
+import type { IEnvironment, WorkflowListResponseDto, WorkflowResponseDto } from '@novu/shared';
+import { WorkflowOriginEnum, WorkflowStatusEnum } from '@novu/shared';
 import { useMutation } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';


### PR DESCRIPTION
### What changed? Why was the change needed?

Ties env name in sync toast to the actual workflow that was synced rather than the current environment.

This fixes an issue where:
1. wf was synced to e.g. prod
2. toast showed "synced to prod"
3. user switched to dev
4. toast changed labels to "dev"