### PR TITLE
fix(dashboard,api-service): rename maily for loop to repeat

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,7 +37,7 @@
     "@aws-sdk/client-secrets-manager": "^3.716.0",
     "@godaddy/terminus": "^4.12.1",
     "@google-cloud/storage": "^6.2.3",
-    "@maily-to/render": "^0.0.17",
+    "@maily-to/render": "^0.0.19",
     "@nestjs/axios": "3.0.3",
     "@nestjs/common": "10.4.1",
     "@nestjs/core": "10.4.1",

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -559,13 +559,13 @@ describe('EmailOutputRendererUsecase', () => {
     });
   });
 
-  describe('for block transformation and expansion', () => {
-    it('should handle for loop block transformation with array of objects', async () => {
+  describe('repeat block transformation and expansion', () => {
+    it('should handle repeat loop block transformation with array of objects', async () => {
       const mockTipTapNode: MailyJSONContent = {
         type: 'doc',
         content: [
           {
-            type: 'for',
+            type: 'repeat',
             attrs: {
               each: 'payload.comments',
               isUpdatingKey: false,
@@ -610,7 +610,7 @@ describe('EmailOutputRendererUsecase', () => {
 
       const renderCommand = {
         controlValues: {
-          subject: 'For Loop Test',
+          subject: 'Repeat Loop Test',
           body: JSON.stringify(mockTipTapNode),
         },
         fullPayloadForRender: {
@@ -626,12 +626,12 @@ describe('EmailOutputRendererUsecase', () => {
       expect(result.body).to.include('This is an author: <!-- -->Jane<!-- -->Post Title');
     });
 
-    it('should handle for loop block transformation with array of primitives', async () => {
+    it('should handle repeat loop block transformation with array of primitives', async () => {
       const mockTipTapNode: MailyJSONContent = {
         type: 'doc',
         content: [
           {
-            type: 'for',
+            type: 'repeat',
             attrs: {
               each: 'payload.names',
               isUpdatingKey: false,
@@ -662,7 +662,7 @@ describe('EmailOutputRendererUsecase', () => {
 
       const renderCommand = {
         controlValues: {
-          subject: 'For Loop Test',
+          subject: 'Repeat Loop Test',
           body: JSON.stringify(mockTipTapNode),
         },
         fullPayloadForRender: {

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -160,7 +160,7 @@ export class EmailOutputRendererUsecase {
     node: MailyJSONContent
   ): node is MailyJSONContent & { attrs: { [MailyAttrsEnum.EACH_KEY]: string } } {
     return !!(
-      node.type === MailyContentTypeEnum.REPEAT &&
+      (node.type === MailyContentTypeEnum.REPEAT || node.type === MailyContentTypeEnum.FOR) &&
       node.attrs &&
       node.attrs[MailyAttrsEnum.EACH_KEY] !== undefined &&
       typeof node.attrs[MailyAttrsEnum.EACH_KEY] === 'string'

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -1,13 +1,14 @@
 /* eslint-disable no-param-reassign */
 import { render as mailyRender, JSONContent as MailyJSONContent } from '@maily-to/render';
 import { Injectable } from '@nestjs/common';
-import { Liquid } from 'liquidjs';
 import { EmailRenderOutput } from '@novu/shared';
 import { InstrumentUsecase } from '@novu/application-generic';
+
 import { FullPayloadForRender, RenderCommand } from './render-command';
 import { WrapMailyInLiquidUseCase } from './maily-to-liquid/wrap-maily-in-liquid.usecase';
-import { MAILY_ITERABLE_MARK, MailyAttrsEnum, MailyContentTypeEnum } from './maily-to-liquid/maily.types';
+import { MAILY_ITERABLE_MARK, MailyAttrsEnum } from './maily-to-liquid/maily.types';
 import { parseLiquid } from '../../../shared/helpers/liquid';
+import { hasShow, isRepeatNode, isVariableNode } from './maily-to-liquid/maily-utils';
 
 export class EmailOutputRendererCommand extends RenderCommand {}
 
@@ -88,15 +89,15 @@ export class EmailOutputRendererUsecase {
     while (queue.length > 0) {
       const current = queue.shift()!;
 
-      if (this.hasShow(current.node)) {
+      if (hasShow(current.node)) {
         await this.handleShowNode(current.node, variables, current.parent);
       }
 
-      if (this.isForNode(current.node)) {
+      if (isRepeatNode(current.node)) {
         await this.handleEachNode(current.node, variables, current.parent);
       }
 
-      if (this.isVariableNode(current.node)) {
+      if (isVariableNode(current.node)) {
         this.processVariableNodeTypes(current.node);
       }
 
@@ -156,23 +157,6 @@ export class EmailOutputRendererUsecase {
     node.text = node.attrs?.id || '';
   }
 
-  private isForNode(
-    node: MailyJSONContent
-  ): node is MailyJSONContent & { attrs: { [MailyAttrsEnum.EACH_KEY]: string } } {
-    return !!(
-      (node.type === MailyContentTypeEnum.REPEAT || node.type === MailyContentTypeEnum.FOR) &&
-      node.attrs &&
-      node.attrs[MailyAttrsEnum.EACH_KEY] !== undefined &&
-      typeof node.attrs[MailyAttrsEnum.EACH_KEY] === 'string'
-    );
-  }
-
-  private hasShow(
-    node: MailyJSONContent
-  ): node is MailyJSONContent & { attrs: { [MailyAttrsEnum.SHOW_IF_KEY]: string } } {
-    return node.attrs?.[MailyAttrsEnum.SHOW_IF_KEY] !== undefined && node.attrs?.[MailyAttrsEnum.SHOW_IF_KEY] !== null;
-  }
-
   /**
    * For 'each' node, multiply the content by the number of items in the iterable array
    * and add indexes to the placeholders.
@@ -229,7 +213,7 @@ export class EmailOutputRendererUsecase {
     return nodes.map((node) => {
       const processedNode = { ...node };
 
-      if (this.isVariableNode(processedNode)) {
+      if (isVariableNode(processedNode)) {
         this.processVariableNodeTypes(processedNode);
 
         if (processedNode.text) {
@@ -256,16 +240,5 @@ export class EmailOutputRendererUsecase {
     } catch {
       return Boolean(normalized);
     }
-  }
-
-  private isVariableNode(
-    node: MailyJSONContent
-  ): node is MailyJSONContent & { attrs: { [MailyAttrsEnum.ID]: string } } {
-    return !!(
-      node.type === MailyContentTypeEnum.VARIABLE &&
-      node.attrs &&
-      node.attrs[MailyAttrsEnum.ID] !== undefined &&
-      typeof node.attrs[MailyAttrsEnum.ID] === 'string'
-    );
   }
 }

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -160,7 +160,7 @@ export class EmailOutputRendererUsecase {
     node: MailyJSONContent
   ): node is MailyJSONContent & { attrs: { [MailyAttrsEnum.EACH_KEY]: string } } {
     return !!(
-      node.type === MailyContentTypeEnum.FOR &&
+      node.type === MailyContentTypeEnum.REPEAT &&
       node.attrs &&
       node.attrs[MailyAttrsEnum.EACH_KEY] !== undefined &&
       typeof node.attrs[MailyAttrsEnum.EACH_KEY] === 'string'

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/maily-utils.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/maily-utils.ts
@@ -1,0 +1,39 @@
+import { JSONContent as MailyJSONContent } from '@maily-to/render';
+
+import { MailyAttrsEnum, MailyContentTypeEnum } from './maily.types';
+
+export const isRepeatNode = (
+  node: MailyJSONContent
+): node is MailyJSONContent & { attrs: { [MailyAttrsEnum.EACH_KEY]: string } } => {
+  return !!(
+    (node.type === MailyContentTypeEnum.REPEAT || node.type === MailyContentTypeEnum.FOR) &&
+    node.attrs &&
+    node.attrs[MailyAttrsEnum.EACH_KEY] !== undefined &&
+    typeof node.attrs[MailyAttrsEnum.EACH_KEY] === 'string'
+  );
+};
+
+export const isVariableNode = (
+  node: MailyJSONContent
+): node is MailyJSONContent & { attrs: { [MailyAttrsEnum.ID]: string } } => {
+  return !!(
+    node.type === MailyContentTypeEnum.VARIABLE &&
+    node.attrs &&
+    node.attrs[MailyAttrsEnum.ID] !== undefined &&
+    typeof node.attrs[MailyAttrsEnum.ID] === 'string'
+  );
+};
+
+export const hasShow = (
+  node: MailyJSONContent
+): node is MailyJSONContent & { attrs: { [MailyAttrsEnum.SHOW_IF_KEY]: string } } => {
+  return node.attrs?.[MailyAttrsEnum.SHOW_IF_KEY] !== undefined && node.attrs?.[MailyAttrsEnum.SHOW_IF_KEY] !== null;
+};
+
+export const hasAttrs = (node: MailyJSONContent): node is MailyJSONContent & { attrs: Record<string, any> } => {
+  return !!node.attrs;
+};
+
+export const hasMarks = (node: MailyJSONContent): node is MailyJSONContent & { marks: Record<string, any>[] } => {
+  return !!node.marks;
+};

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/maily.types.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/maily.types.ts
@@ -1,6 +1,6 @@
 export enum MailyContentTypeEnum {
   VARIABLE = 'variable',
-  FOR = 'for',
+  REPEAT = 'repeat',
   BUTTON = 'button',
   IMAGE = 'image',
   LINK = 'link',

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/maily.types.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/maily.types.ts
@@ -1,6 +1,8 @@
 export enum MailyContentTypeEnum {
   VARIABLE = 'variable',
   REPEAT = 'repeat',
+  // IS DEPRECATED, but kept for backwards compatibility
+  FOR = 'for',
   BUTTON = 'button',
   IMAGE = 'image',
   LINK = 'link',

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/maily.types.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/maily.types.ts
@@ -1,7 +1,10 @@
 export enum MailyContentTypeEnum {
   VARIABLE = 'variable',
   REPEAT = 'repeat',
-  // IS DEPRECATED, but kept for backwards compatibility
+  /**
+   * Legacy enum value maintained for backwards compatibility
+   * @deprecated
+   */
   FOR = 'for',
   BUTTON = 'button',
   IMAGE = 'image',

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/wrap-maily-in-liquid.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/wrap-maily-in-liquid.usecase.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { Injectable } from '@nestjs/common';
 import { JSONContent as MailyJSONContent } from '@maily-to/render';
+
 import { WrapMailyInLiquidCommand } from './wrap-maily-in-liquid.command';
 import {
   MailyContentTypeEnum,
@@ -8,6 +9,7 @@ import {
   MAILY_ITERABLE_MARK,
   MAILY_FIRST_CITIZEN_VARIABLE_KEY,
 } from './maily.types';
+import { hasAttrs, hasMarks, isRepeatNode } from './maily-utils';
 
 /**
  * Enriches Maily JSON content with Liquid syntax repeat variables.
@@ -53,7 +55,7 @@ export class WrapMailyInLiquidUseCase {
     const newNode = { ...node } as MailyJSONContent & { attrs: Record<string, any> };
 
     // if this is a for loop node, track its variable
-    if (this.isForNode(node)) {
+    if (isRepeatNode(node)) {
       parentForLoopKey = node.attrs[MailyAttrsEnum.EACH_KEY];
     }
 
@@ -61,11 +63,11 @@ export class WrapMailyInLiquidUseCase {
       newNode.content = node.content.map((child) => this.wrapVariablesInLiquid(child, parentForLoopKey));
     }
 
-    if (this.hasAttrs(node)) {
+    if (hasAttrs(node)) {
       newNode.attrs = this.processVariableNodeAttributes(node, parentForLoopKey);
     }
 
-    if (this.hasMarks(node)) {
+    if (hasMarks(node)) {
       newNode.marks = this.processNodeMarks(node);
     }
 
@@ -143,25 +145,6 @@ export class WrapMailyInLiquidUseCase {
     const fallbackSuffix = fallback ? ` | default: '${fallback}'` : '';
 
     return `{{ ${variableName}${fallbackSuffix} }}`;
-  }
-
-  private hasAttrs(node: MailyJSONContent): node is MailyJSONContent & { attrs: Record<string, any> } {
-    return !!node.attrs;
-  }
-
-  private hasMarks(node: MailyJSONContent): node is MailyJSONContent & { marks: Record<string, any>[] } {
-    return !!node.marks;
-  }
-
-  private isForNode(
-    node: MailyJSONContent
-  ): node is MailyJSONContent & { attrs: { [MailyAttrsEnum.EACH_KEY]: string } } {
-    return !!(
-      (node.type === MailyContentTypeEnum.REPEAT || node.type === MailyContentTypeEnum.FOR) &&
-      node.attrs &&
-      node.attrs[MailyAttrsEnum.EACH_KEY] !== undefined &&
-      typeof node.attrs[MailyAttrsEnum.EACH_KEY] === 'string'
-    );
   }
 }
 

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/wrap-maily-in-liquid.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/wrap-maily-in-liquid.usecase.ts
@@ -10,12 +10,12 @@ import {
 } from './maily.types';
 
 /**
- * Enriches Maily JSON content with Liquid syntax for variables.
+ * Enriches Maily JSON content with Liquid syntax repeat variables.
  *
  * @example
  * Input:
  * {
- *   type: "for",
+ *   type: "repeat",
  *   attrs: { each: "payload.comments" },
  *   content: [{
  *     type: "variable",
@@ -157,7 +157,7 @@ export class WrapMailyInLiquidUseCase {
     node: MailyJSONContent
   ): node is MailyJSONContent & { attrs: { [MailyAttrsEnum.EACH_KEY]: string } } {
     return !!(
-      node.type === MailyContentTypeEnum.FOR &&
+      node.type === MailyContentTypeEnum.REPEAT &&
       node.attrs &&
       node.attrs[MailyAttrsEnum.EACH_KEY] !== undefined &&
       typeof node.attrs[MailyAttrsEnum.EACH_KEY] === 'string'

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/wrap-maily-in-liquid.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/maily-to-liquid/wrap-maily-in-liquid.usecase.ts
@@ -157,7 +157,7 @@ export class WrapMailyInLiquidUseCase {
     node: MailyJSONContent
   ): node is MailyJSONContent & { attrs: { [MailyAttrsEnum.EACH_KEY]: string } } {
     return !!(
-      node.type === MailyContentTypeEnum.REPEAT &&
+      (node.type === MailyContentTypeEnum.REPEAT || node.type === MailyContentTypeEnum.FOR) &&
       node.attrs &&
       node.attrs[MailyAttrsEnum.EACH_KEY] !== undefined &&
       typeof node.attrs[MailyAttrsEnum.EACH_KEY] === 'string'

--- a/apps/api/src/app/workflows-v2/maily-test-data.ts
+++ b/apps/api/src/app/workflows-v2/maily-test-data.ts
@@ -227,7 +227,7 @@ export function fullCodeSnippet() {
             },
             content: [
               {
-                type: 'for',
+                type: 'repeat',
                 attrs: {
                   each: 'payload.origins',
                   isUpdatingKey: false,
@@ -307,7 +307,7 @@ export function fullCodeSnippet() {
             },
             content: [
               {
-                type: 'for',
+                type: 'repeat',
                 attrs: {
                   each: 'payload.students',
                   isUpdatingKey: false,
@@ -400,12 +400,12 @@ export function fullCodeSnippet() {
         content: [
           {
             type: 'text',
-            text: 'This will be a nested for block',
+            text: 'This will be a nested repeat block',
           },
         ],
       },
       {
-        type: 'for',
+        type: 'repeat',
         attrs: {
           each: 'payload.food.items',
           isUpdatingKey: false,

--- a/apps/dashboard/src/components/workflow-editor/steps/email/extensions/for-view.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/extensions/for-view.tsx
@@ -7,7 +7,7 @@ function TooltipContent({ forNodeEachKey, currentProperty }: { forNodeEachKey: s
   return (
     <p className="mly-top-1/2 mly-left-1/2 -mly-translate-x-1/2 -mly-translate-y-1/2 mly-text-gray-400 mly-shadow-sm absolute z-[1] flex items-center gap-2 rounded-md bg-white px-3 py-1.5">
       <Lightbulb className="size-3.5 stroke-[2] text-gray-400" />
-      Access 'for' loop items using{' '}
+      Access 'repeat' loop items using{' '}
       <code className="mly-px-1 mly-py-0.5 mly-bg-gray-50 mly-rounded mly-font-mono mly-text-gray-400">
         {`{{ ${forNodeEachKey}`}
         <span className="inline-block pr-1">
@@ -71,7 +71,7 @@ export function ForView(props: NodeViewProps) {
   }, []);
 
   return (
-    <NodeViewWrapper draggable="true" data-drag-handle="" data-type="for" className="mly-relative">
+    <NodeViewWrapper draggable="true" data-drag-handle="" data-type="repeat" className="mly-relative">
       <NodeViewContent className="is-editable" />
       {isOnEmptyForNodeLine && forNodeEachKey && (
         <TooltipContent forNodeEachKey={forNodeEachKey} currentProperty={currentProperty} />

--- a/apps/dashboard/src/components/workflow-editor/steps/email/extensions/for.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/extensions/for.tsx
@@ -24,7 +24,7 @@ declare module '@tiptap/core' {
  * @see https://github.com/arikchakma/maily.to/blob/d7ea26e6b28201fc66c241200adaebc689018b03/packages/core/src/editor/nodes/for/for.ts
  */
 export const ForExtension = Node.create({
-  name: 'for',
+  name: 'repeat',
   group: 'block',
   content: '(block|columns)+',
   draggable: true,

--- a/apps/dashboard/src/components/workflow-editor/steps/email/maily.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/maily.tsx
@@ -86,7 +86,7 @@ export const Maily = ({ value, onChange, className, ...rest }: MailyProps) => {
         return dedupAndSortVariables(filteredVariables, queryWithoutSuffix);
       }
 
-      const iterableName = editor?.getAttributes('for')?.each;
+      const iterableName = editor?.getAttributes('repeat')?.each;
 
       const newNamespaces = [...namespaces, ...(iterableName ? [{ name: iterableName, required: false }] : [])];
 
@@ -123,7 +123,7 @@ export const Maily = ({ value, onChange, className, ...rest }: MailyProps) => {
     <>
       <div className={cn('mx-auto flex h-full flex-col items-start', className)} {...rest}>
         <Editor
-          key="for-block-enabled"
+          key="repeat-block-enabled"
           config={DEFAULT_EDITOR_CONFIG}
           blocks={DEFAULT_EDITOR_BLOCKS}
           extensions={extensions}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,8 +373,8 @@ importers:
         specifier: ^6.2.3
         version: 6.9.5(encoding@0.1.13)
       '@maily-to/render':
-        specifier: ^0.0.17
-        version: 0.0.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.0.19
+        version: 0.0.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@nestjs/axios':
         specifier: 3.0.3
         version: 3.0.3(@nestjs/common@10.4.1(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(axios@1.6.8)(rxjs@7.8.1)
@@ -10130,6 +10130,12 @@ packages:
 
   '@maily-to/render@0.0.17':
     resolution: {integrity: sha512-vFDlY9U9XtyDRzeVGVON9tgbzBRrq5wBOMG1aFGc/30soaamK7oYxRqSUbwNmrfT2ScBgL7YFtDLoeRZbpdmeA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.3.1
+
+  '@maily-to/render@0.0.19':
+    resolution: {integrity: sha512-cyR/cRmUj+zcZOKc2yZlBTGFUAJazjoc3YFkBOnx8eMq3N4bHAxC+zT1MsfEqXXiHcw2uW289xxEVkrjKC0xJw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^18.3.1
@@ -47470,6 +47476,14 @@ snapshots:
       - yjs
 
   '@maily-to/render@0.0.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@react-email/components': 0.0.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-email/render': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - react-dom
+
+  '@maily-to/render@0.0.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-email/components': 0.0.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-email/render': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
### What changed? Why was the change needed?

Fix: after updating to the latest Maily we missed renaming the `for` loop to `repeat.` 

### Screenshots

https://github.com/user-attachments/assets/ac6304fe-e4f3-4d29-adf9-9c88321cc9cb

