### PR TITLE
chore(js,react): make render props stricter

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -28,7 +28,7 @@
     "@novu/api": "workspace:*",
     "@novu/framework": "workspace:*",
     "@novu/js": "workspace:*",
-    "@novu/react": "https://pkg.pr.new/novuhq/novu/@novu/react@09f3aae",
+    "@novu/react": "https://pkg.pr.new/novuhq/novu/@novu/react@0bb2cd9",
     "@novu/react-v2": "npm:@novu/react@2.6.6",
     "@novu/shared": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.1",

--- a/packages/js/src/ui/components/Inbox.tsx
+++ b/packages/js/src/ui/components/Inbox.tsx
@@ -16,18 +16,33 @@ import { InboxTabs } from './InboxTabs';
 import { NotificationList } from './Notification';
 import { Button, Popover } from './primitives';
 
-export type InboxProps = {
-  open?: boolean;
-  renderNotification?: NotificationRenderer;
+export type NotificationRendererProps = {
+  renderNotification: NotificationRenderer;
+  renderSubject?: never;
+  renderBody?: never;
+};
+
+export type SubjectBodyRendererProps = {
+  renderNotification?: never;
   renderSubject?: SubjectRenderer;
   renderBody?: BodyRenderer;
+};
+
+export type NoRendererProps = {
+  renderNotification?: undefined;
+  renderSubject?: undefined;
+  renderBody?: undefined;
+};
+
+export type InboxProps = {
+  open?: boolean;
   renderBell?: BellRenderer;
   onNotificationClick?: NotificationClickHandler;
   onPrimaryActionClick?: NotificationActionClickHandler;
   onSecondaryActionClick?: NotificationActionClickHandler;
   placement?: Placement;
   placementOffset?: OffsetOptions;
-};
+} & (NotificationRendererProps | SubjectBodyRendererProps | NoRendererProps);
 
 export enum InboxPage {
   Notifications = 'notifications',
@@ -35,15 +50,12 @@ export enum InboxPage {
 }
 
 export type InboxContentProps = {
-  renderNotification?: NotificationRenderer;
-  renderSubject?: SubjectRenderer;
-  renderBody?: BodyRenderer;
   onNotificationClick?: NotificationClickHandler;
   onPrimaryActionClick?: NotificationActionClickHandler;
   onSecondaryActionClick?: NotificationActionClickHandler;
   initialPage?: InboxPage;
   hideNav?: boolean;
-};
+} & (NotificationRendererProps | SubjectBodyRendererProps | NoRendererProps);
 
 export const InboxContent = (props: InboxContentProps) => {
   const [currentPage, setCurrentPage] = createSignal<InboxPage>(props.initialPage || InboxPage.Notifications);
@@ -116,14 +128,25 @@ export const Inbox = (props: InboxProps) => {
         )}
       />
       <Popover.Content appearanceKey="inbox__popoverContent" portal>
-        <InboxContent
-          renderNotification={props.renderNotification}
-          renderSubject={props.renderSubject}
-          renderBody={props.renderBody}
-          onNotificationClick={props.onNotificationClick}
-          onPrimaryActionClick={props.onPrimaryActionClick}
-          onSecondaryActionClick={props.onSecondaryActionClick}
-        />
+        <Show
+          when={props.renderNotification}
+          fallback={
+            <InboxContent
+              renderSubject={props.renderSubject}
+              renderBody={props.renderBody}
+              onNotificationClick={props.onNotificationClick}
+              onPrimaryActionClick={props.onPrimaryActionClick}
+              onSecondaryActionClick={props.onSecondaryActionClick}
+            />
+          }
+        >
+          <InboxContent
+            renderNotification={props.renderNotification}
+            onNotificationClick={props.onNotificationClick}
+            onPrimaryActionClick={props.onPrimaryActionClick}
+            onSecondaryActionClick={props.onSecondaryActionClick}
+          />
+        </Show>
       </Popover.Content>
     </Popover.Root>
   );

