### PR TITLE
fix(dashboard): Fix subscriber timezone display bug

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-drawer.tsx
@@ -129,6 +129,8 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
         phone: fetchedSubscriberData.phone ?? undefined,
         avatar: fetchedSubscriberData.avatar ?? undefined,
         locale: fetchedSubscriberData.locale ?? undefined,
+        timezone: fetchedSubscriberData.timezone ?? undefined,
+        data: fetchedSubscriberData.data ?? undefined,
       });
     } else if (currentUser && !fetchedSubscriberData && !subscriberData?.subscriberId && !isLoadingSubscriber) {
       setSubscriberData({


### PR DESCRIPTION
### What changed? Why was the change needed?

The `timezone` and `data` fields were added to the subscriber data mapping in `apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-drawer.tsx`.

This change was needed because the `timezone` field was not being auto-populated in the subscriber view mode. Although the backend returned the timezone, it was not being mapped to the local subscriber state, causing it to appear empty in the UI. The `data` field was also included for completeness.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-db2c418a-fc18-48c1-ac4e-927a854b289d) · [Cursor](https://cursor.com/background-agent?bcId=bc-db2c418a-fc18-48c1-ac4e-927a854b289d)

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1753104921255959?thread_ts=1753104921.255959&cid=D0919LNRWE7)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)