### PR TITLE
test(api): snooze/usnooze test coverage

### DIFF
--- a/apps/api/src/app/inbox/e2e/mark-notification-as.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/mark-notification-as.e2e.ts
@@ -20,7 +20,10 @@ import { Novu } from '@novu/api';
 import { mapToDto } from '../utils/notification-mapper';
 import { initNovuClassSdk } from '../../shared/helpers/e2e/sdk/e2e-sdk.helper';
 
-describe('Mark Notification As - /inbox/notifications/:id/{read,unread,archive,unarchive} (PATCH) #novu-v2', async () => {
+// @ts-ignore - Bypassing readonly for testing purposes
+process.env.IS_SNOOZE_ENABLED = 'true';
+
+describe('Mark Notification As - /inbox/notifications/:id/{read,unread,archive,unarchive,snooze,unsnooze} (PATCH) #novu-v2', async () => {
   let session: UserSession;
   let template: NotificationTemplateEntity;
   let subscriber: SubscriberEntity | null;
@@ -31,14 +34,16 @@ describe('Mark Notification As - /inbox/notifications/:id/{read,unread,archive,u
   const updateNotification = async ({
     id,
     status,
+    body,
   }: {
     id: string;
-    status: 'read' | 'unread' | 'archive' | 'unarchive';
+    status: 'read' | 'unread' | 'archive' | 'unarchive' | 'snooze' | 'unsnooze';
+    body?: any;
   }) => {
     return await session.testAgent
       .patch(`/v1/inbox/notifications/${id}/${status}`)
       .set('Authorization', `Bearer ${session.subscriberToken}`)
-      .send();
+      .send(body);
   };
 
   const triggerEvent = async (templateToTrigger: NotificationTemplateEntity, times = 1) => {
@@ -215,5 +220,55 @@ describe('Mark Notification As - /inbox/notifications/:id/{read,unread,archive,u
     expect(body.data.readAt).not.to.be.undefined;
     expect(body.data.isArchived).to.be.false;
     expect(body.data.archivedAt).to.be.null;
+  });
+
+  it('should update the snoozed status', async function () {
+    const snoozeUntil = new Date(Date.now() + 1000 * 60 * 60); // 1 hour in the future
+    const { body, status } = await updateNotification({
+      id: message._id,
+      status: 'snooze',
+      body: { snoozeUntil },
+    });
+
+    const updatedMessage = (await messageRepository.findOne({
+      _environmentId: session.environment._id,
+      _subscriberId: subscriber?._id ?? '',
+      _templateId: template._id,
+    })) as MessageEntity;
+
+    expect(status).to.equal(200);
+    expect(body.data).to.deep.equal(removeUndefinedDeep(mapToDto(updatedMessage)));
+    expect(updatedMessage.seen).to.be.true;
+    expect(updatedMessage.lastSeenDate).not.to.be.undefined;
+    expect(body.data.isSnoozed).to.be.true;
+    expect(body.data.snoozedUntil).to.equal(snoozeUntil.toISOString());
+  });
+
+  it('should update the unsnoozed status', async function () {
+    const now = new Date();
+    const snoozeUntil = new Date(Date.now() + 1000 * 60 * 60); // 1 hour in the future
+
+    // First set up a snoozed notification
+    await updateNotification({
+      id: message._id,
+      status: 'snooze',
+      body: { snoozeUntil },
+    });
+
+    // Then unsnooze it
+    const { body, status } = await updateNotification({ id: message._id, status: 'unsnooze' });
+
+    const updatedMessage = (await messageRepository.findOne({
+      _environmentId: session.environment._id,
+      _subscriberId: subscriber?._id ?? '',
+      _templateId: template._id,
+    })) as MessageEntity;
+
+    expect(status).to.equal(200);
+    expect(body.data).to.deep.equal(removeUndefinedDeep(mapToDto(updatedMessage)));
+    expect(updatedMessage.seen).to.be.true;
+    expect(updatedMessage.lastSeenDate).not.to.be.undefined;
+    expect(body.data.isSnoozed).to.be.false;
+    expect(body.data.snoozedUntil).to.be.undefined;
   });
 });

--- a/apps/api/src/app/inbox/e2e/snooze-unsnooze-notification.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/snooze-unsnooze-notification.e2e.ts
@@ -1,0 +1,181 @@
+import { expect } from 'chai';
+import { UserSession } from '@novu/testing';
+import { MessageRepository, NotificationTemplateEntity, SubscriberEntity, SubscriberRepository } from '@novu/dal';
+import { ActorTypeEnum, ChannelTypeEnum, StepTypeEnum, SystemAvatarIconEnum } from '@novu/shared';
+import { Novu } from '@novu/api';
+import { initNovuClassSdk } from '../../shared/helpers/e2e/sdk/e2e-sdk.helper';
+
+// @ts-ignore - Bypassing readonly for testing purposes
+process.env.IS_SNOOZE_ENABLED = 'true';
+
+describe('Snooze and Unsnooze Notifications - /inbox/notifications/:id/{snooze,unsnooze} (PATCH) #novu-v2', () => {
+  let session: UserSession;
+  let template: NotificationTemplateEntity;
+  let subscriber: SubscriberEntity;
+  const messageRepository = new MessageRepository();
+  const subscriberRepository = new SubscriberRepository();
+  let novuClient: Novu;
+  let notificationId: string;
+
+  const snoozeNotification = async (id: string, snoozeUntil: Date) => {
+    return await session.testAgent
+      .patch(`/v1/inbox/notifications/${id}/snooze`)
+      .set('Authorization', `Bearer ${session.subscriberToken}`)
+      .send({ snoozeUntil });
+  };
+
+  const unsnoozeNotification = async (id: string) => {
+    return await session.testAgent
+      .patch(`/v1/inbox/notifications/${id}/unsnooze`)
+      .set('Authorization', `Bearer ${session.subscriberToken}`)
+      .send();
+  };
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+
+    novuClient = initNovuClassSdk(session);
+
+    template = await session.createTemplate({
+      steps: [
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Test snooze/unsnooze notification',
+          actor: {
+            type: ActorTypeEnum.SYSTEM_ICON,
+            data: SystemAvatarIconEnum.WARNING,
+          },
+        },
+      ],
+    });
+
+    // Trigger the notification
+    await novuClient.trigger({
+      workflowId: template.triggers[0].identifier,
+      to: { subscriberId: session.subscriberId },
+    });
+
+    // Wait for job to complete
+    await session.waitForJobCompletion(template._id);
+
+    subscriber = (await subscriberRepository.findBySubscriberId(
+      session.environment._id,
+      session.subscriberId
+    )) as SubscriberEntity;
+
+    // Find the notification
+    const messages = await messageRepository.find({
+      _environmentId: session.environment._id,
+      _subscriberId: subscriber._id,
+      _templateId: template._id,
+      channel: ChannelTypeEnum.IN_APP,
+    });
+
+    expect(messages.length).to.be.greaterThan(0, 'No notifications found');
+    notificationId = messages[0]._id;
+  });
+
+  it('should successfully snooze a notification', async () => {
+    const snoozeUntil = new Date();
+    snoozeUntil.setHours(snoozeUntil.getHours() + 1); // Snooze for 1 hour
+
+    const response = await snoozeNotification(notificationId, snoozeUntil);
+
+    expect(response.status).to.equal(200);
+
+    // Verify the notification has been marked as snoozed in the database
+    const snoozedNotification = await messageRepository.findOne({
+      _environmentId: session.environment._id,
+      _id: notificationId,
+    });
+
+    expect(snoozedNotification).to.not.be.null;
+    expect(snoozedNotification?.snoozedUntil).to.not.be.null;
+    expect(Boolean(snoozedNotification?.snoozedUntil)).to.equal(true); // Check that it's snoozed
+
+    // Convert dates to timestamps for comparison since exact milliseconds might differ
+    const snoozedUntil = snoozedNotification?.snoozedUntil;
+    const actualSnoozeTime = snoozedUntil ? new Date(snoozedUntil).getTime() : 0;
+    const expectedSnoozeTime = snoozeUntil.getTime();
+
+    // Allow for a small difference due to processing time
+    expect(Math.abs(actualSnoozeTime - expectedSnoozeTime)).to.be.lessThan(5000);
+  });
+
+  it('should successfully unsnooze a notification', async () => {
+    // First snooze the notification
+    const snoozeUntil = new Date();
+    snoozeUntil.setHours(snoozeUntil.getHours() + 1); // Snooze for 1 hour
+
+    await snoozeNotification(notificationId, snoozeUntil);
+
+    // Verify it's snoozed
+    const snoozedNotification = await messageRepository.findOne({
+      _environmentId: session.environment._id,
+      _id: notificationId,
+    });
+
+    expect(snoozedNotification?.snoozedUntil).to.not.be.null;
+
+    // Now unsnooze it
+    const response = await unsnoozeNotification(notificationId);
+
+    expect(response.status).to.equal(200);
+
+    // Verify the notification has been unsnoozed
+    const unsnoozedNotification = await messageRepository.findOne({
+      _environmentId: session.environment._id,
+      _id: notificationId,
+    });
+
+    expect(unsnoozedNotification?.snoozedUntil).to.be.null;
+    expect(Boolean(unsnoozedNotification?.snoozedUntil)).to.equal(false); // Check that it's not snoozed
+  });
+
+  it('should handle attempting to unsnooze a notification that is not snoozed', async () => {
+    // Try to unsnooze a notification that hasn't been snoozed
+    const response = await unsnoozeNotification(notificationId);
+
+    // Should return a 404 error since the notification is not in a snoozed state
+    expect(response.status).to.equal(404);
+  });
+
+  it('should reject snooze with invalid date', async () => {
+    // Try to snooze with a past date
+    const pastDate = new Date();
+    pastDate.setHours(pastDate.getHours() - 1); // 1 hour in the past
+
+    const response = await snoozeNotification(notificationId, pastDate);
+
+    // Should be a validation error
+    expect(response.status).to.equal(422); // Changed from 400 to 422 for validation errors
+  });
+
+  it('should reject snooze with duration exceeding tier limit', async () => {
+    // Set a far future date (e.g., 180 days)
+    const farFutureDate = new Date();
+    farFutureDate.setDate(farFutureDate.getDate() + 180);
+
+    const response = await snoozeNotification(notificationId, farFutureDate);
+
+    expect(response.status).to.equal(402); // Payment Required
+  });
+
+  it('should ensure notifications can only be snoozed by their owner', async () => {
+    // Create a second user
+    const secondSession = new UserSession();
+    await secondSession.initialize();
+
+    // Try to access with wrong user's token
+    const snoozeUntil = new Date();
+    snoozeUntil.setHours(snoozeUntil.getHours() + 1);
+
+    const response = await session.testAgent
+      .patch(`/v1/inbox/notifications/${notificationId}/snooze`)
+      .set('Authorization', `Bearer ${secondSession.subscriberToken}`)
+      .send({ snoozeUntil });
+
+    expect(response.status).to.equal(404);
+  });
+});

