### PR TITLE
fix(web): standardize group by category API call

### DIFF
--- a/apps/web/src/api/notification-templates.ts
+++ b/apps/web/src/api/notification-templates.ts
@@ -1,13 +1,12 @@
 import {
-  ICreateNotificationTemplateDto,
-  INotificationTemplate,
-  IGroupedBlueprint,
-  IPaginationWithQueryParams,
   IBlueprint,
+  ICreateNotificationTemplateDto,
+  IGroupedBlueprint,
+  INotificationTemplate,
+  IPaginationWithQueryParams,
 } from '@novu/shared';
-
-import { api } from './api.client';
 import { BLUEPRINTS_API_URL } from '../config';
+import { api } from './api.client';
 
 export function getNotificationsList({ page = 0, limit = 10, query }: IPaginationWithQueryParams) {
   const params = { page, limit, ...(query && { query }) };
@@ -38,7 +37,7 @@ export async function getBlueprintsGroupedByCategory(): Promise<{
   general: IGroupedBlueprint[];
   popular: IGroupedBlueprint;
 }> {
-  return api.get(`${BLUEPRINTS_API_URL}/v1/blueprints/group-by-category`, { absoluteUrl: true });
+  return api.get(`/v1/blueprints/group-by-category`);
 }
 
 export async function getBlueprintTemplateById(id: string): Promise<IBlueprint> {


### PR DESCRIPTION
### What changed? Why was the change needed?

The `getBlueprintsGroupedByCategory` API call was refactored to use the standard API client, removing its dependency on `REACT_APP_BLUEPRINTS_API_URL` and the `absoluteUrl: true` option. This change standardizes the API call pattern to be consistent with other endpoints in the application, as the `/v1/blueprints/group-by-category` endpoint is available via the regular API URL.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

The endpoint path `/v1/blueprints/group-by-category` has been verified against the API controller and existing tests, confirming its correctness with the standard API client.

</details>

---
<a href="https://cursor.com/background-agent?bcId=bc-0918b11a-48e6-4c8c-a1ba-a7425e417cdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0918b11a-48e6-4c8c-a1ba-a7425e417cdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

