### PR TITLE
feat(api): fail inactive notification trigger

### DIFF
--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
@@ -28,7 +28,9 @@ import {
   ReservedVariablesMap,
   TriggerContextTypeEnum,
   TriggerEventStatusEnum,
+  TriggerSourceEnum,
   WorkflowOriginEnum,
+  WorkflowStatusEnum,
 } from '@novu/shared';
 import {
   EnvironmentEntity,
@@ -139,6 +141,20 @@ export class ParseEventRequest {
       const message = workflowOverride ? 'Workflow is not active by workflow override' : 'Workflow is not active';
       Logger.log(message, LOG_CONTEXT);
 
+      return {
+        acknowledged: true,
+        status: TriggerEventStatusEnum.NOT_ACTIVE,
+      };
+    }
+
+    if (template.status === WorkflowStatusEnum.INACTIVE && !this.isGracefulTriggerAllowed(command.payload.__source)) {
+      return {
+        acknowledged: true,
+        status: TriggerEventStatusEnum.NOT_ACTIVE,
+      };
+    }
+
+    if (template.status === WorkflowStatusEnum.ERROR && !this.isGracefulTriggerAllowed(command.payload.__source)) {
       return {
         acknowledged: true,
         status: TriggerEventStatusEnum.NOT_ACTIVE,
@@ -404,6 +420,10 @@ export class ParseEventRequest {
 
   private isBlockedEmail(email: string): boolean {
     return BLOCKED_DOMAINS.some((domain) => email.includes(domain));
+  }
+
+  private isGracefulTriggerAllowed(source?: string): boolean {
+    return source === TriggerSourceEnum.DASHBOARD;
   }
 }
 

--- a/packages/shared/src/types/notification-templates.ts
+++ b/packages/shared/src/types/notification-templates.ts
@@ -13,6 +13,10 @@ export enum WorkflowCreationSourceEnum {
   DASHBOARD = 'dashboard',
 }
 
+export enum TriggerSourceEnum {
+  DASHBOARD = 'dashboard',
+}
+
 export type WorkflowIntegrationStatus = {
   hasActiveIntegrations: boolean;
   hasPrimaryIntegrations?: boolean;


### PR DESCRIPTION
### What changed? Why was the change needed?

We added issue management under the workflow entity, but we never enforced its usage. This PR ensures that notifications won't be triggered for statuses that are not active.

At the same time, to improve the user experience, we're allowing users to trigger the "Trigger" action directly from the Dashboard. This helps them quickly identify issues while debugging the workflow.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
