### PR TITLE
fix(dashboard): Improve ux for jit variables

### DIFF
--- a/apps/dashboard/src/utils/parseStepVariables.ts
+++ b/apps/dashboard/src/utils/parseStepVariables.ts
@@ -51,13 +51,6 @@ export function parseStepVariables(
     if (typeof obj === 'boolean') return;
 
     if (obj.type === 'object') {
-      // Handle object with additionalProperties
-      if (obj.additionalProperties === true) {
-        result.namespaces.push({
-          name: path,
-        });
-      }
-
       if (!obj.properties) return;
 
       for (const [key, value] of Object.entries(obj.properties)) {


### PR DESCRIPTION
**This change affects every step but Email for now** A PR for email will follow.

Introduce the concept of JIT variables that are added to JIT namespaces as you type.

When the user types foo, we don't suggest anything. Users can pick a payload from the dropdown, but then they need to click on the payload pill and edit the variable name, which is bad UX.

This PR improves the DX by suggesting the following as the user types foo.

- "payload.foo"
- "subscriber.data.foo"

Try it in the preview deployment.