### PR TITLE
fix(application-generic): add bulk sms handler in sms factory fixes NV-6386

### DIFF
--- a/libs/application-generic/src/factories/sms/sms.factory.ts
+++ b/libs/application-generic/src/factories/sms/sms.factory.ts
@@ -31,6 +31,7 @@ import {
   TelnyxHandler,
   TermiiSmsHandler,
   TwilioHandler,
+  BulkSmsHandler,
 } from './handlers';
 import { ISmsFactory, ISmsHandler } from './interfaces';
 
@@ -67,6 +68,7 @@ export class SmsFactory implements ISmsFactory {
     new EazySmsHandler(),
     new MobishastraHandler(),
     new AfroSmsHandler(),
+    new BulkSmsHandler(),
   ];
 
   getHandler(integration: IntegrationEntity) {


### PR DESCRIPTION
### What changed? Why was the change needed?
bulksms handler was not added in SMS factory
<img width="1350" height="430" alt="CleanShot 2025-07-25 at 16 48 50@2x" src="https://github.com/user-attachments/assets/6701f950-6493-4898-abaf-dad92186ff35" />


<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
