### PR TITLE
fix(framework): Duplicate checkIsResponseError from @novu/shared

### DIFF
--- a/packages/framework/src/utils/http.utils.ts
+++ b/packages/framework/src/utils/http.utils.ts
@@ -1,5 +1,10 @@
-import { checkIsResponseError } from '@novu/shared';
+import type { IResponseError } from '@novu/shared';
 import { BridgeError, MissingSecretKeyError, PlatformError } from '../errors';
+
+// TODO: Reuse from @novu/shared after debugging the ESM/CJS import issues in Next.js 13
+export const checkIsResponseError = (err: unknown): err is IResponseError => {
+  return !!err && typeof err === 'object' && 'error' in err && 'message' in err && 'statusCode' in err;
+};
 
 export const initApiClient = (secretKey: string, apiUrl: string) => {
   if (!secretKey) {


### PR DESCRIPTION
### What changed? Why was the change needed?

Bandaid for imports in Nextjs 13. @novu/framework is an ESM/CJS package built with Tsup. @novu/shared is built with tsc. For some reason, there is an import issue in Next.js 13 when @novu/framework imports from @novu/shared.

### References
- https://discord.com/channels/895029566685462578/1311556906288152686
- https://github.com/jainpawan21/nextjs-version-13.4.8-novu-framework