### PR TITLE
fix(api): avoid invalid dates in self-hosted activity feed retention 

### DIFF
--- a/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
@@ -130,9 +130,9 @@ export class GetActivityFeed {
    * @see https://github.com/novuhq/cloud-infra/blob/main/scripts/expiredNotification.js#L93
    */
   private getMaxRetentionPeriodByOrganization(organization: OrganizationEntity) {
-    // 1. Self-hosted gets unlimited retention both community and enterprise
+    // 1. Self-hosted: effectively unlimited, use a large but safe finite window (100 years)
     if (process.env.IS_SELF_HOSTED === 'true') {
-      return Number.MAX_SAFE_INTEGER;
+      return 100 * 365 * 24 * 60 * 60 * 1000; // ~100 years in ms, safe for Date math
     }
 
     const { apiServiceLevel, createdAt } = organization;

--- a/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
@@ -71,15 +71,29 @@ export class GetActivityFeed {
       throw new HttpException('Organization not found', HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    const maxRetentionMs = this.getMaxRetentionPeriodByOrganization(organization);
+    const isSelfHosted = process.env.IS_SELF_HOSTED === 'true';
 
-    const earliestAllowedDate = new Date(Date.now() - maxRetentionMs);
+    // Compute earliest allowed date safely
+    const earliestAllowedDate = isSelfHosted
+      ? new Date(0) // effectively unlimited but safe epoch date
+      : new Date(Date.now() - this.getMaxRetentionPeriodByOrganization(organization));
 
-    // If no after date is provided, default to the earliest allowed date
+    // Parse incoming dates
     const effectiveAfterDate = after ? new Date(after) : earliestAllowedDate;
     const effectiveBeforeDate = before ? new Date(before) : new Date();
 
-    this.validateDateRange(earliestAllowedDate, effectiveAfterDate, effectiveBeforeDate);
+    // Guard invalid inputs to avoid RangeError when serializing
+    if (Number.isNaN(effectiveAfterDate.getTime())) {
+      throw new HttpException('Invalid "after" date', HttpStatus.BAD_REQUEST);
+    }
+    if (Number.isNaN(effectiveBeforeDate.getTime())) {
+      throw new HttpException('Invalid "before" date', HttpStatus.BAD_REQUEST);
+    }
+
+    // Enforce retention limits only for cloud
+    if (!isSelfHosted) {
+      this.validateDateRange(earliestAllowedDate, effectiveAfterDate, effectiveBeforeDate);
+    }
 
     return {
       after: effectiveAfterDate.toISOString(),

--- a/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
@@ -71,22 +71,14 @@ export class GetActivityFeed {
       throw new HttpException('Organization not found', HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    // Compute earliest allowed date safely
-    const earliestAllowedDate = new Date(Date.now() - this.getMaxRetentionPeriodByOrganization(organization));
+    const maxRetentionMs = this.getMaxRetentionPeriodByOrganization(organization);
 
-    // Parse incoming dates
+    const earliestAllowedDate = new Date(Date.now() - maxRetentionMs);
+
+    // If no after date is provided, default to the earliest allowed date
     const effectiveAfterDate = after ? new Date(after) : earliestAllowedDate;
     const effectiveBeforeDate = before ? new Date(before) : new Date();
 
-    // Guard invalid inputs to avoid RangeError when serializing
-    if (Number.isNaN(effectiveAfterDate.getTime())) {
-      throw new HttpException('Invalid "after" date', HttpStatus.BAD_REQUEST);
-    }
-    if (Number.isNaN(effectiveBeforeDate.getTime())) {
-      throw new HttpException('Invalid "before" date', HttpStatus.BAD_REQUEST);
-    }
-
-    // Enforce retention limits
     this.validateDateRange(earliestAllowedDate, effectiveAfterDate, effectiveBeforeDate);
 
     return {

--- a/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
@@ -71,12 +71,8 @@ export class GetActivityFeed {
       throw new HttpException('Organization not found', HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    const isSelfHosted = process.env.IS_SELF_HOSTED === 'true';
-
     // Compute earliest allowed date safely
-    const earliestAllowedDate = isSelfHosted
-      ? new Date(0) // effectively unlimited but safe epoch date
-      : new Date(Date.now() - this.getMaxRetentionPeriodByOrganization(organization));
+    const earliestAllowedDate = new Date(Date.now() - this.getMaxRetentionPeriodByOrganization(organization));
 
     // Parse incoming dates
     const effectiveAfterDate = after ? new Date(after) : earliestAllowedDate;
@@ -90,10 +86,8 @@ export class GetActivityFeed {
       throw new HttpException('Invalid "before" date', HttpStatus.BAD_REQUEST);
     }
 
-    // Enforce retention limits only for cloud
-    if (!isSelfHosted) {
-      this.validateDateRange(earliestAllowedDate, effectiveAfterDate, effectiveBeforeDate);
-    }
+    // Enforce retention limits
+    this.validateDateRange(earliestAllowedDate, effectiveAfterDate, effectiveBeforeDate);
 
     return {
       after: effectiveAfterDate.toISOString(),


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixes NV-6385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted activity feed data retention for self-hosted deployments to a finite window (100 years) instead of an effectively unlimited duration, ensuring consistent and predictable retention behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->