### PR TITLE
chore(dashboard): digest and cards blocks in email editor have a new badge

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/email/blocks/cards.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/blocks/cards.tsx
@@ -6,6 +6,7 @@ import { useTelemetry } from '@/hooks/use-telemetry';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { BlockItem } from '@maily-to/core/blocks';
 import { BlockCustomPreview } from './block-custom-preview';
+import { Badge } from '@/components/primitives/badge';
 
 const createHorizontalCardWithCta: (props: { track: ReturnType<typeof useTelemetry> }) => BlockItem = (props) => {
   const { track } = props;
@@ -373,6 +374,40 @@ export const createCards = (props: { track: ReturnType<typeof useTelemetry> }) =
         description="Add pre-made cards"
       />
     ),
+    render: () => {
+      return (
+        <>
+          <div className="flex h-6 w-6 shrink-0 items-center justify-center">
+            <CardBlocks className="size-4" />
+          </div>
+          <div className="grow">
+            <p className="flex items-center gap-1 font-medium">
+              Cards
+              <Badge color="orange" size="sm" variant="lighter">
+                New
+              </Badge>
+            </p>
+            <p className="text-xs text-gray-400">Add pre-made cards</p>
+          </div>
+          <span className="block px-1 text-gray-400">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="lucide lucide-chevron-right size-3.5 stroke-[2.5]"
+            >
+              <path d="m9 18 6-6-6-6"></path>
+            </svg>
+          </span>
+        </>
+      );
+    },
 
     commands: [
       createCardWithImageAndCta({ track }),

--- a/apps/dashboard/src/components/workflow-editor/steps/email/blocks/digest.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/blocks/digest.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@/components/primitives/badge';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { BlockItem } from '@maily-to/core/blocks';
@@ -16,8 +17,26 @@ export const createDigestBlock = (props: {
     title: 'Digest',
     description: 'Display digested notifications in list.',
     searchTerms: ['digest', 'notification'],
-    icon: <RiShadowLine className="mly-h-4 mly-w-4" />,
+    icon: <RiShadowLine className="h-4 w-4" />,
     preview: '/images/email-editor/digest-block-preview.webp',
+    render: () => {
+      return (
+        <>
+          <div className="flex h-6 w-6 shrink-0 items-center justify-center">
+            <RiShadowLine className="h-4 w-4" />
+          </div>
+          <div className="grow">
+            <p className="flex items-center gap-1 font-medium">
+              Digest
+              <Badge color="orange" size="sm" variant="lighter">
+                New
+              </Badge>
+            </p>
+            <p className="text-xs text-gray-400">Display digested notifications in list.</p>
+          </div>
+        </>
+      );
+    },
     command: ({ editor, range }) => {
       track(TelemetryEvent.DIGEST_BLOCK_ADDED, {
         type: 'digest',


### PR DESCRIPTION
### What changed? Why was the change needed?

The Digest and Cards blocks in the Email Editor will be marked with the "new badge".

### Screenshots

![Screenshot 2025-04-24 at 10 29 02](https://github.com/user-attachments/assets/158ffc85-80e9-408b-8061-591ea7a4b625)


https://github.com/user-attachments/assets/a840fdac-5a55-4f05-92c0-ccc631e1597f


