### PR TITLE
Add sendwithus email provider

### DIFF
--- a/libs/application-generic/src/factories/mail/handlers/index.ts
+++ b/libs/application-generic/src/factories/mail/handlers/index.ts
@@ -1,4 +1,5 @@
 export * from './sendgrid.handler';
+export * from './sendwithus.handler';
 export * from './mailgun.handler';
 export * from './emailjs.handler';
 export * from './mailjet.handler';

--- a/libs/application-generic/src/factories/mail/handlers/sendwithus.handler.ts
+++ b/libs/application-generic/src/factories/mail/handlers/sendwithus.handler.ts
@@ -1,0 +1,18 @@
+import { ChannelTypeEnum, EmailProviderIdEnum, ICredentials } from '@novu/shared';
+import { SendwithusEmailProvider } from '@novu/providers';
+
+import { BaseHandler } from './base.handler';
+
+export class SendwithusHandler extends BaseHandler {
+  constructor() {
+    super('sendwithus' as EmailProviderIdEnum, ChannelTypeEnum.EMAIL);
+  }
+
+  buildProvider(credentials: ICredentials, from?: string) {
+    this.provider = new SendwithusEmailProvider({
+      apiKey: credentials.apiKey,
+      from: from as string,
+      senderName: credentials.senderName,
+    });
+  }
+}

