### PR TITLE
fix(api-service): variable not removed from preview

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/generate-preview/generate-preview.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/generate-preview/generate-preview.usecase.ts
@@ -159,7 +159,11 @@ export class GeneratePreviewUsecase {
       finalVariablesExample = previewTemplateData.variablesExample;
     }
 
-    finalVariablesExample = _.merge(finalVariablesExample, commandVariablesExample || {});
+    if (commandVariablesExample) {
+      // merge only values of common keys between finalVariablesExample and commandVariablesExample
+      const commonKeys = _.pick(commandVariablesExample, Object.keys(finalVariablesExample));
+      finalVariablesExample = _.merge(finalVariablesExample, commonKeys);
+    }
 
     return finalVariablesExample;
   }

--- a/apps/api/src/app/workflows-v2/usecases/generate-preview/generate-preview.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/generate-preview/generate-preview.usecase.ts
@@ -31,7 +31,7 @@ import { GeneratePreviewCommand } from './generate-preview.command';
 import { BuildPayloadSchemaCommand } from '../build-payload-schema/build-payload-schema.command';
 import { BuildPayloadSchema } from '../build-payload-schema/build-payload-schema.usecase';
 import { Variable } from '../../util/template-parser/liquid-parser';
-import { keysToObject } from '../../util/utils';
+import { keysToObject, mergeCommonObjectKeys } from '../../util/utils';
 import { isObjectTipTapNode } from '../../util/tip-tap.util';
 import { buildVariables } from '../../util/build-variables';
 
@@ -159,10 +159,12 @@ export class GeneratePreviewUsecase {
       finalVariablesExample = previewTemplateData.variablesExample;
     }
 
-    if (commandVariablesExample) {
+    if (commandVariablesExample && Object.keys(commandVariablesExample).length > 0) {
       // merge only values of common keys between finalVariablesExample and commandVariablesExample
-      const commonKeys = _.pick(commandVariablesExample, Object.keys(finalVariablesExample));
-      finalVariablesExample = _.merge(finalVariablesExample, commonKeys);
+      finalVariablesExample = mergeCommonObjectKeys(
+        commandVariablesExample as Record<string, unknown>,
+        finalVariablesExample as Record<string, unknown>
+      );
     }
 
     return finalVariablesExample;

--- a/apps/api/src/app/workflows-v2/util/utils.ts
+++ b/apps/api/src/app/workflows-v2/util/utils.ts
@@ -178,12 +178,12 @@ export function mergeCommonObjectKeys(
   target: Record<string, unknown>
 ): Record<string, unknown> {
   /* eslint-disable no-param-reassign */
-  return Object.entries(source).reduce(
-    (merged, [key, sourceValue]) => {
-      const targetValue = target[key];
+  return Object.entries(target).reduce(
+    (merged, [key, targetValue]) => {
+      const sourceValue = source[key];
 
       // If both source and target values are objects, recursively merge them
-      if (isObject(sourceValue) && isObject(targetValue)) {
+      if (isObject(targetValue) && isObject(sourceValue)) {
         merged[key] = mergeCommonObjectKeys(
           sourceValue as Record<string, unknown>,
           targetValue as Record<string, unknown>


### PR DESCRIPTION
### What changed? Why was the change needed?

We want to preserve variable value when switching tabs ([ref](https://github.com/novuhq/novu/pull/7353/files#diff-acc71ec04b35221fbc6481ac89c549d99a778039646e69cd345acba082f8f8d9)) but remove the variable when its removed in the editor.




