### PR TITLE
fix(widget): add docker container healthcheck for widget web

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -42,6 +42,7 @@ USER 1000
 WORKDIR /app
 
 COPY --chown=1000:1000 --from=builder /usr/src/app/apps/web/env.sh /app/env.sh
+COPY --chown=1000:1000 --from=builder /usr/src/app/apps/web/healthchecks/web-server.mjs /app/healthchecks/web-server.mjs
 
 COPY --chown=1000:1000 --from=builder /usr/src/app/apps/web/build /app/build
 COPY --chown=1000:1000 --from=builder /usr/src/app/apps/web/.env.sample /app/.env.sample

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -42,7 +42,7 @@ USER 1000
 WORKDIR /app
 
 COPY --chown=1000:1000 --from=builder /usr/src/app/apps/web/env.sh /app/env.sh
-COPY --chown=1000:1000 --from=builder /usr/src/app/apps/web/healthchecks/web-server.mjs /app/healthchecks/web-server.mjs
+COPY --chown=1000:1000 --from=builder /usr/src/app/apps/web/healthchecks/web-healthcheck.mjs /app/healthchecks/web-healthcheck.mjs
 
 COPY --chown=1000:1000 --from=builder /usr/src/app/apps/web/build /app/build
 COPY --chown=1000:1000 --from=builder /usr/src/app/apps/web/.env.sample /app/.env.sample

--- a/apps/web/healthchecks/web-healthcheck.mjs
+++ b/apps/web/healthchecks/web-healthcheck.mjs
@@ -22,18 +22,20 @@ async function webHealthcheck() {
     const response = await fetch(webServerUrl);
 
     if (response.status === 200) {
-      console.info(`Healthcheck passed for 'web' container at ${webServerUrl}`);
+      const successMessage = `Healthcheck passed for 'web' container at ${webServerUrl}`;
+
+      process.stdout.write(successMessage);
 
       process.exit(0);
     }
 
-    console.error(`Unexpected response status: ${response.status}`);
+    process.stderr.write(`Unexpected response status: ${response.status}`);
 
     process.exit(1);
   } catch (error) {
-    console.info(`Healthcheck failed for 'web' container at ${webServerUrl}`);
+    const errorMessage = `Healthcheck failed for 'web' container at ${webServerUrl}`;
 
-    console.error(error);
+    process.stdout.write(errorMessage + error);
 
     process.exit(1);
   }

--- a/apps/web/healthchecks/web-healthcheck.mjs
+++ b/apps/web/healthchecks/web-healthcheck.mjs
@@ -1,5 +1,5 @@
 /**
- * WARN: 
+ * WARN:
  * Ensure we always return exit code 0 or exit code 1 as these are the defaults docker healthcheck can currently handle
  */
 
@@ -7,33 +7,37 @@
  * NOTE: This should be the port used inside the container.
  * Pass in the port to the script via argv or use default
  */
-const port = process.argv[2] ?? 4200
+const port = process.argv[2] ?? 4200;
 
 // Assemble Webserver Url
-const webServerUrl = `http://127.0.0.1:${port}`
+const webServerUrl = `http://127.0.0.1:${port}`;
 
 /**
-  * Healthcheck for the `web` docker container
-  *
-  * Runs a fetch request and evaluats the response code
-  */
+ * Healthcheck for the `web` docker container
+ *
+ * Runs a fetch request and evaluats the response code
+ */
 async function webHealthcheck() {
   try {
     const response = await fetch(webServerUrl);
 
     if (response.status === 200) {
       console.info(`Healthcheck passed for 'web' container at ${webServerUrl}`);
+
       process.exit(0);
     }
 
     console.error(`Unexpected response status: ${response.status}`);
+
     process.exit(1);
   } catch (error) {
-    console.info(`Healthcheck failed for 'web' container at ${webServerUrl}`)
-    console.error(error)
-    process.exit(1)
+    console.info(`Healthcheck failed for 'web' container at ${webServerUrl}`);
+
+    console.error(error);
+
+    process.exit(1);
   }
 }
 
 // Run Healthcheck
-webHealthcheck()
+webHealthcheck();

