### PR TITLE
fix(api-service): Add writeConcern option to update operations

### DIFF
--- a/apps/api/src/app/internal/usecases/update-subscriber-online-state/update-subscriber-online-state.usecase.ts
+++ b/apps/api/src/app/internal/usecases/update-subscriber-online-state/update-subscriber-online-state.usecase.ts
@@ -26,6 +26,9 @@ export class UpdateSubscriberOnlineState {
       { subscriberId: command.subscriberId, _environmentId: command.environmentId },
       {
         $set: updatePayload,
+      },
+      {
+        writeConcern: { w: 1 },
       }
     );
 

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -323,7 +323,10 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
   async update(
     query: FilterQuery<T_DBModel> & T_Enforcement,
     updateBody: UpdateQuery<T_DBModel>,
-    options: QueryOptions<T_DBModel> & { session?: ClientSession | null } = {}
+    options: QueryOptions<T_DBModel> & {
+      session?: ClientSession | null;
+      writeConcern?: { w: number | 'majority' };
+    } = {}
   ): Promise<{
     matched: number;
     modified: number;


### PR DESCRIPTION
Introduces support for specifying writeConcern in update operations within BaseRepository and applies it to subscriber online state updates. This allows finer control over MongoDB write acknowledgment.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
