### PR TITLE
Fix missing transactionId in notification tests

### DIFF
--- a/packages/js/src/cache/notifications-cache.test.ts
+++ b/packages/js/src/cache/notifications-cache.test.ts
@@ -27,6 +27,7 @@ describe('NotificationsCache', () => {
     notification1 = new Notification(
       {
         id: '1',
+        transactionId: 'tx-1',
         body: 'test1',
         isRead: false,
         isArchived: false,
@@ -49,6 +50,7 @@ describe('NotificationsCache', () => {
     notification2 = new Notification(
       {
         id: '2',
+        transactionId: 'tx-2',
         body: 'test2',
         isRead: false,
         isSeen: false,

--- a/packages/js/src/notifications/notification.ts
+++ b/packages/js/src/notifications/notification.ts
@@ -8,6 +8,7 @@ export class Notification implements Pick<NovuEventEmitter, 'on'>, InboxNotifica
   #inboxService: InboxService;
 
   readonly id: InboxNotification['id'];
+  readonly transactionId: InboxNotification['transactionId'];
   readonly subject?: InboxNotification['subject'];
   readonly body: InboxNotification['body'];
   readonly to: InboxNotification['to'];
@@ -35,6 +36,7 @@ export class Notification implements Pick<NovuEventEmitter, 'on'>, InboxNotifica
     this.#inboxService = inboxService;
 
     this.id = notification.id;
+    this.transactionId = notification.transactionId;
     this.subject = notification.subject;
     this.body = notification.body;
     this.to = notification.to;

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -106,6 +106,7 @@ export type Workflow = {
 
 export type InboxNotification = {
   id: string;
+  transactionId: string;
   subject?: string;
   body: string;
   to: Subscriber;

--- a/packages/js/src/ws/party-socket.ts
+++ b/packages/js/src/ws/party-socket.ts
@@ -47,6 +47,7 @@ const mapToNotification = ({
   tags,
   data,
   workflow,
+  transactionId,
 }: TODO): InboxNotification => {
   const to: Subscriber = {
     id: subscriber?._id,
@@ -67,6 +68,7 @@ const mapToNotification = ({
 
   return {
     id: _id,
+    transactionId,
     subject,
     body: content as string,
     to,

--- a/packages/js/src/ws/socket.ts
+++ b/packages/js/src/ws/socket.ts
@@ -47,6 +47,7 @@ const mapToNotification = ({
   tags,
   data,
   workflow,
+  transactionId,
 }: TODO): InboxNotification => {
   const to: Subscriber = {
     id: subscriber?._id,
@@ -67,6 +68,7 @@ const mapToNotification = ({
 
   return {
     id: _id,
+    transactionId,
     subject,
     body: content as string,
     to,


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves a TypeScript error (`TS2345`) in `notifications-cache.test.ts` by ensuring the `transactionId` property is correctly included in `InboxNotification` objects.

The `transactionId` was made a required property of `InboxNotification`, but the client-side `Notification` class, websocket mappers, and test mocks were not updated accordingly. This change propagates the `transactionId` property throughout the client-side types and objects, ensuring type consistency and fixing the failing tests.

### Screenshots

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

</details>

---
<a href="https://cursor.com/background-agent?bcId=bc-b3180495-e44d-41cc-a554-5f5ce03be521">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3180495-e44d-41cc-a554-5f5ce03be521">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

