### PR TITLE
style(dashboard): unify edit step content button text and icon fixes NV-6116

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
@@ -318,7 +318,7 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
                     className="flex w-full justify-start gap-1.5 text-xs font-medium"
                   >
                     <RiPencilRuler2Fill className="h-4 w-4 text-neutral-600" />
-                    Configure {STEP_TYPE_LABELS[step.type]} Step template{' '}
+                    Edit {STEP_TYPE_LABELS[step.type]} Step content{' '}
                     <RiArrowRightSLine className="ml-auto h-4 w-4 text-neutral-600" />
                   </Button>
                 </Link>

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
@@ -11,7 +11,7 @@ import {
 import { AnimatePresence, motion } from 'motion/react';
 import { HTMLAttributes, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { RiArrowLeftSLine, RiArrowRightSLine, RiCloseFill, RiDeleteBin2Line, RiPencilRuler2Fill } from 'react-icons/ri';
+import { RiArrowLeftSLine, RiArrowRightSLine, RiCloseFill, RiDeleteBin2Line, RiEdit2Line } from 'react-icons/ri';
 import { Link, useNavigate } from 'react-router-dom';
 import { z } from 'zod';
 
@@ -317,7 +317,7 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
                     mode="outline"
                     className="flex w-full justify-start gap-1.5 text-xs font-medium"
                   >
-                    <RiPencilRuler2Fill className="h-4 w-4 text-neutral-600" />
+                    <RiEdit2Line className="h-4 w-4 text-neutral-600" />
                     Edit {STEP_TYPE_LABELS[step.type]} Step content{' '}
                     <RiArrowRightSLine className="ml-auto h-4 w-4 text-neutral-600" />
                   </Button>

--- a/apps/dashboard/tests/page-object-models/step-config-sidebar.ts
+++ b/apps/dashboard/tests/page-object-models/step-config-sidebar.ts
@@ -36,7 +36,7 @@ export class StepConfigSidebar {
   }
 
   async configureTemplateClick(): Promise<void> {
-    const configureInAppTemplateBtn = this.page.getByRole('link').filter({ hasText: /Configure.* template/ });
+    const configureInAppTemplateBtn = this.page.getByRole('link').filter({ hasText: /Edit.* Step content/ });
     await configureInAppTemplateBtn.click();
   }
 


### PR DESCRIPTION
The "Configure {{channel}} Step template" text in the configure step drawer was updated to "Edit {{channel}} Step content" within `apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx`. This change aligns the wording with a more concise "Edit content" approach for improved consistency across the dashboard.

Concurrently, the associated icon was updated from `RiPencilRuler2Fill` to `RiEdit2Line` in the same file. This modification ensures the icon matches the one used in `workflow-node-action-bar.tsx`, creating a unified visual experience for edit actions throughout the interface.