### PR TITLE
fix(dashboard): Delay activity refetch by 5 seconds for async inserts

### DIFF
--- a/apps/dashboard/src/hooks/use-pull-activity.ts
+++ b/apps/dashboard/src/hooks/use-pull-activity.ts
@@ -30,26 +30,35 @@ export const usePullActivity = (activityId?: string | null) => {
 
     // Only stop refetching if we have an activity and it's not pending
     const newShouldRefetch = isPending || !activity?.jobs?.length;
-    setShouldRefetch(newShouldRefetch);
 
-    // invalidate that single activity in the activities list cache
-    queryClient.setQueriesData(
-      { queryKey: [QueryKeys.fetchActivities, currentEnvironment?._id] },
-      (activityResponse: ActivityResponse | undefined) => {
-        if (!activityResponse) return activityResponse;
+    if (newShouldRefetch) {
+      /**
+       * Due to async inserts on the activity list, we want to provide 5 more seconds to refetch the activity
+       * For any non-inserted traces.
+       */
+      setTimeout(() => {
+        setShouldRefetch(newShouldRefetch);
 
-        return {
-          ...activityResponse,
-          data: activityResponse.data.map((el) => {
-            if (el._id === activity._id) {
-              return { ...activity };
-            }
+        // invalidate that single activity in the activities list cache
+        queryClient.setQueriesData(
+          { queryKey: [QueryKeys.fetchActivities, currentEnvironment?._id] },
+          (activityResponse: ActivityResponse | undefined) => {
+            if (!activityResponse) return activityResponse;
 
-            return el;
-          }),
-        };
-      }
-    );
+            return {
+              ...activityResponse,
+              data: activityResponse.data.map((el) => {
+                if (el._id === activity._id) {
+                  return { ...activity };
+                }
+
+                return el;
+              }),
+            };
+          }
+        );
+      }, 5000);
+    }
   }, [activity, queryClient, currentEnvironment, activityId]);
 
   return {


### PR DESCRIPTION
Refetching and cache invalidation for activities now occurs after a 5-second delay when async inserts are detected, allowing time for non-inserted traces to be included. This helps ensure the activity list is up-to-date before stopping refetching.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
