### PR TITLE
fix(shared): remove uneeded AWS s3 env validators

### DIFF
--- a/apps/api/src/config/env.validators.ts
+++ b/apps/api/src/config/env.validators.ts
@@ -88,8 +88,6 @@ export const envValidators = {
     S3_LOCAL_STACK: str({ default: '' }),
     S3_BUCKET_NAME: str(),
     S3_REGION: str(),
-    AWS_ACCESS_KEY_ID: str(),
-    AWS_SECRET_ACCESS_KEY: str(),
   }),
 
   // Production validators

--- a/apps/worker/src/config/env.validators.ts
+++ b/apps/worker/src/config/env.validators.ts
@@ -85,8 +85,6 @@ export const envValidators = {
     S3_LOCAL_STACK: str({ default: '' }),
     S3_BUCKET_NAME: str(),
     S3_REGION: str(),
-    AWS_ACCESS_KEY_ID: str(),
-    AWS_SECRET_ACCESS_KEY: str(),
   }),
 
   // Production validators


### PR DESCRIPTION
### What changed? Why was the change needed?

https://github.com/novuhq/novu/issues/8038

The variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are not used directly by Novu but by the AWS S3 SDK.

Other variables can be provided to ensure authentification like `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`.

Remove those validators allow to use other authentication methods like IRSA for AWS inside an EKS cluster.
