### PR TITLE
feat(novu): Add `--studio-host` option on dev server

### DIFF
--- a/packages/novu/README.MD
+++ b/packages/novu/README.MD
@@ -34,15 +34,16 @@ npx novu@latest dev
 
 ## 🔥 Flags
 
-| flag | long form usage example | description                   | default value               |
-| ---- | ----------------------- | ----------------------------- | --------------------------- |
-| -p   | --port <port>           | Bridge application port       | 4000                        |
-| -r   | --route <route>         | Bridge application route      | /api/novu                   |
-| -o   | --origin <origin>       | Bridge application origin     | http://localhost            |
-| -d   | --dashboard-url <url>   | Novu Cloud dashboard URL      | https://dashboard.novu.co   |
-| -sp  | --studio-port <port>    | Local Studio server port      | 2022                        |
-| -t   | --tunnel <url>          | Self hosted tunnel url        | null                        |
-| -H   | --headless              | Run bridge in headless mode   | false                       |
+| flag | long form usage example | description                 | default value               |
+|------|-------------------------|-----------------------------| --------------------------- |
+| -p   | --port <port>           | Bridge application port     | 4000                        |
+| -r   | --route <route>         | Bridge application route    | /api/novu                   |
+| -o   | --origin <origin>       | Bridge application origin   | http://localhost            |
+| -d   | --dashboard-url <url>   | Novu Cloud dashboard URL    | https://dashboard.novu.co   |
+| -sp  | --studio-port <port>    | Local Studio server port    | 2022                        |
+| -sh  | --studio-host <host>    | Local Studio server host    | localhost                   |
+| -t   | --tunnel <url>          | Self hosted tunnel url      | null                        |
+| -H   | --headless              | Run bridge in headless mode | false                       |
 
 Example: If bridge application is running on port `3002` and Novu account is in `EU` region.
 

--- a/packages/novu/src/commands/dev/types.ts
+++ b/packages/novu/src/commands/dev/types.ts
@@ -5,6 +5,7 @@ export type DevCommandOptions = {
   origin: string;
   region: `${CloudRegionEnum}`;
   studioPort: string;
+  studioHost: string;
   dashboardUrl: string;
   route: string;
   tunnel: string;

--- a/packages/novu/src/dev-server/http-server.ts
+++ b/packages/novu/src/dev-server/http-server.ts
@@ -2,14 +2,13 @@ import http from 'node:http';
 import { AddressInfo } from 'net';
 
 import getPort from 'get-port';
-import { SERVER_HOST } from '../constants';
 import { DevCommandOptions } from '../commands';
 
 export const WELL_KNOWN_ROUTE = '/.well-known/novu';
 export const STUDIO_PATH = '/studio';
 
 export type DevServerOptions = { tunnelOrigin: string; anonymousId?: string } & Partial<
-  Pick<DevCommandOptions, 'origin' | 'port' | 'studioPort' | 'dashboardUrl' | 'route'>
+  Pick<DevCommandOptions, 'origin' | 'port' | 'studioPort' | 'studioHost' | 'dashboardUrl' | 'route'>
 >;
 
 export class DevServer {
@@ -19,7 +18,7 @@ export class DevServer {
   constructor(private options: DevServerOptions) {}
 
   public async listen(): Promise<void> {
-    const port = await getPort({ host: SERVER_HOST, port: Number(this.options.studioPort) });
+    const port = await getPort({ host: this.options.studioHost, port: Number(this.options.studioPort) });
     this.server = http.createServer();
     this.server.on('request', async (req, res) => {
       try {
@@ -41,7 +40,7 @@ export class DevServer {
     });
 
     await new Promise<void>((resolve) => {
-      this.server.listen(port, SERVER_HOST, () => {
+      this.server.listen(port, this.options.studioHost, () => {
         resolve();
       });
     });
@@ -50,7 +49,7 @@ export class DevServer {
   public getAddress() {
     const response = this.server.address() as AddressInfo;
 
-    return `http://${SERVER_HOST}:${response.port}`;
+    return `http://${this.options.studioHost}:${response.port}`;
   }
 
   public getStudioAddress() {

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -71,6 +71,7 @@ program
   .option('-o, --origin <origin>', 'The Bridge endpoint origin')
   .option('-d, --dashboard-url <url>', 'The Novu Cloud Dashboard URL', 'https://dashboard.novu.co')
   .option('-sp, --studio-port <port>', 'The Local Studio server port', '2022')
+  .option('-sh, --studio-host <host>', 'The Local Studio server host', 'localhost')
   .option('-t, --tunnel <url>', 'Self hosted tunnel. e.g. https://my-tunnel.ngrok.app')
   .option('-H, --headless', 'Run the Bridge in headless mode without opening the browser', false)
   .action(async (options: DevCommandOptions) => {


### PR DESCRIPTION
### What changed? Why was the change needed?

Added an option to start the studio server on a different host (than `localhost`).
I'm running the studio server in a docker compose project and need to bind it to the docker network with `--studio-host 0.0.0.0`
