### PR TITLE
fix(providers): unifonic sms provider test error

### DIFF
--- a/packages/providers/src/lib/sms/unifonic/unifonic.provider.spec.ts
+++ b/packages/providers/src/lib/sms/unifonic/unifonic.provider.spec.ts
@@ -32,7 +32,7 @@ describe('UnifonicSmsProvider', () => {
 
     expect(mockedAxios.post).toHaveBeenCalledWith(
       'https://el.cloud.unifonic.com/rest/SMS/messages',
-      expect.stringContaining('AppSid=2W950KLy4G0Ljq7S0GKNbRoBtgKr1T'),
+      expect.stringContaining('AppSid=testSender'),
       expect.objectContaining({
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
### What changed? Why was the change needed?

Updated the `UnifonicSmsProvider` test assertion in `unifonic.provider.spec.ts`. The test was failing because it expected a hardcoded `AppSid` value in the request body, which did not match the `appSid` configured for the test. This change aligns the test expectation with the actual configured `appSid` (`testSender`), resolving the test failure.

### Screenshots

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNS89H/p1756149732857169?thread_ts=1756149732.857169&cid=D0919LNS89H)

<a href="https://cursor.com/background-agent?bcId=bc-3535edd5-8037-4d7d-beeb-2a14b10aec3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3535edd5-8037-4d7d-beeb-2a14b10aec3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

