### PR TITLE
fix(api): dashboard workflow override

### DIFF
--- a/apps/api/src/app/bridge/e2e/sync.e2e.ts
+++ b/apps/api/src/app/bridge/e2e/sync.e2e.ts
@@ -680,9 +680,7 @@ describe('Bridge Sync - /bridge/sync (POST)', async () => {
     });
 
     expect(result.status).to.equal(400);
-    expect(result.body.message).to.contain(
-      `Workflow with same workflow id was already created in Dashboard please use another workflow id ${workflowId}`
-    );
+    expect(result.body.message).to.contain(`was already created in Dashboard. Please use another workflowId.`);
 
     // Verify the original workflow wasn't modified
     const workflows = await workflowsRepository.findOne({

--- a/apps/api/src/app/bridge/e2e/sync.e2e.ts
+++ b/apps/api/src/app/bridge/e2e/sync.e2e.ts
@@ -6,7 +6,7 @@ import {
   MessageTemplateRepository,
   ControlValuesRepository,
 } from '@novu/dal';
-import { WorkflowTypeEnum } from '@novu/shared';
+import { WorkflowOriginEnum, WorkflowTypeEnum } from '@novu/shared';
 import { workflow } from '@novu/framework';
 import { BridgeServer } from '../../../../e2e/bridge.server';
 
@@ -649,5 +649,85 @@ describe('Bridge Sync - /bridge/sync (POST)', async () => {
 
     const secondStepResponse = await session.testAgent.get(`/v1/bridge/controls/${workflowId}/send-email`);
     expect(secondStepResponse.body.data.controls.subject).to.equal('Hello World again');
+  });
+
+  it('should throw an error when trying to sync a workflow with an ID that exists in dashboard', async () => {
+    const workflowId = 'dashboard-created-workflow';
+
+    // First create a workflow directly (simulating dashboard creation)
+    const dashboardWorkflow = await workflowsRepository.create({
+      _environmentId: session.environment._id,
+      name: workflowId,
+      triggers: [{ identifier: workflowId, type: 'event', variables: [] }],
+      steps: [],
+      active: true,
+      draft: false,
+      workflowId,
+      origin: WorkflowOriginEnum.NOVU_CLOUD,
+    });
+
+    // Now try to sync a workflow with the same ID through bridge
+    const newWorkflow = workflow(workflowId, async ({ step }) => {
+      await step.email('send-email', () => ({
+        subject: 'Welcome!',
+        body: 'Hello there',
+      }));
+    });
+    await bridgeServer.start({ workflows: [newWorkflow] });
+
+    const result = await session.testAgent.post(`/v1/bridge/sync`).send({
+      bridgeUrl: bridgeServer.serverPath,
+    });
+
+    expect(result.status).to.equal(400);
+    expect(result.body.message).to.contain(
+      `Workflow with same workflow id was already created in Dashboard please use another workflow id ${workflowId}`
+    );
+
+    // Verify the original workflow wasn't modified
+    const workflows = await workflowsRepository.findOne({
+      _environmentId: session.environment._id,
+      _id: dashboardWorkflow._id,
+    });
+    expect(workflows).to.deep.equal(dashboardWorkflow);
+  });
+
+  it('should allow syncing a workflow with same ID if original was created externally', async () => {
+    const workflowId = 'external-created-workflow';
+
+    // First create a workflow as external
+    const externalWorkflow = await workflowsRepository.create({
+      _environmentId: session.environment._id,
+      name: workflowId,
+      triggers: [{ identifier: workflowId, type: 'event', variables: [] }],
+      steps: [],
+      active: true,
+      draft: false,
+      workflowId,
+      origin: WorkflowOriginEnum.EXTERNAL,
+    });
+
+    // Now try to sync a workflow with the same ID through bridge
+    const newWorkflow = workflow(workflowId, async ({ step }) => {
+      await step.email('send-email', () => ({
+        subject: 'Updated Welcome!',
+        body: 'Updated Hello there',
+      }));
+    });
+    await bridgeServer.start({ workflows: [newWorkflow] });
+
+    const result = await session.testAgent.post(`/v1/bridge/sync`).send({
+      bridgeUrl: bridgeServer.serverPath,
+    });
+
+    expect(result.status).to.equal(201);
+
+    // Verify the workflow was updated
+    const workflows = await workflowsRepository.findOne({
+      _environmentId: session.environment._id,
+      _id: externalWorkflow._id,
+    });
+    expect(workflows?.origin).to.equal(WorkflowOriginEnum.EXTERNAL);
+    expect(workflows?.steps[0]?.stepId).to.equal('send-email');
   });
 });

