### PR TITLE
fix(api-service,dashboard): preview rendering issues when block layout is picked and converting from email step block editor to html fixes NV-6332

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,7 +37,7 @@
     "@aws-sdk/client-secrets-manager": "^3.716.0",
     "@godaddy/terminus": "^4.12.1",
     "@google-cloud/storage": "^6.2.3",
-    "@maily-to/render": "github:novuhq/maily.to#release/v0.1.3-novu.6-render&path:/packages/render",
+    "@maily-to/render": "github:novuhq/maily.to#release/v0.1.3-novu.7-render&path:/packages/render",
     "@nestjs/axios": "3.0.3",
     "@nestjs/common": "10.4.18",
     "@nestjs/core": "10.4.18",

--- a/apps/api/src/app/bridge/usecases/preview-step/preview-step.command.ts
+++ b/apps/api/src/app/bridge/usecases/preview-step/preview-step.command.ts
@@ -10,6 +10,7 @@ export class PreviewStepCommand extends EnvironmentWithUserCommand {
   subscriber?: SubscriberResponseDtoOptional;
   workflowOrigin: ResourceOriginEnum;
   state?: FrameworkPreviousStepsOutputState[];
+  skipLayoutRendering?: boolean;
 }
 export type FrameworkPreviousStepsOutputState = {
   stepId: string;

--- a/apps/api/src/app/bridge/usecases/preview-step/preview-step.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/preview-step/preview-step.usecase.ts
@@ -26,6 +26,7 @@ export class PreviewStep {
       searchParams: {
         [HttpQueryKeysEnum.WORKFLOW_ID]: command.workflowId,
         [HttpQueryKeysEnum.STEP_ID]: command.stepId,
+        skipLayoutRendering: command.skipLayoutRendering ? 'true' : 'false',
       },
       workflowOrigin: command.workflowOrigin,
       retriesLimit: 1,

--- a/apps/api/src/app/environments-v1/novu-bridge-client.ts
+++ b/apps/api/src/app/environments-v1/novu-bridge-client.ts
@@ -46,6 +46,7 @@ export class NovuBridgeClient {
           workflowId: req.query.workflowId as string,
           controlValues: req.body.controls,
           action: req.query.action as PostActionEnum,
+          skipLayoutRendering: req.query.skipLayoutRendering === 'true',
         })
       );
 

--- a/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.command.ts
+++ b/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.command.ts
@@ -1,5 +1,5 @@
 import { EnvironmentLevelCommand } from '@novu/application-generic';
