### PR TITLE
fix(dashboard): Hide issues on step first render

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/edges.tsx
+++ b/apps/dashboard/src/components/workflow-editor/edges.tsx
@@ -74,19 +74,13 @@ export function AddNodeEdge({
                             navigate(
                               buildRoute(ROUTES.EDIT_STEP_TEMPLATE, {
                                 stepSlug: data.steps[indexToAdd].slug,
-                              }),
-                              {
-                                state: { hideValidationErrorsOnFirstRender: true },
-                              }
+                              })
                             );
                           } else if (INLINE_CONFIGURABLE_STEP_TYPES.includes(stepType)) {
                             navigate(
                               buildRoute(ROUTES.EDIT_STEP, {
                                 stepSlug: data.steps[indexToAdd].slug,
-                              }),
-                              {
-                                state: { hideValidationErrorsOnFirstRender: true },
-                              }
+                              })
                             );
                           }
                         },

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -364,19 +364,13 @@ export const AddNode = (_props: NodeProps<NodeType>) => {
                   navigate(
                     buildRoute(ROUTES.EDIT_STEP_TEMPLATE, {
                       stepSlug: data.steps[data.steps.length - 1].slug,
-                    }),
-                    {
-                      state: { hideValidationErrorsOnFirstRender: true },
-                    }
+                    })
                   );
                 } else if (INLINE_CONFIGURABLE_STEP_TYPES.includes(stepType)) {
                   navigate(
                     buildRoute(ROUTES.EDIT_STEP, {
                       stepSlug: data.steps[data.steps.length - 1].slug,
-                    }),
-                    {
-                      state: { hideValidationErrorsOnFirstRender: true },
-                    }
+                    })
                   );
                 }
               },

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
@@ -89,7 +89,6 @@ type ConfigureStepFormProps = {
 export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
   const { step, workflow, update, environment } = props;
   const navigate = useNavigate();
-  const { hideValidationErrorsOnFirstRender } = useLocation().state || {};
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const supportedStepTypes = [
     StepTypeEnum.IN_APP,
@@ -190,15 +189,14 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
       });
     });
 
