### PR TITLE
chore(framework): debug package configuration for the framework

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,11 @@
       "args": ["${workspaceFolder}/apps/api/src/main.ts"],
       "runtimeArgs": ["--nolazy", "-r", "ts-node/register", "-r", "tsconfig-paths/register"],
       "sourceMaps": true,
-      "protocol": "inspector"
+      "protocol": "inspector",
+      "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "smartStep": true,
+      "stopOnEntry": false
     },
     {
       "name": "worker",

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -35,6 +35,7 @@
     "format": "prettier --check --ignore-path .gitignore .",
     "format:fix": "prettier --write --ignore-path .gitignore .",
     "build": "NODE_ENV=production tsup",
+    "debug": "NODE_ENV=production tsup --config tsup-debug.config.ts",
     "build:watch": "tsup --watch",
     "postbuild": "pnpm run check:exports && pnpm check:circulars",
     "check:exports": "attw --pack .",

--- a/packages/framework/tsup-debug.config.ts
+++ b/packages/framework/tsup-debug.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'tsup';
+import { cjsConfig, esmConfig } from './tsup.config';
+
+export default defineConfig([
+  {
+    ...cjsConfig,
+    sourcemap: true,
+    minify: false,
+    minifyWhitespace: false,
+    minifyIdentifiers: false,
+    minifySyntax: false,
+    splitting: false,
+  },
+  {
+    ...esmConfig,
+    sourcemap: true,
+    minify: false,
+    minifyWhitespace: false,
+    minifyIdentifiers: false,
+    minifySyntax: false,
+    splitting: false,
+  },
+]);

--- a/packages/framework/tsup.config.ts
+++ b/packages/framework/tsup.config.ts
@@ -19,15 +19,16 @@ const baseConfig: Options = {
   },
 };
 
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: 'cjs',
-    outDir: 'dist/cjs',
-  },
-  {
-    ...baseConfig,
-    format: 'esm',
-    outDir: 'dist/esm',
-  },
-]);
+export const cjsConfig: Options = {
+  ...baseConfig,
+  format: 'cjs',
+  outDir: 'dist/cjs',
+};
+
+export const esmConfig: Options = {
+  ...baseConfig,
+  format: 'esm',
+  outDir: 'dist/esm',
+};
+
+export default defineConfig([cjsConfig, esmConfig]);


### PR DESCRIPTION
### What changed? Why was the change needed?

This configuration allows debugging the framework and API from VS Code.

### Screenshots


