### PR TITLE
feat(dashboard): Remember last selected subscriber for test workflow fixes NV-6633

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/utils/preview-context-storage.utils.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/utils/preview-context-storage.utils.ts
@@ -113,7 +113,7 @@ export function clearSubscriberData(workflowId: string, environmentId: string): 
 export function cleanupExpiredPreviewData(): void {
   try {
     const keysToRemove: string[] = [];
-    const prefixes = ['preview-context-', 'preview-payload-', 'preview-subscriber-'];
+    const prefixes = ['preview-context-', 'preview-payload-', 'preview-subscriber-', 'test-workflow-subscriber-'];
 
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);

--- a/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-drawer.tsx
@@ -26,10 +26,12 @@ import { useAuth } from '@/context/auth/hooks';
 import { useFetchApiKeys } from '@/hooks/use-fetch-api-keys';
 import { useFetchSubscriber } from '@/hooks/use-fetch-subscriber';
 import { useHasPermission } from '@/hooks/use-has-permission';
+import { useTestWorkflowSubscriberPersistence } from '@/hooks/use-test-workflow-subscriber-persistence';
 import { useTriggerWorkflow } from '@/hooks/use-trigger-workflow';
 import { useWorkflowPayloadPersistence } from '@/hooks/use-workflow-payload-persistence';
 import { generatePostmanCollection, generateTriggerCurlCommand } from '@/utils/code-snippets';
 import { useEnvironment } from '../../../context/environment/hooks';
+import { cleanupExpiredPreviewData } from '../steps/utils/preview-context-storage.utils';
 import { useWorkflow } from '../workflow-provider';
 
 type TestWorkflowDrawerProps = {
@@ -65,6 +67,11 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
   const [subscriberData, setSubscriberData] = useState<Partial<ISubscriberResponseDto> | null>(null);
   const [currentFormData, setCurrentFormData] = useState<{ to: unknown; payload: string } | null>(null);
 
+  // Cleanup expired storage data on component mount
+  useEffect(() => {
+    cleanupExpiredPreviewData();
+  }, []);
+
   const { currentEnvironment } = useEnvironment();
   const { workflow } = useWorkflow();
   const { currentUser } = useAuth();
@@ -82,16 +89,29 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
     environmentId: currentEnvironment?._id || '',
   });
 
+  // Test workflow subscriber persistence
+  const { loadPersistedSubscriber, savePersistedSubscriber, clearPersistedSubscriber } =
+    useTestWorkflowSubscriberPersistence({
+      workflowId: workflow?.workflowId || '',
+      environmentId: currentEnvironment?._id || '',
+    });
+
+  // Load persisted subscriber or fallback to current user
+  const persistedSubscriber = loadPersistedSubscriber();
+  const initialSubscriberId = persistedSubscriber?.subscriberId || currentUser?._id || '';
+
   // Subscriber management - single source of truth
-  const subscriberIdToFetch = subscriberData?.subscriberId || currentUser?._id || '';
+  const subscriberIdToFetch = subscriberData?.subscriberId || initialSubscriberId;
   const {
     data: fetchedSubscriberData,
     refetch: refetchSubscriber,
     isLoading: isLoadingSubscriber,
+    error: subscriberFetchError,
   } = useFetchSubscriber({
     subscriberId: subscriberIdToFetch,
     options: {
       enabled: !!subscriberIdToFetch && !!currentEnvironment,
+      retry: false, // Don't retry if subscriber doesn't exist
     },
   });
 
@@ -110,14 +130,33 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
         data: fetchedSubscriberData.data ?? undefined,
       });
     } else if (currentUser && !fetchedSubscriberData && !subscriberData?.subscriberId && !isLoadingSubscriber) {
-      setSubscriberData({
-        subscriberId: currentUser._id,
-        firstName: currentUser.firstName ?? undefined,
-        lastName: currentUser.lastName ?? undefined,
-        email: currentUser.email ?? undefined,
-      });
+      // If persisted subscriber doesn't exist (error) or no persisted subscriber, fallback to current user
+      const shouldFallbackToCurrentUser = subscriberFetchError || !persistedSubscriber;
+
+      if (shouldFallbackToCurrentUser) {
+        // Clear persisted subscriber if it was found to not exist
+        if (subscriberFetchError && persistedSubscriber) {
+          clearPersistedSubscriber();
+        }
+
+        const fallbackData = {
+          subscriberId: currentUser._id,
+          firstName: currentUser.firstName ?? undefined,
+          lastName: currentUser.lastName ?? undefined,
+          email: currentUser.email ?? undefined,
+        };
+        setSubscriberData(fallbackData);
+      }
     }
