### PR TITLE
Fix node command flag errors

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -54,7 +54,7 @@ ENV NX_DAEMON=false \
     NODE_ENV=local \
     PNPM_STORE_DIR="/tmp/.pnpm-store" \
     PNPM_CACHE_DIR="/tmp/.pnpm-cache" \
-    NODE_OPTIONS="--max-old-space-size=4096"
+    NODE_OPTIONS=--max-old-space-size=4096
 
 # Create minimal directory structure and set permissions
 RUN mkdir -p \

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -53,8 +53,7 @@ RUN npm --no-update-notifier --no-fund --global install \
 ENV NX_DAEMON=false \
     NODE_ENV=local \
     PNPM_STORE_DIR="/tmp/.pnpm-store" \
-    PNPM_CACHE_DIR="/tmp/.pnpm-cache" \
-    NODE_OPTIONS=--max-old-space-size=4096
+    PNPM_CACHE_DIR="/tmp/.pnpm-cache"
 
 # Create minimal directory structure and set permissions
 RUN mkdir -p \


### PR DESCRIPTION
The `NODE_OPTIONS` environment variable was removed from `.cursor/Dockerfile`.

Initially, the intention was to fix a flag duplication error (`--max-old-space-size=4096--max-old-space-size=4096`) by removing quotes from the `NODE_OPTIONS` value, as they were suspected to cause concatenation issues.

Following user feedback, the entire `NODE_OPTIONS` environment variable, which included `--max-old-space-size=4096`, was removed from the Dockerfile. This completely eliminates the source of the flag duplication and allows Node.js to operate with its default memory management settings, resolving the `illegal value for flag` error.