### PR TITLE
fix(dashboard): prevent negative out of bounds position

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/email/variables/variables.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/variables/variables.ts
@@ -93,7 +93,7 @@ export const insertVariableToEditor = ({
 
   // Calculate range for manual typing if not provided by suggestion
   const calculatedRange = range || {
-    from: editor.state.selection.from - queryWithoutSuffix.length - 4, // -4 for '{{ }}'
+    from: Math.max(0, editor.state.selection.from - queryWithoutSuffix.length), // -4 for '{{ }}'
     to: editor.state.selection.from,
   };
 

--- a/apps/dashboard/src/components/workflow-editor/steps/email/variables/variables.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/variables/variables.ts
@@ -93,7 +93,7 @@ export const insertVariableToEditor = ({
 
   // Calculate range for manual typing if not provided by suggestion
   const calculatedRange = range || {
-    from: Math.max(0, editor.state.selection.from - queryWithoutSuffix.length), // -4 for '{{ }}'
+    from: Math.max(0, editor.state.selection.from - queryWithoutSuffix.length - 4), // -4 for '{{ }}'
     to: editor.state.selection.from,
   };
 
@@ -207,7 +207,15 @@ export const calculateVariables = ({
     variables.push({ name: queryWithoutSuffix });
   }
 
-  insertVariableToEditor({ query, editor, isAllowedVariable, isEnhancedDigestEnabled });
+  /* Skip variable insertion by closing "}}" for bubble menus since they require special handling:
+   * 1. They use different positioning logic compared to content variables
+   * 2. Each menu type (repeat, button, etc.) handles variables differently
+   * 3. For now bubble variables can be only added via Enter key which triggers a separate insertion flow
+   *    (which is external somewhere in TipTap or Maily)
+   */
+  if (from === VariableFrom.Content) {
+    insertVariableToEditor({ query, editor, isAllowedVariable, isEnhancedDigestEnabled });
+  }
 
   return dedupAndSortVariables(variables, queryWithoutSuffix);
 };


### PR DESCRIPTION
### What changed? Why was the change needed?

This is only a monkey patch - the current issues lies in the fact that there are 4 different ways to insert a variable and each of them is a different extension having different positions within the editor.

**Cases:**
1. typing variable in regular editor content **fully**, e.g. `{{payload.something}} ` - works ✅ 
2. typing variable in regular editor but pressing "enter" midway - works ✅ 
3. typing variable in Bubble menu (button name, url, repeat block) **fully** - doesn't work, the input has some different coordinates, the variable won't be inserted there ❌ 
4. typing variable in Bubble menu and pressing enter midway - works ✅  - but its not clear what function triggers the insert, its internal in the library somewhere
5. typing variable fully in Repeat bubble menu - doesn't work ❌ - compared to other bubble menus, this menu has variable mode by default, e.g. typing "{{" doesnt make sense

Essentially, there is a big problem when inserting variable to bubble menus using full variable name, because we don't have the correct `from` and `to` coordinates - we need to find a way how is the variable being inserted when enter is pressed and do the same. There is a lot of confusion introduced by combining multiple libraries and extensions for the variables.