### PR TITLE
fix(api-service): Add optimistic step support for variable schema building fixes NV-6051

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/build-step-issues/build-step-issues.command.ts
+++ b/apps/api/src/app/workflows-v2/usecases/build-step-issues/build-step-issues.command.ts
@@ -3,6 +3,7 @@ import { EnvironmentWithUserObjectCommand } from '@novu/application-generic';
 import { StepTypeEnum, ResourceOriginEnum } from '@novu/shared';
 import { IsDefined, IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
 import { JSONSchemaDto } from '../../../shared/dtos/json-schema.dto';
+import { IOptimisticStepInfo } from '../build-variable-schema/build-available-variable-schema.command';
 
 export class BuildStepIssuesCommand extends EnvironmentWithUserObjectCommand {
   /**
@@ -31,4 +32,11 @@ export class BuildStepIssuesCommand extends EnvironmentWithUserObjectCommand {
   @IsObject()
   @IsDefined()
   controlSchema: JSONSchemaDto;
+
+  /**
+   * Optimistic step information for sync scenarios where steps aren't persisted yet
+   * but need to be considered for variable schema building
+   */
+  @IsOptional()
+  optimisticSteps?: IOptimisticStepInfo[];
 }

--- a/apps/api/src/app/workflows-v2/usecases/build-step-issues/build-step-issues.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/build-step-issues/build-step-issues.usecase.ts
@@ -75,6 +75,7 @@ export class BuildStepIssuesUsecase {
         stepInternalId,
         workflow: persistedWorkflow,
         ...(controlValuesDto ? { optimisticControlValues: controlValuesDto } : {}),
+        ...(command.optimisticSteps ? { optimisticSteps: command.optimisticSteps } : {}),
       })
     );
 

--- a/apps/api/src/app/workflows-v2/usecases/build-variable-schema/build-available-variable-schema.command.ts
+++ b/apps/api/src/app/workflows-v2/usecases/build-variable-schema/build-available-variable-schema.command.ts
@@ -1,6 +1,13 @@
 import { EnvironmentWithUserCommand } from '@novu/application-generic';
 import { NotificationTemplateEntity } from '@novu/dal';
+import { StepTypeEnum } from '@novu/shared';
 import { IsDefined, IsOptional, IsString } from 'class-validator';
+
+// Type for optimistic step data used during sync
+export interface IOptimisticStepInfo {
+  stepId: string;
+  type: StepTypeEnum;
+}
 
 export class BuildVariableSchemaCommand extends EnvironmentWithUserCommand {
   @IsOptional()
@@ -15,4 +22,11 @@ export class BuildVariableSchemaCommand extends EnvironmentWithUserCommand {
    */
   @IsOptional()
   optimisticControlValues?: Record<string, unknown>;
+
+  /**
+   * Optimistic step information for sync scenarios where steps aren't persisted yet
+   * but need to be considered for variable schema building
+   */
+  @IsOptional()
+  optimisticSteps?: IOptimisticStepInfo[];
 }


### PR DESCRIPTION
Introduces the IOptimisticStepInfo interface and updates relevant use cases and commands to support optimistic (not yet persisted) steps during workflow synchronization. This allows variable schema and step issue building logic to consider both persisted and in-memory steps, improving accuracy in sync scenarios.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
