### PR TITLE
revert(api): Return all preference channels for Subscriber Preference API

### DIFF
--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -240,6 +240,7 @@ export class InboxController {
         in_app: body.in_app,
         push: body.push,
         sms: body.sms,
+        includeInactiveChannels: false,
       })
     );
   }
@@ -263,6 +264,7 @@ export class InboxController {
         push: body.push,
         sms: body.sms,
         workflowId,
+        includeInactiveChannels: false,
       })
     );
   }

--- a/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
@@ -120,6 +120,7 @@ describe('GetInboxPreferences', () => {
         organizationId: command.organizationId,
         environmentId: command.environmentId,
         subscriberId: command.subscriberId,
+        includeInactiveChannels: false,
       })
     );
 
@@ -130,6 +131,7 @@ describe('GetInboxPreferences', () => {
         subscriberId: command.subscriberId,
         organizationId: command.organizationId,
         tags: undefined,
+        includeInactiveChannels: false,
       })
     );
 
@@ -208,6 +210,7 @@ describe('GetInboxPreferences', () => {
         organizationId: command.organizationId,
         environmentId: command.environmentId,
         subscriberId: command.subscriberId,
+        includeInactiveChannels: false,
       })
     );
 
@@ -218,6 +221,7 @@ describe('GetInboxPreferences', () => {
         subscriberId: command.subscriberId,
         organizationId: command.organizationId,
         tags: command.tags,
+        includeInactiveChannels: false,
       })
     );
 

--- a/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.usecase.ts
@@ -27,6 +27,7 @@ export class GetInboxPreferences {
         organizationId: command.organizationId,
         environmentId: command.environmentId,
         subscriberId: command.subscriberId,
+        includeInactiveChannels: false,
       })
     );
 
@@ -41,6 +42,7 @@ export class GetInboxPreferences {
         subscriberId: command.subscriberId,
         organizationId: command.organizationId,
         tags: command.tags,
+        includeInactiveChannels: false,
       })
     );
     const workflowPreferences = subscriberWorkflowPreferences.map((subscriberWorkflowPreference) => {

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.command.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.command.ts
@@ -32,4 +32,8 @@ export class UpdatePreferencesCommand extends EnvironmentWithSubscriber {
   @IsDefined()
   @IsEnum(PreferenceLevelEnum)
   readonly level: PreferenceLevelEnum;
+
+  @IsDefined()
+  @IsBoolean()
+  readonly includeInactiveChannels: boolean;
 }

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.spec.ts
@@ -95,6 +95,7 @@ describe('UpdatePreferences', () => {
       subscriberId: 'not-found',
       level: PreferenceLevelEnum.GLOBAL,
       chat: true,
+      includeInactiveChannels: false,
     };
 
     subscriberRepositoryMock.findBySubscriberId.resolves(undefined);
@@ -115,6 +116,7 @@ describe('UpdatePreferences', () => {
       level: PreferenceLevelEnum.TEMPLATE,
       chat: true,
       workflowId: 'not-found',
+      includeInactiveChannels: false,
     };
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
@@ -135,6 +137,7 @@ describe('UpdatePreferences', () => {
       subscriberId: 'test-mockSubscriber',
       level: PreferenceLevelEnum.GLOBAL,
       chat: true,
+      includeInactiveChannels: false,
     };
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
@@ -149,6 +152,7 @@ describe('UpdatePreferences', () => {
         environmentId: command.environmentId,
         organizationId: command.organizationId,
         subscriberId: mockedSubscriber.subscriberId,
+        includeInactiveChannels: false,
       }),
     ]);
 
@@ -181,6 +185,7 @@ describe('UpdatePreferences', () => {
       workflowId: '6447aff3d89122e250412c28',
       chat: true,
       email: false,
+      includeInactiveChannels: false,
     };
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -124,6 +124,7 @@ export class UpdatePreferences {
           environmentId: command.environmentId,
           template: workflow,
           subscriber,
+          includeInactiveChannels: command.includeInactiveChannels,
         })
       );
 
@@ -146,6 +147,7 @@ export class UpdatePreferences {
         organizationId: command.organizationId,
         environmentId: command.environmentId,
         subscriberId: command.subscriberId,
+        includeInactiveChannels: command.includeInactiveChannels,
       })
     );
 

