### PR TITLE
fix(dashboard): regression variable plugin

### DIFF
--- a/apps/dashboard/src/components/primitives/control-input/variable-plugin/plugin-view.ts
+++ b/apps/dashboard/src/components/primitives/control-input/variable-plugin/plugin-view.ts
@@ -54,7 +54,9 @@ export class VariablePluginView {
         continue;
       }
 
-      const { fullLiquidExpression, name, start, end, filtersArray } = parsedVariable;
+      const { fullLiquidExpression, name, filtersArray } = parsedVariable;
+      const start = match.index;
+      const end = start + match[0].length;
 
       // Skip creating pills for variables that are currently being edited
       // This allows users to modify variables without the pill getting in the way

--- a/apps/dashboard/src/utils/liquid.ts
+++ b/apps/dashboard/src/utils/liquid.ts
@@ -3,8 +3,6 @@ export type VariableMatch = {
   liquidVariable: string;
   name: string;
   nameRoot: string;
-  start: number;
-  end: number;
   filtersArray: string[];
   filters: string;
 };
@@ -52,8 +50,6 @@ export function parseVariable(variable: string): VariableMatch | undefined {
     return;
   }
 
-  const start = match.index;
-  const end = start + match[0].length;
   const fullLiquidExpression = match[1].trim();
   const parts = fullLiquidExpression.split('|').map((part) => part.trim());
   const name = parts[0];
@@ -64,8 +60,6 @@ export function parseVariable(variable: string): VariableMatch | undefined {
     liquidVariable,
     name,
     nameRoot: name.trim().split('.')[0],
-    start,
-    end,
     filtersArray: hasFilters ? parts.slice(1) : [],
     filters: hasFilters ? `| ${parts.slice(1).join(' | ')}` : '',
   };


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixed the regression issue with the CodeMirror variable plugin that was not calculating the correct start and end positions when the variable was inserted.

### Screenshots

