### PR TITLE
feat(dashboard,api): translation fallback & deletion fixes NV-6211

### DIFF
--- a/apps/api/src/app/workflows-v1/usecases/create-workflow/create-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v1/usecases/create-workflow/create-workflow.usecase.ts
@@ -147,8 +147,9 @@ export class CreateWorkflow {
 
   private async toggleV2TranslationsForWorkflow(workflowIdentifier: string, command: CreateWorkflowCommand) {
     const isEnterprise = process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
+    const isSelfHosted = process.env.NOVU_SELF_HOSTED === 'true';
 
-    if (!isEnterprise) {
+    if (!isEnterprise || isSelfHosted) {
       return;
     }
 

--- a/apps/api/src/app/workflows-v1/usecases/delete-workflow/delete-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v1/usecases/delete-workflow/delete-workflow.usecase.ts
@@ -1,4 +1,5 @@
 import { Injectable, Optional } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 import {
   ControlValuesRepository,
   LocalizationResourceEnum,
@@ -19,7 +20,6 @@ import {
 } from '@novu/application-generic';
 import { DeleteWorkflowCommand } from './delete-workflow.command';
 import { GetWorkflowWithPreferencesCommand } from '../get-workflow-with-preferences/get-workflow-with-preferences.command';
-import { ModuleRef } from '@nestjs/core';
 
 @Injectable()
 export class DeleteWorkflowUseCase {
@@ -116,6 +116,7 @@ export class DeleteWorkflowUseCase {
     }
 
     try {
+      // eslint-disable-next-line global-require
       const deleteTranslationGroup = this.moduleRef.get(require('@novu/ee-translation')?.DeleteTranslationGroup, {
         strict: false,
       });
@@ -134,7 +135,7 @@ export class DeleteWorkflowUseCase {
         error: error instanceof Error ? error.message : String(error),
       });
 
-      throw error;
+      // translation group might not be present, so we can ignore the error
     }
   }
 }

--- a/apps/api/src/app/workflows-v1/usecases/delete-workflow/delete-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v1/usecases/delete-workflow/delete-workflow.usecase.ts
@@ -1,6 +1,7 @@
 import { Injectable, Optional } from '@nestjs/common';
 import {
   ControlValuesRepository,
+  LocalizationResourceEnum,
   MessageTemplateRepository,
   NotificationTemplateEntity,
   NotificationTemplateRepository,
@@ -14,9 +15,11 @@ import {
   Instrument,
   InstrumentUsecase,
   SendWebhookMessage,
+  PinoLogger,
 } from '@novu/application-generic';
 import { DeleteWorkflowCommand } from './delete-workflow.command';
 import { GetWorkflowWithPreferencesCommand } from '../get-workflow-with-preferences/get-workflow-with-preferences.command';
+import { ModuleRef } from '@nestjs/core';
 
 @Injectable()
 export class DeleteWorkflowUseCase {
@@ -26,6 +29,8 @@ export class DeleteWorkflowUseCase {
     private getWorkflowByIdsUseCase: GetWorkflowByIdsUseCase,
     private controlValuesRepository: ControlValuesRepository,
     private deletePreferencesUsecase: DeletePreferencesUseCase,
+    private moduleRef: ModuleRef,
+    private logger: PinoLogger,
     @Optional()
     private sendWebhookMessage?: SendWebhookMessage
   ) {}
@@ -92,11 +97,44 @@ export class DeleteWorkflowUseCase {
         })
       );
 
+      await this.deleteTranslationGroup(command);
+
       await this.notificationTemplateRepository.delete({
         _id: workflow._id,
         _organizationId: command.organizationId,
         _environmentId: command.environmentId,
       });
     });
