### PR TITLE
chore(dashboard): revert trigger success toast

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-tabs.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { RiPlayCircleLine, RiProgress1Fill } from 'react-icons/ri';
 import { useForm } from 'react-hook-form';
 // eslint-disable-next-line
@@ -15,11 +15,10 @@ import { useTriggerWorkflow } from '@/hooks/use-trigger-workflow';
 import { showToast } from '../../primitives/sonner-helpers';
 import { buildDynamicFormSchema, makeObjectFromSchema, TestWorkflowFormType } from '../schema';
 import { TestWorkflowForm } from './test-workflow-form';
-import { SuccessButtonToast } from '@/components/success-button-toast';
 import { toast } from 'sonner';
+import { ToastClose, ToastIcon } from '@/components/primitives/sonner';
 
 export const TestWorkflowTabs = ({ testData }: { testData: WorkflowTestDataResponseDto }) => {
-  const navigate = useNavigate();
   const { environmentSlug = '', workflowSlug = '' } = useParams<{ environmentSlug: string; workflowSlug: string }>();
   const { workflow } = useFetchWorkflow({
     workflowSlug,
@@ -51,16 +50,21 @@ export const TestWorkflowTabs = ({ testData }: { testData: WorkflowTestDataRespo
       showToast({
         variant: 'lg',
         children: ({ close }) => (
-          <SuccessButtonToast
-            title="Test workflow triggered successfully"
-            description={`Test workflow ${workflowSlug} was triggered successfully`}
-            actionLabel="View activity feed"
-            onAction={() => {
-              close();
-              navigate(buildRoute(LEGACY_ROUTES.ACTIVITY_FEED, { transactionId }));
-            }}
-            onClose={close}
-          />
+          <>
+            <ToastIcon variant="default" />
+            <div className="flex flex-col gap-2">
+              <span className="font-medium">Test workflow triggered successfully</span>
+              <span className="text-foreground-600">{`Test workflow ${workflowSlug} was triggered successfully`}</span>
+              <Link
+                to={`${LEGACY_ROUTES.ACTIVITY_FEED}?transactionId=${transactionId}`}
+                reloadDocument
+                className="text-foreground-950 flex items-center gap-1 text-sm font-medium"
+              >
+                View activity feed
+              </Link>
+            </div>
+            <ToastClose onClick={close} />
+          </>
         ),
         options: {
           position: 'bottom-right',


### PR DESCRIPTION
### What changed? Why was the change needed?

Reverted the changes we did for the success trigger workflow toast, because navigate doesn't support full page reload.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
