### PR TITLE
chore(dashboard): email editor layout select component and editor state in prod env fixes NV-6353

### DIFF
--- a/apps/dashboard/src/components/primitives/variable-editor.tsx
+++ b/apps/dashboard/src/components/primitives/variable-editor.tsx
@@ -42,6 +42,7 @@ type VariableEditorProps = {
   onManageSchemaClick?: (variableName: string) => void;
   skipContainerClick?: boolean;
   children?: React.ReactNode;
+  disabled?: boolean;
 } & Pick<
   EditorProps,
   | 'className'
@@ -91,6 +92,7 @@ export function VariableEditor({
   onCreateNewVariable = () => Promise.resolve(),
   onManageSchemaClick = () => {},
   children,
+  disabled = false,
 }: VariableEditorProps) {
   const isCustomHtmlEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_HTML_EDITOR_ENABLED);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -348,6 +350,7 @@ export function VariableEditor({
         onChange={onChange}
         onBlur={onBlur}
         tagStyles={tagStyles}
+        editable={!disabled}
       />
       {isVariablePopoverOpen && (
         <EditVariablePopover

--- a/apps/dashboard/src/components/workflow-editor/control-input/control-input.tsx
+++ b/apps/dashboard/src/components/workflow-editor/control-input/control-input.tsx
@@ -40,6 +40,7 @@ type ControlInputProps = {
   multiline?: boolean;
   indentWithTab?: boolean;
   enableTranslations?: boolean;
+  disabled?: boolean;
 };
 
 export function ControlInput({
@@ -56,6 +57,7 @@ export function ControlInput({
   indentWithTab,
   isAllowedVariable,
   enableTranslations = false,
+  disabled = false,
 }: ControlInputProps) {
   const viewRef = useRef<EditorView | null>(null);
   const lastCompletionRef = useRef<CompletionRange | null>(null);
@@ -124,6 +126,7 @@ export function ControlInput({
       skipContainerClick={isTranslationPopoverOpen}
       onManageSchemaClick={openSchemaDrawer}
       onCreateNewVariable={handleCreateNewVariable}
+      disabled={disabled}
     >
       <EditorOverlays
         isTranslationPopoverOpen={isTranslationPopoverOpen}

--- a/apps/dashboard/src/components/workflow-editor/steps/chat/chat-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/chat/chat-editor.tsx
@@ -1,16 +1,23 @@
-import { FeatureFlagsKeysEnum, type UiSchema } from '@novu/shared';
+import { EnvironmentTypeEnum, FeatureFlagsKeysEnum, type UiSchema } from '@novu/shared';
 
 import { getComponentByType } from '@/components/workflow-editor/steps/component-utils';
 import { TabsSection } from '@/components/workflow-editor/steps/tabs-section';
 import { useFeatureFlag } from '../../../../hooks/use-feature-flag';
 import { cn } from '../../../../utils/ui';
+import { useEnvironment } from '@/context/environment/hooks';
+import { StepEditorUnavailable } from '../step-editor-unavailable';
 
 type ChatEditorProps = { uiSchema: UiSchema };
 
 export const ChatEditor = (props: ChatEditorProps) => {
+  const { currentEnvironment } = useEnvironment();
   const isV2TemplateEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_V2_TEMPLATE_EDITOR_ENABLED);
   const { uiSchema } = props;
   const { body } = uiSchema?.properties ?? {};
+
+  if (currentEnvironment?.type !== EnvironmentTypeEnum.DEV) {
+    return <StepEditorUnavailable />;
+  }
 
   return (
     <div className="flex h-full flex-col">

--- a/apps/dashboard/src/components/workflow-editor/steps/component-utils.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/component-utils.tsx
@@ -1,4 +1,4 @@
-import { UiComponentEnum } from '@novu/shared';
+import { EnvironmentTypeEnum, UiComponentEnum } from '@novu/shared';
 
 import { DelayAmount } from '@/components/workflow-editor/steps/delay/delay-amount';
 import { DigestKey } from '@/components/workflow-editor/steps/digest/digest-key';
@@ -18,12 +18,20 @@ import { BypassSanitizationSwitch } from './shared/bypass-sanitization-switch';
 import { useWorkflow } from '../workflow-provider';
 import { useSaveForm } from './save-form-context';
 import { LayoutSelect } from './email/layout-select';
+import { useEnvironment } from '@/context/environment/hooks';
 
 const EmailEditorSelectInternal = () => {
   const { isUpdatePatchPending } = useWorkflow();
   const { saveForm } = useSaveForm();
+  const { currentEnvironment } = useEnvironment();
 
-  return <EmailEditorSelect isLoading={isUpdatePatchPending} saveForm={saveForm} />;
+  return (
+    <EmailEditorSelect
+      isLoading={isUpdatePatchPending}
+      saveForm={saveForm}
+      disabled={currentEnvironment?.type !== EnvironmentTypeEnum.DEV}
+    />
+  );
 };
 
 export const getComponentByType = ({ component }: { component?: UiComponentEnum }) => {

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-editor.tsx
@@ -1,12 +1,21 @@
-import { FeatureFlagsKeysEnum, UiComponentEnum, UiSchemaGroupEnum, type UiSchema } from '@novu/shared';
+import {
+  EnvironmentTypeEnum,
+  FeatureFlagsKeysEnum,
+  UiComponentEnum,
+  UiSchemaGroupEnum,
+  type UiSchema,
+} from '@novu/shared';
 import { getComponentByType } from '@/components/workflow-editor/steps/component-utils';
 import { EmailPreviewHeader } from '@/components/workflow-editor/steps/email/email-preview';
 import { cn } from '../../../../utils/ui';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { useEnvironment } from '@/context/environment/hooks';
+import { StepEditorUnavailable } from '../step-editor-unavailable';
 
 type EmailEditorProps = { uiSchema: UiSchema; isEditorV2?: boolean };
 
 export const EmailEditor = (props: EmailEditorProps) => {
+  const { currentEnvironment } = useEnvironment();
   const { uiSchema, isEditorV2 = false } = props;
   const isHtmlEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_HTML_EDITOR_ENABLED);
   const isLayoutsPageActive = useFeatureFlag(FeatureFlagsKeysEnum.IS_LAYOUTS_PAGE_ACTIVE);
@@ -38,7 +47,11 @@ export const EmailEditor = (props: EmailEditorProps) => {
           </div>
         )}
       </div>
-      {getComponentByType({ component: body.component })}
+      {currentEnvironment?.type === EnvironmentTypeEnum.DEV ? (
+        getComponentByType({ component: body.component })
+      ) : (
+        <StepEditorUnavailable />
+      )}
     </div>
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-subject.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-subject.tsx
@@ -5,6 +5,8 @@ import { useParseVariables } from '@/hooks/use-parse-variables';
 import { capitalize, containsHTMLEntities } from '@/utils/string';
 import { cn } from '@/utils/ui';
 import { useFormContext } from 'react-hook-form';
+import { useEnvironment } from '@/context/environment/hooks';
+import { EnvironmentTypeEnum } from '@novu/shared';
 
 const subjectKey = 'subject';
 
@@ -12,6 +14,7 @@ export const EmailSubject = () => {
   const { control, getValues } = useFormContext();
   const { step, digestStepBeforeCurrent } = useWorkflow();
   const { variables, isAllowedVariable } = useParseVariables(step?.variables, digestStepBeforeCurrent?.stepId);
+  const { currentEnvironment } = useEnvironment();
 
   return (
     <FormField
@@ -33,6 +36,7 @@ export const EmailSubject = () => {
                 value={field.value}
                 onChange={(val) => field.onChange(val)}
                 enableTranslations
+                disabled={currentEnvironment?.type !== EnvironmentTypeEnum.DEV}
               />
             </FormControl>
             <FormMessage className="mb-2">

--- a/apps/dashboard/src/components/workflow-editor/steps/email/layout-select.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/layout-select.tsx
@@ -3,18 +3,23 @@ import { useFormContext } from 'react-hook-form';
 
 import { FormControl, FormField, FormItem, FormMessage } from '@/components/primitives/form/form';
 import { useFetchLayouts } from '@/hooks/use-fetch-layouts';
-import { FacetedFormFilter } from '@/components/primitives/form/faceted-filter/facated-form-filter';
-import { RiExpandUpDownLine, RiLayout5Line } from 'react-icons/ri';
+import { RiLayout5Line } from 'react-icons/ri';
 import { useSaveForm } from '../save-form-context';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/primitives/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
+import { useEnvironment } from '@/context/environment/hooks';
+import { EnvironmentTypeEnum } from '@novu/shared';
 
 export const LayoutSelect = () => {
+  const { currentEnvironment } = useEnvironment();
   const { control } = useFormContext();
   const { data, isFetching } = useFetchLayouts({ limit: 100, refetchOnWindowFocus: false });
   const { saveForm } = useSaveForm();
 
   const layoutsSortedByDefault = useMemo(() => {
-    return data?.layouts
+    if (!data?.layouts) return [];
+
+    return data.layouts
       .sort((a, b) => {
         if (a.isDefault) return -1;
         if (b.isDefault) return 1;
@@ -41,28 +46,37 @@ export const LayoutSelect = () => {
                     e.preventDefault();
                   }}
                 >
-                  <FacetedFormFilter
-                    type="single"
-                    size="small"
-                    title="Layout"
-                    icon={RiLayout5Line}
-                    placeholder="Search layout"
-                    className="bg-bg-weak border-transparent hover:border-transparent hover:bg-neutral-100 [&_span]:text-neutral-600"
-                    selected={field.value ? [field.value] : undefined}
-                    disabled={isFetching || layoutsSortedByDefault?.length === 0}
-                    hidePlusIcon
-                    options={layoutsSortedByDefault}
-                    onSelect={(value) => {
-                      if (value.length > 0) {
-                        field.onChange(value[0]);
-                        return;
-                      }
-
-                      field.onChange(null);
+                  <Select
+                    value={field.value ?? 'no_layout'}
+                    onValueChange={(value) => {
+                      const newValue = value === 'no_layout' ? null : value;
+                      field.onChange(newValue);
                       saveForm({ forceSubmit: true });
                     }}
-                    trailingNode={<RiExpandUpDownLine className="text-text-soft size-3" />}
-                  />
+                    disabled={
+                      isFetching ||
+                      layoutsSortedByDefault?.length === 0 ||
+                      currentEnvironment?.type !== EnvironmentTypeEnum.DEV
+                    }
+                  >
+                    <SelectTrigger
+                      size="2xs"
+                      className="bg-bg-weak border-transparent hover:border-transparent hover:bg-neutral-100 [&_span]:text-neutral-600"
+                    >
+                      <RiLayout5Line className="text-text-soft mr-2 size-4" />
+                      <SelectValue placeholder="Select layout" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="no_layout" className="text-paragraph-xs">
+                        No layout
+                      </SelectItem>
+                      {layoutsSortedByDefault.map((layout) => (
+                        <SelectItem key={layout.value} value={layout.value} className="text-paragraph-xs">
+                          {layout.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </TooltipTrigger>
                 {layoutsSortedByDefault?.length === 0 && <TooltipContent>No layouts found</TooltipContent>}
               </Tooltip>

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor.tsx
@@ -1,13 +1,14 @@
-import { FeatureFlagsKeysEnum, UiSchemaGroupEnum, type UiSchema } from '@novu/shared';
+import { EnvironmentTypeEnum, FeatureFlagsKeysEnum, UiSchemaGroupEnum, type UiSchema } from '@novu/shared';
 
 import { Notification5Fill } from '@/components/icons';
-import { Badge } from '@/components/primitives/badge';
 import { Separator } from '@/components/primitives/separator';
 import { getComponentByType } from '@/components/workflow-editor/steps/component-utils';
 import { InAppTabsSection } from '@/components/workflow-editor/steps/in-app/in-app-tabs-section';
 import { RiInstanceLine } from 'react-icons/ri';
 import { useFeatureFlag } from '../../../../hooks/use-feature-flag';
 import { cn } from '../../../../utils/ui';
+import { StepEditorUnavailable } from '../step-editor-unavailable';
+import { useEnvironment } from '@/context/environment/hooks';
 
 const avatarKey = 'avatar';
 const subjectKey = 'subject';
@@ -19,6 +20,7 @@ const disableOutputSanitizationKey = 'disableOutputSanitization';
 const dataObjectKey = 'data';
 
 export const InAppEditor = ({ uiSchema }: { uiSchema: UiSchema }) => {
+  const { currentEnvironment } = useEnvironment();
   const isV2TemplateEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_V2_TEMPLATE_EDITOR_ENABLED);
 
   if (uiSchema.group !== UiSchemaGroupEnum.IN_APP) {
@@ -35,6 +37,10 @@ export const InAppEditor = ({ uiSchema }: { uiSchema: UiSchema }) => {
     [disableOutputSanitizationKey]: disableOutputSanitization,
     [dataObjectKey]: dataObject,
   } = uiSchema.properties ?? {};
+
+  if (currentEnvironment?.type !== EnvironmentTypeEnum.DEV) {
+    return <StepEditorUnavailable />;
+  }
 
   return (
     <div className="flex flex-col">

--- a/apps/dashboard/src/components/workflow-editor/steps/push/push-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/push/push-editor.tsx
@@ -1,16 +1,23 @@
-import { FeatureFlagsKeysEnum, type UiSchema } from '@novu/shared';
+import { EnvironmentTypeEnum, FeatureFlagsKeysEnum, type UiSchema } from '@novu/shared';
 
 import { getComponentByType } from '@/components/workflow-editor/steps/component-utils';
 import { TabsSection } from '@/components/workflow-editor/steps/tabs-section';
 import { useFeatureFlag } from '../../../../hooks/use-feature-flag';
 import { cn } from '../../../../utils/ui';
+import { useEnvironment } from '@/context/environment/hooks';
+import { StepEditorUnavailable } from '../step-editor-unavailable';
 
 type PushEditorProps = { uiSchema: UiSchema };
 
 export const PushEditor = (props: PushEditorProps) => {
+  const { currentEnvironment } = useEnvironment();
   const isV2TemplateEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_V2_TEMPLATE_EDITOR_ENABLED);
   const { uiSchema } = props;
   const { body, subject } = uiSchema?.properties ?? {};
+
+  if (currentEnvironment?.type !== EnvironmentTypeEnum.DEV) {
+    return <StepEditorUnavailable />;
+  }
 
   return (
     <div className="flex h-full flex-col">

--- a/apps/dashboard/src/components/workflow-editor/steps/sms/sms-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/sms/sms-editor.tsx
@@ -1,17 +1,24 @@
 import { Sms } from '@/components/icons';
-import { FeatureFlagsKeysEnum, type UiSchema } from '@novu/shared';
+import { EnvironmentTypeEnum, FeatureFlagsKeysEnum, type UiSchema } from '@novu/shared';
 
 import { getComponentByType } from '@/components/workflow-editor/steps/component-utils';
 import { TabsSection } from '@/components/workflow-editor/steps/tabs-section';
 import { useFeatureFlag } from '../../../../hooks/use-feature-flag';
 import { cn } from '../../../../utils/ui';
+import { StepEditorUnavailable } from '../step-editor-unavailable';
+import { useEnvironment } from '@/context/environment/hooks';
 
 type SmsEditorProps = { uiSchema: UiSchema };
 
 export const SmsEditor = (props: SmsEditorProps) => {
+  const { currentEnvironment } = useEnvironment();
   const isV2TemplateEditorEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_V2_TEMPLATE_EDITOR_ENABLED);
   const { uiSchema } = props;
   const { body } = uiSchema.properties ?? {};
+
+  if (currentEnvironment?.type !== EnvironmentTypeEnum.DEV) {
+    return <StepEditorUnavailable />;
+  }
 
   return (
     <div className="flex h-full flex-col">

--- a/apps/dashboard/src/components/workflow-editor/steps/step-editor-layout.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/step-editor-layout.tsx
@@ -1,8 +1,8 @@
-import { WorkflowResponseDto, EnvironmentTypeEnum, StepResponseDto, PermissionsEnum } from '@novu/shared';
+import { WorkflowResponseDto, StepResponseDto, PermissionsEnum } from '@novu/shared';
 import { cn } from '@/utils/ui';
-import { RiCodeBlock, RiEdit2Line, RiEyeLine, RiPlayCircleLine, RiLockLine, RiArrowRightSLine } from 'react-icons/ri';
+import { RiCodeBlock, RiEdit2Line, RiEyeLine, RiPlayCircleLine } from 'react-icons/ri';
 import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { IssuesPanel } from '@/components/issues-panel';
 import { StepEditorFactory } from '@/components/workflow-editor/steps/editor/step-editor-factory';
 import { StepPreviewFactory } from '@/components/workflow-editor/steps/preview/step-preview-factory';
@@ -17,8 +17,6 @@ import { useFetchWorkflowTestData } from '@/hooks/use-fetch-workflow-test-data';
 import { Protect } from '../../../utils/protect';
 import { parseJsonValue } from '@/components/workflow-editor/steps/utils/preview-context.utils';
 import { LocaleSelect } from '@/components/primitives/locale-select';
-import { useEnvironment } from '../../../context/environment/hooks';
-import { buildRoute, ROUTES } from '@/utils/routes';
 import { useIsTranslationEnabled } from '@/hooks/use-is-translation-enabled';
 import { useFetchTranslationGroup } from '@/hooks/use-fetch-translation-group';
 import { LocalizationResourceEnum } from '@/types/translations';
@@ -31,11 +29,9 @@ type StepEditorLayoutProps = {
 };
 
 function StepEditorContent() {
-  const { currentEnvironment, switchEnvironment, oppositeEnvironment } = useEnvironment();
   const { step, isSubsequentLoad, editorValue, workflow, selectedLocale, setSelectedLocale } = useStepEditor();
   const editorTitle = getEditorTitle(step.type);
   const { workflowSlug = '' } = useParams<{ workflowSlug: string }>();
-  const navigate = useNavigate();
   const [isTestDrawerOpen, setIsTestDrawerOpen] = useState(false);
   const { testData } = useFetchWorkflowTestData({ workflowSlug });
   const isTranslationsEnabled = useIsTranslationEnabled();
@@ -54,22 +50,7 @@ function StepEditorContent() {
     setIsTestDrawerOpen(true);
   };
 
-  const handleSwitchToDevelopment = () => {
-    const developmentEnvironment = oppositeEnvironment?.name === 'Development' ? oppositeEnvironment : null;
-
-    if (developmentEnvironment?.slug) {
-      switchEnvironment(developmentEnvironment.slug);
-      navigate(
-        buildRoute(ROUTES.EDIT_WORKFLOW, {
-          environmentSlug: developmentEnvironment.slug,
-          workflowSlug: workflow.workflowId,
-        })
-      );
-    }
-  };
-
   const currentPayload = parseJsonValue(editorValue).payload;
-  const developmentEnvironment = oppositeEnvironment?.name === 'Development' ? oppositeEnvironment : null;
 
   return (
     <ResizableLayout autoSaveId="step-editor-main-layout">
@@ -105,39 +86,7 @@ function StepEditorContent() {
               </PanelHeader>
               <div className="flex-1 overflow-y-auto">
                 <div className="h-full p-3">
-                  {currentEnvironment?.type === EnvironmentTypeEnum.DEV ? (
-                    <StepEditorFactory />
-                  ) : (
-                    <div className="flex h-full items-center justify-center p-6">
-                      <div className="max-w-md space-y-4 text-center">
-                        <div className="flex justify-center">
-                          <div className="bg-neutral-alpha-50 rounded-full p-3">
-                            <RiLockLine className="text-neutral-alpha-400 h-8 w-8" />
-                          </div>
-                        </div>
-                        <div className="space-y-2">
-                          <h3 className="text-base font-medium text-neutral-600">Step editor unavailable</h3>
-                          <p className="text-sm leading-relaxed text-neutral-500">
-                            Step editing is only available in development environments. Switch to a development
-                            environment to modify this step.
-                          </p>
-                        </div>
-                        {developmentEnvironment && (
-                          <div className="flex justify-center pt-2">
-                            <Button
-                              variant="secondary"
-                              size="xs"
-                              mode="gradient"
-                              onClick={handleSwitchToDevelopment}
-                              trailingIcon={RiArrowRightSLine}
-                            >
-                              Switch to {developmentEnvironment.name}
-                            </Button>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  )}
+                  <StepEditorFactory />
                 </div>
               </div>
             </ResizableLayout.EditorPanel>

--- a/apps/dashboard/src/components/workflow-editor/steps/step-editor-unavailable.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/step-editor-unavailable.tsx
@@ -1,0 +1,61 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Button } from '@/components/primitives/button';
+import { useEnvironment } from '@/context/environment/hooks';
+import { buildRoute, ROUTES } from '@/utils/routes';
+import { RiArrowRightSLine, RiLockLine } from 'react-icons/ri';
+import { useStepEditor } from './context/step-editor-context';
+
+export const StepEditorUnavailable = () => {
+  const navigate = useNavigate();
+  const { switchEnvironment, oppositeEnvironment } = useEnvironment();
+  const { workflow } = useStepEditor();
+
+  const handleSwitchToDevelopment = () => {
+    const developmentEnvironment = oppositeEnvironment?.name === 'Development' ? oppositeEnvironment : null;
+
+    if (developmentEnvironment?.slug) {
+      switchEnvironment(developmentEnvironment.slug);
+      navigate(
+        buildRoute(ROUTES.EDIT_WORKFLOW, {
+          environmentSlug: developmentEnvironment.slug,
+          workflowSlug: workflow.workflowId,
+        })
+      );
+    }
+  };
+
+  const developmentEnvironment = oppositeEnvironment?.name === 'Development' ? oppositeEnvironment : null;
+
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="max-w-md space-y-4 text-center">
+        <div className="flex justify-center">
+          <div className="bg-neutral-alpha-50 rounded-full p-3">
+            <RiLockLine className="text-neutral-alpha-400 h-8 w-8" />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <h3 className="text-base font-medium text-neutral-600">Step editor unavailable</h3>
+          <p className="text-sm leading-relaxed text-neutral-500">
+            Step editing is only available in development environments. Switch to a development environment to modify
+            this step.
+          </p>
+        </div>
+        {developmentEnvironment && (
+          <div className="flex justify-center pt-2">
+            <Button
+              variant="secondary"
+              size="xs"
+              mode="gradient"
+              onClick={handleSwitchToDevelopment}
+              trailingIcon={RiArrowRightSLine}
+            >
+              Switch to {developmentEnvironment.name}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
### What changed? Why was the change needed?

Email editor:
- updated the layout picker component to a regular select
- improved the email editor state in prod env, where the user can see now: editor type, subject, layout

### Screenshots
<img width="1536" height="1065" alt="Screenshot 2025-07-28 at 18 01 51" src="https://github.com/user-attachments/assets/33b9978f-850f-47c1-aa68-34e952038fee" />
<img width="1538" height="1063" alt="Screenshot 2025-07-28 at 18 24 36" src="https://github.com/user-attachments/assets/15f96dad-4ec1-4b95-bb3b-358d53f6b951" />


https://github.com/user-attachments/assets/e26f7f71-f297-418b-86c4-568d5d525401



