### PR TITLE
feat(dashboard,api): translations target locale fixes NV-6230

### DIFF
--- a/apps/api/src/app/organization/dtos/get-organization-settings.dto.ts
+++ b/apps/api/src/app/organization/dtos/get-organization-settings.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean } from 'class-validator';
+import { IsArray, IsBoolean, IsString, IsOptional } from 'class-validator';
 import { IsValidLocale } from '@novu/application-generic';
 
 export class GetOrganizationSettingsDto {
@@ -16,4 +16,13 @@ export class GetOrganizationSettingsDto {
   })
   @IsValidLocale()
   defaultLocale: string;
+
+  @ApiProperty({
+    description: 'Target locales',
+    example: ['en-US', 'es-ES'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  targetLocales?: string[];
 }

--- a/apps/api/src/app/organization/dtos/update-organization-settings.dto.ts
+++ b/apps/api/src/app/organization/dtos/update-organization-settings.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsValidLocale } from '@novu/application-generic';
-import { IsBoolean, IsOptional } from 'class-validator';
+import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class UpdateOrganizationSettingsDto {
   @ApiProperty({
@@ -18,4 +18,13 @@ export class UpdateOrganizationSettingsDto {
   @IsOptional()
   @IsValidLocale()
   defaultLocale?: string;
+
+  @ApiProperty({
+    description: 'Target locales',
+    example: ['en-US', 'es-ES'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true }) // TODO: validate locales
+  targetLocales?: string[];
 }

--- a/apps/api/src/app/organization/ee.organization.controller.ts
+++ b/apps/api/src/app/organization/ee.organization.controller.ts
@@ -121,6 +121,7 @@ export class EEOrganizationController {
         organizationId: user.organizationId,
         removeNovuBranding: body.removeNovuBranding,
         defaultLocale: body.defaultLocale,
+        targetLocales: body.targetLocales,
       })
     );
   }

--- a/apps/api/src/app/organization/usecases/get-organization-settings/get-organization-settings.usecase.ts
+++ b/apps/api/src/app/organization/usecases/get-organization-settings/get-organization-settings.usecase.ts
@@ -18,6 +18,7 @@ export class GetOrganizationSettings {
     return {
       removeNovuBranding: organization.removeNovuBranding || false,
       defaultLocale: organization.defaultLocale || DEFAULT_LOCALE,
+      targetLocales: organization.targetLocales || [],
     };
   }
 }

--- a/apps/api/src/app/organization/usecases/update-organization-settings/update-organization-settings.command.ts
+++ b/apps/api/src/app/organization/usecases/update-organization-settings/update-organization-settings.command.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsOptional, IsArray, IsString } from 'class-validator';
 import { AuthenticatedCommand, IsValidLocale } from '@novu/application-generic';
 
 export class UpdateOrganizationSettingsCommand extends AuthenticatedCommand {
@@ -12,4 +12,9 @@ export class UpdateOrganizationSettingsCommand extends AuthenticatedCommand {
   @IsOptional()
   @IsValidLocale()
   defaultLocale?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  targetLocales?: string[];
 }

--- a/apps/api/src/app/organization/usecases/update-organization-settings/update-organization-settings.usecase.ts
+++ b/apps/api/src/app/organization/usecases/update-organization-settings/update-organization-settings.usecase.ts
@@ -61,6 +61,24 @@ export class UpdateOrganizationSettings {
         );
       }
     }
+
+    if (command.targetLocales !== undefined || command.defaultLocale !== undefined) {
+      const canUseTranslations = getFeatureForTierAsBoolean(
+        FeatureNameEnum.AUTO_TRANSLATIONS,
+        organization.apiServiceLevel || ApiServiceLevelEnum.FREE
+      );
+
+      if (!canUseTranslations) {
+        throw new HttpException(
+          {
+            error: 'Payment Required',
+            message:
+              'Update of locales is a part of the translation feature. Please upgrade to a paid plan to access this feature.',
+          },
+          HttpStatus.PAYMENT_REQUIRED
+        );
+      }
+    }
   }
 
   private buildUpdateFields(command: UpdateOrganizationSettingsCommand): Partial<OrganizationEntity> {
@@ -74,6 +92,10 @@ export class UpdateOrganizationSettings {
       updateFields.defaultLocale = command.defaultLocale;
     }
 
+    if (command.targetLocales !== undefined) {
+      updateFields.targetLocales = command.targetLocales;
+    }
+
     return updateFields;
   }
 
