### PR TITLE
fix(api-service): Add instrumentation decorators to usecases and remove redudndat calls 

### DIFF
--- a/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
@@ -249,6 +249,16 @@ describe('GetInboxPreferences', () => {
       environmentId: command.environmentId,
       subscriberId: command.subscriberId,
       includeInactiveChannels: false,
+      subscriber: {
+        _id: 'test-mockSubscriber',
+        subscriberId: 'test-mockSubscriber',
+        firstName: 'test',
+        lastName: 'test',
+        email: 'test@test.com',
+        _organizationId: 'org-1',
+        _environmentId: 'env-1',
+        deleted: false,
+      },
     });
 
     expect(getSubscriberPreferenceMock.execute.calledOnce).to.be.true;
@@ -260,6 +270,16 @@ describe('GetInboxPreferences', () => {
       severity: command.severity,
       includeInactiveChannels: false,
       criticality: command.criticality,
+      subscriber: {
+        _id: 'test-mockSubscriber',
+        subscriberId: 'test-mockSubscriber',
+        firstName: 'test',
+        lastName: 'test',
+        email: 'test@test.com',
+        _organizationId: 'org-1',
+        _environmentId: 'env-1',
+        deleted: false,
+      },
     });
 
     expect(result).to.deep.equal([

--- a/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
@@ -1,4 +1,5 @@
 import { AnalyticsService } from '@novu/application-generic';
+import { SubscriberRepository } from '@novu/dal';
 import {
   ChannelTypeEnum,
   ISubscriberPreferenceResponse,
@@ -64,16 +65,18 @@ describe('GetInboxPreferences', () => {
   let analyticsServiceMock: sinon.SinonStubbedInstance<AnalyticsService>;
   let getSubscriberGlobalPreferenceMock: sinon.SinonStubbedInstance<GetSubscriberGlobalPreference>;
   let getSubscriberPreferenceMock: sinon.SinonStubbedInstance<GetSubscriberPreference>;
-
+  let subscriberRepositoryMock: sinon.SinonStubbedInstance<SubscriberRepository>;
   beforeEach(() => {
     getSubscriberPreferenceMock = sinon.createStubInstance(GetSubscriberPreference);
     analyticsServiceMock = sinon.createStubInstance(AnalyticsService);
     getSubscriberGlobalPreferenceMock = sinon.createStubInstance(GetSubscriberGlobalPreference);
+    subscriberRepositoryMock = sinon.createStubInstance(SubscriberRepository);
 
     getInboxPreferences = new GetInboxPreferences(
       getSubscriberGlobalPreferenceMock as any,
       analyticsServiceMock as any,
-      getSubscriberPreferenceMock as any
+      getSubscriberPreferenceMock as any,
+      subscriberRepositoryMock as any
     );
   });
 

--- a/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
@@ -92,15 +92,13 @@ describe('GetInboxPreferences', () => {
       criticality: WorkflowCriticalityEnum.NON_CRITICAL,
     });
 
-    getSubscriberGlobalPreferenceMock.execute.rejects(
-      new Error(`Subscriber with id ${command.subscriberId} not found`)
-    );
+    subscriberRepositoryMock.findBySubscriberId.resolves(null);
 
     try {
       await getInboxPreferences.execute(command);
     } catch (error) {
       expect(error).to.be.instanceOf(Error);
-      expect(error.message).to.equal(`Subscriber with id ${command.subscriberId} not found`);
+      expect(error.message).to.equal(`Subscriber ${command.subscriberId} not found`);
     }
   });
 
@@ -136,6 +134,16 @@ describe('GetInboxPreferences', () => {
       environmentId: command.environmentId,
       subscriberId: command.subscriberId,
       includeInactiveChannels: false,
+      subscriber: {
+        _id: 'test-mockSubscriber',
+        subscriberId: 'test-mockSubscriber',
+        firstName: 'test',
+        lastName: 'test',
+        email: 'test@test.com',
+        _organizationId: 'org-1',
+        _environmentId: 'env-1',
+        deleted: false,
+      },
     });
 
     expect(getSubscriberPreferenceMock.execute.calledOnce).to.be.true;
@@ -147,6 +155,16 @@ describe('GetInboxPreferences', () => {
       severity: undefined,
       includeInactiveChannels: false,
       criticality: command.criticality,
+      subscriber: {
+        _id: 'test-mockSubscriber',
+        subscriberId: 'test-mockSubscriber',
+        firstName: 'test',
+        lastName: 'test',
+        email: 'test@test.com',
+        _organizationId: 'org-1',
+        _environmentId: 'env-1',
+        deleted: false,
+      },
     });
 
     expect(result).to.deep.equal([

--- a/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.spec.ts
@@ -112,6 +112,17 @@ describe('GetInboxPreferences', () => {
       criticality: WorkflowCriticalityEnum.NON_CRITICAL,
     });
 
+    subscriberRepositoryMock.findBySubscriberId.resolves({
+      _id: 'test-mockSubscriber',
+      subscriberId: 'test-mockSubscriber',
+      firstName: 'test',
+      lastName: 'test',
+      email: 'test@test.com',
+      _organizationId: 'org-1',
+      _environmentId: 'env-1',
+      deleted: false,
+    } as any);
+
     getSubscriberGlobalPreferenceMock.execute.resolves({
       preference: mockedGlobalPreferences,
     });
@@ -195,6 +206,17 @@ describe('GetInboxPreferences', () => {
       severity: [SeverityLevelEnum.HIGH],
       criticality: WorkflowCriticalityEnum.NON_CRITICAL,
     });
+
+    subscriberRepositoryMock.findBySubscriberId.resolves({
+      _id: 'test-mockSubscriber',
+      subscriberId: 'test-mockSubscriber',
+      firstName: 'test',
+      lastName: 'test',
+      email: 'test@test.com',
+      _organizationId: 'org-1',
+      _environmentId: 'env-1',
+      deleted: false,
+    } as any);
 
     getSubscriberGlobalPreferenceMock.execute.resolves({
       preference: mockedGlobalPreferences,

--- a/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.usecase.ts
@@ -27,7 +27,7 @@ export class GetInboxPreferences {
   async execute(command: GetInboxPreferencesCommand): Promise<InboxPreference[]> {
     const subscriber = await this.getSubscriber(command);
     if (!subscriber) {
-      throw new NotFoundException(`Subscriber ${command.subscriberId} not found`);
+      throw new NotFoundException(`Subscriber with id ${command.subscriberId} not found`);
     }
 
     const globalPreference = await this.getSubscriberGlobalPreference.execute(

--- a/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/get-inbox-preferences/get-inbox-preferences.usecase.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { AnalyticsService, InstrumentUsecase } from '@novu/application-generic';
+import { SubscriberEntity, SubscriberRepository } from '@novu/dal';
 import { PreferenceLevelEnum, SeverityLevelEnum } from '@novu/shared';
 import {
   GetSubscriberGlobalPreference,
@@ -18,17 +19,24 @@ export class GetInboxPreferences {
   constructor(
     private getSubscriberGlobalPreference: GetSubscriberGlobalPreference,
     private analyticsService: AnalyticsService,
-    private getSubscriberPreference: GetSubscriberPreference
+    private getSubscriberPreference: GetSubscriberPreference,
+    private subscriberRepository: SubscriberRepository
   ) {}
 
   @InstrumentUsecase()
   async execute(command: GetInboxPreferencesCommand): Promise<InboxPreference[]> {
+    const subscriber = await this.getSubscriber(command);
+    if (!subscriber) {
+      throw new NotFoundException(`Subscriber ${command.subscriberId} not found`);
+    }
+
     const globalPreference = await this.getSubscriberGlobalPreference.execute(
       GetSubscriberGlobalPreferenceCommand.create({
         organizationId: command.organizationId,
         environmentId: command.environmentId,
         subscriberId: command.subscriberId,
         includeInactiveChannels: false,
+        subscriber,
       })
     );
 
@@ -50,6 +58,7 @@ export class GetInboxPreferences {
         organizationId: command.organizationId,
         tags: command.tags,
         severity,
+        subscriber,
         includeInactiveChannels: false,
         criticality: command.criticality,
       })
@@ -90,5 +99,15 @@ export class GetInboxPreferences {
     });
 
     return [updatedGlobalPreference, ...sortedWorkflowPreferences];
+  }
+
+  private async getSubscriber(command: GetInboxPreferencesCommand): Promise<SubscriberEntity> {
+    const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
+
+    if (!subscriber) {
+      throw new NotFoundException(`Subscriber ${command.subscriberId} not found`);
+    }
+
+    return subscriber;
   }
 }

--- a/apps/api/src/app/inbox/usecases/notifications-count/notifications-count.command.ts
+++ b/apps/api/src/app/inbox/usecases/notifications-count/notifications-count.command.ts
@@ -1,3 +1,4 @@
+import { SubscriberEntity } from '@novu/dal';
 import { SeverityLevelEnum } from '@novu/shared';
 import { IsArray, IsBoolean, IsDefined, IsOptional, IsString } from 'class-validator';
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
@@ -35,4 +36,7 @@ export class NotificationsCountCommand extends EnvironmentWithSubscriber {
   @IsDefined()
   @IsArray()
   filters: NotificationsFilter[];
+
+  @IsOptional()
+  subscriber?: SubscriberEntity;
 }

--- a/apps/api/src/app/inbox/usecases/notifications-count/notifications-count.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/notifications-count/notifications-count.usecase.ts
@@ -25,12 +25,9 @@ export class NotificationsCount {
   async execute(
     command: NotificationsCountCommand
   ): Promise<{ data: Array<{ count: number; filter: NotificationFilter }> }> {
-    const subscriber = await this.subscriberRepository.findBySubscriberId(
-      command.environmentId,
-      command.subscriberId,
-      true,
-      '_id'
-    );
+    const subscriber =
+      command.subscriber ??
+      (await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId, true, '_id'));
 
     if (!subscriber) {
       throw new BadRequestException(

--- a/apps/api/src/app/inbox/usecases/session/session.spec.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.spec.ts
@@ -173,6 +173,7 @@ describe('Session', () => {
       },
     };
     const subscriber = { _id: 'subscriber-id' };
+    const organization = { _id: 'org-id', apiServiceLevel: ApiServiceLevelEnum.FREE };
     const notificationCount = { data: [{ count: 10, filter: {} }] };
     const token = 'token';
 
@@ -182,6 +183,7 @@ describe('Session', () => {
       apiKeys: [{ key: 'api-key', _userId: 'user-id' }],
       name: 'Development',
     } as any);
+    organizationRepository.findOne.resolves(organization as any);
     selectIntegration.execute.resolves(mockIntegration);
     createSubscriber.execute.resolves(subscriber as any);
     notificationsCount.execute.resolves(notificationCount);
@@ -210,11 +212,13 @@ describe('Session', () => {
       },
     };
     const subscriber = { _id: 'subscriber-id' };
+    const organization = { _id: 'org-id', apiServiceLevel: ApiServiceLevelEnum.FREE };
     const environment = { _id: 'env-id', _organizationId: 'org-id', name: 'env-name', apiKeys: [{ key: 'api-key' }] };
     const notificationCount = { data: [{ count: 10, filter: {} }] };
     const token = 'token';
 
     environmentRepository.findEnvironmentByIdentifier.resolves(environment as any);
+    organizationRepository.findOne.resolves(organization as any);
     selectIntegration.execute.resolves({ ...mockIntegration, credentials: { hmac: false } });
     createSubscriber.execute.resolves(subscriber as any);
     notificationsCount.execute.resolves(notificationCount);
@@ -247,6 +251,7 @@ describe('Session', () => {
       origin: 'origin',
     };
 
+    const organization = { _id: 'org-id', apiServiceLevel: ApiServiceLevelEnum.FREE };
     const environment = { _id: 'env-id', _organizationId: 'org-id', name: 'env-name', apiKeys: [{ key: 'api-key' }] };
     const integration = { ...mockIntegration, credentials: { hmac: false } };
     const subscriber = { _id: 'subscriber-id' };
@@ -255,6 +260,7 @@ describe('Session', () => {
 
     environmentRepository.findEnvironmentByIdentifier.resolves(environment as any);
     selectIntegration.execute.resolves(integration);
+    organizationRepository.findOne.resolves(organization as any);
     createSubscriber.execute.resolves(subscriber as any);
     notificationsCount.execute.resolves(notificationCount);
     authService.getSubscriberWidgetToken.resolves(token);
@@ -287,11 +293,13 @@ describe('Session', () => {
     };
 
     const environment = { _id: 'env-id', _organizationId: 'org-id', name: 'env-name', apiKeys: [{ key: 'api-key' }] };
+    const organization = { _id: 'org-id', apiServiceLevel: ApiServiceLevelEnum.FREE };
     const integration = { ...mockIntegration, credentials: { hmac: false } };
     const subscriber = { _id: 'subscriber-id' };
     const notificationCount = { data: [{ count: 10, filter: {} }] };
     const token = 'token';
 
+    organizationRepository.findOne.resolves(organization as any);
     environmentRepository.findEnvironmentByIdentifier.resolves(environment as any);
     selectIntegration.execute.resolves(integration);
     createSubscriber.execute.resolves(subscriber as any);

--- a/apps/api/src/app/inbox/usecases/session/session.spec.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.spec.ts
@@ -183,7 +183,7 @@ describe('Session', () => {
       apiKeys: [{ key: 'api-key', _userId: 'user-id' }],
       name: 'Development',
     } as any);
-    organizationRepository.findOne.resolves(organization as any);
+    organizationRepository.findById.resolves(organization as any);
     selectIntegration.execute.resolves(mockIntegration);
     createSubscriber.execute.resolves(subscriber as any);
     notificationsCount.execute.resolves(notificationCount);
@@ -218,7 +218,7 @@ describe('Session', () => {
     const token = 'token';
 
     environmentRepository.findEnvironmentByIdentifier.resolves(environment as any);
-    organizationRepository.findOne.resolves(organization as any);
+    organizationRepository.findById.resolves(organization as any);
     selectIntegration.execute.resolves({ ...mockIntegration, credentials: { hmac: false } });
     createSubscriber.execute.resolves(subscriber as any);
     notificationsCount.execute.resolves(notificationCount);
@@ -260,7 +260,7 @@ describe('Session', () => {
 
     environmentRepository.findEnvironmentByIdentifier.resolves(environment as any);
     selectIntegration.execute.resolves(integration);
-    organizationRepository.findOne.resolves(organization as any);
+    organizationRepository.findById.resolves(organization as any);
     createSubscriber.execute.resolves(subscriber as any);
     notificationsCount.execute.resolves(notificationCount);
     authService.getSubscriberWidgetToken.resolves(token);
@@ -299,7 +299,7 @@ describe('Session', () => {
     const notificationCount = { data: [{ count: 10, filter: {} }] };
     const token = 'token';
 
-    organizationRepository.findOne.resolves(organization as any);
+    organizationRepository.findById.resolves(organization as any);
     environmentRepository.findEnvironmentByIdentifier.resolves(environment as any);
     selectIntegration.execute.resolves(integration);
     createSubscriber.execute.resolves(subscriber as any);
@@ -311,22 +311,22 @@ describe('Session', () => {
     });
 
     // FREE plan should have 24 hours max snooze duration
-    organizationRepository.findOne.resolves({ apiServiceLevel: ApiServiceLevelEnum.FREE } as any);
+    organizationRepository.findById.resolves({ apiServiceLevel: ApiServiceLevelEnum.FREE } as any);
     const freeResponse: SubscriberSessionResponseDto = await session.execute(command);
     expect(freeResponse.maxSnoozeDurationHours).to.equal(24);
 
     // PRO plan should have 90 days max snooze duration
-    organizationRepository.findOne.resolves({ apiServiceLevel: ApiServiceLevelEnum.PRO } as any);
+    organizationRepository.findById.resolves({ apiServiceLevel: ApiServiceLevelEnum.PRO } as any);
     const proResponse: SubscriberSessionResponseDto = await session.execute(command);
     expect(proResponse.maxSnoozeDurationHours).to.equal(90 * 24);
 
     // BUSINESS/TEAM plan should have 90 days max snooze duration
-    organizationRepository.findOne.resolves({ apiServiceLevel: ApiServiceLevelEnum.BUSINESS } as any);
+    organizationRepository.findById.resolves({ apiServiceLevel: ApiServiceLevelEnum.BUSINESS } as any);
     const businessResponse: SubscriberSessionResponseDto = await session.execute(command);
     expect(businessResponse.maxSnoozeDurationHours).to.equal(90 * 24);
 
     // ENTERPRISE plan should have 90 days max snooze duration
-    organizationRepository.findOne.resolves({ apiServiceLevel: ApiServiceLevelEnum.ENTERPRISE } as any);
+    organizationRepository.findById.resolves({ apiServiceLevel: ApiServiceLevelEnum.ENTERPRISE } as any);
     const enterpriseResponse: SubscriberSessionResponseDto = await session.execute(command);
     expect(enterpriseResponse.maxSnoozeDurationHours).to.equal(90 * 24);
   });

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -163,6 +163,7 @@ export class Session {
         environmentId: environment._id,
         subscriberId: subscriber.subscriberId,
         filters: [{ read: false, snoozed: false }],
+        subscriber: subscriberEntity,
       })
     );
     const [{ count: totalUnreadCount }] = data;
@@ -201,14 +202,20 @@ export class Session {
     }
 
     const token = await this.authService.getSubscriberWidgetToken(subscriberEntity);
+    const organization = await this.organizationRepository.findById(environment._organizationId);
+
+    if (!organization) {
+      throw new NotFoundException('Organization not found');
+    }
 
     const { removeNovuBranding } = await this.getOrganizationSettingsUsecase.execute(
       GetOrganizationSettingsCommand.create({
         organizationId: environment._organizationId,
+        organization,
       })
     );
 
-    const maxSnoozeDurationHours = await this.getMaxSnoozeDurationHours(environment);
+    const maxSnoozeDurationHours = await this.getMaxSnoozeDurationHours(organization?.apiServiceLevel);
 
     /**
      * We want to prevent the playground inbox demo from marking the integration as connected
@@ -312,18 +319,14 @@ export class Session {
     return applicationIdentifier;
   }
 
-  private async getMaxSnoozeDurationHours(environment: EnvironmentEntity) {
+  private async getMaxSnoozeDurationHours(apiServiceLevel: ApiServiceLevelEnum) {
     if (process.env.NOVU_ENTERPRISE !== 'true') {
       return 0;
     }
 
-    const organization = await this.organizationRepository.findOne({
-      _id: environment._organizationId,
-    });
-
     const tierLimitMs = getFeatureForTierAsNumber(
       FeatureNameEnum.PLATFORM_MAX_SNOOZE_DURATION,
-      organization?.apiServiceLevel || ApiServiceLevelEnum.FREE,
+      apiServiceLevel || ApiServiceLevelEnum.FREE,
       true
     );
 

--- a/apps/api/src/app/organization/dtos/get-organization-settings.dto.ts
+++ b/apps/api/src/app/organization/dtos/get-organization-settings.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsValidLocale } from '@novu/application-generic';
+import { OrganizationEntity } from '@novu/dal';
 import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class GetOrganizationSettingsDto {

--- a/apps/api/src/app/organization/usecases/get-organization-settings/get-organization-settings.command.ts
+++ b/apps/api/src/app/organization/usecases/get-organization-settings/get-organization-settings.command.ts
@@ -1,7 +1,11 @@
 import { BaseCommand } from '@novu/application-generic';
-import { IsNotEmpty } from 'class-validator';
+import { OrganizationEntity } from '@novu/dal';
+import { IsNotEmpty, IsOptional } from 'class-validator';
 
 export class GetOrganizationSettingsCommand extends BaseCommand {
   @IsNotEmpty()
   readonly organizationId: string;
+
+  @IsOptional()
+  readonly organization?: OrganizationEntity;
 }

--- a/apps/api/src/app/organization/usecases/get-organization-settings/get-organization-settings.usecase.ts
+++ b/apps/api/src/app/organization/usecases/get-organization-settings/get-organization-settings.usecase.ts
@@ -9,7 +9,7 @@ export class GetOrganizationSettings {
   constructor(private organizationRepository: CommunityOrganizationRepository) {}
 
   async execute(command: GetOrganizationSettingsCommand): Promise<GetOrganizationSettingsDto> {
-    const organization = await this.organizationRepository.findById(command.organizationId);
+    const organization = command.organization ?? (await this.organizationRepository.findById(command.organizationId));
 
     if (!organization) {
       throw new NotFoundException('Organization not found');

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-global-preference/get-subscriber-global-preference.command.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-global-preference/get-subscriber-global-preference.command.ts
@@ -1,8 +1,12 @@
 import { EnvironmentWithSubscriber } from '@novu/application-generic';
-import { IsBoolean, IsDefined } from 'class-validator';
+import { SubscriberEntity } from '@novu/dal';
+import { IsBoolean, IsDefined, IsOptional } from 'class-validator';
 
 export class GetSubscriberGlobalPreferenceCommand extends EnvironmentWithSubscriber {
   @IsBoolean()
   @IsDefined()
   includeInactiveChannels: boolean;
+
+  @IsOptional()
+  subscriber?: SubscriberEntity;
 }

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-global-preference/get-subscriber-global-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-global-preference/get-subscriber-global-preference.usecase.ts
@@ -23,7 +23,7 @@ export class GetSubscriberGlobalPreference {
 
   @InstrumentUsecase()
   async execute(command: GetSubscriberGlobalPreferenceCommand) {
-    const subscriber = await this.getSubscriber(command);
+    const subscriber = command.subscriber ?? (await this.getSubscriber(command));
 
     const activeChannels = await this.getActiveChannels(command);
 
@@ -81,6 +81,7 @@ export class GetSubscriberGlobalPreference {
         organizationId: command.organizationId,
         includeInactiveChannels: command.includeInactiveChannels,
         criticality: WorkflowCriticalityEnum.NON_CRITICAL,
+        subscriber: command.subscriber,
       })
     );
 

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.command.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.command.ts
@@ -1,4 +1,5 @@
 import { EnvironmentWithSubscriber } from '@novu/application-generic';
+import { SubscriberEntity } from '@novu/dal';
 import { SeverityLevelEnum, WorkflowCriticalityEnum } from '@novu/shared';
 import { IsArray, IsBoolean, IsDefined, IsEnum, IsOptional, IsString } from 'class-validator';
 
@@ -20,4 +21,7 @@ export class GetSubscriberPreferenceCommand extends EnvironmentWithSubscriber {
   @IsEnum(WorkflowCriticalityEnum)
   @IsOptional()
   criticality: WorkflowCriticalityEnum;
+
+  @IsOptional()
+  subscriber?: SubscriberEntity;
 }

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
@@ -39,7 +39,9 @@ export class GetSubscriberPreference {
 
   @InstrumentUsecase()
   async execute(command: GetSubscriberPreferenceCommand): Promise<ISubscriberPreferenceResponse[]> {
-    const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
+    const subscriber =
+      command.subscriber ??
+      (await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId));
     if (!subscriber) {
       throw new NotFoundException(`Subscriber with id: ${command.subscriberId} not found`);
     }

--- a/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
@@ -5,6 +5,7 @@ import {
   CreateOrUpdateSubscriberUseCase,
   createHash,
   decryptApiKey,
+  InstrumentUsecase,
   LogDecorator,
   SelectIntegration,
   SelectIntegrationCommand,
@@ -28,6 +29,7 @@ export class InitializeSession {
   ) {}
 
   @LogDecorator()
+  @InstrumentUsecase()
   async execute(command: InitializeSessionCommand): Promise<SessionInitializeResponseDto> {
     const environment = await this.environmentRepository.findEnvironmentByIdentifier(command.applicationIdentifier);
 

--- a/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.usecase.ts
+++ b/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.usecase.ts
@@ -1,6 +1,7 @@
 import { ConflictException, Injectable } from '@nestjs/common';
 import { SubscriberEntity, SubscriberRepository } from '@novu/dal';
 import { RetryOnError } from '../../decorators/retry-on-error-decorator';
+import { InstrumentUsecase } from '../../instrumentation';
 import { AnalyticsService, buildSubscriberKey, InvalidateCacheService } from '../../services';
 import { OAuthHandlerEnum, UpdateSubscriberChannel, UpdateSubscriberChannelCommand } from '../subscribers';
 import { UpdateSubscriber, UpdateSubscriberCommand } from '../update-subscriber';
@@ -20,6 +21,7 @@ export class CreateOrUpdateSubscriberUseCase {
     maxRetries: 3,
     delay: 500,
   })
+  @InstrumentUsecase()
   async execute(command: CreateOrUpdateSubscriberCommand) {
     const persistedSubscriber = await this.getExistingSubscriber(command);
     if (command.failIfExists && persistedSubscriber) {
@@ -38,10 +40,12 @@ export class CreateOrUpdateSubscriberUseCase {
       await this.updateCredentials(command);
     }
 
-    return await this.fetchSubscriber({
-      _environmentId: command.environmentId,
-      subscriberId: command.subscriberId,
-    });
+    return persistedSubscriber && !command.allowUpdate
+      ? persistedSubscriber
+      : await this.fetchSubscriber({
+          _environmentId: command.environmentId,
+          subscriberId: command.subscriberId,
+        });
   }
 
   private async updateSubscriber(command: CreateOrUpdateSubscriberCommand, existingSubscriber: SubscriberEntity) {

--- a/libs/application-generic/src/usecases/select-integration/select-integration.usecase.ts
+++ b/libs/application-generic/src/usecases/select-integration/select-integration.usecase.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { IntegrationEntity, IntegrationRepository, TenantEntity, TenantRepository } from '@novu/dal';
 import { CHANNELS_WITH_PRIMARY } from '@novu/shared';
+import { Instrument, InstrumentUsecase } from '../../instrumentation';
 import { CachedQuery } from '../../services/cache/interceptors/cached-query.interceptor';
 import { buildIntegrationKey } from '../../services/cache/key-builders/queries';
 import { ConditionsFilter, ConditionsFilterCommand } from '../conditions-filter';
@@ -19,6 +20,7 @@ export class SelectIntegration {
     private normalizeVariablesUsecase: NormalizeVariables
   ) {}
 
+  @InstrumentUsecase()
   @CachedQuery({
     builder: ({ organizationId, ...command }: SelectIntegrationCommand) =>
       buildIntegrationKey().cache({
@@ -88,6 +90,7 @@ export class SelectIntegration {
     return GetDecryptedIntegrations.getDecryptedCredentials(integration);
   }
 
+  @Instrument()
   private async getPrimaryIntegration(command: SelectIntegrationCommand): Promise<IntegrationEntity | null> {
     const isChannelSupportsPrimary = CHANNELS_WITH_PRIMARY.includes(command.channelType);
 


### PR DESCRIPTION
Applied @InstrumentUsecase decorator to InitializeSession, CreateOrUpdateSubscriberUseCase, and SelectIntegration usecases for enhanced instrumentation. Also added @Instrument to getPrimaryIntegration method in SelectIntegration. Updated logic in CreateOrUpdateSubscriberUseCase to return existing subscriber when allowUpdate is false.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
