### PR TITLE
fix(dashboard): add control values to step editor in-app preview

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/configure-in-app-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-in-app-preview.tsx
@@ -2,19 +2,26 @@ import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { usePreviewStep } from '@/hooks';
 import { InAppPreview } from '@/components/workflow-editor/in-app-preview';
+import { useStepEditorContext } from '@/components/workflow-editor/steps/hooks';
 
 export function ConfigureInAppPreview() {
   const { previewStep, data, isPending: isPreviewPending } = usePreviewStep();
+  const { step, isPendingStep } = useStepEditorContext();
+
   const { workflowSlug, stepSlug } = useParams<{
     workflowSlug: string;
     stepSlug: string;
   }>();
 
   useEffect(() => {
-    if (workflowSlug && stepSlug) {
-      previewStep({ workflowSlug, stepSlug });
-    }
-  }, [workflowSlug, stepSlug, previewStep]);
+    if (!workflowSlug || !stepSlug || !step || isPendingStep) return;
+
+    previewStep({
+      workflowSlug,
+      stepSlug,
+      data: { controlValues: step.controls.values, previewPayload: {} },
+    });
+  }, [workflowSlug, stepSlug, previewStep, step, isPendingStep]);
 
   return <InAppPreview data={data} truncateBody isLoading={isPreviewPending} />;
 }

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step.tsx
@@ -12,8 +12,9 @@ import { useStep } from './use-step';
 import { ConfirmationModal } from '@/components/confirmation-modal';
 import { ConfigureStepContent } from './configure-step-content';
 import { PageMeta } from '@/components/page-meta';
+import { StepEditorProvider } from '@/components/workflow-editor/steps/step-editor-provider';
 
-export function ConfigureStep() {
+const ConfigureStepInternal = () => {
   const { step } = useStep();
   const navigate = useNavigate();
   const { currentEnvironment } = useEnvironment();
@@ -99,4 +100,12 @@ export function ConfigureStep() {
       </motion.div>
     </>
   );
-}
+};
+
+export const ConfigureStep = () => {
+  return (
+    <StepEditorProvider>
+      <ConfigureStepInternal />
+    </StepEditorProvider>
+  );
+};


### PR DESCRIPTION
### What changed? Why was the change needed?

The preview endpoint needs control values on payload. The control values are available in `StepEditorProvider`.