### PR TITLE
fix(dashboard): Show failed toast on triggering inactive workflows

### DIFF
--- a/apps/dashboard/src/api/workflows.ts
+++ b/apps/dashboard/src/api/workflows.ts
@@ -27,7 +27,7 @@ export const fetchWorkflowTestData = async ({
 };
 
 export async function triggerWorkflow({ name, payload, to }: { name: string; payload: unknown; to: unknown }) {
-  return post<{ data: { transactionId: string } }>(`/events/trigger`, {
+  return post<{ data: { transactionId?: string } }>(`/events/trigger`, {
     name,
     to,
     payload: { ...(payload ?? {}), __source: 'dashboard' },

--- a/apps/dashboard/src/components/primitives/form/avatar-picker.tsx
+++ b/apps/dashboard/src/components/primitives/form/avatar-picker.tsx
@@ -56,7 +56,7 @@ export const AvatarPicker = forwardRef<HTMLInputElement, AvatarPickerProps>(
           <PopoverTrigger asChild>
             <Button variant="outline" size="icon" className="text-foreground-600 relative size-full overflow-hidden">
               {value ? (
-                <Avatar className="bg-transparent p-px">
+                <Avatar className="bg-transparent p-1">
                   <AvatarImage src={value as string} />
                 </Avatar>
               ) : (

--- a/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-tabs.tsx
@@ -47,11 +47,32 @@ export const TestWorkflowTabs = ({ testData }: { testData: WorkflowTestDataRespo
       const {
         data: { transactionId },
       } = await triggerWorkflow({ name: workflow?.workflowId ?? '', to: data.to, payload: data.payload });
-      showToast({
+      if (!transactionId) {
+        return showToast({
+          variant: 'lg',
+          children: ({ close }) => (
+            <>
+              <ToastIcon variant="error" />
+              <div className="flex flex-col gap-2">
+                <span className="font-medium">Test workflow failed</span>
+                <span className="text-foreground-600 inline">
+                  Workflow <span className="font-bold">{workflow?.name}</span> cannot be triggered. Ensure that it is
+                  active and requires not further actions.
+                </span>
+              </div>
+              <ToastClose onClick={close} />
+            </>
+          ),
+          options: {
+            position: 'bottom-right',
+          },
+        });
+      }
+      return showToast({
         variant: 'lg',
         children: ({ close }) => (
           <>
-            <ToastIcon variant="default" />
+            <ToastIcon variant="success" />
             <div className="flex flex-col gap-2">
               <span className="font-medium">Test workflow succeeded</span>
               <span className="text-foreground-600 inline">


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<img width="434" alt="Screenshot 2024-12-02 at 2 18 25 PM" src="https://github.com/user-attachments/assets/c46978de-8d54-4c84-af9e-1bd923bf2a29">
<img width="429" alt="Screenshot 2024-12-02 at 2 18 48 PM" src="https://github.com/user-attachments/assets/8f9fc04e-f05f-4c87-ba66-d784c727487b">

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
