### PR TITLE
fix(api) avoid using redis lock if subscriber exist

### DIFF
--- a/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.usecase.ts
+++ b/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.usecase.ts
@@ -36,6 +36,12 @@ export class CreateOrUpdateSubscriberUseCase {
   ) {}
 
   async execute(command: CreateOrUpdateSubscriberCommand) {
+    const existingSubscriber = await this.getExistingSubscriber(command);
+
+    if (existingSubscriber) {
+      return await this.updateSubscriber(command, existingSubscriber);
+    }
+
     return await this.eventsDistributedLockService.applyLock<SubscriberEntity>(
       {
         resource: buildDedupSubscriberKey({


### PR DESCRIPTION
### What changed? Why was the change needed?
accesing redis on evey subscriber interaction is causing performance issues, the change is trying to limit the lock interactions 
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
