### PR TITLE
chore(dashboard): improve side nav on smaller screens fixes NV-6389

### DIFF
--- a/apps/dashboard/src/components/side-navigation/side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/side-navigation.tsx
@@ -101,7 +101,7 @@ export const SideNavigation = () => {
   };
 
   return (
-    <aside className="bg-neutral-alpha-50 relative flex h-full w-[275px] flex-shrink-0 flex-col overflow-auto">
+    <aside className="bg-neutral-alpha-50 relative flex h-full w-[275px] flex-shrink-0 flex-col">
       <SidebarContent className="h-full">
         <OrganizationDropdown />
         <EnvironmentDropdown
@@ -109,7 +109,7 @@ export const SideNavigation = () => {
           data={environments}
           onChange={onEnvironmentChange}
         />
-        <nav className="flex h-full flex-1 flex-col">
+        <nav className="flex h-full flex-1 flex-col overflow-auto">
           <div className="flex flex-col gap-4">
             <NavigationGroup>
               <Protect permission={PermissionsEnum.WORKFLOW_READ}>


### PR DESCRIPTION
### What changed? Why was the change needed?

Dashboard on the smaller screens when there is not enough height for the side nav make sure that the org and env dropdowns stay at the top but all the rest links scroll in the section.

### Screenshots


https://github.com/user-attachments/assets/b16e0555-c46d-4a6b-88c9-1ebc11ac0b66

