### PR TITLE
feat(js): auto-load new notifications on first inbox open fixes NV-5976

### DIFF
--- a/packages/js/src/ui/context/CountContext.tsx
+++ b/packages/js/src/ui/context/CountContext.tsx
@@ -111,7 +111,10 @@ export const CountProvider = (props: ParentProps) => {
     };
     const hasLessThenMinAmount = (cachedData?.notifications.length || 0) < MIN_AMOUNT_OF_NOTIFICATIONS;
 
-    if (hasLessThenMinAmount) {
+    // Auto-load notifications when:
+    // 1. Cache is nearly empty
+    // 2. OR inbox is closed (will be auto-loaded when opened)
+    if (hasLessThenMinAmount || !isOpened()) {
       notificationsCache.update(tabSpecificFilterForCache, {
         ...cachedData,
         notifications: [notification, ...cachedData.notifications],
@@ -120,6 +123,7 @@ export const CountProvider = (props: ParentProps) => {
       return;
     }
 
+    // Only show banner when inbox is already open and new notification is received
     setNewNotificationCounts((oldMap) => {
       const key = createKey({ tags, data, severity }); // Use specific tab's tags and data for the key
 


### PR DESCRIPTION
### What changed? Why was the change needed?

This fix introduces two behaviors:
1. Inbox is closed when a new notification arrives → Notifications will automatically load when the inbox is opened, eliminating the need to click the “New notifications” banner.
2. Inbox is open when a new notification arrives → The list will not refresh automatically, preventing interruptions if the user is reading or interacting with an existing notification. Original behaviour with the "new notifications" banner is kept.

https://github.com/user-attachments/assets/48c331a8-4fcb-4fca-b47e-b9c58d0e073b

