### PR TITLE
fix(api-service,dal): activity feed item can have deleted workflow or subscriber data

### DIFF
--- a/apps/api/src/app/notifications/usecases/get-activity-feed/map-feed-item-to.dto.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity-feed/map-feed-item-to.dto.ts
@@ -4,6 +4,8 @@ import {
   NotificationFeedItemEntity,
   NotificationStepEntity,
   StepFilter,
+  SubscriberFeedItem,
+  TemplateFeedItem,
 } from '@novu/dal';
 import {
   DigestTypeEnum,
@@ -36,22 +38,22 @@ import {
   DigestMetadataDto,
 } from '../../dtos/activities-response.dto';
 
-function buildSubscriberDto(entity: NotificationFeedItemEntity): ActivityNotificationSubscriberResponseDto {
+function buildSubscriberDto(subscriber: SubscriberFeedItem): ActivityNotificationSubscriberResponseDto {
   return {
-    _id: entity.subscriber._id,
-    subscriberId: entity.subscriber.subscriberId,
-    email: entity.subscriber.email,
-    firstName: entity.subscriber.firstName,
-    lastName: entity.subscriber.lastName,
-    phone: entity.subscriber.phone,
+    _id: subscriber._id,
+    subscriberId: subscriber.subscriberId,
+    email: subscriber.email,
+    firstName: subscriber.firstName,
+    lastName: subscriber.lastName,
+    phone: subscriber.phone,
   };
 }
 
-function buildTemplate(entity: NotificationFeedItemEntity): ActivityNotificationTemplateResponseDto {
+function buildTemplate(template: TemplateFeedItem): ActivityNotificationTemplateResponseDto {
   return {
-    _id: entity.template._id,
-    name: entity.template.name,
-    triggers: entity.template.triggers,
+    _id: template._id,
+    name: template.name,
+    triggers: template.triggers,
   };
 }
 
@@ -72,8 +74,8 @@ export function mapFeedItemToDto(entity: NotificationFeedItemEntity): ActivityNo
     controls: entity.controls,
     payload: entity.payload,
     to: entity.to,
-    subscriber: buildSubscriberDto(entity),
-    template: buildTemplate(entity),
+    subscriber: entity.subscriber ? buildSubscriberDto(entity.subscriber) : undefined,
+    template: entity.template ? buildTemplate(entity.template) : undefined,
   };
 }
 

--- a/libs/dal/src/repositories/notification/notification.feed.Item.entity.ts
+++ b/libs/dal/src/repositories/notification/notification.feed.Item.entity.ts
@@ -6,8 +6,8 @@ import { SubscriberEntity } from '../subscriber';
 import { NotificationEntity } from './notification.entity';
 
 export type NotificationFeedItemEntity = Omit<NotificationEntity, 'template'> & {
-  template: TemplateFeedItem;
-  subscriber: SubscriberFeedItem;
+  template?: TemplateFeedItem;
+  subscriber?: SubscriberFeedItem;
   jobs: JobFeedItem[];
 };
 export type TemplateFeedItem = Pick<NotificationTemplateEntity, '_id' | 'name' | 'triggers'>;


### PR DESCRIPTION
### What changed? Why was the change needed?

The Activity Feed items can have deleted workflow or subscriber information.

### Screenshots


![Screenshot 2025-01-16 at 13 07 36](https://github.com/user-attachments/assets/e98712e2-95de-4b35-ada4-9562f360038f)