--- a/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
@@ -162,9 +162,25 @@ export class Sync {
     command: SyncCommand,
     workflowsFromBridge: DiscoverWorkflowOutput[]
   ): Promise<NotificationTemplateEntity[]> {
+    const existingFrameworkWorkflows = await Promise.all(
+      workflowsFromBridge.map((workflow) =>
+        this.notificationTemplateRepository.findByTriggerIdentifier(command.environmentId, workflow.workflowId)
+      )
+    );
+
+    existingFrameworkWorkflows.forEach((workflow, index) => {
+      if (workflow?.origin && workflow.origin !== WorkflowOriginEnum.EXTERNAL) {
+        throw new BadRequestException(
+          'Workflow with same workflow id was already created in Dashboard please use another workflow id ' +
+            `${workflowsFromBridge[index].workflowId}`
+        );
+      }
+    });
+
     return Promise.all(
-      workflowsFromBridge.map(async (workflow) => {
-        let savedWorkflow = await this.upsertWorkflow(command, workflow);
+      workflowsFromBridge.map(async (workflow, index) => {
+        const existingFrameworkWorkflow = existingFrameworkWorkflows[index];
+        let savedWorkflow = await this.upsertWorkflow(command, workflow, existingFrameworkWorkflow);
 
         const validatedWorkflowWithIssues = await this.workflowUpdatePostProcess.execute({
           user: {
@@ -197,24 +213,18 @@ export class Sync {
 
   private async upsertWorkflow(
     command: SyncCommand,
-    workflow: DiscoverWorkflowOutput
+    workflow: DiscoverWorkflowOutput,
+    existingFrameworkWorkflow: NotificationTemplateEntity | null
   ): Promise<NotificationTemplateEntity> {
-    const workflowExist = await this.notificationTemplateRepository.findByTriggerIdentifier(
-      command.environmentId,
-      workflow.workflowId
-    );
-
-    let savedWorkflow: NotificationTemplateEntity | undefined;
-
-    if (workflowExist) {
-      savedWorkflow = await this.updateWorkflowUsecase.execute(
-        UpdateWorkflowCommand.create(this.mapDiscoverWorkflowToUpdateWorkflowCommand(workflowExist, command, workflow))
+    if (existingFrameworkWorkflow) {
+      return await this.updateWorkflowUsecase.execute(
+        UpdateWorkflowCommand.create(
+          this.mapDiscoverWorkflowToUpdateWorkflowCommand(existingFrameworkWorkflow, command, workflow)
+        )
       );
-    } else {
-      savedWorkflow = await this.createWorkflow(command, workflow);
     }
 
-    return savedWorkflow;
+    return await this.createWorkflow(command, workflow);
   }
 
   private async createWorkflow(

--- a/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
@@ -170,9 +170,9 @@ export class Sync {
 
     existingFrameworkWorkflows.forEach((workflow, index) => {
       if (workflow?.origin && workflow.origin !== WorkflowOriginEnum.EXTERNAL) {
+        const { workflowId } = workflowsFromBridge[index];
         throw new BadRequestException(
-          'Workflow with same workflow id was already created in Dashboard please use another workflow id ' +
-            `${workflowsFromBridge[index].workflowId}`
+          `Workflow ${workflowId} was already created in Dashboard. Please use another workflowId.`
         );
       }
     });


### PR DESCRIPTION
### What changed? Why was the change needed?

The bug is the following:
1. Enter the new dashboard.
2. Create new workflow and call it new-workflow
3. A new dashboard first workflow will be created with origin novu-cloud.
4. Go to framework create workflow with workflowId new-workflow
5. Sync Bridge.
6. This update the workflow we created in step 2. meaning we will have dashboard first workflow with framework workflow data.

![image](https://github.com/user-attachments/assets/50ad5814-1dc9-4206-89f6-16dd476a955c)

Fixing: [NV-4898](https://linear.app/novu/issue/NV-4898/store-and-evaluate-skip-conditions-in-shared-bridgeendpoint)


### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
