### PR TITLE
fix(api-service): clarify transactionId usage for delivery idempotency

### DIFF
--- a/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
@@ -227,7 +227,7 @@ export class TriggerEventRequestDto {
   to: TriggerRecipientsPayload;
 
   @ApiPropertyOptional({
-    description: 'A unique identifier for this transaction, we will generate a UUID if not provided.',
+    description: 'A unique identifier for deduplication. If the same `transactionId` is sent again, the trigger is ignored. Useful to prevent duplicate notifications. The retention period depends on your billing tier.',
   })
   @IsString()
   @IsOptional()

--- a/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
@@ -227,7 +227,8 @@ export class TriggerEventRequestDto {
   to: TriggerRecipientsPayload;
 
   @ApiPropertyOptional({
-    description: 'A unique identifier for deduplication. If the same `transactionId` is sent again, the trigger is ignored. Useful to prevent duplicate notifications. The retention period depends on your billing tier.',
+    description: `A unique identifier for deduplication. If the same **transactionId** is sent again, 
+      the trigger is ignored. Useful to prevent duplicate notifications. The retention period depends on your billing tier.`,
   })
   @IsString()
   @IsOptional()

--- a/apps/api/src/app/events/events.controller.ts
+++ b/apps/api/src/app/events/events.controller.ts
@@ -82,7 +82,7 @@ export class EventsController {
     description: `
     Trigger event is the main (and only) way to send notifications to subscribers. The trigger identifier is used to match the particular workflow associated with it. Additional information can be passed according the body interface below.
     
-    To prevent duplicate triggers, you can optionally pass a \`transactionId\` in the request body. If the same \`transactionId\` is used again, the trigger will be ignored. The retention period depends on your billing tier.    `,
+    To prevent duplicate triggers, you can optionally pass a **transactionId** in the request body. If the same **transactionId** is used again, the trigger will be ignored. The retention period depends on your billing tier.`
   })
   @SdkMethodName('trigger')
   @SdkUsageExample('Trigger Notification Event')

--- a/apps/api/src/app/events/events.controller.ts
+++ b/apps/api/src/app/events/events.controller.ts
@@ -80,8 +80,9 @@ export class EventsController {
   @ApiOperation({
     summary: 'Trigger event',
     description: `
-    Ensures the request is processed only once. If the same \`idempotency-key\` is sent within a short time window (for example, on retry), the original response is replayed. For longer-term deduplication across events, use the \`transactionId\` field in the body instead.
-    `,
+    Trigger event is the main (and only) way to send notifications to subscribers. The trigger identifier is used to match the particular workflow associated with it. Additional information can be passed according the body interface below.
+    
+    To prevent duplicate triggers, you can optionally pass a \`transactionId\` in the request body. If the same \`transactionId\` is used again, the trigger will be ignored. The retention period depends on your billing tier.    `,
   })
   @SdkMethodName('trigger')
   @SdkUsageExample('Trigger Notification Event')

--- a/apps/api/src/app/events/events.controller.ts
+++ b/apps/api/src/app/events/events.controller.ts
@@ -80,9 +80,7 @@ export class EventsController {
   @ApiOperation({
     summary: 'Trigger event',
     description: `
-    Trigger event is the main (and only) way to send notifications to subscribers. 
-    The trigger identifier is used to match the particular workflow associated with it. 
-    Additional information can be passed according the body interface below.
+    Ensures the request is processed only once. If the same \`idempotency-key\` is sent within a short time window (for example, on retry), the original response is replayed. For longer-term deduplication across events, use the \`transactionId\` field in the body instead.
     `,
   })
   @SdkMethodName('trigger')

--- a/apps/api/src/app/subscribers/subscribersV1.controller.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.controller.ts
@@ -323,8 +323,8 @@ export class SubscribersV1Controller {
   @RequireAuthentication()
   @ApiResponse(SubscriberResponseDto)
   @ApiOperation({
-    summary: 'Create or Partially Update provider credentials',
-    description: `Create or Partially credentials for a provider such as **slack** and **FCM**. 
+    summary: 'Update provider credentials',
+    description: `Update credentials for a provider such as **slack** and **FCM**. 
       **providerId** is required field. This API creates the **deviceTokens** or replaces the existing ones.`,
   })
   @SdkGroupName('Subscribers.Credentials')


### PR DESCRIPTION
### What changed? Why was the change needed?

Had to clarify transactionId usage for delivery idempotency. This was needed because a potential client has this confusion when trying out Novu.
