### PR TITLE
fix(dashboard): run queue invocations safely

### DIFF
--- a/apps/dashboard/src/hooks/use-invocation-queue.ts
+++ b/apps/dashboard/src/hooks/use-invocation-queue.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
+import * as Sentry from '@sentry/react';
 
 type CallbackFunction = () => Promise<unknown>;
 
@@ -64,6 +65,7 @@ export function useInvocationQueue<T extends CallbackFunction = CallbackFunction
     } catch (error) {
       // If the invocation fails, we want to log the error and continue with the next invocation
       console.error('Error processing queue item:', error);
+      Sentry.captureException(error);
     }
   }, []);
 

--- a/apps/dashboard/src/hooks/use-invocation-queue.ts
+++ b/apps/dashboard/src/hooks/use-invocation-queue.ts
@@ -64,7 +64,6 @@ export function useInvocationQueue<T extends CallbackFunction = CallbackFunction
       await invocation();
     } catch (error) {
       // If the invocation fails, we want to log the error and continue with the next invocation
-      console.error('Error processing queue item:', error);
       Sentry.captureException(error);
     }
   }, []);


### PR DESCRIPTION
### What changed? Why was the change needed?

API errors would result in client freezing, due to unhandled error state.


Simulating 0.33 error rate from API:

https://github.com/user-attachments/assets/d7dd5d24-fdfc-416d-9dcd-e5b7d55374f2

