### PR TITLE
chore(root): enhance release workflows with pnpm setup and dependency installation

### DIFF
--- a/.github/workflows/manual-post-release.yml
+++ b/.github/workflows/manual-post-release.yml
@@ -36,6 +36,34 @@ jobs:
         run: |
           git pull origin next
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+          run_install: false
+
+      - name: Setup Node Version
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.0'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build:packages
+
+      - name: Publish packages to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          export NX_RELEASE_TAG=latest
+          pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }}
+
       - name: Create and push tags
         run: |
           echo "Creating tags for packages: ${{ github.event.inputs.packages }}"

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -98,17 +98,13 @@ jobs:
       - name: Build packages
         run: pnpm run build:packages
 
-      - name: Publish packages
+      - name: Publish packages (nightly only)
+        if: ${{ github.event.inputs.nightly }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          if [ "${{ github.event.inputs.nightly }}" = "true" ]; then
-            export NX_RELEASE_TAG=nightly
-            pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }}
-          else
-            export NX_RELEASE_TAG=latest
-            pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }}
-          fi
+          export NX_RELEASE_TAG=nightly
+          pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }}
 
       - name: Create Pull Request
         id: create-pr


### PR DESCRIPTION
This pull request updates the release workflow configuration for publishing npm packages. The main changes include adding explicit steps for setting up the Node.js environment and pnpm in the manual post-release workflow, and simplifying the conditional logic for nightly vs. latest package publishing in the release workflow.

**Manual Post-Release Workflow Improvements:**

* Added steps to install `pnpm` using `pnpm/action-setup@v4` and set up Node.js version 20.19.0 with caching for pnpm dependencies in `.github/workflows/manual-post-release.yml`.
* Added explicit steps to install dependencies with `pnpm install --frozen-lockfile`, build packages, and publish them to npm using the `nx-release-publish` command.

**Release Workflow Simplification:**

* Simplified the publishing step in `.github/workflows/release-packages.yml` by making the publish step conditional on the `nightly` input, removing the previous if/else shell logic and only publishing with the `nightly` tag when appropriate.
