### PR TITLE
feat(api-service): get, delete, duplicate layout endpoints

### DIFF
--- a/apps/api/src/app/layouts-v2/layouts.controller.ts
+++ b/apps/api/src/app/layouts-v2/layouts.controller.ts
@@ -142,6 +142,7 @@ export class LayoutsController {
   }
 
   @Post(':layoutId/duplicate')
+  @ExternalApiAccessible()
   @ApiOperation({
     summary: 'Duplicate a layout',
     description:

--- a/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.spec.ts
+++ b/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.spec.ts
@@ -1,0 +1,312 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { ConflictException } from '@nestjs/common';
+import {
+  AnalyticsService,
+  GetLayoutCommand as GetLayoutCommandV1,
+  GetLayoutUseCase as GetLayoutUseCaseV1,
+} from '@novu/application-generic';
+import { LayoutRepository, ControlValuesRepository } from '@novu/dal';
+import { ChannelTypeEnum, ControlValuesLevelEnum, ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
+
+import { DeleteLayoutUseCase } from './delete-layout.use-case';
+import { DeleteLayoutCommand } from './delete-layout.command';
+
+describe('DeleteLayoutUseCase', () => {
+  let getLayoutUseCaseV1Mock: sinon.SinonStubbedInstance<GetLayoutUseCaseV1>;
+  let layoutRepositoryMock: sinon.SinonStubbedInstance<LayoutRepository>;
+  let controlValuesRepositoryMock: sinon.SinonStubbedInstance<ControlValuesRepository>;
+  let analyticsServiceMock: sinon.SinonStubbedInstance<AnalyticsService>;
+  let deleteLayoutUseCase: DeleteLayoutUseCase;
+
+  const mockUser = {
+    _id: 'user_id',
+    environmentId: 'env_id',
+    organizationId: 'org_id',
+  };
+
+  const mockLayout = {
+    _id: 'layout_id',
+    identifier: 'layout_identifier',
+    name: 'Test Layout',
+    isDefault: false,
+    createdAt: '2023-01-01T00:00:00Z',
+    updatedAt: '2023-01-01T00:00:00Z',
+    _environmentId: 'env_id',
+    _organizationId: 'org_id',
+    origin: ResourceOriginEnum.NOVU_CLOUD,
+    type: ResourceTypeEnum.BRIDGE,
+    channel: ChannelTypeEnum.EMAIL,
+  };
+
+  const mockDefaultLayout = {
+    ...mockLayout,
+    isDefault: true,
+    name: 'Default Layout',
+  };
+
+  const mockStepControlValues = [
+    {
+      _id: 'step_control_1',
+      _environmentId: 'env_id',
+      _organizationId: 'org_id',
+      level: ControlValuesLevelEnum.STEP_CONTROLS,
+      controls: {
+        email: {
+          layoutId: 'layout_id',
+          subject: 'Test Subject',
+        },
+      },
+    },
+    {
+      _id: 'step_control_2',
+      _environmentId: 'env_id',
+      _organizationId: 'org_id',
+      level: ControlValuesLevelEnum.STEP_CONTROLS,
+      controls: {
+        email: {
+          layoutId: 'layout_id',
+          body: 'Test Body',
+        },
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    getLayoutUseCaseV1Mock = sinon.createStubInstance(GetLayoutUseCaseV1);
+    layoutRepositoryMock = sinon.createStubInstance(LayoutRepository);
+    controlValuesRepositoryMock = sinon.createStubInstance(ControlValuesRepository);
+    analyticsServiceMock = sinon.createStubInstance(AnalyticsService);
+
+    deleteLayoutUseCase = new DeleteLayoutUseCase(
+      getLayoutUseCaseV1Mock as any,
+      layoutRepositoryMock as any,
+      controlValuesRepositoryMock as any,
+      analyticsServiceMock as any
+    );
+
+    // Default mocks
+    getLayoutUseCaseV1Mock.execute.resolves(mockLayout as any);
+    controlValuesRepositoryMock.findMany.resolves(mockStepControlValues as any);
+    controlValuesRepositoryMock.updateOne.resolves({} as any);
+    controlValuesRepositoryMock.delete.resolves({} as any);
+    layoutRepositoryMock.deleteLayout.resolves();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('execute', () => {
+    it('should successfully delete non-default layout', async () => {
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      await deleteLayoutUseCase.execute(command);
+
+      // Verify v1 use case was called with correct parameters
+      expect(getLayoutUseCaseV1Mock.execute.calledOnce).to.be.true;
+      const v1Command = getLayoutUseCaseV1Mock.execute.firstCall.args[0];
+      expect(v1Command.layoutIdOrInternalId).to.equal('layout_identifier');
+      expect(v1Command.environmentId).to.equal('env_id');
+      expect(v1Command.organizationId).to.equal('org_id');
+      expect(v1Command.type).to.equal(ResourceTypeEnum.BRIDGE);
+      expect(v1Command.origin).to.equal(ResourceOriginEnum.NOVU_CLOUD);
+
+      // Verify layout was deleted from repository
+      expect(layoutRepositoryMock.deleteLayout.calledOnce).to.be.true;
+      expect(layoutRepositoryMock.deleteLayout.firstCall.args).to.deep.equal(['layout_id', 'env_id', 'org_id']);
+
+      // Verify control values were deleted
+      expect(controlValuesRepositoryMock.delete.calledOnce).to.be.true;
+      expect(controlValuesRepositoryMock.delete.firstCall.args[0]).to.deep.equal({
+        _environmentId: 'env_id',
+        _organizationId: 'org_id',
+        _layoutId: 'layout_id',
+        level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+      });
+    });
+
+    it('should throw ConflictException when trying to delete default layout', async () => {
+      getLayoutUseCaseV1Mock.execute.resolves(mockDefaultLayout as any);
+
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'default_layout',
+        user: mockUser as any,
+      });
+
+      try {
+        await deleteLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.be.instanceOf(ConflictException);
+        expect(error.message).to.include('is being used as a default layout, it can not be deleted');
+      }
+
+      // Verify layout was not deleted
+      expect(layoutRepositoryMock.deleteLayout.called).to.be.false;
+    });
+
+    it('should remove layout references from step controls', async () => {
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      await deleteLayoutUseCase.execute(command);
+
+      // Verify findMany was called to get step controls
+      expect(controlValuesRepositoryMock.findMany.calledOnce).to.be.true;
+      expect(controlValuesRepositoryMock.findMany.firstCall.args[0]).to.deep.equal({
+        _environmentId: 'env_id',
+        _organizationId: 'org_id',
+        level: ControlValuesLevelEnum.STEP_CONTROLS,
+        'controls.layoutId': 'layout_id',
+      });
+
+      // Verify updateOne was called for each step control
+      expect(controlValuesRepositoryMock.updateOne.callCount).to.equal(2);
+
+      // Check first update call
+      expect(controlValuesRepositoryMock.updateOne.firstCall.args[0]).to.deep.equal({
+        _id: 'step_control_1',
+        _environmentId: 'env_id',
+        _organizationId: 'org_id',
+      });
+      expect(controlValuesRepositoryMock.updateOne.firstCall.args[1]).to.deep.equal({
+        $unset: { 'controls.layoutId': '' },
+      });
+
+      // Check second update call
+      expect(controlValuesRepositoryMock.updateOne.secondCall.args[0]).to.deep.equal({
+        _id: 'step_control_2',
+        _environmentId: 'env_id',
+        _organizationId: 'org_id',
+      });
+      expect(controlValuesRepositoryMock.updateOne.secondCall.args[1]).to.deep.equal({
+        $unset: { 'controls.layoutId': '' },
+      });
+    });
+
+    it('should handle case where no step controls reference the layout', async () => {
+      controlValuesRepositoryMock.findMany.resolves([]);
+
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      await deleteLayoutUseCase.execute(command);
+
+      // Verify findMany was still called
+      expect(controlValuesRepositoryMock.findMany.calledOnce).to.be.true;
+
+      // Verify updateOne was not called since no step controls exist
+      expect(controlValuesRepositoryMock.updateOne.called).to.be.false;
+
+      // Verify layout was still deleted
+      expect(layoutRepositoryMock.deleteLayout.calledOnce).to.be.true;
+    });
+
+    it('should track analytics event', async () => {
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      await deleteLayoutUseCase.execute(command);
+
+      expect(analyticsServiceMock.track.calledOnce).to.be.true;
+      expect(analyticsServiceMock.track.firstCall.args[0]).to.equal('Delete layout - [Layouts]');
+      expect(analyticsServiceMock.track.firstCall.args[1]).to.equal('user_id');
+      expect(analyticsServiceMock.track.firstCall.args[2]).to.deep.equal({
+        _organizationId: 'org_id',
+        _environmentId: 'env_id',
+        layoutId: 'layout_id',
+      });
+    });
+
+    it('should propagate error from v1 use case', async () => {
+      const error = new Error('Layout not found');
+      getLayoutUseCaseV1Mock.execute.rejects(error);
+
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'non_existent',
+        user: mockUser as any,
+      });
+
+      try {
+        await deleteLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (thrownError) {
+        expect(thrownError.message).to.equal('Layout not found');
+      }
+    });
+
+    it('should propagate error from step controls cleanup', async () => {
+      const error = new Error('Database error');
+      controlValuesRepositoryMock.findMany.rejects(error);
+
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      try {
+        await deleteLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (thrownError) {
+        expect(thrownError.message).to.equal('Database error');
+      }
+    });
+
+    it('should propagate error from step controls update', async () => {
+      const error = new Error('Update error');
+      controlValuesRepositoryMock.updateOne.rejects(error);
+
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      try {
+        await deleteLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (thrownError) {
+        expect(thrownError.message).to.equal('Update error');
+      }
+    });
+
+    it('should propagate error from layout deletion', async () => {
+      const error = new Error('Delete error');
+      layoutRepositoryMock.deleteLayout.rejects(error);
+
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      try {
+        await deleteLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (thrownError) {
+        expect(thrownError.message).to.equal('Delete error');
+      }
+    });
+
+    it('should validate deletion order: step controls cleanup before layout deletion', async () => {
+      const command = DeleteLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      await deleteLayoutUseCase.execute(command);
+
+      // Verify step controls operations were called before layout deletion
+      expect(controlValuesRepositoryMock.findMany.calledBefore(layoutRepositoryMock.deleteLayout)).to.be.true;
+      expect(controlValuesRepositoryMock.updateOne.calledBefore(layoutRepositoryMock.deleteLayout)).to.be.true;
+    });
+  });
+});

--- a/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.ts
+++ b/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.ts
@@ -1,9 +1,87 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ConflictException } from '@nestjs/common';
+import {
+  GetLayoutCommand as GetLayoutCommandV1,
+  GetLayoutUseCase as GetLayoutUseCaseV1,
+  AnalyticsService,
+} from '@novu/application-generic';
+import { LayoutRepository, ControlValuesRepository } from '@novu/dal';
+import { ControlValuesLevelEnum, ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
+
 import { DeleteLayoutCommand } from './delete-layout.command';
 
 @Injectable()
 export class DeleteLayoutUseCase {
+  constructor(
+    private getLayoutUseCaseV1: GetLayoutUseCaseV1,
+    private layoutRepository: LayoutRepository,
+    private controlValuesRepository: ControlValuesRepository,
+    private analyticsService: AnalyticsService
+  ) {}
+
   async execute(command: DeleteLayoutCommand): Promise<void> {
-    throw new Error('Method not implemented.');
+    const layout = await this.getLayoutUseCaseV1.execute(
+      GetLayoutCommandV1.create({
+        layoutIdOrInternalId: command.layoutIdOrInternalId,
+        environmentId: command.user.environmentId,
+        organizationId: command.user.organizationId,
+        type: ResourceTypeEnum.BRIDGE,
+        origin: ResourceOriginEnum.NOVU_CLOUD,
+      })
+    );
+
+    if (layout.isDefault) {
+      throw new ConflictException(
+        `Layout with id ${command.layoutIdOrInternalId} is being used as a default layout, it can not be deleted`
+      );
+    }
+
+    await this.removeLayoutReferencesFromStepControls({
+      layoutId: layout._id!,
+      environmentId: layout._environmentId,
+      organizationId: layout._organizationId,
+    });
+
+    await this.layoutRepository.deleteLayout(layout._id!, layout._environmentId, layout._organizationId);
+
+    await this.controlValuesRepository.delete({
+      _environmentId: command.user.environmentId,
+      _organizationId: command.user.organizationId,
+      _layoutId: layout._id!,
+      level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+    });
+
+    this.analyticsService.track('Delete layout - [Layouts]', command.user._id, {
+      _organizationId: command.user.organizationId,
+      _environmentId: command.user.environmentId,
+      layoutId: layout._id!,
+    });
+  }
+
+  private async removeLayoutReferencesFromStepControls({
+    layoutId,
+    environmentId,
+    organizationId,
+  }: {
+    layoutId: string;
+    environmentId: string;
+    organizationId: string;
+  }): Promise<void> {
+    const stepControlValues = await this.controlValuesRepository.findMany({
+      level: ControlValuesLevelEnum.STEP_CONTROLS,
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+      'controls.layoutId': layoutId,
+    });
+
+    for (const controlValue of stepControlValues) {
+      await this.controlValuesRepository.updateOne(
+        {
+          _id: controlValue._id,
+          _environmentId: environmentId,
+          _organizationId: organizationId,
+        },
+        { $unset: { 'controls.layoutId': '' } }
+      );
+    }
   }
 }

--- a/apps/api/src/app/layouts-v2/usecases/duplicate-layout/duplicate-layout.use-case.spec.ts
+++ b/apps/api/src/app/layouts-v2/usecases/duplicate-layout/duplicate-layout.use-case.spec.ts
@@ -1,0 +1,318 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import {
+  AnalyticsService,
+  GetLayoutCommand as GetLayoutCommandV1,
+  GetLayoutUseCase as GetLayoutUseCaseV1,
+} from '@novu/application-generic';
+import { ControlValuesRepository } from '@novu/dal';
+import { ChannelTypeEnum, ControlValuesLevelEnum, ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
+
+import { DuplicateLayoutUseCase } from './duplicate-layout.use-case';
+import { DuplicateLayoutCommand } from './duplicate-layout.command';
+import { UpsertLayoutUseCase } from '../upsert-layout';
+
+describe('DuplicateLayoutUseCase', () => {
+  let getLayoutUseCaseV1Mock: sinon.SinonStubbedInstance<GetLayoutUseCaseV1>;
+  let upsertLayoutUseCaseMock: sinon.SinonStubbedInstance<UpsertLayoutUseCase>;
+  let controlValuesRepositoryMock: sinon.SinonStubbedInstance<ControlValuesRepository>;
+  let analyticsServiceMock: sinon.SinonStubbedInstance<AnalyticsService>;
+  let duplicateLayoutUseCase: DuplicateLayoutUseCase;
+
+  const mockUser = {
+    _id: 'user_id',
+    environmentId: 'env_id',
+    organizationId: 'org_id',
+  };
+
+  const mockOriginalLayout = {
+    _id: 'original_layout_id',
+    identifier: 'original_layout_identifier',
+    name: 'Original Layout',
+    isDefault: false,
+    createdAt: '2023-01-01T00:00:00Z',
+    updatedAt: '2023-01-01T00:00:00Z',
+    _environmentId: 'env_id',
+    _organizationId: 'org_id',
+    origin: ResourceOriginEnum.NOVU_CLOUD,
+    type: ResourceTypeEnum.BRIDGE,
+    channel: ChannelTypeEnum.EMAIL,
+  };
+
+  const mockOriginalControlValues = {
+    _id: 'original_control_values_id',
+    _environmentId: 'env_id',
+    _organizationId: 'org_id',
+    _layoutId: 'original_layout_id',
+    level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+    controls: {
+      email: {
+        content: '<html><body>{{content}}</body></html>',
+        subject: 'Original Subject',
+      },
+    },
+  };
+
+  const mockDuplicatedLayout = {
+    _id: 'duplicated_layout_id',
+    layoutId: 'duplicated_layout_identifier',
+    name: 'Duplicated Layout',
+    isDefault: false,
+    createdAt: '2023-01-02T00:00:00Z',
+    updatedAt: '2023-01-02T00:00:00Z',
+    _environmentId: 'env_id',
+    _organizationId: 'org_id',
+    origin: ResourceOriginEnum.NOVU_CLOUD,
+    type: ResourceTypeEnum.BRIDGE,
+    controls: {
+      schema: {},
+      values: {
+        email: mockOriginalControlValues.controls.email,
+      },
+    },
+  };
+
+  const mockOverrides = {
+    name: 'Duplicated Layout',
+  };
+
+  beforeEach(() => {
+    getLayoutUseCaseV1Mock = sinon.createStubInstance(GetLayoutUseCaseV1);
+    upsertLayoutUseCaseMock = sinon.createStubInstance(UpsertLayoutUseCase);
+    controlValuesRepositoryMock = sinon.createStubInstance(ControlValuesRepository);
+    analyticsServiceMock = sinon.createStubInstance(AnalyticsService);
+
+    duplicateLayoutUseCase = new DuplicateLayoutUseCase(
+      getLayoutUseCaseV1Mock as any,
+      upsertLayoutUseCaseMock as any,
+      controlValuesRepositoryMock as any,
+      analyticsServiceMock as any
+    );
+
+    // Default mocks
+    getLayoutUseCaseV1Mock.execute.resolves(mockOriginalLayout as any);
+    controlValuesRepositoryMock.findOne.resolves(mockOriginalControlValues as any);
+    upsertLayoutUseCaseMock.execute.resolves(mockDuplicatedLayout as any);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('execute', () => {
+    it('should successfully duplicate layout with control values', async () => {
+      const command = DuplicateLayoutCommand.create({
+        layoutIdOrInternalId: 'original_layout_identifier',
+        overrides: mockOverrides,
+        user: mockUser as any,
+      });
+
+      const result = await duplicateLayoutUseCase.execute(command);
+
+      expect(result).to.deep.equal(mockDuplicatedLayout);
+
+      // Verify v1 use case was called with correct parameters
+      expect(getLayoutUseCaseV1Mock.execute.calledOnce).to.be.true;
+      const v1Command = getLayoutUseCaseV1Mock.execute.firstCall.args[0];
+      expect(v1Command.layoutIdOrInternalId).to.equal('original_layout_identifier');
+      expect(v1Command.environmentId).to.equal('env_id');
+      expect(v1Command.organizationId).to.equal('org_id');
+      expect(v1Command.type).to.equal(ResourceTypeEnum.BRIDGE);
+      expect(v1Command.origin).to.equal(ResourceOriginEnum.NOVU_CLOUD);
+
+      // Verify control values repository was called
+      expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.true;
+      expect(controlValuesRepositoryMock.findOne.firstCall.args[0]).to.deep.equal({
+        _environmentId: 'env_id',
+        _organizationId: 'org_id',
+        _layoutId: 'original_layout_id',
+        level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+      });
+
+      // Verify upsert use case was called with correct parameters
+      expect(upsertLayoutUseCaseMock.execute.calledOnce).to.be.true;
+      const upsertCommand = upsertLayoutUseCaseMock.execute.firstCall.args[0];
+      expect(upsertCommand.layoutDto.name).to.equal('Duplicated Layout');
+      expect(upsertCommand.layoutDto.controlValues).to.deep.equal(mockOriginalControlValues.controls);
+      expect(upsertCommand.user).to.deep.equal(mockUser);
+    });
+
+    it('should duplicate layout without control values when none exist', async () => {
+      controlValuesRepositoryMock.findOne.resolves(null);
+
+      const command = DuplicateLayoutCommand.create({
+        layoutIdOrInternalId: 'original_layout_identifier',
+        overrides: mockOverrides,
+        user: mockUser as any,
+      });
+
+      const result = await duplicateLayoutUseCase.execute(command);
+
+      expect(result).to.deep.equal(mockDuplicatedLayout);
+
+      // Verify control values repository was called
+      expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.true;
+
+      // Verify upsert use case was called with null control values
+      expect(upsertLayoutUseCaseMock.execute.calledOnce).to.be.true;
+      const upsertCommand = upsertLayoutUseCaseMock.execute.firstCall.args[0];
+      expect(upsertCommand.layoutDto.controlValues).to.be.null;
+    });
+
+    it('should handle empty control values controls', async () => {
+      const controlValuesWithEmptyControls = {
+        ...mockOriginalControlValues,
+        controls: undefined,
+      };
+      controlValuesRepositoryMock.findOne.resolves(controlValuesWithEmptyControls as any);
+
+      const command = DuplicateLayoutCommand.create({
+        layoutIdOrInternalId: 'original_layout_identifier',
+        overrides: mockOverrides,
+        user: mockUser as any,
+      });
+
+      const result = await duplicateLayoutUseCase.execute(command);
+
+      expect(result).to.deep.equal(mockDuplicatedLayout);
+
+      // Verify upsert use case was called with null control values
+      expect(upsertLayoutUseCaseMock.execute.calledOnce).to.be.true;
+      const upsertCommand = upsertLayoutUseCaseMock.execute.firstCall.args[0];
+      expect(upsertCommand.layoutDto.controlValues).to.be.null;
+    });
+
+    it('should track analytics event', async () => {
+      const command = DuplicateLayoutCommand.create({
+        layoutIdOrInternalId: 'original_layout_identifier',
+        overrides: mockOverrides,
+        user: mockUser as any,
+      });
+
+      await duplicateLayoutUseCase.execute(command);
+
+      expect(analyticsServiceMock.track.calledOnce).to.be.true;
+      expect(analyticsServiceMock.track.firstCall.args[0]).to.equal('Duplicate layout - [Layouts]');
+      expect(analyticsServiceMock.track.firstCall.args[1]).to.equal('user_id');
+      expect(analyticsServiceMock.track.firstCall.args[2]).to.deep.equal({
+        _organizationId: 'org_id',
+        _environmentId: 'env_id',
+        originalLayoutId: 'original_layout_id',
+        duplicatedLayoutId: 'duplicated_layout_id',
+      });
+    });
+
+    it('should use override name correctly', async () => {
+      const customOverrides = {
+        name: 'Custom Duplicated Name',
+      };
+
+      const command = DuplicateLayoutCommand.create({
+        layoutIdOrInternalId: 'original_layout_identifier',
+        overrides: customOverrides,
+        user: mockUser as any,
+      });
+
+      await duplicateLayoutUseCase.execute(command);
+
+      expect(upsertLayoutUseCaseMock.execute.calledOnce).to.be.true;
+      const upsertCommand = upsertLayoutUseCaseMock.execute.firstCall.args[0];
+      expect(upsertCommand.layoutDto.name).to.equal('Custom Duplicated Name');
+    });
+
+    it('should propagate error from v1 use case', async () => {
+      const error = new Error('Layout not found');
+      getLayoutUseCaseV1Mock.execute.rejects(error);
+
+      const command = DuplicateLayoutCommand.create({
+        layoutIdOrInternalId: 'non_existent',
+        overrides: mockOverrides,
+        user: mockUser as any,
+      });
+
+      try {
+        await duplicateLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (thrownError) {
+        expect(thrownError.message).to.equal('Layout not found');
+      }
+    });
+
+    it('should propagate error from control values repository', async () => {
+      const error = new Error('Database error');
+      controlValuesRepositoryMock.findOne.rejects(error);
+
+      const command = DuplicateLayoutCommand.create({
+        layoutIdOrInternalId: 'original_layout_identifier',
+        overrides: mockOverrides,
+        user: mockUser as any,
+      });
+
+      try {
+        await duplicateLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (thrownError) {
+        expect(thrownError.message).to.equal('Database error');
+      }
+    });
+
+    it('should propagate error from upsert use case', async () => {
+      const error = new Error('Upsert error');
+      upsertLayoutUseCaseMock.execute.rejects(error);
+
+      const command = DuplicateLayoutCommand.create({
+        layoutIdOrInternalId: 'original_layout_identifier',
+        overrides: mockOverrides,
+        user: mockUser as any,
+      });
+
+      try {
+        await duplicateLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (thrownError) {
+        expect(thrownError.message).to.equal('Upsert error');
+      }
+    });
+
+    it('should validate execution order: get original before duplicate creation', async () => {
+      const command = DuplicateLayoutCommand.create({
+        layoutIdOrInternalId: 'original_layout_identifier',
+        overrides: mockOverrides,
+        user: mockUser as any,
+      });
+
+      await duplicateLayoutUseCase.execute(command);
+
+      // Verify original layout was fetched before duplication
+      expect(getLayoutUseCaseV1Mock.execute.calledBefore(upsertLayoutUseCaseMock.execute)).to.be.true;
+      expect(controlValuesRepositoryMock.findOne.calledBefore(upsertLayoutUseCaseMock.execute)).to.be.true;
+    });
+
+    it('should preserve original layout control values structure', async () => {
+      const complexControlValues = {
+        ...mockOriginalControlValues,
+        controls: {
+          email: {
+            content: '<html><head><style>body { margin: 0; }</style></head><body>{{content}}</body></html>',
+            subject: 'Complex Subject {{payload.name}}',
+            preheader: 'Preview text',
+            customField: 'custom value',
+          },
+        },
+      };
+      controlValuesRepositoryMock.findOne.resolves(complexControlValues as any);
+
+      const command = DuplicateLayoutCommand.create({
+        layoutIdOrInternalId: 'original_layout_identifier',
+        overrides: mockOverrides,
+        user: mockUser as any,
+      });
+
+      await duplicateLayoutUseCase.execute(command);
+
+      expect(upsertLayoutUseCaseMock.execute.calledOnce).to.be.true;
+      const upsertCommand = upsertLayoutUseCaseMock.execute.firstCall.args[0];
+      expect(upsertCommand.layoutDto.controlValues).to.deep.equal(complexControlValues.controls);
+    });
+  });
+});

--- a/apps/api/src/app/layouts-v2/usecases/duplicate-layout/duplicate-layout.use-case.ts
+++ b/apps/api/src/app/layouts-v2/usecases/duplicate-layout/duplicate-layout.use-case.ts
@@ -1,10 +1,60 @@
 import { Injectable } from '@nestjs/common';
+import {
+  GetLayoutCommand as GetLayoutCommandV1,
+  GetLayoutUseCase as GetLayoutUseCaseV1,
+  AnalyticsService,
+} from '@novu/application-generic';
+import { ControlValuesRepository } from '@novu/dal';
+import { ControlValuesLevelEnum, ResourceOriginEnum, ResourceTypeEnum, slugify } from '@novu/shared';
+
 import { DuplicateLayoutCommand } from './duplicate-layout.command';
 import { LayoutResponseDto } from '../../dtos';
+import { UpsertLayoutCommand, UpsertLayoutUseCase } from '../upsert-layout';
 
 @Injectable()
 export class DuplicateLayoutUseCase {
+  constructor(
+    private getLayoutUseCaseV1: GetLayoutUseCaseV1,
+    private upsertLayoutUseCase: UpsertLayoutUseCase,
+    private controlValuesRepository: ControlValuesRepository,
+    private analyticsService: AnalyticsService
+  ) {}
+
   async execute(command: DuplicateLayoutCommand): Promise<LayoutResponseDto> {
-    throw new Error('Method not implemented.');
+    const originalLayout = await this.getLayoutUseCaseV1.execute(
+      GetLayoutCommandV1.create({
+        layoutIdOrInternalId: command.layoutIdOrInternalId,
+        environmentId: command.user.environmentId,
+        organizationId: command.user.organizationId,
+        type: ResourceTypeEnum.BRIDGE,
+        origin: ResourceOriginEnum.NOVU_CLOUD,
+      })
+    );
+
+    const originalControlValues = await this.controlValuesRepository.findOne({
+      _environmentId: command.user.environmentId,
+      _organizationId: command.user.organizationId,
+      _layoutId: originalLayout._id!,
+      level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+    });
+
+    const duplicatedLayout = await this.upsertLayoutUseCase.execute(
+      UpsertLayoutCommand.create({
+        layoutDto: {
+          name: command.overrides.name,
+          controlValues: originalControlValues?.controls ?? null,
+        },
+        user: command.user,
+      })
+    );
+
+    this.analyticsService.track('Duplicate layout - [Layouts]', command.user._id, {
+      _organizationId: command.user.organizationId,
+      _environmentId: command.user.environmentId,
+      originalLayoutId: originalLayout._id!,
+      duplicatedLayoutId: duplicatedLayout._id,
+    });
+
+    return duplicatedLayout;
   }
 }

--- a/apps/api/src/app/layouts-v2/usecases/get-layout/get-layout.use-case.spec.ts
+++ b/apps/api/src/app/layouts-v2/usecases/get-layout/get-layout.use-case.spec.ts
@@ -1,0 +1,266 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import {
+  AnalyticsService,
+  GetLayoutCommand as GetLayoutCommandV1,
+  GetLayoutUseCase as GetLayoutUseCaseV1,
+} from '@novu/application-generic';
+import { ControlValuesRepository } from '@novu/dal';
+import { ChannelTypeEnum, ControlValuesLevelEnum, ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
+
+import { GetLayoutUseCase } from './get-layout.use-case';
+import { GetLayoutCommand } from './get-layout.command';
+import { LayoutVariablesSchemaUseCase } from '../layout-variables-schema';
+
+describe('GetLayoutUseCase', () => {
+  let getLayoutUseCaseV1Mock: sinon.SinonStubbedInstance<GetLayoutUseCaseV1>;
+  let controlValuesRepositoryMock: sinon.SinonStubbedInstance<ControlValuesRepository>;
+  let layoutVariablesSchemaUseCaseMock: sinon.SinonStubbedInstance<LayoutVariablesSchemaUseCase>;
+  let analyticsServiceMock: sinon.SinonStubbedInstance<AnalyticsService>;
+  let getLayoutUseCase: GetLayoutUseCase;
+
+  const mockUser = {
+    _id: 'user_id',
+    environmentId: 'env_id',
+    organizationId: 'org_id',
+  };
+
+  const mockLayout = {
+    _id: 'layout_id',
+    identifier: 'layout_identifier',
+    name: 'Test Layout',
+    isDefault: false,
+    createdAt: '2023-01-01T00:00:00Z',
+    updatedAt: '2023-01-01T00:00:00Z',
+    _environmentId: 'env_id',
+    _organizationId: 'org_id',
+    origin: ResourceOriginEnum.NOVU_CLOUD,
+    type: ResourceTypeEnum.BRIDGE,
+    channel: ChannelTypeEnum.EMAIL,
+    controls: {
+      dataSchema: {},
+      uiSchema: {},
+    },
+  };
+
+  const mockControlValues = {
+    _id: 'control_values_id',
+    _environmentId: 'env_id',
+    _organizationId: 'org_id',
+    _layoutId: 'layout_id',
+    level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+    controls: {
+      email: {
+        content: '<html><body>{{content}}</body></html>',
+      },
+    },
+  };
+
+  const mockVariablesSchema = {
+    type: 'object',
+    properties: {
+      content: {
+        type: 'string',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    getLayoutUseCaseV1Mock = sinon.createStubInstance(GetLayoutUseCaseV1);
+    controlValuesRepositoryMock = sinon.createStubInstance(ControlValuesRepository);
+    layoutVariablesSchemaUseCaseMock = sinon.createStubInstance(LayoutVariablesSchemaUseCase);
+    analyticsServiceMock = sinon.createStubInstance(AnalyticsService);
+
+    getLayoutUseCase = new GetLayoutUseCase(
+      getLayoutUseCaseV1Mock as any,
+      controlValuesRepositoryMock as any,
+      layoutVariablesSchemaUseCaseMock as any,
+      analyticsServiceMock as any
+    );
+
+    // Default mocks
+    getLayoutUseCaseV1Mock.execute.resolves(mockLayout as any);
+    controlValuesRepositoryMock.findOne.resolves(mockControlValues as any);
+    layoutVariablesSchemaUseCaseMock.execute.resolves(mockVariablesSchema as any);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('execute', () => {
+    it('should successfully get layout with control values', async () => {
+      const command = GetLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      const result = await getLayoutUseCase.execute(command);
+
+      expect(result).to.deep.include({
+        _id: 'layout_id',
+        layoutId: 'layout_identifier',
+        name: 'Test Layout',
+        isDefault: false,
+        origin: ResourceOriginEnum.NOVU_CLOUD,
+        type: ResourceTypeEnum.BRIDGE,
+      });
+
+      expect(result.controls).to.exist;
+      expect(result.controls.values?.email).to.deep.equal(mockControlValues.controls.email);
+      expect(result.variables).to.deep.equal(mockVariablesSchema);
+
+      // Verify v1 use case was called with correct parameters
+      expect(getLayoutUseCaseV1Mock.execute.calledOnce).to.be.true;
+      const v1Command = getLayoutUseCaseV1Mock.execute.firstCall.args[0];
+      expect(v1Command.layoutIdOrInternalId).to.equal('layout_identifier');
+      expect(v1Command.environmentId).to.equal('env_id');
+      expect(v1Command.organizationId).to.equal('org_id');
+      expect(v1Command.type).to.equal(ResourceTypeEnum.BRIDGE);
+      expect(v1Command.origin).to.equal(ResourceOriginEnum.NOVU_CLOUD);
+    });
+
+    it('should get layout without control values when none exist', async () => {
+      controlValuesRepositoryMock.findOne.resolves(null);
+
+      const command = GetLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      const result = await getLayoutUseCase.execute(command);
+
+      expect(result.controls.values).to.deep.equal({});
+      expect(result.variables).to.deep.equal(mockVariablesSchema);
+
+      // Verify control values repository was called with correct parameters
+      expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.true;
+      expect(controlValuesRepositoryMock.findOne.firstCall.args[0]).to.deep.equal({
+        _environmentId: 'env_id',
+        _organizationId: 'org_id',
+        _layoutId: 'layout_id',
+        level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+      });
+    });
+
+    it('should call layout variables schema use case', async () => {
+      const command = GetLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      await getLayoutUseCase.execute(command);
+
+      expect(layoutVariablesSchemaUseCaseMock.execute.calledOnce).to.be.true;
+      const schemaCommand = layoutVariablesSchemaUseCaseMock.execute.firstCall.args[0];
+      expect(schemaCommand.user).to.deep.equal(mockUser);
+    });
+
+    it('should track analytics event', async () => {
+      const command = GetLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      await getLayoutUseCase.execute(command);
+
+      expect(analyticsServiceMock.track.calledOnce).to.be.true;
+      expect(analyticsServiceMock.track.firstCall.args[0]).to.equal('Get layout - [Layouts]');
+      expect(analyticsServiceMock.track.firstCall.args[1]).to.equal('user_id');
+      expect(analyticsServiceMock.track.firstCall.args[2]).to.deep.equal({
+        _organizationId: 'org_id',
+        _environmentId: 'env_id',
+        layoutId: 'layout_id',
+      });
+    });
+
+    it('should handle empty control values controls', async () => {
+      const controlValuesWithEmptyControls = {
+        ...mockControlValues,
+        controls: undefined,
+      };
+      controlValuesRepositoryMock.findOne.resolves(controlValuesWithEmptyControls as any);
+
+      const command = GetLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      const result = await getLayoutUseCase.execute(command);
+
+      expect(result.controls.values).to.deep.equal({});
+    });
+
+    it('should pass through layout properties correctly', async () => {
+      const defaultLayout = {
+        ...mockLayout,
+        isDefault: true,
+        name: 'Default Layout',
+      };
+      getLayoutUseCaseV1Mock.execute.resolves(defaultLayout as any);
+
+      const command = GetLayoutCommand.create({
+        layoutIdOrInternalId: 'default_layout',
+        user: mockUser as any,
+      });
+
+      const result = await getLayoutUseCase.execute(command);
+
+      expect(result.isDefault).to.be.true;
+      expect(result.name).to.equal('Default Layout');
+      expect(result.createdAt).to.equal('2023-01-01T00:00:00Z');
+      expect(result.updatedAt).to.equal('2023-01-01T00:00:00Z');
+    });
+
+    it('should propagate error from v1 use case', async () => {
+      const error = new Error('Layout not found');
+      getLayoutUseCaseV1Mock.execute.rejects(error);
+
+      const command = GetLayoutCommand.create({
+        layoutIdOrInternalId: 'non_existent',
+        user: mockUser as any,
+      });
+
+      try {
+        await getLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (thrownError) {
+        expect(thrownError.message).to.equal('Layout not found');
+      }
+    });
+
+    it('should propagate error from control values repository', async () => {
+      const error = new Error('Database error');
+      controlValuesRepositoryMock.findOne.rejects(error);
+
+      const command = GetLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      try {
+        await getLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (thrownError) {
+        expect(thrownError.message).to.equal('Database error');
+      }
+    });
+
+    it('should propagate error from layout variables schema use case', async () => {
+      const error = new Error('Schema error');
+      layoutVariablesSchemaUseCaseMock.execute.rejects(error);
+
+      const command = GetLayoutCommand.create({
+        layoutIdOrInternalId: 'layout_identifier',
+        user: mockUser as any,
+      });
+
+      try {
+        await getLayoutUseCase.execute(command);
+        expect.fail('Should have thrown an error');
+      } catch (thrownError) {
+        expect(thrownError.message).to.equal('Schema error');
+      }
+    });
+  });
+});

--- a/apps/api/src/app/layouts-v2/usecases/get-layout/get-layout.use-case.ts
+++ b/apps/api/src/app/layouts-v2/usecases/get-layout/get-layout.use-case.ts
@@ -1,10 +1,61 @@
 import { Injectable } from '@nestjs/common';
+import {
+  AnalyticsService,
+  GetLayoutCommand as GetLayoutCommandV1,
+  GetLayoutUseCase as GetLayoutUseCaseV1,
+} from '@novu/application-generic';
+import { ControlValuesRepository } from '@novu/dal';
+import { ControlValuesLevelEnum, ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
+
 import { GetLayoutCommand } from './get-layout.command';
 import { LayoutResponseDto } from '../../dtos';
+import { mapToResponseDto } from '../mapper';
+import { LayoutVariablesSchemaUseCase } from '../layout-variables-schema';
+import { LayoutVariablesSchemaCommand } from '../layout-variables-schema/layout-variables-schema.command';
 
 @Injectable()
 export class GetLayoutUseCase {
+  constructor(
+    private getLayoutUseCaseV1: GetLayoutUseCaseV1,
+    private controlValuesRepository: ControlValuesRepository,
+    private layoutVariablesSchemaUseCase: LayoutVariablesSchemaUseCase,
+    private analyticsService: AnalyticsService
+  ) {}
+
   async execute(command: GetLayoutCommand): Promise<LayoutResponseDto> {
-    throw new Error('Method not implemented.');
+    const layout = await this.getLayoutUseCaseV1.execute(
+      GetLayoutCommandV1.create({
+        layoutIdOrInternalId: command.layoutIdOrInternalId,
+        environmentId: command.user.environmentId,
+        organizationId: command.user.organizationId,
+        type: ResourceTypeEnum.BRIDGE,
+        origin: ResourceOriginEnum.NOVU_CLOUD,
+      })
+    );
+
+    const controlValues = await this.controlValuesRepository.findOne({
+      _environmentId: command.user.environmentId,
+      _organizationId: command.user.organizationId,
+      _layoutId: layout._id!,
+      level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+    });
+
+    const layoutVariablesSchema = await this.layoutVariablesSchemaUseCase.execute(
+      LayoutVariablesSchemaCommand.create({
+        user: command.user,
+      })
+    );
+
+    this.analyticsService.track('Get layout - [Layouts]', command.user._id, {
+      _organizationId: command.user.organizationId,
+      _environmentId: command.user.environmentId,
+      layoutId: layout._id!,
+    });
+
+    return mapToResponseDto({
+      layout,
+      controlValues: controlValues?.controls ?? null,
+      variables: layoutVariablesSchema,
+    });
   }
 }

--- a/apps/api/src/app/layouts-v2/usecases/upsert-layout/upsert-layout.usecase.ts
+++ b/apps/api/src/app/layouts-v2/usecases/upsert-layout/upsert-layout.usecase.ts
@@ -61,7 +61,7 @@ export class UpsertLayoutUseCase {
 
     let upsertedLayout: LayoutDto;
     if (existingLayout) {
-      this.mixpanelTrack(command, 'Layout Update - [API]');
+      this.mixpanelTrack(command, 'Layout Update - [Layouts]');
 
       upsertedLayout = await this.updateLayoutUseCaseV0.execute(
         UpdateLayoutCommand.create({
@@ -75,7 +75,7 @@ export class UpsertLayoutUseCase {
         })
       );
     } else {
-      this.mixpanelTrack(command, 'Layout Created - [API]');
+      this.mixpanelTrack(command, 'Layout Create - [Layouts]');
 
       const defaultLayout = await this.layoutRepository.findOne({
         _organizationId: command.user.organizationId,

--- a/libs/application-generic/src/utils/sanitize-control-values.ts
+++ b/libs/application-generic/src/utils/sanitize-control-values.ts
@@ -83,6 +83,7 @@ function sanitizeEmail(controlValues: EmailControlType) {
     body: sanitizeEmptyInput(controlValues.body, EMPTY_TIP_TAP),
     skip: controlValues.skip,
     disableOutputSanitization: controlValues.disableOutputSanitization,
+    layoutId: controlValues.layoutId,
   };
 
   return filterNullishValues(emailControls);

--- a/libs/dal/src/repositories/control-values/control-values.repository.ts
+++ b/libs/dal/src/repositories/control-values/control-values.repository.ts
@@ -23,6 +23,7 @@ export interface FindControlValuesQuery {
   _stepId?: string;
   _layoutId?: string;
   level?: ControlValuesLevelEnum;
+  [key: string]: unknown;
 }
 
 export class ControlValuesRepository extends BaseRepository<


### PR DESCRIPTION
### What changed? Why was the change needed?

Layouts: get, delete, and duplicate endpoints.
Improved preview for the case when the layout is removed from the workflow, we want it to still work and not break.
Fixed the issue with the non-default layout not being picked for the preview.

### Screenshots
![Screenshot 2025-06-26 at 00 17 14](https://github.com/user-attachments/assets/560e80aa-f0e1-452d-877b-7b6db816679a)

![Screenshot 2025-06-26 at 00 05 01](https://github.com/user-attachments/assets/3b219bdf-1f92-4815-9fbb-c67d131efd73)

![Screenshot 2025-06-25 at 23 38 14](https://github.com/user-attachments/assets/8f335248-4881-4ccb-bce1-491ca1334654)






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for duplicating layouts via the external API.
  * Implemented layout duplication and deletion workflows, including proper cleanup of references and analytics tracking.
  * Enabled retrieval of layouts with enriched control values and variable schemas.

* **Bug Fixes**
  * Centralized and improved email body rendering when layouts are active, ensuring consistent handling and formatting.

* **Tests**
  * Introduced comprehensive test suites for layout duplication, deletion, and retrieval use cases to ensure correct behavior and error handling.

* **Chores**
  * Updated event names for analytics tracking related to layout creation and updates.
  * Extended utility and repository interfaces to support additional properties and improved data handling.
  * Enhanced control values sanitization to include the layout ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->