### PR TITLE
feat(dashboard): styling for read-only input fields

### DIFF
--- a/apps/dashboard/src/components/primitives/input.tsx
+++ b/apps/dashboard/src/components/primitives/input.tsx
@@ -5,7 +5,37 @@ import { cva, VariantProps } from 'class-variance-authority';
 import { inputVariants } from '@/components/primitives/variants';
 
 const inputFieldVariants = cva(
-  'text-foreground-950 flex w-full flex-nowrap items-center gap-1.5 rounded-md border bg-transparent transition-colors focus-within:outline-none focus-visible:outline-none hover:bg-neutral-50 has-[input:disabled]:cursor-not-allowed has-[input:disabled]:opacity-50 has-[input[value=""]]:text-foreground-400 has-[input:disabled]:bg-neutral-alpha-100 has-[input:disabled]:text-foreground-300',
+  [
+    // Base styles
+    'text-foreground-950',
+    'flex w-full flex-nowrap',
+    'items-center gap-1.5',
+    'rounded-md border',
+    'bg-transparent',
+    'transition-colors',
+
+    // Focus states
+    'focus-within:outline-none',
+    'focus-visible:outline-none',
+
+    // Hover state
+    'hover:bg-neutral-50',
+
+    // Disabled state
+    'has-[input:disabled]:cursor-not-allowed',
+    'has-[input:disabled]:text-foreground-300',
+    'has-[input:disabled]:bg-neutral-alpha-100',
+    'has-[input:disabled]:opacity-50',
+
+    // Empty value state
+    'has-[input[value=""]]:text-foreground-400',
+
+    // Read-only state
+    'has-[input:read-only]:text-foreground-700',
+    'has-[input:read-only]:bg-neutral-alpha-100',
+    'has-[input:read-only]:opacity-70',
+    'has-[input:read-only]:border-neutral-alpha-200',
+  ].join(' '),
   {
     variants: {
       size: {


### PR DESCRIPTION
### What changed? Why was the change needed?

Before:

![image](https://github.com/user-attachments/assets/0dd94ab2-9e42-4ec5-a2c7-7b0b57feb03d)

After:

![image](https://github.com/user-attachments/assets/12ac9c52-5151-4dae-8cd8-8f58a8494e36)
