### PR TITLE
fix(dashboard): Update dashboard translation doc links

### DIFF
--- a/apps/dashboard/src/components/translations/translation-list-upgrade-cta.tsx
+++ b/apps/dashboard/src/components/translations/translation-list-upgrade-cta.tsx
@@ -47,7 +47,7 @@ export const TranslationListUpgradeCta = () => {
         >
           {IS_SELF_HOSTED ? 'Contact Sales' : 'Upgrade now'}
         </Button>
-        <Link to={'https://docs.novu.co/platform/translations'} target="_blank">
+        <Link to={'https://docs.novu.co/platform/workflow/translations'} target="_blank">
           <LinkButton size="sm" leadingIcon={RiBookMarkedLine}>
             How does this help?
           </LinkButton>

--- a/apps/dashboard/src/components/translations/translation-onboarding-page.tsx
+++ b/apps/dashboard/src/components/translations/translation-onboarding-page.tsx
@@ -131,7 +131,7 @@ export const TranslationOnboardingPage = () => {
                     description={
                       <>
                         Don't worry about getting this perfect — you can add more languages anytime.{' '}
-                        <Link to="https://docs.novu.co/platform/translations" className="underline">
+                        <Link to="https://docs.novu.co/platform/workflow/translations" className="underline">
                           Learn more.
                         </Link>
                       </>
@@ -202,7 +202,7 @@ export const TranslationOnboardingPage = () => {
               View workflows
             </Button>
 
-            <Link to="https://docs.novu.co/platform/translations" target="_blank">
+            <Link to="https://docs.novu.co/platform/workflow/translations" target="_blank">
               <LinkButton variant="gray" leadingIcon={RiBookMarkedLine} size="sm">
                 Learn more in docs
               </LinkButton>


### PR DESCRIPTION
### What changed? Why was the change needed?

Updated three instances of the translation documentation link in the `apps/dashboard` directory from `https://docs.novu.co/platform/translations` to the correct URL: `https://docs.novu.co/platform/workflow/translations`. This change ensures users are directed to the most up-to-date and accurate documentation page for translations.

### Screenshots

N/A - This change updates documentation links and has no visual impact on the UI.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1753859142699379?thread_ts=1753859142.699379&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-28e52e0b-b59c-4f19-b07d-7b938834bfa4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28e52e0b-b59c-4f19-b07d-7b938834bfa4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>