### PR TITLE
chore(api-service): email step ui schema migration

### DIFF
--- a/apps/api/migrations/email-step-ui-schema-html-editor/email-step-ui-schema-html-editor-migration.spec.ts
+++ b/apps/api/migrations/email-step-ui-schema-html-editor/email-step-ui-schema-html-editor-migration.spec.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import { UserSession } from '@novu/testing';
+import { StepTypeEnum, UiComponentEnum, UiSchemaGroupEnum, WorkflowCreationSourceEnum } from '@novu/shared';
+import { Novu } from '@novu/api';
+import { run } from './email-step-ui-schema-html-editor-migration';
+
+describe('Update email step ui schema migration test #novu-v2', () => {
+  let session: UserSession;
+  let novuClient: Novu;
+  const workflows = ['test', 'test2'];
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+
+    for (const workflow of workflows) {
+      await session.testAgent.post(`/v2/workflows`).send({
+        __source: WorkflowCreationSourceEnum.DASHBOARD,
+        name: workflow,
+        workflowId: workflow,
+        steps: [
+          {
+            name: 'email',
+            type: StepTypeEnum.EMAIL,
+            controlValues: {
+              body: '',
+              subject: '',
+            },
+          },
+        ],
+      });
+    }
+  });
+
+  it('should update email step ui schema to html editor', async () => {
+    // run the migration
+    await run();
+
+    for (const workflow of workflows) {
+      const response = await session.testAgent.get(`/v2/workflows/${workflow}`);
+      const workflow1 = response.body.data;
+
+      expect(workflow1.steps[0].controls?.uiSchema?.group).to.equal(UiSchemaGroupEnum.EMAIL);
+      expect(workflow1.steps[0].controls?.uiSchema?.properties?.body?.component).to.equal(UiComponentEnum.EMAIL_BODY);
+      expect(workflow1.steps[0].controls?.uiSchema?.properties?.subject?.component).to.equal(
+        UiComponentEnum.TEXT_INLINE_LABEL
+      );
+      expect(workflow1.steps[0].controls?.uiSchema?.properties?.skip?.component).to.equal(UiComponentEnum.QUERY_EDITOR);
+      expect(workflow1.steps[0].controls?.uiSchema?.properties?.editorType?.component).to.equal(
+        UiComponentEnum.EMAIL_EDITOR_SELECT
+      );
+      expect(workflow1.steps[0].controls?.uiSchema?.properties?.editorType?.placeholder).to.equal('block');
+      expect(workflow1.steps[0].controls?.uiSchema?.properties?.disableOutputSanitization?.component).to.equal(
+        UiComponentEnum.DISABLE_SANITIZATION_SWITCH
+      );
+      expect(workflow1.steps[0].controls?.uiSchema?.properties?.disableOutputSanitization?.placeholder).to.equal(false);
+    }
+  });
+});

--- a/apps/api/migrations/email-step-ui-schema-html-editor/email-step-ui-schema-html-editor-migration.ts
+++ b/apps/api/migrations/email-step-ui-schema-html-editor/email-step-ui-schema-html-editor-migration.ts
@@ -1,0 +1,55 @@
+import '../../src/config';
+import { MessageTemplateRepository, OrganizationRepository } from '@novu/dal';
+import { NestFactory } from '@nestjs/core';
+import { PinoLogger } from '@novu/application-generic';
+import { UiComponentEnum } from '@novu/shared';
+import { AppModule } from '../../src/app.module';
+
+export async function run() {
+  const app = await NestFactory.create(AppModule, {
+    logger: false,
+  });
+  const logger = await app.resolve(PinoLogger);
+  logger.setContext('EmailStepUiSchemaHtmlEditorMigration');
+
+  logger.info('Start migration - update email step ui schema to html editor');
+
+  const organizationRepository = app.get(OrganizationRepository);
+  const messageTemplateRepository = app.get(MessageTemplateRepository);
+
+  const organizations = await organizationRepository.find({});
+
+  for (const organization of organizations) {
+    const messageTemplates = await messageTemplateRepository.find({
+      _organizationId: organization._id,
+      type: 'email',
+      'controls.uiSchema': { $exists: true },
+    });
+
+    logger.info(`Found ${messageTemplates.length} notification templates, for organization ${organization.name}`);
+
+    for (const notificationTemplate of messageTemplates) {
+      logger.info(`Update notification template ${notificationTemplate._id}`);
+      await messageTemplateRepository.update(
+        { _id: notificationTemplate._id, _organizationId: organization._id },
+        {
+          $set: {
+            'controls.uiSchema.properties.body': {
+              component: UiComponentEnum.EMAIL_BODY,
+            },
+            'controls.uiSchema.properties.editorType': {
+              component: UiComponentEnum.EMAIL_EDITOR_SELECT,
+              placeholder: 'block',
+            },
+          },
+        }
+      );
+      logger.info(`Updated notification template ${notificationTemplate._id}`);
+    }
+  }
+
+  logger.info('End migration.\n');
+  await app.close();
+}
+
+run();


### PR DESCRIPTION
### What changed? Why was the change needed?

Email Step UI Schema migration to support the new HTML editor type.

### Screenshots

![Screenshot 2025-06-13 at 13 58 23](https://github.com/user-attachments/assets/182e0551-48b5-49eb-9893-b1980dfbe432)

