### PR TITLE
feat(api): 'Missing' issue missing when the control value has empty string

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/validate-content/prepare-and-validate-content/prepare-and-validate-content.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/validate-content/prepare-and-validate-content/prepare-and-validate-content.usecase.ts
@@ -106,13 +106,13 @@ export class PrepareAndValidateContentUsecase {
     let flatSanitizedControlValues: Record<string, unknown> = flattenJson(controlValues);
     const controlValueToContentIssues: Record<string, ContentIssue[]> = {};
 
+    flatSanitizedControlValues = this.removeEmptyValuesFromMap(flatSanitizedControlValues);
     this.overloadMissingRequiredValuesIssues(
       defaultControlValues,
       flatSanitizedControlValues,
       controlValueToContentIssues
     );
 
-    flatSanitizedControlValues = this.removeEmptyValuesFromMap(flatSanitizedControlValues);
     flatSanitizedControlValues = this.removeIllegalValuesAndOverloadIssues(
       flatSanitizedControlValues,
       controlValueToValidPlaceholders,

--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -223,6 +223,20 @@ describe('Workflow Controller E2E API Testing', () => {
           }
         }
       });
+      it('should show control value required when empty', async () => {
+        const { issues, status } = await createWorkflowAndReturnStepIssues(
+          { steps: [{ ...buildInAppStep(), controlValues: { body: '' } }] },
+          0
+        );
+        expect(status, JSON.stringify(issues)).to.equal(WorkflowStatusEnum.ERROR);
+        expect(issues).to.be.ok;
+        if (issues.controls) {
+          expect(issues.controls?.body).to.be.ok;
+          if (issues.controls?.body) {
+            expect(issues.controls?.body[0].issueType).to.be.equal(StepContentIssueEnum.MISSING_VALUE);
+          }
+        }
+      });
 
       it('should show digest control value issues when illegal value provided', async () => {
         const steps = [{ ...buildDigestStep() }];


### PR DESCRIPTION

### What changed? Why was the change needed?

@desiprisg found that the FE is sending default values  '' causing the issue mechanism to ignore the missing control value, found the problem lies in the order as we do sanitize for it, added a test as well to validate the behavior

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
