### PR TITLE
fix(api-service): Redlock + logs + fetch cached entity removed from create update subsc…

### DIFF
--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -207,6 +207,11 @@ subscriberSchema.index({
   _id: 1,
 });
 
+subscriberSchema.index(
+  { _environmentId: 1, subscriberId: 1 },
+  { name: 'unique_subscriber_per_environment', unique: true, partialFilterExpression: { deleted: false } }
+);
+
 subscriberSchema.plugin(mongooseDelete, { deletedAt: true, deletedBy: true, overrideMethods: 'all' });
 
 export const Subscriber =


### PR DESCRIPTION

### What changed? Why was the change needed?


Removed locking mechanism from create-update subscribers after index has been applied on database along with debugging logging and caching on fetch



<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
