### PR TITLE
fix(api-service): Reverting create update inner change

### DIFF
--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -3566,8 +3566,6 @@ async function createSimpleWorkflow(session) {
 }
 
 function simpleTrigger(novuClient: Novu, template, subscriberID: string) {
-  console.log(`Triggering workflow${subscriberID}`);
-
   return novuClient.trigger({
     workflowId: template.triggers[0].identifier,
     to: [subscriberID],

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -65,7 +65,6 @@ export class Session {
         environmentId: environment._id,
         organizationId: environment._organizationId,
         subscriberId: command.subscriberId,
-        isUpsert: true,
       })
     );
 

--- a/apps/api/src/app/subscribers-v2/subscribers.module.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.module.ts
@@ -33,9 +33,17 @@ import { UpdateSubscriberPreferences } from './usecases/update-subscriber-prefer
 import { UpdatePreferences } from '../inbox/usecases/update-preferences/update-preferences.usecase';
 import { GetSubscriberGlobalPreference } from '../subscribers/usecases/get-subscriber-global-preference';
 import { GetSubscriberPreference } from '../subscribers/usecases/get-subscriber-preference';
+import { CreateSubscriber } from './usecases/create-subscriber/create-subscriber.usecase';
 
 const USE_CASES = [
   ListSubscribersUseCase,
+  CreateOrUpdateSubscriberUseCase,
+  UpdateSubscriber,
+  UpdateSubscriberChannel,
+  EventsDistributedLockService,
+  IntegrationRepository,
+  DistributedLockService,
+  CacheInMemoryProviderService,
   CreateOrUpdateSubscriberUseCase,
   UpdateSubscriber,
   UpdateSubscriberChannel,
@@ -54,6 +62,7 @@ const USE_CASES = [
   UpdatePreferences,
   GetSubscriberTemplatePreference,
   UpsertPreferences,
+  CreateSubscriber,
 ];
 
 const DAL_MODELS = [

--- a/apps/api/src/app/subscribers-v2/usecases/create-subscriber/create-subscriber.command.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/create-subscriber/create-subscriber.command.ts
@@ -1,0 +1,10 @@
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
+import { EnvironmentCommand } from '../../../shared/commands/project.command';
+import { CreateSubscriberRequestDto } from '../../dtos/create-subscriber.dto';
+
+export class CreateSubscriberCommand extends EnvironmentCommand {
+  @ValidateNested()
+  @Type(() => CreateSubscriberRequestDto)
+  createSubscriberRequestDto: CreateSubscriberRequestDto;
+}

--- a/apps/api/src/app/subscribers-v2/usecases/create-subscriber/create-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/create-subscriber/create-subscriber.usecase.ts
@@ -1,0 +1,31 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { SubscriberRepository } from '@novu/dal';
+import { CreateOrUpdateSubscriberUseCase } from '@novu/application-generic';
+import { SubscriberResponseDto } from '../../../subscribers/dtos';
+import { mapSubscriberEntityToDto } from '../list-subscribers/map-subscriber-entity-to.dto';
+import { CreateSubscriberCommand } from './create-subscriber.command';
+import { mapSubscriberRequestToCommand } from '../../utils/create-subscriber.mapper';
+
+@Injectable()
+export class CreateSubscriber {
+  constructor(
+    private subscriberRepository: SubscriberRepository,
+    private createOrUpdateSubscriberUsecase: CreateOrUpdateSubscriberUseCase
+  ) {}
+
+  async execute(command: CreateSubscriberCommand): Promise<SubscriberResponseDto> {
+    const { subscriberId } = command.createSubscriberRequestDto;
+    const existingSubscriber = await this.subscriberRepository.findOne({
+      subscriberId,
+      _environmentId: command.environmentId,
+      _organizationId: command.organizationId,
+    });
+
+    if (existingSubscriber) {
+      throw new ConflictException(`Subscriber: ${subscriberId} already exists`);
+    }
+    const subscriberEntity = await this.createOrUpdateSubscriberUsecase.execute(mapSubscriberRequestToCommand(command));
+
+    return mapSubscriberEntityToDto(subscriberEntity);
+  }
+}

--- a/apps/api/src/app/subscribers-v2/utils/create-subscriber.mapper.ts
+++ b/apps/api/src/app/subscribers-v2/utils/create-subscriber.mapper.ts
@@ -4,14 +4,14 @@ import { IChannelCredentials, IChannelSettings, SubscriberEntity } from '@novu/d
 import { CreateSubscriberRequestDto } from '../dtos/create-subscriber.dto';
 import { ChannelSettingsDto, SubscriberResponseDto } from '../../subscribers/dtos';
 import { ChannelCredentials } from '../../shared/dtos/subscriber-channel';
+import { CreateSubscriberCommand } from '../usecases/create-subscriber/create-subscriber.command';
 
-export function mapSubscriberRequestToCommand(
-  dto: CreateSubscriberRequestDto,
-  user: UserSessionData
-): CreateOrUpdateSubscriberCommand {
+export function mapSubscriberRequestToCommand(command: CreateSubscriberCommand): CreateOrUpdateSubscriberCommand {
+  const dto = command.createSubscriberRequestDto;
+
   return {
-    organizationId: user.organizationId,
-    environmentId: user.environmentId,
+    organizationId: command.organizationId,
+    environmentId: command.environmentId,
     subscriberId: dto.subscriberId,
     email: dto.email ?? undefined,
     firstName: dto.firstName ?? undefined,
@@ -21,7 +21,6 @@ export function mapSubscriberRequestToCommand(
     locale: dto.locale ?? undefined,
     data: dto.data ? mapCustomData(dto.data) : undefined,
     timezone: dto.timezone,
-    isUpsert: false,
   };
 }
 

--- a/apps/api/src/app/subscribers/subscribersV1.controller.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.controller.ts
@@ -214,7 +214,6 @@ export class SubscribersV1Controller {
         locale: body.locale,
         data: body.data,
         channels: body.channels,
-        isUpsert: true,
       })
     );
   }

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
@@ -2,8 +2,8 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import axios from 'axios';
 
 import {
-  CreateOrUpdateSubscriberCommand,
   CreateOrUpdateSubscriberUseCase,
+  CreateOrUpdateSubscriberCommand,
   decryptCredentials,
   IChannelCredentialsCommand,
   OAuthHandlerEnum,
@@ -68,7 +68,6 @@ export class ChatOauthCallback {
         organizationId,
         environmentId: command.environmentId,
         subscriberId: command?.subscriberId,
-        isUpsert: true,
       })
     );
 

--- a/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
@@ -61,7 +61,6 @@ export class InitializeSession {
       lastName: command.lastName,
       email: command.email,
       phone: command.phone,
-      isUpsert: true,
     });
     const subscriber = await this.createOrUpdateSubscriberUsecase.execute(commandos);
 

