### PR TITLE
fix(dashboard): Add chat channel to delivery trend tooltip fixes NV-6546

### DIFF
--- a/apps/dashboard/src/components/analytics/charts/delivery-trends-chart.tsx
+++ b/apps/dashboard/src/components/analytics/charts/delivery-trends-chart.tsx
@@ -21,6 +21,10 @@ const chartConfig = {
     label: 'Push',
     color: '#06b6d4',
   },
+  chat: {
+    label: 'Chat',
+    color: '#10b981',
+  },
   sms: {
     label: 'SMS',
     color: '#facc15',
@@ -182,6 +186,7 @@ export function DeliveryTrendsChart({ data, isLoading }: DeliveryTrendsChartProp
             strokeWidth={2}
           />
           <Bar dataKey="push" stackId="a" barSize={20} fill="#06b6d4" radius={3} stroke="#ffffff" strokeWidth={2} />
+          <Bar dataKey="chat" stackId="a" barSize={20} fill="#10b981" radius={3} stroke="#ffffff" strokeWidth={2} />
           <Bar dataKey="sms" stackId="a" barSize={20} fill="#facc15" radius={3} stroke="#ffffff" strokeWidth={2} />
           <Bar
             dataKey="inApp"

--- a/apps/dashboard/src/components/analytics/constants/analytics-tooltips.ts
+++ b/apps/dashboard/src/components/analytics/constants/analytics-tooltips.ts
@@ -1,6 +1,6 @@
 export const ANALYTICS_TOOLTIPS = {
   MESSAGES_DELIVERED:
-    'Shows the total number of messages generated across all channels (Email, SMS, Push, In-App) during the selected time period.',
+    'Shows the total number of messages generated across all channels (Email, SMS, Push, Chat, In-App) during the selected time period.',
 
   ACTIVE_SUBSCRIBERS:
     'Displays the count of unique subscribers who have received at least one message during the selected time period.',
@@ -12,7 +12,7 @@ export const ANALYTICS_TOOLTIPS = {
     'Calculates the average number of messages sent per subscriber during the selected time period.',
 
   DELIVERY_TREND:
-    'Visualizes daily delivery volume breakdown by channel:\n\n• Email\n• SMS\n• Push\n• In-App\n\nShows trends over the selected time period.',
+    'Visualizes daily delivery volume breakdown by channel:\n\n• Email\n• SMS\n• Push\n• Chat\n• In-App\n\nShows trends over the selected time period.',
 
   INTERACTION_TREND:
     'Shows daily interaction patterns over time:\n\n• Message sent\n• Message seen\n• Message read\n• Message snoozed\n\nVisualizes user engagement trends with your notifications.',


### PR DESCRIPTION
Adds Chat channel to the Delivery Trend chart configuration and tooltip descriptions to fix missing channel display.

The existing `DeliveryTooltip` component already included the Chat channel, but the chart's `chartConfig`, the `Bar` component for rendering Chat data, and the static tooltip descriptions were not updated to reflect it. This PR completes the integration of the Chat channel into the analytics dashboard's visual representation and descriptions.

---
Linear Issue: [NV-6546](https://linear.app/novu/issue/NV-6546/chat-channel-is-missing-on-tooltip-content-of-delivery-trend)

<a href="https://cursor.com/background-agent?bcId=bc-9248d979-708f-4f91-9814-e18bdf6e29bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9248d979-708f-4f91-9814-e18bdf6e29bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

