### PR TITLE
fix(application-generic): store internal workflow id in notification

### DIFF
--- a/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
@@ -31,7 +31,6 @@ export class SubscriberJobBound {
     private storeSubscriberJobs: StoreSubscriberJobs,
     private createNotificationJobs: CreateNotificationJobs,
     private createOrUpdateSubscriberUsecase: CreateOrUpdateSubscriberUseCase,
-
     private integrationRepository: IntegrationRepository,
     private notificationTemplateRepository: NotificationTemplateRepository,
     private logger: PinoLogger,
@@ -60,12 +59,12 @@ export class SubscriberJobBound {
       environmentName,
     } = command;
 
-    const template =
-      this.mapBridgeWorkflow(command) ??
-      (await this.getNotificationTemplate({
-        _id: templateId,
-        environmentId,
-      }));
+    const template = command.bridge?.workflow
+      ? await this.mapBridgeWorkflow(command)
+      : await this.getNotificationTemplate({
+          _id: templateId,
+          environmentId,
+        });
 
     if (!template) {
       throw new BadRequestException(`Workflow id ${templateId} was not found`);
@@ -170,12 +169,19 @@ export class SubscriberJobBound {
     );
   }
 
-  private mapBridgeWorkflow(command: SubscriberJobBoundCommand): NotificationTemplateEntity | null {
+  private async mapBridgeWorkflow(command: SubscriberJobBoundCommand): Promise<NotificationTemplateEntity | null> {
     const bridgeWorkflow = command.bridge?.workflow;
 
     if (!bridgeWorkflow) {
       return null;
     }
+
+    const storedWorkflowId = (
+      await this.notificationTemplateRepository.findByTriggerIdentifier(
+        command.environmentId,
+        bridgeWorkflow.workflowId
+      )
+    )?._id;
 
     /*
      * Cast used to convert data type for further processing.
@@ -184,6 +190,7 @@ export class SubscriberJobBound {
     return {
       ...bridgeWorkflow,
       type: WorkflowTypeEnum.BRIDGE,
+      _id: storedWorkflowId,
       steps: bridgeWorkflow.steps.map((step) => {
         const stepControlVariables = command.controls?.steps?.[step.stepId];
 

--- a/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
@@ -60,8 +60,8 @@ export class SubscriberJobBound {
     } = command;
 
     const template = command.bridge?.workflow
-      ? await this.mapBridgeWorkflow(command)
-      : await this.getNotificationTemplate({
+      ? await this.getCodeFirstWorkflow(command)
+      : await this.getWorkflow({
           _id: templateId,
           environmentId,
         });
@@ -169,14 +169,14 @@ export class SubscriberJobBound {
     );
   }
 
-  private async mapBridgeWorkflow(command: SubscriberJobBoundCommand): Promise<NotificationTemplateEntity | null> {
+  private async getCodeFirstWorkflow(command: SubscriberJobBoundCommand): Promise<NotificationTemplateEntity | null> {
     const bridgeWorkflow = command.bridge?.workflow;
 
     if (!bridgeWorkflow) {
       return null;
     }
 
-    const storedWorkflowId = (
+    const syncedWorkflowId = (
       await this.notificationTemplateRepository.findByTriggerIdentifier(
         command.environmentId,
         bridgeWorkflow.workflowId
@@ -190,7 +190,7 @@ export class SubscriberJobBound {
     return {
       ...bridgeWorkflow,
       type: WorkflowTypeEnum.BRIDGE,
-      _id: storedWorkflowId,
+      _id: syncedWorkflowId,
       steps: bridgeWorkflow.steps.map((step) => {
         const stepControlVariables = command.controls?.steps?.[step.stepId];
 
@@ -234,7 +234,7 @@ export class SubscriberJobBound {
     return true;
   }
 
-  private async getNotificationTemplate({ _id, environmentId }: { _id: string; environmentId: string }) {
+  private async getWorkflow({ _id, environmentId }: { _id: string; environmentId: string }) {
     return await this.notificationTemplateRepository.findById(_id, environmentId);
   }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixing the notification reference to a workflow for code-first workflows.
![image](https://github.com/user-attachments/assets/48579a96-f529-49b2-9879-8281495de10d)


### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