--- a/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
@@ -115,7 +115,6 @@ export class SubscriberJobBound {
         data: subscriber?.data,
         channels: subscriber?.channels,
         activeWorkerName: process.env.ACTIVE_WORKER,
-        isUpsert: true,
       })
     );
 

--- a/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.command.ts
+++ b/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.command.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsEmail, IsLocale, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsEmail, IsLocale, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { SubscriberEntity } from '@novu/dal';
 import { ISubscriberChannel, SubscriberCustomData } from '@novu/shared';
@@ -6,8 +6,6 @@ import { ISubscriberChannel, SubscriberCustomData } from '@novu/shared';
 import { EnvironmentCommand } from '../../commands';
 
 export class CreateOrUpdateSubscriberCommand extends EnvironmentCommand {
-  @IsBoolean()
-  isUpsert?: boolean;
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => value?.toString().trim())

--- a/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.usecase.ts
+++ b/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.usecase.ts
@@ -1,4 +1,4 @@
-import { ConflictException, forwardRef, Inject, Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { SubscriberEntity, SubscriberRepository } from '@novu/dal';
 import { PinoLogger } from 'nestjs-pino';
 import {
@@ -9,10 +9,10 @@ import {
   EventsDistributedLockService,
   InvalidateCacheService,
 } from '../../services';
-import { OAuthHandlerEnum, UpdateSubscriberChannel, UpdateSubscriberChannelCommand } from '../subscribers';
 import { UpdateSubscriber, UpdateSubscriberCommand } from '../update-subscriber';
-import { CreateOrUpdateSubscriberCommand } from './create-or-update-subscriber.command';
+import { OAuthHandlerEnum, UpdateSubscriberChannel, UpdateSubscriberChannelCommand } from '../subscribers';
 import { RetryOnError } from '../../decorators/retry-on-error-decorator';
+import { CreateOrUpdateSubscriberCommand } from './create-or-update-subscriber.command';
 
 @Injectable()
 export class CreateOrUpdateSubscriberUseCase {
@@ -53,12 +53,10 @@ export class CreateOrUpdateSubscriberUseCase {
   }
 
   private async createOrUpdateSubscriber(command: CreateOrUpdateSubscriberCommand): Promise<SubscriberEntity> {
-    const existingSubscriber = await this.getExistingSubscriber(command);
-    if (existingSubscriber) {
-      if (!command.isUpsert) {
-        throw new ConflictException(`Subscriber: ${command.subscriberId} already exists`);
-      }
-      await this.updateSubscriber(command, existingSubscriber);
+    const persistedSubscriber = await this.getExistingSubscriber(command);
+
+    if (persistedSubscriber) {
+      await this.updateSubscriber(command, persistedSubscriber);
     } else {
       await this.createSubscriber(command);
     }

--- a/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
@@ -201,7 +201,6 @@ export class TriggerEvent {
       data: subscriberPayload?.data,
       channels: subscriberPayload?.channels,
       activeWorkerName: getActiveWorker(),
-      isUpsert: true,
     });
   }
   private async getAndUpdateWorkflowById(command: {


### PR DESCRIPTION
### What changed? Why was the change needed?
Wrong structural decision let us to decide to revert and not use upsert directly from the controller in order to keep the validations at place 

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
