### PR TITLE
fix(api-service): add topics to both getSubscriber and search subscriber endpoints

### DIFF
--- a/apps/api/src/app/subscribers-v2/e2e/get-subscriber.e2e.ts
+++ b/apps/api/src/app/subscribers-v2/e2e/get-subscriber.e2e.ts
@@ -24,7 +24,13 @@ describe('Get Subscriber - /subscribers/:subscriberId (GET) #novu-v2', () => {
 
     validateSubscriber(res.result, subscriber);
   });
-
+  it('should fetch subscriber topics', async () => {
+    const topicKey = 'test-topic';
+    await novuClient.topics.subscribers.assign({ subscribers: [subscriber.subscriberId] }, topicKey);
+    const res = await novuClient.subscribers.retrieve(subscriber.subscriberId);
+    expect(res.result.topics).to.not.be.empty;
+    expect(res.result.topics![0]).to.equal(topicKey);
+  });
   it('should return 404 if subscriberId does not exist', async () => {
     const invalidSubscriberId = `non-existent-${randomBytes(2).toString('hex')}`;
     const { error } = await expectSdkExceptionGeneric(() => novuClient.subscribers.retrieve(invalidSubscriberId));

--- a/apps/api/src/app/subscribers-v2/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.ts
@@ -12,10 +12,10 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import {
+  CreateOrUpdateSubscriberCommand,
+  CreateOrUpdateSubscriberUseCase,
   ExternalApiAccessible,
   UserSession,
-  CreateOrUpdateSubscriberUseCase,
-  CreateOrUpdateSubscriberCommand,
 } from '@novu/application-generic';
 import { ApiRateLimitCategoryEnum, SubscriberCustomData, UserSessionData } from '@novu/shared';
 import { ApiCommonResponses, ApiResponse } from '../shared/framework/response.decorator';

--- a/apps/api/src/app/subscribers-v2/usecases/get-subscriber/get-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/get-subscriber/get-subscriber.usecase.ts
@@ -1,12 +1,15 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { SubscriberEntity, SubscriberRepository } from '@novu/dal';
+import { SubscriberEntity, SubscriberRepository, TopicSubscribersRepository } from '@novu/dal';
 import { GetSubscriberCommand } from './get-subscriber.command';
 import { mapSubscriberEntityToDto } from '../list-subscribers/map-subscriber-entity-to.dto';
 import { SubscriberResponseDto } from '../../../subscribers/dtos';
 
 @Injectable()
 export class GetSubscriber {
-  constructor(private subscriberRepository: SubscriberRepository) {}
+  constructor(
+    private subscriberRepository: SubscriberRepository,
+    private topicSubscribersRepository: TopicSubscribersRepository
+  ) {}
 
   async execute(command: GetSubscriberCommand): Promise<SubscriberResponseDto> {
     const subscriber = await this.fetchSubscriber({
@@ -14,12 +17,15 @@ export class GetSubscriber {
       subscriberId: command.subscriberId,
       _organizationId: command.organizationId,
     });
-
+    const topics = await this.topicSubscribersRepository.fetchSubscriberTopics({
+      _environmentId: command.environmentId,
+      subscriberIds: [command.subscriberId],
+    });
     if (!subscriber) {
       throw new NotFoundException(`Subscriber: ${command.subscriberId} was not found`);
     }
 
-    return mapSubscriberEntityToDto(subscriber);
+    return mapSubscriberEntityToDto(subscriber, topics[command.subscriberId]);
   }
 
   private async fetchSubscriber({

--- a/apps/api/src/app/subscribers-v2/usecases/list-subscribers/list-subscribers.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/list-subscribers/list-subscribers.usecase.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InstrumentUsecase } from '@novu/application-generic';
-import { SubscriberRepository } from '@novu/dal';
+import { SubscriberRepository, TopicSubscribersRepository } from '@novu/dal';
 import { ListSubscribersCommand } from './list-subscribers.command';
 import { ListSubscribersResponseDto } from '../../dtos/list-subscribers-response.dto';
 import { DirectionEnum } from '../../../shared/dtos/base-responses';
@@ -8,7 +8,10 @@ import { mapSubscriberEntityToDto } from './map-subscriber-entity-to.dto';
 
 @Injectable()
 export class ListSubscribersUseCase {
-  constructor(private subscriberRepository: SubscriberRepository) {}
+  constructor(
+    private subscriberRepository: SubscriberRepository,
+    private topicSubscribersRepository: TopicSubscribersRepository
+  ) {}
 
   @InstrumentUsecase()
   async execute(command: ListSubscribersCommand): Promise<ListSubscribersResponseDto> {
@@ -26,9 +29,16 @@ export class ListSubscribersUseCase {
       organizationId: command.user.organizationId,
       includeCursor: command.includeCursor,
     });
+    const subscriberIds = pagination.subscribers.map((subscriber) => subscriber.subscriberId);
+    const subscriberIdToTopics = await this.topicSubscribersRepository.fetchSubscriberTopics({
+      subscriberIds,
+      _environmentId: command.user.environmentId,
+    });
 
     return {
-      data: pagination.subscribers.map((subscriber) => mapSubscriberEntityToDto(subscriber)),
+      data: pagination.subscribers.map((subscriber) =>
+        mapSubscriberEntityToDto(subscriber, subscriberIdToTopics[subscriber.subscriberId])
+      ),
       next: pagination.next,
       previous: pagination.previous,
     };

--- a/apps/api/src/app/subscribers-v2/usecases/list-subscribers/map-subscriber-entity-to.dto.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/list-subscribers/map-subscriber-entity-to.dto.ts
@@ -1,7 +1,7 @@
 import { SubscriberEntity } from '@novu/dal';
 import { SubscriberResponseDto } from '../../../subscribers/dtos';
 
-export function mapSubscriberEntityToDto(subscriber: SubscriberEntity): SubscriberResponseDto {
+export function mapSubscriberEntityToDto(subscriber: SubscriberEntity, topics?: string[]): SubscriberResponseDto {
   return {
     _id: subscriber._id,
     firstName: subscriber.firstName,
@@ -17,7 +17,7 @@ export function mapSubscriberEntityToDto(subscriber: SubscriberEntity): Subscrib
     data: subscriber.data,
     lastOnlineAt: subscriber.lastOnlineAt,
     isOnline: subscriber.isOnline,
-    topics: subscriber.topics,
+    topics,
     channels: subscriber.channels,
     locale: subscriber.locale,
     timezone: subscriber.timezone,

--- a/apps/api/src/app/subscribers-v2/usecases/patch-subscriber/patch-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/patch-subscriber/patch-subscriber.usecase.ts
@@ -11,9 +11,9 @@ import {
 } from '@novu/dal';
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { SubscriberResponseDto } from '../../../subscribers/dtos';
-import { mapSubscriberEntityToDto } from '../list-subscribers/map-subscriber-entity-to.dto';
 import { PatchSubscriberCommand } from './patch-subscriber.command';
 import { subscriberIdSchema } from '../../../events/utils/trigger-recipient-validation';
+import { GetSubscriber } from '../get-subscriber/get-subscriber.usecase';
 
 @Injectable()
 export class PatchSubscriber {
@@ -22,6 +22,7 @@ export class PatchSubscriber {
     private featureFlagService: FeatureFlagsService,
     private environmentRepository: EnvironmentRepository,
     private communityOrganizationRepository: CommunityOrganizationRepository,
+    private getSubscriber: GetSubscriber,
     private logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -86,7 +87,11 @@ export class PatchSubscriber {
       throw new NotFoundException(`Subscriber: ${command.subscriberId} was not found`);
     }
 
-    return mapSubscriberEntityToDto(updatedSubscriber);
+    return this.getSubscriber.execute({
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      subscriberId: updatedSubscriber.subscriberId,
+    });
   }
 
   private async validateItem({

--- a/apps/api/src/app/subscribers/dtos/subscriber-response.dto.ts
+++ b/apps/api/src/app/subscribers/dtos/subscriber-response.dto.ts
@@ -63,7 +63,6 @@ export class SubscriberResponseDto {
   @ApiPropertyOptional({
     description: 'An array of topics that the subscriber is subscribed to.',
     type: [String],
-    deprecated: true,
   })
   topics?: string[];
 

--- a/apps/api/src/app/subscribers/e2e/get-subscribers.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/get-subscribers.e2e.ts
@@ -16,8 +16,10 @@ describe('Get Subscribers - /subscribers (GET) #novu-v2', function () {
   });
 
   it('should list created subscriber', async function () {
+    const subscriberId = '123';
+    const topicKey = 'test-topic';
     await novuClient.subscribers.create({
-      subscriberId: '123',
+      subscriberId,
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@doe.com',
@@ -29,5 +31,25 @@ describe('Get Subscribers - /subscribers (GET) #novu-v2', function () {
     expect(filteredData.length).to.equal(1);
     const subscriber = filteredData[0];
     expect(subscriber.subscriberId).to.equal('123');
+  });
+  it('should search created subscriber', async function () {
+    const subscriberId = '123';
+    const topicKey = 'test-topic';
+    await novuClient.subscribers.create({
+      subscriberId,
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john@doe.com',
+      phone: '+972523333333',
+    });
+    await novuClient.topics.subscribers.assign({ subscribers: [subscriberId] }, topicKey);
+    const response = await novuClient.subscribers.search({});
+
+    const filteredData = response.result.data.filter((user) => user.lastName !== 'Test');
+    expect(filteredData.length).to.equal(1);
+    const subscriber = filteredData[0];
+    expect(subscriber.subscriberId).to.equal('123');
+    expect(subscriber.topics).to.not.be.empty;
+    expect(subscriber.topics![0]).to.equal(topicKey);
   });
 });

--- a/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
@@ -1,14 +1,15 @@
 import { ExternalSubscriberId } from '@novu/shared';
 
+import mongoose from 'mongoose';
 import {
   CreateTopicSubscribersEntity,
-  TopicSubscribersEntity,
   TopicSubscribersDBModel,
+  TopicSubscribersEntity,
 } from './topic-subscribers.entity';
 import { TopicSubscribers } from './topic-subscribers.schema';
 import { EnvironmentId, OrganizationId, TopicId, TopicKey } from './types';
 import { BaseRepository } from '../base-repository';
-import type { EnforceEnvOrOrgIds } from '../../types/enforce';
+import type { EnforceEnvOrOrgIds } from '../../types';
 
 export class TopicSubscribersRepository extends BaseRepository<
   TopicSubscribersDBModel,
@@ -85,6 +86,34 @@ export class TopicSubscribersRepository extends BaseRepository<
     });
   }
 
+  async fetchSubscriberTopics({
+    subscriberIds,
+    _environmentId,
+  }: {
+    subscriberIds: string[];
+    _environmentId: string;
+  }): Promise<Record<string, string[]>> {
+    const subscriberTopics = await this._model.aggregate([
+      {
+        $match: {
+          _environmentId: new mongoose.Types.ObjectId(_environmentId),
+          externalSubscriberId: { $in: subscriberIds },
+        },
+      },
+      {
+        $group: {
+          _id: '$externalSubscriberId',
+          topics: { $addToSet: '$topicKey' },
+        },
+      },
+    ]);
+
+    return subscriberTopics.reduce((acc, item) => {
+      acc[item._id] = item.topics;
+
+      return acc;
+    }, {});
+  }
   async removeSubscribers(
     _environmentId: EnvironmentId,
     _organizationId: OrganizationId,

--- a/libs/dal/src/repositories/topic/topic.repository.ts
+++ b/libs/dal/src/repositories/topic/topic.repository.ts
@@ -1,6 +1,6 @@
 import { FilterQuery } from 'mongoose';
 
-import { TopicEntity, TopicDBModel } from './topic.entity';
+import { TopicDBModel, TopicEntity } from './topic.entity';
 import { Topic } from './topic.schema';
 import { EnvironmentId, ExternalSubscriberId, OrganizationId, TopicId, TopicKey, TopicName } from './types';
 import { BaseRepository } from '../base-repository';

--- a/libs/internal-sdk/src/lib/config.ts
+++ b/libs/internal-sdk/src/lib/config.ts
@@ -63,6 +63,6 @@ export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0",
   sdkVersion: "0.1.19",
-  genVersion: "2.578.0",
-  userAgent: "speakeasy-sdk/typescript 0.1.19 2.578.0 1.0 @novu/api",
+  genVersion: "2.585.2",
+  userAgent: "speakeasy-sdk/typescript 0.1.19 2.585.2 1.0 @novu/api",
 } as const;

--- a/libs/internal-sdk/src/models/components/subscriberresponsedto.ts
+++ b/libs/internal-sdk/src/models/components/subscriberresponsedto.ts
@@ -53,8 +53,6 @@ export type SubscriberResponseDto = {
   channels?: Array<ChannelSettingsDto> | undefined;
   /**
    * An array of topics that the subscriber is subscribed to.
-   *
-   * @deprecated field: This will be removed in a future release, please migrate away from it as soon as possible.
    */
   topics?: Array<string> | undefined;
   /**

--- a/libs/internal-sdk/src/sdk/workflows.ts
+++ b/libs/internal-sdk/src/sdk/workflows.ts
@@ -66,10 +66,10 @@ export class Workflows extends ClientSDK {
   }
 
   /**
-   * Get subscriber
+   * Get webhook support status for provider
    *
    * @remarks
-   * Get subscriber by your internal id used to identify the subscriber
+   * Return the status of the webhook for this provider, if it is supported or if it is not based on a boolean value
    */
   async retrieve(
     workflowId: string,
@@ -87,10 +87,10 @@ export class Workflows extends ClientSDK {
   }
 
   /**
-   * Delete topic
+   * Delete subscriber credentials by providerId
    *
    * @remarks
-   * Delete a topic by its topic key if it has no subscribers
+   * Delete subscriber credentials such as slack and expo tokens.
    */
   async delete(
     workflowId: string,


### PR DESCRIPTION
### What changed? Why was the change needed?
Added topics in two api's, the documentation said it was there but it was never populated

1. Get subscriber
2. Search Subscriber
Added tests to validate behavior 

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
