### PR TITLE
chore(root): Remove extra build step

### DIFF
--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -30,9 +30,6 @@ jobs:
         with:
           submodules: true
 
-      - name: build api
-        run: pnpm build:api --skip-nx-cache
-
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/prod-deploy-worker.yml
+++ b/.github/workflows/prod-deploy-worker.yml
@@ -30,9 +30,6 @@ jobs:
         with:
           submodules: true
 
-      - name: build worker
-        run: pnpm build:worker --skip-nx-cache
-
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/prod-deploy-ws.yml
+++ b/.github/workflows/prod-deploy-ws.yml
@@ -31,9 +31,6 @@ jobs:
         run: |
           echo "BULL_MQ_PRO_NPM_TOKEN=${{ secrets.BULL_MQ_PRO_NPM_TOKEN }}" >> $GITHUB_ENV
 
-      - name: build ws
-        run: pnpm build:ws
-
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
### What changed? Why was the change needed?

Remove extra build steps during production deployments. Building already happens inside docker.

This will save us 3 minutes for each prod deployment.