### PR TITLE
fix(dashboard): update CodeMirror wrapping logic

### DIFF
--- a/apps/dashboard/src/components/primitives/control-input/variable-plugin/variable-theme.ts
+++ b/apps/dashboard/src/components/primitives/control-input/variable-plugin/variable-theme.ts
@@ -14,5 +14,6 @@ export const variablePillTheme = EditorView.baseTheme({
   },
   '.cm-line': {
     paddingLeft: 0,
+    wordBreak: 'break-word',
   },
 });

--- a/apps/dashboard/src/components/primitives/editor.tsx
+++ b/apps/dashboard/src/components/primitives/editor.tsx
@@ -131,6 +131,7 @@ const baseTheme = (options: { multiline?: boolean }) =>
     'div.cm-content': {
       padding: 0,
       whiteSpace: options.multiline ? 'pre-wrap' : 'pre',
+      ...(options.multiline ? { wordBreak: 'break-word' } : {}),
       width: '1px', // Any width value would do to make the editor work exactly like an input when more text than its width is added
     },
     'div.cm-gutters': {

--- a/apps/dashboard/src/components/primitives/editor.tsx
+++ b/apps/dashboard/src/components/primitives/editor.tsx
@@ -130,7 +130,7 @@ const baseTheme = (options: { multiline?: boolean }) =>
     },
     'div.cm-content': {
       padding: 0,
-      whiteSpace: 'preserve nowrap',
+      whiteSpace: options.multiline ? 'pre-wrap' : 'pre',
       width: '1px', // Any width value would do to make the editor work exactly like an input when more text than its width is added
     },
     'div.cm-gutters': {
@@ -218,7 +218,7 @@ export const Editor = React.forwardRef<ReactCodeMirrorRef, EditorProps>(
   ) => {
     const onChangeRef = useDataRef(onChange);
     const extensions = useMemo(
-      () => [...(extensionsProp ?? []), baseTheme({ multiline })],
+      () => [baseTheme({ multiline }), ...(extensionsProp ?? [])],
       [extensionsProp, multiline]
     );
 

--- a/apps/dashboard/src/components/primitives/editor.tsx
+++ b/apps/dashboard/src/components/primitives/editor.tsx
@@ -127,6 +127,7 @@ const baseTheme = (options: { multiline?: boolean }) =>
     '.cm-line': {
       marginLeft: '1px',
       lineHeight: '20px',
+      ...(options.multiline ? { wordBreak: 'break-word' } : {}),
     },
     'div.cm-content': {
       padding: 0,


### PR DESCRIPTION
## Summary
- adjust code editor base theme to wrap lines when multiline
- ensure extension order allows variable pill theme to override

## Testing
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684592f19638832eacc9116db07447cc