### PR TITLE
feat(api,js): add tx id to inbox notification fixes NV-6457

### DIFF
--- a/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.spec.ts
+++ b/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.spec.ts
@@ -71,6 +71,7 @@ describe('SnoozeNotification', () => {
 
   const mockNotification: InboxNotification = {
     id: validNotificationId,
+    transactionId: 'transaction-id',
     body: 'Test notification',
     to: {
       subscriberId: validSubscriberId,

--- a/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.spec.ts
+++ b/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.spec.ts
@@ -55,6 +55,7 @@ describe('UnsnoozeNotification', () => {
 
   const mockNotification: InboxNotification = {
     id: validNotificationId,
+    transactionId: 'transaction-id',
     body: 'Test notification content',
     to: {
       subscriberId: validSubscriberId,

--- a/apps/api/src/app/inbox/utils/notification-mapper.ts
+++ b/apps/api/src/app/inbox/utils/notification-mapper.ts
@@ -24,6 +24,7 @@ const mapSingleItem = ({
   severity,
   data,
   template,
+  transactionId,
 }: MessageEntity): InboxNotification => {
   const to: Subscriber = {
     id: subscriber?._id ?? '',
@@ -39,6 +40,7 @@ const mapSingleItem = ({
 
   return {
     id: _id,
+    transactionId,
     subject,
     body: content as string,
     to,

--- a/apps/api/src/app/inbox/utils/types.ts
+++ b/apps/api/src/app/inbox/utils/types.ts
@@ -23,6 +23,7 @@ type Action = {
 
 export type InboxNotification = {
   id: string;
+  transactionId: string;
   subject?: string;
   body: string;
   to: Subscriber;

--- a/packages/js/src/cache/notifications-cache.test.ts
+++ b/packages/js/src/cache/notifications-cache.test.ts
@@ -27,6 +27,7 @@ describe('NotificationsCache', () => {
     notification1 = new Notification(
       {
         id: '1',
+        transactionId: 'tx-1',
         body: 'test1',
         isRead: false,
         isArchived: false,
@@ -49,6 +50,7 @@ describe('NotificationsCache', () => {
     notification2 = new Notification(
       {
         id: '2',
+        transactionId: 'tx-2',
         body: 'test2',
         isRead: false,
         isSeen: false,

--- a/packages/js/src/notifications/notification.ts
+++ b/packages/js/src/notifications/notification.ts
@@ -8,6 +8,7 @@ export class Notification implements Pick<NovuEventEmitter, 'on'>, InboxNotifica
   #inboxService: InboxService;
 
   readonly id: InboxNotification['id'];
+  readonly transactionId: InboxNotification['transactionId'];
   readonly subject?: InboxNotification['subject'];
   readonly body: InboxNotification['body'];
   readonly to: InboxNotification['to'];
@@ -35,6 +36,7 @@ export class Notification implements Pick<NovuEventEmitter, 'on'>, InboxNotifica
     this.#inboxService = inboxService;
 
     this.id = notification.id;
+    this.transactionId = notification.transactionId;
     this.subject = notification.subject;
     this.body = notification.body;
     this.to = notification.to;

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -106,6 +106,7 @@ export type Workflow = {
 
 export type InboxNotification = {
   id: string;
+  transactionId: string;
   subject?: string;
   body: string;
   to: Subscriber;

--- a/packages/js/src/ws/party-socket.ts
+++ b/packages/js/src/ws/party-socket.ts
@@ -29,6 +29,7 @@ const UNREAD_COUNT_CHANGED: NotificationUnreadEvent = 'notifications.unread_coun
 
 const mapToNotification = ({
   _id,
+  transactionId,
   content,
   read,
   seen,
@@ -67,6 +68,7 @@ const mapToNotification = ({
 
   return {
     id: _id,
+    transactionId,
     subject,
     body: content as string,
     to,

--- a/packages/js/src/ws/socket.ts
+++ b/packages/js/src/ws/socket.ts
@@ -29,6 +29,7 @@ const UNREAD_COUNT_CHANGED: NotificationUnreadEvent = 'notifications.unread_coun
 
 const mapToNotification = ({
   _id,
+  transactionId,
   content,
   read,
   seen,
@@ -67,6 +68,7 @@ const mapToNotification = ({
 
   return {
     id: _id,
+    transactionId,
     subject,
     body: content as string,
     to,

--- a/playground/nextjs/src/pages/hooks/_components/notion-theme.tsx
+++ b/playground/nextjs/src/pages/hooks/_components/notion-theme.tsx
@@ -86,6 +86,8 @@ export const NotionTheme = () => {
   const { counts } = useCounts({ filters: [{ read: false, tags: ['chat'] }] });
   const { notifications, isLoading, isFetching, hasMore, fetchMore, error } = useNotifications(filter);
 
+  console.log(notifications);
+
   return (
     <div className="flex min-h-[600px] w-full max-w-[1200px] rounded-lg bg-white">
       <div className="flex w-[240px] shrink-0 flex-col border-gray-200 bg-[#f7f7f5] p-4 shadow-lg">

--- a/playground/nextjs/src/pages/hooks/_components/notion-theme.tsx
+++ b/playground/nextjs/src/pages/hooks/_components/notion-theme.tsx
@@ -86,8 +86,6 @@ export const NotionTheme = () => {
   const { counts } = useCounts({ filters: [{ read: false, tags: ['chat'] }] });
   const { notifications, isLoading, isFetching, hasMore, fetchMore, error } = useNotifications(filter);
 
-  console.log(notifications);
-
   return (
     <div className="flex min-h-[600px] w-full max-w-[1200px] rounded-lg bg-white">
       <div className="flex w-[240px] shrink-0 flex-col border-gray-200 bg-[#f7f7f5] p-4 shadow-lg">


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Notifications now include a transaction ID, available across API responses, WebSocket updates, and the JavaScript SDK.
  - Developers can access transactionId on notification objects for easier tracking and correlation.

- Tests
  - Updated test fixtures to include transactionId in notification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->