### PR TITLE
fix(api-service): workflow creation api flow didn't generate payload schema

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/build-payload-schema/build-payload-schema.command.ts
+++ b/apps/api/src/app/workflows-v2/usecases/build-payload-schema/build-payload-schema.command.ts
@@ -1,10 +1,10 @@
 import { EnvironmentWithUserCommand } from '@novu/application-generic';
-import { IsString, IsObject, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsString, IsObject, IsOptional } from 'class-validator';
 
 export class BuildPayloadSchemaCommand extends EnvironmentWithUserCommand {
   @IsString()
-  @IsNotEmpty()
-  workflowId: string;
+  @IsOptional()
+  workflowId?: string;
 
   /**
    * Control values used for preview purposes

--- a/apps/api/src/app/workflows-v2/usecases/build-payload-schema/build-payload-schema.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/build-payload-schema/build-payload-schema.usecase.ts
@@ -23,7 +23,7 @@ export class BuildPayloadSchema {
   private async getControlValues(command: BuildPayloadSchemaCommand) {
     let controlValues = command.controlValues ? [command.controlValues] : [];
 
-    if (!controlValues.length) {
+    if (!controlValues.length && command.workflowId) {
       controlValues = (
         await this.controlValuesRepository.find(
           {

--- a/apps/api/src/app/workflows-v2/usecases/build-variable-schema/build-available-variable-schema.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/build-variable-schema/build-available-variable-schema.usecase.ts
@@ -62,7 +62,7 @@ export class BuildAvailableVariableSchemaUsecase {
     workflow: NotificationTemplateEntity | undefined,
     command: BuildAvailableVariableSchemaCommand
   ): Promise<JSONSchemaDto> {
-    if (workflow && !workflow?.steps.length) {
+    if (workflow && workflow.steps.length === 0) {
       return {
         type: 'object',
         properties: {},

--- a/apps/api/src/app/workflows-v2/usecases/build-variable-schema/build-available-variable-schema.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/build-variable-schema/build-available-variable-schema.usecase.ts
@@ -62,7 +62,7 @@ export class BuildAvailableVariableSchemaUsecase {
     workflow: NotificationTemplateEntity | undefined,
     command: BuildAvailableVariableSchemaCommand
   ): Promise<JSONSchemaDto> {
-    if (!workflow) {
+    if (workflow && !workflow?.steps.length) {
       return {
         type: 'object',
         properties: {},
@@ -70,7 +70,7 @@ export class BuildAvailableVariableSchemaUsecase {
       };
     }
 
-    if (workflow.payloadSchema) {
+    if (workflow?.payloadSchema) {
       return parsePayloadSchema(workflow.payloadSchema, { safe: true }) || emptyJsonSchema();
     }
 
@@ -79,7 +79,7 @@ export class BuildAvailableVariableSchemaUsecase {
         environmentId: command.environmentId,
         organizationId: command.organizationId,
         userId: command.userId,
-        workflowId: workflow._id,
+        workflowId: workflow?._id,
         ...(command.optimisticControlValues ? { controlValues: command.optimisticControlValues } : {}),
       })
     );

--- a/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -30,7 +30,6 @@ import {
   WorkflowStatusEnum,
   StepIssues,
   ControlSchemas,
-  DigestUnitEnum,
 } from '@novu/shared';
 import {
   CreateWorkflow as CreateWorkflowGeneric,

--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -275,6 +275,39 @@ describe('Workflow Controller E2E API Testing', () => {
         await assertValuesInSteps(workflowCreated);
       }
     });
+
+    it('should allow creating a workflow with a payload schema if only control values are provided with a payload variable used', async () => {
+      const steps = [
+        {
+          ...buildEmailStep(),
+          controlValues: {
+            body: 'Welcome {{payload.name}}',
+            subject: 'Hello {{payload.name}}',
+          },
+        },
+      ];
+
+      const nameSuffix = `Test Workflow${new Date().toISOString()}`;
+
+      const createWorkflowDto: CreateWorkflowDto = buildCreateWorkflowDto(`payload-test-${nameSuffix}`, { steps });
+      const res = await workflowsClient.createWorkflow(createWorkflowDto);
+      expect(res.isSuccessResult()).to.be.true;
+
+      const workflow = res.value as WorkflowResponseDto;
+      expect(workflow).to.be.ok;
+
+      expect(workflow.steps[0].variables).to.be.ok;
+
+      const stepData = await getStepData(workflow._id, workflow.steps[0]._id);
+      expect(stepData.variables).to.be.ok;
+
+      const { properties } = stepData.variables as JSONSchemaDto;
+      expect(properties).to.be.ok;
+
+      const payloadProperties = properties?.payload as JSONSchemaDto;
+      expect(payloadProperties).to.be.ok;
+      expect(payloadProperties.properties?.name).to.be.ok;
+    });
   });
 
   describe('Update Workflow Permutations', () => {

--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -276,7 +276,7 @@ describe('Workflow Controller E2E API Testing', () => {
       }
     });
 
-    it('should allow creating a workflow with a payload schema if only control values are provided with a payload variable used', async () => {
+    it('should generate a payload schema if only control values are provided with a payload variable used', async () => {
       const steps = [
         {
           ...buildEmailStep(),
@@ -289,7 +289,7 @@ describe('Workflow Controller E2E API Testing', () => {
 
       const nameSuffix = `Test Workflow${new Date().toISOString()}`;
 
-      const createWorkflowDto: CreateWorkflowDto = buildCreateWorkflowDto(`payload-test-${nameSuffix}`, { steps });
+      const createWorkflowDto: CreateWorkflowDto = buildCreateWorkflowDto(`${nameSuffix}`, { steps });
       const res = await workflowsClient.createWorkflow(createWorkflowDto);
       expect(res.isSuccessResult()).to.be.true;
 

--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -276,7 +276,7 @@ describe('Workflow Controller E2E API Testing', () => {
       }
     });
 
-    it('should generate a payload schema if only control values are provided with a payload variable used', async () => {
+    it('should generate a payload schema if only control values are provided during workflow creation', async () => {
       const steps = [
         {
           ...buildEmailStep(),

--- a/apps/dashboard/src/components/auth/inbox-playground.tsx
+++ b/apps/dashboard/src/components/auth/inbox-playground.tsx
@@ -112,7 +112,7 @@ export function InboxPlayground() {
      */
     const initializeDemoWorkflow = async () => {
       const workflow = data?.workflows.find((workflow) => workflow.workflowId?.includes(ONBOARDING_DEMO_WORKFLOW_ID));
-      if (workflow) {
+      if (!workflow) {
         await createDemoWorkflow({ environment: currentEnvironment! });
       }
     };

--- a/apps/dashboard/src/components/auth/inbox-playground.tsx
+++ b/apps/dashboard/src/components/auth/inbox-playground.tsx
@@ -112,7 +112,7 @@ export function InboxPlayground() {
      */
     const initializeDemoWorkflow = async () => {
       const workflow = data?.workflows.find((workflow) => workflow.workflowId?.includes(ONBOARDING_DEMO_WORKFLOW_ID));
-      if (!workflow) {
+      if (workflow) {
         await createDemoWorkflow({ environment: currentEnvironment! });
       }
     };


### PR DESCRIPTION
### What changed? Why was the change needed?
- Fixes the issue where API-generated workflows are lacking the payload schema, and it only works on upsert
- 
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
