### PR TITLE
style(dashboard): Refine code font sizes and add new stroke variable

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -17,7 +17,7 @@
       rel="stylesheet"
     />
     <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;1,400;1,500&display=swap"
       rel="stylesheet"
     />
     <% if (env.VITE_GTM) { %>

--- a/apps/dashboard/src/components/html-editor.tsx
+++ b/apps/dashboard/src/components/html-editor.tsx
@@ -39,7 +39,7 @@ type HtmlEditorProps = {
 };
 
 const gutterElementClassName =
-  '[&_.cm-gutterElement]:flex [&_.cm-gutterElement]:items-center [&_.cm-gutterElement]:justify-end [&_.cm-gutterElement]:text-text-soft [&_.cm-gutterElement]:font-code [&_.cm-gutterElement]:text-code-sm [&_.cm-gutterElement>span]:h-full';
+  '[&_.cm-gutterElement]:flex [&_.cm-gutterElement]:items-center [&_.cm-gutterElement]:justify-end [&_.cm-gutterElement]:text-text-soft [&_.cm-gutterElement]:font-code [&_.cm-gutterElement]:text-code-xs [&_.cm-gutterElement>span]:h-full';
 
 /**
  * The HtmlEditor component is a wrapper around the VariableEditor and adds the formatting, html and liquid syntax highlighting.

--- a/apps/dashboard/src/components/variable/components/reorder-filter-item.tsx
+++ b/apps/dashboard/src/components/variable/components/reorder-filter-item.tsx
@@ -112,7 +112,7 @@ export const ReorderFilterItem = (props: ReorderFilterItemProps) => {
             onClick={preventClick}
           />
 
-          <span className="text-code-sm select-none">{filterDef?.label}</span>
+          <span className="text-code-xs select-none">{filterDef?.label}</span>
           <Tooltip>
             <TooltipTrigger className="cursor-pointer" asChild>
               <span>

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -263,6 +263,7 @@
 
     --stroke-strong: var(--neutral-950);
     --stroke-sub: var(--neutral-300);
+    --stroke-weak: var(--neutral-100);
     --stroke-soft: var(--neutral-200);
     --stroke-white: var(--neutral-0);
 

--- a/apps/dashboard/tailwind.config.ts
+++ b/apps/dashboard/tailwind.config.ts
@@ -192,12 +192,22 @@ export const texts = {
       fontWeight: '500',
     },
   ],
-  'code-sm': [
+  'code-xs': [
     '0.75rem',
     {
       lineHeight: '1rem',
-      letterSpacing: '-0.015em',
+      letterSpacing: '-0.0125em',
       fontWeight: '500',
+      fontFamily: 'var(--font-code)',
+    },
+  ],
+  'code-2xs': [
+    '0.625rem',
+    {
+      lineHeight: '0.9375rem',
+      letterSpacing: '-0.0125em',
+      fontWeight: '400',
+      fontFamily: 'var(--font-code)',
     },
   ],
 };
@@ -462,10 +472,18 @@ export default {
         weak: 'hsl(var(--bg-weak))',
         white: 'hsl(var(--bg-white))',
       },
+      icon: {
+        strong: 'hsl(var(--icon-strong))',
+        sub: 'hsl(var(--icon-sub))',
+        soft: 'hsl(var(--icon-soft))',
+        disabled: 'hsl(var(--icon-disabled))',
+        white: 'hsl(var(--icon-white))',
+      },
       stroke: {
         strong: 'hsl(var(--stroke-strong))',
         sub: 'hsl(var(--stroke-sub))',
         soft: 'hsl(var(--stroke-soft))',
+        weak: 'hsl(var(--stroke-weak))',
         white: 'hsl(var(--stroke-white))',
       },
       text: {


### PR DESCRIPTION
Updated font weights in JetBrains Mono import and replaced 'code-sm' with 'code-xs' for smaller code text in components. Added 'code-xs' and 'code-2xs' text styles in Tailwind config, introduced new 'stroke-weak' variable in CSS, and extended Tailwind theme with icon and stroke color mappings.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
