### PR TITLE
feat(worker): Implement bulk event sending method

### DIFF
--- a/enterprise/workers/socket/src/handlers/websocket.ts
+++ b/enterprise/workers/socket/src/handlers/websocket.ts
@@ -78,3 +78,105 @@ export async function handleSendMessage(context: Context) {
 		return context.json({ error: 'Internal server error' }, 500);
 	}
 }
+
+// Send bulk messages handler - Protected by internal API key authentication
+export async function handleSendBulkMessages(context: Context) {
+	try {
+		const { messages, environmentId } = await context.req.json();
+
+		// Validate required fields
+		if (!messages || !Array.isArray(messages)) {
+			return context.json({ error: 'Missing or invalid required field: messages (must be an array)' }, 400);
+		}
+
+		if (!environmentId) {
+			return context.json({ error: 'Missing required field: environmentId' }, 400);
+		}
+
+		if (typeof environmentId !== 'string') {
+			return context.json({ error: 'Invalid field type: environmentId must be a string' }, 400);
+		}
+
+		if (messages.length === 0) {
+			return context.json({ error: 'Messages array cannot be empty' }, 400);
+		}
+
+		if (messages.length > 100) {
+			return context.json({ error: 'Maximum 100 messages allowed per bulk request' }, 400);
+		}
+
+		const results = [];
+		const errors = [];
+		const region = context.env.REGION;
+		const namespace = region === 'eu' ? context.env.WEBSOCKET_ROOM.jurisdiction('eu') : context.env.WEBSOCKET_ROOM;
+
+		for (let i = 0; i < messages.length; i++) {
+			const message = messages[i];
+
+			try {
+				// Validate individual message
+				if (!message.userId || !message.event) {
+					errors.push({
+						index: i,
+						error: 'Missing required fields: userId and event',
+						message,
+					});
+					continue;
+				}
+
+				if (typeof message.userId !== 'string' || typeof message.event !== 'string') {
+					errors.push({
+						index: i,
+						error: 'Invalid field types: userId and event must be strings',
+						message,
+					});
+					continue;
+				}
+
+				// Create room ID based on environment and user
+				const roomId = `${environmentId}:${message.userId}`;
+
+				console.log(`[Internal API Bulk] Routing message ${i + 1}/${messages.length} to room: ${roomId} for user: ${message.userId}, event: ${message.event}`);
+
+				// Get the Durable Object instance for the appropriate room
+				const id = namespace.idFromName(roomId);
+				const stub = namespace.get(id);
+
+				await stub.sendToUser(message.userId, message.event, message.data);
+
+				results.push({
+					index: i,
+					success: true,
+					roomId,
+					userId: message.userId,
+					event: message.event,
+				});
+			} catch (error) {
+				console.error(`Error processing bulk message ${i}:`, error);
+				errors.push({
+					index: i,
+					error: 'Internal server error',
+					message,
+				});
+			}
+		}
+
+		const response = {
+			success: errors.length === 0,
+			processed: results.length,
+			failed: errors.length,
+			total: messages.length,
+			timestamp: new Date().toISOString(),
+			results,
+			...(errors.length > 0 && { errors }),
+		};
+
+		const statusCode = errors.length === 0 ? 200 : errors.length === messages.length ? 500 : 207;
+
+		return context.json(response, statusCode);
+	} catch (error) {
+		console.error('Error processing bulk messages:', error);
+
+		return context.json({ error: 'Internal server error' }, 500);
+	}
+}

--- a/enterprise/workers/socket/src/index.ts
+++ b/enterprise/workers/socket/src/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { authenticateJWT } from './middleware/auth';
 import { authenticateInternalAPI } from './middleware/internal-auth';
-import { handleWebSocketUpgrade, handleSendMessage } from './handlers/websocket';
+import { handleWebSocketUpgrade, handleSendMessage, handleSendBulkMessages } from './handlers/websocket';
 import { WebSocketRoom } from './durable-objects/websocket-room';
 import type { IEnv } from './types';
 
@@ -10,6 +10,8 @@ const app = new Hono<{ Bindings: IEnv }>();
 app.get('/', authenticateJWT, handleWebSocketUpgrade);
 
 app.post('/send', authenticateInternalAPI, handleSendMessage);
+
+app.post('/send/bulk', authenticateInternalAPI, handleSendBulkMessages);
 
 app.get('/health', (context) => context.text('OK'));
 

--- a/enterprise/workers/socket/src/types/index.ts
+++ b/enterprise/workers/socket/src/types/index.ts
@@ -19,3 +19,38 @@ export interface IWebSocketRoom {
 	getActiveConnectionsForUser(userId: string): number;
 	getConnectedUsers(): string[];
 }
