### PR TITLE
fix(dashboard): Remove default dropdown option fixes NV-6245

### DIFF
--- a/apps/dashboard/src/components/variable/constants.ts
+++ b/apps/dashboard/src/components/variable/constants.ts
@@ -220,15 +220,6 @@ const FILTERS: Filters[] = [
     sampleValue: '2024-01-20',
   },
   {
-    label: 'Default',
-    value: 'default',
-    hasParam: true,
-    description: 'Use default value if input is empty.',
-    example: '"" | default: "¯\\_(ツ)_/¯" → ¯\\_(ツ)_/¯',
-    params: [{ label: 'Default value', type: 'string' }],
-    sampleValue: '',
-  },
-  {
     label: 'JSON',
     value: 'json',
     description: 'Convert object to JSON string.',


### PR DESCRIPTION
### What changed? Why was the change needed?

Removed the "Default" filter option from the variable dropdown in `apps/dashboard/src/components/variable/constants.ts`. This filter is no longer needed as the default value functionality is now handled by the payload schema.

Fixes: [NV-6245](https://linear.app/novu/issue/NV-6245/limit-access-to-raw-liquid-field-for-users)

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-ffae65af-e0c9-45ad-8b65-4e35119f328a) · [Cursor](https://cursor.com/background-agent?bcId=bc-ffae65af-e0c9-45ad-8b65-4e35119f328a)

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1753181418224019?thread_ts=1753181418.224019&cid=D0919LNRWE7)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)