### PR TITLE
fix(dashboard): Fix close icon padding in tag input

### DIFF
--- a/apps/dashboard/src/components/primitives/tag-input.tsx
+++ b/apps/dashboard/src/components/primitives/tag-input.tsx
@@ -77,7 +77,7 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
               <Badge key={index} variant="outline" kind="tag" className="gap-1">
                 <span>{tag}</span>
                 <button type="button" onClick={() => removeTag(tag)}>
-                  <RiCloseFill className="size-3" />
+                  <RiCloseFill className="-mr-0.5 size-3" />
                   <span className="sr-only">Remove tag</span>
                 </button>
               </Badge>


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
The icon has some padding by itself, so we're using negative margin to line it up in the button here.
### Screenshots
Before:
![image](https://github.com/user-attachments/assets/67499892-a4c4-4478-9b3f-46387e622f55)
After:
![image](https://github.com/user-attachments/assets/314b7de0-d14f-4c0b-a53e-03ec1e651c89)

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