-    if (!hideValidationErrorsOnFirstRender) {
+    // @ts-expect-error - isNew doesn't exist on StepResponseDto and it's too much work to override the @novu/shared types now. See useUpdateWorkflow.ts for more details
+    if (!step.isNew) {
       // Set new errors from stepIssues
       Object.entries(stepIssues).forEach(([key, value]) => {
         // @ts-expect-error - dynamic key
         form.setError(`controlValues.${key}`, { message: value });
       });
     }
-    // Do not add hideValidationErrorsOnFirstRender so as not to trigger a rerender on the navigation that happens as soon as drawer is closing
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [form, step]);
 
   useEffect(() => {

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
@@ -11,7 +11,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { HTMLAttributes, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { RiArrowLeftSLine, RiArrowRightSLine, RiCloseFill, RiDeleteBin2Line, RiPencilRuler2Fill } from 'react-icons/ri';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { z } from 'zod';
 
 import { ConfirmationModal } from '@/components/confirmation-modal';

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-template-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-template-form.tsx
@@ -12,7 +12,7 @@ import { UpdateWorkflowFn } from '@/components/workflow-editor/workflow-provider
 import { useDataRef } from '@/hooks/use-data-ref';
 import { useFormAutosave } from '@/hooks/use-form-autosave';
 import { type StepResponseDto, StepTypeEnum, StepUpdateDto, type WorkflowResponseDto } from '@novu/shared';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import { useLocation } from 'react-router-dom';
 
@@ -39,8 +39,6 @@ type ConfigureStepTemplateFormProps = StepEditorProps & {
 
 export const ConfigureStepTemplateForm = (props: ConfigureStepTemplateFormProps) => {
   const { workflow, step, update } = props;
-  const { hideValidationErrorsOnFirstRender } = useLocation().state || {};
-
   const defaultValues = useMemo(() => getStepDefaultValues(step), [step]);
 
   const form = useForm({
@@ -79,14 +77,12 @@ export const ConfigureStepTemplateForm = (props: ConfigureStepTemplateFormProps)
       }
     });
 
-    if (!hideValidationErrorsOnFirstRender) {
-      // Set new errors from stepIssues
+    // @ts-expect-error - isNew doesn't exist on StepResponseDto and it's too much work to override the @novu/shared types now. See useUpdateWorkflow.ts for more details
+    if (!step.isNew) {
       Object.entries(stepIssues).forEach(([key, value]) => {
         form.setError(key as string, { message: value });
       });
     }
-    // Do not add hideValidationErrorsOnFirstRender so as not to trigger a rerender on the navigation that happens as soon as drawer is closing
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [form, step]);
 
   useEffect(() => {

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-template-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-template-form.tsx
@@ -12,9 +12,8 @@ import { UpdateWorkflowFn } from '@/components/workflow-editor/workflow-provider
 import { useDataRef } from '@/hooks/use-data-ref';
 import { useFormAutosave } from '@/hooks/use-form-autosave';
 import { type StepResponseDto, StepTypeEnum, StepUpdateDto, type WorkflowResponseDto } from '@novu/shared';
-import { useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
-import { useLocation } from 'react-router-dom';
 
 const STEP_TYPE_TO_TEMPLATE_FORM: Record<StepTypeEnum, (args: StepEditorProps) => React.JSX.Element | null> = {
   [StepTypeEnum.EMAIL]: EmailTabs,

--- a/apps/dashboard/src/hooks/use-update-workflow.ts
+++ b/apps/dashboard/src/hooks/use-update-workflow.ts
@@ -8,6 +8,33 @@ import type { WorkflowResponseDto } from '@novu/shared';
 
 type UpdateWorkflowParameters = OmitEnvironmentFromParameters<typeof updateWorkflow>;
 
+/**
+ * This function marks the new steps in the workflow by comparing the previous workflow with the current one
+ *
+ * It is used to prevent the validation errors from being shown on the first render of a new step
+ *
+ * NOTE: This solution doesn't work in development mode because of React Strict Mode that causes the workflow to be patched twice on step addition
+ * @param previousWorkflow
+ * @param currentWorkflow
+ * @returns
+ */
+function markNewSteps(previousWorkflow: WorkflowResponseDto, currentWorkflow: WorkflowResponseDto) {
+  if (!previousWorkflow || !currentWorkflow) {
+    return currentWorkflow;
+  }
+
+  const previousStepIds = new Set(previousWorkflow.steps.map((step) => step.stepId));
+
+  currentWorkflow.steps.forEach((step) => {
+    if (!previousStepIds.has(step.stepId)) {
+      // @ts-expect-error - isNew doesn't exist on StepResponseDto and it's too much work to override the @novu/shared types now
+      step.isNew = true;
+    }
+  });
+
+  return currentWorkflow;
+}
+
 export const useUpdateWorkflow = (
   options?: UseMutationOptions<WorkflowResponseDto, unknown, UpdateWorkflowParameters>
 ) => {
@@ -19,6 +46,16 @@ export const useUpdateWorkflow = (
     ...options,
     onSuccess: async (data, variables, context) => {
       const workflowId = getWorkflowIdFromSlug({ slug: data.slug, divider: WORKFLOW_DIVIDER });
+      const previousData = await queryClient.getQueryData<WorkflowResponseDto>([
+        QueryKeys.fetchWorkflow,
+        currentEnvironment?._id,
+        workflowId,
+      ]);
+
+      if (previousData) {
+        markNewSteps(previousData, data);
+      }
+
       await queryClient.setQueryData([QueryKeys.fetchWorkflow, currentEnvironment?._id, workflowId], data);
       await queryClient.invalidateQueries({
         queryKey: [QueryKeys.fetchWorkflowTestData, currentEnvironment?._id, workflowId],


### PR DESCRIPTION
### What changed? Why was the change needed?

This is the second attempt to hide the step issues the first time we open the step editor right after its creation.

The previous implementation use History Push State suffered from the issue of not rendering any issue even after the first autosave.

The second attempt resolves that. So issues should be hidden from the form right after its creation until the first autosave.