### PR TITLE
fix(dashboard): Ensure URL Input gets the available width

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/url-input.tsx
+++ b/apps/dashboard/src/components/workflow-editor/url-input.tsx
@@ -43,7 +43,7 @@ export const URLInput = ({
               control={control}
               name={urlKey}
               render={({ field }) => (
-                <FormItem className="mr-auto min-w-px max-w-full">
+                <FormItem className="min-w-px max-w-full basis-full">
                   <FormControl>
                     {asEditor ? (
                       <Editor


### PR DESCRIPTION
### What changed? Why was the change needed?

Ensure URL Input gets the available width. That way, the text cursor is active at its full width while hovering making it behave like an actual input.

<img width="599" alt="Screenshot 2024-12-06 at 01 37 25" src="https://github.com/user-attachments/assets/c0c06219-d01e-4012-855b-ac6cbe5346a8">
