### PR TITLE
fix(root): update enterprise and selfHosted options to accept string values and add parsing function

### DIFF
--- a/scripts/dotenvcreate.mjs
+++ b/scripts/dotenvcreate.mjs
@@ -22,9 +22,9 @@ const { argv } = yargs(hideBin(process.argv))
   })
   .option('enterprise', {
     alias: 'e',
-    type: 'boolean',
+    type: 'string',
     description: 'Whether this is an enterprise deployment',
-    default: false,
+    default: 'false',
   })
   .option('env', {
     alias: 'v',
@@ -34,12 +34,25 @@ const { argv } = yargs(hideBin(process.argv))
   })
   .option('selfHosted', {
     alias: 'h',
-    type: 'boolean',
+    type: 'string',
     description: 'Whether this is a self-hosted enterprise deployment',
-    default: false,
+    default: 'false',
   });
 
-const { secretName, region, enterprise, env, selfHosted } = argv;
+const { secretName, region, env } = argv;
+
+// Helper function to parse string boolean values
+function parseBooleanString(value) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const lowerValue = value.toLowerCase().trim();
+    return lowerValue === 'true' || lowerValue === '1' || lowerValue === 'yes';
+  }
+  return false;
+}
+
+const enterprise = parseBooleanString(argv.enterprise);
+const selfHosted = parseBooleanString(argv.selfHosted);
 
 // Check deployment mode
 if (!enterprise) {


### PR DESCRIPTION
This pull request updates the `scripts/dotenvcreate.mjs` file to improve handling of boolean-like user inputs by converting them from strings to actual boolean values. The changes include modifying the types of certain options and introducing a helper function for parsing string boolean values.

### Improvements to input handling:

* Changed the `type` of the `enterprise` and `selfHosted` options from `boolean` to `string` and updated their default values from `false` to `'false'`. This allows for more flexible input handling when these options are passed as command-line arguments. [[1]](diffhunk://#diff-a578f0a6ab5e0a5879077b17feaae38b35436aca3677242fb2f6fcac730efeefL25-R27) [[2]](diffhunk://#diff-a578f0a6ab5e0a5879077b17feaae38b35436aca3677242fb2f6fcac730efeefL37-R55)

* Added a helper function, `parseBooleanString`, to convert string representations of boolean values (e.g., `'true'`, `'1'`, `'yes'`) into actual boolean values. This function is used to parse the `enterprise` and `selfHosted` options after they are retrieved from `argv`.