### PR TITLE
fix(dashboard): add padding to allow the popover to be close on click

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/email/maily-config.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/maily-config.tsx
@@ -64,6 +64,7 @@ export const DEFAULT_EDITOR_CONFIG = {
   hasMenuBar: false,
   wrapClassName: 'min-h-0 max-h-full flex flex-col w-full h-full',
   bodyClassName: '!bg-transparent flex flex-col basis-full !border-none !mt-0 [&>div]:basis-full [&_.tiptap]:h-full',
+  contentClassName: 'pb-10',
   /**
    * Special characters like "{{" and "/" can trigger event menus in the editor.
    * When autofocus is enabled and the last line ends with one of these characters,


### PR DESCRIPTION
### What changed? Why was the change needed?
also fixes: [nv-5772-email-editor-add-space-at-bottom-to-make-it-easier-to-type](https://linear.app/novu/issue/NV-5772/email-editor-add-space-at-bottom-to-make-it-easier-to-type)
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

https://github.com/user-attachments/assets/4596b609-158f-4759-996a-c60f927e1d19


<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
