### PR TITLE
style(dashboard): Align changelog cover image to top

### DIFF
--- a/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
+++ b/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
@@ -250,7 +250,7 @@ function ChangelogCard({
               <img
                 src={changelog.imageUrl}
                 alt={changelog.title}
-                className="h-full w-full rounded-[6px] object-cover"
+                className="h-full w-full rounded-[6px] object-cover object-top"
                 onError={(e) => {
                   // Hide image if it fails to load
                   e.currentTarget.style.display = 'none';


### PR DESCRIPTION
### What changed? Why was the change needed?

The `ChangelogCard` cover image now aligns to the top of its container. Previously, the `object-cover` class centered the image, often cutting off important text or content at the top. Adding `object-top` ensures the top portion of the image is preserved, improving the visual presentation of changelog cards.

### Screenshots

<!-- Please add screenshots showing the before and after of a changelog card with a cover image. -->

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1757495301729629?thread_ts=1757495301.729629&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-90629e43-e461-45c0-b4e4-20234faa6a69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-90629e43-e461-45c0-b4e4-20234faa6a69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

