### PR TITLE
fix(api-service): on global preferences update reset workflow preferences per env

### DIFF
--- a/apps/api/src/app/subscribers/e2e/update-global-preference.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/update-global-preference.e2e.ts
@@ -1,14 +1,17 @@
-import { ChannelTypeEnum } from '@novu/shared';
+import { ChannelTypeEnum, StepTypeEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-import { updateGlobalPreferences } from './helpers';
+import { SubscriberRepository } from '@novu/dal';
+import { getPreference, updateGlobalPreferences } from './helpers';
 
 describe('Update Subscribers global preferences - /subscribers/:subscriberId/preferences (PATCH)', function () {
   let session: UserSession;
+  let subscriberRepository: SubscriberRepository;
 
   beforeEach(async () => {
     session = new UserSession();
+    subscriberRepository = new SubscriberRepository();
     await session.initialize();
   });
 
@@ -87,6 +90,69 @@ describe('Update Subscribers global preferences - /subscribers/:subscriberId/pre
       [ChannelTypeEnum.SMS]: true,
       [ChannelTypeEnum.IN_APP]: false,
     });
+  });
+
+  it('should update user global preferences and override the workflow preferences for the dev environment', async function () {
+    // create a template in dev environment
+    await session.createTemplate({
+      steps: [
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Hello',
+        },
+      ],
+      noFeedId: true,
+    });
+
+    await session.switchToProdEnvironment();
+    // create a subscriber in prod environment
+    await subscriberRepository.create({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      subscriberId: session.subscriberId,
+    });
+    // create a template in prod environment
+    await session.createTemplate({
+      steps: [
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Hello',
+        },
+      ],
+      noFeedId: true,
+    });
+
+    await session.switchToDevEnvironment();
+    // update the subscriber global preferences in dev environment
+    const response = await updateGlobalPreferences(
+      {
+        enabled: true,
+        preferences: [{ type: ChannelTypeEnum.IN_APP, enabled: false }],
+      },
+      session
+    );
+
+    expect(response.data.data.preference.enabled).to.eql(true);
+    expect(response.data.data.preference.channels).to.eql({
+      [ChannelTypeEnum.EMAIL]: true,
+      [ChannelTypeEnum.PUSH]: true,
+      [ChannelTypeEnum.CHAT]: true,
+      [ChannelTypeEnum.SMS]: true,
+      [ChannelTypeEnum.IN_APP]: false,
+    });
+
+    // get the subscriber preferences in dev environment
+    const getDevPreferencesResponse = await getPreference(session);
+    const devPreferences = getDevPreferencesResponse.data.data;
+    expect(devPreferences.every((item) => !!item.preference.channels.in_app)).to.be.false;
+
+    await session.switchToProdEnvironment();
+
+    // get the subscriber preferences in prod environment
+    session.apiKey = session.environment.apiKeys[0].key;
+    const getProdPreferencesResponse = await getPreference(session);
+    const prodPreferences = getProdPreferencesResponse.data.data;
+    expect(prodPreferences.every((item) => !!item.preference.channels.in_app)).to.be.true;
   });
 
   // `enabled` flag is not used anymore. The presence of a preference object means that the subscriber has enabled notifications.

--- a/apps/api/src/app/subscribers/e2e/update-global-preference.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/update-global-preference.e2e.ts
@@ -92,7 +92,7 @@ describe('Update Subscribers global preferences - /subscribers/:subscriberId/pre
     });
   });
 
-  it('should update user global preferences and override the workflow preferences for the dev environment', async function () {
+  it('should update user global preferences only for the current environment', async function () {
     // create a template in dev environment
     await session.createTemplate({
       steps: [

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
@@ -10,6 +10,7 @@ import { UpsertSubscriberGlobalPreferencesCommand } from './upsert-subscriber-gl
 import { UpsertSubscriberWorkflowPreferencesCommand } from './upsert-subscriber-workflow-preferences.command';
 import { UpsertUserWorkflowPreferencesCommand } from './upsert-user-workflow-preferences.command';
 import { deepMerge } from '../../utils';
+import { Instrument } from '../../instrumentation';
 
 export type WorkflowPreferencesFull = Omit<PreferencesEntity, 'preferences'> & {
   preferences: WorkflowPreferences;
@@ -34,6 +35,7 @@ type UpsertPreferencesCommand = Omit<
 export class UpsertPreferences {
   constructor(private preferencesRepository: PreferencesRepository) {}
 
+  @Instrument()
   public async upsertWorkflowPreferences(
     command: UpsertWorkflowPreferencesCommand,
   ): Promise<WorkflowPreferencesFull> {
@@ -46,6 +48,7 @@ export class UpsertPreferences {
     }) as Promise<WorkflowPreferencesFull>;
   }
 
+  @Instrument()
   public async upsertSubscriberGlobalPreferences(
     command: UpsertSubscriberGlobalPreferencesCommand,
   ) {
@@ -78,7 +81,7 @@ export class UpsertPreferences {
 
     await this.preferencesRepository.update(
       {
-        _organizationId: command.organizationId,
+        _environmentId: command.environmentId,
         _subscriberId: command._subscriberId,
         type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
         $or: channelTypes.map((channelType) => ({
@@ -91,6 +94,7 @@ export class UpsertPreferences {
     );
   }
 
+  @Instrument()
   public async upsertSubscriberWorkflowPreferences(
     command: UpsertSubscriberWorkflowPreferencesCommand,
   ) {
@@ -104,6 +108,7 @@ export class UpsertPreferences {
     });
   }
 
+  @Instrument()
   public async upsertUserWorkflowPreferences(
     command: UpsertUserWorkflowPreferencesCommand,
   ): Promise<WorkflowPreferencesFull> {


### PR DESCRIPTION
### What changed? Why was the change needed?

Fix: when global preferences are updated, reset the workflow preferences per env.

### Screenshots
