### PR TITLE
fix(dashboard): Center align input leading and trailing nodes

### DIFF
--- a/apps/dashboard/src/components/primitives/input.tsx
+++ b/apps/dashboard/src/components/primitives/input.tsx
@@ -281,7 +281,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ) => {
     return (
       <InputRoot size={size} hasError={hasError}>
-        {leadingNode && <div className="space-y-1">{trailingNode}</div>}
+        {leadingNode && <div className="flex flex-col justify-center gap-1">{leadingNode}</div>}
         <InputWrapper>
           {inlineLeadingNode}
           {LeadingIcon && <InputIcon as={LeadingIcon} />}
@@ -289,7 +289,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           {TrailingIcon && <InputIcon as={TrailingIcon} />}
           {inlineTrailingNode}
         </InputWrapper>
-        {trailingNode && <div className="space-y-1">{trailingNode}</div>}
+        {trailingNode && <div className="flex flex-col justify-center gap-1">{trailingNode}</div>}
       </InputRoot>
     );
   }


### PR DESCRIPTION
### What changed? Why was the change needed?
Center align input leading and trailing nodes

### Screenshots
<img width="581" alt="Screenshot 2025-04-11 at 3 56 14 PM" src="https://github.com/user-attachments/assets/3a9dcde4-f5a6-4078-9431-25545bf83b9e" />
