### PR TITLE
Update dashboard layout docs links

### DIFF
--- a/apps/dashboard/src/components/layouts/layout-list-blank.tsx
+++ b/apps/dashboard/src/components/layouts/layout-list-blank.tsx
@@ -21,7 +21,7 @@ export const LayoutListBlank = () => {
         <p className="text-text-soft text-paragraph-sm max-w-[48ch]">
           Layouts let you reuse structure, stay consistent, and ship faster. Create once, plug anywhere — your emails
           (and teammates) will love you for it.{' '}
-          <Link to="https://docs.novu.co/platform/layouts" className="underline">
+          <Link to="https://docs.novu.co/platform/workflow/layouts" className="underline">
             Learn more ↗
           </Link>
         </p>

--- a/apps/dashboard/src/components/layouts/layouts-list-upgrade-cta.tsx
+++ b/apps/dashboard/src/components/layouts/layouts-list-upgrade-cta.tsx
@@ -134,7 +134,7 @@ export const LayoutsListUpgradeCta = () => {
             >
               {IS_SELF_HOSTED ? 'Contact Sales' : 'Upgrade plan'}
             </Button>
-            <Link to={'https://docs.novu.co/platform/concepts/layouts'} target="_blank">
+            <Link to={'https://docs.novu.co/platform/workflow/layouts'} target="_blank">
               <LinkButton size="sm" leadingIcon={RiBookMarkedLine}>
                 <span className="underline">How does this help?</span>
               </LinkButton>

--- a/apps/dashboard/src/pages/new-layout-drawer.tsx
+++ b/apps/dashboard/src/pages/new-layout-drawer.tsx
@@ -135,7 +135,7 @@ export const NewLayoutDrawer = (props: NewLayoutDrawerProps) => {
             <div>
               <SheetDescription>
                 Create a reusable email layout template for your notifications.{' '}
-                <ExternalLink href="https://docs.novu.co/platform/concepts/layouts">Learn more</ExternalLink>
+                <ExternalLink href="https://docs.novu.co/platform/workflow/layouts">Learn more</ExternalLink>
               </SheetDescription>
             </div>
           </SheetHeader>


### PR DESCRIPTION
### What changed? Why was the change needed?

Updated all outdated layout documentation links within the `apps/dashboard` directory to point to the correct URL: `https://docs.novu.co/platform/workflow/layouts`. This ensures users are directed to the most current and relevant documentation.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

N/A

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1753862061925159?thread_ts=1753862061.925159&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-fe6ca3a4-3b16-49e3-aa83-977223b78efd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe6ca3a4-3b16-49e3-aa83-977223b78efd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>