### PR TITLE
fix(dashboard): support of updating integration idenitifer field value

### DIFF
--- a/apps/dashboard/src/components/integrations/components/integration-general-settings.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-general-settings.tsx
@@ -166,7 +166,7 @@ export function GeneralSettings({
               Identifier
             </FormLabel>
             <FormControl>
-              <Input id="identifier" {...field} readOnly={mode === 'update'} hasError={!!fieldState.error} />
+              <Input id="identifier" {...field} hasError={!!fieldState.error} />
             </FormControl>
             <FormMessage />
           </FormItem>


### PR DESCRIPTION
### What changed? Why was the change needed?
fix: remove `readOnly` prop to allow updating the integration identifier field
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
