### PR TITLE
feat(dal): add unique index on _environmentId and key in topic schema

### DIFF
--- a/libs/dal/src/repositories/topic/topic.schema.ts
+++ b/libs/dal/src/repositories/topic/topic.schema.ts
@@ -34,5 +34,13 @@ topicSchema.index({
   key: 1,
 });
 
+topicSchema.index({
+  _environmentId: 1,
+  key: 1,
+}, {
+  unique: true,
+});
+
+
 export const Topic =
   (mongoose.models.Topic as mongoose.Model<TopicDBModel>) || mongoose.model<TopicDBModel>('Topic', topicSchema);


### PR DESCRIPTION
This pull request introduces a new unique index to the `topicSchema` in the `libs/dal/src/repositories/topic/topic.schema.ts` file. This ensures that the combination of `_environmentId` and `key` is unique within the database.

Schema updates:

* [`libs/dal/src/repositories/topic/topic.schema.ts`](diffhunk://#diff-ccc7cfbbb27a15c1f0ecb37d84f5de1d2e71c94ad4621fc92ad85ab3248044b5R37-R44): Added a unique index on the `_environmentId` and `key` fields in `topicSchema` to enforce uniqueness for these combinations.

This fixes NV-5900