### PR TITLE
poc feat(api-service): add subscriber filtering to broadcast events

### DIFF
--- a/BROADCAST_FILTER.md
+++ b/BROADCAST_FILTER.md
@@ -1,0 +1,93 @@
+# Broadcast Notification Filtering
+
+This feature allows API clients to filter which subscribers receive broadcast notifications by providing MongoDB-compatible query filters.
+
+## Implementation Overview
+
+The implementation adds a `subscriberFilter` parameter to the broadcast endpoint that allows passing MongoDB-compatible query filters to narrow down which subscribers should receive the notification.
+
+### Key Changes
+
+1. Added `subscriberFilter` field to the DTOs:
+
+   - `TriggerEventToAllRequestDto` (API request DTO)
+   - `TriggerEventToAllCommand` (Controller to usecase command)
+   - `TriggerEventBroadcastCommand` (Base broadcast command)
+   - `ParseEventRequestBroadcastCommand` (Parse event request command)
+
+2. Modified the `TriggerBroadcast` usecase to use the filter when querying subscribers:
+
+   ```typescript
+   // Base query includes environment and organization
+   const query: Record<string, unknown> = {
+     _environmentId: command.environmentId,
+     _organizationId: command.organizationId,
+   };
+
+   // Add subscriber filter if provided
+   if (command.subscriberFilter && Object.keys(command.subscriberFilter).length > 0) {
+     Object.assign(query, command.subscriberFilter);
+   }
+
+   for await (const subscriber of this.subscriberRepository.findBatch(
+     query,
+     'subscriberId',
+     {},
+     subscriberFetchBatchSize
+   )) {
+     // Process each subscriber
+   }
+   ```
+
+3. Updated API documentation to explain the feature and provide examples of filter usage.
+
+4. Added e2e tests to verify the functionality.
+
+## Usage Examples
+
+```javascript
+// Trigger broadcast to subscribers in the USA
+await novuClient.triggerBroadcast({
+  name: 'new-feature-announcement',
+  payload: {
+    featureName: 'Broadcast Filtering',
+  },
+  subscriberFilter: {
+    'data.country': 'USA',
+  },
+});
+
+// Trigger broadcast to premium or enterprise subscribers
+await novuClient.triggerBroadcast({
+  name: 'premium-announcement',
+  payload: {
+    message: 'New premium features available!',
+  },
+  subscriberFilter: {
+    'data.plan': { $in: ['premium', 'enterprise'] },
+  },
+});
+
+// Trigger broadcast to subscribers with names starting with 'A'
+await novuClient.triggerBroadcast({
+  name: 'special-offer',
+  payload: {
+    offer: 'Special discount for A-names!',
+  },
+  subscriberFilter: {
+    firstName: { $regex: '^A' },
+  },
+});
+```
+
+## Security Considerations
+
+- The filter is directly passed to MongoDB, so it's important to validate the input in production.
+- In a future version, consider implementing a more structured filtering approach with predefined operators.
+- The feature allows querying any field on the subscriber object, including sensitive ones. Consider restricting this to only certain fields if needed.
+
+## Performance Considerations
+
+- For very large subscriber bases, complex queries might impact performance.
+- Consider adding monitoring to track the execution time of filtered broadcasts.
+- Future optimizations could include indexing commonly filtered fields in the subscriber collection.

--- a/apps/api/src/app/events/dtos/trigger-event-to-all-request.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-to-all-request.dto.ts
@@ -81,4 +81,17 @@ export class TriggerEventToAllRequestDto {
   @ValidateNested()
   @Type(() => TenantPayloadDto)
   tenant?: TriggerTenantContext;
+
+  @ApiPropertyOptional({
+    description: 'MongoDB-compatible query to filter subscribers who should receive the notification',
+    example: {
+      'data.country': 'USA',
+      'data.plan': { $in: ['premium', 'enterprise'] },
+      lastName: { $regex: '^A' },
+    },
+    type: 'object',
+  })
+  @IsObject()
+  @IsOptional()
+  subscriberFilter?: Record<string, unknown>;
 }