-import { IsDefined, IsEnum, IsObject, IsString } from 'class-validator';
+import { IsBoolean, IsDefined, IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
 import { PostActionEnum } from '@novu/framework/internal';
 
 export class ConstructFrameworkWorkflowCommand extends EnvironmentLevelCommand {
@@ -13,4 +13,8 @@ export class ConstructFrameworkWorkflowCommand extends EnvironmentLevelCommand {
 
   @IsEnum(PostActionEnum)
   action: PostActionEnum;
+
+  @IsOptional()
+  @IsBoolean()
+  skipLayoutRendering?: boolean;
 }

--- a/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts
@@ -73,7 +73,7 @@ export class ConstructFrameworkWorkflow {
       }
     }
 
-    return this.constructFrameworkWorkflow(dbWorkflow);
+    return this.constructFrameworkWorkflow(dbWorkflow, command.skipLayoutRendering);
   }
 
   private async constructLayoutPreviewWorkflow(command: ConstructFrameworkWorkflowCommand): Promise<Workflow> {
@@ -107,19 +107,20 @@ export class ConstructFrameworkWorkflow {
   }
 
   @Instrument()
-  private constructFrameworkWorkflow(dbWorkflow: NotificationTemplateEntity): Workflow {
+  private constructFrameworkWorkflow(dbWorkflow: NotificationTemplateEntity, skipLayoutRendering?: boolean): Workflow {
     return workflow(
       dbWorkflow.triggers[0].identifier,
       async ({ step, payload, subscriber }) => {
         const fullPayloadForRender: FullPayloadForRender = { payload, subscriber, steps: {} };
         for (const staticStep of dbWorkflow.steps) {
-          fullPayloadForRender.steps[staticStep.stepId || staticStep._templateId] = await this.constructStep(
+          fullPayloadForRender.steps[staticStep.stepId || staticStep._templateId] = await this.constructStep({
             step,
             staticStep,
             fullPayloadForRender,
             dbWorkflow,
-            subscriber.locale ?? undefined
-          );
+            locale: subscriber.locale ?? undefined,
+            skipLayoutRendering,
+          });
         }
       },
       {
@@ -138,13 +139,21 @@ export class ConstructFrameworkWorkflow {
   }
 
   @Instrument()
-  private constructStep(
-    step: Step,
-    staticStep: NotificationStepEntity,
-    fullPayloadForRender: FullPayloadForRender,
-    dbWorkflow: NotificationTemplateEntity,
-    locale?: string
-  ): StepOutput<Record<string, unknown>> {
+  private constructStep({
+    step,
+    staticStep,
+    fullPayloadForRender,
+    dbWorkflow,
+    locale,
+    skipLayoutRendering,
+  }: {
+    step: Step;
+    staticStep: NotificationStepEntity;
+    fullPayloadForRender: FullPayloadForRender;
+    dbWorkflow: NotificationTemplateEntity;
+    locale?: string;
+    skipLayoutRendering?: boolean;
+  }): StepOutput<Record<string, unknown>> {
     const stepTemplate = staticStep.template;
 
     if (!stepTemplate) {
@@ -190,6 +199,7 @@ export class ConstructFrameworkWorkflow {
               organizationId: dbWorkflow._organizationId,
               workflowId: dbWorkflow._id,
               locale,
+              skipLayoutRendering,
             });
           },
           this.constructChannelStepOptions(staticStep, fullPayloadForRender)

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { JSONContent as MailyJSONContent } from '@maily-to/render';
 import { FeatureFlagsService, PinoLogger } from '@novu/application-generic';
 import { ControlValuesRepository } from '@novu/dal';
-import { ControlValuesLevelEnum } from '@novu/shared';
+import { ControlValuesLevelEnum, LAYOUT_CONTENT_VARIABLE } from '@novu/shared';
 import { ModuleRef } from '@nestjs/core';
 import { EmailOutputRendererCommand, EmailOutputRendererUsecase } from './email-output-renderer.usecase';
 import { FullPayloadForRender } from './render-command';
@@ -1028,6 +1028,305 @@ describe('EmailOutputRendererUsecase', () => {
 
       const result = await emailOutputRendererUsecase.execute(renderCommand);
       expect(result.body).to.include('href="https://example.com"');
+    });
+  });
+
+  describe('enhanceContentVariable functionality', () => {
+    beforeEach(() => {
+      // Disable layouts feature flag for these tests to focus on step content only
+      featureFlagsServiceMock.getFlag.resolves(false);
+    });
+
+    it('should process content variable with shouldDangerouslySetInnerHTML behavior', async () => {
+      const mockMailyContent = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'variable',
+                attrs: {
+                  id: LAYOUT_CONTENT_VARIABLE,
+                  label: 'Content',
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Content Variable Test',
+          body: JSON.stringify(mockMailyContent),
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          [LAYOUT_CONTENT_VARIABLE]: '<strong>Injected Content</strong>',
+        },
+        workflowId: mockDbWorkflow._id,
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      // The content variable should be processed and the HTML should contain the injected content
+      expect(result.body).to.include('<strong>Injected Content</strong>');
+      expect(result.subject).to.equal('Content Variable Test');
+    });
+
+    it('should process non-content variables normally through liquid templating', async () => {
+      const mockMailyContent = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'variable',
+                attrs: {
+                  id: 'payload.name',
+                  label: 'Name',
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Non-Content Variable Test',
+          body: JSON.stringify(mockMailyContent),
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { name: 'John Doe' },
+        },
+        workflowId: mockDbWorkflow._id,
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      // Regular variables should be processed through liquid templating
+      expect(result.body).to.include('John Doe');
+      expect(result.subject).to.equal('Non-Content Variable Test');
+    });
+  });
+
+  describe('skipLayoutRendering functionality', () => {
+    const simpleBodyContent = '<p>Step content {{payload.name}}</p>';
+    const layoutContent = '<html><body><div class="layout">{{content}}</div></body></html>';
+
+    let mockControlValuesEntity: any;
+    let mockLayoutDto: any;
+
+    beforeEach(() => {
+      // Enable layouts feature flag for these tests
+      featureFlagsServiceMock.getFlag.resolves(true);
+
+      mockControlValuesEntity = {
+        controls: {
+          email: {
+            body: layoutContent,
+          },
+        },
+      };
+
+      mockLayoutDto = {
+        _id: 'test_layout_id',
+        isDefault: false,
+      };
+
+      controlValuesRepositoryMock.findOne.resolves(mockControlValuesEntity as any);
+      getLayoutUseCase.execute.resolves(mockLayoutDto as any);
+    });
+
+    it('should skip layout rendering when skipLayoutRendering is true', async () => {
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Skip Layout Test',
+          body: simpleBodyContent,
+          layoutId: 'test_layout_id',
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { name: 'John' },
+        },
+        workflowId: mockDbWorkflow._id,
+        skipLayoutRendering: true,
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('Step content John');
+      expect(result.body).to.not.include('class="layout"');
+      expect(result.body).to.not.include('<html>');
+      expect(result.body).to.not.include('<body>');
+
+      // Verify that layout was fetched but not applied
+      expect(getLayoutUseCase.execute.calledOnce).to.be.true;
+      expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.true;
+    });
+
+    it('should apply layout rendering when skipLayoutRendering is false', async () => {
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Apply Layout Test',
+          body: simpleBodyContent,
+          layoutId: 'test_layout_id',
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { name: 'John' },
+        },
+        workflowId: mockDbWorkflow._id,
+        skipLayoutRendering: false,
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('Step content John');
+      expect(result.body).to.include('class="layout"');
+      expect(result.body).to.include('<html>');
+      expect(result.body).to.include('<body>');
+
+      expect(getLayoutUseCase.execute.calledOnce).to.be.true;
+      expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.true;
+    });
+
+    it('should apply layout rendering when skipLayoutRendering is undefined', async () => {
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Default Layout Test',
+          body: simpleBodyContent,
+          layoutId: 'test_layout_id',
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { name: 'John' },
+        },
+        workflowId: mockDbWorkflow._id,
+        // skipLayoutRendering not specified
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('Step content John');
+      expect(result.body).to.include('class="layout"');
+      expect(result.body).to.include('<html>');
+      expect(result.body).to.include('<body>');
+
+      expect(getLayoutUseCase.execute.calledOnce).to.be.true;
+      expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.true;
+    });
+
+    it('should skip layout rendering with maily content when skipLayoutRendering is true', async () => {
+      const mailyStepContent = JSON.stringify({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Hello {{payload.name}}',
+              },
+            ],
+          },
+        ],
+      });
+
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Skip Layout Maily Test',
+          body: mailyStepContent,
+          layoutId: 'test_layout_id',
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { name: 'John' },
+        },
+        workflowId: mockDbWorkflow._id,
+        skipLayoutRendering: true,
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('Hello John');
+      expect(result.body).to.not.include('class="layout"');
+      expect(result.body).to.not.include('<html>');
+
+      // Should still process the maily content and apply liquid templating
+      expect(result.body).to.not.include('{{payload.name}}');
+    });
+
+    it('should properly clean content even when skipping layout rendering', async () => {
+      const bodyWithDoctype = '<!DOCTYPE html><p>Content {{payload.name}}</p><!--$-->';
+
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Clean Content Test',
+          body: bodyWithDoctype,
+          layoutId: 'test_layout_id',
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { name: 'John' },
+        },
+        workflowId: mockDbWorkflow._id,
+        skipLayoutRendering: true,
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('Content John');
+      expect(result.body).to.not.include('<!DOCTYPE');
+      expect(result.body).to.not.include('<!--$-->');
+      expect(result.body).to.not.include('class="layout"');
+    });
+
+    it('should handle skipLayoutRendering when no layout controls exist', async () => {
+      controlValuesRepositoryMock.findOne.resolves(null);
+
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'No Layout Test',
+          body: simpleBodyContent,
+          layoutId: 'non_existent_layout_id',
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { name: 'John' },
+        },
+        workflowId: mockDbWorkflow._id,
+        skipLayoutRendering: true,
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('Step content John');
+      expect(result.body).to.not.include('class="layout"');
+
+      // Should still attempt to fetch layout but gracefully handle null result
+      expect(getLayoutUseCase.execute.calledOnce).to.be.true;
+      expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.true;
     });
   });
 

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -205,7 +205,8 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
     const cleanedStepBodyHtml = stepBodyHtml
       .replace(/<!DOCTYPE.*?>/g, '')
       .replace(/<!--\$-->/g, '')
