### PR TITLE
feat(js): headless bulk update preferences

### DIFF
--- a/apps/api/src/app/inbox/dtos/bulk-update-preferences-request.dto.ts
+++ b/apps/api/src/app/inbox/dtos/bulk-update-preferences-request.dto.ts
@@ -1,0 +1,18 @@
+import { IsArray, IsDefined, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+import { UpdatePreferencesRequestDto } from './update-preferences-request.dto';
+
+export class BulkUpdatePreferenceItemDto extends UpdatePreferencesRequestDto {
+  @IsDefined()
+  @IsString()
+  readonly workflowIdOrInternalId: string;
+}
+
+export class BulkUpdatePreferencesRequestDto {
+  @IsDefined()
+  @IsArray()
+  @Type(() => BulkUpdatePreferenceItemDto)
+  @ValidateNested({ each: true })
+  readonly preferences: BulkUpdatePreferenceItemDto[];
+}

--- a/apps/api/src/app/inbox/dtos/bulk-update-preferences-request.dto.ts
+++ b/apps/api/src/app/inbox/dtos/bulk-update-preferences-request.dto.ts
@@ -6,7 +6,7 @@ import { UpdatePreferencesRequestDto } from './update-preferences-request.dto';
 export class BulkUpdatePreferenceItemDto extends UpdatePreferencesRequestDto {
   @IsDefined()
   @IsString()
-  readonly workflowIdOrInternalId: string;
+  readonly workflowId: string;
 }
 
 export class BulkUpdatePreferencesRequestDto {

--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -315,6 +315,10 @@ export class InboxController {
     );
   }
 
+  /**
+   * IMPORTANT: Make sure this endpoint route is defined before the single workflow preference update endpoint
+   * "PATCH /preferences/:workflowIdOrIdentifier", otherwise, the single workflow preference update endpoint will be triggered instead
+   */
   @UseGuards(AuthGuard('subscriberJwt'))
   @Patch('/preferences/bulk')
   async bulkUpdateWorkflowPreferences(

--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -10,7 +10,6 @@ import {
   Query,
   UseGuards,
   Headers,
-  BadRequestException,
 } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
@@ -52,6 +51,9 @@ import { SnoozeNotificationCommand } from './usecases/snooze-notification/snooze
 import { SnoozeNotification } from './usecases/snooze-notification/snooze-notification.usecase';
 import { UnsnoozeNotificationCommand } from './usecases/unsnooze-notification/unsnooze-notification.command';
 import { UnsnoozeNotification } from './usecases/unsnooze-notification/unsnooze-notification.usecase';
+import { BulkUpdatePreferencesRequestDto } from './dtos/bulk-update-preferences-request.dto';
+import { BulkUpdatePreferences } from './usecases/bulk-update-preferences/bulk-update-preferences.usecase';
+import { BulkUpdatePreferencesCommand } from './usecases/bulk-update-preferences/bulk-update-preferences.command';
 
 @ApiCommonResponses()
 @Controller('/inbox')
@@ -66,6 +68,7 @@ export class InboxController {
     private updateAllNotifications: UpdateAllNotifications,
     private getInboxPreferencesUsecase: GetInboxPreferences,
     private updatePreferencesUsecase: UpdatePreferences,
+    private bulkUpdatePreferencesUsecase: BulkUpdatePreferences,
     private snoozeNotificationUsecase: SnoozeNotification,
     private unsnoozeNotificationUsecase: UnsnoozeNotification
   ) {}
@@ -313,10 +316,26 @@ export class InboxController {
   }
 
   @UseGuards(AuthGuard('subscriberJwt'))
-  @Patch('/preferences/:workflowId')
+  @Patch('/preferences/bulk')
+  async bulkUpdateWorkflowPreferences(
+    @SubscriberSession() subscriberSession: SubscriberEntity,
+    @Body() body: BulkUpdatePreferencesRequestDto
+  ): Promise<GetPreferencesResponseDto[]> {
+    return await this.bulkUpdatePreferencesUsecase.execute(
+      BulkUpdatePreferencesCommand.create({
+        organizationId: subscriberSession._organizationId,
+        subscriberId: subscriberSession.subscriberId,
+        environmentId: subscriberSession._environmentId,
+        preferences: body.preferences,
+      })
+    );
+  }
+
+  @UseGuards(AuthGuard('subscriberJwt'))
+  @Patch('/preferences/:workflowIdOrIdentifier')
   async updateWorkflowPreference(
     @SubscriberSession() subscriberSession: SubscriberEntity,
-    @Param('workflowId') workflowId: string,
+    @Param('workflowIdOrIdentifier') workflowIdOrIdentifier: string,
     @Body() body: UpdatePreferencesRequestDto
   ): Promise<InboxPreference> {
     return await this.updatePreferencesUsecase.execute(
@@ -330,7 +349,7 @@ export class InboxController {
         in_app: body.in_app,
         push: body.push,
         sms: body.sms,
-        workflowId,
+        workflowIdOrIdentifier,
         includeInactiveChannels: false,
       })
     );

--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.command.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.command.ts
@@ -1,0 +1,13 @@
+// apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.command.ts
+import { IsArray, IsDefined } from 'class-validator';
+import { Type } from 'class-transformer';
+
+import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
+import { BulkUpdatePreferenceItemDto } from '../../dtos/bulk-update-preferences-request.dto';
+
+export class BulkUpdatePreferencesCommand extends EnvironmentWithSubscriber {
+  @IsDefined()
+  @IsArray()
+  @Type(() => BulkUpdatePreferenceItemDto)
+  readonly preferences: BulkUpdatePreferenceItemDto[];
+}

--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.spec.ts
@@ -1,0 +1,409 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { UnprocessableEntityException, NotFoundException, BadRequestException } from '@nestjs/common';
+import { AnalyticsService } from '@novu/application-generic';
+import { NotificationTemplateRepository, SubscriberRepository } from '@novu/dal';
+import { PreferenceLevelEnum, TriggerTypeEnum } from '@novu/shared';
+
+import { BulkUpdatePreferences } from './bulk-update-preferences.usecase';
+import { UpdatePreferences } from '../update-preferences/update-preferences.usecase';
+import { BulkUpdatePreferencesCommand } from './bulk-update-preferences.command';
+
+const mockedSubscriber: any = {
+  _id: '6447aff3d89122e250412c29',
+  subscriberId: 'test-mockSubscriber',
+  firstName: 'test',
+  lastName: 'test',
+};
+
+const mockedWorkflow1: any = {
+  _id: '6447aff3d89122e250412c28',
+  name: 'test-workflow-1',
+  critical: false,
+  triggers: [{ identifier: 'test-trigger-1' }],
+  tags: [],
+  data: undefined,
+};
+
+const mockedWorkflow2: any = {
+  _id: '6447aff3d89122e250412c30',
+  name: 'test-workflow-2',
+  critical: false,
+  triggers: [{ identifier: 'test-trigger-2' }],
+  tags: [],
+  data: undefined,
+};
+
+const mockedInboxPreference1: any = {
+  level: PreferenceLevelEnum.TEMPLATE,
+  enabled: true,
+  channels: {
+    email: true,
+    in_app: true,
+    sms: false,
+    push: false,
+    chat: true,
+  },
+  workflow: {
+    id: mockedWorkflow1._id,
+    identifier: mockedWorkflow1.triggers[0].identifier,
+    name: mockedWorkflow1.name,
+    critical: mockedWorkflow1.critical,
+    tags: mockedWorkflow1.tags,
+    data: mockedWorkflow1.data,
+  },
+};
+
+const mockedInboxPreference2: any = {
+  level: PreferenceLevelEnum.TEMPLATE,
+  enabled: true,
+  channels: {
+    email: false,
+    in_app: true,
+    sms: true,
+    push: false,
+    chat: true,
+  },
+  workflow: {
+    id: mockedWorkflow2._id,
+    identifier: mockedWorkflow2.triggers[0].identifier,
+    name: mockedWorkflow2.name,
+    critical: mockedWorkflow2.critical,
+    tags: mockedWorkflow2.tags,
+    data: mockedWorkflow2.data,
+  },
+};
+
+describe('BulkUpdatePreferences', () => {
+  let bulkUpdatePreferences: BulkUpdatePreferences;
+  let subscriberRepositoryMock: sinon.SinonStubbedInstance<SubscriberRepository>;
+  let analyticsServiceMock: sinon.SinonStubbedInstance<AnalyticsService>;
+  let notificationTemplateRepositoryMock: sinon.SinonStubbedInstance<NotificationTemplateRepository>;
+  let updatePreferencesUsecaseMock: sinon.SinonStubbedInstance<UpdatePreferences>;
+
+  beforeEach(() => {
+    subscriberRepositoryMock = sinon.createStubInstance(SubscriberRepository);
+    analyticsServiceMock = sinon.createStubInstance(AnalyticsService);
+    notificationTemplateRepositoryMock = sinon.createStubInstance(NotificationTemplateRepository);
+    updatePreferencesUsecaseMock = sinon.createStubInstance(UpdatePreferences);
+
+    bulkUpdatePreferences = new BulkUpdatePreferences(
+      notificationTemplateRepositoryMock as any,
+      subscriberRepositoryMock as any,
+      analyticsServiceMock as any,
+      updatePreferencesUsecaseMock as any
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should throw exception when subscriber is not found', async () => {
+    const command = BulkUpdatePreferencesCommand.create({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'not-found',
+      preferences: [
+        {
+          workflowIdOrInternalId: mockedWorkflow1._id,
+          in_app: true,
+        },
+      ],
+    });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(undefined);
+
+    try {
+      await bulkUpdatePreferences.execute(command);
+      expect.fail('Should throw an exception');
+    } catch (error) {
+      expect(error).to.be.instanceOf(NotFoundException);
+      expect(error.message).to.equal(`Subscriber with id: ${command.subscriberId} is not found`);
+    }
+  });
+
+  it('should throw exception when no preferences are provided', async () => {
+    const command = BulkUpdatePreferencesCommand.create({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      preferences: [],
+    });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+
+    try {
+      await bulkUpdatePreferences.execute(command);
+      expect.fail('Should throw an exception');
+    } catch (error) {
+      expect(error).to.be.instanceOf(BadRequestException);
+      expect(error.message).to.equal('No preferences provided for bulk update');
+    }
+  });
+
+  it('should throw exception when preferences exceed maximum limit', async () => {
+    const preferences = Array(101).fill({
+      workflowIdOrInternalId: mockedWorkflow1._id,
+      in_app: true,
+    });
+
+    const command = BulkUpdatePreferencesCommand.create({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      preferences,
+    });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+
+    try {
+      await bulkUpdatePreferences.execute(command);
+      expect.fail('Should throw an exception');
+    } catch (error) {
+      expect(error).to.be.instanceOf(UnprocessableEntityException);
+      expect(error.message).to.equal('Exceeded maximum limit of 100 preferences for bulk update');
+    }
+  });
+
+  it('should correctly separate internal IDs from identifiers when querying workflows', async () => {
+    const command = BulkUpdatePreferencesCommand.create({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      preferences: [
+        {
+          workflowIdOrInternalId: mockedWorkflow1._id,
+          in_app: true,
+        },
+        {
+          workflowIdOrInternalId: 'test-trigger-2',
+          in_app: false,
+        },
+      ],
+    });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+    notificationTemplateRepositoryMock.find.resolves([mockedWorkflow1, mockedWorkflow2]);
+    updatePreferencesUsecaseMock.execute.onFirstCall().resolves(mockedInboxPreference1);
+    updatePreferencesUsecaseMock.execute.onSecondCall().resolves(mockedInboxPreference2);
+
+    await bulkUpdatePreferences.execute(command);
+
+    const findCallArgs = notificationTemplateRepositoryMock.find.firstCall.args[0];
+    expect(findCallArgs).to.deep.equal({
+      _environmentId: 'env-1',
+      $or: [{ _id: { $in: [mockedWorkflow1._id] } }, { 'triggers.identifier': { $in: ['test-trigger-2'] } }],
+    });
+  });
+
+  it('should handle mixed ID types correctly', async () => {
+    const nonObjectIdString = 'simple-identifier-string';
+
+    const command = BulkUpdatePreferencesCommand.create({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      preferences: [
+        {
+          workflowIdOrInternalId: mockedWorkflow1._id, // ObjectId
+          in_app: true,
+        },
+        {
+          workflowIdOrInternalId: nonObjectIdString, // Non-ObjectId string
+          email: true,
+        },
+      ],
+    });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+    notificationTemplateRepositoryMock.find.resolves([
+      mockedWorkflow1,
+      { ...mockedWorkflow2, triggers: [{ type: TriggerTypeEnum.EVENT, identifier: nonObjectIdString }] },
+    ]);
+    updatePreferencesUsecaseMock.execute.onFirstCall().resolves(mockedInboxPreference1);
+    updatePreferencesUsecaseMock.execute.onSecondCall().resolves({
+      ...mockedInboxPreference2,
+      workflow: { ...mockedInboxPreference2.workflow, identifier: nonObjectIdString },
+    });
+
+    await bulkUpdatePreferences.execute(command);
+
+    const findCallArgs = notificationTemplateRepositoryMock.find.firstCall.args[0];
+    expect(findCallArgs?.$or?.[0]?._id?.$in).to.include(mockedWorkflow1._id);
+    expect(findCallArgs?.$or?.[1]?.['triggers.identifier']?.$in).to.include(nonObjectIdString);
+  });
+
+  it('should deduplicate preferences when different identifiers resolve to the same workflow', async () => {
+    const internalId = mockedWorkflow1._id;
+    const triggerIdentifier = mockedWorkflow1.triggers[0].identifier;
+
+    const command = BulkUpdatePreferencesCommand.create({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      preferences: [
+        {
+          workflowIdOrInternalId: internalId,
+          in_app: true,
+          email: false,
+        },
+        {
+          workflowIdOrInternalId: triggerIdentifier,
+          in_app: false,
+          email: true,
+        },
+      ],
+    });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+    notificationTemplateRepositoryMock.find.resolves([mockedWorkflow1]);
+    updatePreferencesUsecaseMock.execute.resolves(mockedInboxPreference1);
+
+    const result = await bulkUpdatePreferences.execute(command);
+
+    expect(updatePreferencesUsecaseMock.execute.callCount).to.equal(1);
+
+    const updateArgs = updatePreferencesUsecaseMock.execute.firstCall.args[0];
+    expect(updateArgs).to.include({
+      workflowIdOrIdentifier: internalId,
+      in_app: false,
+      email: true,
+    });
+
+    expect(result.length).to.equal(1);
+  });
+
+  it('should throw exception when a workflow is not found', async () => {
+    const command = BulkUpdatePreferencesCommand.create({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      preferences: [
+        {
+          workflowIdOrInternalId: 'non-existent-id',
+          in_app: true,
+        },
+      ],
+    });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+    notificationTemplateRepositoryMock.find.resolves([]);
+
+    try {
+      await bulkUpdatePreferences.execute(command);
+      expect.fail('Should throw an exception');
+    } catch (error) {
+      expect(error).to.be.instanceOf(NotFoundException);
+      expect(error.message).to.include('Workflows with ids: non-existent-id not found');
+    }
+  });
+
+  it('should throw exception when a workflow is critical', async () => {
+    const criticalWorkflow = { ...mockedWorkflow1, critical: true };
+
+    const command = BulkUpdatePreferencesCommand.create({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      preferences: [
+        {
+          workflowIdOrInternalId: criticalWorkflow._id,
+          in_app: true,
+        },
+      ],
+    });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+    notificationTemplateRepositoryMock.find.resolves([criticalWorkflow]);
+
+    try {
+      await bulkUpdatePreferences.execute(command);
+      expect.fail('Should throw an exception');
+    } catch (error) {
+      expect(error).to.be.instanceOf(BadRequestException);
+      expect(error.message).to.include(`Critical workflows with ids: ${criticalWorkflow._id} cannot be updated`);
+    }
+  });
+
+  it('should update multiple workflow preferences in parallel', async () => {
+    const command = BulkUpdatePreferencesCommand.create({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      preferences: [
+        {
+          workflowIdOrInternalId: mockedWorkflow1._id,
+          in_app: true,
+          email: false,
+        },
+        {
+          workflowIdOrInternalId: mockedWorkflow2._id,
+          sms: true,
+          chat: true,
+        },
+      ],
+    });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+    notificationTemplateRepositoryMock.find.resolves([mockedWorkflow1, mockedWorkflow2]);
+
+    updatePreferencesUsecaseMock.execute.onFirstCall().resolves(mockedInboxPreference1);
+    updatePreferencesUsecaseMock.execute.onSecondCall().resolves(mockedInboxPreference2);
+
+    const result = await bulkUpdatePreferences.execute(command);
+
+    expect(updatePreferencesUsecaseMock.execute.calledTwice).to.be.true;
+
+    const firstCallArgs = updatePreferencesUsecaseMock.execute.firstCall.args[0];
+    expect(firstCallArgs).to.include({
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      subscriberId: command.subscriberId,
+      workflowIdOrIdentifier: mockedWorkflow1._id,
+      level: PreferenceLevelEnum.TEMPLATE,
+      in_app: true,
+      email: false,
+    });
+
+    const secondCallArgs = updatePreferencesUsecaseMock.execute.secondCall.args[0];
+    expect(secondCallArgs).to.include({
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      subscriberId: command.subscriberId,
+      workflowIdOrIdentifier: mockedWorkflow2._id,
+      level: PreferenceLevelEnum.TEMPLATE,
+      sms: true,
+      chat: true,
+    });
+
+    expect(analyticsServiceMock.mixpanelTrack.calledOnce).to.be.true;
+
+    expect(result).to.deep.equal([mockedInboxPreference1, mockedInboxPreference2]);
+  });
+
+  it('should support lookup by workflow identifier', async () => {
+    const command = BulkUpdatePreferencesCommand.create({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      preferences: [
+        {
+          workflowIdOrInternalId: 'test-trigger-1', // Using identifier instead of ID
+          in_app: true,
+        },
+      ],
+    });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+    notificationTemplateRepositoryMock.find.resolves([mockedWorkflow1]);
+    updatePreferencesUsecaseMock.execute.resolves(mockedInboxPreference1);
+
+    const result = await bulkUpdatePreferences.execute(command);
+
+    const updateArgs = updatePreferencesUsecaseMock.execute.firstCall.args[0];
+    expect(updateArgs.workflowIdOrIdentifier).to.equal(mockedWorkflow1._id);
+
+    expect(result).to.deep.equal([mockedInboxPreference1]);
+  });
+});

--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.spec.ts
@@ -106,7 +106,7 @@ describe('BulkUpdatePreferences', () => {
       subscriberId: 'not-found',
       preferences: [
         {
-          workflowIdOrInternalId: mockedWorkflow1._id,
+          workflowId: mockedWorkflow1._id,
           in_app: true,
         },
       ],
@@ -173,11 +173,11 @@ describe('BulkUpdatePreferences', () => {
       subscriberId: 'test-mockSubscriber',
       preferences: [
         {
-          workflowIdOrInternalId: mockedWorkflow1._id,
+          workflowId: mockedWorkflow1._id,
           in_app: true,
         },
         {
-          workflowIdOrInternalId: 'test-trigger-2',
+          workflowId: 'test-trigger-2',
           in_app: false,
         },
       ],
@@ -206,11 +206,11 @@ describe('BulkUpdatePreferences', () => {
       subscriberId: 'test-mockSubscriber',
       preferences: [
         {
-          workflowIdOrInternalId: mockedWorkflow1._id, // ObjectId
+          workflowId: mockedWorkflow1._id, // ObjectId
           in_app: true,
         },
         {
-          workflowIdOrInternalId: nonObjectIdString, // Non-ObjectId string
+          workflowId: nonObjectIdString, // Non-ObjectId string
           email: true,
         },
       ],
@@ -244,12 +244,12 @@ describe('BulkUpdatePreferences', () => {
       subscriberId: 'test-mockSubscriber',
       preferences: [
         {
-          workflowIdOrInternalId: internalId,
+          workflowId: internalId,
           in_app: true,
           email: false,
         },
         {
-          workflowIdOrInternalId: triggerIdentifier,
+          workflowId: triggerIdentifier,
           in_app: false,
           email: true,
         },
@@ -281,7 +281,7 @@ describe('BulkUpdatePreferences', () => {
       subscriberId: 'test-mockSubscriber',
       preferences: [
         {
-          workflowIdOrInternalId: 'non-existent-id',
+          workflowId: 'non-existent-id',
           in_app: true,
         },
       ],
@@ -308,7 +308,7 @@ describe('BulkUpdatePreferences', () => {
       subscriberId: 'test-mockSubscriber',
       preferences: [
         {
-          workflowIdOrInternalId: criticalWorkflow._id,
+          workflowId: criticalWorkflow._id,
           in_app: true,
         },
       ],
@@ -333,12 +333,12 @@ describe('BulkUpdatePreferences', () => {
       subscriberId: 'test-mockSubscriber',
       preferences: [
         {
-          workflowIdOrInternalId: mockedWorkflow1._id,
+          workflowId: mockedWorkflow1._id,
           in_app: true,
           email: false,
         },
         {
-          workflowIdOrInternalId: mockedWorkflow2._id,
+          workflowId: mockedWorkflow2._id,
           sms: true,
           chat: true,
         },
@@ -389,7 +389,7 @@ describe('BulkUpdatePreferences', () => {
       subscriberId: 'test-mockSubscriber',
       preferences: [
         {
-          workflowIdOrInternalId: 'test-trigger-1', // Using identifier instead of ID
+          workflowId: 'test-trigger-1', // Using identifier instead of ID
           in_app: true,
         },
       ],

--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
@@ -1,0 +1,111 @@
+import { Injectable, NotFoundException, BadRequestException, UnprocessableEntityException } from '@nestjs/common';
+import { AnalyticsService, InstrumentUsecase } from '@novu/application-generic';
+import {
+  NotificationTemplateEntity,
+  NotificationTemplateRepository,
+  SubscriberRepository,
+  BaseRepository,
+} from '@novu/dal';
+import { PreferenceLevelEnum } from '@novu/shared';
+
+import { AnalyticsEventsEnum } from '../../utils';
+import { InboxPreference } from '../../utils/types';
+import { BulkUpdatePreferencesCommand } from './bulk-update-preferences.command';
+import { UpdatePreferences } from '../update-preferences/update-preferences.usecase';
+import { UpdatePreferencesCommand } from '../update-preferences/update-preferences.command';
+import { BulkUpdatePreferenceItemDto } from '../../dtos/bulk-update-preferences-request.dto';
+
+const MAX_BULK_LIMIT = 100;
+
+@Injectable()
+export class BulkUpdatePreferences {
+  constructor(
+    private notificationTemplateRepository: NotificationTemplateRepository,
+    private subscriberRepository: SubscriberRepository,
+    private analyticsService: AnalyticsService,
+    private updatePreferencesUsecase: UpdatePreferences
+  ) {}
+
+  @InstrumentUsecase()
+  async execute(command: BulkUpdatePreferencesCommand): Promise<InboxPreference[]> {
+    const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
+    if (!subscriber) throw new NotFoundException(`Subscriber with id: ${command.subscriberId} is not found`);
+
+    if (command.preferences.length === 0) {
+      throw new BadRequestException('No preferences provided for bulk update');
+    }
+
+    if (command.preferences.length > MAX_BULK_LIMIT) {
+      throw new UnprocessableEntityException(`Exceeded maximum limit of ${MAX_BULK_LIMIT} preferences for bulk update`);
+    }
+
+    const allWorkflowIds = command.preferences.map((preference) => preference.workflowIdOrInternalId);
+    const workflowInternalIds = allWorkflowIds.filter((id) => BaseRepository.isInternalId(id));
+    const workflowIdentifiers = allWorkflowIds.filter((id) => !BaseRepository.isInternalId(id));
+
+    const dbWorkflows = await this.notificationTemplateRepository.find({
+      _environmentId: command.environmentId,
+      $or: [{ _id: { $in: workflowInternalIds } }, { 'triggers.identifier': { $in: workflowIdentifiers } }],
+    });
+
+    const allValidWorkflowsMap = new Map<string, NotificationTemplateEntity>();
+    if (dbWorkflows && dbWorkflows.length > 0) {
+      for (const workflow of dbWorkflows) {
+        allValidWorkflowsMap.set(workflow._id, workflow);
+
+        if (workflow.triggers?.[0]?.identifier) {
+          allValidWorkflowsMap.set(workflow.triggers[0].identifier, workflow);
+        }
+      }
+    }
+
+    const invalidWorkflowIds = allWorkflowIds.filter((id) => !allValidWorkflowsMap.has(id));
+    if (invalidWorkflowIds.length > 0) {
+      throw new NotFoundException(`Workflows with ids: ${invalidWorkflowIds.join(', ')} not found`);
+    }
+
+    const criticalWorkflows = dbWorkflows.filter((workflow) => workflow.critical);
+    if (criticalWorkflows.length > 0) {
+      const criticalWorkflowIds = criticalWorkflows.map((workflow) => workflow._id);
+      throw new BadRequestException(`Critical workflows with ids: ${criticalWorkflowIds.join(', ')} cannot be updated`);
+    }
+
+    // deduplicate preferences by workflow document ID, it ensures we only process one update per actual workflow document
+    const workflowPreferencesMap = new Map<string, BulkUpdatePreferenceItemDto>();
+    for (const preference of command.preferences) {
+      const workflow = allValidWorkflowsMap.get(preference.workflowIdOrInternalId);
+      if (workflow) {
+        workflowPreferencesMap.set(workflow._id, preference);
+      }
+    }
+
+    const updatePromises = Array.from(workflowPreferencesMap.entries()).map(async ([workflowId, preferenceItem]) => {
+      return this.updatePreferencesUsecase.execute(
+        UpdatePreferencesCommand.create({
+          organizationId: command.organizationId,
+          subscriberId: command.subscriberId,
+          environmentId: command.environmentId,
+          level: PreferenceLevelEnum.TEMPLATE,
+          chat: preferenceItem.chat,
+          email: preferenceItem.email,
+          in_app: preferenceItem.in_app,
+          push: preferenceItem.push,
+          sms: preferenceItem.sms,
+          workflowIdOrIdentifier: workflowId,
+          includeInactiveChannels: false,
+        })
+      );
+    });
+
+    const updatedPreferences = await Promise.all(updatePromises);
+
+    this.analyticsService.mixpanelTrack(AnalyticsEventsEnum.UPDATE_PREFERENCES_BULK, '', {
+      _organization: command.organizationId,
+      _subscriber: subscriber._id,
+      workflowIds: Array.from(workflowPreferencesMap.keys()),
+      level: PreferenceLevelEnum.TEMPLATE,
+    });
+
+    return updatedPreferences;
+  }
+}

--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
@@ -39,7 +39,7 @@ export class BulkUpdatePreferences {
       throw new UnprocessableEntityException(`Exceeded maximum limit of ${MAX_BULK_LIMIT} preferences for bulk update`);
     }
 
-    const allWorkflowIds = command.preferences.map((preference) => preference.workflowIdOrInternalId);
+    const allWorkflowIds = command.preferences.map((preference) => preference.workflowId);
     const workflowInternalIds = allWorkflowIds.filter((id) => BaseRepository.isInternalId(id));
     const workflowIdentifiers = allWorkflowIds.filter((id) => !BaseRepository.isInternalId(id));
 
@@ -73,7 +73,7 @@ export class BulkUpdatePreferences {
     // deduplicate preferences by workflow document ID, it ensures we only process one update per actual workflow document
     const workflowPreferencesMap = new Map<string, BulkUpdatePreferenceItemDto>();
     for (const preference of command.preferences) {
-      const workflow = allValidWorkflowsMap.get(preference.workflowIdOrInternalId);
+      const workflow = allValidWorkflowsMap.get(preference.workflowId);
       if (workflow) {
         workflowPreferencesMap.set(workflow._id, preference);
       }

--- a/apps/api/src/app/inbox/usecases/index.ts
+++ b/apps/api/src/app/inbox/usecases/index.ts
@@ -1,4 +1,4 @@
-import { GetSubscriberTemplatePreference, StandardQueueService } from '@novu/application-generic';
+import { GetSubscriberTemplatePreference, GetWorkflowByIdsUseCase } from '@novu/application-generic';
 import { GetNotifications } from './get-notifications/get-notifications.usecase';
 import { GetInboxPreferences } from './get-inbox-preferences/get-inbox-preferences.usecase';
 import { MarkManyNotificationsAs } from './mark-many-notifications-as/mark-many-notifications-as.usecase';
@@ -11,6 +11,7 @@ import { UpdatePreferences } from './update-preferences/update-preferences.useca
 import { GetSubscriberGlobalPreference } from '../../subscribers/usecases/get-subscriber-global-preference';
 import { SnoozeNotification } from './snooze-notification/snooze-notification.usecase';
 import { UnsnoozeNotification } from './unsnooze-notification/unsnooze-notification.usecase';
+import { BulkUpdatePreferences } from './bulk-update-preferences/bulk-update-preferences.usecase';
 
 export const USE_CASES = [
   Session,
@@ -23,7 +24,9 @@ export const USE_CASES = [
   GetInboxPreferences,
   GetSubscriberGlobalPreference,
   GetSubscriberTemplatePreference,
+  GetWorkflowByIdsUseCase,
   UpdatePreferences,
+  BulkUpdatePreferences,
   SnoozeNotification,
   UnsnoozeNotification,
 ];

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.command.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.command.ts
@@ -1,13 +1,12 @@
-import { IsBoolean, IsDefined, IsEnum, IsMongoId, IsOptional, ValidateIf } from 'class-validator';
-import { ButtonTypeEnum, MessageActionStatusEnum, PreferenceLevelEnum } from '@novu/shared';
+import { IsBoolean, IsDefined, IsEnum, IsOptional, ValidateIf } from 'class-validator';
+import { PreferenceLevelEnum } from '@novu/shared';
 
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
 
 export class UpdatePreferencesCommand extends EnvironmentWithSubscriber {
   @IsOptional()
   @ValidateIf((object) => object.level === PreferenceLevelEnum.TEMPLATE)
-  @IsMongoId()
-  readonly workflowId?: string;
+  readonly workflowIdOrIdentifier?: string;
 
   @IsOptional()
   @IsBoolean()

--- a/apps/api/src/app/inbox/utils/analytics.ts
+++ b/apps/api/src/app/inbox/utils/analytics.ts
@@ -7,4 +7,5 @@ export enum AnalyticsEventsEnum {
   UPDATE_ALL_NOTIFICATIONS = 'Update All Notifications - [Inbox]',
   FETCH_PREFERENCES = 'Fetch Preferences - [Inbox]',
   UPDATE_PREFERENCES = 'Update Preferences - [Inbox]',
+  UPDATE_PREFERENCES_BULK = 'Update Preferences Bulk - [Inbox]',
 }

--- a/apps/api/src/app/subscribers-v2/usecases/update-subscriber-preferences/update-subscriber-preferences.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/update-subscriber-preferences/update-subscriber-preferences.usecase.ts
@@ -37,7 +37,7 @@ export class UpdateSubscriberPreferences {
         environmentId: command.environmentId,
         subscriberId: command.subscriberId,
         level: command.workflowIdOrInternalId ? PreferenceLevelEnum.TEMPLATE : PreferenceLevelEnum.GLOBAL,
-        workflowId,
+        workflowIdOrIdentifier: workflowId,
         includeInactiveChannels: false,
         ...command.channels,
       })

--- a/apps/api/src/app/subscribers/subscribersV1.controller.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.controller.ts
@@ -475,7 +475,7 @@ export class SubscribersV1Controller {
         environmentId: user.environmentId,
         organizationId: user.organizationId,
         subscriberId,
-        workflowId,
+        workflowIdOrIdentifier: workflowId,
         level: PreferenceLevelEnum.TEMPLATE,
         includeInactiveChannels: true,
         ...(body.channel && { [body.channel.type]: body.channel.enabled }),

--- a/apps/api/src/app/subscribers/usecases/index.ts
+++ b/apps/api/src/app/subscribers/usecases/index.ts
@@ -3,6 +3,7 @@ import {
   GetSubscriberTemplatePreference,
   UpdateSubscriber,
   UpdateSubscriberChannel,
+  GetWorkflowByIdsUseCase,
 } from '@novu/application-generic';
 
 import { GetSubscribers } from './get-subscribers';
@@ -47,5 +48,6 @@ export const USE_CASES = [
   CreateIntegration,
   CheckIntegration,
   CheckIntegrationEMail,
+  GetWorkflowByIdsUseCase,
   UpdatePreferences,
 ];

--- a/apps/api/src/app/widgets/widgets.controller.ts
+++ b/apps/api/src/app/widgets/widgets.controller.ts
@@ -455,7 +455,7 @@ export class WidgetsController {
         environmentId: subscriberSession._environmentId,
         organizationId: subscriberSession._organizationId,
         subscriberId: subscriberSession.subscriberId,
-        workflowId: templateId,
+        workflowIdOrIdentifier: templateId,
         level: PreferenceLevelEnum.TEMPLATE,
         includeInactiveChannels: false,
         ...(body.channel && { [body.channel.type]: body.channel.enabled }),

--- a/packages/js/scripts/size-limit.mjs
+++ b/packages/js/scripts/size-limit.mjs
@@ -15,7 +15,7 @@ const modules = [
   {
     name: 'UMD minified',
     filePath: umdPath,
-    limitInBytes: 145_000,
+    limitInBytes: 150_000,
   },
   {
     name: 'UMD gzip',

--- a/packages/js/src/api/inbox-service.ts
+++ b/packages/js/src/api/inbox-service.ts
@@ -168,6 +168,16 @@ export class InboxService {
     return this.#httpClient.get(`${INBOX_ROUTE}/preferences${query}`);
   }
 
+  bulkUpdatePreferences(
+    preferences: Array<
+      {
+        workflowId: string;
+      } & ChannelPreference
+    >
+  ): Promise<PreferencesResponse[]> {
+    return this.#httpClient.patch(`${INBOX_ROUTE}/preferences/bulk`, { preferences });
+  }
+
   updateGlobalPreferences(channels: ChannelPreference): Promise<PreferencesResponse> {
     return this.#httpClient.patch(`${INBOX_ROUTE}/preferences`, channels);
   }

--- a/packages/js/src/event-emitter/types.ts
+++ b/packages/js/src/event-emitter/types.ts
@@ -14,7 +14,7 @@ import type {
   UnsnoozeArgs,
 } from '../notifications';
 import { Preference } from '../preferences/preference';
-import { ListPreferencesArgs, UpdatePreferencesArgs } from '../preferences/types';
+import { ListPreferencesArgs, UpdatePreferenceArgs } from '../preferences/types';
 import type { InitializeSessionArgs } from '../session';
 import { Session, WebSocketEvent } from '../types';
 
@@ -57,7 +57,8 @@ type NotificationsReadArchivedAllEvents = BaseEvents<
   Notification[]
 >;
 type PreferencesFetchEvents = BaseEvents<'preferences.list', ListPreferencesArgs, Preference[]>;
-type PreferenceUpdateEvents = BaseEvents<'preference.update', UpdatePreferencesArgs, Preference>;
+type PreferenceUpdateEvents = BaseEvents<'preference.update', UpdatePreferenceArgs, Preference>;
+type PreferencesBulkUpdateEvents = BaseEvents<'preferences.bulk_update', Array<UpdatePreferenceArgs>, Preference[]>;
 type SocketConnectEvents = BaseEvents<'socket.connect', { socketUrl: string }, undefined>;
 export type NotificationReceivedEvent = `notifications.${WebSocketEvent.RECEIVED}`;
 export type NotificationUnseenEvent = `notifications.${WebSocketEvent.UNSEEN}`;
@@ -89,6 +90,7 @@ export type Events = SessionInitializeEvents &
   PreferencesFetchEvents & {
     'preferences.list.updated': { data: Preference[] };
   } & PreferenceUpdateEvents &
+  PreferencesBulkUpdateEvents &
   SocketConnectEvents &
   SocketEvents &
   NotificationReadEvents &
@@ -116,6 +118,6 @@ export type NotificationEvents = keyof (NotificationReadEvents &
   NotificationsReadAllEvents &
   NotificationsArchivedAllEvents &
   NotificationsReadArchivedAllEvents);
-export type PreferenceEvents = keyof PreferenceUpdateEvents;
+export type PreferenceEvents = keyof (PreferenceUpdateEvents & PreferencesBulkUpdateEvents);
 
 export type EventHandler<T = unknown> = (event: T) => void;

--- a/packages/js/src/preferences/preference.ts
+++ b/packages/js/src/preferences/preference.ts
@@ -4,7 +4,7 @@ import { NovuEventEmitter } from '../event-emitter';
 import { ChannelPreference, PreferenceLevel, Result, Workflow, Prettify } from '../types';
 import { updatePreference } from './helpers';
 import { PreferencesCache } from '../cache/preferences-cache';
-import { UpdatePreferencesArgs } from './types';
+import { UpdatePreferenceArgs } from './types';
 
 type PreferenceLike = Pick<Preference, 'level' | 'enabled' | 'channels' | 'workflow'>;
 
@@ -45,9 +45,13 @@ export class Preference {
 
   update({
     channels,
-    /** @deprecated Use channels instead */
     channelPreferences,
-  }: Prettify<Pick<UpdatePreferencesArgs, 'channels' | 'channelPreferences'>>): Result<Preference> {
+  }: Prettify<
+    Pick<UpdatePreferenceArgs, 'channels'> & {
+      /** @deprecated Use channels instead */
+      channelPreferences?: ChannelPreference;
+    }
+  >): Result<Preference> {
     return updatePreference({
       emitter: this.#emitter,
       apiService: this.#apiService,
@@ -56,12 +60,7 @@ export class Preference {
       args: {
         workflowId: this.workflow?.id,
         channels: channels || channelPreferences,
-        preference: {
-          level: this.level,
-          enabled: this.enabled,
-          channels: this.channels,
-          workflow: this.workflow,
-        },
+        preference: this,
       },
     });
   }

--- a/packages/js/src/preferences/preferences.ts
+++ b/packages/js/src/preferences/preferences.ts
@@ -2,9 +2,10 @@ import { InboxService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
 import { BaseModule } from '../base-module';
 import { Preference } from './preference';
-import type { ListPreferencesArgs } from './types';
+import type { BasePreferenceArgs, InstancePreferenceArgs, ListPreferencesArgs, UpdatePreferenceArgs } from './types';
 import { Result } from '../types';
 import { PreferencesCache } from '../cache/preferences-cache';
+import { bulkUpdatePreference, updatePreference } from './helpers';
 
 export class Preferences extends BaseModule {
   #useCache: boolean;
@@ -62,5 +63,33 @@ export class Preferences extends BaseModule {
         throw error;
       }
     });
+  }
+
+  async update(args: BasePreferenceArgs): Result<Preference>;
+  async update(args: InstancePreferenceArgs): Result<Preference>;
+  async update(args: UpdatePreferenceArgs): Result<Preference> {
+    return this.callWithSession(() =>
+      updatePreference({
+        emitter: this._emitter,
+        apiService: this._inboxService,
+        cache: this.cache,
+        useCache: this.#useCache,
+        args,
+      })
+    );
+  }
+
+  async bulkUpdate(args: Array<BasePreferenceArgs>): Result<Preference[]>;
+  async bulkUpdate(args: Array<InstancePreferenceArgs>): Result<Preference[]>;
+  async bulkUpdate(args: Array<UpdatePreferenceArgs>): Result<Preference[]> {
+    return this.callWithSession(() =>
+      bulkUpdatePreference({
+        emitter: this._emitter,
+        apiService: this._inboxService,
+        cache: this.cache,
+        useCache: this.#useCache,
+        args,
+      })
+    );
   }
 }

--- a/packages/js/src/preferences/types.ts
+++ b/packages/js/src/preferences/types.ts
@@ -1,4 +1,4 @@
-import { ChannelPreference, PreferenceLevel, Workflow } from '../types';
+import { ChannelPreference, Preference, PreferenceLevel, Workflow } from '../types';
 
 export type FetchPreferencesArgs = {
   level?: PreferenceLevel;
@@ -9,15 +9,14 @@ export type ListPreferencesArgs = {
   tags?: string[];
 };
 
-export type UpdatePreferencesArgs = {
-  workflowId?: string;
+export type BasePreferenceArgs = {
+  workflowId: string;
   channels: ChannelPreference;
-  /** @deprecated Use channels instead */
-  channelPreferences?: ChannelPreference;
-  preference?: {
-    level: PreferenceLevel;
-    enabled: boolean;
-    channels: ChannelPreference;
-    workflow?: Workflow;
-  };
 };
+
+export type InstancePreferenceArgs = {
+  preference: Preference;
+  channels: ChannelPreference;
+};
+
+export type UpdatePreferenceArgs = BasePreferenceArgs | InstancePreferenceArgs;


### PR DESCRIPTION
### What changed? Why was the change needed?

Changes in the `@novu/js` headless:
- bulk update preferences `novu.preferences.bulkUpdate`
- exposed update for the single preference `novu.preferences.update`

### Screenshots

![Screenshot 2025-05-13 at 10 12 36](https://github.com/user-attachments/assets/645de3aa-3a9c-4ace-9c22-7949a945320b)
![Screenshot 2025-05-13 at 10 12 42](https://github.com/user-attachments/assets/c65442b9-dcfa-4b03-9d2e-63adef841961)

