### PR TITLE
fix(js): Truncate workflow name and center empty notifications text

### DIFF
--- a/packages/js/src/ui/components/Notification/NotificationList.tsx
+++ b/packages/js/src/ui/components/Notification/NotificationList.tsx
@@ -21,7 +21,7 @@ const EmptyNotificationList = () => {
       )}
     >
       <EmptyIcon class={style('notificationListEmptyNoticeIcon')} />
-      <p class={style('notificationListEmptyNotice')} data-localization="notifications.emptyNotice">
+      <p class={(style('notificationListEmptyNotice'), 'nt-text-center')} data-localization="notifications.emptyNotice">
         {t('notifications.emptyNotice')}
       </p>
     </div>

--- a/packages/js/src/ui/components/elements/Preferences/Preferences.tsx
+++ b/packages/js/src/ui/components/elements/Preferences/Preferences.tsx
@@ -148,17 +148,14 @@ const PreferencesRow = (props: {
         <div
           class={style(
             'workflowLabelContainer',
-            'nt-flex nt-justify-between nt-flex-nowrap nt-self-stretch nt-cursor-pointer nt-items-center'
+            'nt-flex nt-justify-between nt-flex-nowrap nt-self-stretch nt-cursor-pointer nt-items-center nt-overflow-hidden'
           )}
           onClick={() => setIsOpen((prev) => !prev)}
           data-open={isOpen()}
         >
-          <div>
+          <div class={style('workflowLabelHeader', 'nt-overflow-hidden')}>
             <div
-              class={style(
-                'workflowLabel',
-                'nt-text-base nt-font-semibold nt-text-start nt-flex nt-items-center nt-gap-1'
-              )}
+              class={style('workflowLabel', 'nt-text-base nt-font-semibold nt-truncate')}
               data-localization={props.localizationKey}
               data-open={isOpen()}
             >

--- a/packages/js/src/ui/config/appearanceKeys.ts
+++ b/packages/js/src/ui/config/appearanceKeys.ts
@@ -111,6 +111,7 @@ export const appearanceKeys = [
   // workflow
   'workflowContainer',
   'workflowLabel',
+  'workflowLabelHeader',
   'workflowLabelContainer',
   'workflowContainerDisabledNotice',
   'workflowLabelDisabled__icon',


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
<img width="472" alt="Screenshot 2024-11-25 at 1 56 38 PM" src="https://github.com/user-attachments/assets/5d0e3e8e-e49b-435a-9d3f-adc3dcdee6a5">
<img width="432" alt="Screenshot 2024-11-25 at 1 58 21 PM" src="https://github.com/user-attachments/assets/d027f607-6d9d-472c-878d-cf4e788f4beb">

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
