### PR TITLE
style(api): Use slugify for default values of payload JSON

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/validate-content/collect-placeholders/collect-placeholder-with-defaults.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/validate-content/collect-placeholders/collect-placeholder-with-defaults.usecase.ts
@@ -1,4 +1,5 @@
 import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { slugify } from '@novu/shared';
 import { PlaceholderAggregation } from './placeholder.aggregation';
 import { HydrateEmailSchemaUseCase } from '../../../../environments-v1/usecases/output-renderers';
 import { CollectPlaceholderWithDefaultsCommand } from './collect-placeholder-with-defaults.command';
@@ -110,7 +111,7 @@ function extractLiquidJSPlaceholders(text: string) {
     } else {
       matches.push({
         placeholder: `{{${trimmedContent}}}`,
-        defaultValue,
+        defaultValue: slugify(defaultValue, { separator: '_' }),
       });
     }
   }


### PR DESCRIPTION
### What changed? Why was the change needed?
* Use slugify for default values of payload JSON

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
_Mini Preview_
![image](https://github.com/user-attachments/assets/7bdf8bc9-4c5f-4044-83a5-a43981407188)

_Preview Tab_
![image](https://github.com/user-attachments/assets/7e888585-01d0-48fe-a601-7c9c9531b7d8)

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
