### PR TITLE
fix(dashboard): add gap between email tippy buttons

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/email/maily.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/maily.tsx
@@ -164,6 +164,7 @@ export const Maily = ({ value, onChange, className, ...rest }: MailyProps) => {
               border-radius: 4px;
               box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.04), 0px 1px 2px 0px rgba(0, 0, 0, 0.02);
               border-radius: 4px;
+              margin: 2px;
             }
           }
         `}


### PR DESCRIPTION
### What changed? Why was the change needed?

![image](https://github.com/user-attachments/assets/22add4ab-ad5a-4349-a1c6-d1ef05374c88)

