### PR TITLE
chore(api): Migrate all V1 Preferences to V2 Preferences

### DIFF
--- a/apps/api/migrations/preference-centralization/preference-centralization-migration.spec.ts
+++ b/apps/api/migrations/preference-centralization/preference-centralization-migration.spec.ts
@@ -1,0 +1,201 @@
+import { expect } from 'chai';
+import { NestFactory } from '@nestjs/core';
+import {
+  SubscriberPreferenceRepository,
+  NotificationTemplateRepository,
+  PreferenceLevelEnum,
+  PreferencesRepository,
+} from '@novu/dal';
+import { UpsertPreferences } from '@novu/application-generic';
+import { DEFAULT_WORKFLOW_PREFERENCES, PreferencesTypeEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import { INestApplication } from '@nestjs/common';
+import { AppModule } from '../../src/app.module';
+import { preferenceCentralization } from './preference-centralization-migration';
+
+describe('Preference Centralization Migration', function () {
+  let app: INestApplication;
+  let session: UserSession;
+  let subscriberPreferenceRepository: SubscriberPreferenceRepository;
+  let notificationTemplateRepository: NotificationTemplateRepository;
+  let preferenceRepository: PreferencesRepository;
+  let upsertPreferences: UpsertPreferences;
+
+  before(async () => {
+    app = await NestFactory.create(AppModule, { logger: false });
+    subscriberPreferenceRepository = app.get(SubscriberPreferenceRepository);
+    notificationTemplateRepository = app.get(NotificationTemplateRepository);
+    preferenceRepository = app.get(PreferencesRepository);
+    upsertPreferences = app.get(UpsertPreferences);
+  });
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+
+    // Clean up the repositories before each test
+    await subscriberPreferenceRepository._model.deleteMany({});
+    await notificationTemplateRepository._model.deleteMany({});
+    await preferenceRepository._model.deleteMany({});
+  });
+
+  after(async () => {
+    await app.close();
+  });
+
+  it('should migrate subscriber global preferences', async function () {
+    await subscriberPreferenceRepository.create({
+      _subscriberId: session.subscriberId,
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      level: PreferenceLevelEnum.GLOBAL,
+      channels: { email: true, sms: true },
+    });
+
+    await preferenceCentralization();
+
+    const updatedPreferences = await preferenceRepository.find({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+    expect(updatedPreferences.length).to.equal(1);
+    expect(updatedPreferences[0].type).to.equal(PreferencesTypeEnum.SUBSCRIBER_GLOBAL);
+    expect(updatedPreferences[0].preferences).to.deep.equal({
+      all: { enabled: true, readOnly: false },
+      channels: {
+        push: {},
+        chat: {},
+        in_app: {},
+        email: { enabled: true },
+        sms: { enabled: true },
+      },
+    });
+  });
+
+  it('should migrate subscriber workflow preferences', async function () {
+    await subscriberPreferenceRepository.create({
+      _subscriberId: session.subscriberId,
+      _templateId: NotificationTemplateRepository.createObjectId(),
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      level: PreferenceLevelEnum.TEMPLATE,
+      channels: { push: true },
+    });
+
+    await preferenceCentralization();
+
+    const updatedPreferences = await preferenceRepository.find({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+    expect(updatedPreferences.length).to.equal(1);
+    expect(updatedPreferences[0].type).to.equal(PreferencesTypeEnum.SUBSCRIBER_WORKFLOW);
+    expect(updatedPreferences[0].preferences).to.deep.equal({
+      all: { enabled: true, readOnly: false },
+      channels: {
+        push: { enabled: true },
+        chat: {},
+        email: {},
+        in_app: {},
+        sms: {},
+      },
+    });
+  });
+
+  it('should migrate workflows with preference settings and critical flag true', async function () {
+    await notificationTemplateRepository.create({
+      _creatorId: session.user._id,
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      critical: true,
+      preferenceSettings: { email: true, sms: false, push: true, in_app: true, chat: true },
+    });
+
+    await preferenceCentralization();
+
+    const updatedPreferences = await preferenceRepository.find({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+    expect(updatedPreferences.length).to.equal(2);
+    const workflowPreference = updatedPreferences.find(
+      (preference) => preference.type === PreferencesTypeEnum.WORKFLOW_RESOURCE
+    );
+    const userPreference = updatedPreferences.find(
+      (preference) => preference.type === PreferencesTypeEnum.USER_WORKFLOW
+    );
+
+    expect(workflowPreference?.preferences).to.deep.equal(DEFAULT_WORKFLOW_PREFERENCES);
+    expect(userPreference?.preferences).to.deep.equal({
+      all: { enabled: true, readOnly: true },
+      channels: {
+        push: { enabled: true },
+        chat: { enabled: true },
+        email: { enabled: true },
+        in_app: { enabled: true },
+        sms: { enabled: false },
+      },
+    });
+  });
+
+  it('should migrate workflows with preference settings and critical flag false', async function () {
+    await notificationTemplateRepository.create({
+      _creatorId: session.user._id,
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      critical: false,
+      preferenceSettings: { email: true, sms: false, push: true, in_app: true, chat: true },
+    });
+
+    await preferenceCentralization();
+
+    const updatedPreferences = await preferenceRepository.find({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+    expect(updatedPreferences.length).to.equal(2);
+    const workflowPreference = updatedPreferences.find(
+      (preference) => preference.type === PreferencesTypeEnum.WORKFLOW_RESOURCE
+    );
+    const userPreference = updatedPreferences.find(
+      (preference) => preference.type === PreferencesTypeEnum.USER_WORKFLOW
+    );
+
+    expect(workflowPreference?.preferences).to.deep.equal(DEFAULT_WORKFLOW_PREFERENCES);
+    expect(userPreference?.preferences).to.deep.equal({
+      all: { enabled: true, readOnly: false },
+      channels: {
+        push: { enabled: true },
+        chat: { enabled: true },
+        email: { enabled: true },
+        in_app: { enabled: true },
+        sms: { enabled: false },
+      },
+    });
+  });
+
+  it('should migrate workflows without preference settings', async function () {
+    await notificationTemplateRepository.create({
+      _creatorId: session.user._id,
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+
+    await preferenceCentralization();
+
+    const updatedPreferences = await preferenceRepository.find({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+    expect(updatedPreferences.length).to.equal(2);
+    const workflowPreference = updatedPreferences.find(
+      (preference) => preference.type === PreferencesTypeEnum.WORKFLOW_RESOURCE
+    );
+    const userPreference = updatedPreferences.find(
+      (preference) => preference.type === PreferencesTypeEnum.USER_WORKFLOW
+    );
+
+    expect(workflowPreference?.preferences).to.deep.equal(DEFAULT_WORKFLOW_PREFERENCES);
+    expect(userPreference?.preferences).to.deep.equal(DEFAULT_WORKFLOW_PREFERENCES);
+  });
+});

--- a/apps/api/migrations/preference-centralization/preference-centralization-migration.ts
+++ b/apps/api/migrations/preference-centralization/preference-centralization-migration.ts
@@ -1,0 +1,202 @@
+/* eslint-disable no-console */
+import '../../src/config';
+
+import { NestFactory } from '@nestjs/core';
+import { SubscriberPreferenceRepository, NotificationTemplateRepository, PreferenceLevelEnum } from '@novu/dal';
+import {
+  UpsertPreferences,
+  UpsertWorkflowPreferencesCommand,
+  UpsertUserWorkflowPreferencesCommand,
+  UpsertSubscriberGlobalPreferencesCommand,
+  UpsertSubscriberWorkflowPreferencesCommand,
+} from '@novu/application-generic';
+import { buildWorkflowPreferencesFromPreferenceChannels, DEFAULT_WORKFLOW_PREFERENCES } from '@novu/shared';
+
+import { AppModule } from '../../src/app.module';
+
+const BATCH_SIZE = 100;
+
+/**
+ * Sleep for a random amount of time between 80% and 120% of the provided duration.
+ * @param ms - The duration to sleep for in milliseconds.
+ * @returns A promise that resolves after the randomized sleep duration.
+ */
+const sleep = (ms: number) => {
+  const randomFactor = 1 + (Math.random() - 0.5) * 0.4; // Random factor between 0.8 and 1.2
+  const randomizedMs = ms * randomFactor;
+
+  return new Promise((resolve) => {
+    setTimeout(resolve, randomizedMs);
+  });
+};
+
+const counter: Record<string, { success: number; error: number }> = {
+  subscriberGlobal: { success: 0, error: 0 },
+  subscriberWorkflow: { success: 0, error: 0 },
+  subscriberUnknown: { success: 0, error: 0 },
+  workflow: { success: 0, error: 0 },
+};
+
+let lastProcessedWorkflowId: string | undefined;
+let lastProcessedSubscriberId: string | undefined;
+
+process.on('SIGINT', () => {
+  console.log('\nGracefully shutting down from SIGINT (Ctrl+C)');
+  console.log({ counter });
+  if (lastProcessedWorkflowId) {
+    console.log(`Last processed workflow preference ID: ${lastProcessedWorkflowId}`);
+  }
+  if (lastProcessedSubscriberId) {
+    console.log(`Last processed subscriber preference ID: ${lastProcessedSubscriberId}`);
+  }
+  process.exit();
+});
+
+/**
+ * Migration to centralize workflow and subscriber preferences.
+ * - subscriber global preference
+ *    -> preferences with subscriber global type
+ * - subscriber workflow preferences
+ *    -> preferences with subscriber workflow type
+ * - workflow preferences
+ *   -> preferences with workflow-resource type
+ *   -> preferences with user-workflow type
+ */
+export async function preferenceCentralization(startWorkflowId?: string, startSubscriberId?: string) {
+  const app = await NestFactory.create(AppModule, {
+    logger: false,
+  });
+  console.log('start migration - preference centralization');
+
+  const upsertPreferences = app.get(UpsertPreferences);
+  const subscriberPreferenceRepository = app.get(SubscriberPreferenceRepository);
+  const workflowPreferenceRepository = app.get(NotificationTemplateRepository);
+
+  await migrateWorkflowPreferences(workflowPreferenceRepository, upsertPreferences, startWorkflowId);
+  console.log({ counter });
+  await migrateSubscriberPreferences(subscriberPreferenceRepository, upsertPreferences, startSubscriberId);
+
+  console.log('end migration - preference centralization');
+  console.log({ counter });
+  console.log(`Processed workflow preference with ID: ${lastProcessedWorkflowId}`);
+  console.log(`Processed subscriber preference with ID: ${lastProcessedSubscriberId}`);
+
+  app.close();
+}
+
+async function migrateWorkflowPreferences(
+  workflowPreferenceRepository: NotificationTemplateRepository,
+  upsertPreferences: UpsertPreferences,
+  startWorkflowId?: string
+) {
+  console.log('start workflow preference migration');
+  let query = {};
+  if (startWorkflowId) {
+    console.log(`Starting from workflow preference ID: ${startWorkflowId}`);
+    query = { _id: { $gt: startWorkflowId } };
+  }
+  const workflowPreferenceCursor = await workflowPreferenceRepository._model
+    .find(query)
+    .sort({ _id: 1 })
+    .batchSize(BATCH_SIZE)
+    .cursor();
+
+  for await (const workflowPreference of workflowPreferenceCursor) {
+    await sleep(10);
+    try {
+      const userWorkflowPreferenceToUpsert = UpsertUserWorkflowPreferencesCommand.create({
+        userId: workflowPreference._creatorId.toString(),
+        templateId: workflowPreference._id.toString(),
+        environmentId: workflowPreference._environmentId.toString(),
+        organizationId: workflowPreference._organizationId.toString(),
+        preferences: buildWorkflowPreferencesFromPreferenceChannels(
+          workflowPreference.critical,
+          workflowPreference.preferenceSettings
+        ),
+      });
+
+      await upsertPreferences.upsertUserWorkflowPreferences(userWorkflowPreferenceToUpsert);
+
+      const workflowPreferenceToUpsert = UpsertWorkflowPreferencesCommand.create({
+        templateId: workflowPreference._id.toString(),
+        environmentId: workflowPreference._environmentId.toString(),
+        organizationId: workflowPreference._organizationId.toString(),
+        preferences: DEFAULT_WORKFLOW_PREFERENCES,
+      });
+
+      await upsertPreferences.upsertWorkflowPreferences(workflowPreferenceToUpsert);
+
+      counter.workflow.success += 1;
+      lastProcessedWorkflowId = workflowPreference._id.toString();
+    } catch (error) {
+      console.error(error);
+      counter.workflow.error += 1;
+    }
+  }
+
+  console.log('end workflow preference migration');
+}
+
+async function migrateSubscriberPreferences(
+  subscriberPreferenceRepository: SubscriberPreferenceRepository,
+  upsertPreferences: UpsertPreferences,
+  startSubscriberId?: string
+) {
+  console.log('start subscriber preference migration');
+  let query = {};
+  if (startSubscriberId) {
+    console.log(`Starting from subscriber preference ID: ${startSubscriberId}`);
+    query = { _id: { $gt: startSubscriberId } };
+  }
+  const subscriberPreferenceCursor = await subscriberPreferenceRepository._model
+    .find(query)
+    .sort({ _id: 1 })
+    .batchSize(BATCH_SIZE)
+    .cursor();
+
+  for await (const subscriberPreference of subscriberPreferenceCursor) {
+    await sleep(10);
+    try {
+      if (subscriberPreference.level === PreferenceLevelEnum.GLOBAL) {
+        const preferenceToUpsert = UpsertSubscriberGlobalPreferencesCommand.create({
+          _subscriberId: subscriberPreference._subscriberId.toString(),
+          environmentId: subscriberPreference._environmentId.toString(),
+          organizationId: subscriberPreference._organizationId.toString(),
+          preferences: buildWorkflowPreferencesFromPreferenceChannels(false, subscriberPreference.channels),
+        });
+
+        await upsertPreferences.upsertSubscriberGlobalPreferences(preferenceToUpsert);
+
+        counter.subscriberGlobal.success += 1;
+      } else if (subscriberPreference.level === PreferenceLevelEnum.TEMPLATE) {
+        const preferenceToUpsert = UpsertSubscriberWorkflowPreferencesCommand.create({
+          _subscriberId: subscriberPreference._subscriberId.toString(),
+          templateId: subscriberPreference._templateId.toString(),
+          environmentId: subscriberPreference._environmentId.toString(),
+          organizationId: subscriberPreference._organizationId.toString(),
+          preferences: buildWorkflowPreferencesFromPreferenceChannels(false, subscriberPreference.channels),
+        });
+
+        await upsertPreferences.upsertSubscriberWorkflowPreferences(preferenceToUpsert);
+
+        counter.subscriberWorkflow.success += 1;
+      } else {
+        console.error(`Invalid preference level ${subscriberPreference.level}`);
+        counter.subscriberUnknown.error += 1;
+      }
+      lastProcessedSubscriberId = subscriberPreference._id.toString();
+    } catch (error) {
+      console.error(error);
+      if (subscriberPreference.level === PreferenceLevelEnum.GLOBAL) {
+        counter.subscriberGlobal.error += 1;
+      } else if (subscriberPreference.level === PreferenceLevelEnum.TEMPLATE) {
+        counter.subscriberWorkflow.error += 1;
+      }
+    }
+  }
+
+  console.log('end subscriber preference migration');
+}
+
+// Call the function with optional starting IDs
+preferenceCentralization(process.argv[2], process.argv[3]);


### PR DESCRIPTION
### What changed? Why was the change needed?
* Migrate all V1 Preferences to V2 Preferences
  * subscriber global preference
    * preferences with subscriber global type
  * subscriber workflow preferences
    * preferences with subscriber worklow type
  * workflow preferences
    * preferences with workflow-resource type
    * preferences with user-workflow type

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
_Successful tests with migration logs_
![image](https://github.com/user-attachments/assets/8d533c0e-65d8-48d5-a843-c86145c91014)

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