+
+export interface IBulkMessage {
+	userId: string;
+	event: string;
+	data?: any;
+}
+
+export interface IBulkSendRequest {
+	messages: IBulkMessage[];
+	environmentId: string;
+}
+
+export interface IBulkMessageResult {
+	index: number;
+	success: true;
+	roomId: string;
+	userId: string;
+	event: string;
+}
+
+export interface IBulkMessageError {
+	index: number;
+	error: string;
+	message: IBulkMessage;
+}
+
+export interface IBulkSendResponse {
+	success: boolean;
+	processed: number;
+	failed: number;
+	total: number;
+	timestamp: string;
+	results: IBulkMessageResult[];
+	errors?: IBulkMessageError[];
+}

--- a/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
+++ b/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
@@ -51,21 +51,49 @@ export class SocketWorkerService {
         return;
       }
 
-      await this.sendMessageInternal(
-        userId,
-        event,
-        { message: storedMessage },
-        organizationId,
-        environmentId,
-        subscriberId
-      );
-
       // Only recalculate the counts if we send a messageId/message.
       if (messageId) {
-        await Promise.all([
-          this.sendUnseenCount(userId, environmentId, organizationId),
-          this.sendUnreadCount(userId, environmentId, organizationId),
-        ]);
+        // Prepare bulk messages: main message + unseen count + unread count
+        const messages = [
+          {
+            userId,
+            event,
+            data: { message: storedMessage },
+          },
+        ];
+
+        // Get unseen count data
+        const unseenData = await this.getUnseenCountData(userId, environmentId);
+        if (unseenData) {
+          messages.push({
+            userId,
+            event: WebSocketEventEnum.UNSEEN,
+            data: unseenData,
+          });
+        }
+
+        // Get unread count data
+        const unreadData = await this.getUnreadCountData(userId, environmentId);
+        if (unreadData) {
+          messages.push({
+            userId,
+            event: WebSocketEventEnum.UNREAD,
+            data: unreadData,
+          });
+        }
+
+        // Send all messages in bulk
+        await this.sendBulkMessages(messages, environmentId);
+      } else {
+        // No messageId, just send the main message
+        await this.sendMessageInternal(
+          userId,
+          event,
+          { message: storedMessage },
+          organizationId,
+          environmentId,
+          subscriberId
+        );
       }
     } else if (event === WebSocketEventEnum.UNREAD) {
       await this.sendUnreadCount(userId, environmentId, organizationId);
@@ -73,6 +101,77 @@ export class SocketWorkerService {
       await this.sendUnseenCount(userId, environmentId, organizationId);
     } else {
       await this.sendMessageInternal(userId, event, data, organizationId, environmentId, subscriberId);
+    }
+  }
+
+  private async sendBulkMessages(
+    messages: Array<{ userId: string; event: string; data: any }>,
+    environmentId?: string
+  ): Promise<void> {
+    if (!this.socketWorkerUrl) {
+      Logger.debug('Socket worker URL not configured, skipping bulk dispatch', LOG_CONTEXT);
+
+      return;
+    }
+
+    if (!this.socketWorkerApiKey) {
+      Logger.error('Socket worker API key not configured, cannot dispatch bulk messages', LOG_CONTEXT);
+
+      return;
+    }
+
+    try {
+      const payload = {
+        messages,
+        environmentId,
+      };
+
+      Logger.log(`Dispatching ${messages.length} bulk messages to socket worker`, LOG_CONTEXT);
+
+      const response = await got.post(`${this.socketWorkerUrl}/send/bulk`, {
+        json: payload,
+        headers: {
+          Authorization: `Bearer ${this.socketWorkerApiKey}`,
+        },
+        responseType: 'json',
+        timeout: 10000, // 10 second timeout for bulk requests
+        retry: {
+          limit: 2,
+          methods: ['POST'],
+          statusCodes: [408, 429, 500, 502, 503, 504],
+        },
+      });
+
+      const result = response.body as any;
+      Logger.debug(
+        `Successfully dispatched bulk messages: ${result.processed}/${result.total} processed`,
+        LOG_CONTEXT
+      );
+
+      if (result.failed > 0) {
+        Logger.warn(`${result.failed} messages failed in bulk dispatch`, LOG_CONTEXT);
+      }
+    } catch (error) {
+      if (error instanceof HTTPError) {
+        const { statusCode } = error.response;
+        const errorText = error.response.body || error.message;
+
+        if (statusCode === 401) {
+          Logger.error(
+            `Unauthorized request to socket worker - check API key configuration: ${errorText}`,
+            LOG_CONTEXT
+          );
+        } else {
+          Logger.error(`Failed to dispatch bulk messages to socket worker: ${statusCode} - ${errorText}`, LOG_CONTEXT);
+        }
+      } else if (error instanceof RequestError) {
+        Logger.error(`Request error dispatching bulk messages to socket worker: ${error.message}`, LOG_CONTEXT);
+      } else {
+        Logger.error(
+          `Error dispatching bulk messages to socket worker: ${error instanceof Error ? error.message : String(error)}`,
+          LOG_CONTEXT
+        );
+      }
     }
   }
 
