### PR TITLE
chore(dashboard): in-app editor polished inbox preview

### DIFF
--- a/apps/dashboard/src/components/primitives/accordion.tsx
+++ b/apps/dashboard/src/components/primitives/accordion.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
-import { ChevronDownIcon } from '@radix-ui/react-icons';
+import { RiArrowDownSLine } from 'react-icons/ri';
 
 import { cn } from '@/utils/ui';
 
@@ -35,7 +35,7 @@ const AccordionTrigger = React.forwardRef<React.ElementRef<typeof AccordionPrimi
       >
         {children}
         {withChevron && (
-          <ChevronDownIcon className="text-muted-foreground h-4 w-4 shrink-0 transition-transform duration-200" />
+          <RiArrowDownSLine className="text-foreground-400 h-4 w-4 shrink-0 transition-transform duration-200" />
         )}
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
@@ -52,7 +52,7 @@ const AccordionContent = React.forwardRef<
     className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
     {...props}
   >
-    <div className={cn('pb-4 pt-0', className)}>{children}</div>
+    <div className={cn('pt-0', className)}>{children}</div>
   </AccordionPrimitive.Content>
 ));
 AccordionContent.displayName = AccordionPrimitive.Content.displayName;

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-in-app-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-in-app-preview.tsx
@@ -4,7 +4,7 @@ import { usePreviewStep } from '@/hooks';
 import { InAppPreview } from '@/components/workflow-editor/in-app-preview';
 
 export function ConfigureInAppPreview() {
-  const { previewStep, data } = usePreviewStep();
+  const { previewStep, data, isPending: isPreviewPending } = usePreviewStep();
   const { workflowSlug, stepSlug } = useParams<{
     workflowSlug: string;
     stepSlug: string;
@@ -16,9 +16,5 @@ export function ConfigureInAppPreview() {
     }
   }, [workflowSlug, stepSlug, previewStep]);
 
-  if (!data) {
-    return null;
-  }
-
-  return <InAppPreview data={data} />;
+  return <InAppPreview data={data} truncateBody isLoading={isPreviewPending} />;
 }

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-content.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-content.tsx
@@ -38,23 +38,33 @@ export const ConfigureStepContent = () => {
 
           {!firstError && <ConfigureInAppPreview />}
         </SidebarContent>
-        <Separator />
         {firstError && (
-          <SidebarContent>
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-medium">Action required</span>
-              <Link to="https://docs.novu.co/sdks/framework/typescript/steps/inApp" reloadDocument className="text-xs">
-                <span>Help?</span>
+          <>
+            <Separator />
+            <SidebarContent>
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium">Action required</span>
+                <Link
+                  to="https://docs.novu.co/sdks/framework/typescript/steps/inApp"
+                  reloadDocument
+                  className="text-xs"
+                >
+                  <span>Help?</span>
+                </Link>
+              </div>
+              <Link to={'./edit'} relative="path" state={{ stepType: step.type }}>
+                <Button
+                  variant="outline"
+                  className="flex w-full justify-start gap-1.5 text-xs font-medium"
+                  type="button"
+                >
+                  <span className="bg-destructive h-4 min-w-1 rounded-full" />
+                  <span className="overflow-hidden text-ellipsis">{firstError}</span>
+                  <RiArrowRightUpLine className="text-destructive ml-auto h-4 w-4" />
+                </Button>
               </Link>
-            </div>
-            <Link to={'./edit'} relative="path" state={{ stepType: step.type }}>
-              <Button variant="outline" className="flex w-full justify-start gap-1.5 text-xs font-medium" type="button">
-                <span className="bg-destructive h-4 min-w-1 rounded-full" />
-                <span className="overflow-hidden text-ellipsis">{firstError}</span>
-                <RiArrowRightUpLine className="text-destructive ml-auto h-4 w-4" />
-              </Button>
-            </Link>
-          </SidebarContent>
+            </SidebarContent>
+          </>
         )}
       </>
     );

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor-preview.tsx
@@ -1,25 +1,36 @@
-import { useState } from 'react';
-import { RiArrowDownSLine, RiArrowUpSLine } from 'react-icons/ri';
+import { CSSProperties, useEffect, useRef, useState } from 'react';
+import { GeneratePreviewResponseDto } from '@novu/shared';
 
 import { Notification5Fill } from '@/components/icons';
 import { Code2 } from '@/components/icons/code-2';
 import { Button } from '@/components/primitives/button';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/primitives/collapsible';
 import { Editor } from '@/components/primitives/editor';
 import { InAppPreview } from '@/components/workflow-editor/in-app-preview';
