### PR TITLE
fix(dashboard): Update interaction tooltip for in-app channel fixes NV-6548

### DIFF
--- a/apps/dashboard/src/components/analytics/constants/analytics-tooltips.ts
+++ b/apps/dashboard/src/components/analytics/constants/analytics-tooltips.ts
@@ -6,7 +6,7 @@ export const ANALYTICS_TOOLTIPS = {
     'Displays the count of unique subscribers who have received at least one message during the selected time period.',
 
   INTERACTIONS:
-    'Shows total user interactions with messages:\n\n• Message seen\n• Message read\n• Message snoozed\n• Message archived\n\nTracks engagement across in-app notifications with more channels coming soon.',
+    'Shows total user interactions with Inbox messages:\n\n• Message seen\n• Message read\n• Message snoozed\n• Message archived\n\nCurrently tracks engagement for Inbox channel only. More channels coming soon.',
 
   AVG_MESSAGES_PER_SUBSCRIBER:
     'Calculates the average number of messages sent per subscriber during the selected time period.',
@@ -15,7 +15,7 @@ export const ANALYTICS_TOOLTIPS = {
     'Visualizes daily delivery volume breakdown by channel:\n\n• Email\n• SMS\n• Push\n• In-App\n\nShows trends over the selected time period.',
 
   INTERACTION_TREND:
-    'Shows daily interaction patterns over time:\n\n• Message sent\n• Message seen\n• Message read\n• Message snoozed\n\nVisualizes user engagement trends with your notifications.',
+    'Shows daily interaction patterns over time for Inbox messages:\n\n• Message sent\n• Message seen\n• Message read\n• Message snoozed\n\nVisualizes user engagement trends for Inbox channel only. More channels coming soon.',
 
   TOP_WORKFLOWS_BY_VOLUME:
     'Displays the workflow runs with the highest volume, showing which workflows are most actively used.',


### PR DESCRIPTION
Update interaction tooltips to clarify Inbox-only scope and mention upcoming channels.

---
Linear Issue: [NV-6548](https://linear.app/novu/issue/NV-6548/interaction-trend-tooltip-content-should-have-mentioned-that-it-is-for)

<a href="https://cursor.com/background-agent?bcId=bc-fe409606-dd44-4cde-bc96-303081ac0114">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe409606-dd44-4cde-bc96-303081ac0114">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

