### PR TITLE
feat(dashboard): manage translations sidedrawer

### DIFF
--- a/apps/dashboard/src/api/api.client.ts
+++ b/apps/dashboard/src/api/api.client.ts
@@ -52,7 +52,14 @@ const request = async <T>(
     };
 
     if (body) {
-      config.body = JSON.stringify(body);
+      if (body instanceof FormData) {
+        // For FormData, don't stringify and don't set Content-Type (let browser handle it)
+        config.body = body;
+        // Remove Content-Type header for FormData
+        delete (config.headers as Record<string, string>)['Content-Type'];
+      } else {
+        config.body = JSON.stringify(body);
+      }
     }
 
     const baseUrl = API_HOSTNAME ?? 'https://api.novu.co';

--- a/apps/dashboard/src/api/translations.ts
+++ b/apps/dashboard/src/api/translations.ts
@@ -1,5 +1,6 @@
-import { getV2 } from './api.client';
+import { delV2, getV2, postV2 } from './api.client';
 import { IEnvironment } from '@novu/shared';
+import { LocalizationResourceEnum } from '@novu/dal';
 
 export type TranslationsFilter = {
   query?: string;
@@ -8,11 +9,19 @@ export type TranslationsFilter = {
 };
 
 export type TranslationGroup = {
-  _id: string;
   resourceId: string;
   resourceName: string;
-  resourceType: string;
+  resourceType: LocalizationResourceEnum;
   locales: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type Translation = {
+  resourceId: string;
+  resourceType: LocalizationResourceEnum;
+  locale: string;
+  content: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
 };
@@ -22,6 +31,26 @@ export type GetTranslationsListResponse = {
   total: number;
   limit: number;
   offset: number;
+};
+
+export type GetTranslationsResponse = {
+  data: Translation[];
+  total: number;
+};
+
+export type UploadTranslationsRequest = {
+  resourceId: string;
+  resourceType: LocalizationResourceEnum;
+  files: File[];
+};
+
+export type UploadTranslationsResponse = {
+  data: {
+    totalFiles: number;
+    successfulUploads: number;
+    failedUploads: number;
+    errors: string[];
+  };
 };
 
 export const getTranslationsList = async ({
@@ -43,4 +72,122 @@ export const getTranslationsList = async ({
   const endpoint = `/translations/list${queryString ? `?${queryString}` : ''}`;
 
   return getV2<GetTranslationsListResponse>(endpoint, { environment });
+};
+
+export const getTranslations = async ({
+  environment,
+  resourceId,
+  resourceType,
+  locale,
+}: {
+  environment: IEnvironment;
+  resourceId: string;
+  resourceType: LocalizationResourceEnum;
+  locale?: string;
+}): Promise<GetTranslationsResponse> => {
+  const searchParams = new URLSearchParams();
+
+  searchParams.append('resourceId', resourceId);
+  searchParams.append('resourceType', resourceType);
+
+  if (locale) {
+    searchParams.append('locale', locale);
+  }
+
+  const queryString = searchParams.toString();
+  const endpoint = `/translations?${queryString}`;
+
+  return getV2<GetTranslationsResponse>(endpoint, { environment });
+};
+
+export type GetTranslationResponse = {
+  data: Translation;
+};
+
+export const getTranslation = async ({
+  environment,
+  resourceId,
+  resourceType,
+  locale,
+}: {
+  environment: IEnvironment;
+  resourceId: string;
+  resourceType: LocalizationResourceEnum;
+  locale: string;
+}): Promise<Translation> => {
+  const endpoint = `/translations/${resourceType}/${resourceId}/${locale}`;
+  const response = await getV2<GetTranslationResponse>(endpoint, { environment });
+  return response.data;
+};
+
+export type SaveTranslationRequest = {
+  resourceId: string;
+  resourceType: LocalizationResourceEnum;
+  locale: string;
+  content: Record<string, unknown>;
+};
+
+export type SaveTranslationResponse = {
+  data: Translation;
+};
+
+export const saveTranslation = async ({
+  environment,
+  resourceId,
+  resourceType,
+  locale,
+  content,
+}: SaveTranslationRequest & { environment: IEnvironment }): Promise<Translation> => {
+  const endpoint = '/translations';
+  const response = await postV2<SaveTranslationResponse>(endpoint, {
+    body: {
+      resourceId,
+      resourceType,
+      locale,
+      content,
+    },
+    environment,
+  });
+  return response.data;
+};
+
+export type DeleteTranslationRequest = {
+  resourceId: string;
+  resourceType: LocalizationResourceEnum;
+  locale: string;
+};
+
+export const deleteTranslation = async ({
+  environment,
+  resourceId,
+  resourceType,
+  locale,
+}: DeleteTranslationRequest & { environment: IEnvironment }): Promise<void> => {
+  const endpoint = `/translations/${resourceType}/${resourceId}/${locale}`;
+
+  await delV2(endpoint, { environment });
+};
+
+export const uploadTranslations = async ({
+  environment,
+  resourceId,
+  resourceType,
+  files,
+}: UploadTranslationsRequest & { environment: IEnvironment }): Promise<UploadTranslationsResponse['data']> => {
+  const formData = new FormData();
+
+  formData.append('resourceId', resourceId);
+  formData.append('resourceType', resourceType);
+
+  files.forEach((file) => {
+    formData.append('files', file);
+  });
+
+  const endpoint = '/translations/upload';
+  const response = await postV2<UploadTranslationsResponse>(endpoint, {
+    body: formData,
+    environment,
+  });
+
+  return response.data;
 };

--- a/apps/dashboard/src/components/flag-circle.tsx
+++ b/apps/dashboard/src/components/flag-circle.tsx
@@ -1,0 +1,95 @@
+import { RiEarthLine } from 'react-icons/ri';
+import { type Country } from 'react-phone-number-input';
+import flags from 'react-phone-number-input/flags';
+import { cn } from '@/utils/ui';
+
+// Helper function to get flag for locale
+function getLocaleFlag(localeCode: string) {
+  const countryCode = localeCode.split('_')?.[1] as Country;
+  return (countryCode && flags[countryCode]) || RiEarthLine;
+}
+
+type FlagCircleProps = {
+  locale: string;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+  showBorder?: boolean;
+  style?: React.CSSProperties;
+};
+
+export function FlagCircle({ locale, size = 'md', className, showBorder = false, style }: FlagCircleProps) {
+  const Flag = getLocaleFlag(locale);
+
+  const sizeClasses = {
+    sm: 'h-4 w-4',
+    md: 'h-5 w-5',
+    lg: 'h-6 w-6',
+  };
+
+  const borderClasses = showBorder ? 'border-2 border-white' : '';
+
+  return (
+    <div
+      className={cn('overflow-hidden rounded-full', sizeClasses[size], borderClasses, className)}
+      style={style}
+      title={locale}
+    >
+      <Flag className="h-full w-full scale-150 object-cover" title={locale} />
+    </div>
+  );
+}
+
+type StackedFlagCirclesProps = {
+  locales: string[];
+  maxVisible?: number;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+};
+
+export function StackedFlagCircles({ locales, maxVisible = 4, size = 'md', className }: StackedFlagCirclesProps) {
+  const sizeClasses = {
+    sm: 'h-4 w-4',
+    md: 'h-5 w-5',
+    lg: 'h-6 w-6',
+  };
+
+  const overlapOffset = {
+    sm: '-6px',
+    md: '-8px',
+    lg: '-10px',
+  };
+
+  return (
+    <div className={cn('flex items-center', className)}>
+      {locales.slice(0, maxVisible).map((locale, index) => (
+        <FlagCircle
+          key={locale}
+          locale={locale}
+          size={size}
+          showBorder={true}
+          className={cn({
+            relative: true,
+          })}
+          style={{
+            marginLeft: index > 0 ? overlapOffset[size] : '0',
+            zIndex: index + 1,
+          }}
+        />
+      ))}
+      {locales.length > maxVisible && (
+        <div
+          className={cn(
+            'flex items-center justify-center rounded-full border-2 border-white bg-neutral-100 text-xs font-medium text-neutral-700',
+            sizeClasses[size]
+          )}
+          style={{
+            marginLeft: overlapOffset[size],
+            zIndex: maxVisible + 1,
+          }}
+        >
+          +{locales.length - maxVisible}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/translations/constants.ts
+++ b/apps/dashboard/src/components/translations/constants.ts
@@ -1,0 +1,20 @@
+// Default pagination settings
+export const DEFAULT_TRANSLATIONS_LIMIT = 10;
+export const DEFAULT_TRANSLATIONS_OFFSET = 0;
+
+// File validation
+export const ACCEPTED_FILE_EXTENSION = '.json';
+
+// Date format options
+export const DATE_FORMAT_OPTIONS = {
+  month: 'short' as const,
+  day: 'numeric' as const,
+  year: 'numeric' as const,
+};
+
+export const TIME_FORMAT_OPTIONS = {
+  hour12: false as const,
+  hour: '2-digit' as const,
+  minute: '2-digit' as const,
+  second: '2-digit' as const,
+};

--- a/apps/dashboard/src/components/translations/hooks/use-translations-url-state.tsx
+++ b/apps/dashboard/src/components/translations/hooks/use-translations-url-state.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { DEFAULT_TRANSLATIONS_LIMIT, DEFAULT_TRANSLATIONS_OFFSET } from '../constants';
 
 export type TranslationsFilter = {
   query: string;
@@ -9,8 +10,8 @@ export type TranslationsFilter = {
 
 export const defaultTranslationsFilter: TranslationsFilter = {
   query: '',
-  limit: 50,
-  offset: 0,
+  limit: DEFAULT_TRANSLATIONS_LIMIT,
+  offset: DEFAULT_TRANSLATIONS_OFFSET,
 };
 
 export type TranslationsUrlState = {
@@ -27,10 +28,10 @@ type UseTranslationsUrlStateProps = {
   limit?: number;
 };
 
-export const useTranslationsUrlState = ({
+export function useTranslationsUrlState({
   total = 0,
-  limit = 50,
-}: UseTranslationsUrlStateProps): TranslationsUrlState => {
+  limit = DEFAULT_TRANSLATIONS_LIMIT,
+}: UseTranslationsUrlStateProps): TranslationsUrlState {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const filterValues = useMemo(() => {
@@ -97,4 +98,4 @@ export const useTranslationsUrlState = ({
     handlePrevious,
     handleFirst,
   };
-};
+}

--- a/apps/dashboard/src/components/translations/index.ts
+++ b/apps/dashboard/src/components/translations/index.ts
@@ -1,7 +1,0 @@
-export * from './translation-list';
-export * from './translation-row';
-export * from './translations-filters';
-export * from './translation-list-blank';
-export * from '../list-no-results';
-export * from './hooks/use-translations-url-state';
-export * from './hooks/use-translations-navigate';

--- a/apps/dashboard/src/components/translations/translation-drawer/editor-actions.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/editor-actions.tsx
@@ -1,0 +1,117 @@
+import { RiFileUploadLine, RiDownloadLine, RiDeleteBinLine } from 'react-icons/ri';
+import { useState } from 'react';
+import { Button } from '@/components/primitives/button';
+import { CopyButton } from '@/components/primitives/copy-button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
+import { FlagCircle } from '@/components/flag-circle';
+import { TranslationImportTrigger } from '../translation-import-trigger';
+import { ConfirmationModal } from '@/components/confirmation-modal';
+import { getLocaleDisplayName } from '../utils';
+import { useTranslationFileOperations } from './hooks';
+import { TranslationResource } from './types';
+
+type EditorActionsProps = {
+  selectedLocale: string;
+  contentToCopy: string;
+  content: Record<string, unknown>;
+  resource: TranslationResource;
+  onImportSuccess?: () => void;
+  onDelete: (locale: string) => void | Promise<void>;
+  isDeleting?: boolean;
+};
+
+export function EditorActions({
+  selectedLocale,
+  contentToCopy,
+  content,
+  resource,
+  onImportSuccess,
+  onDelete,
+  isDeleting = false,
+}: EditorActionsProps) {
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const { handleDownload } = useTranslationFileOperations();
+  const displayName = getLocaleDisplayName(selectedLocale);
+
+  const handleDeleteClick = () => setIsDeleteModalOpen(true);
+
+  const handleDeleteConfirm = async () => {
+    await onDelete(selectedLocale);
+    setIsDeleteModalOpen(false);
+  };
+
+  return (
+    <>
+      <div className="flex flex-col items-start gap-6 self-stretch px-3 pb-3 pt-3">
+        <div className="flex w-full items-center justify-between">
+          <div className="flex items-center gap-3">
+            <FlagCircle locale={selectedLocale} size="md" />
+            <div className="flex items-center gap-1">
+              <span className="text-sm font-medium text-neutral-600">{selectedLocale}</span>
+              <span className="text-sm text-neutral-400">({displayName})</span>
+            </div>
+          </div>
+          <TranslationImportTrigger resource={resource} onSuccess={onImportSuccess}>
+            <Button variant="secondary" mode="outline" size="xs" leadingIcon={RiFileUploadLine}>
+              Import locale(s)
+            </Button>
+          </TranslationImportTrigger>
+        </div>
+
+        <div className="flex w-full items-center justify-between">
+          <span className="text-sm font-medium text-neutral-900">Translation JSON</span>
+          <div className="flex items-center gap-1">
+            <CopyButton
+              valueToCopy={contentToCopy}
+              size="xs"
+              className="rounded-md border border-neutral-200 bg-white px-2 py-1.5 text-neutral-700 hover:border-neutral-300 hover:bg-neutral-50"
+            />
+            <Tooltip>
+              <TooltipTrigger>
+                <Button
+                  variant="secondary"
+                  mode="outline"
+                  size="xs"
+                  className="px-2 py-1.5"
+                  onClick={() => handleDownload(selectedLocale, content)}
+                >
+                  <RiDownloadLine className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Export translation JSON</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger>
+                <Button
+                  variant="secondary"
+                  mode="outline"
+                  size="xs"
+                  className="px-2 py-1.5 text-neutral-700 hover:text-red-500"
+                  onClick={handleDeleteClick}
+                >
+                  <RiDeleteBinLine className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Delete {selectedLocale} translation</TooltipContent>
+            </Tooltip>
+          </div>
+        </div>
+      </div>
+
+      <ConfirmationModal
+        open={isDeleteModalOpen}
+        onOpenChange={setIsDeleteModalOpen}
+        onConfirm={handleDeleteConfirm}
+        title="Delete translation"
+        description={
+          <span>
+            Are you sure you want to delete the <span className="font-bold">{selectedLocale}</span> translation? This
+            action cannot be undone.
+          </span>
+        }
+        confirmButtonText="Delete translation"
+        isLoading={isDeleting}
+      />
+    </>
+  );
+}

--- a/apps/dashboard/src/components/translations/translation-drawer/editor-panel.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/editor-panel.tsx
@@ -1,0 +1,129 @@
+import { RiFileTextLine } from 'react-icons/ri';
+import { Skeleton } from '@/components/primitives/skeleton';
+import { Editor } from '@/components/primitives/editor';
+import { cn } from '@/utils/ui';
+import { loadLanguage } from '@uiw/codemirror-extensions-langs';
+import { DATE_FORMAT_OPTIONS, TIME_FORMAT_OPTIONS } from '../constants';
+import { formatTranslationDate, formatTranslationTime } from '../utils';
+import { EditorActions } from './editor-actions';
+import { TranslationResource } from './types';
+
+type JSONEditorProps = {
+  content: string;
+  onChange: (value: string) => void;
+  error: string | null;
+  updatedAt: string;
+};
+
+function JSONEditor({ content, onChange, error, updatedAt }: JSONEditorProps) {
+  return (
+    <div className="flex-1 px-3 pb-3">
+      <div
+        className={cn(
+          'relative h-[calc(100%-10rem)] rounded-lg border bg-white p-4',
+          error ? 'border-red-300' : 'border-neutral-200'
+        )}
+      >
+        <Editor
+          value={content}
+          onChange={onChange}
+          lang="json"
+          extensions={[loadLanguage('json')?.extension ?? []]}
+          basicSetup={{ lineNumbers: true, defaultKeymap: true }}
+          placeholder="Enter JSON content..."
+          className={cn('h-full overflow-auto', error ? 'pb-8' : '')}
+          foldGutter
+        />
+        {error && (
+          <div className="absolute bottom-2 left-3 right-3 text-xs text-red-500">
+            <span className="font-medium">Invalid JSON:</span> {error}
+          </div>
+        )}
+      </div>
+      <div className="mt-2 px-1">
+        <span className="text-2xs text-neutral-400">
+          Last updated at {formatTranslationDate(updatedAt, DATE_FORMAT_OPTIONS)}{' '}
+          {formatTranslationTime(updatedAt, TIME_FORMAT_OPTIONS)} UTC
+        </span>
+      </div>
+    </div>
+  );
+}
+
+type EditorPanelProps = {
+  selectedLocale: string | null;
+  selectedTranslation: any;
+  isLoadingTranslation: boolean;
+  translationError: any;
+  modifiedContent: Record<string, unknown> | null;
+  jsonError: string | null;
+  onContentChange: (content: string) => void;
+  onDelete: (locale: string) => void | Promise<void>;
+  resource: TranslationResource;
+  onImportSuccess?: () => void;
+  isDeleting?: boolean;
+};
+
+export function EditorPanel({
+  selectedLocale,
+  selectedTranslation,
+  isLoadingTranslation,
+  translationError,
+  modifiedContent,
+  jsonError,
+  onContentChange,
+  onDelete,
+  resource,
+  onImportSuccess,
+  isDeleting = false,
+}: EditorPanelProps) {
+  if (!selectedLocale) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <div className="text-center">
+          <RiFileTextLine className="mx-auto mb-4 h-12 w-12 text-neutral-400" />
+          <p className="text-sm text-neutral-500">Select a locale to view and edit translations</p>
+        </div>
+      </div>
+    );
+  }
+
+  const contentToUse = modifiedContent || selectedTranslation?.content || {};
+  const contentToCopy = JSON.stringify(contentToUse, null, 2);
+
+  return (
+    <div className="flex flex-1 flex-col bg-neutral-50">
+      <EditorActions
+        selectedLocale={selectedLocale}
+        contentToCopy={contentToCopy}
+        content={contentToUse}
+        resource={resource}
+        onImportSuccess={onImportSuccess}
+        onDelete={onDelete}
+        isDeleting={isDeleting}
+      />
+
+      {isLoadingTranslation ? (
+        <div className="flex-1 px-3 pb-3">
+          <div className="space-y-4">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        </div>
+      ) : translationError ? (
+        <div className="flex h-32 items-center justify-center">
+          <p className="text-sm text-red-500">Failed to load translation for {selectedLocale}</p>
+        </div>
+      ) : selectedTranslation?.content ? (
+        <JSONEditor
+          content={JSON.stringify(contentToUse, null, 2)}
+          onChange={onContentChange}
+          error={jsonError}
+          updatedAt={selectedTranslation.updatedAt}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/translations/translation-drawer/hooks/index.ts
+++ b/apps/dashboard/src/components/translations/translation-drawer/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './use-translation-editor';
+export * from './use-translation-file-operations';

--- a/apps/dashboard/src/components/translations/translation-drawer/hooks/use-translation-editor.ts
+++ b/apps/dashboard/src/components/translations/translation-drawer/hooks/use-translation-editor.ts
@@ -1,0 +1,42 @@
+import { useState, useCallback, useEffect } from 'react';
+import { Translation } from '@/api/translations';
+
+export function useTranslationEditor(selectedTranslation: Translation | undefined) {
+  const [modifiedContent, setModifiedContent] = useState<Record<string, unknown> | null>(null);
+  const [jsonError, setJsonError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setModifiedContent(null);
+    setJsonError(null);
+  }, [selectedTranslation?.locale]);
+
+  const handleContentChange = useCallback(
+    (newContentString: string) => {
+      try {
+        const parsed = JSON.parse(newContentString);
+        setJsonError(null);
+
+        const hasChanged =
+          selectedTranslation && JSON.stringify(parsed) !== JSON.stringify(selectedTranslation.content);
+
+        setModifiedContent(hasChanged ? parsed : null);
+      } catch (error) {
+        setJsonError(error instanceof Error ? error.message : 'Invalid JSON format');
+      }
+    },
+    [selectedTranslation]
+  );
+
+  const resetContent = useCallback(() => {
+    setModifiedContent(null);
+    setJsonError(null);
+  }, []);
+
+  return {
+    modifiedContent,
+    jsonError,
+    handleContentChange,
+    resetContent,
+    hasUnsavedChanges: !!modifiedContent,
+  };
+}

--- a/apps/dashboard/src/components/translations/translation-drawer/hooks/use-translation-file-operations.ts
+++ b/apps/dashboard/src/components/translations/translation-drawer/hooks/use-translation-file-operations.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+
+export function useTranslationFileOperations() {
+  const handleDownload = useCallback((locale: string, content: Record<string, unknown>) => {
+    const jsonString = JSON.stringify(content, null, 2);
+    const blob = new Blob([jsonString], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${locale}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, []);
+
+  return {
+    handleDownload,
+  };
+}

--- a/apps/dashboard/src/components/translations/translation-drawer/locale-list.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/locale-list.tsx
@@ -1,0 +1,114 @@
+import { RiArrowRightSLine } from 'react-icons/ri';
+import { Button } from '@/components/primitives/button';
+import { StatusBadge } from '@/components/primitives/status-badge';
+import { FlagCircle } from '@/components/flag-circle';
+import { cn } from '@/utils/ui';
+import { DATE_FORMAT_OPTIONS, TIME_FORMAT_OPTIONS } from '../constants';
+import { getLocaleDisplayName, formatTranslationDate, formatTranslationTime } from '../utils';
+
+type TranslationStatusProps = {
+  updatedAt: string;
+};
+
+function TranslationStatus({ updatedAt }: TranslationStatusProps) {
+  return (
+    <div className="flex flex-col items-start gap-3 self-stretch border-b border-neutral-100 p-4">
+      <div className="flex w-full items-center justify-between">
+        <span className="text-sm text-neutral-600">Status</span>
+        <StatusBadge variant="light" status="completed" className="text-xs">
+          <div
+            className={cn(
+              'relative size-1.5 animate-[pulse-shadow_1s_ease-in-out_infinite] rounded-full',
+              'bg-success [--pulse-color:var(--success)]'
+            )}
+          />
+          Up-to-date
+        </StatusBadge>
+      </div>
+      <div className="flex w-full items-center justify-between">
+        <span className="text-sm text-neutral-600">Last updated at</span>
+        <span className="font-code text-xs text-neutral-400">
+          {formatTranslationDate(updatedAt, DATE_FORMAT_OPTIONS)}{' '}
+          {formatTranslationTime(updatedAt, TIME_FORMAT_OPTIONS)} UTC
+        </span>
+      </div>
+    </div>
+  );
+}
+
+type LocaleButtonProps = {
+  locale: string;
+  isSelected: boolean;
+  onClick: () => void;
+};
+
+function LocaleButton({ locale, isSelected, onClick }: LocaleButtonProps) {
+  const displayName = getLocaleDisplayName(locale);
+
+  return (
+    <Button
+      variant="secondary"
+      mode="outline"
+      className={cn(
+        'h-10 w-full justify-start gap-3 px-3 py-2 text-sm font-normal',
+        isSelected ? 'border-neutral-200 bg-neutral-50' : 'border-neutral-100'
+      )}
+      onClick={onClick}
+      trailingIcon={RiArrowRightSLine}
+    >
+      <FlagCircle locale={locale} size="md" />
+      <span className="font-medium text-neutral-900">{locale}</span>
+      <span className="text-neutral-500"> ({displayName})</span>
+      <span className="ml-auto" />
+    </Button>
+  );
+}
+
+type LocaleListProps = {
+  locales: string[];
+  selectedLocale: string | null;
+  onLocaleSelect: (locale: string) => void;
+  updatedAt: string;
+  hasUnsavedChanges?: boolean;
+  onUnsavedChangesCheck?: (action: () => void) => void;
+};
+
+export function LocaleList({
+  locales,
+  selectedLocale,
+  onLocaleSelect,
+  updatedAt,
+  hasUnsavedChanges = false,
+  onUnsavedChangesCheck,
+}: LocaleListProps) {
+  const handleLocaleClick = (locale: string) => {
+    if (hasUnsavedChanges && onUnsavedChangesCheck) {
+      onUnsavedChangesCheck(() => onLocaleSelect(locale));
+    } else {
+      onLocaleSelect(locale);
+    }
+  };
+
+  return (
+    <div className="w-[400px] border-r border-neutral-200">
+      <TranslationStatus updatedAt={updatedAt} />
+
+      <div className="p-4">
+        {!locales.length ? (
+          <div className="p-4 text-center text-sm text-neutral-500">No locales found</div>
+        ) : (
+          <div className="space-y-2">
+            {locales.map((locale) => (
+              <LocaleButton
+                key={locale}
+                locale={locale}
+                isSelected={selectedLocale === locale}
+                onClick={() => handleLocaleClick(locale)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/translations/translation-drawer/translation-drawer-content.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/translation-drawer-content.tsx
@@ -1,0 +1,122 @@
+import { Button } from '@/components/primitives/button';
+import { UnsavedChangesAlertDialog } from '@/components/unsaved-changes-alert-dialog';
+import { TranslationGroup } from '@/api/translations';
+import { TranslationHeader } from './translation-header';
+import { LocaleList } from './locale-list';
+import { EditorPanel } from './editor-panel';
+import { useTranslationDrawerLogic } from './use-translation-drawer-logic';
+import { forwardRef, useImperativeHandle, useState, useCallback } from 'react';
+
+type TranslationDrawerContentProps = {
+  translationGroup: TranslationGroup;
+  onTranslationGroupUpdated?: (resourceId: string) => void | Promise<void>;
+};
+
+export interface TranslationDrawerContentRef {
+  hasUnsavedChanges: () => boolean;
+}
+
+export const TranslationDrawerContent = forwardRef<TranslationDrawerContentRef, TranslationDrawerContentProps>(
+  ({ translationGroup, onTranslationGroupUpdated }, ref) => {
+    const [isUnsavedChangesDialogOpen, setIsUnsavedChangesDialogOpen] = useState(false);
+    const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
+
+    const {
+      selectedLocale,
+      selectedTranslation,
+      isLoadingTranslation,
+      translationError,
+      resource,
+      editor,
+      saveTranslationMutation,
+      deleteTranslationMutation,
+      handleLocaleSelect,
+      handleSave,
+      handleDelete,
+    } = useTranslationDrawerLogic(translationGroup, onTranslationGroupUpdated);
+
+    const canSave = selectedLocale && editor.modifiedContent && !saveTranslationMutation.isPending && !editor.jsonError;
+
+    const checkUnsavedChanges = useCallback(
+      (action: () => void) => {
+        if (editor.hasUnsavedChanges) {
+          setPendingAction(() => action);
+          setIsUnsavedChangesDialogOpen(true);
+        } else {
+          action();
+        }
+      },
+      [editor.hasUnsavedChanges]
+    );
+
+    const handleDiscardChanges = useCallback(() => {
+      if (pendingAction) {
+        pendingAction();
+        setPendingAction(null);
+      }
+
+      setIsUnsavedChangesDialogOpen(false);
+    }, [pendingAction]);
+
+    const handleCancelChange = useCallback(() => {
+      setPendingAction(null);
+      setIsUnsavedChangesDialogOpen(false);
+    }, []);
+
+    useImperativeHandle(ref, () => ({
+      hasUnsavedChanges: () => editor.hasUnsavedChanges,
+    }));
+
+    return (
+      <div className="flex h-full w-full flex-col">
+        <TranslationHeader resourceName={translationGroup.resourceName} />
+
+        <div className="flex h-full">
+          <LocaleList
+            locales={translationGroup.locales}
+            selectedLocale={selectedLocale}
+            onLocaleSelect={handleLocaleSelect}
+            updatedAt={translationGroup.updatedAt}
+            hasUnsavedChanges={editor.hasUnsavedChanges}
+            onUnsavedChangesCheck={checkUnsavedChanges}
+          />
+
+          <EditorPanel
+            selectedLocale={selectedLocale}
+            selectedTranslation={selectedTranslation}
+            isLoadingTranslation={isLoadingTranslation}
+            translationError={translationError}
+            modifiedContent={editor.modifiedContent}
+            jsonError={editor.jsonError}
+            onContentChange={editor.handleContentChange}
+            onDelete={handleDelete}
+            resource={resource}
+            onImportSuccess={() => onTranslationGroupUpdated?.(resource.resourceId)}
+            isDeleting={deleteTranslationMutation.isPending}
+          />
+        </div>
+
+        <div className="flex items-center justify-end border-t border-neutral-200 bg-white px-6 py-3">
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={!canSave}
+            onClick={handleSave}
+            isLoading={saveTranslationMutation.isPending}
+          >
+            Save changes
+          </Button>
+        </div>
+
+        <UnsavedChangesAlertDialog
+          show={isUnsavedChangesDialogOpen}
+          description="You have unsaved changes to the current translation. These changes will be lost if you continue."
+          onCancel={handleCancelChange}
+          onProceed={handleDiscardChanges}
+        />
+      </div>
+    );
+  }
+);
+
+TranslationDrawerContent.displayName = 'TranslationDrawerContent';

--- a/apps/dashboard/src/components/translations/translation-drawer/translation-drawer.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/translation-drawer.tsx
@@ -1,0 +1,78 @@
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/primitives/sheet';
+import { VisuallyHidden } from '@/components/primitives/visually-hidden';
+import { UnsavedChangesAlertDialog } from '@/components/unsaved-changes-alert-dialog';
+import { TranslationGroup } from '@/api/translations';
+import { TranslationDrawerContent, TranslationDrawerContentRef } from './translation-drawer-content';
+import { useState, useRef, useCallback } from 'react';
+
+type TranslationDrawerProps = {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  translationGroup: TranslationGroup | null;
+  onTranslationGroupUpdated?: (resourceId: string) => void | Promise<void>;
+};
+
+export function TranslationDrawer({
+  isOpen,
+  onOpenChange,
+  translationGroup,
+  onTranslationGroupUpdated,
+}: TranslationDrawerProps) {
+  const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
+  const drawerContentRef = useRef<TranslationDrawerContentRef>(null);
+
+  const handleCloseAttempt = useCallback(
+    (event?: Event | KeyboardEvent) => {
+      event?.preventDefault();
+
+      if (drawerContentRef.current?.hasUnsavedChanges()) {
+        setShowUnsavedDialog(true);
+      } else {
+        onOpenChange(false);
+      }
+    },
+    [onOpenChange]
+  );
+
+  const handleConfirmClose = useCallback(() => {
+    setShowUnsavedDialog(false);
+    onOpenChange(false);
+  }, [onOpenChange]);
+
+  return (
+    <>
+      <Sheet open={isOpen} onOpenChange={onOpenChange}>
+        <SheetContent
+          side="right"
+          className="w-[1100px] !max-w-none"
+          onInteractOutside={handleCloseAttempt}
+          onEscapeKeyDown={handleCloseAttempt}
+        >
+          <VisuallyHidden>
+            <SheetTitle />
+            <SheetDescription />
+          </VisuallyHidden>
+          {translationGroup ? (
+            <TranslationDrawerContent
+              key={`${translationGroup.resourceId}-${translationGroup.updatedAt}`}
+              translationGroup={translationGroup}
+              onTranslationGroupUpdated={onTranslationGroupUpdated}
+              ref={drawerContentRef}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <p className="text-sm text-neutral-500">No translation group selected</p>
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      <UnsavedChangesAlertDialog
+        show={showUnsavedDialog}
+        description="You have unsaved changes to the current translation. These changes will be lost if you close the drawer."
+        onCancel={() => setShowUnsavedDialog(false)}
+        onProceed={handleConfirmClose}
+      />
+    </>
+  );
+}

--- a/apps/dashboard/src/components/translations/translation-drawer/translation-header.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/translation-header.tsx
@@ -1,0 +1,16 @@
+import { RiTranslate2 } from 'react-icons/ri';
+
+type TranslationHeaderProps = {
+  resourceName: string;
+};
+
+export function TranslationHeader({ resourceName }: TranslationHeaderProps) {
+  return (
+    <header className="border-bg-soft flex h-12 w-full flex-row items-center gap-3 border-b px-3 py-4">
+      <div className="flex flex-1 items-center gap-2 overflow-hidden text-sm font-medium">
+        <RiTranslate2 className="h-4 w-4 text-neutral-600" />
+        <span className="flex-1 truncate pr-10">{resourceName}</span>
+      </div>
+    </header>
+  );
+}

--- a/apps/dashboard/src/components/translations/translation-drawer/types.ts
+++ b/apps/dashboard/src/components/translations/translation-drawer/types.ts
@@ -1,0 +1,11 @@
+import { LocalizationResourceEnum } from '@novu/dal';
+
+export type TranslationResource = {
+  resourceId: string;
+  resourceType: LocalizationResourceEnum;
+};
+
+export type TranslationError = {
+  message: string;
+  code?: string;
+};

--- a/apps/dashboard/src/components/translations/translation-drawer/use-translation-drawer-logic.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/use-translation-drawer-logic.tsx
@@ -1,0 +1,88 @@
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { TranslationGroup } from '@/api/translations';
+import { useFetchTranslation } from '@/hooks/use-fetch-translation';
+import { useSaveTranslation } from '@/hooks/use-save-translation';
+import { useDeleteTranslation } from '@/hooks/use-delete-translation';
+import { useTranslationEditor } from './hooks';
+
+export function useTranslationDrawerLogic(
+  translationGroup: TranslationGroup,
+  onTranslationGroupUpdated?: (resourceId: string) => void | Promise<void>
+) {
+  const [selectedLocale, setSelectedLocale] = useState<string | null>(null);
+
+  const resource = useMemo(
+    () => ({
+      resourceId: translationGroup.resourceId,
+      resourceType: translationGroup.resourceType,
+    }),
+    [translationGroup.resourceId, translationGroup.resourceType]
+  );
+
+  useEffect(() => {
+    const firstLocale = translationGroup.locales[0] || null;
+    setSelectedLocale(firstLocale);
+  }, [translationGroup.locales, translationGroup.updatedAt]);
+
+  const {
+    data: selectedTranslation,
+    isLoading: isLoadingTranslation,
+    error: translationError,
+  } = useFetchTranslation({
+    resourceId: resource.resourceId,
+    resourceType: resource.resourceType,
+    locale: selectedLocale || '',
+  });
+
+  const editor = useTranslationEditor(selectedTranslation);
+  const saveTranslationMutation = useSaveTranslation();
+  const deleteTranslationMutation = useDeleteTranslation();
+
+  const handleLocaleSelect = useCallback((locale: string) => {
+    setSelectedLocale(locale);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!editor.modifiedContent || !selectedLocale) return;
+
+    await saveTranslationMutation.mutateAsync({
+      ...resource,
+      locale: selectedLocale,
+      content: editor.modifiedContent,
+    });
+
+    editor.resetContent();
+  }, [editor, selectedLocale, saveTranslationMutation, resource]);
+
+  const handleDelete = useCallback(
+    async (locale: string) => {
+      await deleteTranslationMutation.mutateAsync({
+        ...resource,
+        locale,
+      });
+
+      onTranslationGroupUpdated?.(resource.resourceId);
+
+      const remainingLocales = translationGroup.locales.filter((l) => l !== locale);
+      const nextLocale = remainingLocales[0] || null;
+      setSelectedLocale(nextLocale);
+    },
+    [deleteTranslationMutation, resource, onTranslationGroupUpdated, translationGroup.locales]
+  );
+
+  return {
+    selectedLocale,
+    selectedTranslation,
+    isLoadingTranslation,
+    translationError,
+    resource,
+
+    editor,
+    saveTranslationMutation,
+    deleteTranslationMutation,
+
+    handleLocaleSelect,
+    handleSave,
+    handleDelete,
+  };
+}

--- a/apps/dashboard/src/components/translations/translation-import-trigger.tsx
+++ b/apps/dashboard/src/components/translations/translation-import-trigger.tsx
@@ -1,11 +1,7 @@
 import { useRef, useCallback, ReactElement, cloneElement } from 'react';
 import { useUploadTranslations } from '@/hooks/use-upload-translations';
 import { ACCEPTED_FILE_EXTENSION } from './constants';
-
-type TranslationResource = {
-  resourceId: string;
-  resourceType: string;
-};
+import { TranslationResource } from './translation-drawer/types';
 
 type TranslationImportTriggerProps = {
   resource: TranslationResource;

--- a/apps/dashboard/src/components/translations/translation-import-trigger.tsx
+++ b/apps/dashboard/src/components/translations/translation-import-trigger.tsx
@@ -1,0 +1,65 @@
+import { useRef, useCallback, ReactElement, cloneElement } from 'react';
+import { useUploadTranslations } from '@/hooks/use-upload-translations';
+import { ACCEPTED_FILE_EXTENSION } from './constants';
+
+type TranslationResource = {
+  resourceId: string;
+  resourceType: string;
+};
+
+type TranslationImportTriggerProps = {
+  resource: TranslationResource;
+  onSuccess?: () => void;
+  children: ReactElement;
+};
+
+export function TranslationImportTrigger({ resource, onSuccess, children }: TranslationImportTriggerProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const uploadMutation = useUploadTranslations();
+
+  const handleFileChange = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = event.target.files;
+      if (!files || files.length === 0) return;
+
+      try {
+        const result = await uploadMutation.mutateAsync({
+          ...resource,
+          files: Array.from(files),
+        });
+
+        if (result.successfulUploads > 0) {
+          onSuccess?.();
+        }
+      } finally {
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
+      }
+    },
+    [uploadMutation, resource, onSuccess]
+  );
+
+  const handleClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_FILE_EXTENSION}
+        multiple
+        onChange={handleFileChange}
+        className="hidden"
+      />
+      {cloneElement(children, {
+        onClick: (e: React.MouseEvent) => {
+          children.props.onClick?.(e);
+          handleClick();
+        },
+      })}
+    </>
+  );
+}

--- a/apps/dashboard/src/components/translations/translation-list.tsx
+++ b/apps/dashboard/src/components/translations/translation-list.tsx
@@ -131,7 +131,7 @@ function TranslationListContent({ translations, onTranslationClick, onImportSucc
     <>
       {translations.map((translation) => (
         <TranslationRow
-          key={translation._id}
+          key={translation.resourceId}
           translation={translation}
           onTranslationClick={onTranslationClick}
           onImportSuccess={onImportSuccess}

--- a/apps/dashboard/src/components/translations/translation-list.tsx
+++ b/apps/dashboard/src/components/translations/translation-list.tsx
@@ -1,49 +1,67 @@
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes, useState, useCallback } from 'react';
 
 import { cn } from '@/utils/ui';
 import { DefaultPagination } from '@/components/default-pagination';
-import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/primitives/table';
 import {
-  TranslationsFilter,
-  TranslationsUrlState,
-  useTranslationsUrlState,
-} from '@/components/translations/hooks/use-translations-url-state';
-import { TranslationListBlank } from '@/components/translations/translation-list-blank';
-import { ListNoResults } from '@/components/list-no-results';
-import { TranslationRow, TranslationRowSkeleton } from '@/components/translations/translation-row';
-import { TranslationsFilters } from '@/components/translations/translations-filters';
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableFooter,
+  TableCell,
+} from '@/components/primitives/table';
+import { TranslationGroup } from '@/api/translations';
 import { useFetchTranslations } from '@/hooks/use-fetch-translations';
+import { DEFAULT_TRANSLATIONS_LIMIT } from './constants';
 
-type TranslationListFiltersProps = HTMLAttributes<HTMLDivElement> &
+import { TranslationsFilter, TranslationsUrlState, useTranslationsUrlState } from './hooks/use-translations-url-state';
+import { TranslationListBlank } from './translation-list-blank';
+import { ListNoResults } from '../list-no-results';
+import { TranslationRow, TranslationRowSkeleton } from './translation-row';
+import { TranslationsFilters } from './translations-filters';
+import { TranslationDrawer } from './translation-drawer/translation-drawer';
+
+type TranslationListHeaderProps = HTMLAttributes<HTMLDivElement> &
   Pick<TranslationsUrlState, 'filterValues' | 'handleFiltersChange' | 'resetFilters'> & {
     isFetching?: boolean;
   };
 
-const TranslationListWrapper = (props: TranslationListFiltersProps) => {
-  const { className, children, filterValues, handleFiltersChange, resetFilters, isFetching, ...rest } = props;
-
+function TranslationListHeader({
+  className,
+  filterValues,
+  handleFiltersChange,
+  resetFilters,
+  isFetching,
+  ...props
+}: TranslationListHeaderProps) {
   return (
-    <div className={cn('flex h-full flex-col p-2', className)} {...rest}>
-      <div className="flex items-center justify-between">
-        <TranslationsFilters
-          onFiltersChange={handleFiltersChange}
-          filterValues={filterValues}
-          onReset={resetFilters}
-          isFetching={isFetching}
-          className="py-2.5"
-        />
-      </div>
-      {children}
+    <div className={cn('flex items-center justify-between py-2.5', className)} {...props}>
+      <TranslationsFilters
+        onFiltersChange={handleFiltersChange}
+        filterValues={filterValues}
+        onReset={resetFilters}
+        isFetching={isFetching}
+      />
     </div>
   );
+}
+
+type TranslationTableProps = HTMLAttributes<HTMLTableElement> & {
+  children: React.ReactNode;
+  data?: {
+    total: number;
+    limit: number;
+    offset: number;
+  };
 };
 
-type TranslationListTableProps = HTMLAttributes<HTMLTableElement>;
+function TranslationTable({ children, data, ...props }: TranslationTableProps) {
+  const currentPage = data ? Math.floor(data.offset / data.limit) + 1 : 1;
+  const totalPages = data ? Math.ceil(data.total / data.limit) : 1;
 
-const TranslationListTable = (props: TranslationListTableProps) => {
-  const { children, ...rest } = props;
   return (
-    <Table {...rest}>
+    <Table {...props}>
       <TableHeader>
         <TableRow>
           <TableHead>Resource</TableHead>
@@ -54,41 +72,193 @@ const TranslationListTable = (props: TranslationListTableProps) => {
         </TableRow>
       </TableHeader>
       <TableBody>{children}</TableBody>
+      {data && data.limit < data.total && (
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={3}>
+              <div className="flex items-center justify-between">
+                <span className="text-foreground-600 block text-sm font-normal">
+                  Page {currentPage} of {totalPages}
+                </span>
+                <DefaultPagination
+                  hrefFromOffset={(offset) => {
+                    const params = new URLSearchParams(window.location.search);
+
+                    if (offset === 0) {
+                      params.delete('offset');
+                    } else {
+                      params.set('offset', offset.toString());
+                    }
+
+                    return `${window.location.pathname}?${params.toString()}`;
+                  }}
+                  totalCount={data.total}
+                  limit={data.limit}
+                  offset={data.offset}
+                />
+              </div>
+            </TableCell>
+            <TableCell colSpan={2} />
+          </TableRow>
+        </TableFooter>
+      )}
     </Table>
   );
+}
+
+type TranslationSkeletonListProps = {
+  count: number;
 };
+
+function TranslationSkeletonList({ count }: TranslationSkeletonListProps) {
+  return (
+    <>
+      {Array.from({ length: count }, (_, index) => (
+        <TranslationRowSkeleton key={index} />
+      ))}
+    </>
+  );
+}
+
+type TranslationListContentProps = {
+  translations: TranslationGroup[];
+  onTranslationClick: (translation: TranslationGroup) => void;
+  onImportSuccess?: () => void;
+};
+
+function TranslationListContent({ translations, onTranslationClick, onImportSuccess }: TranslationListContentProps) {
+  return (
+    <>
+      {translations.map((translation) => (
+        <TranslationRow
+          key={translation._id}
+          translation={translation}
+          onTranslationClick={onTranslationClick}
+          onImportSuccess={onImportSuccess}
+        />
+      ))}
+    </>
+  );
+}
+
+type TranslationListContainerProps = HTMLAttributes<HTMLDivElement> & {
+  children: React.ReactNode;
+  filterValues: TranslationsFilter;
+  handleFiltersChange: (filters: Partial<TranslationsFilter>) => void;
+  resetFilters: () => void;
+  isFetching?: boolean;
+};
+
+function TranslationListContainer({
+  className,
+  children,
+  filterValues,
+  handleFiltersChange,
+  resetFilters,
+  isFetching,
+  ...props
+}: TranslationListContainerProps) {
+  return (
+    <div className={cn('flex h-full flex-col p-2', className)} {...props}>
+      <TranslationListHeader
+        filterValues={filterValues}
+        handleFiltersChange={handleFiltersChange}
+        resetFilters={resetFilters}
+        isFetching={isFetching}
+      />
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+}
+
+function useTranslationListLogic() {
+  const [selectedTranslationGroup, setSelectedTranslationGroup] = useState<TranslationGroup | null>(null);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  const { filterValues, handleFiltersChange, resetFilters } = useTranslationsUrlState({
+    total: 0,
+  });
+
+  const { data, isPending, isFetching, refetch } = useFetchTranslations(filterValues);
+
+  const handleTranslationClick = useCallback((translationGroup: TranslationGroup) => {
+    setSelectedTranslationGroup(translationGroup);
+    setIsDrawerOpen(true);
+  }, []);
+
+  const handleDrawerClose = useCallback((isOpen: boolean) => {
+    setIsDrawerOpen(isOpen);
+
+    if (!isOpen) {
+      setSelectedTranslationGroup(null);
+    }
+  }, []);
+
+  const handleTranslationGroupUpdated = useCallback(
+    async (resourceId: string) => {
+      const result = await refetch();
+      const updatedGroup = result.data?.data.find((group) => group.resourceId === resourceId);
+
+      if (updatedGroup) {
+        setSelectedTranslationGroup({ ...updatedGroup });
+      }
+    },
+    [refetch]
+  );
+
+  const areFiltersApplied = filterValues.query !== '';
+
+  return {
+    selectedTranslationGroup,
+    isDrawerOpen,
+    filterValues,
+    handleFiltersChange,
+    resetFilters,
+    data,
+    isPending,
+    isFetching,
+    refetch,
+    handleTranslationClick,
+    handleDrawerClose,
+    handleTranslationGroupUpdated,
+    areFiltersApplied,
+  };
+}
 
 type TranslationListProps = HTMLAttributes<HTMLDivElement>;
 
-export const TranslationList = (props: TranslationListProps) => {
-  const { filterValues, handleFiltersChange, resetFilters } = useTranslationsUrlState({
-    total: 0,
-    limit: 50,
-  });
+export function TranslationList(props: TranslationListProps) {
+  const {
+    selectedTranslationGroup,
+    isDrawerOpen,
+    filterValues,
+    handleFiltersChange,
+    resetFilters,
+    data,
+    isPending,
+    isFetching,
+    refetch,
+    handleTranslationClick,
+    handleDrawerClose,
+    handleTranslationGroupUpdated,
+    areFiltersApplied,
+  } = useTranslationListLogic();
 
-  const { data, isPending, isFetching } = useFetchTranslations(filterValues);
-
-  const areFiltersApplied = (Object.keys(filterValues) as (keyof TranslationsFilter)[]).some(
-    (key) => key === 'query' && filterValues[key] !== ''
-  );
-
-  const limit = data?.limit || 50;
+  const limit = data?.limit || DEFAULT_TRANSLATIONS_LIMIT;
 
   if (isPending) {
     return (
-      <TranslationListWrapper
+      <TranslationListContainer
         filterValues={filterValues}
         handleFiltersChange={handleFiltersChange}
         resetFilters={resetFilters}
         isFetching={isFetching}
         {...props}
       >
-        <TranslationListTable>
-          {new Array(limit).fill(0).map((_, index) => (
-            <TranslationRowSkeleton key={index} />
-          ))}
-        </TranslationListTable>
-      </TranslationListWrapper>
+        <TranslationTable>
+          <TranslationSkeletonList count={limit} />
+        </TranslationTable>
+      </TranslationListContainer>
     );
   }
 
@@ -98,7 +268,7 @@ export const TranslationList = (props: TranslationListProps) => {
 
   if (!data?.data.length) {
     return (
-      <TranslationListWrapper
+      <TranslationListContainer
         filterValues={filterValues}
         handleFiltersChange={handleFiltersChange}
         resetFilters={resetFilters}
@@ -110,42 +280,32 @@ export const TranslationList = (props: TranslationListProps) => {
           description="We couldn't find any translations that match your search criteria. Try adjusting your filters."
           onClearFilters={resetFilters}
         />
-      </TranslationListWrapper>
+      </TranslationListContainer>
     );
   }
 
   return (
-    <TranslationListWrapper
+    <TranslationListContainer
       filterValues={filterValues}
       handleFiltersChange={handleFiltersChange}
       resetFilters={resetFilters}
       isFetching={isFetching}
       {...props}
     >
-      <TranslationListTable>
-        {data.data.map((translation) => (
-          <TranslationRow key={translation._id} translation={translation} />
-        ))}
-      </TranslationListTable>
-
-      {data.total > data.limit && (
-        <DefaultPagination
-          offset={data.offset}
-          limit={data.limit}
-          totalCount={data.total}
-          hrefFromOffset={(offset) => {
-            const params = new URLSearchParams(window.location.search);
-
-            if (offset === 0) {
-              params.delete('offset');
-            } else {
-              params.set('offset', offset.toString());
-            }
-
-            return `${window.location.pathname}?${params.toString()}`;
-          }}
+      <TranslationTable data={data}>
+        <TranslationListContent
+          translations={data.data}
+          onTranslationClick={handleTranslationClick}
+          onImportSuccess={() => refetch()}
         />
-      )}
-    </TranslationListWrapper>
+      </TranslationTable>
+
+      <TranslationDrawer
+        isOpen={isDrawerOpen}
+        onOpenChange={handleDrawerClose}
+        translationGroup={selectedTranslationGroup}
+        onTranslationGroupUpdated={handleTranslationGroupUpdated}
+      />
+    </TranslationListContainer>
   );
-};
+}

--- a/apps/dashboard/src/components/translations/translation-row.tsx
+++ b/apps/dashboard/src/components/translations/translation-row.tsx
@@ -1,8 +1,11 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, useCallback } from 'react';
 import { RiDeleteBin2Line, RiDownloadLine, RiMore2Fill, RiRouteFill, RiUploadLine } from 'react-icons/ri';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { buildRoute, ROUTES } from '@/utils/routes';
+import { TranslationGroup } from '@/api/translations';
+import { formatDateSimple } from '@/utils/format-date';
+import { cn } from '@/utils/ui';
 
 import { CompactButton } from '@/components/primitives/button-compact';
 import { CopyButton } from '@/components/primitives/copy-button';
@@ -18,167 +21,216 @@ import { TableCell, TableRow } from '@/components/primitives/table';
 import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/components/primitives/tooltip';
 import { TimeDisplayHoverCard } from '@/components/time-display-hover-card';
 import TruncatedText from '@/components/truncated-text';
-import { formatDateSimple } from '@/utils/format-date';
-import { cn } from '@/utils/ui';
-import { TranslationGroup } from '@/api/translations';
+import { StackedFlagCircles } from '@/components/flag-circle';
+import { TranslationImportTrigger } from './translation-import-trigger';
 
-type TranslationRowProps = {
-  translation: TranslationGroup;
+type TranslationTableCellProps = ComponentProps<typeof TableCell>;
+
+function TranslationTableCell({ className, children, ...props }: TranslationTableCellProps) {
+  return (
+    <TableCell className={cn('group-hover:bg-neutral-alpha-50 text-text-sub relative', className)} {...props}>
+      {children}
+      <span className="sr-only">Edit translation</span>
+    </TableCell>
+  );
+}
+
+type ResourceInfoProps = {
+  resourceId: string;
+  resourceName: string;
 };
 
-const TranslationTableCell = ({ className, children, ...rest }: ComponentProps<typeof TableCell>) => (
-  <TableCell className={cn('group-hover:bg-neutral-alpha-50 text-text-sub relative', className)} {...rest}>
-    {children}
-    <span className="sr-only">Edit translation</span>
-  </TableCell>
-);
-
-export const TranslationRowSkeleton = () => (
-  <TableRow>
-    <TranslationTableCell>
-      <div className="flex items-center gap-3">
-        <Skeleton className="size-4" />
-        <div className="flex flex-col gap-1">
-          <Skeleton className="h-4 w-32" />
-          <Skeleton className="h-3 w-24" />
+function ResourceInfo({ resourceId, resourceName }: ResourceInfoProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <Tooltip delayDuration={300}>
+        <TooltipTrigger>
+          <RiRouteFill className="text-feature size-4" />
+        </TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent>
+            <span className="font-medium">Workflow Translation</span>
+          </TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+      <div>
+        <div className="flex items-center gap-1">
+          <TruncatedText className="max-w-[32ch]">{resourceName}</TruncatedText>
+        </div>
+        <div className="flex items-center gap-1 transition-opacity duration-200">
+          <TruncatedText className="text-foreground-400 font-code block max-w-[40ch] text-xs">
+            {resourceId}
+          </TruncatedText>
+          <CopyButton
+            className="z-10 flex size-2 p-0 px-1 opacity-0 group-hover:opacity-100"
+            valueToCopy={resourceId}
+            size="2xs"
+          />
         </div>
       </div>
-    </TranslationTableCell>
-    <TranslationTableCell>
-      <div className="flex gap-1">
-        <Skeleton className="h-5 w-8 rounded-full" />
-        <Skeleton className="h-5 w-8 rounded-full" />
-        <Skeleton className="h-5 w-8 rounded-full" />
-      </div>
-    </TranslationTableCell>
-    <TranslationTableCell>
-      <Skeleton className="h-4 w-24" />
-    </TranslationTableCell>
-    <TranslationTableCell>
-      <Skeleton className="h-4 w-24" />
-    </TranslationTableCell>
-    <TranslationTableCell>
-      <Skeleton className="h-8 w-8" />
-    </TranslationTableCell>
-  </TableRow>
-);
+    </div>
+  );
+}
 
-export const TranslationRow = ({ translation }: TranslationRowProps) => {
-  const navigate = useNavigate();
-  const { environmentSlug } = useParams<{ environmentSlug: string }>();
+type TranslationActionsMenuProps = {
+  translation: TranslationGroup;
+  onGoToWorkflow: (e: React.MouseEvent) => void;
+  onStopPropagation: (e: React.MouseEvent) => void;
+  onImportSuccess?: () => void;
+};
 
-  const stopPropagation = (e: React.MouseEvent) => {
-    // don't propagate the click event to the row
-    e.stopPropagation();
-  };
-
-  const handleGoToWorkflow = (e: React.MouseEvent) => {
-    stopPropagation(e);
-
-    if (environmentSlug) {
-      navigate(
-        buildRoute(ROUTES.EDIT_WORKFLOW, {
-          environmentSlug: environmentSlug,
-          workflowSlug: translation.resourceId,
-        })
-      );
-    }
+function TranslationActionsMenu({
+  translation,
+  onGoToWorkflow,
+  onStopPropagation,
+  onImportSuccess,
+}: TranslationActionsMenuProps) {
+  const resource = {
+    resourceId: translation.resourceId,
+    resourceType: translation.resourceType,
   };
 
   return (
-    <TableRow
-      key={translation._id}
-      className="group relative isolate cursor-pointer"
-      onClick={() => {
-        // TODO: Navigate to edit translation page when implemented
-      }}
-    >
-      <TranslationTableCell className="flex items-center gap-2 font-medium">
-        <Tooltip delayDuration={300}>
-          <TooltipTrigger>
-            <RiRouteFill className="text-feature size-4" />
-          </TooltipTrigger>
-          <TooltipPortal>
-            <TooltipContent>
-              <span className="font-medium">Workflow Translation</span>
-            </TooltipContent>
-          </TooltipPortal>
-        </Tooltip>
-        <div>
-          <div className="flex items-center gap-1">
-            <TruncatedText className="max-w-[32ch]">{translation.resourceName}</TruncatedText>
-          </div>
-          <div className="flex items-center gap-1 transition-opacity duration-200">
-            <TruncatedText className="text-foreground-400 font-code block max-w-[40ch] text-xs">
-              {translation.resourceId}
-            </TruncatedText>
-            <CopyButton
-              className="z-10 flex size-2 p-0 px-1 opacity-0 group-hover:opacity-100"
-              valueToCopy={translation.resourceId}
-              size="2xs"
-            />
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild onClick={onStopPropagation}>
+        <CompactButton variant="ghost" icon={RiMore2Fill} className="z-10 h-8 w-8 p-0" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuGroup>
+          <DropdownMenuItem onClick={onGoToWorkflow} className="flex cursor-pointer items-center gap-2">
+            <RiRouteFill className="h-4 w-4" />
+            <span>Go to workflow</span>
+          </DropdownMenuItem>
+          <TranslationImportTrigger resource={resource} onSuccess={onImportSuccess}>
+            <DropdownMenuItem onClick={onStopPropagation} className="flex cursor-pointer items-center gap-2">
+              <RiUploadLine className="h-4 w-4" />
+              <span>Import translations</span>
+            </DropdownMenuItem>
+          </TranslationImportTrigger>
+          <DropdownMenuItem onClick={onStopPropagation} className="flex cursor-pointer items-center gap-2">
+            <RiDownloadLine className="h-4 w-4" />
+            <span>Export translations</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={onStopPropagation}
+            className="text-destructive flex cursor-pointer items-center gap-2"
+          >
+            <RiDeleteBin2Line className="h-4 w-4" />
+            <span>Disable & delete translation</span>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function useTranslationRowLogic(translation: TranslationGroup) {
+  const navigate = useNavigate();
+  const { environmentSlug } = useParams<{ environmentSlug: string }>();
+
+  const stopPropagation = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
+
+  const handleGoToWorkflow = useCallback(
+    (e: React.MouseEvent) => {
+      stopPropagation(e);
+
+      if (environmentSlug) {
+        navigate(
+          buildRoute(ROUTES.EDIT_WORKFLOW, {
+            environmentSlug: environmentSlug,
+            workflowSlug: translation.resourceId,
+          })
+        );
+      }
+    },
+    [environmentSlug, navigate, translation.resourceId, stopPropagation]
+  );
+
+  return {
+    stopPropagation,
+    handleGoToWorkflow,
+  };
+}
+
+export function TranslationRowSkeleton() {
+  return (
+    <TableRow>
+      <TranslationTableCell>
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-4" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-24" />
           </div>
         </div>
       </TranslationTableCell>
       <TranslationTableCell>
-        <div className="flex flex-wrap gap-1">
-          {translation.locales.slice(0, 3).map((locale) => (
-            <span
-              key={locale}
-              className="inline-flex items-center rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700"
-            >
-              {locale}
-            </span>
-          ))}
-          {translation.locales.length > 3 && (
-            <span className="inline-flex items-center rounded-full bg-neutral-100 px-2 py-1 text-xs font-medium text-neutral-700">
-              +{translation.locales.length - 3}
-            </span>
-          )}
+        <div className="flex gap-1">
+          <Skeleton className="h-5 w-8 rounded-full" />
+          <Skeleton className="h-5 w-8 rounded-full" />
+          <Skeleton className="h-5 w-8 rounded-full" />
         </div>
       </TranslationTableCell>
+      <TranslationTableCell>
+        <Skeleton className="h-4 w-24" />
+      </TranslationTableCell>
+      <TranslationTableCell>
+        <Skeleton className="h-4 w-24" />
+      </TranslationTableCell>
+      <TranslationTableCell>
+        <Skeleton className="h-8 w-8" />
+      </TranslationTableCell>
+    </TableRow>
+  );
+}
+
+type TranslationRowProps = {
+  translation: TranslationGroup;
+  onTranslationClick?: (translation: TranslationGroup) => void;
+  onImportSuccess?: () => void;
+};
+
+export function TranslationRow({ translation, onTranslationClick, onImportSuccess }: TranslationRowProps) {
+  const { stopPropagation, handleGoToWorkflow } = useTranslationRowLogic(translation);
+
+  const handleRowClick = useCallback(() => {
+    onTranslationClick?.(translation);
+  }, [onTranslationClick, translation]);
+
+  return (
+    <TableRow key={translation._id} className="group relative isolate cursor-pointer" onClick={handleRowClick}>
+      <TranslationTableCell className="font-medium">
+        <ResourceInfo resourceId={translation.resourceId} resourceName={translation.resourceName} />
+      </TranslationTableCell>
+
+      <TranslationTableCell>
+        <StackedFlagCircles locales={translation.locales} maxVisible={4} size="md" />
+      </TranslationTableCell>
+
       <TranslationTableCell>
         <TimeDisplayHoverCard date={new Date(translation.createdAt)}>
           {formatDateSimple(translation.createdAt)}
         </TimeDisplayHoverCard>
       </TranslationTableCell>
+
       <TranslationTableCell>
         <TimeDisplayHoverCard date={new Date(translation.updatedAt)}>
           {formatDateSimple(translation.updatedAt)}
         </TimeDisplayHoverCard>
       </TranslationTableCell>
+
       <TranslationTableCell>
         <div className="flex justify-end">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild onClick={stopPropagation}>
-              <CompactButton variant="ghost" icon={RiMore2Fill} className="z-10 h-8 w-8 p-0" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-64">
-              <DropdownMenuGroup>
-                <DropdownMenuItem onClick={handleGoToWorkflow} className="flex cursor-pointer items-center gap-2">
-                  <RiRouteFill className="h-4 w-4" />
-                  <span>Go to workflow</span>
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={stopPropagation} className="flex cursor-pointer items-center gap-2">
-                  <RiUploadLine className="h-4 w-4" />
-                  <span>Import translations</span>
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={stopPropagation} className="flex cursor-pointer items-center gap-2">
-                  <RiDownloadLine className="h-4 w-4" />
-                  <span>Export translations</span>
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={stopPropagation}
-                  className="text-destructive flex cursor-pointer items-center gap-2"
-                >
-                  <RiDeleteBin2Line className="h-4 w-4" />
-                  <span>Disable & delete translation</span>
-                </DropdownMenuItem>
-              </DropdownMenuGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <TranslationActionsMenu
+            translation={translation}
+            onGoToWorkflow={handleGoToWorkflow}
+            onStopPropagation={stopPropagation}
+            onImportSuccess={onImportSuccess}
+          />
         </div>
       </TranslationTableCell>
     </TableRow>
   );
-};
+}

--- a/apps/dashboard/src/components/translations/translation-row.tsx
+++ b/apps/dashboard/src/components/translations/translation-row.tsx
@@ -200,7 +200,7 @@ export function TranslationRow({ translation, onTranslationClick, onImportSucces
   }, [onTranslationClick, translation]);
 
   return (
-    <TableRow key={translation._id} className="group relative isolate cursor-pointer" onClick={handleRowClick}>
+    <TableRow key={translation.resourceId} className="group relative isolate cursor-pointer" onClick={handleRowClick}>
       <TranslationTableCell className="font-medium">
         <ResourceInfo resourceId={translation.resourceId} resourceName={translation.resourceName} />
       </TranslationTableCell>

--- a/apps/dashboard/src/components/translations/translations-filters.tsx
+++ b/apps/dashboard/src/components/translations/translations-filters.tsx
@@ -5,28 +5,97 @@ import { RiDownloadLine, RiLoader4Line, RiSettings4Line } from 'react-icons/ri';
 import { Button } from '@/components/primitives/button';
 import { FacetedFormFilter } from '@/components/primitives/form/faceted-filter/facated-form-filter';
 import { Form, FormField, FormItem, FormRoot } from '@/components/primitives/form/form';
-import {
-  defaultTranslationsFilter,
-  TranslationsFilter,
-} from '@/components/translations/hooks/use-translations-url-state';
+import { FlagCircle } from '@/components/flag-circle';
 import { cn } from '@/utils/ui';
 
-export type TranslationsFiltersProps = HTMLAttributes<HTMLFormElement> & {
-  onFiltersChange: (filter: TranslationsFilter) => void;
-  filterValues: TranslationsFilter;
-  onReset?: () => void;
-  isFetching?: boolean;
+import { defaultTranslationsFilter, TranslationsFilter } from './hooks/use-translations-url-state';
+
+type SearchFilterProps = {
+  value: string;
+  onChange: (value: string) => void;
 };
 
-export function TranslationsFilters(props: TranslationsFiltersProps) {
-  const { onFiltersChange, filterValues, onReset, className, isFetching, ...rest } = props;
+function SearchFilter({ value, onChange }: SearchFilterProps) {
+  return (
+    <FacetedFormFilter
+      type="text"
+      size="small"
+      title="Search"
+      value={value}
+      onChange={onChange}
+      placeholder="Search translations..."
+    />
+  );
+}
 
+type FilterResetButtonProps = {
+  isVisible: boolean;
+  isFetching?: boolean;
+  onReset: () => void;
+};
+
+function FilterResetButton({ isVisible, isFetching, onReset }: FilterResetButtonProps) {
+  if (!isVisible) return null;
+
+  return (
+    <div className="flex items-center gap-1">
+      <Button variant="secondary" mode="ghost" size="2xs" onClick={onReset}>
+        Reset
+      </Button>
+      {isFetching && <RiLoader4Line className="h-3 w-3 animate-spin text-neutral-400" />}
+    </div>
+  );
+}
+
+type DefaultLocaleButtonProps = {
+  locale: string;
+};
+
+function DefaultLocaleButton({ locale }: DefaultLocaleButtonProps) {
+  return (
+    <button className="group flex h-8 items-center overflow-hidden rounded-lg border border-neutral-200 bg-neutral-50 text-xs hover:bg-neutral-50 focus:bg-neutral-100">
+      <span className="px-3 py-2">Default locale</span>
+      <span className="flex items-center gap-2 border-l border-neutral-200 bg-white p-2 font-medium text-neutral-700 group-hover:bg-neutral-50">
+        <FlagCircle locale={locale} size="sm" />
+        {locale}
+      </span>
+    </button>
+  );
+}
+
+type ActionButtonsProps = {
+  onExport: () => void;
+  onConfigure: () => void;
+  defaultLocale?: string;
+};
+
+function ActionButtons({ onExport, onConfigure, defaultLocale = 'en_US' }: ActionButtonsProps) {
+  return (
+    <div className="ml-auto flex items-center gap-2">
+      <Button variant="secondary" mode="lighter" size="xs" className="!w-8" onClick={onExport}>
+        <RiDownloadLine className="h-3 w-3" />
+      </Button>
+
+      <DefaultLocaleButton locale={defaultLocale} />
+
+      <Button variant="secondary" mode="lighter" size="xs" onClick={onConfigure}>
+        <RiSettings4Line className="mr-2 h-4 w-4" />
+        Configure translations
+      </Button>
+    </div>
+  );
+}
+
+function useTranslationsFiltersLogic(
+  filterValues: TranslationsFilter,
+  onFiltersChange: (filter: TranslationsFilter) => void,
+  onReset?: () => void
+) {
   const form = useForm<TranslationsFilter>({
     values: filterValues,
-    defaultValues: {
-      ...filterValues,
-    },
+    defaultValues: filterValues,
   });
+
   const { formState, watch } = form;
 
   useEffect(() => {
@@ -45,54 +114,58 @@ export function TranslationsFilters(props: TranslationsFiltersProps) {
 
   const isResetButtonVisible = formState.isDirty || filterValues.query !== '';
 
+  return {
+    form,
+    handleReset,
+    isResetButtonVisible,
+  };
+}
+
+export type TranslationsFiltersProps = HTMLAttributes<HTMLFormElement> & {
+  onFiltersChange: (filter: TranslationsFilter) => void;
+  filterValues: TranslationsFilter;
+  onReset?: () => void;
+  isFetching?: boolean;
+  onExport?: () => void;
+  onConfigure?: () => void;
+  defaultLocale?: string;
+};
+
+export function TranslationsFilters({
+  onFiltersChange,
+  filterValues,
+  onReset,
+  className,
+  isFetching,
+  onExport = () => {},
+  onConfigure = () => {},
+  defaultLocale,
+  ...props
+}: TranslationsFiltersProps) {
+  const { form, handleReset, isResetButtonVisible } = useTranslationsFiltersLogic(
+    filterValues,
+    onFiltersChange,
+    onReset
+  );
+
   return (
     <Form {...form}>
-      <FormRoot className={cn('flex w-full items-center justify-between gap-2', className)} {...rest}>
+      <FormRoot className={cn('flex w-full items-center justify-between gap-2', className)} {...props}>
         <div className="flex flex-1 items-center gap-2">
           <FormField
             control={form.control}
             name="query"
             render={({ field }) => (
               <FormItem className="relative">
-                <FacetedFormFilter
-                  type="text"
-                  size="small"
-                  title="Search"
-                  value={field.value}
-                  onChange={field.onChange}
-                  placeholder="Search translations..."
-                />
+                <SearchFilter value={field.value} onChange={field.onChange} />
               </FormItem>
             )}
           />
 
-          {isResetButtonVisible && (
-            <div className="flex items-center gap-1">
-              <Button variant="secondary" mode="ghost" size="2xs" onClick={handleReset}>
-                Reset
-              </Button>
-              {isFetching && <RiLoader4Line className="h-3 w-3 animate-spin text-neutral-400" />}
-            </div>
-          )}
+          <FilterResetButton isVisible={isResetButtonVisible} isFetching={isFetching} onReset={handleReset} />
         </div>
 
-        <div className="ml-auto flex items-center gap-2">
-          <Button variant="secondary" mode="lighter" size="xs" className="!w-8" onClick={() => {}}>
-            <RiDownloadLine className="h-3 w-3" />
-          </Button>
-
-          <button className="group flex h-8 items-center overflow-hidden rounded-lg border border-neutral-200 bg-neutral-50 text-xs hover:bg-neutral-50 focus:bg-neutral-100">
-            <span className="px-3 py-2">Default locale</span>
-            <span className="border-l border-neutral-200 bg-white p-2 font-medium text-neutral-700 group-hover:bg-neutral-50">
-              en_US
-            </span>
-          </button>
-
-          <Button variant="secondary" mode="lighter" size="xs" onClick={() => {}}>
-            <RiSettings4Line className="mr-2 h-4 w-4" />
-            Configure translations
-          </Button>
-        </div>
+        <ActionButtons onExport={onExport} onConfigure={onConfigure} defaultLocale={defaultLocale} />
       </FormRoot>
     </Form>
   );

--- a/apps/dashboard/src/components/translations/utils.ts
+++ b/apps/dashboard/src/components/translations/utils.ts
@@ -1,0 +1,45 @@
+import { locales } from '@/utils/locales';
+
+/**
+ * Get a human-readable display name for a locale code
+ * @param localeCode - The locale code (e.g., 'en_US', 'es_ES')
+ * @returns A formatted display name (e.g., 'English, United States')
+ */
+export function getLocaleDisplayName(localeCode: string): string {
+  const locale = locales.find((l) => l.langIso === localeCode);
+
+  if (locale?.langName) {
+    // Extract language and country from langName like "Spanish (Spain)" -> "Spanish, Spain"
+    const match = locale.langName.match(/^(.+?)\s*\((.+?)\)$/);
+
+    if (match) {
+      return `${match[1]}, ${match[2]}`;
+    }
+
+    return locale.langName;
+  }
+
+  return localeCode;
+}
+
+/**
+ * Format a date for display in the translations module
+ * @param date - The date to format
+ * @param options - Intl.DateTimeFormatOptions
+ * @returns Formatted date string
+ */
+export function formatTranslationDate(date: Date | string, options: Intl.DateTimeFormatOptions): string {
+  const dateObj = typeof date === 'string' ? new Date(date) : date;
+  return dateObj.toLocaleDateString('en-US', options);
+}
+
+/**
+ * Format a time for display in the translations module
+ * @param date - The date to format
+ * @param options - Intl.DateTimeFormatOptions
+ * @returns Formatted time string
+ */
+export function formatTranslationTime(date: Date | string, options: Intl.DateTimeFormatOptions): string {
+  const dateObj = typeof date === 'string' ? new Date(date) : date;
+  return dateObj.toLocaleTimeString('en-US', options);
+}

--- a/apps/dashboard/src/components/unsaved-changes-alert-dialog.tsx
+++ b/apps/dashboard/src/components/unsaved-changes-alert-dialog.tsx
@@ -40,12 +40,10 @@ export const UnsavedChangesAlertDialog = (props: UnsavedChangesAlertDialogProps)
         <Separator />
 
         <AlertDialogFooter>
-          <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={onProceed} asChild>
-            <Button trailingIcon={RiArrowRightSLine} variant="error" mode="ghost" size="xs">
-              Proceed anyway
-            </Button>
-          </AlertDialogAction>
+          <AlertDialogCancel onClick={onProceed} asChild>
+            <Button size="xs">Proceed anyway</Button>
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={onCancel}>Cancel</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/apps/dashboard/src/hooks/use-delete-translation.ts
+++ b/apps/dashboard/src/hooks/use-delete-translation.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEnvironment } from '@/context/environment/hooks';
+import { deleteTranslation } from '@/api/translations';
+import { QueryKeys } from '@/utils/query-keys';
+import { OmitEnvironmentFromParameters } from '@/utils/types';
+
+type DeleteTranslationParameters = OmitEnvironmentFromParameters<typeof deleteTranslation>;
+
+export const useDeleteTranslation = () => {
+  const { currentEnvironment } = useEnvironment();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (args: DeleteTranslationParameters) => deleteTranslation({ environment: currentEnvironment!, ...args }),
+    onSuccess: async (_, variables) => {
+      // Invalidate and refetch all translation-related queries
+      await queryClient.invalidateQueries({
+        queryKey: [QueryKeys.fetchTranslation, currentEnvironment?._id],
+        exact: false,
+      });
+
+      await queryClient.invalidateQueries({
+        queryKey: [QueryKeys.fetchTranslations, currentEnvironment?._id],
+        exact: false,
+      });
+
+      // Force refetch to ensure data is fresh
+      await queryClient.refetchQueries({
+        queryKey: [QueryKeys.fetchTranslations, currentEnvironment?._id],
+        exact: false,
+      });
+    },
+  });
+};

--- a/apps/dashboard/src/hooks/use-fetch-translation.ts
+++ b/apps/dashboard/src/hooks/use-fetch-translation.ts
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
+import { LocalizationResourceEnum } from '@novu/dal';
 import { useEnvironment } from '@/context/environment/hooks';
 import { getTranslation } from '@/api/translations';
 import { QueryKeys } from '@/utils/query-keys';
 
 type FetchTranslationParams = {
   resourceId: string;
-  resourceType: string;
+  resourceType: LocalizationResourceEnum;
   locale: string;
 };
 

--- a/apps/dashboard/src/hooks/use-fetch-translation.ts
+++ b/apps/dashboard/src/hooks/use-fetch-translation.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEnvironment } from '@/context/environment/hooks';
+import { getTranslation } from '@/api/translations';
+import { QueryKeys } from '@/utils/query-keys';
+
+type FetchTranslationParams = {
+  resourceId: string;
+  resourceType: string;
+  locale: string;
+};
+
+export const useFetchTranslation = ({ resourceId, resourceType, locale }: FetchTranslationParams) => {
+  const { currentEnvironment } = useEnvironment();
+
+  return useQuery({
+    queryKey: [QueryKeys.fetchTranslation, resourceId, resourceType, locale, currentEnvironment?._id],
+    queryFn: async () => {
+      if (!currentEnvironment) {
+        throw new Error('Environment is required');
+      }
+
+      return getTranslation({
+        environment: currentEnvironment,
+        resourceId,
+        resourceType,
+        locale,
+      });
+    },
+    enabled: !!currentEnvironment && !!locale && !!resourceId,
+  });
+};

--- a/apps/dashboard/src/hooks/use-fetch-translations.ts
+++ b/apps/dashboard/src/hooks/use-fetch-translations.ts
@@ -1,12 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { useEnvironment } from '@/context/environment/hooks';
 import { getTranslationsList, TranslationsFilter } from '@/api/translations';
+import { QueryKeys } from '@/utils/query-keys';
 
 export const useFetchTranslations = (filterValues: TranslationsFilter) => {
   const { currentEnvironment } = useEnvironment();
 
   return useQuery({
-    queryKey: ['translations', filterValues, currentEnvironment?._id],
+    queryKey: [QueryKeys.fetchTranslations, filterValues, currentEnvironment?._id],
     queryFn: async () => {
       if (!currentEnvironment) {
         throw new Error('Environment is required');

--- a/apps/dashboard/src/hooks/use-save-translation.ts
+++ b/apps/dashboard/src/hooks/use-save-translation.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEnvironment } from '@/context/environment/hooks';
+import { saveTranslation } from '@/api/translations';
+import { QueryKeys } from '@/utils/query-keys';
+import { OmitEnvironmentFromParameters } from '@/utils/types';
+
+type SaveTranslationParameters = OmitEnvironmentFromParameters<typeof saveTranslation>;
+
+export const useSaveTranslation = () => {
+  const { currentEnvironment } = useEnvironment();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (args: SaveTranslationParameters) => saveTranslation({ environment: currentEnvironment!, ...args }),
+    onSuccess: (result, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [
+          QueryKeys.fetchTranslation,
+          variables.resourceId,
+          variables.resourceType,
+          variables.locale,
+          currentEnvironment?._id,
+        ],
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.fetchTranslations, currentEnvironment?._id],
+      });
+    },
+  });
+};

--- a/apps/dashboard/src/hooks/use-upload-translations.ts
+++ b/apps/dashboard/src/hooks/use-upload-translations.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEnvironment } from '@/context/environment/hooks';
+import { uploadTranslations } from '@/api/translations';
+import { QueryKeys } from '@/utils/query-keys';
+import { OmitEnvironmentFromParameters } from '@/utils/types';
+
+type UploadTranslationsParameters = OmitEnvironmentFromParameters<typeof uploadTranslations>;
+
+export const useUploadTranslations = () => {
+  const { currentEnvironment } = useEnvironment();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (args: UploadTranslationsParameters) =>
+      uploadTranslations({ environment: currentEnvironment!, ...args }),
+    onSuccess: async (result, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: [QueryKeys.fetchTranslation, currentEnvironment?._id],
+      });
+
+      await queryClient.invalidateQueries({
+        queryKey: [QueryKeys.fetchTranslations, currentEnvironment?._id],
+        exact: false,
+      });
+
+      await queryClient.refetchQueries({
+        queryKey: [QueryKeys.fetchTranslations, currentEnvironment?._id],
+        exact: false,
+      });
+    },
+  });
+};

--- a/apps/dashboard/src/utils/query-keys.ts
+++ b/apps/dashboard/src/utils/query-keys.ts
@@ -17,4 +17,6 @@ export const QueryKeys = Object.freeze({
   fetchTopics: 'fetchTopics',
   myOrganization: 'myOrganization',
   organizationSettings: 'organizationSettings',
+  fetchTranslations: 'fetchTranslations',
+  fetchTranslation: 'fetchTranslation',
 });


### PR DESCRIPTION
### What changed? Why was the change needed?

EE PR: https://github.com/novuhq/packages-enterprise/pull/322

Whats not included in the PR:
- translation status (up-to-date)
- translation global settings (default locale etc) - other opened PR
- export
- some error/success handling - toasts, error messages etc

https://github.com/user-attachments/assets/df7113ff-3c45-44d9-967a-608628402462





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive translations management interface, including a side drawer for editing, importing, exporting, and deleting translations.
  * Added locale flag and display name components, as well as a stacked flag display for multiple locales.
  * Enabled upload of translation files and bulk translation management.
  * Provided utilities for formatting locale names, dates, and times.

* **Improvements**
  * Refactored translation list and filters into modular, reusable components for better clarity and maintainability.
  * Enhanced pagination and filtering in the translations list.
  * Improved handling of multipart form data for translation uploads.

* **Bug Fixes**
  * Ensured proper handling of unsaved changes with confirmation dialogs to prevent accidental data loss.

* **Chores**
  * Standardized and centralized query keys for translation-related data fetching and mutations.
  * Updated default pagination and file extension constants for translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->