### PR TITLE
fix(dashboard): Resolve chat preview undefined length error fixes NV-6280

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview.tsx
@@ -15,7 +15,7 @@ export const ChatPreview = ({
   variant?: 'mini' | 'default';
 }) => {
   const isValidChatPreview =
-    previewData?.result.type === ChannelTypeEnum.CHAT && previewData?.result.preview.body.length > 0;
+    previewData?.result.type === ChannelTypeEnum.CHAT && previewData?.result.preview.body?.length > 0;
   const body = isValidChatPreview ? ((previewData?.result.preview as ChatRenderOutput)?.body ?? '') : '';
 
   return (


### PR DESCRIPTION
### What changed? Why was the change needed?

Added optional chaining (`?.`) to `previewData?.result.preview.body` in `apps/dashboard/src/components/workflow-editor/steps/chat/chat-preview.tsx`.

This change prevents a `TypeError: Cannot read properties of undefined (reading 'length')` that occurred when `previewData?.result.preview.body` was `undefined`, which was preventing users from viewing/editing chat steps in the workflow editor. The fix ensures robust handling of potentially undefined properties.

Relevant links:
- Slack thread: [https://app.plain.com/workspace/w_01HE2X2JVN730ZBA6QZ59X8BZ8/thread/th_01K07TMGEQN7S9S4VJQXN9SXFB](https://app.plain.com/workspace/w_01HE2X2JVN730ZBA6QZ59X8BZ8/thread/th_01K07TMGEQN7S9S4VJQXN9SXFB)
- Sentry: [https://novu-r9.sentry.io/issues/6759567632/events/0270fae1ca3d406384700f06d6d66c6b/](https://novu-r9.sentry.io/issues/6759567632/events/0270fae1ca3d406384700f06d6d66c6b/)
- Loom: [https://www.loom.com/share/20382244e6324f8c96c6d0f6a2b6d78d](https://www.loom.com/share/20382244e6324f8c96c6d0f6a2b6d78d)
- Plain issue: NV-6280 Error viewing/editing chat step on new dashboard

### Screenshots

<!-- No visual changes -->

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-a80fbcaf-15cf-44b6-9b39-40b680b5ce45) · [Cursor](https://cursor.com/background-agent?bcId=bc-a80fbcaf-15cf-44b6-9b39-40b680b5ce45)

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1753074466215729?thread_ts=1753074466.215729&cid=C06GS20SPE0)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)