### PR TITLE
fix(application-generic): Introduce API_INTERNAL_ORIGIN

### DIFF
--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
@@ -285,7 +285,7 @@ export class ExecuteBridgeRequest {
       return `http://localhost:${process.env.PORT}`;
     }
 
-    const apiUrl = process.env.API_ROOT_URL;
+    const apiUrl = process.env.API_INTERNAL_ORIGIN || process.env.API_ROOT_URL;
 
     if (!apiUrl) {
       throw new Error('API_ROOT_URL environment variable is not set');


### PR DESCRIPTION
### What changed? Why was the change needed?

This env variable is used to set the internal API origin so that the workers speaks to the shared bridge URL provided by the API via the internal VPC in Novu cloud.