### PR TITLE
fix(root): update prePopulateEnv call to use 'dashboard' instead of widget

### DIFF
--- a/scripts/setup-env-files.js
+++ b/scripts/setup-env-files.js
@@ -19,7 +19,7 @@ const prePopulateEnv = (apps, folderBasePath, exampleEnvFilePath = 'src/.example
   const appsBasePath = `${__dirname}/../apps`;
   console.log('----------------------------------------');
   prePopulateEnv(['api', 'ws', 'worker'], appsBasePath);
-  prePopulateEnv(['web', 'widget'], appsBasePath, '.example.env', '.env');
+  prePopulateEnv(['web', 'dashboard'], appsBasePath, '.example.env', '.env');
   console.log('Finished populating .env files');
   console.log('----------------------------------------');
 })();


### PR DESCRIPTION

### What changed? Why was the change needed?

This fixes NV-5903 and #8250
### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
