### PR TITLE
fix(dashboard): activity feed stale refresh

### DIFF
--- a/apps/dashboard/src/components/activity/activity-feed-content.tsx
+++ b/apps/dashboard/src/components/activity/activity-feed-content.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { ActivityError } from '@/components/activity/activity-error';
 import { ActivityFilters } from '@/components/activity/activity-filters';
@@ -13,11 +14,12 @@ import { defaultActivityFilters } from '@/components/activity/constants';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/primitives/resizable';
 import { UpdatedAgo } from '@/components/updated-ago';
 import { useActivityUrlState } from '@/hooks/use-activity-url-state';
-import { useFetchActivities } from '@/hooks/use-fetch-activities';
 import { usePullActivity } from '@/hooks/use-pull-activity';
 import { ActivityFiltersData } from '@/types/activity';
 import { cn } from '../../utils/ui';
 import { EmptyTopicsIllustration } from '../topics/empty-topics-illustration';
+import { useEnvironment } from '@/context/environment/hooks';
+import { QueryKeys } from '@/utils/query-keys';
 
 type ActivityFeedContentProps = {
   initialFilters?: Partial<ActivityFiltersData>;
@@ -37,9 +39,11 @@ export function ActivityFeedContent({
   const { activityItemId, filters, filterValues, handleActivitySelect, handleFiltersChange } = useActivityUrlState();
   const { activity, isPending, error } = usePullActivity(activityItemId);
 
+  const queryClient = useQueryClient();
+  const { currentEnvironment } = useEnvironment();
+
   // Track last updated time for the activities list
   const [lastUpdated, setLastUpdated] = useState(new Date());
-  const { refetch } = useFetchActivities({ filters, page: 0, limit: 10 });
 
   useEffect(() => {
     setLastUpdated(new Date());
@@ -123,7 +127,7 @@ export function ActivityFeedContent({
   );
 
   const handleRefresh = async () => {
-    await refetch();
+    await queryClient.invalidateQueries({ queryKey: [QueryKeys.fetchActivities, currentEnvironment?._id] });
     setLastUpdated(new Date());
   };
 


### PR DESCRIPTION
### What changed? Why was the change needed?

The dashboard refresh button was not rendering new workflow runs, as reported in [NV-6463](https://linear.app/novu/issue/NV-6463/dashboard-refresh-button-will-not-render-new-workflow-runs). This was due to the refresh button calling a separate `useFetchActivities` refetch with a different query key than the one used by the activity table.

To resolve this, the refresh logic in `ActivityFeedContent` was updated to invalidate the correct React Query key (`QueryKeys.fetchActivities` combined with the current environment ID). This ensures that the activity table's data is properly refetched and new workflow runs are displayed.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

A full monorepo build was not performed due to dependency issues, but the dashboard file compiles locally and the change is type-safe.

</details>

---
<a href="https://cursor.com/background-agent?bcId=bc-d46baa8c-2cfb-45b6-b080-e010bf872001">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d46baa8c-2cfb-45b6-b080-e010bf872001">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

