### PR TITLE
feat(dashboard): Email step preview

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-editor-preview.tsx
@@ -1,14 +1,26 @@
+import { ChannelTypeEnum, type StepDataDto, type WorkflowResponseDto } from '@novu/shared';
 import { CSSProperties, useEffect, useRef, useState } from 'react';
-import { type StepDataDto, type WorkflowResponseDto } from '@novu/shared';
 
-import { Notification5Fill } from '@/components/icons';
 import { Code2 } from '@/components/icons/code-2';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/primitives/accordion';
 import { Button } from '@/components/primitives/button';
 import { Editor } from '@/components/primitives/editor';
-import { loadLanguage } from '@uiw/codemirror-extensions-langs';
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/primitives/accordion';
-import { useEditorPreview } from '../use-editor-preview';
+import { Skeleton } from '@/components/primitives/skeleton';
+import { Tabs, TabsList, TabsTrigger } from '@/components/primitives/tabs';
+import {
+  EmailPreviewBody,
+  EmailPreviewBodyMobile,
+  EmailPreviewContentMobile,
+  EmailPreviewHeader,
+  EmailPreviewSubject,
+  EmailPreviewSubjectMobile,
+} from '@/components/workflow-editor/steps/email/email-preview';
 import { EmailTabsPreviewSection } from '@/components/workflow-editor/steps/email/email-tabs-section';