--- a/packages/js/src/ui/components/Renderer.tsx
+++ b/packages/js/src/ui/components/Renderer.tsx
@@ -19,12 +19,28 @@ export const novuComponents = {
   Inbox,
   InboxContent,
   Bell,
-  Notifications: (props: Omit<InboxContentProps, 'hideNav' | 'initialPage'>) => (
-    <InboxContent {...props} hideNav={true} initialPage={InboxPage.Notifications} />
-  ),
-  Preferences: (props: Omit<InboxContentProps, 'hideNav' | 'initialPage'>) => (
-    <InboxContent {...props} hideNav={true} initialPage={InboxPage.Preferences} />
-  ),
+  Notifications: (props: Omit<InboxContentProps, 'hideNav' | 'initialPage'>) => {
+    if (props.renderNotification) {
+      const { renderBody, renderSubject, ...propsWithoutBodyAndSubject } = props;
+
+      return <InboxContent {...propsWithoutBodyAndSubject} hideNav={true} initialPage={InboxPage.Notifications} />;
+    }
+
+    const { renderNotification, ...propsWithoutRenderNotification } = props;
+
+    return <InboxContent {...propsWithoutRenderNotification} hideNav={true} initialPage={InboxPage.Notifications} />;
+  },
+  Preferences: (props: Omit<InboxContentProps, 'hideNav' | 'initialPage'>) => {
+    if (props.renderNotification) {
+      const { renderBody, renderSubject, ...propsWithoutBodyAndSubject } = props;
+
+      return <InboxContent {...propsWithoutBodyAndSubject} hideNav={true} initialPage={InboxPage.Preferences} />;
+    }
+
+    const { renderNotification, ...propsWithoutRenderNotification } = props;
+
+    return <InboxContent {...propsWithoutRenderNotification} hideNav={true} initialPage={InboxPage.Preferences} />;
+  },
 };
 
 export type NovuComponent = { name: NovuComponentName; props?: any };

