### PR TITLE
fix(api): Scripts for subscriber/remove-duplicated-subscribers not trigger

### DIFF
--- a/apps/api/migrations/subscribers/remove-duplicated-subscribers/remove-duplicated-subscribers.migration.ts
+++ b/apps/api/migrations/subscribers/remove-duplicated-subscribers/remove-duplicated-subscribers.migration.ts
@@ -191,3 +191,5 @@ function mergeSubscriberChannels(subscriber: ISubscriber, mergedChannelsMap) {
     }
   }
 }
+
+removeDuplicatedSubscribers()


### PR DESCRIPTION
The migration script just not trigger.

