### PR TITLE
fix(api-service): preview payload should respect user provided arrays when items added/removed

### DIFF
--- a/apps/api/src/app/workflows-v2/util/utils.ts
+++ b/apps/api/src/app/workflows-v2/util/utils.ts
@@ -191,18 +191,8 @@ export function mergeCommonObjectKeys(
       const sourceValue = source[key];
 
       if (Array.isArray(targetValue) && Array.isArray(sourceValue)) {
-        const sourceValueLength = sourceValue.length;
-        const targetValueLength = targetValue.length;
-        const maxLength = Math.max(sourceValueLength, targetValueLength);
-
-        merged[key] = Array.from({ length: maxLength }, (_, index) => {
-          if (index < sourceValueLength) {
-            // if we have a corresponding source item, use it
-            return sourceValue[index];
-          }
-
-          // otherwise keep the target item
-          return targetValue[index];
+        merged[key] = Array.from({ length: sourceValue.length }, (_, index) => {
+          return sourceValue[index];
         });
       } else if (isObject(targetValue) && isObject(sourceValue)) {
         merged[key] = mergeCommonObjectKeys(


### PR DESCRIPTION
### What changed? Why was the change needed?

The Email Preview payload example should respect the changes the user made to the arrays. 

### Screenshots



https://github.com/user-attachments/assets/d0672c2e-8ec4-444a-8f5d-4c7173f7aaed

