### PR TITLE
fix(api-service): v1 widget and subscriber template preferences return tags

### DIFF
--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.spec.ts
@@ -50,6 +50,7 @@ const mockedWorkflow: any = {
   critical: false,
   triggers: [{ identifier: 'test-trigger' }],
   tags: [],
+  data: undefined,
 };
 
 describe('UpdatePreferences', () => {
@@ -213,6 +214,7 @@ describe('UpdatePreferences', () => {
         name: mockedWorkflow.name,
         critical: mockedWorkflow.critical,
         tags: mockedWorkflow.tags,
+        data: mockedWorkflow.data,
       },
     });
   });

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -130,6 +130,7 @@ export class UpdatePreferences {
           name: workflow.name,
           critical: workflow.critical,
           tags: workflow.tags,
+          data: workflow.data,
         },
       };
     }

--- a/apps/api/src/app/inbox/utils/types.ts
+++ b/apps/api/src/app/inbox/utils/types.ts
@@ -1,4 +1,4 @@
-import type { ChannelTypeEnum, Redirect, IPreferenceChannels, PreferenceLevelEnum } from '@novu/shared';
+import type { ChannelTypeEnum, Redirect, IPreferenceChannels, PreferenceLevelEnum, CustomDataType } from '@novu/shared';
 
 export type Subscriber = {
   id: string;
@@ -45,6 +45,7 @@ export type Workflow = {
   name: string;
   critical: boolean;
   tags?: string[];
+  data?: CustomDataType;
 };
 
 export type InboxPreference = {

--- a/apps/api/src/app/subscribers/subscribersV1.controller.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.controller.ts
@@ -493,6 +493,8 @@ export class SubscribersV1Controller {
         _id: result.workflow.id,
         name: result.workflow.name,
         critical: result.workflow.critical,
+        tags: result.workflow.tags,
+        data: result.workflow.data,
         triggers: [
           {
             identifier: result.workflow.identifier,

--- a/apps/api/src/app/widgets/dtos/update-subscriber-preference-response.dto.ts
+++ b/apps/api/src/app/widgets/dtos/update-subscriber-preference-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
+  CustomDataType,
   INotificationTrigger,
   INotificationTriggerVariable,
   ITemplateConfiguration,
@@ -119,6 +120,18 @@ class TemplateResponse implements ITemplateConfiguration {
     type: [NotificationTriggerResponse], // Use an array syntax
   })
   triggers: NotificationTriggerResponse[];
+
+  @ApiProperty({
+    description: 'Tags applied to the workflow.',
+    type: [String],
+  })
+  tags?: string[];
+
+  @ApiProperty({
+    description: 'The custom data of the workflow.',
+    type: Object,
+  })
+  data?: CustomDataType;
 
   @ApiPropertyOptional({
     description: "The date and time the workflow was last updated. It's in ISO 8601 format.",

--- a/apps/api/src/app/widgets/widgets.controller.ts
+++ b/apps/api/src/app/widgets/widgets.controller.ts
@@ -473,6 +473,8 @@ export class WidgetsController {
         _id: result.workflow.id,
         name: result.workflow.name,
         critical: result.workflow.critical,
+        tags: result.workflow.tags,
+        data: result.workflow.data,
         triggers: [
           {
             identifier: result.workflow.identifier,


### PR DESCRIPTION
### What changed? Why was the change needed?

API service changes: the v1 widgets and subscribers' GET/PATCH preferences endpoints should return the `tags, data` properties from the workflow.

### Screenshots

![Screenshot 2025-03-21 at 11 16 41](https://github.com/user-attachments/assets/c6035bf2-9a92-4e5f-9024-96eada9749d0)
![Screenshot 2025-03-21 at 11 15 38](https://github.com/user-attachments/assets/f3a4101d-4456-460f-a89d-afd87419763f)
![Screenshot 2025-03-21 at 11 15 31](https://github.com/user-attachments/assets/df6e16ac-f7e5-4445-aa68-efe956ff21fb)
![Screenshot 2025-03-21 at 10 49 42](https://github.com/user-attachments/assets/6ad04843-7ea0-42fd-8a1d-3a4602ba3c5c)
![Screenshot 2025-03-21 at 10 48 22](https://github.com/user-attachments/assets/634cef6d-6c65-4b1e-812d-699f898a2ff1)
![Screenshot 2025-03-21 at 10 43 24](https://github.com/user-attachments/assets/cf986aa6-0e86-4e1f-9ff8-3ea70c12f116)
![Screenshot 2025-03-21 at 10 36 17](https://github.com/user-attachments/assets/7a83a71f-23db-4388-9cb4-90f0d0e9af81)
