### PR TITLE
feat(js): Typed notification data object

### DIFF
--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -5,6 +5,17 @@ export type { Notification } from './notifications';
 export type { Preference } from './preferences/preference';
 export type { NovuError } from './utils/errors';
 
+declare global {
+  /**
+   * If you want to provide custom types for the notification.data object,
+   * simply redeclare this rule in the global namespace.
+   * Every notification object will use the provided type.
+   */
+  interface NotificationData {
+    [k: string]: unknown;
+  }
+}
+
 export enum NotificationStatus {
   READ = 'read',
   SEEN = 'seen',
@@ -112,7 +123,7 @@ export type InboxNotification = {
   secondaryAction?: Action;
   channelType: ChannelType;
   tags?: string[];
-  data?: Record<string, unknown>;
+  data?: NotificationData;
   redirect?: Redirect;
   workflowId: string;
 };

--- a/playground/nextjs/src/pages/render-notification/index.tsx
+++ b/playground/nextjs/src/pages/render-notification/index.tsx
@@ -2,6 +2,13 @@ import Title from '@/components/Title';
 import { novuConfig } from '@/utils/config';
 import { Inbox } from '@novu/nextjs';
 
+declare global {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  interface NotificationData {
+    foo: string;
+  }
+}
+
 export default function Home() {
   return (
     <>
@@ -27,6 +34,7 @@ export default function Home() {
               <div>
                 <div className="text-xl font-bold">{notification.subject || 'Subject'}</div>
                 <div>{notification.body}</div>
+                {notification.data?.foo && <div>{notification.data.foo}</div>}
                 {!notification.isRead && (
                   <div className="border-background absolute right-2 top-2 size-2 rounded-full border bg-blue-500" />
                 )}


### PR DESCRIPTION
### What changed? Why was the change needed?

You can now declare your notification data type to avoid typecasting:
```
declare global {
  interface NotificationData {
    foo: string;
  }
}
```