### PR TITLE
fix(api): Preview email body if subject is missing

### DIFF
--- a/libs/application-generic/src/utils/sanitize-control-values.ts
+++ b/libs/application-generic/src/utils/sanitize-control-values.ts
@@ -79,7 +79,7 @@ function sanitizeEmail(controlValues: EmailControlType) {
   });
 
   const emailControls: EmailControlType = {
-    subject: controlValues.subject,
+    subject: sanitizeEmptyInput(controlValues.subject, ' '),
     body: sanitizeEmptyInput(controlValues.body, EMPTY_TIP_TAP),
     skip: controlValues.skip,
     disableOutputSanitization: controlValues.disableOutputSanitization,


### PR DESCRIPTION
### What changed? Why was the change needed?

Subject is now required with a stricter validation both in the API and the Framework schema.

This has the side-effect that preview fails unless subject has a value. To fix that and allow previewing emails in the Dashboard with empty subject, we did this hack for now.