### PR TITLE
feat(dashboard): email editor allow selecting layout fixes NV-6133

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -1136,7 +1136,7 @@ describe('EmailOutputRendererUsecase', () => {
         expect(getLayoutUseCase.execute.called).to.be.true;
       });
 
-      it('should use default layout when layoutId is null', async () => {
+      it('should not use layout when layoutId is null', async () => {
         const renderCommand: EmailOutputRendererCommand = {
           environmentId: 'fake_env_id',
           organizationId: 'fake_org_id',
@@ -1154,26 +1154,12 @@ describe('EmailOutputRendererUsecase', () => {
 
         const result = await emailOutputRendererUsecase.execute(renderCommand);
 
-        expect(result.body).to.include('class="layout"');
+        expect(result.body).to.not.include('class="layout"');
         expect(result.body).to.include('Step content John');
-        expect(result.body).to.include('<html>');
+        expect(result.body).to.not.include('<html>');
 
-        // Verify layout repository was called first to find default layout
-        expect(getLayoutUseCase.execute.calledOnce).to.be.true;
-        expect(getLayoutUseCase.execute.firstCall.args[0]).to.deep.eq({
-          organizationId: 'fake_org_id',
-          environmentId: 'fake_env_id',
-          skipAdditionalFields: true,
-        });
-
-        // Then control values repository should be called with the default layout ID
-        expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.true;
-        expect(controlValuesRepositoryMock.findOne.firstCall.args[0]).to.deep.eq({
-          _organizationId: 'fake_org_id',
-          _environmentId: 'fake_env_id',
-          _layoutId: 'default_layout_id',
-          level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
-        });
+        expect(getLayoutUseCase.execute.calledOnce).to.be.false;
+        expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.false;
       });
 
       it('should render without layout when no layout controls are found', async () => {
@@ -1203,36 +1189,6 @@ describe('EmailOutputRendererUsecase', () => {
 
         // Verify repository was called but returned null
         expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.true;
-      });
-
-      it('should render without layout when default layout does not exist', async () => {
-        getLayoutUseCase.execute.resolves(undefined);
-
-        const renderCommand: EmailOutputRendererCommand = {
-          environmentId: 'fake_env_id',
-          organizationId: 'fake_org_id',
-          controlValues: {
-            subject: 'Layout Test',
-            body: simpleBodyContent,
-            layoutId: null,
-          },
-          fullPayloadForRender: {
-            ...mockFullPayload,
-            payload: { name: 'John' },
-          },
-          workflowId: mockDbWorkflow._id,
-        };
-
-        const result = await emailOutputRendererUsecase.execute(renderCommand);
-
-        expect(result.body).to.include('Step content John');
-        expect(result.body).to.not.include('class="layout"');
-        expect(result.body).to.not.include('<html>');
-
-        // Verify layout repository was called but returned null
-        expect(getLayoutUseCase.execute.calledOnce).to.be.true;
-        // Control values repository should not be called when default layout is not found
-        expect(controlValuesRepositoryMock.findOne.called).to.be.false;
       });
 
       it('should clean step content before injecting into layout', async () => {
@@ -1440,7 +1396,7 @@ describe('EmailOutputRendererUsecase', () => {
         });
       });
 
-      it('should pass correct repository query parameters for default layout', async () => {
+      it('should not call layout repository when layoutId is null', async () => {
         const renderCommand: EmailOutputRendererCommand = {
           environmentId: 'fake_env_id',
           organizationId: 'fake_org_id',
@@ -1456,22 +1412,12 @@ describe('EmailOutputRendererUsecase', () => {
           workflowId: mockDbWorkflow._id,
         };
 
-        await emailOutputRendererUsecase.execute(renderCommand);
+        const result = await emailOutputRendererUsecase.execute(renderCommand);
 
-        expect(getLayoutUseCase.execute.calledOnce).to.be.true;
-        expect(getLayoutUseCase.execute.firstCall.args[0]).to.deep.eq({
-          organizationId: 'fake_org_id',
-          environmentId: 'fake_env_id',
-          skipAdditionalFields: true,
-        });
-
-        expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.true;
-        expect(controlValuesRepositoryMock.findOne.firstCall.args[0]).to.deep.eq({
-          _organizationId: 'fake_org_id',
-          _environmentId: 'fake_env_id',
-          _layoutId: 'default_layout_id',
-          level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
-        });
+        expect(getLayoutUseCase.execute.called).to.be.false;
+        expect(controlValuesRepositoryMock.findOne.called).to.be.false;
+        expect(result.body).to.include('Step content John');
+        expect(result.body).to.not.include('class="layout"');
       });
 
       it('should not call layout repository when layoutId is undefined', async () => {
@@ -1531,28 +1477,6 @@ describe('EmailOutputRendererUsecase', () => {
         // Should handle missing email controls gracefully
         expect(result.body).to.not.include('Step content John');
         expect(result.body).to.not.include('class="layout"');
-      });
-
-      it('should call repository methods in correct order for default layout', async () => {
-        const renderCommand: EmailOutputRendererCommand = {
-          environmentId: 'fake_env_id',
-          organizationId: 'fake_org_id',
-          controlValues: {
-            subject: 'Layout Test',
-            body: simpleBodyContent,
-            layoutId: null,
-          },
-          fullPayloadForRender: {
-            ...mockFullPayload,
-            payload: { name: 'John' },
-          },
-          workflowId: mockDbWorkflow._id,
-        };
-
-        await emailOutputRendererUsecase.execute(renderCommand);
-
-        // Verify call order: layout repository should be called before control values repository
-        expect(getLayoutUseCase.execute.calledBefore(controlValuesRepositoryMock.findOne)).to.be.true;
       });
     });
   });

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -184,24 +184,6 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
         _layoutId: layout._id,
         level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
       });
-    } else if (layoutId === null) {
-      // otherwise find the default layout controls
-      const defaultEmailLayout = await this.getLayoutUseCase.execute(
-        GetLayoutCommand.create({
-          environmentId,
-          organizationId,
-          skipAdditionalFields: true,
-        })
-      );
-
-      layoutControlsEntity = defaultEmailLayout
-        ? await this.controlValuesRepository.findOne({
-            _organizationId: organizationId,
-            _environmentId: environmentId,
-            _layoutId: defaultEmailLayout._id,
-            level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
-          })
-        : null;
     }
 
     const stepBodyHtml = await this.processBodyContent({

--- a/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
@@ -198,8 +198,8 @@ describe('Upsert Workflow #novu-v2', function () {
         process.env.IS_HTML_EDITOR_ENABLED = 'false';
       });
 
-      it('should assign default v2 layout when creating email step with null layoutId', async () => {
-        const layout = await createLayout({
+      it('should not use layoutId when null is provided', async () => {
+        await createLayout({
           name: 'Test Layout',
           layoutId: 'test-layout',
           source: LayoutCreationSourceEnum.Dashboard,
@@ -226,8 +226,7 @@ describe('Upsert Workflow #novu-v2', function () {
         const emailStep = workflow.steps[0] as EmailStepResponseDto;
         expect(emailStep.type).to.equal(StepTypeEnum.Email);
 
-        // should get default layoutId
-        expect(emailStep.controls.values.layoutId).to.equal(layout.layoutId);
+        expect(emailStep.controls.values.layoutId).to.equal(null);
       });
 
       it('should keep layoutId as undefined when not specified and there is no default layout', async () => {

--- a/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -397,18 +397,7 @@ export class UpsertWorkflowUseCase {
         organization: { _id: command.user.organizationId },
       });
 
-      // Assign default layoutId if null (but not if undefined)
-      if (isLayoutsPageActive && emailControlValues.layoutId === null) {
-        const defaultLayout = await this.getLayoutUseCase.execute(
-          GetLayoutCommand.create({
-            environmentId: command.user.environmentId,
-            organizationId: command.user.organizationId,
-            userId: command.user._id,
-            skipAdditionalFields: true,
-          })
-        );
-        emailControlValues.layoutId = defaultLayout.layoutId;
-      } else if (isLayoutsPageActive && typeof emailControlValues.layoutId === 'string') {
+      if (isLayoutsPageActive && typeof emailControlValues.layoutId === 'string') {
         const layout = await this.getLayoutUseCase.execute(
           GetLayoutCommand.create({
             layoutIdOrInternalId: emailControlValues.layoutId,

--- a/apps/dashboard/src/components/primitives/form/faceted-filter/facated-form-filter.tsx
+++ b/apps/dashboard/src/components/primitives/form/faceted-filter/facated-form-filter.tsx
@@ -24,8 +24,12 @@ export function FacetedFormFilter({
   onOpenChange,
   icon: Icon,
   hideTitle = false,
+  hidePlusIcon = false,
   hideSearch = false,
   hideClear = false,
+  className,
+  trailingNode,
+  disabled,
 }: FacetedFilterProps) {
   const [searchQuery, setSearchQuery] = React.useState('');
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -154,18 +158,21 @@ export function FacetedFormFilter({
             'rounded-lg border-neutral-200 ring-0 ring-offset-0 transition-colors duration-200 ease-out',
             sizes.trigger,
             isEmpty && 'border-[1px] border-dashed px-1.5 hover:border-neutral-300',
-            !isEmpty && 'border-[1px] bg-white'
+            !isEmpty && 'border-[1px] bg-white',
+            className
           )}
+          disabled={disabled}
         >
           <div className="flex items-center gap-1">
             {Icon && <Icon className="h-4 w-4 text-neutral-600" />}
-            {isEmpty && <PlusCircle className="h-4 w-4 text-neutral-300" />}
+            {isEmpty && !hidePlusIcon && <PlusCircle className="h-4 w-4 text-neutral-300" />}
             {(isEmpty || !hideTitle) && (
               <span className={cn('text-xs font-normal', isEmpty ? 'text-neutral-400' : 'text-neutral-600')}>
                 {title}
               </span>
             )}
             {!isEmpty && renderTriggerContent()}
+            {trailingNode}
           </div>
         </Button>
       </PopoverTrigger>

--- a/apps/dashboard/src/components/primitives/form/faceted-filter/types.ts
+++ b/apps/dashboard/src/components/primitives/form/faceted-filter/types.ts
@@ -24,6 +24,10 @@ export interface FacetedFilterProps {
   onOpenChange?: (open: boolean) => void;
   icon?: ComponentType<{ className?: string }>;
   hideTitle?: boolean;
+  hidePlusIcon?: boolean;
   hideSearch?: boolean;
   hideClear?: boolean;
+  className?: string;
+  trailingNode?: React.ReactNode;
+  disabled?: boolean;
 }

--- a/apps/dashboard/src/components/workflow-editor/edges.tsx
+++ b/apps/dashboard/src/components/workflow-editor/edges.tsx
@@ -9,6 +9,7 @@ import { AddStepMenu } from './add-step-menu';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useFetchLayouts } from '@/hooks/use-fetch-layouts';
 
 export type AddNodeEdgeType = Edge<{ isLast: boolean; addStepIndex: number }>;
 
@@ -28,6 +29,14 @@ export function AddNodeEdge({
   const has = useHasPermission();
   const { currentEnvironment } = useEnvironment();
   const isV2TemplateEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_V2_TEMPLATE_EDITOR_ENABLED);
+  const isLayoutsPageActive = useFeatureFlag(FeatureFlagsKeysEnum.IS_LAYOUTS_PAGE_ACTIVE);
+  const { data: layoutsResponse, isFetching: isFetchingLayouts } = useFetchLayouts({
+    limit: 100,
+    refetchOnWindowFocus: false,
+  });
+  const defaultLayout = layoutsResponse?.layouts.find((layout) => layout.isDefault);
+  const addDefaultLayout = isLayoutsPageActive && !!defaultLayout;
+  const defaultLayoutId = defaultLayout?.layoutId;
 
   const isReadOnly =
     workflow?.origin === ResourceOriginEnum.EXTERNAL ||
@@ -62,10 +71,10 @@ export function AddNodeEdge({
             {!isReadOnly && (
               <AddStepMenu
                 onMenuItemClick={async (stepType) => {
-                  if (workflow) {
+                  if (workflow && !isFetchingLayouts) {
                     const indexToAdd = data.addStepIndex;
 
-                    const newStep = createStep(stepType);
+                    const newStep = createStep(stepType, addDefaultLayout ? defaultLayoutId : undefined);
 
                     const updatedSteps = [
                       ...workflow.steps.slice(0, indexToAdd),

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -25,6 +25,7 @@ import { ConfirmationModal } from '@/components/confirmation-modal';
 import { useState, useCallback, useRef } from 'react';
 import { StepCreateDto } from '@novu/shared';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { useFetchLayouts } from '@/hooks/use-fetch-layouts';
 
 export type NodeData = {
   addStepIndex?: number;
@@ -556,8 +557,16 @@ export const AddNode = (_props: NodeProps<NodeType>) => {
   const has = useHasPermission();
   const { currentEnvironment } = useEnvironment();
   const isV2TemplateEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_V2_TEMPLATE_EDITOR_ENABLED);
+  const isLayoutsPageActive = useFeatureFlag(FeatureFlagsKeysEnum.IS_LAYOUTS_PAGE_ACTIVE);
+  const { data: layoutsResponse, isFetching: isFetchingLayouts } = useFetchLayouts({
+    limit: 100,
+    refetchOnWindowFocus: false,
+  });
+  const defaultLayout = layoutsResponse?.layouts.find((layout) => layout.isDefault);
+  const addDefaultLayout = isLayoutsPageActive && !!defaultLayout;
+  const defaultLayoutId = defaultLayout?.layoutId;
 
-  if (!workflow) {
+  if (!workflow || isFetchingLayouts) {
     return null;
   }
 
@@ -579,7 +588,7 @@ export const AddNode = (_props: NodeProps<NodeType>) => {
           update(
             {
               ...workflow,
-              steps: [...workflow.steps, createStep(stepType)],
+              steps: [...workflow.steps, createStep(stepType, addDefaultLayout ? defaultLayoutId : undefined)],
             },
             {
               onSuccess: (data) => {

--- a/apps/dashboard/src/components/workflow-editor/step-utils.ts
+++ b/apps/dashboard/src/components/workflow-editor/step-utils.ts
@@ -115,7 +115,7 @@ export const updateStepInWorkflow = (
   };
 };
 
-export const createStep = (type: StepTypeEnum): StepCreateDto => {
+export const createStep = (type: StepTypeEnum, defaultLayoutId: string | undefined): StepCreateDto => {
   const controlValue: Record<string, unknown> = {};
 
   if (type === StepTypeEnum.DIGEST) {
@@ -129,6 +129,10 @@ export const createStep = (type: StepTypeEnum): StepCreateDto => {
     controlValue.amount = DEFAULT_CONTROL_DELAY_AMOUNT;
     controlValue.unit = DEFAULT_CONTROL_DELAY_UNIT;
     controlValue.type = DEFAULT_CONTROL_DELAY_TYPE;
+  }
+
+  if (type === StepTypeEnum.EMAIL && defaultLayoutId) {
+    controlValue.layoutId = defaultLayoutId;
   }
 
   return {

--- a/apps/dashboard/src/components/workflow-editor/steps/component-utils.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/component-utils.tsx
@@ -17,6 +17,7 @@ import { DataObject } from './base/data-object';
 import { BypassSanitizationSwitch } from './shared/bypass-sanitization-switch';
 import { useWorkflow } from '../workflow-provider';
 import { useSaveForm } from './save-form-context';
+import { LayoutSelect } from './email/layout-select';
 
 const EmailEditorSelectInternal = () => {
   const { isUpdatePatchPending } = useWorkflow();
@@ -94,6 +95,10 @@ export const getComponentByType = ({ component }: { component?: UiComponentEnum 
 
     case UiComponentEnum.CHAT_BODY: {
       return <BaseBody />;
+    }
+
+    case UiComponentEnum.LAYOUT_SELECT: {
+      return <LayoutSelect />;
     }
 
     default: {

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-editor.tsx
@@ -3,18 +3,20 @@ import { getComponentByType } from '@/components/workflow-editor/steps/component
 import { EmailPreviewHeader } from '@/components/workflow-editor/steps/email/email-preview';
 import { cn } from '../../../../utils/ui';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { Code2 } from '@/components/icons/code-2';
 
 type EmailEditorProps = { uiSchema: UiSchema; isEditorV2?: boolean };
 
 export const EmailEditor = (props: EmailEditorProps) => {
   const { uiSchema, isEditorV2 = false } = props;
   const isHtmlEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_HTML_EDITOR_ENABLED);
+  const isLayoutsPageActive = useFeatureFlag(FeatureFlagsKeysEnum.IS_LAYOUTS_PAGE_ACTIVE);
 
   if (uiSchema.group !== UiSchemaGroupEnum.EMAIL) {
     return null;
   }
 
-  const { body, subject, disableOutputSanitization, editorType } = uiSchema.properties ?? {};
+  const { body, subject, disableOutputSanitization, editorType, layoutId } = uiSchema.properties ?? {};
 
   return (
     <div className="flex h-full flex-col">
@@ -31,6 +33,15 @@ export const EmailEditor = (props: EmailEditorProps) => {
         </div>
 
         <div className={cn(isEditorV2 && 'px-3 py-0')}>{getComponentByType({ component: subject.component })}</div>
+        {isLayoutsPageActive && (
+          <div className="flex items-center gap-0.5 border-b border-t border-neutral-100 px-1 py-0.5">
+            <div className="px-[5px] py-1">
+              <Code2 className="size-3.5" />
+            </div>
+            <span className="h-[22px] w-px border-r border-neutral-100" />
+            {getComponentByType({ component: layoutId?.component ?? UiComponentEnum.LAYOUT_SELECT })}
+          </div>
+        )}
       </div>
       {getComponentByType({ component: body.component })}
     </div>

--- a/apps/dashboard/src/components/workflow-editor/steps/email/layout-select.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/layout-select.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { FormControl, FormField, FormItem, FormMessage } from '@/components/primitives/form/form';
+import { useFetchLayouts } from '@/hooks/use-fetch-layouts';
+import { FacetedFormFilter } from '@/components/primitives/form/faceted-filter/facated-form-filter';
+import { RiExpandUpDownLine, RiLayout5Line } from 'react-icons/ri';
+import { useSaveForm } from '../save-form-context';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
+
+export const LayoutSelect = () => {
+  const { control } = useFormContext();
+  const { data, isFetching } = useFetchLayouts({ limit: 100, refetchOnWindowFocus: false });
+  const { saveForm } = useSaveForm();
+
+  const layoutsSortedByDefault = useMemo(() => {
+    return data?.layouts
+      .sort((a, b) => {
+        if (a.isDefault) return -1;
+        if (b.isDefault) return 1;
+        return 0;
+      })
+      .map((layout) => ({
+        label: layout.isDefault ? `${layout.name} (Default)` : layout.name,
+        value: layout.layoutId,
+      }));
+  }, [data]);
+
+  return (
+    <FormField
+      control={control}
+      name="layoutId"
+      render={({ field }) => {
+        return (
+          <FormItem className="w-full">
+            <FormControl>
+              <Tooltip>
+                <TooltipTrigger
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                  }}
+                >
+                  <FacetedFormFilter
+                    type="single"
+                    size="small"
+                    title="Transactional layout"
+                    icon={RiLayout5Line}
+                    placeholder="Search layout"
+                    className="bg-bg-weak border-transparent hover:border-transparent hover:bg-neutral-100 [&_span]:text-neutral-600"
+                    selected={field.value ? [field.value] : undefined}
+                    disabled={isFetching || layoutsSortedByDefault?.length === 0}
+                    hidePlusIcon
+                    options={layoutsSortedByDefault}
+                    onSelect={(value) => {
+                      if (value.length > 0) {
+                        field.onChange(value[0]);
+                        return;
+                      }
+
+                      field.onChange(null);
+                      saveForm({ forceSubmit: true });
+                    }}
+                    trailingNode={<RiExpandUpDownLine className="text-text-soft size-3" />}
+                  />
+                </TooltipTrigger>
+                {layoutsSortedByDefault?.length === 0 && <TooltipContent>No layouts found</TooltipContent>}
+              </Tooltip>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        );
+      }}
+    />
+  );
+};

--- a/apps/dashboard/src/hooks/use-fetch-layouts.tsx
+++ b/apps/dashboard/src/hooks/use-fetch-layouts.tsx
@@ -1,9 +1,10 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { DirectionEnum } from '@novu/shared';
+import { DirectionEnum, FeatureFlagsKeysEnum } from '@novu/shared';
 
 import { QueryKeys } from '@/utils/query-keys';
 import { useEnvironment } from '../context/environment/hooks';
 import { getLayouts } from '@/api/layouts';
+import { useFeatureFlag } from './use-feature-flag';
 
 interface UseLayoutsParams {
   limit?: number;
@@ -11,6 +12,7 @@ interface UseLayoutsParams {
   query?: string;
   orderBy?: string;
   orderDirection?: DirectionEnum;
+  refetchOnWindowFocus?: boolean;
 }
 
 export const useFetchLayouts = ({
@@ -19,15 +21,17 @@ export const useFetchLayouts = ({
   query = '',
   orderBy = '',
   orderDirection = DirectionEnum.DESC,
+  refetchOnWindowFocus = true,
 }: UseLayoutsParams = {}) => {
   const { currentEnvironment } = useEnvironment();
+  const isLayoutsPageActive = useFeatureFlag(FeatureFlagsKeysEnum.IS_LAYOUTS_PAGE_ACTIVE);
 
   const layoutsQuery = useQuery({
     queryKey: [QueryKeys.fetchLayouts, currentEnvironment?._id, { limit, offset, query, orderBy, orderDirection }],
     queryFn: () => getLayouts({ environment: currentEnvironment!, limit, offset, query, orderBy, orderDirection }),
     placeholderData: keepPreviousData,
-    enabled: !!currentEnvironment?._id,
-    refetchOnWindowFocus: true,
+    enabled: !!currentEnvironment?._id && isLayoutsPageActive,
+    refetchOnWindowFocus,
   });
 
   const currentPage = Math.floor(offset / limit) + 1;


### PR DESCRIPTION
### What changed? Why was the change needed?

Email Editor: allow selecting a layout

### Screenshots



https://github.com/user-attachments/assets/720d8f3a-e67b-43bb-9039-e3d89714c56f


https://github.com/user-attachments/assets/042a3f83-e15e-4ff2-adfc-6539563a84c1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a layout selection component for transactional email steps, allowing users to choose from available layouts when the layouts feature is enabled.
  * Enhanced workflow editor to automatically associate new email steps with the default layout if available and the feature is active.
  * Extended faceted filter components with new customization options, including hiding the plus icon, adding custom classes, trailing nodes, and disabling the filter.

* **Improvements**
  * Email editor UI now displays a layout selection section when the layouts feature is enabled.
  * Layout fetching logic now respects feature flag status and can be configured to avoid unnecessary refetching.

* **Bug Fixes**
  * Email steps with a null layout no longer default to an automatic layout assignment; they remain without a layout unless explicitly set.

* **Tests**
  * Updated and removed tests to reflect new behavior regarding layout assignment when layoutId is null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->