### PR TITLE
feat(dashboard): in-app editor loading state

### DIFF
--- a/apps/dashboard/src/components/primitives/form/avatar-picker.tsx
+++ b/apps/dashboard/src/components/primitives/form/avatar-picker.tsx
@@ -1,14 +1,20 @@
+import { useState, forwardRef, useMemo } from 'react';
+import { liquid } from '@codemirror/lang-liquid';
+import { EditorView } from '@uiw/react-codemirror';
+import { RiEdit2Line, RiErrorWarningFill, RiImageEditFill } from 'react-icons/ri';
+
 import { Avatar, AvatarImage } from '@/components/primitives/avatar';
 import { Button } from '@/components/primitives/button';
 import { FormMessage } from '@/components/primitives/form/form';
-import { Input, InputField } from '@/components/primitives/input';
+import { InputField } from '@/components/primitives/input';
 import { Label } from '@/components/primitives/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/primitives/popover';
 import { Separator } from '@/components/primitives/separator';
 import TextSeparator from '@/components/primitives/text-separator';
-import { useState, forwardRef } from 'react';
-import { RiEdit2Line, RiErrorWarningFill, RiImageEditFill } from 'react-icons/ri';
 import { useFormField } from './form-context';
+import { Editor } from '../editor';
+import { useStepEditorContext } from '@/components/workflow-editor/steps/hooks';
+import { parseStepVariablesToLiquidVariables } from '@/utils/parseStepVariablesToLiquidVariables';
 
 const predefinedAvatars = [
   `${window.location.origin}/images/avatar.svg`,
@@ -25,25 +31,31 @@ const predefinedAvatars = [
   `${window.location.origin}/images/error-warning.svg`,
 ];
 
-type AvatarPickerProps = React.InputHTMLAttributes<HTMLInputElement>;
+type AvatarPickerProps = {
+  name: string;
+  value: string;
+  onChange?: (value: string) => void;
+};
 
-export const AvatarPicker = forwardRef<HTMLInputElement, AvatarPickerProps>(({ id, ...props }, ref) => {
+export const AvatarPicker = forwardRef<HTMLInputElement, AvatarPickerProps>(({ name, value, onChange }, ref) => {
+  const { step } = useStepEditorContext();
+  const variables = useMemo(() => (step ? parseStepVariablesToLiquidVariables(step.variables) : []), [step]);
   const [isOpen, setIsOpen] = useState(false);
   const { error } = useFormField();
 
   const handlePredefinedAvatarClick = (url: string) => {
-    props.onChange?.({ target: { value: url } } as React.ChangeEvent<HTMLInputElement>);
+    onChange?.(url);
     setIsOpen(false);
   };
 
   return (
-    <div className="space-y-2">
+    <div className="size-10 space-y-2">
       <Popover modal={true} open={isOpen} onOpenChange={setIsOpen}>
         <PopoverTrigger asChild>
           <Button variant="outline" size="icon" className="text-foreground-600 relative size-10">
-            {props.value ? (
+            {value ? (
               <Avatar className="p-px">
-                <AvatarImage src={props.value as string} />
+                <AvatarImage src={value as string} />
               </Avatar>
             ) : (
               <RiImageEditFill className="size-5" />
@@ -62,8 +74,20 @@ export const AvatarPicker = forwardRef<HTMLInputElement, AvatarPickerProps>(({ i
               <Separator />
               <div className="space-y-1">
                 <Label>Avatar URL</Label>
-                <InputField>
-                  <Input type="url" id={id} placeholder="Enter avatar URL" ref={ref} {...props} />
+                <InputField className="px-1" state={error ? 'error' : 'default'}>
+                  <Editor
+                    ref={ref}
+                    placeholder="Enter avatar URL"
+                    id={name}
+                    extensions={[
+                      liquid({
+                        variables,
+                      }),
+                      EditorView.lineWrapping,
+                    ]}
+                    value={`${value}`}
+                    onChange={(newValue) => onChange?.(newValue)}
+                  />
                 </InputField>
                 <FormMessage />
               </div>

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-content.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-content.tsx
@@ -29,7 +29,7 @@ export const ConfigureStepContent = () => {
         </SidebarContent>
         <Separator />
         <SidebarContent>
-          <Link to={'./edit'} relative="path">
+          <Link to={'./edit'} relative="path" state={{ stepType: step.type }}>
             <Button variant="outline" className="flex w-full justify-start gap-1.5 text-xs font-medium" type="button">
               <RiPencilRuler2Fill className="h-4 w-4 text-neutral-600" />
               Configure in-app template <RiArrowRightSLine className="ml-auto h-4 w-4 text-neutral-600" />
@@ -47,7 +47,7 @@ export const ConfigureStepContent = () => {
                 <span>Help?</span>
               </Link>
             </div>
-            <Link to={'./edit'} relative="path">
+            <Link to={'./edit'} relative="path" state={{ stepType: step.type }}>
               <Button variant="outline" className="flex w-full justify-start gap-1.5 text-xs font-medium" type="button">
                 <span className="bg-destructive h-4 min-w-1 rounded-full" />
                 <span className="overflow-hidden text-ellipsis">{firstError}</span>
@@ -69,7 +69,7 @@ export const ConfigureStepContent = () => {
       {!EXCLUDED_EDITOR_TYPES.includes(step?.type ?? '') && (
         <>
           <SidebarContent>
-            <Link to={'./edit'} relative="path">
+            <Link to={'./edit'} relative="path" state={{ stepType: step?.type }}>
               <Button variant="outline" className="flex w-full justify-start gap-1.5 text-xs font-medium" type="button">
                 <RiPencilRuler2Fill className="h-4 w-4 text-neutral-600" />
                 Configure {step?.type} template <RiArrowRightSLine className="ml-auto h-4 w-4 text-neutral-600" />

--- a/apps/dashboard/src/components/workflow-editor/steps/edit-step-sidebar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/edit-step-sidebar.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useMemo } from 'react';
 import { motion } from 'framer-motion';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import {
   Sheet,
@@ -10,45 +9,25 @@ import {
   SheetPortal,
   SheetTitle,
 } from '@/components/primitives/sheet';
-import { useFetchWorkflow } from '@/hooks/use-fetch-workflow';
 import { StepEditor } from '@/components/workflow-editor/steps/step-editor';
-import { useFetchStep } from '@/hooks/use-fetch-step';
 import { VisuallyHidden } from '@/components/primitives/visually-hidden';
 import { PageMeta } from '@/components/page-meta';
-import { getStepBase62Id } from '@/utils/step';
-import { EXCLUDED_EDITOR_TYPES } from '@/utils/constants';
+import { StepSkeleton } from './step-skeleton';
+import { StepEditorProvider } from './step-editor-provider';
+import { useStepEditorContext } from './hooks';
+import { useWorkflowEditorContext } from '../hooks';
 
 const transitionSetting = { ease: [0.29, 0.83, 0.57, 0.99], duration: 0.4 };
 
-export const EditStepSidebar = () => {
-  const { workflowSlug = '', stepSlug = '' } = useParams<{ workflowSlug: string; stepSlug: string }>();
+const EditStepSidebarInternal = () => {
   const navigate = useNavigate();
-
-  const { workflow } = useFetchWorkflow({
-    workflowSlug,
-  });
-
-  const { step } = useFetchStep({ workflowSlug, stepSlug });
-  const stepType = useMemo(
-    () => workflow?.steps.find((el) => getStepBase62Id(el.slug) === getStepBase62Id(stepSlug))?.type,
-    [stepSlug, workflow]
-  );
-
+  const { workflow, isPendingWorkflow } = useWorkflowEditorContext();
+  const { step, stepType, isPendingStep, isRefetchingStep } = useStepEditorContext();
   const handleCloseSidebar = () => {
     navigate('..', { relative: 'path' });
   };
 
-  const isNotSupportedEditorType = EXCLUDED_EDITOR_TYPES.includes(stepType ?? '');
-
-  useEffect(() => {
-    if (isNotSupportedEditorType) {
-      navigate('..', { relative: 'path' });
-    }
-  }, [isNotSupportedEditorType, navigate]);
-
-  if (isNotSupportedEditorType) {
-    return null;
-  }
+  const isPending = isPendingWorkflow || isPendingStep || isRefetchingStep;
 
   return (
     <>
@@ -89,12 +68,25 @@ export const EditStepSidebar = () => {
                 <SheetTitle />
                 <SheetDescription />
               </VisuallyHidden>
-              {/* TODO: show loading indicator */}
-              {workflow && step && stepType && <StepEditor workflow={workflow} step={step} stepType={stepType} />}
+              {isPending ? (
+                <StepSkeleton stepType={stepType} />
+              ) : (
+                <>
+                  {workflow && step && stepType && <StepEditor workflow={workflow} step={step} stepType={stepType} />}
+                </>
+              )}
             </motion.div>
           </SheetContentBase>
         </SheetPortal>
       </Sheet>
     </>
+  );
+};
+
+export const EditStepSidebar = () => {
+  return (
+    <StepEditorProvider>
+      <EditStepSidebarInternal />
+    </StepEditorProvider>
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/edit-step-sidebar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/edit-step-sidebar.tsx
@@ -69,7 +69,7 @@ const EditStepSidebarInternal = () => {
                 <SheetDescription />
               </VisuallyHidden>
               {isPending ? (
-                <StepSkeleton stepType={stepType} />
+                <StepSkeleton stepType={stepType} workflowOrigin={workflow?.origin} />
               ) : (
                 <>
                   {workflow && step && stepType && <StepEditor workflow={workflow} step={step} stepType={stepType} />}

--- a/apps/dashboard/src/components/workflow-editor/steps/hooks.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/hooks.ts
@@ -1,0 +1,4 @@
+import { createContextHook } from '@/utils/context';
+import { StepEditorContext } from './step-editor-context';
+
+export const useStepEditorContext = createContextHook(StepEditorContext);

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-action.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-action.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { RiEdit2Line, RiExpandUpDownLine, RiForbid2Line } from 'react-icons/ri';
 import { liquid } from '@codemirror/lang-liquid';
@@ -26,6 +26,8 @@ import { URLInput } from '@/components/workflow-editor/url-input';
 import { cn } from '@/utils/ui';
 import { urlTargetTypes } from '@/utils/url';
 import { Editor } from '@/components/primitives/editor';
+import { parseStepVariablesToLiquidVariables } from '@/utils/parseStepVariablesToLiquidVariables';
+import { useStepEditorContext } from '../hooks';
 
 const primaryActionKey = 'primaryAction';
 const secondaryActionKey = 'secondaryAction';
@@ -146,6 +148,8 @@ const ConfigureActionPopover = (props: ComponentProps<typeof PopoverTrigger> & {
     ...rest
   } = props;
   const { control } = useFormContext();
+  const { step } = useStepEditorContext();
+  const variables = useMemo(() => (step ? parseStepVariablesToLiquidVariables(step.variables) : []), [step]);
 
   return (
     <Popover modal={false}>
@@ -174,7 +178,7 @@ const ConfigureActionPopover = (props: ComponentProps<typeof PopoverTrigger> & {
                       height="30px"
                       extensions={[
                         liquid({
-                          variables: [{ type: 'variable', label: 'asdf' }],
+                          variables,
                         }),
                         EditorView.lineWrapping,
                       ]}
@@ -195,6 +199,7 @@ const ConfigureActionPopover = (props: ComponentProps<typeof PopoverTrigger> & {
                 targetKey: `${actionKey}.redirect.target`,
               }}
               withHint={false}
+              variables={variables}
             />
           </div>
         </div>

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-body.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-body.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { liquid } from '@codemirror/lang-liquid';
 import { EditorView } from '@uiw/react-codemirror';
 import { useFormContext } from 'react-hook-form';
@@ -5,10 +6,9 @@ import { useFormContext } from 'react-hook-form';
 import { Editor } from '@/components/primitives/editor';
 import { FormControl, FormField, FormItem, FormMessage } from '@/components/primitives/form/form';
 import { InputField } from '@/components/primitives/input';
-import { useFetchStep } from '@/hooks/use-fetch-step';
 import { parseStepVariablesToLiquidVariables } from '@/utils/parseStepVariablesToLiquidVariables';
 import { capitalize } from '@/utils/string';
-import { useParams } from 'react-router-dom';
+import { useStepEditorContext } from '../hooks';
 
 const bodyKey = 'body';
 
@@ -17,10 +17,8 @@ export const InAppBody = () => {
     control,
     formState: { errors },
   } = useFormContext();
-
-  const { workflowSlug = '', stepSlug = '' } = useParams<{ workflowSlug: string; stepSlug: string }>();
-
-  const { step } = useFetchStep({ workflowSlug, stepSlug });
+  const { step } = useStepEditorContext();
+  const variables = useMemo(() => (step ? parseStepVariablesToLiquidVariables(step.variables) : []), [step]);
 
   return (
     <FormField
@@ -36,7 +34,7 @@ export const InAppBody = () => {
                 id={field.name}
                 extensions={[
                   liquid({
-                    variables: step ? parseStepVariablesToLiquidVariables(step.variables) : [],
+                    variables,
                   }),
                   EditorView.lineWrapping,
                 ]}

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-redirect.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-redirect.tsx
@@ -1,8 +1,15 @@
+import { useMemo } from 'react';
+
 import { FormLabel } from '@/components/primitives/form/form';
 import { URLInput } from '../../url-input';
 import { urlTargetTypes } from '@/utils/url';
+import { useStepEditorContext } from '../hooks';
+import { parseStepVariablesToLiquidVariables } from '@/utils/parseStepVariablesToLiquidVariables';
 
 export const InAppRedirect = () => {
+  const { step } = useStepEditorContext();
+  const variables = useMemo(() => (step ? parseStepVariablesToLiquidVariables(step.variables) : []), [step]);
+
   return (
     <div className="flex flex-col gap-1">
       <FormLabel hint="">Redirect URL</FormLabel>
@@ -15,6 +22,7 @@ export const InAppRedirect = () => {
           urlKey: 'redirect.url',
           targetKey: 'redirect.target',
         }}
+        variables={variables}
       />
     </div>
   );

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-subject.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-subject.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { liquid } from '@codemirror/lang-liquid';
 import { EditorView } from '@uiw/react-codemirror';
@@ -6,9 +7,8 @@ import { FormControl, FormField, FormItem, FormMessage } from '@/components/prim
 import { InputField } from '@/components/primitives/input';
 import { Editor } from '@/components/primitives/editor';
 import { capitalize } from '@/utils/string';
-import { useParams } from 'react-router-dom';
-import { useFetchStep } from '@/hooks/use-fetch-step';
 import { parseStepVariablesToLiquidVariables } from '@/utils/parseStepVariablesToLiquidVariables';
+import { useStepEditorContext } from '../hooks';
 
 const subjectKey = 'subject';
 
@@ -17,9 +17,8 @@ export const InAppSubject = () => {
     control,
     formState: { errors },
   } = useFormContext();
-  const { workflowSlug = '', stepSlug = '' } = useParams<{ workflowSlug: string; stepSlug: string }>();
-
-  const { step } = useFetchStep({ workflowSlug, stepSlug });
+  const { step } = useStepEditorContext();
+  const variables = useMemo(() => (step ? parseStepVariablesToLiquidVariables(step.variables) : []), [step]);
 
   return (
     <FormField
@@ -35,7 +34,7 @@ export const InAppSubject = () => {
                 id={field.name}
                 extensions={[
                   liquid({
-                    variables: step ? parseStepVariablesToLiquidVariables(step.variables) : [],
+                    variables,
                   }),
                   EditorView.lineWrapping,
                 ]}

--- a/apps/dashboard/src/components/workflow-editor/steps/step-editor-context.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/step-editor-context.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+import { type StepDataDto, StepTypeEnum } from '@novu/shared';
+
+export type StepEditorContextType = {
+  isPendingStep: boolean;
+  isRefetchingStep: boolean;
+  step?: StepDataDto;
+  stepType?: StepTypeEnum;
+};
+
+export const StepEditorContext = createContext<StepEditorContextType>({} as StepEditorContextType);

--- a/apps/dashboard/src/components/workflow-editor/steps/step-editor-provider.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/step-editor-provider.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useMemo, type ReactNode } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { StepTypeEnum } from '@novu/shared';
+
+import { StepEditorContext } from './step-editor-context';
+import { useFetchStep } from '@/hooks/use-fetch-step';
+import { useWorkflowEditorContext } from '../hooks';
+import { getStepBase62Id } from '@/utils/step';
+import { EXCLUDED_EDITOR_TYPES } from '@/utils/constants';
+
+export const StepEditorProvider = ({ children }: { children: ReactNode }) => {
+  const { workflowSlug = '', stepSlug = '' } = useParams<{ workflowSlug: string; stepSlug: string }>();
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const { workflow } = useWorkflowEditorContext();
+  const { step, isPending: isPendingStep, isRefetching: isRefetchingStep } = useFetchStep({ workflowSlug, stepSlug });
+
+  const navigationStepType = state?.stepType as StepTypeEnum | undefined;
+  const stepType = useMemo(
+    () =>
+      navigationStepType ?? workflow?.steps.find((el) => getStepBase62Id(el.slug) === getStepBase62Id(stepSlug))?.type,
+    [navigationStepType, stepSlug, workflow]
+  );
+
+  const value = useMemo(
+    () => ({ isPendingStep, isRefetchingStep, step, stepType }),
+    [isPendingStep, isRefetchingStep, step, stepType]
+  );
+
+  const isNotSupportedEditorType = EXCLUDED_EDITOR_TYPES.includes(stepType ?? '');
+
+  useEffect(() => {
+    if (isNotSupportedEditorType) {
+      navigate('..', { relative: 'path' });
+    }
+  }, [isNotSupportedEditorType, navigate]);
+
+  if (isNotSupportedEditorType) {
+    return null;
+  }
+
+  return <StepEditorContext.Provider value={value}>{children}</StepEditorContext.Provider>;
+};

--- a/apps/dashboard/src/components/workflow-editor/steps/step-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/step-editor.tsx
@@ -4,17 +4,17 @@ import { OtherStepTabs } from './other-steps-tabs';
 
 const STEP_TYPE_TO_EDITOR: Record<
   StepTypeEnum,
-  (args: { workflow: WorkflowResponseDto; step: StepDataDto }) => React.JSX.Element
+  (args: { workflow: WorkflowResponseDto; step: StepDataDto }) => React.JSX.Element | null
 > = {
   [StepTypeEnum.EMAIL]: OtherStepTabs,
   [StepTypeEnum.CHAT]: OtherStepTabs,
   [StepTypeEnum.IN_APP]: InAppTabs,
   [StepTypeEnum.SMS]: OtherStepTabs,
   [StepTypeEnum.PUSH]: OtherStepTabs,
-  [StepTypeEnum.DIGEST]: () => <div>DIGEST Editor</div>,
-  [StepTypeEnum.DELAY]: () => <div>DELAY Editor</div>,
-  [StepTypeEnum.TRIGGER]: () => <div>TRIGGER Editor</div>,
-  [StepTypeEnum.CUSTOM]: () => <div>CUSTOM Editor</div>,
+  [StepTypeEnum.DIGEST]: () => null,
+  [StepTypeEnum.DELAY]: () => null,
+  [StepTypeEnum.TRIGGER]: () => null,
+  [StepTypeEnum.CUSTOM]: () => null,
 };
 
 export const StepEditor = ({

--- a/apps/dashboard/src/components/workflow-editor/steps/step-skeleton.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/step-skeleton.tsx
@@ -9,8 +9,17 @@ import { Button } from '@/components/primitives/button';
 import { Separator } from '@/components/primitives/separator';
 import { Tabs, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import { Notification5Fill } from '@/components/icons';
+import { WorkflowOriginEnum } from '@/utils/enums';
 
-const STEP_TYPE_TO_SKELETON_CONTENT: Record<StepTypeEnum, () => React.JSX.Element | null> = {
+const SingleLineSkeleton = () => {
+  return (
+    <div className="flex h-full flex-col gap-1">
+      <Skeleton className="h-10 w-full" />
+    </div>
+  );
+};
+
+const STEP_TYPE_TO_SKELETON_CONTENT: Record<StepTypeEnum | string, () => React.JSX.Element | null> = {
   [StepTypeEnum.EMAIL]: () => {
     return (
       <div className="flex h-full flex-col gap-1">
@@ -19,14 +28,7 @@ const STEP_TYPE_TO_SKELETON_CONTENT: Record<StepTypeEnum, () => React.JSX.Elemen
       </div>
     );
   },
-  [StepTypeEnum.CHAT]: () => {
-    return (
-      <div className="flex h-full flex-col gap-1">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-full w-full" />
-      </div>
-    );
-  },
+  [StepTypeEnum.CHAT]: SingleLineSkeleton,
   [StepTypeEnum.IN_APP]: () => {
     return (
       <>
@@ -44,64 +46,24 @@ const STEP_TYPE_TO_SKELETON_CONTENT: Record<StepTypeEnum, () => React.JSX.Elemen
       </>
     );
   },
-  [StepTypeEnum.SMS]: () => {
-    return (
-      <div className="flex h-full flex-col gap-1">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-full w-full" />
-      </div>
-    );
-  },
-  [StepTypeEnum.PUSH]: () => {
-    return (
-      <div className="flex h-full flex-col gap-1">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-full w-full" />
-      </div>
-    );
-  },
-  [StepTypeEnum.DIGEST]: () => {
-    return (
-      <div className="flex h-full flex-col gap-1">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-full w-full" />
-      </div>
-    );
-  },
-  [StepTypeEnum.DELAY]: () => {
-    return (
-      <div className="flex h-full flex-col gap-1">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-full w-full" />
-      </div>
-    );
-  },
-  [StepTypeEnum.TRIGGER]: () => {
-    return (
-      <div className="flex h-full flex-col gap-1">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-full w-full" />
-      </div>
-    );
-  },
-  [StepTypeEnum.CUSTOM]: () => {
-    return (
-      <div className="flex h-full flex-col gap-1">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-full w-full" />
-      </div>
-    );
-  },
+  [StepTypeEnum.SMS]: SingleLineSkeleton,
+  [StepTypeEnum.PUSH]: SingleLineSkeleton,
+  [StepTypeEnum.DIGEST]: () => null,
+  [StepTypeEnum.DELAY]: () => null,
+  [StepTypeEnum.TRIGGER]: () => null,
+  [StepTypeEnum.CUSTOM]: () => null,
 };
 
-export const StepSkeleton = ({ stepType }: { stepType?: StepTypeEnum }) => {
+export const StepSkeleton = ({
+  stepType,
+  workflowOrigin,
+}: {
+  stepType?: StepTypeEnum;
+  workflowOrigin?: WorkflowOriginEnum;
+}) => {
   const navigate = useNavigate();
 
-  if (!stepType) {
-    return null;
-  }
-
-  const SkeletonContent = STEP_TYPE_TO_SKELETON_CONTENT[stepType];
+  const SkeletonContent = STEP_TYPE_TO_SKELETON_CONTENT[stepType ?? ''];
 
   return (
     <div className="flex h-full flex-1 flex-col">
@@ -139,7 +101,11 @@ export const StepSkeleton = ({ stepType }: { stepType?: StepTypeEnum }) => {
       </header>
       <Separator />
       <div className="flex h-full w-full flex-col gap-3 px-3 py-3.5">
-        <SkeletonContent />
+        {workflowOrigin && workflowOrigin !== WorkflowOriginEnum.EXTERNAL ? (
+          <SkeletonContent />
+        ) : (
+          <SingleLineSkeleton />
+        )}
       </div>
       <Separator />
       <footer className="flex justify-end px-3 py-3.5">

--- a/apps/dashboard/src/components/workflow-editor/steps/step-skeleton.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/step-skeleton.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { StepTypeEnum } from '@novu/shared';
+import { RiEdit2Line, RiPencilRuler2Line } from 'react-icons/ri';
+import { useNavigate } from 'react-router-dom';
+import { Cross2Icon } from '@radix-ui/react-icons';
+
+import { Skeleton } from '@/components/primitives/skeleton';
+import { Button } from '@/components/primitives/button';
+import { Separator } from '@/components/primitives/separator';
+import { Tabs, TabsList, TabsTrigger } from '@/components/primitives/tabs';
+import { Notification5Fill } from '@/components/icons';
+
+const STEP_TYPE_TO_SKELETON_CONTENT: Record<StepTypeEnum, () => React.JSX.Element | null> = {
+  [StepTypeEnum.EMAIL]: () => {
+    return (
+      <div className="flex h-full flex-col gap-1">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-full w-full" />
+      </div>
+    );
+  },
+  [StepTypeEnum.CHAT]: () => {
+    return (
+      <div className="flex h-full flex-col gap-1">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-full w-full" />
+      </div>
+    );
+  },
+  [StepTypeEnum.IN_APP]: () => {
+    return (
+      <>
+        <div className="flex items-center gap-2.5">
+          <RiPencilRuler2Line className="text-foreground-950 size-5 p-0.5 text-sm font-medium" />
+          <span>In-app Template</span>
+        </div>
+        <div className="flex flex-col gap-1 rounded-xl border border-neutral-100 p-1">
+          <div className="flex gap-1">
+            <Skeleton className="h-10 min-w-10" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+          <Skeleton className="h-32 w-full" />
+        </div>
+      </>
+    );
+  },
+  [StepTypeEnum.SMS]: () => {
+    return (
+      <div className="flex h-full flex-col gap-1">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-full w-full" />
+      </div>
+    );
+  },
+  [StepTypeEnum.PUSH]: () => {
+    return (
+      <div className="flex h-full flex-col gap-1">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-full w-full" />
+      </div>
+    );
+  },
+  [StepTypeEnum.DIGEST]: () => {
+    return (
+      <div className="flex h-full flex-col gap-1">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-full w-full" />
+      </div>
+    );
+  },
+  [StepTypeEnum.DELAY]: () => {
+    return (
+      <div className="flex h-full flex-col gap-1">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-full w-full" />
+      </div>
+    );
+  },
+  [StepTypeEnum.TRIGGER]: () => {
+    return (
+      <div className="flex h-full flex-col gap-1">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-full w-full" />
+      </div>
+    );
+  },
+  [StepTypeEnum.CUSTOM]: () => {
+    return (
+      <div className="flex h-full flex-col gap-1">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-full w-full" />
+      </div>
+    );
+  },
+};
+
+export const StepSkeleton = ({ stepType }: { stepType?: StepTypeEnum }) => {
+  const navigate = useNavigate();
+
+  if (!stepType) {
+    return null;
+  }
+
+  const SkeletonContent = STEP_TYPE_TO_SKELETON_CONTENT[stepType];
+
+  return (
+    <div className="flex h-full flex-1 flex-col">
+      <header className="flex flex-row items-center gap-3 px-3 py-1.5">
+        <div className="mr-auto flex items-center gap-2.5 text-sm font-medium">
+          <RiEdit2Line className="size-4" />
+          <span>Configure Template</span>
+        </div>
+        <Tabs defaultValue="editor" className="ml-auto">
+          <TabsList className="w-min">
+            <TabsTrigger value="editor" className="gap-1.5" disabled>
+              <RiPencilRuler2Line className="size-5 p-0.5" />
+              <span>Editor</span>
+            </TabsTrigger>
+            <TabsTrigger value="preview" className="gap-1.5" disabled>
+              <Notification5Fill className="size-5 p-0.5" />
+              <span>Preview</span>
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        <Button
+          variant="ghost"
+          size="xs"
+          className="size-6"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            navigate('../', { relative: 'path' });
+          }}
+        >
+          <Cross2Icon className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </Button>
+      </header>
+      <Separator />
+      <div className="flex h-full w-full flex-col gap-3 px-3 py-3.5">
+        <SkeletonContent />
+      </div>
+      <Separator />
+      <footer className="flex justify-end px-3 py-3.5">
+        <Button className="ml-auto" variant="default" disabled>
+          Save step
+        </Button>
+      </footer>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/workflow-editor/url-input.tsx
+++ b/apps/dashboard/src/components/workflow-editor/url-input.tsx
@@ -16,6 +16,7 @@ type URLInputProps = Omit<InputProps, 'value' | 'onChange' | 'size'> & {
     urlKey: string;
     targetKey: string;
   };
+  variables: Array<{ type: string; label: string }>;
 } & Pick<InputFieldProps, 'size'>;
 
 export const URLInput = ({
@@ -25,6 +26,7 @@ export const URLInput = ({
   placeholder,
   fields: { urlKey, targetKey },
   withHint = true,
+  variables = [],
 }: URLInputProps) => {
   const { control, getFieldState } = useFormContext();
   const url = getFieldState(`${urlKey}`);
@@ -50,7 +52,7 @@ export const URLInput = ({
                         height={size === 'md' ? '38px' : '30px'}
                         extensions={[
                           liquid({
-                            variables: [{ type: 'variable', label: 'asdf' }],
+                            variables,
                           }),
                           EditorView.lineWrapping,
                         ]}

--- a/apps/dashboard/src/components/workflow-editor/workflow-editor-context.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-editor-context.tsx
@@ -3,9 +3,11 @@ import { WorkflowResponseDto } from '@novu/shared';
 import type { StepTypeEnum } from '@/utils/enums';
 
 export type WorkflowEditorContextType = {
+  isPendingWorkflow: boolean;
+  workflow?: WorkflowResponseDto;
+  isReadOnly: boolean;
   addStep: (channelType: StepTypeEnum, stepIndex?: number) => void;
   deleteStep: (stepSlug: string) => void;
-  isReadOnly: boolean;
   resetWorkflowForm: (workflow: WorkflowResponseDto) => void;
 };
 

--- a/apps/dashboard/src/components/workflow-editor/workflow-editor-provider.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-editor-provider.tsx
@@ -58,7 +58,11 @@ export const WorkflowEditorProvider = ({ children }: { children: ReactNode }) =>
   const navigate = useNavigate();
   const [toastId, setToastId] = useState<string | number>('');
 
-  const { workflow, error } = useFetchWorkflow({
+  const {
+    workflow,
+    isPending: isPendingWorkflow,
+    error,
+  } = useFetchWorkflow({
     workflowSlug,
   });
   const defaultFormValues = useMemo(
@@ -193,12 +197,14 @@ export const WorkflowEditorProvider = ({ children }: { children: ReactNode }) =>
 
   const value = useMemo(
     () => ({
+      isPendingWorkflow,
+      workflow,
       isReadOnly,
       addStep,
       deleteStep,
       resetWorkflowForm,
     }),
-    [addStep, isReadOnly, deleteStep, resetWorkflowForm]
+    [isPendingWorkflow, workflow, isReadOnly, addStep, deleteStep, resetWorkflowForm]
   );
 
   return (

--- a/apps/dashboard/src/hooks/use-fetch-step.tsx
+++ b/apps/dashboard/src/hooks/use-fetch-step.tsx
@@ -6,7 +6,7 @@ import { fetchStep } from '@/api/steps';
 
 export const useFetchStep = ({ workflowSlug, stepSlug }: { workflowSlug: string; stepSlug: string }) => {
   const { currentEnvironment } = useEnvironment();
-  const { data, isPending, error } = useQuery<StepDataDto>({
+  const { data, isPending, isRefetching, error } = useQuery<StepDataDto>({
     queryKey: [QueryKeys.fetchWorkflow, currentEnvironment?._id, workflowSlug, stepSlug],
     queryFn: () => fetchStep({ workflowSlug, stepSlug }),
     enabled: !!currentEnvironment?._id && !!stepSlug,
@@ -15,6 +15,7 @@ export const useFetchStep = ({ workflowSlug, stepSlug }: { workflowSlug: string;
   return {
     step: data,
     isPending,
+    isRefetching,
     error,
   };
 };


### PR DESCRIPTION
### What changed? Why was the change needed?

1. In-App Editor loading skeleton.
2. Refactored the editor code a bit and introduced `StepEditorContext` which is the central place where we fetch the step information. More about in the comments.
3. Added the `variables` to missing In-App form fields.

### Screenshots
![Screenshot 2024-11-14 at 14 33 44](https://github.com/user-attachments/assets/eb80787e-a525-4920-bce1-2e04987eae5e)

![Screenshot 2024-11-14 at 14 44 34](https://github.com/user-attachments/assets/f8fb7268-71c7-4891-a510-840eb3c80d12)



https://github.com/user-attachments/assets/9bfd5d05-3697-4de9-b022-8a3826f28e9f


https://github.com/user-attachments/assets/d9b778aa-f29a-4c3d-9ce1-51eb7c5d0754

