### PR TITLE
fix(dashboard): allow only parsable json in preview editor

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-editor-preview.tsx
@@ -7,7 +7,7 @@ import { ConfigurePreviewAccordion } from '../shared/configure-preview-accordion
 
 type ChatEditorPreviewProps = {
   editorValue: string;
-  setEditorValue: (value: string) => void;
+  setEditorValue: (value: string) => Error | null;
   previewStep: () => void;
   previewData?: GeneratePreviewResponseDto;
   isPreviewPending: boolean;

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-editor-preview.tsx
@@ -19,7 +19,7 @@ import { ConfigurePreviewAccordion } from '../shared/configure-preview-accordion
 
 type EmailEditorPreviewProps = {
   editorValue: string;
-  setEditorValue: (value: string) => void;
+  setEditorValue: (value: string) => Error | null;
   previewStep: () => void;
   previewData?: GeneratePreviewResponseDto;
   isPreviewPending: boolean;

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor-preview.tsx
@@ -1,12 +1,12 @@
-import { GeneratePreviewResponseDto } from '@novu/shared';
 import { Notification5Fill } from '@/components/icons';
 import { InAppTabsSection } from '@/components/workflow-editor/steps/in-app/in-app-tabs-section';
-import { InboxPreview } from './inbox-preview';
+import { GeneratePreviewResponseDto } from '@novu/shared';
 import { ConfigurePreviewAccordion } from '../shared/configure-preview-accordion';
+import { InboxPreview } from './inbox-preview';
 
 type InAppEditorPreviewProps = {
   editorValue: string;
-  setEditorValue: (value: string) => void;
+  setEditorValue: (value: string) => Error | null;
   previewStep: () => void;
   previewData?: GeneratePreviewResponseDto;
   isPreviewPending: boolean;

--- a/apps/dashboard/src/components/workflow-editor/steps/push/push-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/push/push-editor-preview.tsx
@@ -6,7 +6,7 @@ import { ConfigurePreviewAccordion } from '../shared/configure-preview-accordion
 
 type PushEditorPreviewProps = {
   editorValue: string;
-  setEditorValue: (value: string) => void;
+  setEditorValue: (value: string) => Error | null;
   previewStep: () => void;
   previewData?: GeneratePreviewResponseDto;
   isPreviewPending: boolean;

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/configure-preview-accordion.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/configure-preview-accordion.tsx
@@ -3,13 +3,13 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/
 import { Button } from '@/components/primitives/button';
 import { Editor } from '@/components/primitives/editor';
 import { loadLanguage } from '@uiw/codemirror-extensions-langs';
-import { CSSProperties, useEffect, useRef, useState } from 'react';
+import { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 
 const extensions = [loadLanguage('json')?.extension ?? []];
 
 type ConfigurePreviewAccordionProps = {
   editorValue: string;
-  setEditorValue: (value: string) => void;
+  setEditorValue: (value: string) => Error | null;
   onUpdate: () => void;
 };
 
@@ -19,7 +19,7 @@ export const ConfigurePreviewAccordion = ({
   onUpdate,
 }: ConfigurePreviewAccordionProps) => {
   const [accordionValue, setAccordionValue] = useState<string | undefined>('payload');
-  const [payloadError, setPayloadError] = useState('');
+  const [payloadError, setPayloadError] = useState<string | null>(null);
   const [height, setHeight] = useState(0);
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -33,6 +33,18 @@ export const ConfigurePreviewAccordion = ({
 
     return () => clearTimeout(timeout);
   }, [editorValue]);
+
+  const setEditorValueCallback = useCallback(
+    (value: string) => {
+      const error = setEditorValue(value);
+      if (error) {
+        setPayloadError(error.message);
+      } else {
+        setPayloadError(null);
+      }
+    },
+    [setEditorValue]
+  );
 
   return (
     <Accordion type="single" collapsible value={accordionValue} onValueChange={setAccordionValue}>
@@ -50,7 +62,7 @@ export const ConfigurePreviewAccordion = ({
         >
           <Editor
             value={editorValue}
-            onChange={setEditorValue}
+            onChange={setEditorValueCallback}
             lang="json"
             extensions={extensions}
             className="border-neutral-alpha-200 bg-background text-foreground-600 mx-0 mt-0 rounded-lg border border-dashed p-3"
@@ -62,14 +74,8 @@ export const ConfigurePreviewAccordion = ({
             variant="secondary"
             mode="outline"
             className="self-end"
-            onClick={() => {
-              try {
-                onUpdate();
-                setPayloadError('');
-              } catch (e) {
-                setPayloadError(String(e));
-              }
-            }}
+            disabled={payloadError !== null}
+            onClick={onUpdate}
           >
             Apply
           </Button>

--- a/apps/dashboard/src/components/workflow-editor/steps/sms/sms-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/sms/sms-editor-preview.tsx
@@ -1,13 +1,13 @@
 import { Sms } from '@/components/icons';
-import { SmsPreview } from '@/components/workflow-editor/steps/sms/sms-preview';
 import { InlineToast } from '@/components/primitives/inline-toast';
+import { SmsPreview } from '@/components/workflow-editor/steps/sms/sms-preview';
 import { TabsSection } from '@/components/workflow-editor/steps/tabs-section';
-import { ConfigurePreviewAccordion } from '../shared/configure-preview-accordion';
 import { GeneratePreviewResponseDto } from '@novu/shared';
+import { ConfigurePreviewAccordion } from '../shared/configure-preview-accordion';
 
 type SmsEditorPreviewProps = {
   editorValue: string;
-  setEditorValue: (value: string) => void;
+  setEditorValue: (value: string) => Error | null;
   previewStep: () => void;
   previewData?: GeneratePreviewResponseDto;
   isPreviewPending: boolean;

--- a/apps/dashboard/src/components/workflow-editor/steps/use-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/use-editor-preview.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash.isequal';
+import { useCallback, useEffect, useState } from 'react';
 
-import { usePreviewStep } from '@/hooks/use-preview-step';
 import { useDataRef } from '@/hooks/use-data-ref';
+import { usePreviewStep } from '@/hooks/use-preview-step';
 
 export const useEditorPreview = ({
   workflowSlug,
@@ -23,7 +23,7 @@ export const useEditorPreview = ({
     onSuccess: (res) => {
       const newValue = JSON.stringify(res.previewPayloadExample, null, 2);
       if (!isEqual(editorValue, newValue)) {
-        setEditorValue(newValue);
+        setEditorValueSafe(newValue);
       }
     },
     onError: (error) => {
@@ -48,6 +48,16 @@ export const useEditorPreview = ({
     });
   }, [dataRef, previewStep]);
 
+  const setEditorValueSafe = (value: string): Error | null => {
+    try {
+      JSON.parse(value);
+      setEditorValue(value);
+      return null;
+    } catch (e) {
+      return e as Error;
+    }
+  };
+
   const previewStepCallback = useCallback(() => {
     return previewStep({
       workflowSlug,
@@ -58,7 +68,7 @@ export const useEditorPreview = ({
 
   return {
     editorValue,
-    setEditorValue,
+    setEditorValue: setEditorValueSafe,
     previewStep: previewStepCallback,
     previewData,
     isPreviewPending,


### PR DESCRIPTION
### What changed? Why was the change needed?

Tab switch was triggering autosave with unparsable JSON causing uncaught error and ultimately crashing the app.

Now we allow only parsable string to be stored as editor value. If you leave the editor in unparsable state it will get overwritten with the latest parsable state.

Before:

https://github.com/user-attachments/assets/15ab1ea5-e525-4886-9d12-4cd3ceea5696

After:

https://github.com/user-attachments/assets/74c2d6e0-48ee-4cf3-baee-b7acbf9221c4


