### PR TITLE
fix(dashboard): align heading with the gutter

### DIFF
--- a/apps/dashboard/src/components/dashboard-layout.tsx
+++ b/apps/dashboard/src/components/dashboard-layout.tsx
@@ -18,7 +18,7 @@ export const DashboardLayout = ({
       <div className="relative flex h-full w-full">
         <SideNavigation />
         <div className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden">
-          <HeaderNavigation startItems={headerStartItems} className="pt-4" />
+          <HeaderNavigation startItems={headerStartItems} className="px-6 pt-4" />
 
           <div className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden">{children}</div>
         </div>


### PR DESCRIPTION
### What changed? Why was the change needed?

Left and right header alignment.

![image](https://github.com/user-attachments/assets/10967e08-ed11-40ef-af0c-bb71f65770bf)

![image](https://github.com/user-attachments/assets/727d3130-64ba-4c53-b73f-1cc7bbbd0050)