### PR TITLE
fix(dashboard): in-app editor body focus ring expands with field size

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-body.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-body.tsx
@@ -24,7 +24,7 @@ export const InAppBody = () => {
           <FormControl>
             <InputRoot hasError={!!fieldState.error}>
               <ControlInput
-                className="h-[7.75rem]"
+                className="min-h-[7.75rem]"
                 indentWithTab={false}
                 placeholder={capitalize(field.name)}
                 id={field.name}


### PR DESCRIPTION
### What changed? Why was the change needed?

Dashboard In-App Editor - the body field in focus state has a ring and that ring was staying at the same height even when the field grew in height. This PR fixes that.

### Screenshots

BEFORE:


https://github.com/user-attachments/assets/117ee940-f422-49b2-a153-d41dff645e72

AFTER:


https://github.com/user-attachments/assets/3b00cbc9-b253-4918-9537-800f2af7c12e

