### PR TITLE
chore(api-service): email step layoutId control value revert the value meaning fixes NV-6202

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -1135,14 +1135,12 @@ describe('EmailOutputRendererUsecase', () => {
         expect(getLayoutUseCase.execute.called).to.be.true;
       });
 
-      it('should use default layout when layoutId is undefined', async () => {
-        const renderCommand = {
-          environmentId: 'fake_env_id',
-          organizationId: 'fake_org_id',
+      it('should use default layout when layoutId is null', async () => {
+        const renderCommand: EmailOutputRendererCommand = {
           controlValues: {
             subject: 'Layout Test',
             body: simpleBodyContent,
-            // layoutId is undefined
+            layoutId: null,
           },
           fullPayloadForRender: {
             ...mockFullPayload,
@@ -1214,7 +1212,7 @@ describe('EmailOutputRendererUsecase', () => {
           controlValues: {
             subject: 'Layout Test',
             body: simpleBodyContent,
-            // layoutId is undefined, should look for default
+            layoutId: null,
           },
           fullPayloadForRender: {
             ...mockFullPayload,
@@ -1447,7 +1445,7 @@ describe('EmailOutputRendererUsecase', () => {
           controlValues: {
             subject: 'Layout Test',
             body: simpleBodyContent,
-            // layoutId is undefined
+            layoutId: null,
           },
           fullPayloadForRender: {
             ...mockFullPayload,
@@ -1475,14 +1473,11 @@ describe('EmailOutputRendererUsecase', () => {
         });
       });
 
-      it('should not call layout repository when layoutId is explicitly set to null', async () => {
-        const renderCommand = {
-          environmentId: 'fake_env_id',
-          organizationId: 'fake_org_id',
+      it('should not call layout repository when layoutId is undefined', async () => {
+        const renderCommand: EmailOutputRendererCommand = {
           controlValues: {
             subject: 'Layout Test',
             body: simpleBodyContent,
-            layoutId: null, // explicitly set to null
           },
           fullPayloadForRender: {
             ...mockFullPayload,
@@ -1542,7 +1537,7 @@ describe('EmailOutputRendererUsecase', () => {
           controlValues: {
             subject: 'Layout Test',
             body: simpleBodyContent,
-            // layoutId is undefined
+            layoutId: null,
           },
           fullPayloadForRender: {
             ...mockFullPayload,

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -175,7 +175,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
         _layoutId: layout._id,
         level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
       });
-    } else if (typeof layoutId === 'undefined') {
+    } else if (layoutId === null) {
       // otherwise find the default layout controls
       const defaultEmailLayout = await this.getLayoutUseCase.execute(
         GetLayoutCommand.create({

--- a/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -381,8 +381,8 @@ export class UpsertWorkflowUseCase {
         organization: { _id: command.user.organizationId },
       });
 
-      // Assign default layoutId if undefined (but not if null)
-      if (isLayoutsPageActive && emailControlValues.layoutId === undefined) {
+      // Assign default layoutId if null (but not if undefined)
+      if (isLayoutsPageActive && emailControlValues.layoutId === null) {
         const defaultLayout = await this.getLayoutUseCase.execute(
           GetLayoutCommand.create({
             environmentId: command.user.environmentId,
@@ -393,8 +393,7 @@ export class UpsertWorkflowUseCase {
         );
         emailControlValues.layoutId = defaultLayout.layoutId;
       } else if (isLayoutsPageActive && typeof emailControlValues.layoutId === 'string') {
-        // Check if the layout exists
-        await this.getLayoutUseCase.execute(
+        const layout = await this.getLayoutUseCase.execute(
           GetLayoutCommand.create({
             layoutIdOrInternalId: emailControlValues.layoutId,
             environmentId: command.user.environmentId,
@@ -403,6 +402,7 @@ export class UpsertWorkflowUseCase {
             skipAdditionalFields: true,
           })
         );
+        emailControlValues.layoutId = layout.layoutId;
       }
 
       const isMaily = isStringifiedMailyJSONContent(emailControlValues.body);

--- a/libs/application-generic/src/schemas/control/email-control.schema.ts
+++ b/libs/application-generic/src/schemas/control/email-control.schema.ts
@@ -39,7 +39,6 @@ export const emailUiSchema: UiSchema = {
     },
     layoutId: {
       component: UiComponentEnum.LAYOUT_SELECT,
-      placeholder: '',
     },
   },
 };


### PR DESCRIPTION
### What changed? Why was the change needed?

Email Step `layoutId` control value meaning:
`layoutId: undefined` - no layout
`layoutId: null` - use default layout
`layoutId: string` - use the specified layout

### Screenshots

https://github.com/user-attachments/assets/ee850434-3cbe-43d0-a153-9f06506975d3


