### PR TITLE
fix(dashboard): Add shrink-0 to workflow status icon

### DIFF
--- a/apps/dashboard/src/components/primitives/badge.tsx
+++ b/apps/dashboard/src/components/primitives/badge.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 const badgeVariants = cva(
-  'inline-flex items-center gap-1 h-fit border text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center [&>svg]:shrink-0 gap-1 h-fit border text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
Before:
<img width="304" alt="Screenshot 2024-11-20 at 8 40 40 AM" src="https://github.com/user-attachments/assets/29948f49-fbc5-4be3-a889-3aa0b5440218">

After:
<img width="277" alt="Screenshot 2024-11-20 at 8 40 59 AM" src="https://github.com/user-attachments/assets/8c6a2184-58b3-4675-be49-3743f0633ce8">

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
