### PR TITLE
feat(dashboard): Handle double click for navigable channel nodes fixes NV-6632

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -31,7 +31,7 @@ export type NodeData = {
   error?: string;
   name?: string;
   stepSlug?: string;
-  controlValues?: Record<string, any>;
+  controlValues?: Record<string, unknown>;
   workflowSlug?: string;
   environment?: string;
   isTemplateStorePreview?: boolean;

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -332,7 +332,7 @@ const NodeWrapper = ({ children, data, type }: { children: React.ReactNode; data
       const timeout = setTimeout(() => {
         navigate(buildRoute(ROUTES.EDIT_STEP, { stepSlug: data.stepSlug ?? '' }));
         setClickTimeout(null);
-      }, 350);
+      }, 250);
 
       setClickTimeout(timeout);
     },

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -307,8 +307,8 @@ const NodeWrapper = ({ children, data, type }: { children: React.ReactNode; data
   const isNavigatableChannelNode = TEMPLATE_CONFIGURABLE_STEP_TYPES.includes(type);
 
   const handleClick = useCallback(
-    (e: React.MouseEvent) => {
-      const clickCount = (e as any).detail ?? 1;
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const clickCount = e.detail ?? 1;
 
       if (clickTimeout) {
         clearTimeout(clickTimeout);
@@ -332,7 +332,7 @@ const NodeWrapper = ({ children, data, type }: { children: React.ReactNode; data
       const timeout = setTimeout(() => {
         navigate(buildRoute(ROUTES.EDIT_STEP, { stepSlug: data.stepSlug ?? '' }));
         setClickTimeout(null);
-      }, 220);
+      }, 350);
 
       setClickTimeout(timeout);
     },

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -308,46 +308,35 @@ const NodeWrapper = ({ children, data, type }: { children: React.ReactNode; data
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
+      const clickCount = (e as any).detail ?? 1;
 
-      // Clear any existing timeout
       if (clickTimeout) {
         clearTimeout(clickTimeout);
         setClickTimeout(null);
-        return; // This is actually a double-click, so don't navigate
       }
 
-      // Set a timeout for single-click navigation
-      const timeout = setTimeout(() => {
-        navigate(buildRoute(ROUTES.EDIT_STEP, { stepSlug: data.stepSlug ?? '' }));
-        setClickTimeout(null);
-      }, 300); // 300ms delay to detect double-clicks
+      if (clickCount > 1) {
+        if (isNavigatableChannelNode && data.stepSlug) {
+          navigate(
+            buildRoute(ROUTES.EDIT_STEP_TEMPLATE, {
+              stepSlug: data.stepSlug,
+            })
+          );
+        } else {
+          navigate(buildRoute(ROUTES.EDIT_STEP, { stepSlug: data.stepSlug ?? '' }));
+        }
 
-      setClickTimeout(timeout);
-    },
-    [clickTimeout, navigate, data.stepSlug]
-  );
-
-  const handleDoubleClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (!isNavigatableChannelNode || !data.stepSlug) {
         return;
       }
 
-      e.preventDefault();
-      e.stopPropagation();
-
-      // Clear the single-click timeout
-      if (clickTimeout) {
-        clearTimeout(clickTimeout);
+      const timeout = setTimeout(() => {
+        navigate(buildRoute(ROUTES.EDIT_STEP, { stepSlug: data.stepSlug ?? '' }));
         setClickTimeout(null);
-      }
+      }, 220);
 
-      // Navigate to edit content (template editor) on double-click
-      navigate(buildRoute(ROUTES.EDIT_STEP_TEMPLATE, { stepSlug: data.stepSlug }));
+      setClickTimeout(timeout);
     },
-    [isNavigatableChannelNode, data.stepSlug, navigate, clickTimeout]
+    [clickTimeout, navigate, data.stepSlug, isNavigatableChannelNode]
   );
 
   const handleKeyDown = useCallback(
@@ -377,7 +366,6 @@ const NodeWrapper = ({ children, data, type }: { children: React.ReactNode; data
   return (
     <div
       onClick={handleClick}
-      onDoubleClick={handleDoubleClick}
       onKeyDown={handleKeyDown}
       className="contents cursor-pointer"
       data-testid={`${type}-node`}

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -332,7 +332,7 @@ const NodeWrapper = ({ children, data, type }: { children: React.ReactNode; data
       const timeout = setTimeout(() => {
         navigate(buildRoute(ROUTES.EDIT_STEP, { stepSlug: data.stepSlug ?? '' }));
         setClickTimeout(null);
-      }, 250);
+      }, 150);
 
       setClickTimeout(timeout);
     },

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -1,7 +1,7 @@
 import { EnvironmentTypeEnum, PermissionsEnum, ResourceOriginEnum, StepCreateDto } from '@novu/shared';
 import { Node as FlowNode, Handle, NodeProps, Position } from '@xyflow/react';
 import { AnimatePresence, motion } from 'motion/react';
-import { ComponentProps, useCallback, useState } from 'react';
+import { ComponentProps, useCallback, useEffect, useState } from 'react';
 import { RiInsertRowTop, RiPlayCircleLine } from 'react-icons/ri';
 import { RQBJsonLogic } from 'react-querybuilder';
 import { Link, useNavigate, useParams } from 'react-router-dom';
@@ -301,22 +301,91 @@ const StepNode = (props: StepNodeProps) => {
 };
 
 const NodeWrapper = ({ children, data, type }: { children: React.ReactNode; data: NodeData; type: StepTypeEnum }) => {
+  const navigate = useNavigate();
+  const [clickTimeout, setClickTimeout] = useState<NodeJS.Timeout | null>(null);
+
+  const isNavigatableChannelNode = TEMPLATE_CONFIGURABLE_STEP_TYPES.includes(type);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Clear any existing timeout
+      if (clickTimeout) {
+        clearTimeout(clickTimeout);
+        setClickTimeout(null);
+        return; // This is actually a double-click, so don't navigate
+      }
+
+      // Set a timeout for single-click navigation
+      const timeout = setTimeout(() => {
+        navigate(buildRoute(ROUTES.EDIT_STEP, { stepSlug: data.stepSlug ?? '' }));
+        setClickTimeout(null);
+      }, 300); // 300ms delay to detect double-clicks
+
+      setClickTimeout(timeout);
+    },
+    [clickTimeout, navigate, data.stepSlug]
+  );
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isNavigatableChannelNode || !data.stepSlug) {
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Clear the single-click timeout
+      if (clickTimeout) {
+        clearTimeout(clickTimeout);
+        setClickTimeout(null);
+      }
+
+      // Navigate to edit content (template editor) on double-click
+      navigate(buildRoute(ROUTES.EDIT_STEP_TEMPLATE, { stepSlug: data.stepSlug }));
+    },
+    [isNavigatableChannelNode, data.stepSlug, navigate, clickTimeout]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        navigate(buildRoute(ROUTES.EDIT_STEP, { stepSlug: data.stepSlug ?? '' }));
+      }
+    },
+    [navigate, data.stepSlug]
+  );
+
+  // Clean up timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (clickTimeout) {
+        clearTimeout(clickTimeout);
+      }
+    };
+  }, [clickTimeout]);
+
   if (data.isTemplateStorePreview) {
     return children;
   }
 
   return (
-    <Link
-      to={buildRoute(ROUTES.EDIT_STEP, { stepSlug: data.stepSlug ?? '' })}
-      onClick={(e) => {
-        // Prevent any bubbling that might interfere with the navigation
-        e.stopPropagation();
-      }}
-      className="contents"
+    <div
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
+      onKeyDown={handleKeyDown}
+      className="contents cursor-pointer"
       data-testid={`${type}-node`}
+      role="button"
+      tabIndex={0}
     >
       {children}
-    </Link>
+    </div>
   );
 };
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Implemented double-click navigation for workflow nodes in the dashboard. When a navigatable channel node (e.g., Email, SMS, In-App, Chat, Push) is double-clicked, the user is now directed to the edit content/template page. Single-click behavior remains unchanged, navigating to the step configuration page.

This enhancement provides a quicker and more intuitive way for users to access and edit the content of relevant channel steps, improving the workflow editing experience.

### Screenshots

<!-- No visual changes that require screenshots. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

- The `NodeWrapper` component was refactored to use a `div` with custom click handlers instead of a `Link` component to manage the single and double click logic.
- A timeout-based mechanism is used to distinguish between single and double clicks, ensuring that single clicks still navigate to the step configuration after a short delay, unless a double-click occurs.
- Keyboard navigation (Enter/Space) is supported for single-click behavior.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1757255039119969?thread_ts=1757255039.119969&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-fa3b7163-b86a-4259-8748-cf9c50d1d00e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa3b7163-b86a-4259-8748-cf9c50d1d00e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

