### PR TITLE
fix(dashboard,js): Fix line breaks being ignored

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/in-app-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/in-app-preview.tsx
@@ -115,7 +115,9 @@ export const InAppPreviewBody = (props: InAppPreviewBodyProps) => {
     );
   }
 
-  return <Markdown className={cn('text-foreground-400 text-xs font-normal', className)} {...rest} />;
+  return (
+    <Markdown className={cn('text-foreground-400 whitespace-pre-wrap text-xs font-normal', className)} {...rest} />
+  );
 };
 
 type InAppPreviewActionsProps = HTMLAttributes<HTMLDivElement>;

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview.tsx
@@ -1,5 +1,5 @@
-import { RiSendPlane2Fill } from 'react-icons/ri';
 import { ChannelTypeEnum, ChatRenderOutput, GeneratePreviewResponseDto } from '@novu/shared';
+import { RiSendPlane2Fill } from 'react-icons/ri';
 
 import { LogoCircle } from '@/components/icons';
 import { Skeleton } from '@/components/primitives/skeleton';
@@ -37,7 +37,7 @@ export const ChatPreview = ({
               <Skeleton className="h-4 w-1/2" />
             ) : (
               <span
-                className={cn('text-foreground-950 min-h-4 text-xs font-normal', {
+                className={cn('text-foreground-950 min-h-4 whitespace-pre-wrap text-xs font-normal', {
                   'line-clamp-3': variant === 'mini',
                 })}
                 title={variant === 'mini' ? body : undefined}

--- a/apps/dashboard/src/components/workflow-editor/steps/push/push-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/push/push-preview.tsx
@@ -1,8 +1,8 @@
-import { HTMLAttributes } from 'react';
-import { HTMLMotionProps, motion } from 'motion/react';
-import { ChannelTypeEnum, GeneratePreviewResponseDto, PushRenderOutput } from '@novu/shared';
 import { Skeleton } from '@/components/primitives/skeleton';
 import { cn } from '@/utils/ui';
+import { ChannelTypeEnum, GeneratePreviewResponseDto, PushRenderOutput } from '@novu/shared';
+import { HTMLMotionProps, motion } from 'motion/react';
+import { HTMLAttributes } from 'react';
 
 export function PushPreview({
   isPreviewPending,
@@ -52,7 +52,7 @@ export const PushSubjectPreview = ({ subject, isPending, className, ...rest }: P
   }
 
   return (
-    <div className={cn('flex items-center gap-1.5', className)} {...rest}>
+    <div className={cn('flex items-center gap-1.5 whitespace-pre-wrap', className)} {...rest}>
       <div className="flex-1">
         <span className="line-clamp-1 min-h-4 text-xs font-medium">{subject}</span>
       </div>
@@ -68,7 +68,7 @@ type PushBodyPreviewProps = HTMLAttributes<HTMLDivElement> & {
 export const PushBodyPreview = ({ body, isPending, className, ...rest }: PushBodyPreviewProps) => {
   if (isPending) {
     return (
-      <div className="flex flex-col gap-1" {...rest}>
+      <div className="flex flex-col gap-1 whitespace-pre-wrap" {...rest}>
         <Skeleton className="h-3 w-full" />
         <Skeleton className="h-3 w-2/3" />
       </div>

--- a/apps/dashboard/src/components/workflow-editor/steps/sms/sms-phone.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/sms/sms-phone.tsx
@@ -7,7 +7,7 @@ const SmsChatBubble = ({ children }: { children: React.ReactNode }) => (
     transition={{ duration: 0.3, ease: 'easeOut' }}
     className="relative my-1 inline-block max-w-[90%] rounded-2xl bg-[#e9ecef] px-4 py-2 text-sm text-[#2b2b33] before:absolute before:bottom-0 before:left-[-7px] before:h-5 before:w-5 before:rounded-br-[15px] before:bg-[#e9ecef] before:content-[''] after:absolute after:bottom-0 after:left-[-10px] after:h-5 after:w-[10px] after:rounded-br-[10px] after:bg-white after:content-['']"
   >
-    <div className="line-clamp-4 min-h-4 overflow-hidden break-words text-xs">{children}</div>
+    <div className="line-clamp-4 min-h-4 overflow-hidden whitespace-pre-wrap break-words text-xs">{children}</div>
   </motion.div>
 );
 
@@ -18,7 +18,7 @@ const ErrorChatBubble = ({ children }: { children: React.ReactNode }) => (
     transition={{ duration: 0.3, ease: 'easeOut' }}
     className="relative my-1 inline-block max-w-[90%] rounded-2xl bg-[#FEE4E2] px-4 py-2 text-sm text-[#D92D20] before:absolute before:bottom-0 before:left-[-7px] before:h-5 before:w-5 before:rounded-br-[15px] before:bg-[#FEE4E2] before:content-[''] after:absolute after:bottom-0 after:left-[-10px] after:h-5 after:w-[10px] after:rounded-br-[10px] after:bg-white after:content-['']"
   >
-    <div className="line-clamp-4 overflow-hidden break-words text-xs">{children}</div>
+    <div className="line-clamp-4 overflow-hidden whitespace-pre-wrap break-words text-xs">{children}</div>
   </motion.div>
 );
 

--- a/packages/js/src/ui/components/Notification/DefaultNotification.tsx
+++ b/packages/js/src/ui/components/Notification/DefaultNotification.tsx
@@ -211,14 +211,19 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
         <Show when={props.notification.subject}>
           {(subject) => (
             <Markdown
-              class={style('notificationSubject', 'nt-text-start')}
+              appearanceKey="notificationSubject__strong"
+              class="nt-text-start"
               strongAppearanceKey="notificationSubject__strong"
             >
               {subject()}
             </Markdown>
           )}
         </Show>
-        <Markdown class={style('notificationBody', 'nt-text-start')} strongAppearanceKey="notificationBody__strong">
+        <Markdown
+          appearanceKey="notificationBody__strong"
+          strongAppearanceKey="notificationBody__strong"
+          class="nt-text-start nt-whitespace-pre-wrap"
+        >
           {props.notification.body}
         </Markdown>
         <div class={style('notificationCustomActions', 'nt-flex nt-flex-wrap nt-gap-4 nt-mt-4')}>

--- a/packages/js/src/ui/components/elements/Markdown.tsx
+++ b/packages/js/src/ui/components/elements/Markdown.tsx
@@ -1,5 +1,5 @@
-import { createMemo, For, JSX } from 'solid-js';
-import { useStyle } from '../../helpers';
+import { createMemo, For, JSX, splitProps } from 'solid-js';
+import { cn, useStyle } from '../../helpers';
 import { parseMarkdownIntoTokens } from '../../internal';
 import { AppearanceKey } from '../../types';
 
@@ -11,20 +11,22 @@ const Bold = (props: { children?: JSX.Element; appearanceKey?: AppearanceKey }) 
 const Text = (props: { children?: JSX.Element }) => props.children;
 
 type MarkdownProps = JSX.HTMLAttributes<HTMLParagraphElement> & {
+  appearanceKey: AppearanceKey;
   strongAppearanceKey: AppearanceKey;
   children: string;
 };
 const Markdown = (props: MarkdownProps) => {
-  const { children, strongAppearanceKey, ...rest } = props;
+  const [local, rest] = splitProps(props, ['class', 'children', 'appearanceKey', 'strongAppearanceKey']);
+  const style = useStyle();
 
-  const tokens = createMemo(() => parseMarkdownIntoTokens(children));
+  const tokens = createMemo(() => parseMarkdownIntoTokens(local.children));
 
   return (
-    <p {...rest}>
+    <p class={style(local.appearanceKey, cn(local.class))} {...rest}>
       <For each={tokens()}>
         {(token) => {
           if (token.type === 'bold') {
-            return <Bold appearanceKey={strongAppearanceKey}>{token.content}</Bold>;
+            return <Bold appearanceKey={local.strongAppearanceKey}>{token.content}</Bold>;
           } else {
             return <Text>{token.content}</Text>;
           }


### PR DESCRIPTION
### What changed? Why was the change needed?

Currently, all line breaks are ignored in all previews besides email, since we have not applied `white-space: pre-wrap`.

We also need to do this in the `js` package.

### Screenshots
AFTER:
<img width="390" alt="Screenshot 2025-02-06 at 1 36 27 PM" src="https://github.com/user-attachments/assets/bccd98aa-5b9b-4360-b317-c8b80cfa25f1" />
<img width="394" alt="Screenshot 2025-02-06 at 1 37 12 PM" src="https://github.com/user-attachments/assets/9685341f-9124-407a-a1f6-13565ceb4381" />
<img width="439" alt="Screenshot 2025-02-06 at 1 37 19 PM" src="https://github.com/user-attachments/assets/5d42af84-9598-42fc-867f-92ae2adcda71" />
<img width="388" alt="Screenshot 2025-02-06 at 1 37 26 PM" src="https://github.com/user-attachments/assets/88005149-53f9-4823-b78a-8e692079224a" />

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
