### PR TITLE
fix(api-service): email 'if' condition truthy values

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -334,7 +334,16 @@ describe('EmailOutputRendererUsecase', () => {
   });
 
   describe('conditional block transformation (showIfKey)', () => {
-    it('should render content when showIfKey condition is true', async () => {
+    describe('truthy conditions', () => {
+      const truthyValues = [
+        { value: true, desc: 'boolean true' },
+        { value: 1, desc: 'number 1' },
+        { value: 'true', desc: 'string "true"' },
+        { value: 'yes', desc: 'string "yes"' },
+        { value: {}, desc: 'empty object' },
+        { value: [], desc: 'empty array' },
+      ];
+
       const mockTipTapNode: MailyJSONContent = {
         type: 'doc',
         content: [
@@ -371,27 +380,39 @@ describe('EmailOutputRendererUsecase', () => {
         ],
       };
 
-      const renderCommand = {
-        controlValues: {
-          subject: 'Conditional Test',
-          body: JSON.stringify(mockTipTapNode),
-        },
-        fullPayloadForRender: {
-          ...mockFullPayload,
-          payload: {
-            isPremium: true,
-          },
-        },
-      };
+      truthyValues.forEach(({ value, desc }) => {
+        it(`should render content when showIfKey is ${desc}`, async () => {
+          const renderCommand = {
+            controlValues: {
+              subject: 'Conditional Test',
+              body: JSON.stringify(mockTipTapNode),
+            },
+            fullPayloadForRender: {
+              ...mockFullPayload,
+              payload: {
+                isPremium: value,
+              },
+            },
+          };
 
-      const result = await emailOutputRendererUsecase.execute(renderCommand);
+          const result = await emailOutputRendererUsecase.execute(renderCommand);
 
-      expect(result.body).to.include('Before condition');
-      expect(result.body).to.include('Premium content');
-      expect(result.body).to.include('After condition');
+          expect(result.body).to.include('Before condition');
+          expect(result.body).to.include('Premium content');
+          expect(result.body).to.include('After condition');
+        });
+      });
     });
 
-    it('should not render content when showIfKey condition is false', async () => {
+    describe('falsy conditions', () => {
+      const falsyValues = [
+        { value: false, desc: 'boolean false' },
+        { value: 0, desc: 'number 0' },
+        { value: '', desc: 'empty string' },
+        { value: null, desc: 'null' },
+        { value: undefined, desc: 'undefined' },
+      ];
+
       const mockTipTapNode: MailyJSONContent = {
         type: 'doc',
         content: [
@@ -423,34 +444,33 @@ describe('EmailOutputRendererUsecase', () => {
                 type: 'text',
                 text: 'After condition',
               },
-              {
-                type: 'text',
-                text: 'After condition 2',
-              },
             ],
           },
         ],
       };
 
-      const renderCommand = {
-        controlValues: {
-          subject: 'Conditional Test',
-          body: JSON.stringify(mockTipTapNode),
-        },
-        fullPayloadForRender: {
-          ...mockFullPayload,
-          payload: {
-            isPremium: false,
-          },
-        },
-      };
+      falsyValues.forEach(({ value, desc }) => {
+        it(`should not render content when showIfKey is ${desc}`, async () => {
+          const renderCommand = {
+            controlValues: {
+              subject: 'Conditional Test',
+              body: JSON.stringify(mockTipTapNode),
+            },
+            fullPayloadForRender: {
+              ...mockFullPayload,
+              payload: {
+                isPremium: value,
+              },
+            },
+          };
 
-      const result = await emailOutputRendererUsecase.execute(renderCommand);
+          const result = await emailOutputRendererUsecase.execute(renderCommand);
 
-      expect(result.body).to.include('Before condition');
-      expect(result.body).to.not.include('Premium content');
-      expect(result.body).to.include('After condition');
-      expect(result.body).to.include('After condition 2');
+          expect(result.body).to.include('Before condition');
+          expect(result.body).to.not.include('Premium content');
+          expect(result.body).to.include('After condition');
+        });
+      });
     });
 
     it('should handle nested conditional blocks correctly', async () => {

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -339,6 +339,7 @@ describe('EmailOutputRendererUsecase', () => {
         { value: true, desc: 'boolean true' },
         { value: 1, desc: 'number 1' },
         { value: 'true', desc: 'string "true"' },
+        { value: 'TRUE', desc: 'string "TRUE"' },
         { value: 'yes', desc: 'string "yes"' },
         { value: {}, desc: 'empty object' },
         { value: [], desc: 'empty array' },
@@ -411,6 +412,7 @@ describe('EmailOutputRendererUsecase', () => {
         { value: '', desc: 'empty string' },
         { value: null, desc: 'null' },
         { value: undefined, desc: 'undefined' },
+        { value: 'UNDEFINED', desc: 'string "UNDEFINED"' },
       ];
 
       const mockTipTapNode: MailyJSONContent = {

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -245,12 +245,15 @@ export class EmailOutputRendererUsecase {
     });
   }
 
-  private stringToBoolean(value: unknown): boolean {
-    if (typeof value === 'string') {
-      return value.toLowerCase() === 'true';
-    }
+  private stringToBoolean(value: string): boolean {
+    const normalized = value.toLowerCase().trim();
+    if (normalized === 'false' || normalized === 'null' || normalized === 'undefined') return false;
 
-    return false;
+    try {
+      return Boolean(JSON.parse(value));
+    } catch {
+      return Boolean(value);
+    }
   }
 
   private isVariableNode(

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -250,9 +250,9 @@ export class EmailOutputRendererUsecase {
     if (normalized === 'false' || normalized === 'null' || normalized === 'undefined') return false;
 
     try {
-      return Boolean(JSON.parse(value));
+      return Boolean(JSON.parse(normalized));
     } catch {
-      return Boolean(value);
+      return Boolean(normalized);
     }
   }
 

--- a/apps/api/src/app/workflows-v2/util/utils.ts
+++ b/apps/api/src/app/workflows-v2/util/utils.ts
@@ -241,7 +241,7 @@ export function mergeCommonObjectKeys(
           sourceValue as Record<string, unknown>
         );
       } else {
-        merged[key] = sourceValue ?? targetValue;
+        merged[key] = key in source ? sourceValue : targetValue;
       }
 
       return merged;


### PR DESCRIPTION
### What changed? Why was the change needed?

Evaluate true and false conditions from payload based on JS evaluation.
