### PR TITLE
fix(dashboard,web): opt-in page flickering; login/logout redirect

### DIFF
--- a/apps/web/src/components/layout/components/PrivatePageLayout.tsx
+++ b/apps/web/src/components/layout/components/PrivatePageLayout.tsx
@@ -70,7 +70,12 @@ export function PrivatePageLayout() {
 
   if (IS_EE_AUTH_ENABLED) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    useOptInRedirect();
+    const shouldRedirect = useOptInRedirect();
+
+    if (shouldRedirect) {
+      // prevent flickering of the legacy layout until the redirect is done
+      return null;
+    }
   }
 
   return (


### PR DESCRIPTION
### What changed? Why was the change needed?

* fixes a temporary flick of legacy workflows page when redirecting to new dashboard
* redirect for opt-in users will happen on any domain where the legacy web is deployed

Fixes: NV-4838, NV-4825