-import { GeneratePreviewResponseDto } from '@novu/shared';
 import { loadLanguage } from '@uiw/codemirror-extensions-langs';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/primitives/accordion';
 
 type InAppEditorPreviewProps = {
   value: string;
   onChange: (value: string) => void;
   previewData?: GeneratePreviewResponseDto;
   applyPreview: () => void;
+  isPreviewLoading?: boolean;
 };
 export const InAppEditorPreview = (props: InAppEditorPreviewProps) => {
-  const { value, onChange, previewData, applyPreview } = props;
-  const [isEditorOpen, setIsEditorOpen] = useState(true);
+  const { value, onChange, previewData, applyPreview, isPreviewLoading } = props;
+  const [accordionValue, setAccordionValue] = useState('payload');
   const [payloadError, setPayloadError] = useState('');
+  const [height, setHeight] = useState(0);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      if (contentRef.current) {
+        const rect = contentRef.current.getBoundingClientRect();
+        setHeight(rect.height);
+      }
+    }, 0);
+  }, [value]);
 
   return (
     <div className="flex flex-col gap-3">
@@ -28,52 +39,48 @@ export const InAppEditorPreview = (props: InAppEditorPreviewProps) => {
         In-app template
       </div>
 
-      <Collapsible
-        open={isEditorOpen}
-        onOpenChange={setIsEditorOpen}
-        className="bg-neutral-alpha-50 border-neutral-alpha-200 flex w-full flex-col gap-2 rounded-lg border p-2"
-      >
-        <CollapsibleTrigger className="flex w-full items-center justify-between text-sm">
-          <div className="flex items-center gap-1">
-            <Code2 className="size-5" />
-            Configure preview
-          </div>
+      <InAppPreview data={previewData} isLoading={isPreviewLoading} />
 
-          {isEditorOpen ? (
-            <RiArrowUpSLine className="text-neutral-alpha-400 size-5" />
-          ) : (
-            <RiArrowDownSLine className="text-neutral-alpha-400 size-5" />
-          )}
-        </CollapsibleTrigger>
-
-        <CollapsibleContent className="flex flex-col gap-2 rounded-lg p-1">
-          <Editor
-            value={value}
-            onChange={onChange}
-            lang="json"
-            extensions={[loadLanguage('json')?.extension ?? []]}
-            className="border-neutral-alpha-200 bg-background text-foreground-600 rounded-lg border border-dashed p-3"
-          />
-          {payloadError && <p className="text-destructive text-xs">{payloadError}</p>}
-          <Button
-            size="xs"
-            type="button"
-            variant="outline"
-            className="self-end"
-            onClick={() => {
-              try {
-                applyPreview();
-              } catch (e) {
-                setPayloadError(String(e));
-              }
-            }}
+      <Accordion type="single" collapsible value={accordionValue} onValueChange={setAccordionValue}>
+        <AccordionItem value="payload">
+          <AccordionTrigger>
+            <div className="flex items-center gap-1">
+              <Code2 className="size-5" />
+              Configure preview
+            </div>
+          </AccordionTrigger>
+          <AccordionContent
+            ref={contentRef}
+            className="flex flex-col gap-2"
+            style={{ '--radix-collapsible-content-height': `${height}px` } as CSSProperties}
           >
-            Apply
-          </Button>
-        </CollapsibleContent>
-      </Collapsible>
-
-      {previewData && <InAppPreview data={previewData} />}
+            <Editor
+              value={value}
+              onChange={onChange}
+              lang="json"
+              extensions={[loadLanguage('json')?.extension ?? []]}
+              className="border-neutral-alpha-200 bg-background text-foreground-600 mx-0 mt-0 rounded-lg border border-dashed p-3"
+            />
+            {payloadError && <p className="text-destructive text-xs">{payloadError}</p>}
+            <Button
+              size="xs"
+              type="button"
+              variant="outline"
+              className="self-end"
+              onClick={() => {
+                try {
+                  applyPreview();
+                  setPayloadError('');
+                } catch (e) {
+                  setPayloadError(String(e));
+                }
+              }}
+            >
+              Apply
+            </Button>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </div>
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-tabs.tsx
@@ -64,7 +64,7 @@ export const InAppTabs = ({ workflow, step }: { workflow: WorkflowResponseDto; s
     }
   }, [controlErrors, setError]);
 
-  const { previewStep, data: previewData } = usePreviewStep();
+  const { previewStep, data: previewData, isPending: isPreviewPending } = usePreviewStep();
   const { isPending, updateWorkflow } = useUpdateWorkflow({
     onSuccess: (data) => {
       resetWorkflowForm(data);
@@ -197,6 +197,7 @@ export const InAppTabs = ({ workflow, step }: { workflow: WorkflowResponseDto; s
                 value={editorValue}
                 onChange={setEditorValue}
                 previewData={previewData}
+                isPreviewLoading={isPreviewPending}
                 applyPreview={() => {
                   previewStep({
                     stepSlug,


### PR DESCRIPTION
### What changed? Why was the change needed?

In-App Editor polished Inbox preview component.
The designs between Inbox preview in the Configure Step Sidebar and the In-App Editor were not consistent, so I had to take a decision on a few things:
- added in the header line between bell and Inbox buttons
- used the font 12px for the subject
- used body color gray

Did also additional improvements:
- Inbox preview skeleton loader
- Collapsible payload with nice animation


<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots


![Screenshot 2024-11-16 at 00 06 55](https://github.com/user-attachments/assets/044faa20-ff74-4f85-9c7e-d5bff36f81c4)
![Screenshot 2024-11-16 at 00 07 18](https://github.com/user-attachments/assets/89ea6c50-cd06-4bec-ab0c-b4791058159a)

https://github.com/user-attachments/assets/bb44daf5-f3a6-4657-b79b-487b6a0b1926


https://github.com/user-attachments/assets/4ccd1c02-9d64-4bbb-a2a2-2f1b96de62d3


