### PR TITLE
chore(root): update runner environment from blacksmith to ubuntu-latest

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   check:
     name: Verify
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   main:
     name: Validate PR titles
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/milestone-assign.yml
+++ b/.github/workflows/milestone-assign.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/on-pr-change.yml
+++ b/.github/workflows/on-pr-change.yml
@@ -8,7 +8,7 @@ on:
       - edited
 jobs:
   check-branches:
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Check branches
         env:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,7 +9,7 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr-manager.yml
+++ b/.github/workflows/pr-manager.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Process stale PRs
         uses: actions/stale@v9


### PR DESCRIPTION
### What changed? Why was the change needed?

Moving back to ghRunners as we disable renovateHQ, we should be able to get machines back. 

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
