### PR TITLE
feat(novu): Add `--headless` flag to prevent automatic browser open with `npx novu dev` command

### DIFF
--- a/packages/novu/README.MD
+++ b/packages/novu/README.MD
@@ -36,12 +36,13 @@ npx novu@latest dev
 
 | flag | long form usage example | description                   | default value               |
 | ---- | ----------------------- | ----------------------------- | --------------------------- |
-| -p   | --port <port>           | local bridge application port | 4000                        |
-| -r   | --route <route>         | bridge application route      | /api/novu                   |
-| -o   | --origin <origin>       | bridge application origin     | http://localhost            |
-| -d   | --dashboard-url <url>   | Novu cloud dashboard URL      | https://dashboard.novu.co   |
+| -p   | --port <port>           | Bridge application port       | 4000                        |
+| -r   | --route <route>         | Bridge application route      | /api/novu                   |
+| -o   | --origin <origin>       | Bridge application origin     | http://localhost            |
+| -d   | --dashboard-url <url>   | Novu Cloud dashboard URL      | https://dashboard.novu.co   |
 | -sp  | --studio-port <port>    | Local Studio server port      | 2022                        |
-| -t   | --tunnel <url>          | self hosted tunnel url        | https://my-tunnel.ngrok.app |
+| -t   | --tunnel <url>          | Self hosted tunnel url        | null                        |
+| -H   | --headless              | Run bridge in headless mode   | false                       |
 
 Example: If bridge application is running on port `3002` and Novu account is in `EU` region.
 

--- a/packages/novu/src/commands/dev/dev.ts
+++ b/packages/novu/src/commands/dev/dev.ts
@@ -50,7 +50,7 @@ export async function devCommand(options: DevCommandOptions, anonymousId?: strin
 
   dashboardSpinner.succeed(`🖥️  Dashboard → ${parsedOptions.dashboardUrl}`);
   studioSpinner.succeed(`🎨 Studio    → ${httpServer.getStudioAddress()}`);
-  if (process.env.NODE_ENV !== 'dev') {
+  if (process.env.NODE_ENV !== 'dev' && parsedOptions.open === true) {
     await open(httpServer.getStudioAddress());
   }
 

--- a/packages/novu/src/commands/dev/dev.ts
+++ b/packages/novu/src/commands/dev/dev.ts
@@ -50,7 +50,7 @@ export async function devCommand(options: DevCommandOptions, anonymousId?: strin
 
   dashboardSpinner.succeed(`🖥️  Dashboard → ${parsedOptions.dashboardUrl}`);
   studioSpinner.succeed(`🎨 Studio    → ${httpServer.getStudioAddress()}`);
-  if (process.env.NODE_ENV !== 'dev' && parsedOptions.open === true) {
+  if (process.env.NODE_ENV !== 'dev' && parsedOptions.headless === false) {
     await open(httpServer.getStudioAddress());
   }
 

--- a/packages/novu/src/commands/dev/types.ts
+++ b/packages/novu/src/commands/dev/types.ts
@@ -8,7 +8,7 @@ export type DevCommandOptions = {
   dashboardUrl: string;
   route: string;
   tunnel: string;
-  open: boolean; // commander.js negates flags prefixed with `--no`, so `--no-open` is `open: false`
+  headless: boolean;
 };
 
 export type LocalTunnelResponse = {

--- a/packages/novu/src/commands/dev/types.ts
+++ b/packages/novu/src/commands/dev/types.ts
@@ -8,6 +8,7 @@ export type DevCommandOptions = {
   dashboardUrl: string;
   route: string;
   tunnel: string;
+  open: boolean; // commander.js negates flags prefixed with `--no`, so `--no-open` is `open: false`
 };
 
 export type LocalTunnelResponse = {

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -72,6 +72,7 @@ program
   .option('-d, --dashboard-url <url>', 'The Novu Cloud Dashboard URL', 'https://dashboard.novu.co')
   .option('-sp, --studio-port <port>', 'The Local Studio server port', '2022')
   .option('-t, --tunnel <url>', 'Self hosted tunnel. e.g. https://my-tunnel.ngrok.app')
+  .option('--no-open', 'Do not open the browser automatically')
   .action(async (options: DevCommandOptions) => {
     analytics.track({
       identity: {

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -65,14 +65,14 @@ program
   Running with a custom tunnel:
   (e.g., npx novu@latest dev --tunnel https://my-tunnel.ngrok.app)`
   )
-  .usage('[-p <port>] [-r <route>] [-o <origin>] [-d <dashboard-url>] [-sp <studio-port>]')
+  .usage('[-p <port>] [-r <route>] [-o <origin>] [-d <dashboard-url>] [-sp <studio-port>] [-t <url>] [-H]')
   .option('-p, --port <port>', 'The local Bridge endpoint port', '4000')
   .option('-r, --route <route>', 'The Bridge endpoint route', '/api/novu')
   .option('-o, --origin <origin>', 'The Bridge endpoint origin')
   .option('-d, --dashboard-url <url>', 'The Novu Cloud Dashboard URL', 'https://dashboard.novu.co')
   .option('-sp, --studio-port <port>', 'The Local Studio server port', '2022')
   .option('-t, --tunnel <url>', 'Self hosted tunnel. e.g. https://my-tunnel.ngrok.app')
-  .option('--no-open', 'Do not open the browser automatically')
+  .option('-H, --headless', 'Run the Bridge in headless mode without opening the browser', false)
   .action(async (options: DevCommandOptions) => {
     analytics.track({
       identity: {


### PR DESCRIPTION
### What changed? Why was the change needed?
* Add `--no-open` flag to prevent automatic browser open with `npx novu dev` command
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

Docs PR: https://github.com/novuhq/docs/pull/735

### Screenshots
_Demonstration of with/without `--headless` flag_

https://github.com/user-attachments/assets/b1e00048-d972-4ae1-b306-e42df22fc163

_Updated `-h` command docs_
```bash
Usage: novu dev [-p <port>] [-r <route>] [-o <origin>] [-d <dashboard-url>] [-sp <studio-port>] [-t <url>] [-H]

Start Novu Studio and a local tunnel

  Running the Bridge application on port 4000:
  (e.g., npx novu@latest dev -p 4000)

  Running the Bridge application on a different route:
  (e.g., npx novu@latest dev -r /v1/api/novu)

  Running with a custom tunnel:
  (e.g., npx novu@latest dev --tunnel https://my-tunnel.ngrok.app)

Options:
  -p, --port <port>          The local Bridge endpoint port (default: "4000")
  -r, --route <route>        The Bridge endpoint route (default: "/api/novu")
  -o, --origin <origin>      The Bridge endpoint origin
  -d, --dashboard-url <url>  The Novu Cloud Dashboard URL (default:
                             "https://dashboard.novu.co")
  -sp, --studio-port <port>  The Local Studio server port (default: "2022")
  -t, --tunnel <url>         Self hosted tunnel. e.g.
                             https://my-tunnel.ngrok.app
  -H, --headless             Run the Bridge in headless mode without opening the
                             browser (default: false)
  -h, --help                 display help for command
```

<!-- If the changes are visual, include screenshots or screencasts. -->
Docs PR: https://github.com/novuhq/novu/pull/7021

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
