### PR TITLE
fix(api): Remove workflow caching from Redis

### DIFF
--- a/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.usecase.ts
+++ b/apps/api/src/app/change/usecases/promote-notification-template-change/promote-notification-template-change.usecase.ts
@@ -18,8 +18,6 @@ import {
 } from '@novu/shared';
 import {
   buildGroupedBlueprintsKey,
-  buildNotificationTemplateIdentifierKey,
-  buildNotificationTemplateKey,
   DeletePreferencesCommand,
   DeletePreferencesUseCase,
   InvalidateCacheService,
@@ -234,9 +232,6 @@ export class PromoteNotificationTemplateChange {
     );
     await this.updateWorkflowPreferences(item._id, command, newItem.critical, newItem.preferenceSettings);
 
-    // Invalidate after mutations
-    await this.invalidateNotificationTemplate(item, command.organizationId);
-
     return updatedTemplate;
   }
 
@@ -314,27 +309,5 @@ export class PromoteNotificationTemplateChange {
         });
       }
     }
-  }
-
-  private async invalidateNotificationTemplate(item: NotificationTemplateEntity, organizationId: string) {
-    const productionEnvironmentId = await this.getProductionEnvironmentId(organizationId);
-
-    /**
-     * Only invalidate cache of Production environment cause the development environment cache invalidation is handled
-     * during the CRUD operations itself
-     */
-    await this.invalidateCache.invalidateByKey({
-      key: buildNotificationTemplateKey({
-        _id: item._id,
-        _environmentId: productionEnvironmentId,
-      }),
-    });
-
-    await this.invalidateCache.invalidateByKey({
-      key: buildNotificationTemplateIdentifierKey({
-        templateIdentifier: item.triggers[0].identifier,
-        _environmentId: productionEnvironmentId,
-      }),
-    });
   }
 }

--- a/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
+++ b/apps/api/src/app/events/e2e/process-subscriber.e2e.ts
@@ -9,13 +9,7 @@ import {
 } from '@novu/dal';
 import { UserSession, SubscribersService } from '@novu/testing';
 import { ChannelTypeEnum, ISubscribersDefine, IUpdateNotificationTemplateDto, StepTypeEnum } from '@novu/shared';
-import {
-  buildNotificationTemplateIdentifierKey,
-  buildNotificationTemplateKey,
-  CacheInMemoryProviderService,
-  CacheService,
-  InvalidateCacheService,
-} from '@novu/application-generic';
+import { CacheInMemoryProviderService, CacheService, InvalidateCacheService } from '@novu/application-generic';
 
 import { UpdateSubscriberPreferenceRequestDto } from '../../widgets/dtos/update-subscriber-preference-request.dto';
 
@@ -194,14 +188,6 @@ describe('Trigger event - process subscriber /v1/events/trigger (POST) #novu-v2'
     });
 
     expect(message.length).to.equal(2);
