### PR TITLE
fix(dashboard): Email step editor/preview UI fixes

### DIFF
--- a/apps/dashboard/src/components/primitives/popover.tsx
+++ b/apps/dashboard/src/components/primitives/popover.tsx
@@ -23,7 +23,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        `bg-background text-foreground-950 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-72 rounded-md border p-4 shadow-md outline-none ${arrowClipPathClassName}`,
+        `bg-background text-foreground-950 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-72 overflow-auto rounded-md border p-4 shadow-md outline-none ${arrowClipPathClassName}`,
         className
       )}
       {...props}

--- a/apps/dashboard/src/components/workflow-editor/add-step-menu.tsx
+++ b/apps/dashboard/src/components/workflow-editor/add-step-menu.tsx
@@ -129,21 +129,21 @@ export const AddStepMenu = ({
               </MenuItemsGroup>
             </MenuGroup>
             <MenuGroup>
-              <MenuTitle>Action Steps</MenuTitle>
+              <MenuTitle>Actions</MenuTitle>
               <MenuItemsGroup>
-                <MenuItem
-                  stepType={StepTypeEnum.DIGEST}
-                  disabled={!areNewStepsEnabled}
-                  onClick={() => handleMenuItemClick(StepTypeEnum.DIGEST)}
-                >
-                  Digest
-                </MenuItem>
                 <MenuItem
                   stepType={StepTypeEnum.DELAY}
                   disabled={!areNewStepsEnabled}
                   onClick={() => handleMenuItemClick(StepTypeEnum.DELAY)}
                 >
                   Delay
+                </MenuItem>
+                <MenuItem
+                  stepType={StepTypeEnum.DIGEST}
+                  disabled={!areNewStepsEnabled}
+                  onClick={() => handleMenuItemClick(StepTypeEnum.DIGEST)}
+                >
+                  Digest
                 </MenuItem>
               </MenuItemsGroup>
             </MenuGroup>

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-template.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-template.tsx
@@ -1,14 +1,7 @@
 import { motion } from 'motion/react';
 import { useNavigate } from 'react-router-dom';
 
-import {
-  Sheet,
-  SheetContentBase,
-  SheetDescription,
-  SheetOverlay,
-  SheetPortal,
-  SheetTitle,
-} from '@/components/primitives/sheet';
+import { Sheet, SheetContentBase, SheetDescription, SheetPortal, SheetTitle } from '@/components/primitives/sheet';
 import { ConfigureStepTemplateForm } from '@/components/workflow-editor/steps/configure-step-template-form';
 import { VisuallyHidden } from '@/components/primitives/visually-hidden';
 import { PageMeta } from '@/components/page-meta';
@@ -26,7 +19,10 @@ export const ConfigureStepTemplate = () => {
   const navigate = useNavigate();
   const { workflow, update, step } = useWorkflow();
   const handleCloseSheet = () => {
-    navigate('..', { relative: 'path' });
+    if (step) {
+      // Do not use relative path here, calling twice will result in moving further back
+      navigate(`../steps/${step.slug}`);
+    }
   };
 
   if (!workflow || !step) {
@@ -36,22 +32,21 @@ export const ConfigureStepTemplate = () => {
   return (
     <>
       <PageMeta title={`Edit ${step?.name}`} />
-      <Sheet open>
+      <Sheet modal={false} open>
+        <motion.div
+          initial={{
+            opacity: 0,
+          }}
+          animate={{
+            opacity: 1,
+          }}
+          exit={{
+            opacity: 0,
+          }}
+          className="fixed inset-0 z-50 h-screen w-screen bg-black/20"
+          transition={transitionSetting}
+        />
         <SheetPortal>
-          <SheetOverlay asChild>
-            <motion.div
-              initial={{
-                opacity: 0,
-              }}
-              animate={{
-                opacity: 1,
-              }}
-              exit={{
-                opacity: 0,
-              }}
-              transition={transitionSetting}
-            />
-          </SheetOverlay>
           <SheetContentBase asChild onInteractOutside={handleCloseSheet} onEscapeKeyDown={handleCloseSheet}>
             <motion.div
               initial={{

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-editor-preview.tsx
@@ -15,7 +15,7 @@ import {
   EmailPreviewSubject,
   EmailPreviewSubjectMobile,
 } from '@/components/workflow-editor/steps/email/email-preview';
-import { EmailTabsPreviewSection } from '@/components/workflow-editor/steps/email/email-tabs-section';
+import { EmailTabsSection } from '@/components/workflow-editor/steps/email/email-tabs-section';
 import { TabsContent } from '@radix-ui/react-tabs';
 import { loadLanguage } from '@uiw/codemirror-extensions-langs';
 import { RiMacLine, RiSmartphoneFill } from 'react-icons/ri';
@@ -67,7 +67,7 @@ export const EmailEditorPreview = ({ workflow, step, formValues }: EmailEditorPr
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab}>
-      <div className="flex w-full items-center justify-between p-3">
+      <EmailTabsSection className="flex w-full items-center justify-between">
         <EmailPreviewHeader />
         <TabsList>
           <TabsTrigger value="mobile">
@@ -77,10 +77,18 @@ export const EmailEditorPreview = ({ workflow, step, formValues }: EmailEditorPr
             <RiMacLine className="size-4" />
           </TabsTrigger>
         </TabsList>
-      </div>
-      <div className="relative flex flex-col gap-3">
+      </EmailTabsSection>
+      <div className="relative flex flex-col">
         {isPreviewPending ? (
-          <Skeleton className="h-96 w-full" />
+          <div className="flex flex-col">
+            <EmailTabsSection className="py-2">
+              <Skeleton className="h-6 w-full" />
+            </EmailTabsSection>
+            <Separator className="bg-neutral-100" />
+            <EmailTabsSection>
+              <Skeleton className="h-96 w-full" />
+            </EmailTabsSection>
+          </div>
         ) : (
           <>
             {previewData?.result?.type == ChannelTypeEnum.EMAIL ? (
@@ -95,8 +103,8 @@ export const EmailEditorPreview = ({ workflow, step, formValues }: EmailEditorPr
                 </TabsContent>
                 <TabsContent value="desktop">
                   <EmailPreviewSubject subject={previewData.result.preview.subject} />
-                  <Separator className="bg-neutral-200" />
-                  <EmailPreviewBody body={previewData.result.preview.body} />
+                  <Separator className="bg-neutral-100" />
+                  <EmailPreviewBody body={previewData.result.preview.body} className="bg-background rounded-lg" />
                 </TabsContent>
               </>
             ) : (
@@ -104,7 +112,7 @@ export const EmailEditorPreview = ({ workflow, step, formValues }: EmailEditorPr
             )}
           </>
         )}
-        <EmailTabsPreviewSection>
+        <EmailTabsSection>
           <Accordion type="single" collapsible value={accordionValue} onValueChange={setAccordionValue}>
             <AccordionItem value="payload">
               <AccordionTrigger>
@@ -145,7 +153,7 @@ export const EmailEditorPreview = ({ workflow, step, formValues }: EmailEditorPr
               </AccordionContent>
             </AccordionItem>
           </Accordion>
-        </EmailTabsPreviewSection>
+        </EmailTabsSection>
       </div>
     </Tabs>
   );

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-editor.tsx
@@ -1,22 +1,33 @@
 import { Separator } from '@/components/primitives/separator';
 import { getComponentByType } from '@/components/workflow-editor/steps/component-utils';
 import { EmailPreviewHeader } from '@/components/workflow-editor/steps/email/email-preview';
+import { EmailTabsSection } from '@/components/workflow-editor/steps/email/email-tabs-section';
 import { type UiSchema } from '@novu/shared';
+import { motion } from 'motion/react';
 
 const subjectKey = 'subject';
 const emailEditorKey = 'emailEditor';
 
-type EmailEditorProps = { uiSchema?: UiSchema };
+type EmailEditorProps = { uiSchema: UiSchema };
 export const EmailEditor = (props: EmailEditorProps) => {
   const { uiSchema } = props;
   const { [emailEditorKey]: emailEditor, [subjectKey]: subject } = uiSchema?.properties ?? {};
 
   return (
     <>
-      <EmailPreviewHeader />
-      <div className="px-8 py-2">{getComponentByType({ component: subject.component })}</div>
+      <EmailTabsSection>
+        <EmailPreviewHeader />
+      </EmailTabsSection>
+      <EmailTabsSection className="-mx-[2px] -my-[3px] px-7 py-2">
+        {getComponentByType({ component: subject.component })}
+      </EmailTabsSection>
       <Separator className="bg-neutral-100" />
-      <div className="pl-6">{emailEditor && getComponentByType({ component: emailEditor.component })}</div>
+      {/* extra padding on the left to account for the drag handle */}
+      <EmailTabsSection className="pl-14">
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+          {emailEditor && getComponentByType({ component: emailEditor.component })}
+        </motion.div>
+      </EmailTabsSection>
     </>
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-preview.tsx
@@ -30,22 +30,22 @@ export const EmailPreviewSubject = (props: EmailPreviewSubjectProps) => {
   const { subject, className, ...rest } = props;
 
   return (
-    <h3 className={cn('px-6 py-4', className)} {...rest}>
+    <h3 className={cn('px-8 py-2', className)} {...rest}>
       {subject}
     </h3>
   );
 };
 
-type EmailPreviewBodyProps = HTMLAttributes<HTMLIFrameElement> & {
+type EmailPreviewBodyProps = HTMLAttributes<HTMLDivElement> & {
   body: string;
 };
 export const EmailPreviewBody = (props: EmailPreviewBodyProps) => {
   const { body, className, ...rest } = props;
 
   return (
-    <iframe
-      className={cn('mx-auto h-96 w-full py-6', className)}
-      src={'data:text/html,' + encodeURIComponent(body)}
+    <div
+      className={cn('mx-auto min-h-96 w-full overflow-auto px-8 py-6', className)}
+      dangerouslySetInnerHTML={{ __html: body }}
       {...rest}
     />
   );
@@ -58,16 +58,16 @@ export const EmailPreviewContentMobile = (props: EmailPreviewContentMobileProps)
   return <div className={cn('bg-background max-w-sm', className)} {...rest} />;
 };
 
-type EmailPreviewBodyMobileProps = HTMLAttributes<HTMLIFrameElement> & {
+type EmailPreviewBodyMobileProps = HTMLAttributes<HTMLDivElement> & {
   body: string;
 };
 export const EmailPreviewBodyMobile = (props: EmailPreviewBodyMobileProps) => {
   const { body, className, ...rest } = props;
 
   return (
-    <iframe
-      className={cn('mx-auto h-96 w-full px-4', className)}
-      src={'data:text/html,' + encodeURIComponent(body)}
+    <div
+      className={cn('mx-auto min-h-96 w-full px-4', className)}
+      dangerouslySetInnerHTML={{ __html: body }}
       {...rest}
     />
   );
@@ -80,7 +80,7 @@ export const EmailPreviewSubjectMobile = (props: EmailPreviewSubjectMobileProps)
   const { subject, className, ...rest } = props;
 
   return (
-    <div className={cn('bg-neutral-50 px-6 py-4', className)} {...rest}>
+    <div className={cn('bg-neutral-50 p-4', className)} {...rest}>
       <h3 className="line-clamp-2">{subject}</h3>
     </div>
   );

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-tabs-section.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-tabs-section.tsx
@@ -2,13 +2,7 @@ import { cn } from '@/utils/ui';
 import { HTMLAttributes } from 'react';
 
 type EmailTabsSectionProps = HTMLAttributes<HTMLDivElement>;
-export const EmailTabsEditSection = (props: EmailTabsSectionProps) => {
+export const EmailTabsSection = (props: EmailTabsSectionProps) => {
   const { className, ...rest } = props;
-  return <div className={cn('p-4', className)} {...rest} />;
-};
-
-type EmailTabsPreviewSectionProps = HTMLAttributes<HTMLDivElement>;
-export const EmailTabsPreviewSection = (props: EmailTabsPreviewSectionProps) => {
-  const { className, ...rest } = props;
-  return <div className={cn('p-4', className)} {...rest} />;
+  return <div className={cn('px-4 py-3', className)} {...rest} />;
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-tabs.tsx
@@ -11,19 +11,21 @@ import { StepEditorProps } from '@/components/workflow-editor/steps/configure-st
 import { EmailEditor } from '@/components/workflow-editor/steps/email/email-editor';
 import { EmailEditorPreview } from '@/components/workflow-editor/steps/email/email-editor-preview';
 import { CustomStepControls } from '../controls/custom-step-controls';
-import { EmailTabsEditSection } from '@/components/workflow-editor/steps/email/email-tabs-section';
+import { EmailTabsSection } from '@/components/workflow-editor/steps/email/email-tabs-section';
 import { WorkflowOriginEnum } from '@novu/shared';
+import { useState } from 'react';
 
-const tabsContentClassName = 'h-full w-full overflow-y-auto';
+const tabsContentClassName = 'h-full w-full overflow-y-auto data-[state=inactive]:hidden';
 
 export const EmailTabs = (props: StepEditorProps) => {
   const { workflow, step } = props;
   const { dataSchema, uiSchema } = step.controls;
   const form = useFormContext();
   const navigate = useNavigate();
+  const [tabsValue, setTabsValue] = useState('editor');
 
   return (
-    <Tabs defaultValue="editor" className="flex h-full flex-1 flex-col">
+    <Tabs defaultValue="editor" value={tabsValue} onValueChange={setTabsValue} className="flex h-full flex-1 flex-col">
       <header className="flex flex-row items-center gap-3 px-3 py-1.5">
         <div className="mr-auto flex items-center gap-2.5 text-sm font-medium">
           <RiEdit2Line className="size-4" />
@@ -55,20 +57,18 @@ export const EmailTabs = (props: StepEditorProps) => {
         </Button>
       </header>
       <Separator />
-      <TabsContent value="editor" className={tabsContentClassName}>
-        {workflow.origin === WorkflowOriginEnum.NOVU_CLOUD && (
-          <EmailTabsEditSection>
-            <EmailEditor uiSchema={uiSchema} />
-          </EmailTabsEditSection>
-        )}
+      <TabsContent value="editor" forceMount className={tabsContentClassName}>
+        {workflow.origin === WorkflowOriginEnum.NOVU_CLOUD && uiSchema && <EmailEditor uiSchema={uiSchema} />}
         {workflow.origin === WorkflowOriginEnum.EXTERNAL && (
-          <EmailTabsEditSection>
+          <EmailTabsSection>
             <CustomStepControls dataSchema={dataSchema} origin={workflow.origin} />
-          </EmailTabsEditSection>
+          </EmailTabsSection>
         )}
       </TabsContent>
-      <TabsContent value="preview" className={tabsContentClassName}>
-        <EmailEditorPreview workflow={workflow} step={step} formValues={form.getValues()} />
+      <TabsContent value="preview" forceMount className={tabsContentClassName}>
+        {tabsValue === 'preview' && (
+          <EmailEditorPreview workflow={workflow} step={step} formValues={form.getValues()} />
+        )}
       </TabsContent>
       <Separator />
     </Tabs>

--- a/apps/dashboard/src/components/workflow-editor/steps/email/maily.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/maily.tsx
@@ -24,7 +24,7 @@ export const Maily = (props: MailyProps) => {
       render={({ field }) => {
         return (
           <>
-            <div className={cn('mx-auto w-full pl-4', className)} {...rest}>
+            <div className={cn('mx-auto w-full', className)} {...rest}>
               <FormControl>
                 <Editor
                   config={{


### PR DESCRIPTION
### What changed? Why was the change needed?
* Fix layout shift of the email header
* Fix overflow of tag input
* Let email preview fill height of container
* Sort available action-steps alphabetically in the Channels dropdown
* Fix double overlay click resulting into moving back to workflow list (when in configure template)
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
