### PR TITLE
fix(api-service): email preview - allow previewing user provided payload for arrays

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
@@ -119,13 +119,15 @@ export class PreviewUsecase {
         };
       }
 
-      const previewPayloadExample = this.mergePayloadExample(
+      let previewPayloadExample = this.mergePayloadExample(
         workflow,
-        isEnhancedDigestEnabled
-          ? enhanceEventCountValue(previewTemplateData.payloadExample)
-          : previewTemplateData.payloadExample,
+        previewTemplateData.payloadExample,
         userPayloadExample
       );
+
+      if (isEnhancedDigestEnabled) {
+        previewPayloadExample = enhanceEventCountValue(previewPayloadExample);
+      }
 
       const executeOutput = await this.executePreviewUsecase(
         command,

--- a/apps/api/src/app/workflows-v2/util/utils.ts
+++ b/apps/api/src/app/workflows-v2/util/utils.ts
@@ -191,8 +191,12 @@ export function mergeCommonObjectKeys(
       const sourceValue = source[key];
 
       if (Array.isArray(targetValue) && Array.isArray(sourceValue)) {
-        merged[key] = targetValue.map((_, index) => {
-          if (index < sourceValue.length) {
+        const sourceValueLength = sourceValue.length;
+        const targetValueLength = targetValue.length;
+        const maxLength = Math.max(sourceValueLength, targetValueLength);
+
+        merged[key] = Array.from({ length: maxLength }, (_, index) => {
+          if (index < sourceValueLength) {
             // if we have a corresponding source item, use it
             return sourceValue[index];
           }


### PR DESCRIPTION
### What changed? Why was the change needed?

Email Preview - when the user provides the example payload and if that payload has arrays we would like to preserve it for the preview.

### Screenshots


https://github.com/user-attachments/assets/f277012d-838f-42ad-b693-3cc400ce3955

