### PR TITLE
fix(api-service): add strict typing to feature flag service

### DIFF
--- a/libs/application-generic/src/services/feature-flags/types.ts
+++ b/libs/application-generic/src/services/feature-flags/types.ts
@@ -3,16 +3,21 @@ import { FeatureFlagsKeysEnum } from '@novu/shared';
 
 type PartialWithId<T> = Partial<T> & { _id: string };
 
-export type FeatureFlagContextBase = {
-  environment?: PartialWithId<EnvironmentEntity>;
-  organization?: PartialWithId<OrganizationEntity>;
-  user?: PartialWithId<UserEntity>;
-};
+type RequireAtLeastOne<T> = {
+  [K in keyof T]: { [P in K]: T[P] } & Partial<T>;
+}[keyof T];
+
+export type FeatureFlagContextBase = RequireAtLeastOne<{
+  environment: PartialWithId<EnvironmentEntity>;
+  organization: PartialWithId<OrganizationEntity>;
+  user: PartialWithId<UserEntity>;
+}>;
 
 export type FeatureFlagContext<T_Result> = FeatureFlagContextBase & {
   key: FeatureFlagsKeysEnum;
   defaultValue: T_Result;
 };
+
 export interface IFeatureFlagsService {
   isEnabled: boolean;
 


### PR DESCRIPTION
### What changed? Why was the change needed?

The feature flag service will fail at runtime and resolve to false if you don't provide one of the context variables (user, env, org).

Now it will fail statically and also on build time.

https://github.com/user-attachments/assets/8280a6e5-f748-46e5-a618-7b1610617cc7

