### PR TITLE
fix(dashboard): editor multiline property

### DIFF
--- a/apps/dashboard/src/components/auth/customize-inbox-playground.tsx
+++ b/apps/dashboard/src/components/auth/customize-inbox-playground.tsx
@@ -174,7 +174,6 @@ function NotificationConfigSection() {
                 <InputRoot hasError={!!fieldState.error}>
                   <InputWrapper className="flex h-9 items-center justify-center px-1">
                     <Editor
-                      multiline={false}
                       indentWithTab={false}
                       fontFamily="inherit"
                       placeholder={capitalize(field.name)}

--- a/apps/dashboard/src/components/primitives/form/avatar-picker.tsx
+++ b/apps/dashboard/src/components/primitives/form/avatar-picker.tsx
@@ -84,7 +84,6 @@ export const AvatarPicker = forwardRef<HTMLInputElement, AvatarPickerProps>(
                   <InputRoot className="overflow-visible">
                     <InputWrapper className="flex h-9 items-center justify-center p-2.5">
                       <Editor
-                        multiline={false}
                         indentWithTab={false}
                         fontFamily="inherit"
                         ref={ref}

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/configure-preview-accordion.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/configure-preview-accordion.tsx
@@ -53,6 +53,7 @@ export const ConfigurePreviewAccordion = ({
             onChange={setEditorValue}
             lang="json"
             extensions={extensions}
+            multiline
             className="border-neutral-alpha-200 bg-background text-foreground-600 mx-0 mt-0 rounded-lg border border-dashed p-3"
           />
           {payloadError && <p className="text-destructive text-xs">{payloadError}</p>}

--- a/apps/dashboard/src/components/workflow-editor/test-workflow/snippet-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/snippet-editor.tsx
@@ -34,6 +34,7 @@ export const SnippetEditor = ({
       value={value}
       extensions={extensions}
       basicSetup={basicSetup}
+      multiline
     />
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-form.tsx
@@ -99,6 +99,7 @@ export const TestWorkflowForm = ({ workflow }: { workflow?: WorkflowResponseDto 
                       extensions={extensions}
                       className="overflow-auto"
                       {...restField}
+                      multiline
                     />
                     <FormMessage />
                   </PanelContent>


### PR DESCRIPTION
### What changed? Why was the change needed?

Since `multiline` is `false` by default on `Editor` component, in some places like "Configure payload" it was not possible to create a newline and it should be.
