### PR TITLE
feat(dashboard,api): trigger translations with liquid pattern

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -265,19 +265,17 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
       const escapedPayloadForJson = this.deepEscapePayloadStrings(payload);
       const liquifiedMaily = wrapMailyInLiquid(this.enhanceContentVariable(body));
       const transformedMaily = await this.transformMailyContent(liquifiedMaily, escapedPayloadForJson);
-      const parsedMaily = await this.parseMailyContentByLiquid(transformedMaily, escapedPayloadForJson);
-
-      // Apply translations to the liquid-processed Maily JSON before rendering
       const translatedMaily = await this.processMailyTranslations({
-        mailyContent: parsedMaily,
+        mailyContent: transformedMaily,
         variables: escapedPayloadForJson,
         environmentId,
         organizationId,
         workflowId,
         locale,
       });
+      const parsedMaily = await this.parseMailyContentByLiquid(translatedMaily, escapedPayloadForJson);
 
-      const renderedHtml = await mailyRender(translatedMaily, { noHtmlWrappingTags });
+      const renderedHtml = await mailyRender(parsedMaily, { noHtmlWrappingTags });
 
       return this.cleanupRenderedHtml(renderedHtml);
     } else {

--- a/apps/api/src/app/shared/utils/template-parser/new-liquid-parser.ts
+++ b/apps/api/src/app/shared/utils/template-parser/new-liquid-parser.ts
@@ -1,4 +1,5 @@
 import { FILTER_VALIDATORS, LiquidFilterIssue } from '@novu/framework/internal';
+import { TRANSLATION_NAMESPACE_SEPARATOR, LAYOUT_CONTENT_VARIABLE } from '@novu/shared';
 
 import {
   AssignTag,
@@ -16,7 +17,6 @@ import {
   UnlessTag,
   LiquidError,
 } from 'liquidjs';
-import { LAYOUT_CONTENT_VARIABLE } from '@novu/shared';
 import { DIGEST_EVENTS_VARIABLE_PATTERN, isLiquidErrors, isValidDynamicPath, isValidTemplate } from './parser-utils';
 import { JSONSchemaDto } from '../../dtos/json-schema.dto';
 import type { ProcessContext, VariableDetails, Variable } from './types';
@@ -255,6 +255,8 @@ function validateVariable({
 
   const isAllowedVariable = isPropertyAllowed(variableSchema, variableName);
   const isContentVariable = variableName === LAYOUT_CONTENT_VARIABLE && isAllowedVariable;
+  const isTranslationVariable = variableName.startsWith(TRANSLATION_NAMESPACE_SEPARATOR);
+
   if (isLocalVariable) {
     return;
   }
@@ -274,7 +276,7 @@ function validateVariable({
     return;
   }
 
-  if (isAllowedVariable) {
+  if (isAllowedVariable || isTranslationVariable) {
     validVariables.push({
       name: variableName,
       output,

--- a/apps/dashboard/src/components/issues-panel.tsx
+++ b/apps/dashboard/src/components/issues-panel.tsx
@@ -27,7 +27,7 @@ export function IssuesPanel({
   const issueCount = countIssues(issues);
 
   const defaultHintMessage = isTranslationEnabled
-    ? 'Type {{ to access variables or {t. to access translation keys.'
+    ? 'Type {{ to access variables or {{t. to access translation keys.'
     : 'Type {{ to access variables.';
 
   const displayHintMessage = hintMessage || defaultHintMessage;

--- a/apps/dashboard/src/components/primitives/translation-plugin/autocomplete.ts
+++ b/apps/dashboard/src/components/primitives/translation-plugin/autocomplete.ts
@@ -1,7 +1,6 @@
 import { Completion, CompletionContext, CompletionSource } from '@codemirror/autocomplete';
 import { EditorView } from '@uiw/react-codemirror';
-import { TRANSLATION_TRIGGER_CHARACTER } from '@novu/shared';
-import { TRANSLATION_PREFIX_LENGTH } from './constants';
+import { TRANSLATION_TRIGGER_CHARACTER, TRANSLATION_DELIMITER_CLOSE } from '@novu/shared';
 import { isInsideVariableContext } from './utils';
 import { TranslationKey, TranslationCompletionOption, TranslationAutocompleteConfig } from '@/types/translations';
 import { createRoot } from 'react-dom/client';
@@ -94,10 +93,10 @@ function createApplyFunction(translationOption: TranslationCompletionOption, con
     const afterCursor = content.slice(to);
 
     const needsOpening = !beforeCursor.endsWith(TRANSLATION_TRIGGER_CHARACTER);
-    const needsClosing = !afterCursor.startsWith('}');
+    const needsClosing = !afterCursor.startsWith(TRANSLATION_DELIMITER_CLOSE);
 
-    const wrappedValue = `${needsOpening ? TRANSLATION_TRIGGER_CHARACTER : ''}${selectedValue}${needsClosing ? '}' : ''}`;
-    const finalCursorPos = from + wrappedValue.length + (needsClosing ? 0 : 1);
+    const wrappedValue = `${needsOpening ? TRANSLATION_TRIGGER_CHARACTER : ''}${selectedValue}${needsClosing ? TRANSLATION_DELIMITER_CLOSE : ''}`;
+    const finalCursorPos = from + wrappedValue.length + (needsClosing ? 0 : 2);
 
     view.dispatch({
       changes: { from, to, insert: wrappedValue },
@@ -121,8 +120,8 @@ export function createTranslationAutocompleteSource(config: TranslationAutocompl
     const lastTranslationStart = beforeCursor.lastIndexOf(TRANSLATION_TRIGGER_CHARACTER);
     if (lastTranslationStart === -1) return null;
 
-    const insideTranslation = state.sliceDoc(lastTranslationStart + TRANSLATION_PREFIX_LENGTH, pos);
-    if (insideTranslation.includes('}')) return null;
+    const insideTranslation = state.sliceDoc(lastTranslationStart + TRANSLATION_TRIGGER_CHARACTER.length, pos);
+    if (insideTranslation.includes(TRANSLATION_DELIMITER_CLOSE)) return null;
 
     const searchText = insideTranslation.trim();
     const matchingKeys = findMatchingKeys(searchText, translationKeys);
@@ -139,7 +138,7 @@ export function createTranslationAutocompleteSource(config: TranslationAutocompl
 
     if (allSuggestions.length > 0 || lastTranslationStart !== -1) {
       return {
-        from: lastTranslationStart + TRANSLATION_PREFIX_LENGTH,
+        from: lastTranslationStart + TRANSLATION_TRIGGER_CHARACTER.length,
         to: pos,
         options: allSuggestions.map(
           (suggestion): Completion => ({

--- a/apps/dashboard/src/components/primitives/translation-plugin/constants.ts
+++ b/apps/dashboard/src/components/primitives/translation-plugin/constants.ts
@@ -1,3 +1,0 @@
-export const TRANSLATION_PILL_HEIGHT = 18;
-export const TRANSLATION_PREFIX_LENGTH = 3; // Length of "{t."
-export const TRANSLATION_PATTERN = /\{t\.([^}]*)/;

--- a/apps/dashboard/src/components/primitives/translation-plugin/pill-widget.ts
+++ b/apps/dashboard/src/components/primitives/translation-plugin/pill-widget.ts
@@ -3,8 +3,9 @@ import { CSSProperties, createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RiErrorWarningLine } from 'react-icons/ri';
 import { TranslateVariableIcon } from '@/components/icons/translate-variable';
-import { TRANSLATION_PILL_HEIGHT } from './constants';
 import { formatDisplayKey } from './utils';
+
+export const TRANSLATION_PILL_HEIGHT = 18;
 
 export class TranslationPillWidget extends WidgetType {
   private clickHandler: (e: MouseEvent) => void;

--- a/apps/dashboard/src/components/primitives/translation-plugin/plugin-view.ts
+++ b/apps/dashboard/src/components/primitives/translation-plugin/plugin-view.ts
@@ -1,6 +1,6 @@
 import { Decoration, DecorationSet, EditorView, Range } from '@uiw/react-codemirror';
 import { MutableRefObject } from 'react';
-import { TRANSLATION_KEY_SINGLE_REGEX } from '@novu/shared';
+import { TRANSLATION_KEY_REGEX } from '@novu/shared';
 import { isTypingTranslation, parseTranslation } from './utils';
 import { TranslationPillWidget } from './pill-widget';
 import { validateTranslationKey } from '@/hooks/use-translation-validation';
@@ -50,7 +50,7 @@ export class TranslationPluginView {
     const decorations: Range<Decoration>[] = [];
     const content = view.state.doc.toString();
     const pos = view.state.selection.main.head;
-    const regex = new RegExp(TRANSLATION_KEY_SINGLE_REGEX.source, 'g');
+    const regex = new RegExp(TRANSLATION_KEY_REGEX.source, 'g');
 
     let match: RegExpExecArray | null = null;
 

--- a/apps/dashboard/src/components/primitives/translation-plugin/utils.ts
+++ b/apps/dashboard/src/components/primitives/translation-plugin/utils.ts
@@ -1,24 +1,64 @@
 import { CompletionContext } from '@codemirror/autocomplete';
-import { TRANSLATION_KEY_SINGLE_REGEX } from '@novu/shared';
+import {
+  TRANSLATION_KEY_SINGLE_REGEX,
+  TRANSLATION_DELIMITER_OPEN,
+  TRANSLATION_DELIMITER_CLOSE,
+  TRANSLATION_NAMESPACE_SEPARATOR,
+} from '@novu/shared';
 
+/**
+ * Checks if user is currently typing a translation pattern (e.g., {{t.some...)
+ * Used to prevent showing pill decorations while actively typing
+ */
 export function isTypingTranslation(content: string, pos: number): boolean {
   const beforeCursor = content.slice(0, pos);
-  const afterCursor = content.slice(pos);
-  const lastOpenBrackets = beforeCursor.lastIndexOf('{t.');
-  const nextCloseBrackets = afterCursor.indexOf('}');
 
-  return lastOpenBrackets !== -1 && (nextCloseBrackets === -1 || beforeCursor.indexOf('}', lastOpenBrackets) === -1);
+  // Check if we have an incomplete translation pattern before cursor
+  const hasOpenPattern = beforeCursor.includes(TRANSLATION_DELIMITER_OPEN + TRANSLATION_NAMESPACE_SEPARATOR);
+  if (!hasOpenPattern) return false;
+
+  // Find the last occurrence of translation start
+  const lastPatternStart = beforeCursor.lastIndexOf(TRANSLATION_DELIMITER_OPEN + TRANSLATION_NAMESPACE_SEPARATOR);
+  const patternToCheck = beforeCursor.slice(lastPatternStart);
+
+  // If the pattern is not closed, we're typing
+  return !patternToCheck.includes(TRANSLATION_DELIMITER_CLOSE);
 }
 
+/**
+ * Determines if cursor is inside a variable context ({{payload.x}}) vs translation context ({{t.x}})
+ * Used by autocomplete to avoid conflicts between variable and translation suggestions
+ */
 export function isInsideVariableContext(context: CompletionContext): boolean {
   const { state, pos } = context;
   const beforeCursor = state.sliceDoc(0, pos);
-  const lastOpenBrace = beforeCursor.lastIndexOf('{{');
-  const lastCloseBrace = beforeCursor.lastIndexOf('}}');
 
-  return lastOpenBrace !== -1 && (lastCloseBrace === -1 || lastOpenBrace > lastCloseBrace);
+  const lastOpen = beforeCursor.lastIndexOf(TRANSLATION_DELIMITER_OPEN);
+  const lastClose = beforeCursor.lastIndexOf(TRANSLATION_DELIMITER_CLOSE);
+
+  // Not inside any delimiters
+  if (lastOpen === -1) return false;
+
+  // We're inside delimiters if open comes after close
+  if (lastClose === -1 || lastOpen > lastClose) {
+    // Check what follows the opening delimiter
+    const contentAfterOpen = beforeCursor.slice(lastOpen + TRANSLATION_DELIMITER_OPEN.length).trim();
+
+    // It's NOT a variable if it starts with translation namespace
+    const isTranslation =
+      contentAfterOpen.startsWith(TRANSLATION_NAMESPACE_SEPARATOR) ||
+      contentAfterOpen === TRANSLATION_NAMESPACE_SEPARATOR.slice(0, -1); // just "t"
+
+    return !isTranslation;
+  }
+
+  return false;
 }
 
+/**
+ * Parses a complete translation expression to extract the key
+ * Example: "{{t.welcome}}" -> { key: "welcome", fullExpression: "{{t.welcome}}" }
+ */
 export function parseTranslation(translation: string): { key: string; fullExpression: string } | undefined {
   if (translation.includes('\n')) return undefined;
 
@@ -31,8 +71,13 @@ export function parseTranslation(translation: string): { key: string; fullExpres
   return { key, fullExpression: translation };
 }
 
+/**
+ * Formats translation key for compact display
+ * Example: "common.buttons.submit" -> "..buttons.submit"
+ */
 export function formatDisplayKey(translationKey: string): string {
   if (!translationKey) return '';
-  const keyParts = translationKey.split('.');
-  return keyParts.length >= 2 ? '..' + keyParts.slice(-2).join('.') : translationKey;
+
+  const parts = translationKey.split('.');
+  return parts.length >= 2 ? '..' + parts.slice(-2).join('.') : translationKey;
 }

--- a/apps/dashboard/src/components/primitives/variable-editor.tsx
+++ b/apps/dashboard/src/components/primitives/variable-editor.tsx
@@ -199,11 +199,15 @@ export function VariableEditor({
 
   const autocompletionExtension = useMemo(() => {
     const dynamicCompletionSource: CompletionSource = (context) => {
-      const sources = [variableCompletionSource];
+      const sources = [];
 
+      // Put translation completion sources first to give them higher priority
       if (callbacksRef.current.completionSources) {
         sources.push(...callbacksRef.current.completionSources);
       }
+
+      // Add variable completion source last
+      sources.push(variableCompletionSource);
 
       for (const source of sources) {
         const result = source(context);
@@ -245,12 +249,16 @@ export function VariableEditor({
 
     // For props that rarely change, we can check them dynamically
     const baseExtensions = [...(callbacksRef.current.multiline ? [EditorView.lineWrapping] : []), variablePillTheme];
-    const allExtensions = [...baseExtensions, autocompletionExtension, variablePluginExtension];
+    const allExtensions = [...baseExtensions, autocompletionExtension];
 
-    // Handle external extensions
+    // Add external extensions (including translation plugin) BEFORE variable plugin
+    // This ensures translation patterns are processed first
     if (callbacksRef.current.extensions) {
       allExtensions.push(...callbacksRef.current.extensions);
     }
+
+    // Add variable plugin last so it doesn't interfere with translation patterns
+    allExtensions.push(variablePluginExtension);
 
     extensionsRef.current = allExtensions;
     return extensionsRef.current;

--- a/apps/dashboard/src/components/workflow-editor/steps/email/translations/translation-decorator.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/translations/translation-decorator.tsx
@@ -1,7 +1,13 @@
 import { InlineDecoratorExtension, getInlineDecoratorSuggestionsReact } from '@maily-to/core/extensions';
 import { TranslationPill } from './translation-pill';
 import { AnyExtension } from '@tiptap/core';
-import { TRANSLATION_KEY_SINGLE_REGEX, TRANSLATION_TRIGGER_CHARACTER } from '@novu/shared';
+import {
+  TRANSLATION_KEY_SINGLE_REGEX,
+  TRANSLATION_TRIGGER_CHARACTER,
+  TRANSLATION_DELIMITER_OPEN,
+  TRANSLATION_DELIMITER_CLOSE,
+  TRANSLATION_DEFAULT_TEMPLATE,
+} from '@novu/shared';
 import { TranslationSuggestionsListView, TranslationKeyItem } from './translation-suggestions-list-view';
 import { TranslationKey } from '@/types/translations';
 import { forwardRef } from 'react';
@@ -17,15 +23,15 @@ export const createTranslationExtension = (
 
   return InlineDecoratorExtension.configure({
     triggerPattern: TRANSLATION_TRIGGER_CHARACTER,
-    closingPattern: '}',
-    openingPattern: '{',
+    closingPattern: TRANSLATION_DELIMITER_CLOSE,
+    openingPattern: TRANSLATION_DELIMITER_OPEN,
     extractKey: (text: string) => {
       const match = text.match(TRANSLATION_KEY_SINGLE_REGEX);
       return match ? match[1] : null;
     },
-    formatPattern: (key: string) => `{t.${key}}`,
+    formatPattern: (key: string) => TRANSLATION_DEFAULT_TEMPLATE(key),
     isPatternMatch: (value: string) => {
-      return value.startsWith('{') && value.endsWith('}');
+      return value.startsWith(TRANSLATION_DELIMITER_OPEN) && value.endsWith(TRANSLATION_DELIMITER_CLOSE);
     },
     decoratorComponent: TranslationPill,
     suggestion: {
@@ -61,7 +67,7 @@ export const createTranslationExtension = (
          * list in the editor (not in the bubble menu). It calls the onSelectItem
          * callback with the selected item.
          */
-        const query = `{t.${props.id}} `; // Added space after the closing brace
+        const query = `${TRANSLATION_DEFAULT_TEMPLATE(props.id)} `; // Added space after the closing brace
 
         // Insert the translation key
         editor.chain().focus().insertContentAt(range, query).run();

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-body.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-body.tsx
@@ -21,7 +21,7 @@ function getFormMessage(
   const hints = ['Type {{ to access variables, or wrap text in ** for bold.'];
 
   if (isTranslationEnabled) {
-    hints.push('Type {t. to access translation keys.');
+    hints.push('Type {{t. to access translation keys.');
 
     return hints.join(' ');
   }

--- a/apps/dashboard/src/hooks/use-editor-translation-overlay.ts
+++ b/apps/dashboard/src/hooks/use-editor-translation-overlay.ts
@@ -4,9 +4,9 @@ import { EditorView } from '@uiw/react-codemirror';
 import { CompletionRange } from '@/components/primitives/variable-editor';
 import { useTranslationCompletionSource } from '@/hooks/use-translation-completion-source';
 import { useTranslationPluginExtension } from '@/hooks/use-translation-plugin-extension';
-import { TRANSLATION_PILL_HEIGHT } from '@/components/primitives/translation-plugin/constants';
 import { WorkflowResponseDto } from '@novu/shared';
 import { useIsTranslationEnabled } from './use-is-translation-enabled';
+import { TRANSLATION_PILL_HEIGHT } from '@/components/primitives/translation-plugin/pill-widget';
 
 type UseTranslationEditorProps = {
   viewRef: React.MutableRefObject<EditorView | null>;

--- a/apps/dashboard/src/hooks/use-translations.ts
+++ b/apps/dashboard/src/hooks/use-translations.ts
@@ -1,5 +1,6 @@
 import { EditorView } from '@uiw/react-codemirror';
 import { MutableRefObject, useCallback, useState } from 'react';
+import { TRANSLATION_DEFAULT_TEMPLATE, TRANSLATION_DELIMITER_CLOSE } from '@novu/shared';
 
 export interface SelectedTranslation {
   translationKey: string;
@@ -58,7 +59,7 @@ export function useTranslations(viewRef: MutableRefObject<EditorView | null>, on
       // This prevents finding the wrong occurrence when there are multiple similar translations
       const { from, to } = selectedTranslation;
       const view = viewRef.current;
-      const newExpression = `{t.${newKey}}`;
+      const newExpression = TRANSLATION_DEFAULT_TEMPLATE(newKey);
 
       // Calculate the actual end position by looking for the closing bracket
       // This mimics what the variable plugin does
@@ -66,8 +67,8 @@ export function useTranslations(viewRef: MutableRefObject<EditorView | null>, on
 
       const contentAfterFrom = currentContent.slice(from);
 
-      const closingBracketPos = contentAfterFrom.indexOf('}');
-      const actualEnd = closingBracketPos > -1 ? from + closingBracketPos + 1 : to;
+      const closingBracketPos = contentAfterFrom.indexOf(TRANSLATION_DELIMITER_CLOSE);
+      const actualEnd = closingBracketPos > -1 ? from + closingBracketPos + 2 : to;
 
       const changes = {
         from,

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -1154,6 +1154,65 @@ describe('Novu Client', () => {
       expect(body).toBe('body');
     });
 
+    it('should not parse translation patterns as liquid variables', async () => {
+      const newWorkflow = workflow(
+        'test-workflow',
+        async ({ step }) => {
+          await step.email(
+            'send-email',
+            async (controls) => ({
+              body: controls.body,
+              subject: controls.subject,
+            }),
+            {
+              controlSchema: {
+                type: 'object',
+                properties: {
+                  body: { type: 'string' },
+                  subject: { type: 'string' },
+                },
+                required: ['body', 'subject'],
+                additionalProperties: false,
+              } as const,
+            }
+          );
+        },
+        {
+          payloadSchema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+            required: [],
+            additionalProperties: false,
+          } as const,
+        }
+      );
+
+      await client.addWorkflows([newWorkflow]);
+
+      const event: Event = {
+        action: PostActionEnum.EXECUTE,
+        payload: { name: 'John' },
+        workflowId: 'test-workflow',
+        stepId: 'send-email',
+        subscriber: { email: 'test@example.com' },
+        state: [],
+        controls: {
+          body: 'Hello {{t.welcome}} {{payload.name}}! Click {{t.button.submit}} to continue.',
+          subject: 'Welcome {{t.title}} - {{payload.name}}',
+        },
+      };
+
+      const emailExecutionResult = await client.executeWorkflow(event);
+
+      // Translation patterns should be preserved when t.* values are undefined
+      expect(emailExecutionResult.outputs).toEqual({
+        body: 'Hello {{t.welcome}} John! Click {{t.button.submit}} to continue.',
+        subject: 'Welcome {{t.title}} - John',
+      });
+    });
+
     it('should throw error on execute action without payload', async () => {
       const newWorkflow = workflow('test-workflow', async ({ step }) => {
         await step.email('send-email', async () => ({ body: 'Test Body', subject: 'Subject' }));

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -713,7 +713,7 @@ export class Client {
    * Transforms {{t.key}} to {{t.key | default: "{{t.key}}"}}
    */
   private preprocessTranslationPatterns(template: string): string {
-    return template.replace(/\{\{\s*t\.([^}\s|]+)\s*\}\}/g, '{{ t.$1 | default: "{{t.$1}}" }}');
+    return template.replace(/\{\{\s*t\.(\w+(?:\.\w+)*)\s*\}\}/g, '{{ t.$1 | default: "{{t.$1}}" }}');
   }
 
   /**

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -690,18 +690,30 @@ export class Client {
 
   private async compileControls(templateControls: Record<string, unknown>, event: Event) {
     try {
-      const templateString = this.templateEngine.parse(JSON.stringify(templateControls));
+      const templateString = this.preprocessTranslationPatterns(JSON.stringify(templateControls));
+      const parsedTemplate = this.templateEngine.parse(templateString);
 
-      const compiledString = await this.templateEngine.render(templateString, {
+      const renderVariables = {
         payload: event.payload,
         subscriber: event.subscriber,
         steps: buildSteps(event.state),
-      });
+        t: {}, // Empty object so t.* properties are undefined and trigger default filters
+      };
+
+      const compiledString = await this.templateEngine.render(parsedTemplate, renderVariables);
 
       return JSON.parse(compiledString);
     } catch (error) {
       throw new StepControlCompilationFailedError(event.workflowId, event.stepId, error);
     }
+  }
+
+  /**
+   * Preprocesses translation patterns to preserve them when values are undefined.
+   * Transforms {{t.key}} to {{t.key | default: "{{t.key}}"}}
+   */
+  private preprocessTranslationPatterns(template: string): string {
+    return template.replace(/\{\{\s*t\.([^}\s|]+)\s*\}\}/g, '{{ t.$1 | default: "{{t.$1}}" }}');
   }
 
   /**

--- a/packages/shared/src/consts/translation/translation.constants.ts
+++ b/packages/shared/src/consts/translation/translation.constants.ts
@@ -4,14 +4,48 @@
 export const DEFAULT_LOCALE = 'en_US';
 
 /**
- * Regular expression to match translation keys in the format {t.key}
+ * Translation namespace separator
  */
-export const TRANSLATION_KEY_REGEX = /\{t\.([^}]+)\}/g;
+export const TRANSLATION_NAMESPACE_SEPARATOR = 't.';
 
 /**
- * Regular expression to match a single translation key in the format {t.key}
+ * Regular expression to match translation keys in the format {{t.key}} with optional spaces
+ * Matches: {{t.key}}, {{ t.key }}, {{  t.key  }}, etc.
+ */
+export const TRANSLATION_KEY_REGEX = /\{\{\s*t\.([^}]+?)\s*\}\}/g;
+
+/**
+ * Regular expression to match a single translation key in the format {{t.key}} with optional spaces
  * (non-global version for single matches)
  */
-export const TRANSLATION_KEY_SINGLE_REGEX = /\{t\.([^}]+)\}/;
+export const TRANSLATION_KEY_SINGLE_REGEX = /\{\{\s*t\.([^}]+?)\s*\}\}/;
 
-export const TRANSLATION_TRIGGER_CHARACTER = '{t.';
+/**
+ * Translation trigger character (without spaces)
+ */
+export const TRANSLATION_TRIGGER_CHARACTER = '{{t.';
+
+/**
+ * Opening delimiter for translation format
+ */
+export const TRANSLATION_DELIMITER_OPEN = '{{';
+
+/**
+ * Closing delimiter for translation format
+ */
+export const TRANSLATION_DELIMITER_CLOSE = '}}';
+
+/**
+ * Length of the translation prefix ({{t.)
+ */
+export const TRANSLATION_PREFIX_LENGTH = 4;
+
+/**
+ * Template for missing translation placeholder
+ */
+export const MISSING_TRANSLATION_TEMPLATE = (key: string) => `[Translation missing: ${key}]`;
+
+/**
+ * Default template for translation key patterns
+ */
+export const TRANSLATION_DEFAULT_TEMPLATE = (key: string) => `{{t.${key}}}`;


### PR DESCRIPTION
### What changed? Why was the change needed?

EE PR: https://github.com/novuhq/packages-enterprise/pull/341

Fixes NV-6316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling and recognition of translation keys using standardized double curly brace syntax (e.g., {{t.key}}) throughout the app.
  * Enhanced template parsing to preserve translation placeholders when values are missing.

* **Bug Fixes**
  * Corrected hint messages to display the proper translation key syntax ({{t.key}}) in the UI.
  * Fixed translation key detection and completion logic for more accurate suggestions.

* **Refactor**
  * Centralized and standardized translation key formatting and delimiter constants for consistency across components.
  * Reordered completion and extension priorities to improve translation and variable editing experience.

* **Documentation**
  * Added descriptive comments to key translation utility functions for improved clarity.

* **Tests**
  * Added tests to ensure translation patterns are not misinterpreted as template variables during workflow execution.

* **Chores**
  * Updated and cleaned up unused or redundant constants and imports related to translation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->