-
-    const notificationTemplateKey = buildNotificationTemplateKey({
-      _id: template._id,
-      _environmentId: session.environment._id,
-    });
-    await invalidateCache.invalidateByKey({
-      key: notificationTemplateKey,
-    });
 
     const updateData = {
       channel: {

--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
@@ -6,8 +6,6 @@ import { merge } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
-  buildNotificationTemplateIdentifierKey,
-  CachedEntity,
   ExecuteBridgeRequest,
   ExecuteBridgeRequestCommand,
   ExecuteBridgeRequestDto,
@@ -236,13 +234,6 @@ export class ParseEventRequest {
   }
 
   @Instrument()
-  @CachedEntity({
-    builder: (command: { triggerIdentifier: string; environmentId: string }) =>
-      buildNotificationTemplateIdentifierKey({
-        _environmentId: command.environmentId,
-        templateIdentifier: command.triggerIdentifier,
-      }),
-  })
   private async getNotificationTemplateByTriggerIdentifier(command: {
     triggerIdentifier: string;
     environmentId: string;

--- a/apps/api/src/app/workflows-v1/usecases/change-template-active-status/change-template-active-status.usecase.ts
+++ b/apps/api/src/app/workflows-v1/usecases/change-template-active-status/change-template-active-status.usecase.ts
@@ -1,13 +1,7 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { ChangeRepository, NotificationTemplateEntity, NotificationTemplateRepository } from '@novu/dal';
 import { ChangeEntityTypeEnum } from '@novu/shared';
-import {
-  buildNotificationTemplateIdentifierKey,
-  buildNotificationTemplateKey,
-  CreateChange,
-  CreateChangeCommand,
-  InvalidateCacheService,
-} from '@novu/application-generic';
+import { CreateChange, CreateChangeCommand, InvalidateCacheService } from '@novu/application-generic';
 
 import { ChangeTemplateActiveStatusCommand } from './change-template-active-status.command';
 
@@ -38,20 +32,6 @@ export class ChangeTemplateActiveStatus {
     if (foundTemplate.active === command.active) {
       throw new BadRequestException('You must provide a different status from the current status');
     }
-
-    await this.invalidateCache.invalidateByKey({
-      key: buildNotificationTemplateKey({
-        _id: command.templateId,
-        _environmentId: command.environmentId,
-      }),
-    });
-
-    await this.invalidateCache.invalidateByKey({
-      key: buildNotificationTemplateIdentifierKey({
-        templateIdentifier: foundTemplate.triggers[0].identifier,
-        _environmentId: command.environmentId,
-      }),
-    });
 
     await this.notificationTemplateRepository.update(
       {

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -12,7 +12,6 @@ import {
 } from '@novu/shared';
 import {
   AnalyticsService,
-  buildNotificationTemplateKey,
   buildSubscriberKey,
   CachedEntity,
   ConditionsFilter,
@@ -400,13 +399,6 @@ export class SendMessage {
     };
   }
 
-  @CachedEntity({
-    builder: (command: { _id: string; environmentId: string }) =>
-      buildNotificationTemplateKey({
-        _environmentId: command.environmentId,
-        _id: command._id,
-      }),
-  })
   private async getWorkflow({ _id, environmentId }: { _id: string; environmentId: string }) {
     return await this.notificationTemplateRepository.findById(_id, environmentId);
   }

--- a/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
@@ -3,7 +3,6 @@ import { Injectable, Logger } from '@nestjs/common';
 import {
   AnalyticsService,
   ApiException,
-  buildNotificationTemplateKey,
   CachedEntity,
   CreateNotificationJobs,
   CreateNotificationJobsCommand,
@@ -228,13 +227,6 @@ export class SubscriberJobBound {
     return true;
   }
 
-  @CachedEntity({
-    builder: (command: { _id: string; environmentId: string }) =>
-      buildNotificationTemplateKey({
-        _environmentId: command.environmentId,
-        _id: command._id,
-      }),
-  })
   private async getNotificationTemplate({ _id, environmentId }: { _id: string; environmentId: string }) {
     return await this.notificationTemplateRepository.findById(_id, environmentId);
   }

--- a/libs/application-generic/src/services/cache/key-builders/entities.spec.ts
+++ b/libs/application-generic/src/services/cache/key-builders/entities.spec.ts
@@ -1,16 +1,5 @@
-import {
-  buildEnvironmentByApiKey,
-  buildNotificationTemplateIdentifierKey,
-  buildNotificationTemplateKey,
-  buildSubscriberKey,
-  buildUserKey,
-} from './entities';
-import {
-  CacheKeyTypeEnum,
-  CacheKeyPrefixEnum,
-  IdentifierPrefixEnum,
-  OrgScopePrefixEnum,
-} from './identifiers';
+import { buildEnvironmentByApiKey, buildSubscriberKey, buildUserKey } from './entities';
+import { CacheKeyTypeEnum, CacheKeyPrefixEnum, IdentifierPrefixEnum, OrgScopePrefixEnum } from './identifiers';
 import { buildUnscopedKey } from './builder.base';
 
 describe('Key builder for entities', () => {
@@ -60,38 +49,6 @@ describe('Key builder for entities', () => {
         identifier,
       });
       expect(actualKey).toEqual(expectedKey);
-    });
-  });
-
-  describe('buildNotificationTemplateKey', () => {
-    it('should build the correct key with ID', () => {
-      const type = CacheKeyTypeEnum.ENTITY;
-      const keyEntity = CacheKeyPrefixEnum.NOTIFICATION_TEMPLATE;
-      const identifierPrefix = IdentifierPrefixEnum.ID;
-      const identifier = '123';
-      const environmentId = '456';
-      const expectedKey = `{${type}:${keyEntity}:${OrgScopePrefixEnum.ENVIRONMENT_ID}=${environmentId}:${identifierPrefix}=${identifier}}`;
-      const result = buildNotificationTemplateKey({
-        _id: identifier,
-        _environmentId: environmentId,
-      });
-      expect(result).toEqual(expectedKey);
-    });
-  });
-
-  describe('buildNotificationTemplateIdentifierKey', () => {
-    it('should build the correct key with ID', () => {
-      const type = CacheKeyTypeEnum.ENTITY;
-      const keyEntity = CacheKeyPrefixEnum.NOTIFICATION_TEMPLATE;
-      const identifierPrefix = IdentifierPrefixEnum.TEMPLATE_IDENTIFIER;
-      const identifier = '123';
-      const environmentId = '456';
-      const expectedKey = `{${type}:${keyEntity}:${OrgScopePrefixEnum.ENVIRONMENT_ID}=${environmentId}:${identifierPrefix}=${identifier}}`;
-      const result = buildNotificationTemplateIdentifierKey({
-        templateIdentifier: identifier,
-        _environmentId: environmentId,
-      });
-      expect(result).toEqual(expectedKey);
     });
   });
 });

--- a/libs/application-generic/src/services/cache/key-builders/entities.ts
+++ b/libs/application-generic/src/services/cache/key-builders/entities.ts
@@ -65,36 +65,6 @@ export const buildUserKey = ({ _id }: { _id: string }): string =>
     identifierPrefix: IdentifierPrefixEnum.ID,
   });
 
-export const buildNotificationTemplateKey = ({
-  _id,
-  _environmentId,
-}: {
-  _id: string;
-  _environmentId: string;
-}): string =>
-  buildEnvironmentScopedKeyById({
-    type: CacheKeyTypeEnum.ENTITY,
-    keyEntity: CacheKeyPrefixEnum.NOTIFICATION_TEMPLATE,
-    environmentId: _environmentId,
-    identifierPrefix: IdentifierPrefixEnum.ID,
-    identifier: _id,
-  });
-
-export const buildNotificationTemplateIdentifierKey = ({
-  templateIdentifier,
-  _environmentId,
-}: {
-  templateIdentifier: string;
-  _environmentId: string;
-}): string =>
-  buildEnvironmentScopedKeyById({
-    type: CacheKeyTypeEnum.ENTITY,
-    keyEntity: CacheKeyPrefixEnum.NOTIFICATION_TEMPLATE,
-    environmentId: _environmentId,
-    identifierPrefix: IdentifierPrefixEnum.TEMPLATE_IDENTIFIER,
-    identifier: templateIdentifier,
-  });
-
 export const buildEnvironmentByApiKey = ({ apiKey }: { apiKey: string }): string =>
   buildUnscopedKey({
     type: CacheKeyTypeEnum.ENTITY,

--- a/libs/application-generic/src/usecases/create-workflow/create-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/create-workflow/create-workflow.usecase.ts
@@ -19,12 +19,7 @@ import {
 import { PinoLogger } from 'nestjs-pino';
 import { CreateWorkflowCommand, NotificationStep, NotificationStepVariantCommand } from './create-workflow.command';
 import { CreateChange, CreateChangeCommand } from '../create-change';
-import {
-  AnalyticsService,
-  buildNotificationTemplateIdentifierKey,
-  buildNotificationTemplateKey,
-  InvalidateCacheService,
-} from '../../services';
+import { AnalyticsService, InvalidateCacheService } from '../../services';
 import { ContentService } from '../../services/content.service';
 import { isVariantEmpty } from '../../utils/variants';
 import { CreateMessageTemplate, CreateMessageTemplateCommand } from '../message-template';
@@ -307,19 +302,6 @@ export class CreateWorkflow {
         })
       );
     }
-
-    await this.invalidateCache.invalidateByKey({
-      key: buildNotificationTemplateIdentifierKey({
-        templateIdentifier: savedWorkflow.triggers[0].identifier,
-        _environmentId: command.environmentId,
-      }),
-    });
-    await this.invalidateCache.invalidateByKey({
-      key: buildNotificationTemplateKey({
-        _id: savedWorkflow._id,
-        _environmentId: command.environmentId,
-      }),
-    });
 
     const item = await this.notificationTemplateRepository.findById(savedWorkflow._id, command.environmentId);
     if (!item) throw new NotFoundException(`Workflow ${savedWorkflow._id} is not found`);

--- a/libs/application-generic/src/usecases/workflow/update-workflow/update-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/workflow/update-workflow/update-workflow.usecase.ts
@@ -22,13 +22,7 @@ import {
   WorkflowOriginEnum,
 } from '@novu/shared';
 
-import {
-  AnalyticsService,
-  buildNotificationTemplateIdentifierKey,
-  buildNotificationTemplateKey,
-  ContentService,
-  InvalidateCacheService,
-} from '../../../services';
+import { AnalyticsService, ContentService, InvalidateCacheService } from '../../../services';
 import { UpdateWorkflowCommand } from './update-workflow.command';
 import { isVariantEmpty } from '../../../utils/variants';
 import { ApiException, PlatformException } from '../../../utils/exceptions';
@@ -279,21 +273,6 @@ export class UpdateWorkflow {
           $set: updatePayload,
         }
       );
-
-      // Invalidate cache after update
-      await this.invalidateCache.invalidateByKey({
-        key: buildNotificationTemplateKey({
-          _id: existingTemplate._id,
-          _environmentId: command.environmentId,
-        }),
-      });
-
-      await this.invalidateCache.invalidateByKey({
-        key: buildNotificationTemplateIdentifierKey({
-          templateIdentifier: existingTemplate.triggers[0].identifier,
-          _environmentId: command.environmentId,
-        }),
-      });
 
       notificationTemplateWithStepTemplate = await this.getWorkflowByIdsUseCase.execute(
         GetWorkflowByIdsCommand.create({

--- a/libs/dal/src/repositories/notification-template/notification-template.repository.ts
+++ b/libs/dal/src/repositories/notification-template/notification-template.repository.ts
@@ -10,11 +10,6 @@ import { NotificationTemplateDBModel, NotificationTemplateEntity } from './notif
 import { NotificationTemplate } from './notification-template.schema';
 
 type NotificationTemplateQuery = FilterQuery<NotificationTemplateDBModel> & EnforceEnvOrOrgIds;
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export interface FindByIdQuery {
-  id: string;
-  environmentId: string;
-}
 
 export class NotificationTemplateRepository extends BaseRepository<
   NotificationTemplateDBModel,
@@ -39,6 +34,7 @@ export class NotificationTemplateRepository extends BaseRepository<
 
     return this.mapEntity(item);
   }
+
   async findAllByTriggerIdentifier(environmentId: string, identifier: string): Promise<NotificationTemplateEntity[]> {
     const requestQuery: NotificationTemplateQuery = {
       _environmentId: environmentId,
@@ -51,7 +47,14 @@ export class NotificationTemplateRepository extends BaseRepository<
   }
 
   async findById(id: string, environmentId: string) {
-    return this.findByIdQuery({ id, environmentId });
+    const item = await this.MongooseModel.findOne({
+      _id: id,
+      _environmentId: environmentId,
+    })
+      .populate('steps.template')
+      .populate('steps.variants.template');
+
+    return this.mapEntity(item);
   }
 
   async findByTriggerIdentifierAndUpdate(environmentId: string, triggerIdentifier: string, lastTriggeredAt: Date) {
@@ -65,17 +68,6 @@ export class NotificationTemplateRepository extends BaseRepository<
         lastTriggeredAt,
       },
     }).populate('steps.template');
-
-    return this.mapEntity(item);
-  }
-
-  async findByIdQuery(query: FindByIdQuery) {
-    const item = await this.MongooseModel.findOne({
-      _id: query.id,
-      _environmentId: query.environmentId,
-    })
-      .populate('steps.template')
-      .populate('steps.variants.template');
 
     return this.mapEntity(item);
   }

--- a/libs/dal/src/repositories/notification-template/notification-template.schema.ts
+++ b/libs/dal/src/repositories/notification-template/notification-template.schema.ts
@@ -260,15 +260,28 @@ notificationTemplateSchema.virtual('notificationGroup', {
 });
 
 notificationTemplateSchema.index({
-  _organizationId: 1,
+  _environmentId: 1,
   'triggers.identifier': 1,
 });
 
 notificationTemplateSchema.index({
   _environmentId: 1,
+  _id: 1,
+});
+
+// TODO: Deprecate this index. Use the envId, triggerId instead
+notificationTemplateSchema.index({
+  _organizationId: 1,
+  'triggers.identifier': 1,
+});
+
+// TODO: Deprecate this index. Use the envId, triggerId instead
+notificationTemplateSchema.index({
+  _environmentId: 1,
   name: 1,
 });
 
+// TODO: Deprecate this index. Use the envId, triggerId instead
 notificationTemplateSchema.index({
   _environmentId: 1,
   'triggers.identifier': 1,


### PR DESCRIPTION
### What changed? Why was the change needed?

Use Mongo indexes instead and reduce the need to populate and invalidate the cache.