### PR TITLE
feat(root): add manual post-release workflow for tagging and GitHub releases

### DIFF
--- a/.github/workflows/manual-post-release.yml
+++ b/.github/workflows/manual-post-release.yml
@@ -1,0 +1,100 @@
+name: Manual Post-Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: 'Packages to create tags and releases for (comma-separated)'
+        required: true
+        type: string
+        default: '@novu/js,@novu/react,@novu/nextjs,@novu/react-native'
+      version:
+        description: 'Version to tag and release (e.g., v3.0.0)'
+        required: true
+        type: string
+        default: 'v3.0.0'
+      create_github_release:
+        description: 'Create GitHub releases for the packages'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  manual_post_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: next
+
+      - name: Pull latest changes
+        run: |
+          git pull origin next
+
+      - name: Create and push tags
+        run: |
+          echo "Creating tags for packages: ${{ github.event.inputs.packages }}"
+          IFS=',' read -ra PACKAGES <<< "${{ github.event.inputs.packages }}"
+          for package in "${PACKAGES[@]}"; do
+            package=$(echo $package | xargs)  # trim whitespace
+            tag_name="${package}@${{ github.event.inputs.version }}"
+            echo "Creating tag: $tag_name"
+            git tag "$tag_name"
+            echo "Pushing tag: $tag_name"
+            git push origin "$tag_name"
+          done
+
+      - name: Create GitHub Releases
+        if: ${{ github.event.inputs.create_github_release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Creating GitHub releases for packages: ${{ github.event.inputs.packages }}"
+          
+          # Get the git diff for changelog files to capture what was actually added
+          echo "Capturing changelog changes from git diff..."
+          git diff HEAD~1 HEAD --name-only | grep -i changelog || echo "No changelog files changed"
+          
+          IFS=',' read -ra PACKAGES <<< "${{ github.event.inputs.packages }}"
+          for package in "${PACKAGES[@]}"; do
+            package=$(echo $package | xargs)  # trim whitespace
+            tag_name="${package}@${{ github.event.inputs.version }}"
+            
+            echo "Creating GitHub release for $package with tag: $tag_name"
+            
+            # Extract changelog content from git diff for this package
+            package_name=$(echo $package | sed 's/@novu\///')
+            release_body="Release of ${package} version ${{ github.event.inputs.version }}"
+            
+            # Try to find changelog diff for this specific package
+            possible_paths=(
+              "packages/${package_name}/CHANGELOG.md"
+              "${package_name}/CHANGELOG.md"
+              "CHANGELOG.md"
+            )
+            
+            for changelog_path in "${possible_paths[@]}"; do
+              if git diff HEAD~1 HEAD --name-only | grep -q "$changelog_path"; then
+                echo "Found changelog changes in: $changelog_path"
+                # Get the diff content (only additions, clean up the format)
+                changelog_diff=$(git diff HEAD~1 HEAD "$changelog_path" | grep "^+" | grep -v "^+++" | sed 's/^+//' | head -50)
+                if [ -n "$changelog_diff" ]; then
+                  release_body="$changelog_diff"
+                  break
+                fi
+              fi
+            done
+            
+            # Create the GitHub release
+            gh release create "$tag_name" \
+              --title "$tag_name" \
+              --notes "$release_body" \
+              --target next
+            
+            echo "✅ Created GitHub release for $tag_name"
+          done 

--- a/.github/workflows/manual-post-release.yml
+++ b/.github/workflows/manual-post-release.yml
@@ -15,10 +15,10 @@ on:
         default: 'v3.0.0'
       create_github_release:
         description: 'Create GitHub releases for the packages'
-        required: false
+        required: true
         type: boolean
-        default: true
-
+        default: false
+        
 jobs:
   manual_post_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -23,10 +23,21 @@ on:
         required: false
         type: boolean
         default: false
+      create_github_release:
+        description: 'Create GitHub releases for the packages'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      pr_number: ${{ steps.create-pr.outputs.pull-request-number }}
+      pr_url: ${{ steps.create-pr.outputs.pull-request-url }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,6 +108,7 @@ jobs:
           fi
 
       - name: Create Pull Request
+        id: create-pr
         if: ${{ !github.event.inputs.nightly }}
         uses: peter-evans/create-pull-request@v5
         with:
@@ -109,4 +121,64 @@ jobs:
             Packages released:
             ${{ github.event.inputs.packages }}
           branch: release-${{ github.event.inputs.version }}
-          base: next 
+          base: next
+
+  post_release:
+    needs: release
+    if: ${{ !github.event.inputs.nightly && needs.release.outputs.pr_number }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: next
+
+      - name: Wait for manual PR merge
+        id: wait_merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "📋 Waiting for manual merge of PR #${{ needs.release.outputs.pr_number }}"
+          echo "🔗 PR URL: ${{ needs.release.outputs.pr_url }}"
+          echo "Please review and merge the PR manually. This workflow will wait up to 30 minutes..."
+          
+          # Wait up to 30 minutes for manual merge
+          for i in {1..180}; do
+            status=$(gh pr view ${{ needs.release.outputs.pr_number }} --json state --jq '.state')
+            if [ "$status" = "MERGED" ]; then
+              echo "✅ PR has been merged!"
+              echo "merged=true" >> $GITHUB_OUTPUT
+              break
+            fi
+            
+            echo "⏳ Still waiting for manual merge... (attempt $i/180)"
+            sleep 10
+          done
+          
+          # Final check
+          status=$(gh pr view ${{ needs.release.outputs.pr_number }} --json state --jq '.state')
+          if [ "$status" != "MERGED" ]; then
+            echo "❌ PR was not merged within the timeout period (30 minutes). Current status: $status"
+            echo "You can manually run the 'Manual Post-Release' workflow after merging the PR."
+            echo "merged=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+
+      - name: Trigger Manual Post-Release Workflow
+        if: steps.wait_merge.outputs.merged == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🚀 Triggering Manual Post-Release workflow..."
+          gh workflow run manual-post-release.yml \
+            -f packages="${{ github.event.inputs.packages }}" \
+            -f version="${{ github.event.inputs.version }}" \
+            -f create_github_release="${{ github.event.inputs.create_github_release }}"
+          
+          echo "✅ Manual Post-Release workflow has been triggered!"
+          echo "You can monitor its progress in the Actions tab." 

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -20,14 +20,14 @@ on:
         default: '@novu/js@v3.4.0'
       nightly:
         description: 'Publish as nightly release'
-        required: false
+        required: true
         type: boolean
         default: false
       create_github_release:
         description: 'Create GitHub releases for the packages'
-        required: false
+        required: true
         type: boolean
-        default: true
+        default: false
 
 jobs:
   release:


### PR DESCRIPTION
### What changed? Why was the change needed?

Only reason for PR not to be created had been permission missing. With this I have automated the steps after PR merge also.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