-  }, [fetchedSubscriberData, currentUser, subscriberData?.subscriberId, isLoadingSubscriber]);
+  }, [
+    fetchedSubscriberData,
+    currentUser,
+    subscriberData?.subscriberId,
+    isLoadingSubscriber,
+    subscriberFetchError,
+    persistedSubscriber,
+    clearPersistedSubscriber,
+  ]);
 
   const payload = useMemo(() => {
     if (initialPayload && Object.keys(initialPayload).length > 0) {
@@ -147,9 +186,14 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
     }
   }, [watchedPayload, initialPayload, savePersistedPayload]);
 
-  const handleSubscriberSelect = useCallback((subscriber: ISubscriberResponseDto) => {
-    setSubscriberData(subscriber);
-  }, []);
+  const handleSubscriberSelect = useCallback(
+    (subscriber: ISubscriberResponseDto) => {
+      setSubscriberData(subscriber);
+      // Persist the selected subscriber for future use
+      savePersistedSubscriber(subscriber);
+    },
+    [savePersistedSubscriber]
+  );
 
   const handleSubscriberDrawerClose = useCallback(
     (open: boolean) => {

--- a/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-drawer.tsx
@@ -96,12 +96,18 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
       environmentId: currentEnvironment?._id || '',
     });
 
-  // Load persisted subscriber or fallback to current user
-  const persistedSubscriber = loadPersistedSubscriber();
-  const initialSubscriberId = persistedSubscriber?.subscriberId || currentUser?._id || '';
+  // Track if we've initialized the subscriber data
+  const [hasInitializedSubscriber, setHasInitializedSubscriber] = useState(false);
+
+  // Reset initialization flag when drawer closes
+  useEffect(() => {
+    if (!isOpen) {
+      setHasInitializedSubscriber(false);
+    }
+  }, [isOpen]);
 
   // Subscriber management - single source of truth
-  const subscriberIdToFetch = subscriberData?.subscriberId || initialSubscriberId;
+  const subscriberIdToFetch = subscriberData?.subscriberId || currentUser?._id || '';
   const {
     data: fetchedSubscriberData,
     refetch: refetchSubscriber,
@@ -115,9 +121,48 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
     },
   });
 
