### PR TITLE
feat(js,react): useNotifications hook realtime updates fixes NV-5502

### DIFF
--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -18,4 +18,9 @@ export {
   Subscriber,
   WebSocketEvent,
 } from './types';
-export { areTagsEqual, isSameFilter } from './utils/notification-utils';
+export {
+  areTagsEqual,
+  checkNotificationDataFilter,
+  checkNotificationMatchesFilter,
+  isSameFilter,
+} from './utils/notification-utils';

--- a/packages/js/src/ui/context/CountContext.tsx
+++ b/packages/js/src/ui/context/CountContext.tsx
@@ -1,5 +1,6 @@
 import { Accessor, createContext, createMemo, createSignal, onMount, ParentProps, useContext } from 'solid-js';
 import { Notification, NotificationFilter } from '../../types';
+import { checkNotificationDataFilter, checkNotificationTagFilter } from '../../utils/notification-utils';
 import { getTagsFromTab } from '../helpers';
 import { useNovuEvent } from '../helpers/useNovuEvent';
 import { useWebSocketEvent } from '../helpers/useWebSocketEvent';
@@ -122,69 +123,13 @@ export const CountProvider = (props: ParentProps) => {
 
       const currentTabs = tabs();
 
-      // Helper function to check if notification data matches tab's data filter criteria
-      function checkNotificationDataAgainstTabData(
-        notificationData: Notification['data'],
-        tabFilterData: NotificationFilter['data']
-      ): boolean {
-        if (!tabFilterData || Object.keys(tabFilterData).length === 0) {
-          // No data filter defined on the tab, so it's a match on the data aspect.
-          return true;
-        }
-        if (!notificationData) {
-          // Tab has a data filter, but the notification has no data.
-          return false;
-        }
-
-        return Object.entries(tabFilterData).every(([key, filterValue]) => {
-          const notifValue = notificationData[key];
-
-          if (notifValue === undefined && filterValue !== undefined) {
-            // Key is specified in tab's data filter, but this key is not present in the notification's data.
-            return false;
-          }
-
-          if (Array.isArray(filterValue)) {
-            if (Array.isArray(notifValue)) {
-              /*
-               * Both filter value and notification value are arrays.
-               * Check for set equality (same elements, regardless of order).
-               */
-              if (filterValue.length !== notifValue.length) return false;
-              /*
-               * Ensure elements are of primitive types for direct sort and comparison.
-               * If elements can be objects, a more sophisticated comparison is needed.
-               */
-              const sortedFilterValue = [...(filterValue as (string | number | boolean)[])].sort();
-              const sortedNotifValue = [...(notifValue as (string | number | boolean)[])].sort();
-
-              return sortedFilterValue.every((val, index) => val === sortedNotifValue[index]);
-            } else {
-              /*
-               * Filter value is an array, notification value is scalar.
-               * Check if the scalar notification value is present in the filter array.
-               */
-              return (filterValue as unknown[]).includes(notifValue);
-            }
-          } else {
-            // Filter value is scalar. Notification value must be equal.
-            return notifValue === filterValue;
-          }
-        });
-      }
-
       if (currentTabs.length > 0) {
         for (const tab of currentTabs) {
           const tabTags = getTagsFromTab(tab);
           const tabDataFilterCriteria = tab.filter?.data;
 
-          const matchesTagFilter =
-            tabTags.length === 0 || (notification.tags && tabTags.some((tag) => notification.tags!.includes(tag)));
-
-          const matchesDataFilterCriteria = checkNotificationDataAgainstTabData(
-            notification.data,
-            tabDataFilterCriteria
-          );
+          const matchesTagFilter = checkNotificationTagFilter(notification.tags, tabTags);
+          const matchesDataFilterCriteria = checkNotificationDataFilter(notification.data, tabDataFilterCriteria);
 
           if (matchesTagFilter && matchesDataFilterCriteria) {
             updateNewNotificationCountsOrCache(notification, tabTags, tabDataFilterCriteria);

--- a/packages/js/src/utils/notification-utils.ts
+++ b/packages/js/src/utils/notification-utils.ts
@@ -1,4 +1,4 @@
-import { NotificationFilter, NotificationStatus } from '../types';
+import { Notification, NotificationFilter, NotificationStatus } from '../types';
 import { arrayValuesEqual } from './arrays';
 
 export const SEEN_OR_UNSEEN = [NotificationStatus.SEEN, NotificationStatus.UNSEEN];
@@ -35,3 +35,116 @@ export const isSameFilter = (filter1: NotificationFilter, filter2: NotificationF
     filter1.seen === filter2.seen
   );
 };
+
+export function checkNotificationDataFilter(
+  notificationData: Notification['data'],
+  filterData: NotificationFilter['data']
+): boolean {
+  if (!filterData || Object.keys(filterData).length === 0) {
+    // No data filter defined, so it's a match on the data aspect.
+    return true;
+  }
+  if (!notificationData) {
+    // Filter has data criteria, but the notification has no data.
+    return false;
+  }
+
+  return Object.entries(filterData).every(([key, filterValue]) => {
+    const notifValue = notificationData[key];
+
+    if (notifValue === undefined && filterValue !== undefined) {
+      // Key is specified in filter, but not present in notification data.
+      return false;
+    }
+
+    if (Array.isArray(filterValue)) {
+      if (Array.isArray(notifValue)) {
+        /*
+         * Both filter value and notification value are arrays.
+         * Check for set equality (same elements, regardless of order).
+         */
+        if (filterValue.length !== notifValue.length) return false;
+        /*
+         * Ensure elements are of primitive types for direct sort and comparison.
+         * If elements can be objects, a more sophisticated comparison is needed.
+         */
+        const sortedFilterValue = [...(filterValue as (string | number | boolean)[])].sort();
+        const sortedNotifValue = [...(notifValue as (string | number | boolean)[])].sort();
+
+        return sortedFilterValue.every((val, index) => val === sortedNotifValue[index]);
+      } else {
+        /*
+         * Filter value is an array, notification value is scalar.
+         * Check if the scalar notification value is present in the filter array.
+         */
+        return (filterValue as unknown[]).includes(notifValue);
+      }
+    } else {
+      // Filter value is scalar. Notification value must be equal.
+      return notifValue === filterValue;
+    }
+  });
+}
+
+/**
+ * Check if notification tags match the filter tags criteria.
+ */
+export function checkNotificationTagFilter(
+  notificationTags: string[] | undefined,
+  filterTags: string[] | undefined
+): boolean {
+  if (!filterTags || filterTags.length === 0) {
+    // No tag filter specified, so it matches
+    return true;
+  }
+
+  if (!notificationTags || notificationTags.length === 0) {
+    // Filter has tags but notification has none
+    return false;
+  }
+
+  // Check if notification has any of the required tags
+  return filterTags.some((tag) => notificationTags.includes(tag));
+}
+
+/**
+ * Check if notification matches basic filter criteria (read, seen, archived, snoozed).
+ */
+export function checkBasicFilters(
+  notification: Notification,
+  filter: Pick<NotificationFilter, 'read' | 'seen' | 'archived' | 'snoozed'>
+): boolean {
+  // Check read status
+  if (filter.read !== undefined && notification.isRead !== filter.read) {
+    return false;
+  }
+
+  // Check seen status
+  if (filter.seen !== undefined && notification.isSeen !== filter.seen) {
+    return false;
+  }
+
+  // Check archived status
+  if (filter.archived !== undefined && notification.isArchived !== filter.archived) {
+    return false;
+  }
+
+  // Check snoozed status
+  if (filter.snoozed !== undefined && notification.isSnoozed !== filter.snoozed) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Complete notification filter check combining all criteria.
+ * This is the main function that should be used by both React and SolidJS implementations.
+ */
+export function checkNotificationMatchesFilter(notification: Notification, filter: NotificationFilter): boolean {
+  return (
+    checkBasicFilters(notification, filter) &&
+    checkNotificationTagFilter(notification.tags, filter.tags) &&
+    checkNotificationDataFilter(notification.data, filter.data)
+  );
+}

--- a/packages/react/src/hooks/useNotifications.ts
+++ b/packages/react/src/hooks/useNotifications.ts
@@ -1,5 +1,6 @@
-import { isSameFilter, ListNotificationsResponse, Notification, NotificationFilter, NovuError } from '@novu/js';
-import { useEffect, useRef, useState } from 'react';
+import { checkNotificationMatchesFilter, isSameFilter, Notification, NotificationFilter, NovuError } from '@novu/js';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useWebSocketEvent } from './internal/useWebsocketEvent';
 import { useNovu } from './NovuProvider';
 
 /**
@@ -18,9 +19,8 @@ import { useNovu } from './NovuProvider';
  *   tags: ['important']
  * });
  *
- * // Get seen but unread notifications
+ * // Get notifications (auto-updates in real time when new notifications arrive)
  * const { notifications } = useNotifications({
- *   seen: true,
  *   read: false
  * });
  * ```
@@ -76,7 +76,7 @@ export const useNotifications = (props?: UseNotificationsProps): UseNotification
     onError,
   } = props || {};
   const filterRef = useRef<NotificationFilter | undefined>(undefined);
-  const { notifications, on } = useNovu();
+  const { notifications } = useNovu();
   const [data, setData] = useState<Array<Notification>>();
   const [error, setError] = useState<NovuError>();
   const [isLoading, setIsLoading] = useState(true);
@@ -85,21 +85,60 @@ export const useNotifications = (props?: UseNotificationsProps): UseNotification
   const length = data?.length;
   const after = length ? data[length - 1].id : undefined;
 
-  const sync = (event: { data?: ListNotificationsResponse }) => {
-    if (!event.data || (filterRef.current && !isSameFilter(filterRef.current, event.data.filter))) {
-      return;
-    }
-    setData(event.data.notifications);
-    setHasMore(event.data.hasMore);
-  };
+  useWebSocketEvent({
+    event: 'notifications.unread_count_changed',
+    eventHandler: () => {
+      void refetch();
+    },
+  });
 
-  useEffect(() => {
-    const cleanup = on('notifications.list.updated', sync);
+  useWebSocketEvent({
+    event: 'notifications.unseen_count_changed',
+    eventHandler: () => {
+      void refetch();
+    },
+  });
 
-    return () => {
-      cleanup();
-    };
-  }, []);
+  useWebSocketEvent({
+    event: 'notifications.notification_received',
+    eventHandler: ({ result: notification }) => {
+      const currentFilter = filterRef.current;
+      const matches = currentFilter ? checkNotificationMatchesFilter(notification, currentFilter) : false;
+      if (matches) void refetch();
+    },
+  });
+
+  const fetchNotifications = useCallback(
+    async (options?: { refetch: boolean }) => {
+      if (options?.refetch) {
+        setError(undefined);
+        setIsLoading(true);
+        setIsFetching(false);
+      }
+      setIsFetching(true);
+      const response = await notifications.list({
+        tags,
+        data: dataFilter,
+        read,
+        archived,
+        snoozed,
+        seen,
+        limit,
+        after: options?.refetch ? undefined : after,
+      });
+      if (response.error) {
+        setError(response.error);
+        onError?.(response.error);
+      } else if (response.data) {
+        onSuccess?.(response.data.notifications);
+        setData(response.data.notifications);
+        setHasMore(response.data.hasMore);
+      }
+      setIsLoading(false);
+      setIsFetching(false);
+    },
+    [notifications, tags, dataFilter, read, archived, snoozed, seen, limit, after, onError, onSuccess]
+  );
 
   useEffect(() => {
     const newFilter = { tags, data: dataFilter, read, archived, snoozed, seen };
@@ -110,36 +149,7 @@ export const useNotifications = (props?: UseNotificationsProps): UseNotification
     filterRef.current = newFilter;
 
     fetchNotifications({ refetch: true });
-  }, [tags, dataFilter, read, archived, snoozed, seen]);
-
-  const fetchNotifications = async (options?: { refetch: boolean }) => {
-    if (options?.refetch) {
-      setError(undefined);
-      setIsLoading(true);
-      setIsFetching(false);
-    }
-    setIsFetching(true);
-    const response = await notifications.list({
-      tags,
-      data: dataFilter,
-      read,
-      archived,
-      snoozed,
-      seen,
-      limit,
-      after: options?.refetch ? undefined : after,
-    });
-    if (response.error) {
-      setError(response.error);
-      onError?.(response.error);
-    } else {
-      onSuccess?.(response.data!.notifications);
-      setData(response.data!.notifications);
-      setHasMore(response.data!.hasMore);
-    }
-    setIsLoading(false);
-    setIsFetching(false);
-  };
+  }, [tags, dataFilter, read, archived, snoozed, seen, notifications, fetchNotifications]);
 
   const refetch = () => {
     notifications.clearCache({ filter: { tags, read, archived, snoozed, seen, data: dataFilter } });


### PR DESCRIPTION
### What changed? Why was the change needed?

Adds realtime updates to `useNotifications()` hook for all filters.

This approach is a bit more naive and more consistent with how the useCounts() hook works already. 

Alternative approach with direct cache manipulation and less API calls - more aligned with how `@novu/js` Inbox does realtime updates, however more complicated : https://github.com/novuhq/novu/pull/8885

I think I would prefer this approach cause its slightly more simpler code-wise and aligned with the other hook. 

https://github.com/user-attachments/assets/ab09ef3a-8702-4878-8675-0550f093a9ec

