### PR TITLE
feat(dashboard): Add button for API key regeneration fixes NV-6142

### DIFF
--- a/apps/dashboard/src/api/environments.ts
+++ b/apps/dashboard/src/api/environments.ts
@@ -43,6 +43,6 @@ export async function deleteEnvironment({ environment }: { environment: IEnviron
   return del(`/environments/${environment._id}`);
 }
 
-export async function regenerateApiKeys(): Promise<{ data: IApiKey[] }> {
-  return post<{ data: IApiKey[] }>(`/environments/api-keys/regenerate`, {});
+export async function regenerateApiKeys({ environment }: { environment: IEnvironment }): Promise<{ data: IApiKey[] }> {
+  return post<{ data: IApiKey[] }>(`/environments/api-keys/regenerate`, { environment });
 }

--- a/apps/dashboard/src/api/environments.ts
+++ b/apps/dashboard/src/api/environments.ts
@@ -42,3 +42,7 @@ export async function createEnvironment(payload: { name: string; color: string }
 export async function deleteEnvironment({ environment }: { environment: IEnvironment }): Promise<void> {
   return del(`/environments/${environment._id}`);
 }
+
+export async function regenerateApiKeys(): Promise<{ data: IApiKey[] }> {
+  return post<{ data: IApiKey[] }>(`/environments/api-keys/regenerate`, {});
+}

--- a/apps/dashboard/src/components/regenerate-api-keys-dialog.tsx
+++ b/apps/dashboard/src/components/regenerate-api-keys-dialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogPortal,
   DialogTitle,
 } from '@/components/primitives/dialog';
-import { FormInput } from '@/components/primitives/form/form';
+import { Input } from '@/components/primitives/input';
 import { IEnvironment } from '@novu/shared';
 import { useState } from 'react';
 import { RiAlertFill } from 'react-icons/ri';
@@ -70,7 +70,7 @@ export const RegenerateApiKeysDialog = ({
             </div>
           </div>
           <div className="mt-4">
-            <FormInput
+            <Input
               placeholder={environment.name}
               value={environmentName}
               onChange={(e) => setEnvironmentName(e.target.value)}

--- a/apps/dashboard/src/components/regenerate-api-keys-dialog.tsx
+++ b/apps/dashboard/src/components/regenerate-api-keys-dialog.tsx
@@ -35,6 +35,7 @@ export const RegenerateApiKeysDialog = ({
     if (!newOpen) {
       setEnvironmentName('');
     }
+
     onOpenChange(newOpen);
   };
 
@@ -53,33 +54,50 @@ export const RegenerateApiKeysDialog = ({
     <Dialog modal open={open} onOpenChange={handleOpenChange}>
       <DialogPortal>
         <DialogOverlay />
-        <DialogContent className="overflow-hidden sm:max-w-[440px]">
+        <DialogContent className="overflow-hidden sm:max-w-[480px]">
           <div className="flex items-start gap-4 self-stretch">
             <div className="bg-warning/10 flex items-center justify-center gap-2 rounded-[10px] p-2">
               <RiAlertFill className="text-warning size-6" />
             </div>
-            <div className="flex flex-1 flex-col items-start gap-1">
+            <div className="flex flex-1 flex-col items-start gap-3">
               <DialogTitle className="text-md font-medium">Regenerate API Keys</DialogTitle>
-              <DialogDescription className="text-foreground-600">
-                This will invalidate all existing API keys for the <span className="font-bold">{environment.name}</span>{' '}
-                environment. All applications using the current keys will need to be updated with the new keys.
-                <br />
-                <br />
-                Type <span className="font-bold">{environment.name}</span> to confirm:
+              <DialogDescription className="text-foreground-600 space-y-3">
+                <p>
+                  This action will invalidate all existing API keys for the{' '}
+                  <span className="text-foreground-950 font-semibold">{environment.name}</span> environment.
+                </p>
+                <p className="text-sm">
+                  All applications using the current keys will need to be updated with the new keys immediately after
+                  regeneration.
+                </p>
               </DialogDescription>
+
+              <div className="w-full space-y-2">
+                <label htmlFor="environment-confirmation" className="text-foreground-700 text-sm font-medium">
+                  Type <span className="text-foreground-950 font-semibold">{environment.name}</span> to confirm
+                </label>
+                <Input
+                  id="environment-confirmation"
+                  placeholder={`Enter "${environment.name}" to confirm`}
+                  value={environmentName}
+                  onChange={(e) => setEnvironmentName(e.target.value)}
+                  autoFocus
+                  autoComplete="off"
+                  className="font-mono"
+                />
+              </div>
             </div>
           </div>
-          <div className="mt-4">
-            <Input
-              placeholder={environment.name}
-              value={environmentName}
-              onChange={(e) => setEnvironmentName(e.target.value)}
-              autoFocus
-            />
-          </div>
-          <DialogFooter>
+
+          <DialogFooter className="gap-3">
             <DialogClose asChild aria-label="Close">
-              <Button type="button" size="sm" mode="outline" variant="secondary" onClick={() => handleOpenChange(false)}>
+              <Button
+                type="button"
+                size="sm"
+                mode="outline"
+                variant="secondary"
+                onClick={() => handleOpenChange(false)}
+              >
                 Cancel
               </Button>
             </DialogClose>

--- a/apps/dashboard/src/components/regenerate-api-keys-dialog.tsx
+++ b/apps/dashboard/src/components/regenerate-api-keys-dialog.tsx
@@ -1,0 +1,102 @@
+import { Button } from '@/components/primitives/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from '@/components/primitives/dialog';
+import { FormInput } from '@/components/primitives/form/form';
+import { IEnvironment } from '@novu/shared';
+import { useState } from 'react';
+import { RiAlertFill } from 'react-icons/ri';
+
+interface RegenerateApiKeysDialogProps {
+  environment?: IEnvironment;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isLoading?: boolean;
+}
+
+export const RegenerateApiKeysDialog = ({
+  environment,
+  open,
+  onOpenChange,
+  onConfirm,
+  isLoading,
+}: RegenerateApiKeysDialogProps) => {
+  const [environmentName, setEnvironmentName] = useState('');
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      setEnvironmentName('');
+    }
+    onOpenChange(newOpen);
+  };
+
+  const handleConfirm = () => {
+    onConfirm();
+    setEnvironmentName('');
+  };
+
+  const isConfirmDisabled = environmentName !== environment?.name || isLoading;
+
+  if (!environment) {
+    return null;
+  }
+
+  return (
+    <Dialog modal open={open} onOpenChange={handleOpenChange}>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogContent className="overflow-hidden sm:max-w-[440px]">
+          <div className="flex items-start gap-4 self-stretch">
+            <div className="bg-warning/10 flex items-center justify-center gap-2 rounded-[10px] p-2">
+              <RiAlertFill className="text-warning size-6" />
+            </div>
+            <div className="flex flex-1 flex-col items-start gap-1">
+              <DialogTitle className="text-md font-medium">Regenerate API Keys</DialogTitle>
+              <DialogDescription className="text-foreground-600">
+                This will invalidate all existing API keys for the <span className="font-bold">{environment.name}</span>{' '}
+                environment. All applications using the current keys will need to be updated with the new keys.
+                <br />
+                <br />
+                Type <span className="font-bold">{environment.name}</span> to confirm:
+              </DialogDescription>
+            </div>
+          </div>
+          <div className="mt-4">
+            <FormInput
+              placeholder={environment.name}
+              value={environmentName}
+              onChange={(e) => setEnvironmentName(e.target.value)}
+              autoFocus
+            />
+          </div>
+          <DialogFooter>
+            <DialogClose asChild aria-label="Close">
+              <Button type="button" size="sm" mode="outline" variant="secondary" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+            </DialogClose>
+
+            <Button
+              type="button"
+              size="sm"
+              variant="error"
+              onClick={handleConfirm}
+              isLoading={isLoading}
+              disabled={isConfirmDisabled}
+            >
+              Regenerate Keys
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
+  );
+};

--- a/apps/dashboard/src/hooks/use-fetch-api-keys.ts
+++ b/apps/dashboard/src/hooks/use-fetch-api-keys.ts
@@ -1,8 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { QueryKeys } from '@/utils/query-keys';
 import { useEnvironment } from '@/context/environment/hooks';
 import { IApiKey } from '@novu/shared';
-import { getApiKeys } from '../api/environments';
+import { getApiKeys, regenerateApiKeys } from '../api/environments';
 
 export const useFetchApiKeys = ({ enabled = true }: { enabled?: boolean } = {}) => {
   const { currentEnvironment } = useEnvironment();
@@ -14,4 +14,19 @@ export const useFetchApiKeys = ({ enabled = true }: { enabled?: boolean } = {}) 
   });
 
   return query;
+};
+
+export const useRegenerateApiKeys = () => {
+  const { currentEnvironment } = useEnvironment();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: regenerateApiKeys,
+    onSuccess: () => {
+      // Invalidate the API keys query to refetch the new keys
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.getApiKeys, currentEnvironment?._id],
+      });
+    },
+  });
 };

