### PR TITLE
fix(dashboard): Ensure all timeouts are cleared on component unmount

### DIFF
--- a/apps/dashboard/src/components/primitives/hover-to-copy.tsx
+++ b/apps/dashboard/src/components/primitives/hover-to-copy.tsx
@@ -14,7 +14,8 @@ export const HoverToCopy = (props: HoverToCopyProps) => {
     try {
       await navigator.clipboard.writeText(valueToCopy);
       setIsCopied(true);
-      setTimeout(() => setIsCopied(false), 1500);
+      const timeout = setTimeout(() => setIsCopied(false), 1500);
+      return () => clearTimeout(timeout);
     } catch (err) {
       console.error('Failed to copy text: ', err);
     }

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow.tsx
@@ -40,7 +40,7 @@ export function ConfigureWorkflow() {
 
   useLayoutEffect(() => {
     if (shouldUpdateWorkflowSlug) {
-      setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         navigate(
           buildRoute(ROUTES.EDIT_WORKFLOW, {
             environmentSlug: currentEnvironment?.slug ?? '',
@@ -53,6 +53,8 @@ export function ConfigureWorkflow() {
         );
       }, 0);
       setIsBlurred(false);
+
+      return () => clearTimeout(timeoutId);
     }
   }, [shouldUpdateWorkflowSlug, workflow?.slug, currentEnvironment?.slug, navigate]);
 

--- a/apps/dashboard/src/components/workflow-editor/steps/common-fields.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/common-fields.tsx
@@ -21,15 +21,16 @@ export function CommonFields() {
   const shouldUpdateStepSlug = isBlurred && isStepSlugChanged;
 
   useLayoutEffect(() => {
-    if (shouldUpdateStepSlug) {
-      setTimeout(() => {
+    const timeout = setTimeout(() => {
+      if (shouldUpdateStepSlug) {
         navigate(buildRoute(`../${ROUTES.CONFIGURE_STEP}`, { stepSlug: step?.slug ?? '' }), {
           replace: true,
           state: { skipAnimation: true },
         });
-      }, 0);
+      }
       setIsBlurred(false);
-    }
+    }, 0);
+    return () => clearTimeout(timeout);
   }, [shouldUpdateStepSlug, step, navigate]);
 
   return (

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor-preview.tsx
@@ -9,6 +9,14 @@ import { InAppPreview } from '@/components/workflow-editor/in-app-preview';
 import { loadLanguage } from '@uiw/codemirror-extensions-langs';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/primitives/accordion';
 
+const getInitialAccordionValue = (value: string) => {
+  try {
+    return Object.keys(JSON.parse(value)).length > 0 ? 'payload' : undefined;
+  } catch (e) {
+    return undefined;
+  }
+};
+
 type InAppEditorPreviewProps = {
   value: string;
   onChange: (value: string) => void;
@@ -18,10 +26,14 @@ type InAppEditorPreviewProps = {
 };
 export const InAppEditorPreview = (props: InAppEditorPreviewProps) => {
   const { value, onChange, previewData, applyPreview, isPreviewLoading } = props;
-  const [accordionValue, setAccordionValue] = useState<string | undefined>('payload');
+  const [accordionValue, setAccordionValue] = useState<string | undefined>(getInitialAccordionValue(value));
   const [payloadError, setPayloadError] = useState('');
   const [height, setHeight] = useState(0);
   const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setAccordionValue(getInitialAccordionValue(value));
+  }, [value]);
 
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -30,6 +42,7 @@ export const InAppEditorPreview = (props: InAppEditorPreviewProps) => {
         setHeight(rect.height);
       }
     }, 0);
+
     return () => clearTimeout(timeout);
   }, [value]);
 

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor-preview.tsx
@@ -9,14 +9,6 @@ import { InAppPreview } from '@/components/workflow-editor/in-app-preview';
 import { loadLanguage } from '@uiw/codemirror-extensions-langs';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/primitives/accordion';
 
-const getInitialAccordionValue = (value: string) => {
-  try {
-    return Object.keys(JSON.parse(value)).length > 0 ? 'payload' : undefined;
-  } catch (e) {
-    return undefined;
-  }
-};
-
 type InAppEditorPreviewProps = {
   value: string;
   onChange: (value: string) => void;
@@ -26,24 +18,19 @@ type InAppEditorPreviewProps = {
 };
 export const InAppEditorPreview = (props: InAppEditorPreviewProps) => {
   const { value, onChange, previewData, applyPreview, isPreviewLoading } = props;
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(getInitialAccordionValue(value));
+  const [accordionValue, setAccordionValue] = useState<string | undefined>('payload');
   const [payloadError, setPayloadError] = useState('');
   const [height, setHeight] = useState(0);
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setAccordionValue(getInitialAccordionValue(value));
-  }, [value]);
-
-  console.log({ value });
-
-  useEffect(() => {
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       if (contentRef.current) {
         const rect = contentRef.current.getBoundingClientRect();
         setHeight(rect.height);
       }
     }, 0);
+    return () => clearTimeout(timeout);
   }, [value]);
 
   return (


### PR DESCRIPTION
### What changed? Why was the change needed?
* Ensure all timeouts are cleared on component unmount, by calling the result of `setTimeout` with `clearTimeout`
  * clearing timeouts are critical in frontends, where timeouts that haven't completed can lead to memory leaks and performance issues. More info can be found [here](https://www.dhiwise.com/post/ultimate-guide-to-using-react-cleartimeout-in-applications)

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