--- a/packages/react/src/components/Inbox.tsx
+++ b/packages/react/src/components/Inbox.tsx
@@ -28,13 +28,29 @@ const _DefaultInbox = (props: DefaultInboxProps) => {
 
   const mount = React.useCallback(
     (element: HTMLElement) => {
+      if (renderNotification) {
+        return novuUI.mountComponent({
+          name: 'Inbox',
+          props: {
+            open,
+            renderNotification: renderNotification
+              ? (el, notification) => mountElement(el, renderNotification(notification))
+              : undefined,
+            renderBell: renderBell ? (el, unreadCount) => mountElement(el, renderBell(unreadCount)) : undefined,
+            onNotificationClick,
+            onPrimaryActionClick,
+            onSecondaryActionClick,
+            placementOffset,
+            placement,
+          },
+          element,
+        });
+      }
+
       return novuUI.mountComponent({
         name: 'Inbox',
         props: {
           open,
-          renderNotification: renderNotification
-            ? (el, notification) => mountElement(el, renderNotification(notification))
-            : undefined,
           renderSubject: renderSubject
             ? (el, notification) => mountElement(el, renderSubject(notification))
             : undefined,

--- a/packages/react/src/components/InboxContent.tsx
+++ b/packages/react/src/components/InboxContent.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
 import type { NotificationClickHandler, NotificationActionClickHandler, InboxPage } from '@novu/js/ui';
 import { Mounter } from './Mounter';
-import { NotificationsRenderer, SubjectRenderer, BodyRenderer } from '../utils/types';
+import { NoRendererProps, SubjectBodyRendererProps, NotificationRendererProps } from '../utils/types';
 import { useRenderer } from '../context/RendererContext';
 import { useNovuUI } from '../context/NovuUIContext';
 import { withRenderer } from './Renderer';
-import { useDataRef } from '../hooks/internal/useDataRef';
 
 export type InboxContentProps = {
-  renderNotification?: NotificationsRenderer;
-  renderSubject?: SubjectRenderer;
-  renderBody?: BodyRenderer;
   onNotificationClick?: NotificationClickHandler;
   onPrimaryActionClick?: NotificationActionClickHandler;
   onSecondaryActionClick?: NotificationActionClickHandler;
   initialPage?: InboxPage;
   hideNav?: boolean;
-};
+} & (NotificationRendererProps | SubjectBodyRendererProps | NoRendererProps);
 
 const _InboxContent = React.memo((props: InboxContentProps) => {
   const {
@@ -34,13 +30,27 @@ const _InboxContent = React.memo((props: InboxContentProps) => {
 
   const mount = React.useCallback(
     (element: HTMLElement) => {
+      if (renderNotification) {
+        return novuUI.mountComponent({
+          name: 'InboxContent',
+          element,
+          props: {
+            renderNotification: renderNotification
+              ? (el, notification) => mountElement(el, renderNotification(notification))
+              : undefined,
+            onNotificationClick,
+            onPrimaryActionClick,
+            onSecondaryActionClick,
+            initialPage,
+            hideNav,
+          },
+        });
+      }
+
       return novuUI.mountComponent({
         name: 'InboxContent',
         element,
         props: {
-          renderNotification: renderNotification
-            ? (el, notification) => mountElement(el, renderNotification(notification))
-            : undefined,
           renderSubject: renderSubject
             ? (el, notification) => mountElement(el, renderSubject(notification))
             : undefined,

--- a/packages/react/src/components/Notifications.tsx
+++ b/packages/react/src/components/Notifications.tsx
@@ -1,39 +1,61 @@
 import React from 'react';
 import type { NotificationClickHandler, NotificationActionClickHandler } from '@novu/js/ui';
 import { Mounter } from './Mounter';
-import { NotificationsRenderer } from '../utils/types';
+import { NoRendererProps, NotificationRendererProps, SubjectBodyRendererProps } from '../utils/types';
 import { useRenderer } from '../context/RendererContext';
 import { useNovuUI } from '../context/NovuUIContext';
 import { withRenderer } from './Renderer';
 
 export type NotificationProps = {
-  renderNotification?: NotificationsRenderer;
   onNotificationClick?: NotificationClickHandler;
   onPrimaryActionClick?: NotificationActionClickHandler;
   onSecondaryActionClick?: NotificationActionClickHandler;
-};
+} & (NotificationRendererProps | SubjectBodyRendererProps | NoRendererProps);
 
 const _Notifications = React.memo((props: NotificationProps) => {
-  const { onNotificationClick, onPrimaryActionClick, renderNotification, onSecondaryActionClick } = props;
+  const {
+    renderNotification,
+    renderSubject,
+    renderBody,
+    onNotificationClick,
+    onPrimaryActionClick,
+    onSecondaryActionClick,
+  } = props;
   const { novuUI } = useNovuUI();
   const { mountElement } = useRenderer();
 
   const mount = React.useCallback(
     (element: HTMLElement) => {
+      if (renderNotification) {
+        return novuUI.mountComponent({
+          name: 'Notifications',
+          element,
+          props: {
+            renderNotification: renderNotification
+              ? (el, notification) => mountElement(el, renderNotification(notification))
+              : undefined,
+            onNotificationClick,
+            onPrimaryActionClick,
+            onSecondaryActionClick,
+          },
+        });
+      }
+
       return novuUI.mountComponent({
         name: 'Notifications',
         element,
         props: {
-          renderNotification: renderNotification
-            ? (el, notification) => mountElement(el, renderNotification(notification))
+          renderSubject: renderSubject
+            ? (el, notification) => mountElement(el, renderSubject(notification))
             : undefined,
+          renderBody: renderBody ? (el, notification) => mountElement(el, renderBody(notification)) : undefined,
           onNotificationClick,
           onPrimaryActionClick,
           onSecondaryActionClick,
         },
       });
     },
-    [renderNotification, onNotificationClick, onPrimaryActionClick, onSecondaryActionClick]
+    [renderNotification, renderSubject, renderBody, onNotificationClick, onPrimaryActionClick, onSecondaryActionClick]
   );
 
   return <Mounter mount={mount} />;

--- a/packages/react/src/utils/types.ts
+++ b/packages/react/src/utils/types.ts
@@ -41,10 +41,28 @@ export type BaseProps = {
   routerPush?: RouterPush;
 };
 
+export type NotificationRendererProps = {
+  renderNotification: NotificationsRenderer;
+  renderSubject?: never;
+  renderBody?: never;
+};
+
+export type SubjectBodyRendererProps = {
+  renderNotification?: never;
+  renderSubject?: SubjectRenderer;
+  renderBody?: BodyRenderer;
+};
+
+export type NoRendererProps = {
+  renderNotification?: undefined;
+  renderSubject?: undefined;
+  renderBody?: undefined;
+};
+
 export type DefaultProps = BaseProps &
   DefaultInboxProps & {
     children?: never;
-  };
+  } & (NotificationRendererProps | SubjectBodyRendererProps | NoRendererProps);
 
 export type WithChildrenProps = BaseProps & {
   children: React.ReactNode;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -708,8 +708,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/js
       '@novu/react':
-        specifier: https://pkg.pr.new/novuhq/novu/@novu/react@09f3aae
-        version: https://pkg.pr.new/novuhq/novu/@novu/react@09f3aae(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: https://pkg.pr.new/novuhq/novu/@novu/react@0bb2cd9
+        version: https://pkg.pr.new/novuhq/novu/@novu/react@0bb2cd9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@novu/react-v2':
         specifier: npm:@novu/react@2.6.6
         version: '@novu/react@2.6.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
@@ -10624,8 +10624,8 @@ packages:
   '@novu/js@2.6.6':
     resolution: {integrity: sha512-kX6vSQvrQ1A6gHU5QvgrBMg/xnoCp3y61BjGO73f7hOWl3WD8kC0AkQ91kAA8L6BdpwJff6hTt1yS5sLBYE/mg==}
 
-  '@novu/js@https://pkg.pr.new/novuhq/novu/@novu/js@09f3aae7effbbdb9ca8e9a99f84a143ba7836426':
-    resolution: {tarball: https://pkg.pr.new/novuhq/novu/@novu/js@09f3aae7effbbdb9ca8e9a99f84a143ba7836426}
+  '@novu/js@https://pkg.pr.new/novuhq/novu/@novu/js@0bb2cd97942650c3bd96fa52c3e05c5e216f4aab':
+    resolution: {tarball: https://pkg.pr.new/novuhq/novu/@novu/js@0bb2cd97942650c3bd96fa52c3e05c5e216f4aab}
     version: 2.6.6
 
   '@novu/ntfr-client@0.0.4':
@@ -10641,8 +10641,8 @@ packages:
       react-dom:
         optional: true
 
-  '@novu/react@https://pkg.pr.new/novuhq/novu/@novu/react@09f3aae':
-    resolution: {tarball: https://pkg.pr.new/novuhq/novu/@novu/react@09f3aae}
+  '@novu/react@https://pkg.pr.new/novuhq/novu/@novu/react@0bb2cd9':
+    resolution: {tarball: https://pkg.pr.new/novuhq/novu/@novu/react@0bb2cd9}
     version: 2.6.6
     peerDependencies:
       react: '>=17'
@@ -47561,7 +47561,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novu/js@https://pkg.pr.new/novuhq/novu/@novu/js@09f3aae7effbbdb9ca8e9a99f84a143ba7836426':
+  '@novu/js@https://pkg.pr.new/novuhq/novu/@novu/js@0bb2cd97942650c3bd96fa52c3e05c5e216f4aab':
     dependencies:
       '@floating-ui/dom': 1.6.13
       class-variance-authority: 0.7.0
@@ -47601,9 +47601,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@novu/react@https://pkg.pr.new/novuhq/novu/@novu/react@09f3aae(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@novu/react@https://pkg.pr.new/novuhq/novu/@novu/react@0bb2cd9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@novu/js': https://pkg.pr.new/novuhq/novu/@novu/js@09f3aae7effbbdb9ca8e9a99f84a143ba7836426
+      '@novu/js': https://pkg.pr.new/novuhq/novu/@novu/js@0bb2cd97942650c3bd96fa52c3e05c5e216f4aab
       react: 18.3.1
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
### What changed? Why was the change needed?

Inbox render props stricter types.
When `renderNotification` prop is used, the `renderSubject, renderBody` is not allowed, and vice-versa.

### Screenshots

![Screenshot 2025-03-11 at 12 18 03](https://github.com/user-attachments/assets/81bbc371-1724-4d31-8bb3-de58cc22ee80)
![Screenshot 2025-03-11 at 12 17 50](https://github.com/user-attachments/assets/f5806ae9-504e-45dd-9515-4d5ad5f96fdd)
![Screenshot 2025-03-11 at 12 17 41](https://github.com/user-attachments/assets/78a09a34-4adf-432d-8a62-95b6a59fe2d1)
![Screenshot 2025-03-11 at 12 16 11](https://github.com/user-attachments/assets/cd415244-92f1-4cf4-9482-621493edf724)
![Screenshot 2025-03-11 at 12 16 03](https://github.com/user-attachments/assets/e067dec6-4ea2-4cf4-82cf-2565e143d4eb)
![Screenshot 2025-03-11 at 12 15 55](https://github.com/user-attachments/assets/1fa1d11b-80c7-469e-aa21-3d527cd79b05)
![Screenshot 2025-03-11 at 12 15 36](https://github.com/user-attachments/assets/3b9842bc-44b4-4c9c-8440-f68ecefbf847)
![Screenshot 2025-03-11 at 12 15 25](https://github.com/user-attachments/assets/2c843307-5edc-4b23-b8ac-8d5664995f8d)
![Screenshot 2025-03-11 at 12 15 07](https://github.com/user-attachments/assets/8ccc8d49-9c12-4f34-8265-63bb29e8dea7)