@@ -81,6 +103,7 @@ export class UpdateOrganizationSettings {
     return {
       removeNovuBranding: organization.removeNovuBranding || false,
       defaultLocale: organization.defaultLocale || DEFAULT_LOCALE,
+      targetLocales: organization.targetLocales || [],
     };
   }
 }

--- a/apps/api/src/app/translations/e2e/v2/get-translation-group.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v2/get-translation-group.e2e-ee.ts
@@ -101,6 +101,15 @@ describe('Get single translation group - /v2/translations/group/:resourceType/:r
   });
 
   it('should include outdatedLocales when present', async () => {
+    // First, set organization default locale and target locales
+    await session.testAgent
+      .patch('/v1/organizations/settings')
+      .send({
+        defaultLocale: 'en_US',
+        targetLocales: ['es_ES', 'fr_FR', 'de_DE'], // Configure target locales
+      })
+      .expect(200);
+
     const translations = [
       {
         resourceId: workflowId,
@@ -122,12 +131,15 @@ describe('Get single translation group - /v2/translations/group/:resourceType/:r
       },
     ];
 
-    // Create translations
+    /*
+     * Create translations for en_US (default) and es_ES only
+     * fr_FR and de_DE are configured as targets but missing = outdated
+     */
     for (const translation of translations) {
       await session.testAgent.post('/v2/translations').send(translation).expect(200);
     }
 
-    // Update the default locale (en_US) to make es_ES outdated
+    // Update the default locale (en_US) to add new keys, making es_ES out of sync
     await session.testAgent
       .post('/v2/translations')
       .send({
@@ -137,7 +149,7 @@ describe('Get single translation group - /v2/translations/group/:resourceType/:r
         content: {
           'welcome.title': 'Welcome Updated',
           'welcome.message': 'Hello there, updated!',
-          'new.key': 'New content',
+          'new.key': 'New content', // This key is missing in es_ES
         },
       })
       .expect(200);
@@ -150,11 +162,59 @@ describe('Get single translation group - /v2/translations/group/:resourceType/:r
     expect(body.data.resourceId).to.equal(workflowId);
     expect(body.data.locales).to.include.members(['en_US', 'es_ES']);
 
-    // Should include outdatedLocales if there are any
-    if (body.data.outdatedLocales) {
-      expect(body.data.outdatedLocales).to.be.an('array');
-      expect(body.data.outdatedLocales).to.include('es_ES');
-    }
+    // Should include outdatedLocales: es_ES (out of sync), fr_FR (missing), de_DE (missing)
+    expect(body.data.outdatedLocales).to.be.an('array');
+    expect(body.data.outdatedLocales).to.have.lengthOf(3);
+    expect(body.data.outdatedLocales).to.include.members(['es_ES', 'fr_FR', 'de_DE']);
+  });
+
+  it('should not include outdatedLocales when no target locales are configured', async () => {
+    // Ensure no target locales are configured (only default locale)
+    await session.testAgent
+      .patch('/v1/organizations/settings')
+      .send({
+        defaultLocale: 'en_US',
+        // No targetLocales specified
+      })
+      .expect(200);
+
+    // Create some translations
+    await session.testAgent
+      .post('/v2/translations')
+      .send({
+        resourceId: workflowId,
+        resourceType: LocalizationResourceEnum.WORKFLOW,
+        locale: 'en_US',
+        content: {
+          'welcome.title': 'Welcome',
+          'welcome.message': 'Hello there!',
+        },
+      })
+      .expect(200);
+
+    // Even if we have other locales not in target list
+    await session.testAgent
+      .post('/v2/translations')
+      .send({
+        resourceId: workflowId,
+        resourceType: LocalizationResourceEnum.WORKFLOW,
+        locale: 'es_ES',
+        content: {
+          'welcome.title': 'Bienvenido',
+        },
+      })
+      .expect(200);
+
+    // Get the translation group
+    const { body } = await session.testAgent
+      .get(`/v2/translations/group/${LocalizationResourceEnum.WORKFLOW}/${workflowId}`)
+      .expect(200);
+
+    expect(body.data.resourceId).to.equal(workflowId);
+    expect(body.data.locales).to.include.members(['en_US', 'es_ES']);
+
+    // Should not include outdatedLocales since no target locales are configured
+    expect(body.data).to.not.have.property('outdatedLocales');
   });
 
   it('should return 404 for non-existent translation group', async () => {

--- a/apps/dashboard/src/api/organization.ts
+++ b/apps/dashboard/src/api/organization.ts
@@ -4,11 +4,13 @@ import { post, get, patch } from './api.client';
 export type GetOrganizationSettingsDto = {
   removeNovuBranding: boolean;
   defaultLocale: string;
+  targetLocales: string[];
 };
 
 export type UpdateOrganizationSettingsDto = {
   removeNovuBranding?: boolean;
   defaultLocale?: string;
+  targetLocales?: string[];
 };
 
 export function updateClerkOrgMetadata({

--- a/apps/dashboard/src/components/primitives/locale-select.tsx
+++ b/apps/dashboard/src/components/primitives/locale-select.tsx
@@ -4,17 +4,30 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { RiArrowDownSLine, RiCheckLine } from 'react-icons/ri';
 import { Button, ButtonProps } from './button';
 import { Input } from './input';
-import { FlagCircle } from '../flag-circle';
+import { FlagCircle, StackedFlagCircles } from '../flag-circle';
 import TruncatedText from '../truncated-text';
 
-type LocaleSelectProps = Omit<ButtonProps, 'onChange'> & {
-  value?: string;
+type BaseLocaleSelectProps = {
   disabled?: boolean;
   readOnly?: boolean;
-  onChange: (val: string) => void;
   placeholder?: string;
   availableLocales?: string[];
+  className?: string;
+} & Omit<ButtonProps, 'onChange'>;
+
+type SingleSelectProps = BaseLocaleSelectProps & {
+  value?: string;
+  onChange: (val: string) => void;
+  multiSelect?: false;
 };
+
+type MultiSelectProps = BaseLocaleSelectProps & {
+  value?: string[];
+  onChange: (val: string[]) => void;
+  multiSelect: true;
+};
+
+type LocaleSelectProps = SingleSelectProps | MultiSelectProps;
 
 // Get most common locales for better performance
 const COMMON_LOCALES = [
@@ -44,27 +57,8 @@ const COMMON_LOCALES = [
   'ro_RO',
 ];
 
-export function LocaleSelect(props: LocaleSelectProps) {
-  const {
-    value,
-    disabled,
-    readOnly,
-    onChange,
-    className,
-    placeholder = 'Select locale',
-    availableLocales,
-    ...rest
-  } = props;
-  const [isOpen, setIsOpen] = useState(false);
-  const [searchValue, setSearchValue] = useState('');
-  const [dropdownPosition, setDropdownPosition] = useState<'left' | 'right'>('left');
-  const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
-
-  const currentLocale = locales.find((locale) => locale.langIso === value);
-
-  // Get the base locales list - either all locales or filtered by availableLocales
+// Shared hook for locale filtering logic
+function useLocaleFiltering(availableLocales?: string[], searchValue: string = '') {
   const baseLocales = useMemo(() => {
     if (availableLocales && availableLocales.length > 0) {
       return locales.filter((locale) => availableLocales.includes(locale.langIso));
@@ -73,15 +67,12 @@ export function LocaleSelect(props: LocaleSelectProps) {
     return locales;
   }, [availableLocales]);
 
-  // Optimize locale filtering with memoization
   const filteredLocales = useMemo(() => {
     if (!searchValue.trim()) {
-      // If we have availableLocales, show them in order, otherwise show common locales first
       if (availableLocales && availableLocales.length > 0) {
         return baseLocales.slice(0, 100);
       }
 
-      // Show common locales first, then others
       const common = baseLocales.filter((locale) => COMMON_LOCALES.includes(locale.langIso));
       const others = baseLocales.filter((locale) => !COMMON_LOCALES.includes(locale.langIso));
       return [...common, ...others].slice(0, 100);
@@ -98,10 +89,100 @@ export function LocaleSelect(props: LocaleSelectProps) {
       .slice(0, 100);
   }, [searchValue, baseLocales, availableLocales]);
 
+  const showSearchLimitMessage =
+    searchValue &&
+    baseLocales.filter(
+      (locale) =>
+        locale.langIso.toLowerCase().includes(searchValue.toLowerCase()) ||
+        locale.langName.toLowerCase().includes(searchValue.toLowerCase()) ||
+        locale.name.toLowerCase().includes(searchValue.toLowerCase())
+    ).length > 100;
+
+  return { filteredLocales, showSearchLimitMessage };
+}
+
+// Single select trigger content
+function SingleSelectTrigger({ value, placeholder }: { value?: string; placeholder: string }) {
+  const currentLocale = locales.find((locale) => locale.langIso === value);
+
+  return (
+    <div className="flex max-w-full flex-1 items-center gap-2 overflow-hidden">
+      {value && <FlagCircle locale={value} size="sm" />}
+      <span className="text-xs font-normal text-neutral-950">
+        {currentLocale ? (
+          <TruncatedText>
+            {currentLocale.langIso} - {currentLocale.langName}
+          </TruncatedText>
+        ) : (
+          <span className="text-neutral-400">{placeholder}</span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+// Multi select trigger content
+function MultiSelectTrigger({ value, placeholder }: { value?: string[]; placeholder: string }) {
+  const selectedLocales = value ? locales.filter((locale) => value.includes(locale.langIso)) : [];
+
+  if (selectedLocales.length === 0) {
+    return <span className="text-xs font-normal text-neutral-400">{placeholder}</span>;
+  }
+
+  if (selectedLocales.length <= 4) {
+    return (
+      <div className="flex items-center gap-1.5 overflow-hidden">
+        {selectedLocales.map((locale, index) => (
+          <div key={locale.langIso} className="flex shrink-0 items-center gap-1">
+            <FlagCircle locale={locale.langIso} size="sm" />
+            <span className="text-xs font-normal text-neutral-950">{locale.langIso}</span>
+            {index < selectedLocales.length - 1 && <span className="text-neutral-400">•</span>}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <StackedFlagCircles locales={selectedLocales.map((locale) => locale.langIso)} maxVisible={10} size="md" />
+      <span className="text-xs font-normal text-neutral-950">{selectedLocales.length} locales selected</span>
+    </div>
+  );
+}
+
+export function LocaleSelect(props: LocaleSelectProps) {
+  const {
+    value,
+    disabled,
+    readOnly,
+    onChange,
+    className,
+    placeholder = 'Select locale',
+    availableLocales,
+    multiSelect = false,
+    ...rest
+  } = props;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+  const [dropdownPosition, setDropdownPosition] = useState<'left' | 'right'>('left');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const { filteredLocales, showSearchLimitMessage } = useLocaleFiltering(availableLocales, searchValue);
+
   const handleSelect = (localeValue: string) => {
-    onChange(localeValue);
-    setIsOpen(false);
-    setSearchValue('');
+    if (multiSelect && Array.isArray(value)) {
+      const newValue = value.includes(localeValue) ? value.filter((v) => v !== localeValue) : [...value, localeValue];
+      (onChange as (val: string[]) => void)(newValue);
+      // Don't close for multi-select
+    } else {
+      (onChange as (val: string) => void)(localeValue);
+      setIsOpen(false);
+      setSearchValue('');
+    }
   };
 
   const handleToggle = () => {
@@ -114,7 +195,6 @@ export function LocaleSelect(props: LocaleSelectProps) {
         const spaceOnRight = viewportWidth - rect.right;
         const spaceOnLeft = rect.left;
 
-        // If there's not enough space on the right but enough on the left, position left
         if (spaceOnRight < dropdownWidth && spaceOnLeft >= dropdownWidth) {
           setDropdownPosition('right');
         } else {
@@ -136,7 +216,6 @@ export function LocaleSelect(props: LocaleSelectProps) {
 
     if (isOpen) {
       document.addEventListener('mousedown', handleClickOutside);
-      // Focus the search input when dropdown opens
       setTimeout(() => inputRef.current?.focus(), 0);
     }
 
@@ -145,22 +224,12 @@ export function LocaleSelect(props: LocaleSelectProps) {
     };
   }, [isOpen]);
 
-  // Handle keyboard navigation
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       setIsOpen(false);
       setSearchValue('');
     }
   };
-
-  const showSearchLimitMessage =
-    searchValue &&
-    baseLocales.filter(
-      (locale) =>
-        locale.langIso.toLowerCase().includes(searchValue.toLowerCase()) ||
-        locale.langName.toLowerCase().includes(searchValue.toLowerCase()) ||
-        locale.name.toLowerCase().includes(searchValue.toLowerCase())
-    ).length > 100;
 
   return (
     <div ref={containerRef} className="relative">
@@ -173,22 +242,15 @@ export function LocaleSelect(props: LocaleSelectProps) {
         type="button"
         {...rest}
       >
-        <div className="flex max-w-full flex-1 items-center gap-2 overflow-hidden">
-          {value && <FlagCircle locale={value} size="sm" />}
-          <span className="text-xs font-normal text-neutral-950">
-            {currentLocale ? (
-              <TruncatedText>
-                {currentLocale.langIso} - {currentLocale.langName}
-              </TruncatedText>
-            ) : (
-              <span className="text-neutral-400">{placeholder}</span>
-            )}
-          </span>
+        {multiSelect ? (
+          <MultiSelectTrigger value={value as string[]} placeholder={placeholder} />
+        ) : (
+          <SingleSelectTrigger value={value as string} placeholder={placeholder} />
+        )}
 
-          <RiArrowDownSLine
-            className={cn('ml-auto size-4 opacity-50', disabled || readOnly ? 'hidden' : 'opacity-100')}
-          />
-        </div>
+        <RiArrowDownSLine
+          className={cn('ml-auto size-4 opacity-50', disabled || readOnly ? 'hidden' : 'opacity-100')}
+        />
       </Button>
 
       {isOpen && (
@@ -216,7 +278,9 @@ export function LocaleSelect(props: LocaleSelectProps) {
             ) : (
               <>
                 {filteredLocales.map((locale) => {
-                  const isSelected = locale.langIso === value;
+                  const isSelected = multiSelect
+                    ? (value as string[])?.includes(locale.langIso)
+                    : locale.langIso === value;
 
                   return (
                     <button
@@ -227,7 +291,7 @@ export function LocaleSelect(props: LocaleSelectProps) {
                         isSelected && 'bg-accent'
                       )}
                       onClick={() => handleSelect(locale.langIso)}
-                      onMouseDown={(e) => e.preventDefault()} // Prevent blur on click
+                      onMouseDown={(e) => e.preventDefault()}
                     >
                       <FlagCircle locale={locale.langIso} size="sm" className="shrink-0" />
                       <div className="flex-1 overflow-hidden text-left">

--- a/apps/dashboard/src/components/translations/translation-drawer/editor-panel.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/editor-panel.tsx
@@ -48,7 +48,7 @@ function JSONEditor({ content, onChange, error, updatedAt, isOutdated }: JSONEdi
           <InlineToast
             variant="warning"
             title="Warning:"
-            description="Some keys in this locale don't match the default locale. Add missing keys or remove extra ones to sync translations."
+            description="Some keys in this target locale don't match the default locale. Add missing keys or remove extra ones to sync translations."
           />
         </div>
       )}
@@ -129,7 +129,7 @@ export function EditorPanel({
         <div className="flex h-32 items-center justify-center">
           <p className="text-sm text-red-500">Failed to load translation for {selectedLocale}</p>
         </div>
-      ) : selectedTranslation?.content ? (
+      ) : selectedTranslation ? (
         <JSONEditor
           content={JSON.stringify(contentToUse, null, 2)}
           onChange={onContentChange}

--- a/apps/dashboard/src/components/translations/translation-drawer/locale-list.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/locale-list.tsx
@@ -74,8 +74,8 @@ function LocaleButton({ locale, isSelected, isDefault, isOutdated, onClick }: Lo
             </TooltipTrigger>
             <TooltipContent>
               <span className="text-xs">
-                Some keys in this locale don't match the default locale. Add missing keys or remove extra ones to sync
-                translations.
+                Some keys in this target locale don't match the default locale. Add missing keys or remove extra ones to
+                sync translations.
               </span>
             </TooltipContent>
           </Tooltip>

--- a/apps/dashboard/src/components/translations/translation-settings-drawer.tsx
+++ b/apps/dashboard/src/components/translations/translation-settings-drawer.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useEffect, useMemo, useState, useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/primitives/sheet';
-import { Form, FormControl, FormField, FormItem, FormLabel } from '@/components/primitives/form/form';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/primitives/form/form';
 import { LocaleSelect } from '@/components/primitives/locale-select';
 import { Separator } from '@/components/primitives/separator';
 import { Skeleton } from '@/components/primitives/skeleton';
@@ -16,6 +16,7 @@ import { DEFAULT_LOCALE } from '@novu/shared';
 
 interface TranslationSettingsFormData {
   defaultLocale: string;
+  targetLocales: string[];
 }
 
 interface TranslationSettingsDrawerProps {
@@ -32,6 +33,7 @@ export const TranslationSettingsDrawer = forwardRef<HTMLDivElement, TranslationS
     const form = useForm<TranslationSettingsFormData>({
       defaultValues: {
         defaultLocale: DEFAULT_LOCALE,
+        targetLocales: [],
       },
     });
 
@@ -40,6 +42,7 @@ export const TranslationSettingsDrawer = forwardRef<HTMLDivElement, TranslationS
       if (organizationSettings?.data) {
         form.reset({
           defaultLocale: organizationSettings.data.defaultLocale,
+          targetLocales: organizationSettings.data.targetLocales || [],
         });
       }
     }, [organizationSettings, form]);
@@ -49,7 +52,10 @@ export const TranslationSettingsDrawer = forwardRef<HTMLDivElement, TranslationS
     const hasUnsavedChanges = useMemo(() => {
       if (!organizationSettings?.data) return false;
 
-      return formValues.defaultLocale !== organizationSettings.data.defaultLocale;
+      return (
+        formValues.defaultLocale !== organizationSettings.data.defaultLocale ||
+        JSON.stringify(formValues.targetLocales) !== JSON.stringify(organizationSettings.data.targetLocales)
+      );
     }, [formValues, organizationSettings?.data]);
 
     const handleSave = () => {
@@ -57,6 +63,7 @@ export const TranslationSettingsDrawer = forwardRef<HTMLDivElement, TranslationS
       updateSettings.mutate(
         {
           defaultLocale: values.defaultLocale,
+          targetLocales: values.targetLocales,
         },
         {
           onSuccess: () => {
@@ -108,38 +115,64 @@ export const TranslationSettingsDrawer = forwardRef<HTMLDivElement, TranslationS
               </header>
 
               <div className="flex flex-1 flex-col overflow-y-auto">
-                <div className="p-6">
+                <div className="px-3 py-4">
                   {isLoading ? (
                     <div className="space-y-6">
-                      <div className="flex w-full items-center justify-between">
-                        <Skeleton className="h-4 w-32" />
-                        <Skeleton className="h-6 w-12" />
+                      <div className="space-y-1">
+                        <Skeleton className="h-4 w-24" />
+                        <Skeleton className="h-8 w-full" />
                       </div>
-                      <Separator />
-                      <div className="space-y-3">
+                      <div className="space-y-1">
                         <Skeleton className="h-4 w-24" />
                         <Skeleton className="h-8 w-full" />
                       </div>
                     </div>
                   ) : (
                     <Form {...form}>
-                      <FormField
-                        control={form.control}
-                        name="defaultLocale"
-                        render={({ field }) => (
-                          <FormItem className="space-y-1">
-                            <FormLabel
-                              className="text-text-sub gap-1"
-                              tooltip="The fallback locale used when translations are not available for a user's preferred language"
-                            >
-                              Default locale
-                            </FormLabel>
-                            <FormControl>
-                              <LocaleSelect value={field.value} onChange={field.onChange} className="w-full" />
-                            </FormControl>
-                          </FormItem>
-                        )}
-                      />
+                      <div className="space-y-6">
+                        <FormField
+                          control={form.control}
+                          name="defaultLocale"
+                          render={({ field }) => (
+                            <FormItem className="space-y-1">
+                              <FormLabel
+                                className="text-text-sub gap-1"
+                                tooltip="The primary language for your translations - serves as fallback when language specific translations are not available"
+                              >
+                                Default locale
+                              </FormLabel>
+                              <FormControl>
+                                <LocaleSelect value={field.value} onChange={field.onChange} className="w-full" />
+                              </FormControl>
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name="targetLocales"
+                          render={({ field }) => (
+                            <FormItem className="space-y-1">
+                              <FormLabel
+                                className="text-text-sub gap-1"
+                                tooltip="Languages you want to translate into. We'll check if they're in sync with your default locale."
+                              >
+                                Target locales
+                              </FormLabel>
+                              <FormControl>
+                                <LocaleSelect
+                                  value={field.value}
+                                  onChange={field.onChange}
+                                  className="w-full"
+                                  multiSelect={true}
+                                />
+                              </FormControl>
+                              <span className="text-text-soft text-2xs">
+                                Select all languages you want to translate into
+                              </span>
+                            </FormItem>
+                          )}
+                        />
+                      </div>
                     </Form>
                   )}
                 </div>

--- a/apps/dashboard/src/components/translations/translation-status.tsx
+++ b/apps/dashboard/src/components/translations/translation-status.tsx
@@ -25,8 +25,8 @@ export function TranslationStatus({ outdatedLocales, className }: TranslationSta
           <div className="max-w-xs">
             <p className="font-medium">Translation requires update</p>
             <p className="mt-1 text-xs text-neutral-400">
-              Some locales have missing or extra translation keys compared to the default locale. Review and update
-              translations to ensure all keys are consistent.
+              Some target locales have missing or extra translation keys compared to the default locale. Review and
+              update translations to ensure all keys are consistent.
             </p>
           </div>
         </TooltipContent>

--- a/apps/dashboard/src/components/translations/translations-filters.tsx
+++ b/apps/dashboard/src/components/translations/translations-filters.tsx
@@ -1,6 +1,6 @@
 import { HTMLAttributes, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { RiLoader4Line } from 'react-icons/ri';
+import { RiLoader4Line, RiSettingsLine } from 'react-icons/ri';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { Button } from '@/components/primitives/button';
@@ -88,6 +88,9 @@ function ActionButtons() {
   return (
     <div className="ml-auto flex items-center gap-2">
       <DefaultLocaleButton locale={defaultLocale} onClick={handleConfigure} />
+      <Button variant="secondary" mode="lighter" onClick={handleConfigure} leadingIcon={RiSettingsLine}>
+        Configure translations
+      </Button>
     </div>
   );
 }

--- a/apps/dashboard/src/components/workflow-editor/workflow-translation-status.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-translation-status.tsx
@@ -57,7 +57,7 @@ export function WorkflowTranslationStatus({ workflowId, className }: WorkflowTra
           <div className="max-w-xs">
             <p className="font-medium">Locales out of sync</p>
             <p className="mt-1 text-xs text-neutral-400">
-              Translation keys were added or removed from the default locale. Update other locales to stay up to date.
+              Translation keys were added or removed from the default locale. Update targetlocales to stay up to date.
             </p>
             <a href={translationsUrl} target="_blank" rel="noopener noreferrer" className="mt-2 block underline">
               Manage translations ↗

--- a/apps/dashboard/src/components/workflow-editor/workflow-translation-status.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-translation-status.tsx
@@ -57,7 +57,7 @@ export function WorkflowTranslationStatus({ workflowId, className }: WorkflowTra
           <div className="max-w-xs">
             <p className="font-medium">Locales out of sync</p>
             <p className="mt-1 text-xs text-neutral-400">
-              Translation keys were added or removed from the default locale. Update targetlocales to stay up to date.
+              Translation keys were added or removed from the default locale. Update target locales to stay up to date.
             </p>
             <a href={translationsUrl} target="_blank" rel="noopener noreferrer" className="mt-2 block underline">
               Manage translations ↗

--- a/apps/dashboard/src/hooks/use-fetch-translation.ts
+++ b/apps/dashboard/src/hooks/use-fetch-translation.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { LocalizationResourceEnum } from '@/types/translations';
 import { useEnvironment } from '@/context/environment/hooks';
-import { getTranslation } from '@/api/translations';
+import { getTranslation, Translation } from '@/api/translations';
 import { QueryKeys } from '@/utils/query-keys';
 
 type FetchTranslationParams = {
@@ -15,18 +15,40 @@ export const useFetchTranslation = ({ resourceId, resourceType, locale }: FetchT
 
   return useQuery({
     queryKey: [QueryKeys.fetchTranslation, resourceId, resourceType, locale, currentEnvironment?._id],
-    queryFn: async () => {
+    queryFn: async (): Promise<Translation> => {
       if (!currentEnvironment) {
         throw new Error('Environment is required');
       }
 
-      return getTranslation({
-        environment: currentEnvironment,
-        resourceId,
-        resourceType,
-        locale,
-      });
+      try {
+        return await getTranslation({
+          environment: currentEnvironment,
+          resourceId,
+          resourceType,
+          locale,
+        });
+      } catch (error: any) {
+        // If translation doesn't exist (404), return a default structure so users can create it
+        if (
+          error?.status === 404 ||
+          error?.response?.status === 404 ||
+          (error instanceof Error && error.message.includes('404'))
+        ) {
+          return {
+            resourceId,
+            resourceType,
+            locale,
+            content: {}, // Empty content for new translations
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          };
+        }
+
+        // Re-throw other errors
+        throw error;
+      }
     },
     enabled: !!currentEnvironment && !!locale && !!resourceId,
+    retry: false, // Don't retry 404s
   });
 };

--- a/libs/dal/src/repositories/organization/organization.entity.ts
+++ b/libs/dal/src/repositories/organization/organization.entity.ts
@@ -15,6 +15,8 @@ export class OrganizationEntity implements IOrganizationEntity {
 
   defaultLocale?: string;
 
+  targetLocales?: string[];
+
   domain?: string;
 
   productUseCases?: ProductUseCases;

--- a/libs/dal/src/repositories/organization/organization.schema.ts
+++ b/libs/dal/src/repositories/organization/organization.schema.ts
@@ -37,6 +37,7 @@ const organizationSchema = new Schema<OrganizationDBModel>(
       select: false,
     },
     defaultLocale: Schema.Types.String,
+    targetLocales: [Schema.Types.String],
     domain: Schema.Types.String,
     language: [Schema.Types.String],
     removeNovuBranding: Schema.Types.Boolean,

--- a/packages/shared/src/entities/organization/organization.interface.ts
+++ b/packages/shared/src/entities/organization/organization.interface.ts
@@ -13,6 +13,7 @@ export interface IOrganizationEntity {
     direction?: 'ltr' | 'rtl';
   };
   defaultLocale?: string;
+  targetLocales?: string[];
   domain?: string;
   productUseCases?: ProductUseCases;
   language?: string[];


### PR DESCRIPTION
### What changed? Why was the change needed?

EE PR: https://github.com/novuhq/packages-enterprise/pull/330


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple target locales for organizations, allowing selection and management of target locales alongside the default locale.
  * Enhanced translation settings UI to include a multi-select field for target locales.
  * Translation status and tooltips now clearly reference "target locales" for improved clarity.

* **Bug Fixes**
  * Improved error handling for missing translations, ensuring graceful UI fallback when translations are not found.

* **Tests**
  * Added test cases to verify handling of outdated and missing target locales in translation groups.

* **Refactor**
  * Updated locale selection component to support both single and multi-select modes for better usability and modularity.

* **Chores**
  * Updated internal types and schemas to support the new target locales property across organization settings and entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->