### PR TITLE
fix(web, dashboard): Remove additional quotes in PHP code snippet

### DIFF
--- a/apps/dashboard/src/utils/code-snippets.ts
+++ b/apps/dashboard/src/utils/code-snippets.ts
@@ -93,9 +93,10 @@ const transformJsonToPhpArray = (data: Record<string, unknown>, indentLevel = 4)
   const obj = entries
     .map(([key, value]) => {
       return `
-${indent}'${key}' => '${JSON.stringify(value)}',`;
+${indent}'${key}' => ${JSON.stringify(value)},`;
     })
-    .join('');
+    .join('')
+    .replace(/"/g, "'");
 
   return `${obj}${Object.keys(data).length > 0 ? `\n${new Array(indentLevel - 4).fill(' ').join('')}` : ''}`;
 };

--- a/apps/web/src/utils/codeSnippets.ts
+++ b/apps/web/src/utils/codeSnippets.ts
@@ -79,9 +79,10 @@ const transformJsonToPhpArray = (data: Record<string, unknown>, indentLevel = 4)
   const obj = entries
     .map(([key, value]) => {
       return `
-${indent}'${key}' => '${JSON.stringify(value)}',`;
+${indent}'${key}' => ${JSON.stringify(value)},`;
     })
-    .join('');
+    .join('')
+    .replace(/"/g, "'");
 
   return `${obj}${Object.keys(data).length > 0 ? `\n${new Array(indentLevel - 4).fill(' ').join('')}` : ''}`;
 };


### PR DESCRIPTION
### What changed? Why was the change needed?
* Remove additional quotes in PHP code snippet

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
_BEFORE - extra quotes shown in `payload` and `subscriber` object_
![image](https://github.com/user-attachments/assets/430ba017-0b8e-482f-b31e-7c2a9e2de1a2)

_AFTER - No extra quotes present in `payload` and `subscriber` object_
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/2078b690-0688-4d07-b463-a689b1245668">

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

closes https://github.com/novuhq/novu/issues/6748