### PR TITLE
fix(api, application-generic): Filter with supplied `tags` when fetching subscriber preferences

### DIFF
--- a/apps/api/src/app/inbox/e2e/get-preferences.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/get-preferences.e2e.ts
@@ -60,6 +60,7 @@ describe('Get all preferences - /inbox/preferences (GET)', function () {
   it('should allow filtering preferences by tags', async function () {
     const newsletterTag = 'newsletter';
     const securityTag = 'security';
+    const marketingTag = 'marketing';
     await session.createTemplate({
       noFeedId: true,
       tags: [newsletterTag],
@@ -67,6 +68,14 @@ describe('Get all preferences - /inbox/preferences (GET)', function () {
     await session.createTemplate({
       noFeedId: true,
       tags: [securityTag],
+    });
+    await session.createTemplate({
+      noFeedId: true,
+      tags: [marketingTag],
+    });
+    await session.createTemplate({
+      noFeedId: true,
+      tags: [],
     });
 
     const response = await session.testAgent

--- a/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
@@ -129,6 +129,7 @@ describe('GetInboxPreferences', () => {
         environmentId: command.environmentId,
         subscriberId: command.subscriberId,
         organizationId: command.organizationId,
+        tags: undefined,
       })
     );
 
@@ -216,6 +217,7 @@ describe('GetInboxPreferences', () => {
         environmentId: command.environmentId,
         subscriberId: command.subscriberId,
         organizationId: command.organizationId,
+        tags: command.tags,
       })
     );
 

--- a/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.usecase.ts
@@ -40,6 +40,7 @@ export class GetInboxPreferences {
         environmentId: command.environmentId,
         subscriberId: command.subscriberId,
         organizationId: command.organizationId,
+        tags: command.tags,
       })
     );
     const workflowPreferences = subscriberWorkflowPreferences.map((subscriberWorkflowPreference) => {

--- a/libs/application-generic/src/usecases/get-subscriber-preference/get-subscriber-preference.command.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-preference/get-subscriber-preference.command.ts
@@ -1,3 +1,9 @@
+import { IsArray, IsOptional, IsString } from 'class-validator';
 import { EnvironmentWithSubscriber } from '../../commands/project.command';
 
-export class GetSubscriberPreferenceCommand extends EnvironmentWithSubscriber {}
+export class GetSubscriberPreferenceCommand extends EnvironmentWithSubscriber {
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+}

--- a/libs/application-generic/src/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
@@ -40,6 +40,7 @@ export class GetSubscriberPreference {
       {
         organizationId: command.organizationId,
         environmentId: command.environmentId,
+        tags: command.tags,
       },
     );
 


### PR DESCRIPTION
### What changed? Why was the change needed?
* Filter with supplied `tags` when fetching subscriber preferences
  * Update the test to include workflows which don't match the supplied tags

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