--- a/libs/application-generic/src/factories/mail/mail.factory.ts
+++ b/libs/application-generic/src/factories/mail/mail.factory.ts
@@ -1,6 +1,7 @@
 import { IntegrationEntity } from '@novu/dal';
 import {
   SendgridHandler,
+  SendwithusHandler,
   MailgunHandler,
   EmailJsHandler,
   MailjetHandler,
@@ -26,6 +27,7 @@ import { IMailHandler } from './interfaces/send.handler.interface';
 export class MailFactory {
   handlers: IMailHandler[] = [
     new SendgridHandler(),
+    new SendwithusHandler(),
     new MailgunHandler(),
     new NetCoreHandler(),
     new EmailJsHandler(),

--- a/packages/providers/src/lib/email/index.ts
+++ b/packages/providers/src/lib/email/index.ts
@@ -16,6 +16,7 @@ export * from './plunk/plunk.provider';
 export * from './postmark/postmark.provider';
 export * from './resend/resend.provider';
 export * from './sendgrid/sendgrid.provider';
+export * from './sendwithus/sendwithus.provider';
 export * from './ses/ses.config';
 export * from './ses/ses.provider';
 export * from './sparkpost/sparkpost.error';

--- a/packages/providers/src/lib/email/sendwithus/sendwithus.provider.spec.ts
+++ b/packages/providers/src/lib/email/sendwithus/sendwithus.provider.spec.ts
@@ -1,0 +1,90 @@
+import { SendwithusEmailProvider } from './sendwithus.provider';
+import { IEmailOptions } from '@novu/stateless';
+
+const mockConfig = {
+  apiKey: 'test-api-key',
+  from: 'test@example.com',
+  senderName: 'Test Sender',
+};
+
+const mockNovuMessage: IEmailOptions = {
+  to: ['test@example.com'],
+  subject: 'Test Subject',
+  html: '<div>Test HTML Content</div>',
+  text: 'Test Text Content',
+  from: 'sender@example.com',
+};
+
+test('should trigger sendwithus correctly', async () => {
+  const provider = new SendwithusEmailProvider(mockConfig);
+  const payload = provider['createPayload'](mockNovuMessage);
+
+  expect(payload).toEqual({
+    template: 'novu_direct_send',
+    recipient: {
+      address: 'test@example.com',
+      name: 'test@example.com',
+    },
+    sender: {
+      address: 'sender@example.com',
+      name: 'Test Sender',
+    },
+    template_data: {
+      subject: 'Test Subject',
+      html_content: '<div>Test HTML Content</div>',
+      text_content: 'Test Text Content',
+    },
+  });
+});
+
+test('should handle CC and BCC correctly', async () => {
+  const provider = new SendwithusEmailProvider(mockConfig);
+  const messageWithCcBcc: IEmailOptions = {
+    ...mockNovuMessage,
+    cc: ['cc1@example.com', 'cc2@example.com'],
+    bcc: ['bcc1@example.com'],
+  };
+
+  const payload = provider['createPayload'](messageWithCcBcc);
+
+  expect(payload.cc).toEqual([
+    { address: 'cc1@example.com' },
+    { address: 'cc2@example.com' },
+  ]);
+  expect(payload.bcc).toEqual([{ address: 'bcc1@example.com' }]);
+});
+
+test('should handle reply-to correctly', async () => {
+  const provider = new SendwithusEmailProvider(mockConfig);
+  const messageWithReplyTo: IEmailOptions = {
+    ...mockNovuMessage,
+    replyTo: 'reply@example.com',
+  };
+
+  const payload = provider['createPayload'](messageWithReplyTo);
+
+  expect(payload.sender.reply_to).toBe('reply@example.com');
+});
+
+test('should handle attachments correctly', async () => {
+  const provider = new SendwithusEmailProvider(mockConfig);
+  const messageWithAttachments: IEmailOptions = {
+    ...mockNovuMessage,
+    attachments: [
+      {
+        mime: 'text/plain',
+        file: Buffer.from('test content'),
+        name: 'test.txt',
+      },
+    ],
+  };
+
+  const payload = provider['createPayload'](messageWithAttachments);
+
+  expect(payload.files).toEqual([
+    {
+      id: 'test.txt',
+      data: Buffer.from('test content').toString('base64'),
+    },
+  ]);
+});

--- a/packages/providers/src/lib/email/sendwithus/sendwithus.provider.ts
+++ b/packages/providers/src/lib/email/sendwithus/sendwithus.provider.ts
@@ -1,0 +1,143 @@
+import { EmailProviderIdEnum } from '@novu/shared';
+import {
+  ChannelTypeEnum,
+  ISendMessageSuccessResponse,
+  IEmailOptions,
+  IEmailProvider,
+  ICheckIntegrationResponse,
+  CheckIntegrationResponseEnum,
+  IAttachmentOptions,
+} from '@novu/stateless';
+import axios, { AxiosInstance } from 'axios';
+import { BaseProvider, CasingEnum } from '../../../base.provider';
+import { WithPassthrough } from '../../../utils/types';
+
+export class SendwithusEmailProvider extends BaseProvider implements IEmailProvider {
+  id = 'sendwithus' as EmailProviderIdEnum;
+  protected casing: CasingEnum = CasingEnum.SNAKE_CASE;
+  channelType = ChannelTypeEnum.EMAIL as ChannelTypeEnum.EMAIL;
+  private axiosInstance: AxiosInstance;
+
+  constructor(
+    private config: {
+      apiKey: string;
+      from: string;
+      senderName: string;
+    }
+  ) {
+    super();
+    this.axiosInstance = axios.create({
+      baseURL: 'https://api.sendwithus.com/api/v1',
+      auth: {
+        username: this.config.apiKey,
+        password: '',
+      },
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  async sendMessage(
+    options: IEmailOptions,
+    bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
+  ): Promise<ISendMessageSuccessResponse> {
+    const payload = this.createPayload(options);
+    const response = await this.axiosInstance.post(
+      '/send',
+      this.transform(bridgeProviderData, payload).body
+    );
+
+    return {
+      id: response.data.receipt_id,
+      date: new Date().toISOString(),
+    };
+  }
+
+  async checkIntegration(options: IEmailOptions): Promise<ICheckIntegrationResponse> {
+    try {
+      const payload = this.createPayload(options);
+      await this.axiosInstance.post('/send', payload);
+
+      return {
+        success: true,
+        message: 'Integration successful',
+        code: CheckIntegrationResponseEnum.SUCCESS,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: error?.response?.data?.message || error.message,
+        code: this.mapErrorToCode(error?.response?.status),
+      };
+    }
+  }
+
+  private createPayload(options: IEmailOptions) {
+    const attachments = this.mapAttachments(options.attachments || []);
+    
+    // For direct email sending (non-template based), sendwithus requires a template
+    // We'll create a simple template with the HTML/text content
+    const payload: any = {
+      template: 'novu_direct_send',
+      recipient: {
+        address: options.to[0],
+        name: options.to[0],
+      },
+      template_data: {
+        subject: options.subject,
+        html_content: options.html,
+        text_content: options.text,
+        ...options.customData,
+      },
+    };
+
+    // Add sender information if provided
+    if (options.from || this.config.from) {
+      payload.sender = {
+        address: options.from || this.config.from,
+        name: options.senderName || this.config.senderName,
+      };
+
+      if (options.replyTo) {
+        payload.sender.reply_to = options.replyTo;
+      }
+    }
+
+    if (options.cc && options.cc.length > 0) {
+      payload.cc = options.cc.map(email => ({ address: email }));
+    }
+
+    if (options.bcc && options.bcc.length > 0) {
+      payload.bcc = options.bcc.map(email => ({ address: email }));
+    }
+
+    if (options.headers) {
+      payload.headers = options.headers;
+    }
+
+    if (attachments.length > 0) {
+      payload.files = attachments;
+    }
+
+    return payload;
+  }
+
+  private mapAttachments(attachments: IAttachmentOptions[]): any[] {
+    return attachments.map(attachment => ({
+      id: attachment.name,
+      data: attachment.file.toString('base64'),
+    }));
+  }
+
+  private mapErrorToCode(statusCode?: number): CheckIntegrationResponseEnum {
+    switch (statusCode) {
+      case 401:
+        return CheckIntegrationResponseEnum.BAD_CREDENTIALS;
+      case 403:
+        return CheckIntegrationResponseEnum.INVALID_EMAIL;
+      default:
+        return CheckIntegrationResponseEnum.FAILED;
+    }
+  }
+}

--- a/packages/shared/src/consts/providers/channels/email.ts
+++ b/packages/shared/src/consts/providers/channels/email.ts
@@ -8,6 +8,7 @@ import {
   nodemailerConfig,
   postmarkConfig,
   sendgridConfig,
+  sendwithusConfig,
   sendinblueConfig,
   sesConfig,
   outlook365Config,
@@ -78,6 +79,14 @@ export const emailProviders: IProviderConfig[] = [
     credentials: sendgridConfig,
     docReference: `https://docs.novu.co/integrations/providers/email/sendgrid${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'sendgrid.png', dark: 'sendgrid.png' },
+  },
+  {
+    id: 'sendwithus' as EmailProviderIdEnum,
+    displayName: 'Sendwithus',
+    channel: ChannelTypeEnum.EMAIL,
+    credentials: sendwithusConfig,
+    docReference: `https://support.sendwithus.com/api/`,
+    logoFileName: { light: 'sendwithus.png', dark: 'sendwithus.png' },
   },
   {
     id: EmailProviderIdEnum.Sendinblue,

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -210,6 +210,16 @@ export const sendgridConfig: IConfigCredentials[] = [
   ...mailConfigBase,
 ];
 
+export const sendwithusConfig: IConfigCredentials[] = [
+  {
+    key: CredentialsKeyEnum.ApiKey,
+    displayName: 'API Key',
+    type: 'string',
+    required: true,
+  },
+  ...mailConfigBase,
+];
+
 export const resendConfig: IConfigCredentials[] = [
   {
     key: CredentialsKeyEnum.ApiKey,

--- a/packages/shared/src/types/providers.ts
+++ b/packages/shared/src/types/providers.ts
@@ -71,6 +71,7 @@ export enum EmailProviderIdEnum {
   SparkPost = 'sparkpost',
   EmailWebhook = 'email-webhook',
   Braze = 'braze',
+  Sendwithus = 'sendwithus',
 }
 
 export enum SmsProviderIdEnum {


### PR DESCRIPTION
%23%23%23 What changed%3F Why was the change needed%3F

Added Sendwithus as a new email provider. This change was needed to expand the range of supported email service providers for users, following the existing patterns for email integrations.

This includes:
-   Core provider implementation (`@novu/providers`).
-   API and worker support (`@novu/application-generic`).
-   Dashboard UI configuration (`@novu/shared`).
-   Unit tests for the new provider.

Relevant documentation: [Sendwithus API](https://support.sendwithus.com/api/%23sendapi)

%23%23%23 Screenshots

<!-- No direct visual changes are introduced by this PR. The UI will render based on the new configuration. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

%23%23%23 Related enterprise PR

%23%23%23 Special notes for your reviewer

</details>