### PR TITLE
fix(dashboard): unselect steps on canvas click

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
@@ -31,6 +31,9 @@ import { Step } from '@/utils/types';
 import { getFirstControlsErrorMessage, getFirstBodyErrorMessage } from './step-utils';
 import { useWorkflow } from '@/components/workflow-editor/workflow-provider';
 import { useEnvironment } from '@/context/environment/hooks';
+import { buildRoute } from '@/utils/routes';
+import { ROUTES } from '@/utils/routes';
+import { useNavigate } from 'react-router-dom';
 
 const nodeTypes = {
   trigger: TriggerNode,
@@ -89,6 +92,7 @@ const WorkflowCanvasChild = ({ steps }: { steps: Step[] }) => {
   const reactFlowInstance = useReactFlow();
   const { currentEnvironment } = useEnvironment();
   const { workflow: currentWorkflow } = useWorkflow();
+  const navigate = useNavigate();
 
   const [nodes, edges] = useMemo(() => {
     const triggerNode = {
@@ -183,6 +187,17 @@ const WorkflowCanvasChild = ({ steps }: { steps: Step[] }) => {
         panOnScroll
         selectionOnDrag
         panOnDrag={panOnDrag}
+        onPaneClick={() => {
+          // unselect node if clicked on background
+          if (currentEnvironment?.slug && currentWorkflow?.slug) {
+            navigate(
+              buildRoute(ROUTES.EDIT_WORKFLOW, {
+                environmentSlug: currentEnvironment.slug,
+                workflowSlug: currentWorkflow.slug,
+              })
+            );
+          }
+        }}
       >
         <Controls showZoom={false} showInteractive={false} />
         <Background variant={BackgroundVariant.Dots} gap={12} size={1} />


### PR DESCRIPTION
### What changed? Why was the change needed?

If I'm in workflow editor in a step drawer and I want to edit e.g. workflow tags/name. Its very unintuitive that I have to explicitly click "x" on step drawer, it should be deselected on background click.

https://github.com/user-attachments/assets/18ef5644-8fa3-4d48-9f9b-188ebc48311f

