### PR TITLE
fix(dashboard): add text truncation for transactionid and subscriber

### DIFF
--- a/apps/dashboard/src/components/activity/components/activity-table-row.tsx
+++ b/apps/dashboard/src/components/activity/components/activity-table-row.tsx
@@ -12,6 +12,11 @@ type ActivityTableRowProps = {
   className?: string;
 };
 
+function truncateText(text: string, maxLength: number = 26): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength) + '...';
+}
+
 function getSubscriberDisplay(
   subscriber?: Pick<ISubscriber, '_id' | 'subscriberId' | 'firstName' | 'lastName'>,
   variant: 'default' | 'compact' = 'default'
@@ -38,6 +43,12 @@ export function ActivityTableRow({ activity, isSelected, onClick, className }: A
     onClick?.(activity._id);
   };
 
+  const subscriberDisplay = getSubscriberDisplay(
+    activity.subscriber as Pick<ISubscriber, '_id' | 'subscriberId' | 'firstName' | 'lastName'>
+  );
+  const truncatedTransactionId = truncateText(activity.transactionId);
+  const truncatedSubscriberDisplay = subscriberDisplay ? truncateText(subscriberDisplay) : '';
+
   return (
     <TableRow
       className={cn('relative cursor-pointer hover:bg-neutral-50', isSelected && 'bg-neutral-50', className)}
@@ -52,15 +63,9 @@ export function ActivityTableRow({ activity, isSelected, onClick, className }: A
             {activity.template?.name || 'Deleted workflow'}
           </span>
           <span className="text-foreground-400 text-[10px] leading-[14px]">
-            <div className="bg-bg-weak font-code inline-block rounded-sm px-1.5">
-              {activity.transactionId}
-              {getSubscriberDisplay(
-                activity.subscriber as Pick<ISubscriber, '_id' | 'subscriberId' | 'firstName' | 'lastName'>
-              )
-                ? ` • ${getSubscriberDisplay(
-                    activity.subscriber as Pick<ISubscriber, '_id' | 'subscriberId' | 'firstName' | 'lastName'>
-                  )}`
-                : ''}
+            <div className="bg-bg-weak font-code inline-block rounded-sm px-1.5" title={`${activity.transactionId}${subscriberDisplay ? ` • ${subscriberDisplay}` : ''}`}>
+              {truncatedTransactionId}
+              {truncatedSubscriberDisplay ? ` • ${truncatedSubscriberDisplay}` : ''}
             </div>
           </span>
         </div>


### PR DESCRIPTION
### What changed? Why was the change needed?

Before 

<img width="749" height="1077" alt="image" src="https://github.com/user-attachments/assets/35791dc2-a06e-420f-8bd8-b433c19b5515" />




After 

<img width="628" height="709" alt="image" src="https://github.com/user-attachments/assets/a3bff410-df6e-421f-be57-f3d549d0ece5" />


<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
