### PR TITLE
fix(dashboard): Add Remove Novu Branding to Inbox

### DIFF
--- a/apps/dashboard/src/api/integrations.ts
+++ b/apps/dashboard/src/api/integrations.ts
@@ -10,6 +10,7 @@ export type CreateIntegrationData = {
   active: boolean;
   primary?: boolean;
   _environmentId: string;
+  removeNovuBranding?: boolean;
 };
 
 export enum CheckIntegrationResponseEnum {
@@ -26,6 +27,7 @@ export type UpdateIntegrationData = {
   primary: boolean;
   credentials: Record<string, string>;
   check: boolean;
+  removeNovuBranding?: boolean;
 };
 
 export async function getIntegrations({ environment }: { environment: IEnvironment }) {

--- a/apps/dashboard/src/components/integrations/components/integration-configuration.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-configuration.tsx
@@ -4,7 +4,7 @@ import { Label } from '@/components/primitives/label';
 import { Separator } from '@/components/primitives/separator';
 import { useAuth } from '@/context/auth/hooks';
 import { useEnvironment, useFetchEnvironments } from '@/context/environment/hooks';
-import { IIntegration, IProviderConfig } from '@novu/shared';
+import { IIntegration } from '@novu/shared';
 import { useEffect } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { RiInputField } from 'react-icons/ri';
@@ -14,6 +14,7 @@ import { EnvironmentDropdown } from '../../side-navigation/environment-dropdown'
 import { CredentialsSection } from './integration-credentials';
 import { GeneralSettings } from './integration-general-settings';
 import { isDemoIntegration } from './utils/helpers';
+import { IProviderConfig } from '@novu/shared';
 
 type IntegrationFormData = {
   name: string;
@@ -23,6 +24,7 @@ type IntegrationFormData = {
   check: boolean;
   primary: boolean;
   environmentId: string;
+  removeNovuBranding?: boolean;
 };
 
 type IntegrationConfigurationProps = {
@@ -64,6 +66,7 @@ export function IntegrationConfiguration({
           primary: integration.primary ?? false,
           credentials: integration.credentials as Record<string, string>,
           environmentId: integration._environmentId,
+          removeNovuBranding: integration.removeNovuBranding,
         }
       : {
           name: provider?.displayName ?? '',
@@ -72,6 +75,7 @@ export function IntegrationConfiguration({
           primary: true,
           credentials: {},
           environmentId: currentEnvironment?._id ?? '',
+          removeNovuBranding: false,
         },
   });
 
@@ -125,6 +129,8 @@ export function IntegrationConfiguration({
                 mode={mode}
                 hidePrimarySelector={!isChannelSupportPrimary}
                 disabledPrimary={!hasOtherProviders && integration?.primary}
+                // TODO: This is an ugly hack. The GeneralSettigns section should be redefined for in-app step.
+                isForInAppStep={provider?.channel === 'in_app'}
               />
             </AccordionContent>
           </AccordionItem>

--- a/apps/dashboard/src/components/integrations/components/integration-credentials.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-credentials.tsx
@@ -13,6 +13,7 @@ type IntegrationFormData = {
   check: boolean;
   primary: boolean;
   environmentId: string;
+  removeNovuBranding?: boolean;
 };
 
 type CredentialsSectionProps = {

--- a/apps/dashboard/src/components/integrations/components/integration-general-settings.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-general-settings.tsx
@@ -79,7 +79,7 @@ export function GeneralSettings({
                   Remove "Powered by Novu" branding
                 </FormLabel>
                 <FormControl>
-                  {disabled ? (
+                  {isFreePlan ? (
                     <HoverCard openDelay={100} closeDelay={100}>
                       <HoverCardTrigger asChild>{switchControl}</HoverCardTrigger>
                       <HoverCardPortal>

--- a/apps/dashboard/src/components/integrations/components/integration-general-settings.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-general-settings.tsx
@@ -2,7 +2,11 @@ import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/comp
 import { Input } from '@/components/primitives/input';
 import { Separator } from '@/components/primitives/separator';
 import { Switch } from '@/components/primitives/switch';
+import { Button } from '@/components/primitives/button';
+import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { Control } from 'react-hook-form';
+import { ApiServiceLevelEnum } from '@novu/shared';
+import { HoverCard, HoverCardPortal, HoverCardContent, HoverCardTrigger } from '@/components/primitives/hover-card';
 
 type IntegrationFormData = {
   name: string;
@@ -12,6 +16,7 @@ type IntegrationFormData = {
   check: boolean;
   primary: boolean;
   environmentId: string;
+  removeNovuBranding?: boolean;
 };
 
 type GeneralSettingsProps = {
@@ -19,9 +24,18 @@ type GeneralSettingsProps = {
   mode: 'create' | 'update';
   hidePrimarySelector?: boolean;
   disabledPrimary?: boolean;
+  isForInAppStep?: boolean;
 };
 
-export function GeneralSettings({ control, mode, hidePrimarySelector, disabledPrimary }: GeneralSettingsProps) {
+export function GeneralSettings({
+  control,
+  mode,
+  hidePrimarySelector,
+  disabledPrimary,
+  isForInAppStep,
+}: GeneralSettingsProps) {
+  const { subscription, isLoading: isLoadingSubscription } = useFetchSubscription();
+
   return (
     <div className="border-neutral-alpha-200 bg-background text-foreground-600 mx-0 mt-0 flex flex-col gap-2 rounded-lg border p-3">
       <FormField
@@ -42,6 +56,52 @@ export function GeneralSettings({ control, mode, hidePrimarySelector, disabledPr
           </FormItem>
         )}
       />
+      {isForInAppStep && (
+        <FormField
+          control={control}
+          name="removeNovuBranding"
+          render={({ field }) => {
+            const isFreePlan = subscription?.apiServiceLevel === ApiServiceLevelEnum.FREE;
+            const disabled = isFreePlan || isLoadingSubscription;
+            const value = disabled ? false : field.value;
+
+            const switchControl = <Switch disabled={disabled} onCheckedChange={field.onChange} checked={value} />;
+
+            return (
+              <FormItem className="flex items-center justify-between gap-2">
+                <FormLabel
+                  className="text-xs"
+                  htmlFor="active"
+                  tooltip='Hide "Powered by Novu" branding from your <Inbox />'
+                >
+                  Remove "Powered by Novu" branding
+                </FormLabel>
+                <FormControl>
+                  {disabled ? (
+                    <HoverCard openDelay={100} closeDelay={100}>
+                      <HoverCardTrigger asChild>{switchControl}</HoverCardTrigger>
+                      {disabled && (
+                        <HoverCardPortal>
+                          <HoverCardContent className="w-fit" align="end" sideOffset={4}>
+                            <div className="flex max-w-52 flex-col gap-2 text-wrap text-xs">
+                              <span>Upgrade your billing plan to remove Novu branding</span>
+                              <Button variant="primary" mode="lighter" size="xs">
+                                Upgrade now
+                              </Button>
+                            </div>
+                          </HoverCardContent>
+                        </HoverCardPortal>
+                      )}
+                    </HoverCard>
+                  ) : (
+                    switchControl
+                  )}
+                </FormControl>
+              </FormItem>
+            );
+          }}
+        />
+      )}
 
       {!hidePrimarySelector && (
         <FormField

--- a/apps/dashboard/src/components/integrations/components/integration-general-settings.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-general-settings.tsx
@@ -7,6 +7,8 @@ import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { Control } from 'react-hook-form';
 import { ApiServiceLevelEnum } from '@novu/shared';
 import { HoverCard, HoverCardPortal, HoverCardContent, HoverCardTrigger } from '@/components/primitives/hover-card';
+import { ROUTES } from '@/utils/routes';
+import { Link } from 'react-router-dom';
 
 type IntegrationFormData = {
   name: string;
@@ -80,18 +82,18 @@ export function GeneralSettings({
                   {disabled ? (
                     <HoverCard openDelay={100} closeDelay={100}>
                       <HoverCardTrigger asChild>{switchControl}</HoverCardTrigger>
-                      {disabled && (
-                        <HoverCardPortal>
-                          <HoverCardContent className="w-fit" align="end" sideOffset={4}>
-                            <div className="flex max-w-52 flex-col gap-2 text-wrap text-xs">
-                              <span>Upgrade your billing plan to remove Novu branding</span>
+                      <HoverCardPortal>
+                        <HoverCardContent className="w-fit" align="end" sideOffset={4}>
+                          <div className="flex max-w-52 flex-col gap-2 text-wrap text-xs">
+                            <span>Upgrade your billing plan to remove Novu branding</span>
+                            <Link to={ROUTES.SETTINGS_BILLING}>
                               <Button variant="primary" mode="lighter" size="xs">
                                 Upgrade now
                               </Button>
-                            </div>
-                          </HoverCardContent>
-                        </HoverCardPortal>
-                      )}
+                            </Link>
+                          </div>
+                        </HoverCardContent>
+                      </HoverCardPortal>
                     </HoverCard>
                   ) : (
                     switchControl

--- a/apps/dashboard/src/components/integrations/components/update-integration-sidebar.tsx
+++ b/apps/dashboard/src/components/integrations/components/update-integration-sidebar.tsx
@@ -81,6 +81,7 @@ export function UpdateIntegrationSidebar({ isOpened }: UpdateIntegrationSidebarP
           primary: data.primary,
           credentials: data.credentials,
           check: data.check,
+          removeNovuBranding: data.removeNovuBranding,
         },
       });
 

--- a/apps/dashboard/src/components/integrations/types.ts
+++ b/apps/dashboard/src/components/integrations/types.ts
@@ -21,6 +21,7 @@ export type IntegrationFormData = {
   credentials: Record<string, any>;
   check: boolean;
   environmentId: string;
+  removeNovuBranding?: boolean;
 };
 
 export type IntegrationStep = 'select' | 'configure';

--- a/apps/dashboard/src/components/primitives/form/form.tsx
+++ b/apps/dashboard/src/components/primitives/form/form.tsx
@@ -68,7 +68,7 @@ const FormLabel = React.forwardRef<
               e.stopPropagation();
             }}
           >
-            <BsFillInfoCircleFill className="text-foreground-300 -mt-0.5 inline size-3" />
+            <BsFillInfoCircleFill className="text-foreground-300 ml-1 inline size-3" />
           </TooltipTrigger>
           <TooltipContent className="max-w-56">{tooltip}</TooltipContent>
         </Tooltip>


### PR DESCRIPTION
### What changed? Why was the change needed?

Add missing toggle to Inbox integration page

<img width="462" alt="Screenshot 2025-01-31 at 17 23 58" src="https://github.com/user-attachments/assets/358e50d6-678b-47b6-9cfd-7aac4d0f3e8a" />