@@ -147,7 +246,7 @@ export class SocketWorkerService {
     }
   }
 
-  private async sendUnreadCountChange(userId: string, environmentId: string, organizationId?: string): Promise<void> {
+  private async getUnreadCountData(userId: string, environmentId: string): Promise<any | null> {
     try {
       const unreadCount = await this.messageRepository.getCount(
         environmentId,
@@ -162,25 +261,21 @@ export class SocketWorkerService {
       const paginationIndication: UnreadCountPaginationIndication =
         unreadCount > 100 ? { unreadCount: 100, hasMore: true } : { unreadCount, hasMore: false };
 
-      await this.sendMessageInternal(
-        userId,
-        WebSocketEventEnum.UNREAD,
-        {
-          unreadCount: paginationIndication.unreadCount,
-          hasMore: paginationIndication.hasMore,
-        },
-        organizationId,
-        environmentId
-      );
+      return {
+        unreadCount: paginationIndication.unreadCount,
+        hasMore: paginationIndication.hasMore,
+      };
     } catch (error) {
       Logger.error(
-        `Error sending unread count change: ${error instanceof Error ? error.message : String(error)}`,
+        `Error getting unread count data: ${error instanceof Error ? error.message : String(error)}`,
         LOG_CONTEXT
       );
+
+      return null;
     }
   }
 
-  private async sendUnseenCountChange(userId: string, environmentId: string, organizationId?: string): Promise<void> {
+  private async getUnseenCountData(userId: string, environmentId: string): Promise<any | null> {
     try {
       const unseenCount = await this.messageRepository.getCount(
         environmentId,
@@ -195,16 +290,40 @@ export class SocketWorkerService {
       const paginationIndication: UnseenCountPaginationIndication =
         unseenCount > 100 ? { unseenCount: 100, hasMore: true } : { unseenCount, hasMore: false };
 
-      await this.sendMessageInternal(
-        userId,
-        WebSocketEventEnum.UNSEEN,
-        {
-          unseenCount: paginationIndication.unseenCount,
-          hasMore: paginationIndication.hasMore,
-        },
-        organizationId,
-        environmentId
+      return {
+        unseenCount: paginationIndication.unseenCount,
+        hasMore: paginationIndication.hasMore,
+      };
+    } catch (error) {
+      Logger.error(
+        `Error getting unseen count data: ${error instanceof Error ? error.message : String(error)}`,
+        LOG_CONTEXT
       );
+
+      return null;
+    }
+  }
+
+  private async sendUnreadCountChange(userId: string, environmentId: string, organizationId?: string): Promise<void> {
+    try {
+      const data = await this.getUnreadCountData(userId, environmentId);
+      if (data) {
+        await this.sendMessageInternal(userId, WebSocketEventEnum.UNREAD, data, organizationId, environmentId);
+      }
+    } catch (error) {
+      Logger.error(
+        `Error sending unread count change: ${error instanceof Error ? error.message : String(error)}`,
+        LOG_CONTEXT
+      );
+    }
+  }
+
+  private async sendUnseenCountChange(userId: string, environmentId: string, organizationId?: string): Promise<void> {
+    try {
+      const data = await this.getUnseenCountData(userId, environmentId);
+      if (data) {
+        await this.sendMessageInternal(userId, WebSocketEventEnum.UNSEEN, data, organizationId, environmentId);
+      }
     } catch (error) {
       Logger.error(
         `Error sending unseen count change: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
%23%23%23 What changed%3F Why was the change needed%3F

*   **What:** Implemented a new `/send/bulk` endpoint in the socket worker and refactored the `SocketWorkerService` to utilize it.
*   **Why:** To allow sending multiple events (e.g., a new message, unread count, unseen count) in a single HTTP request, significantly reducing network overhead and improving performance for common event dispatch flows. Previously, these events were sent via separate HTTP calls.

%23%23%23 Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

%23%23%23 Related enterprise PR

<!-- A link to a dependent pull request  -->

%23%23%23 Special notes for your reviewer

*   The new `/send/bulk` endpoint supports up to 100 messages per request and provides detailed success/failure reporting for individual messages within the bulk operation.
*   The `SocketWorkerService` now combines the main message, unread count, and unseen count updates into a single bulk request when a `RECEIVED` event with a `messageId` is processed.

</details>