### PR TITLE
fix(dashboard): layout select click causing refresh of the page

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/email/layout-select.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/layout-select.tsx
@@ -39,12 +39,7 @@ export const LayoutSelect = () => {
           <FormItem className="w-full">
             <FormControl>
               <Tooltip>
-                <TooltipTrigger
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                  }}
-                >
+                <TooltipTrigger disabled={layoutsSortedByDefault?.length === 0}>
                   <Select
                     value={field.value ?? 'no_layout'}
                     onValueChange={(value) => {


### PR DESCRIPTION
### What changed? Why was the change needed?

Clicking on the Layout Select when there are no items available was causing the page to refresh.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