--- a/apps/dashboard/src/hooks/use-fetch-api-keys.ts
+++ b/apps/dashboard/src/hooks/use-fetch-api-keys.ts
@@ -21,7 +21,7 @@ export const useRegenerateApiKeys = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: regenerateApiKeys,
+    mutationFn: () => regenerateApiKeys({ environment: currentEnvironment! }),
     onSuccess: () => {
       // Invalidate the API keys query to refetch the new keys
       queryClient.invalidateQueries({

--- a/apps/dashboard/src/pages/api-keys.tsx
+++ b/apps/dashboard/src/pages/api-keys.tsx
@@ -8,12 +8,18 @@ import { ExternalLink } from '@/components/shared/external-link';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { RiEyeLine, RiEyeOffLine } from 'react-icons/ri';
+import { RiEyeLine, RiEyeOffLine, RiLoopRightFill } from 'react-icons/ri';
 import { DashboardLayout } from '../components/dashboard-layout';
 import { Container } from '../components/primitives/container';
 import { HelpTooltipIndicator } from '../components/primitives/help-tooltip-indicator';
 import { API_HOSTNAME } from '../config';
-import { useFetchApiKeys } from '../hooks/use-fetch-api-keys';
+import { useFetchApiKeys, useRegenerateApiKeys } from '../hooks/use-fetch-api-keys';
+import { RegenerateApiKeysDialog } from '../components/regenerate-api-keys-dialog';
+import { showErrorToast, showSuccessToast } from '../components/primitives/sonner-helpers';
+import { CompactButton } from '../components/primitives/button-compact';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../components/primitives/tooltip';
+import { PermissionsEnum } from '@novu/shared';
+import { useHasPermission } from '../hooks/use-has-permission';
 
 interface ApiKeysFormData {
   apiKey: string;
@@ -26,6 +32,10 @@ export function ApiKeysPage() {
   const { currentEnvironment } = useEnvironment();
   const apiKeys = apiKeysQuery.data?.data;
   const isLoading = apiKeysQuery.isLoading;
+  const [isRegenerateDialogOpen, setIsRegenerateDialogOpen] = useState(false);
+  const regenerateApiKeysMutation = useRegenerateApiKeys();
+  const has = useHasPermission();
+  const canRegenerateApiKeys = has({ permission: PermissionsEnum.API_KEY_WRITE });
 
   const form = useForm<ApiKeysFormData>({
     values: {
@@ -34,6 +44,17 @@ export function ApiKeysPage() {
       identifier: currentEnvironment?.identifier ?? '',
     },
   });
+
+  const handleRegenerateKeys = async () => {
+    try {
+      await regenerateApiKeysMutation.mutateAsync();
+      showSuccessToast('API keys regenerated successfully');
+      setIsRegenerateDialogOpen(false);
+    } catch (e: any) {
+      const message = e?.message || 'Failed to regenerate API keys';
+      showErrorToast(message);
+    }
+  };
 
   if (!currentEnvironment) {
     return null;
@@ -87,6 +108,9 @@ export function ApiKeysPage() {
                     value={form.getValues('apiKey')}
                     secret
                     isLoading={isLoading}
+                    showRegenerateButton={canRegenerateApiKeys}
+                    onRegenerateClick={() => setIsRegenerateDialogOpen(true)}
+                    isRegenerateLoading={regenerateApiKeysMutation.isPending}
                   />
                 </div>
               </CardContent>
@@ -114,6 +138,13 @@ export function ApiKeysPage() {
           </Form>
         </Container>
       </DashboardLayout>
+      <RegenerateApiKeysDialog
+        environment={currentEnvironment}
+        open={isRegenerateDialogOpen}
+        onOpenChange={setIsRegenerateDialogOpen}
+        onConfirm={handleRegenerateKeys}
+        isLoading={regenerateApiKeysMutation.isPending}
+      />
     </>
   );
 }
@@ -125,6 +156,9 @@ interface SettingFieldProps {
   secret?: boolean;
   isLoading?: boolean;
   readOnly?: boolean;
+  showRegenerateButton?: boolean;
+  onRegenerateClick?: () => void;
+  isRegenerateLoading?: boolean;
 }
 
 function SettingField({
@@ -134,6 +168,9 @@ function SettingField({
   secret = false,
   isLoading = false,
   readOnly = true,
+  showRegenerateButton = false,
+  onRegenerateClick,
+  isRegenerateLoading,
 }: SettingFieldProps) {
   const [showSecret, setShowSecret] = useState(false);
 
@@ -156,6 +193,7 @@ function SettingField({
           <>
             <Skeleton className="h-[38px] flex-1 rounded-lg" />
             {secret && <Skeleton className="h-[38px] w-[38px] rounded-lg" />}
+            {showRegenerateButton && <Skeleton className="h-[38px] w-[38px] rounded-lg" />}
           </>
         ) : (
           <>
@@ -176,6 +214,20 @@ function SettingField({
                 )
               }
             />
+            {showRegenerateButton && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <CompactButton
+                    size="md"
+                    variant="stroke"
+                    icon={RiLoopRightFill}
+                    onClick={onRegenerateClick}
+                    disabled={isRegenerateLoading}
+                  />
+                </TooltipTrigger>
+                <TooltipContent>Regenerate API Key</TooltipContent>
+              </Tooltip>
+            )}
           </>
         )}
       </div>

--- a/apps/dashboard/src/pages/api-keys.tsx
+++ b/apps/dashboard/src/pages/api-keys.tsx
@@ -218,11 +218,12 @@ function SettingField({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <CompactButton
-                    size="md"
+                    size="lg"
                     variant="stroke"
                     icon={RiLoopRightFill}
                     onClick={onRegenerateClick}
                     disabled={isRegenerateLoading}
+                    className="h-[38px] w-[38px]"
                   />
                 </TooltipTrigger>
                 <TooltipContent>Regenerate API Key</TooltipContent>

--- a/apps/dashboard/src/pages/api-keys.tsx
+++ b/apps/dashboard/src/pages/api-keys.tsx
@@ -16,7 +16,7 @@ import { API_HOSTNAME } from '../config';
 import { useFetchApiKeys, useRegenerateApiKeys } from '../hooks/use-fetch-api-keys';
 import { RegenerateApiKeysDialog } from '../components/regenerate-api-keys-dialog';
 import { showErrorToast, showSuccessToast } from '../components/primitives/sonner-helpers';
-import { CompactButton } from '../components/primitives/button-compact';
+import { Button } from '../components/primitives/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../components/primitives/tooltip';
 import { PermissionsEnum } from '@novu/shared';
 import { useHasPermission } from '../hooks/use-has-permission';
@@ -217,14 +217,16 @@ function SettingField({
             {showRegenerateButton && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <CompactButton
-                    size="lg"
-                    variant="stroke"
-                    icon={RiLoopRightFill}
+                  <Button
+                    size="md"
+                    variant="secondary"
+                    mode="outline"
                     onClick={onRegenerateClick}
                     disabled={isRegenerateLoading}
-                    className="h-[38px] w-[38px]"
-                  />
+                    className="h-[38px] min-w-[38px] p-0"
+                  >
+                    <RiLoopRightFill className="h-4 w-4" />
+                  </Button>
                 </TooltipTrigger>
                 <TooltipContent>Regenerate API Key</TooltipContent>
               </Tooltip>


### PR DESCRIPTION
https://www.loom.com/share/3ab664116ccb45c291b4a02f7d119798

API key regeneration functionality was added to the environments page.

*   A `regenerateApiKeys()` function was added to `apps/dashboard/src/api/environments.ts` to call the existing API endpoint.
*   A `useRegenerateApiKeys()` React Query hook was created in `apps/dashboard/src/hooks/use-fetch-api-keys.ts` to handle the mutation and invalidate API key queries on success.
*   A new `RegenerateApiKeysDialog` component was introduced in `apps/dashboard/src/components/regenerate-api-keys-dialog.tsx`. This dialog requires users to type the environment name for confirmation, ensuring consistency with existing platform dialogs.
*   The `SettingField` component, used within `apps/dashboard/src/pages/api-keys.tsx`, was enhanced to display a "Regenerate API Key" button next to the Secret Key field.
*   The button uses the `RiLoopRightFill` icon and includes a tooltip.
*   Permission checks using `PermissionsEnum.API_KEY_WRITE` ensure the button is only visible to authorized users.
*   Success/error toasts and loading states were integrated for improved user experience.