### PR TITLE
Update active subscriber tooltip definition

### DIFF
--- a/apps/dashboard/src/components/analytics/constants/analytics-tooltips.ts
+++ b/apps/dashboard/src/components/analytics/constants/analytics-tooltips.ts
@@ -3,7 +3,7 @@ export const ANALYTICS_TOOLTIPS = {
     'Shows the total number of messages generated across all channels (Email, SMS, Push, In-App) during the selected time period.',
 
   ACTIVE_SUBSCRIBERS:
-    'Displays the count of unique subscribers who have received at least one message during the selected time period.',
+    'Active subscriber is a subscriber who received at least one notification in the selected time period.',
 
   INTERACTIONS:
     'Shows total user interactions with messages:\n\n• Message seen\n• Message read\n• Message snoozed\n• Message archived\n\nTracks engagement across in-app notifications with more channels coming soon.',


### PR DESCRIPTION
Update the 'Active subscribers' tooltip to clarify its definition as per Linear issue NV-6545.

---
Linear Issue: [NV-6545](https://linear.app/novu/issue/NV-6545/tool-tip-content-on-active-subscribers-should-have-info-what-is-the)

<a href="https://cursor.com/background-agent?bcId=bc-54343c07-62ae-4837-bd55-e076559ccc2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54343c07-62ae-4837-bd55-e076559ccc2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

