### PR TITLE
feat(dashboard): update button text from 'Import language(s)' to 'Import translation(s)'

### DIFF
--- a/apps/dashboard/src/components/translations/translation-drawer/editor-actions.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/editor-actions.tsx
@@ -130,7 +130,7 @@ export function EditorActions({ selectedTranslation, modifiedContent, isReadOnly
           </div>
 
           <TranslationImportTrigger resource={resource}>
-            <UploadButton disabled={isReadOnly}>Import language(s)</UploadButton>
+            <UploadButton disabled={isReadOnly}>Import translation(s)</UploadButton>
           </TranslationImportTrigger>
         </div>
 


### PR DESCRIPTION
# feat(dashboard): update button text from 'Import language(s)' to 'Import translation(s)'

## Summary
Updated the button text in the translation editor drawer from "Import language(s)" to "Import translation(s)" to better reflect the actual functionality. The button allows users to import translation JSON files (e.g., `fr_FR.json` containing translation key-value pairs) rather than importing languages themselves.

This change improves clarity for users by using more accurate terminology that aligns with what the feature actually does - importing translation files for specific locales.

## Review & Testing Checklist for Human
- [ ] Verify the button text displays correctly in the translation drawer UI
- [ ] Confirm the import functionality still works as expected (button should trigger file upload dialog)
- [ ] Check that the new terminology feels natural and accurate in the context of the translation workflow

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["apps/dashboard/src/components/translations/<br/>translation-drawer/editor-actions.tsx"]:::major-edit
    B["TranslationImportTrigger"]:::context
    C["UploadButton Component"]:::context
    
    A --> B
    B --> C
    C -.-> D["Button Text:<br/>'Import translation(s)'"]:::major-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- This is a simple text-only change with no functional modifications
- Change was requested by Adam Chmara (@ChmaraX) to improve user experience clarity
- The feature imports translation JSON files (like `fr_FR.json` with key-value pairs), so "translation(s)" is more accurate than "language(s)"

**Link to Devin run**: https://app.devin.ai/sessions/3538d2093ab340ce8597e6fa56b07df4  
**Requested by**: Adam Chmara (@ChmaraX)