### PR TITLE
fix(api): update _feedId typing for proper SDK generation

### DIFF
--- a/apps/api/src/app/widgets/dtos/feeds-response.dto.ts
+++ b/apps/api/src/app/widgets/dtos/feeds-response.dto.ts
@@ -73,10 +73,11 @@ export class NotificationFeedItemDto implements INotificationDto {
   })
   _subscriberId: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Identifier for the feed associated with the notification.',
     example: 'feed_445566',
     type: String,
+    nullable: true,
   })
   _feedId?: string | null;
 

--- a/apps/api/src/app/widgets/dtos/feeds-response.dto.ts
+++ b/apps/api/src/app/widgets/dtos/feeds-response.dto.ts
@@ -78,7 +78,7 @@ export class NotificationFeedItemDto implements INotificationDto {
     example: 'feed_445566',
     type: String,
   })
-  _feedId: string;
+  _feedId?: string | null;
 
   @ApiProperty({
     description: 'Identifier for the job that triggered the notification.',

--- a/libs/dal/src/repositories/message/message.entity.ts
+++ b/libs/dal/src/repositories/message/message.entity.ts
@@ -82,7 +82,7 @@ export class MessageEntity {
 
   cta: IMessageCTA;
 
-  _feedId: string;
+  _feedId?: string;
 
   status: 'sent' | 'error' | 'warning';
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Feed id can be `null` for messages, should also be updated in the SDK after merge https://github.com/novuhq/novu-ts

https://github.com/novuhq/novu/issues/8298
