### PR TITLE
fix(dashboard): Correct workflow identifier in activity panel fixes NV-6282

### DIFF
--- a/apps/dashboard/src/components/activity/components/activity-overview.tsx
+++ b/apps/dashboard/src/components/activity/components/activity-overview.tsx
@@ -77,14 +77,14 @@ export function ActivityOverview({ activity }: ActivityOverviewProps) {
   return (
     <motion.div {...fadeIn} className="px-3 py-2">
       <div className="mb-2 flex flex-col gap-[12px]">
-        <OverviewItem label="Workflow Identifier" value={activity.template?.name || 'Deleted workflow'}>
+        <OverviewItem label="Workflow Identifier" value={activity.template?.triggers?.[0]?.identifier || 'Deleted workflow'}>
           <Link
             to={activity.template?._id ? workflowPath : '#'}
             className={cn('text-foreground-600 cursor-pointer font-mono text-xs group-hover:underline', {
               'text-foreground-300 cursor-not-allowed': !activity.template?._id,
             })}
           >
-            {activity.template?.name || 'Deleted workflow'}
+            {activity.template?.triggers?.[0]?.identifier || 'Deleted workflow'}
           </Link>
         </OverviewItem>
 


### PR DESCRIPTION
### What changed? Why was the change needed?

The "Workflow Identifier" row in the activity panel now correctly displays the workflow's unique identifier (`activity.template?.triggers?.[0]?.identifier`) instead of its name (`activity.template?.name`). This change was needed because the activity panel was showing the workflow name where the identifier was expected, leading to incorrect information for users.

**Relevant links:**
- Slack thread: [Loom Video](https://www.loom.com/share/ed56af9eb1c9469b94128f7cbebd87d3)
- Linear ticket: NV-6282

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->
[Add screenshots of the activity panel showing the correct workflow identifier here]

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-6e839884-9200-496c-ad09-4d635b76d024) · [Cursor](https://cursor.com/background-agent?bcId=bc-6e839884-9200-496c-ad09-4d635b76d024)

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1753068339081349?thread_ts=1753068339.081349&cid=C06GS20SPE0)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)