### PR TITLE
fix(root): nx release publish issue for syntax error fixes NV-6506

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -103,9 +103,11 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ "${{ github.event.inputs.nightly }}" = "true" ]; then
-            pnpm nx release publish --projects=${{ github.event.inputs.packages }} --tag nightly
+            export NX_RELEASE_TAG=nightly
+            pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }}
           else
-            pnpm nx release publish --projects=${{ github.event.inputs.packages }}
+            export NX_RELEASE_TAG=latest
+            pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }}
           fi
 
       - name: Create Pull Request

--- a/packages/add-inbox/package.json
+++ b/packages/add-inbox/package.json
@@ -21,7 +21,7 @@
     "prebuild": "rimraf dist",
     "build": "tsc",
     "start": "ts-node src/cli/index.ts",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build > /dev/null 2>&1"
   },
   "keywords": [
     "novu",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -78,7 +78,6 @@
     "check": "biome check .",
     "check:fix": "biome check --write .",
     "test": "jest",
-    "publish": "pnpm publish",
     "publish:rc": "pnpm publish --tag rc"
   },
   "browserslist": {

--- a/packages/js/project.json
+++ b/packages/js/project.json
@@ -8,6 +8,12 @@
       "options": {
         "command": "npx biome lint packages/js"
       }
+    },
+    "nx-release-publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cd packages/js && pnpm publish --access public --no-git-checks --tag ${NX_RELEASE_TAG:-latest}"
+      }
     }
   }
 }

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -66,7 +66,6 @@
     "build": "tsup && pnpm run build:declarations && pnpm run check-exports",
     "build:declarations": "tsc -p tsconfig.declarations.json",
     "check-exports": "attw --pack . --ignore-rules unexpected-module-syntax",
-    "publish": "pnpm publish",
     "publish:rc": "pnpm publish --tag rc"
   },
   "browserslist": {

--- a/packages/nextjs/project.json
+++ b/packages/nextjs/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "@novu/nextjs",
+  "sourceRoot": "packages/nextjs/src",
+  "projectType": "library",
+  "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cd packages/nextjs && pnpm publish --access public --no-git-checks --tag ${NX_RELEASE_TAG:-latest}"
+      }
+    }
+  }
+}

--- a/packages/react-native/project.json
+++ b/packages/react-native/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "@novu/react-native",
+  "sourceRoot": "packages/react-native/src",
+  "projectType": "library",
+  "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cd packages/react-native && pnpm publish --access public --no-git-checks --tag ${NX_RELEASE_TAG:-latest}"
+      }
+    }
+  }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -96,7 +96,6 @@
     "check-exports": "attw --pack .",
     "check": "biome check .",
     "check:fix": "biome check --write .",
-    "publish": "pnpm publish",
     "publish:rc": "pnpm publish --tag rc"
   },
   "browserslist": {

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "@novu/react",
+  "sourceRoot": "packages/react/src",
+  "projectType": "library",
+  "targets": {
+    "nx-release-publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cd packages/react && pnpm publish --access public --no-git-checks --tag ${NX_RELEASE_TAG:-latest}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request updates the release workflow and publishing configuration for several packages to improve consistency and automation. The main changes involve switching to Nx's `run-many` command for publishing, introducing a custom `nx-release-publish` target for each package, and removing direct publish scripts from package manifests.

**Release workflow improvements:**

* Updated `.github/workflows/release-packages.yml` to use `pnpm nx run-many -t nx-release-publish` for publishing packages, with support for nightly and latest tags via the `NX_RELEASE_TAG` environment variable.

**Nx publish target additions:**

* Added a new `nx-release-publish` target to `project.json` files for `@novu/js`, `@novu/react`, `@novu/nextjs`, and `@novu/react-native`, enabling consistent publishing with custom options (public access, no git checks, dynamic tag). [[1]](diffhunk://#diff-a14fea68ee91e10681bea2e76c6d4726691ad8c3604de0ce5c0afa0d46ea861dR11-R16) [[2]](diffhunk://#diff-c47e14b052fab5f95556d22e24f043a2aaec7a1118d140699cae1e96b29b6f82R1-R13) [[3]](diffhunk://#diff-42671098f3562d810925eeb6de778dff2698bbb8b8e42a0e2bcb459245edecc9R1-R13) [[4]](diffhunk://#diff-8c7fdd818e901ec8e663dfaf79ce634c35ebb2a01b4800b74e3f0d0521dacba5R1-R13)

**Package manifest cleanup:**

* Removed the `"publish"` script from the `package.json` files of `@novu/js`, `@novu/react`, and `@novu/nextjs`, centralizing publish logic in Nx targets instead. [[1]](diffhunk://#diff-85663742722a5cab2cdb125e621f4f1a54b489e9d4e91bc63411997b3bc61a76L81) [[2]](diffhunk://#diff-1f344ac391eeecc21ec0f01fb07430a47f4b80d20485c125447d54c33c4bbfc4L99) [[3]](diffhunk://#diff-e5237f683dda3354b835c7c7c94b9759db2c743d4ba94d47d7f8b8e0b2bfb442L69)

**Build and publish script refinement:**

* Updated the `prepublishOnly` script in `packages/add-inbox/package.json` to suppress build output for cleaner logs.