### PR TITLE
feat(dashboard): Remove completion tag after setup

### DIFF
--- a/apps/dashboard/src/components/side-navigation/getting-started-menu-item.tsx
+++ b/apps/dashboard/src/components/side-navigation/getting-started-menu-item.tsx
@@ -1,6 +1,6 @@
 import { useUser } from '@clerk/clerk-react';
 import { motion } from 'motion/react';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { RiCloseFill, RiQuestionLine, RiSparkling2Fill } from 'react-icons/ri';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useTelemetry } from '@/hooks/use-telemetry';
@@ -22,28 +22,12 @@ export function HomeMenuItem() {
 
   const allStepsCompleted = completedSteps === totalSteps;
 
-  // Track when the menu is automatically hidden due to completion
-  useEffect(() => {
-    if (allStepsCompleted && !hasTrackedAutoHide.current && !user?.unsafeMetadata?.hideGettingStarted) {
-      hasTrackedAutoHide.current = true;
-      track(TelemetryEvent.WELCOME_MENU_HIDDEN, {
-        completedSteps: steps.filter((step) => step.status === 'completed').map((step) => step.id),
-        totalSteps,
-        allStepsCompleted: true,
-        autoHidden: true,
-      });
-    }
-  }, [allStepsCompleted, steps, totalSteps, track, user?.unsafeMetadata?.hideGettingStarted]);
-
-  const handleClose = async (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-
+  const hideGettingStarted = useCallback(async (autoHidden: boolean) => {
     track(TelemetryEvent.WELCOME_MENU_HIDDEN, {
       completedSteps: steps.filter((step) => step.status === 'completed').map((step) => step.id),
       totalSteps,
       allStepsCompleted,
-      autoHidden: false,
+      autoHidden,
     });
 
     await user?.update({
@@ -52,9 +36,23 @@ export function HomeMenuItem() {
         hideGettingStarted: true,
       },
     });
+  }, [track, steps, totalSteps, allStepsCompleted, user]);
+
+  // Auto-hide when all steps are completed
+  useEffect(() => {
+    if (allStepsCompleted && !hasTrackedAutoHide.current && !user?.unsafeMetadata?.hideGettingStarted) {
+      hasTrackedAutoHide.current = true;
+      hideGettingStarted(true);
+    }
+  }, [allStepsCompleted, user?.unsafeMetadata?.hideGettingStarted, hideGettingStarted]);
+
+  const handleClose = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    await hideGettingStarted(false);
   };
 
-  if (user?.unsafeMetadata?.hideGettingStarted || allStepsCompleted) {
+  if (user?.unsafeMetadata?.hideGettingStarted) {
     return null;
   }
 

--- a/apps/dashboard/src/components/side-navigation/getting-started-menu-item.tsx
+++ b/apps/dashboard/src/components/side-navigation/getting-started-menu-item.tsx
@@ -1,5 +1,6 @@
 import { useUser } from '@clerk/clerk-react';
 import { motion } from 'motion/react';
+import { useEffect, useRef } from 'react';
 import { RiCloseFill, RiQuestionLine, RiSparkling2Fill } from 'react-icons/ri';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useTelemetry } from '@/hooks/use-telemetry';
@@ -17,8 +18,22 @@ export function HomeMenuItem() {
   const { currentEnvironment } = useEnvironment();
   const { user } = useUser();
   const track = useTelemetry();
+  const hasTrackedAutoHide = useRef(false);
 
   const allStepsCompleted = completedSteps === totalSteps;
+
+  // Track when the menu is automatically hidden due to completion
+  useEffect(() => {
+    if (allStepsCompleted && !hasTrackedAutoHide.current && !user?.unsafeMetadata?.hideGettingStarted) {
+      hasTrackedAutoHide.current = true;
+      track(TelemetryEvent.WELCOME_MENU_HIDDEN, {
+        completedSteps: steps.filter((step) => step.status === 'completed').map((step) => step.id),
+        totalSteps,
+        allStepsCompleted: true,
+        autoHidden: true,
+      });
+    }
+  }, [allStepsCompleted, steps, totalSteps, track, user?.unsafeMetadata?.hideGettingStarted]);
 
   const handleClose = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -28,6 +43,7 @@ export function HomeMenuItem() {
       completedSteps: steps.filter((step) => step.status === 'completed').map((step) => step.id),
       totalSteps,
       allStepsCompleted,
+      autoHidden: false,
     });
 
     await user?.update({
@@ -38,7 +54,7 @@ export function HomeMenuItem() {
     });
   };
 
-  if (user?.unsafeMetadata?.hideGettingStarted) {
+  if (user?.unsafeMetadata?.hideGettingStarted || allStepsCompleted) {
     return null;
   }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR addresses Linear issue [NV-6490](https://linear.app/novu/issue/NV-6490).

Previously, the "Getting Started" menu item would show a "4/4" completion tag or a close button even after all onboarding steps were completed, requiring manual dismissal.

This change modifies the `getting-started-menu-item.tsx` component to:
*   Automatically hide the entire "Getting Started" menu item once all onboarding steps are completed.
*   Add telemetry to distinguish between automatic hiding (due to completion) and manual closing of the menu.

This improves the user experience by automatically removing the completion tag and menu when it's no longer relevant.

### Screenshots

N/A

---
Linear Issue: [NV-6490](https://linear.app/novu/issue/NV-6490/remove-completion-tag-after-setup)

<a href="https://cursor.com/background-agent?bcId=bc-cc367dde-9400-4824-911f-4b20afa3438c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc367dde-9400-4824-911f-4b20afa3438c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

