### PR TITLE
fix(api-service): Optimize bulk preference updates with workflow caching

### DIFF
--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
@@ -70,31 +70,41 @@ export class BulkUpdatePreferences {
     }
 
     // deduplicate preferences by workflow document ID, it ensures we only process one update per actual workflow document
-    const workflowPreferencesMap = new Map<string, BulkUpdatePreferenceItemDto>();
+    const workflowPreferencesMap = new Map<
+      string,
+      { preference: BulkUpdatePreferenceItemDto; workflow: NotificationTemplateEntity }
+    >();
     for (const preference of command.preferences) {
       const workflow = allValidWorkflowsMap.get(preference.workflowId);
       if (workflow) {
-        workflowPreferencesMap.set(workflow._id, preference);
+        workflowPreferencesMap.set(workflow._id, {
+          preference,
+          workflow,
+        });
       }
     }
 
-    const updatePromises = Array.from(workflowPreferencesMap.entries()).map(async ([workflowId, preferenceItem]) => {
-      return this.updatePreferencesUsecase.execute(
-        UpdatePreferencesCommand.create({
-          organizationId: command.organizationId,
-          subscriberId: command.subscriberId,
-          environmentId: command.environmentId,
-          level: PreferenceLevelEnum.TEMPLATE,
-          chat: preferenceItem.chat,
-          email: preferenceItem.email,
-          in_app: preferenceItem.in_app,
-          push: preferenceItem.push,
-          sms: preferenceItem.sms,
-          workflowIdOrIdentifier: workflowId,
-          includeInactiveChannels: false,
-        })
-      );
-    });
+    const updatePromises = Array.from(workflowPreferencesMap.entries()).map(
+      async ([workflowId, { preference, workflow }]) => {
+        return this.updatePreferencesUsecase.execute(
+          UpdatePreferencesCommand.create({
+            organizationId: command.organizationId,
+            subscriberId: command.subscriberId,
+            environmentId: command.environmentId,
+            level: PreferenceLevelEnum.TEMPLATE,
+            chat: preference.chat,
+            email: preference.email,
+            in_app: preference.in_app,
+            push: preference.push,
+            sms: preference.sms,
+            workflowIdOrIdentifier: workflowId,
+            workflow,
+            includeInactiveChannels: false,
+            subscriber,
+          })
+        );
+      }
+    );
 
     const updatedPreferences = await Promise.all(updatePromises);
 

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.command.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.command.ts
@@ -1,6 +1,6 @@
+import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
 import { PreferenceLevelEnum } from '@novu/shared';
 import { IsBoolean, IsDefined, IsEnum, IsOptional, ValidateIf } from 'class-validator';
-
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
 
 export class UpdatePreferencesCommand extends EnvironmentWithSubscriber {
@@ -35,4 +35,10 @@ export class UpdatePreferencesCommand extends EnvironmentWithSubscriber {
   @IsDefined()
   @IsBoolean()
   readonly includeInactiveChannels: boolean;
+
+  @IsOptional()
+  readonly subscriber?: SubscriberEntity;
+
+  @IsOptional()
+  readonly workflow?: NotificationTemplateEntity;
 }

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -44,19 +44,23 @@ export class UpdatePreferences {
 
   @InstrumentUsecase()
   async execute(command: UpdatePreferencesCommand): Promise<InboxPreference> {
-    const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
+    const subscriber =
+      command.subscriber ??
+      (await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId));
     if (!subscriber) throw new NotFoundException(`Subscriber with id: ${command.subscriberId} is not found`);
 
     let workflowId: string | undefined;
 
     if (command.level === PreferenceLevelEnum.TEMPLATE && command.workflowIdOrIdentifier) {
-      const workflow = await this.getWorkflowByIdsUsecase.execute(
-        GetWorkflowByIdsCommand.create({
-          environmentId: command.environmentId,
-          organizationId: command.organizationId,
-          workflowIdOrInternalId: command.workflowIdOrIdentifier,
-        })
-      );
+      const workflow =
+        command.workflow ??
+        (await this.getWorkflowByIdsUsecase.execute(
+          GetWorkflowByIdsCommand.create({
+            environmentId: command.environmentId,
+            organizationId: command.organizationId,
+            workflowIdOrInternalId: command.workflowIdOrIdentifier,
+          })
+        ));
 
       if (workflow.critical) {
         throw new BadRequestException(
@@ -127,13 +131,15 @@ export class UpdatePreferences {
     subscriber: SubscriberEntity
   ): Promise<InboxPreference> {
     if (command.level === PreferenceLevelEnum.TEMPLATE && command.workflowIdOrIdentifier) {
-      const workflow = await this.getWorkflowByIdsUsecase.execute(
-        GetWorkflowByIdsCommand.create({
-          environmentId: command.environmentId,
-          organizationId: command.organizationId,
-          workflowIdOrInternalId: command.workflowIdOrIdentifier,
-        })
-      );
+      const workflow =
+        command.workflow ??
+        (await this.getWorkflowByIdsUsecase.execute(
+          GetWorkflowByIdsCommand.create({
+            environmentId: command.environmentId,
+            organizationId: command.organizationId,
+            workflowIdOrInternalId: command.workflowIdOrIdentifier,
+          })
+        ));
 
       const { preference } = await this.getSubscriberTemplatePreferenceUsecase.execute(
         GetSubscriberTemplatePreferenceCommand.create({

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -42,7 +42,7 @@ export class GetSubscriberTemplatePreference {
 
   @InstrumentUsecase()
   async execute(command: GetSubscriberTemplatePreferenceCommand): Promise<ISubscriberPreferenceResponse> {
-    const subscriber = await this.getSubscriber(command);
+    const subscriber = command.subscriber ?? (await this.getSubscriber(command));
 
     const initialChannels = await this.getChannels(command);
 


### PR DESCRIPTION
BulkUpdatePreferences now passes cached workflow and subscriber entities to UpdatePreferencesUsecase, reducing redundant database queries. UpdatePreferencesCommand and usecase are updated to accept optional workflow and subscriber objects, improving performance for bulk operations.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
