### PR TITLE
fix(js): Fix event triggering

### DIFF
--- a/packages/js/src/event-emitter/novu-event-emitter.ts
+++ b/packages/js/src/event-emitter/novu-event-emitter.ts
@@ -1,5 +1,5 @@
 import mitt, { Emitter } from 'mitt';
-import { EventHandler, Events, EventNames } from './types';
+import { EventHandler, EventNames, Events } from './types';
 
 export class NovuEventEmitter {
   #mittEmitter: Emitter<Events>;

--- a/packages/js/src/novu.ts
+++ b/packages/js/src/novu.ts
@@ -67,6 +67,7 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
       if (this.socket.isSocketEvent(eventName)) {
         this.socket.connect();
       }
+
       const cleanup = this.#emitter.on(eventName, listener);
 
       return () => {

--- a/packages/js/src/ui/helpers/useBrowserTabsChannel.ts
+++ b/packages/js/src/ui/helpers/useBrowserTabsChannel.ts
@@ -9,9 +9,9 @@ export const useBrowserTabsChannel = <T = unknown>({
 }) => {
   const [tabsChannel] = createSignal(new BroadcastChannel(channelName));
 
-  const postMessage = (data: T) => {
+  const postMessage = (args: T) => {
     const channel = tabsChannel();
-    channel.postMessage(data);
+    channel.postMessage(args);
   };
 
   onMount(() => {

--- a/packages/js/src/ui/helpers/useWebSocketEvent.ts
+++ b/packages/js/src/ui/helpers/useWebSocketEvent.ts
@@ -12,7 +12,8 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
   eventHandler: (args: Events[E]) => void;
 }) => {
   const novu = useNovu();
-  const channelName = `nv_ws_connection:a=${novu.applicationIdentifier}:s=${novu.subscriberId}`;
+  const channelName = `nv_ws_connection:a=${novu.applicationIdentifier}:s=${novu.subscriberId}:e=${webSocketEvent}`;
+
   const { postMessage } = useBrowserTabsChannel({ channelName, onMessage });
 
   const updateReadCount: EventHandler<Events[E]> = (data) => {

--- a/packages/react/src/hooks/internal/useWebsocketEvent.ts
+++ b/packages/react/src/hooks/internal/useWebsocketEvent.ts
@@ -12,7 +12,12 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
   eventHandler: (args: Events[E]) => void;
 }) => {
   const novu = useNovu();
-  const { postMessage } = useBrowserTabsChannel({ channelName: `nv.${webSocketEvent}`, onMessage });
+  const channelName = `nv_ws_connection:a=${novu.applicationIdentifier}:s=${novu.subscriberId}:e=${webSocketEvent}`;
+
+  const { postMessage } = useBrowserTabsChannel({
+    channelName,
+    onMessage,
+  });
 
   const updateReadCount: EventHandler<Events[E]> = (data) => {
     onMessage(data);
@@ -21,7 +26,7 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
 
   useEffect(() => {
     let cleanup: () => void;
-    const resolveLock = requestLock(`nv.${webSocketEvent}`, () => {
+    const resolveLock = requestLock(channelName, () => {
       cleanup = novu.on(webSocketEvent, updateReadCount);
     });
 


### PR DESCRIPTION
### What changed? Why was the change needed?

By not checking anything on `onMessage` we are essentially triggering all handlers on any event. I've added a check but I'm not sure if this is the best solution. I'd first like to understand why we have this logic in place. We also have it on the react package so there needs to be a fix there too most likely.