### PR TITLE
fix(api, ws, dashboard, worker): new release v2.2.0

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/api-service",
-  "version": "2.1.13",
+  "version": "2.2.0",
   "description": "description",
   "author": "",
   "private": "true",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@novu/dashboard",
   "private": true,
-  "version": "2.1.15",
+  "version": "2.2.0",
   "type": "module",
   "scripts": {
     "start": "vite",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/worker",
-  "version": "2.1.9",
+  "version": "2.2.0",
   "description": "description",
   "author": "",
   "private": "true",

--- a/apps/ws/package.json
+++ b/apps/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/ws",
-  "version": "2.1.9",
+  "version": "2.2.0",
   "description": "",
   "author": "",
   "private": true,

--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       retries: 5
 
   api:
-    image: 'ghcr.io/novuhq/novu/api:2.2.0-rc.1'
+    image: 'ghcr.io/novuhq/novu/api:2.2.0'
     depends_on:
       - mongodb
       - redis
@@ -87,7 +87,7 @@ services:
     ports:
       - ${API_PORT}:${API_PORT}
   worker:
-    image: 'ghcr.io/novuhq/novu/worker:2.2.0-rc.1'
+    image: 'ghcr.io/novuhq/novu/worker:2.2.0'
     depends_on:
       - mongodb
       - redis
@@ -125,7 +125,7 @@ services:
       IS_EMAIL_INLINE_CSS_DISABLED: ${IS_EMAIL_INLINE_CSS_DISABLED}
       IS_USE_MERGED_DIGEST_ID_ENABLED: ${IS_USE_MERGED_DIGEST_ID_ENABLED}
   ws:
-    image: 'ghcr.io/novuhq/novu/ws:2.2.0-rc.1'
+    image: 'ghcr.io/novuhq/novu/ws:2.2.0'
     depends_on:
       - mongodb
       - redis
@@ -153,7 +153,7 @@ services:
       - ${WS_PORT}:${WS_PORT}
 
   dashboard:
-    image: 'ghcr.io/novuhq/novu/dashboard:2.2.0-rc.1'
+    image: 'ghcr.io/novuhq/novu/dashboard:2.2.0'
     depends_on:
       - api
       - worker


### PR DESCRIPTION
This pull request updates the version numbers for multiple services and synchronizes them across the project. It also updates the Docker Compose configuration to use the stable `2.2.0` images instead of the release candidate (`2.2.0-rc.1`).

### Version Updates in `package.json` Files:
* Updated the version of `@novu/api-service` to `2.2.0` in `apps/api/package.json`.
* Updated the version of `@novu/dashboard` to `2.2.0` in `apps/dashboard/package.json`.
* Updated the version of `@novu/worker` to `2.2.0` in `apps/worker/package.json`.
* Updated the version of `@novu/ws` to `2.2.0` in `apps/ws/package.json`.

### Docker Compose Configuration Updates:
* Updated the `api` service image to `ghcr.io/novuhq/novu/api:2.2.0` in `docker/community/docker-compose.yml`.
* Updated the `worker` service image to `ghcr.io/novuhq/novu/worker:2.2.0` in `docker/community/docker-compose.yml`.
* Updated the `ws` service image to `ghcr.io/novuhq/novu/ws:2.2.0` in `docker/community/docker-compose.yml`.
* Updated the `dashboard` service image to `ghcr.io/novuhq/novu/dashboard:2.2.0` in `docker/community/docker-compose.yml`.

This fixes NV-5829