### PR TITLE
fix(dashboard): Tiny crate with fixes

### DIFF
--- a/apps/dashboard/src/components/activity/activity-logs.tsx
+++ b/apps/dashboard/src/components/activity/activity-logs.tsx
@@ -41,7 +41,7 @@ export function ActivityLogs({
   const queryClient = useQueryClient();
   const { currentEnvironment } = useEnvironment();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  const workflowDeletedExist = !!activity?.template;
+  const workflowExists = !!activity?.template;
 
   const resentMetadata = {
     __resent_transaction_id: activity.transactionId,
@@ -152,20 +152,20 @@ export function ActivityLogs({
             <div className="flex items-center justify-between border-b border-neutral-100 p-3">
               <h3 className="text-foreground-950 text-sm font-medium">Request payload</h3>
               <div className="flex items-center gap-2">
-                <Button
-                  variant="secondary"
-                  mode="ghost"
-                  size="sm"
-                  onClick={() => handleResend()}
-                  className="text-xs"
-                  disabled={isPending || !workflowDeletedExist}
-                  type="button"
-                >
-                  <RepeatPlay
-                    className={cn('size-3', isPending || (!workflowDeletedExist && 'text-text-disabled opacity-50'))}
-                  />
-                  Resend
-                </Button>
+                {workflowExists && (
+                  <Button
+                    variant="secondary"
+                    mode="ghost"
+                    size="sm"
+                    onClick={() => handleResend()}
+                    className="text-xs"
+                    disabled={isPending}
+                    type="button"
+                  >
+                    <RepeatPlay className={cn('size-3', { 'text-text-disabled opacity-50': isPending })} />
+                    Resend
+                  </Button>
+                )}
                 <PopoverClose asChild ref={popoverCloseRef}>
                   <CompactButton size="md" variant="ghost" icon={RiCloseFill} type="button">
                     <span className="sr-only">Close</span>

--- a/apps/dashboard/src/components/workflow-editor/steps/email/blocks/digest.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/blocks/digest.tsx
@@ -13,7 +13,7 @@ export const createDigestBlock = (props: {
   const maxIterations = 5;
 
   return {
-    title: 'Digest block',
+    title: 'Digest',
     description: 'Display digested notifications in list.',
     searchTerms: ['digest', 'notification'],
     icon: <RiShadowLine className="mly-h-4 mly-w-4" />,

--- a/apps/dashboard/src/components/workflow-editor/steps/email/maily-config.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/maily-config.tsx
@@ -137,7 +137,7 @@ const getAvailableBlocks = (blocks: BlockGroupItem[], editor: TiptapEditor | nul
   const isInsideRepeat = editor && isInsideRepeatBlock(editor);
 
   if (isInsideRepeat) {
-    const filteredBlocks = ['Repeat', 'Digest block'];
+    const filteredBlocks = ['Repeat', 'Digest'];
 
     return blocks.map((block) => ({
       ...block,


### PR DESCRIPTION
### What changed? Why was the change needed?

1. Rename Digest block to Digest to stick to the naming conventions
2. Show the Retrigger button in Activity feed only if the workflow is not deleted.