--- a/apps/api/src/app/subscribers/e2e/get-preferences.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/get-preferences.e2e.ts
@@ -2,9 +2,10 @@ import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 import { NotificationTemplateEntity } from '@novu/dal';
 
-import { getPreference } from './helpers';
+import { PreferenceLevelEnum } from '@novu/shared';
+import { getPreference, getPreferenceByLevel } from './helpers';
 
-describe('Get Subscribers preferences - /subscribers/preferences/:subscriberId (GET)', function () {
+describe('Get Subscribers workflow preferences - /subscribers/:subscriberId/preferences (GET)', function () {
   let session: UserSession;
   let template: NotificationTemplateEntity;
 
@@ -16,13 +17,44 @@ describe('Get Subscribers preferences - /subscribers/preferences/:subscriberId (
     });
   });
 
-  it('should get subscriber preferences', async function () {
-    const response = await getPreference(session);
-
+  it('should get subscriber workflow preferences with inactive channels by default', async function () {
+    const response = await getPreference(session, session.subscriberId);
     const data = response.data.data[0];
 
-    expect(data.preference.channels.email).to.equal(true);
-    expect(data.preference.channels.in_app).to.equal(true);
+    expect(data.preference.channels).to.deep.equal({
+      email: true,
+      in_app: true,
+      push: true,
+      chat: true,
+      sms: true,
+    });
+  });
+
+  it('should get subscriber workflow preferences with inactive channels when includeInactiveChannels is true', async function () {
+    const response = await getPreference(session, session.subscriberId, {
+      includeInactiveChannels: true,
+    });
+    const data = response.data.data[0];
+
+    expect(data.preference.channels).to.deep.equal({
+      email: true,
+      in_app: true,
+      push: true,
+      chat: true,
+      sms: true,
+    });
+  });
+
+  it('should get subscriber workflow preferences with active channels when includeInactiveChannels is false', async function () {
+    const response = await getPreference(session, session.subscriberId, {
+      includeInactiveChannels: false,
+    });
+    const data = response.data.data[0];
+
+    expect(data.preference.channels).to.deep.equal({
+      email: true,
+      in_app: true,
+    });
   });
 
   it('should handle un existing subscriberId', async function () {
@@ -35,5 +67,62 @@ describe('Get Subscribers preferences - /subscribers/preferences/:subscriberId (
 
     expect(error).to.be.ok;
     expect(error?.response.data.message).to.contain('not found');
+  });
+});
+
+describe('Get Subscribers preferences by level - /subscribers/:subscriberId/preferences/:level (GET)', function () {
+  let session: UserSession;
+  let template: NotificationTemplateEntity;
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+    template = await session.createTemplate({
+      noFeedId: true,
+    });
+  });
+
+  const levels = Object.values(PreferenceLevelEnum);
+
+  levels.forEach((level) => {
+    it(`should get subscriber ${level} preferences with inactive channels by default`, async function () {
+      const response = await getPreferenceByLevel(session, session.subscriberId, level);
+      const data = response.data.data[0];
+
+      expect(data.preference.channels).to.deep.equal({
+        email: true,
+        in_app: true,
+        push: true,
+        chat: true,
+        sms: true,
+      });
+    });
+
+    it(`should get subscriber ${level} preferences with inactive channels when includeInactiveChannels is true`, async function () {
+      const response = await getPreferenceByLevel(session, session.subscriberId, level, {
+        includeInactiveChannels: true,
+      });
+      const data = response.data.data[0];
+
+      expect(data.preference.channels).to.deep.equal({
+        email: true,
+        in_app: true,
+        push: true,
+        chat: true,
+        sms: true,
+      });
+    });
+
+    it(`should get subscriber ${level} preferences with active channels when includeInactiveChannels is false`, async function () {
+      const response = await getPreferenceByLevel(session, session.subscriberId, level, {
+        includeInactiveChannels: false,
+      });
+      const data = response.data.data[0];
+
+      expect(data.preference.channels).to.deep.equal({
+        email: true,
+        in_app: true,
+      });
+    });
   });
 });

--- a/apps/api/src/app/subscribers/e2e/helpers/index.ts
+++ b/apps/api/src/app/subscribers/e2e/helpers/index.ts
@@ -1,5 +1,5 @@
 import { UserSession } from '@novu/testing';
-import { IUpdateNotificationTemplateDto } from '@novu/shared';
+import { IUpdateNotificationTemplateDto, PreferenceLevelEnum } from '@novu/shared';
 import axios from 'axios';
 
 import { UpdateSubscriberOnlineFlagRequestDto } from '../../dtos/update-subscriber-online-flag-request.dto';
