### PR TITLE
chore(js): inbox adjust severity colors

### DIFF
--- a/packages/js/src/ui/components/Notification/DefaultNotification.tsx
+++ b/packages/js/src/ui/components/Notification/DefaultNotification.tsx
@@ -127,11 +127,11 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
           '[&:not(:first-child)]:nt-border-t nt-border-neutral-alpha-100',
           {
             'nt-cursor-pointer': !props.notification.isRead || !!props.notification.redirect?.url,
-            'nt-bg-severity-high-alpha-50 hover:nt-bg-severity-high-alpha-25':
+            'nt-bg-severity-high-alpha-100 hover:nt-bg-severity-high-alpha-50':
               props.notification.severity === SeverityLevelEnum.HIGH,
-            'nt-bg-severity-medium-alpha-50 hover:nt-bg-severity-medium-alpha-25':
+            'nt-bg-severity-medium-alpha-100 hover:nt-bg-severity-medium-alpha-50':
               props.notification.severity === SeverityLevelEnum.MEDIUM,
-            'nt-bg-severity-low-alpha-50 hover:nt-bg-severity-low-alpha-25':
+            'nt-bg-severity-low-alpha-100 hover:nt-bg-severity-low-alpha-50':
               props.notification.severity === SeverityLevelEnum.LOW,
           }
         )


### PR DESCRIPTION
### What changed? Why was the change needed?

Inbox - adjusted severity colors

### Screenshots

<img width="565" height="730" alt="Screenshot 2025-08-18 at 16 27 07" src="https://github.com/user-attachments/assets/92f85288-d8fd-4b6a-b6c1-4152939c46c9" />
