### PR TITLE
fix(dashboard): update CMD in Dockerfile to include proxy configuration

### DIFF
--- a/apps/dashboard/dockerfile
+++ b/apps/dashboard/dockerfile
@@ -41,4 +41,4 @@ RUN chmod +x /app/docker-entrypoint.sh
 ENTRYPOINT [ "/app/docker-entrypoint.sh" ]
 # Expose the port the app runs on
 EXPOSE 4000
-CMD [ "http-server", "dist", "-p", "4000" ]
+CMD [ "http-server", "dist", "-p", "4000", "--proxy", "http://localhost:4000?" ]


### PR DESCRIPTION
This pull request updates the `apps/dashboard/dockerfile` to enhance the application's proxying capabilities.

### Dockerfile update:

* Modified the `CMD` instruction to include a `--proxy` option, enabling requests to be proxied to `http://localhost:4000`. This change supports improved handling of API requests during local development.