-  // Initialize subscriber data
+  // Initialize subscriber data from persisted storage when drawer opens
   useEffect(() => {
-    if (fetchedSubscriberData) {
+    if (
+      !hasInitializedSubscriber &&
+      isOpen &&
+      workflow?.workflowId &&
+      currentEnvironment?._id &&
+      currentUser &&
+      !subscriberData?.subscriberId
+    ) {
+      const persistedSubscriber = loadPersistedSubscriber();
+
+      if (persistedSubscriber) {
+        // Try to use the persisted subscriber
+        setSubscriberData(persistedSubscriber);
+      } else {
+        // No persisted subscriber, use current user
+        const fallbackData = {
+          subscriberId: currentUser._id,
+          firstName: currentUser.firstName ?? undefined,
+          lastName: currentUser.lastName ?? undefined,
+          email: currentUser.email ?? undefined,
+        };
+        setSubscriberData(fallbackData);
+      }
+
+      setHasInitializedSubscriber(true);
+    }
+  }, [
+    hasInitializedSubscriber,
+    isOpen,
+    workflow?.workflowId,
+    currentEnvironment?._id,
+    currentUser,
+    subscriberData?.subscriberId,
+    loadPersistedSubscriber,
+  ]);
+
+  // Handle fetched subscriber data and error cases
+  useEffect(() => {
+    if (fetchedSubscriberData && subscriberData?.subscriberId === fetchedSubscriberData.subscriberId) {
+      // Update with fresh data from server
       setSubscriberData({
         subscriberId: fetchedSubscriberData.subscriberId,
         firstName: fetchedSubscriberData.firstName ?? undefined,
@@ -129,32 +174,28 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
         timezone: fetchedSubscriberData.timezone ?? undefined,
         data: fetchedSubscriberData.data ?? undefined,
       });
-    } else if (currentUser && !fetchedSubscriberData && !subscriberData?.subscriberId && !isLoadingSubscriber) {
-      // If persisted subscriber doesn't exist (error) or no persisted subscriber, fallback to current user
-      const shouldFallbackToCurrentUser = subscriberFetchError || !persistedSubscriber;
+    } else if (
+      subscriberFetchError &&
+      subscriberData?.subscriberId &&
+      subscriberData.subscriberId !== currentUser?._id &&
+      currentUser
+    ) {
+      // Persisted subscriber doesn't exist, clear it and fallback to current user
+      clearPersistedSubscriber();
 
-      if (shouldFallbackToCurrentUser) {
-        // Clear persisted subscriber if it was found to not exist
-        if (subscriberFetchError && persistedSubscriber) {
-          clearPersistedSubscriber();
-        }
-
-        const fallbackData = {
-          subscriberId: currentUser._id,
-          firstName: currentUser.firstName ?? undefined,
-          lastName: currentUser.lastName ?? undefined,
-          email: currentUser.email ?? undefined,
-        };
-        setSubscriberData(fallbackData);
-      }
+      const fallbackData = {
+        subscriberId: currentUser._id,
+        firstName: currentUser.firstName ?? undefined,
+        lastName: currentUser.lastName ?? undefined,
+        email: currentUser.email ?? undefined,
+      };
+      setSubscriberData(fallbackData);
     }
   }, [
     fetchedSubscriberData,
-    currentUser,
-    subscriberData?.subscriberId,
-    isLoadingSubscriber,
     subscriberFetchError,
-    persistedSubscriber,
+    subscriberData?.subscriberId,
+    currentUser,
     clearPersistedSubscriber,
   ]);
 

--- a/apps/dashboard/src/hooks/use-test-workflow-subscriber-persistence.ts
+++ b/apps/dashboard/src/hooks/use-test-workflow-subscriber-persistence.ts
@@ -1,0 +1,71 @@
+import { type ISubscriberResponseDto } from '@novu/shared';
+import { useCallback } from 'react';
+import { clearFromStorage, loadFromStorage, saveToStorage } from '@/utils/local-storage';
+
+type UseTestWorkflowSubscriberPersistenceProps = {
+  workflowId: string;
+  environmentId: string;
+};
+
+type PersistedSubscriberData = {
+  subscriberId: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  avatar?: string;
+  locale?: string;
+  timezone?: string;
+  data?: Record<string, unknown>;
+};
+
+function getTestWorkflowSubscriberStorageKey(workflowId: string, environmentId: string): string {
+  return `test-workflow-subscriber-${workflowId}-${environmentId}`;
+}
+
+export function useTestWorkflowSubscriberPersistence({
+  workflowId,
+  environmentId,
+}: UseTestWorkflowSubscriberPersistenceProps) {
+  const loadPersistedSubscriber = useCallback((): PersistedSubscriberData | null => {
+    if (!workflowId || !environmentId) return null;
+
+    const storageKey = getTestWorkflowSubscriberStorageKey(workflowId, environmentId);
+    return loadFromStorage<PersistedSubscriberData>(storageKey, 'subscriber');
+  }, [workflowId, environmentId]);
+
+  const savePersistedSubscriber = useCallback(
+    (subscriber: ISubscriberResponseDto) => {
+      if (!workflowId || !environmentId) return;
+
+      const subscriberData: PersistedSubscriberData = {
+        subscriberId: subscriber.subscriberId,
+        firstName: subscriber.firstName ?? undefined,
+        lastName: subscriber.lastName ?? undefined,
+        email: subscriber.email ?? undefined,
+        phone: subscriber.phone ?? undefined,
+        avatar: subscriber.avatar ?? undefined,
+        locale: subscriber.locale ?? undefined,
+        timezone: subscriber.timezone ?? undefined,
+        data: subscriber.data ?? undefined,
+      };
+
+      const storageKey = getTestWorkflowSubscriberStorageKey(workflowId, environmentId);
+      saveToStorage(storageKey, subscriberData, 'subscriber');
+    },
+    [workflowId, environmentId]
+  );
+
+  const clearPersistedSubscriber = useCallback(() => {
+    if (!workflowId || !environmentId) return;
+
+    const storageKey = getTestWorkflowSubscriberStorageKey(workflowId, environmentId);
+    clearFromStorage(storageKey, 'subscriber');
+  }, [workflowId, environmentId]);
+
+  return {
+    loadPersistedSubscriber,
+    savePersistedSubscriber,
+    clearPersistedSubscriber,
+  };
+}


### PR DESCRIPTION
### What changed? Why was the change needed?

Implemented persistence for the selected subscriber in the test workflow drawer. This change remembers the last chosen subscriber for a specific workflow and environment, pre-filling it the next time the drawer is opened. If the persisted subscriber is no longer found, it gracefully falls back to the current logged-in user. This enhances the user experience by reducing repetitive selections during workflow testing.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->
[No screenshots provided, but visual changes are present in the subscriber selection dropdown.]

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

*   A new hook `useTestWorkflowSubscriberPersistence` handles saving and loading subscriber data to local storage.
*   The `TestWorkflowDrawer` now uses this hook for initialization and updates.
*   Includes robust fallback logic: Persisted Subscriber -> Current User Subscriber.
*   Clears invalid persisted subscriber data if it no longer exists.
*   Storage cleanup for expired data is integrated.
*   The persistence works for both workflow-level and step-level test drawers.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1757255495708079?thread_ts=1757255495.708079&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-b1dd3eee-d70e-475c-ad15-db1ee8b6a42c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b1dd3eee-d70e-475c-ad15-db1ee8b6a42c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

