### PR TITLE
fix(node): add includeInactiveChannels option in sdk method

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -337,12 +337,18 @@ await novu.subscribers.updateOnlineStatus('subscriberId', false);
 
 - #### Get subscriber preference for all workflows
 
+This method returns subscriber preference for all workflows with inactive channels by default. To get subscriber preference for all workflows without inactive (means only active) channels, pass `false` as second argument.
+
 ```ts
 import { Novu } from '@novu/node';
 
 const novu = new Novu('<NOVU_SECRET_KEY>');
 
-await novu.subscribers.getPreference('subscriberId');
+// return subscriber preference for all workflows without inactive channels
+await novu.subscribers.getPreference('subscriberId', false);
+
+// return subscriber preference for all workflows with inactive channels
+await novu.subscribers.getPreference('subscriberId', true);
 ```
 
 - #### Get subscriber global preference
@@ -756,11 +762,21 @@ await novu.messages.list(params);
 - #### Delete a message by `messageId`
 
 ```ts
-import { Novu, ChannelTypeEnum } from '@novu/node';
+import { Novu } from '@novu/node';
 
 const novu = new Novu('<NOVU_SECRET_KEY>');
 
 await novu.messages.deleteById('messageId');
+```
+
+- #### Delete multiple messages by `transactionId`
+
+```ts
+import { Novu } from '@novu/node';
+
+const novu = new Novu('<NOVU_SECRET_KEY>');
+
+await novu.messages.deleteByTransactionId('transactionId');
 ```
 
 ### Layouts

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -345,10 +345,14 @@ import { Novu } from '@novu/node';
 const novu = new Novu('<NOVU_SECRET_KEY>');
 
 // return subscriber preference for all workflows without inactive channels
-await novu.subscribers.getPreference('subscriberId', false);
+await novu.subscribers.getPreference('subscriberId', {
+  includeInactiveChannels: false,
+});
 
 // return subscriber preference for all workflows with inactive channels
-await novu.subscribers.getPreference('subscriberId', true);
+await novu.subscribers.getPreference('subscriberId', {
+  includeInactiveChannels: true,
+});
 ```
 
 - #### Get subscriber global preference

--- a/packages/node/src/lib/subscribers/subscriber.interface.ts
+++ b/packages/node/src/lib/subscribers/subscriber.interface.ts
@@ -34,7 +34,10 @@ export interface ISubscribers {
    */
   unsetCredentials(subscriberId: string, providerId: string);
   updateOnlineStatus(subscriberId: string, online: boolean);
-  getPreference(subscriberId: string, includeInactiveChannels: boolean);
+  getPreference(
+    subscriberId: string,
+    { includeInactiveChannels }: { includeInactiveChannels: boolean },
+  );
   getGlobalPreference(subscriberId: string);
   getPreferenceByLevel(subscriberId: string, level: PreferenceLevelEnum);
   updatePreference(

--- a/packages/node/src/lib/subscribers/subscriber.interface.ts
+++ b/packages/node/src/lib/subscribers/subscriber.interface.ts
@@ -34,7 +34,7 @@ export interface ISubscribers {
    */
   unsetCredentials(subscriberId: string, providerId: string);
   updateOnlineStatus(subscriberId: string, online: boolean);
-  getPreference(subscriberId: string);
+  getPreference(subscriberId: string, includeInactiveChannels: boolean);
   getGlobalPreference(subscriberId: string);
   getPreferenceByLevel(subscriberId: string, level: PreferenceLevelEnum);
   updatePreference(

--- a/packages/node/src/lib/subscribers/subscribers.spec.ts
+++ b/packages/node/src/lib/subscribers/subscribers.spec.ts
@@ -193,7 +193,7 @@ describe('test use of novus node package - Subscribers class', () => {
   test('should get subscriber preference', async () => {
     mockedAxios.get.mockResolvedValue({});
 
-    await novu.subscribers.getPreference('test-subscriber-preference');
+    await novu.subscribers.getPreference('test-subscriber-preference', true);
 
     expect(mockedAxios.get).toHaveBeenCalled();
     expect(mockedAxios.get).toHaveBeenCalledWith(

--- a/packages/node/src/lib/subscribers/subscribers.spec.ts
+++ b/packages/node/src/lib/subscribers/subscribers.spec.ts
@@ -199,7 +199,7 @@ describe('test use of novus node package - Subscribers class', () => {
 
     expect(mockedAxios.get).toHaveBeenCalled();
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      '/subscribers/test-subscriber-preference/preferences',
+      '/subscribers/test-subscriber-preference/preferences?includeInactiveChannels=true',
     );
   });
 

--- a/packages/node/src/lib/subscribers/subscribers.spec.ts
+++ b/packages/node/src/lib/subscribers/subscribers.spec.ts
@@ -193,7 +193,9 @@ describe('test use of novus node package - Subscribers class', () => {
   test('should get subscriber preference', async () => {
     mockedAxios.get.mockResolvedValue({});
 
-    await novu.subscribers.getPreference('test-subscriber-preference', true);
+    await novu.subscribers.getPreference('test-subscriber-preference', {
+      includeInactiveChannels: true,
+    });
 
     expect(mockedAxios.get).toHaveBeenCalled();
     expect(mockedAxios.get).toHaveBeenCalledWith(

--- a/packages/node/src/lib/subscribers/subscribers.ts
+++ b/packages/node/src/lib/subscribers/subscribers.ts
@@ -93,7 +93,7 @@ export class Subscribers extends WithHttp implements ISubscribers {
 
   async getPreference(
     subscriberId: string,
-    { includeInactiveChannels }: { includeInactiveChannels: boolean },
+    { includeInactiveChannels = true }: { includeInactiveChannels: boolean },
   ) {
     return await this.http.get(
       `/subscribers/${subscriberId}/preferences?includeInactiveChannels=${includeInactiveChannels}`,

--- a/packages/node/src/lib/subscribers/subscribers.ts
+++ b/packages/node/src/lib/subscribers/subscribers.ts
@@ -93,7 +93,7 @@ export class Subscribers extends WithHttp implements ISubscribers {
 
   async getPreference(
     subscriberId: string,
-    includeInactiveChannels: boolean = true,
+    { includeInactiveChannels }: { includeInactiveChannels: boolean },
   ) {
     return await this.http.get(
       `/subscribers/${subscriberId}/preferences?includeInactiveChannels=${includeInactiveChannels}`,

--- a/packages/node/src/lib/subscribers/subscribers.ts
+++ b/packages/node/src/lib/subscribers/subscribers.ts
@@ -91,8 +91,13 @@ export class Subscribers extends WithHttp implements ISubscribers {
     return await this.http.delete(`/subscribers/${subscriberId}`);
   }
 
-  async getPreference(subscriberId: string) {
-    return await this.http.get(`/subscribers/${subscriberId}/preferences`);
+  async getPreference(
+    subscriberId: string,
+    includeInactiveChannels: boolean = true,
+  ) {
+    return await this.http.get(
+      `/subscribers/${subscriberId}/preferences?includeInactiveChannels=${includeInactiveChannels}`,
+    );
   }
 
   async getGlobalPreference(subscriberId: string) {


### PR DESCRIPTION
### What changed? Why was the change needed?
- Add `includeInactiveChannels` option in subscriber.getPreference method
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

Ref: [Discord Post](https://discord.com/channels/895029566685462578/1310170281700229180)

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
