### PR TITLE
fix(api): Do not thow 500 when deleting an non existing message

### DIFF
--- a/libs/dal/src/repositories/message/message.repository.ts
+++ b/libs/dal/src/repositories/message/message.repository.ts
@@ -638,16 +638,7 @@ export class MessageRepository extends BaseRepository<MessageDBModel, MessageEnt
   }
 
   async delete(query: MessageQuery) {
-    const message = await this.findOne({
-      _id: query._id,
-      _environmentId: query._environmentId,
-    });
-
-    if (!message) {
-      throw new DalException(`Could not find a message with id ${query._id}`);
-    }
-
-    return await this.message.delete({ _id: message._id, _environmentId: message._environmentId });
+    return await this.message.delete({ _id: query._id, _environmentId: query._environmentId });
   }
 
   async deleteMany(query: MessageQuery) {


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixes https://novu-r9.sentry.io/auth/login/novu-r9/?referrer=slack