--- a/apps/api/src/app/events/e2e/broadcast-event-filter.e2e.ts
+++ b/apps/api/src/app/events/e2e/broadcast-event-filter.e2e.ts
@@ -1,0 +1,326 @@
+import { SubscriberEntity, SubscriberRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+import axios from 'axios';
+import { StepTypeEnum } from '@novu/shared';
+
+describe('Broadcast Event Filter - /events/trigger/broadcast (POST) #novu-v2', async () => {
+  let session: UserSession;
+  const subscriberRepository = new SubscriberRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  it('should trigger only to subscribers matching the filter', async () => {
+    // Create 5 subscribers with different data
+    const subscriberIds: string[] = [];
+
+    // Create first subscriber with country=USA
+    await axios.post(
+      `${session.serverUrl}/v1/subscribers`,
+      {
+        subscriberId: 'subscriber-usa-1',
+        firstName: 'Subscriber',
+        lastName: 'USA 1',
+        email: 'usa1@example.com',
+        data: {
+          country: 'USA',
+          plan: 'premium',
+        },
+      },
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+    subscriberIds.push('subscriber-usa-1');
+
+    // Create second subscriber with country=USA
+    await axios.post(
+      `${session.serverUrl}/v1/subscribers`,
+      {
+        subscriberId: 'subscriber-usa-2',
+        firstName: 'Subscriber',
+        lastName: 'USA 2',
+        email: 'usa2@example.com',
+        data: {
+          country: 'USA',
+          plan: 'basic',
+        },
+      },
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+    subscriberIds.push('subscriber-usa-2');
+
+    // Create third subscriber with country=Canada
+    await axios.post(
+      `${session.serverUrl}/v1/subscribers`,
+      {
+        subscriberId: 'subscriber-canada-1',
+        firstName: 'Subscriber',
+        lastName: 'Canada 1',
+        email: 'canada1@example.com',
+        data: {
+          country: 'Canada',
+          plan: 'premium',
+        },
+      },
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+    subscriberIds.push('subscriber-canada-1');
+
+    // Create a template for testing broadcasts
+    const templateResponse = await session.createTemplate({
+      steps: [
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Test broadcast notification {{country}}',
+        },
+      ],
+    });
+
+    // Trigger a broadcast with a filter for USA subscribers
+    const response = await axios.post(
+      `${session.serverUrl}/v1/events/trigger/broadcast`,
+      {
+        name: templateResponse.triggers[0].identifier,
+        payload: {
+          country: 'United States',
+        },
+        subscriberFilter: {
+          'data.country': 'USA',
+        },
+      },
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+
+    // eslint-disable-next-line no-console
+    console.log('2222222', response.data.data);
+    // eslint-disable-next-line no-console
+    console.log('3333333', response.data.data.acknowledged);
+
+    // Check response
+    expect(response.data.data.acknowledged).to.be.true;
+    expect(response.data.data.status).to.equal('processed');
+    expect(response.data.data.transactionId).to.exist;
+
+    // Wait for messages to be processed
+    await session.waitForSubscriberQueueCompletion();
+    await session.waitForStandardQueueCompletion();
+    await session.waitForWorkflowQueueCompletion();
+
+    // Get subscribers' notifications
+    const usaSubscriber1 = await getSubscriber('subscriber-usa-1');
+    const usaSubscriber2 = await getSubscriber('subscriber-usa-2');
+    const canadaSubscriber = await getSubscriber('subscriber-canada-1');
+
+    // Get the subscribers' notification feeds
+    const usaSubscriber1NotificationResponse = await axios.get(
+      `${session.serverUrl}/v1/subscribers/${usaSubscriber1._id}/notifications/feed`,
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+
+    const usaSubscriber2NotificationResponse = await axios.get(
+      `${session.serverUrl}/v1/subscribers/${usaSubscriber2._id}/notifications/feed`,
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+
+    const canadaSubscriberNotificationResponse = await axios.get(
+      `${session.serverUrl}/v1/subscribers/${canadaSubscriber._id}/notifications/feed`,
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+
+    // USA subscribers should have notifications
+    expect(usaSubscriber1NotificationResponse.data.data.length).to.be.greaterThan(0);
+    expect(usaSubscriber2NotificationResponse.data.data.length).to.be.greaterThan(0);
+
+    // Canada subscriber should not have notifications
+    expect(canadaSubscriberNotificationResponse.data.data.length).to.equal(0);
+  });
+
+  it('should filter subscribers by complex query', async () => {
+    // Create 5 subscribers with different data
+    const subscriberIds: string[] = [];
+
+    // Create premium USA subscriber
+    await axios.post(
+      `${session.serverUrl}/v1/subscribers`,
+      {
+        subscriberId: 'premium-usa',
+        firstName: 'Premium',
+        lastName: 'USA',
+        email: 'premium-usa@example.com',
+        data: {
+          country: 'USA',
+          plan: 'premium',
+          accountCreated: '2022-01-01',
+        },
+      },
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+    subscriberIds.push('premium-usa');
+
+    // Create premium Canada subscriber
+    await axios.post(
+      `${session.serverUrl}/v1/subscribers`,
+      {
+        subscriberId: 'premium-canada',
+        firstName: 'Premium',
+        lastName: 'Canada',
+        email: 'premium-canada@example.com',
+        data: {
+          country: 'Canada',
+          plan: 'premium',
+          accountCreated: '2022-02-01',
+        },
+      },
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+    subscriberIds.push('premium-canada');
+
+    // Create basic USA subscriber
+    await axios.post(
+      `${session.serverUrl}/v1/subscribers`,
+      {
+        subscriberId: 'basic-usa',
+        firstName: 'Basic',
+        lastName: 'USA',
+        email: 'basic-usa@example.com',
+        data: {
+          country: 'USA',
+          plan: 'basic',
+          accountCreated: '2023-01-01',
+        },
+      },
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+    subscriberIds.push('basic-usa');
+
+    // Create a template for testing broadcasts
+    const templateResponse = await session.createTemplate({
+      steps: [
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Test broadcast with complex filter',
+        },
+      ],
+    });
+
+    // Trigger a broadcast with a complex filter (premium plan subscribers)
+    const response = await axios.post(
+      `${session.serverUrl}/v1/events/trigger/broadcast`,
+      {
+        name: templateResponse.triggers[0].identifier,
+        payload: {
+          message: 'Premium subscribers notification',
+        },
+        subscriberFilter: {
+          'data.plan': 'premium',
+        },
+      },
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+
+    // Check response
+    expect(response.data.data.acknowledged).to.be.true;
+    expect(response.data.data.status).to.equal('processed');
+    expect(response.data.data.transactionId).to.exist;
+
+    // Wait for messages to be processed
+    await session.waitForSubscriberQueueCompletion();
+    await session.waitForStandardQueueCompletion();
+    await session.waitForWorkflowQueueCompletion();
+
+    // Get subscribers' notifications
+    const premiumUsaSubscriber = await getSubscriber('premium-usa');
+    const premiumCanadaSubscriber = await getSubscriber('premium-canada');
+    const basicUsaSubscriber = await getSubscriber('basic-usa');
+
+    // Get the subscribers' notification feeds
+    const premiumUsaNotificationResponse = await axios.get(
+      `${session.serverUrl}/v1/subscribers/${premiumUsaSubscriber._id}/notifications/feed`,
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+
+    const premiumCanadaNotificationResponse = await axios.get(
+      `${session.serverUrl}/v1/subscribers/${premiumCanadaSubscriber._id}/notifications/feed`,
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+
+    const basicUsaNotificationResponse = await axios.get(
+      `${session.serverUrl}/v1/subscribers/${basicUsaSubscriber._id}/notifications/feed`,
+      {
+        headers: {
+          authorization: `ApiKey ${session.apiKey}`,
+        },
+      }
+    );
+
+    // Premium subscribers should have notifications
+    expect(premiumUsaNotificationResponse.data.data.length).to.be.greaterThan(0);
+    expect(premiumCanadaNotificationResponse.data.data.length).to.be.greaterThan(0);
+
+    // Basic subscriber should not have notifications
+    expect(basicUsaNotificationResponse.data.data.length).to.equal(0);
+  });
+
+  async function getSubscriber(subscriberId: string): Promise<SubscriberEntity> {
+    const subscriber = await subscriberRepository.findBySubscriberId(session.environment._id, subscriberId);
+    if (!subscriber) {
+      throw new Error(`Subscriber ${subscriberId} not found`);
+    }
+
+    return subscriber;
+  }
+});

--- a/apps/api/src/app/events/events.controller.ts
+++ b/apps/api/src/app/events/events.controller.ts
@@ -132,9 +132,17 @@ export class EventsController {
   @SdkUsageExample('Broadcast Event to All')
   @SdkGroupName('')
   @ApiOperation({
-    summary: 'Broadcast event to all',
-    description: `Trigger a broadcast event to all existing subscribers, could be used to send announcements, etc.
-      In the future could be used to trigger events to a subset of subscribers based on defined filters.`,
+    summary: 'Broadcast event to subscribers',
+    description: `Trigger a broadcast event to subscribers, could be used to send announcements, etc.
+      You can filter which subscribers receive the notification by providing a subscriberFilter parameter with MongoDB query operators.
+      
+      Examples:
+      - Filter by country: { "data.country": "USA" }
+      - Filter by plan: { "data.plan": "premium" }
+      - Filter with $in operator: { "data.plan": { "$in": ["premium", "enterprise"] } }
+      - Filter with $regex: { "lastName": { "$regex": "^A" } }
+      
+      If no filter is provided, the notification will be sent to all subscribers.`,
   })
   @ApiCreatedResponse({
     description: 'Broadcast request has been registered successfully ',
@@ -157,6 +165,7 @@ export class EventsController {
         transactionId,
         overrides: body.overrides || {},
         actor: body.actor,
+        subscriberFilter: body.subscriberFilter,
       })
     );
   }

--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.command.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.command.ts
@@ -1,4 +1,4 @@
-import { IsDefined, IsEnum, IsOptional, IsString, ValidateIf, ValidateNested } from 'class-validator';
+import { IsDefined, IsEnum, IsObject, IsOptional, IsString, ValidateIf, ValidateNested } from 'class-validator';
 import {
   AddressingTypeEnum,
   StatelessControls,
@@ -63,6 +63,10 @@ export class ParseEventRequestMulticastCommand extends ParseEventRequestBaseComm
 export class ParseEventRequestBroadcastCommand extends ParseEventRequestBaseCommand {
   @IsEnum(AddressingTypeEnum)
   addressingType: AddressingTypeEnum.BROADCAST;
+
+  @IsObject()
+  @IsOptional()
+  subscriberFilter?: Record<string, unknown>;
 }
 
 export type ParseEventRequestCommand = ParseEventRequestMulticastCommand | ParseEventRequestBroadcastCommand;

--- a/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.command.ts
+++ b/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.command.ts
@@ -28,4 +28,8 @@ export class TriggerEventToAllCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @IsString()
   bridgeUrl?: string;
+
+  @IsObject()
+  @IsOptional()
+  subscriberFilter?: Record<string, unknown>;
 }

--- a/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.usecase.ts
+++ b/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.usecase.ts
@@ -27,6 +27,7 @@ export class TriggerEventToAll {
         tenant: command.tenant,
         requestCategory: TriggerRequestCategoryEnum.SINGLE,
         bridgeUrl: command.bridgeUrl,
+        subscriberFilter: command.subscriberFilter,
       })
     );
 

--- a/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
@@ -40,6 +40,8 @@ import {
   isStringifiedMailyJSONContent,
 } from '../../../environments-v1/usecases/output-renderers/maily-to-liquid/wrap-maily-in-liquid.command';
 import { GeneratePreviewResponseDto, JSONSchemaDto, PreviewPayloadDto, StepResponseDto } from '../../dtos';
+import { hasAttrs } from '../../../environments-v1/usecases/output-renderers/maily-to-liquid/maily-utils';
+import { MailyContentTypeEnum } from '../../../environments-v1/usecases/output-renderers/maily-to-liquid/maily.types';
 
 const LOG_CONTEXT = 'GeneratePreviewUsecase';
 
@@ -307,24 +309,74 @@ export class PreviewUsecase {
       const isMailyJSONContent = isStringifiedMailyJSONContent(controlValues);
 
       for (const invalidVariable of invalidVariables) {
-        let variableOutput = invalidVariable.output;
-
         if (isMailyJSONContent) {
-          variableOutput = variableOutput.replace(/\{\{|\}\}/g, '').trim();
-        }
+          const variableOutput = invalidVariable.output.replace(/\{\{|\}\}/g, '').trim();
 
-        if (!controlValuesString.includes(variableOutput)) {
-          continue;
-        }
+          controlValuesString = this.handleMailyJSONContent(controlValuesString, variableOutput);
+        } else {
+          if (!controlValuesString.includes(invalidVariable.output)) {
+            continue;
+          }
 
-        const EMPTY_STRING = '';
-        controlValuesString = replaceAll(controlValuesString, variableOutput, EMPTY_STRING);
+          const EMPTY_STRING = '';
+          controlValuesString = replaceAll(controlValuesString, invalidVariable.output, EMPTY_STRING);
+        }
       }
 
       return JSON.parse(controlValuesString);
     } catch (error) {
       return controlValues;
     }
+  }
+
+  /**
+   * Processes Maily JSON content to replace invalid variables with empty strings
+   * Traverses the Maily document structure and replaces variables that match the invalidVariableOutput
+   */
+  private handleMailyJSONContent(mailyJsonString: string, variableOutput: string): string {
+    try {
+      const mailyContent = JSON.parse(mailyJsonString);
+      const processedContent = this.wrapVariablesInLiquid(mailyContent, variableOutput);
+
+      return JSON.stringify(processedContent);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log('######################## error', error);
+
+      // If parsing fails, return the original string
+      return mailyJsonString;
+    }
+  }
+
+  private wrapVariablesInLiquid(node: MailyJSONContent, variableOutput: string): MailyJSONContent {
+    const newNode = { ...node } as MailyJSONContent & { attrs: Record<string, any> };
+
+    if (node.content) {
+      newNode.content = node.content.map((child) => this.wrapVariablesInLiquid(child, variableOutput));
+    }
+
+    if (hasAttrs(node)) {
+      newNode.attrs = this.processVariableNodeAttributes(node, variableOutput);
+    }
+
+    return newNode;
+  }
+
+  private processVariableNodeAttributes(
+    node: MailyJSONContent & { attrs: Record<string, string> },
+    variableOutput: string
+  ) {
+    // eslint-disable-next-line no-console
+    console.log('11111 node', node);
+    const { attrs, type } = node;
+
+    if (type !== MailyContentTypeEnum.VARIABLE) {
+      return attrs;
+    }
+
+    const { output } = node;
+
+    return attrs;
   }
 
   /*

--- a/libs/application-generic/src/usecases/trigger-broadcast/trigger-broadcast.command.ts
+++ b/libs/application-generic/src/usecases/trigger-broadcast/trigger-broadcast.command.ts
@@ -1,9 +1,4 @@
-import {
-  IsDefined,
-  IsOptional,
-  IsString,
-  ValidateNested,
-} from 'class-validator';
+import { IsDefined, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
 import { ITenantDefine } from '@novu/shared';

--- a/libs/application-generic/src/usecases/trigger-broadcast/trigger-broadcast.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-broadcast/trigger-broadcast.usecase.ts
@@ -34,11 +34,19 @@ export class TriggerBroadcast {
     const subscriberFetchBatchSize = 500;
     let subscribers: SubscriberEntity[] = [];
 
+    // Base query includes environment and organization
+    const query: Record<string, unknown> = {
+      _environmentId: command.environmentId,
+      _organizationId: command.organizationId,
+    };
+
+    // Add subscriber filter if provided
+    if (command.subscriberFilter && Object.keys(command.subscriberFilter).length > 0) {
+      Object.assign(query, command.subscriberFilter);
+    }
+
     for await (const subscriber of this.subscriberRepository.findBatch(
-      {
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-      },
+      query as any,
       'subscriberId',
       {},
       subscriberFetchBatchSize

--- a/libs/application-generic/src/usecases/trigger-event/trigger-event.command.ts
+++ b/libs/application-generic/src/usecases/trigger-event/trigger-event.command.ts
@@ -1,11 +1,4 @@
-import {
-  IsDefined,
-  IsEnum,
-  IsOptional,
-  IsString,
-  ValidateIf,
-  ValidateNested,
-} from 'class-validator';
+import { IsDefined, IsEnum, IsOptional, IsString, ValidateIf, ValidateNested } from 'class-validator';
 
 import {
   AddressingTypeEnum,
@@ -69,8 +62,9 @@ export class TriggerEventMulticastCommand extends TriggerEventBaseCommand {
 export class TriggerEventBroadcastCommand extends TriggerEventBaseCommand {
   @IsEnum(AddressingTypeEnum)
   addressingType: AddressingTypeEnum.BROADCAST;
+
+  @IsOptional()
+  subscriberFilter?: Record<string, unknown>;
 }
 
-export type TriggerEventCommand =
-  | TriggerEventMulticastCommand
-  | TriggerEventBroadcastCommand;
+export type TriggerEventCommand = TriggerEventMulticastCommand | TriggerEventBroadcastCommand;


### PR DESCRIPTION
Enhanced the broadcast event functionality to allow filtering of subscribers using a MongoDB-compatible query. Updated the EventsController, DTOs, and related use cases to support the new subscriberFilter parameter, enabling more targeted notifications.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
