### PR TITLE
docs(api): correct description for /credentials endpoints

### DIFF
--- a/apps/api/src/app/subscribers/subscribersV1.controller.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.controller.ts
@@ -294,9 +294,9 @@ export class SubscribersV1Controller {
   @RequireAuthentication()
   @ApiResponse(SubscriberResponseDto)
   @ApiOperation({
-    summary: 'Update provider credentials',
-    description: `Update credentials for a provider such as slack and push tokens. 
-      **providerId** is required field. This API replaces the existing deviceTokens with the provided ones.`,
+    summary: 'Upsert provider credentials',
+    description: `Upsert credentials for a provider such as slack and push tokens. 
+      **providerId** is required field. This API creates **deviceTokens** or replaces the existing with the provided ones.`,
   })
   @SdkGroupName('Subscribers.Credentials')
   async updateSubscriberChannel(
@@ -323,9 +323,9 @@ export class SubscribersV1Controller {
   @RequireAuthentication()
   @ApiResponse(SubscriberResponseDto)
   @ApiOperation({
-    summary: 'Upsert provider credentials',
-    description: `Update credentials for a provider such as **slack** and **FCM**. 
-      **providerId** is required field. This API appends the **deviceTokens** to the existing ones.`,
+    summary: 'Create or Partially Update provider credentials',
+    description: `Create or Partially credentials for a provider such as **slack** and **FCM**. 
+      **providerId** is required field. This API creates the **deviceTokens** or appends to the existing ones.`,
   })
   @SdkGroupName('Subscribers.Credentials')
   @SdkMethodName('append')

--- a/apps/api/src/app/subscribers/subscribersV1.controller.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.controller.ts
@@ -296,7 +296,7 @@ export class SubscribersV1Controller {
   @ApiOperation({
     summary: 'Upsert provider credentials',
     description: `Upsert credentials for a provider such as slack and push tokens. 
-      **providerId** is required field. This API creates **deviceTokens** or replaces the existing with the provided ones.`,
+      **providerId** is required field. This API creates **deviceTokens** or appends to the existing ones.`,
   })
   @SdkGroupName('Subscribers.Credentials')
   async updateSubscriberChannel(
@@ -325,7 +325,7 @@ export class SubscribersV1Controller {
   @ApiOperation({
     summary: 'Create or Partially Update provider credentials',
     description: `Create or Partially credentials for a provider such as **slack** and **FCM**. 
-      **providerId** is required field. This API creates the **deviceTokens** or appends to the existing ones.`,
+      **providerId** is required field. This API creates the **deviceTokens** or replaces the existing ones.`,
   })
   @SdkGroupName('Subscribers.Credentials')
   @SdkMethodName('append')


### PR DESCRIPTION
fixes #8660 
This pull request updates the descriptions and summaries of two API to reflect their actual functionality:
- `PATCH /credentials`
- `PUT /credentials`

### What changed? Why was the change needed?

`PUT` upserts credentials, while `PATCH` not only partially updates, but creates credentials as well.