### PR TITLE
feat(providers): provide the ability to send to include_external_user…

### DIFF
--- a/packages/providers/src/lib/push/one-signal/one-signal.provider.ts
+++ b/packages/providers/src/lib/push/one-signal/one-signal.provider.ts
@@ -36,10 +36,14 @@ export class OneSignalPushProvider
     options: IPushOptions,
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {},
   ): Promise<ISendMessageSuccessResponse> {
-    const { sound, badge, ...overrides } = options.overrides ?? {};
+    const { sound, badge, oneSignalOptions, ...overrides } = options.overrides ?? {};
+    
+    const targetingParam = oneSignalOptions?.useExternalUserIds
+      ? { include_external_user_ids: options.target }
+      : { include_player_ids: options.target };
 
     const notification = this.transform(bridgeProviderData, {
-      include_player_ids: options.target,
+      ...targetingParam,
       app_id: this.config.appId,
       headings: { en: options.title },
       contents: { en: options.content },

--- a/packages/stateless/src/lib/provider/provider.interface.ts
+++ b/packages/stateless/src/lib/provider/provider.interface.ts
@@ -73,6 +73,7 @@ export interface IPushOptions {
       };
     };
     fcmOptions?: { analyticsLabel?: string };
+    oneSignalOptions?: { useExternalUserIds?: boolean }
   };
   subscriber: object;
   step: {


### PR DESCRIPTION
### What changed? Why was the change needed?

Implements: https://github.com/novuhq/novu/issues/3479#issue-1721795062, https://discord.com/channels/895029566685462578/1185702635219714219/1185702635219714219

This pull request enhances the functionality of the OneSignal push notification provider by adding support for targeting users via external user IDs. It includes changes to the provider's main class and its test suite to accommodate this new feature.

* **Provider Class Changes:**
  * Added `oneSignalOptions` to the overrides in the `OneSignalPushProvider` class to support targeting via `include_external_user_ids` or `include_player_ids` based on the `useExternalUserIds` flag.

* **Interface Changes:**
  * Updated the `IPushOptions` interface to include the new `oneSignalOptions` field with an optional `useExternalUserIds` boolean property.

* **Test Suite Additions:**
  * Added new tests to verify that `include_external_user_ids` is used when `useExternalUserIds` is true.
  * Added tests to ensure `include_player_ids` is used when `useExternalUserIds` is false.
  * Added tests to confirm that `include_player_ids` is the default when `oneSignalOptions` is not provided.…_ids instead of include_player_ids

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
