### PR TITLE
docs(dashboard): Update documentation links in payload schema

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
@@ -220,7 +220,7 @@ export function PayloadSchemaDrawer({
                 </SheetTitle>
                 <SheetDescription className="text-paragraph-xs mt-0">
                   Manage workflow schema for reliable notifications.{' '}
-                  <ExternalLink href="https://docs.novu.co/platform/concepts/workflows">Learn more</ExternalLink>
+                  <ExternalLink href="https://docs.novu.co/platform/workflow/build-a-workflow#manage-payload-schema">Learn more</ExternalLink>
                 </SheetDescription>
               </SheetHeader>
               <Separator />
@@ -306,7 +306,7 @@ export function PayloadSchemaDrawer({
               </SheetMain>
               <SheetFooter className="border-neutral-content-weak space-between flex border-t px-3 py-1.5">
                 <div className="flex w-full flex-row items-center justify-between gap-2">
-                  <Link to="https://docs.novu.co/platform/concepts/payloads" target="_blank">
+                  <Link to="https://docs.novu.co/platform/workflow/build-a-workflow#manage-payload-schema" target="_blank">
                     <Button variant="secondary" mode="ghost" size="xs" leadingIcon={RiFileMarkedLine}>
                       View Docs
                     </Button>


### PR DESCRIPTION
Documentation links within the payload schema drawer in `apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx` were updated.

Specifically:
*   The "Learn more" link's `href` attribute was changed from `https://docs.novu.co/platform/concepts/workflows` to `https://docs.novu.co/platform/workflow/build-a-workflow#manage-payload-schema`.
*   The "View Docs" link's `to` attribute was changed from `https://docs.novu.co/platform/concepts/payloads` to `https://docs.novu.co/platform/workflow/build-a-workflow#manage-payload-schema`.

Both links now direct to the specified documentation section for managing payload schemas, ensuring consistency and accuracy in the provided resources.