### PR TITLE
feat(js): Add global workflow container appearance key fixes NV-6561

### DIFF
--- a/packages/js/src/ui/components/elements/Preferences/Preferences.tsx
+++ b/packages/js/src/ui/components/elements/Preferences/Preferences.tsx
@@ -108,11 +108,13 @@ export const Preferences = () => {
         'nt-px-3 nt-py-4 nt-flex nt-flex-col nt-gap-1 nt-overflow-y-auto nt-h-full nt-pr-0 [scrollbar-gutter:stable]'
       )}
     >
-      <PreferencesRow
-        iconKey="cogs"
-        preference={allPreferences().globalPreference}
-        onChange={() => updatePreference(allPreferences().globalPreference)}
-      />
+      <div class={style('globalWorkflowContainer')}>
+        <PreferencesRow
+          iconKey="cogs"
+          preference={allPreferences().globalPreference}
+          onChange={() => updatePreference(allPreferences().globalPreference)}
+        />
+      </div>
       <Show
         when={groupedPreferences().length > 0}
         fallback={

--- a/packages/js/src/ui/config/appearanceKeys.ts
+++ b/packages/js/src/ui/config/appearanceKeys.ts
@@ -184,6 +184,7 @@ export const appearanceKeys = [
 
   // workflow
   'workflowContainer',
+  'globalWorkflowContainer',
   'workflowLabel',
   'workflowLabelHeader',
   'workflowLabelHeaderContainer',


### PR DESCRIPTION
### What changed? Why was the change needed?

Adds a new `globalWorkflowContainer` appearance key and wraps the global preference section in the `Preferences` component with it. This enables developers to specifically target and style the global preference workflow container using appearance props, addressing [NV-6561](https://linear.app/novu/issue/NV-6561).

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

The `AppearanceKey` type is automatically updated. The change was verified with successful builds and type checks.

</details>

---
Linear Issue: [NV-6561](https://linear.app/novu/issue/NV-6561/option-to-hide-global-preference-in-inbox-preference-view)

<a href="https://cursor.com/background-agent?bcId=bc-7ed3f751-868d-46ab-8630-1725361ffe92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ed3f751-868d-46ab-8630-1725361ffe92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

