### PR TITLE
chore(api-service): remove redundant CLERK_ENABLED env var

### DIFF
--- a/.github/workflows/reusable-api-e2e.yml
+++ b/.github/workflows/reusable-api-e2e.yml
@@ -108,7 +108,6 @@ jobs:
         env:
           LAUNCH_DARKLY_SDK_KEY: ${{ secrets.LAUNCH_DARKLY_SDK_KEY }}
           CI_EE_TEST: true
-          CLERK_ENABLED: true
           CLERK_ISSUER_URL: ${{ vars.CLERK_ISSUER_URL }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           CLERK_WEBHOOK_SECRET: ${{ secrets.CLERK_WEBHOOK_SECRET }}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,7 +27,7 @@
     "generate:sdk": " (cd ../../libs/internal-sdk && speakeasy run --skip-compile --minimal --skip-versioning) && (cd ../../libs/internal-sdk && pnpm build) ",
     "test": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' NODE_ENV=test mocha --require ts-node/register --exit 'src/**/*.spec.ts'",
     "test:e2e:novu-v1": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' NODE_ENV=test mocha --grep '#novu-v1' --require ts-node/register --exit --file e2e/setup.ts src/**/*.e2e{,-ee}.ts",
-    "test:e2e:novu-v2": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' NODE_ENV=test CI_EE_TEST=true CLERK_ENABLED=true NODE_OPTIONS=--max_old_space_size=8192 mocha --grep '#novu-v2' --require ts-node/register --exit --file e2e/setup.ts 'src/**/*.e2e{,-ee}.ts'",
+    "test:e2e:novu-v2": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' NODE_ENV=test CI_EE_TEST=true NODE_OPTIONS=--max_old_space_size=8192 mocha --grep '#novu-v2' --require ts-node/register --exit --file e2e/setup.ts 'src/**/*.e2e{,-ee}.ts'",
     "migration": "cross-env NODE_ENV=local MIGRATION=true ts-node --transpileOnly",
     "link:submodules": "pnpm link ../../enterprise/packages/auth && pnpm link ../../enterprise/packages/translation && pnpm link ../../enterprise/packages/billing",
     "admin:remove-user-account": "cross-env NODE_ENV=local MIGRATION=true ts-node --transpileOnly ./admin/remove-user-account.ts",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,7 +6,6 @@ import { Client, NovuModule } from '@novu/framework/nest';
 
 import { Type } from '@nestjs/common/interfaces/type.interface';
 import { ForwardReference } from '@nestjs/common/interfaces/modules/forward-reference.interface';
-import { isClerkEnabled } from '@novu/shared';
 import { SentryModule } from '@sentry/nestjs/setup';
 import { ApiExcludeController } from '@nestjs/swagger';
 import { usageLimitsWorkflow } from '@novu/notifications';
@@ -120,7 +119,7 @@ const baseModules: Array<Type | DynamicModule | Promise<DynamicModule> | Forward
 
 const enterpriseModules = enterpriseImports();
 
-if (!isClerkEnabled()) {
+if (process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true') {
   const communityModules = [InvitesModule];
   baseModules.push(...communityModules);
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -119,7 +119,7 @@ const baseModules: Array<Type | DynamicModule | Promise<DynamicModule> | Forward
 
 const enterpriseModules = enterpriseImports();
 
-if (process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true') {
+if (process.env.NOVU_ENTERPRISE !== 'true' && process.env.CI_EE_TEST !== 'true') {
   const communityModules = [InvitesModule];
   baseModules.push(...communityModules);
 }

--- a/apps/api/src/app/auth/auth.module.ts
+++ b/apps/api/src/app/auth/auth.module.ts
@@ -1,10 +1,11 @@
 import { Global, MiddlewareConsumer, Module, ModuleMetadata } from '@nestjs/common';
-import { isClerkEnabled } from '@novu/shared';
 import { getCommunityAuthModuleConfig, configure as configureCommunity } from './community.auth.module.config';
 import { getEEModuleConfig, configure as configureEE } from './ee.auth.module.config';
 
+const isEnterprise = process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
+
 function getModuleConfig(): ModuleMetadata {
-  if (isClerkEnabled()) {
+  if (isEnterprise) {
     return getEEModuleConfig();
   } else {
     return getCommunityAuthModuleConfig();
@@ -15,7 +16,7 @@ function getModuleConfig(): ModuleMetadata {
 @Module(getModuleConfig())
 export class AuthModule {
   public configure(consumer: MiddlewareConsumer) {
-    if (isClerkEnabled()) {
+    if (isEnterprise) {
       configureEE(consumer);
     } else {
       configureCommunity(consumer);

--- a/apps/api/src/app/billing/e2e/get-platform-notification-usage.e2e-ee.ts
+++ b/apps/api/src/app/billing/e2e/get-platform-notification-usage.e2e-ee.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import { EnvironmentRepository, NotificationRepository, CommunityOrganizationRepository } from '@novu/dal';
 import { UserSession } from '@novu/testing';
-import { ApiServiceLevelEnum, isClerkEnabled } from '@novu/shared';
+import { ApiServiceLevelEnum } from '@novu/shared';
 
 describe('GetPlatformNotificationUsage #novu-v2', () => {
   const eeBilling = require('@novu/ee-billing');
@@ -84,7 +84,7 @@ describe('GetPlatformNotificationUsage #novu-v2', () => {
       notificationsCount: org.notificationsCount,
     }));
 
-    if (isClerkEnabled()) {
+    if (process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true') {
       // we have just one organization in Clerk - we don't create new ones on initialize()
       expectedResult = [expectedResult[expectedResult.length - 1]];
     }

--- a/apps/api/src/app/organization/organization.module.ts
+++ b/apps/api/src/app/organization/organization.module.ts
@@ -11,7 +11,6 @@ import {
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { Type } from '@nestjs/common/interfaces/type.interface';
-import { isClerkEnabled } from '@novu/shared';
 import { EnvironmentsModuleV1 } from '../environments-v1/environments-v1.module';
 import { IntegrationModule } from '../integrations/integrations.module';
 import { SharedModule } from '../shared/shared.module';
@@ -37,7 +36,7 @@ const enterpriseImports = (): Array<Type | DynamicModule | Promise<DynamicModule
 };
 
 function getControllers() {
-  if (isClerkEnabled()) {
+  if (process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true') {
     return [EEOrganizationController];
   }
 

--- a/apps/api/src/app/organization/usecases/index.ts
+++ b/apps/api/src/app/organization/usecases/index.ts
@@ -1,4 +1,3 @@
-import { isClerkEnabled } from '@novu/shared';
 import { CreateOrganization } from './create-organization/create-organization.usecase';
 import { GetOrganization } from './get-organization/get-organization.usecase';
 import { AddMember } from './membership/add-member/add-member.usecase';
@@ -13,7 +12,7 @@ import { SyncExternalOrganization } from './create-organization/sync-external-or
 
 // TODO: move ee.organization.controller.ts to EE package
 function getEnterpriseUsecases() {
-  if (isClerkEnabled()) {
+  if (process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true') {
     return [
       {
         provide: 'SyncOrganizationUsecase',

--- a/apps/api/src/app/shared/shared.module.ts
+++ b/apps/api/src/app/shared/shared.module.ts
@@ -46,12 +46,12 @@ import {
   storageService,
 } from '@novu/application-generic';
 
-import { isClerkEnabled, JobTopicNameEnum } from '@novu/shared';
+import { JobTopicNameEnum } from '@novu/shared';
 import { JwtModule } from '@nestjs/jwt';
 import packageJson from '../../../package.json';
 
 function getDynamicAuthProviders() {
-  if (isClerkEnabled()) {
+  if (process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true') {
     const eeAuthPackage = require('@novu/ee-auth');
 
     return eeAuthPackage.injectEEAuthProviders();

--- a/apps/api/src/app/workflows-v1/e2e/create-notification-templates.e2e.ts
+++ b/apps/api/src/app/workflows-v1/e2e/create-notification-templates.e2e.ts
@@ -14,7 +14,6 @@ import {
   EmailProviderIdEnum,
   ChangeEntityTypeEnum,
   INotificationTemplateStep,
-  isClerkEnabled,
   WorkflowTypeEnum,
 } from '@novu/shared';
 import {
@@ -550,7 +549,7 @@ describe('Create Notification template from blueprint - /notification-templates 
 
     const blueprint = (await session.testAgent.get(`/v1/blueprints/${blueprintId}`).send()).body.data;
 
-    if (isClerkEnabled()) {
+    if (process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true') {
       process.env.BLUEPRINT_CREATOR = session.organization._id;
     } else {
       const blueprintOrg = await organizationRepository.create({ name: 'Blueprint Org' });

--- a/libs/testing/src/ee/ee.repository.factory.ts
+++ b/libs/testing/src/ee/ee.repository.factory.ts
@@ -1,6 +1,5 @@
 /* eslint-disable global-require */
 import { CommunityOrganizationRepository, CommunityUserRepository, CommunityMemberRepository } from '@novu/dal';
-import { isClerkEnabled } from '@novu/shared';
 import { ClerkClientMock } from './clerk-client.mock';
 
 /**
@@ -11,7 +10,7 @@ import { ClerkClientMock } from './clerk-client.mock';
  *
  */
 export function getEERepository<T>(className: 'OrganizationRepository' | 'MemberRepository' | 'UserRepository'): T {
-  if (isClerkEnabled()) {
+  if (process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true') {
     switch (className) {
       case 'OrganizationRepository':
         return getEEOrganizationRepository();

--- a/libs/testing/src/user.session.ts
+++ b/libs/testing/src/user.session.ts
@@ -8,7 +8,6 @@ import {
   EmailBlockTypeEnum,
   IApiRateLimitMaximum,
   IEmailBlock,
-  isClerkEnabled,
   JobTopicNameEnum,
   StepTypeEnum,
 } from '@novu/shared';
@@ -37,6 +36,8 @@ import { EEUserService } from './ee/ee.user.service';
 import { EEOrganizationService } from './ee/ee.organization.service';
 import { TEST_USER_PASSWORD } from './constants';
 import { ClerkJwtPayload } from './ee/types';
+
+const isEnterprise = process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
 
 type UserSessionOptions = {
   noOrganization?: boolean;
@@ -94,7 +95,7 @@ export class UserSession {
   }
 
   async initialize(options?: UserSessionOptions) {
-    if (isClerkEnabled()) {
+    if (isEnterprise) {
       // The ids of pre-seeded Clerk resources (MongoDB: clerk_users, clerk_organizations, clerk_organization_memberships)
       await this.initializeEE(options);
     } else {
@@ -215,7 +216,7 @@ export class UserSession {
   }
 
   async fetchJWT() {
-    if (isClerkEnabled()) {
+    if (isEnterprise) {
       await this.fetchJwtEE();
     } else {
       await this.fetchJwtCommunity();
@@ -223,7 +224,7 @@ export class UserSession {
   }
 
   async addOrganization() {
-    if (isClerkEnabled()) {
+    if (isEnterprise) {
       return await this.addOrganizationEE('clerk_org_1');
     } else {
       return await this.addOrganizationCommunity();
@@ -404,7 +405,7 @@ export class UserSession {
       this.environment = environment;
       await this.testAgent.post(`/v1/auth/environments/${environmentId}/switch`);
 
-      if (isClerkEnabled()) {
+      if (isEnterprise) {
         await this.fetchJwtEE();
       } else {
         await this.fetchJwtCommunity();
@@ -463,7 +464,7 @@ export class UserSession {
   }
 
   public async updateOrganizationServiceLevel(serviceLevel: ApiServiceLevelEnum) {
-    const organizationService = isClerkEnabled() ? new EEOrganizationService() : new OrganizationService();
+    const organizationService = isEnterprise ? new EEOrganizationService() : new OrganizationService();
 
     await organizationService.updateServiceLevel(this.organization._id, serviceLevel);
   }

--- a/packages/shared/src/utils/env.ts
+++ b/packages/shared/src/utils/env.ts
@@ -49,6 +49,3 @@ export const getEnvVariable = (name: string, context?): string => {
 
   return '';
 };
-
-export const isClerkEnabled = () =>
-  (process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true') && process.env.CLERK_ENABLED === 'true';


### PR DESCRIPTION
### What changed? Why was the change needed?

`CLERK_ENABLED` flag is not needed because `NOVU_ENTERPRISE` equals `CLERK_ENABLED`. We will never run enterprise without Clerk enabled and vice-versa. It mostly only creates confusion when setting up env variables.

This flag made sense only for a period where we had Clerk logic already in code but it was not yet enabled on enterprise - we're running enterprise without Clerk. 

Correct me if I'm wrong but I think there will likely never be a usecase where we will want to run enterprise/cloud without Clerk enabled - that would equal to running community version (`NOVU_ENTERPRISE = false`), which new dashboard v2 doesn't support since we don't have configuration without Clerk components. 