### PR TITLE
fix(api-service): request logs filtering fix

### DIFF
--- a/apps/api/src/app/logs/logs.controller.ts
+++ b/apps/api/src/app/logs/logs.controller.ts
@@ -22,8 +22,8 @@ export class LogsController {
     query: GetRequestsDto
   ): Promise<GetRequestsResponseDto> {
     const command = GetRequestsCommand.create({
+      environmentId: user.environmentId,
       organizationId: user.organizationId,
-      userId: user._id,
       hoursAgo: query.created,
       ...query,
       statusCodes: query.statusCode,

--- a/apps/api/src/app/logs/usecases/get-requests/get-requests.command.ts
+++ b/apps/api/src/app/logs/usecases/get-requests/get-requests.command.ts
@@ -1,7 +1,7 @@
 import { IsArray, IsNumber, IsOptional, IsString } from 'class-validator';
-import { OrganizationCommand } from '@novu/application-generic';
+import { EnvironmentCommand } from '@novu/application-generic';
 
-export class GetRequestsCommand extends OrganizationCommand {
+export class GetRequestsCommand extends EnvironmentCommand {
   @IsNumber()
   @IsOptional()
   public page?: number;

--- a/apps/api/src/app/logs/usecases/get-requests/get-requests.usecase.ts
+++ b/apps/api/src/app/logs/usecases/get-requests/get-requests.usecase.ts
@@ -16,6 +16,7 @@ export class GetRequests {
 
     const where: Where<RequestLog> = {
       organization_id: command.organizationId,
+      environment_id: command.environmentId,
     };
 
     if (command.statusCodes) {


### PR DESCRIPTION
Updated the GetRequestsCommand to extend EnvironmentCommand and include environmentId. The logs controller and use case now handle environmentId, ensuring request logs are scoped by environment as well as organization.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