-      .replace(/<!--\/\$-->/g, '');
+      .replace(/<!--\/\$-->/g, '')
+      .replace(/<!--[\s\S]*?-->/g, '');
 
     if (!layoutControlsEntity || skipLayoutRendering) {
       return cleanedStepBodyHtml;

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -24,6 +24,7 @@ import {
   isLinkNode,
   isRepeatNode,
   isVariableNode,
+  replaceMailyNodesByCondition,
   wrapMailyInLiquid,
 } from '../../../shared/helpers/maily-utils';
 import { NOVU_BRANDING_HTML } from './novu-branding-html';
@@ -40,6 +41,7 @@ export class EmailOutputRendererCommand extends RenderCommand {
   organizationId: string;
   workflowId?: string;
   locale?: string;
+  skipLayoutRendering?: boolean;
 }
 
 function isJsonString(str: string): boolean {
@@ -90,7 +92,8 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
       };
     }
 
-    const { fullPayloadForRender, environmentId, organizationId, workflowId, locale } = renderCommand;
+    const { fullPayloadForRender, environmentId, organizationId, workflowId, locale, skipLayoutRendering } =
+      renderCommand;
 
     const isLayoutsPageActive = await this.featureFlagsService.getFlag({
       key: FeatureFlagsKeysEnum.IS_LAYOUTS_PAGE_ACTIVE,
@@ -120,6 +123,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
         organizationId,
         workflowId,
         locale,
+        skipLayoutRendering,
       });
     } else {
       renderedHtml = await this.processBodyContent({
@@ -157,6 +161,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
     organizationId,
     workflowId,
     locale,
+    skipLayoutRendering,
   }: {
     body: string;
     layoutId?: string | null;
@@ -165,6 +170,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
     organizationId: string;
     workflowId?: string;
     locale?: string;
+    skipLayoutRendering?: boolean;
   }): Promise<string> {
     let layoutControlsEntity: ControlValuesEntity | null = null;
     // if the step control values have a layoutId then find layout controls entity
@@ -196,11 +202,15 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
       noHtmlWrappingTags: !!layoutControlsEntity,
     });
 
