### PR TITLE
fix(dashboard): Add onBlur handling to data object key-value inputs

### DIFF
--- a/apps/dashboard/src/components/primitives/control-input/control-input.tsx
+++ b/apps/dashboard/src/components/primitives/control-input/control-input.tsx
@@ -22,6 +22,7 @@ type ControlInputProps = {
   className?: string;
   value: string;
   onChange: (value: string) => void;
+  onBlur?: () => void;
   variables: LiquidVariable[];
   isAllowedVariable: IsAllowedVariable;
   placeholder?: string;
@@ -35,6 +36,7 @@ type ControlInputProps = {
 export function ControlInput({
   value,
   onChange,
+  onBlur,
   variables,
   className,
   placeholder,
@@ -50,6 +52,7 @@ export function ControlInput({
       className={cn(variants({ size }), className)}
       value={value}
       onChange={onChange}
+      onBlur={onBlur}
       variables={variables}
       isAllowedVariable={isAllowedVariable}
       placeholder={placeholder}

--- a/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
@@ -220,7 +220,9 @@ export function PayloadSchemaDrawer({
                 </SheetTitle>
                 <SheetDescription className="text-paragraph-xs mt-0">
                   Manage workflow schema for reliable notifications.{' '}
-                  <ExternalLink href="https://docs.novu.co/platform/workflow/build-a-workflow#manage-payload-schema">Learn more</ExternalLink>
+                  <ExternalLink href="https://docs.novu.co/platform/workflow/build-a-workflow#manage-payload-schema">
+                    Learn more
+                  </ExternalLink>
                 </SheetDescription>
               </SheetHeader>
               <Separator />
@@ -306,7 +308,10 @@ export function PayloadSchemaDrawer({
               </SheetMain>
               <SheetFooter className="border-neutral-content-weak space-between flex border-t px-3 py-1.5">
                 <div className="flex w-full flex-row items-center justify-between gap-2">
-                  <Link to="https://docs.novu.co/platform/workflow/build-a-workflow#manage-payload-schema" target="_blank">
+                  <Link
+                    to="https://docs.novu.co/platform/workflow/build-a-workflow#manage-payload-schema"
+                    target="_blank"
+                  >
                     <Button variant="secondary" mode="ghost" size="xs" leadingIcon={RiFileMarkedLine}>
                       View Docs
                     </Button>
@@ -318,14 +323,7 @@ export function PayloadSchemaDrawer({
                     onClick={handleSaveWithValidation}
                     isLoading={isSaving}
                     data-test-id="save-payload-schema-btn"
-                    disabled={
-                      !isSchemaValid ||
-                      !formState.isValid ||
-                      isSaving ||
-                      isLoadingWorkflow ||
-                      isImportMode ||
-                      fields.length === 0
-                    }
+                    disabled={!isSchemaValid || !formState.isValid || isSaving || isLoadingWorkflow || isImportMode}
                   >
                     Save Changes
                   </Button>


### PR DESCRIPTION
Introduces onBlur support to ControlInput and updates the data object editor to update the parent form when key or value fields lose focus. This ensures that changes are propagated only when editing is complete, improving form consistency and reducing unnecessary updates.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
