### PR TITLE
feat(dashboard): add useBeforeUnload hook to prevent accidental tab closure during updates

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/workflow-provider.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-provider.tsx
@@ -23,6 +23,7 @@ import { useInvocationQueue } from '@/hooks/use-invocation-queue';
 import { showErrorToast, showSavingToast, showSuccessToast } from './toasts';
 import { STEP_DIVIDER } from '@/utils/step';
 import { getWorkflowIdFromSlug } from '@/utils/step';
+import { useBeforeUnload } from '@/hooks/use-before-unload';
 
 export type WorkflowContextType = {
   isPending: boolean;
@@ -103,6 +104,11 @@ export const WorkflowProvider = ({ children }: { children: ReactNode }) => {
   });
 
   const isUpdatePatchPending = isPatchPending || isUpdatePending || hasPendingItems;
+  /**
+   * Prevents the user from accidentally closing the tab or window
+   * while an update is in progress.
+   */
+  useBeforeUnload(isUpdatePatchPending);
 
   const update = useCallback(
     (data: UpdateWorkflowDto) => {

--- a/apps/dashboard/src/hooks/use-before-unload.ts
+++ b/apps/dashboard/src/hooks/use-before-unload.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+export function useBeforeUnload(hasUnsavedChanges: boolean) {
+  useEffect(() => {
+    const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // Included for legacy support, e.g. Chrome/Edge < 119
+      event.returnValue = true;
+    };
+    if (hasUnsavedChanges) {
+      window.addEventListener('beforeunload', beforeUnloadHandler);
+    }
+
+    return () => {
+      window.removeEventListener('beforeunload', beforeUnloadHandler);
+    };
+  }, [hasUnsavedChanges]);
+}


### PR DESCRIPTION


### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots




https://github.com/user-attachments/assets/a238a050-c6b0-4502-85db-92cc124431a4


<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