-    if (!layoutControlsEntity) {
-      return stepBodyHtml;
+    const cleanedStepBodyHtml = stepBodyHtml
+      .replace(/<!DOCTYPE.*?>/g, '')
+      .replace(/<!--\$-->/g, '')
+      .replace(/<!--\/\$-->/g, '');
+
+    if (!layoutControlsEntity || skipLayoutRendering) {
+      return cleanedStepBodyHtml;
     }
 
-    const cleanedStepBodyHtml = stepBodyHtml.replace(/<!DOCTYPE.*?>/, '').replace(/<!--\/$-->/, '');
     const layoutControlValues = layoutControlsEntity.controls as LayoutControlType;
 
     return this.processBodyContent({
@@ -214,6 +224,23 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
       workflowId,
       locale,
     });
+  }
+
+  private enhanceContentVariable(body: string) {
+    return JSON.stringify(
+      replaceMailyNodesByCondition(
+        body,
+        (node) => node.type === 'variable' && node.attrs?.id === LAYOUT_CONTENT_VARIABLE,
+        (node) =>
+          ({
+            ...node,
+            attrs: {
+              ...node.attrs,
+              shouldDangerouslySetInnerHTML: true,
+            },
+          }) satisfies MailyJSONContent
+      )
+    );
   }
 
   private async processBodyContent({
@@ -235,7 +262,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
   }): Promise<string> {
     if (typeof body === 'object' || (typeof body === 'string' && isJsonString(body))) {
       const escapedPayloadForJson = this.deepEscapePayloadStrings(payload);
-      const liquifiedMaily = wrapMailyInLiquid(body);
+      const liquifiedMaily = wrapMailyInLiquid(this.enhanceContentVariable(body));
       const transformedMaily = await this.transformMailyContent(liquifiedMaily, escapedPayloadForJson);
       const parsedMaily = await this.parseMailyContentByLiquid(transformedMaily, escapedPayloadForJson);
 

--- a/apps/api/src/app/layouts-v2/utils/layout-templates.ts
+++ b/apps/api/src/app/layouts-v2/utils/layout-templates.ts
@@ -64,18 +64,13 @@ export const DEFAULT_LAYOUT = {
         },
         {
           type: 'paragraph',
-          attrs: { textAlign: 'center', showIfKey: null },
+          attrs: { textAlign: null, showIfKey: null },
           content: [
             {
               type: 'variable',
-              attrs: {
-                id: 'content',
-                label: null,
-                fallback: null,
-                required: false,
-                aliasFor: null,
-              },
+              attrs: { id: 'content', label: null, fallback: null, required: false, aliasFor: null },
             },
+            { type: 'text', text: ' ' },
           ],
         },
         { type: 'horizontalRule' },

--- a/apps/api/src/app/shared/utils/build-variables.ts
+++ b/apps/api/src/app/shared/utils/build-variables.ts
@@ -13,11 +13,13 @@ export function buildVariables({
   variableSchema,
   controlValue,
   logger,
+  suggestPayloadNamespace = true,
 }: {
   useNewLiquidParser: boolean;
   variableSchema: JSONSchemaDto | undefined;
   controlValue: unknown | Record<string, unknown>;
   logger?: PinoLogger;
+  suggestPayloadNamespace?: boolean;
 }): VariableDetails {
   let variableControlValue = controlValue;
 
@@ -49,6 +51,7 @@ export function buildVariables({
     const { validVariables, invalidVariables } = newExtractLiquidTemplateVariables({
       template: typeof variableControlValue === 'string' ? variableControlValue : JSON.stringify(variableControlValue),
       variableSchema,
+      suggestPayloadNamespace,
     });
 
     return {

--- a/apps/api/src/app/shared/utils/issues.ts
+++ b/apps/api/src/app/shared/utils/issues.ts
@@ -148,6 +148,7 @@ export const processControlValuesByLiquid = ({
       useNewLiquidParser,
       variableSchema,
       controlValue: currentValue,
+      suggestPayloadNamespace: false,
     });
 
     // Prioritize invalid variable validation over content compilation since it provides more granular error details

--- a/apps/api/src/app/shared/utils/template-parser/new-liquid-parser.ts
+++ b/apps/api/src/app/shared/utils/template-parser/new-liquid-parser.ts
@@ -36,23 +36,27 @@ const parserEngine = buildLiquidParser();
 export function extractLiquidTemplateVariables({
   template,
   variableSchema,
+  suggestPayloadNamespace = true,
 }: {
   template: string;
   variableSchema?: JSONSchemaDto;
+  suggestPayloadNamespace?: boolean;
 }): VariableDetails {
   if (!isValidTemplate(template)) {
     return { validVariables: [], invalidVariables: [] };
   }
 
-  return processLiquidRawOutput({ template, variableSchema });
+  return processLiquidRawOutput({ template, variableSchema, suggestPayloadNamespace });
 }
 
 function processLiquidRawOutput({
   template,
   variableSchema,
+  suggestPayloadNamespace = true,
 }: {
   template: string;
   variableSchema?: JSONSchemaDto;
+  suggestPayloadNamespace?: boolean;
 }): VariableDetails {
   const validVariables: Array<Variable> = [];
   const invalidVariables: Array<Variable> = [];
@@ -66,7 +70,7 @@ function processLiquidRawOutput({
   }
 
   try {
-    const result = parseByLiquid({ template, variableSchema });
+    const result = parseByLiquid({ template, variableSchema, suggestPayloadNamespace });
     result.validVariables.forEach((variable) => addVariable(variable, true));
     result.invalidVariables.forEach((variable) => addVariable(variable, false));
   } catch (error: unknown) {
@@ -110,9 +114,11 @@ function processLiquidRawOutput({
 function parseByLiquid({
   template,
   variableSchema,
+  suggestPayloadNamespace = true,
 }: {
   template: string;
   variableSchema?: JSONSchemaDto;
+  suggestPayloadNamespace?: boolean;
 }): VariableDetails {
   const validVariables: Array<Variable> = [];
   const invalidVariables: Array<Variable> = [];
@@ -124,13 +130,21 @@ function parseByLiquid({
     invalidVariables,
     variableSchema,
     localVariables: new Set(),
+    suggestPayloadNamespace,
   });
 
   return { validVariables, invalidVariables };
 }
 
 function processTemplates(context: ProcessContext) {
-  const { templates, validVariables, invalidVariables, variableSchema, localVariables = new Set() } = context;
+  const {
+    templates,
+    validVariables,
+    invalidVariables,
+    variableSchema,
+    localVariables = new Set(),
+    suggestPayloadNamespace,
+  } = context;
 
   templates.forEach((template: Template) => {
     if (isOutputToken(template)) {
@@ -140,6 +154,7 @@ function processTemplates(context: ProcessContext) {
         invalidVariables,
         variableSchema,
         localVariables,
+        suggestPayloadNamespace,
       });
     } else if (isTagToken(template)) {
       processTagToken({
@@ -218,6 +233,7 @@ function validateVariable({
   output,
   outputStart,
   outputEnd,
+  suggestPayloadNamespace,
 }: {
   variableName: string;
   validVariables: Array<Variable>;
@@ -227,6 +243,7 @@ function validateVariable({
   output: string;
   outputStart: number;
   outputEnd: number;
+  suggestPayloadNamespace?: boolean;
 }) {
   // Check if this variable has no namespace (single part)
   const hasNoNamespace = variableName.split('.').length === 1;
@@ -246,7 +263,9 @@ function validateVariable({
     // Otherwise, it's invalid (missing namespace)
     invalidVariables.push({
       name: variableName,
-      message: `missing namespace. Did you mean {{payload.${variableName}}}?`,
+      message: suggestPayloadNamespace
+        ? `invalid or missing namespace. Did you mean {{payload.${variableName}}}?`
+        : 'invalid or missing namespace',
       output,
       outputStart,
       outputEnd,
@@ -279,12 +298,14 @@ function validateOutputToken({
   invalidVariables,
   variableSchema,
   localVariables,
+  suggestPayloadNamespace,
 }: {
   template: Template;
   validVariables: Array<Variable>;
   invalidVariables: Array<Variable>;
   variableSchema?: JSONSchemaDto;
   localVariables: Set<string>;
+  suggestPayloadNamespace?: boolean;
 }) {
   const result = extractProps(template);
   const variableName = buildVariable(result.props);
@@ -377,6 +398,7 @@ function validateOutputToken({
     output,
     outputStart,
     outputEnd,
+    suggestPayloadNamespace,
   });
 }
 

--- a/apps/api/src/app/shared/utils/template-parser/types.ts
+++ b/apps/api/src/app/shared/utils/template-parser/types.ts
@@ -47,4 +47,5 @@ export type ProcessContext = {
   invalidVariables: Array<Variable>;
   variableSchema?: JSONSchemaDto;
   localVariables?: Set<string>;
+  suggestPayloadNamespace?: boolean;
 };

--- a/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
@@ -547,7 +547,6 @@ describe('Upsert Workflow #novu-v2', function () {
       const updatedEmailStep = updatedWorkflow.steps[0] as EmailStepResponseDto;
 
       expect(updatedEmailStep.controls.values.editorType).to.equal('html');
-      expect(updatedEmailStep.controls.values.body).to.contain('<!DOCTYPE');
       expect(updatedEmailStep.controls.values.body).to.contain('<html');
       expect(updatedEmailStep.controls.values.body).to.contain('<body');
       expect(updatedEmailStep.controls.values.body).to.contain(`>

--- a/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
@@ -198,6 +198,76 @@ describe('Upsert Workflow #novu-v2', function () {
         process.env.IS_HTML_EDITOR_ENABLED = 'false';
       });
 
+      it('should skip layout rendering when converting Maily JSON to HTML with assigned layoutId', async () => {
+        // First create a layout with distinctive HTML content
+        const layout = await createLayout({
+          name: 'Test Layout for skipLayoutRendering',
+          layoutId: 'test-layout-skip-rendering',
+          source: LayoutCreationSourceEnum.Dashboard,
+        });
+
+        const mailyJsonContent = JSON.stringify({
+          type: 'doc',
+          content: [
+            {
+              type: 'paragraph',
+              content: [
+                {
+                  type: 'text',
+                  text: 'This is email content that should not include layout HTML.',
+                },
+              ],
+            },
+          ],
+        });
+
+        // Create workflow with email step that has layoutId assigned
+        const workflow = await createWorkflow({
+          name: 'Test Workflow with Layout',
+          workflowId: `test-workflow-layout-${Date.now()}`,
+          source: WorkflowCreationSourceEnum.Editor,
+          active: true,
+          steps: [
+            {
+              name: `Email Step with Layout`,
+              type: StepTypeEnum.Email,
+              controlValues: {
+                subject: 'Test Email with Layout',
+                body: mailyJsonContent,
+                editorType: 'block',
+                layoutId: layout.layoutId,
+              },
+            },
+          ],
+        });
+
+        // Switch to HTML editor - this should trigger skipLayoutRendering
+        const updatedWorkflow = await updateWorkflow(workflow.slug, {
+          ...workflow,
+          steps: [
+            {
+              ...workflow.steps[0],
+              controlValues: {
+                ...workflow.steps[0].controls.values,
+                editorType: 'html',
+              },
+            },
+          ],
+        });
+
+        const updatedEmailStep = updatedWorkflow.steps[0] as EmailStepResponseDto;
+
+        expect(updatedEmailStep.controls.values.editorType).to.equal('html');
+        expect(updatedEmailStep.controls.values.layoutId).to.equal(layout.layoutId);
+
+        // The body should contain the converted HTML from Maily JSON
+        expect(updatedEmailStep.controls.values.body).to.not.contain('<!DOCTYPE');
+        expect(updatedEmailStep.controls.values.body).to.not.contain('<html');
+        expect(updatedEmailStep.controls.values.body).to.contain(
+          'This is email content that should not include layout HTML'
+        );
+      });
+
       it('should not use layoutId when null is provided', async () => {
         await createLayout({
           name: 'Test Layout',

--- a/apps/api/src/app/workflows-v2/usecases/preview/preview.command.ts
+++ b/apps/api/src/app/workflows-v2/usecases/preview/preview.command.ts
@@ -5,4 +5,5 @@ export class PreviewCommand extends EnvironmentWithUserObjectCommand {
   workflowIdOrInternalId: string;
   stepIdOrInternalId: string;
   generatePreviewRequestDto: GeneratePreviewRequestDto;
+  skipLayoutRendering?: boolean;
 }

--- a/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
@@ -178,6 +178,7 @@ export class PreviewUsecase {
         workflowId: stepData.workflowId,
         workflowOrigin: stepData.origin,
         state,
+        skipLayoutRendering: command.skipLayoutRendering,
       })
     );
   }

--- a/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -420,6 +420,7 @@ export class UpsertWorkflowUseCase {
             generatePreviewRequestDto: {
               controlValues: emailControlValues,
             },
+            skipLayoutRendering: true,
           })
         );
         let htmlBody = removeBrandingFromHtml((result.preview as EmailRenderOutput).body ?? '');

--- a/apps/dashboard/src/components/workflow-editor/steps/email/layout-select.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/layout-select.tsx
@@ -44,7 +44,7 @@ export const LayoutSelect = () => {
                   <FacetedFormFilter
                     type="single"
                     size="small"
-                    title="Transactional layout"
+                    title="Layout"
                     icon={RiLayout5Line}
                     placeholder="Search layout"
                     className="bg-bg-weak border-transparent hover:border-transparent hover:bg-neutral-100 [&_span]:text-neutral-600"

--- a/libs/application-generic/package.json
+++ b/libs/application-generic/package.json
@@ -45,7 +45,7 @@
     "@google-cloud/storage": "^6.2.3",
     "@hokify/agenda": "^6.3.0",
     "@launchdarkly/node-server-sdk": "^9.7.3",
-    "@maily-to/render": "github:novuhq/maily.to#release/v0.1.3-novu.6-render&path:/packages/render",
+    "@maily-to/render": "github:novuhq/maily.to#release/v0.1.3-novu.7-render&path:/packages/render",
     "@novu/dal": "workspace:*",
     "@novu/framework": "workspace:*",
     "@novu/providers": "workspace:*",

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.command.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.command.ts
@@ -28,7 +28,7 @@ export class ExecuteBridgeRequestCommand extends EnvironmentLevelCommand {
   event?: Omit<Event, `${HttpQueryKeysEnum}`>;
 
   @IsOptional()
-  searchParams?: Partial<Record<HttpQueryKeysEnum, string>>;
+  searchParams?: Partial<Record<HttpQueryKeysEnum | 'skipLayoutRendering', string>>;
 
   @IsOptional()
   processError?: ProcessError;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,8 +373,8 @@ importers:
         specifier: ^6.2.3
         version: 6.12.0(encoding@0.1.13)
       '@maily-to/render':
-        specifier: github:novuhq/maily.to#release/v0.1.3-novu.6-render&path:/packages/render
-        version: https://codeload.github.com/novuhq/maily.to/tar.gz/87ee6fb9a4334f30a7a3eda50df6ba019a7bc41c#path:/packages/render(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: github:novuhq/maily.to#release/v0.1.3-novu.7-render&path:/packages/render
+        version: https://codeload.github.com/novuhq/maily.to/tar.gz/cd50b53283e6f110872a23c7f7b85c838aba66c8#path:/packages/render(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@nestjs/axios':
         specifier: 3.0.3
         version: 3.0.3(@nestjs/common@10.4.18(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(axios@1.9.0)(rxjs@7.8.1)
@@ -2637,8 +2637,8 @@ importers:
         specifier: ^9.7.3
         version: 9.7.3
       '@maily-to/render':
-        specifier: github:novuhq/maily.to#release/v0.1.3-novu.6-render&path:/packages/render
-        version: https://codeload.github.com/novuhq/maily.to/tar.gz/87ee6fb9a4334f30a7a3eda50df6ba019a7bc41c#path:/packages/render(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: github:novuhq/maily.to#release/v0.1.3-novu.7-render&path:/packages/render
+        version: https://codeload.github.com/novuhq/maily.to/tar.gz/cd50b53283e6f110872a23c7f7b85c838aba66c8#path:/packages/render(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@nestjs/common':
         specifier: 10.4.18
         version: 10.4.18(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -8793,9 +8793,9 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  '@maily-to/render@https://codeload.github.com/novuhq/maily.to/tar.gz/87ee6fb9a4334f30a7a3eda50df6ba019a7bc41c#path:/packages/render':
-    resolution: {path: /packages/render, tarball: https://codeload.github.com/novuhq/maily.to/tar.gz/87ee6fb9a4334f30a7a3eda50df6ba019a7bc41c}
-    version: 0.1.3-novu.6-render
+  '@maily-to/render@https://codeload.github.com/novuhq/maily.to/tar.gz/cd50b53283e6f110872a23c7f7b85c838aba66c8#path:/packages/render':
+    resolution: {path: /packages/render, tarball: https://codeload.github.com/novuhq/maily.to/tar.gz/cd50b53283e6f110872a23c7f7b85c838aba66c8}
+    version: 0.1.3-novu.7-render
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^18.3.1
@@ -33290,8 +33290,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.575.0
@@ -33565,11 +33565,11 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
+  '@aws-sdk/client-sso-oidc@3.575.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -33608,7 +33608,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)':
@@ -34127,11 +34126,11 @@ snapshots:
       - aws-crt
     optional: true
 
-  '@aws-sdk/client-sts@3.575.0':
+  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -34170,6 +34169,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.637.0':
@@ -34479,7 +34479,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
       '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
@@ -35012,7 +35012,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
@@ -35546,7 +35546,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -35555,7 +35555,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -40366,7 +40366,7 @@ snapshots:
       - y-protocols
       - yjs
 
-  '@maily-to/render@https://codeload.github.com/novuhq/maily.to/tar.gz/87ee6fb9a4334f30a7a3eda50df6ba019a7bc41c#path:/packages/render(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@maily-to/render@https://codeload.github.com/novuhq/maily.to/tar.gz/cd50b53283e6f110872a23c7f7b85c838aba66c8#path:/packages/render(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@react-email/components': 0.0.25(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@react-email/render': 1.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)


### PR DESCRIPTION
### What changed? Why was the change needed?

[**Maily PR**](https://github.com/novuhq/maily.to/pull/28)

Fixed a couple of layout issues:
- When layout is created with a Maily blocks and the Email Step is also Maily blocks the preview was not working
- When switching the Email Step editor type from blocks to HTML the generated HTML contained doubled layout
- Variable errors mentioning "payload" namespace

### Screenshots


https://github.com/user-attachments/assets/695876e4-e501-4e92-9840-75c396347bcb




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to skip layout rendering when previewing or converting email steps, allowing content to be rendered without layout wrappers.
  * Enhanced handling of special content variables for email templates, supporting direct HTML rendering in specific scenarios.

* **Bug Fixes**
  * Improved content conversion when switching editor types, ensuring layout wrappers are omitted as expected.

* **Tests**
  * Added comprehensive tests to verify layout skipping and special variable rendering behaviors.

* **Style**
  * Updated UI wording from "Transactional layout" to "Layout" in the workflow editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->