### PR TITLE
fix(novu): Respect .env values for API URL and SECRET_KEY

### DIFF
--- a/packages/novu/src/constants/constants.ts
+++ b/packages/novu/src/constants/constants.ts
@@ -4,6 +4,9 @@ dotenv.config();
 // CLI Server
 export const SERVER_HOST = 'localhost';
 
+// Novu Cloud
+export const { NOVU_API_URL, NOVU_SECRET_KEY } = process.env;
+
 // segment analytics
 export const ANALYTICS_ENABLED = process.env.ANALYTICS_ENABLED !== 'false';
 export const SEGMENTS_WRITE_KEY = process.env.CLI_SEGMENT_WRITE_KEY || 'tz68K6ytWx6AUqDl30XAwiIoUfr7iWVW';

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
-import { green } from 'picocolors';
 import { v4 as uuidv4 } from 'uuid';
 import { devCommand, DevCommandOptions } from './commands';
 import { sync } from './commands/sync';
 import { AnalyticService, ConfigService } from './services';
 import { IInitCommandOptions, init } from './commands/init';
+import { NOVU_API_URL, NOVU_SECRET_KEY } from './constants';
 
 const analytics = new AnalyticService();
 export const config = new ConfigService();
@@ -31,14 +31,15 @@ program
   (e.g., npx novu@latest sync -b https://acme.org/api/novu -s NOVU_SECRET_KEY -a https://eu.api.novu.co)`
   )
   .usage('-b <url> -s <secret-key> [-a <url>]')
-  .option('-a, --api-url <url>', 'The Novu Cloud API URL', 'https://api.novu.co')
+  .option('-a, --api-url <url>', 'The Novu Cloud API URL', NOVU_API_URL || 'https://api.novu.co')
   .requiredOption(
     '-b, --bridge-url <url>',
     'The Novu endpoint URL hosted in the Bridge application, by convention ends in /api/novu'
   )
   .requiredOption(
     '-s, --secret-key <secret-key>',
-    'The Novu Secret Key. Obtainable at https://dashboard.novu.co/api-keys'
+    'The Novu Secret Key. Obtainable at https://dashboard.novu.co/api-keys',
+    NOVU_SECRET_KEY || ''
   )
   .action(async (options) => {
     analytics.track({


### PR DESCRIPTION
### What changed? Why was the change needed?
This is just a DX improvement for `npx novu sync` command. If these env vars are set, novu sync command should use them instead of requiring the corresponding CLI Argumentthe