### PR TITLE
feat(framework): Control logging

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -264,6 +264,7 @@ export default tsEslint.config(
       'unused-imports': fixupPluginRules(unusedImports),
     },
     rules: {
+      'id-length': 'off',
       'max-len': 'off',
       '@typescript-eslint/no-explicit-any': 'error',
       'import/prefer-default-export': 0,

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -24,7 +24,7 @@ describe('Novu Client', () => {
       }));
     });
 
-    client = new Client({ secretKey: 'some-secret-key' });
+    client = new Client({ secretKey: 'some-secret-key', logging: true });
     await client.addWorkflows([newWorkflow]);
   });
 

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -40,6 +40,7 @@ import {
   EMOJI,
   log,
   resolveApiUrl,
+  resolveLogging,
   resolveSecretKey,
   sanitizeHtmlInObject,
   stringifyDataStructureWithSingleQuotes,
@@ -49,6 +50,7 @@ import { validateData } from './validators';
 import { mockSchema } from './jsonSchemaFaker';
 import { prettyPrintDiscovery } from './resources/workflow/pretty-print-discovery';
 import { deepMerge } from './utils/object.utils';
+import build from 'next/dist/build';
 
 function isRuntimeInDevelopment() {
   return ['development', undefined].includes(process.env.NODE_ENV);
@@ -72,9 +74,12 @@ export class Client {
 
   public strictAuthentication: boolean;
 
+  public logging: boolean = true;
+
   constructor(options?: ClientOptions) {
     const builtOpts = this.buildOptions(options);
     this.apiUrl = builtOpts.apiUrl;
+    this.logging = builtOpts.logging;
     this.secretKey = builtOpts.secretKey;
     this.strictAuthentication = builtOpts.strictAuthentication;
 
@@ -82,11 +87,18 @@ export class Client {
       stringifyDataStructureWithSingleQuotes(value, spaces)
     );
     this.templateEngine.registerFilter('digest', digest);
+
+    if (this.logging) {
+      log.enable();
+    } else {
+      log.disable();
+    }
   }
 
   private buildOptions(providedOptions?: ClientOptions) {
     const builtConfiguration: Required<ClientOptions> = {
       apiUrl: resolveApiUrl(providedOptions?.apiUrl),
+      logging: resolveLogging(providedOptions?.logging),
       secretKey: resolveSecretKey(providedOptions?.secretKey),
       strictAuthentication: !isRuntimeInDevelopment(),
     };
@@ -404,8 +416,7 @@ export class Client {
     const actionMessage = actionMessages[event.action];
 
     const actionMessageFormatted = `${actionMessage} workflowId:`;
-    // eslint-disable-next-line no-console
-    console.log(`\n${log.bold(log.underline(actionMessageFormatted))} '${event.workflowId}'`);
+    log((l) => `\n${l.bold(l.underline(actionMessageFormatted))} '${event.workflowId}'`);
     const workflow = this.getWorkflow(event.workflowId);
 
     const startTime = process.hrtime();
@@ -487,15 +498,14 @@ export class Client {
     const elapsedNanoseconds = endTime[1];
     const elapsedTimeInMilliseconds = elapsedSeconds * 1_000 + elapsedNanoseconds / 1_000_000;
 
-    const emoji = executionError ? EMOJI.ERROR : EMOJI.SUCCESS;
     const resultMessages = {
       [PostActionEnum.EXECUTE]: 'Executed',
       [PostActionEnum.PREVIEW]: 'Previewed',
     } as const;
     const resultMessage = resultMessages[event.action];
 
-    // eslint-disable-next-line no-console
-    console.log(`${emoji} ${resultMessage} workflowId: \`${event.workflowId}\``);
+    const emoji = executionError ? EMOJI.ERROR : EMOJI.SUCCESS;
+    log(`${emoji} ${resultMessage} workflowId: \`${event.workflowId}\``);
 
     this.prettyPrintExecute(event, elapsedTimeInMilliseconds, executionError);
 
@@ -545,16 +555,11 @@ export class Client {
     } as const;
     const actionMessage = actionMessages[event.action];
     const message = error ? 'Failed to execute' : actionMessage;
-    const executionLog = error ? log.error : log.success;
     const logMessage = `${successPrefix} ${message} workflowId: '${event.workflowId}`;
-    // eslint-disable-next-line no-console
-    console.log(`\n  ${log.bold(executionLog(logMessage))}'`);
-    // eslint-disable-next-line no-console
-    console.log(`  ├ ${EMOJI.STEP} stepId: '${event.stepId}'`);
-    // eslint-disable-next-line no-console
-    console.log(`  ├ ${EMOJI.ACTION} action: '${event.action}'`);
-    // eslint-disable-next-line no-console
-    console.log(`  └ ${EMOJI.DURATION} duration: '${duration.toFixed(2)}ms'\n`);
+    log((l) => `\n  ${l.bold(error ? l.error(logMessage) : l.success(logMessage))}`);
+    log((l) => `  ├ ${l.emoji.STEP} stepId: '${event.stepId}'`);
+    log((l) => `  ├ ${l.emoji.ACTION} action: '${event.action}'`);
+    log((l) => `  └ ${l.emoji.DURATION} duration: '${duration.toFixed(2)}ms'\n`);
   }
 
   private async executeProviders(
@@ -587,8 +592,7 @@ export class Client {
 
     outputs: Record<string, unknown>
   ): Record<string, unknown> {
-    // eslint-disable-next-line no-console
-    console.log(`  ${EMOJI.MOCK} Mocked provider: \`${provider.type}\``);
+    log((l) => `  ${l.emoji.MOCK} Mocked provider: \`${provider.type}\``);
     const mockOutput = this.mock(provider.outputs.schema);
 
     return mockOutput;
@@ -616,7 +620,7 @@ export class Client {
           step.stepId,
           provider.type
         );
-        console.log(`  ${EMOJI.SUCCESS} Executed provider: \`${provider.type}\``);
+        log((l) => `  ${l.emoji.SUCCESS} Executed provider: \`${provider.type}\``);
 
         return {
           ...validatedOutput,
@@ -624,12 +628,12 @@ export class Client {
         };
       } else {
         // No-op. We don't execute providers for hydrated steps
-        console.log(`  ${EMOJI.HYDRATED} Hydrated provider: \`${provider.type}\``);
+        log((l) => `  ${l.emoji.HYDRATED} Hydrated provider: \`${provider.type}\``);
 
         return {};
       }
     } catch (error) {
-      console.log(`  ${EMOJI.ERROR} Failed to execute provider: \`${provider.type}\``);
+      log((l) => `  ${l.emoji.ERROR} Failed to execute provider: \`${provider.type}\``);
 
       throw new ProviderExecutionFailedError(provider.type, event.action, error);
     }
@@ -655,14 +659,14 @@ export class Client {
 
         const providers = await this.executeProviders(event, step, validatedOutput);
 
-        console.log(`  ${EMOJI.SUCCESS} Executed stepId: \`${step.stepId}\``);
+        log(`  ${EMOJI.SUCCESS} Executed stepId: \`${step.stepId}\``);
 
         return {
           outputs: validatedOutput,
           providers,
         };
       } catch (error) {
-        console.log(`  ${EMOJI.ERROR} Failed to execute stepId: \`${step.stepId}\``);
+        log(`  ${EMOJI.ERROR} Failed to execute stepId: \`${step.stepId}\``);
         if (isFrameworkError(error)) {
           throw error;
         } else {
@@ -682,7 +686,7 @@ export class Client {
             event.workflowId,
             step.stepId
           );
-          console.log(`  ${EMOJI.HYDRATED} Hydrated stepId: \`${step.stepId}\``);
+          log(`  ${EMOJI.HYDRATED} Hydrated stepId: \`${step.stepId}\``);
 
           return {
             outputs: validatedOutput,
@@ -692,7 +696,7 @@ export class Client {
           throw new ExecutionStateCorruptError(event.workflowId, step.stepId);
         }
       } catch (error) {
-        console.log(`  ${EMOJI.ERROR} Failed to hydrate stepId: \`${step.stepId}\``);
+        log(`  ${EMOJI.ERROR} Failed to hydrate stepId: \`${step.stepId}\``);
 
         throw error;
       }
@@ -742,7 +746,7 @@ export class Client {
     try {
       return await this.constructStepForPreview(event, step);
     } catch (error) {
-      console.log(`  ${EMOJI.ERROR} Failed to preview stepId: \`${step.stepId}\``);
+      log(`  ${EMOJI.ERROR} Failed to preview stepId: \`${step.stepId}\``);
 
       if (isFrameworkError(error)) {
         throw error;
@@ -787,7 +791,7 @@ export class Client {
       step.stepId
     );
 
-    console.log(`  ${EMOJI.MOCK} Mocked stepId: \`${step.stepId}\``);
+    log(`  ${EMOJI.MOCK} Mocked stepId: \`${step.stepId}\``);
 
     return {
       outputs: validatedOutput,

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -50,7 +50,6 @@ import { validateData } from './validators';
 import { mockSchema } from './jsonSchemaFaker';
 import { prettyPrintDiscovery } from './resources/workflow/pretty-print-discovery';
 import { deepMerge } from './utils/object.utils';
-import build from 'next/dist/build';
 
 function isRuntimeInDevelopment() {
   return ['development', undefined].includes(process.env.NODE_ENV);

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -275,6 +275,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
          * Log bridge server errors to assist the Developer in debugging errors with their integration.
          * This path is reached when the Bridge application throws an error, ensuring they can see the error in their logs.
          */
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         log((l) => l.error(error.message || error.toString()));
       }
 
@@ -283,6 +284,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
       return this.createError(error);
     } else {
       const bridgeError = new BridgeError(error);
+      // eslint-disable-next-line @typescript-eslint/no-base-to-string
       log((l) => l.error(bridgeError.message || bridgeError.toString()));
 
       return this.createError(bridgeError);

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -21,7 +21,7 @@ import {
   SigningKeyNotFoundError,
 } from './errors';
 import type { Awaitable, EventTriggerParams, Workflow } from './types';
-import { initApiClient, createHmacSubtle } from './utils';
+import { initApiClient, createHmacSubtle, log } from './utils';
 import { isPlatformError } from './errors/guard.errors';
 
 export type ServeHandlerOptions = {
@@ -275,8 +275,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
          * Log bridge server errors to assist the Developer in debugging errors with their integration.
          * This path is reached when the Bridge application throws an error, ensuring they can see the error in their logs.
          */
-        // eslint-disable-next-line no-console
-        console.error(error);
+        log((l) => l.error(error.message || error.toString()));
       }
 
       return this.createError(error);
@@ -284,8 +283,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
       return this.createError(error);
     } else {
       const bridgeError = new BridgeError(error);
-      // eslint-disable-next-line no-console
-      console.error(bridgeError);
+      log((l) => l.error(bridgeError.message || bridgeError.toString()));
 
       return this.createError(bridgeError);
     }

--- a/packages/framework/src/resources/workflow/pretty-print-discovery.ts
+++ b/packages/framework/src/resources/workflow/pretty-print-discovery.ts
@@ -1,20 +1,17 @@
 import type { DiscoverWorkflowOutput } from '../../types';
-import { EMOJI, log } from '../../utils';
+import { log } from '../../utils';
 
 export function prettyPrintDiscovery(discoveredWorkflow: DiscoverWorkflowOutput): void {
-  // eslint-disable-next-line no-console
-  console.log(`\n${log.bold(log.underline('Discovered workflowId:'))} '${discoveredWorkflow.workflowId}'`);
+  log((l) => `\n${l.bold(l.underline('Discovered workflowId:'))} '${discoveredWorkflow.workflowId}'`);
   discoveredWorkflow.steps.forEach((step, i) => {
     const isLastStep = i === discoveredWorkflow.steps.length - 1;
     const prefix = isLastStep ? '└' : '├';
-    // eslint-disable-next-line no-console
-    console.log(`${prefix} ${EMOJI.STEP} Discovered stepId: '${step.stepId}'\tType: '${step.type}'`);
+    log((l) => `${prefix} ${l.emoji.STEP} Discovered stepId: '${step.stepId}'\tType: '${step.type}'`);
     step.providers.forEach((provider, providerIndex) => {
       const isLastProvider = providerIndex === step.providers.length - 1;
       const stepPrefix = isLastStep ? ' ' : '│';
       const providerPrefix = isLastProvider ? '└' : '├';
-      // eslint-disable-next-line no-console
-      console.log(`${stepPrefix} ${providerPrefix} ${EMOJI.PROVIDER} Discovered provider: '${provider.type}'`);
+      log((l) => `${stepPrefix} ${providerPrefix} ${l.emoji.PROVIDER} Discovered provider: '${provider.type}'`);
     });
   });
 }

--- a/packages/framework/src/types/config.types.ts
+++ b/packages/framework/src/types/config.types.ts
@@ -23,4 +23,9 @@ export type ClientOptions = {
    * Defaults to true.
    */
   strictAuthentication?: boolean;
+
+  /**
+   * Enable/disable logging of workflows and execution details
+   */
+  logging?: boolean;
 };

--- a/packages/framework/src/utils/env.utils.ts
+++ b/packages/framework/src/utils/env.utils.ts
@@ -1,4 +1,5 @@
 import { Response as CrossFetchResponse } from 'cross-fetch';
+import { log } from './log.utils';
 
 export const getResponse = (): typeof Response => {
   if (typeof Response !== 'undefined') {
@@ -31,8 +32,7 @@ export const getBridgeUrl = async (): Promise<string> => {
       return `${data.tunnelOrigin}${data.route}`;
     }
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(error);
+    log((l) => l.error((error as Error).message));
   }
 
   return '';

--- a/packages/framework/src/utils/log.utils.ts
+++ b/packages/framework/src/utils/log.utils.ts
@@ -1,29 +1,72 @@
 import chalk from 'chalk';
 
-export const log = {
-  info: (message: string) => chalk.blue(message),
-  warning: (message: string) => chalk.yellow(message),
-  error: (message: string) => chalk.red(message),
-  success: (message: string) => chalk.green(message),
-  underline: (message: string) => chalk.underline(message),
-  bold: (message: string) => chalk.bold(message),
-};
+function info(message: string) {
+  return chalk.blue(message);
+}
+
+function warning(message: string) {
+  return chalk.yellow(message);
+}
+
+function error(message: string) {
+  return chalk.red(message);
+}
+
+function success(message: string) {
+  return chalk.green(message);
+}
+
+function underline(message: string) {
+  return chalk.underline(message);
+}
+
+function bold(message: string) {
+  return chalk.bold(message);
+}
+
 export const EMOJI = {
-  SUCCESS: log.success('✔'),
-  ERROR: log.error('✗'),
-  WARNING: log.warning('⚠'),
-  INFO: log.info('ℹ'),
-  ARROW: log.bold('→'),
-  MOCK: log.info('○'),
-  HYDRATED: log.bold(log.info('→')),
-  STEP: log.info('σ'),
-  ACTION: log.info('α'),
-  DURATION: log.info('Δ'),
-  PROVIDER: log.info('⚙'),
-  OUTPUT: log.info('⇢'),
-  INPUT: log.info('⇠'),
-  WORKFLOW: log.info('ω'),
-  STATE: log.info('σ'),
-  EXECUTE: log.info('ε'),
-  PREVIEW: log.info('ρ'),
+  SUCCESS: success('✔'),
+  ERROR: error('✗'),
+  WARNING: warning('⚠'),
+  INFO: info('ℹ'),
+  ARROW: bold('→'),
+  MOCK: info('○'),
+  HYDRATED: bold(info('→')),
+  STEP: info('σ'),
+  ACTION: info('α'),
+  DURATION: info('Δ'),
+  PROVIDER: info('⚙'),
+  OUTPUT: info('⇢'),
+  INPUT: info('⇠'),
+  WORKFLOW: info('ω'),
+  STATE: info('σ'),
+  EXECUTE: info('ε'),
+  PREVIEW: info('ρ'),
 };
+
+const f = {
+  info,
+  warning,
+  error,
+  success,
+  underline,
+  bold,
+  emoji: EMOJI,
+};
+
+let enabled = true;
+
+export function log(message: string | ((formatter: typeof f) => string)): void {
+  if (!enabled) {
+    return;
+  }
+
+  if (typeof message === 'string') {
+    console.log(message);
+  } else if (typeof message === 'function') {
+    console.log(message(f));
+  }
+}
+
+log.enable = () => (enabled = true);
+log.disable = () => (enabled = false);

--- a/packages/framework/src/utils/log.utils.ts
+++ b/packages/framework/src/utils/log.utils.ts
@@ -62,11 +62,17 @@ export function log(message: string | ((formatter: typeof f) => string)): void {
   }
 
   if (typeof message === 'string') {
+    // eslint-disable-next-line no-console
     console.log(message);
   } else if (typeof message === 'function') {
+    // eslint-disable-next-line no-console
     console.log(message(f));
   }
 }
 
-log.enable = () => (enabled = true);
-log.disable = () => (enabled = false);
+log.enable = () => {
+  enabled = true;
+};
+log.disable = () => {
+  enabled = false;
+};

--- a/packages/framework/src/utils/options.utils.ts
+++ b/packages/framework/src/utils/options.utils.ts
@@ -5,3 +5,15 @@ export function resolveApiUrl(providedApiUrl?: string): string {
 export function resolveSecretKey(providedSecretKey?: string): string {
   return providedSecretKey || process.env.NOVU_SECRET_KEY || process.env.NOVU_API_KEY || '';
 }
+
+export function resolveLogging(providedLogging?: boolean): boolean {
+  if (providedLogging !== undefined) {
+    return providedLogging;
+  }
+  if (process.env.NOVU_LOGGING !== undefined) {
+    return process.env.NOVU_LOGGING === 'true';
+  }
+
+  // Disable verbose logging in test and production environments
+  return ['test', 'production'].includes(process.env.NODE_ENV);
+}

--- a/packages/framework/src/utils/options.utils.ts
+++ b/packages/framework/src/utils/options.utils.ts
@@ -15,5 +15,5 @@ export function resolveLogging(providedLogging?: boolean): boolean {
   }
 
   // Disable verbose logging in test and production environments
-  return ['test', 'production'].includes(process.env.NODE_ENV);
+  return !['test', 'production'].includes(process.env.NODE_ENV);
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

Add coarse-graining logging control and test logs to prevent flooding production. 

This is the first step in switching on/off framework logging so we can use it in production and e2e tests. In future work, we need to add logging levels and log differently in development (log everything) and production (log only errors and a summary of the discovered workflows).