### PR TITLE
feat(dashboard): Workflow Step action bar

### DIFF
--- a/apps/dashboard/src/components/primitives/control-input/control-input.tsx
+++ b/apps/dashboard/src/components/primitives/control-input/control-input.tsx
@@ -198,6 +198,29 @@ export function ControlInput({
     [setSelectedVariable]
   );
 
+  /**
+   * This is a workaround to focus the editor when clicking on the container.
+   * It's a known issue with Codemirror in case of the container is bigger in size than a single focusable row.
+   */
+  const handleContainerClick = useCallback(
+    (event: React.MouseEvent) => {
+      // Don't focus if a variable popover is open or if clicking on interactive elements
+      if (isVariablePopoverOpen) return;
+
+      const target = event.target as HTMLElement;
+
+      // Don't focus if clicking on variable pills or other interactive elements
+      if (target.closest('.cm-variable-pill') || target.closest('[role="button"]') || target.closest('button')) {
+        return;
+      }
+
+      if (viewRef.current) {
+        viewRef.current.focus();
+      }
+    },
+    [isVariablePopoverOpen]
+  );
+
   useEffect(() => {
     // calculate popover trigger position when variable is selected
     if (selectedVariable && viewRef.current && containerRef.current) {
@@ -218,7 +241,7 @@ export function ControlInput({
   }, [selectedVariable]);
 
   return (
-    <div ref={containerRef} className={cn(variants({ size }), className)}>
+    <div ref={containerRef} className={cn(variants({ size }), className)} onClick={handleContainerClick}>
       <Editor
         key={schemaKey}
         fontFamily="inherit"

--- a/apps/dashboard/src/components/workflow-editor/base-node.tsx
+++ b/apps/dashboard/src/components/workflow-editor/base-node.tsx
@@ -134,8 +134,9 @@ const nodeVariants = cva(
   {
     variants: {
       variant: {
-        default: 'rounded-lg pointer-events-auto [&_span:not(.hover-trigger,.error-trigger)]:pointer-events-none',
-        sm: 'text-neutral-400 w-min rounded-lg pointer-events-auto [&_span:not(.hover-trigger,.error-trigger)]:pointer-events-none',
+        default:
+          'rounded-lg pointer-events-auto [&_span:not(.hover-trigger,.error-trigger,.action-bar-trigger)]:pointer-events-none [&_.action-bar-trigger]:pointer-events-auto',
+        sm: 'text-neutral-400 w-min rounded-lg pointer-events-auto [&_span:not(.hover-trigger,.error-trigger,.action-bar-trigger)]:pointer-events-none [&_.action-bar-trigger]:pointer-events-auto',
       },
     },
     defaultVariants: {

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -98,7 +98,6 @@ const StepNode = (props: StepNodeProps) => {
   const { workflow: currentWorkflow, update } = useWorkflow();
   const { currentEnvironment } = useEnvironment();
   const has = useHasPermission();
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const conditionsCount = useConditionsCount(data.controlValues?.skip as RQBJsonLogic);
 
@@ -124,8 +123,6 @@ const StepNode = (props: StepNodeProps) => {
       },
       {
         onSuccess: () => {
-          setIsDeleteModalOpen(false);
-
           if (currentEnvironment?.slug && currentWorkflow?.slug) {
             navigate(
               buildRoute(ROUTES.EDIT_WORKFLOW, {
@@ -242,7 +239,8 @@ const StepNode = (props: StepNodeProps) => {
               <div style={{ pointerEvents: 'auto', position: 'relative', zIndex: 1000 }}>
                 <WorkflowNodeActionBar
                   stepType={type}
-                  onRemoveClick={() => setIsDeleteModalOpen(true)}
+                  stepName={data.name || 'Untitled Step'}
+                  onRemoveClick={handleRemoveStep}
                   onEditContentClick={handleEditContent}
                   onCopyClick={handleCopyStep}
                 />
@@ -250,15 +248,6 @@ const StepNode = (props: StepNodeProps) => {
             )}
           </AnimatePresence>
         </Node>
-
-        <ConfirmationModal
-          open={isDeleteModalOpen}
-          onOpenChange={setIsDeleteModalOpen}
-          onConfirm={handleRemoveStep}
-          title="Delete step?"
-          description="This action is permanent and cannot be undone."
-          confirmButtonText="Delete step"
-        />
       </>
     );
   }
@@ -272,7 +261,8 @@ const StepNode = (props: StepNodeProps) => {
             <div style={{ pointerEvents: 'auto', position: 'relative', zIndex: 1000 }}>
               <WorkflowNodeActionBar
                 stepType={type}
-                onRemoveClick={() => setIsDeleteModalOpen(true)}
+                stepName={data.name || 'Untitled Step'}
+                onRemoveClick={handleRemoveStep}
                 onEditContentClick={handleEditContent}
                 onCopyClick={handleCopyStep}
               />
@@ -280,15 +270,6 @@ const StepNode = (props: StepNodeProps) => {
           )}
         </AnimatePresence>
       </Node>
-
-      <ConfirmationModal
-        open={isDeleteModalOpen}
-        onOpenChange={setIsDeleteModalOpen}
-        onConfirm={handleRemoveStep}
-        title="Delete step?"
-        description="This action is permanent and cannot be undone."
-        confirmButtonText="Delete step"
-      />
     </>
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -23,6 +23,7 @@ import { useEnvironment } from '@/context/environment/hooks';
 import { AnimatePresence } from 'motion/react';
 import { ConfirmationModal } from '@/components/confirmation-modal';
 import { useState, useCallback } from 'react';
+import { StepCreateDto } from '@novu/shared';
 
 export type NodeData = {
   addStepIndex?: number;
@@ -138,6 +139,62 @@ const StepNode = (props: StepNodeProps) => {
     );
   }, [data.stepSlug, currentWorkflow, currentEnvironment?.slug, update, navigate]);
 
+  const handleCopyStep = useCallback(() => {
+    if (!data.stepSlug || !currentWorkflow || !type) {
+      return;
+    }
+
+    const currentStepIndex = currentWorkflow.steps.findIndex((s) => s.slug === data.stepSlug);
+
+    if (currentStepIndex === -1) {
+      return;
+    }
+
+    const currentStep = currentWorkflow.steps[currentStepIndex];
+
+    // Create a new step by copying the current step structure
+    const copiedStep: StepCreateDto = {
+      name: `${currentStep.name} (Copy)`,
+      type: currentStep.type,
+      controlValues: { ...currentStep.controls.values },
+    };
+
+    // Insert the copied step immediately after the current step
+    const newSteps = [...currentWorkflow.steps];
+    newSteps.splice(currentStepIndex + 1, 0, copiedStep as any);
+
+    update(
+      {
+        ...currentWorkflow,
+        steps: newSteps,
+      },
+      {
+        onSuccess: (updatedWorkflow) => {
+          // Navigate to the newly created step
+          const newStep = updatedWorkflow.steps[currentStepIndex + 1];
+
+          if (newStep && currentEnvironment?.slug) {
+            const isTemplateConfigurable = TEMPLATE_CONFIGURABLE_STEP_TYPES.includes(type);
+
+            if (isTemplateConfigurable) {
+              navigate(
+                buildRoute(ROUTES.EDIT_STEP_TEMPLATE, {
+                  stepSlug: newStep.slug,
+                })
+              );
+            } else if (INLINE_CONFIGURABLE_STEP_TYPES.includes(type)) {
+              navigate(
+                buildRoute(ROUTES.EDIT_STEP, {
+                  stepSlug: newStep.slug,
+                })
+              );
+            }
+          }
+        },
+      }
+    );
+  }, [data.stepSlug, currentWorkflow, type, currentEnvironment?.slug, update, navigate]);
+
   const handleEditContent = useCallback(() => {
     if (!data.stepSlug || !currentEnvironment?.slug || !type) {
       return;
@@ -187,6 +244,7 @@ const StepNode = (props: StepNodeProps) => {
                   stepType={type}
                   onRemoveClick={() => setIsDeleteModalOpen(true)}
                   onEditContentClick={handleEditContent}
+                  onCopyClick={handleCopyStep}
                 />
               </div>
             )}
@@ -216,6 +274,7 @@ const StepNode = (props: StepNodeProps) => {
                 stepType={type}
                 onRemoveClick={() => setIsDeleteModalOpen(true)}
                 onEditContentClick={handleEditContent}
+                onCopyClick={handleCopyStep}
               />
             </div>
           )}

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -238,7 +238,7 @@ const StepNode = (props: StepNodeProps) => {
   if (hasConditions) {
     return (
       <>
-        <div className="relative pt-2" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        <div className="relative pt-1" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
           <Node
             aria-selected={isSelected}
             className={cn('group rounded-tl-none [&>span]:rounded-tl-none', className)}
@@ -275,7 +275,7 @@ const StepNode = (props: StepNodeProps) => {
 
   return (
     <>
-      <div className="relative pt-2" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      <div className="relative pt-1" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
         <Node aria-selected={isSelected} className={cn('group', className)} {...rest}>
           {rest.children}
         </Node>

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -22,7 +22,7 @@ import { WorkflowNodeActionBar } from './workflow-node-action-bar';
 import { useEnvironment } from '@/context/environment/hooks';
 import { AnimatePresence } from 'motion/react';
 import { ConfirmationModal } from '@/components/confirmation-modal';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { StepCreateDto } from '@novu/shared';
 
 export type NodeData = {
@@ -98,6 +98,8 @@ const StepNode = (props: StepNodeProps) => {
   const { workflow: currentWorkflow, update } = useWorkflow();
   const { currentEnvironment } = useEnvironment();
   const has = useHasPermission();
+  const [isHovered, setIsHovered] = useState(false);
+  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const conditionsCount = useConditionsCount(data.controlValues?.skip as RQBJsonLogic);
 
@@ -110,6 +112,25 @@ const StepNode = (props: StepNodeProps) => {
   const hasConditions = conditionsCount > 0;
   const isReadOnly =
     currentWorkflow?.origin === WorkflowOriginEnum.EXTERNAL || !has({ permission: PermissionsEnum.WORKFLOW_WRITE });
+
+  const handleMouseEnter = () => {
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+    }
+
+    hoverTimeoutRef.current = setTimeout(() => {
+      setIsHovered(true);
+    }, 150);
+  };
+
+  const handleMouseLeave = () => {
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+      hoverTimeoutRef.current = null;
+    }
+
+    setIsHovered(false);
+  };
 
   const handleRemoveStep = useCallback(() => {
     if (!data.stepSlug || !currentWorkflow) {
@@ -217,25 +238,27 @@ const StepNode = (props: StepNodeProps) => {
   if (hasConditions) {
     return (
       <>
-        <Node
-          aria-selected={isSelected}
-          className={cn('group rounded-tl-none [&>span]:rounded-tl-none', className)}
-          pill={
-            <>
-              <RiFilter3Fill className="text-foreground-400 size-3" />
-              <span className="text-foreground-400 text-xs">{conditionsCount}</span>
-            </>
-          }
-          onPillClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            navigate(buildRoute(ROUTES.EDIT_STEP_CONDITIONS, { stepSlug: data.stepSlug ?? '' }));
-          }}
-          {...rest}
-        >
-          {rest.children}
+        <div className="relative pt-12" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+          <Node
+            aria-selected={isSelected}
+            className={cn('group rounded-tl-none [&>span]:rounded-tl-none', className)}
+            pill={
+              <>
+                <RiFilter3Fill className="text-foreground-400 size-3" />
+                <span className="text-foreground-400 text-xs">{conditionsCount}</span>
+              </>
+            }
+            onPillClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              navigate(buildRoute(ROUTES.EDIT_STEP_CONDITIONS, { stepSlug: data.stepSlug ?? '' }));
+            }}
+            {...rest}
+          >
+            {rest.children}
+          </Node>
           <AnimatePresence>
-            {isSelected && !isReadOnly && !data.isTemplateStorePreview && type && (
+            {isHovered && !isReadOnly && !data.isTemplateStorePreview && type && (
               <WorkflowNodeActionBar
                 stepType={type}
                 stepName={data.name || 'Untitled Step'}
@@ -245,17 +268,19 @@ const StepNode = (props: StepNodeProps) => {
               />
             )}
           </AnimatePresence>
-        </Node>
+        </div>
       </>
     );
   }
 
   return (
     <>
-      <Node aria-selected={isSelected} className={cn('group', className)} {...rest}>
-        {rest.children}
+      <div className="relative pt-12" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        <Node aria-selected={isSelected} className={cn('group', className)} {...rest}>
+          {rest.children}
+        </Node>
         <AnimatePresence>
-          {isSelected && !isReadOnly && !data.isTemplateStorePreview && type && (
+          {isHovered && !isReadOnly && !data.isTemplateStorePreview && type && (
             <WorkflowNodeActionBar
               stepType={type}
               stepName={data.name || 'Untitled Step'}
@@ -265,7 +290,7 @@ const StepNode = (props: StepNodeProps) => {
             />
           )}
         </AnimatePresence>
-      </Node>
+      </div>
     </>
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -238,7 +238,7 @@ const StepNode = (props: StepNodeProps) => {
   if (hasConditions) {
     return (
       <>
-        <div className="relative pt-12" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        <div className="relative pt-2" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
           <Node
             aria-selected={isSelected}
             className={cn('group rounded-tl-none [&>span]:rounded-tl-none', className)}
@@ -275,7 +275,7 @@ const StepNode = (props: StepNodeProps) => {
 
   return (
     <>
-      <div className="relative pt-12" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      <div className="relative pt-2" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
         <Node aria-selected={isSelected} className={cn('group', className)} {...rest}>
           {rest.children}
         </Node>

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -18,6 +18,11 @@ import { STEP_TYPE_TO_ICON } from '../icons/utils';
 import { AddStepMenu } from './add-step-menu';
 import { Node, NodeBody, NodeError, NodeHeader, NodeIcon, NodeName } from './base-node';
 import { useHasPermission } from '@/hooks/use-has-permission';
+import { WorkflowNodeActionBar } from './workflow-node-action-bar';
+import { useEnvironment } from '@/context/environment/hooks';
+import { AnimatePresence } from 'motion/react';
+import { ConfirmationModal } from '@/components/confirmation-modal';
+import { useState, useCallback } from 'react';
 
 export type NodeData = {
   addStepIndex?: number;
@@ -78,14 +83,21 @@ export const TriggerNode = ({
   );
 };
 
-type StepNodeProps = ComponentProps<typeof Node> & { data: NodeData };
+type StepNodeProps = ComponentProps<typeof Node> & {
+  data: NodeData;
+  type?: StepTypeEnum;
+};
 
 const StepNode = (props: StepNodeProps) => {
   const navigate = useNavigate();
-  const { className, data, ...rest } = props;
+  const { className, data, type, ...rest } = props;
   const { stepSlug } = useParams<{
     stepSlug: string;
   }>();
+  const { workflow: currentWorkflow, update } = useWorkflow();
+  const { currentEnvironment } = useEnvironment();
+  const has = useHasPermission();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const conditionsCount = useConditionsCount(data.controlValues?.skip as RQBJsonLogic);
 
@@ -96,29 +108,126 @@ const StepNode = (props: StepNodeProps) => {
     !!data.stepSlug;
 
   const hasConditions = conditionsCount > 0;
+  const isReadOnly =
+    currentWorkflow?.origin === WorkflowOriginEnum.EXTERNAL || !has({ permission: PermissionsEnum.WORKFLOW_WRITE });
+
+  const handleRemoveStep = useCallback(() => {
+    if (!data.stepSlug || !currentWorkflow) {
+      return;
+    }
+
+    update(
+      {
+        ...currentWorkflow,
+        steps: currentWorkflow.steps.filter((s) => s.slug !== data.stepSlug),
+      },
+      {
+        onSuccess: () => {
+          setIsDeleteModalOpen(false);
+
+          if (currentEnvironment?.slug && currentWorkflow?.slug) {
+            navigate(
+              buildRoute(ROUTES.EDIT_WORKFLOW, {
+                environmentSlug: currentEnvironment.slug,
+                workflowSlug: currentWorkflow.slug,
+              })
+            );
+          }
+        },
+      }
+    );
+  }, [data.stepSlug, currentWorkflow, currentEnvironment?.slug, update, navigate]);
+
+  const handleEditContent = useCallback(() => {
+    if (!data.stepSlug || !currentEnvironment?.slug || !type) {
+      return;
+    }
+
+    const isTemplateConfigurable = TEMPLATE_CONFIGURABLE_STEP_TYPES.includes(type);
+
+    if (isTemplateConfigurable) {
+      navigate(
+        buildRoute(ROUTES.EDIT_STEP_TEMPLATE, {
+          stepSlug: data.stepSlug,
+        })
+      );
+    } else {
+      navigate(
+        buildRoute(ROUTES.EDIT_STEP, {
+          stepSlug: data.stepSlug,
+        })
+      );
+    }
+  }, [data.stepSlug, currentEnvironment?.slug, navigate, type]);
 
   if (hasConditions) {
     return (
-      <Node
-        aria-selected={isSelected}
-        className={cn('group rounded-tl-none [&>span]:rounded-tl-none', className)}
-        pill={
-          <>
-            <RiFilter3Fill className="text-foreground-400 size-3" />
-            <span className="text-foreground-400 text-xs">{conditionsCount}</span>
-          </>
-        }
-        onPillClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          navigate(buildRoute(ROUTES.EDIT_STEP_CONDITIONS, { stepSlug: data.stepSlug ?? '' }));
-        }}
-        {...rest}
-      />
+      <>
+        <Node
+          aria-selected={isSelected}
+          className={cn('group rounded-tl-none [&>span]:rounded-tl-none', className)}
+          pill={
+            <>
+              <RiFilter3Fill className="text-foreground-400 size-3" />
+              <span className="text-foreground-400 text-xs">{conditionsCount}</span>
+            </>
+          }
+          onPillClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            navigate(buildRoute(ROUTES.EDIT_STEP_CONDITIONS, { stepSlug: data.stepSlug ?? '' }));
+          }}
+          {...rest}
+        >
+          {rest.children}
+          <AnimatePresence>
+            {isSelected && !isReadOnly && !data.isTemplateStorePreview && type && (
+              <WorkflowNodeActionBar
+                stepType={type}
+                onRemoveClick={() => setIsDeleteModalOpen(true)}
+                onEditContentClick={handleEditContent}
+              />
+            )}
+          </AnimatePresence>
+        </Node>
+
+        <ConfirmationModal
+          open={isDeleteModalOpen}
+          onOpenChange={setIsDeleteModalOpen}
+          onConfirm={handleRemoveStep}
+          title="Delete step?"
+          description="This action is permanent and cannot be undone."
+          confirmButtonText="Delete step"
+        />
+      </>
     );
   }
 
-  return <Node aria-selected={isSelected} className={cn('group', className)} {...rest} />;
+  return (
+    <>
+      <Node aria-selected={isSelected} className={cn('group', className)} {...rest}>
+        {rest.children}
+        <AnimatePresence>
+          {isSelected && !isReadOnly && !data.isTemplateStorePreview && type && (
+            <WorkflowNodeActionBar
+              stepType={type}
+              onRemoveClick={() => setIsDeleteModalOpen(true)}
+              onEditContentClick={handleEditContent}
+            />
+          )}
+        </AnimatePresence>
+      </Node>
+
+      <ConfirmationModal
+        open={isDeleteModalOpen}
+        onOpenChange={setIsDeleteModalOpen}
+        onConfirm={handleRemoveStep}
+        title="Delete step?"
+        description="This action is permanent and cannot be undone."
+        confirmButtonText="Delete step"
+      />
+    </>
+  );
 };
 
 const NodeWrapper = ({ children, data, type }: { children: React.ReactNode; data: NodeData; type: StepTypeEnum }) => {
@@ -146,7 +255,7 @@ export const EmailNode = ({ data }: NodeProps<NodeType>) => {
 
   return (
     <NodeWrapper data={data} type={StepTypeEnum.EMAIL}>
-      <StepNode data={data}>
+      <StepNode data={data} type={StepTypeEnum.EMAIL}>
         <NodeHeader type={StepTypeEnum.EMAIL}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.EMAIL]}>
             <Icon />
@@ -176,7 +285,7 @@ export const SmsNode = (props: NodeProps<NodeType>) => {
 
   return (
     <NodeWrapper data={data} type={StepTypeEnum.SMS}>
-      <StepNode data={data}>
+      <StepNode data={data} type={StepTypeEnum.SMS}>
         <NodeHeader type={StepTypeEnum.SMS}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.SMS]}>
             <Icon />
@@ -204,7 +313,7 @@ export const InAppNode = (props: NodeProps<NodeType>) => {
 
   return (
     <NodeWrapper data={data} type={StepTypeEnum.IN_APP}>
-      <StepNode data={data}>
+      <StepNode data={data} type={StepTypeEnum.IN_APP}>
         <NodeHeader type={StepTypeEnum.IN_APP}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.IN_APP]}>
             <Icon />
@@ -232,7 +341,7 @@ export const PushNode = (props: NodeProps<NodeType>) => {
 
   return (
     <NodeWrapper data={data} type={StepTypeEnum.PUSH}>
-      <StepNode data={data}>
+      <StepNode data={data} type={StepTypeEnum.PUSH}>
         <NodeHeader type={StepTypeEnum.PUSH}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.PUSH]}>
             <Icon />
@@ -260,7 +369,7 @@ export const ChatNode = (props: NodeProps<NodeType>) => {
 
   return (
     <NodeWrapper data={data} type={StepTypeEnum.CHAT}>
-      <StepNode data={data}>
+      <StepNode data={data} type={StepTypeEnum.CHAT}>
         <NodeHeader type={StepTypeEnum.CHAT}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.CHAT]}>
             <Icon />
@@ -288,7 +397,7 @@ export const DelayNode = (props: NodeProps<NodeType>) => {
 
   return (
     <NodeWrapper data={data} type={StepTypeEnum.DELAY}>
-      <StepNode data={data}>
+      <StepNode data={data} type={StepTypeEnum.DELAY}>
         <NodeHeader type={StepTypeEnum.DELAY}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.DELAY]}>
             <Icon />
@@ -312,7 +421,7 @@ export const DigestNode = (props: NodeProps<NodeType>) => {
 
   return (
     <NodeWrapper data={data} type={StepTypeEnum.DIGEST}>
-      <StepNode data={data}>
+      <StepNode data={data} type={StepTypeEnum.DIGEST}>
         <NodeHeader type={StepTypeEnum.DIGEST}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.DIGEST]}>
             <Icon />
@@ -336,7 +445,7 @@ export const CustomNode = (props: NodeProps<NodeType>) => {
 
   return (
     <NodeWrapper data={data} type={StepTypeEnum.CUSTOM}>
-      <StepNode data={data}>
+      <StepNode data={data} type={StepTypeEnum.CUSTOM}>
         <NodeHeader type={StepTypeEnum.CUSTOM}>
           <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.CUSTOM]}>
             <Icon />

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -236,15 +236,13 @@ const StepNode = (props: StepNodeProps) => {
           {rest.children}
           <AnimatePresence>
             {isSelected && !isReadOnly && !data.isTemplateStorePreview && type && (
-              <div style={{ pointerEvents: 'auto', position: 'relative', zIndex: 1000 }}>
-                <WorkflowNodeActionBar
-                  stepType={type}
-                  stepName={data.name || 'Untitled Step'}
-                  onRemoveClick={handleRemoveStep}
-                  onEditContentClick={handleEditContent}
-                  onCopyClick={handleCopyStep}
-                />
-              </div>
+              <WorkflowNodeActionBar
+                stepType={type}
+                stepName={data.name || 'Untitled Step'}
+                onRemoveClick={handleRemoveStep}
+                onEditContentClick={handleEditContent}
+                onCopyClick={handleCopyStep}
+              />
             )}
           </AnimatePresence>
         </Node>
@@ -258,15 +256,13 @@ const StepNode = (props: StepNodeProps) => {
         {rest.children}
         <AnimatePresence>
           {isSelected && !isReadOnly && !data.isTemplateStorePreview && type && (
-            <div style={{ pointerEvents: 'auto', position: 'relative', zIndex: 1000 }}>
-              <WorkflowNodeActionBar
-                stepType={type}
-                stepName={data.name || 'Untitled Step'}
-                onRemoveClick={handleRemoveStep}
-                onEditContentClick={handleEditContent}
-                onCopyClick={handleCopyStep}
-              />
-            </div>
+            <WorkflowNodeActionBar
+              stepType={type}
+              stepName={data.name || 'Untitled Step'}
+              onRemoveClick={handleRemoveStep}
+              onEditContentClick={handleEditContent}
+              onCopyClick={handleCopyStep}
+            />
           )}
         </AnimatePresence>
       </Node>

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -182,11 +182,13 @@ const StepNode = (props: StepNodeProps) => {
           {rest.children}
           <AnimatePresence>
             {isSelected && !isReadOnly && !data.isTemplateStorePreview && type && (
-              <WorkflowNodeActionBar
-                stepType={type}
-                onRemoveClick={() => setIsDeleteModalOpen(true)}
-                onEditContentClick={handleEditContent}
-              />
+              <div style={{ pointerEvents: 'auto', position: 'relative', zIndex: 1000 }}>
+                <WorkflowNodeActionBar
+                  stepType={type}
+                  onRemoveClick={() => setIsDeleteModalOpen(true)}
+                  onEditContentClick={handleEditContent}
+                />
+              </div>
             )}
           </AnimatePresence>
         </Node>
@@ -209,11 +211,13 @@ const StepNode = (props: StepNodeProps) => {
         {rest.children}
         <AnimatePresence>
           {isSelected && !isReadOnly && !data.isTemplateStorePreview && type && (
-            <WorkflowNodeActionBar
-              stepType={type}
-              onRemoveClick={() => setIsDeleteModalOpen(true)}
-              onEditContentClick={handleEditContent}
-            />
+            <div style={{ pointerEvents: 'auto', position: 'relative', zIndex: 1000 }}>
+              <WorkflowNodeActionBar
+                stepType={type}
+                onRemoveClick={() => setIsDeleteModalOpen(true)}
+                onEditContentClick={handleEditContent}
+              />
+            </div>
           )}
         </AnimatePresence>
       </Node>

--- a/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
@@ -119,7 +119,7 @@ const mapStepToNode = ({
     : undefined;
 
   return {
-    id: generateUUID(),
+    id: `node-${step.slug}`,
     position: { x: previousPosition.x, y: previousPosition.y + Y_DISTANCE },
     data: {
       name: step.name,
@@ -144,9 +144,13 @@ const WorkflowCanvasChild = ({
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const reactFlowInstance = useReactFlow();
   const { currentEnvironment } = useEnvironment();
-  const { workflow: currentWorkflow } = useWorkflow();
+  const { workflow: currentWorkflow, update } = useWorkflow();
   const navigate = useNavigate();
   const { user } = useUser();
+  const has = useHasPermission();
+
+  const isReadOnly =
+    currentWorkflow?.origin === WorkflowOriginEnum.EXTERNAL || !has({ permission: PermissionsEnum.WORKFLOW_WRITE });
 
   const [nodes, edges] = useMemo(() => {
     const triggerNode: Node<NodeData, 'trigger'> = {
@@ -271,6 +275,7 @@ const WorkflowCanvasChild = ({
       >
         <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
       </ReactFlow>
+
       {currentWorkflow &&
         currentEnvironment?.name === EnvironmentEnum.DEVELOPMENT &&
         currentWorkflow.origin === WorkflowOriginEnum.NOVU_CLOUD &&

--- a/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
@@ -119,7 +119,7 @@ const mapStepToNode = ({
     : undefined;
 
   return {
-    id: `node-${step.slug}`,
+    id: generateUUID(),
     position: { x: previousPosition.x, y: previousPosition.y + Y_DISTANCE },
     data: {
       name: step.name,
@@ -144,13 +144,9 @@ const WorkflowCanvasChild = ({
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const reactFlowInstance = useReactFlow();
   const { currentEnvironment } = useEnvironment();
-  const { workflow: currentWorkflow, update } = useWorkflow();
+  const { workflow: currentWorkflow } = useWorkflow();
   const navigate = useNavigate();
   const { user } = useUser();
-  const has = useHasPermission();
-
-  const isReadOnly =
-    currentWorkflow?.origin === WorkflowOriginEnum.EXTERNAL || !has({ permission: PermissionsEnum.WORKFLOW_WRITE });
 
   const [nodes, edges] = useMemo(() => {
     const triggerNode: Node<NodeData, 'trigger'> = {

--- a/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
@@ -66,7 +66,7 @@ export const WorkflowNodeActionBar = ({
             ease: 'easeInOut',
           },
         }}
-        className="action-bar-trigger pointer-events-auto absolute left-0 right-0 top-[-35px] z-50 flex justify-center"
+        className="action-bar-trigger pointer-events-auto absolute left-0 right-0 top-[-38px] z-50 flex justify-center"
         style={{
           pointerEvents: 'auto',
           transformOrigin: 'top center',

--- a/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
@@ -47,169 +47,134 @@ export const WorkflowNodeActionBar = ({
   return (
     <>
       <motion.div
-        initial={{ opacity: 0, scale: 0.95, y: 4 }}
+        initial={{ opacity: 0, y: 5 }}
         animate={{
           opacity: 1,
-          scale: 1,
           y: 0,
           transition: {
             type: 'spring',
-            stiffness: 300,
-            damping: 25,
+            stiffness: 400,
+            damping: 30,
             mass: 0.6,
           },
         }}
         exit={{
           opacity: 0,
-          scale: 0.98,
-          y: 2,
+          y: 4,
           transition: {
-            duration: 0.12,
-            ease: 'easeIn',
+            duration: 0.15,
+            ease: 'easeInOut',
           },
         }}
-        className="action-bar-trigger pointer-events-auto absolute bottom-[-42px] right-0 z-50 -translate-y-full"
+        className="action-bar-trigger pointer-events-auto absolute left-0 right-0 top-[5px] z-50 flex justify-center"
         style={{
           pointerEvents: 'auto',
-          transformOrigin: 'bottom center',
+          transformOrigin: 'top center',
         }}
       >
         <motion.div
           initial={{ scaleY: 0, opacity: 0 }}
           animate={{
             scaleY: 1,
-            opacity: 1,
+            opacity: 0.8,
             transition: {
               delay: 0.05,
-              duration: 0.15,
-              ease: 'easeOut',
+              type: 'spring',
+              stiffness: 400,
+              damping: 25,
             },
           }}
           exit={{
             scaleY: 0,
             opacity: 0,
             transition: {
-              duration: 0.08,
+              duration: 0.1,
+              ease: 'easeIn',
             },
           }}
-          className="absolute bottom-[-12px] left-1/2 h-3 w-[2px] -translate-x-1/2 bg-gradient-to-b from-neutral-200 to-transparent"
-          style={{ transformOrigin: 'top center' }}
+          className="absolute left-1/2 top-[-12px] h-3 w-[2px] -translate-x-1/2 bg-gradient-to-t from-neutral-200 to-transparent"
+          style={{ transformOrigin: 'bottom center' }}
         />
 
         <motion.div
-          className="pointer-events-auto mb-2 flex items-center overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-lg"
-          initial={{ boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0)' }}
+          className="pointer-events-auto mt-2 flex items-center overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-lg"
+          initial={{ opacity: 0, y: 4 }}
           animate={{
-            boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+            opacity: 1,
+            y: 0,
             transition: {
-              delay: 0.08,
-              duration: 0.2,
+              delay: 0.03,
+              type: 'spring',
+              stiffness: 400,
+              damping: 30,
+            },
+          }}
+          exit={{
+            opacity: 0,
+            y: 2,
+            transition: {
+              duration: 0.12,
+              ease: 'easeInOut',
             },
           }}
         >
           {isChannelStep && (
             <>
-              <motion.div
-                initial={{ opacity: 0, x: -4 }}
-                animate={{
-                  opacity: 1,
-                  x: 0,
-                  transition: {
-                    delay: 0.1,
-                    duration: 0.15,
-                  },
+              <Button
+                size="2xs"
+                variant="secondary"
+                mode="ghost"
+                className="pointer-events-auto gap-1.5 rounded-l-lg rounded-r-none px-2 py-1 text-xs"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onEditContentClick();
                 }}
               >
-                <Button
-                  size="2xs"
-                  variant="secondary"
-                  mode="ghost"
-                  className="pointer-events-auto gap-1.5 rounded-l-lg rounded-r-none px-2 py-1 text-xs"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    onEditContentClick();
-                  }}
-                >
-                  <RiEdit2Line className="h-3.5 w-3.5" />
-                  Edit content
-                </Button>
-              </motion.div>
-              <motion.div
-                className="h-6 w-px bg-neutral-100"
-                initial={{ scaleY: 0 }}
-                animate={{
-                  scaleY: 1,
-                  transition: {
-                    delay: 0.12,
-                    duration: 0.1,
-                  },
-                }}
-              />
+                <RiEdit2Line className="h-3.5 w-3.5" />
+                Edit content
+              </Button>
+              <div className="h-6 w-px bg-neutral-100" />
             </>
           )}
-          <motion.div
-            initial={{ opacity: 0, x: -4 }}
-            animate={{
-              opacity: 1,
-              x: 0,
-              transition: {
-                delay: isChannelStep ? 0.14 : 0.1,
-                duration: 0.15,
-              },
-            }}
-          >
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  size="2xs"
-                  variant="secondary"
-                  mode="ghost"
-                  className="pointer-events-auto gap-1.5 rounded-none px-2 py-1 text-xs"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setIsCopyModalOpen(true);
-                  }}
-                >
-                  <RiFileCopyLine className="h-3.5 w-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Duplicate the current step</TooltipContent>
-            </Tooltip>
-          </motion.div>
-          <motion.div
-            initial={{ opacity: 0, x: -4 }}
-            animate={{
-              opacity: 1,
-              x: 0,
-              transition: {
-                delay: isChannelStep ? 0.16 : 0.12,
-                duration: 0.15,
-              },
-            }}
-          >
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  size="2xs"
-                  variant="secondary"
-                  mode="ghost"
-                  className={`text-text-sub pointer-events-auto gap-1.5 px-2 py-1 text-xs ${
-                    isChannelStep ? 'rounded-l-none rounded-r-lg' : 'rounded-lg'
-                  }`}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setIsDeleteModalOpen(true);
-                  }}
-                >
-                  <RiDeleteBin2Line className="text-error-base h-3.5 w-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Delete step</TooltipContent>
-            </Tooltip>
-          </motion.div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="2xs"
+                variant="secondary"
+                mode="ghost"
+                className="pointer-events-auto gap-1.5 rounded-none px-2 py-1 text-xs"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setIsCopyModalOpen(true);
+                }}
+              >
+                <RiFileCopyLine className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Duplicate the current step</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="2xs"
+                variant="secondary"
+                mode="ghost"
+                className={`text-text-sub pointer-events-auto gap-1.5 px-2 py-1 text-xs ${
+                  isChannelStep ? 'rounded-l-none rounded-r-lg' : 'rounded-lg'
+                }`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setIsDeleteModalOpen(true);
+                }}
+              >
+                <RiDeleteBin2Line className="text-error-base h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Delete step</TooltipContent>
+          </Tooltip>
         </motion.div>
       </motion.div>
 

--- a/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
@@ -124,7 +124,7 @@ export const WorkflowNodeActionBar = ({
                   size="2xs"
                   variant="secondary"
                   mode="ghost"
-                  className="pointer-events-auto gap-1.5 px-2 py-1 text-xs"
+                  className="pointer-events-auto gap-1.5 rounded-l-lg rounded-r-none px-2 py-1 text-xs"
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
@@ -165,7 +165,7 @@ export const WorkflowNodeActionBar = ({
                   size="2xs"
                   variant="secondary"
                   mode="ghost"
-                  className="pointer-events-auto gap-1.5 px-2 py-1 text-xs"
+                  className="pointer-events-auto gap-1.5 rounded-none px-2 py-1 text-xs"
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
@@ -195,7 +195,9 @@ export const WorkflowNodeActionBar = ({
                   size="2xs"
                   variant="secondary"
                   mode="ghost"
-                  className="text-text-sub pointer-events-auto gap-1.5 rounded-[7px] px-2 py-1 text-xs"
+                  className={`text-text-sub pointer-events-auto gap-1.5 px-2 py-1 text-xs ${
+                    isChannelStep ? 'rounded-l-none rounded-r-lg' : 'rounded-lg'
+                  }`}
                   onClick={(e) => {
                     e.preventDefault();
                     e.stopPropagation();

--- a/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
@@ -66,7 +66,7 @@ export const WorkflowNodeActionBar = ({
             ease: 'easeInOut',
           },
         }}
-        className="action-bar-trigger pointer-events-auto absolute left-0 right-0 top-[5px] z-50 flex justify-center"
+        className="action-bar-trigger pointer-events-auto absolute left-0 right-0 top-[-35px] z-50 flex justify-center"
         style={{
           pointerEvents: 'auto',
           transformOrigin: 'top center',

--- a/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
@@ -1,6 +1,9 @@
 import { motion } from 'motion/react';
-import { RiDeleteBin2Line, RiEdit2Line, RiEditLine } from 'react-icons/ri';
+import { RiDeleteBin2Line, RiEdit2Line, RiFileCopyLine } from 'react-icons/ri';
+import { useState } from 'react';
 import { Button } from '@/components/primitives/button';
+import { ConfirmationModal } from '@/components/confirmation-modal';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { StepTypeEnum } from '@/utils/enums';
 
 const CHANNEL_STEP_TYPES = [
@@ -15,54 +18,100 @@ type WorkflowNodeActionBarProps = {
   stepType: StepTypeEnum;
   onRemoveClick: () => void;
   onEditContentClick: () => void;
+  onCopyClick: () => void;
 };
 
-export const WorkflowNodeActionBar = ({ stepType, onRemoveClick, onEditContentClick }: WorkflowNodeActionBarProps) => {
+export const WorkflowNodeActionBar = ({
+  stepType,
+  onRemoveClick,
+  onEditContentClick,
+  onCopyClick,
+}: WorkflowNodeActionBarProps) => {
+  const [isCopyModalOpen, setIsCopyModalOpen] = useState(false);
   const isChannelStep = CHANNEL_STEP_TYPES.includes(stepType);
 
+  const handleCopyConfirm = () => {
+    onCopyClick();
+    setIsCopyModalOpen(false);
+  };
+
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 5 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 5 }}
-      transition={{ duration: 0.15 }}
-      className="action-bar-trigger pointer-events-auto absolute left-[-5px] top-[-118px] z-50 -translate-y-full"
-      style={{ pointerEvents: 'auto' }}
-    >
-      <div className="pointer-events-auto mb-2 flex items-center gap-1 rounded-lg border border-neutral-200 bg-white shadow-lg">
-        {isChannelStep && (
-          <>
-            <Button
-              size="2xs"
-              variant="secondary"
-              mode="ghost"
-              className="pointer-events-auto gap-1.5 px-2 py-1 text-xs"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                onEditContentClick();
-              }}
-            >
-              <RiEdit2Line className="h-3.5 w-3.5" />
-              Edit content
-            </Button>
-            <div className="h-6 w-px bg-neutral-100" />
-          </>
-        )}
-        <Button
-          size="2xs"
-          variant="secondary"
-          mode="ghost"
-          className="text-text-sub pointer-events-auto gap-1.5 rounded-[7px] px-2 py-1 text-xs"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onRemoveClick();
-          }}
-        >
-          <RiDeleteBin2Line className="text-error-base h-3.5 w-3.5" />
-        </Button>
-      </div>
-    </motion.div>
+    <>
+      <motion.div
+        initial={{ opacity: 0, y: 5 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 5 }}
+        transition={{ duration: 0.15 }}
+        className="action-bar-trigger pointer-events-auto absolute left-[-5px] top-[-118px] z-50 -translate-y-full"
+        style={{ pointerEvents: 'auto' }}
+      >
+        <div className="pointer-events-auto mb-2 flex items-center rounded-lg border border-neutral-200 bg-white shadow-lg">
+          {isChannelStep && (
+            <>
+              <Button
+                size="2xs"
+                variant="secondary"
+                mode="ghost"
+                className="pointer-events-auto gap-1.5 px-2 py-1 text-xs"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onEditContentClick();
+                }}
+              >
+                <RiEdit2Line className="h-3.5 w-3.5" />
+                Edit content
+              </Button>
+              <div className="h-6 w-px bg-neutral-100" />
+            </>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="2xs"
+                variant="secondary"
+                mode="ghost"
+                className="pointer-events-auto gap-1.5 px-2 py-1 text-xs"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setIsCopyModalOpen(true);
+                }}
+              >
+                <RiFileCopyLine className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Duplicate the current step</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="2xs"
+                variant="secondary"
+                mode="ghost"
+                className="text-text-sub pointer-events-auto gap-1.5 rounded-[7px] px-2 py-1 text-xs"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onRemoveClick();
+                }}
+              >
+                <RiDeleteBin2Line className="text-error-base h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Delete step</TooltipContent>
+          </Tooltip>
+        </div>
+      </motion.div>
+
+      <ConfirmationModal
+        open={isCopyModalOpen}
+        onOpenChange={setIsCopyModalOpen}
+        onConfirm={handleCopyConfirm}
+        title="Copy step"
+        description="Are you sure you want to duplicate this step? A step will be created immediately below the current step."
+        confirmButtonText="Copy step"
+      />
+    </>
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/primitives/button';
 import { ConfirmationModal } from '@/components/confirmation-modal';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { StepTypeEnum } from '@/utils/enums';
+import TruncatedText from '@/components/truncated-text';
 
 const CHANNEL_STEP_TYPES = [
   StepTypeEnum.EMAIL,
@@ -16,6 +17,7 @@ const CHANNEL_STEP_TYPES = [
 
 type WorkflowNodeActionBarProps = {
   stepType: StepTypeEnum;
+  stepName: string;
   onRemoveClick: () => void;
   onEditContentClick: () => void;
   onCopyClick: () => void;
@@ -23,16 +25,23 @@ type WorkflowNodeActionBarProps = {
 
 export const WorkflowNodeActionBar = ({
   stepType,
+  stepName,
   onRemoveClick,
   onEditContentClick,
   onCopyClick,
 }: WorkflowNodeActionBarProps) => {
   const [isCopyModalOpen, setIsCopyModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const isChannelStep = CHANNEL_STEP_TYPES.includes(stepType);
 
   const handleCopyConfirm = () => {
     onCopyClick();
     setIsCopyModalOpen(false);
+  };
+
+  const handleDeleteConfirm = () => {
+    onRemoveClick();
+    setIsDeleteModalOpen(false);
   };
 
   return (
@@ -93,7 +102,7 @@ export const WorkflowNodeActionBar = ({
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  onRemoveClick();
+                  setIsDeleteModalOpen(true);
                 }}
               >
                 <RiDeleteBin2Line className="text-error-base h-3.5 w-3.5" />
@@ -111,6 +120,20 @@ export const WorkflowNodeActionBar = ({
         title="Copy step"
         description="Are you sure you want to duplicate this step? A step will be created immediately below the current step."
         confirmButtonText="Copy step"
+      />
+
+      <ConfirmationModal
+        open={isDeleteModalOpen}
+        onOpenChange={setIsDeleteModalOpen}
+        onConfirm={handleDeleteConfirm}
+        title="Proceeding will delete the step"
+        description={
+          <>
+            You're about to delete the <TruncatedText className="max-w-[32ch] font-bold">{stepName}</TruncatedText>{' '}
+            step, this action is permanent.
+          </>
+        }
+        confirmButtonText="Delete"
       />
     </>
   );

--- a/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
@@ -1,0 +1,59 @@
+import { motion } from 'motion/react';
+import { RiDeleteBin2Line, RiEditLine } from 'react-icons/ri';
+import { Button } from '@/components/primitives/button';
+import { StepTypeEnum } from '@/utils/enums';
+
+const CHANNEL_STEP_TYPES = [
+  StepTypeEnum.EMAIL,
+  StepTypeEnum.SMS,
+  StepTypeEnum.IN_APP,
+  StepTypeEnum.PUSH,
+  StepTypeEnum.CHAT,
+];
+
+type WorkflowNodeActionBarProps = {
+  stepType: StepTypeEnum;
+  onRemoveClick: () => void;
+  onEditContentClick: () => void;
+};
+
+export const WorkflowNodeActionBar = ({ stepType, onRemoveClick, onEditContentClick }: WorkflowNodeActionBarProps) => {
+  const isChannelStep = CHANNEL_STEP_TYPES.includes(stepType);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 5 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 5 }}
+      transition={{ duration: 0.15 }}
+      className="absolute right-0 top-[-35px] z-50 -translate-y-full"
+    >
+      <div className="mb-2 flex items-center gap-1 rounded-lg border border-neutral-200 bg-white shadow-lg">
+        {isChannelStep && (
+          <>
+            <Button
+              size="2xs"
+              variant="secondary"
+              mode="ghost"
+              className="gap-1.5 px-2 py-1 text-xs"
+              onClick={onEditContentClick}
+            >
+              <RiEditLine className="h-3.5 w-3.5" />
+              Edit content
+            </Button>
+            <div className="h-4 w-px bg-neutral-200" />
+          </>
+        )}
+        <Button
+          size="2xs"
+          variant="secondary"
+          mode="ghost"
+          className="gap-1.5 px-2 py-1 text-xs"
+          onClick={onRemoveClick}
+        >
+          <RiDeleteBin2Line className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </motion.div>
+  );
+};

--- a/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'motion/react';
-import { RiDeleteBin2Line, RiEditLine } from 'react-icons/ri';
+import { RiDeleteBin2Line, RiEdit2Line, RiEditLine } from 'react-icons/ri';
 import { Button } from '@/components/primitives/button';
 import { StepTypeEnum } from '@/utils/enums';
 
@@ -26,32 +26,41 @@ export const WorkflowNodeActionBar = ({ stepType, onRemoveClick, onEditContentCl
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 5 }}
       transition={{ duration: 0.15 }}
-      className="absolute right-0 top-[-35px] z-50 -translate-y-full"
+      className="action-bar-trigger pointer-events-auto absolute left-[-5px] top-[-118px] z-50 -translate-y-full"
+      style={{ pointerEvents: 'auto' }}
     >
-      <div className="mb-2 flex items-center gap-1 rounded-lg border border-neutral-200 bg-white shadow-lg">
+      <div className="pointer-events-auto mb-2 flex items-center gap-1 rounded-lg border border-neutral-200 bg-white shadow-lg">
         {isChannelStep && (
           <>
             <Button
               size="2xs"
               variant="secondary"
               mode="ghost"
-              className="gap-1.5 px-2 py-1 text-xs"
-              onClick={onEditContentClick}
+              className="pointer-events-auto gap-1.5 px-2 py-1 text-xs"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onEditContentClick();
+              }}
             >
-              <RiEditLine className="h-3.5 w-3.5" />
+              <RiEdit2Line className="h-3.5 w-3.5" />
               Edit content
             </Button>
-            <div className="h-4 w-px bg-neutral-200" />
+            <div className="h-6 w-px bg-neutral-100" />
           </>
         )}
         <Button
           size="2xs"
           variant="secondary"
           mode="ghost"
-          className="gap-1.5 px-2 py-1 text-xs"
-          onClick={onRemoveClick}
+          className="text-text-sub pointer-events-auto gap-1.5 rounded-[7px] px-2 py-1 text-xs"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onRemoveClick();
+          }}
         >
-          <RiDeleteBin2Line className="h-3.5 w-3.5" />
+          <RiDeleteBin2Line className="text-error-base h-3.5 w-3.5" />
         </Button>
       </div>
     </motion.div>

--- a/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
@@ -217,9 +217,9 @@ export const WorkflowNodeActionBar = ({
         open={isCopyModalOpen}
         onOpenChange={setIsCopyModalOpen}
         onConfirm={handleCopyConfirm}
-        title="Copy step"
+        title="Duplicate step"
         description="Are you sure you want to duplicate this step? A step will be created immediately below the current step."
-        confirmButtonText="Copy step"
+        confirmButtonText="Duplicate step"
       />
 
       <ConfirmationModal

--- a/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-node-action-bar.tsx
@@ -47,70 +47,168 @@ export const WorkflowNodeActionBar = ({
   return (
     <>
       <motion.div
-        initial={{ opacity: 0, y: 5 }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0, y: 5 }}
-        transition={{ duration: 0.15 }}
-        className="action-bar-trigger pointer-events-auto absolute left-[-5px] top-[-118px] z-50 -translate-y-full"
-        style={{ pointerEvents: 'auto' }}
+        initial={{ opacity: 0, scale: 0.95, y: 4 }}
+        animate={{
+          opacity: 1,
+          scale: 1,
+          y: 0,
+          transition: {
+            type: 'spring',
+            stiffness: 300,
+            damping: 25,
+            mass: 0.6,
+          },
+        }}
+        exit={{
+          opacity: 0,
+          scale: 0.98,
+          y: 2,
+          transition: {
+            duration: 0.12,
+            ease: 'easeIn',
+          },
+        }}
+        className="action-bar-trigger pointer-events-auto absolute bottom-[-42px] right-0 z-50 -translate-y-full"
+        style={{
+          pointerEvents: 'auto',
+          transformOrigin: 'bottom center',
+        }}
       >
-        <div className="pointer-events-auto mb-2 flex items-center rounded-lg border border-neutral-200 bg-white shadow-lg">
+        <motion.div
+          initial={{ scaleY: 0, opacity: 0 }}
+          animate={{
+            scaleY: 1,
+            opacity: 1,
+            transition: {
+              delay: 0.05,
+              duration: 0.15,
+              ease: 'easeOut',
+            },
+          }}
+          exit={{
+            scaleY: 0,
+            opacity: 0,
+            transition: {
+              duration: 0.08,
+            },
+          }}
+          className="absolute bottom-[-12px] left-1/2 h-3 w-[2px] -translate-x-1/2 bg-gradient-to-b from-neutral-200 to-transparent"
+          style={{ transformOrigin: 'top center' }}
+        />
+
+        <motion.div
+          className="pointer-events-auto mb-2 flex items-center overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-lg"
+          initial={{ boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0)' }}
+          animate={{
+            boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+            transition: {
+              delay: 0.08,
+              duration: 0.2,
+            },
+          }}
+        >
           {isChannelStep && (
             <>
-              <Button
-                size="2xs"
-                variant="secondary"
-                mode="ghost"
-                className="pointer-events-auto gap-1.5 px-2 py-1 text-xs"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onEditContentClick();
+              <motion.div
+                initial={{ opacity: 0, x: -4 }}
+                animate={{
+                  opacity: 1,
+                  x: 0,
+                  transition: {
+                    delay: 0.1,
+                    duration: 0.15,
+                  },
                 }}
               >
-                <RiEdit2Line className="h-3.5 w-3.5" />
-                Edit content
-              </Button>
-              <div className="h-6 w-px bg-neutral-100" />
+                <Button
+                  size="2xs"
+                  variant="secondary"
+                  mode="ghost"
+                  className="pointer-events-auto gap-1.5 px-2 py-1 text-xs"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onEditContentClick();
+                  }}
+                >
+                  <RiEdit2Line className="h-3.5 w-3.5" />
+                  Edit content
+                </Button>
+              </motion.div>
+              <motion.div
+                className="h-6 w-px bg-neutral-100"
+                initial={{ scaleY: 0 }}
+                animate={{
+                  scaleY: 1,
+                  transition: {
+                    delay: 0.12,
+                    duration: 0.1,
+                  },
+                }}
+              />
             </>
           )}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                size="2xs"
-                variant="secondary"
-                mode="ghost"
-                className="pointer-events-auto gap-1.5 px-2 py-1 text-xs"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  setIsCopyModalOpen(true);
-                }}
-              >
-                <RiFileCopyLine className="h-3.5 w-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Duplicate the current step</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                size="2xs"
-                variant="secondary"
-                mode="ghost"
-                className="text-text-sub pointer-events-auto gap-1.5 rounded-[7px] px-2 py-1 text-xs"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  setIsDeleteModalOpen(true);
-                }}
-              >
-                <RiDeleteBin2Line className="text-error-base h-3.5 w-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Delete step</TooltipContent>
-          </Tooltip>
-        </div>
+          <motion.div
+            initial={{ opacity: 0, x: -4 }}
+            animate={{
+              opacity: 1,
+              x: 0,
+              transition: {
+                delay: isChannelStep ? 0.14 : 0.1,
+                duration: 0.15,
+              },
+            }}
+          >
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="2xs"
+                  variant="secondary"
+                  mode="ghost"
+                  className="pointer-events-auto gap-1.5 px-2 py-1 text-xs"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setIsCopyModalOpen(true);
+                  }}
+                >
+                  <RiFileCopyLine className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Duplicate the current step</TooltipContent>
+            </Tooltip>
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0, x: -4 }}
+            animate={{
+              opacity: 1,
+              x: 0,
+              transition: {
+                delay: isChannelStep ? 0.16 : 0.12,
+                duration: 0.15,
+              },
+            }}
+          >
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="2xs"
+                  variant="secondary"
+                  mode="ghost"
+                  className="text-text-sub pointer-events-auto gap-1.5 rounded-[7px] px-2 py-1 text-xs"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setIsDeleteModalOpen(true);
+                  }}
+                >
+                  <RiDeleteBin2Line className="text-error-base h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Delete step</TooltipContent>
+            </Tooltip>
+          </motion.div>
+        </motion.div>
       </motion.div>
 
       <ConfirmationModal


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
https://www.loom.com/share/268b5fdc0e0b481ca747c31601a0784b?sid=d74b3493-6793-4f38-9f5e-e6e2f7705f63

![CleanShot 2025-06-03 at 18 46 27](https://github.com/user-attachments/assets/ecbfc593-8123-40cf-b41c-eec3818109da)

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an action bar to workflow nodes, providing UI controls for editing, duplicating, and deleting steps with confirmation dialogs.
  - Enhanced workflow step nodes to support step management actions, including copy, remove, and edit, with permission-based read-only mode.
- **Improvements**
  - Updated node interaction behavior to improve pointer event handling for action bar elements.
  - Node IDs are now generated deterministically based on step slugs for improved consistency.
- **User Interface**
  - Animated transitions and tooltips added to the workflow node action bar for a smoother and more informative user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->