### PR TITLE
fix(react): apiUrl prop passing to novu/js

### DIFF
--- a/packages/react/src/hooks/NovuProvider.tsx
+++ b/packages/react/src/hooks/NovuProvider.tsx
@@ -19,6 +19,7 @@ export const NovuProvider = ({
   subscriberId,
   subscriberHash,
   backendUrl,
+  apiUrl,
   socketUrl,
   useCache,
 }: NovuProviderProps) => {
@@ -28,6 +29,7 @@ export const NovuProvider = ({
       subscriberId={subscriberId}
       subscriberHash={subscriberHash}
       backendUrl={backendUrl}
+      apiUrl={apiUrl}
       socketUrl={socketUrl}
       useCache={useCache}
       userAgentType="hooks"
@@ -48,6 +50,7 @@ export const InternalNovuProvider = ({
   subscriberId,
   subscriberHash,
   backendUrl,
+  apiUrl,
   socketUrl,
   useCache,
   userAgentType,
@@ -59,11 +62,12 @@ export const InternalNovuProvider = ({
         subscriberId,
         subscriberHash,
         backendUrl,
+        apiUrl,
         socketUrl,
         useCache,
         __userAgent: `${baseUserAgent} ${userAgentType}`,
       }),
-    [applicationIdentifier, subscriberId, subscriberHash, backendUrl, socketUrl, useCache, userAgentType]
+    [applicationIdentifier, subscriberId, subscriberHash, backendUrl, apiUrl, socketUrl, useCache, userAgentType]
   );
 
   return <NovuContext.Provider value={novu}>{children}</NovuContext.Provider>;


### PR DESCRIPTION
### What changed? Why was the change needed?

We have deprecated the backendUrl prop and redirect users to `apiUrl` however we never passed the `apiUrl` from the react wrapper to novu/js which was causing it to not work. 

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
