### PR TITLE
chore(dashboard,api-service): revert blocking the preview when template has issues

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-tabs.tsx
@@ -10,7 +10,7 @@ import { ChatEditorPreview } from '@/components/workflow-editor/steps/chat/chat-
 import { useEditorPreview } from '../use-editor-preview';
 
 export const ChatTabs = (props: StepEditorProps) => {
-  const { workflow, step, hasStepValidationErrors } = props;
+  const { workflow, step } = props;
   const { dataSchema, uiSchema } = step.controls;
   const [tabsValue, setTabsValue] = useState('editor');
   const form = useFormContext();
@@ -47,7 +47,6 @@ export const ChatTabs = (props: StepEditorProps) => {
       tabsValue={tabsValue}
       onTabChange={setTabsValue}
       previewStep={previewStep}
-      hasStepValidationErrors={hasStepValidationErrors}
     />
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-template-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-template-form.tsx
@@ -29,12 +29,11 @@ const STEP_TYPE_TO_TEMPLATE_FORM: Record<StepTypeEnum, (args: StepEditorProps) =
 };
 
 export type StepEditorProps = {
-  hasStepValidationErrors: boolean;
   workflow: WorkflowResponseDto;
   step: StepResponseDto;
 };
 
-type ConfigureStepTemplateFormProps = Omit<StepEditorProps, 'hasStepValidationErrors'> & {
+type ConfigureStepTemplateFormProps = StepEditorProps & {
   update: UpdateWorkflowFn;
 };
 
@@ -98,16 +97,11 @@ export const ConfigureStepTemplateForm = (props: ConfigureStepTemplateFormProps)
 
   const value = useMemo(() => ({ saveForm }), [saveForm]);
 
-  const hasStepValidationErrors = useMemo(() => {
-    const stepIssues = flattenIssues(step.issues?.controls);
-    return hideValidationErrorsOnFirstRender ? false : Object.keys(stepIssues).length > 0;
-  }, [step.issues?.controls, hideValidationErrorsOnFirstRender]);
-
   return (
     <Form {...form}>
       <FormRoot className="flex h-full flex-col" onBlur={onBlur}>
         <SaveFormContext.Provider value={value}>
-          <TemplateForm workflow={workflow} step={step} hasStepValidationErrors={hasStepValidationErrors} />
+          <TemplateForm workflow={workflow} step={step} />
         </SaveFormContext.Provider>
       </FormRoot>
     </Form>

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-template-issue-cta.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-template-issue-cta.tsx
@@ -56,8 +56,8 @@ export const ConfigureStepTemplateIssueCta = (props: ConfigureStepTemplateIssueC
         type="button"
       >
         <span className={cn(`h-full min-w-1 rounded-full`, { 'bg-destructive': isError, 'bg-bg-sub': !isError })} />
-        <div className="flex flex-col items-start gap-0.5">
-          <TruncatedText className="font-medium">{truncatedTextContent}</TruncatedText>
+        <div className="flex flex-col items-start gap-0.5 overflow-hidden">
+          <TruncatedText className="w-full font-medium">{truncatedTextContent}</TruncatedText>
           <p className="text-text-soft text-wrap text-start">{issue.message}</p>
         </div>
         <RiArrowRightUpLine

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-tabs.tsx
@@ -9,7 +9,7 @@ import { CustomStepControls } from '../controls/custom-step-controls';
 import { useEditorPreview } from '../use-editor-preview';
 
 export const EmailTabs = (props: StepEditorProps) => {
-  const { workflow, step, hasStepValidationErrors } = props;
+  const { workflow, step } = props;
   const { dataSchema, uiSchema } = step.controls;
   const form = useFormContext();
   const [tabsValue, setTabsValue] = useState('editor');
@@ -47,7 +47,6 @@ export const EmailTabs = (props: StepEditorProps) => {
       previewContent={previewContent}
       tabsValue={tabsValue}
       onTabChange={setTabsValue}
-      hasStepValidationErrors={hasStepValidationErrors}
     />
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-tabs.tsx
@@ -9,7 +9,7 @@ import { CustomStepControls } from '../controls/custom-step-controls';
 import { useEditorPreview } from '../use-editor-preview';
 
 export const InAppTabs = (props: StepEditorProps) => {
-  const { workflow, step, hasStepValidationErrors } = props;
+  const { workflow, step } = props;
   const { dataSchema, uiSchema } = step.controls;
   const form = useFormContext();
   const [tabsValue, setTabsValue] = useState('editor');
@@ -47,7 +47,6 @@ export const InAppTabs = (props: StepEditorProps) => {
       previewContent={previewContent}
       tabsValue={tabsValue}
       onTabChange={setTabsValue}
-      hasStepValidationErrors={hasStepValidationErrors}
     />
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/other-steps-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/other-steps-tabs.tsx
@@ -3,7 +3,7 @@ import { CustomStepControls } from './controls/custom-step-controls';
 import { TemplateTabs } from './template-tabs';
 import type { StepEditorProps } from './configure-step-template-form';
 
-export const OtherStepTabs = ({ workflow, step, hasStepValidationErrors }: StepEditorProps) => {
+export const OtherStepTabs = ({ workflow, step }: StepEditorProps) => {
   const { dataSchema } = step.controls;
   const [tabsValue, setTabsValue] = useState('editor');
 
@@ -21,7 +21,6 @@ export const OtherStepTabs = ({ workflow, step, hasStepValidationErrors }: StepE
       previewContent={previewContent}
       tabsValue={tabsValue}
       onTabChange={setTabsValue}
-      hasStepValidationErrors={hasStepValidationErrors}
     />
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/push/push-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/push/push-tabs.tsx
@@ -9,7 +9,7 @@ import { useFormContext } from 'react-hook-form';
 import { useEditorPreview } from '../use-editor-preview';
 
 export const PushTabs = (props: StepEditorProps) => {
-  const { workflow, step, hasStepValidationErrors } = props;
+  const { workflow, step } = props;
   const { dataSchema, uiSchema } = step.controls;
   const [tabsValue, setTabsValue] = useState('editor');
   const form = useFormContext();
@@ -46,7 +46,6 @@ export const PushTabs = (props: StepEditorProps) => {
       previewContent={previewContent}
       tabsValue={tabsValue}
       onTabChange={setTabsValue}
-      hasStepValidationErrors={hasStepValidationErrors}
     />
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/sms/sms-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/sms/sms-tabs.tsx
@@ -9,7 +9,7 @@ import { useFormContext } from 'react-hook-form';
 import { useEditorPreview } from '../use-editor-preview';
 
 export const SmsTabs = (props: StepEditorProps) => {
-  const { workflow, step, hasStepValidationErrors } = props;
+  const { workflow, step } = props;
   const { dataSchema, uiSchema } = step.controls;
   const form = useFormContext();
   const [tabsValue, setTabsValue] = useState('editor');
@@ -47,7 +47,6 @@ export const SmsTabs = (props: StepEditorProps) => {
       tabsValue={tabsValue}
       onTabChange={setTabsValue}
       previewStep={previewStep}
-      hasStepValidationErrors={hasStepValidationErrors}
     />
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/template-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/template-tabs.tsx
@@ -6,7 +6,6 @@ import { Notification5Fill } from '@/components/icons';
 import { Separator } from '@/components/primitives/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import { CompactButton } from '../../primitives/button-compact';
-import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/components/primitives/tooltip';
 
 interface TemplateTabsProps {
   editorContent: React.ReactNode;
@@ -14,7 +13,6 @@ interface TemplateTabsProps {
   tabsValue: string;
   onTabChange: (tab: string) => void;
   previewStep?: () => void;
-  hasStepValidationErrors?: boolean;
 }
 
 export const TemplateTabs = ({
@@ -23,7 +21,6 @@ export const TemplateTabs = ({
   tabsValue,
   onTabChange,
   previewStep,
-  hasStepValidationErrors = false,
 }: TemplateTabsProps) => {
   const navigate = useNavigate();
 
@@ -47,24 +44,9 @@ export const TemplateTabs = ({
             <RiPencilRuler2Line className="size-5 p-0.5" />
             <span>Editor</span>
           </TabsTrigger>
-          <TabsTrigger value="preview" className="gap-1.5" disabled={!previewContent || hasStepValidationErrors}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="flex gap-1.5">
-                  <Notification5Fill className="size-5 p-0.5" />
-                  <span>Preview</span>
-                </div>
-              </TooltipTrigger>
-              <TooltipPortal>
-                {hasStepValidationErrors && (
-                  <TooltipContent className="flex min-w-min max-w-[200px]" side="bottom">
-                    <span className="text-xs font-normal">
-                      Preview is disabled due to validation issues that need to be addressed
-                    </span>
-                  </TooltipContent>
-                )}
-              </TooltipPortal>
-            </Tooltip>
+          <TabsTrigger value="preview" className="gap-1.5" disabled={!previewContent}>
+            <Notification5Fill className="size-5 p-0.5" />
+            <span>Preview</span>
           </TabsTrigger>
         </TabsList>
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Revert blocking the preview tab when the template has issues.
We decided that the invalid variables should be replaced with empty string so the preview will still work. I've applied that logic to the Maily control values as it was the only one not working.

### Screenshots


https://github.com/user-attachments/assets/56a21bb1-fb80-41b8-b80d-9eade033b929

![Screenshot 2025-04-24 at 13 17 20](https://github.com/user-attachments/assets/d689bb3a-a2e2-4d3a-b23f-c08a45089b92)
![Screenshot 2025-04-24 at 13 17 13](https://github.com/user-attachments/assets/af7c3234-5c2d-44ec-aec3-486d8ed3afa7)

