### PR TITLE
feat(dashboard): Add y-axis to analytics charts fixes NV-6543

### DIFF
--- a/apps/dashboard/src/components/analytics/charts/active-subscribers-trend-chart.tsx
+++ b/apps/dashboard/src/components/analytics/charts/active-subscribers-trend-chart.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { Line, LineChart, XAxis } from 'recharts';
+import { Line, LineChart, XAxis, YAxis } from 'recharts';
 import { type ActiveSubscribersTrendDataPoint } from '../../../api/activity';
 
 import { ChartConfig, ChartContainer, ChartTooltip, NovuTooltip } from '../../primitives/chart';
@@ -73,6 +73,16 @@ export function ActiveSubscribersTrendChart({ data, isLoading, error }: ActiveSu
               return '';
             }}
             domain={['dataMin', 'dataMax']}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tick={{ fontSize: 10, fill: '#99a0ae' }}
+            width={40}
+            tickFormatter={(value) => {
+              if (value >= 1000) return `${(value / 1000).toFixed(0)}k`;
+              return value.toString();
+            }}
           />
           {includeTooltip && <ChartTooltip cursor={false} content={<NovuTooltip showTotal={false} />} />}
           <Line

--- a/apps/dashboard/src/components/analytics/charts/delivery-trends-chart.tsx
+++ b/apps/dashboard/src/components/analytics/charts/delivery-trends-chart.tsx
@@ -1,6 +1,6 @@
 import { StepTypeEnum } from '@novu/shared';
 import { useCallback, useMemo } from 'react';
-import { Bar, BarChart, XAxis } from 'recharts';
+import { Bar, BarChart, XAxis, YAxis } from 'recharts';
 import { type ChartDataPoint } from '../../../api/activity';
 import { STEP_TYPE_TO_ICON } from '../../icons/utils';
 
@@ -174,6 +174,16 @@ export function DeliveryTrendsChart({ data, isLoading }: DeliveryTrendsChartProp
             axisLine={false}
             tick={{ fontSize: 10, fill: '#99a0ae' }}
             ticks={[firstDate, lastDate]}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tick={{ fontSize: 10, fill: '#99a0ae' }}
+            width={40}
+            tickFormatter={(value) => {
+              if (value >= 1000) return `${(value / 1000).toFixed(0)}k`;
+              return value.toString();
+            }}
           />
           {includeTooltip && <ChartTooltip cursor={false} content={<DeliveryTooltip />} />}
           <Bar

--- a/apps/dashboard/src/components/analytics/charts/interaction-trend-chart.tsx
+++ b/apps/dashboard/src/components/analytics/charts/interaction-trend-chart.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { Line, LineChart, XAxis } from 'recharts';
+import { Line, LineChart, XAxis, YAxis } from 'recharts';
 import { type InteractionTrendDataPoint } from '../../../api/activity';
 
 import { ChartConfig, ChartContainer, ChartTooltip, NovuTooltip } from '../../primitives/chart';
@@ -92,6 +92,16 @@ export function InteractionTrendChart({ data, isLoading, error }: InteractionTre
             tick={{ fontSize: 10, fill: '#99a0ae', textAnchor: 'middle' }}
             ticks={[firstDate, lastDate]}
             domain={['dataMin', 'dataMax']}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tick={{ fontSize: 10, fill: '#99a0ae' }}
+            width={40}
+            tickFormatter={(value) => {
+              if (value >= 1000) return `${(value / 1000).toFixed(0)}k`;
+              return value.toString();
+            }}
           />
           {includeTooltip && <ChartTooltip cursor={false} content={<NovuTooltip showTotal={false} />} />}
           <Line dataKey="messageSeen" name="Seen" stroke="#60a5fa" strokeWidth={2} dot={false} type="monotone" />

--- a/apps/dashboard/src/components/analytics/charts/workflow-runs-trend-chart.tsx
+++ b/apps/dashboard/src/components/analytics/charts/workflow-runs-trend-chart.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { Line, LineChart, XAxis } from 'recharts';
+import { Line, LineChart, XAxis, YAxis } from 'recharts';
 import { type WorkflowRunsTrendDataPoint } from '../../../api/activity';
 
 import { ChartConfig, ChartContainer, ChartTooltip, NovuTooltip } from '../../primitives/chart';
@@ -98,6 +98,16 @@ export function WorkflowRunsTrendChart({ data, isLoading, error }: WorkflowRunsT
               return '';
             }}
             domain={['dataMin', 'dataMax']}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tick={{ fontSize: 10, fill: '#99a0ae' }}
+            width={40}
+            tickFormatter={(value) => {
+              if (value >= 1000) return `${(value / 1000).toFixed(0)}k`;
+              return value.toString();
+            }}
           />
           {includeTooltip && <ChartTooltip cursor={false} content={<NovuTooltip showTotal={false} />} />}
           <Line dataKey="success" name="Completed" stroke="#34d399" strokeWidth={2} dot={false} type="monotone" />


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR addresses Linear issue [NV-6543](https://linear.app/novu/issue/NV-6543) by introducing a minimalistic Y-axis to the following charts on the analytics dashboard:

*   `DeliveryTrendsChart`
*   `InteractionTrendChart`
*   `WorkflowRunsTrendChart`
*   `ActiveSubscribersTrendChart`

Previously, these charts lacked a visible Y-axis, requiring users to hover to see data values. The addition of a Y-axis provides immediate visual context, improving data readability and enabling quicker comparison of trends and values at a glance. The Y-axis includes smart formatting (e.g., "1k" for 1000) and consistent styling.

### Screenshots

<!-- Please include screenshots of the updated charts with the new Y-axis. -->

---
Linear Issue: [NV-6543](https://linear.app/novu/issue/NV-6543/no-information-for-y-axis-on-the-charts)

<a href="https://cursor.com/background-agent?bcId=bc-8c52f0f1-c69e-4db8-ae40-71906c65c255">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c52f0f1-c69e-4db8-ae40-71906c65c255">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

