### PR TITLE
feat(dashboard): Add websocket url to api keys page fixes NV-6550

### DIFF
--- a/apps/dashboard/src/pages/api-keys.tsx
+++ b/apps/dashboard/src/pages/api-keys.tsx
@@ -137,7 +137,7 @@ export function ApiKeysPage() {
               <CardContent className="rounded-b-xl border-t bg-neutral-50 bg-white p-4">
                 <div className="space-y-4">
                   <SettingField
-                    label="Novu API Hostname"
+                    label="API Hostname"
                     tooltip={IS_SELF_HOSTED 
                       ? 'Your self-hosted Novu API endpoint'
                       : `For Novu Cloud in the ${region} region`
@@ -145,7 +145,7 @@ export function ApiKeysPage() {
                     value={API_HOSTNAME}
                   />
                   <SettingField
-                    label="Novu WebSocket Hostname"
+                    label="WebSocket Hostname"
                     tooltip={IS_SELF_HOSTED 
                       ? 'Your self-hosted Novu WebSocket endpoint'
                       : `WebSocket endpoint for Novu Cloud in the ${region} region`

--- a/apps/dashboard/src/pages/api-keys.tsx
+++ b/apps/dashboard/src/pages/api-keys.tsx
@@ -126,8 +126,8 @@ export function ApiKeysPage() {
                 API URLs
                 <p className="text-foreground-500 mt-1 text-xs font-normal">
                   {IS_SELF_HOSTED 
-                    ? 'API endpoint for your self-hosted Novu instance. '
-                    : `URLs for Novu Cloud in the ${region} region. `
+                    ? 'API and WebSocket endpoints for your self-hosted Novu instance. '
+                    : `API and WebSocket URLs for Novu Cloud in the ${region} region. `
                   }
                   <ExternalLink href="https://docs.novu.co/api-reference/overview" className="text-foreground-500">
                     Learn more
@@ -144,31 +144,17 @@ export function ApiKeysPage() {
                     }
                     value={API_HOSTNAME}
                   />
+                  <SettingField
+                    label="Novu WebSocket Hostname"
+                    tooltip={IS_SELF_HOSTED 
+                      ? 'Your self-hosted Novu WebSocket endpoint'
+                      : `WebSocket endpoint for Novu Cloud in the ${region} region`
+                    }
+                    value={getWebSocketUrl(WEBSOCKET_HOSTNAME)}
+                  />
                 </div>
               </CardContent>
             </Card>
-            {IS_SELF_HOSTED && (
-              <Card className="w-full overflow-hidden shadow-none">
-                <CardHeader>
-                  WebSocket URLs
-                  <p className="text-foreground-500 mt-1 text-xs font-normal">
-                    WebSocket endpoint for your self-hosted Novu instance.{' '}
-                    <ExternalLink href="https://docs.novu.co/platform/sdks/overview" className="text-foreground-500">
-                      Learn more
-                    </ExternalLink>
-                  </p>
-                </CardHeader>
-                <CardContent className="rounded-b-xl border-t bg-neutral-50 bg-white p-4">
-                  <div className="space-y-4">
-                    <SettingField
-                      label="Novu WebSocket Hostname"
-                      tooltip="Your self-hosted Novu WebSocket endpoint"
-                      value={getWebSocketUrl(WEBSOCKET_HOSTNAME)}
-                    />
-                  </div>
-                </CardContent>
-              </Card>
-            )}
           </Form>
         </Container>
       </DashboardLayout>


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR adds the Novu WebSocket Hostname to the API Keys page, addressing Linear issue [NV-6550](https://linear.app/novu/issue/NV-6550).

Previously, the WebSocket URL was only displayed for self-hosted instances. This change unifies the display logic to show the WebSocket URL for both cloud (US/EU regions) and self-hosted deployments, ensuring users can easily access the correct regional WebSocket endpoint. The field is located below the Novu API Hostname, as requested.

### Screenshots

<img width="800" alt="Screenshot of the API Keys page with the new WebSocket Hostname field" src="image_1.png">

---
Linear Issue: [NV-6550](https://linear.app/novu/issue/NV-6550/add-websocket-url-on-the-api-keys-page)

<a href="https://cursor.com/background-agent?bcId=bc-ce54e239-cd25-45a7-acc4-3732b97da42a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce54e239-cd25-45a7-acc4-3732b97da42a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

