### PR TITLE
feat(providers): Handle Mandrill email templates

### DIFF
--- a/packages/providers/src/lib/email/mandrill/mandril.interface.ts
+++ b/packages/providers/src/lib/email/mandrill/mandril.interface.ts
@@ -1,21 +1,33 @@
 export interface IMandrilInterface {
   messages: {
     send: (options: IMandrillSendOptions) => Promise<IMandrillSendResponse[]>;
+    sendTemplate: (options: IMandrillTemplateSendOptions) => Promise<IMandrillSendResponse[]>;
   };
   users: {
     ping: () => Promise<string>;
   };
 }
 
+interface IMandrillSendOptionsMessage {
+  from_email: string;
+  from_name: string;
+  subject: string;
+  html: string;
+  to: { email: string; type: 'to' | string }[];
+  attachments: IMandrillAttachment[];
+}
+interface IMandrillTemplateSendOptionsMessage extends IMandrillSendOptionsMessage {
+  global_merge_vars?: { name: string; content: string }[];
+}
+
 export interface IMandrillSendOptions {
-  message: {
-    from_email: string;
-    from_name: string;
-    subject: string;
-    html: string;
-    to: { email: string; type: 'to' | string }[];
-    attachments: IMandrillAttachment[];
-  };
+  message: IMandrillSendOptionsMessage;
+}
+
+export interface IMandrillTemplateSendOptions {
+  template_name: string;
+  template_content: { name: string; content: string }[];
+  message: IMandrillTemplateSendOptionsMessage;
 }
 
 export interface IMandrillAttachment {


### PR DESCRIPTION
### What changed? Why was the change needed?
Provided functionality to send Mandrill template emails
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

![image](https://github.com/user-attachments/assets/666f116b-6125-410a-911d-47f67c85b10d)

