### PR TITLE
feat(api): add exception log

### DIFF
--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -27,7 +27,19 @@ export class AllExceptionsFilter implements ExceptionFilter {
   ): ErrorDto {
     const responseBody = this.buildBaseResponseBody(status, request, message);
     if (status !== HttpStatus.INTERNAL_SERVER_ERROR) {
-      return message instanceof Object ? { ...responseBody, ...message } : responseBody;
+      const error = message instanceof Object ? { ...responseBody, ...message } : responseBody;
+      this.logger.error({
+        /**
+         * It's important to use `err` as the key, pino (the logger we use) will
+         * log an empty object if the key is not `err`
+         *
+         * @see https://github.com/pinojs/pino/issues/819#issuecomment-611995074
+         */
+        err: exception,
+        error,
+      });
+
+      return error;
     }
 
     return this.build500Error(exception, responseBody);


### PR DESCRIPTION
### What changed? Why was the change needed?

It seems we rely heavily on the Pino logger's `request errored` event to give us details about errors. However, the error object is quite limited and only provides minimal information.

`{ error :  {class, message, stack} }`
![image](https://github.com/user-attachments/assets/b106fd1a-df50-4e3b-b166-467721f138ef)


I tried passing extra data, but it wasn't provided. Even pinoLogger.assign didn’t include the additional workflow ID parameter.
Adding another log in the exception filter, like we do for 5XX errors, allows us to include more parameters.

![image](https://github.com/user-attachments/assets/43fdddea-7f53-46df-9d46-40de53acfe55)


We could add this log to provide a structured object. 

The next step could be disabling autoLogging in the Pino logger since `request errored` is already handled in the ExceptionFilter. 

If `request completed` is needed, we can add it to the Next.js Interceptor.
### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