+  }
+
+  private async deleteTranslationGroup(command: DeleteWorkflowCommand) {
+    const isEnterprise = process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
+    const isSelfHosted = process.env.NOVU_SELF_HOSTED === 'true';
+
+    if (!isEnterprise || isSelfHosted) {
+      return;
+    }
+
+    try {
+      const deleteTranslationGroup = this.moduleRef.get(require('@novu/ee-translation')?.DeleteTranslationGroup, {
+        strict: false,
+      });
+
+      await deleteTranslationGroup.execute({
+        resourceId: command.workflowIdOrInternalId,
+        resourceType: LocalizationResourceEnum.WORKFLOW,
+        organizationId: command.organizationId,
+        environmentId: command.environmentId,
+        userId: command.userId,
+      });
+    } catch (error) {
+      this.logger.error(`Failed to delete translations for workflow`, {
+        workflowIdentifier: command.workflowIdOrInternalId,
+        organizationId: command.organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      throw error;
+    }
   }
 }

--- a/apps/api/src/app/workflows-v1/usecases/update-workflow/update-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v1/usecases/update-workflow/update-workflow.usecase.ts
@@ -352,8 +352,9 @@ export class UpdateWorkflow {
 
   private async toggleV2TranslationsForWorkflow(workflowIdentifier: string, command: UpdateWorkflowCommand) {
     const isEnterprise = process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
+    const isSelfHosted = process.env.NOVU_SELF_HOSTED === 'true';
 
-    if (!isEnterprise) {
+    if (!isEnterprise || isSelfHosted) {
       return;
     }
 

--- a/apps/api/src/app/workflows-v2/usecases/patch-workflow/patch-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/patch-workflow/patch-workflow.usecase.ts
@@ -153,8 +153,9 @@ export class PatchWorkflowUsecase {
 
   private async toggleV2TranslationsForWorkflow(workflowIdentifier: string, command: PatchWorkflowCommand) {
     const isEnterprise = process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
+    const isSelfHosted = process.env.NOVU_SELF_HOSTED === 'true';
 
-    if (!isEnterprise) {
+    if (!isEnterprise || isSelfHosted) {
       return;
     }
 

--- a/apps/dashboard/src/components/translations/translation-row.tsx
+++ b/apps/dashboard/src/components/translations/translation-row.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps, useCallback } from 'react';
-import { RiDeleteBin2Line, RiDownloadLine, RiMore2Fill, RiRouteFill } from 'react-icons/ri';
+import { RiDeleteBin2Line, RiMore2Fill, RiRouteFill } from 'react-icons/ri';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { buildRoute, ROUTES } from '@/utils/routes';
@@ -88,10 +88,6 @@ function TranslationActionsMenu({ onGoToWorkflow, onStopPropagation, onDeleteCli
           <DropdownMenuItem onClick={onGoToWorkflow} className="flex cursor-pointer items-center gap-2">
             <RiRouteFill className="h-4 w-4" />
             <span>Go to workflow</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={onStopPropagation} className="flex cursor-pointer items-center gap-2">
-            <RiDownloadLine className="h-4 w-4" />
-            <span>Export translations</span>
           </DropdownMenuItem>
           <DropdownMenuItem onClick={onDeleteClick} className="text-destructive flex cursor-pointer items-center gap-2">
             <RiDeleteBin2Line className="h-4 w-4" />

--- a/apps/dashboard/src/components/translations/translations-filters.tsx
+++ b/apps/dashboard/src/components/translations/translations-filters.tsx
@@ -1,6 +1,6 @@
 import { HTMLAttributes, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { RiDownloadLine, RiLoader4Line } from 'react-icons/ri';
+import { RiLoader4Line } from 'react-icons/ri';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { Button } from '@/components/primitives/button';
@@ -87,10 +87,6 @@ function ActionButtons() {
 
   return (
     <div className="ml-auto flex items-center gap-2">
-      <Button variant="secondary" mode="lighter" size="xs" className="!w-8" onClick={() => {}}>
-        <RiDownloadLine className="h-3 w-3" />
-      </Button>
-
       <DefaultLocaleButton locale={defaultLocale} onClick={handleConfigure} />
     </div>
   );

--- a/apps/dashboard/src/components/workflow-editor/control-input/control-input.tsx
+++ b/apps/dashboard/src/components/workflow-editor/control-input/control-input.tsx
@@ -78,6 +78,7 @@ export function ControlInput({
     handleTranslationPopoverOpenChange,
     translationTriggerPosition,
     isTranslationPopoverOpen,
+    shouldEnableTranslations,
   } = useEditorTranslationOverlay({
     viewRef,
     lastCompletionRef,
@@ -140,7 +141,7 @@ export function ControlInput({
           }
         }}
         highlightedVariableKey={highlightedVariableKey}
-        enableTranslations={enableTranslations}
+        enableTranslations={shouldEnableTranslations}
       />
     </VariableEditor>
   );

--- a/apps/dashboard/src/components/workflow-editor/steps/context/step-editor-context.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/context/step-editor-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, ReactNode, useMemo, useState } from 'react';
+import { createContext, useContext, ReactNode, useMemo, useState, useEffect, useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
 import {
   WorkflowResponseDto,
@@ -8,6 +8,7 @@ import {
   DEFAULT_LOCALE,
 } from '@novu/shared';
 import { useEditorPreview } from '@/components/workflow-editor/steps/use-editor-preview';
+import { useFetchOrganizationSettings } from '@/hooks/use-fetch-organization-settings';
 
 type StepEditorContextType = {
   workflow: WorkflowResponseDto;
@@ -36,7 +37,17 @@ type StepEditorProviderProps = {
 export function StepEditorProvider({ children, workflow, step }: StepEditorProviderProps) {
   const form = useFormContext();
   const controlValues = form.watch();
+  const { data: organizationSettings } = useFetchOrganizationSettings();
   const [selectedLocale, setSelectedLocale] = useState<string>(DEFAULT_LOCALE);
+  const hasInitialized = useRef(false);
+
+  // Set to organization default when settings load (only once)
+  useEffect(() => {
+    if (organizationSettings?.data?.defaultLocale && !hasInitialized.current) {
+      setSelectedLocale(organizationSettings.data.defaultLocale);
+      hasInitialized.current = true;
+    }
+  }, [organizationSettings?.data?.defaultLocale]);
 
   const { editorValue, setEditorValue, previewData, isPreviewPending, isFetching } = useEditorPreview({
     workflowSlug: workflow.workflowId,

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-body.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-body.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { Variable } from '@maily-to/core/extensions';
-import { FeatureFlagsKeysEnum } from '@novu/shared';
 
 import { FormField } from '@/components/primitives/form/form';
 import { Maily } from '../../../maily/maily';
@@ -14,7 +13,6 @@ import { useCreateVariable } from '@/components/variable/hooks/use-create-variab
 import { useWorkflowSchema } from '../../workflow-schema-provider';
 import { useCreateTranslationKey } from '@/hooks/use-create-translation-key';
 import { useFetchTranslationKeys } from '@/hooks/use-fetch-translation-keys';
-import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { createEditorBlocks } from '../../../maily/maily-config';
 import {
@@ -130,7 +128,6 @@ function createVariableNodeView(variables: LiquidVariable[], isAllowedVariable: 
 }
 
 export const EmailBody = () => {
-  const isTranslationEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_TRANSLATION_ENABLED);
   const viewRef = useRef<EditorView | null>(null);
   const lastCompletionRef = useRef<CompletionRange | null>(null);
   const { control, setValue } = useFormContext();
@@ -139,6 +136,13 @@ export const EmailBody = () => {
   const { isPayloadSchemaEnabled, currentSchema, getSchemaPropertyByKey } = useWorkflowSchema();
   const { saveForm } = useSaveForm();
   const track = useTelemetry();
+
+  const onChange = useCallback(
+    (value: string) => {
+      setValue('body', value);
+    },
+    [setValue]
+  );
 
   const blocks = useMemo(() => {
     return createEditorBlocks({ track, digestStepBeforeCurrent });
@@ -160,6 +164,23 @@ export const EmailBody = () => {
 
   const parsedVariables = useParseVariables(variablesSchema, digestStepBeforeCurrent?.stepId, isPayloadSchemaEnabled);
 
+  const {
+    translationCompletionSource,
+    translationPluginExtension,
+    selectedTranslation,
+    handleTranslationDelete,
+    handleTranslationReplaceKey,
+    handleTranslationPopoverOpenChange,
+    translationTriggerPosition,
+    isTranslationPopoverOpen,
+    shouldEnableTranslations,
+  } = useEditorTranslationOverlay({
+    viewRef,
+    lastCompletionRef,
+    onChange,
+    workflow,
+  });
+
   const createTranslationKeyMutation = useCreateTranslationKey();
 
   const handleCreateNewTranslationKey = useCallback(
@@ -177,7 +198,7 @@ export const EmailBody = () => {
 
   const { translationKeys, isLoading: isTranslationKeysLoading } = useFetchTranslationKeys({
     workflowId: workflow?._id || '',
-    enabled: isTranslationEnabled && !!workflow?._id,
+    enabled: shouldEnableTranslations && !!workflow?._id,
   });
 
   // Create a key that changes when variables or translation state changes to force extension recreation
@@ -188,14 +209,14 @@ export const EmailBody = () => {
       .join(',');
 
     // Include translation state to force re-mount when translation extension becomes ready
-    const translationState = `translation-${isTranslationEnabled ? 'enabled' : 'disabled'}-${isTranslationKeysLoading ? 'loading' : 'loaded'}-${translationKeys.length}`;
+    const translationState = `translation-${shouldEnableTranslations ? 'enabled' : 'disabled'}-${isTranslationKeysLoading ? 'loading' : 'loaded'}-${translationKeys.length}`;
 
     return `vars-${variableNames.length}-${variableNames.slice(0, 100)}-${translationState}`;
   }, [
     parsedVariables.primitives,
     parsedVariables.arrays,
     parsedVariables.namespaces,
-    isTranslationEnabled,
+    shouldEnableTranslations,
     isTranslationKeysLoading,
     translationKeys.length,
   ]);
@@ -211,30 +232,6 @@ export const EmailBody = () => {
     },
     [parsedVariables]
   );
-
-  const onChange = useCallback(
-    (value: string) => {
-      setValue('body', value);
-    },
-    [setValue]
-  );
-
-  const {
-    translationCompletionSource,
-    translationPluginExtension,
-    selectedTranslation,
-    handleTranslationDelete,
-    handleTranslationReplaceKey,
-    handleTranslationPopoverOpenChange,
-    translationTriggerPosition,
-    isTranslationPopoverOpen,
-  } = useEditorTranslationOverlay({
-    viewRef,
-    lastCompletionRef,
-    onChange,
-    workflow,
-    enableTranslations: isTranslationEnabled,
-  });
 
   const { enhancedIsAllowedVariable } = useEnhancedVariableValidation({
     isAllowedVariable: parsedVariables.isAllowedVariable,
@@ -293,7 +290,7 @@ export const EmailBody = () => {
                   }
                 }}
                 highlightedVariableKey={highlightedVariableKey}
-                enableTranslations={isTranslationEnabled}
+                enableTranslations={shouldEnableTranslations}
               />
             </HtmlEditor>
           );
@@ -307,7 +304,7 @@ export const EmailBody = () => {
             variables={parsedVariables}
             blocks={blocks}
             isPayloadSchemaEnabled={isPayloadSchemaEnabled}
-            isTranslationEnabled={isTranslationEnabled && !isTranslationKeysLoading}
+            isTranslationEnabled={shouldEnableTranslations && !isTranslationKeysLoading}
             translationKeys={translationKeys}
             addDigestVariables={!!digestStepBeforeCurrent?.stepId}
             onCreateNewTranslationKey={handleCreateNewTranslationKey}

--- a/apps/dashboard/src/components/workflow-editor/steps/preview-context-panel.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/preview-context-panel.tsx
@@ -107,7 +107,6 @@ export function PreviewContextPanel({
     loadPersistedSubscriber,
   });
 
-  // Sync subscriber locale with selected locale
   useEffect(() => {
     if (selectedLocale && localParsedData.subscriber.locale !== selectedLocale) {
       updateJsonSection('subscriber', {
@@ -115,14 +114,7 @@ export function PreviewContextPanel({
         locale: selectedLocale,
       });
     }
-  }, [selectedLocale, localParsedData.subscriber, updateJsonSection]);
-
-  // Sync selected locale with subscriber locale when subscriber locale changes
-  useEffect(() => {
-    if (localParsedData.subscriber.locale && localParsedData.subscriber.locale !== selectedLocale && onLocaleChange) {
-      onLocaleChange(localParsedData.subscriber.locale);
-    }
-  }, [localParsedData.subscriber.locale, selectedLocale, onLocaleChange]);
+  }, [localParsedData.subscriber, selectedLocale, updateJsonSection]);
 
   const handleClearPersistedPayload = () => {
     clearPersistedPayload();
@@ -137,7 +129,7 @@ export function PreviewContextPanel({
   const handleClearPersistedSubscriber = () => {
     clearPersistedSubscriber();
 
-    updateJsonSection('subscriber', createDefaultSubscriberData(selectedLocale));
+    updateJsonSection('subscriber', createDefaultSubscriberData(selectedLocale || DEFAULT_LOCALE));
   };
 
   const canClearPersisted = !!(workflow?.workflowId && currentStepId && currentEnvironment?._id);

--- a/apps/dashboard/src/components/workflow-editor/steps/utils/preview-context.utils.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/utils/preview-context.utils.ts
@@ -33,7 +33,10 @@ export function createSubscriberData(subscriber: ISubscriberResponseDto): Previe
   };
 }
 
-export function createSubscriberDataFromUser(user: IUserEntity): PreviewSubscriberData {
+export function createSubscriberDataFromUser(
+  user: IUserEntity,
+  locale: string = DEFAULT_LOCALE
+): PreviewSubscriberData {
   return {
     subscriberId: user.email || user._id,
     firstName: user.firstName || '',
@@ -41,7 +44,7 @@ export function createSubscriberDataFromUser(user: IUserEntity): PreviewSubscrib
     email: user.email || '',
     phone: '',
     avatar: user.profilePicture || '',
-    locale: DEFAULT_LOCALE,
+    locale,
   };
 }
 

--- a/apps/dashboard/src/hooks/use-editor-translation-overlay.ts
+++ b/apps/dashboard/src/hooks/use-editor-translation-overlay.ts
@@ -1,13 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import { EditorView } from '@uiw/react-codemirror';
-import { FeatureFlagsKeysEnum } from '@novu/shared';
 
 import { CompletionRange } from '@/components/primitives/variable-editor';
-import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useTranslationCompletionSource } from '@/hooks/use-translation-completion-source';
 import { useTranslationPluginExtension } from '@/hooks/use-translation-plugin-extension';
 import { TRANSLATION_PILL_HEIGHT } from '@/components/primitives/translation-plugin/constants';
 import { WorkflowResponseDto } from '@novu/shared';
+import { useIsTranslationEnabled } from './use-is-translation-enabled';
 
 type UseTranslationEditorProps = {
   viewRef: React.MutableRefObject<EditorView | null>;
@@ -22,9 +21,9 @@ export function useEditorTranslationOverlay({
   lastCompletionRef,
   onChange,
   workflow,
-  enableTranslations = false,
+  enableTranslations = true,
 }: UseTranslationEditorProps) {
-  const isTranslationEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_TRANSLATION_ENABLED);
+  const isTranslationEnabled = useIsTranslationEnabled();
   const shouldEnableTranslations = isTranslationEnabled && enableTranslations;
 
   const [translationTriggerPosition, setTranslationTriggerPosition] = useState<{ top: number; left: number } | null>(

--- a/apps/dashboard/src/hooks/use-translation-completion-source.ts
+++ b/apps/dashboard/src/hooks/use-translation-completion-source.ts
@@ -1,13 +1,12 @@
 import { useMemo } from 'react';
-import { FeatureFlagsKeysEnum } from '@novu/shared';
-import { useFeatureFlag } from './use-feature-flag';
 import { createTranslationAutocompleteSource } from '@/components/primitives/translation-plugin/autocomplete';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { useFetchTranslationKeys } from './use-fetch-translation-keys';
 import { useCreateTranslationKey } from './use-create-translation-key';
+import { useIsTranslationEnabled } from './use-is-translation-enabled';
 
 export const useTranslationCompletionSource = ({ workflow }: { workflow?: { _id: string } }) => {
-  const isTranslationEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_TRANSLATION_ENABLED);
+  const isTranslationEnabled = useIsTranslationEnabled();
   const createTranslationKeyMutation = useCreateTranslationKey();
   const { translationKeys } = useFetchTranslationKeys({
     workflowId: workflow?._id || '',

--- a/apps/dashboard/src/hooks/use-translation-validation.ts
+++ b/apps/dashboard/src/hooks/use-translation-validation.ts
@@ -37,9 +37,8 @@ export const useTranslationValidation = ({
       };
     }
 
-    // If no translation keys are provided, assume valid
     if (!availableKeys || availableKeys.length === 0) {
-      return { hasError: false, errorMessage: '', isValidKey: true };
+      return { hasError: true, errorMessage: 'Translation key not found in default locale.', isValidKey: false };
     }
 
     const existingKeys = availableKeys.map((key) => key.name);
@@ -47,7 +46,7 @@ export const useTranslationValidation = ({
 
     return {
       hasError: !isValidKey,
-      errorMessage: isValidKey ? '' : 'Translation key not found',
+      errorMessage: isValidKey ? '' : 'Translation key not found in default locale.',
       isValidKey,
     };
   }, [translationKey, availableKeys, isLoading, allowEmpty]);
@@ -69,9 +68,9 @@ export const validateTranslationKey = (
     return { hasError: false, errorMessage: '', isValidKey: false };
   }
 
-  // If no translation keys are provided, assume valid (backwards compatibility)
+  // If no translation keys are provided, show error
   if (!availableKeys || availableKeys.length === 0) {
-    return { hasError: false, errorMessage: '', isValidKey: true };
+    return { hasError: true, errorMessage: 'Translation key not found in default locale.', isValidKey: false };
   }
 
   const existingKeys = availableKeys.map((key) => key.name);
@@ -79,7 +78,7 @@ export const validateTranslationKey = (
 
   return {
     hasError: !isValidKey,
-    errorMessage: isValidKey ? '' : 'Translation key not found',
+    errorMessage: isValidKey ? '' : 'Translation key not found in default locale.',
     isValidKey,
   };
 };


### PR DESCRIPTION
### What changed? Why was the change needed?

EE PR: https://github.com/novuhq/packages-enterprise/pull/326


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization default locale is now automatically set as the selected locale in the workflow editor when available.

* **Bug Fixes**
  * Improved handling of translation key validation to treat missing or empty translation keys as errors, with clearer error messages.
  * Ensured a locale is always set when clearing or creating subscriber data in workflow editor previews.

* **Improvements**
  * Disabled translation toggling features in self-hosted environments across workflow creation, update, and patching.
  * Deleting a workflow now also removes associated translation groups in eligible environments.

* **UI Changes**
  * Removed "Export translations" actions and related icons from translation menus and filters.

* **API Changes**
  * The function for creating subscriber data now allows specifying a locale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->