### PR TITLE
fix(api-service,dashboard): step conditions begins with operator plus ui fixes for cut inputs

### DIFF
--- a/apps/api/src/app/shared/services/query-parser/query-parser.service.spec.ts
+++ b/apps/api/src/app/shared/services/query-parser/query-parser.service.spec.ts
@@ -17,7 +17,7 @@ describe('QueryParserService', () => {
       const rule: RulesLogic<AdditionalOperation> = {
         and: [
           { '=': [{ var: 'value' }, 42] },
-          { beginsWith: [{ var: 'text' }, 'hello'] },
+          { startsWith: [{ var: 'text' }, 'hello'] },
           { notBetween: [{ var: 'number' }, [1, 5]] },
         ],
       };
@@ -29,7 +29,7 @@ describe('QueryParserService', () => {
 
     describe('Error Handling', () => {
       it('should handle invalid data types gracefully', () => {
-        const rule: RulesLogic<AdditionalOperation> = { beginsWith: [{ var: 'text' }, 123] };
+        const rule: RulesLogic<AdditionalOperation> = { startsWith: [{ var: 'text' }, 123] };
         const data = { text: 'hello' };
         const { result, error } = evaluateRules(rule, data);
         expect(error).to.be.undefined;
@@ -95,9 +95,9 @@ describe('QueryParserService', () => {
       });
     });
 
-    describe('beginsWith operator', () => {
+    describe('startsWith operator', () => {
       it('should return true when string begins with given value', () => {
-        const rule: RulesLogic<AdditionalOperation> = { beginsWith: [{ var: 'text' }, 'hello'] };
+        const rule: RulesLogic<AdditionalOperation> = { startsWith: [{ var: 'text' }, 'hello'] };
         const data = { text: 'hello world' };
         const { result, error } = evaluateRules(rule, data);
         expect(error).to.be.undefined;
@@ -105,7 +105,7 @@ describe('QueryParserService', () => {
       });
 
       it('should return false when string does not begin with given value', () => {
-        const rule: RulesLogic<AdditionalOperation> = { beginsWith: [{ var: 'text' }, 'world'] };
+        const rule: RulesLogic<AdditionalOperation> = { startsWith: [{ var: 'text' }, 'world'] };
         const data = { text: 'hello world' };
         const { result, error } = evaluateRules(rule, data);
         expect(error).to.be.undefined;

--- a/apps/api/src/app/shared/services/query-parser/query-parser.service.ts
+++ b/apps/api/src/app/shared/services/query-parser/query-parser.service.ts
@@ -108,7 +108,7 @@ const initializeCustomOperators = (): void => {
   });
 
   jsonLogic.add_operation(
-    'beginsWith',
+    'startsWith',
     createStringOperator((input, value) => input.startsWith(value))
   );
 

--- a/apps/dashboard/src/components/conditions-editor/value-editor.tsx
+++ b/apps/dashboard/src/components/conditions-editor/value-editor.tsx
@@ -20,17 +20,16 @@ export const ValueEditor = (props: ValueEditorProps) => {
   if ((operator === 'between' || operator === 'notBetween') && (type === 'select' || type === 'text')) {
     const editors = ['from', 'to'].map((key, i) => {
       return (
-        <InputRoot key={key} size="2xs" className="w-28" hasError={!!error && !valueAsArray[i]}>
-          <InputWrapper className="h-7">
-            <ControlInput
-              multiline={false}
-              indentWithTab={false}
-              placeholder="value"
-              value={valueAsArray[i] ?? ''}
-              onChange={(newValue) => multiValueHandler(newValue, i)}
-              variables={variables}
-            />
-          </InputWrapper>
+        <InputRoot key={key} className="w-28" hasError={!!error && !valueAsArray[i]}>
+          <ControlInput
+            multiline={false}
+            indentWithTab={false}
+            placeholder="value"
+            value={valueAsArray[i] ?? ''}
+            onChange={(newValue) => multiValueHandler(newValue, i)}
+            variables={variables}
+            size="2xs"
+          />
         </InputRoot>
       );
     });
@@ -49,17 +48,16 @@ export const ValueEditor = (props: ValueEditorProps) => {
 
   return (
     <div className="flex flex-col gap-1">
-      <InputRoot size="2xs" className="w-40" hasError={!!error}>
-        <InputWrapper className="h-7">
-          <ControlInput
-            multiline={false}
-            indentWithTab={false}
-            placeholder="value"
-            value={value ?? ''}
-            onChange={handleOnChange}
-            variables={variables}
-          />
-        </InputWrapper>
+      <InputRoot className="w-40" hasError={!!error}>
+        <ControlInput
+          multiline={false}
+          indentWithTab={false}
+          placeholder="value"
+          value={value ?? ''}
+          onChange={handleOnChange}
+          variables={variables}
+          size="2xs"
+        />
       </InputRoot>
       {error && <span className="text-destructive text-xs">{error?.message}</span>}
     </div>

--- a/apps/dashboard/src/components/conditions-editor/value-editor.tsx
+++ b/apps/dashboard/src/components/conditions-editor/value-editor.tsx
@@ -1,7 +1,7 @@
 import { useValueEditor, ValueEditorProps } from 'react-querybuilder';
 import { useFormContext } from 'react-hook-form';
 
-import { InputRoot, InputWrapper } from '@/components/primitives/input';
+import { InputRoot } from '@/components/primitives/input';
 import { LiquidVariable } from '@/utils/parseStepVariablesToLiquidVariables';
 import { ControlInput } from '../primitives/control-input/control-input';
 

--- a/apps/dashboard/src/components/primitives/control-input/control-input.tsx
+++ b/apps/dashboard/src/components/primitives/control-input/control-input.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef } from 'react';
 import { autocompletion } from '@codemirror/autocomplete';
 import { EditorView } from '@uiw/react-codemirror';
 import { cn } from '@/utils/ui';
+import { cva } from 'class-variance-authority';
 
 import { Editor } from '@/components/primitives/editor';
 import { Popover, PopoverTrigger } from '@/components/primitives/popover';
@@ -11,6 +12,19 @@ import { useVariables } from './hooks/use-variables';
 import { createVariableExtension } from './variable-plugin';
 import { variablePillTheme } from './variable-plugin/variable-theme';
 import { VariablePopover } from './variable-popover';
+
+const variants = cva('relative w-full', {
+  variants: {
+    size: {
+      md: 'p-2.5',
+      sm: 'p-2.5',
+      '2xs': 'px-2 py-1.5',
+    },
+  },
+  defaultVariants: {
+    size: 'sm',
+  },
+});
 
 type CompletionRange = {
   from: number;
@@ -24,7 +38,7 @@ type ControlInputProps = {
   variables: LiquidVariable[];
   placeholder?: string;
   autoFocus?: boolean;
-  size?: 'md' | 'sm';
+  size?: 'md' | 'sm' | '2xs';
   id?: string;
   multiline?: boolean;
   indentWithTab?: boolean;
@@ -88,7 +102,7 @@ export function ControlInput({
   );
 
   return (
-    <div className={cn('relative h-full w-full p-2.5', className)}>
+    <div className={variants({ size, className })}>
       <Editor
         fontFamily="inherit"
         multiline={multiline}

--- a/apps/dashboard/src/components/primitives/editor.tsx
+++ b/apps/dashboard/src/components/primitives/editor.tsx
@@ -17,6 +17,7 @@ const variants = cva('h-full w-full flex-1 [&_.cm-focused]:outline-none', {
     size: {
       md: 'text-base',
       sm: 'text-xs',
+      '2xs': 'text-xs',
     },
   },
   defaultVariants: {
@@ -123,6 +124,9 @@ const baseTheme = (options: { multiline?: boolean }) =>
       borderRight: 'none',
       color: 'hsl(var(--foreground-400))',
     },
+    '.cm-placeholder': {
+      fontWeight: 'normal',
+    },
   });
 
 export type EditorProps = {
@@ -133,7 +137,7 @@ export type EditorProps = {
   height?: string;
   onChange?: (value: string) => void;
   fontFamily?: 'inherit';
-  size?: 'sm' | 'md';
+  size?: 'sm' | 'md' | '2xs';
 } & ReactCodeMirrorProps;
 
 export const Editor = React.forwardRef<ReactCodeMirrorRef, EditorProps>(

--- a/apps/dashboard/src/components/workflow-editor/steps/digest/digest-key.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/digest/digest-key.tsx
@@ -18,7 +18,7 @@ export const DigestKey = () => {
       control={control}
       name="controlValues.digestKey"
       render={({ field }) => (
-        <FormItem className="flex w-full flex-col overflow-hidden">
+        <FormItem className="flex w-full flex-col">
           <>
             <FormLabel
               optional
@@ -29,7 +29,7 @@ export const DigestKey = () => {
             <InputRoot>
               <InputWrapper className="flex h-[28px] items-center gap-1 border-r border-neutral-100 pr-1">
                 <FormLabel className="flex h-full items-center gap-1 border-r border-neutral-100 pr-1">
-                  <Code2 className="-ml-1.5 size-5" />
+                  <Code2 className="text-feature -ml-1.5 size-4" />
                   <span className="text-foreground-600 text-xs font-normal">subscriberId</span>
                 </FormLabel>
                 <ControlInput
@@ -40,7 +40,7 @@ export const DigestKey = () => {
                   value={field.value}
                   onChange={field.onChange}
                   variables={variables}
-                  size="md"
+                  size="sm"
                 />
               </InputWrapper>
             </InputRoot>


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixes:
- Step Conditions - begins with operator; when the workflow was triggered it was failing
- Step Conditions - the value input was cut and had the wrong styles applied
- Digest step - digest key field

### Screenshots

https://github.com/user-attachments/assets/01f154c5-f346-4af1-b65a-d43f657ab1f8

![Screenshot 2025-01-24 at 13 00 41](https://github.com/user-attachments/assets/fc4b7438-bd0b-4fda-9985-715d5e71e6c0)
![Screenshot 2025-01-24 at 13 00 30](https://github.com/user-attachments/assets/df852885-a826-40aa-8e90-7c872b3781e0)

