### PR TITLE
perf(api-service): Optimize preferences fetching and upsert logic

### DIFF
--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.spec.ts
@@ -184,17 +184,17 @@ describe('BulkUpdatePreferences', () => {
     });
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
-    notificationTemplateRepositoryMock.find.resolves([mockedWorkflow1, mockedWorkflow2]);
+    notificationTemplateRepositoryMock.findForBulkPreferences.resolves([mockedWorkflow1, mockedWorkflow2]);
+    environmentRepositoryMock.findOne.resolves({ _id: 'env-1' } as any);
     updatePreferencesUsecaseMock.execute.onFirstCall().resolves(mockedInboxPreference1);
     updatePreferencesUsecaseMock.execute.onSecondCall().resolves(mockedInboxPreference2);
 
     await bulkUpdatePreferences.execute(command);
 
-    const findCallArgs = notificationTemplateRepositoryMock.find.firstCall.args[0];
-    expect(findCallArgs).to.deep.equal({
-      _environmentId: 'env-1',
-      $or: [{ _id: { $in: [mockedWorkflow1._id] } }, { 'triggers.identifier': { $in: ['test-trigger-2'] } }],
-    });
+    const findCallArgs = notificationTemplateRepositoryMock.findForBulkPreferences.firstCall.args;
+    expect(findCallArgs[0]).to.equal('env-1'); // environmentId
+    expect(findCallArgs[1]).to.deep.equal([mockedWorkflow1._id]); // internal IDs
+    expect(findCallArgs[2]).to.deep.equal(['test-trigger-2']); // identifiers
   });
 
   it('should handle mixed ID types correctly', async () => {
@@ -217,10 +217,11 @@ describe('BulkUpdatePreferences', () => {
     });
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
-    notificationTemplateRepositoryMock.find.resolves([
+    notificationTemplateRepositoryMock.findForBulkPreferences.resolves([
       mockedWorkflow1,
       { ...mockedWorkflow2, triggers: [{ type: TriggerTypeEnum.EVENT, identifier: nonObjectIdString }] },
     ]);
+    environmentRepositoryMock.findOne.resolves({ _id: 'env-1' } as any);
     updatePreferencesUsecaseMock.execute.onFirstCall().resolves(mockedInboxPreference1);
     updatePreferencesUsecaseMock.execute.onSecondCall().resolves({
       ...mockedInboxPreference2,
@@ -229,9 +230,9 @@ describe('BulkUpdatePreferences', () => {
 
     await bulkUpdatePreferences.execute(command);
 
-    const findCallArgs = notificationTemplateRepositoryMock.find.firstCall.args[0];
-    expect(findCallArgs?.$or?.[0]?._id?.$in).to.include(mockedWorkflow1._id);
-    expect(findCallArgs?.$or?.[1]?.['triggers.identifier']?.$in).to.include(nonObjectIdString);
+    const findCallArgs = notificationTemplateRepositoryMock.findForBulkPreferences.firstCall.args;
+    expect(findCallArgs[1]).to.include(mockedWorkflow1._id); // internal IDs
+    expect(findCallArgs[2]).to.include(nonObjectIdString); // identifiers
   });
 
   it('should deduplicate preferences when different identifiers resolve to the same workflow', async () => {
@@ -257,7 +258,8 @@ describe('BulkUpdatePreferences', () => {
     });
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
-    notificationTemplateRepositoryMock.find.resolves([mockedWorkflow1]);
+    notificationTemplateRepositoryMock.findForBulkPreferences.resolves([mockedWorkflow1]);
+    environmentRepositoryMock.findOne.resolves({ _id: 'env-1' } as any);
     updatePreferencesUsecaseMock.execute.resolves(mockedInboxPreference1);
 
     const result = await bulkUpdatePreferences.execute(command);
@@ -288,7 +290,7 @@ describe('BulkUpdatePreferences', () => {
     });
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
-    notificationTemplateRepositoryMock.find.resolves([]);
+    notificationTemplateRepositoryMock.findForBulkPreferences.resolves([]);
 
     try {
       await bulkUpdatePreferences.execute(command);
@@ -315,7 +317,7 @@ describe('BulkUpdatePreferences', () => {
     });
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
-    notificationTemplateRepositoryMock.find.resolves([criticalWorkflow]);
+    notificationTemplateRepositoryMock.findForBulkPreferences.resolves([criticalWorkflow]);
 
     try {
       await bulkUpdatePreferences.execute(command);
@@ -346,7 +348,8 @@ describe('BulkUpdatePreferences', () => {
     });
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
-    notificationTemplateRepositoryMock.find.resolves([mockedWorkflow1, mockedWorkflow2]);
+    notificationTemplateRepositoryMock.findForBulkPreferences.resolves([mockedWorkflow1, mockedWorkflow2]);
+    environmentRepositoryMock.findOne.resolves({ _id: 'env-1' } as any);
 
     updatePreferencesUsecaseMock.execute.onFirstCall().resolves(mockedInboxPreference1);
     updatePreferencesUsecaseMock.execute.onSecondCall().resolves(mockedInboxPreference2);
@@ -396,7 +399,8 @@ describe('BulkUpdatePreferences', () => {
     });
 
     subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
-    notificationTemplateRepositoryMock.find.resolves([mockedWorkflow1]);
+    notificationTemplateRepositoryMock.findForBulkPreferences.resolves([mockedWorkflow1]);
+    environmentRepositoryMock.findOne.resolves({ _id: 'env-1' } as any);
     updatePreferencesUsecaseMock.execute.resolves(mockedInboxPreference1);
 
     const result = await bulkUpdatePreferences.execute(command);

--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
@@ -44,10 +44,11 @@ export class BulkUpdatePreferences {
     const workflowInternalIds = allWorkflowIds.filter((id) => BaseRepository.isInternalId(id));
     const workflowIdentifiers = allWorkflowIds.filter((id) => !BaseRepository.isInternalId(id));
 
-    const dbWorkflows = await this.notificationTemplateRepository.find({
-      _environmentId: command.environmentId,
-      $or: [{ _id: { $in: workflowInternalIds } }, { 'triggers.identifier': { $in: workflowIdentifiers } }],
-    });
+    const dbWorkflows = await this.notificationTemplateRepository.findForBulkPreferences(
+      command.environmentId,
+      workflowInternalIds,
+      workflowIdentifiers
+    );
 
     const allValidWorkflowsMap = new Map<string, NotificationTemplateEntity>();
     if (dbWorkflows && dbWorkflows.length > 0) {

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -211,6 +211,7 @@ export class UpdatePreferences {
           _subscriberId: item._subscriberId,
           templateId: item.workflowId,
           preferences,
+          returnPreference: false,
         })
       );
     } else {
@@ -220,6 +221,7 @@ export class UpdatePreferences {
           environmentId: item.environmentId,
           organizationId: item.organizationId,
           _subscriberId: item._subscriberId,
+          returnPreference: false,
         })
       );
     }

--- a/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
@@ -92,61 +92,81 @@ export class GetPreferences {
   ): IPreferenceChannels {
     const builtPreferences = buildWorkflowPreferences(workflowPreferences);
 
-    const mappedPreferences = Object.entries(builtPreferences.channels ?? {}).reduce(
-      (acc, [channel, preference]) => ({
-        ...acc,
-        [channel]: preference.enabled,
-      }),
-      {} as IPreferenceChannels
-    );
+    const mappedPreferences = Object.entries(builtPreferences.channels ?? {}).reduce((acc, [channel, preference]) => {
+      acc[channel as keyof IPreferenceChannels] = preference.enabled;
+
+      return acc;
+    }, {} as IPreferenceChannels);
 
     return mappedPreferences;
   }
 
   private async getPreferencesFromDb(command: GetPreferencesCommand): Promise<PreferenceSet> {
-    // Always fetch workflow-level preferences
-    const workflowPreferencesPromises = [
-      this.preferencesRepository.findOne({
+    // Build query conditions for all preference types
+    const queryConditions: Array<{
+      _templateId?: string;
+      _subscriberId?: string;
+      type: PreferencesTypeEnum;
+    }> = [
+      // Workflow resource preferences
+      {
         _templateId: command.templateId,
-        _environmentId: command.environmentId,
         type: PreferencesTypeEnum.WORKFLOW_RESOURCE,
-      }) as Promise<PreferenceSet['workflowResourcePreference'] | null>,
-      this.preferencesRepository.findOne({
+      },
+      // User workflow preferences
+      {
         _templateId: command.templateId,
-        _environmentId: command.environmentId,
         type: PreferencesTypeEnum.USER_WORKFLOW,
-      }) as Promise<PreferenceSet['workflowUserPreference'] | null>,
+      },
     ];
 
-    // Only fetch subscriber preferences if subscriberId is provided
-    const subscriberPreferencesPromises = command.subscriberId
-      ? [
-          this.preferencesRepository.findOne({
-            _subscriberId: command.subscriberId,
-            _environmentId: command.environmentId,
-            _templateId: command.templateId,
-            type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
-          }) as Promise<PreferenceSet['subscriberWorkflowPreference'] | null>,
-          this.preferencesRepository.findOne({
-            _subscriberId: command.subscriberId,
-            _environmentId: command.environmentId,
-            type: PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
-          }) as Promise<PreferenceSet['subscriberGlobalPreference'] | null>,
-        ]
-      : [Promise.resolve(null), Promise.resolve(null)];
+    // Add subscriber preferences if subscriberId is provided
+    if (command.subscriberId) {
+      queryConditions.push(
+        // Subscriber workflow preferences
+        {
+          _subscriberId: command.subscriberId,
+          _templateId: command.templateId,
+          type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
+        },
+        // Subscriber global preferences
+        {
+          _subscriberId: command.subscriberId,
+          type: PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
+        }
+      );
+    }
 
-    const [
-      workflowResourcePreference,
-      workflowUserPreference,
-      subscriberWorkflowPreference,
-      subscriberGlobalPreference,
-    ] = await Promise.all([...workflowPreferencesPromises, ...subscriberPreferencesPromises]);
+    const allPreferences = await this.preferencesRepository.find(
+      {
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+        $or: queryConditions,
+      },
+      undefined,
+      { readPreference: 'secondaryPreferred' }
+    );
 
-    return {
-      ...(workflowResourcePreference ? { workflowResourcePreference } : {}),
-      ...(workflowUserPreference ? { workflowUserPreference } : {}),
-      ...(subscriberWorkflowPreference ? { subscriberWorkflowPreference } : {}),
-      ...(subscriberGlobalPreference ? { subscriberGlobalPreference } : {}),
-    };
+    // Map results back to expected structure
+    const result: PreferenceSet = {};
+
+    for (const preference of allPreferences) {
+      switch (preference.type) {
+        case PreferencesTypeEnum.WORKFLOW_RESOURCE:
+          result.workflowResourcePreference = preference as PreferenceSet['workflowResourcePreference'];
+          break;
+        case PreferencesTypeEnum.USER_WORKFLOW:
+          result.workflowUserPreference = preference as PreferenceSet['workflowUserPreference'];
+          break;
+        case PreferencesTypeEnum.SUBSCRIBER_WORKFLOW:
+          result.subscriberWorkflowPreference = preference as PreferenceSet['subscriberWorkflowPreference'];
+          break;
+        case PreferencesTypeEnum.SUBSCRIBER_GLOBAL:
+          result.subscriberGlobalPreference = preference as PreferenceSet['subscriberGlobalPreference'];
+          break;
+      }
+    }
+
+    return result;
   }
 }

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -165,12 +165,15 @@ export class GetSubscriberTemplatePreference {
     if (stepMissingTemplate) {
       const messageIds = activeSteps.map((step) => step._templateId);
 
-      const messageTemplates = await this.messageTemplateRepository.find({
-        _environmentId: command.environmentId,
-        _id: {
-          $in: messageIds,
+      const messageTemplates = await this.messageTemplateRepository.find(
+        {
+          _environmentId: command.environmentId,
+          _id: {
+            $in: messageIds,
+          },
         },
-      });
+        '_id type'
+      );
 
       return [
         ...new Set(messageTemplates.map((messageTemplate) => messageTemplate.type) as unknown as ChannelTypeEnum[]),

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
@@ -33,13 +33,16 @@ export class UpsertPreferences {
 
   @Instrument()
   public async upsertWorkflowPreferences(command: UpsertWorkflowPreferencesCommand): Promise<WorkflowPreferencesFull> {
-    return this.upsert({
+    const result = await this.upsert({
       templateId: command.templateId,
       environmentId: command.environmentId,
       organizationId: command.organizationId,
       preferences: command.preferences,
       type: PreferencesTypeEnum.WORKFLOW_RESOURCE,
-    }) as Promise<WorkflowPreferencesFull>;
+      returnPreference: true,
+    });
+
+    return result as WorkflowPreferencesFull;
   }
 
   @Instrument()
@@ -102,14 +105,17 @@ export class UpsertPreferences {
   public async upsertUserWorkflowPreferences(
     command: UpsertUserWorkflowPreferencesCommand
   ): Promise<WorkflowPreferencesFull> {
-    return this.upsert({
+    const result = await this.upsert({
       userId: command.userId,
       environmentId: command.environmentId,
       organizationId: command.organizationId,
       preferences: command.preferences,
       templateId: command.templateId,
       type: PreferencesTypeEnum.USER_WORKFLOW,
-    }) as Promise<WorkflowPreferencesFull>;
+      returnPreference: true,
+    });
+
+    return result as WorkflowPreferencesFull;
   }
 
   private async upsert(command: UpsertPreferencesCommand): Promise<PreferencesEntity | undefined> {

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
@@ -52,6 +52,7 @@ export class UpsertPreferences {
       organizationId: command.organizationId,
       preferences: command.preferences,
       type: PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
+      returnPreference: command.returnPreference,
     });
   }
 
@@ -93,6 +94,7 @@ export class UpsertPreferences {
       preferences: command.preferences,
       templateId: command.templateId,
       type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
+      returnPreference: command.returnPreference,
     });
   }
 
@@ -110,7 +112,7 @@ export class UpsertPreferences {
     }) as Promise<WorkflowPreferencesFull>;
   }
 
-  private async upsert(command: UpsertPreferencesCommand): Promise<PreferencesEntity> {
+  private async upsert(command: UpsertPreferencesCommand): Promise<PreferencesEntity | undefined> {
     const foundPreference = await this.getPreference(command);
 
     if (foundPreference) {
@@ -154,7 +156,11 @@ export class UpsertPreferences {
       }
     );
 
-    return await this.getPreference(command);
+    if (command.returnPreference) {
+      return await this.getPreference(command);
+    }
+
+    return undefined;
   }
 
   private async deletePreferences(command: UpsertPreferencesCommand, preferencesId: string) {

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-global-preferences.command.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-global-preferences.command.ts
@@ -8,5 +8,5 @@ export class UpsertSubscriberGlobalPreferencesCommand extends UpsertPreferencesP
 
   @IsOptional()
   @IsBoolean()
-  readonly returnPreference: boolean = true;
+  readonly returnPreference?: boolean = true;
 }

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-global-preferences.command.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-global-preferences.command.ts
@@ -1,8 +1,12 @@
-import { IsMongoId, IsNotEmpty } from 'class-validator';
+import { IsBoolean, IsMongoId, IsNotEmpty, IsOptional } from 'class-validator';
 import { UpsertPreferencesPartialBaseCommand } from './upsert-preferences.command';
 
 export class UpsertSubscriberGlobalPreferencesCommand extends UpsertPreferencesPartialBaseCommand {
   @IsNotEmpty()
   @IsMongoId()
   readonly _subscriberId: string;
+
+  @IsOptional()
+  @IsBoolean()
+  readonly returnPreference: boolean = true;
 }

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-workflow-preferences.command.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-workflow-preferences.command.ts
@@ -1,8 +1,12 @@
-import { IsMongoId, IsNotEmpty } from 'class-validator';
+import { IsBoolean, IsMongoId, IsNotEmpty, IsOptional } from 'class-validator';
 import { UpsertSubscriberGlobalPreferencesCommand } from './upsert-subscriber-global-preferences.command';
 
 export class UpsertSubscriberWorkflowPreferencesCommand extends UpsertSubscriberGlobalPreferencesCommand {
   @IsNotEmpty()
   @IsMongoId()
   readonly templateId: string;
+
+  @IsBoolean()
+  @IsOptional()
+  readonly returnPreference: boolean = true;
 }

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-workflow-preferences.command.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-subscriber-workflow-preferences.command.ts
@@ -8,5 +8,5 @@ export class UpsertSubscriberWorkflowPreferencesCommand extends UpsertSubscriber
 
   @IsBoolean()
   @IsOptional()
-  readonly returnPreference: boolean = true;
+  readonly returnPreference?: boolean = true;
 }

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -127,7 +127,13 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
   async find(
     query: FilterQuery<T_DBModel> & T_Enforcement,
     select: ProjectionType<T_MappedEntity> = '',
-    options: { limit?: number; sort?: any; skip?: number; session?: ClientSession | null } = {}
+    options: {
+      limit?: number;
+      sort?: any;
+      skip?: number;
+      session?: ClientSession | null;
+      readPreference?: 'secondaryPreferred' | 'primary';
+    } = {}
   ): Promise<T_MappedEntity[]> {
     const { session, ...queryOptions } = options;
 
@@ -136,6 +142,7 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
     })
       .skip(queryOptions.skip as number)
       .limit(queryOptions.limit as number)
+      .read(queryOptions.readPreference || 'primary')
       .lean();
 
     if (session) {

--- a/libs/dal/src/repositories/notification-template/notification-template.repository.ts
+++ b/libs/dal/src/repositories/notification-template/notification-template.repository.ts
@@ -45,6 +45,24 @@ export class NotificationTemplateRepository extends BaseRepository<
     return this.mapEntities(items);
   }
 
+  async findForBulkPreferences(
+    environmentId: string,
+    ids: string[],
+    identifiers: string[],
+    session?: ClientSession | null
+  ) {
+    const requestQuery: NotificationTemplateQuery = {
+      _environmentId: environmentId,
+      $or: [{ _id: { $in: ids } }, { 'triggers.identifier': { $in: identifiers } }],
+    };
+
+    const query = this.MongooseModel.find(requestQuery, undefined, { session }).populate('steps.template', { type: 1 });
+
+    const items = await query;
+
+    return this.mapEntities(items);
+  }
+
   async findByTriggerIdentifierBulk(environmentId: string, identifiers: string[], session?: ClientSession | null) {
     const requestQuery: NotificationTemplateQuery = {
       _environmentId: environmentId,


### PR DESCRIPTION
Refactored preferences fetching to use a single query with read preference for efficiency. Added 'returnPreference' flag to upsert commands and logic to optionally return updated preferences. Introduced 'findForBulkPreferences' in notification template repository for bulk operations. Improved mapping and validation in related use cases.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
