### PR TITLE
fix(application-generic): update condition checks for IS_SELF_HOSTED environment variable fixes NV-6606

### DIFF
--- a/libs/application-generic/src/services/in-memory-provider/cache-in-memory-provider.service.ts
+++ b/libs/application-generic/src/services/in-memory-provider/cache-in-memory-provider.service.ts
@@ -27,11 +27,11 @@ export class CacheInMemoryProviderService {
    * mapping in the /in-memory-provider/providers/index.ts
    */
   private selectProvider(): InMemoryProviderEnum {
-    if (process.env.IS_SELF_HOSTED && process.env.NOVU_ENTERPRISE === 'false') {
+    if (process.env.IS_SELF_HOSTED === 'true' && process.env.NOVU_ENTERPRISE === 'false') {
       return InMemoryProviderEnum.REDIS;
     }
 
-    if (process.env.IS_SELF_HOSTED && process.env.NOVU_ENTERPRISE === 'true') {
+    if (process.env.IS_SELF_HOSTED === 'true' && process.env.NOVU_ENTERPRISE === 'true') {
       return InMemoryProviderEnum.REDIS_MASTER_SLAVE;
     }
 

--- a/libs/application-generic/src/services/in-memory-provider/web-sockets-in-memory-provider.service.ts
+++ b/libs/application-generic/src/services/in-memory-provider/web-sockets-in-memory-provider.service.ts
@@ -25,7 +25,7 @@ export class WebSocketsInMemoryProviderService {
    * mapping in the /in-memory-provider/providers/index.ts
    */
   private selectProvider(): InMemoryProviderEnum {
-    if (process.env.IS_SELF_HOSTED && process.env.NOVU_ENTERPRISE === 'false') {
+    if (process.env.IS_SELF_HOSTED === 'true' && process.env.NOVU_ENTERPRISE === 'false') {
       return InMemoryProviderEnum.REDIS;
     }
 

--- a/libs/application-generic/src/services/in-memory-provider/workflow-in-memory-provider.service.ts
+++ b/libs/application-generic/src/services/in-memory-provider/workflow-in-memory-provider.service.ts
@@ -27,7 +27,7 @@ export class WorkflowInMemoryProviderService {
    * mapping in the /in-memory-provider/providers/index.ts
    */
   private selectProvider(): InMemoryProviderEnum {
-    if (process.env.IS_SELF_HOSTED) {
+    if (process.env.IS_SELF_HOSTED === 'true') {
       return InMemoryProviderEnum.REDIS;
     }
 


### PR DESCRIPTION
This pull request updates the logic for selecting in-memory providers based on environment variables in several services. The changes ensure that the checks for `IS_SELF_HOSTED` explicitly compare its value to `'true'`, improving clarity and correctness in provider selection.

Environment variable comparison updates:

* Changed `IS_SELF_HOSTED` checks to explicitly compare with `'true'` in `CacheInMemoryProviderService`, ensuring accurate provider selection for both enterprise and non-enterprise scenarios.
* Updated `IS_SELF_HOSTED` comparison to `'true'` in `WebSocketsInMemoryProviderService` for consistent provider selection logic.
* Modified `IS_SELF_HOSTED` check to `'true'` in `WorkflowInMemoryProviderService`, standardizing the condition for selecting the Redis provider.