### PR TITLE
fix(api-service): Pass environment entity to update preferences usecase

### DIFF
--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.spec.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { AnalyticsService } from '@novu/application-generic';
-import { NotificationTemplateRepository, SubscriberRepository } from '@novu/dal';
+import { EnvironmentRepository, NotificationTemplateRepository, SubscriberRepository } from '@novu/dal';
 import { PreferenceLevelEnum, TriggerTypeEnum } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -79,18 +79,19 @@ describe('BulkUpdatePreferences', () => {
   let analyticsServiceMock: sinon.SinonStubbedInstance<AnalyticsService>;
   let notificationTemplateRepositoryMock: sinon.SinonStubbedInstance<NotificationTemplateRepository>;
   let updatePreferencesUsecaseMock: sinon.SinonStubbedInstance<UpdatePreferences>;
-
+  let environmentRepositoryMock: sinon.SinonStubbedInstance<EnvironmentRepository>;
   beforeEach(() => {
     subscriberRepositoryMock = sinon.createStubInstance(SubscriberRepository);
     analyticsServiceMock = sinon.createStubInstance(AnalyticsService);
     notificationTemplateRepositoryMock = sinon.createStubInstance(NotificationTemplateRepository);
     updatePreferencesUsecaseMock = sinon.createStubInstance(UpdatePreferences);
-
+    environmentRepositoryMock = sinon.createStubInstance(EnvironmentRepository);
     bulkUpdatePreferences = new BulkUpdatePreferences(
       notificationTemplateRepositoryMock as any,
       subscriberRepositoryMock as any,
       analyticsServiceMock as any,
-      updatePreferencesUsecaseMock as any
+      updatePreferencesUsecaseMock as any,
+      environmentRepositoryMock as any
     );
   });
 

--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException, UnprocessableEntity
 import { AnalyticsService, InstrumentUsecase } from '@novu/application-generic';
 import {
   BaseRepository,
+  EnvironmentRepository,
   NotificationTemplateEntity,
   NotificationTemplateRepository,
   SubscriberRepository,
@@ -22,7 +23,8 @@ export class BulkUpdatePreferences {
     private notificationTemplateRepository: NotificationTemplateRepository,
     private subscriberRepository: SubscriberRepository,
     private analyticsService: AnalyticsService,
-    private updatePreferencesUsecase: UpdatePreferences
+    private updatePreferencesUsecase: UpdatePreferences,
+    private environmentRepository: EnvironmentRepository
   ) {}
 
   @InstrumentUsecase()
@@ -84,6 +86,13 @@ export class BulkUpdatePreferences {
       }
     }
 
+    const environment = await this.environmentRepository.findOne({
+      _id: command.environmentId,
+    });
+    if (!environment) {
+      throw new Error(`Environment not found for id ${command.environmentId}`);
+    }
+
     const updatePromises = Array.from(workflowPreferencesMap.entries()).map(
       async ([workflowId, { preference, workflow }]) => {
         return this.updatePreferencesUsecase.execute(
@@ -101,6 +110,7 @@ export class BulkUpdatePreferences {
             workflow,
             includeInactiveChannels: false,
             subscriber,
+            environment,
           })
         );
       }

--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
@@ -89,9 +89,6 @@ export class BulkUpdatePreferences {
     const environment = await this.environmentRepository.findOne({
       _id: command.environmentId,
     });
-    if (!environment) {
-      throw new Error(`Environment not found for id ${command.environmentId}`);
-    }
 
     const updatePromises = Array.from(workflowPreferencesMap.entries()).map(
       async ([workflowId, { preference, workflow }]) => {
@@ -110,7 +107,8 @@ export class BulkUpdatePreferences {
             workflow,
             includeInactiveChannels: false,
             subscriber,
-            environment,
+            // biome-ignore lint/style/noNonNullAssertion: environment is always found
+            environment: environment!,
           })
         );
       }

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.command.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.command.ts
@@ -1,4 +1,4 @@
-import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
+import { EnvironmentEntity, NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
 import { PreferenceLevelEnum } from '@novu/shared';
 import { IsBoolean, IsDefined, IsEnum, IsOptional, ValidateIf } from 'class-validator';
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
@@ -41,4 +41,7 @@ export class UpdatePreferencesCommand extends EnvironmentWithSubscriber {
 
   @IsOptional()
   readonly workflow?: NotificationTemplateEntity;
+
+  @IsOptional()
+  readonly environment?: EnvironmentEntity;
 }

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -85,6 +85,7 @@ export class UpdatePreferences {
       },
       organizationId: command.organizationId,
       environmentId: command.environmentId,
+      environment: command.environment,
     });
 
     return newPreference;


### PR DESCRIPTION
The bulk update preferences usecase now fetches the environment entity and passes it to the update preferences usecase. The UpdatePreferencesCommand and usecase have been updated to accept and use the environment entity, ensuring environment context is available during preference updates.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
