### PR TITLE
fix(api-service): Add timezone property to subscriber schema fixes NV-6257

### DIFF
--- a/apps/api/src/app/layouts-v2/e2e/preview-layout.e2e.ts
+++ b/apps/api/src/app/layouts-v2/e2e/preview-layout.e2e.ts
@@ -253,6 +253,7 @@ describe('Preview Layout #novu-v2', () => {
             email: 'john.doe@example.com',
             locale: 'en-US',
             phone: '+1234567890',
+            timezone: 'America/New_York',
           },
         },
       };
@@ -290,6 +291,7 @@ describe('Preview Layout #novu-v2', () => {
             email: 'jane.smith@example.com',
             locale: 'en-US',
             phone: '+1234567890',
+            timezone: 'America/New_York',
           },
         },
       };

--- a/apps/api/src/app/shared/utils/create-schema.ts
+++ b/apps/api/src/app/shared/utils/create-schema.ts
@@ -70,6 +70,7 @@ export const buildSubscriberSchema = (subscriber: unknown) => {
       phone: { type: JsonSchemaTypeEnum.STRING, description: "Subscriber's phone number (optional)" },
       avatar: { type: JsonSchemaTypeEnum.STRING, description: "URL to the subscriber's avatar image (optional)" },
       locale: { type: JsonSchemaTypeEnum.STRING, description: 'Locale for the subscriber (optional)' },
+      timezone: { type: JsonSchemaTypeEnum.STRING, description: 'Timezone for the subscriber (optional)' },
       subscriberId: { type: JsonSchemaTypeEnum.STRING, description: 'Unique identifier for the subscriber' },
       isOnline: {
         type: JsonSchemaTypeEnum.BOOLEAN,

--- a/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
@@ -107,6 +107,9 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
               subscriberId: {
                 type: 'string',
               },
+              timezone: {
+                type: 'string',
+              },
             },
             type: 'object',
           },
@@ -154,6 +157,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
           phone: '+1234567890',
           avatar: 'https://example.com/avatar.png',
           locale: 'en-US',
+          timezone: 'America/New_York',
           data: {},
         },
         payload: {},
@@ -244,6 +248,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
           phone: '+1234567890',
           avatar: 'https://example.com/avatar.png',
           locale: 'en-US',
+          timezone: 'America/New_York',
           data: {},
         },
         payload: {
@@ -346,6 +351,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
           phone: '+1234567890',
           avatar: 'https://example.com/avatar.png',
           locale: 'en-US',
+          timezone: 'America/New_York',
           data: {},
         },
         payload: {
@@ -522,6 +528,9 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
               subscriberId: {
                 type: 'string',
               },
+              timezone: {
+                type: 'string',
+              },
             },
             type: 'object',
           },
@@ -562,6 +571,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
           phone: '+1234567890',
           avatar: 'https://example.com/avatar.png',
           locale: 'en-US',
+          timezone: 'America/New_York',
           data: {},
         },
         payload: {
@@ -665,6 +675,9 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
                 type: 'string',
               },
               subscriberId: {
+                type: 'string',
+              },
+              timezone: {
                 type: 'string',
               },
             },
@@ -781,6 +794,9 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
                 type: 'string',
               },
               subscriberId: {
+                type: 'string',
+              },
+              timezone: {
                 type: 'string',
               },
             },

--- a/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
@@ -720,6 +720,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
           phone: '+1234567890',
           avatar: 'https://example.com/avatar.png',
           locale: 'en-US',
+          timezone: 'America/New_York',
           data: {},
         },
         payload: {
@@ -839,6 +840,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
           phone: '+1234567890',
           avatar: 'https://example.com/avatar.png',
           locale: 'en-US',
+          timezone: 'America/New_York',
           data: {},
         },
         payload: {
@@ -1106,6 +1108,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
       phone: '+1234567890',
       avatar: 'https://example.com/avatar.png',
       locale: 'en-US',
+      timezone: 'America/New_York',
       data: {},
     });
     expect(actualPayload.payload).to.deep.equal({
@@ -1231,6 +1234,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
       phone: '+1234567890',
       avatar: 'https://example.com/avatar.png',
       locale: 'en-US',
+      timezone: 'America/New_York',
       data: {},
     });
     expect(actualPayload.payload).to.deep.equal({
@@ -1413,6 +1417,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
       phone: '+1234567890',
       avatar: 'https://example.com/avatar.png',
       locale: 'en-US',
+      timezone: 'America/New_York',
       data: {},
     });
     expect(actualPayload.payload).to.deep.equal({

--- a/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
@@ -1929,6 +1929,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
           lastName: 'Doe',
           locale: 'en-US',
           phone: '+1234567890',
+          timezone: 'America/New_York',
         },
       };
       const previewResponse5 = await novuClient.workflows.steps.generatePreview({

--- a/apps/api/src/app/workflows-v2/maily-test-data.ts
+++ b/apps/api/src/app/workflows-v2/maily-test-data.ts
@@ -504,6 +504,7 @@ export function previewPayloadExample() {
       phone: '+1234567890',
       avatar: 'https://example.com/avatar.png',
       locale: 'en-US',
+      timezone: 'America/New_York',
       data: {},
     },
     steps: {},

--- a/apps/api/src/app/workflows-v2/usecases/preview/services/mock-data-generator.service.ts
+++ b/apps/api/src/app/workflows-v2/usecases/preview/services/mock-data-generator.service.ts
@@ -117,6 +117,7 @@ export class MockDataGeneratorService {
       phone: '+1234567890',
       avatar: 'https://example.com/avatar.png',
       locale: 'en-US',
+      timezone: 'America/New_York',
       data: {},
     };
   }

--- a/apps/api/src/app/workflows-v2/usecases/preview/services/schema-builder.service.ts
+++ b/apps/api/src/app/workflows-v2/usecases/preview/services/schema-builder.service.ts
@@ -67,6 +67,7 @@ export class SchemaBuilderService {
           phone: { type: JsonSchemaTypeEnum.STRING },
           avatar: { type: JsonSchemaTypeEnum.STRING },
           locale: { type: JsonSchemaTypeEnum.STRING },
+          timezone: { type: JsonSchemaTypeEnum.STRING },
           data: { type: JsonSchemaTypeEnum.OBJECT, additionalProperties: true },
         },
         additionalProperties: true,


### PR DESCRIPTION
### What changed? Why was the change needed?

The `timezone` property has been added to the subscriber schema definitions within the API.

This change was needed to ensure consistency of the `timezone` property across all subscriber schema definitions. While the database and dashboard already included this property, the API schema definitions were missing it.

Specifically, the `timezone` property was added to:
- `apps/api/src/app/shared/utils/create-schema.ts` (in `buildSubscriberSchema`)
- `apps/api/src/app/workflows-v2/usecases/preview/services/schema-builder.service.ts` (in inline subscriber schema)
- `apps/api/src/app/workflows-v2/usecases/preview/services/mock-data-generator.service.ts` (for mock data generation)

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1752669701294029?thread_ts=1752669701.294029&cid=D0919LNRWE7)