### PR TITLE
feat(framework): add `fetchOptions` parameter to `Client` for custom fetch configuration

### DIFF
--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -67,6 +67,8 @@ export class Client {
 
   public apiUrl: string;
 
+  public fetchOptions?: Record<string, any>;
+
   public version: string = SDK_VERSION;
 
   public strictAuthentication: boolean;
@@ -75,6 +77,7 @@ export class Client {
     const builtOpts = this.buildOptions(options);
     this.apiUrl = builtOpts.apiUrl;
     this.secretKey = builtOpts.secretKey;
+    this.fetchOptions = builtOpts.fetchOptions;
     this.strictAuthentication = builtOpts.strictAuthentication;
     this.templateEngine.registerFilter('json', (value, spaces) =>
       stringifyDataStructureWithSingleQuotes(value, spaces)
@@ -85,6 +88,7 @@ export class Client {
     const builtConfiguration: Required<ClientOptions> = {
       apiUrl: resolveApiUrl(providedOptions?.apiUrl),
       secretKey: resolveSecretKey(providedOptions?.secretKey),
+      fetchOptions: providedOptions?.fetchOptions ?? {},
       strictAuthentication: !isRuntimeInDevelopment(),
     };
 

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -72,7 +72,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
     this.handler = options.handler;
     this.client = options.client ? options.client : new Client();
     this.workflows = options.workflows;
-    this.http = initApiClient(this.client.secretKey, this.client.apiUrl);
+    this.http = initApiClient(this.client.secretKey, this.client.apiUrl, this.client.fetchOptions);
     this.frameworkName = options.frameworkName;
     this.hmacEnabled = this.client.strictAuthentication;
   }

--- a/packages/framework/src/resources/workflow/workflow.resource.ts
+++ b/packages/framework/src/resources/workflow/workflow.resource.ts
@@ -36,7 +36,7 @@ export function workflow<
   const options = workflowOptions || {};
 
   const trigger: Workflow<T_PayloadUnvalidated>['trigger'] = async (event) => {
-    const apiClient = initApiClient(resolveSecretKey(event.secretKey), resolveApiUrl(event.apiUrl));
+    const apiClient = initApiClient(resolveSecretKey(event.secretKey), resolveApiUrl(event.apiUrl), event.fetchOptions);
 
     const unvalidatedData = (event.payload || {}) as T_PayloadUnvalidated;
     let validatedData: T_PayloadValidated;

--- a/packages/framework/src/types/config.types.ts
+++ b/packages/framework/src/types/config.types.ts
@@ -23,4 +23,10 @@ export type ClientOptions = {
    * Defaults to true.
    */
   strictAuthentication?: boolean;
+
+  /**
+   * Additional fetch options to be passed to the fetch API.
+   * This can be used to set custom agent, headers, etc.
+   */
+  fetchOptions?: Record<string, any>;
 };

--- a/packages/framework/src/types/event.types.ts
+++ b/packages/framework/src/types/event.types.ts
@@ -59,6 +59,10 @@ export type EventTriggerParams<T_Payload = EventPayload> = {
    * Override secret key for the trigger
    */
   secretKey?: string;
+  /**
+   * Additional fetch options to be passed to the fetch API.
+   */
+  fetchOptions?: Record<string, any>;
 } & ConditionalPartial<
   {
     /**

--- a/packages/framework/src/utils/http.utils.ts
+++ b/packages/framework/src/utils/http.utils.ts
@@ -1,7 +1,9 @@
 import { checkIsResponseError } from '../shared';
 import { BridgeError, MissingSecretKeyError, PlatformError } from '../errors';
 
-export const initApiClient = (secretKey: string, apiUrl: string) => {
+export const initApiClient = (secretKey: string, apiUrl: string, fetchOptions?: Record<string, any>) => {
+  const { headers: additionalHeaders, ...restFetchOptions } = fetchOptions || {};
+
   if (!secretKey) {
     throw new MissingSecretKeyError();
   }
@@ -9,8 +11,10 @@ export const initApiClient = (secretKey: string, apiUrl: string) => {
   return {
     post: async <T = unknown>(route: string, data: Record<string, unknown>): Promise<T> => {
       const response = await fetch(`${apiUrl}/v1${route}`, {
+        ...restFetchOptions,
         method: 'POST',
         headers: {
+          ...additionalHeaders,
           'Content-Type': 'application/json',
           Authorization: `ApiKey ${secretKey}`,
         },
@@ -30,8 +34,10 @@ export const initApiClient = (secretKey: string, apiUrl: string) => {
     delete: async <T = unknown>(route: string): Promise<T> => {
       return (
         await fetch(`${apiUrl}/v1${route}`, {
+          ...restFetchOptions,
           method: 'DELETE',
           headers: {
+            ...additionalHeaders,
             'Content-Type': 'application/json',
             Authorization: `ApiKey ${secretKey}`,
           },


### PR DESCRIPTION
### What changed? Why was the change needed?

As a developer based in China, I often face issues with accessing Novu’s services due to the Great Firewall (GFW). This leads to timeouts when my local services attempt to send requests to Novu’s servers. Adding fetchOptions would allow me to use tools like https-proxy-agent to bypass these restrictions by routing requests through a proxy server.

close #7432