### PR TITLE
nv-5687-bug-return-topics-array-in-get-subscriber-response-v2-api

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="TypeScriptCompiler">
+    <option name="useTypesFromServer" value="true" />
+  </component>
+</project>

--- a/apps/api/src/app/subscribers-v2/e2e/get-subscriber.e2e.ts
+++ b/apps/api/src/app/subscribers-v2/e2e/get-subscriber.e2e.ts
@@ -24,13 +24,6 @@ describe('Get Subscriber - /subscribers/:subscriberId (GET) #novu-v2', () => {
 
     validateSubscriber(res.result, subscriber);
   });
-  it('should fetch subscriber topics', async () => {
-    const topicKey = 'test-topic';
-    await novuClient.topics.subscribers.assign({ subscribers: [subscriber.subscriberId] }, topicKey);
-    const res = await novuClient.subscribers.retrieve(subscriber.subscriberId);
-    expect(res.result.topics).to.not.be.empty;
-    expect(res.result.topics![0]).to.equal(topicKey);
-  });
   it('should return 404 if subscriberId does not exist', async () => {
     const invalidSubscriberId = `non-existent-${randomBytes(2).toString('hex')}`;
     const { error } = await expectSdkExceptionGeneric(() => novuClient.subscribers.retrieve(invalidSubscriberId));

--- a/apps/api/src/app/subscribers-v2/e2e/get-subscriber.e2e.ts
+++ b/apps/api/src/app/subscribers-v2/e2e/get-subscriber.e2e.ts
@@ -24,7 +24,13 @@ describe('Get Subscriber - /subscribers/:subscriberId (GET) #novu-v2', () => {
 
     validateSubscriber(res.result, subscriber);
   });
-
+  it('should fetch subscriber topics', async () => {
+    const topicKey = 'test-topic';
+    await novuClient.topics.subscribers.assign({ subscribers: [subscriber.subscriberId] }, topicKey);
+    const res = await novuClient.subscribers.retrieve(subscriber.subscriberId);
+    expect(res.result.topics).to.not.be.empty;
+    expect(res.result.topics![0]).to.equal(topicKey);
+  });
   it('should return 404 if subscriberId does not exist', async () => {
     const invalidSubscriberId = `non-existent-${randomBytes(2).toString('hex')}`;
     const { error } = await expectSdkExceptionGeneric(() => novuClient.subscribers.retrieve(invalidSubscriberId));

--- a/apps/api/src/app/subscribers-v2/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.ts
@@ -12,10 +12,10 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import {
+  CreateOrUpdateSubscriberCommand,
+  CreateOrUpdateSubscriberUseCase,
   ExternalApiAccessible,
   UserSession,
-  CreateOrUpdateSubscriberUseCase,
-  CreateOrUpdateSubscriberCommand,
 } from '@novu/application-generic';
 import { ApiRateLimitCategoryEnum, SubscriberCustomData, UserSessionData } from '@novu/shared';
 import { ApiCommonResponses, ApiResponse } from '../shared/framework/response.decorator';

--- a/apps/api/src/app/subscribers-v2/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.ts
@@ -94,9 +94,7 @@ export class SubscribersController {
   @ExternalApiAccessible()
   @ApiOperation({
     summary: 'Get subscriber',
-    description: `Get subscriber by your internal id used to identify the subscriber, 
-    topics have been removed from the response use
-     GET: v1/topics to retrieve the subscriber topic list`,
+    description: `Get subscriber by your internal id used to identify the subscriber`,
   })
   @ApiResponse(SubscriberResponseDto)
   @SdkMethodName('retrieve')

--- a/apps/api/src/app/subscribers-v2/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.ts
@@ -94,7 +94,9 @@ export class SubscribersController {
   @ExternalApiAccessible()
   @ApiOperation({
     summary: 'Get subscriber',
-    description: 'Get subscriber by your internal id used to identify the subscriber',
+    description: `Get subscriber by your internal id used to identify the subscriber, 
+    topics have been removed from the response use
+     GET: v1/topics to retrieve the subscriber topic list`,
   })
   @ApiResponse(SubscriberResponseDto)
   @SdkMethodName('retrieve')

--- a/apps/api/src/app/subscribers-v2/usecases/get-subscriber/get-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/get-subscriber/get-subscriber.usecase.ts
@@ -1,12 +1,15 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { SubscriberEntity, SubscriberRepository } from '@novu/dal';
+import { SubscriberEntity, SubscriberRepository, TopicSubscribersRepository } from '@novu/dal';
 import { GetSubscriberCommand } from './get-subscriber.command';
 import { mapSubscriberEntityToDto } from '../list-subscribers/map-subscriber-entity-to.dto';
 import { SubscriberResponseDto } from '../../../subscribers/dtos';
 
 @Injectable()
 export class GetSubscriber {
-  constructor(private subscriberRepository: SubscriberRepository) {}
+  constructor(
+    private subscriberRepository: SubscriberRepository,
+    private topicSubscribersRepository: TopicSubscribersRepository
+  ) {}
 
   async execute(command: GetSubscriberCommand): Promise<SubscriberResponseDto> {
     const subscriber = await this.fetchSubscriber({
@@ -14,12 +17,15 @@ export class GetSubscriber {
       subscriberId: command.subscriberId,
       _organizationId: command.organizationId,
     });
-
+    const topics = await this.topicSubscribersRepository.fetchSubscriberTopics({
+      _environmentId: command.environmentId,
+      subscriberIds: [command.subscriberId],
+    });
     if (!subscriber) {
       throw new NotFoundException(`Subscriber: ${command.subscriberId} was not found`);
     }
 
-    return mapSubscriberEntityToDto(subscriber);
+    return mapSubscriberEntityToDto(subscriber, topics[command.subscriberId]);
   }
 
   private async fetchSubscriber({

--- a/apps/api/src/app/subscribers-v2/usecases/get-subscriber/get-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/get-subscriber/get-subscriber.usecase.ts
@@ -1,15 +1,12 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { SubscriberEntity, SubscriberRepository, TopicSubscribersRepository } from '@novu/dal';
+import { SubscriberEntity, SubscriberRepository } from '@novu/dal';
 import { GetSubscriberCommand } from './get-subscriber.command';
 import { mapSubscriberEntityToDto } from '../list-subscribers/map-subscriber-entity-to.dto';
 import { SubscriberResponseDto } from '../../../subscribers/dtos';
 
 @Injectable()
 export class GetSubscriber {
-  constructor(
-    private subscriberRepository: SubscriberRepository,
-    private topicSubscribersRepository: TopicSubscribersRepository
-  ) {}
+  constructor(private subscriberRepository: SubscriberRepository) {}
 
   async execute(command: GetSubscriberCommand): Promise<SubscriberResponseDto> {
     const subscriber = await this.fetchSubscriber({
@@ -17,15 +14,11 @@ export class GetSubscriber {
       subscriberId: command.subscriberId,
       _organizationId: command.organizationId,
     });
-    const topics = await this.topicSubscribersRepository.fetchSubscriberTopics({
-      _environmentId: command.environmentId,
-      subscriberIds: [command.subscriberId],
-    });
     if (!subscriber) {
       throw new NotFoundException(`Subscriber: ${command.subscriberId} was not found`);
     }
 
-    return mapSubscriberEntityToDto(subscriber, topics[command.subscriberId]);
+    return mapSubscriberEntityToDto(subscriber);
   }
 
   private async fetchSubscriber({

--- a/apps/api/src/app/subscribers-v2/usecases/list-subscribers/list-subscribers.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/list-subscribers/list-subscribers.usecase.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InstrumentUsecase } from '@novu/application-generic';
-import { SubscriberRepository } from '@novu/dal';
+import { SubscriberRepository, TopicSubscribersRepository } from '@novu/dal';
 import { ListSubscribersCommand } from './list-subscribers.command';
 import { ListSubscribersResponseDto } from '../../dtos/list-subscribers-response.dto';
 import { DirectionEnum } from '../../../shared/dtos/base-responses';
@@ -8,7 +8,10 @@ import { mapSubscriberEntityToDto } from './map-subscriber-entity-to.dto';
 
 @Injectable()
 export class ListSubscribersUseCase {
-  constructor(private subscriberRepository: SubscriberRepository) {}
+  constructor(
+    private subscriberRepository: SubscriberRepository,
+    private topicSubscribersRepository: TopicSubscribersRepository
+  ) {}
 
   @InstrumentUsecase()
   async execute(command: ListSubscribersCommand): Promise<ListSubscribersResponseDto> {
@@ -26,9 +29,16 @@ export class ListSubscribersUseCase {
       organizationId: command.user.organizationId,
       includeCursor: command.includeCursor,
     });
+    const subscriberIds = pagination.subscribers.map((subscriber) => subscriber.subscriberId);
+    const subscriberIdToTopics = await this.topicSubscribersRepository.fetchSubscriberTopics({
+      subscriberIds,
+      _environmentId: command.user.environmentId,
+    });
 
     return {
-      data: pagination.subscribers.map((subscriber) => mapSubscriberEntityToDto(subscriber)),
+      data: pagination.subscribers.map((subscriber) =>
+        mapSubscriberEntityToDto(subscriber, subscriberIdToTopics[subscriber.subscriberId])
+      ),
       next: pagination.next,
       previous: pagination.previous,
     };

--- a/apps/api/src/app/subscribers-v2/usecases/list-subscribers/list-subscribers.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/list-subscribers/list-subscribers.usecase.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InstrumentUsecase } from '@novu/application-generic';
-import { SubscriberRepository, TopicSubscribersRepository } from '@novu/dal';
+import { SubscriberRepository } from '@novu/dal';
 import { ListSubscribersCommand } from './list-subscribers.command';
 import { ListSubscribersResponseDto } from '../../dtos/list-subscribers-response.dto';
 import { DirectionEnum } from '../../../shared/dtos/base-responses';
@@ -8,10 +8,7 @@ import { mapSubscriberEntityToDto } from './map-subscriber-entity-to.dto';
 
 @Injectable()
 export class ListSubscribersUseCase {
-  constructor(
-    private subscriberRepository: SubscriberRepository,
-    private topicSubscribersRepository: TopicSubscribersRepository
-  ) {}
+  constructor(private subscriberRepository: SubscriberRepository) {}
 
   @InstrumentUsecase()
   async execute(command: ListSubscribersCommand): Promise<ListSubscribersResponseDto> {
@@ -29,16 +26,9 @@ export class ListSubscribersUseCase {
       organizationId: command.user.organizationId,
       includeCursor: command.includeCursor,
     });
-    const subscriberIds = pagination.subscribers.map((subscriber) => subscriber.subscriberId);
-    const subscriberIdToTopics = await this.topicSubscribersRepository.fetchSubscriberTopics({
-      subscriberIds,
-      _environmentId: command.user.environmentId,
-    });
 
     return {
-      data: pagination.subscribers.map((subscriber) =>
-        mapSubscriberEntityToDto(subscriber, subscriberIdToTopics[subscriber.subscriberId])
-      ),
+      data: pagination.subscribers.map((subscriber) => mapSubscriberEntityToDto(subscriber)),
       next: pagination.next,
       previous: pagination.previous,
     };

--- a/apps/api/src/app/subscribers-v2/usecases/list-subscribers/map-subscriber-entity-to.dto.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/list-subscribers/map-subscriber-entity-to.dto.ts
@@ -1,7 +1,7 @@
 import { SubscriberEntity } from '@novu/dal';
 import { SubscriberResponseDto } from '../../../subscribers/dtos';
 
-export function mapSubscriberEntityToDto(subscriber: SubscriberEntity): SubscriberResponseDto {
+export function mapSubscriberEntityToDto(subscriber: SubscriberEntity, topics?: string[]): SubscriberResponseDto {
   return {
     _id: subscriber._id,
     firstName: subscriber.firstName,
@@ -17,7 +17,7 @@ export function mapSubscriberEntityToDto(subscriber: SubscriberEntity): Subscrib
     data: subscriber.data,
     lastOnlineAt: subscriber.lastOnlineAt,
     isOnline: subscriber.isOnline,
-    topics: subscriber.topics,
+    topics,
     channels: subscriber.channels,
     locale: subscriber.locale,
     timezone: subscriber.timezone,

--- a/apps/api/src/app/subscribers-v2/usecases/list-subscribers/map-subscriber-entity-to.dto.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/list-subscribers/map-subscriber-entity-to.dto.ts
@@ -1,7 +1,7 @@
 import { SubscriberEntity } from '@novu/dal';
 import { SubscriberResponseDto } from '../../../subscribers/dtos';
 
-export function mapSubscriberEntityToDto(subscriber: SubscriberEntity, topics?: string[]): SubscriberResponseDto {
+export function mapSubscriberEntityToDto(subscriber: SubscriberEntity): SubscriberResponseDto {
   return {
     _id: subscriber._id,
     firstName: subscriber.firstName,
@@ -17,7 +17,6 @@ export function mapSubscriberEntityToDto(subscriber: SubscriberEntity, topics?: 
     data: subscriber.data,
     lastOnlineAt: subscriber.lastOnlineAt,
     isOnline: subscriber.isOnline,
-    topics,
     channels: subscriber.channels,
     locale: subscriber.locale,
     timezone: subscriber.timezone,

--- a/apps/api/src/app/subscribers-v2/usecases/patch-subscriber/patch-subscriber.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/patch-subscriber/patch-subscriber.usecase.ts
@@ -11,9 +11,9 @@ import {
 } from '@novu/dal';
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { SubscriberResponseDto } from '../../../subscribers/dtos';
-import { mapSubscriberEntityToDto } from '../list-subscribers/map-subscriber-entity-to.dto';
 import { PatchSubscriberCommand } from './patch-subscriber.command';
 import { subscriberIdSchema } from '../../../events/utils/trigger-recipient-validation';
+import { GetSubscriber } from '../get-subscriber/get-subscriber.usecase';
 
 @Injectable()
 export class PatchSubscriber {
@@ -22,6 +22,7 @@ export class PatchSubscriber {
     private featureFlagService: FeatureFlagsService,
     private environmentRepository: EnvironmentRepository,
     private communityOrganizationRepository: CommunityOrganizationRepository,
+    private getSubscriber: GetSubscriber,
     private logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -86,7 +87,11 @@ export class PatchSubscriber {
       throw new NotFoundException(`Subscriber: ${command.subscriberId} was not found`);
     }
 
-    return mapSubscriberEntityToDto(updatedSubscriber);
+    return this.getSubscriber.execute({
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      subscriberId: updatedSubscriber.subscriberId,
+    });
   }
 
   private async validateItem({

--- a/apps/api/src/app/subscribers-v2/utils/create-subscriber.mapper.ts
+++ b/apps/api/src/app/subscribers-v2/utils/create-subscriber.mapper.ts
@@ -1,5 +1,3 @@
-import { SubscriberCustomData, UserSessionData } from '@novu/shared';
-import { CreateOrUpdateSubscriberCommand } from '@novu/application-generic';
 import { IChannelCredentials, IChannelSettings, SubscriberEntity } from '@novu/dal';
 import { ChannelSettingsDto, SubscriberResponseDto } from '../../subscribers/dtos';
 import { ChannelCredentials } from '../../shared/dtos/subscriber-channel';
@@ -14,7 +12,6 @@ export function mapSubscriberEntityToResponseDto(entity: SubscriberEntity): Subs
     avatar: entity.avatar,
     subscriberId: entity.subscriberId,
     channels: entity.channels?.map(mapChannelSettings),
-    topics: entity.topics,
     isOnline: entity.isOnline,
     lastOnlineAt: entity.lastOnlineAt,
     _organizationId: entity._organizationId,

--- a/apps/api/src/app/subscribers/dtos/subscriber-response.dto.ts
+++ b/apps/api/src/app/subscribers/dtos/subscriber-response.dto.ts
@@ -52,12 +52,6 @@ export class SubscriberResponseDtoOptional {
   })
   channels?: ChannelSettingsDto[];
 
-  @ApiPropertyOptional({
-    description: 'An array of topics that the subscriber is subscribed to.',
-    type: [String],
-  })
-  topics?: string[];
-
   @ApiProperty({
     description: 'Indicates whether the subscriber is currently online.',
     type: Boolean,

--- a/apps/api/src/app/subscribers/dtos/subscriber-response.dto.ts
+++ b/apps/api/src/app/subscribers/dtos/subscriber-response.dto.ts
@@ -55,7 +55,6 @@ export class SubscriberResponseDtoOptional {
   @ApiPropertyOptional({
     description: 'An array of topics that the subscriber is subscribed to.',
     type: [String],
-    deprecated: true,
   })
   topics?: string[];
 

--- a/apps/api/src/app/subscribers/e2e/get-subscribers.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/get-subscribers.e2e.ts
@@ -16,8 +16,10 @@ describe('Get Subscribers - /subscribers (GET) #novu-v2', function () {
   });
 
   it('should list created subscriber', async function () {
+    const subscriberId = '123';
+    const topicKey = 'test-topic';
     await novuClient.subscribers.create({
-      subscriberId: '123',
+      subscriberId,
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@doe.com',
@@ -29,5 +31,25 @@ describe('Get Subscribers - /subscribers (GET) #novu-v2', function () {
     expect(filteredData.length).to.equal(1);
     const subscriber = filteredData[0];
     expect(subscriber.subscriberId).to.equal('123');
+  });
+  it('should search created subscriber', async function () {
+    const subscriberId = '123';
+    const topicKey = 'test-topic';
+    await novuClient.subscribers.create({
+      subscriberId,
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john@doe.com',
+      phone: '+972523333333',
+    });
+    await novuClient.topics.subscribers.assign({ subscribers: [subscriberId] }, topicKey);
+    const response = await novuClient.subscribers.search({});
+
+    const filteredData = response.result.data.filter((user) => user.lastName !== 'Test');
+    expect(filteredData.length).to.equal(1);
+    const subscriber = filteredData[0];
+    expect(subscriber.subscriberId).to.equal('123');
+    expect(subscriber.topics).to.not.be.empty;
+    expect(subscriber.topics![0]).to.equal(topicKey);
   });
 });

--- a/apps/api/src/app/topics/dtos/filter-topics.dto.ts
+++ b/apps/api/src/app/topics/dtos/filter-topics.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 import { Transform } from 'class-transformer';
 import { TopicDto } from './topic.dto';
@@ -36,6 +36,18 @@ export class FilterTopicsRequestDto {
   @IsString()
   @IsOptional()
   public key?: string;
+
+  @ApiProperty({
+    example: 'false',
+    required: false,
+    type: 'boolean',
+    default: false, // Set the default value in the documentation
+    description: 'should return subscriber list, default is false',
+  })
+  @IsBoolean()
+  @Transform(({ value }) => value === 'true')
+  @IsOptional()
+  public shouldReturnSubscriberList?: boolean = true;
 
   @ApiProperty({
     example: 'someSubscriberId',

--- a/apps/api/src/app/topics/dtos/filter-topics.dto.ts
+++ b/apps/api/src/app/topics/dtos/filter-topics.dto.ts
@@ -36,6 +36,16 @@ export class FilterTopicsRequestDto {
   @IsString()
   @IsOptional()
   public key?: string;
+
+  @ApiProperty({
+    example: 'someSubscriberId',
+    required: false,
+    type: 'string',
+    description: 'filterByTopicsAssignedToSubscriberId',
+  })
+  @IsString()
+  @IsOptional()
+  public subscriberId?: string;
 }
 
 export class FilterTopicsResponseDto {

--- a/apps/api/src/app/topics/dtos/topic.dto.ts
+++ b/apps/api/src/app/topics/dtos/topic.dto.ts
@@ -1,21 +1,48 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsOptional, IsString } from 'class-validator';
 
 export class TopicDto {
-  @ApiPropertyOptional()
+  @ApiProperty({
+    description: 'Unique identifier for the topic',
+    example: '613b1f8e4f1a2c001c8e4b1a',
+  })
+  @IsString()
   _id: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Identifier for the organization that owns the topic',
+    example: 'org-12345',
+  })
+  @IsString()
   _organizationId: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Identifier for the environment associated with the topic',
+    example: 'env-67890',
+  })
+  @IsString()
   _environmentId: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Key for the topic, used for identifying it uniquely',
+    example: 'topic-key-01',
+  })
+  @IsString()
   key: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Name of the topic',
+    example: 'My First Topic',
+  })
+  @IsString()
   name: string;
 
-  @ApiProperty()
-  subscribers: string[];
+  @ApiPropertyOptional({
+    description: 'List of subscriber IDs for the topic',
+    example: ['sub-001', 'sub-002'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  subscribers?: string[];
 }

--- a/apps/api/src/app/topics/e2e/filter-topics.e2e.ts
+++ b/apps/api/src/app/topics/e2e/filter-topics.e2e.ts
@@ -40,7 +40,18 @@ describe('Filter topics - /topics (GET) #novu-v2', async () => {
     expect(subscribers).to.have.members(result.map((subscriber) => subscriber.externalSubscriberId));
     novuClient = initNovuClassSdk(session);
   });
-
+  describe('filter by subscriberId', () => {
+    it('should show all topics assigned to a subscriber', async () => {
+      await novuClient.topics.subscribers.assign({ subscribers: [session.subscriberId] }, 'someTopic');
+      const response = await novuClient.topics.list({ subscriberId: session.subscriberId });
+      const { totalCount, page, pageSize, data } = response.result;
+      expect(totalCount).to.eql(1);
+      expect(page).to.eql(0);
+      expect(pageSize).to.eql(10);
+      expect(data.length).to.eql(1);
+      expect(data[0].key).to.eql('someTopic');
+    });
+  });
   it('should return a validation error if the params provided are not in the right type', async () => {
     const response = await session.testAgent.get(`/v1/topics?page=first&pageSize=big`);
     expect(response.statusCode).to.eql(422);

--- a/apps/api/src/app/topics/topics.controller.ts
+++ b/apps/api/src/app/topics/topics.controller.ts
@@ -183,7 +183,7 @@ export class TopicsController {
     return await this.filterTopicsUseCase.execute(
       FilterTopicsCommand.create({
         environmentId: user.environmentId,
-        key: query?.key,
+        keys: query?.key ? [query?.key] : [],
         organizationId: user.organizationId,
         page: query?.page,
         pageSize: query?.pageSize,

--- a/apps/api/src/app/topics/topics.controller.ts
+++ b/apps/api/src/app/topics/topics.controller.ts
@@ -59,9 +59,8 @@ export class TopicsController {
     private getTopicSubscriberUseCase: GetTopicSubscriberUseCase,
     private getTopicUseCase: GetTopicUseCase,
     private removeSubscribersUseCase: RemoveSubscribersUseCase,
-    private renameTopicUseCase: RenameTopicUseCase,
-  ) {
-  }
+    private renameTopicUseCase: RenameTopicUseCase
+  ) {}
 
   @Post('')
   @ExternalApiAccessible()
@@ -69,7 +68,7 @@ export class TopicsController {
   @ApiOperation({ summary: 'Topic creation', description: 'Create a topic' })
   async createTopic(
     @UserSession() user: UserSessionData,
-    @Body() body: CreateTopicRequestDto,
+    @Body() body: CreateTopicRequestDto
   ): Promise<CreateTopicResponseDto> {
     const topic = await this.createTopicUseCase.execute(
       CreateTopicCommand.create({
@@ -78,7 +77,7 @@ export class TopicsController {
         name: body.name,
         organizationId: user.organizationId,
         userId: user._id,
-      }),
+      })
     );
 
     return {
@@ -98,7 +97,7 @@ export class TopicsController {
   async assign(
     @UserSession() user: UserSessionData,
     @Param('topicKey') topicKey: TopicKey,
-    @Body() body: AddSubscribersRequestDto,
+    @Body() body: AddSubscribersRequestDto
   ): Promise<AssignSubscriberToTopicDto> {
     const { existingExternalSubscribers, nonExistingExternalSubscribers } = await this.addSubscribersUseCase.execute(
       AddSubscribersCommand.create({
@@ -107,7 +106,7 @@ export class TopicsController {
         subscribers: body.subscribers,
         userId: user._id,
         topicKey,
-      }),
+      })
     );
 
     return {
@@ -131,7 +130,7 @@ export class TopicsController {
   async getTopicSubscriber(
     @UserSession() user: UserSessionData,
     @Param('topicKey') topicKey: TopicKey,
-    @Param('externalSubscriberId') externalSubscriberId: ExternalSubscriberId,
+    @Param('externalSubscriberId') externalSubscriberId: ExternalSubscriberId
   ): Promise<TopicSubscriberDto> {
     return await this.getTopicSubscriberUseCase.execute(
       GetTopicSubscriberCommand.create({
@@ -139,7 +138,7 @@ export class TopicsController {
         organizationId: user.organizationId,
         externalSubscriberId,
         topicKey,
-      }),
+      })
     );
   }
 
@@ -154,7 +153,7 @@ export class TopicsController {
   async removeSubscribers(
     @UserSession() user: UserSessionData,
     @Param('topicKey') topicKey: TopicKey,
-    @Body() body: RemoveSubscribersRequestDto,
+    @Body() body: RemoveSubscribersRequestDto
   ): Promise<void> {
     await this.removeSubscribersUseCase.execute(
       RemoveSubscribersCommand.create({
@@ -162,7 +161,7 @@ export class TopicsController {
         organizationId: user.organizationId,
         topicKey,
         subscribers: body.subscribers,
-      }),
+      })
     );
   }
 
@@ -179,17 +178,18 @@ export class TopicsController {
   })
   async listTopics(
     @UserSession() user: UserSessionData,
-    @Query() query?: FilterTopicsRequestDto,
+    @Query() query?: FilterTopicsRequestDto
   ): Promise<FilterTopicsResponseDto> {
     return await this.filterTopicsUseCase.execute(
       FilterTopicsCommand.create({
         environmentId: user.environmentId,
         keys: query?.key ? [query?.key] : [],
-        subscriberId: query?.subscriberId
+        subscriberId: query?.subscriberId,
         organizationId: user.organizationId,
+        shouldReturnSubscriberList: query?.shouldReturnSubscriberList,
         page: query?.page,
         pageSize: query?.pageSize,
-      }),
+      })
     );
   }
 
@@ -207,7 +207,7 @@ export class TopicsController {
         environmentId: user.environmentId,
         topicKey,
         organizationId: user.organizationId,
-      }),
+      })
     );
   }
 
@@ -218,14 +218,14 @@ export class TopicsController {
   @ApiParam({ name: 'topicKey', description: 'The topic key', type: String, required: true })
   async getTopic(
     @UserSession() user: UserSessionData,
-    @Param('topicKey') topicKey: TopicKey,
+    @Param('topicKey') topicKey: TopicKey
   ): Promise<GetTopicResponseDto> {
     return await this.getTopicUseCase.execute(
       GetTopicCommand.create({
         environmentId: user.environmentId,
         topicKey,
         organizationId: user.organizationId,
-      }),
+      })
     );
   }
 
@@ -238,7 +238,7 @@ export class TopicsController {
   async renameTopic(
     @UserSession() user: UserSessionData,
     @Param('topicKey') topicKey: TopicKey,
-    @Body() body: RenameTopicRequestDto,
+    @Body() body: RenameTopicRequestDto
   ): Promise<RenameTopicResponseDto> {
     return await this.renameTopicUseCase.execute(
       RenameTopicCommand.create({
@@ -246,7 +246,7 @@ export class TopicsController {
         topicKey,
         name: body.name,
         organizationId: user.organizationId,
-      }),
+      })
     );
   }
 }

--- a/apps/api/src/app/topics/topics.controller.ts
+++ b/apps/api/src/app/topics/topics.controller.ts
@@ -59,8 +59,9 @@ export class TopicsController {
     private getTopicSubscriberUseCase: GetTopicSubscriberUseCase,
     private getTopicUseCase: GetTopicUseCase,
     private removeSubscribersUseCase: RemoveSubscribersUseCase,
-    private renameTopicUseCase: RenameTopicUseCase
-  ) {}
+    private renameTopicUseCase: RenameTopicUseCase,
+  ) {
+  }
 
   @Post('')
   @ExternalApiAccessible()
@@ -68,7 +69,7 @@ export class TopicsController {
   @ApiOperation({ summary: 'Topic creation', description: 'Create a topic' })
   async createTopic(
     @UserSession() user: UserSessionData,
-    @Body() body: CreateTopicRequestDto
+    @Body() body: CreateTopicRequestDto,
   ): Promise<CreateTopicResponseDto> {
     const topic = await this.createTopicUseCase.execute(
       CreateTopicCommand.create({
@@ -77,7 +78,7 @@ export class TopicsController {
         name: body.name,
         organizationId: user.organizationId,
         userId: user._id,
-      })
+      }),
     );
 
     return {
@@ -97,7 +98,7 @@ export class TopicsController {
   async assign(
     @UserSession() user: UserSessionData,
     @Param('topicKey') topicKey: TopicKey,
-    @Body() body: AddSubscribersRequestDto
+    @Body() body: AddSubscribersRequestDto,
   ): Promise<AssignSubscriberToTopicDto> {
     const { existingExternalSubscribers, nonExistingExternalSubscribers } = await this.addSubscribersUseCase.execute(
       AddSubscribersCommand.create({
@@ -106,7 +107,7 @@ export class TopicsController {
         subscribers: body.subscribers,
         userId: user._id,
         topicKey,
-      })
+      }),
     );
 
     return {
@@ -130,7 +131,7 @@ export class TopicsController {
   async getTopicSubscriber(
     @UserSession() user: UserSessionData,
     @Param('topicKey') topicKey: TopicKey,
-    @Param('externalSubscriberId') externalSubscriberId: ExternalSubscriberId
+    @Param('externalSubscriberId') externalSubscriberId: ExternalSubscriberId,
   ): Promise<TopicSubscriberDto> {
     return await this.getTopicSubscriberUseCase.execute(
       GetTopicSubscriberCommand.create({
@@ -138,7 +139,7 @@ export class TopicsController {
         organizationId: user.organizationId,
         externalSubscriberId,
         topicKey,
-      })
+      }),
     );
   }
 
@@ -153,7 +154,7 @@ export class TopicsController {
   async removeSubscribers(
     @UserSession() user: UserSessionData,
     @Param('topicKey') topicKey: TopicKey,
-    @Body() body: RemoveSubscribersRequestDto
+    @Body() body: RemoveSubscribersRequestDto,
   ): Promise<void> {
     await this.removeSubscribersUseCase.execute(
       RemoveSubscribersCommand.create({
@@ -161,7 +162,7 @@ export class TopicsController {
         organizationId: user.organizationId,
         topicKey,
         subscribers: body.subscribers,
-      })
+      }),
     );
   }
 
@@ -178,16 +179,17 @@ export class TopicsController {
   })
   async listTopics(
     @UserSession() user: UserSessionData,
-    @Query() query?: FilterTopicsRequestDto
+    @Query() query?: FilterTopicsRequestDto,
   ): Promise<FilterTopicsResponseDto> {
     return await this.filterTopicsUseCase.execute(
       FilterTopicsCommand.create({
         environmentId: user.environmentId,
         keys: query?.key ? [query?.key] : [],
+        subscriberId: query?.subscriberId
         organizationId: user.organizationId,
         page: query?.page,
         pageSize: query?.pageSize,
-      })
+      }),
     );
   }
 
@@ -205,7 +207,7 @@ export class TopicsController {
         environmentId: user.environmentId,
         topicKey,
         organizationId: user.organizationId,
-      })
+      }),
     );
   }
 
@@ -216,14 +218,14 @@ export class TopicsController {
   @ApiParam({ name: 'topicKey', description: 'The topic key', type: String, required: true })
   async getTopic(
     @UserSession() user: UserSessionData,
-    @Param('topicKey') topicKey: TopicKey
+    @Param('topicKey') topicKey: TopicKey,
   ): Promise<GetTopicResponseDto> {
     return await this.getTopicUseCase.execute(
       GetTopicCommand.create({
         environmentId: user.environmentId,
         topicKey,
         organizationId: user.organizationId,
-      })
+      }),
     );
   }
 
@@ -236,7 +238,7 @@ export class TopicsController {
   async renameTopic(
     @UserSession() user: UserSessionData,
     @Param('topicKey') topicKey: TopicKey,
-    @Body() body: RenameTopicRequestDto
+    @Body() body: RenameTopicRequestDto,
   ): Promise<RenameTopicResponseDto> {
     return await this.renameTopicUseCase.execute(
       RenameTopicCommand.create({
@@ -244,7 +246,7 @@ export class TopicsController {
         topicKey,
         name: body.name,
         organizationId: user.organizationId,
-      })
+      }),
     );
   }
 }

--- a/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.command.ts
+++ b/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.command.ts
@@ -1,11 +1,15 @@
-import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { IsArray, IsBoolean, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class FilterTopicsCommand extends EnvironmentCommand {
-  @IsString()
+  @IsArray()
   @IsOptional()
   keys?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  shouldReturnSubscriberList?: boolean = false;
 
   @IsOptional()
   @IsInt()

--- a/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.command.ts
+++ b/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.command.ts
@@ -1,11 +1,11 @@
 import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
-import { TopicKey } from '../../types';
+import { ApiProperty } from '@nestjs/swagger';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class FilterTopicsCommand extends EnvironmentCommand {
   @IsString()
   @IsOptional()
-  key?: TopicKey;
+  keys?: string[];
 
   @IsOptional()
   @IsInt()
@@ -17,4 +17,14 @@ export class FilterTopicsCommand extends EnvironmentCommand {
   @Min(0)
   @Max(10)
   pageSize?: number = 10;
+
+  @ApiProperty({
+    example: 'someSubscriberId',
+    required: false,
+    type: 'string',
+    description: 'filter By Topics Assigned To Subscriber Id',
+  })
+  @IsString()
+  @IsOptional()
+  public subscriberId?: string;
 }

--- a/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.use-case.ts
+++ b/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.use-case.ts
@@ -1,16 +1,24 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { EnvironmentId, OrganizationId, TopicEntity, TopicRepository } from '@novu/dal';
-
+import { TopicEntity, TopicRepository, TopicSubscribersRepository } from '@novu/dal';
 import { FilterTopicsCommand } from './filter-topics.command';
 
-import { TopicDto } from '../../dtos/topic.dto';
+import { TopicDto } from '../../dtos';
 import { ExternalSubscriberId } from '../../types';
 
 const DEFAULT_TOPIC_LIMIT = 10;
+interface ITopicsPaginationObject {
+  limit: number;
+  page: number;
+  pageSize: number;
+  skip: number;
+}
 
 @Injectable()
 export class FilterTopicsUseCase {
-  constructor(private topicRepository: TopicRepository) {}
+  constructor(
+    private topicRepository: TopicRepository,
+    private topicSubscriberRepository: TopicSubscribersRepository
+  ) {}
 
   async execute(command: FilterTopicsCommand) {
     const { pageSize = DEFAULT_TOPIC_LIMIT, page = 0 } = command;
@@ -18,35 +26,65 @@ export class FilterTopicsUseCase {
     if (pageSize > DEFAULT_TOPIC_LIMIT) {
       throw new BadRequestException(`Page size can not be larger then ${DEFAULT_TOPIC_LIMIT}`);
     }
-
-    const query = this.mapFromCommandToEntity(command);
-
-    const totalCount = await this.topicRepository.count(query);
-
-    const skipTimes = page <= 0 ? 0 : page;
-    const pagination = {
+    const pagination: ITopicsPaginationObject = {
       limit: pageSize,
-      skip: skipTimes * pageSize,
+      skip: (page <= 0 ? 0 : page) * pageSize,
+      pageSize,
+      page,
     };
 
+    if (this.hasSubscriberId(command)) {
+      return await this.buildPagedTopicListForSubscriberId(command, pagination);
+    }
+
+    const query = this.mapFromCommandToEntity(command);
     const filteredTopics = await this.topicRepository.filterTopics(query, pagination);
 
     return {
       page,
-      totalCount,
+      totalCount: await this.topicRepository.count(query),
       pageSize,
       data: filteredTopics.map(this.mapFromEntityToDto),
     };
   }
 
-  private mapFromCommandToEntity(
-    command: FilterTopicsCommand
-  ): Pick<TopicEntity, '_environmentId' | 'key' | '_organizationId'> {
+  private async buildPagedTopicListForSubscriberId(
+    command: FilterTopicsCommand & { subscriberId: string },
+    pagination: ITopicsPaginationObject
+  ) {
+    const { pagedTopics, totalCount } = await this.getPagedSubscriberKeys(command, pagination);
+    // eslint-disable-next-line no-param-reassign
+    command.keys = [...pagedTopics, ...(command.keys || [])];
+    const query = this.mapFromCommandToEntity(command);
+    const filteredTopics = await this.topicRepository.filterTopics(query, pagination);
+
     return {
+      page: pagination.limit,
+      totalCount,
+      pageSize: pagination.pageSize,
+      data: filteredTopics.map(this.mapFromEntityToDto),
+    };
+  }
+
+  private hasSubscriberId(command: FilterTopicsCommand): command is FilterTopicsCommand & { subscriberId: string } {
+    return !!command.subscriberId;
+  }
+
+  private mapFromCommandToEntity(command: FilterTopicsCommand) {
+    const baseQuery = {
       _environmentId: command.environmentId,
       _organizationId: command.organizationId,
-      ...(command.key && { key: command.key }),
-    } as Pick<TopicEntity, '_environmentId' | 'key' | '_organizationId'>;
+    };
+
+    // Handle key filtering
+    if (command.keys?.length) {
+      return {
+        ...baseQuery,
+        key: { $in: command.keys },
+      };
+    }
+
+    return baseQuery;
   }
 
   private mapFromEntityToDto(topic: TopicEntity & { subscribers: ExternalSubscriberId[] }): TopicDto {
@@ -56,5 +94,30 @@ export class FilterTopicsUseCase {
       _organizationId: topic._organizationId,
       _environmentId: topic._environmentId,
     };
+  }
+
+  private async getPagedSubscriberKeys(
+    command: FilterTopicsCommand & { subscriberId: string },
+    pagination: {
+      limit: number;
+      skip: number;
+    }
+  ) {
+    const pagedTopics = (
+      await this.topicSubscriberRepository.fetchSubscriberTopics({
+        subscriberIds: [command.subscriberId],
+        _environmentId: command.environmentId,
+        limit: pagination.limit,
+        offset: pagination.skip,
+      })
+    )[command.subscriberId];
+    const totalCount = (
+      await this.topicSubscriberRepository.fetchSubscriberTopicCounts({
+        subscriberIds: [command.subscriberId],
+        _environmentId: command.environmentId,
+      })
+    )[command.subscriberId];
+
+    return { pagedTopics, totalCount };
   }
 }

--- a/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.use-case.ts
+++ b/apps/api/src/app/topics/use-cases/filter-topics/filter-topics.use-case.ts
@@ -38,14 +38,28 @@ export class FilterTopicsUseCase {
     }
 
     const query = this.mapFromCommandToEntity(command);
-    const filteredTopics = await this.topicRepository.filterTopics(query, pagination);
+    const filteredTopics = await this.getPaginatedTopics(command, query, pagination);
 
     return {
       page,
       totalCount: await this.topicRepository.count(query),
       pageSize,
-      data: filteredTopics.map(this.mapFromEntityToDto),
+      data: filteredTopics.map((topic) => this.mapFromEntityToDto(topic)),
     };
+  }
+
+  async getPaginatedTopics(
+    command: FilterTopicsCommand,
+    query:
+      | { _environmentId: string; _organizationId: string }
+      | { key: { $in: string[] }; _environmentId: string; _organizationId: string },
+    pagination: ITopicsPaginationObject
+  ) {
+    if (command.shouldReturnSubscriberList) {
+      return await this.topicRepository.filterTopicsWithSubscribers(query, pagination);
+    }
+
+    return await this.topicRepository.filterTopics(query, pagination);
   }
 
   private async buildPagedTopicListForSubscriberId(
@@ -56,13 +70,13 @@ export class FilterTopicsUseCase {
     // eslint-disable-next-line no-param-reassign
     command.keys = [...pagedTopics, ...(command.keys || [])];
     const query = this.mapFromCommandToEntity(command);
-    const filteredTopics = await this.topicRepository.filterTopics(query, pagination);
+    const filteredTopics = await this.getPaginatedTopics(command, query, pagination);
 
     return {
-      page: pagination.limit,
+      page: pagination.page,
       totalCount,
       pageSize: pagination.pageSize,
-      data: filteredTopics.map(this.mapFromEntityToDto),
+      data: filteredTopics.map((topic) => this.mapFromEntityToDto(topic)),
     };
   }
 
@@ -87,12 +101,14 @@ export class FilterTopicsUseCase {
     return baseQuery;
   }
 
-  private mapFromEntityToDto(topic: TopicEntity & { subscribers: ExternalSubscriberId[] }): TopicDto {
+  private mapFromEntityToDto(topic: (TopicEntity & { subscribers: ExternalSubscriberId[] }) | TopicEntity): TopicDto {
     return {
-      ...topic,
       _id: topic._id,
       _organizationId: topic._organizationId,
       _environmentId: topic._environmentId,
+      key: topic.key,
+      name: topic.name,
+      subscribers: 'subscribers' in topic ? topic.subscribers : undefined,
     };
   }
 

--- a/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
@@ -1,14 +1,15 @@
 import { ExternalSubscriberId } from '@novu/shared';
 
+import mongoose from 'mongoose';
 import {
   CreateTopicSubscribersEntity,
-  TopicSubscribersEntity,
   TopicSubscribersDBModel,
+  TopicSubscribersEntity,
 } from './topic-subscribers.entity';
 import { TopicSubscribers } from './topic-subscribers.schema';
 import { EnvironmentId, OrganizationId, TopicId, TopicKey } from './types';
 import { BaseRepository } from '../base-repository';
-import type { EnforceEnvOrOrgIds } from '../../types/enforce';
+import type { EnforceEnvOrOrgIds } from '../../types';
 
 export class TopicSubscribersRepository extends BaseRepository<
   TopicSubscribersDBModel,
@@ -85,6 +86,34 @@ export class TopicSubscribersRepository extends BaseRepository<
     });
   }
 
+  async fetchSubscriberTopics({
+    subscriberIds,
+    _environmentId,
+  }: {
+    subscriberIds: string[];
+    _environmentId: string;
+  }): Promise<Record<string, string[]>> {
+    const subscriberTopics = await this._model.aggregate([
+      {
+        $match: {
+          _environmentId: new mongoose.Types.ObjectId(_environmentId),
+          externalSubscriberId: { $in: subscriberIds },
+        },
+      },
+      {
+        $group: {
+          _id: '$externalSubscriberId',
+          topics: { $addToSet: '$topicKey' },
+        },
+      },
+    ]);
+
+    return subscriberTopics.reduce((acc, item) => {
+      acc[item._id] = item.topics;
+
+      return acc;
+    }, {});
+  }
   async removeSubscribers(
     _environmentId: EnvironmentId,
     _organizationId: OrganizationId,

--- a/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
@@ -89,9 +89,13 @@ export class TopicSubscribersRepository extends BaseRepository<
   async fetchSubscriberTopics({
     subscriberIds,
     _environmentId,
+    limit = 10, // Default limit
+    offset = 0, // Default offset
   }: {
     subscriberIds: string[];
     _environmentId: string;
+    limit?: number; // Optional parameter for limit
+    offset?: number; // Optional parameter for offset
   }): Promise<Record<string, string[]>> {
     const subscriberTopics = await this._model.aggregate([
       {
@@ -101,15 +105,53 @@ export class TopicSubscribersRepository extends BaseRepository<
         },
       },
       {
+        $sort: { topicKey: 1 }, // Sort by topicKey in ascending order
+      },
+      {
         $group: {
           _id: '$externalSubscriberId',
           topics: { $addToSet: '$topicKey' },
         },
       },
+      {
+        $skip: offset, // Skip the number of documents specified by offset
+      },
+      {
+        $limit: limit, // Limit the number of documents returned
+      },
     ]);
 
     return subscriberTopics.reduce((acc, item) => {
       acc[item._id] = item.topics;
+
+      return acc;
+    }, {});
+  }
+
+  async fetchSubscriberTopicCounts({
+    subscriberIds,
+    _environmentId,
+  }: {
+    subscriberIds: string[];
+    _environmentId: string;
+  }): Promise<Record<string, number>> {
+    const subscriberTopicCounts = await this._model.aggregate([
+      {
+        $match: {
+          _environmentId: new mongoose.Types.ObjectId(_environmentId),
+          externalSubscriberId: { $in: subscriberIds },
+        },
+      },
+      {
+        $group: {
+          _id: '$externalSubscriberId',
+          topicCount: { $sum: 1 }, // Count the number of topics per subscriber
+        },
+      },
+    ]);
+
+    return subscriberTopicCounts.reduce((acc, item) => {
+      acc[item._id] = item.topicCount; // Map subscriber ID to topic count
 
       return acc;
     }, {});

--- a/libs/dal/src/repositories/topic/topic.repository.ts
+++ b/libs/dal/src/repositories/topic/topic.repository.ts
@@ -1,6 +1,6 @@
 import { FilterQuery } from 'mongoose';
 
-import { TopicEntity, TopicDBModel } from './topic.entity';
+import { TopicDBModel, TopicEntity } from './topic.entity';
 import { Topic } from './topic.schema';
 import { EnvironmentId, ExternalSubscriberId, OrganizationId, TopicId, TopicKey, TopicName } from './types';
 import { BaseRepository } from '../base-repository';

--- a/libs/dal/src/repositories/topic/topic.repository.ts
+++ b/libs/dal/src/repositories/topic/topic.repository.ts
@@ -51,8 +51,33 @@ export class TopicRepository extends BaseRepository<TopicDBModel, TopicEntity, E
       _environmentId: environmentId,
     });
   }
-
   async filterTopics(
+    query: FilterQuery<TopicDBModel>,
+    pagination: { limit: number; skip: number }
+  ): Promise<TopicEntity[]> {
+    const parsedQuery = { ...query };
+    if (query._id) {
+      parsedQuery._id = this.convertStringToObjectId(query._id);
+    }
+
+    parsedQuery._environmentId = this.convertStringToObjectId(query._environmentId);
+    parsedQuery._organizationId = this.convertStringToObjectId(query._organizationId);
+
+    return await this.aggregate([
+      {
+        $match: parsedQuery,
+      },
+      lookup,
+      {
+        $skip: pagination.skip,
+      },
+      {
+        $limit: pagination.limit,
+      },
+    ]);
+  }
+
+  async filterTopicsWithSubscribers(
     query: FilterQuery<TopicDBModel>,
     pagination: { limit: number; skip: number }
   ): Promise<TopicEntity & { subscribers: ExternalSubscriberId[] }[]> {
@@ -64,7 +89,7 @@ export class TopicRepository extends BaseRepository<TopicDBModel, TopicEntity, E
     parsedQuery._environmentId = this.convertStringToObjectId(query._environmentId);
     parsedQuery._organizationId = this.convertStringToObjectId(query._organizationId);
 
-    const data = await this.aggregate([
+    return await this.aggregate([
       {
         $match: parsedQuery,
       },
@@ -77,8 +102,6 @@ export class TopicRepository extends BaseRepository<TopicDBModel, TopicEntity, E
         $limit: pagination.limit,
       },
     ]);
-
-    return data;
   }
 
   async findTopic(

--- a/libs/internal-sdk/src/funcs/subscribersRetrieve.ts
+++ b/libs/internal-sdk/src/funcs/subscribersRetrieve.ts
@@ -28,7 +28,9 @@ import { Result } from "../types/fp.js";
  * Get subscriber
  *
  * @remarks
- * Get subscriber by your internal id used to identify the subscriber
+ * Get subscriber by your internal id used to identify the subscriber,
+ *     topics have been removed from the response use
+ *      GET: v1/topics to retrieve the subscriber topic list
  */
 export function subscribersRetrieve(
   client: NovuCore,

--- a/libs/internal-sdk/src/funcs/topicsList.ts
+++ b/libs/internal-sdk/src/funcs/topicsList.ts
@@ -98,6 +98,7 @@ async function $do(
     "key": payload.key,
     "page": payload.page,
     "pageSize": payload.pageSize,
+    "subscriberId": payload.subscriberId,
   });
 
   const headers = new Headers(compactMap({

--- a/libs/internal-sdk/src/funcs/topicsList.ts
+++ b/libs/internal-sdk/src/funcs/topicsList.ts
@@ -98,6 +98,7 @@ async function $do(
     "key": payload.key,
     "page": payload.page,
     "pageSize": payload.pageSize,
+    "shouldReturnSubscriberList": payload.shouldReturnSubscriberList,
     "subscriberId": payload.subscriberId,
   });
 

--- a/libs/internal-sdk/src/models/components/gettopicresponsedto.ts
+++ b/libs/internal-sdk/src/models/components/gettopicresponsedto.ts
@@ -9,12 +9,30 @@ import { Result as SafeParseResult } from "../../types/fp.js";
 import { SDKValidationError } from "../errors/sdkvalidationerror.js";
 
 export type GetTopicResponseDto = {
-  id?: string | undefined;
+  /**
+   * Unique identifier for the topic
+   */
+  id: string;
+  /**
+   * Identifier for the organization that owns the topic
+   */
   organizationId: string;
+  /**
+   * Identifier for the environment associated with the topic
+   */
   environmentId: string;
+  /**
+   * Key for the topic, used for identifying it uniquely
+   */
   key: string;
+  /**
+   * Name of the topic
+   */
   name: string;
-  subscribers: Array<string>;
+  /**
+   * List of subscriber IDs for the topic
+   */
+  subscribers?: Array<string> | undefined;
 };
 
 /** @internal */
@@ -23,12 +41,12 @@ export const GetTopicResponseDto$inboundSchema: z.ZodType<
   z.ZodTypeDef,
   unknown
 > = z.object({
-  _id: z.string().optional(),
+  _id: z.string(),
   _organizationId: z.string(),
   _environmentId: z.string(),
   key: z.string(),
   name: z.string(),
-  subscribers: z.array(z.string()),
+  subscribers: z.array(z.string()).optional(),
 }).transform((v) => {
   return remap$(v, {
     "_id": "id",
@@ -39,12 +57,12 @@ export const GetTopicResponseDto$inboundSchema: z.ZodType<
 
 /** @internal */
 export type GetTopicResponseDto$Outbound = {
-  _id?: string | undefined;
+  _id: string;
   _organizationId: string;
   _environmentId: string;
   key: string;
   name: string;
-  subscribers: Array<string>;
+  subscribers?: Array<string> | undefined;
 };
 
 /** @internal */
@@ -53,12 +71,12 @@ export const GetTopicResponseDto$outboundSchema: z.ZodType<
   z.ZodTypeDef,
   GetTopicResponseDto
 > = z.object({
-  id: z.string().optional(),
+  id: z.string(),
   organizationId: z.string(),
   environmentId: z.string(),
   key: z.string(),
   name: z.string(),
-  subscribers: z.array(z.string()),
+  subscribers: z.array(z.string()).optional(),
 }).transform((v) => {
   return remap$(v, {
     id: "_id",

--- a/libs/internal-sdk/src/models/components/renametopicresponsedto.ts
+++ b/libs/internal-sdk/src/models/components/renametopicresponsedto.ts
@@ -9,12 +9,30 @@ import { Result as SafeParseResult } from "../../types/fp.js";
 import { SDKValidationError } from "../errors/sdkvalidationerror.js";
 
 export type RenameTopicResponseDto = {
-  id?: string | undefined;
+  /**
+   * Unique identifier for the topic
+   */
+  id: string;
+  /**
+   * Identifier for the organization that owns the topic
+   */
   organizationId: string;
+  /**
+   * Identifier for the environment associated with the topic
+   */
   environmentId: string;
+  /**
+   * Key for the topic, used for identifying it uniquely
+   */
   key: string;
+  /**
+   * Name of the topic
+   */
   name: string;
-  subscribers: Array<string>;
+  /**
+   * List of subscriber IDs for the topic
+   */
+  subscribers?: Array<string> | undefined;
 };
 
 /** @internal */
@@ -23,12 +41,12 @@ export const RenameTopicResponseDto$inboundSchema: z.ZodType<
   z.ZodTypeDef,
   unknown
 > = z.object({
-  _id: z.string().optional(),
+  _id: z.string(),
   _organizationId: z.string(),
   _environmentId: z.string(),
   key: z.string(),
   name: z.string(),
-  subscribers: z.array(z.string()),
+  subscribers: z.array(z.string()).optional(),
 }).transform((v) => {
   return remap$(v, {
     "_id": "id",
@@ -39,12 +57,12 @@ export const RenameTopicResponseDto$inboundSchema: z.ZodType<
 
 /** @internal */
 export type RenameTopicResponseDto$Outbound = {
-  _id?: string | undefined;
+  _id: string;
   _organizationId: string;
   _environmentId: string;
   key: string;
   name: string;
-  subscribers: Array<string>;
+  subscribers?: Array<string> | undefined;
 };
 
 /** @internal */
@@ -53,12 +71,12 @@ export const RenameTopicResponseDto$outboundSchema: z.ZodType<
   z.ZodTypeDef,
   RenameTopicResponseDto
 > = z.object({
-  id: z.string().optional(),
+  id: z.string(),
   organizationId: z.string(),
   environmentId: z.string(),
   key: z.string(),
   name: z.string(),
-  subscribers: z.array(z.string()),
+  subscribers: z.array(z.string()).optional(),
 }).transform((v) => {
   return remap$(v, {
     id: "_id",

--- a/libs/internal-sdk/src/models/components/subscriberresponsedto.ts
+++ b/libs/internal-sdk/src/models/components/subscriberresponsedto.ts
@@ -49,8 +49,6 @@ export type SubscriberResponseDto = {
   channels?: Array<ChannelSettingsDto> | undefined;
   /**
    * An array of topics that the subscriber is subscribed to.
-   *
-   * @deprecated field: This will be removed in a future release, please migrate away from it as soon as possible.
    */
   topics?: Array<string> | undefined;
   /**

--- a/libs/internal-sdk/src/models/components/subscriberresponsedto.ts
+++ b/libs/internal-sdk/src/models/components/subscriberresponsedto.ts
@@ -48,10 +48,6 @@ export type SubscriberResponseDto = {
    */
   channels?: Array<ChannelSettingsDto> | undefined;
   /**
-   * An array of topics that the subscriber is subscribed to.
-   */
-  topics?: Array<string> | undefined;
-  /**
    * Indicates whether the subscriber is currently online.
    */
   isOnline?: boolean | undefined;
@@ -111,7 +107,6 @@ export const SubscriberResponseDto$inboundSchema: z.ZodType<
   avatar: z.string().optional(),
   locale: z.string().optional(),
   channels: z.array(ChannelSettingsDto$inboundSchema).optional(),
-  topics: z.array(z.string()).optional(),
   isOnline: z.boolean().optional(),
   lastOnlineAt: z.string().optional(),
   __v: z.number().optional(),
@@ -142,7 +137,6 @@ export type SubscriberResponseDto$Outbound = {
   avatar?: string | undefined;
   locale?: string | undefined;
   channels?: Array<ChannelSettingsDto$Outbound> | undefined;
-  topics?: Array<string> | undefined;
   isOnline?: boolean | undefined;
   lastOnlineAt?: string | undefined;
   __v?: number | undefined;
@@ -170,7 +164,6 @@ export const SubscriberResponseDto$outboundSchema: z.ZodType<
   avatar: z.string().optional(),
   locale: z.string().optional(),
   channels: z.array(ChannelSettingsDto$outboundSchema).optional(),
-  topics: z.array(z.string()).optional(),
   isOnline: z.boolean().optional(),
   lastOnlineAt: z.string().optional(),
   v: z.number().optional(),

--- a/libs/internal-sdk/src/models/components/subscriberresponsedtooptional.ts
+++ b/libs/internal-sdk/src/models/components/subscriberresponsedtooptional.ts
@@ -48,12 +48,6 @@ export type SubscriberResponseDtoOptional = {
    */
   channels?: Array<ChannelSettingsDto> | undefined;
   /**
-   * An array of topics that the subscriber is subscribed to.
-   *
-   * @deprecated field: This will be removed in a future release, please migrate away from it as soon as possible.
-   */
-  topics?: Array<string> | undefined;
-  /**
    * Indicates whether the subscriber is currently online.
    */
   isOnline?: boolean | undefined;
@@ -89,7 +83,6 @@ export const SubscriberResponseDtoOptional$inboundSchema: z.ZodType<
   avatar: z.string().optional(),
   locale: z.string().optional(),
   channels: z.array(ChannelSettingsDto$inboundSchema).optional(),
-  topics: z.array(z.string()).optional(),
   isOnline: z.boolean().optional(),
   lastOnlineAt: z.string().optional(),
   __v: z.number().optional(),
@@ -112,7 +105,6 @@ export type SubscriberResponseDtoOptional$Outbound = {
   avatar?: string | undefined;
   locale?: string | undefined;
   channels?: Array<ChannelSettingsDto$Outbound> | undefined;
-  topics?: Array<string> | undefined;
   isOnline?: boolean | undefined;
   lastOnlineAt?: string | undefined;
   __v?: number | undefined;
@@ -134,7 +126,6 @@ export const SubscriberResponseDtoOptional$outboundSchema: z.ZodType<
   avatar: z.string().optional(),
   locale: z.string().optional(),
   channels: z.array(ChannelSettingsDto$outboundSchema).optional(),
-  topics: z.array(z.string()).optional(),
   isOnline: z.boolean().optional(),
   lastOnlineAt: z.string().optional(),
   v: z.number().optional(),

--- a/libs/internal-sdk/src/models/components/topicdto.ts
+++ b/libs/internal-sdk/src/models/components/topicdto.ts
@@ -9,12 +9,30 @@ import { Result as SafeParseResult } from "../../types/fp.js";
 import { SDKValidationError } from "../errors/sdkvalidationerror.js";
 
 export type TopicDto = {
-  id?: string | undefined;
+  /**
+   * Unique identifier for the topic
+   */
+  id: string;
+  /**
+   * Identifier for the organization that owns the topic
+   */
   organizationId: string;
+  /**
+   * Identifier for the environment associated with the topic
+   */
   environmentId: string;
+  /**
+   * Key for the topic, used for identifying it uniquely
+   */
   key: string;
+  /**
+   * Name of the topic
+   */
   name: string;
-  subscribers: Array<string>;
+  /**
+   * List of subscriber IDs for the topic
+   */
+  subscribers?: Array<string> | undefined;
 };
 
 /** @internal */
@@ -23,12 +41,12 @@ export const TopicDto$inboundSchema: z.ZodType<
   z.ZodTypeDef,
   unknown
 > = z.object({
-  _id: z.string().optional(),
+  _id: z.string(),
   _organizationId: z.string(),
   _environmentId: z.string(),
   key: z.string(),
   name: z.string(),
-  subscribers: z.array(z.string()),
+  subscribers: z.array(z.string()).optional(),
 }).transform((v) => {
   return remap$(v, {
     "_id": "id",
@@ -39,12 +57,12 @@ export const TopicDto$inboundSchema: z.ZodType<
 
 /** @internal */
 export type TopicDto$Outbound = {
-  _id?: string | undefined;
+  _id: string;
   _organizationId: string;
   _environmentId: string;
   key: string;
   name: string;
-  subscribers: Array<string>;
+  subscribers?: Array<string> | undefined;
 };
 
 /** @internal */
@@ -53,12 +71,12 @@ export const TopicDto$outboundSchema: z.ZodType<
   z.ZodTypeDef,
   TopicDto
 > = z.object({
-  id: z.string().optional(),
+  id: z.string(),
   organizationId: z.string(),
   environmentId: z.string(),
   key: z.string(),
   name: z.string(),
-  subscribers: z.array(z.string()),
+  subscribers: z.array(z.string()).optional(),
 }).transform((v) => {
   return remap$(v, {
     id: "_id",

--- a/libs/internal-sdk/src/models/operations/topicscontrollerlisttopics.ts
+++ b/libs/internal-sdk/src/models/operations/topicscontrollerlisttopics.ts
@@ -23,6 +23,10 @@ export type TopicsControllerListTopicsRequest = {
    */
   key?: string | undefined;
   /**
+   * should return subscriber list, default is false
+   */
+  shouldReturnSubscriberList?: boolean | undefined;
+  /**
    * filterByTopicsAssignedToSubscriberId
    */
   subscriberId?: string | undefined;
@@ -46,6 +50,7 @@ export const TopicsControllerListTopicsRequest$inboundSchema: z.ZodType<
   page: z.number().int().default(0),
   pageSize: z.number().int().default(10),
   key: z.string().optional(),
+  shouldReturnSubscriberList: z.boolean().default(false),
   subscriberId: z.string().optional(),
   "idempotency-key": z.string().optional(),
 }).transform((v) => {
@@ -59,6 +64,7 @@ export type TopicsControllerListTopicsRequest$Outbound = {
   page: number;
   pageSize: number;
   key?: string | undefined;
+  shouldReturnSubscriberList: boolean;
   subscriberId?: string | undefined;
   "idempotency-key"?: string | undefined;
 };
@@ -72,6 +78,7 @@ export const TopicsControllerListTopicsRequest$outboundSchema: z.ZodType<
   page: z.number().int().default(0),
   pageSize: z.number().int().default(10),
   key: z.string().optional(),
+  shouldReturnSubscriberList: z.boolean().default(false),
   subscriberId: z.string().optional(),
   idempotencyKey: z.string().optional(),
 }).transform((v) => {

--- a/libs/internal-sdk/src/models/operations/topicscontrollerlisttopics.ts
+++ b/libs/internal-sdk/src/models/operations/topicscontrollerlisttopics.ts
@@ -23,6 +23,10 @@ export type TopicsControllerListTopicsRequest = {
    */
   key?: string | undefined;
   /**
+   * filterByTopicsAssignedToSubscriberId
+   */
+  subscriberId?: string | undefined;
+  /**
    * A header for idempotency purposes
    */
   idempotencyKey?: string | undefined;
@@ -42,6 +46,7 @@ export const TopicsControllerListTopicsRequest$inboundSchema: z.ZodType<
   page: z.number().int().default(0),
   pageSize: z.number().int().default(10),
   key: z.string().optional(),
+  subscriberId: z.string().optional(),
   "idempotency-key": z.string().optional(),
 }).transform((v) => {
   return remap$(v, {
@@ -54,6 +59,7 @@ export type TopicsControllerListTopicsRequest$Outbound = {
   page: number;
   pageSize: number;
   key?: string | undefined;
+  subscriberId?: string | undefined;
   "idempotency-key"?: string | undefined;
 };
 
@@ -66,6 +72,7 @@ export const TopicsControllerListTopicsRequest$outboundSchema: z.ZodType<
   page: z.number().int().default(0),
   pageSize: z.number().int().default(10),
   key: z.string().optional(),
+  subscriberId: z.string().optional(),
   idempotencyKey: z.string().optional(),
 }).transform((v) => {
   return remap$(v, {

--- a/libs/internal-sdk/src/react-query/subscribersRetrieve.ts
+++ b/libs/internal-sdk/src/react-query/subscribersRetrieve.ts
@@ -32,7 +32,9 @@ export type SubscribersRetrieveQueryData =
  * Get subscriber
  *
  * @remarks
- * Get subscriber by your internal id used to identify the subscriber
+ * Get subscriber by your internal id used to identify the subscriber,
+ *     topics have been removed from the response use
+ *      GET: v1/topics to retrieve the subscriber topic list
  */
 export function useSubscribersRetrieve(
   subscriberId: string,
@@ -55,7 +57,9 @@ export function useSubscribersRetrieve(
  * Get subscriber
  *
  * @remarks
- * Get subscriber by your internal id used to identify the subscriber
+ * Get subscriber by your internal id used to identify the subscriber,
+ *     topics have been removed from the response use
+ *      GET: v1/topics to retrieve the subscriber topic list
  */
 export function useSubscribersRetrieveSuspense(
   subscriberId: string,

--- a/libs/internal-sdk/src/react-query/topicsList.ts
+++ b/libs/internal-sdk/src/react-query/topicsList.ts
@@ -89,6 +89,7 @@ export function setTopicsListData(
       page?: number | undefined;
       pageSize?: number | undefined;
       key?: string | undefined;
+      shouldReturnSubscriberList?: boolean | undefined;
       subscriberId?: string | undefined;
       idempotencyKey?: string | undefined;
     },
@@ -107,6 +108,7 @@ export function invalidateTopicsList(
       page?: number | undefined;
       pageSize?: number | undefined;
       key?: string | undefined;
+      shouldReturnSubscriberList?: boolean | undefined;
       subscriberId?: string | undefined;
       idempotencyKey?: string | undefined;
     }]
@@ -142,6 +144,7 @@ export function buildTopicsListQuery(
       page: request.page,
       pageSize: request.pageSize,
       key: request.key,
+      shouldReturnSubscriberList: request.shouldReturnSubscriberList,
       subscriberId: request.subscriberId,
       idempotencyKey: request.idempotencyKey,
     }),
@@ -168,6 +171,7 @@ export function queryKeyTopicsList(
     page?: number | undefined;
     pageSize?: number | undefined;
     key?: string | undefined;
+    shouldReturnSubscriberList?: boolean | undefined;
     subscriberId?: string | undefined;
     idempotencyKey?: string | undefined;
   },

--- a/libs/internal-sdk/src/react-query/topicsList.ts
+++ b/libs/internal-sdk/src/react-query/topicsList.ts
@@ -89,6 +89,7 @@ export function setTopicsListData(
       page?: number | undefined;
       pageSize?: number | undefined;
       key?: string | undefined;
+      subscriberId?: string | undefined;
       idempotencyKey?: string | undefined;
     },
   ],
@@ -106,6 +107,7 @@ export function invalidateTopicsList(
       page?: number | undefined;
       pageSize?: number | undefined;
       key?: string | undefined;
+      subscriberId?: string | undefined;
       idempotencyKey?: string | undefined;
     }]
   >,
@@ -140,6 +142,7 @@ export function buildTopicsListQuery(
       page: request.page,
       pageSize: request.pageSize,
       key: request.key,
+      subscriberId: request.subscriberId,
       idempotencyKey: request.idempotencyKey,
     }),
     queryFn: async function topicsListQueryFn(
@@ -165,6 +168,7 @@ export function queryKeyTopicsList(
     page?: number | undefined;
     pageSize?: number | undefined;
     key?: string | undefined;
+    subscriberId?: string | undefined;
     idempotencyKey?: string | undefined;
   },
 ): QueryKey {

--- a/libs/internal-sdk/src/sdk/subscribers.ts
+++ b/libs/internal-sdk/src/sdk/subscribers.ts
@@ -90,7 +90,9 @@ export class Subscribers extends ClientSDK {
    * Get subscriber
    *
    * @remarks
-   * Get subscriber by your internal id used to identify the subscriber
+   * Get subscriber by your internal id used to identify the subscriber,
+   *     topics have been removed from the response use
+   *      GET: v1/topics to retrieve the subscriber topic list
    */
   async retrieve(
     subscriberId: string,


### PR DESCRIPTION
### What changed? Why was the change needed?
Following a bug report we decided @scopsy and I to remove the non working deprecated topics field from the subscriber entity and replace the functionality using the topics controller which now has the ability to request topics to a subscriber Id in a paged manner ( sense there could be many) 
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
