### PR TITLE
feat(add-inbox): implement custom backend and socket URL configuration fixes NV-6580

### DIFF
--- a/packages/add-inbox/README.md
+++ b/packages/add-inbox/README.md
@@ -20,11 +20,13 @@ This will guide you through an interactive process to add the Novu Inbox compone
 - ✅ Automatic dependency installation
 - ✅ Component creation in your project's component directory
 - ✅ Environment variable setup for Novu configuration
+- ✅ Custom backend and socket URL configuration
+- ✅ Region-based configuration (US/EU)
 
 ## Example Usage in Your App
 
 ```jsx
-import NovuInbox from '@/components/ui/inbox/novuInbox';
+import NovuInbox from '@/components/ui/inbox/NovuInbox';
 
 // Inside your component
 return (
@@ -50,3 +52,19 @@ For Next.js:
 ```
 NEXT_PUBLIC_NOVU_APP_ID=your_novu_app_id_here
 ```
+
+## Custom Backend Configuration
+
+When using custom backend and socket URLs, the generated component will include the appropriate props:
+
+```jsx
+<Inbox 
+  applicationIdentifier={process.env.NEXT_PUBLIC_NOVU_APP_ID}
+  subscriberId={subscriberId}
+  backendUrl="https://api.my-novu-instance.com"
+  socketUrl="https://ws.my-novu-instance.com"
+  // ... other props
+/>
+```
+
+If no custom URLs are provided, the component will use Novu's default URLs or region-specific URLs (EU region uses `https://eu.api.novu.co` and `https://eu.ws.novu.co`).

--- a/packages/add-inbox/README.md
+++ b/packages/add-inbox/README.md
@@ -62,9 +62,9 @@ When using custom backend and socket URLs, the generated component will include 
   applicationIdentifier={process.env.NEXT_PUBLIC_NOVU_APP_ID}
   subscriberId={subscriberId}
   backendUrl="https://api.my-novu-instance.com"
-  socketUrl="https://ws.my-novu-instance.com"
+  socketUrl="wss://ws.my-novu-instance.com"
   // ... other props
 />
 ```
 
-If no custom URLs are provided, the component will use Novu's default URLs or region-specific URLs (EU region uses `https://eu.api.novu.co` and `https://eu.ws.novu.co`).
+If no custom URLs are provided, the component will use Novu's default URLs or region-specific URLs (EU region uses `https://eu.api.novu.co` and `wss://eu.ws.novu.co`).

--- a/packages/add-inbox/src/cli/index.ts
+++ b/packages/add-inbox/src/cli/index.ts
@@ -375,9 +375,14 @@ function validateBackendUrl(backendUrl: string | undefined): boolean {
     return false;
   }
 
-  // Basic URL validation
+  // URL validation with HTTP/HTTPS protocol enforcement
   try {
-    new URL(backendUrl);
+    const url = new URL(backendUrl);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      logger.error('Invalid backendUrl provided. Backend URL must use HTTP or HTTPS protocol.');
+      
+      return false;
+    }
   } catch {
     logger.error('Invalid backendUrl provided. It must be a valid URL.');
 
@@ -395,9 +400,14 @@ function validateSocketUrl(socketUrl: string | undefined): boolean {
     return false;
   }
 
-  // Basic URL validation
+  // URL validation with WebSocket protocol enforcement
   try {
-    new URL(socketUrl);
+    const url = new URL(socketUrl);
+    if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+      logger.error('Invalid socketUrl provided. WebSocket URL must use WS or WSS protocol.');
+      
+      return false;
+    }
   } catch {
     logger.error('Invalid socketUrl provided. It must be a valid URL.');
 

--- a/packages/add-inbox/src/cli/index.ts
+++ b/packages/add-inbox/src/cli/index.ts
@@ -56,12 +56,23 @@ async function promptUserConfiguration(analytics?: AnalyticsService): Promise<IU
     return null;
   }
 
+  // Determine effective region and show warnings
+  let effectiveRegion = region;
+  if (backendUrl || socketUrl) {
+    // When custom URLs are provided, region is not needed
+    if (region !== 'us') {
+      logger.warning('\n⚠️  Custom backend/socket URLs provided. Region parameter will be ignored.');
+      logger.gray('   The custom URLs will take precedence over region-based configuration.');
+    }
+    effectiveRegion = 'us'; // Default to 'us' when custom URLs are provided
+  }
+
   // Use detected framework directly without prompting
   const initialResponses: Partial<IUserConfig> = {
     framework: detectedFramework,
     appId,
     subscriberId,
-    region,
+    region: effectiveRegion,
     backendUrl,
     socketUrl,
   };