--- a/apps/api/src/app/inbox/e2e/snooze-unsnooze-notification.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/snooze-unsnooze-notification.e2e.ts
@@ -31,6 +31,48 @@ describe('Snooze and Unsnooze Notifications - /inbox/notifications/:id/{snooze,u
       .send();
   };
 
+  const getNotification = async (id: string) => {
+    const response = await session.testAgent
+      .get(`/v1/inbox/notifications`)
+      .set('Authorization', `Bearer ${session.subscriberToken}`);
+
+    if (response.status !== 200) {
+      return response;
+    }
+
+    // Find the specific notification in the results
+    const notification = response.body.data.find((notif) => notif.id === id);
+    if (notification) {
+      // Return a response object that mimics a single notification endpoint response
+      return {
+        status: 200,
+        body: notification,
+      };
+    }
+
+    // Return 404 if notification not found
+    return {
+      status: 404,
+      body: { message: 'Notification not found' },
+    };
+  };
+
+  // Helper to get notifications with specific filters
+  const getNotificationsWithFilter = async (filter: { snoozed?: boolean } = {}) => {
+    let url = `/v1/inbox/notifications`;
+    const queryParams: string[] = [];
+
+    if (filter.snoozed !== undefined) {
+      queryParams.push(`snoozed=${filter.snoozed}`);
+    }
+
+    if (queryParams.length > 0) {
+      url += `?${queryParams.join('&')}`;
+    }
+
+    return await session.testAgent.get(url).set('Authorization', `Bearer ${session.subscriberToken}`);
+  };
+
   beforeEach(async () => {
     session = new UserSession();
     await session.initialize();
@@ -80,27 +122,22 @@ describe('Snooze and Unsnooze Notifications - /inbox/notifications/:id/{snooze,u
     const snoozeUntil = new Date();
     snoozeUntil.setHours(snoozeUntil.getHours() + 1); // Snooze for 1 hour
 
-    const response = await snoozeNotification(notificationId, snoozeUntil);
+    // Call the snooze API
+    const snoozeResponse = await snoozeNotification(notificationId, snoozeUntil);
+    expect(snoozeResponse.status).to.equal(200);
 
-    expect(response.status).to.equal(200);
+    // Verify through snoozed filter API that the notification is snoozed
+    const snoozedList = await getNotificationsWithFilter({ snoozed: true });
+    expect(snoozedList.status).to.equal(200);
 
-    // Verify the notification has been marked as snoozed in the database
-    const snoozedNotification = await messageRepository.findOne({
-      _environmentId: session.environment._id,
-      _id: notificationId,
-    });
+    const snoozedNotification = snoozedList.body.data.find((notification) => notification.id === notificationId);
+    expect(snoozedNotification).to.not.be.undefined;
+    expect(snoozedNotification).to.have.property('snoozedUntil').that.is.not.null;
 
-    expect(snoozedNotification).to.not.be.null;
-    expect(snoozedNotification?.snoozedUntil).to.not.be.null;
-    expect(Boolean(snoozedNotification?.snoozedUntil)).to.equal(true); // Check that it's snoozed
-
-    // Convert dates to timestamps for comparison since exact milliseconds might differ
-    const snoozedUntil = snoozedNotification?.snoozedUntil;
-    const actualSnoozeTime = snoozedUntil ? new Date(snoozedUntil).getTime() : 0;
+    // Verify the snooze time is approximately correct
+    const responseSnoozedTime = new Date(snoozedNotification.snoozedUntil).getTime();
     const expectedSnoozeTime = snoozeUntil.getTime();
-
-    // Allow for a small difference due to processing time
-    expect(Math.abs(actualSnoozeTime - expectedSnoozeTime)).to.be.lessThan(5000);
+    expect(Math.abs(responseSnoozedTime - expectedSnoozeTime)).to.be.lessThan(5000);
   });
 
   it('should successfully unsnooze a notification', async () => {
@@ -110,27 +147,18 @@ describe('Snooze and Unsnooze Notifications - /inbox/notifications/:id/{snooze,u
 
     await snoozeNotification(notificationId, snoozeUntil);
 
-    // Verify it's snoozed
-    const snoozedNotification = await messageRepository.findOne({
-      _environmentId: session.environment._id,
-      _id: notificationId,
-    });
-
-    expect(snoozedNotification?.snoozedUntil).to.not.be.null;
+    // Verify it's snoozed via API using the snoozed filter
+    const snoozedList = await getNotificationsWithFilter({ snoozed: true });
+    expect(snoozedList.status).to.equal(200);
+    expect(snoozedList.body.data.some((notification) => notification.id === notificationId)).to.be.true;
 
     // Now unsnooze it
-    const response = await unsnoozeNotification(notificationId);
+    const unsnoozeResponse = await unsnoozeNotification(notificationId);
+    expect(unsnoozeResponse.status).to.equal(200);
 
-    expect(response.status).to.equal(200);
-
-    // Verify the notification has been unsnoozed
-    const unsnoozedNotification = await messageRepository.findOne({
-      _environmentId: session.environment._id,
-      _id: notificationId,
-    });
-
-    expect(unsnoozedNotification?.snoozedUntil).to.be.null;
-    expect(Boolean(unsnoozedNotification?.snoozedUntil)).to.equal(false); // Check that it's not snoozed
+    // Verify the notification has been unsnoozed via API
+    const unsnoozedResponse = await getNotification(notificationId);
+    expect(unsnoozedResponse.body).to.have.property('isSnoozed').that.equals(false);
   });
 
   it('should handle attempting to unsnooze a notification that is not snoozed', async () => {

--- a/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.spec.ts
+++ b/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.spec.ts
@@ -24,7 +24,7 @@ import { MarkNotificationAs } from '../mark-notification-as/mark-notification-as
 import { MarkNotificationAsCommand } from '../mark-notification-as/mark-notification-as.command';
 import { InboxNotification } from '../../utils/types';
 
-describe.only('SnoozeNotification', () => {
+describe('SnoozeNotification', () => {
   const validNotificationId = '507f1f77bcf86cd799439011';
   const validEnvId = '507f1f77bcf86cd799439012';
   const validOrgId = '507f1f77bcf86cd799439013';

--- a/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.spec.ts
+++ b/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.spec.ts
@@ -1,0 +1,249 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { NotFoundException, HttpException, HttpStatus } from '@nestjs/common';
+import {
+  CreateExecutionDetails,
+  CreateExecutionDetailsCommand,
+  StandardQueueService,
+  FeatureFlagsService,
+  PinoLogger,
+} from '@novu/application-generic';
+import {
+  JobEntity,
+  JobRepository,
+  MessageRepository,
+  MessageEntity,
+  CommunityOrganizationRepository,
+  OrganizationEntity,
+} from '@novu/dal';
+import { ApiServiceLevelEnum, ChannelTypeEnum, JobStatusEnum } from '@novu/shared';
+
+import { SnoozeNotification } from './snooze-notification.usecase';
+import { SnoozeNotificationCommand } from './snooze-notification.command';
+import { MarkNotificationAs } from '../mark-notification-as/mark-notification-as.usecase';
+import { MarkNotificationAsCommand } from '../mark-notification-as/mark-notification-as.command';
+import { InboxNotification } from '../../utils/types';
+
+describe.only('SnoozeNotification', () => {
+  const validNotificationId = '507f1f77bcf86cd799439011';
+  const validEnvId = '507f1f77bcf86cd799439012';
+  const validOrgId = '507f1f77bcf86cd799439013';
+  const validJobId = '507f1f77bcf86cd799439014';
+  const validSubscriberId = '507f1f77bcf86cd799439015';
+
+  // Snooze durations in days
+  const SNOOZE_DURATION = {
+    ONE_HOUR: 1 / 24,
+    ONE_DAY: 1,
+    THIRTY_DAYS: 30, // Exceeds free tier limit
+    NINETY_DAYS: 90, // Paid tier max
+    HUNDRED_DAYS: 100, // Exceeds paid tier limit
+  };
+
+  let snoozeNotification: SnoozeNotification;
+  let loggerMock: sinon.SinonStubbedInstance<PinoLogger>;
+  let messageRepositoryMock: sinon.SinonStubbedInstance<MessageRepository>;
+  let jobRepositoryMock: sinon.SinonStubbedInstance<JobRepository>;
+  let standardQueueServiceMock: sinon.SinonStubbedInstance<StandardQueueService>;
+  let organizationRepositoryMock: sinon.SinonStubbedInstance<CommunityOrganizationRepository>;
+  let createExecutionDetailsMock: sinon.SinonStubbedInstance<CreateExecutionDetails>;
+  let markNotificationAsMock: sinon.SinonStubbedInstance<MarkNotificationAs>;
+  let featureFlagsServiceMock: sinon.SinonStubbedInstance<FeatureFlagsService>;
+
+  const mockMessage: MessageEntity = {
+    _id: validNotificationId,
+    _jobId: validJobId,
+    _environmentId: validEnvId,
+    channel: ChannelTypeEnum.IN_APP,
+    _subscriberId: validSubscriberId,
+  } as MessageEntity;
+
+  const mockJob: JobEntity = {
+    _id: validJobId,
+    _environmentId: validEnvId,
+    _organizationId: validOrgId,
+    _userId: validSubscriberId,
+    payload: {
+      subscriberId: validSubscriberId,
+    },
+    transactionId: 'transaction-id',
+    status: JobStatusEnum.PENDING,
+  } as JobEntity;
+
+  const mockNotification: InboxNotification = {
+    id: validNotificationId,
+    body: 'Test notification',
+    to: {
+      subscriberId: validSubscriberId,
+      id: validSubscriberId,
+    },
+    isRead: false,
+    isArchived: false,
+    isSnoozed: true,
+    snoozedUntil: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+    channelType: ChannelTypeEnum.IN_APP,
+  };
+
+  beforeEach(() => {
+    loggerMock = sinon.createStubInstance(PinoLogger);
+    messageRepositoryMock = sinon.createStubInstance(MessageRepository);
+    jobRepositoryMock = sinon.createStubInstance(JobRepository);
+    standardQueueServiceMock = sinon.createStubInstance(StandardQueueService);
+    organizationRepositoryMock = sinon.createStubInstance(CommunityOrganizationRepository);
+    createExecutionDetailsMock = sinon.createStubInstance(CreateExecutionDetails);
+    markNotificationAsMock = sinon.createStubInstance(MarkNotificationAs);
+    featureFlagsServiceMock = sinon.createStubInstance(FeatureFlagsService);
+
+    // Mock the MarkNotificationAsCommand.create method
+    sinon.stub(MarkNotificationAsCommand, 'create').returns({
+      environmentId: validEnvId,
+      organizationId: validOrgId,
+      subscriberId: validSubscriberId,
+      notificationId: validNotificationId,
+      snoozedUntil: new Date(),
+    } as MarkNotificationAsCommand);
+
+    sinon.stub(CreateExecutionDetailsCommand, 'create').returns({} as any);
+    sinon.stub(CreateExecutionDetailsCommand, 'getDetailsFromJob').returns({} as any);
+
+    // @ts-expect-error Mocking the withTransaction method
+    messageRepositoryMock.withTransaction = sinon.stub().callsFake((callback) => callback());
+
+    snoozeNotification = new SnoozeNotification(
+      loggerMock as any,
+      messageRepositoryMock as any,
+      jobRepositoryMock as any,
+      standardQueueServiceMock as any,
+      organizationRepositoryMock as any,
+      createExecutionDetailsMock as any,
+      markNotificationAsMock as any,
+      featureFlagsServiceMock as any
+    );
+
+    sinon.stub(JobRepository, 'createObjectId').returns('new-job-id');
+
+    jobRepositoryMock.create.resolves(mockJob);
+    jobRepositoryMock.findOne.resolves(mockJob);
+    markNotificationAsMock.execute.resolves(mockNotification);
+    featureFlagsServiceMock.getFlag.resolves(true);
+    createExecutionDetailsMock.execute.resolves();
+
+    const orgEntity = {
+      _id: validOrgId,
+      name: 'Test Org',
+      apiServiceLevel: ApiServiceLevelEnum.BUSINESS,
+      createdAt: '2023-01-01T00:00:00.000Z',
+      updatedAt: '2023-01-01T00:00:00.000Z',
+    } as OrganizationEntity;
+
+    organizationRepositoryMock.findOne.resolves(orgEntity);
+    standardQueueServiceMock.add.resolves();
+    messageRepositoryMock.findOne.resolves(mockMessage);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should throw NotFoundException when notification is not found', async () => {
+    const command = createCommand(SNOOZE_DURATION.ONE_HOUR);
+    messageRepositoryMock.findOne.resolves(null);
+
+    try {
+      await snoozeNotification.execute(command);
+      expect.fail('Should have thrown NotFoundException');
+    } catch (err) {
+      expect(err).to.be.instanceOf(NotFoundException);
+    }
+  });
+
+  it('should throw HttpException when snooze duration exceeds free tier limit (24 hours)', async () => {
+    // Testing with 30 days (exceeds free tier 24-hour limit)
+    const command = createCommand(SNOOZE_DURATION.THIRTY_DAYS);
+
+    // Set organization to free tier
+    const freeOrgEntity = {
+      _id: validOrgId,
+      name: 'Test Org',
+      apiServiceLevel: ApiServiceLevelEnum.FREE,
+      createdAt: '2023-01-01T00:00:00.000Z',
+      updatedAt: '2023-01-01T00:00:00.000Z',
+    } as OrganizationEntity;
+
+    organizationRepositoryMock.findOne.resolves(freeOrgEntity);
+
+    try {
+      await snoozeNotification.execute(command);
+      expect.fail('Should have thrown HttpException');
+    } catch (err) {
+      expect(err).to.be.instanceOf(HttpException);
+      expect(err.getStatus()).to.equal(HttpStatus.PAYMENT_REQUIRED);
+    }
+  });
+
+  it('should throw HttpException when snooze duration exceeds paid tier limit (90 days)', async () => {
+    // Create a command with duration exceeding 90 days (paid tier max)
+    const command = createCommand(SNOOZE_DURATION.HUNDRED_DAYS);
+
+    try {
+      await snoozeNotification.execute(command);
+      expect.fail('Should have thrown HttpException');
+    } catch (err) {
+      expect(err).to.be.instanceOf(HttpException);
+      expect(err.getStatus()).to.equal(HttpStatus.PAYMENT_REQUIRED);
+    }
+  });
+
+  it('should successfully snooze a notification', async () => {
+    const command = createCommand(SNOOZE_DURATION.ONE_HOUR);
+
+    const result = await snoozeNotification.execute(command);
+
+    expect(result).to.deep.equal(mockNotification);
+    expect(jobRepositoryMock.create.calledOnce).to.be.true;
+    const createCallArg = jobRepositoryMock.create.firstCall.args[0];
+    expect(createCallArg).to.have.property('status', JobStatusEnum.PENDING);
+    expect(createCallArg).to.have.property('delay').that.is.a('number');
+    expect(createCallArg.payload).to.have.property('unsnooze', true);
+
+    expect(markNotificationAsMock.execute.calledOnce).to.be.true;
+    expect(standardQueueServiceMock.add.calledOnce).to.be.true;
+    expect(createExecutionDetailsMock.execute.called).to.be.true;
+  });
+
+  it('should enqueue job with correct parameters', async () => {
+    const delay = 3600000; // 1 hour in milliseconds
+
+    await snoozeNotification.enqueueJob(mockJob, delay);
+
+    expect(standardQueueServiceMock.add.calledOnce).to.be.true;
+    const addCallArg = standardQueueServiceMock.add.firstCall.args[0];
+
+    expect(addCallArg.data).to.deep.equal({
+      _environmentId: mockJob._environmentId,
+      _id: mockJob._id,
+      _organizationId: mockJob._organizationId,
+      _userId: mockJob._userId,
+    });
+
+    if (addCallArg.options) {
+      expect(addCallArg.options).to.have.property('delay', delay);
+      expect(addCallArg.options).to.have.property('attempts', 3);
+      expect(addCallArg.options.backoff).to.have.property('type', 'exponential');
+    }
+  });
+
+  function createCommand(days: number): SnoozeNotificationCommand {
+    const snoozeUntil = new Date();
+    snoozeUntil.setDate(snoozeUntil.getDate() + days);
+
+    return {
+      environmentId: validEnvId,
+      organizationId: validOrgId,
+      subscriberId: validSubscriberId,
+      notificationId: validNotificationId,
+      snoozeUntil,
+    } as SnoozeNotificationCommand;
+  }
+});

--- a/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.usecase.ts
@@ -88,6 +88,7 @@ export class SnoozeNotification {
 
       return snoozedNotification;
     } catch (error) {
+      this.logger.error({ error }, 'Failed to snooze notification');
       throw new InternalServerErrorException(`Failed to snooze notification: ${error.message}`);
     }
   }

--- a/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.spec.ts
+++ b/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.spec.ts
@@ -1,0 +1,174 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { NotFoundException } from '@nestjs/common';
+import {
+  CreateExecutionDetails,
+  CreateExecutionDetailsCommand,
+  FeatureFlagsService,
+  PinoLogger,
+} from '@novu/application-generic';
+import { JobEntity, JobRepository, MessageRepository, MessageEntity } from '@novu/dal';
+import { ChannelTypeEnum, JobStatusEnum } from '@novu/shared';
+
+import { UnsnoozeNotification } from './unsnooze-notification.usecase';
+import { UnsnoozeNotificationCommand } from './unsnooze-notification.command';
+import { MarkNotificationAs } from '../mark-notification-as/mark-notification-as.usecase';
+import { MarkNotificationAsCommand } from '../mark-notification-as/mark-notification-as.command';
+import { InboxNotification } from '../../utils/types';
+
+describe('UnsnoozeNotification', () => {
+  const validNotificationId = '507f1f77bcf86cd799439011';
+  const validEnvId = '507f1f77bcf86cd799439012';
+  const validOrgId = '507f1f77bcf86cd799439013';
+  const validJobId = '507f1f77bcf86cd799439014';
+  const validSubscriberId = '507f1f77bcf86cd799439015';
+  const validNotificationId2 = '507f1f77bcf86cd799439016';
+
+  let unsnoozeNotification: UnsnoozeNotification;
+  let loggerMock: sinon.SinonStubbedInstance<PinoLogger>;
+  let messageRepositoryMock: sinon.SinonStubbedInstance<MessageRepository>;
+  let jobRepositoryMock: sinon.SinonStubbedInstance<JobRepository>;
+  let createExecutionDetailsMock: sinon.SinonStubbedInstance<CreateExecutionDetails>;
+  let markNotificationAsMock: sinon.SinonStubbedInstance<MarkNotificationAs>;
+  let featureFlagsServiceMock: sinon.SinonStubbedInstance<FeatureFlagsService>;
+
+  const snoozedUntil = new Date();
+  snoozedUntil.setHours(snoozedUntil.getHours() + 1);
+
+  const mockMessage = {
+    _id: validNotificationId,
+    _jobId: validJobId,
+    _environmentId: validEnvId,
+    channel: ChannelTypeEnum.IN_APP,
+    _subscriberId: validSubscriberId,
+    _notificationId: validNotificationId2,
+    snoozedUntil,
+  } as unknown as MessageEntity;
+
+  const mockJob: JobEntity = {
+    _id: validJobId,
+    _environmentId: validEnvId,
+    _organizationId: validOrgId,
+    _userId: validSubscriberId,
+    _notificationId: validNotificationId2,
+    payload: {
+      subscriberId: validSubscriberId,
+      unsnooze: true,
+    },
+    transactionId: 'transaction-id',
+    status: JobStatusEnum.PENDING,
+    delay: 3600000,
+  } as JobEntity;
+
+  const mockNotification: InboxNotification = {
+    id: validNotificationId,
+    body: 'Test notification content',
+    to: {
+      subscriberId: validSubscriberId,
+      id: validSubscriberId,
+    },
+    isRead: false,
+    isArchived: false,
+    isSnoozed: false,
+    snoozedUntil: null,
+    createdAt: new Date().toISOString(),
+    channelType: ChannelTypeEnum.IN_APP,
+  };
+
+  beforeEach(() => {
+    loggerMock = sinon.createStubInstance(PinoLogger);
+    messageRepositoryMock = sinon.createStubInstance(MessageRepository);
+    jobRepositoryMock = sinon.createStubInstance(JobRepository);
+    createExecutionDetailsMock = sinon.createStubInstance(CreateExecutionDetails);
+    markNotificationAsMock = sinon.createStubInstance(MarkNotificationAs);
+    featureFlagsServiceMock = sinon.createStubInstance(FeatureFlagsService);
+
+    sinon.stub(MarkNotificationAsCommand, 'create').returns({
+      environmentId: validEnvId,
+      organizationId: validOrgId,
+      subscriberId: validSubscriberId,
+      notificationId: validNotificationId,
+      snoozedUntil: null,
+    } as MarkNotificationAsCommand);
+
+    sinon.stub(CreateExecutionDetailsCommand, 'create').returns({} as any);
+    sinon.stub(CreateExecutionDetailsCommand, 'getDetailsFromJob').returns({} as any);
+
+    // @ts-expect-error Mocking the withTransaction method
+    messageRepositoryMock.withTransaction = sinon.stub().callsFake((callback) => callback());
+
+    unsnoozeNotification = new UnsnoozeNotification(
+      loggerMock as any,
+      messageRepositoryMock as any,
+      jobRepositoryMock as any,
+      markNotificationAsMock as any,
+      createExecutionDetailsMock as any,
+      featureFlagsServiceMock as any
+    );
+
+    jobRepositoryMock.findOneAndDelete.resolves(mockJob);
+    markNotificationAsMock.execute.resolves(mockNotification);
+    featureFlagsServiceMock.getFlag.resolves(true);
+    createExecutionDetailsMock.execute.resolves();
+    messageRepositoryMock.findOne.resolves(mockMessage);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should throw NotFoundException when snoozed notification is not found', async () => {
+    const command = createCommand();
+    messageRepositoryMock.findOne.resolves(null);
+
+    try {
+      await unsnoozeNotification.execute(command);
+      expect.fail('Should have thrown NotFoundException');
+    } catch (err) {
+      expect(err).to.be.instanceOf(NotFoundException);
+    }
+  });
+
+  it('should successfully unsnooze a notification', async () => {
+    const command = createCommand();
+
+    const result = await unsnoozeNotification.execute(command);
+
+    expect(result).to.deep.equal(mockNotification);
+    expect(jobRepositoryMock.findOneAndDelete.calledOnce).to.be.true;
+    expect(markNotificationAsMock.execute.calledOnce).to.be.true;
+
+    // Verify that markNotificationAs was called with the correct args
+    const markNotificationAsArgs = markNotificationAsMock.execute.firstCall.args[0];
+    expect(markNotificationAsArgs).to.have.property('environmentId', validEnvId);
+    expect(markNotificationAsArgs).to.have.property('subscriberId', validSubscriberId);
+    expect(markNotificationAsArgs).to.have.property('notificationId', validNotificationId);
+    expect(markNotificationAsArgs).to.have.property('snoozedUntil', null);
+
+    // Verify that createExecutionDetails was called
+    expect(createExecutionDetailsMock.execute.calledOnce).to.be.true;
+  });
+
+  it('should handle missing scheduled job gracefully', async () => {
+    const command = createCommand();
+    jobRepositoryMock.findOneAndDelete.resolves(null);
+
+    const result = await unsnoozeNotification.execute(command);
+
+    // Verify we still get a result even without a job
+    expect(result).to.deep.equal(mockNotification);
+    expect(jobRepositoryMock.findOneAndDelete.calledOnce).to.be.true;
+    expect(markNotificationAsMock.execute.calledOnce).to.be.true;
+    expect(createExecutionDetailsMock.execute.called).to.be.false;
+    expect(loggerMock.error.calledOnce).to.be.true;
+  });
+
+  function createCommand(): UnsnoozeNotificationCommand {
+    return {
+      environmentId: validEnvId,
+      organizationId: validOrgId,
+      subscriberId: validSubscriberId,
+      notificationId: validNotificationId,
+    } as UnsnoozeNotificationCommand;
+  }
+});


### PR DESCRIPTION
### What changed? Why was the change needed?

Added new unit and e2e tests covering snooze functionality + update existing tests to account for snooze/unsnooze.
