### PR TITLE
fix(dashboard): Remove testData prop from TestWorkflowDrawer

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/step-editor-layout.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/step-editor-layout.tsx
@@ -13,7 +13,6 @@ import { StepEditorProvider, useStepEditor } from '@/components/workflow-editor/
 import { PreviewContextContainer } from '@/components/workflow-editor/steps/context/preview-context-container';
 import { Button } from '@/components/primitives/button';
 import { TestWorkflowDrawer } from '@/components/workflow-editor/test-workflow/test-workflow-drawer';
-import { useFetchWorkflowTestData } from '@/hooks/use-fetch-workflow-test-data';
 import { Protect } from '../../../utils/protect';
 import { parseJsonValue } from '@/components/workflow-editor/steps/utils/preview-context.utils';
 
@@ -26,9 +25,7 @@ type StepEditorLayoutProps = {
 function StepEditorContent() {
   const { step, isSubsequentLoad, editorValue } = useStepEditor();
   const editorTitle = getEditorTitle(step.type);
-  const { workflowSlug = '' } = useParams<{ workflowSlug: string }>();
   const [isTestDrawerOpen, setIsTestDrawerOpen] = useState(false);
-  const { testData } = useFetchWorkflowTestData({ workflowSlug });
 
   const handleTestWorkflowClick = () => {
     setIsTestDrawerOpen(true);
@@ -98,7 +95,6 @@ function StepEditorContent() {
       <TestWorkflowDrawer
         isOpen={isTestDrawerOpen}
         onOpenChange={setIsTestDrawerOpen}
-        testData={testData}
         initialPayload={currentPayload}
       />
     </ResizableLayout>

--- a/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-drawer.tsx
@@ -40,7 +40,6 @@ import { API_HOSTNAME } from '@/config';
 type TestWorkflowDrawerProps = {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  testData?: WorkflowTestDataResponseDto;
   initialPayload?: PayloadData;
 };
 
@@ -69,7 +68,7 @@ const generateCurlCommand = (data: { workflowId: string; to: unknown; payload: s
 };
 
 export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerProps>((props, forwardedRef) => {
-  const { isOpen, onOpenChange, testData, initialPayload } = props;
+  const { isOpen, onOpenChange, initialPayload } = props;
   const [transactionId, setTransactionId] = useState<string>();
   const { currentEnvironment } = useEnvironment();
 
@@ -139,7 +138,7 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
     setSubscriberData(subscriber);
   }, []);
 
-  const to = useMemo(() => createMockObjectFromSchema(testData?.to ?? {}), [testData]);
+  const to = useMemo(() => createMockObjectFromSchema({}), []);
 
   const payload = useMemo(() => {
     // Priority: initialPayload (from step editor) > persisted > payloadExample > empty
@@ -153,7 +152,7 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
 
   const form = useForm<TestWorkflowFormType>({
     mode: 'onSubmit',
-    resolver: zodResolver(buildDynamicFormSchema({ to: testData?.to ?? {} })),
+    resolver: zodResolver(buildDynamicFormSchema({ to: {} })),
     values: { to, payload: JSON.stringify(payload, null, 2) },
   });
 

--- a/apps/dashboard/src/pages/test-workflow-drawer-page.tsx
+++ b/apps/dashboard/src/pages/test-workflow-drawer-page.tsx
@@ -1,16 +1,10 @@
 import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { TestWorkflowDrawer } from '@/components/workflow-editor/test-workflow/test-workflow-drawer';
-import { useFetchWorkflowTestData } from '@/hooks/use-fetch-workflow-test-data';
 
 export function TestWorkflowDrawerPage() {
   const [open, setOpen] = useState(true);
   const navigate = useNavigate();
-  const { workflowSlug } = useParams<{ workflowSlug: string }>();
-
-  const { testData } = useFetchWorkflowTestData({
-    workflowSlug: workflowSlug ?? '',
-  });
 
   const handleOpenChange = (isOpen: boolean) => {
     setOpen(isOpen);
@@ -20,5 +14,5 @@ export function TestWorkflowDrawerPage() {
     }
   };
 
-  return <TestWorkflowDrawer isOpen={open} onOpenChange={handleOpenChange} testData={testData} />;
+  return <TestWorkflowDrawer isOpen={open} onOpenChange={handleOpenChange} />;
 }


### PR DESCRIPTION
Refactored TestWorkflowDrawer and related components to eliminate the testData prop and its associated data fetching logic. The drawer now uses empty schemas for mock data generation and form validation, simplifying the component interface.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
