### PR TITLE
fix(dashboard): don't use defaultValues for async content

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
@@ -57,10 +57,16 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
     navigate(buildRoute(ROUTES.EDIT_WORKFLOW, { environmentSlug: environment.slug!, workflowSlug: workflow.slug }));
   };
 
+  const defaultValues = {
+    name: step.name,
+    stepId: step.stepId,
+  };
+
   const form = useForm<z.infer<typeof stepSchema>>({
-    defaultValues: {
-      name: step.name,
-      stepId: step.stepId,
+    defaultValues,
+    values: {
+      ...defaultValues,
+      ...step.controls.values,
     },
     resolver: zodResolver(stepSchema),
     shouldFocusError: false,

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-template-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-template-form.tsx
@@ -60,6 +60,10 @@ export const ConfigureStepTemplateForm = (props: ConfigureStepTemplateFormProps)
   const form = useForm({
     resolver: zodResolver(schema),
     defaultValues,
+    values: {
+      ...defaultValues,
+      ...step.controls.values,
+    },
     shouldFocusError: false,
   });
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Details: https://linear.app/novu/issue/NV-4941/step-form-values-are-not-being-properly-updated-after-revisiting


https://github.com/user-attachments/assets/8dd1ec79-7021-4090-84cb-ec4f72a3f2c9

