### PR TITLE
fix(api-service): switching to html editor when preview fails

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -355,7 +355,7 @@ export class UpsertWorkflowUseCase {
             },
           })
         );
-        let htmlBody = (result.preview as EmailRenderOutput).body;
+        let htmlBody = (result.preview as EmailRenderOutput).body ?? '';
         htmlBody = this.removeBrandingFromHtml(htmlBody);
         emailControlValues.body = htmlBody;
       } else if (emailControlValues.editorType === 'block' && !isMaily) {


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixed the potential issue when switching to the HTML editor and the Preview usecase fails rendering the content.
I was not able to reproduce it, but Adam has noticed that on his staging account the `body` for some reason was set to `null` when he switched to the HTML editor.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
