### PR TITLE
fix(dashboard): Hide new workflow creation in prod fixes NV-6583

### DIFF
--- a/apps/dashboard/src/components/command-palette/commands/workflow-commands.tsx
+++ b/apps/dashboard/src/components/command-palette/commands/workflow-commands.tsx
@@ -1,14 +1,16 @@
-import { PermissionsEnum } from '@novu/shared';
+import { PermissionsEnum, EnvironmentTypeEnum } from '@novu/shared';
 import { RiFileAddLine, RiRouteFill } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
 import { useFetchWorkflows } from '@/hooks/use-fetch-workflows';
 import { useHasPermission } from '@/hooks/use-has-permission';
+import { useEnvironment } from '@/context/environment/hooks';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { Command, CommandExecutionContext } from '../command-types';
 
 export function useWorkflowCommands(context: CommandExecutionContext): Command[] {
   const navigate = useNavigate();
   const hasWorkflowWrite = useHasPermission();
+  const { currentEnvironment } = useEnvironment();
 
   const { data: workflowsData } = useFetchWorkflows({
     limit: 50,
@@ -17,8 +19,12 @@ export function useWorkflowCommands(context: CommandExecutionContext): Command[]
 
   const commands: Command[] = [];
 
-  // Create new workflow
-  if (hasWorkflowWrite({ permission: PermissionsEnum.WORKFLOW_WRITE }) && context.environmentSlug) {
+  // Create new workflow - only show in development environment
+  if (
+    hasWorkflowWrite({ permission: PermissionsEnum.WORKFLOW_WRITE }) && 
+    context.environmentSlug && 
+    currentEnvironment?.type === EnvironmentTypeEnum.DEV
+  ) {
     commands.push({
       id: 'workflow-create',
       label: 'Create New Workflow',
@@ -32,7 +38,10 @@ export function useWorkflowCommands(context: CommandExecutionContext): Command[]
           navigate(buildRoute(ROUTES.WORKFLOWS_CREATE, { environmentSlug: context.environmentSlug }));
         }
       },
-      isVisible: () => hasWorkflowWrite({ permission: PermissionsEnum.WORKFLOW_WRITE }) && !!context.environmentSlug,
+      isVisible: () => 
+        hasWorkflowWrite({ permission: PermissionsEnum.WORKFLOW_WRITE }) && 
+        !!context.environmentSlug && 
+        currentEnvironment?.type === EnvironmentTypeEnum.DEV,
     });
   }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

The "Create New Workflow" option in Command K is now hidden in non-development (read-only) environments. This change prevents users from attempting to create new workflows in production or other read-only environments, addressing the bug reported in [NV-6583](https://linear.app/novu/issue/NV-6583). The option remains visible only in development environments.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

The visibility logic for the "Create New Workflow" command now includes a check for `currentEnvironment?.type === EnvironmentTypeEnum.DEV`, aligning with existing patterns for environment-based feature toggling within the codebase.

</details>

---
Linear Issue: [NV-6583](https://linear.app/novu/issue/NV-6583/command-k-allows-to-create-new-workflow-in-read-only-env-prod)

<a href="https://cursor.com/background-agent?bcId=bc-b846419c-d782-4eb7-aae1-e14509fb9d1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b846419c-d782-4eb7-aae1-e14509fb9d1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

