### PR TITLE
fix(framework): preserve the translation keys supported in json fixes NV-6537

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,8 @@
       "!libs/design-system",
       "!.github",
       "!scripts",
-      "!packages/framework/scripts"
+      "!packages/framework/scripts",
+      "!packages/framework/src/jsonSchemaFaker.js"
     ]
   },
   "formatter": {

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -1199,8 +1199,9 @@ describe('Novu Client', () => {
         subscriber: { email: 'test@example.com' },
         state: [],
         controls: {
-          body: 'Hello {{t.welcome}} {{payload.name}}! Click {{t.button.submit}} to continue.',
-          subject: 'Welcome {{t.title}} - {{payload.name}}',
+          body: 'Hello body {{payload.name}}! {{t.single}} {{t.with-dash}} {{t.with_underscore}} {{t.123}} {{t.你好}}', // single, no nesting
+          subject:
+            'Hello subject {{payload.name}}! {{t.nested.single}} {{t.nested-with-dash.single}} {{t.nested_with_underscore.single}} {{t.123.single}} {{t.你好.single}}', // with nesting
         },
       };
 
@@ -1208,8 +1209,9 @@ describe('Novu Client', () => {
 
       // Translation patterns should be preserved when t.* values are undefined
       expect(emailExecutionResult.outputs).toEqual({
-        body: 'Hello {{t.welcome}} John! Click {{t.button.submit}} to continue.',
-        subject: 'Welcome {{t.title}} - John',
+        body: 'Hello body John! {{t.single}} {{t.with-dash}} {{t.with_underscore}} {{t.123}} {{t.你好}}',
+        subject:
+          'Hello subject John! {{t.nested.single}} {{t.nested-with-dash.single}} {{t.nested_with_underscore.single}} {{t.123.single}} {{t.你好.single}}',
       });
     });
 

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -708,7 +708,7 @@ export class Client {
    * Transforms {{t.key}} to {{t.key | default: "{{t.key}}"}}
    */
   private preprocessTranslationPatterns(template: string): string {
-    return template.replace(/\{\{\s*t\.([^\s}]+)\s*\}\}/g, '{{ t.$1 | default: "{{t.$1}}" }}');
+    return template.replace(/\{\{\s*t\.([\p{L}\p{N}_.-]+)\s*\}\}/gu, '{{ t.$1 | default: "{{t.$1}}" }}');
   }
 
   /**

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -708,7 +708,7 @@ export class Client {
    * Transforms {{t.key}} to {{t.key | default: "{{t.key}}"}}
    */
   private preprocessTranslationPatterns(template: string): string {
-    return template.replace(/\{\{\s*t\.(\w+(?:\.\w+)*)\s*\}\}/g, '{{ t.$1 | default: "{{t.$1}}" }}');
+    return template.replace(/\{\{\s*t\.([^\s}]+)\s*\}\}/g, '{{ t.$1 | default: "{{t.$1}}" }}');
   }
 
   /**

--- a/packages/framework/src/jsonSchemaFaker.js
+++ b/packages/framework/src/jsonSchemaFaker.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 /*
  * Json-schema-faker is causing big HMR and Webpack headaches when @novu/framework is used in Next.js.
  * To address the issue, we decided to go old-school and hardcode the IIFE version of the source code in our package.

--- a/packages/framework/src/validators/validator.test.ts
+++ b/packages/framework/src/validators/validator.test.ts
@@ -309,7 +309,7 @@ describe('validators', () => {
     ];
 
     schemas.forEach((schema) => {
-      return describe(`using ${schema}`, () => {
+      describe(`using ${schema}`, () => {
         testCases
           .filter((testCase) => testCase.schemas[schema] !== null)
           .forEach((testCase) => {
@@ -516,7 +516,7 @@ describe('validators', () => {
     ];
 
     schemas.forEach((schema) => {
-      return describe(`using ${schema}`, () => {
+      describe(`using ${schema}`, () => {
         testCases
           .filter((testCase) => testCase.schemas[schema] !== null)
           .forEach((testCase) => {

--- a/packages/novu/src/commands/init/index.ts
+++ b/packages/novu/src/commands/init/index.ts
@@ -87,7 +87,9 @@ export async function init(program: IInitCommandOptions, anonymousId?: string): 
   if (!validation.valid) {
     console.error(`Could not create a project called ${red(`"${projectName}"`)} because of npm naming restrictions:`);
 
-    (validation as any).problems.forEach((problem: string) => console.error(`    ${red(bold('*'))} ${problem}`));
+    (validation as any).problems.forEach((problem: string) => {
+      console.error(`    ${red(bold('*'))} ${problem}`);
+    });
     process.exit(1);
   }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Framework: fixed the regexp that preserves the translations keys, now it supports keys with: `words, numbers, dashes, underscores, utf-8 characters`

### Screenshots

<img width="1551" height="1069" alt="Screenshot 2025-08-20 at 12 49 16" src="https://github.com/user-attachments/assets/1cfcfd63-5b39-448e-8757-81d789266149" />

