### PR TITLE
fix(api-service): increase allowed payload size for bridge & handle error

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -730,7 +730,8 @@
     "autoload",
     "novugo",
     "titleize",
-    "oklch"
+    "oklch",
+    "Duplicable"
   ],
   "flagWords": [],
   "patterns": [

--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -22,6 +22,7 @@ const extendedBodySizeRoutes = [
   '/v1/layouts',
   '/v1/bridge/sync',
   '/v1/bridge/diff',
+  '/v1/environments/:environmentId/bridge',
 ];
 
 // Validate the ENV variables after launching SENTRY, so missing variables will report to sentry

--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -1,4 +1,4 @@
-import { ArgumentsHost, ExceptionFilter, HttpException, HttpStatus } from '@nestjs/common';
+import { ArgumentsHost, ExceptionFilter, HttpException, HttpStatus, PayloadTooLargeException } from '@nestjs/common';
 import { Response } from 'express';
 import { CommandValidationException, PinoLogger } from '@novu/application-generic';
 import { randomUUID } from 'node:crypto';
@@ -62,7 +62,15 @@ export class AllExceptionsFilter implements ExceptionFilter {
       return this.handleOtherHttpExceptions(exception, request);
     }
 
+    if (this.isPayloadTooLargeError(exception)) {
+      return this.handleOtherHttpExceptions(new PayloadTooLargeException(), request);
+    }
+
     return this.buildA5xxError(request, exception);
+  }
+
+  private isPayloadTooLargeError(exception: unknown) {
+    return exception?.constructor?.name === 'PayloadTooLargeError';
   }
 
   private buildA5xxError(request: Request, exception: unknown) {

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
@@ -415,6 +415,13 @@ export class ExecuteBridgeRequest {
           code: BRIDGE_EXECUTION_ERROR.BRIDGE_METHOD_NOT_CONFIGURED.code,
           statusCode: HttpStatus.BAD_REQUEST,
         };
+      } else if (error.response.statusCode === 413) {
+        Logger.error(`Payload too large for \`${url}\``, LOG_CONTEXT);
+        bridgeErrorData = {
+          message: BRIDGE_EXECUTION_ERROR.PAYLOAD_TOO_LARGE.message(url),
+          code: BRIDGE_EXECUTION_ERROR.PAYLOAD_TOO_LARGE.code,
+          statusCode: HttpStatus.PAYLOAD_TOO_LARGE,
+        };
       } else {
         Logger.error(
           `Unknown bridge request error calling \`${url}\`: \`${JSON.stringify(body)}\``,

--- a/libs/application-generic/src/utils/bridge.ts
+++ b/libs/application-generic/src/utils/bridge.ts
@@ -1,9 +1,5 @@
 import { DigestTypeEnum } from '@novu/shared';
-import {
-  DigestOutput,
-  DigestRegularOutput,
-  DigestTimedOutput,
-} from '@novu/framework/internal';
+import { DigestOutput, DigestRegularOutput, DigestTimedOutput } from '@novu/framework/internal';
 
 export function getDigestType(outputs: DigestOutput): DigestTypeEnum {
   if (isTimedDigestOutput(outputs)) {
@@ -15,24 +11,18 @@ export function getDigestType(outputs: DigestOutput): DigestTypeEnum {
   return DigestTypeEnum.REGULAR;
 }
 
-export const isTimedDigestOutput = (
-  outputs: DigestOutput | undefined,
-): outputs is DigestTimedOutput => {
+export const isTimedDigestOutput = (outputs: DigestOutput | undefined): outputs is DigestTimedOutput => {
   return (outputs as DigestTimedOutput)?.cron != null;
 };
 
-export const isLookBackDigestOutput = (
-  outputs: DigestOutput,
-): outputs is DigestRegularOutput => {
+export const isLookBackDigestOutput = (outputs: DigestOutput): outputs is DigestRegularOutput => {
   return (
     (outputs as DigestRegularOutput)?.lookBackWindow?.amount != null &&
     (outputs as DigestRegularOutput)?.lookBackWindow?.unit != null
   );
 };
 
-export const isRegularDigestOutput = (
-  outputs: DigestOutput,
-): outputs is DigestRegularOutput => {
+export const isRegularDigestOutput = (outputs: DigestOutput): outputs is DigestRegularOutput => {
   return !isTimedDigestOutput(outputs) && !isLookBackDigestOutput(outputs);
 };
 
@@ -90,8 +80,11 @@ export const BRIDGE_EXECUTION_ERROR = {
   },
   SELF_SIGNED_CERTIFICATE: {
     code: 'SelfSignedCertificate',
-    message: (url: string) =>
-      `Bridge Endpoint can't use a self signed certificate in production environments.`,
+    message: (url: string) => `Bridge Endpoint can't use a self signed certificate in production environments.`,
+  },
+  PAYLOAD_TOO_LARGE: {
+    code: 'PayloadTooLarge',
+    message: (url: string) => `Payload too large for \`${url}\``,
   },
   UNKNOWN_BRIDGE_REQUEST_ERROR: {
     code: 'UnknownBridgeRequestError',
@@ -99,7 +92,6 @@ export const BRIDGE_EXECUTION_ERROR = {
   },
   UNKNOWN_BRIDGE_NON_REQUEST_ERROR: {
     code: 'UnknownBridgeNonRequestError',
-    message: (url: string) =>
-      `Unknown bridge non-request error calling \`${url}\``,
+    message: (url: string) => `Unknown bridge non-request error calling \`${url}\``,
   },
 } satisfies Record<string, { code: string; message: (url: string) => string }>;


### PR DESCRIPTION
- Increase allowed payload size for bridge endpoint to match the other extended ones (20mb)
- Pass `PayloadTooLarge` error back to bridge response so its non-retryable