### PR TITLE
fix(api-service): optional message tempate id Fixes NV-5983

### DIFF
--- a/apps/api/src/app/widgets/dtos/feeds-response.dto.ts
+++ b/apps/api/src/app/widgets/dtos/feeds-response.dto.ts
@@ -45,7 +45,7 @@ export class NotificationFeedItemDto implements INotificationDto {
   })
   _environmentId: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Identifier for the message template used.',
     example: 'message_template_54321',
     type: String,

--- a/libs/internal-sdk/index.js.map
+++ b/libs/internal-sdk/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["src/index.ts"],"names":[],"mappings":";AAAA;;GAEG;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAEH,kDAAgC;AAChC,wDAAwC;AACxC,+CAA6B"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["src/index.ts"],"names":[],"mappings":";AAAA;;GAEG;;;;;;;;;;;;;;;;;;;;;;;;;;;;;AAEH,kDAAgC;AAChC,wDAAwC;AACxC,yCAA2C;AAAlC,qGAAA,UAAU,OAAA;AAEnB,+CAA6B"}

--- a/libs/internal-sdk/src/funcs/subscribersDelete.ts
+++ b/libs/internal-sdk/src/funcs/subscribersDelete.ts
@@ -25,10 +25,11 @@ import { APICall, APIPromise } from "../types/async.js";
 import { Result } from "../types/fp.js";
 
 /**
- * Delete subscriber
+ * Delete a subscriber
  *
  * @remarks
- * Deletes a subscriber entity from the Novu platform along with associated messages, preferences, and topic subscriptions
+ * Deletes a subscriber entity from the Novu platform along with associated messages, preferences, and topic subscriptions.
+ *       **subscriberId** is a required field.
  */
 export function subscribersDelete(
   client: NovuCore,

--- a/libs/internal-sdk/src/funcs/subscribersRetrieve.ts
+++ b/libs/internal-sdk/src/funcs/subscribersRetrieve.ts
@@ -28,7 +28,7 @@ import { Result } from "../types/fp.js";
  * Retrieve a subscriber
  *
  * @remarks
- * Retrive a subscriber by its unique key identifier **subscriberId**.
+ * Retrieve a subscriber by its unique key identifier **subscriberId**.
  *     **subscriberId** field is required.
  */
 export function subscribersRetrieve(

--- a/libs/internal-sdk/src/funcs/topicsSubscriptionsList.ts
+++ b/libs/internal-sdk/src/funcs/topicsSubscriptionsList.ts
@@ -28,7 +28,7 @@ import { Result } from "../types/fp.js";
  * List topic subscriptions
  *
  * @remarks
- * List all topics that a subscriber is subscribed to.
+ * List all subscriptions of subscribers for a topic.
  *     Checkout all available filters in the query section.
  */
 export function topicsSubscriptionsList(

--- a/libs/internal-sdk/src/index.ts
+++ b/libs/internal-sdk/src/index.ts
@@ -4,4 +4,6 @@
 
 export * from "./lib/config.js";
 export * as files from "./lib/files.js";
+export { HTTPClient } from "./lib/http.js";
+export type { Fetcher, HTTPClientOptions } from "./lib/http.js";
 export * from "./sdk/sdk.js";

--- a/libs/internal-sdk/src/lib/config.ts
+++ b/libs/internal-sdk/src/lib/config.ts
@@ -67,6 +67,6 @@ export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "2.2.0",
   sdkVersion: "0.1.21",
-  genVersion: "2.616.1",
-  userAgent: "speakeasy-sdk/typescript 0.1.21 2.616.1 2.2.0 @novu/api",
+  genVersion: "2.618.0",
+  userAgent: "speakeasy-sdk/typescript 0.1.21 2.618.0 2.2.0 @novu/api",
 } as const;

--- a/libs/internal-sdk/src/models/components/notificationfeeditemdto.ts
+++ b/libs/internal-sdk/src/models/components/notificationfeeditemdto.ts
@@ -63,7 +63,7 @@ export type NotificationFeedItemDto = {
   /**
    * Identifier for the message template used.
    */
-  messageTemplateId: string;
+  messageTemplateId?: string | undefined;
   /**
    * Identifier for the organization sending the notification.
    */
@@ -184,7 +184,7 @@ export const NotificationFeedItemDto$inboundSchema: z.ZodType<
   _id: z.string(),
   _templateId: z.string(),
   _environmentId: z.string(),
-  _messageTemplateId: z.string(),
+  _messageTemplateId: z.string().optional(),
   _organizationId: z.string(),
   _notificationId: z.string(),
   _subscriberId: z.string(),
@@ -230,7 +230,7 @@ export type NotificationFeedItemDto$Outbound = {
   _id: string;
   _templateId: string;
   _environmentId: string;
-  _messageTemplateId: string;
+  _messageTemplateId?: string | undefined;
   _organizationId: string;
   _notificationId: string;
   _subscriberId: string;
@@ -264,7 +264,7 @@ export const NotificationFeedItemDto$outboundSchema: z.ZodType<
   id: z.string(),
   templateId: z.string(),
   environmentId: z.string(),
-  messageTemplateId: z.string(),
+  messageTemplateId: z.string().optional(),
   organizationId: z.string(),
   notificationId: z.string(),
   subscriberId: z.string(),

--- a/libs/internal-sdk/src/models/components/updateintegrationrequestdto.ts
+++ b/libs/internal-sdk/src/models/components/updateintegrationrequestdto.ts
@@ -29,10 +29,6 @@ export type UpdateIntegrationRequestDto = {
    */
   active?: boolean | undefined;
   credentials?: CredentialsDto | undefined;
-  /**
-   * If true, the Novu branding will be removed from the Inbox component
-   */
-  removeNovuBranding?: boolean | undefined;
   check?: boolean | undefined;
   conditions?: Array<StepFilterDto> | undefined;
 };
@@ -48,7 +44,6 @@ export const UpdateIntegrationRequestDto$inboundSchema: z.ZodType<
   _environmentId: z.string().optional(),
   active: z.boolean().optional(),
   credentials: CredentialsDto$inboundSchema.optional(),
-  removeNovuBranding: z.boolean().optional(),
   check: z.boolean().optional(),
   conditions: z.array(StepFilterDto$inboundSchema).optional(),
 }).transform((v) => {
@@ -64,7 +59,6 @@ export type UpdateIntegrationRequestDto$Outbound = {
   _environmentId?: string | undefined;
   active?: boolean | undefined;
   credentials?: CredentialsDto$Outbound | undefined;
-  removeNovuBranding?: boolean | undefined;
   check?: boolean | undefined;
   conditions?: Array<StepFilterDto$Outbound> | undefined;
 };
@@ -80,7 +74,6 @@ export const UpdateIntegrationRequestDto$outboundSchema: z.ZodType<
   environmentId: z.string().optional(),
   active: z.boolean().optional(),
   credentials: CredentialsDto$outboundSchema.optional(),
-  removeNovuBranding: z.boolean().optional(),
   check: z.boolean().optional(),
   conditions: z.array(StepFilterDto$outboundSchema).optional(),
 }).transform((v) => {

--- a/libs/internal-sdk/src/react-query/subscribersDelete.ts
+++ b/libs/internal-sdk/src/react-query/subscribersDelete.ts
@@ -26,10 +26,11 @@ export type SubscribersDeleteMutationData =
   operations.SubscribersControllerRemoveSubscriberResponse;
 
 /**
- * Delete subscriber
+ * Delete a subscriber
  *
  * @remarks
- * Deletes a subscriber entity from the Novu platform along with associated messages, preferences, and topic subscriptions
+ * Deletes a subscriber entity from the Novu platform along with associated messages, preferences, and topic subscriptions.
+ *       **subscriberId** is a required field.
  */
 export function useSubscribersDeleteMutation(
   options?: MutationHookOptions<

--- a/libs/internal-sdk/src/react-query/subscribersRetrieve.ts
+++ b/libs/internal-sdk/src/react-query/subscribersRetrieve.ts
@@ -32,7 +32,7 @@ export type SubscribersRetrieveQueryData =
  * Retrieve a subscriber
  *
  * @remarks
- * Retrive a subscriber by its unique key identifier **subscriberId**.
+ * Retrieve a subscriber by its unique key identifier **subscriberId**.
  *     **subscriberId** field is required.
  */
 export function useSubscribersRetrieve(
@@ -56,7 +56,7 @@ export function useSubscribersRetrieve(
  * Retrieve a subscriber
  *
  * @remarks
- * Retrive a subscriber by its unique key identifier **subscriberId**.
+ * Retrieve a subscriber by its unique key identifier **subscriberId**.
  *     **subscriberId** field is required.
  */
 export function useSubscribersRetrieveSuspense(

--- a/libs/internal-sdk/src/react-query/topicsSubscriptionsList.ts
+++ b/libs/internal-sdk/src/react-query/topicsSubscriptionsList.ts
@@ -32,7 +32,7 @@ export type TopicsSubscriptionsListQueryData =
  * List topic subscriptions
  *
  * @remarks
- * List all topics that a subscriber is subscribed to.
+ * List all subscriptions of subscribers for a topic.
  *     Checkout all available filters in the query section.
  */
 export function useTopicsSubscriptionsList(
@@ -54,7 +54,7 @@ export function useTopicsSubscriptionsList(
  * List topic subscriptions
  *
  * @remarks
- * List all topics that a subscriber is subscribed to.
+ * List all subscriptions of subscribers for a topic.
  *     Checkout all available filters in the query section.
  */
 export function useTopicsSubscriptionsListSuspense(

--- a/libs/internal-sdk/src/sdk/subscribers.ts
+++ b/libs/internal-sdk/src/sdk/subscribers.ts
@@ -92,7 +92,7 @@ export class Subscribers extends ClientSDK {
    * Retrieve a subscriber
    *
    * @remarks
-   * Retrive a subscriber by its unique key identifier **subscriberId**.
+   * Retrieve a subscriber by its unique key identifier **subscriberId**.
    *     **subscriberId** field is required.
    */
   async retrieve(
@@ -131,10 +131,11 @@ export class Subscribers extends ClientSDK {
   }
 
   /**
-   * Delete subscriber
+   * Delete a subscriber
    *
    * @remarks
-   * Deletes a subscriber entity from the Novu platform along with associated messages, preferences, and topic subscriptions
+   * Deletes a subscriber entity from the Novu platform along with associated messages, preferences, and topic subscriptions.
+   *       **subscriberId** is a required field.
    */
   async delete(
     subscriberId: string,

--- a/libs/internal-sdk/src/sdk/subscriptions.ts
+++ b/libs/internal-sdk/src/sdk/subscriptions.ts
@@ -15,7 +15,7 @@ export class Subscriptions extends ClientSDK {
    * List topic subscriptions
    *
    * @remarks
-   * List all topics that a subscriber is subscribed to.
+   * List all subscriptions of subscribers for a topic.
    *     Checkout all available filters in the query section.
    */
   async list(


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Made the `messageTemplateId` property optional in notification feed items.
  - Added public exports for HTTP client functionality and related types in the SDK.

- **Bug Fixes**
  - Removed the `removeNovuBranding` property from integration update requests.

- **Documentation**
  - Improved and clarified descriptions in SDK documentation and comments, including typo corrections and more accurate method explanations.

- **Chores**
  - Updated SDK version metadata to 2.618.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->