### PR TITLE
fix(dashboard): maily footer rendering issue fixes NV-6439

### DIFF
--- a/apps/dashboard/src/components/maily/blocks/cards.tsx
+++ b/apps/dashboard/src/components/maily/blocks/cards.tsx
@@ -295,7 +295,7 @@ const createInformationCardWithLogo: (props: { track: ReturnType<typeof useTelem
                 {
                   type: 'column',
                   attrs: {
-                    width: '5',
+                    width: 5,
                     verticalAlign: 'top',
                   },
                   content: [

--- a/apps/dashboard/src/components/maily/blocks/footers.tsx
+++ b/apps/dashboard/src/components/maily/blocks/footers.tsx
@@ -321,7 +321,7 @@ export const createFooterLogoWithSimpleText: (props: { track: ReturnType<typeof 
               content: [
                 {
                   type: 'column',
-                  attrs: { width: '50%', verticalAlign: 'middle', showIfKey: null },
+                  attrs: { width: 50, verticalAlign: 'middle', showIfKey: null },
                   content: [
                     {
                       type: 'paragraph',
@@ -351,7 +351,7 @@ export const createFooterLogoWithSimpleText: (props: { track: ReturnType<typeof 
                 },
                 {
                   type: 'column',
-                  attrs: { width: '50%', showIfKey: null },
+                  attrs: { width: 50, showIfKey: null },
                   content: [
                     {
                       type: 'paragraph',


### PR DESCRIPTION
### What changed? Why was the change needed?

Maily Editor: fixed the footer columns rendering issue. 
The width values are numbers that are taking the percentage of the parent space; currently, in Maily it only works with percentages and it wouldn't be easy to adjust it to any other units, as some logic and calculations are happening based on the percentage assumption.

### Screenshots
<img width="1893" height="1296" alt="Screenshot 2025-08-19 at 15 04 27" src="https://github.com/user-attachments/assets/715868de-e4a0-41b5-93c2-7541480a8cab" />


