### PR TITLE
fix(dashboard): Correct workflowId format in Python and Go snippets

### DIFF
--- a/apps/dashboard/src/utils/code-snippets.ts
+++ b/apps/dashboard/src/utils/code-snippets.ts
@@ -146,7 +146,7 @@ with Novu(
     api_key=${renderedSecretKey},
 ) as novu:
     res = novu.trigger(trigger_event_request_dto=novu_py.TriggerEventRequestDto(
-        workflowId="${identifier}",
+        workflow_id="${identifier}",
         to={
             "subscriber_id": "${(to as { subscriberId: string }).subscriberId}",
         },
@@ -175,7 +175,7 @@ func main() {
 	)
 
 	res, err := s.Trigger(ctx, components.TriggerEventRequestDto{
-		WorkflowId: "${identifier}",
+		WorkflowID: "${identifier}",
 		Payload: ${JSON.stringify(safeParsePayload(payload))},
 		To: components.CreateToSubscriberPayloadDto(
 			components.SubscriberPayloadDto{


### PR DESCRIPTION

### What changed? Why was the change needed?
I found these bugs while fixing sdks yesterday. The snippets are not correct.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
