### PR TITLE
style(dashboard): Refine modal, tooltip, and preview content accordion

### DIFF
--- a/apps/dashboard/src/components/confirmation-modal.tsx
+++ b/apps/dashboard/src/components/confirmation-modal.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/primitives/dialog';
+import { ReactNode } from 'react';
 import { RiAlertFill } from 'react-icons/ri';
 
 type ConfirmationModalProps = {
@@ -17,7 +18,7 @@ type ConfirmationModalProps = {
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
   title: string;
-  description: string;
+  description: ReactNode;
   confirmButtonText: string;
   isLoading?: boolean;
 };

--- a/apps/dashboard/src/components/pause-workflow-dialog.tsx
+++ b/apps/dashboard/src/components/pause-workflow-dialog.tsx
@@ -1,0 +1,7 @@
+export const PauseModalDescription = ({ workflowName }: { workflowName: string }) => (
+  <>
+    The <strong>{workflowName}</strong> workflow cannot be triggered if paused, please confirm to proceed.
+  </>
+);
+
+export const PAUSE_MODAL_TITLE = 'Proceeding will pause the workflow';

--- a/apps/dashboard/src/components/pause-workflow-dialog.tsx
+++ b/apps/dashboard/src/components/pause-workflow-dialog.tsx
@@ -1,6 +1,7 @@
 export const PauseModalDescription = ({ workflowName }: { workflowName: string }) => (
   <>
-    The <strong>{workflowName}</strong> workflow cannot be triggered if paused, please confirm to proceed.
+    Pausing the <strong>{workflowName}</strong> workflow will immediately prevent your integration from being able to
+    trigger it.
   </>
 );
 

--- a/apps/dashboard/src/components/pause-workflow-dialog.tsx
+++ b/apps/dashboard/src/components/pause-workflow-dialog.tsx
@@ -1,6 +1,12 @@
+import TruncatedText from './truncated-text';
+
 export const PauseModalDescription = ({ workflowName }: { workflowName: string }) => (
   <>
-    Pausing the <strong>{workflowName}</strong> workflow will immediately prevent you frombeing able to trigger it.
+    Pausing the{' '}
+    <strong>
+      <TruncatedText className="max-w-[32ch]">{workflowName}</TruncatedText>
+    </strong>{' '}
+    workflow will immediately prevent you from being able to trigger it.
   </>
 );
 

--- a/apps/dashboard/src/components/pause-workflow-dialog.tsx
+++ b/apps/dashboard/src/components/pause-workflow-dialog.tsx
@@ -1,7 +1,6 @@
 export const PauseModalDescription = ({ workflowName }: { workflowName: string }) => (
   <>
-    Pausing the <strong>{workflowName}</strong> workflow will immediately prevent your integration from being able to
-    trigger it.
+    Pausing the <strong>{workflowName}</strong> workflow will immediately prevent you frombeing able to trigger it.
   </>
 );
 

--- a/apps/dashboard/src/components/primitives/hover-to-copy.tsx
+++ b/apps/dashboard/src/components/primitives/hover-to-copy.tsx
@@ -24,6 +24,7 @@ export const HoverToCopy = (props: HoverToCopyProps) => {
     <Tooltip>
       <TooltipTrigger aria-label="Copy to clipboard" onClick={copyToClipboard} {...rest} />
       <TooltipContent
+        side="right"
         onPointerDownOutside={(e) => {
           e.preventDefault();
         }}

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow.tsx
@@ -20,7 +20,7 @@ import { cn } from '@/utils/ui';
 import { SidebarContent, SidebarHeader } from '@/components/side-navigation/Sidebar';
 import { PageMeta } from '../page-meta';
 import { ConfirmationModal } from '../confirmation-modal';
-import { PAUSE_MODAL_DESCRIPTION, PAUSE_MODAL_TITLE } from '@/utils/constants';
+import { PauseModalDescription, PAUSE_MODAL_TITLE } from '../pause-workflow-dialog';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { useEnvironment } from '@/context/environment/hooks';
 
@@ -70,7 +70,7 @@ export function ConfigureWorkflow() {
           setIsPauseModalOpen(false);
         }}
         title={PAUSE_MODAL_TITLE}
-        description={PAUSE_MODAL_DESCRIPTION(workflowName)}
+        description={<PauseModalDescription workflowName={workflowName} />}
         confirmButtonText="Proceed"
       />
       <PageMeta title={workflowName} />

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow.tsx
@@ -20,7 +20,7 @@ import { cn } from '@/utils/ui';
 import { SidebarContent, SidebarHeader } from '@/components/side-navigation/Sidebar';
 import { PageMeta } from '../page-meta';
 import { ConfirmationModal } from '../confirmation-modal';
-import { PauseModalDescription, PAUSE_MODAL_TITLE } from '../pause-workflow-dialog';
+import { PauseModalDescription, PAUSE_MODAL_TITLE } from '@/components/pause-workflow-dialog';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { useEnvironment } from '@/context/environment/hooks';
 

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step.tsx
@@ -84,8 +84,12 @@ const ConfigureStepInternal = () => {
                 open={isDeleteModalOpen}
                 onOpenChange={setIsDeleteModalOpen}
                 onConfirm={onDeleteStep}
-                title="Are you sure?"
-                description={`You're about to delete the ${step?.name}, this action cannot be undone.`}
+                title="Proceeding will delete the step"
+                description={
+                  <>
+                    You're about to delete the <strong>{step?.name}</strong> step, this action is permanent.
+                  </>
+                }
                 confirmButtonText="Delete"
               />
               <Button

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step.tsx
@@ -14,6 +14,7 @@ import { ConfigureStepContent } from './configure-step-content';
 import { PageMeta } from '@/components/page-meta';
 import { StepEditorProvider } from '@/components/workflow-editor/steps/step-editor-provider';
 import { EXCLUDED_EDITOR_TYPES } from '@/utils/constants';
+import TruncatedText from '@/components/truncated-text';
 
 const ConfigureStepInternal = () => {
   const { step } = useStep();
@@ -87,7 +88,11 @@ const ConfigureStepInternal = () => {
                 title="Proceeding will delete the step"
                 description={
                   <>
-                    You're about to delete the <strong>{step?.name}</strong> step, this action is permanent.
+                    You're about to delete the{' '}
+                    <strong>
+                      <TruncatedText className="max-w-[32ch]">{step?.name}</TruncatedText>
+                    </strong>{' '}
+                    step, this action is permanent.
                   </>
                 }
                 confirmButtonText="Delete"

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor-preview.tsx
@@ -9,6 +9,14 @@ import { InAppPreview } from '@/components/workflow-editor/in-app-preview';
 import { loadLanguage } from '@uiw/codemirror-extensions-langs';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/primitives/accordion';
 
+const getInitialAccordionValue = (value: string) => {
+  try {
+    return Object.keys(JSON.parse(value)).length > 0 ? 'payload' : undefined;
+  } catch (e) {
+    return undefined;
+  }
+};
+
 type InAppEditorPreviewProps = {
   value: string;
   onChange: (value: string) => void;
@@ -18,10 +26,16 @@ type InAppEditorPreviewProps = {
 };
 export const InAppEditorPreview = (props: InAppEditorPreviewProps) => {
   const { value, onChange, previewData, applyPreview, isPreviewLoading } = props;
-  const [accordionValue, setAccordionValue] = useState('payload');
+  const [accordionValue, setAccordionValue] = useState<string | undefined>(getInitialAccordionValue(value));
   const [payloadError, setPayloadError] = useState('');
   const [height, setHeight] = useState(0);
   const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setAccordionValue(getInitialAccordionValue(value));
+  }, [value]);
+
+  console.log({ value });
 
   useEffect(() => {
     setTimeout(() => {

--- a/apps/dashboard/src/components/workflow-row.tsx
+++ b/apps/dashboard/src/components/workflow-row.tsx
@@ -39,7 +39,7 @@ import { ConfirmationModal } from './confirmation-modal';
 import { showToast } from './primitives/sonner-helpers';
 import { ToastIcon } from './primitives/sonner';
 import { usePatchWorkflow } from '@/hooks/use-patch-workflow';
-import { PAUSE_MODAL_DESCRIPTION, PAUSE_MODAL_TITLE } from '@/utils/constants';
+import { PauseModalDescription, PAUSE_MODAL_TITLE } from '@/components/pause-workflow-dialog';
 
 type WorkflowRowProps = {
   workflow: WorkflowListResponseDto;
@@ -215,7 +215,7 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
             setIsPauseModalOpen(false);
           }}
           title={PAUSE_MODAL_TITLE}
-          description={PAUSE_MODAL_DESCRIPTION(workflow.name)}
+          description={<PauseModalDescription workflowName={workflow.name} />}
           confirmButtonText="Proceed"
           isLoading={isPauseWorkflowPending}
         />

--- a/apps/dashboard/src/utils/constants.ts
+++ b/apps/dashboard/src/utils/constants.ts
@@ -12,8 +12,3 @@ export const EXCLUDED_EDITOR_TYPES: string[] = [
   StepTypeEnum.TRIGGER,
   StepTypeEnum.CUSTOM,
 ];
-
-export const PAUSE_MODAL_TITLE = 'Proceeding will pause the workflow';
-// convert it to accept dynamic workflow name
-export const PAUSE_MODAL_DESCRIPTION = (workflowName: string) =>
-  `The ${workflowName} cannot be triggered if paused, please confirm to proceed.`;


### PR DESCRIPTION
### What changed? Why was the change needed?
* Refine pause workflow modal copy and styling
* Move copy-text tooltip to right by default
* Stop opening the preview payload JSON accordion when no payload data is present in content
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
_Updated pause workflow modal_
<img width="451" alt="image" src="https://github.com/user-attachments/assets/bb79c6da-f79a-4c07-a894-b67972bf3ed6">

_Updated delete step modal_
<img width="422" alt="image" src="https://github.com/user-attachments/assets/4b7485ec-788a-4d35-8cb3-8b4c243f8e36">

_Moved click to copy tooltip to the right_
<img width="263" alt="image" src="https://github.com/user-attachments/assets/6ba90cc4-95c1-4626-9ec6-11461aadde6c">

still valid collision detection elsewhere
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1e2e884a-12e9-4792-8f42-f585f01bf053">

<img width="312" alt="image" src="https://github.com/user-attachments/assets/3f713f8e-0f56-4b86-a531-2e26b72f3bb9">

_Demo of stop opening the preview payload JSON accordion when no payload data is present in content_

https://github.com/user-attachments/assets/218dc0f9-8421-4650-bcbd-b71025dae959



<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
