### PR TITLE
fix(api): Support fetching V1 Workflows without V2 Preferences

### DIFF
--- a/libs/application-generic/src/usecases/workflow/get-workflow-by-ids/get-workflow-by-ids.usecase.ts
+++ b/libs/application-generic/src/usecases/workflow/get-workflow-by-ids/get-workflow-by-ids.usecase.ts
@@ -9,6 +9,10 @@ import {
   NotificationTemplateEntity,
   NotificationTemplateRepository,
 } from '@novu/dal';
+import {
+  buildWorkflowPreferencesFromPreferenceChannels,
+  DEFAULT_WORKFLOW_PREFERENCES,
+} from '@novu/shared';
 import { GetPreferences, GetPreferencesCommand } from '../../get-preferences';
 
 import { GetWorkflowByIdsCommand } from './get-workflow-by-ids.command';
@@ -60,16 +64,26 @@ export class GetWorkflowByIdsUseCase {
     /**
      * @deprecated - use `userPreferences` and `defaultPreferences` instead
      */
-    const preferenceSettings =
-      GetPreferences.mapWorkflowPreferencesToChannelPreferences(
-        workflowPreferences.preferences,
-      );
+    const preferenceSettings = workflowPreferences
+      ? GetPreferences.mapWorkflowPreferencesToChannelPreferences(
+          workflowPreferences.preferences,
+        )
+      : workflowEntity.preferenceSettings;
+    const userPreferences = workflowPreferences
+      ? workflowPreferences.source.USER_WORKFLOW
+      : buildWorkflowPreferencesFromPreferenceChannels(
+          workflowEntity.critical,
+          workflowEntity.preferenceSettings,
+        );
+    const defaultPreferences = workflowPreferences
+      ? workflowPreferences.source.WORKFLOW_RESOURCE
+      : DEFAULT_WORKFLOW_PREFERENCES;
 
     return {
       ...workflowEntity,
       preferenceSettings,
-      userPreferences: workflowPreferences.source.USER_WORKFLOW,
-      defaultPreferences: workflowPreferences.source.WORKFLOW_RESOURCE,
+      userPreferences,
+      defaultPreferences,
     };
   }
 }


### PR DESCRIPTION
### What changed? Why was the change needed?
* Support fetching V1 Workflows without V2 Preferences
  * add test for fetching V1 Workflows without V2 Preferences
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
