### PR TITLE
fix(api-service): Filter workflows by origin and type in diff use case

### DIFF
--- a/apps/api/src/app/environments-v2/usecases/diff-environment/diff-environment.usecase.ts
+++ b/apps/api/src/app/environments-v2/usecases/diff-environment/diff-environment.usecase.ts
@@ -6,6 +6,7 @@ import {
   NotificationTemplateRepository,
   PreferencesRepository,
 } from '@novu/dal';
+import { ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
 import { WorkflowDataContainer } from '../../../shared/containers/workflow-data.container';
 import { DependencyAnalyzerService, EnvironmentValidationService } from '../../services';
 import { IDiffResult, IEnvironmentDiffResult } from '../../types/sync.types';
@@ -52,6 +53,8 @@ export class DiffEnvironmentUseCase {
 
       const workflows = await this.workflowRepository.findWithTemplates({
         _environmentId: { $in: [sourceEnvironmentId, command.targetEnvironmentId] },
+        origin: ResourceOriginEnum.NOVU_CLOUD,
+        type: ResourceTypeEnum.BRIDGE,
         _organizationId: command.user.organizationId,
       });
 


### PR DESCRIPTION
Added filters for 'origin' (NOVU_CLOUD) and 'type' (BRIDGE) when querying workflows in the DiffEnvironmentUseCase. This ensures only relevant workflows are included in the environment diff process.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
