### PR TITLE
fix(application-generic): Check for environment at the very top

### DIFF
--- a/apps/worker/src/app/workflow/services/workflow.worker.ts
+++ b/apps/worker/src/app/workflow/services/workflow.worker.ts
@@ -5,7 +5,6 @@ import {
   storage,
   Store,
   TriggerEvent,
-  TriggerEventCommand,
   WorkflowWorkerService,
   WorkerOptions,
   WorkerProcessor,


### PR DESCRIPTION
### What changed? Why was the change needed?

Clean up as I was exploring something in the area.

- If environment doesn't exist, the use case needs to throw asap
- Assign logger context, right after environment is resolved
- Remove unused methods