### PR TITLE
fix(dashboard): Polish dashboard editor UI and icons fixes NV-6375

### DIFF
--- a/apps/dashboard/src/components/schema-editor/components/enum-section.tsx
+++ b/apps/dashboard/src/components/schema-editor/components/enum-section.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback } from 'react';
 import { Controller, Path, useFieldArray, type Control } from 'react-hook-form';
-import { RiAddLine, RiDeleteBin6Line, RiDeleteBinLine, RiErrorWarningLine } from 'react-icons/ri';
+import { RiAddLine, RiDeleteBin2Line, RiDeleteBinLine, RiErrorWarningLine } from 'react-icons/ri';
 
 import { Button } from '@/components/primitives/button';
 import { InputPure, InputRoot } from '@/components/primitives/input';
@@ -48,7 +48,7 @@ const EnumChoice = memo<EnumChoiceProps>(function EnumChoice({ enumChoicePath, e
         variant="error"
         mode="ghost"
         size="2xs"
-        leadingIcon={RiDeleteBin6Line}
+        leadingIcon={RiDeleteBin2Line}
         onClick={onRemove}
         aria-label="Delete property"
         className={cn('border-1 !ml-1.5 h-7 w-7 border-neutral-200')}

--- a/apps/dashboard/src/components/schema-editor/components/property-actions.tsx
+++ b/apps/dashboard/src/components/schema-editor/components/property-actions.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { RiSettings4Line, RiDeleteBin6Line } from 'react-icons/ri';
+import { RiSettings4Line, RiDeleteBin2Line } from 'react-icons/ri';
 
 import { Button } from '@/components/primitives/button';
 import { Popover, PopoverTrigger } from '@/components/primitives/popover';
@@ -54,7 +54,7 @@ export function PropertyActions({
         variant="error"
         mode="ghost"
         size="2xs"
-        leadingIcon={RiDeleteBin6Line}
+        leadingIcon={RiDeleteBin2Line}
         onClick={onDeleteProperty}
         aria-label="Delete property"
         className={cn('border-1 !ml-0 h-7 w-7 border-neutral-200')}

--- a/apps/dashboard/src/components/schema-editor/components/property-name-input.tsx
+++ b/apps/dashboard/src/components/schema-editor/components/property-name-input.tsx
@@ -14,6 +14,7 @@ type PropertyNameInputProps = {
   control: Control<SchemaEditorFormValues>;
   isDisabled?: boolean;
   placeholder?: string;
+  autoFocus?: boolean;
 };
 
 export const PropertyNameInput = memo(function PropertyNameInput({
@@ -21,6 +22,7 @@ export const PropertyNameInput = memo(function PropertyNameInput({
   control,
   isDisabled = false,
   placeholder = 'Property name',
+  autoFocus = false,
 }: PropertyNameInputProps) {
   return (
     <div className="flex-1 flex-col">
@@ -41,6 +43,7 @@ export const PropertyNameInput = memo(function PropertyNameInput({
                   placeholder={placeholder}
                   className="text-xs"
                   disabled={isDisabled}
+                  autoFocus={autoFocus}
                 />
                 {fieldState.error && (
                   <TooltipProvider delayDuration={0}>

--- a/apps/dashboard/src/components/schema-editor/schema-property-row.tsx
+++ b/apps/dashboard/src/components/schema-editor/schema-property-row.tsx
@@ -78,7 +78,11 @@ export const SchemaPropertyRow = memo<SchemaPropertyRowProps>(function SchemaPro
       )}
     >
       <div className={cn('flex items-center gap-2', getMarginClassPx(indentationLevel))}>
-        <PropertyNameInput fieldPath={paths.keyName} control={control} />
+        <PropertyNameInput 
+          fieldPath={paths.keyName} 
+          control={control} 
+          autoFocus={isKeyNameEmpty}
+        />
         <PropertyTypeSelector
           definitionPath={paths.definition}
           control={control}

--- a/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
@@ -212,9 +212,9 @@ export function PayloadSchemaDrawer({
           <FormProvider {...payloadSchemaForm}>
             <FormRoot className="flex h-full flex-col">
               <SheetHeader className="space-y-1 px-3 py-4">
-                <SheetTitle className="text-label-lg">
-                  Manage workflow schema{' '}
-                  <Badge color="gray" size="sm" variant="light" className="text-label-xs relative bottom-[1px]">
+                <SheetTitle className="text-label-lg flex items-center gap-2">
+                  Manage workflow schema
+                  <Badge color="gray" size="sm" variant="light" className="text-label-xs">
                     BETA
                   </Badge>
                 </SheetTitle>

--- a/apps/dashboard/src/components/workflow-editor/steps/base/data-object.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/base/data-object.tsx
@@ -128,6 +128,7 @@ const InnerDataObject = ({ field }: { field: FieldValues }) => {
                 <div className="flex flex-col gap-1" key={index}>
                   <div className="grid grid-cols-[3fr,4fr,1.75rem] items-center gap-2">
                     <Input
+                      size="xs"
                       placeholder="Insert property key..."
                       type="text"
                       value={pair.key}
@@ -136,6 +137,7 @@ const InnerDataObject = ({ field }: { field: FieldValues }) => {
                     />
                     <InputRoot>
                       <ControlInput
+                        size="2xs"
                         multiline={false}
                         indentWithTab={false}
                         value={pair.value}
@@ -148,7 +150,12 @@ const InnerDataObject = ({ field }: { field: FieldValues }) => {
                         variables={variables}
                       />
                     </InputRoot>
-                    <Button variant="secondary" mode="outline" className="h-7 px-0" onClick={() => handleRemovePair(index)}>
+                    <Button
+                      variant="secondary"
+                      mode="outline"
+                      className="w-7.5 h-8 px-0"
+                      onClick={() => handleRemovePair(index)}
+                    >
                       <RiDeleteBin2Line className="size-4" />
                     </Button>
                   </div>
@@ -163,6 +170,7 @@ const InnerDataObject = ({ field }: { field: FieldValues }) => {
             <Button
               variant="secondary"
               mode="lighter"
+              size="2xs"
               className="self-start"
               onClick={() => {
                 handleAddPair();

--- a/apps/dashboard/src/components/workflow-editor/steps/base/data-object.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/base/data-object.tsx
@@ -148,7 +148,7 @@ const InnerDataObject = ({ field }: { field: FieldValues }) => {
                         variables={variables}
                       />
                     </InputRoot>
-                    <Button variant="secondary" mode="outline" className="h-7" onClick={() => handleRemovePair(index)}>
+                    <Button variant="secondary" mode="outline" className="h-7 px-0" onClick={() => handleRemovePair(index)}>
                       <RiDeleteBin2Line className="size-4" />
                     </Button>
                   </div>

--- a/apps/dashboard/src/components/workflow-editor/steps/base/data-object.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/base/data-object.tsx
@@ -14,7 +14,7 @@ import { useParseVariables } from '@/hooks/use-parse-variables';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { TelemetryEvent } from '@/utils/telemetry';
 import React from 'react';
-import { RiAddLine, RiDeleteBin6Line, RiInputField } from 'react-icons/ri';
+import { RiAddLine, RiDeleteBin2Line, RiInputField } from 'react-icons/ri';
 import { Link } from 'react-router-dom';
 
 const dataObjectKey = 'data';
@@ -149,7 +149,7 @@ const InnerDataObject = ({ field }: { field: FieldValues }) => {
                       />
                     </InputRoot>
                     <Button variant="secondary" mode="outline" className="h-7" onClick={() => handleRemovePair(index)}>
-                      <RiDeleteBin6Line className="size-4" />
+                      <RiDeleteBin2Line className="size-4" />
                     </Button>
                   </div>
                   <FormMessage keyName={isDuplicate ? '' : pair.key}>


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR addresses several UI inconsistencies and usability improvements within the dashboard application:

*   **Auto-focus for new schema properties**: The property name input now automatically focuses when a new property is added to a workflow schema, improving the user experience by allowing immediate typing.
*   **Consistent delete icons**: Standardized the delete icon across the Schema Editor and In-App Data Object editor to `RiDeleteBin2Line`, ensuring visual consistency with other delete actions in the application.
*   **BETA tag alignment**: Corrected the vertical alignment of the "BETA" tag next to the Schema editor title for a cleaner visual presentation.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1753218709397189?thread_ts=1753218709.397189&cid=D0919LNRWE7) • [Open in Web](https://www.cursor.com/agents?id=bc-5062235f-bc64-4acd-96e0-4c70fcace5fe) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5062235f-bc64-4acd-96e0-4c70fcace5fe)