### PR TITLE
fix(js,react,next): Named type exports

### DIFF
--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -1,4 +1,18 @@
 export type { EventHandler, Events, SocketEventNames } from './event-emitter';
 export { Novu } from './novu';
-export * from './types';
+export {
+  ChannelPreference,
+  ChannelType,
+  FiltersCountResponse,
+  InboxNotification,
+  ListNotificationsResponse,
+  Notification,
+  NotificationFilter,
+  NotificationStatus,
+  NovuError,
+  NovuOptions,
+  Preference,
+  PreferenceLevel,
+  WebSocketEvent,
+} from './types';
 export { areTagsEqual, isSameFilter } from './utils/notification-utils';

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -33,10 +33,6 @@ export enum NotificationActionStatus {
   DONE = 'done',
 }
 
-export enum CtaType {
-  REDIRECT = 'redirect',
-}
-
 export enum PreferenceLevel {
   GLOBAL = 'global',
   TEMPLATE = 'template',
@@ -50,21 +46,10 @@ export enum ChannelType {
   PUSH = 'push',
 }
 
-export enum PreferenceOverrideSource {
-  SUBSCRIBER = 'subscriber',
-  TEMPLATE = 'template',
-  WORKFLOW_OVERRIDE = 'workflowOverride',
-}
-
 export enum WebSocketEvent {
   RECEIVED = 'notification_received',
   UNREAD = 'unread_count_changed',
   UNSEEN = 'unseen_count_changed',
-}
-
-export enum ActionTypeEnum {
-  PRIMARY = 'primary',
-  SECONDARY = 'secondary',
 }
 
 export type Session = {
@@ -72,21 +57,6 @@ export type Session = {
   totalUnreadCount: number;
   removeNovuBranding: boolean;
   isDevelopmentMode: boolean;
-};
-
-export type MessageButton = {
-  type: NotificationButton;
-  content: string;
-  resultContent?: string;
-};
-
-export type MessageAction = {
-  status?: NotificationActionStatus;
-  buttons?: MessageButton[];
-  result: {
-    payload?: Record<string, unknown>;
-    type?: NotificationButton;
-  };
 };
 
 export type Subscriber = {
@@ -101,6 +71,11 @@ export type Redirect = {
   url: string;
   target?: '_self' | '_blank' | '_parent' | '_top' | '_unfencedTop';
 };
+
+export enum ActionTypeEnum {
+  PRIMARY = 'primary',
+  SECONDARY = 'secondary',
+}
 
 export type Action = {
   label: string;

--- a/packages/js/src/ui/index.ts
+++ b/packages/js/src/ui/index.ts
@@ -1,5 +1,24 @@
 export type { Notification } from '../notifications';
 export type { InboxPage, InboxProps } from './components';
-export * from './types';
 export { NovuUI } from './novuUI';
 export type { BaseNovuUIOptions, NovuUIOptions } from './novuUI';
+export {
+  Appearance,
+  AppearanceKey,
+  BellRenderer,
+  BodyRenderer,
+  Elements,
+  ElementStyles,
+  Localization,
+  LocalizationKey,
+  NotificationActionClickHandler,
+  NotificationClickHandler,
+  NotificationRenderer,
+  NotificationStatus,
+  NovuProviderProps,
+  PreferencesFilter,
+  RouterPush,
+  SubjectRenderer,
+  Tab,
+  Variables,
+} from './types';

--- a/packages/nextjs/src/app-router/index.ts
+++ b/packages/nextjs/src/app-router/index.ts
@@ -1,18 +1,8 @@
 'use client';
 
-export { Inbox } from './Inbox';
-export { Bell, Preferences, Notifications, InboxContent, NovuProvider } from '@novu/react';
+// First export to override anything that we redeclare
+export type * from '@novu/react';
 
-export type {
-  BaseProps,
-  BellProps,
-  BellRenderer,
-  DefaultInboxProps,
-  DefaultProps,
-  InboxContentProps,
-  InboxProps,
-  Notification,
-  NotificationProps,
-  NotificationsRenderer,
-  WithChildrenProps,
-} from '@novu/react';
+export { Inbox } from './Inbox';
+
+export { Bell, Preferences, Notifications, InboxContent, NovuProvider } from '@novu/react';

--- a/packages/nextjs/src/pages-router/index.ts
+++ b/packages/nextjs/src/pages-router/index.ts
@@ -1,18 +1,8 @@
 'use client';
 
-export { Inbox } from './Inbox';
-export { Bell, Preferences, Notifications, InboxContent, NovuProvider } from '@novu/react';
+// First export to override anything that we redeclare
+export type * from '@novu/react';
 
-export type {
-  BaseProps,
-  BellProps,
-  BellRenderer,
-  DefaultInboxProps,
-  DefaultProps,
-  InboxContentProps,
-  InboxProps,
-  Notification,
-  NotificationProps,
-  NotificationsRenderer,
-  WithChildrenProps,
-} from '@novu/react';
+export { Inbox } from './Inbox';
+
+export { Bell, Preferences, Notifications, InboxContent, NovuProvider } from '@novu/react';

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -1,18 +1,6 @@
 /* eslint-disable no-restricted-imports */
 
-export type {
-  BaseProps,
-  DefaultInboxProps,
-  DefaultProps,
-  NoRendererProps,
-  NotificationRendererProps,
-  SubjectBodyRendererProps,
-  WithChildrenProps,
-  BellRenderer,
-  BodyRenderer,
-  NotificationsRenderer,
-  Notification,
-} from '@novu/react';
+export type * from '@novu/react';
 
 export {
   Inbox,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,59 @@
-export * from './components';
-export * from './hooks';
-export type * from './utils/types';
+export type {
+  FiltersCountResponse,
+  ListNotificationsResponse,
+  NovuError,
+  Preference,
+  ChannelPreference,
+  Notification,
+  ChannelType,
+  InboxNotification,
+  NotificationFilter,
+  NotificationStatus,
+  NovuOptions,
+  PreferenceLevel,
+  WebSocketEvent,
+} from '@novu/js';
+
+export type {
+  Appearance,
+  AppearanceKey,
+  Elements,
+  ElementStyles,
+  Localization,
+  LocalizationKey,
+  NotificationActionClickHandler,
+  NotificationClickHandler,
+  NotificationRenderer,
+  PreferencesFilter,
+  RouterPush,
+  Tab,
+  Variables,
+} from '@novu/js/ui';
+
+export { Inbox, Bell, InboxContent, Notifications, NovuProvider, Preferences } from './components';
+export { useNovu, useCounts, useNotifications, usePreferences } from './hooks';
+
+export type { InboxProps, BellProps, InboxContentProps, NotificationProps, NovuProviderProps } from './components';
+
+export type {
+  UseCountsProps,
+  UseCountsResult,
+  UseNotificationsProps,
+  UseNotificationsResult,
+  UsePreferencesProps,
+  UsePreferencesResult,
+} from './hooks';
+
+export type {
+  NotificationsRenderer,
+  SubjectRenderer,
+  BodyRenderer,
+  BellRenderer,
+  DefaultInboxProps,
+  BaseProps,
+  NotificationRendererProps,
+  SubjectBodyRendererProps,
+  NoRendererProps,
+  DefaultProps,
+  WithChildrenProps,
+} from './utils/types';

--- a/packages/react/src/server/index.tsx
+++ b/packages/react/src/server/index.tsx
@@ -8,8 +8,6 @@ import type { UseCountsProps, UseCountsResult } from '../hooks/useCounts';
 import type { InboxProps } from '../components/Inbox';
 import type { NovuProviderProps } from '../hooks/NovuProvider';
 
-export * from '../utils/types';
-
 /**
  * Exporting all components from the components folder
  * as empty functions to fix build errors in SSR
@@ -60,3 +58,59 @@ export function usePreferences(_: UsePreferencesProps): UsePreferencesResult {
     refetch: () => Promise.resolve(),
   };
 }
+
+export type {
+  FiltersCountResponse,
+  ListNotificationsResponse,
+  NovuError,
+  Preference,
+  ChannelPreference,
+  Notification,
+  ChannelType,
+  InboxNotification,
+  NotificationFilter,
+  NotificationStatus,
+  NovuOptions,
+  PreferenceLevel,
+} from '@novu/js';
+
+export type {
+  Appearance,
+  AppearanceKey,
+  Elements,
+  ElementStyles,
+  Localization,
+  LocalizationKey,
+  NotificationActionClickHandler,
+  NotificationClickHandler,
+  NotificationRenderer,
+  PreferencesFilter,
+  RouterPush,
+  Tab,
+  Variables,
+} from '@novu/js/ui';
+
+export type { InboxProps, BellProps, InboxContentProps, NotificationProps, NovuProviderProps } from '../components';
+
+export type {
+  UseCountsProps,
+  UseCountsResult,
+  UseNotificationsProps,
+  UseNotificationsResult,
+  UsePreferencesProps,
+  UsePreferencesResult,
+} from '../hooks';
+
+export type {
+  NotificationsRenderer,
+  SubjectRenderer,
+  BodyRenderer,
+  BellRenderer,
+  DefaultInboxProps,
+  BaseProps,
+  NotificationRendererProps,
+  SubjectBodyRendererProps,
+  NoRendererProps,
+  DefaultProps,
+  WithChildrenProps,
+} from '../utils/types';

--- a/packages/react/src/utils/types.ts
+++ b/packages/react/src/utils/types.ts
@@ -67,5 +67,3 @@ export type DefaultProps = BaseProps &
 export type WithChildrenProps = BaseProps & {
   children: React.ReactNode;
 };
-
-export type { Notification };


### PR DESCRIPTION
### What changed? Why was the change needed?
I've deleted any useless types and converted all exports to named from `@novu/js`, `@novu/js/ui` and `@novu/react`. 
`@novu/nextjs` re-exports `@novu/react` types.
