### PR TITLE
style(dashboard): Fix all modal and toast text overflow

### DIFF
--- a/apps/dashboard/src/components/pause-workflow-dialog.tsx
+++ b/apps/dashboard/src/components/pause-workflow-dialog.tsx
@@ -2,11 +2,8 @@ import TruncatedText from './truncated-text';
 
 export const PauseModalDescription = ({ workflowName }: { workflowName: string }) => (
   <>
-    Pausing the{' '}
-    <strong>
-      <TruncatedText className="max-w-[32ch]">{workflowName}</TruncatedText>
-    </strong>{' '}
-    workflow will immediately prevent you from being able to trigger it.
+    Pausing the <TruncatedText className="max-w-[32ch] font-bold">{workflowName}</TruncatedText> workflow will
+    immediately prevent you from being able to trigger it.
   </>
 );
 

--- a/apps/dashboard/src/components/success-button-toast.tsx
+++ b/apps/dashboard/src/components/success-button-toast.tsx
@@ -1,10 +1,11 @@
 import { Button } from '@/components/primitives/button';
 import { ToastClose, ToastIcon } from '@/components/primitives/sonner';
+import { ReactNode } from 'react';
 import { RiArrowRightSLine } from 'react-icons/ri';
 
 interface SuccessToastProps {
   title: string;
-  description: string;
+  description: ReactNode;
   actionLabel: string;
   onAction: () => void;
   onClose: () => void;

--- a/apps/dashboard/src/components/truncated-text.tsx
+++ b/apps/dashboard/src/components/truncated-text.tsx
@@ -26,11 +26,19 @@ export default function TruncatedText(props: TruncatedTextProps) {
     <Tooltip>
       <TooltipTrigger asChild>
         {asChild ? (
-          <Slot ref={textRef} className={cn('block truncate', className)} {...rest}>
+          <Slot
+            ref={textRef}
+            className={cn('truncate', isTruncated && 'block', !isTruncated && 'inline-flex', className)}
+            {...rest}
+          >
             {children}
           </Slot>
         ) : (
-          <span ref={textRef} className={cn('block truncate', className)} {...rest}>
+          <span
+            ref={textRef}
+            className={cn('truncate', isTruncated && 'block', !isTruncated && 'inline-flex', className)}
+            {...rest}
+          >
             {children}
           </span>
         )}

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
@@ -206,10 +206,8 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
                 description={
                   <>
                     You're about to delete the{' '}
-                    <strong>
-                      <TruncatedText className="max-w-[32ch]">{step.name}</TruncatedText>
-                    </strong>{' '}
-                    step, this action is permanent.
+                    <TruncatedText className="max-w-[32ch] font-bold">{step.name}</TruncatedText> step, this action is
+                    permanent.
                   </>
                 }
                 confirmButtonText="Delete"

--- a/apps/dashboard/src/components/workflow-editor/steps/use-debounced-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/use-debounced-preview.tsx
@@ -29,7 +29,9 @@ export const useDebouncedPreview = ({ workflow, step }: { workflow: WorkflowResp
           children: () => (
             <>
               <ToastIcon variant="error" />
-              <span className="text-sm">Failed to preview, Error: ${err.message}</span>
+              <span className="text-sm">
+                Failed to preview step <span className="font-bold">{step.name}</span> with error: {err.message}
+              </span>
             </>
           ),
           options: {

--- a/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-tabs.tsx
@@ -55,7 +55,7 @@ export const TestWorkflowTabs = ({ testData }: { testData: WorkflowTestDataRespo
             <div className="flex flex-col gap-2">
               <span className="font-medium">Test workflow succeeded</span>
               <span className="text-foreground-600 inline">
-                Workflow <strong>{workflow?.name}</strong> was triggered successfully.
+                Workflow <span className="font-bold">{workflow?.name}</span> was triggered successfully.
               </span>
               <Link
                 to={`${LEGACY_ROUTES.ACTIVITY_FEED}?transactionId=${transactionId}`}

--- a/apps/dashboard/src/components/workflow-row.tsx
+++ b/apps/dashboard/src/components/workflow-row.tsx
@@ -81,7 +81,9 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
         children: () => (
           <>
             <ToastIcon variant="success" />
-            <span className="text-sm">Deleted</span>
+            <span className="text-sm">
+              Deleted workflow <span className="font-bold">{workflow.name}</span>.
+            </span>
           </>
         ),
         options: toastOptions,
@@ -92,7 +94,9 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
         children: () => (
           <>
             <ToastIcon variant="error" />
-            <span className="text-sm">Failed to delete</span>
+            <span className="text-sm">
+              Failed to delete workflow <span className="font-bold">{workflow.name}</span>.
+            </span>
           </>
         ),
         options: toastOptions,
@@ -112,7 +116,9 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
         children: () => (
           <>
             <ToastIcon variant="success" />
-            <span className="text-sm">{data.active ? 'Enabled' : 'Paused'} workflow</span>
+            <span className="text-sm">
+              {data.active ? 'Enabled' : 'Paused'} workflow <span className="font-bold">{workflow.name}</span>.
+            </span>
           </>
         ),
         options: toastOptions,
@@ -123,7 +129,10 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
         children: () => (
           <>
             <ToastIcon variant="error" />
-            <span className="text-sm">Failed to {workflow.active ? 'enable' : 'pause'} workflow</span>
+            <span className="text-sm">
+              Failed to {workflow.active ? 'enable' : 'pause'} workflow{' '}
+              <span className="font-bold">{workflow.name}</span>.
+            </span>
           </>
         ),
         options: toastOptions,
@@ -206,10 +215,8 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
           description={
             <>
               You're about to delete the{' '}
-              <strong>
-                <TruncatedText className="max-w-[32ch]">{workflow.name}</TruncatedText>
-              </strong>{' '}
-              workflow, this action is permanent. <br />
+              <TruncatedText className="max-w-[32ch] font-bold">{workflow.name}</TruncatedText> workflow, this action is
+              permanent. <br />
               <br />
               You won't be able to trigger this workflow anymore.
             </>

--- a/apps/dashboard/src/components/workflow-row.tsx
+++ b/apps/dashboard/src/components/workflow-row.tsx
@@ -203,7 +203,17 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
           onOpenChange={setIsDeleteModalOpen}
           onConfirm={onDeleteWorkflow}
           title="Are you sure?"
-          description={`You're about to delete the ${workflow.name}, this action cannot be undone.`}
+          description={
+            <>
+              You're about to delete the{' '}
+              <strong>
+                <TruncatedText className="max-w-[32ch]">{workflow.name}</TruncatedText>
+              </strong>{' '}
+              workflow, this action is permanent. <br />
+              <br />
+              You won't be able to trigger this workflow anymore.
+            </>
+          }
           confirmButtonText="Delete"
           isLoading={isDeleteWorkflowPending}
         />

--- a/apps/dashboard/src/hooks/use-sync-workflow.tsx
+++ b/apps/dashboard/src/hooks/use-sync-workflow.tsx
@@ -3,6 +3,7 @@ import { syncWorkflow } from '@/api/workflows';
 import { ConfirmationModal } from '@/components/confirmation-modal';
 import { showToast } from '@/components/primitives/sonner-helpers';
 import { SuccessButtonToast } from '@/components/success-button-toast';
+import TruncatedText from '@/components/truncated-text';
 import { useEnvironment } from '@/context/environment/hooks';
 import type { IEnvironment, WorkflowListResponseDto, WorkflowResponseDto } from '@novu/shared';
 import { WorkflowOriginEnum, WorkflowStatusEnum } from '@novu/shared';
@@ -66,7 +67,11 @@ export function useSyncWorkflow(workflow: WorkflowListResponseDto) {
       children: ({ close }) => (
         <SuccessButtonToast
           title={`Workflow synced to ${environment?.name}`}
-          description={`Workflow '${workflow.name}' has been successfully synced to ${environment?.name}.`}
+          description={
+            <>
+              Workflow <strong>{workflow.name}</strong> has been successfully synced to {environment?.name}.
+            </>
+          }
           actionLabel={`Switch to ${environment?.name}`}
           onAction={() => {
             close();
@@ -127,7 +132,17 @@ export function useSyncWorkflow(workflow: WorkflowListResponseDto) {
           setShowConfirmModal(false);
         }}
         title={`Sync workflow to ${oppositeEnvironment?.name}`}
-        description={`Workflow already exists in ${oppositeEnvironment?.name}. Proceeding will overwrite the existing workflow.`}
+        description={
+          <>
+            Workflow{' '}
+            <TruncatedText className="max-w-[32ch]">
+              <strong>{workflow.name}</strong>
+            </TruncatedText>{' '}
+            already exists in {oppositeEnvironment?.name}.<br />
+            <br />
+            Proceeding will overwrite the existing workflow.
+          </>
+        }
         confirmButtonText="Proceed"
         isLoading={isPending}
       />

--- a/apps/dashboard/src/hooks/use-sync-workflow.tsx
+++ b/apps/dashboard/src/hooks/use-sync-workflow.tsx
@@ -1,6 +1,7 @@
 import { getV2, NovuApiError } from '@/api/api.client';
 import { syncWorkflow } from '@/api/workflows';
 import { ConfirmationModal } from '@/components/confirmation-modal';
+import { ToastIcon } from '@/components/primitives/sonner';
 import { showToast } from '@/components/primitives/sonner-helpers';
 import { SuccessButtonToast } from '@/components/success-button-toast';
 import TruncatedText from '@/components/truncated-text';
@@ -69,7 +70,8 @@ export function useSyncWorkflow(workflow: WorkflowListResponseDto) {
           title={`Workflow synced to ${environment?.name}`}
           description={
             <>
-              Workflow <strong>{workflow.name}</strong> has been successfully synced to {environment?.name}.
+              Workflow <span className="font-bold">{workflow.name}</span> has been successfully synced to{' '}
+              {environment?.name}.
             </>
           }
           actionLabel={`Switch to ${environment?.name}`}
@@ -102,7 +104,14 @@ export function useSyncWorkflow(workflow: WorkflowListResponseDto) {
       }).then((res) => ({ workflow: res.data, environment: oppositeEnvironment || undefined })),
     onMutate: () => {
       setIsLoading(true);
-      loadingToast = toast.loading('Syncing workflow...');
+      loadingToast = toast.loading(
+        <>
+          <ToastIcon variant="default" />
+          <span className="text-sm">
+            Syncing workflow <span className="font-bold">{workflow.name}</span> to {oppositeEnvironment?.name}...
+          </span>
+        </>
+      );
     },
     onSuccess: ({ workflow, environment }) => onSyncSuccess(workflow, environment),
     onError: onSyncError,
@@ -134,11 +143,8 @@ export function useSyncWorkflow(workflow: WorkflowListResponseDto) {
         title={`Sync workflow to ${oppositeEnvironment?.name}`}
         description={
           <>
-            Workflow{' '}
-            <TruncatedText className="max-w-[32ch]">
-              <strong>{workflow.name}</strong>
-            </TruncatedText>{' '}
-            already exists in {oppositeEnvironment?.name}.<br />
+            Workflow <TruncatedText className="max-w-[32ch] font-bold">{workflow.name}</TruncatedText> already exists in{' '}
+            {oppositeEnvironment?.name}.<br />
             <br />
             Proceeding will overwrite the existing workflow.
           </>


### PR DESCRIPTION
### What changed? Why was the change needed?
* Fix workflow deletion modal text overflow
* Add copy to inform that the workflow won't be able to be triggered
* Make `TruncatedText` have `inline-flex` when text should _not_ be truncated to ensure children display on same line as siblings
* Add consistent usage of workflow+step name in mutation toasts
* Replace `strong` tag usage with `font-bold` classname to ensure that styling updates are inherited from Tailwind config

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
_Updated delete modal_
<img width="450" alt="image" src="https://github.com/user-attachments/assets/7f5091e4-45ac-46f8-9169-50bbd9480625">

_Sync to Prod modal with short workflow name now displays as inline_
<img width="450" alt="image" src="https://github.com/user-attachments/assets/6e99dd97-fbca-4645-96a1-33fedfad5486">

_Sync to Prod modal with long workflow name continues to display as block_
<img width="424" alt="image" src="https://github.com/user-attachments/assets/08e1756f-9b40-4307-ae67-de2387e65cd2">

_Pause Workflow modal_
<img width="452" alt="image" src="https://github.com/user-attachments/assets/6e619d1c-1a7e-4e68-bf13-788addc9d187">

_Delete step modal_
<img width="451" alt="image" src="https://github.com/user-attachments/assets/88812f6b-8ed7-4ead-9d14-18507a736eee">

_Updated pause toast to include workflow name_
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/2e3089ad-021b-43ad-b5da-4764cd9193a5">

_Updated delete toast to include workflow name_
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/665562bb-f3ca-4a82-9472-532f673a520b">

_Update sync toast to include workflow name_
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/dea32138-0bfe-4647-b626-27b2495b4dec">


<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
