### PR TITLE
fix(dashboard): show read only schema & preferences drawer in prod env

### DIFF
--- a/apps/dashboard/src/components/schema-editor/components/array-section.tsx
+++ b/apps/dashboard/src/components/schema-editor/components/array-section.tsx
@@ -24,6 +24,7 @@ interface ArrayItemPropertyProps {
   arrayItemPath: string;
   onCheckVariableUsage?: (keyName: string, parentPath: string) => VariableUsageInfo;
   depth: number;
+  readOnly?: boolean;
 }
 
 const ArrayItemProperty = memo<ArrayItemPropertyProps>(function ArrayItemProperty({
@@ -35,6 +36,7 @@ const ArrayItemProperty = memo<ArrayItemPropertyProps>(function ArrayItemPropert
   arrayItemPath,
   onCheckVariableUsage,
   depth,
+  readOnly = false,
 }) {
   const itemNestedItem = useWatch({
     control,
@@ -58,6 +60,7 @@ const ArrayItemProperty = memo<ArrayItemPropertyProps>(function ArrayItemPropert
       variableUsageInfo={itemVariableUsageInfo}
       onCheckVariableUsage={onCheckVariableUsage}
       depth={depth + 1}
+      readOnly={readOnly}
     />
   );
 });
@@ -72,6 +75,7 @@ interface ArraySectionProps {
   currentFullPath: string;
   onCheckVariableUsage?: (keyName: string, parentPath: string) => VariableUsageInfo;
   depth: number;
+  readOnly?: boolean;
 }
 
 export const ArraySection = memo<ArraySectionProps>(function ArraySection({
@@ -84,6 +88,7 @@ export const ArraySection = memo<ArraySectionProps>(function ArraySection({
   currentFullPath,
   onCheckVariableUsage,
   depth,
+  readOnly = false,
 }) {
   const itemSchemaObject = useWatch({ control, name: itemSchemaObjectPath }) as JSONSchema7 | undefined;
   const itemIsObject = itemSchemaObject?.type === 'object';
@@ -124,6 +129,7 @@ export const ArraySection = memo<ArraySectionProps>(function ArraySection({
           control={control}
           setValue={setValue}
           getValues={getValues}
+          isDisabled={readOnly}
         />
       </div>
 
@@ -139,6 +145,7 @@ export const ArraySection = memo<ArraySectionProps>(function ArraySection({
               arrayItemPath={arrayItemPath}
               onCheckVariableUsage={onCheckVariableUsage}
               depth={depth}
+              readOnly={readOnly}
             />
           ))}
           {isAtMaxDepth && (
@@ -154,7 +161,7 @@ export const ArraySection = memo<ArraySectionProps>(function ArraySection({
               onClick={handleAddArrayItemObjectProperty}
               leadingIcon={RiAddLine}
               className="mt-1"
-              disabled={isAtMaxDepth}
+              disabled={isAtMaxDepth || readOnly}
             >
               Add Item Property
             </Button>

--- a/apps/dashboard/src/components/schema-editor/components/object-section.tsx
+++ b/apps/dashboard/src/components/schema-editor/components/object-section.tsx
@@ -21,6 +21,7 @@ interface NestedPropertyProps {
   currentFullPath: string;
   onCheckVariableUsage?: (keyName: string, parentPath: string) => VariableUsageInfo;
   depth: number;
+  readOnly?: boolean;
 }
 
 const NestedProperty = memo<NestedPropertyProps>(function NestedProperty({
@@ -32,6 +33,7 @@ const NestedProperty = memo<NestedPropertyProps>(function NestedProperty({
   currentFullPath,
   onCheckVariableUsage,
   depth,
+  readOnly = false,
 }) {
   const nestedItem = useWatch({
     control,
@@ -54,6 +56,7 @@ const NestedProperty = memo<NestedPropertyProps>(function NestedProperty({
       variableUsageInfo={nestedVariableUsageInfo}
       onCheckVariableUsage={onCheckVariableUsage}
       depth={depth + 1}
+      readOnly={readOnly}
     />
   );
 });
@@ -65,6 +68,7 @@ interface ObjectSectionProps {
   currentFullPath: string;
   onCheckVariableUsage?: (keyName: string, parentPath: string) => VariableUsageInfo;
   depth: number;
+  readOnly?: boolean;
 }
 
 export const ObjectSection = memo<ObjectSectionProps>(function ObjectSection({
@@ -74,6 +78,7 @@ export const ObjectSection = memo<ObjectSectionProps>(function ObjectSection({
   currentFullPath,
   onCheckVariableUsage,
   depth,
+  readOnly = false,
 }) {
   const { fields, append, remove } = useFieldArray({
     control,
@@ -109,6 +114,7 @@ export const ObjectSection = memo<ObjectSectionProps>(function ObjectSection({
           currentFullPath={currentFullPath}
           onCheckVariableUsage={onCheckVariableUsage}
           depth={depth}
+          readOnly={readOnly}
         />
       ))}
       {isAtMaxDepth && (
@@ -123,7 +129,7 @@ export const ObjectSection = memo<ObjectSectionProps>(function ObjectSection({
           mode="lighter"
           onClick={handleAddNestedProperty}
           leadingIcon={RiAddLine}
-          disabled={isAtMaxDepth}
+          disabled={isAtMaxDepth || readOnly}
         >
           Add Nested Property
         </Button>

--- a/apps/dashboard/src/components/schema-editor/components/property-actions.tsx
+++ b/apps/dashboard/src/components/schema-editor/components/property-actions.tsx
@@ -55,9 +55,10 @@ export function PropertyActions({
         mode="ghost"
         size="2xs"
         leadingIcon={RiDeleteBin2Line}
-        onClick={onDeleteProperty}
+        onClick={isDisabled ? undefined : onDeleteProperty}
         aria-label="Delete property"
         className={cn('border-1 !ml-0 h-7 w-7 border-neutral-200')}
+        disabled={isDisabled}
       />
     </>
   );

--- a/apps/dashboard/src/components/schema-editor/schema-editor.tsx
+++ b/apps/dashboard/src/components/schema-editor/schema-editor.tsx
@@ -20,6 +20,7 @@ interface SchemaEditorProps {
   removeProperty: (index: number) => void;
   methods: UseFormReturn<SchemaEditorFormValues>;
   highlightedPropertyKey?: string | null;
+  readOnly?: boolean;
 }
 
 export function SchemaEditor({
@@ -30,6 +31,7 @@ export function SchemaEditor({
   removeProperty,
   methods,
   highlightedPropertyKey,
+  readOnly = false,
 }: SchemaEditorProps) {
   const { workflow } = useWorkflow();
 
@@ -81,6 +83,7 @@ export function SchemaEditor({
               variableUsageInfo={variableUsageInfo}
               onCheckVariableUsage={checkVariableUsage}
               depth={0}
+              readOnly={readOnly}
             />
           );
         })}
@@ -91,7 +94,7 @@ export function SchemaEditor({
             size="2xs"
             onClick={() => addProperty()}
             leadingIcon={RiAddLine}
-            disabled={!formState.isValid && fields.length > 0}
+            disabled={readOnly || (!formState.isValid && fields.length > 0)}
           >
             Add property
           </Button>

--- a/apps/dashboard/src/components/schema-editor/schema-property-row.tsx
+++ b/apps/dashboard/src/components/schema-editor/schema-property-row.tsx
@@ -30,6 +30,7 @@ export interface SchemaPropertyRowProps {
   onCheckVariableUsage?: (keyName: string, parentPath: string) => VariableUsageInfo;
   className?: string;
   depth?: number;
+  readOnly?: boolean;
 }
 
 export const SchemaPropertyRow = memo<SchemaPropertyRowProps>(function SchemaPropertyRow(props) {
@@ -44,6 +45,7 @@ export const SchemaPropertyRow = memo<SchemaPropertyRowProps>(function SchemaPro
     onCheckVariableUsage,
     className,
     depth = 0,
+    readOnly = false,
   } = props;
 
   const { setValue, getValues } = useFormContext();
@@ -77,12 +79,13 @@ export const SchemaPropertyRow = memo<SchemaPropertyRowProps>(function SchemaPro
       )}
     >
       <div className={cn('flex items-center gap-2', getMarginClassPx(indentationLevel))}>
-        <PropertyNameInput fieldPath={paths.keyName} control={control} autoFocus={isKeyNameEmpty} />
+        <PropertyNameInput fieldPath={paths.keyName} control={control} autoFocus={isKeyNameEmpty} isDisabled={readOnly} />
         <PropertyTypeSelector
           definitionPath={paths.definition}
           control={control}
           setValue={setValue}
           getValues={getValues}
+          isDisabled={readOnly}
         />
 
         <div className="flex items-center gap-1.5">
@@ -98,7 +101,7 @@ export const SchemaPropertyRow = memo<SchemaPropertyRowProps>(function SchemaPro
                         id={`${pathPrefix}-isRequired-checkbox`}
                         checked={!!field.value}
                         onCheckedChange={field.onChange}
-                        disabled={isKeyNameEmpty}
+                        disabled={isKeyNameEmpty || readOnly}
                       />
                     </div>
                   </TooltipTrigger>
@@ -114,7 +117,7 @@ export const SchemaPropertyRow = memo<SchemaPropertyRowProps>(function SchemaPro
           propertyKeyForDisplay={currentKeyName || ''}
           isRequiredPath={paths.isRequired}
           onDeleteProperty={onDeleteProperty}
-          isDisabled={isKeyNameEmpty}
+          isDisabled={isKeyNameEmpty || readOnly}
           variableUsageInfo={variableUsageInfo}
         />
       </div>
@@ -132,6 +135,7 @@ export const SchemaPropertyRow = memo<SchemaPropertyRowProps>(function SchemaPro
           currentFullPath={currentFullPath}
           onCheckVariableUsage={onCheckVariableUsage}
           depth={depth}
+          readOnly={readOnly}
         />
       )}
 
@@ -146,6 +150,7 @@ export const SchemaPropertyRow = memo<SchemaPropertyRowProps>(function SchemaPro
           currentFullPath={currentFullPath}
           onCheckVariableUsage={onCheckVariableUsage}
           depth={depth}
+          readOnly={readOnly}
         />
       )}
     </div>

--- a/apps/dashboard/src/components/workflow-editor/channel-preferences-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/channel-preferences-form.tsx
@@ -42,6 +42,7 @@ import { SeveritySelectItem } from './severity-select-item';
 type ConfigureWorkflowFormProps = {
   workflow: WorkflowResponseDto;
   update: UpdateWorkflowFn;
+  isReadOnly?: boolean;
 };
 
 const CHANNEL_LABELS_LOOKUP: Record<`${ChannelTypeEnum}` | 'all', string> = {
@@ -61,10 +62,11 @@ const checkHasEveryChannelSameValue = (
 };
 
 export const ChannelPreferencesForm = (props: ConfigureWorkflowFormProps) => {
-  const { workflow, update } = props;
+  const { workflow, update, isReadOnly: readOnlyProp } = props;
   const track = useTelemetry();
   const has = useHasPermission();
-  const isReadOnly = !has({ permission: PermissionsEnum.WORKFLOW_WRITE });
+  const permissionReadOnly = !has({ permission: PermissionsEnum.WORKFLOW_WRITE });
+  const isReadOnly = readOnlyProp ?? permissionReadOnly;
   const isNotificationSeverityEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_NOTIFICATION_SEVERITY_ENABLED);
 
   const isDefaultPreferences = useMemo(() => workflow.preferences.user === null, [workflow.preferences.user]);
@@ -100,7 +102,7 @@ export const ChannelPreferencesForm = (props: ConfigureWorkflowFormProps) => {
 
   const overrideForm = useForm({
     defaultValues: {
-      override: isDashboardWorkflow ? true : !isDefaultPreferences,
+      override: isReadOnly ? false : isDashboardWorkflow ? true : !isDefaultPreferences,
     },
   });
 
@@ -243,6 +245,7 @@ export const ChannelPreferencesForm = (props: ConfigureWorkflowFormProps) => {
                               new_status: checked,
                             });
                           }}
+                          disabled={isReadOnly}
                         />
                       </FormControl>
                     </FormItem>
@@ -265,7 +268,11 @@ export const ChannelPreferencesForm = (props: ConfigureWorkflowFormProps) => {
                       Critical workflow
                     </FormLabel>
                     <FormControl>
-                      <Switch checked={field.value} onCheckedChange={handleCriticalToggle} disabled={!override} />
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={handleCriticalToggle}
+                        disabled={!override || isReadOnly}
+                      />
                     </FormControl>
                   </FormItem>
                 )}
@@ -297,9 +304,7 @@ export const ChannelPreferencesForm = (props: ConfigureWorkflowFormProps) => {
                                 <span className="text-text-soft text-2xs">Why it matters:</span>
                                 <ul className="text-text-sub text-2xs list-disc pl-4">
                                   <li>
-                                    {
-                                      'Helps your subscribers spot what’s urgent. Affects color coding, ordering, and behavior in <Inbox />.'
-                                    }
+                                    {'Helps your subscribers spot what’s urgent. Affects color coding, ordering, and behavior in <Inbox />.'}
                                   </li>
                                 </ul>
                               </div>
@@ -364,7 +369,7 @@ export const ChannelPreferencesForm = (props: ConfigureWorkflowFormProps) => {
                     <Checkbox
                       checked={field.value}
                       onCheckedChange={handleAllToggle}
-                      disabled={!override || formDataToRender?.channelsInUse.length === 0}
+                      disabled={!override || isReadOnly || formDataToRender?.channelsInUse.length === 0}
                     />
                   </FormControl>
                 )}
@@ -397,7 +402,7 @@ export const ChannelPreferencesForm = (props: ConfigureWorkflowFormProps) => {
                             <Switch
                               checked={field.value}
                               onCheckedChange={(checked) => handleChannelToggle(channel as ChannelTypeEnum, checked)}
-                              disabled={!override}
+                              disabled={!override || isReadOnly}
                             />
                           </FormControl>
                         </FormItem>

--- a/apps/dashboard/src/components/workflow-editor/channel-preferences.tsx
+++ b/apps/dashboard/src/components/workflow-editor/channel-preferences.tsx
@@ -1,12 +1,18 @@
 import { useWorkflow } from '@/components/workflow-editor/workflow-provider';
 import { ChannelPreferencesForm } from './channel-preferences-form';
+import { useEnvironment } from '@/context/environment/hooks';
+import { EnvironmentTypeEnum, ResourceOriginEnum } from '@novu/shared';
 
 export function ChannelPreferences() {
   const { workflow, update } = useWorkflow();
+  const { currentEnvironment } = useEnvironment();
 
   if (!workflow) {
     return null;
   }
 
-  return <ChannelPreferencesForm workflow={workflow} update={update} />;
+  const isReadOnly =
+    workflow.origin === ResourceOriginEnum.EXTERNAL || currentEnvironment?.type !== EnvironmentTypeEnum.DEV;
+
+  return <ChannelPreferencesForm workflow={workflow} update={update} isReadOnly={isReadOnly} />;
 }

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -220,12 +220,13 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
         onConfirm={onDeleteWorkflow}
         isLoading={isDeleteWorkflowPending}
       />
-      <PayloadSchemaDrawer
-        workflow={workflow}
-        isOpen={isPayloadSchemaDrawerOpen}
-        onOpenChange={setIsPayloadSchemaDrawerOpen}
-        onSave={handleSavePayloadSchema}
-      />
+              <PayloadSchemaDrawer
+          workflow={workflow}
+          isOpen={isPayloadSchemaDrawerOpen}
+          onOpenChange={setIsPayloadSchemaDrawerOpen}
+          onSave={handleSavePayloadSchema}
+          readOnly={isReadOnly}
+        />
       <PageMeta title={workflow.name} />
       <motion.div
         className={cn('relative flex h-full w-full flex-col')}
@@ -452,10 +453,10 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
             </SidebarContent>
           </FormRoot>
         </Form>
-        {currentEnvironment?.type === EnvironmentTypeEnum.DEV && (
-          <>
-            <Separator />
-            <SidebarContent size="lg">
+                {true && (
+           <>
+             <Separator />
+             <SidebarContent size="lg">
               <Link to={ROUTES.EDIT_WORKFLOW_PREFERENCES}>
                 <Button
                   variant="secondary"

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -453,8 +453,7 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
             </SidebarContent>
           </FormRoot>
         </Form>
-                {true && (
-           <>
+                <>
              <Separator />
              <SidebarContent size="lg">
               <Link to={ROUTES.EDIT_WORKFLOW_PREFERENCES}>
@@ -499,7 +498,6 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
             </SidebarContent>
             <Separator />
           </>
-        )}
       </motion.div>
     </>
   );

--- a/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
@@ -39,6 +39,7 @@ type PayloadSchemaDrawerProps = {
   isLoadingWorkflow?: boolean;
   onSave?: (schema: JSONSchema7) => void;
   highlightedPropertyKey?: string | null;
+  readOnly?: boolean;
 };
 
 type PayloadSchemaFormData = {
@@ -52,6 +53,7 @@ export function PayloadSchemaDrawer({
   isLoadingWorkflow,
   onSave,
   highlightedPropertyKey,
+  readOnly = false,
 }: PayloadSchemaDrawerProps) {
   const [drawerSchema, setDrawerSchema] = useState<JSONSchema7 | undefined>(workflow?.payloadSchema);
   const [originalSchema, setOriginalSchema] = useState<JSONSchema7 | undefined>();
@@ -252,7 +254,7 @@ export function PayloadSchemaDrawer({
                             payloadSchemaForm.setValue('validatePayload', value, { shouldDirty: true });
                             setValidatePayload(value);
                           }}
-                          disabled={isLoadingWorkflow}
+                          disabled={isLoadingWorkflow || readOnly}
                         />
                       </div>
                     </>
@@ -261,16 +263,18 @@ export function PayloadSchemaDrawer({
                   {isLoadingWorkflow ? (
                     <div className="flex h-full items-center justify-center">Loading workflow schema...</div>
                   ) : hasPayloadSchema ? (
-                    <SchemaEditor
-                      key={workflow?.slug}
-                      control={control}
-                      fields={fields}
-                      formState={formState}
-                      addProperty={addProperty}
-                      removeProperty={removeProperty}
-                      methods={formMethods}
-                      highlightedPropertyKey={highlightedPropertyKey}
-                    />
+                    <div className={readOnly ? 'pointer-events-none' : undefined}>
+                      <SchemaEditor
+                        key={workflow?.slug}
+                        control={control}
+                        fields={fields}
+                        formState={formState}
+                        addProperty={addProperty}
+                        removeProperty={removeProperty}
+                        methods={formMethods}
+                        highlightedPropertyKey={highlightedPropertyKey}
+                      />
+                    </div>
                   ) : isImportMode ? (
                     <PayloadImportEditor
                       isLoadingActivity={isLoadingActivity}
@@ -282,13 +286,17 @@ export function PayloadSchemaDrawer({
                       isManualImport={isManualImport}
                     />
                   ) : (
-                    <PayloadSchemaEmptyState
-                      onAddProperty={addProperty}
-                      isPayloadSchemaEnabled={true}
-                      hasNoSchema={!workflow?.payloadSchema}
-                      onImportSchema={handleImportSchema}
-                      onImportFromJson={handleImportFromJson}
-                    />
+                    readOnly ? (
+                      <div className="text-text-soft text-xs p-2">No payload schema defined.</div>
+                    ) : (
+                      <PayloadSchemaEmptyState
+                        onAddProperty={addProperty}
+                        isPayloadSchemaEnabled={true}
+                        hasNoSchema={!workflow?.payloadSchema}
+                        onImportSchema={handleImportSchema}
+                        onImportFromJson={handleImportFromJson}
+                      />
+                    )
                   )}
                 </div>
 
@@ -320,7 +328,9 @@ export function PayloadSchemaDrawer({
                     onClick={handleSaveWithValidation}
                     isLoading={isSaving}
                     data-test-id="save-payload-schema-btn"
-                    disabled={!isSchemaValid || !formState.isValid || isSaving || isLoadingWorkflow || isImportMode}
+                    disabled={
+                      readOnly || !isSchemaValid || !formState.isValid || isSaving || isLoadingWorkflow || isImportMode
+                    }
                   >
                     Save Changes
                   </Button>

--- a/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
@@ -263,18 +263,17 @@ export function PayloadSchemaDrawer({
                   {isLoadingWorkflow ? (
                     <div className="flex h-full items-center justify-center">Loading workflow schema...</div>
                   ) : hasPayloadSchema ? (
-                    <div className={readOnly ? 'pointer-events-none' : undefined}>
-                      <SchemaEditor
-                        key={workflow?.slug}
-                        control={control}
-                        fields={fields}
-                        formState={formState}
-                        addProperty={addProperty}
-                        removeProperty={removeProperty}
-                        methods={formMethods}
-                        highlightedPropertyKey={highlightedPropertyKey}
-                      />
-                    </div>
+                    <SchemaEditor
+                      key={workflow?.slug}
+                      control={control}
+                      fields={fields}
+                      formState={formState}
+                      addProperty={addProperty}
+                      removeProperty={removeProperty}
+                      methods={formMethods}
+                      highlightedPropertyKey={highlightedPropertyKey}
+                      readOnly={readOnly}
+                    />
                   ) : isImportMode ? (
                     <PayloadImportEditor
                       isLoadingActivity={isLoadingActivity}
@@ -286,17 +285,13 @@ export function PayloadSchemaDrawer({
                       isManualImport={isManualImport}
                     />
                   ) : (
-                    readOnly ? (
-                      <div className="text-text-soft text-xs p-2">No payload schema defined.</div>
-                    ) : (
-                      <PayloadSchemaEmptyState
-                        onAddProperty={addProperty}
-                        isPayloadSchemaEnabled={true}
-                        hasNoSchema={!workflow?.payloadSchema}
-                        onImportSchema={handleImportSchema}
-                        onImportFromJson={handleImportFromJson}
-                      />
-                    )
+                    <PayloadSchemaEmptyState
+                      onAddProperty={readOnly ? () => {} : addProperty}
+                      isPayloadSchemaEnabled={true}
+                      hasNoSchema={!workflow?.payloadSchema}
+                      onImportSchema={readOnly ? () => {} : handleImportSchema}
+                      onImportFromJson={readOnly ? () => {} : handleImportFromJson}
+                    />
                   )}
                 </div>
 

--- a/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/payload-schema-drawer.tsx
@@ -286,11 +286,12 @@ export function PayloadSchemaDrawer({
                     />
                   ) : (
                     <PayloadSchemaEmptyState
-                      onAddProperty={readOnly ? () => {} : addProperty}
+                      onAddProperty={addProperty}
                       isPayloadSchemaEnabled={true}
                       hasNoSchema={!workflow?.payloadSchema}
-                      onImportSchema={readOnly ? () => {} : handleImportSchema}
-                      onImportFromJson={readOnly ? () => {} : handleImportFromJson}
+                      onImportSchema={handleImportSchema}
+                      onImportFromJson={handleImportFromJson}
+                      disabled={readOnly}
                     />
                   )}
                 </div>

--- a/apps/dashboard/src/components/workflow-editor/payload-schema/components/payload-schema-empty-state.tsx
+++ b/apps/dashboard/src/components/workflow-editor/payload-schema/components/payload-schema-empty-state.tsx
@@ -8,6 +8,7 @@ type PayloadSchemaEmptyStateProps = {
   hasNoSchema: boolean;
   onImportSchema: () => void;
   onImportFromJson: () => void;
+  disabled?: boolean;
 };
 
 export function PayloadSchemaEmptyState({
@@ -16,6 +17,7 @@ export function PayloadSchemaEmptyState({
   hasNoSchema,
   onImportSchema,
   onImportFromJson,
+  disabled = false,
 }: PayloadSchemaEmptyStateProps) {
   const isNewSchemaScenario = isPayloadSchemaEnabled && hasNoSchema;
 
@@ -41,19 +43,19 @@ export function PayloadSchemaEmptyState({
 
       <div className="flex flex-col gap-2">
         <div className="flex flex-row items-center justify-center">
-          <Button variant="secondary" mode="outline" size="2xs" leadingIcon={RiAddLine} onClick={onAddProperty}>
+          <Button variant="secondary" mode="outline" size="2xs" leadingIcon={RiAddLine} onClick={onAddProperty} disabled={disabled}>
             Add property
           </Button>
         </div>
 
         {isNewSchemaScenario && (
-          <LinkButton className="text-label-xs" underline onClick={onImportSchema}>
+          <LinkButton className="text-label-xs" underline onClick={onImportSchema} disabled={disabled}>
             Import schema from recent payload
           </LinkButton>
         )}
 
         {!isNewSchemaScenario && (
-          <LinkButton className="text-label-xs" underline onClick={onImportFromJson}>
+          <LinkButton className="text-label-xs" underline onClick={onImportFromJson} disabled={disabled}>
             Import from JSON object
           </LinkButton>
         )}


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR introduces read-only functionality for the Workflow Preferences and Payload Schema drawers, addressing the requirement in [NV-6478](https://linear.app/novu/issue/NV-6478/dashboard-the-user-should-be-able-to-read-the-preferences-and-payload).

Previously, these drawers were only accessible and editable in the DEV environment. The change allows users to view (but not modify) these configurations in all environments (or for external workflows).

Specifically:
*   The "Preferences" and "Manage Payload Schema" buttons are now always visible.
*   When opened outside of the DEV environment, the drawers render in a read-only state, disabling all interactive elements (switches, toggles, save buttons) and preventing schema editing.

Fixes NV-6478

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

*   Please verify that all interactive elements within `ChannelPreferencesForm` and `PayloadSchemaDrawer` are correctly disabled when `isReadOnly` is true.
*   Confirm the logic for determining `isReadOnly` (based on environment type or workflow origin) is accurate.

</details>

---
<a href="https://cursor.com/background-agent?bcId=bc-d7073678-2d6a-41ba-abf7-9282386f9d96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7073678-2d6a-41ba-abf7-9282386f9d96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced read-only mode across Schema Editor and Payload Schema Drawer, disabling edits, type changes, and save actions.
  * Array/Object sections and property rows now respect read-only, including “Add property” buttons and selectors.
  * Channel Preferences now supports read-only; switches and overrides disable accordingly.
  * Read-only is auto-applied when workflows are external or environment isn’t development.
  * “Configure channel preferences” is now visible in all environments.
* Bug Fixes
  * Delete action no longer triggers when the button is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->