### PR TITLE
feat(js,dashboard): inbox snooze improvements

### DIFF
--- a/apps/dashboard/src/components/billing/plan.tsx
+++ b/apps/dashboard/src/components/billing/plan.tsx
@@ -223,7 +223,7 @@ const buildFeatureArray: (columns: ApiServiceLevelEnum[], featureFlags: FeatureF
     ...(featureFlags[FeatureFlagsKeysEnum.IS_SNOOZE_ENABLED]
       ? [
           {
-            label: '"Remind me later" functionality',
+            label: 'Snooze functionality',
             values: buildTableRowRecord({
               featureName: FeatureNameEnum.PLATFORM_MAX_SNOOZE_DURATION,
             }),

--- a/apps/web/src/ee/billing/components/Features.tsx
+++ b/apps/web/src/ee/billing/components/Features.tsx
@@ -1,10 +1,9 @@
 import { css } from '@novu/novui/css';
 import { Text } from '@novu/novui';
 import styled from '@emotion/styled';
-import { ApiServiceLevelEnum } from '@novu/shared';
+import { ApiServiceLevelEnum, FeatureFlagsKeysEnum } from '@novu/shared';
 import { IconCheck as _IconCheck } from '@novu/novui/icons';
 import { useFeatureFlag } from '../../../hooks/useFeatureFlag';
-import { FeatureFlagsKeysEnum } from '@novu/shared';
 
 const TitleCell = styled.div`
   display: flex;
@@ -274,7 +273,7 @@ const featuresDefinition: Feature<SupportedPlansEnum>[] = [
     },
   },
   {
-    label: '"Remind me later" functionality',
+    label: 'Snooze functionality',
     values: {
       [SupportedPlansEnum.FREE]: { value: '-' },
       [SupportedPlansEnum.PRO]: { value: 'Up to 90 days' },
@@ -398,9 +397,10 @@ export const Features = () => {
   const isSnoozeEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_SNOOZE_ENABLED);
 
   const filteredFeatures = featuresDefinition.filter((feature) => {
-    if (!isSnoozeEnabled && feature.label === '"Remind me later" functionality') {
+    if (!isSnoozeEnabled && feature.label === 'Snooze functionality') {
       return false;
     }
+
     return true;
   });
 

--- a/packages/js/src/ui/components/Notification/NotificationActions.tsx
+++ b/packages/js/src/ui/components/Notification/NotificationActions.tsx
@@ -21,19 +21,24 @@ export const SNOOZE_PRESETS = [
     getDate: () => new Date(Date.now() + 1 * 60 * 60 * 1000),
   },
   {
-    key: 'snooze.options.inTwelveHours',
-    hours: 12,
-    getDate: () => new Date(Date.now() + 12 * 60 * 60 * 1000),
-  },
-  {
     key: 'snooze.options.inOneDay',
     hours: 24,
-    getDate: () => new Date(Date.now() + 1 * 24 * 60 * 60 * 1000),
+    getDate: () => {
+      const date = new Date(Date.now() + 1 * 24 * 60 * 60 * 1000);
+      date.setHours(9, 0, 0, 0);
+
+      return date;
+    },
   },
   {
     key: 'snooze.options.inOneWeek',
     hours: 168,
-    getDate: () => new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    getDate: () => {
+      const date = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      date.setHours(9, 0, 0, 0);
+
+      return date;
+    },
   },
 ] satisfies {
   key: Extract<LocalizationKey, `snooze.options.${string}`>;
@@ -45,27 +50,62 @@ export const formatSnoozeOption = (
   preset: (typeof SNOOZE_PRESETS)[number],
   t: (key: LocalizationKey) => string,
   locale: string
-): string => {
+): { label: string; time: string } => {
   const date = preset.getDate();
 
-  // For hour-based presets (1 hour, 12 hours), just show the translation without time
-  if (preset.hours <= 12) {
-    return t(preset.key);
-  }
+  // Format day (e.g., "Mon")
+  const dayName = new Intl.DateTimeFormat(locale, { weekday: 'short' }).format(date);
 
   // Format time (e.g., "9:00 AM")
   const timeString = new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: 'numeric' }).format(date);
 
   // For weekly option, show "Next Monday" etc.
   if (preset.key === 'snooze.options.inOneWeek') {
-    // Get the day name (e.g., "Monday")
-    const dayName = new Intl.DateTimeFormat(locale, { weekday: 'long' }).format(date);
+    const fullDayName = new Intl.DateTimeFormat(locale, { weekday: 'long' }).format(date);
 
-    return `${t(preset.key)} ${dayName}, ${timeString}`;
+    return { label: `${t(preset.key)} ${fullDayName}`, time: `${dayName}, ${timeString}` };
   }
 
-  // Fallback to original translation
-  return `${t(preset.key)}, ${timeString}`;
+  return { label: t(preset.key), time: `${dayName}, ${timeString}` };
+};
+
+const SnoozeDropdownItem = (props: {
+  label: string;
+  time: string;
+  onClick?: (e: MouseEvent) => void;
+  asChild?: (props: any) => JSX.Element;
+}) => {
+  const style = useStyle();
+
+  const content = (
+    <>
+      <div class={style('dropdownItem', 'nt-flex nt-items-center nt-flex-1')}>
+        <Clock
+          class={style('notificationSnooze__dropdownItem__icon', 'nt-size-3 nt-text-foreground-alpha-400 nt-mr-2')}
+        />
+        <span class={style('dropdownItemLabel')}>{props.label}</span>
+      </div>
+      <span class={style('dropdownItemRight__icon', 'nt-text-foreground-alpha-300 nt-ml-2')}>{props.time}</span>
+    </>
+  );
+
+  if (props.asChild) {
+    return props.asChild({
+      class: style('notificationSnooze__dropdownItem', dropdownItemVariants()),
+      onClick: props.onClick,
+      children: content,
+    });
+  }
+
+  return (
+    <Dropdown.Item
+      appearanceKey="notificationSnooze__dropdownItem"
+      onClick={props.onClick}
+      class={style('dropdownItem', 'nt-justify-between')}
+    >
+      {content}
+    </Dropdown.Item>
+  );
 };
 
 export const ReadButton = (props: { notification: Notification }) => {
@@ -249,20 +289,20 @@ export const SnoozeButton = (props: { notification: Notification }) => {
             />
             <Dropdown.Content portal appearanceKey="notificationSnooze__dropdownContent">
               <For each={availableSnoozePresets()}>
-                {(preset) => (
-                  <Dropdown.Item
-                    appearanceKey="notificationSnooze__dropdownItem"
-                    onClick={async (e) => {
-                      e.stopPropagation();
-                      await props.notification.snooze(preset.getDate().toISOString());
-                    }}
-                  >
-                    <Clock
-                      class={style('notificationSnooze__dropdownItem__icon', 'nt-size-3 nt-text-foreground-alpha-400')}
+                {(preset) => {
+                  const option = formatSnoozeOption(preset, t, locale());
+
+                  return (
+                    <SnoozeDropdownItem
+                      label={option.label}
+                      time={option.time}
+                      onClick={async (e) => {
+                        e.stopPropagation();
+                        await props.notification.snooze(preset.getDate().toISOString());
+                      }}
                     />
-                    {formatSnoozeOption(preset, t, locale())}
-                  </Dropdown.Item>
-                )}
+                  );
+                }}
               </For>
 
               <Popover.Root
@@ -270,24 +310,17 @@ export const SnoozeButton = (props: { notification: Notification }) => {
                 onOpenChange={setIsSnoozeDateTimePickerOpen}
                 placement="bottom-start"
               >
-                <Dropdown.Item
-                  asChild={(props) => (
+                <SnoozeDropdownItem
+                  label={t('snooze.options.customTime')}
+                  time=""
+                  asChild={(childProps) => (
                     <Popover.Trigger
-                      class={style('notificationSnooze__dropdownItem', dropdownItemVariants())}
-                      {...props}
+                      {...childProps}
                       onClick={(e) => {
                         e.stopPropagation();
-                        props.onClick?.(e);
+                        childProps.onClick?.(e);
                       }}
-                    >
-                      <Clock
-                        class={style(
-                          'notificationSnooze__dropdownItem__icon',
-                          'nt-size-3 nt-text-foreground-alpha-400'
-                        )}
-                      />
-                      {t('snooze.options.customTime')}
-                    </Popover.Trigger>
+                    />
                   )}
                 />
                 <Popover.Content

--- a/packages/js/src/ui/components/Notification/NotificationActions.tsx
+++ b/packages/js/src/ui/components/Notification/NotificationActions.tsx
@@ -53,20 +53,17 @@ export const formatSnoozeOption = (
 ): { label: string; time: string } => {
   const date = preset.getDate();
 
-  // Format day (e.g., "Mon")
+  // Format weekday (e.g., "Wed")
   const dayName = new Intl.DateTimeFormat(locale, { weekday: 'short' }).format(date);
 
-  // Format time (e.g., "9:00 AM")
+  // Format date and month (e.g., "26 Mar")
+  const dateMonth = new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'short' }).format(date);
+
+  // Format time (e.g., "9:00 PM")
   const timeString = new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: 'numeric' }).format(date);
 
-  // For weekly option, show "Next Monday" etc.
-  if (preset.key === 'snooze.options.inOneWeek') {
-    const fullDayName = new Intl.DateTimeFormat(locale, { weekday: 'long' }).format(date);
-
-    return { label: `${t(preset.key)} ${fullDayName}`, time: `${dayName}, ${timeString}` };
-  }
-
-  return { label: t(preset.key), time: `${dayName}, ${timeString}` };
+  // Combine to e.g. "Wed, 26 Mar, 9:00 PM"
+  return { label: t(preset.key), time: `${dayName}, ${dateMonth}, ${timeString}` };
 };
 
 const SnoozeDropdownItem = (props: {
@@ -85,7 +82,9 @@ const SnoozeDropdownItem = (props: {
         />
         <span class={style('dropdownItemLabel')}>{props.label}</span>
       </div>
-      <span class={style('dropdownItemRight__icon', 'nt-text-foreground-alpha-300 nt-ml-2')}>{props.time}</span>
+      <span class={style('dropdownItemRight__icon', 'nt-text-foreground-alpha-300 nt-ml-2 nt-text-xs')}>
+        {props.time}
+      </span>
     </>
   );
 

--- a/packages/js/src/ui/config/defaultLocalization.ts
+++ b/packages/js/src/ui/config/defaultLocalization.ts
@@ -22,7 +22,7 @@ export const defaultLocalization = {
   'notification.actions.unread.tooltip': 'Mark as unread',
   'notification.actions.archive.tooltip': 'Archive',
   'notification.actions.unarchive.tooltip': 'Unarchive',
-  'notification.actions.snooze.tooltip': 'Snooze until...',
+  'notification.actions.snooze.tooltip': 'Snooze',
   'notification.actions.unsnooze.tooltip': 'Unsnooze',
   'notification.snoozedUntil': 'Snoozed until',
   'preferences.title': 'Preferences',
@@ -34,13 +34,12 @@ export const defaultLocalization = {
   'snooze.datePicker.timePickerLabel': 'Time',
   'snooze.datePicker.apply': 'Apply',
   'snooze.datePicker.cancel': 'Cancel',
-  'snooze.options.anHourFromNow': 'Hour from now',
+  'snooze.options.anHourFromNow': 'An hour from now',
   'snooze.datePicker.pastDateTooltip': 'Selected time must be at least 3 minutes in the future',
   'snooze.datePicker.noDateSelectedTooltip': 'Please select a date',
   'snooze.datePicker.exceedingLimitTooltip': ({ days }: { days: number }) =>
     `Selected time cannot exceed ${days === 1 ? '24 hours' : `${days} days`} from now`,
   'snooze.options.customTime': 'Custom time...',
-  'snooze.options.inTwelveHours': '12 hours',
   'snooze.options.inOneDay': 'Tomorrow',
   'snooze.options.inOneWeek': 'Next',
 } as const;

--- a/packages/js/src/ui/config/defaultLocalization.ts
+++ b/packages/js/src/ui/config/defaultLocalization.ts
@@ -41,7 +41,7 @@ export const defaultLocalization = {
     `Selected time cannot exceed ${days === 1 ? '24 hours' : `${days} days`} from now`,
   'snooze.options.customTime': 'Custom time...',
   'snooze.options.inOneDay': 'Tomorrow',
-  'snooze.options.inOneWeek': 'Next',
+  'snooze.options.inOneWeek': 'Next week',
 } as const;
 
 export const [dynamicLocalization, setDynamicLocalization] = createSignal<Record<string, string>>({});


### PR DESCRIPTION
- removed "12 hours" option - seems unnecessary
- changed the snooze dropdown options
- aligned the time to "9:00 AM" for options snoozing for more than 1 day
- Renamed "Next <day>" to next week, since the day is already there

![image](https://github.com/user-attachments/assets/3bbc6847-2fde-4742-8d51-015e84c5d9d9)
