### PR TITLE
feat(js,react): inbox render props for avatar, default and custom actions fixes NV-6535

### DIFF
--- a/packages/js/src/cache/notifications-cache.ts
+++ b/packages/js/src/cache/notifications-cache.ts
@@ -252,7 +252,9 @@ export class NotificationsCache {
 
         value.notifications
           .filter((el) => typeof read === 'undefined' || read === el.isRead)
-          .forEach((notification) => uniqueNotifications.set(notification.id, notification));
+          .forEach((notification) => {
+            uniqueNotifications.set(notification.id, notification);
+          });
       }
     });
 

--- a/packages/js/src/ui/components/Inbox.tsx
+++ b/packages/js/src/ui/components/Inbox.tsx
@@ -3,8 +3,11 @@ import { createMemo, createSignal, Match, Show, Switch } from 'solid-js';
 import { useInboxContext } from '../context';
 import { cn, useStyle } from '../helpers';
 import type {
+  AvatarRenderer,
   BellRenderer,
   BodyRenderer,
+  CustomActionsRenderer,
+  DefaultActionsRenderer,
   NotificationActionClickHandler,
   NotificationClickHandler,
   NotificationRenderer,
@@ -18,20 +21,29 @@ import { Button, Popover } from './primitives';
 
 export type NotificationRendererProps = {
   renderNotification: NotificationRenderer;
+  renderAvatar?: never;
   renderSubject?: never;
   renderBody?: never;
+  renderDefaultActions?: never;
+  renderCustomActions?: never;
 };
 
 export type SubjectBodyRendererProps = {
   renderNotification?: never;
+  renderAvatar?: AvatarRenderer;
   renderSubject?: SubjectRenderer;
   renderBody?: BodyRenderer;
+  renderDefaultActions?: DefaultActionsRenderer;
+  renderCustomActions?: CustomActionsRenderer;
 };
 
 export type NoRendererProps = {
   renderNotification?: undefined;
+  renderAvatar?: undefined;
   renderSubject?: undefined;
   renderBody?: undefined;
+  renderDefaultActions?: undefined;
+  renderCustomActions?: undefined;
 };
 
 export type InboxProps = {
@@ -92,8 +104,11 @@ export const InboxContent = (props: InboxContentProps) => {
             fallback={
               <NotificationList
                 renderNotification={props.renderNotification}
+                renderAvatar={props.renderAvatar}
                 renderSubject={props.renderSubject}
                 renderBody={props.renderBody}
+                renderDefaultActions={props.renderDefaultActions}
+                renderCustomActions={props.renderCustomActions}
                 onNotificationClick={props.onNotificationClick}
                 onPrimaryActionClick={props.onPrimaryActionClick}
                 onSecondaryActionClick={props.onSecondaryActionClick}
@@ -103,8 +118,11 @@ export const InboxContent = (props: InboxContentProps) => {
           >
             <InboxTabs
               renderNotification={props.renderNotification}
+              renderAvatar={props.renderAvatar}
               renderSubject={props.renderSubject}
               renderBody={props.renderBody}
+              renderDefaultActions={props.renderDefaultActions}
+              renderCustomActions={props.renderCustomActions}
               onNotificationClick={props.onNotificationClick}
               onPrimaryActionClick={props.onPrimaryActionClick}
               onSecondaryActionClick={props.onSecondaryActionClick}
@@ -141,8 +159,11 @@ export const Inbox = (props: InboxProps) => {
           when={props.renderNotification}
           fallback={
             <InboxContent
+              renderAvatar={props.renderAvatar}
               renderSubject={props.renderSubject}
               renderBody={props.renderBody}
+              renderDefaultActions={props.renderDefaultActions}
+              renderCustomActions={props.renderCustomActions}
               onNotificationClick={props.onNotificationClick}
               onPrimaryActionClick={props.onPrimaryActionClick}
               onSecondaryActionClick={props.onSecondaryActionClick}

--- a/packages/js/src/ui/components/InboxTabs/InboxTabs.tsx
+++ b/packages/js/src/ui/components/InboxTabs/InboxTabs.tsx
@@ -5,7 +5,10 @@ import { useTabsDropdown } from '../../helpers/useTabsDropdown';
 import { Check as DefaultCheck } from '../../icons';
 import { ArrowDown as DefaultArrowDown } from '../../icons/ArrowDown';
 import {
+  AvatarRenderer,
   BodyRenderer,
+  CustomActionsRenderer,
+  DefaultActionsRenderer,
   NotificationActionClickHandler,
   NotificationClickHandler,
   NotificationRenderer,
@@ -23,8 +26,11 @@ const tabsDropdownTriggerVariants = () =>
   `after:nt-w-full after:nt-h-[2px] after:nt-border-b-2 nt-mb-[0.625rem]`;
 type InboxTabsProps = {
   renderNotification?: NotificationRenderer;
+  renderAvatar?: AvatarRenderer;
   renderSubject?: SubjectRenderer;
   renderBody?: BodyRenderer;
+  renderDefaultActions?: DefaultActionsRenderer;
+  renderCustomActions?: CustomActionsRenderer;
   onNotificationClick?: NotificationClickHandler;
   onPrimaryActionClick?: NotificationActionClickHandler;
   onSecondaryActionClick?: NotificationActionClickHandler;
@@ -143,8 +149,11 @@ export const InboxTabs = (props: InboxTabsProps) => {
         >
           <NotificationList
             renderNotification={props.renderNotification}
+            renderAvatar={props.renderAvatar}
             renderSubject={props.renderSubject}
             renderBody={props.renderBody}
+            renderDefaultActions={props.renderDefaultActions}
+            renderCustomActions={props.renderCustomActions}
             onNotificationClick={props.onNotificationClick}
             onPrimaryActionClick={props.onPrimaryActionClick}
             onSecondaryActionClick={props.onSecondaryActionClick}

--- a/packages/js/src/ui/components/Notification/DefaultNotification.tsx
+++ b/packages/js/src/ui/components/Notification/DefaultNotification.tsx
@@ -7,7 +7,10 @@ import { cn, formatSnoozedUntil, formatToRelativeTime, useStyle } from '../../he
 import { Clock as DefaultClock } from '../../icons/Clock';
 import {
   AppearanceKey,
+  AvatarRenderer,
   type BodyRenderer,
+  CustomActionsRenderer,
+  DefaultActionsRenderer,
   type NotificationActionClickHandler,
   type NotificationClickHandler,
   type SubjectRenderer,
@@ -21,8 +24,11 @@ import { renderNotificationActions } from './NotificationActions';
 
 type DefaultNotificationProps = {
   notification: Notification;
+  renderAvatar?: AvatarRenderer;
   renderSubject?: SubjectRenderer;
   renderBody?: BodyRenderer;
+  renderDefaultActions?: DefaultActionsRenderer;
+  renderCustomActions?: CustomActionsRenderer;
   onNotificationClick?: NotificationClickHandler;
   onPrimaryActionClick?: NotificationActionClickHandler;
   onSecondaryActionClick?: NotificationActionClickHandler;
@@ -151,19 +157,31 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
           })
         )}
       />
+
       <Show
-        when={props.notification.avatar}
+        when={props.renderAvatar}
         fallback={
-          <div
-            class={style('notificationImageLoadingFallback', 'nt-size-8 nt-rounded-lg nt-shrink-0 nt-aspect-square')}
-          />
+          <Show
+            when={props.notification.avatar}
+            fallback={
+              <div
+                class={style(
+                  'notificationImageLoadingFallback',
+                  'nt-size-8 nt-rounded-lg nt-shrink-0 nt-aspect-square'
+                )}
+              />
+            }
+          >
+            <img
+              class={style('notificationImage', 'nt-size-8 nt-rounded-lg nt-object-cover nt-aspect-square')}
+              src={props.notification.avatar}
+            />
+          </Show>
         }
       >
-        <img
-          class={style('notificationImage', 'nt-size-8 nt-rounded-lg nt-object-cover nt-aspect-square')}
-          src={props.notification.avatar}
-        />
+        {(renderAvatar) => <ExternalElementRenderer render={(el) => renderAvatar()(el, props.notification)} />}
       </Show>
+
       <div class={style('notificationContent', 'nt-flex nt-flex-col nt-gap-2 nt-w-full')}>
         <div class={style('notificationTextContainer')}>
           <Show
@@ -199,70 +217,89 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
             {(renderBody) => <ExternalElementRenderer render={(el) => renderBody()(el, props.notification)} />}
           </Show>
         </div>
-        <div
-          class={style(
-            'notificationDefaultActions',
-            `nt-absolute nt-transition nt-duration-100 nt-ease-out nt-gap-0.5 nt-flex nt-shrink-0 nt-opacity-0 group-hover:nt-opacity-100 group-focus-within:nt-opacity-100 nt-justify-center nt-items-center nt-bg-background/90 nt-right-3 nt-top-3 nt-border nt-border-neutral-alpha-100 nt-rounded-lg nt-backdrop-blur-lg nt-p-0.5`
-          )}
+
+        <Show
+          when={props.renderDefaultActions}
+          fallback={
+            <div
+              class={style(
+                'notificationDefaultActions',
+                `nt-absolute nt-transition nt-duration-100 nt-ease-out nt-gap-0.5 nt-flex nt-shrink-0 nt-opacity-0 group-hover:nt-opacity-100 group-focus-within:nt-opacity-100 nt-justify-center nt-items-center nt-bg-background/90 nt-right-3 nt-top-3 nt-border nt-border-neutral-alpha-100 nt-rounded-lg nt-backdrop-blur-lg nt-p-0.5`
+              )}
+            >
+              {renderNotificationActions(props.notification, status)}
+            </div>
+          }
         >
-          {renderNotificationActions(props.notification, status)}
-        </div>
-        <Show when={props.notification.primaryAction || props.notification.secondaryAction}>
-          <div class={style('notificationCustomActions', 'nt-flex nt-flex-wrap nt-gap-2')}>
-            <Show when={props.notification.primaryAction} keyed>
-              {(primaryAction) => (
-                <Button
-                  appearanceKey="notificationPrimaryAction__button"
-                  variant="default"
-                  onClick={(e) => handleActionButtonClick(ActionTypeEnum.PRIMARY, e)}
-                >
-                  {primaryAction.label}
-                </Button>
-              )}
-            </Show>
-            <Show when={props.notification.secondaryAction} keyed>
-              {(secondaryAction) => (
-                <Button
-                  appearanceKey="notificationSecondaryAction__button"
-                  variant="secondary"
-                  onClick={(e) => handleActionButtonClick(ActionTypeEnum.SECONDARY, e)}
-                >
-                  {secondaryAction.label}
-                </Button>
-              )}
-            </Show>
-          </div>
+          {(renderDefaultActions) => (
+            <ExternalElementRenderer render={(el) => renderDefaultActions()(el, props.notification)} />
+          )}
         </Show>
+
+        <Show
+          when={props.renderCustomActions}
+          fallback={
+            <Show when={props.notification.primaryAction || props.notification.secondaryAction}>
+              <div class={style('notificationCustomActions', 'nt-flex nt-flex-wrap nt-gap-2')}>
+                <Show when={props.notification.primaryAction} keyed>
+                  {(primaryAction) => (
+                    <Button
+                      appearanceKey="notificationPrimaryAction__button"
+                      variant="default"
+                      onClick={(e) => handleActionButtonClick(ActionTypeEnum.PRIMARY, e)}
+                    >
+                      {primaryAction.label}
+                    </Button>
+                  )}
+                </Show>
+                <Show when={props.notification.secondaryAction} keyed>
+                  {(secondaryAction) => (
+                    <Button
+                      appearanceKey="notificationSecondaryAction__button"
+                      variant="secondary"
+                      onClick={(e) => handleActionButtonClick(ActionTypeEnum.SECONDARY, e)}
+                    >
+                      {secondaryAction.label}
+                    </Button>
+                  )}
+                </Show>
+              </div>
+            </Show>
+          }
+        >
+          {(renderCustomActions) => (
+            <ExternalElementRenderer render={(el) => renderCustomActions()(el, props.notification)} />
+          )}
+        </Show>
+
         <div class={style('notificationDate', 'nt-text-foreground-alpha-400 nt-flex nt-items-center nt-gap-1')}>
           <Show
             when={snoozedUntil()}
             fallback={
-              <>
-                <Show when={deliveredAt()} fallback={<>{createdAt()}</>}>
-                  {(deliveredAt) => (
-                    <Show when={deliveredAt().length >= 2}>
-                      {' '}
-                      <For each={deliveredAt().slice(-2)}>
-                        {(date, index) => (
-                          <>
-                            <Show when={index() === 0}>{date} ·</Show>
-                            <Show when={index() === 1}>
-                              <Badge appearanceKey="notificationDeliveredAt__badge">
-                                <IconRendererWrapper
-                                  iconKey="clock"
-                                  class={deliveredAtIconClass}
-                                  fallback={<DefaultClock class={deliveredAtIconClass} />}
-                                />
-                                {date}
-                              </Badge>
-                            </Show>
-                          </>
-                        )}
-                      </For>
-                    </Show>
-                  )}
-                </Show>
-              </>
+              <Show when={deliveredAt()} fallback={createdAt()}>
+                {(deliveredAt) => (
+                  <Show when={deliveredAt().length >= 2}>
+                    {' '}
+                    <For each={deliveredAt().slice(-2)}>
+                      {(date, index) => (
+                        <>
+                          <Show when={index() === 0}>{date} ·</Show>
+                          <Show when={index() === 1}>
+                            <Badge appearanceKey="notificationDeliveredAt__badge">
+                              <IconRendererWrapper
+                                iconKey="clock"
+                                class={deliveredAtIconClass}
+                                fallback={<DefaultClock class={deliveredAtIconClass} />}
+                              />
+                              {date}
+                            </Badge>
+                          </Show>
+                        </>
+                      )}
+                    </For>
+                  </Show>
+                )}
+              </Show>
             }
           >
             {(snoozedUntil) => (

--- a/packages/js/src/ui/components/Notification/Notification.tsx
+++ b/packages/js/src/ui/components/Notification/Notification.tsx
@@ -1,7 +1,10 @@
 import { Show } from 'solid-js';
 import type { Notification as NotificationType } from '../../../notifications';
 import type {
+  AvatarRenderer,
   BodyRenderer,
+  CustomActionsRenderer,
+  DefaultActionsRenderer,
   NotificationActionClickHandler,
   NotificationClickHandler,
   NotificationRenderer,
@@ -13,8 +16,11 @@ import { DefaultNotification } from './DefaultNotification';
 type NotificationProps = {
   notification: NotificationType;
   renderNotification?: NotificationRenderer;
+  renderAvatar?: AvatarRenderer;
   renderSubject?: SubjectRenderer;
   renderBody?: BodyRenderer;
+  renderDefaultActions?: DefaultActionsRenderer;
+  renderCustomActions?: CustomActionsRenderer;
   onNotificationClick?: NotificationClickHandler;
   onPrimaryActionClick?: NotificationActionClickHandler;
   onSecondaryActionClick?: NotificationActionClickHandler;
@@ -27,8 +33,11 @@ export const Notification = (props: NotificationProps) => {
       fallback={
         <DefaultNotification
           notification={props.notification}
+          renderAvatar={props.renderAvatar}
           renderSubject={props.renderSubject}
           renderBody={props.renderBody}
+          renderDefaultActions={props.renderDefaultActions}
+          renderCustomActions={props.renderCustomActions}
           onNotificationClick={props.onNotificationClick}
           onPrimaryActionClick={props.onPrimaryActionClick}
           onSecondaryActionClick={props.onSecondaryActionClick}

--- a/packages/js/src/ui/components/Notification/NotificationList.tsx
+++ b/packages/js/src/ui/components/Notification/NotificationList.tsx
@@ -5,7 +5,10 @@ import { DEFAULT_LIMIT, useInboxContext, useNewMessagesCount } from '../../conte
 import { useStyle } from '../../helpers';
 import { useNotificationVisibility } from '../../helpers/useNotificationVisibility';
 import type {
+  AvatarRenderer,
   BodyRenderer,
+  CustomActionsRenderer,
+  DefaultActionsRenderer,
   NotificationActionClickHandler,
   NotificationClickHandler,
   NotificationRenderer,
@@ -17,8 +20,11 @@ import { NotificationListSkeleton } from './NotificationListSkeleton';
 
 type NotificationListProps = {
   renderNotification?: NotificationRenderer;
+  renderAvatar?: AvatarRenderer;
   renderSubject?: SubjectRenderer;
   renderBody?: BodyRenderer;
+  renderDefaultActions?: DefaultActionsRenderer;
+  renderCustomActions?: CustomActionsRenderer;
   onNotificationClick?: NotificationClickHandler;
   onPrimaryActionClick?: NotificationActionClickHandler;
   onSecondaryActionClick?: NotificationActionClickHandler;
@@ -100,8 +106,11 @@ export const NotificationList = (props: NotificationListProps) => {
                   <Notification
                     notification={notification()}
                     renderNotification={props.renderNotification}
+                    renderAvatar={props.renderAvatar}
                     renderSubject={props.renderSubject}
                     renderBody={props.renderBody}
+                    renderDefaultActions={props.renderDefaultActions}
+                    renderCustomActions={props.renderCustomActions}
                     onNotificationClick={props.onNotificationClick}
                     onPrimaryActionClick={props.onPrimaryActionClick}
                     onSecondaryActionClick={props.onSecondaryActionClick}

--- a/packages/js/src/ui/components/Renderer.tsx
+++ b/packages/js/src/ui/components/Renderer.tsx
@@ -24,9 +24,10 @@ export const novuComponents = {
   Bell,
   Notifications: (props: Omit<InboxContentProps, 'hideNav' | 'initialPage'>) => {
     if (props.renderNotification) {
-      const { renderBody, renderSubject, ...propsWithoutBodyAndSubject } = props;
+      const { renderBody, renderSubject, renderAvatar, renderDefaultActions, renderCustomActions, ...otherProps } =
+        props;
 
-      return <InboxContent {...propsWithoutBodyAndSubject} hideNav={true} initialPage={InboxPage.Notifications} />;
+      return <InboxContent {...otherProps} hideNav={true} initialPage={InboxPage.Notifications} />;
     }
 
     const { renderNotification, ...propsWithoutRenderNotification } = props;
@@ -35,9 +36,10 @@ export const novuComponents = {
   },
   Preferences: (props: Omit<InboxContentProps, 'hideNav' | 'initialPage'>) => {
     if (props.renderNotification) {
-      const { renderBody, renderSubject, ...propsWithoutBodyAndSubject } = props;
+      const { renderBody, renderSubject, renderAvatar, renderDefaultActions, renderCustomActions, ...otherProps } =
+        props;
 
-      return <InboxContent {...propsWithoutBodyAndSubject} hideNav={true} initialPage={InboxPage.Preferences} />;
+      return <InboxContent {...otherProps} hideNav={true} initialPage={InboxPage.Preferences} />;
     }
 
     const { renderNotification, ...propsWithoutRenderNotification } = props;

--- a/packages/js/src/ui/index.css
+++ b/packages/js/src/ui/index.css
@@ -349,5 +349,7 @@
   }
 }
 
+/* biome-ignore lint/suspicious/noUnknownAtRules: tailwind */
 @tailwind components;
+/* biome-ignore lint/suspicious/noUnknownAtRules: tailwind */
 @tailwind utilities;

--- a/packages/js/src/ui/types.ts
+++ b/packages/js/src/ui/types.ts
@@ -8,8 +8,11 @@ export type NotificationClickHandler = (notification: Notification) => void;
 export type NotificationActionClickHandler = (notification: Notification) => void;
 
 export type NotificationRenderer = (el: HTMLDivElement, notification: Notification) => () => void;
+export type AvatarRenderer = (el: HTMLDivElement, notification: Notification) => () => void;
 export type SubjectRenderer = (el: HTMLDivElement, notification: Notification) => () => void;
 export type BodyRenderer = (el: HTMLDivElement, notification: Notification) => () => void;
+export type DefaultActionsRenderer = (el: HTMLDivElement, notification: Notification) => () => void;
+export type CustomActionsRenderer = (el: HTMLDivElement, notification: Notification) => () => void;
 export type BellRenderer = (el: HTMLDivElement, unreadCount: UnreadCount) => () => void;
 export type RouterPush = (path: string) => void;
 

--- a/packages/react/src/components/Inbox.tsx
+++ b/packages/react/src/components/Inbox.tsx
@@ -15,8 +15,11 @@ const DefaultInbox = (props: DefaultInboxProps) => {
   const {
     open,
     renderNotification,
+    renderAvatar,
     renderSubject,
     renderBody,
+    renderDefaultActions,
+    renderCustomActions,
     renderBell,
     onNotificationClick,
     onPrimaryActionClick,
@@ -52,10 +55,17 @@ const DefaultInbox = (props: DefaultInboxProps) => {
         name: 'Inbox',
         props: {
           open,
+          renderAvatar: renderAvatar ? (el, notification) => mountElement(el, renderAvatar(notification)) : undefined,
           renderSubject: renderSubject
             ? (el, notification) => mountElement(el, renderSubject(notification))
             : undefined,
           renderBody: renderBody ? (el, notification) => mountElement(el, renderBody(notification)) : undefined,
+          renderDefaultActions: renderDefaultActions
+            ? (el, notification) => mountElement(el, renderDefaultActions(notification))
+            : undefined,
+          renderCustomActions: renderCustomActions
+            ? (el, notification) => mountElement(el, renderCustomActions(notification))
+            : undefined,
           renderBell: renderBell ? (el, unreadCount) => mountElement(el, renderBell(unreadCount)) : undefined,
           onNotificationClick,
           onPrimaryActionClick,
@@ -69,8 +79,11 @@ const DefaultInbox = (props: DefaultInboxProps) => {
     [
       open,
       renderNotification,
+      renderAvatar,
       renderSubject,
       renderBody,
+      renderDefaultActions,
+      renderCustomActions,
       renderBell,
       onNotificationClick,
       onPrimaryActionClick,
@@ -167,8 +180,11 @@ const InboxChild = withRenderer(
     const {
       open,
       renderNotification,
+      renderAvatar,
       renderSubject,
       renderBody,
+      renderDefaultActions,
+      renderCustomActions,
       renderBell,
       onNotificationClick,
       onPrimaryActionClick,
@@ -182,8 +198,11 @@ const InboxChild = withRenderer(
         <DefaultInbox
           open={open}
           renderNotification={renderNotification}
+          renderAvatar={renderAvatar}
           renderSubject={renderSubject}
           renderBody={renderBody}
+          renderDefaultActions={renderDefaultActions}
+          renderCustomActions={renderCustomActions}
           renderBell={renderBell}
           onNotificationClick={onNotificationClick}
           onPrimaryActionClick={onPrimaryActionClick}

--- a/packages/react/src/components/InboxContent.tsx
+++ b/packages/react/src/components/InboxContent.tsx
@@ -19,8 +19,11 @@ const _InboxContent = React.memo((props: InboxContentProps) => {
     onNotificationClick,
     onPrimaryActionClick,
     renderNotification,
+    renderAvatar,
     renderSubject,
     renderBody,
+    renderDefaultActions,
+    renderCustomActions,
     onSecondaryActionClick,
     initialPage,
     hideNav,
@@ -51,10 +54,17 @@ const _InboxContent = React.memo((props: InboxContentProps) => {
         name: 'InboxContent',
         element,
         props: {
+          renderAvatar: renderAvatar ? (el, notification) => mountElement(el, renderAvatar(notification)) : undefined,
           renderSubject: renderSubject
             ? (el, notification) => mountElement(el, renderSubject(notification))
             : undefined,
           renderBody: renderBody ? (el, notification) => mountElement(el, renderBody(notification)) : undefined,
+          renderDefaultActions: renderDefaultActions
+            ? (el, notification) => mountElement(el, renderDefaultActions(notification))
+            : undefined,
+          renderCustomActions: renderCustomActions
+            ? (el, notification) => mountElement(el, renderCustomActions(notification))
+            : undefined,
           onNotificationClick,
           onPrimaryActionClick,
           onSecondaryActionClick,
@@ -63,7 +73,17 @@ const _InboxContent = React.memo((props: InboxContentProps) => {
         },
       });
     },
-    [renderNotification, renderSubject, renderBody, onNotificationClick, onPrimaryActionClick, onSecondaryActionClick]
+    [
+      renderNotification,
+      renderAvatar,
+      renderSubject,
+      renderBody,
+      renderDefaultActions,
+      renderCustomActions,
+      onNotificationClick,
+      onPrimaryActionClick,
+      onSecondaryActionClick,
+    ]
   );
 
   return <Mounter mount={mount} />;

--- a/packages/react/src/components/Notifications.tsx
+++ b/packages/react/src/components/Notifications.tsx
@@ -15,8 +15,11 @@ export type NotificationProps = {
 const _Notifications = React.memo((props: NotificationProps) => {
   const {
     renderNotification,
+    renderAvatar,
     renderSubject,
     renderBody,
+    renderDefaultActions,
+    renderCustomActions,
     onNotificationClick,
     onPrimaryActionClick,
     onSecondaryActionClick,
@@ -45,17 +48,34 @@ const _Notifications = React.memo((props: NotificationProps) => {
         name: 'Notifications',
         element,
         props: {
+          renderAvatar: renderAvatar ? (el, notification) => mountElement(el, renderAvatar(notification)) : undefined,
           renderSubject: renderSubject
             ? (el, notification) => mountElement(el, renderSubject(notification))
             : undefined,
           renderBody: renderBody ? (el, notification) => mountElement(el, renderBody(notification)) : undefined,
+          renderDefaultActions: renderDefaultActions
+            ? (el, notification) => mountElement(el, renderDefaultActions(notification))
+            : undefined,
+          renderCustomActions: renderCustomActions
+            ? (el, notification) => mountElement(el, renderCustomActions(notification))
+            : undefined,
           onNotificationClick,
           onPrimaryActionClick,
           onSecondaryActionClick,
         },
       });
     },
-    [renderNotification, renderSubject, renderBody, onNotificationClick, onPrimaryActionClick, onSecondaryActionClick]
+    [
+      renderNotification,
+      renderAvatar,
+      renderSubject,
+      renderBody,
+      renderDefaultActions,
+      renderCustomActions,
+      onNotificationClick,
+      onPrimaryActionClick,
+      onSecondaryActionClick,
+    ]
   );
 
   return <Mounter mount={mount} />;

--- a/packages/react/src/utils/types.ts
+++ b/packages/react/src/utils/types.ts
@@ -15,8 +15,11 @@ import type {
 import type { ReactNode } from 'react';
 
 export type NotificationsRenderer = (notification: Notification) => React.ReactNode;
+export type AvatarRenderer = (notification: Notification) => React.ReactNode;
 export type SubjectRenderer = (notification: Notification) => React.ReactNode;
 export type BodyRenderer = (notification: Notification) => React.ReactNode;
+export type DefaultActionsRenderer = (notification: Notification) => React.ReactNode;
+export type CustomActionsRenderer = (notification: Notification) => React.ReactNode;
 export type BellRenderer = (unreadCount: UnreadCount) => React.ReactNode;
 
 export type ReactIconRendererProps = { class?: string };
@@ -37,8 +40,11 @@ export type ReactAppearance = ReactTheme & {
 export type DefaultInboxProps = {
   open?: boolean;
   renderNotification?: NotificationsRenderer;
+  renderAvatar?: AvatarRenderer;
   renderSubject?: SubjectRenderer;
   renderBody?: BodyRenderer;
+  renderDefaultActions?: DefaultActionsRenderer;
+  renderCustomActions?: CustomActionsRenderer;
   renderBell?: BellRenderer;
   onNotificationClick?: NotificationClickHandler;
   onPrimaryActionClick?: NotificationActionClickHandler;
@@ -77,20 +83,29 @@ export type BaseProps = KeylessBaseProps | StandardBaseProps;
 
 export type NotificationRendererProps = {
   renderNotification: NotificationsRenderer;
+  renderAvatar?: never;
   renderSubject?: never;
   renderBody?: never;
+  renderDefaultActions?: never;
+  renderCustomActions?: never;
 };
 
 export type SubjectBodyRendererProps = {
   renderNotification?: never;
+  renderAvatar?: AvatarRenderer;
   renderSubject?: SubjectRenderer;
   renderBody?: BodyRenderer;
+  renderDefaultActions?: DefaultActionsRenderer;
+  renderCustomActions?: CustomActionsRenderer;
 };
 
 export type NoRendererProps = {
   renderNotification?: undefined;
+  renderAvatar?: undefined;
   renderSubject?: undefined;
   renderBody?: undefined;
+  renderDefaultActions?: undefined;
+  renderCustomActions?: undefined;
 };
 
 export type DefaultProps = BaseProps &

--- a/playground/nextjs/src/pages/custom-subject-body/index.tsx
+++ b/playground/nextjs/src/pages/custom-subject-body/index.tsx
@@ -8,6 +8,15 @@ export default function CustomSubjectBody() {
       <Title title="Custom Subject Body" />
       <Inbox
         {...novuConfig}
+        renderAvatar={(notification) => {
+          return (
+            <img
+              src="https://avataaars.io/?avatarStyle=Circle&topType=LongHairStraight&accessoriesType=Blank&hairColor=BrownDark&facialHairType=Blank&clotheType=BlazerShirt&eyeType=Default&eyebrowType=Default&mouthType=Default&skinColor=Light"
+              width={40}
+              height={40}
+            />
+          );
+        }}
         renderSubject={(notification) => {
           return (
             <div>
@@ -17,6 +26,16 @@ export default function CustomSubjectBody() {
         }}
         renderBody={(notification) => {
           return <div>Body: {notification.body}</div>;
+        }}
+        renderDefaultActions={(notification) => {
+          return null;
+        }}
+        renderCustomActions={(notification) => {
+          return (
+            <div>
+              <button className="nt-bg-primary nt-text-white nt-rounded-md nt-px-4 nt-py-2">click me</button>
+            </div>
+          );
         }}
       />
     </>


### PR DESCRIPTION
### What changed? Why was the change needed?

Inbox - introduced the three new render props `renderAvatar, renderDefaultActions, renderCustomActions` which could be used to render the custom parts of the notification item.

### Screenshots

<img width="1552" height="1064" alt="Screenshot 2025-08-21 at 13 40 56" src="https://github.com/user-attachments/assets/1656037c-201b-4bba-92b9-e743ed3d978c" />

<img width="1012" height="872" alt="Screenshot 2025-08-21 at 13 41 10" src="https://github.com/user-attachments/assets/33d600ae-d22d-45bd-8585-eeddbf19cd37" />
