### PR TITLE
fix(web): remove isV2Enabled condition for opt in option

### DIFF
--- a/apps/web/src/ee/clerk/components/UserProfileButton.tsx
+++ b/apps/web/src/ee/clerk/components/UserProfileButton.tsx
@@ -9,14 +9,13 @@ import { WEB_APP_URL } from '../../../config';
 export function UserProfileButton() {
   const { optIn } = useNewDashboardOptIn();
   const isNewDashboardEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_NEW_DASHBOARD_ENABLED);
-  const isV2Enabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_V2_ENABLED);
 
   return (
     <UserButton
       afterSignOutUrl={`${WEB_APP_URL}${ROUTES.AUTH_LOGIN}`}
       userProfileUrl={ROUTES.MANAGE_ACCOUNT_USER_PROFILE}
     >
-      {isNewDashboardEnabled && isV2Enabled && (
+      {isNewDashboardEnabled && (
         <UserButton.MenuItems>
           <UserButton.Action
             label="Try out the new Dashboard (beta)"


### PR DESCRIPTION
### What changed? Why was the change needed?
- remove isV2Enabled condition for opt in option so that v1 organizations orgid can be used in FF to enable new dashboard
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

Ref:- [Slack](https://novu.slack.com/archives/C06DU7A7BPV/p1734089132972369?thread_ts=1734079986.609099&cid=C06DU7A7BPV)
### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
