### PR TITLE
fix(api-service): 500 error on activity feed page fixes NV-6642

### DIFF
--- a/apps/api/src/app/workflows-v2/mappers/notification-template-mapper.ts
+++ b/apps/api/src/app/workflows-v2/mappers/notification-template-mapper.ts
@@ -104,7 +104,7 @@ function toStepListResponseDtos(steps: NotificationStepEntity[]): StepListRespon
 
 function toStepListResponseDto(step: NotificationStepEntity): StepListResponseDto {
   // biome-ignore lint/style/noNonNullAssertion: always exists
-  const stepName = step.name!;
+  const stepName = step.name! || 'Missing Name';
   const slug = buildSlug(stepName, ShortIsPrefixEnum.STEP, step._templateId);
 
   return {


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves a 500 error occurring on the activity feed page in production (Linear: [NV-6642](https://linear.app/novu/issue/NV-6642)).

The error was caused by `step.name` being null or undefined in `apps/api/src/app/workflows-v2/mappers/notification-template-mapper.ts`, specifically within the `toStepListResponseDto` function. The original code used a non-null assertion (`step.name!`), which failed when the name was missing.

A fallback (`|| 'Missing Name'`) has been added to `stepName` to ensure a default value is used, preventing the application from crashing.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->
N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---
Linear Issue: [NV-6642](https://linear.app/novu/issue/NV-6642/500-error-on-activity-feed-page-in-production-environment)

<a href="https://cursor.com/background-agent?bcId=bc-ab2215c8-9ebb-4d45-9ec5-642cc10355a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab2215c8-9ebb-4d45-9ec5-642cc10355a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