@@ -28,15 +28,39 @@ export async function updateNotificationTemplate(
   });
 }
 
-export async function getPreference(session: UserSession, subscriberId?: string) {
-  return await axiosInstance.get(
-    `${session.serverUrl}/v1/subscribers/${subscriberId || session.subscriberId}/preferences`,
-    {
-      headers: {
-        authorization: `ApiKey ${session.apiKey}`,
-      },
-    }
-  );
+export async function getPreference(
+  session: UserSession,
+  subscriberId = session.subscriberId,
+  queryParams: { includeInactiveChannels?: boolean } = {}
+) {
+  const url = new URL(`${session.serverUrl}/v1/subscribers/${subscriberId}/preferences`);
+  Object.entries(queryParams).forEach(([key, value]) => {
+    url.searchParams.append(key, String(value));
+  });
+
+  return await axiosInstance.get(url.toString(), {
+    headers: {
+      authorization: `ApiKey ${session.apiKey}`,
+    },
+  });
+}
+
+export async function getPreferenceByLevel(
+  session: UserSession,
+  subscriberId = session.subscriberId,
+  level: PreferenceLevelEnum,
+  queryParams: { includeInactiveChannels?: boolean } = {}
+) {
+  const url = new URL(`${session.serverUrl}/v1/subscribers/${subscriberId}/preferences/${level}`);
+  Object.entries(queryParams).forEach(([key, value]) => {
+    url.searchParams.append(key, String(value));
+  });
+
+  return await axiosInstance.get(url.toString(), {
+    headers: {
+      authorization: `ApiKey ${session.apiKey}`,
+    },
+  });
 }
 
 export async function updateSubscriberOnlineFlag(

--- a/apps/api/src/app/subscribers/e2e/update-global-preference.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/update-global-preference.e2e.ts
@@ -58,14 +58,20 @@ describe('Update Subscribers global preferences - /subscribers/:subscriberId/pre
     expect(response.data.data.preference.channels).to.not.eql({
       [ChannelTypeEnum.IN_APP]: true,
     });
-    expect(response.data.data.preference.channels).to.eql({});
+    expect(response.data.data.preference.channels).to.eql({
+      [ChannelTypeEnum.EMAIL]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
+      [ChannelTypeEnum.IN_APP]: true,
+    });
   });
 
   it('should update user global preferences for multiple channels', async function () {
     const payload = {
       enabled: true,
       preferences: [
-        { type: ChannelTypeEnum.PUSH, enabled: true },
+        { type: ChannelTypeEnum.PUSH, enabled: false },
         { type: ChannelTypeEnum.IN_APP, enabled: false },
         { type: ChannelTypeEnum.SMS, enabled: true },
       ],
@@ -74,13 +80,13 @@ describe('Update Subscribers global preferences - /subscribers/:subscriberId/pre
     const response = await updateGlobalPreferences(payload, session);
 
     expect(response.data.data.preference.enabled).to.eql(true);
-    expect(response.data.data.preference.channels).to.eql({});
-  });
-
-  it('should unset all preferences when the preferences object is empty', async function () {
-    const response = await updateGlobalPreferences({}, session);
-
-    expect(response.data.data.preference.channels).to.eql({});
+    expect(response.data.data.preference.channels).to.eql({
+      [ChannelTypeEnum.EMAIL]: true,
+      [ChannelTypeEnum.PUSH]: false,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
+      [ChannelTypeEnum.IN_APP]: false,
+    });
   });
 
   // `enabled` flag is not used anymore. The presence of a preference object means that the subscriber has enabled notifications.

--- a/apps/api/src/app/subscribers/e2e/update-preference.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/update-preference.e2e.ts
@@ -131,6 +131,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(initialPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
 
     const emptyPreferenceData = {
@@ -145,6 +148,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(preferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
   });
 
@@ -155,6 +161,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(initialPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
 
     const disablePreferenceData = {
@@ -168,6 +177,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(midwayPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
 
     const updateEmailPreferenceData = {
@@ -184,6 +196,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(finalPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: false,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
   });
 
@@ -194,6 +209,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(initialPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
 
     const disablePreferenceData = {
@@ -207,6 +225,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(midwayPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
 
     const enablePreferenceData = {
@@ -220,6 +241,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(finalPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
   });
 
@@ -229,6 +253,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(initialPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
 
     const disableEmailPreferenceData = {
@@ -245,6 +272,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(updatedPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: false,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
 
     const enableEmailPreferenceData = {
@@ -261,6 +291,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(finalPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
   });
 
@@ -270,6 +303,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(initialPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
 
     const updateSmsPreferenceData = {
@@ -286,6 +322,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(finalPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: false,
     });
   });
 
@@ -317,6 +356,8 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
       [ChannelTypeEnum.SMS]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
     });
 
     const updateSmsPreferenceData = {
@@ -334,6 +375,8 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
       [ChannelTypeEnum.SMS]: false,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
     });
   });
 
@@ -370,6 +413,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(initialPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: true,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
 
     const updateSmsPreferenceData = {
@@ -386,6 +432,9 @@ describe('Update Subscribers preferences - /subscribers/:subscriberId/preference
     expect(finalPreferences.preference.channels).to.eql({
       [ChannelTypeEnum.EMAIL]: false,
       [ChannelTypeEnum.IN_APP]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
     });
   });
 });

--- a/apps/api/src/app/subscribers/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers/subscribers.controller.ts
@@ -401,16 +401,25 @@ export class SubscribersController {
   @ApiOperation({
     summary: 'Get subscriber preferences',
   })
+  @ApiQuery({
+    name: 'includeInactiveChannels',
+    type: Boolean,
+    required: false,
+    description:
+      'A flag which specifies if the inactive workflow channels should be included in the retrieved preferences. Default is true',
+  })
   @SdkGroupName('Subscribers.Preferences')
   async listSubscriberPreferences(
     @UserSession() user: UserSessionData,
-    @Param('subscriberId') subscriberId: string
+    @Param('subscriberId') subscriberId: string,
+    @Query('includeInactiveChannels') includeInactiveChannels: boolean
   ): Promise<UpdateSubscriberPreferenceResponseDto[]> {
     const command = GetPreferencesByLevelCommand.create({
       organizationId: user.organizationId,
       subscriberId,
       environmentId: user.environmentId,
       level: PreferenceLevelEnum.TEMPLATE,
+      includeInactiveChannels: includeInactiveChannels ?? true,
     });
 
     return (await this.getPreferenceUsecase.execute(command)) as UpdateSubscriberPreferenceResponseDto[];
@@ -431,17 +440,26 @@ export class SubscribersController {
     required: true,
     description: 'the preferences level to be retrieved (template / global) ',
   })
+  @ApiQuery({
+    name: 'includeInactiveChannels',
+    type: Boolean,
+    required: false,
+    description:
+      'A flag which specifies if the inactive workflow channels should be included in the retrieved preferences. Default is true',
+  })
   @SdkGroupName('Subscribers.Preferences')
   @SdkMethodName('retrieveByLevel')
   async getSubscriberPreferenceByLevel(
     @UserSession() user: UserSessionData,
-    @Param() { parameter, subscriberId }: GetSubscriberPreferencesByLevelParams
+    @Param() { parameter, subscriberId }: GetSubscriberPreferencesByLevelParams,
+    @Query('includeInactiveChannels') includeInactiveChannels: boolean
   ): Promise<GetSubscriberPreferencesResponseDto[]> {
     const command = GetPreferencesByLevelCommand.create({
       organizationId: user.organizationId,
       subscriberId,
       environmentId: user.environmentId,
       level: parameter,
+      includeInactiveChannels: includeInactiveChannels ?? true,
     });
 
     return await this.getPreferenceUsecase.execute(command);
@@ -470,6 +488,7 @@ export class SubscribersController {
         subscriberId,
         workflowId: templateId,
         level: PreferenceLevelEnum.TEMPLATE,
+        includeInactiveChannels: true,
         ...(body.channel && { [body.channel.type]: body.channel.enabled }),
       })
     );
@@ -522,6 +541,7 @@ export class SubscribersController {
         organizationId: user.organizationId,
         subscriberId,
         level: PreferenceLevelEnum.GLOBAL,
+        includeInactiveChannels: true,
         ...channels,
       })
     );

--- a/apps/api/src/app/subscribers/usecases/get-preferences-by-level/get-preferences-by-level.command.ts
+++ b/apps/api/src/app/subscribers/usecases/get-preferences-by-level/get-preferences-by-level.command.ts
@@ -1,4 +1,4 @@
-import { IsDefined, IsEnum, IsString } from 'class-validator';
+import { IsBoolean, IsDefined, IsEnum, IsOptional, IsString } from 'class-validator';
 import { PreferenceLevelEnum } from '@novu/dal';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
@@ -10,4 +10,8 @@ export class GetPreferencesByLevelCommand extends EnvironmentCommand {
   @IsEnum(PreferenceLevelEnum)
   @IsDefined()
   level: PreferenceLevelEnum;
+
+  @IsBoolean()
+  @IsDefined()
+  includeInactiveChannels: boolean;
 }

--- a/apps/api/src/app/subscribers/usecases/get-preferences-by-level/get-preferences-by-level.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-preferences-by-level/get-preferences-by-level.usecase.ts
@@ -22,6 +22,7 @@ export class GetPreferencesByLevel {
         organizationId: command.organizationId,
         environmentId: command.environmentId,
         subscriberId: command.subscriberId,
+        includeInactiveChannels: command.includeInactiveChannels,
       });
       const globalPreferences = await this.getSubscriberGlobalPreference.execute(globalPreferenceCommand);
 
@@ -32,6 +33,7 @@ export class GetPreferencesByLevel {
       organizationId: command.organizationId,
       environmentId: command.environmentId,
       subscriberId: command.subscriberId,
+      includeInactiveChannels: command.includeInactiveChannels,
     });
 
     return await this.getSubscriberPreferenceUsecase.execute(preferenceCommand);

--- a/apps/api/src/app/widgets/widgets.controller.ts
+++ b/apps/api/src/app/widgets/widgets.controller.ts
@@ -414,6 +414,7 @@ export class WidgetsController {
       organizationId: subscriberSession._organizationId,
       subscriberId: subscriberSession.subscriberId,
       environmentId: subscriberSession._environmentId,
+      includeInactiveChannels: false,
     });
 
     return await this.getSubscriberPreferenceUsecase.execute(command);
@@ -429,6 +430,7 @@ export class WidgetsController {
       organizationId: subscriberSession._organizationId,
       subscriberId: subscriberSession.subscriberId,
       environmentId: subscriberSession._environmentId,
+      includeInactiveChannels: false,
       level,
     });
 
