### PR TITLE
fix(dashboard): Modality on configure action popover

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-action.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-action.tsx
@@ -148,7 +148,7 @@ const ConfigureActionPopover = (props: ComponentProps<typeof PopoverTrigger> & {
   const { control } = useFormContext();
 
   return (
-    <Popover modal={false}>
+    <Popover modal={true}>
       <PopoverTrigger {...rest} />
       <PopoverContent className="max-w-72">
         <div className="flex flex-col gap-3">


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
Modality of popover is false by default, so configuring the action was not possible before, since clicking was considered as outside interaction and was closing the popover.

This would not be necessary if we were not inside a `Sheet`. Sheet is a modal and thus, when a popover is portaled into `document.body` it is "outside" our Sheet. By making it a modal, it can receive focus and is placed "on top" of the Sheet.

Another solution would be to not portal the popover or portal it in the Sheet. In that case though, it wouldn't be possible for it to escape the bounds of the Sheet in the screen.
### Screenshots

https://github.com/user-attachments/assets/fa51e708-746f-43f2-b693-bed4e43e40a7


<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
