### PR TITLE
fix(api-service,dashboard): layouts switching from block to html generates content variable fixes NV-6371

### DIFF
--- a/apps/api/src/app/layouts-v2/usecases/preview-layout/preview-utils.ts
+++ b/apps/api/src/app/layouts-v2/usecases/preview-layout/preview-utils.ts
@@ -1,67 +1,30 @@
 import { JSONContent as MailyJSONContent } from '@maily-to/render';
-import { LAYOUT_CONTENT_VARIABLE } from '@novu/shared';
+import { LAYOUT_CONTENT_VARIABLE, LAYOUT_PREVIEW_CONTENT_PLACEHOLDER } from '@novu/shared';
 
 import { replaceMailyNodesByCondition } from '../../../shared/helpers/maily-utils';
 
-const placeholderText = 'Dynamic placeholder content';
-const contentPlaceholder =
-  '<div style="border: 1px dashed #E1E4EA; border-radius: 4px; background: repeating-linear-gradient(-45deg,#F2F5F8,#F2F5F8 4px,#FBFBFB 4px,#FBFBFB 8px); display: flex; justify-content: center; align-items: center; height: 100%; max-height: 140px; padding: 8px;">' +
-  `<span style="background: #FFFFFF; border: 1px solid #E1E4EA; border-radius: 4px; padding: 4px 8px; flex; justify-content: center; align-items: center; font-size: 10px; line-height: 1; color: #99A0AE;">${placeholderText}</span>` +
-  '</div>';
-
 export const enhanceBodyForPreview = (editorType: string, body: string) => {
   if (editorType === 'html') {
-    return body?.replace(new RegExp(`\\{\\{\\s*${LAYOUT_CONTENT_VARIABLE}\\s*\\}\\}`), contentPlaceholder);
+    return body?.replace(
+      new RegExp(`\\{\\{\\s*${LAYOUT_CONTENT_VARIABLE}\\s*\\}\\}`),
+      LAYOUT_PREVIEW_CONTENT_PLACEHOLDER
+    );
   }
 
   return JSON.stringify(
     replaceMailyNodesByCondition(
       body,
       (node) => node.type === 'variable' && node.attrs?.id === LAYOUT_CONTENT_VARIABLE,
-      () =>
-        ({
-          type: 'section',
+      (node) => {
+        return {
+          type: 'text',
+          text: LAYOUT_PREVIEW_CONTENT_PLACEHOLDER,
           attrs: {
-            borderWidth: 1,
-            borderStyle: 'dashed',
-            borderColor: '#E1E4EA',
-            borderRadius: 4,
-            background: 'repeating-linear-gradient(-45deg,#F2F5F8,#F2F5F8 4px,#FBFBFB 4px,#FBFBFB 8px)',
-            paddingTop: 8,
-            paddingRight: 8,
-            paddingBottom: 8,
-            paddingLeft: 8,
-            height: '100%',
-            textAlign: 'center',
-            maxHeight: 140,
-            showIfKey: null,
+            ...node.attrs,
+            shouldDangerouslySetInnerHTML: true,
           },
-          content: [
-            {
-              type: 'paragraph',
-              attrs: {
-                background: '#FFFFFF',
-                border: '1px solid #E1E4EA',
-                borderRadius: 4,
-                paddingTop: 4,
-                paddingRight: 8,
-                paddingBottom: 4,
-                paddingLeft: 8,
-                fontSize: 10,
-                color: '#99A0AE',
-                textAlign: 'center',
-                display: 'inline',
-                showIfKey: null,
-              },
-              content: [
-                {
-                  type: 'text',
-                  text: placeholderText,
-                },
-              ],
-            },
-          ],
-        }) satisfies MailyJSONContent
+        } satisfies MailyJSONContent;
+      }
     )
   );
 };

--- a/apps/dashboard/src/components/layouts/component-utils.tsx
+++ b/apps/dashboard/src/components/layouts/component-utils.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { ChannelTypeEnum, UiComponentEnum } from '@novu/shared';
+import { ChannelTypeEnum, LAYOUT_CONTENT_VARIABLE, UiComponentEnum } from '@novu/shared';
 
 import { EmailEditorSelect } from '@/components/email-editor-select';
 import { LayoutEmailBody } from './layout-email-body';
@@ -24,7 +24,13 @@ const EmailEditorSelectInternal = () => {
       isLoading={false}
       saveForm={async ({ editorType, onSuccess }) => {
         if (editorType === 'html') {
-          const formattedValue = await formatHtml(previewBody);
+          const cleanedBody = previewBody
+            .replace(
+              /<table[^>]*data-content-placeholder[^>]*>[\s\S]*?<\/table>(\s*)/gi,
+              `{{ ${LAYOUT_CONTENT_VARIABLE} }}`
+            )
+            .replace(/<table[^>]*data-novu-branding[^>]*>[\s\S]*?<\/table>(\s*)/gi, '');
+          const formattedValue = await formatHtml(cleanedBody);
           setValue('body', formattedValue);
         } else {
           setValue('body', '{"type":"doc","content":[]}');

--- a/packages/shared/src/consts/layouts.ts
+++ b/packages/shared/src/consts/layouts.ts
@@ -1,3 +1,14 @@
 export const LAYOUT_CONTENT_VARIABLE = 'content';
 export const LAYOUT_PREVIEW_WORKFLOW_ID = 'layout-preview-workflow';
 export const LAYOUT_PREVIEW_EMAIL_STEP = 'layout-preview-email-step';
+export const LAYOUT_PREVIEW_PLACEHOLDER_TEXT = 'Dynamic placeholder content';
+export const LAYOUT_PREVIEW_CONTENT_PLACEHOLDER =
+  `<table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="margin-top: 0; margin-right: 0; margin-bottom: 0; margin-left: 0" data-content-placeholder>` +
+  `<tbody style="width: 100%">` +
+  `<tr style="width: 100%">` +
+  `<td align="left" style="border-color: #e1e4ea;border-width: 1px;border-style: dashed;background: repeating-linear-gradient(-45deg, #f2f5f8, #f2f5f8 4px, #fbfbfb 4px, #fbfbfb 8px);background-color: #ffffff;border-radius: 4px;padding-top: 8px;padding-right: 8px;padding-bottom: 8px;padding-left: 8px;text-align: center;">` +
+  `<p style="font-size: 10px;line-height: 26.25px;margin: 0 0 0px 0;text-align: center;-webkit-font-smoothing: antialiased;-moz-osx-font-smoothing: grayscale;display: inline;background: #ffffff;border: 1px solid #e1e4ea;border-radius: 4px;padding-top: 4px;padding-right: 8px;padding-bottom: 4px;padding-left: 8px;color: #99a0ae;">${LAYOUT_PREVIEW_PLACEHOLDER_TEXT}</p>` +
+  `</td>` +
+  `</tr>` +
+  `</tbody>` +
+  `</table>`;


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixes the issue when switching the layout editor from block to HTML, which now generates it with the content variable included.

### Screenshots


https://github.com/user-attachments/assets/86e2efeb-f87b-48f9-b979-df233154fce2


