### PR TITLE
refactor(api): remove $or query for hash on env

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/generate-unique-api-key/generate-unique-api-key.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/generate-unique-api-key/generate-unique-api-key.usecase.ts
@@ -31,7 +31,6 @@ export class GenerateUniqueApiKey {
     const hashedApiKey = createHash('sha256').update(apiKey).digest('hex');
 
     const environment = await this.environmentRepository.findByApiKey({
-      key: apiKey,
       hash: hashedApiKey,
     });
 

--- a/libs/application-generic/src/services/auth/community.auth.service.ts
+++ b/libs/application-generic/src/services/auth/community.auth.service.ts
@@ -364,7 +364,6 @@ export class CommunityAuthService implements IAuthService {
     const hashedApiKey = createHash('sha256').update(apiKey).digest('hex');
 
     const environment = await this.environmentRepository.findByApiKey({
-      key: apiKey,
       hash: hashedApiKey,
     });
 
@@ -373,16 +372,7 @@ export class CommunityAuthService implements IAuthService {
       return { error: 'API Key not found' };
     }
 
-    let key = environment.apiKeys.find((i) => i.hash === hashedApiKey);
-
-    if (!key) {
-      /*
-       * backward compatibility - delete after encrypt-api-keys-migration execution
-       * find by decrypted key if key not found, because of backward compatibility
-       * use-case: findByApiKey found by decrypted key, so we need to validate by decrypted key
-       */
-      key = environment.apiKeys.find((i) => i.key === apiKey);
-    }
+    const key = environment.apiKeys.find((i) => i.hash === hashedApiKey);
 
     if (!key) {
       return { error: 'API Key not found' };

--- a/libs/application-generic/src/services/auth/community.auth.service.ts
+++ b/libs/application-generic/src/services/auth/community.auth.service.ts
@@ -350,12 +350,6 @@ export class CommunityAuthService implements IAuthService {
     );
   }
 
-  @CachedEntity({
-    builder: ({ apiKey }: { apiKey: string }) =>
-      buildAuthServiceKey({
-        apiKey,
-      }),
-  })
   private async getApiKeyUser({ apiKey }: { apiKey: string }): Promise<{
     environment?: EnvironmentEntity;
     user?: UserEntity;

--- a/libs/dal/src/repositories/environment/environment.repository.ts
+++ b/libs/dal/src/repositories/environment/environment.repository.ts
@@ -58,9 +58,8 @@ export class EnvironmentRepository extends BaseRepository<EnvironmentDBModel, En
     );
   }
 
-  // backward compatibility - update the query to { 'apiKeys.hash': hash } once encrypt-api-keys-migration executed
-  async findByApiKey({ key, hash }: { key: string; hash: string }) {
-    return await this.findOne({ $or: [{ 'apiKeys.key': key }, { 'apiKeys.hash': hash }] });
+  async findByApiKey({ hash }: { hash: string }) {
+    return await this.findOne({ 'apiKeys.hash': hash }, undefined, { readPreference: 'secondaryPreferred' });
   }
 
   async getApiKeys(environmentId: string): Promise<IApiKey[]> {

--- a/libs/dal/src/repositories/environment/environment.schema.ts
+++ b/libs/dal/src/repositories/environment/environment.schema.ts
@@ -77,6 +77,10 @@ environmentSchema.index({
   _organizationId: 1,
 });
 
+environmentSchema.index({
+  'apiKeys.hash': 1,
+});
+
 export const Environment =
   (mongoose.models.Environment as mongoose.Model<EnvironmentDBModel>) ||
   mongoose.model<EnvironmentDBModel>('Environment', environmentSchema);


### PR DESCRIPTION
### What changed? Why was the change needed?

- Removes the legacy $or query to environments when resolving API keys
- Only use the hash key on the environment for matching


This should help with some of the ee API key transaction performance

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->


https://github.com/novuhq/packages-enterprise/pull/243
<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
https://github.com/novuhq/packages-enterprise/pull/243
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
