### PR TITLE
feat(api): Nv 5101 email sent from new dashbord has message clipped block in

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -45,34 +45,26 @@ export class EmailOutputRendererUsecase {
   }
 
   private removeTrailingEmptyLines(node: TipTapNode): TipTapNode {
-    if (!node.content) return node;
+    if (!node.content || node.content.length === 0) return node;
 
-    let shouldKeepFiltering = true;
+    // Iterate from the end of the content and find the first non-empty node
+    let lastIndex = node.content.length;
+    // eslint-disable-next-line no-plusplus
+    for (let i = node.content.length - 1; i >= 0; i--) {
+      const childNode = node.content[i];
 
-    // Filter and remove trailing empty nodes
-    const filteredContent = [...node.content]
-      .reverse()
-      .filter((childNode) => {
-        if (shouldKeepFiltering) {
-          const isEmptyParagraph =
-            childNode.type === 'paragraph' &&
-            !childNode.text && // No text
-            (!childNode.content || childNode.content.length === 0);
+      const isEmptyParagraph =
+        childNode.type === 'paragraph' && !childNode.text && (!childNode.content || childNode.content.length === 0);
 
-          // If the paragraph is empty, remove it
-          if (isEmptyParagraph) {
-            return false;
-          }
+      if (!isEmptyParagraph) {
+        lastIndex = i + 1; // Include this node in the result
+        break;
+      }
+    }
 
-          // Stop filtering once a non-empty node is encountered
-          shouldKeepFiltering = false;
-        }
+    // Slice the content to remove trailing empty nodes
+    const filteredContent = node.content.slice(0, lastIndex);
 
-        return true;
-      })
-      .reverse(); // Reverse back to the original order
-
-    // Return the updated node
     return { ...node, content: filteredContent };
   }
 

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -35,12 +35,24 @@ export class EmailOutputRendererUsecase {
     const parsedTipTap = await this.parseTipTapNodeByLiquid(expandedMailyContent, renderCommand);
     const renderedHtml = await mailyRender(parsedTipTap);
 
+    console.log({
+      expandedMailyContent: parsedTipTap?.content?.[2],
+      first: parsedTipTap?.content?.[1],
+      parsedTipTap,
+      body,
+    });
+
     /**
      * Force type mapping in case undefined control.
      * This passes responsibility to framework to throw type validation exceptions
      * rather than handling invalid types here.
      */
     return { subject: subject as string, body: renderedHtml };
+  }
+
+  private stripEmptyNodes(tiptapNode: TipTapNode[]): TipTapNode {
+    // recursively check if content missing and strip it
+    return tiptapNode;
   }
 
   private async parseTipTapNodeByLiquid(


### PR DESCRIPTION
### What changed? Why was the change needed?
- Remove the empty paragraphs from bottom of the email content to avoid "Message Clipped" indicator on Gmail.
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
