### PR TITLE
fix(dashboard): hide getting started when onboarding complete fixes NV-6490

### DIFF
--- a/apps/dashboard/src/components/side-navigation/getting-started-menu-item.tsx
+++ b/apps/dashboard/src/components/side-navigation/getting-started-menu-item.tsx
@@ -38,7 +38,7 @@ export function GettingStartedMenuItem() {
     });
   };
 
-  if (user?.unsafeMetadata?.hideGettingStarted) {
+  if (user?.unsafeMetadata?.hideGettingStarted || allStepsCompleted) {
     return null;
   }
 


### PR DESCRIPTION
# fix(dashboard): hide getting started when onboarding complete

## Summary

Automatically hides the getting started menu item from the side navigation when all onboarding steps are completed (`allStepsCompleted` is true). This addresses Linear ticket NV-6490 which requested removal of the "4/4" completion tag after setup completion.

**Key Changes:**
- Modified visibility condition in `GettingStartedMenuItem` component to hide when `allStepsCompleted || user?.unsafeMetadata?.hideGettingStarted`
- Preserves existing manual hide functionality as a fallback
- Single line change that leverages existing completion state calculation

## Review & Testing Checklist for Human

- [ ] **Test end-to-end behavior**: Sign into dashboard, complete all onboarding steps (create workflow, connect provider, invite team member), and verify the getting started menu item disappears from side navigation
- [ ] **Verify requirement interpretation**: Confirm that hiding the entire menu item (not just the "4/4" badge) matches the intended behavior described in NV-6490
- [ ] **Test manual hide functionality**: Verify users can still manually close the getting started menu before completing all steps
- [ ] **Check edge cases**: Test what happens when completion state changes (e.g., if new onboarding steps are added in the future)
- [ ] **Verify no regressions**: Ensure the getting started/welcome page itself still functions correctly when accessed directly

**Recommended Test Plan:**
1. Start with a fresh organization or reset onboarding state
2. Navigate through each onboarding step and observe menu behavior
3. Complete final step and confirm menu disappears
4. Test manual close button on incomplete onboarding state

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    SideNav["apps/dashboard/src/components/<br/>side-navigation/<br/>side-navigation.tsx"]:::context
    GettingStarted["apps/dashboard/src/components/<br/>side-navigation/<br/>getting-started-menu-item.tsx"]:::major-edit
    OnboardingHook["apps/dashboard/src/hooks/<br/>use-onboarding-steps.ts"]:::context
    UserTypes["apps/dashboard/src/types/<br/>global.ts"]:::context

    SideNav -->|renders| GettingStarted
    GettingStarted -->|uses| OnboardingHook
    GettingStarted -->|checks| UserTypes
    OnboardingHook -->|calculates| AllStepsCompleted["allStepsCompleted<br/>(completedSteps === totalSteps)"]:::context
    UserTypes -->|defines| HideFlag["hideGettingStarted<br/>(manual hide flag)"]:::context

    AllStepsCompleted -->|OR| VisibilityCheck["if (hideGettingStarted || allStepsCompleted)<br/>return null"]:::major-edit
    HideFlag -->|OR| VisibilityCheck

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Testing limitation**: Unable to fully test the change locally due to dashboard authentication issues, so end-to-end verification by human reviewer is critical
- **Risk assessment**: Medium risk due to potential requirement misinterpretation and limited testing
- **Backward compatibility**: Change preserves existing manual hide functionality
- **Session info**: Requested by @ChmaraX, implemented in Devin session: https://app.devin.ai/sessions/ded7cf843d9c42799f544d4798fbbeea