### PR TITLE
style(dashboard): Update UI for long workflow tags

### DIFF
--- a/apps/dashboard/src/components/primitives/tag-input.tsx
+++ b/apps/dashboard/src/components/primitives/tag-input.tsx
@@ -88,6 +88,7 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
               <Tag
                 key={index}
                 variant="stroke"
+                className="max-w-[12rem] shrink-0"
                 onDismiss={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
@@ -96,7 +97,12 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
                 }}
                 dismissTestId={`tags-badge-remove-${tag}`}
               >
-                <span style={{ wordBreak: 'break-all' }} data-testid="tags-badge-value">
+                <span 
+                  className="truncate max-w-full block" 
+                  style={{ wordBreak: 'break-all' }} 
+                  data-testid="tags-badge-value"
+                  title={tag}
+                >
                   {tag}
                 </span>
               </Tag>
@@ -131,7 +137,7 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
                     className="gap-1"
                     disabled={inputValue === '' || tags.includes(inputValue)}
                   >
-                    {inputValue}
+                    <span className="truncate">{inputValue}</span>
                   </CommandItem>
                 )}
 
@@ -145,7 +151,7 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
                       addTag(tag);
                     }}
                   >
-                    {tag}
+                    <span className="truncate">{tag}</span>
                   </CommandItem>
                 ))}
               </CommandGroup>

--- a/apps/dashboard/src/components/workflow-tags.tsx
+++ b/apps/dashboard/src/components/workflow-tags.tsx
@@ -20,15 +20,15 @@ export const WorkflowTags = (props: WorkflowTagsProps) => {
   }
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1 min-w-0 flex-wrap">
       <>
         {firstTags.map((tag) => (
-          <Badge key={tag} color="purple" size="md" variant="lighter">
-            <TruncatedText>{tag}</TruncatedText>
+          <Badge key={tag} color="purple" size="md" variant="lighter" className="max-w-[8rem] shrink-0">
+            <TruncatedText className="block max-w-full">{tag}</TruncatedText>
           </Badge>
         ))}
         {restTags.length > 0 && (
-          <Badge color="gray" size="md" variant="lighter">
+          <Badge color="gray" size="md" variant="lighter" className="shrink-0">
             +{restTags.length}
           </Badge>
         )}


### PR DESCRIPTION
### What changed? Why was the change needed?

The maximum length of workflow tags was recently increased to 64 characters, which caused UI breakage in the workflow list and workflow update sidebar where tags are displayed. This PR introduces styling adjustments to ensure long tag pills are displayed gracefully without breaking the layout.

Specifically:
- Tag pills in the `TagInput` and `WorkflowTags` components now have a maximum width and truncate long text.
- Tags in the workflow list will now wrap to the next line if they exceed available space.
- Tooltips have been added to truncated tags to show the full tag name on hover.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->
[Add screenshots of the Workflow list and Workflow update sidebar with long tags, before and after the changes.]

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1752503408268219?thread_ts=1752503408.268219&cid=D0919LNRWE7)