### PR TITLE
fix(dashboard): Fix url variables being cut out

### DIFF
--- a/apps/dashboard/src/components/primitives/editor.tsx
+++ b/apps/dashboard/src/components/primitives/editor.tsx
@@ -16,94 +16,106 @@ const editorVariants = cva('h-full w-full flex-1 [&_.cm-focused]:outline-none', 
   },
 });
 
-const baseTheme = EditorView.baseTheme({
-  '&light': {
-    backgroundColor: 'transparent',
-  },
-  '.cm-tooltip-autocomplete .cm-completionIcon-variable': {
-    '&:before': {
-      content: 'Suggestions',
+type baseThemeOptions = {
+  asInput?: boolean;
+};
+const baseTheme = (options: baseThemeOptions) =>
+  EditorView.baseTheme({
+    '&light': {
+      backgroundColor: 'transparent',
     },
-    '&:after': {
-      content: "''",
-      height: '16px',
+    ...(options.asInput
+      ? {
+          '.cm-scroller': {
+            overflow: 'hidden',
+          },
+        }
+      : {}),
+    '.cm-tooltip-autocomplete .cm-completionIcon-variable': {
+      '&:before': {
+        content: 'Suggestions',
+      },
+      '&:after': {
+        content: "''",
+        height: '16px',
+        width: '16px',
+        display: 'block',
+        backgroundRepeat: 'no-repeat',
+        backgroundImage: `url('${functionIcon}')`,
+      },
+    },
+    '.cm-tooltip-autocomplete.cm-tooltip': {
+      position: 'relative',
+      overflow: 'hidden',
+      borderRadius: 'var(--radius)',
+      border: '1px solid var(--neutral-100)',
+      backgroundColor: 'hsl(var(--background))',
+      boxShadow: '0px 1px 3px 0px rgba(16, 24, 40, 0.10), 0px 1px 2px 0px rgba(16, 24, 40, 0.06)',
+      '&:before': {
+        content: "''",
+        top: '0',
+        left: '0',
+        right: '0',
+        height: '30px',
+        display: 'block',
+        backgroundRepeat: 'no-repeat',
+        backgroundImage: `url('${autocompleteHeader}')`,
+      },
+      '&:after': {
+        content: "''",
+        bottom: '30px',
+        left: '0',
+        right: '0',
+        height: '30px',
+        display: 'block',
+        backgroundRepeat: 'no-repeat',
+        backgroundImage: `url('${autocompleteFooter}')`,
+      },
+    },
+    '.cm-tooltip-autocomplete.cm-tooltip > ul[role="listbox"]': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '2px',
+      maxHeight: '12rem',
+      margin: '4px 0',
+      padding: '4px',
+    },
+    '.cm-tooltip-autocomplete.cm-tooltip > ul > li[role="option"]': {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '8px',
+      padding: '4px',
+      fontSize: '12px',
+      fontWeight: '500',
+      lineHeight: '16px',
+      minHeight: '24px',
+      color: 'var(--foreground-950)',
+      borderRadius: 'calc(var(--radius) - 2px)',
+    },
+    '.cm-tooltip-autocomplete.cm-tooltip > ul > li[aria-selected="true"]': {
+      backgroundColor: 'hsl(var(--neutral-100))',
+    },
+    '.cm-tooltip-autocomplete.cm-tooltip .cm-completionIcon': {
+      padding: '0',
       width: '16px',
-      display: 'block',
-      backgroundRepeat: 'no-repeat',
-      backgroundImage: `url('${functionIcon}')`,
+      height: '16px',
     },
-  },
-  '.cm-tooltip-autocomplete.cm-tooltip': {
-    position: 'relative',
-    overflow: 'hidden',
-    borderRadius: 'var(--radius)',
-    border: '1px solid var(--neutral-100)',
-    backgroundColor: 'hsl(var(--background))',
-    boxShadow: '0px 1px 3px 0px rgba(16, 24, 40, 0.10), 0px 1px 2px 0px rgba(16, 24, 40, 0.06)',
-    '&:before': {
-      content: "''",
-      top: '0',
-      left: '0',
-      right: '0',
-      height: '30px',
-      display: 'block',
-      backgroundRepeat: 'no-repeat',
-      backgroundImage: `url('${autocompleteHeader}')`,
+    '.cm-line span.cm-matchingBracket': {
+      backgroundColor: 'hsl(var(--highlighted) / 0.1)',
     },
-    '&:after': {
-      content: "''",
-      bottom: '30px',
-      left: '0',
-      right: '0',
-      height: '30px',
-      display: 'block',
-      backgroundRepeat: 'no-repeat',
-      backgroundImage: `url('${autocompleteFooter}')`,
+    'div.cm-content': {
+      padding: 0,
     },
-  },
-  '.cm-tooltip-autocomplete.cm-tooltip > ul[role="listbox"]': {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '2px',
-    maxHeight: '12rem',
-    margin: '4px 0',
-    padding: '4px',
-  },
-  '.cm-tooltip-autocomplete.cm-tooltip > ul > li[role="option"]': {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    padding: '4px',
-    fontSize: '12px',
-    fontWeight: '500',
-    lineHeight: '16px',
-    minHeight: '24px',
-    color: 'var(--foreground-950)',
-    borderRadius: 'calc(var(--radius) - 2px)',
-  },
-  '.cm-tooltip-autocomplete.cm-tooltip > ul > li[aria-selected="true"]': {
-    backgroundColor: 'hsl(var(--neutral-100))',
-  },
-  '.cm-tooltip-autocomplete.cm-tooltip .cm-completionIcon': {
-    padding: '0',
-    width: '16px',
-    height: '16px',
-  },
-  '.cm-line span.cm-matchingBracket': {
-    backgroundColor: 'hsl(var(--highlighted) / 0.1)',
-  },
-  'div.cm-content': {
-    padding: 0,
-  },
-  'div.cm-gutters': {
-    backgroundColor: 'transparent',
-    borderRight: 'none',
-    color: 'hsl(var(--foreground-400))',
-  },
-});
+    'div.cm-gutters': {
+      backgroundColor: 'transparent',
+      borderRight: 'none',
+      color: 'hsl(var(--foreground-400))',
+    },
+  });
 
 type EditorProps = {
   value: string;
+  asInput?: boolean;
   placeholder?: string;
   className?: string;
   height?: string;
@@ -120,6 +132,7 @@ export const Editor = React.forwardRef<{ focus: () => void; blur: () => void }, 
       className,
       height,
       size,
+      asInput,
       fontFamily,
       onChange,
       extensions,
@@ -151,7 +164,7 @@ export const Editor = React.forwardRef<{ focus: () => void; blur: () => void }, 
     }, [fontFamily]);
 
     const { setContainer, view } = useCodeMirror({
-      extensions: [...(extensions ?? []), baseTheme],
+      extensions: [...(extensions ?? []), baseTheme({ asInput })],
       height,
       placeholder,
       basicSetup: {

--- a/apps/dashboard/src/components/primitives/popover.tsx
+++ b/apps/dashboard/src/components/primitives/popover.tsx
@@ -23,7 +23,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        `bg-background text-foreground-950 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-72 overflow-auto rounded-md border p-4 shadow-md outline-none ${arrowClipPathClassName}`,
+        `bg-background text-foreground-950 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-72 rounded-md border p-4 shadow-md outline-none ${arrowClipPathClassName}`,
         className
       )}
       {...props}

--- a/apps/dashboard/src/components/workflow-editor/url-input.tsx
+++ b/apps/dashboard/src/components/workflow-editor/url-input.tsx
@@ -41,10 +41,11 @@ export const URLInput = ({
               control={control}
               name={urlKey}
               render={({ field }) => (
-                <FormItem className="w-full overflow-hidden">
+                <FormItem className="mr-auto min-w-px max-w-full">
                   <FormControl>
                     {asEditor ? (
                       <Editor
+                        asInput
                         fontFamily="inherit"
                         placeholder={placeholder}
                         extensions={[autocompletion({ override: [completions(variables)] })]}


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
Variables not being cut out:
<img width="404" alt="Screenshot 2024-11-22 at 11 25 48 AM" src="https://github.com/user-attachments/assets/a4e3dc76-2a23-42b3-ae91-6aeb315d0d66">
Editor doesnt overflow out of the container:
<img width="658" alt="Screenshot 2024-11-22 at 11 25 58 AM" src="https://github.com/user-attachments/assets/48256658-6c28-4c2f-8527-f1d7e2ac237b">


<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