@@ -449,6 +451,7 @@ export class WidgetsController {
         subscriberId: subscriberSession.subscriberId,
         workflowId: templateId,
         level: PreferenceLevelEnum.TEMPLATE,
+        includeInactiveChannels: false,
         ...(body.channel && { [body.channel.type]: body.channel.enabled }),
       })
     );
@@ -493,6 +496,7 @@ export class WidgetsController {
         organizationId: subscriberSession._organizationId,
         subscriberId: subscriberSession.subscriberId,
         level: PreferenceLevelEnum.GLOBAL,
+        includeInactiveChannels: false,
         ...channels,
       })
     );

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -398,6 +398,7 @@ export class SendMessage {
           template: workflow,
           subscriber,
           tenant: job.tenant,
+          includeInactiveChannels: false,
         })
       );
       subscriberPreference = preference;

--- a/libs/application-generic/src/usecases/get-subscriber-global-preference/get-subscriber-global-preference.command.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-global-preference/get-subscriber-global-preference.command.ts
@@ -1,5 +1,8 @@
-import { SubscriberEntity } from '@novu/dal';
-
+import { IsBoolean, IsDefined } from 'class-validator';
 import { EnvironmentWithSubscriber } from '../../commands';
 
-export class GetSubscriberGlobalPreferenceCommand extends EnvironmentWithSubscriber {}
+export class GetSubscriberGlobalPreferenceCommand extends EnvironmentWithSubscriber {
+  @IsBoolean()
+  @IsDefined()
+  includeInactiveChannels: boolean;
+}

