### PR TITLE
fix(js): new notification count in banner with multiple tabs fixes NV-6514

### DIFF
--- a/packages/js/src/ui/context/CountContext.tsx
+++ b/packages/js/src/ui/context/CountContext.tsx
@@ -138,6 +138,7 @@ export const CountProvider = (props: ParentProps) => {
       }
 
       const currentTabs = tabs();
+      const processedFilters = new Set<string>();
 
       if (currentTabs.length > 0) {
         for (const tab of currentTabs) {
@@ -155,6 +156,14 @@ export const CountProvider = (props: ParentProps) => {
             (!Array.isArray(tabSeverityFilterCriteria) && tabSeverityFilterCriteria === notification.severity);
 
           if (matchesTagFilter && matchesDataFilterCriteria && matchesSeverityFilterCriteria) {
+            const filterKey = createKey({
+              tags: tabTags,
+              data: tabDataFilterCriteria,
+              severity: tabSeverityFilterCriteria,
+            });
+
+            if (!processedFilters.has(filterKey)) {
+              processedFilters.add(filterKey);
             updateNewNotificationCountsOrCache(
               tab.label,
               notification,
@@ -162,6 +171,7 @@ export const CountProvider = (props: ParentProps) => {
               tabDataFilterCriteria,
               tabSeverityFilterCriteria
             );
+            }
           }
         }
       } else {


### PR DESCRIPTION
### What changed? Why was the change needed?

If inbox has e.g. 2 tabs with same filter, single notification received in both of these tabs/filters should increment the count by +1 once for both (instead of +2 for both).

Before:

https://github.com/user-attachments/assets/741b147f-65c3-4221-9614-ebf925260e59

After:

https://github.com/user-attachments/assets/8f6e8155-f0e4-4b3f-b700-30046b5e5be9


