### PR TITLE
fix(dashboard): Fix Auth type on requests logs  fixes NV-6528

### DIFF
--- a/apps/dashboard/src/components/http-logs/logs-detail-content.tsx
+++ b/apps/dashboard/src/components/http-logs/logs-detail-content.tsx
@@ -178,7 +178,7 @@ export function LogsDetailContent({ log }: LogsDetailContentProps) {
             <div className="flex items-center justify-between">
               <span className="text-text-soft font-mono text-xs font-medium tracking-[-0.24px]">Source</span>
               <span className="text-text-sub font-mono text-xs font-normal tracking-[-0.24px]">
-                {log.schemaType === 'Bearer' ? 'Dashboard' : 'API'}
+                {log.authType === 'Bearer' ? 'Dashboard' : 'API'}
               </span>
             </div>
           </div>

--- a/apps/dashboard/src/types/logs.ts
+++ b/apps/dashboard/src/types/logs.ts
@@ -15,7 +15,7 @@ export type RequestLog = {
   userId: string;
   organizationId: string;
   environmentId: string;
-  schemaType: string;
+  authType: string;
   durationMs: number;
 };
 


### PR DESCRIPTION
Updated the RequestLog type and its usage in logs-detail-content to use 'authType' instead of 'schemaType' for clarity and consistency.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