--- a/libs/application-generic/src/usecases/get-subscriber-global-preference/get-subscriber-global-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-global-preference/get-subscriber-global-preference.usecase.ts
@@ -39,7 +39,12 @@ export class GetSubscriberGlobalPreference {
       subscriberGlobalPreference.channels,
     );
 
-    const channels = filteredPreference(channelsWithDefaults, activeChannels);
+    let channels: IPreferenceChannels;
+    if (command.includeInactiveChannels === true) {
+      channels = channelsWithDefaults;
+    } else {
+      channels = filteredPreference(channelsWithDefaults, activeChannels);
+    }
 
     return {
       preference: {
@@ -99,6 +104,7 @@ export class GetSubscriberGlobalPreference {
           environmentId: command.environmentId,
           subscriberId: command.subscriberId,
           organizationId: command.organizationId,
+          includeInactiveChannels: command.includeInactiveChannels,
         }),
       );
 

--- a/libs/application-generic/src/usecases/get-subscriber-preference/get-subscriber-preference.command.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-preference/get-subscriber-preference.command.ts
@@ -1,4 +1,10 @@
-import { IsArray, IsOptional, IsString } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsDefined,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { EnvironmentWithSubscriber } from '../../commands/project.command';
 
 export class GetSubscriberPreferenceCommand extends EnvironmentWithSubscriber {
@@ -6,4 +12,8 @@ export class GetSubscriberPreferenceCommand extends EnvironmentWithSubscriber {
   @IsArray()
   @IsString({ each: true })
   tags?: string[];
+
+  @IsBoolean()
+  @IsDefined()
+  includeInactiveChannels: boolean;
 }

--- a/libs/application-generic/src/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
@@ -63,6 +63,7 @@ export class GetSubscriberPreference {
             environmentId: command.environmentId,
             template,
             subscriber,
+            includeInactiveChannels: command.includeInactiveChannels,
           }),
         ),
       ),

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.command.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.command.ts
@@ -1,5 +1,5 @@
 import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
