### PR TITLE
perf(api-service): Optimize severity count aggregation in MessageRepository

### DIFF
--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -52,8 +52,6 @@ import { EnvironmentResponseDto } from '../../../environments-v1/dtos/environmen
 import { GenerateUniqueApiKey } from '../../../environments-v1/usecases/generate-unique-api-key/generate-unique-api-key.usecase';
 import { CreateNovuIntegrationsCommand } from '../../../integrations/usecases/create-novu-integrations/create-novu-integrations.command';
 import { CreateNovuIntegrations } from '../../../integrations/usecases/create-novu-integrations/create-novu-integrations.usecase';
-import { GetOrganizationSettingsCommand } from '../../../organization/usecases/get-organization-settings/get-organization-settings.command';
-import { GetOrganizationSettings } from '../../../organization/usecases/get-organization-settings/get-organization-settings.usecase';
 import { isHmacValid } from '../../../shared/helpers/is-valid-hmac';
 import { SubscriberDto, SubscriberSessionRequestDto } from '../../dtos/subscriber-session-request.dto';
 import { SubscriberSessionResponseDto } from '../../dtos/subscriber-session-response.dto';
@@ -89,7 +87,6 @@ export class Session {
     private messageRepository: MessageRepository,
     private preferencesRepository: PreferencesRepository,
     private upsertControlValuesUseCase: UpsertControlValuesUseCase,
-    private getOrganizationSettingsUsecase: GetOrganizationSettings,
     private logger: PinoLogger,
     private featureFlagsService: FeatureFlagsService
   ) {
@@ -202,18 +199,14 @@ export class Session {
     }
 
     const token = await this.authService.getSubscriberWidgetToken(subscriberEntity);
-    const organization = await this.organizationRepository.findById(environment._organizationId);
+    const organization = await this.organizationRepository.findById(
+      environment._organizationId,
+      '_id removeNovuBranding apiServiceLevel'
+    );
 
     if (!organization) {
       throw new NotFoundException('Organization not found');
     }
-
-    const { removeNovuBranding } = await this.getOrganizationSettingsUsecase.execute(
-      GetOrganizationSettingsCommand.create({
-        organizationId: environment._organizationId,
-        organization,
-      })
-    );
 
     const maxSnoozeDurationHours = await this.getMaxSnoozeDurationHours(organization?.apiServiceLevel);
 
@@ -247,7 +240,7 @@ export class Session {
       token,
       totalUnreadCount,
       unreadCount,
-      removeNovuBranding,
+      removeNovuBranding: organization.removeNovuBranding,
       maxSnoozeDurationHours,
       isDevelopmentMode: environment.name.toLowerCase() !== 'production',
     };

--- a/libs/dal/src/repositories/message/message.repository.ts
+++ b/libs/dal/src/repositories/message/message.repository.ts
@@ -6,7 +6,7 @@ import {
   MessagesStatusEnum,
   SeverityLevelEnum,
 } from '@novu/shared';
-import { FilterQuery, Types } from 'mongoose';
+import { FilterQuery, PipelineStage, Types } from 'mongoose';
 
 import { DalException } from '../../shared';
 import { EnforceEnvId } from '../../types/enforce';
@@ -380,13 +380,43 @@ export class MessageRepository extends BaseRepository<MessageDBModel, MessageEnt
   ): Promise<{ severity: SeverityLevelEnum; count: number }[]> {
     const severityLevels = Object.values(SeverityLevelEnum);
 
-    const promises = severityLevels.map((severity) =>
-      this.getCount(environmentId, subscriberId, channel, { ...query, severity: [severity] }, options)
-    );
+    // Get the base filter query without severity filter
+    const baseQuery = await this.getFilterQueryForMessage(environmentId, subscriberId, channel, query);
 
-    const results = await Promise.all(promises);
+    // Use aggregation to count by severity in a single query
+    const aggregationPipeline: PipelineStage[] = [
+      { $match: baseQuery },
+      {
+        $group: {
+          _id: '$severity',
+          count: { $sum: 1 },
+        },
+      },
+    ];
 
-    return results.map((result, index) => ({ severity: severityLevels[index], count: result }));
+    // Apply skip and limit if provided
+    if (options.skip) {
+      aggregationPipeline.push({ $skip: options.skip });
+    }
+    if (options.limit) {
+      aggregationPipeline.push({ $limit: options.limit });
+    }
+
+    const results = await this.MongooseModel.aggregate(aggregationPipeline);
+
+    // Create a map for fast lookup
+    const severityCountMap = new Map<SeverityLevelEnum, number>();
+    for (const result of results) {
+      if (result._id && severityLevels.includes(result._id)) {
+        severityCountMap.set(result._id, result.count);
+      }
+    }
+
+    // Ensure all severity levels are represented, even if count is 0
+    return severityLevels.map((severity) => ({
+      severity,
+      count: severityCountMap.get(severity) || 0,
+    }));
   }
 
   private getReadSeenUpdateQuery(

--- a/libs/dal/src/repositories/message/message.repository.ts
+++ b/libs/dal/src/repositories/message/message.repository.ts
@@ -384,11 +384,14 @@ export class MessageRepository extends BaseRepository<MessageDBModel, MessageEnt
     const baseQuery = await this.getFilterQueryForMessage(environmentId, subscriberId, channel, query);
 
     // Use aggregation to count by severity in a single query
+    // Treat null/missing severity as NONE
     const aggregationPipeline: PipelineStage[] = [
       { $match: baseQuery },
       {
         $group: {
-          _id: '$severity',
+          _id: {
+            $ifNull: ['$severity', SeverityLevelEnum.NONE],
+          },
           count: { $sum: 1 },
         },
       },


### PR DESCRIPTION
Refactored the getCountBySeverity method to use a single MongoDB aggregation pipeline for counting messages by severity, improving performance and reducing multiple queries. Also updated Session usecase to directly access organization settings from the repository instead of a separate usecase.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
