### PR TITLE
feat(dashboard): signout from v2 should navigatefor new login page

### DIFF
--- a/apps/dashboard/src/components/user-profile.tsx
+++ b/apps/dashboard/src/components/user-profile.tsx
@@ -1,14 +1,12 @@
 import { UserButton } from '@clerk/clerk-react';
 import { useNewDashboardOptIn } from '@/hooks/use-new-dashboard-opt-in';
 import { RiSignpostFill } from 'react-icons/ri';
-import { LEGACY_DASHBOARD_URL } from '@/config';
 
 export function UserProfile() {
   const { optOut } = useNewDashboardOptIn();
 
   return (
     <UserButton
-      afterSignOutUrl={`${LEGACY_DASHBOARD_URL}/auth/login`}
       appearance={{
         elements: {
           avatarBox: 'h-6 w-6',

--- a/apps/dashboard/src/context/clerk-provider.tsx
+++ b/apps/dashboard/src/context/clerk-provider.tsx
@@ -4,6 +4,7 @@ import { CLERK_PUBLISHABLE_KEY } from '@/config';
 import { ClerkProvider as _ClerkProvider } from '@clerk/clerk-react';
 import { PropsWithChildren } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../utils/routes';
 
 const CLERK_LOCALIZATION = {
   userProfile: {
@@ -40,6 +41,7 @@ export const ClerkProvider = (props: ClerkProviderProps) => {
       routerPush={(to) => navigate(to)}
       routerReplace={(to) => navigate(to, { replace: true })}
       publishableKey={CLERK_PUBLISHABLE_KEY}
+      afterSignOutUrl={ROUTES.SIGN_IN}
       appearance={{
         userButton: {
           elements: {


### PR DESCRIPTION
### What changed? Why was the change needed?
- V2 Signouts should navigate to v2 login page
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