@@ -401,7 +412,7 @@ function parseCommandLineArgs() {
   program
     .option('--appId <id>', 'Novu Application Identifier')
     .option('--subscriberId <id>', 'Novu Subscriber Identifier')
-    .option('--region <region>', 'Novu Region (eu or us)', 'us')
+    .option('--region <region>', 'Novu Region (eu or us). Optional when using custom URLs.', 'us')
     .option('--backendUrl <url>', 'Custom backend URL for Novu API')
     .option('--socketUrl <url>', 'Custom socket URL for Novu WebSocket connection')
     .parse(process.argv);

--- a/packages/add-inbox/src/cli/index.ts
+++ b/packages/add-inbox/src/cli/index.ts
@@ -22,6 +22,8 @@ interface IUserConfig {
   appId?: string;
   subscriberId?: string;
   region: string;
+  backendUrl?: string;
+  socketUrl?: string;
   packageManager: IPackageManager;
   overwriteComponents: boolean;
   updateEnvExample: boolean;
@@ -40,7 +42,7 @@ interface IPackageJson {
 
 async function promptUserConfiguration(analytics?: AnalyticsService): Promise<IUserConfig | null> {
   // Parse command line arguments
-  const { appId, subscriberId, region } = parseCommandLineArgs();
+  const { appId, subscriberId, region, backendUrl, socketUrl } = parseCommandLineArgs();
 
   // Detect framework first
   const detectedFramework = detectFramework();
@@ -60,6 +62,8 @@ async function promptUserConfiguration(analytics?: AnalyticsService): Promise<IU
     appId,
     subscriberId,
     region,
+    backendUrl,
+    socketUrl,
   };
 
   // Detect package manager
@@ -352,18 +356,62 @@ function validateRegion(region: string): boolean {
   return true;
 }
 
+function validateBackendUrl(backendUrl: string | undefined): boolean {
+  if (backendUrl === undefined || backendUrl === null) return true; // Optional
+  if (typeof backendUrl !== 'string' || backendUrl.trim().length === 0) {
+    logger.error('Invalid backendUrl provided. It must be a non-empty string.');
+
+    return false;
+  }
+
+  // Basic URL validation
+  try {
+    new URL(backendUrl);
+  } catch {
+    logger.error('Invalid backendUrl provided. It must be a valid URL.');
+
+    return false;
+  }
+
+  return true;
+}
+
+function validateSocketUrl(socketUrl: string | undefined): boolean {
+  if (socketUrl === undefined || socketUrl === null) return true; // Optional
+  if (typeof socketUrl !== 'string' || socketUrl.trim().length === 0) {
+    logger.error('Invalid socketUrl provided. It must be a non-empty string.');
+
+    return false;
+  }
+
+  // Basic URL validation
+  try {
+    new URL(socketUrl);
+  } catch {
+    logger.error('Invalid socketUrl provided. It must be a valid URL.');
+
+    return false;
+  }
+
+  return true;
+}
+
 function parseCommandLineArgs() {
   const program = new Command();
   program
     .option('--appId <id>', 'Novu Application Identifier')
     .option('--subscriberId <id>', 'Novu Subscriber Identifier')
     .option('--region <region>', 'Novu Region (eu or us)', 'us')
+    .option('--backendUrl <url>', 'Custom backend URL for Novu API')
+    .option('--socketUrl <url>', 'Custom socket URL for Novu WebSocket connection')
     .parse(process.argv);
 
   return {
     appId: program.opts().appId,
     subscriberId: program.opts().subscriberId,
     region: program.opts().region,
+    backendUrl: program.opts().backendUrl,
+    socketUrl: program.opts().socketUrl,
   };
 }
 
@@ -381,7 +429,7 @@ function validateProjectStructure() {
 }
 
 async function performInstallation(config: IUserConfig, analytics?: AnalyticsService) {
-  const { framework, packageManager, overwriteComponents, updateEnvExample, appId, subscriberId, region } = config;
+  const { framework, packageManager, overwriteComponents, updateEnvExample, appId, subscriberId, region, backendUrl, socketUrl } = config;
 
   try {
     logger.step(1, 'Checking framework and package manager');
@@ -390,6 +438,12 @@ async function performInstallation(config: IUserConfig, analytics?: AnalyticsSer
     logger.gray(`    Setup: ${framework.setup}`);
     logger.success(`  ✓ Detected package manager: ${logger.bold(packageManager.name)}`);
     logger.success(`  ✓ Region: ${logger.bold(region)}`);
+    if (backendUrl) {
+      logger.success(`  ✓ Custom backend URL: ${logger.bold(backendUrl)}`);
+    }
+    if (socketUrl) {
+      logger.success(`  ✓ Custom socket URL: ${logger.bold(socketUrl)}`);
+    }
 
     logger.step(2, 'Installing dependencies');
     await installDependencies(framework, packageManager, analytics);
@@ -399,7 +453,9 @@ async function performInstallation(config: IUserConfig, analytics?: AnalyticsSer
       framework,
       overwriteComponents,
       subscriberId || null,
-      region as 'us' | 'eu' | undefined
+      region as 'us' | 'eu' | undefined,
+      backendUrl || null,
+      socketUrl || null
     );
 
     if (updateEnvExample) {
@@ -492,7 +548,7 @@ function trackCliCompleted(analytics: AnalyticsService, config: IUserConfig, con
 }
 
 async function init() {
-  const { appId, subscriberId, region } = parseCommandLineArgs();
+  const { appId, subscriberId, region, backendUrl, socketUrl } = parseCommandLineArgs();
   const analytics = new AnalyticsService(subscriberId);
   let config: IUserConfig | null = null;
   let errorOrCancelled = false;
@@ -502,13 +558,19 @@ async function init() {
     analytics.track({ event: AnalyticsEventEnum.CLI_STARTED });
 
     // Parse and validate command line arguments
-    const argsValid = validateAppId(appId) && validateSubscriberId(subscriberId) && validateRegion(region);
+    const argsValid = validateAppId(appId) && 
+                     validateSubscriberId(subscriberId) && 
+                     validateRegion(region) &&
+                     validateBackendUrl(backendUrl) &&
+                     validateSocketUrl(socketUrl);
     if (!argsValid) {
       trackCliError(analytics, 'Invalid command line arguments', undefined, {
         step: 'validateArgs',
         appId,
         subscriberId,
         region,
+        backendUrl,
+        socketUrl,
       });
       errorOrCancelled = true;
       process.exit(1);
@@ -547,7 +609,7 @@ async function init() {
       trackCliCompleted(analytics, config);
     }
   } catch (error) {
-    trackCliError(analytics, error, config ?? undefined, { step: 'init', appId, subscriberId, region });
+    trackCliError(analytics, error, config ?? undefined, { step: 'init', appId, subscriberId, region, backendUrl, socketUrl });
     logger.error('\n❌ An unexpected error occurred:');
     logger.error(error instanceof Error ? error.message : String(error));
     errorOrCancelled = true;
@@ -566,4 +628,4 @@ if (typeof require !== 'undefined' && require.main === module) {
   });
 }
 
-export { init, parseCommandLineArgs, validateAppId, validateSubscriberId, validateProjectStructure, validateRegion };
+export { init, parseCommandLineArgs, validateAppId, validateSubscriberId, validateProjectStructure, validateRegion, validateBackendUrl, validateSocketUrl };

--- a/packages/add-inbox/src/generators/component.ts
+++ b/packages/add-inbox/src/generators/component.ts
@@ -10,7 +10,9 @@ export async function createComponentStructure(
   framework: IFramework,
   overwriteComponents: boolean,
   subscriberId: string | null | undefined,
-  region: 'us' | 'eu' = 'us'
+  region: 'us' | 'eu' = 'us',
+  backendUrl: string | null = null,
+  socketUrl: string | null = null
 ): Promise<void> {
   logger.gray('• Creating component structure...');
 
@@ -38,11 +40,11 @@ export async function createComponentStructure(
   // Generate component code based on framework
   let componentCode: string;
   if (framework.framework === FRAMEWORKS.NEXTJS) {
-    componentCode = generateNextJsComponent(subscriberId || null, region as 'us' | 'eu');
+    componentCode = generateNextJsComponent(subscriberId || null, region as 'us' | 'eu', backendUrl, socketUrl);
   } else if (isModernReact()) {
-    componentCode = generateModernReactComponent(subscriberId || null, region);
+    componentCode = generateModernReactComponent(subscriberId || null, region, backendUrl, socketUrl);
   } else {
-    componentCode = generateLegacyReactComponent(subscriberId || null, region);
+    componentCode = generateLegacyReactComponent(subscriberId || null, region, backendUrl, socketUrl);
   }
 
   // Write component file

--- a/packages/add-inbox/src/generators/frameworks/nextjs.ts
+++ b/packages/add-inbox/src/generators/frameworks/nextjs.ts
@@ -34,7 +34,7 @@ export function generateNextJsComponent(
   // Define region-specific configuration
   const regionConfig: IRegionConfigs = {
     eu: {
-      socketUrl: 'https://eu.ws.novu.co',
+      socketUrl: 'wss://eu.ws.novu.co',
       backendUrl: 'https://eu.api.novu.co',
     },
   };

--- a/packages/add-inbox/src/generators/frameworks/nextjs.ts
+++ b/packages/add-inbox/src/generators/frameworks/nextjs.ts
@@ -20,7 +20,12 @@ interface IRegionConfigs {
   eu: IRegionConfig;
 }
 
-export function generateNextJsComponent(subscriberId: string | null = null, region: 'us' | 'eu' = 'us'): string {
+export function generateNextJsComponent(
+  subscriberId: string | null = null, 
+  region: 'us' | 'eu' = 'us',
+  backendUrl: string | null = null,
+  socketUrl: string | null = null
+): string {
   // Define common filter patterns
   const filterByTags = (tags: string[]): IFilterByTags => ({ tags });
   const filterByData = (data: Record<string, unknown>): IFilterByData => ({ data });
@@ -34,8 +39,25 @@ export function generateNextJsComponent(subscriberId: string | null = null, regi
     },
   };
 
+  // Use custom URLs if provided, otherwise fall back to region-based URLs
+  const finalBackendUrl = backendUrl || (region === 'eu' ? regionConfig.eu.backendUrl : null);
+  const finalSocketUrl = socketUrl || (region === 'eu' ? regionConfig.eu.socketUrl : null);
+
   const escapeString = (str: string) =>
     str.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+
+  // Build URL props string
+  let urlProps = '';
+  if (finalBackendUrl || finalSocketUrl) {
+    const props = [];
+    if (finalBackendUrl) {
+      props.push(`backendUrl="${escapeString(finalBackendUrl)}"`);
+    }
+    if (finalSocketUrl) {
+      props.push(`socketUrl="${escapeString(finalSocketUrl)}"`);
+    }
+    urlProps = `\n    ${props.join(' ')}`;
+  }
 
   const componentCode = `'use client';
 
@@ -90,13 +112,7 @@ export default function NovuInbox() {
   return <Inbox 
     applicationIdentifier={process.env.NEXT_PUBLIC_NOVU_APP_ID as string}
     subscriberId={temporarySubscriberId} 
-    tabs={tabs} ${
-      region === 'eu'
-        ? `
-    socketUrl="${regionConfig.eu.socketUrl}" 
-    backendUrl="${regionConfig.eu.backendUrl}"`
-        : ''
-    }
+    tabs={tabs}${urlProps}
     appearance={{
       // To enable dark theme support, uncomment the following line:
       // baseTheme: dark,

--- a/packages/add-inbox/src/generators/frameworks/react.ts
+++ b/packages/add-inbox/src/generators/frameworks/react.ts
@@ -46,17 +46,20 @@ function generateSharedInboxCode(
 ): string {
   // Use custom URLs if provided, otherwise fall back to region-based URLs
   const finalBackendUrl = backendUrl || (region === 'eu' ? 'https://eu.api.novu.co' : null);
-  const finalSocketUrl = socketUrl || (region === 'eu' ? 'https://eu.ws.novu.co' : null);
+  const finalSocketUrl = socketUrl || (region === 'eu' ? 'wss://eu.ws.novu.co' : null);
+
+  const escapeString = (str: string) =>
+    str.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
 
   // Build URL props string
   let urlProps = '';
   if (finalBackendUrl || finalSocketUrl) {
     const props = [];
     if (finalBackendUrl) {
-      props.push(`backendUrl="${finalBackendUrl}"`);
+      props.push(`backendUrl="${escapeString(finalBackendUrl)}"`);
     }
     if (finalSocketUrl) {
-      props.push(`socketUrl="${finalSocketUrl}"`);
+      props.push(`socketUrl="${escapeString(finalSocketUrl)}"`);
     }
     urlProps = `\n    ${props.join(' ')}`;
   }
@@ -67,7 +70,7 @@ function generateSharedInboxCode(
 
 export function NovuInbox() {
  // ${subscriberId ? 'Using provided subscriber ID - replace with your actual subscriber ID from your auth system' : 'TODO: Replace with your actual subscriber ID from your auth system'}
- const temporarySubscriberId = ${subscriberId ? `"${subscriberId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"` : '""'};
+ const temporarySubscriberId = ${subscriberId ? `"${escapeString(subscriberId)}"` : '""'};
 
   const tabs = [
     // Basic tab with no filtering (shows all notifications)

--- a/packages/add-inbox/src/generators/frameworks/react.ts
+++ b/packages/add-inbox/src/generators/frameworks/react.ts
@@ -1,12 +1,17 @@
 import { getReactVersion } from '../react-version';
 
-export function generateReactComponent(subscriberId: string | null = null, region: string = 'us'): string {
+export function generateReactComponent(
+  subscriberId: string | null = null, 
+  region: string = 'us',
+  backendUrl: string | null = null,
+  socketUrl: string | null = null
+): string {
   const reactVersion = getReactVersion();
   const isModernReact = isReactVersionModern(reactVersion);
 
   return isModernReact
-    ? generateModernReactComponent(subscriberId, region)
-    : generateLegacyReactComponent(subscriberId, region);
+    ? generateModernReactComponent(subscriberId, region, backendUrl, socketUrl)
+    : generateLegacyReactComponent(subscriberId, region, backendUrl, socketUrl);
 }
 
 function isReactVersionModern(version: string): boolean {
@@ -32,7 +37,30 @@ function isReactVersionModern(version: string): boolean {
   }
 }
 
-function generateSharedInboxCode(subscriberId: string | null, region: string = 'us', envAccessor: string): string {
+function generateSharedInboxCode(
+  subscriberId: string | null, 
+  region: string = 'us', 
+  envAccessor: string,
+  backendUrl: string | null = null,
+  socketUrl: string | null = null
+): string {
+  // Use custom URLs if provided, otherwise fall back to region-based URLs
+  const finalBackendUrl = backendUrl || (region === 'eu' ? 'https://eu.api.novu.co' : null);
+  const finalSocketUrl = socketUrl || (region === 'eu' ? 'https://eu.ws.novu.co' : null);
+
+  // Build URL props string
+  let urlProps = '';
+  if (finalBackendUrl || finalSocketUrl) {
+    const props = [];
+    if (finalBackendUrl) {
+      props.push(`backendUrl="${finalBackendUrl}"`);
+    }
+    if (finalSocketUrl) {
+      props.push(`socketUrl="${finalSocketUrl}"`);
+    }
+    urlProps = `\n    ${props.join(' ')}`;
+  }
+
   return `import { Inbox } from '@novu/react';
 
 // import { dark } from '@novu/react/themes'; => To enable dark theme support, uncomment this line.
@@ -82,13 +110,7 @@ export function NovuInbox() {
 
   return <Inbox 
     applicationIdentifier={${envAccessor}}
-    subscriberId={temporarySubscriberId}
-    ${
-      region === 'eu'
-        ? `
-    socketUrl="https://eu.ws.novu.co" backendUrl="https://eu.api.novu.co"`
-        : ''
-    }
+    subscriberId={temporarySubscriberId}${urlProps}
     tabs={tabs} appearance={{
       // To enable dark theme support, uncomment the following line:
       // baseTheme: dark,
@@ -108,14 +130,24 @@ export function NovuInbox() {
 }`;
 }
 
-export function generateModernReactComponent(subscriberId: string | null, region: string = 'us'): string {
-  return generateSharedInboxCode(subscriberId, region, "import.meta.env.VITE_NOVU_APP_ID || ''");
+export function generateModernReactComponent(
+  subscriberId: string | null, 
+  region: string = 'us',
+  backendUrl: string | null = null,
+  socketUrl: string | null = null
+): string {
+  return generateSharedInboxCode(subscriberId, region, "import.meta.env.VITE_NOVU_APP_ID || ''", backendUrl, socketUrl);
 }
 
-export function generateLegacyReactComponent(subscriberId: string | null, region: string = 'us'): string {
+export function generateLegacyReactComponent(
+  subscriberId: string | null, 
+  region: string = 'us',
+  backendUrl: string | null = null,
+  socketUrl: string | null = null
+): string {
   return `// Legacy React component (React 16.x)
 // React import is required for JSX in React 16.x
 import React from 'react';
 
-${generateSharedInboxCode(subscriberId, region, "process.env.NOVU_APP_ID || ''")}`;
+${generateSharedInboxCode(subscriberId, region, "process.env.NOVU_APP_ID || ''", backendUrl, socketUrl)}`;
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

- Added support for custom backend and socket URLs in the Novu Inbox component.
- Updated CLI to accept `backendUrl` and `socketUrl` as command line arguments.
- Enhanced component generation functions to utilize custom URLs or fallback to region-specific defaults.
- Updated documentation to reflect new configuration options.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