--- a/apps/web/healthchecks/web-server.mjs
+++ b/apps/web/healthchecks/web-server.mjs
@@ -1,0 +1,39 @@
+/**
+ * WARN: 
+ * Ensure we always return exit code 0 or exit code 1 as these are the defaults docker healthcheck can currently handle
+ */
+
+/**
+ * NOTE: This should be the port used inside the container.
+ * Pass in the port to the script via argv or use default
+ */
+const port = process.argv[2] ?? 4200
+
+// Assemble Webserver Url
+const webServerUrl = `http://127.0.0.1:${port}`
+
+/**
+  * Healthcheck for the `web` docker container
+  *
+  * Runs a fetch request and evaluats the response code
+  */
+async function webHealthcheck() {
+  try {
+    const response = await fetch(webServerUrl);
+
+    if (response.status === 200) {
+      console.info(`Healthcheck passed for 'web' container at ${webServerUrl}`);
+      process.exit(0);
+    }
+
+    console.error(`Unexpected response status: ${response.status}`);
+    process.exit(1);
+  } catch (error) {
+    console.info(`Healthcheck failed for 'web' container at ${webServerUrl}`)
+    console.error(error)
+    process.exit(1)
+  }
+}
+
+// Run Healthcheck
+webHealthcheck()

--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -34,6 +34,16 @@ services:
       - mongodb:/data/db
     ports:
       - 27017:27017
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          "echo 'db.runCommand({ ping: 1 }).ok' | mongosh mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@127.0.0.1:27017/admin --quiet",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
 
   api:
     image: 'ghcr.io/novuhq/novu/api:2.1.1'

--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -175,6 +175,12 @@ services:
     ports:
       - 4200:4200
     command: ['/bin/sh', '-c', 'pnpm run envsetup:docker && pnpm run start:static:build']
+    healthcheck:
+      test:
+        [CMD-SHELL, "node ./healthchecks/web-server.mjs"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
 
 volumes:
   mongodb: ~

--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -174,10 +174,14 @@ services:
       REACT_APP_WS_URL: ${REACT_APP_WS_URL}
     ports:
       - 4200:4200
-    command: ['/bin/sh', '-c', 'pnpm run envsetup:docker && pnpm run start:static:build']
+    command:
+      [
+        '/bin/sh',
+        '-c',
+        'pnpm run envsetup:docker && pnpm run start:static:build',
+      ]
     healthcheck:
-      test:
-        [CMD-SHELL, "node ./healthchecks/web-server.mjs"]
+      test: [CMD-SHELL, 'node ./healthchecks/web-healthcheck.mjs']
       interval: 5s
       timeout: 5s
       retries: 3

--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -9,6 +9,12 @@ services:
       options:
         max-size: '50m'
         max-file: '5'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   mongodb:
     image: mongo:8.0.3


### PR DESCRIPTION
### What changed? Why was the change needed?

The community edition currently was not starting based on removed healthchecks and container dependencies.

- #7478 
- [original pr](https://github.com/novuhq/novu/commit/088a0dcc768dc1efa44f56ab47ff145a8ceb472b)
- @merrcury [comment](https://github.com/novuhq/novu/pull/7929#issuecomment-2732148477) first time contributing to this project let me know if you have additional requirements, if the taken approach is agreeable i will expand on this draft pr
- @Aaron-Ritter feedback is welcome ;)

### Screenshots

![image](https://github.com/user-attachments/assets/3bef6482-cef1-43a0-9189-0ef9a7904685)

### Details

I added a simple node script to check if the web server is up and running that should set an example on how healthchecks could be integrated after removing the `curl` dependency has been removed from the base image.


### Special notes for your reviewer

Ensure that the environment is configured correctly, all ports and variables are set in the .env file.

For testing purposes, build the `novu-web` docker image locally, and exchange the cloud image in the community-compose file for the locally available one.

If you want a failing healthcheck you could pass a port that is NOT running in the container to the healthcheck.


```bash
# Go to web directory
cd apps/web

# Build docker image
pnpm docker:build
```

In the docker compose-compose.yaml file replace (just local testing)

```yaml
    # image: 'ghcr.io/novuhq/novu/web:2.1.1'
    image: novu-web
```

Spin up the local compose stack

