### PR TITLE
fix(dashboard): Fixes push preview widget 

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/push/push-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/push/push-preview.tsx
@@ -101,7 +101,7 @@ export const PushContentContainerPreview = ({ children, className, ...rest }: HT
 
 export const PushBackgroundWithPhone = ({ children, className, ...rest }: HTMLAttributes<HTMLDivElement>) => {
   return (
-    <div className="flex items-center justify-center">
+    <div className="flex items-center justify-center w-full">
       <div
         className={cn("relative h-60 w-full max-w-72 bg-[url('/images/phones/iphone-push.svg')] bg-cover", className)}
         {...rest}


### PR DESCRIPTION
Fixes https://github.com/novuhq/novu/issues/8368

### What changed? Why was the change needed?

Added class `w-full` to the wrapper of the push notifications preview widget. Making sure the wrapper despite being `flex`, consumes all the available width in any parent container. This prevents shrinkage if parent container is also `flex`. 


### Screenshots


<img width="601" alt="Screenshot 2025-05-22 at 10 43 12 AM" src="https://github.com/user-attachments/assets/518765a8-902a-4435-a0d0-47b20aeb8153" />


<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
