### PR TITLE
fix(nextjs): Fix router compat when use client is used

### DIFF
--- a/packages/nextjs/src/pages-router/Inbox.tsx
+++ b/packages/nextjs/src/pages-router/Inbox.tsx
@@ -1,10 +1,21 @@
 'use client';
 
 import { InboxProps, Inbox as RInbox } from '@novu/react';
-import { useRouter } from 'next/router';
+import { useRouter as useAppRouter } from 'next/navigation';
+import { useRouter } from 'next/compat/router';
+
+function AppRouterInbox(props: InboxProps) {
+  const router = useAppRouter();
+
+  return <RInbox routerPush={router.push} {...props} />;
+}
 
 export function Inbox(props: InboxProps) {
   const router = useRouter();
+
+  if (!router) {
+    return <AppRouterInbox {...props} />;
+  }
 
   return <RInbox routerPush={router.push} {...props} />;
 }

--- a/playground/nextjs/src/app/inbox-client/page.tsx
+++ b/playground/nextjs/src/app/inbox-client/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { novuConfig } from '@/utils/config';
+import { Inbox, Notifications, Preferences } from '@novu/nextjs';
+
+export default function InboxPage() {
+  return (
+    <>
+      <h1>Hello from Inbox page</h1>
+      <div className="flex flex-col gap-4">
+        <h1>App Router</h1>
+        <Inbox {...novuConfig}>
+          <h2>My custom Inbox</h2>
+          <Preferences />
+          <Notifications />
+        </Inbox>
+        <Inbox {...novuConfig} />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->
Problem: An error seems to be thrown when using app directory and use client in the file that contains the Inbox.
I'm guessing this happens because use client causes our pages implementation to be used.
This means that it needs to be adaptive. We cannot execute useRouter from next/navigation in pages router and we cannot execute useRouter from next/router in app router.
We can have a InboxCommonProvider that will useRouter from next/compat/router. If that succeeds (it will be the next/router), it means that we are ok. If it fails, it means that the pages router could not be used and we should useRouter from next/navigation instead.
### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
