### PR TITLE
feat(framework): Expose `Workflow` resource type in public API

### DIFF
--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -104,7 +104,7 @@ export class Client {
    *
    * @param workflows - The workflows to add.
    */
-  public async addWorkflows(workflows: Array<Workflow<never>>): Promise<void> {
+  public async addWorkflows(workflows: Array<Workflow>): Promise<void> {
     for (const workflow of workflows) {
       if (this.discoveredWorkflows.has(workflow.id)) {
         continue;
@@ -124,7 +124,7 @@ export class Client {
     }
   }
 
-  private async addWorkflow(workflow: Workflow<never>): Promise<void> {
+  private async addWorkflow(workflow: Workflow): Promise<void> {
     try {
       const definition = await workflow.discover();
       prettyPrintDiscovery(definition);

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -104,7 +104,7 @@ export class Client {
    *
    * @param workflows - The workflows to add.
    */
-  public async addWorkflows(workflows: Array<Workflow>): Promise<void> {
+  public async addWorkflows(workflows: Array<Workflow<never>>): Promise<void> {
     for (const workflow of workflows) {
       if (this.discoveredWorkflows.has(workflow.id)) {
         continue;
@@ -124,7 +124,7 @@ export class Client {
     }
   }
 
-  private async addWorkflow(workflow: Workflow): Promise<void> {
+  private async addWorkflow(workflow: Workflow<never>): Promise<void> {
     try {
       const definition = await workflow.discover();
       prettyPrintDiscovery(definition);

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -1,4 +1,5 @@
 export { Client } from './client';
 export { NovuRequestHandler, type ServeHandlerOptions } from './handler';
 export { workflow } from './resources';
+export type { Workflow } from './types';
 export { CronExpression } from './constants';

--- a/packages/framework/src/types/discover.types.ts
+++ b/packages/framework/src/types/discover.types.ts
@@ -65,10 +65,16 @@ export type DiscoverWorkflowOutput = {
   description?: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Workflow<T_Payload = any> = {
+/**
+ * A workflow resource.
+ *
+ * @property `id` - The unique identifier for the workflow.
+ * @property `trigger` - The function to trigger the workflow.
+ * @property `discover` - The function to discover the workflow definition.
+ */
+export type Workflow<T_Payload = Record<string, unknown>> = {
   /**
-   * The unique identifier of the workflow.
+   * The unique identifier for the workflow.
    */
   id: string;
   /**

--- a/packages/framework/src/types/discover.types.ts
+++ b/packages/framework/src/types/discover.types.ts
@@ -72,7 +72,7 @@ export type DiscoverWorkflowOutput = {
  * @property `trigger` - The function to trigger the workflow.
  * @property `discover` - The function to discover the workflow definition.
  */
-export type Workflow<T_Payload = Record<string, unknown>> = {
+export type Workflow<T_Payload = never> = {
   /**
    * The unique identifier for the workflow.
    */


### PR DESCRIPTION
### What changed? Why was the change needed?
* Expose `Workflow` resource type in public API
  * This typing is useful for library and plugin authors to create generic Novu Framework integrations with type inference

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

closes https://github.com/novuhq/novu/issues/6954

### Screenshots
_Intelliense of exposed `Workflow` type_
<img width="746" alt="image" src="https://github.com/user-attachments/assets/54a18780-4c52-4e87-9e0a-fb2f8f99bc1a">

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
