### PR TITLE
fix(api): upsert preference if exist

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -165,7 +165,7 @@ export class UpsertWorkflowUseCase {
 
   private async upsertUserWorkflowPreferences(workflow: NotificationTemplateEntity, command: UpsertWorkflowCommand) {
     let preferences: WorkflowPreferences | null;
-    if (command.workflowDto.preferences?.user !== undefined) {
+    if (command.workflowDto.preferences?.user !== undefined && command.workflowDto.preferences?.user !== null) {
       preferences = command.workflowDto.preferences.user;
     } else {
       preferences = DEFAULT_WORKFLOW_PREFERENCES;
@@ -183,12 +183,16 @@ export class UpsertWorkflowUseCase {
   }
 
   private async upsertWorkflowPreferences(workflow: NotificationTemplateEntity, command: UpsertWorkflowCommand) {
+    if (!command.workflowDto.preferences?.workflow) {
+      return;
+    }
+
     await this.upsertPreferencesUsecase.upsertWorkflowPreferences(
       UpsertWorkflowPreferencesCommand.create({
         environmentId: workflow._environmentId,
         organizationId: workflow._organizationId,
         templateId: workflow._id,
-        preferences: command.workflowDto.preferences?.workflow || null,
+        preferences: command.workflowDto.preferences.workflow,
       })
     );
   }

--- a/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -165,7 +165,7 @@ export class UpsertWorkflowUseCase {
 
   private async upsertUserWorkflowPreferences(workflow: NotificationTemplateEntity, command: UpsertWorkflowCommand) {
     let preferences: WorkflowPreferences | null;
-    if (command.workflowDto.preferences?.user !== undefined && command.workflowDto.preferences?.user !== null) {
+    if (command.workflowDto.preferences?.user !== undefined) {
       preferences = command.workflowDto.preferences.user;
     } else {
       preferences = DEFAULT_WORKFLOW_PREFERENCES;


### PR DESCRIPTION
### What changed? Why was the change needed?

We are currently throwing an exception if the old preferences do not exist. This is a bug, as we should not enforce the use of preferences.
![image](https://github.com/user-attachments/assets/1c299ed8-4521-418e-9306-41512045e702)

![image](https://github.com/user-attachments/assets/fcd32cf0-da2a-43da-930d-a35a734a9885)


### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
