### PR TITLE
fix(js): add missing on click event for dropdown tabs

### DIFF
--- a/packages/js/src/ui/components/InboxTabs/InboxTab.tsx
+++ b/packages/js/src/ui/components/InboxTabs/InboxTab.tsx
@@ -53,6 +53,7 @@ export const InboxDropdownTab = (props: InboxDropdownTabProps) => {
   return (
     <Dropdown.Item
       class={style('moreTabs__dropdownItem', cn(dropdownItemVariants(), 'nt-flex nt-justify-between nt-gap-2'))}
+      onClick={props.onClick}
     >
       <span class={style('moreTabs__dropdownItemLabel', 'nt-mr-auto')}>{props.label}</span>
       {props.rightIcon}


### PR DESCRIPTION
### What changed? Why was the change needed?

- I added the  missing 'onClick' event for dropdown tabs from the notifications inbox tabs component.
- users could not switch notifications tabs if those were in the dropdown list.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
