### PR TITLE
chore(framework, shared, nextjs): Release new versions

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/cjs/index.d.cts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/nextjs",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "repository": "https://github.com/novuhq/novu",
   "description": "Novu's Next.js SDK for building custom inbox notification experiences",
   "author": "",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/shared",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "",
   "scripts": {
     "start": "npm run start:dev",


### PR DESCRIPTION
### What changed? Why was the change needed?
* Release `@novu/framework`@2.4.0
  * 🚀 Features
    * Bundle native ESM + CJS builds
    * Support Next.js 15, including Turbopack dev (`next dev --turbo`)
    * Support a single package import for all Web Frameworks (for example in Next.js: `import { workflow, serve } from '@novu/framework/next`)
    * Allow specification of mock data for step results
  * 🐛 Bug fixes
    * Ensure missing schemas infer a `Record<string, unknown>` type for corresponding data to enforce consumer-type strictness.
    * Remove erroneous "Hydrate step failed" error log when previewing steps with more than one step
    * Replace all computed property keys for type inference with static declarations to improve compiler performance
    * Stop validating controls for non-previewed step to prevent incorrect validation message
    * Stop logging discovery of `workflow`s that weren't included in the `serve` function
    * Prevent specification of payload and control schemas for primitive types, allowing only object types to be specified
* Release `@novu/shared`@2.4.1
  * remove all dependencies
* Release `@novu/nextjs`@2.6.1
  * Fix readme title

closes https://github.com/novuhq/novu/issues/6332
closes https://github.com/novuhq/novu/issues/6701
closes https://github.com/novuhq/novu/issues/6881

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
