### PR TITLE
ci(root): Notify production deployment completion for eu and us

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -338,3 +338,33 @@ jobs:
         with:
           secret-key: ${{ secrets.NOVU_INTERNAL_SECRET_KEY }}
           bridge-url: ${{ vars.NOVU_BRIDGE_URL }}
+
+  webhook_notification:
+    needs: [deploy, prepare-matrix]
+    runs-on: ubuntu-latest
+    if: |
+      always() && 
+      needs.deploy.result == 'success' && 
+      (contains(github.event.inputs.environment, 'production'))
+    environment: ${{ fromJson(needs.prepare-matrix.outputs.env_matrix).environment[0] }}
+    
+    steps:
+      - name: Send webhook notification for US production
+        if: |
+          github.event.inputs.environment == 'production-us' || 
+          github.event.inputs.environment == 'production-both'
+        run: |
+          curl -X POST https://webhooks.bug0.com/integrations/test/run \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: ${{ secrets.SECRET_KEY }}" \
+            -d '{"url": "https://dashboard.novu.co", "source": "novuhq-novu", "prod": "true"}'
+      
+      - name: Send webhook notification for EU production
+        if: |
+          github.event.inputs.environment == 'production-eu' || 
+          github.event.inputs.environment == 'production-both'
+        run: |
+          curl -X POST https://webhooks.bug0.com/integrations/test/run \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: ${{ secrets.SECRET_KEY }}" \
+            -d '{"url": "https://eu.dashboard.novu.co", "source": "novuhq-novu", "prod": "true"}'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -356,7 +356,7 @@ jobs:
         run: |
           curl -X POST https://webhooks.bug0.com/integrations/test/run \
             -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.SECRET_KEY }}" \
+            -H "x-api-key: ${{ secrets.BUG0_SECRET_KEY }}" \
             -d '{"url": "https://dashboard.novu.co", "source": "novuhq-novu", "prod": "true"}'
       
       - name: Send webhook notification for EU production
@@ -366,5 +366,5 @@ jobs:
         run: |
           curl -X POST https://webhooks.bug0.com/integrations/test/run \
             -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.SECRET_KEY }}" \
+            -H "x-api-key: ${{ secrets.BUG0_SECRET_KEY }}" \
             -d '{"url": "https://eu.dashboard.novu.co", "source": "novuhq-novu", "prod": "true"}'

--- a/.github/workflows/prod-deploy-web.yml
+++ b/.github/workflows/prod-deploy-web.yml
@@ -51,23 +51,3 @@ jobs:
       clerk_is_ee_auth_enabled: true
       new_dashboard_url: https://dashboard.novu.co
     secrets: inherit
-
-  webhook_notification:
-    needs: [deploy_web_eu, deploy_web_us]
-    runs-on: ubuntu-latest
-    if: always() && needs.deploy_web_eu.result == 'success' && needs.deploy_web_us.result == 'success'
-    
-    steps:
-      - name: Send webhook notification for US production
-        run: |
-          curl -X POST https://webhooks.bug0.com/integrations/test/run \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.SECRET_KEY }}" \
-            -d '{"url": "https://dashboard.novu.co", "source": "novuhq-novu", "prod": "true"}'
-      
-      - name: Send webhook notification for EU production
-        run: |
-          curl -X POST https://webhooks.bug0.com/integrations/test/run \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.SECRET_KEY }}" \
-            -d '{"url": "https://eu.dashboard.novu.co", "source": "novuhq-novu", "prod": "true"}'

--- a/.github/workflows/prod-deploy-web.yml
+++ b/.github/workflows/prod-deploy-web.yml
@@ -51,3 +51,23 @@ jobs:
       clerk_is_ee_auth_enabled: true
       new_dashboard_url: https://dashboard.novu.co
     secrets: inherit
+
+  webhook_notification:
+    needs: [deploy_web_eu, deploy_web_us]
+    runs-on: ubuntu-latest
+    if: always() && needs.deploy_web_eu.result == 'success' && needs.deploy_web_us.result == 'success'
+    
+    steps:
+      - name: Send webhook notification for US production
+        run: |
+          curl -X POST https://webhooks.bug0.com/integrations/test/run \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: ${{ secrets.SECRET_KEY }}" \
+            -d '{"url": "https://dashboard.novu.co", "source": "novuhq-novu", "prod": "true"}'
+      
+      - name: Send webhook notification for EU production
+        run: |
+          curl -X POST https://webhooks.bug0.com/integrations/test/run \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: ${{ secrets.SECRET_KEY }}" \
+            -d '{"url": "https://eu.dashboard.novu.co", "source": "novuhq-novu", "prod": "true"}'


### PR DESCRIPTION
### What changed? Why was the change needed?

Added a `webhook_notification` job to the main cloud deployment (`deploy.yml`) and web frontend deployment (`prod-deploy-web.yml`) GitHub Actions workflows.

This change is needed to automatically trigger external integration tests via `bug0.com` webhooks after successful production deployments to both US and EU environments. This ensures the integration testing system is notified when new deployments are live.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

A `SECRET_KEY` GitHub Actions repository secret is required for the webhook authentication.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1754475534574289?thread_ts=1754475534.574289&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-b7a9969d-b8e3-44db-adc0-4f94f0cdbfbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b7a9969d-b8e3-44db-adc0-4f94f0cdbfbc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