+import { TabsContent } from '@radix-ui/react-tabs';
+import { loadLanguage } from '@uiw/codemirror-extensions-langs';
+import { RiMacLine, RiSmartphoneFill } from 'react-icons/ri';
+import { useEditorPreview } from '../use-editor-preview';
+import { Separator } from '@/components/primitives/separator';
 
 const getInitialAccordionValue = (value: string) => {
   try {
@@ -27,7 +39,7 @@ type EmailEditorPreviewProps = {
 export const EmailEditorPreview = ({ workflow, step, formValues }: EmailEditorPreviewProps) => {
   const workflowSlug = workflow.workflowId;
   const stepSlug = step.stepId;
-  const { editorValue, setEditorValue, previewStep } = useEditorPreview({
+  const { editorValue, setEditorValue, isPreviewPending, previewData, previewStep } = useEditorPreview({
     workflowSlug,
     stepSlug,
     controlValues: formValues,
@@ -35,6 +47,7 @@ export const EmailEditorPreview = ({ workflow, step, formValues }: EmailEditorPr
   const [accordionValue, setAccordionValue] = useState<string | undefined>(getInitialAccordionValue(editorValue));
   const [payloadError, setPayloadError] = useState('');
   const [height, setHeight] = useState(0);
+  const [activeTab, setActiveTab] = useState('desktop');
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -53,54 +66,87 @@ export const EmailEditorPreview = ({ workflow, step, formValues }: EmailEditorPr
   }, [editorValue]);
 
   return (
-    <EmailTabsPreviewSection>
-      <div className="relative flex flex-col gap-3">
-        <div className="flex items-center gap-2.5 text-sm font-medium">
-          <Notification5Fill className="size-3" />
-          In-app template editor
-        </div>
-        {/* Email preview goes here */}
-        <Accordion type="single" collapsible value={accordionValue} onValueChange={setAccordionValue}>
-          <AccordionItem value="payload">
-            <AccordionTrigger>
-              <div className="flex items-center gap-1">
-                <Code2 className="size-5" />
-                Configure preview
-              </div>
-            </AccordionTrigger>
-            <AccordionContent
-              ref={contentRef}
-              className="flex flex-col gap-2"
-              style={{ '--radix-collapsible-content-height': `${height}px` } as CSSProperties}
-            >
-              <Editor
-                value={editorValue}
-                onChange={setEditorValue}
-                lang="json"
-                extensions={[loadLanguage('json')?.extension ?? []]}
-                className="border-neutral-alpha-200 bg-background text-foreground-600 mx-0 mt-0 rounded-lg border border-dashed p-3"
-              />
-              {payloadError && <p className="text-destructive text-xs">{payloadError}</p>}
-              <Button
-                size="xs"
-                type="button"
-                variant="outline"
-                className="self-end"
-                onClick={() => {
-                  try {
-                    previewStep();
-                    setPayloadError('');
-                  } catch (e) {
-                    setPayloadError(String(e));
-                  }
-                }}
-              >
-                Apply
-              </Button>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+    <Tabs value={activeTab} onValueChange={setActiveTab}>
+      <div className="flex w-full items-center justify-between p-3">
+        <EmailPreviewHeader />
+        <TabsList>
+          <TabsTrigger value="mobile">
+            <RiSmartphoneFill className="size-4" />
+          </TabsTrigger>
+          <TabsTrigger value="desktop">
+            <RiMacLine className="size-4" />
+          </TabsTrigger>
+        </TabsList>
       </div>
-    </EmailTabsPreviewSection>
+      <div className="relative flex flex-col gap-3">
+        {isPreviewPending ? (
+          <Skeleton className="h-96 w-full" />
+        ) : (
+          <>
+            {previewData?.result?.type == ChannelTypeEnum.EMAIL ? (
+              <>
+                <TabsContent value="mobile">
+                  <div className="w-full bg-neutral-100">
+                    <EmailPreviewContentMobile className="mx-auto">
+                      <EmailPreviewSubjectMobile subject={previewData.result.preview.subject} />
+                      <EmailPreviewBodyMobile body={previewData.result.preview.body} />
+                    </EmailPreviewContentMobile>
+                  </div>
+                </TabsContent>
+                <TabsContent value="desktop">
+                  <EmailPreviewSubject subject={previewData.result.preview.subject} />
+                  <Separator className="bg-neutral-200" />
+                  <EmailPreviewBody body={previewData.result.preview.body} />
+                </TabsContent>
+              </>
+            ) : (
+              <div className="p-6">No preview available</div>
+            )}
+          </>
+        )}
+        <EmailTabsPreviewSection>
+          <Accordion type="single" collapsible value={accordionValue} onValueChange={setAccordionValue}>
+            <AccordionItem value="payload">
+              <AccordionTrigger>
+                <div className="flex items-center gap-1">
+                  <Code2 className="size-5" />
+                  Configure preview
+                </div>
+              </AccordionTrigger>
+              <AccordionContent
+                ref={contentRef}
+                className="flex flex-col gap-2"
+                style={{ '--radix-collapsible-content-height': `${height}px` } as CSSProperties}
+              >
+                <Editor
+                  value={editorValue}
+                  onChange={setEditorValue}
+                  lang="json"
+                  extensions={[loadLanguage('json')?.extension ?? []]}
+                  className="border-neutral-alpha-200 bg-background text-foreground-600 mx-0 mt-0 rounded-lg border border-dashed p-3"
+                />
+                {payloadError && <p className="text-destructive text-xs">{payloadError}</p>}
+                <Button
+                  size="xs"
+                  type="button"
+                  variant="outline"
+                  className="self-end"
+                  onClick={() => {
+                    try {
+                      previewStep();
+                      setPayloadError('');
+                    } catch (e) {
+                      setPayloadError(String(e));
+                    }
+                  }}
+                >
+                  Apply
+                </Button>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </EmailTabsPreviewSection>
+      </div>
+    </Tabs>
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-preview.tsx
@@ -22,3 +22,66 @@ export const EmailPreviewHeader = (props: EmailPreviewHeaderProps) => {
     </div>
   );
 };
+
+type EmailPreviewSubjectProps = HTMLAttributes<HTMLHeadingElement> & {
+  subject: string;
+};
+export const EmailPreviewSubject = (props: EmailPreviewSubjectProps) => {
+  const { subject, className, ...rest } = props;
+
+  return (
+    <h3 className={cn('px-6 py-4', className)} {...rest}>
+      {subject}
+    </h3>
+  );
+};
+
+type EmailPreviewBodyProps = HTMLAttributes<HTMLIFrameElement> & {
+  body: string;
+};
+export const EmailPreviewBody = (props: EmailPreviewBodyProps) => {
+  const { body, className, ...rest } = props;
+
+  return (
+    <iframe
+      className={cn('mx-auto h-96 w-full py-6', className)}
+      src={'data:text/html,' + encodeURIComponent(body)}
+      {...rest}
+    />
+  );
+};
+
+type EmailPreviewContentMobileProps = HTMLAttributes<HTMLDivElement>;
+export const EmailPreviewContentMobile = (props: EmailPreviewContentMobileProps) => {
+  const { className, ...rest } = props;
+
+  return <div className={cn('bg-background max-w-sm', className)} {...rest} />;
+};
+
+type EmailPreviewBodyMobileProps = HTMLAttributes<HTMLIFrameElement> & {
+  body: string;
+};
+export const EmailPreviewBodyMobile = (props: EmailPreviewBodyMobileProps) => {
+  const { body, className, ...rest } = props;
+
+  return (
+    <iframe
+      className={cn('mx-auto h-96 w-full px-4', className)}
+      src={'data:text/html,' + encodeURIComponent(body)}
+      {...rest}
+    />
+  );
+};
+
+type EmailPreviewSubjectMobileProps = HTMLAttributes<HTMLDivElement> & {
+  subject: string;
+};
+export const EmailPreviewSubjectMobile = (props: EmailPreviewSubjectMobileProps) => {
+  const { subject, className, ...rest } = props;
+
+  return (
+    <div className={cn('bg-neutral-50 px-6 py-4', className)} {...rest}>
+      <h3 className="line-clamp-2">{subject}</h3>
+    </div>
+  );
+};


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
This is the email step preview. I've gone a different route on the mobile/desktop tabs to avoid the layout shift.
### Screenshots
<img width="836" alt="Screenshot 2024-12-06 at 10 42 42 AM" src="https://github.com/user-attachments/assets/eaafd271-bf86-4385-921b-876541baea3a">

<img width="833" alt="Screenshot 2024-12-06 at 10 21 33 AM" src="https://github.com/user-attachments/assets/edfecd3d-0928-44ed-84a2-98dad6c32e37">

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