-import { IsDefined, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsBoolean, IsDefined, IsNotEmpty, IsOptional } from 'class-validator';
 
 import { ITenantDefine } from '@novu/shared';
 import { EnvironmentWithSubscriber } from '../../commands';
@@ -14,4 +14,8 @@ export class GetSubscriberTemplatePreferenceCommand extends EnvironmentWithSubsc
 
   @IsOptional()
   tenant?: ITenantDefine;
+
+  @IsDefined()
+  @IsBoolean()
+  includeInactiveChannels: boolean;
 }

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -50,7 +50,7 @@ export class GetSubscriberTemplatePreference {
   ): Promise<ISubscriberPreferenceResponse> {
     const subscriber = await this.getSubscriber(command);
 
-    const initialActiveChannels = await this.getActiveChannels(command);
+    const initialChannels = await this.getChannels(command);
 
     const workflowOverride = await this.getWorkflowOverride(command);
 
@@ -67,7 +67,7 @@ export class GetSubscriberTemplatePreference {
         subscriber: subscriberWorkflowPreference.channels,
         workflowOverride: workflowOverrideChannelPreference,
       },
-      initialActiveChannels,
+      initialChannels,
     );
 
     const template = mapTemplateConfiguration({
@@ -172,11 +172,17 @@ export class GetSubscriberTemplatePreference {
     });
   }
 
-  private async getActiveChannels(
+  private async getChannels(
     command: GetSubscriberTemplatePreferenceCommand,
   ): Promise<IPreferenceChannels> {
-    const activeChannels = await this.queryActiveChannels(command);
-    const initialActiveChannels = filteredPreference(
+    let includedChannels: ChannelTypeEnum[];
+    if (command.includeInactiveChannels === true) {
+      includedChannels = Object.values(ChannelTypeEnum);
+    } else {
+      includedChannels = await this.queryActiveChannels(command);
+    }
+
+    const initialChannels = filteredPreference(
       {
         email: true,
         sms: true,
@@ -184,10 +190,10 @@ export class GetSubscriberTemplatePreference {
         chat: true,
         push: true,
       },
-      activeChannels,
+      includedChannels,
     );
 
-    return initialActiveChannels;
+    return initialChannels;
   }
 
   private async queryActiveChannels(


### PR DESCRIPTION
### What changed? Why was the change needed?
* Return all preference channels for Subscriber Preference API
  * A recent change to preference retrieval across Subscriber, Inbox, and Widget API started returning only the active workflow channels for `POST`, `PUT`, and `GET` endpoints. This was a breaking change and resulted in some users experiencing broken integrations as the Preferences had been retrieved for external consumption. This change reverts the behaviour only on Subscriber Preference endpoints, Inbox & Widget continue to return only active channel preferences.
  * This change additionally adds a `includeInactiveChannels` query parameter for the Subscriber Preference endpoints to control whether to return only active channels. The flag is `true` by default, meaning both active + inactive preferences are returned, restoring functionality to the previous behaviour

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
