### PR TITLE
fix(dashboard): Remove data soon tab from integration store

### DIFF
--- a/apps/dashboard/src/pages/integrations-list-page.tsx
+++ b/apps/dashboard/src/pages/integrations-list-page.tsx
@@ -35,21 +35,6 @@ export function IntegrationsListPage() {
             <TabsTrigger value="providers" variant="regular" size="xl">
               Providers
             </TabsTrigger>
-            <Tooltip>
-              <TooltipTrigger>
-                <TabsTrigger value="data-warehouse" variant="regular" disabled size="xl">
-                  Data{' '}
-                  <Badge color="gray" size="sm" variant="lighter">
-                    SOON
-                  </Badge>
-                </TabsTrigger>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="max-w-xs">
-                  Data warehouse connectors for syncing user data and triggering notifications.
-                </p>
-              </TooltipContent>
-            </Tooltip>
           </TabsList>
           <PermissionButton
             permission={PermissionsEnum.INTEGRATION_WRITE}
@@ -64,9 +49,6 @@ export function IntegrationsListPage() {
         </div>
         <TabsContent value="providers" className="!mt-0 p-2.5">
           <IntegrationsList onItemClick={onItemClick} />
-        </TabsContent>
-        <TabsContent value="data-warehouse">
-          <div className="text-muted-foreground flex h-64 items-center justify-center">Coming soon</div>
         </TabsContent>
       </Tabs>
       <Outlet />


### PR DESCRIPTION
### What changed? Why was the change needed?

Removed the "Data (soon)" tab and its associated content from the integration store page. This change was needed because the data warehouse feature is not currently a focus, and removing the tab simplifies the UI, aligning it with current development priorities.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1754488348116199?thread_ts=1754488348.116199&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-f6dbf30d-b9ee-42d5-b748-f9bfd16d9a2e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6dbf30d-b9ee-42d5-b748-f9bfd16d9a2e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

