### PR TITLE
fix(api-service): keep only editor vars in preview payload

### DIFF
--- a/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
@@ -199,7 +199,6 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
           body: 'This is a body',
         },
         primaryUrlLabel: 'https://example.com',
-        organizationName: 'Novu',
       },
     };
     const { status, body } = await session.testAgent.post(`/v2/workflows/${workflow._id}/step/${stepId}/preview`).send({
@@ -247,7 +246,6 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
             body: 'This is a body',
           },
           primaryUrlLabel: 'https://example.com',
-          organizationName: 'Novu',
         },
       },
     });
@@ -409,7 +407,8 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
       result: {
         preview: {
           subject: 'Welcome John',
-          body: 'Hello John, your order #undefined is ready!', // orderId is not defined in the payload schema or clientVariablesExample
+          // missing orderId will be replaced with placeholder "{{payload.orderId}}"
+          body: 'Hello John, your order #{{payload.orderId}} is ready!',
         },
         type: 'in_app',
       },
@@ -418,6 +417,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
           lastName: '{{payload.lastName}}',
           organizationName: '{{payload.organizationName}}',
           firstName: 'John',
+          orderId: '{{payload.orderId}}',
         },
       },
     });

--- a/apps/api/src/app/workflows-v2/util/utils.ts
+++ b/apps/api/src/app/workflows-v2/util/utils.ts
@@ -256,3 +256,37 @@ export function multiplyArrayItems(obj: Record<string, unknown>, multiplyBy = 3)
 
   return result;
 }
+
+/**
+ * Recursively merges common/overlapping object keys from source into target.
+ *
+ * @example
+ * Target: { subscriber: { phone: '{{subscriber.phone}}', name: '{{subscriber.name}}' } }
+ * Source: { subscriber: { phone: '123' }, payload: { someone: '{{payload.someone}}' }}
+ * Result: { subscriber: { phone: '123', name: '{{subscriber.name}}' } }
+ */
+export function mergeCommonObjectKeys(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>
+): Record<string, unknown> {
+  /* eslint-disable no-param-reassign */
+  return Object.entries(target).reduce(
+    (merged, [key, targetValue]) => {
+      const sourceValue = source[key];
+
+      // If both source and target values are objects, recursively merge them
+      if (isObject(targetValue) && isObject(sourceValue)) {
+        merged[key] = mergeCommonObjectKeys(
+          targetValue as Record<string, unknown>,
+          sourceValue as Record<string, unknown>
+        );
+      } else {
+        // Otherwise, use the target value if it exists, otherwise use the source value
+        merged[key] = targetValue ?? sourceValue;
+      }
+
+      return merged;
+    },
+    {} as Record<string, unknown>
+  );
+}

--- a/apps/api/src/app/workflows-v2/util/utils.ts
+++ b/apps/api/src/app/workflows-v2/util/utils.ts
@@ -282,7 +282,7 @@ export function mergeCommonObjectKeys(
         );
       } else {
         // Otherwise, use the target value if it exists, otherwise use the source value
-        merged[key] = targetValue ?? sourceValue;
+        merged[key] = sourceValue ?? targetValue;
       }
 
       return merged;

--- a/apps/api/src/app/workflows-v2/util/utils.ts
+++ b/apps/api/src/app/workflows-v2/util/utils.ts
@@ -269,19 +269,26 @@ export function mergeCommonObjectKeys(
   target: Record<string, unknown>,
   source: Record<string, unknown>
 ): Record<string, unknown> {
-  /* eslint-disable no-param-reassign */
   return Object.entries(target).reduce(
     (merged, [key, targetValue]) => {
       const sourceValue = source[key];
 
-      // If both source and target values are objects, recursively merge them
-      if (isObject(targetValue) && isObject(sourceValue)) {
+      if (Array.isArray(targetValue) && Array.isArray(sourceValue)) {
+        merged[key] = targetValue.map((_, index) => {
+          if (index < sourceValue.length) {
+            // if we have a corresponding source item, use it
+            return sourceValue[index];
+          }
+
+          // otherwise keep the target item
+          return targetValue[index];
+        });
+      } else if (isObject(targetValue) && isObject(sourceValue)) {
         merged[key] = mergeCommonObjectKeys(
           targetValue as Record<string, unknown>,
           sourceValue as Record<string, unknown>
         );
       } else {
-        // Otherwise, use the target value if it exists, otherwise use the source value
         merged[key] = sourceValue ?? targetValue;
       }
 

--- a/apps/dashboard/src/components/auth/customize-inbox-playground.tsx
+++ b/apps/dashboard/src/components/auth/customize-inbox-playground.tsx
@@ -174,7 +174,6 @@ function NotificationConfigSection() {
                 <InputRoot hasError={!!fieldState.error}>
                   <InputWrapper className="flex h-9 items-center justify-center px-1">
                     <Editor
-                      multiline={false}
                       indentWithTab={false}
                       fontFamily="inherit"
                       placeholder={capitalize(field.name)}

--- a/apps/dashboard/src/components/primitives/form/avatar-picker.tsx
+++ b/apps/dashboard/src/components/primitives/form/avatar-picker.tsx
@@ -84,7 +84,6 @@ export const AvatarPicker = forwardRef<HTMLInputElement, AvatarPickerProps>(
                   <InputRoot className="overflow-visible">
                     <InputWrapper className="flex h-9 items-center justify-center p-2.5">
                       <Editor
-                        multiline={false}
                         indentWithTab={false}
                         fontFamily="inherit"
                         ref={ref}

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/configure-preview-accordion.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/configure-preview-accordion.tsx
@@ -53,6 +53,7 @@ export const ConfigurePreviewAccordion = ({
             onChange={setEditorValue}
             lang="json"
             extensions={extensions}
+            multiline
             className="border-neutral-alpha-200 bg-background text-foreground-600 mx-0 mt-0 rounded-lg border border-dashed p-3"
           />
           {payloadError && <p className="text-destructive text-xs">{payloadError}</p>}

--- a/apps/dashboard/src/components/workflow-editor/test-workflow/snippet-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/snippet-editor.tsx
@@ -34,6 +34,7 @@ export const SnippetEditor = ({
       value={value}
       extensions={extensions}
       basicSetup={basicSetup}
+      multiline
     />
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-form.tsx
@@ -99,6 +99,7 @@ export const TestWorkflowForm = ({ workflow }: { workflow?: WorkflowResponseDto 
                       extensions={extensions}
                       className="overflow-auto"
                       {...restField}
+                      multiline
                     />
                     <FormMessage />
                   </PanelContent>


### PR DESCRIPTION
### What changed? Why was the change needed?

Only common values between editor and payload preview are preserved.

### Screenshots

https://github.com/user-attachments/assets/c227dfa9-fa14-4939-87b2-9c8183768d05

