### PR TITLE
fix(dashboard): clicking outside dropdown closes the whole edit sidebar

### DIFF
--- a/apps/dashboard/src/components/in-app-action-dropdown.tsx
+++ b/apps/dashboard/src/components/in-app-action-dropdown.tsx
@@ -51,7 +51,7 @@ export const InAppActionDropdown = ({ onMenuItemClick }: { onMenuItemClick?: () 
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <div className={cn('mt-3 flex items-center gap-1')}>
           <div className="border-neutral-alpha-200 relative flex min-h-10 w-full flex-wrap items-center justify-end gap-1 rounded-md border p-1 shadow-sm">
             {!primaryAction && !secondaryAction && (
@@ -168,7 +168,7 @@ const ConfigureActionPopover = (props: ComponentProps<typeof PopoverTrigger> & {
   );
 
   return (
-    <Popover modal={true}>
+    <Popover>
       <PopoverTrigger {...rest} />
       <PopoverContent className="max-w-72" side="bottom" align="end">
         <div className="flex flex-col gap-3">

--- a/apps/dashboard/src/components/primitives/form/avatar-picker.tsx
+++ b/apps/dashboard/src/components/primitives/form/avatar-picker.tsx
@@ -53,7 +53,7 @@ export const AvatarPicker = forwardRef<HTMLInputElement, AvatarPickerProps>(
 
     return (
       <div className="size-9 space-y-2">
-        <Popover modal={true} open={isOpen} onOpenChange={setIsOpen}>
+        <Popover open={isOpen} onOpenChange={setIsOpen}>
           <PopoverTrigger asChild>
             <Button variant="outline" size="icon" className="text-foreground-600 relative size-full overflow-hidden">
               {value ? (


### PR DESCRIPTION
### What changed? Why was the change needed?
- Clicking outside of the in app CTA dropdowns would cause the whole edit side menu to be closed.

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
