### PR TITLE
fix(dashboard): disable integration identifier in update mode and add copy button

### DIFF
--- a/apps/dashboard/src/components/integrations/components/integration-general-settings.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-general-settings.tsx
@@ -9,6 +9,7 @@ import { ApiServiceLevelEnum } from '@novu/shared';
 import { HoverCard, HoverCardPortal, HoverCardContent, HoverCardTrigger } from '@/components/primitives/hover-card';
 import { ROUTES } from '@/utils/routes';
 import { Link } from 'react-router-dom';
+import { CopyButton } from '@/components/primitives/copy-button';
 
 type IntegrationFormData = {
   name: string;
@@ -166,7 +167,13 @@ export function GeneralSettings({
               Identifier
             </FormLabel>
             <FormControl>
-              <Input id="identifier" {...field} readOnly={mode === 'update'} hasError={!!fieldState.error} />
+              <Input
+                id="identifier"
+                trailingNode={mode === 'update' ? <CopyButton valueToCopy={field.value} /> : undefined}
+                {...field}
+                disabled={mode === 'update'}
+                hasError={!!fieldState.error}
+              />
             </FormControl>
             <FormMessage />
           </FormItem>


### PR DESCRIPTION
### What changed? Why was the change needed?
- disable state for integration identifier in update mode
- add a copy button with integration identifier in update mode
- in creation mode, the integration identifier field can be customized without a copy button

https://github.com/user-attachments/assets/0e1ca8f1-7ca7-4d29-ab50-ffc341a41e39




ref:- [slack conversation
](https://novu.slack.com/archives/C06DDPTKNF9/p1738844747762299?thread_ts=1738570664.917229&cid=C06DDPTKNF9)
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
