### PR TITLE
fix(dashboard): Prevent translation api calls for unsupported plans

### DIFF
--- a/apps/dashboard/src/components/translations/hooks/use-translation-list-logic.ts
+++ b/apps/dashboard/src/components/translations/hooks/use-translation-list-logic.ts
@@ -1,12 +1,18 @@
 import { useFetchTranslationList } from '@/hooks/use-fetch-translation-list';
 import { useTranslationsUrlState } from './use-translations-url-state';
 
-export function useTranslationListLogic() {
+interface UseTranslationListLogicOptions {
+  enabled?: boolean;
+}
+
+export function useTranslationListLogic(options: UseTranslationListLogicOptions = {}) {
+  const { enabled = true } = options;
+  
   const { filterValues, handleFiltersChange, resetFilters } = useTranslationsUrlState({
     total: 0,
   });
 
-  const { data, isPending, isFetching, refetch } = useFetchTranslationList(filterValues);
+  const { data, isPending, isFetching, refetch } = useFetchTranslationList(filterValues, { enabled });
 
   const areFiltersApplied = filterValues.query !== '';
 

--- a/apps/dashboard/src/components/translations/translation-list.tsx
+++ b/apps/dashboard/src/components/translations/translation-list.tsx
@@ -184,12 +184,21 @@ function TranslationListContainer({
 type TranslationListProps = HTMLAttributes<HTMLDivElement>;
 
 export function TranslationList(props: TranslationListProps) {
-  const { filterValues, handleFiltersChange, resetFilters, data, isPending, isFetching, areFiltersApplied } =
-    useTranslationListLogic();
-
   const navigate = useNavigate();
   const { currentEnvironment } = useEnvironment();
   const { data: organizationSettings } = useFetchOrganizationSettings();
+  const { subscription } = useFetchSubscription();
+
+  const canUseTranslationFeature =
+    getFeatureForTierAsBoolean(
+      FeatureNameEnum.AUTO_TRANSLATIONS,
+      subscription?.apiServiceLevel || ApiServiceLevelEnum.FREE
+    ) &&
+    (!IS_SELF_HOSTED || IS_ENTERPRISE);
+
+  // Only make API call if user has proper tier
+  const { filterValues, handleFiltersChange, resetFilters, data, isPending, isFetching, areFiltersApplied } =
+    useTranslationListLogic({ enabled: canUseTranslationFeature });
 
   const handleTranslationClick = (translation: TranslationGroup) => {
     if (currentEnvironment?.slug) {
@@ -209,15 +218,6 @@ export function TranslationList(props: TranslationListProps) {
 
   const { deleteModalTranslation, isDeletePending, handleDeleteClick, handleDeleteConfirm, handleDeleteCancel } =
     useDeleteTranslationModal();
-
-  const { subscription } = useFetchSubscription();
-
-  const canUseTranslationFeature =
-    getFeatureForTierAsBoolean(
-      FeatureNameEnum.AUTO_TRANSLATIONS,
-      subscription?.apiServiceLevel || ApiServiceLevelEnum.FREE
-    ) &&
-    (!IS_SELF_HOSTED || IS_ENTERPRISE);
 
   const limit = data?.limit || DEFAULT_TRANSLATIONS_LIMIT;
 

--- a/apps/dashboard/src/hooks/use-fetch-translation-list.ts
+++ b/apps/dashboard/src/hooks/use-fetch-translation-list.ts
@@ -3,7 +3,12 @@ import { getTranslationsList, TranslationsFilter } from '@/api/translations';
 import { useEnvironment } from '@/context/environment/hooks';
 import { QueryKeys } from '@/utils/query-keys';
 
-export const useFetchTranslationList = (filterValues: TranslationsFilter) => {
+interface UseFetchTranslationListOptions {
+  enabled?: boolean;
+}
+
+export const useFetchTranslationList = (filterValues: TranslationsFilter, options: UseFetchTranslationListOptions = {}) => {
+  const { enabled = true } = options;
   const { currentEnvironment } = useEnvironment();
 
   return useQuery({
@@ -18,6 +23,6 @@ export const useFetchTranslationList = (filterValues: TranslationsFilter) => {
         ...filterValues,
       });
     },
-    enabled: !!currentEnvironment,
+    enabled: !!currentEnvironment && enabled,
   });
 };


### PR DESCRIPTION
### What changed? Why was the change needed?

Previously, the translations page would make an API request to fetch translations even when the user's subscription plan did not include the feature. This resulted in an unnecessary API call returning a "Payment Required" error before the UI displayed the appropriate upgrade call-to-action.

This change modifies the `TranslationList` component and its associated hooks (`useTranslationListLogic`, `useFetchTranslationList`) to check the user's feature tier *before* initiating the API call. The API request is now only made if the `canUseTranslationFeature` check passes, preventing unnecessary API calls and immediately showing the upgrade CTA when the feature is not available.

### Screenshots

<!-- No visual changes to the UI, only API call prevention. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

The `enabled` parameter was added to `useTranslationListLogic` and `useFetchTranslationList` to conditionally execute the API query. This ensures the API call is only made when `canUseTranslationFeature` is true.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1756385554351059?thread_ts=1756385554.351059&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-8ad70f21-e524-4d7c-a63b-f3329631279c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ad70f21-e524-4d7c-a63b-f3329631279c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

