### PR TITLE
refactor(api): move DTO mapping from usecases to controllers

### DIFF
--- a/apps/api/src/app/channel-connections/usecases/create-channel-connection/create-channel-connection.usecase.ts
+++ b/apps/api/src/app/channel-connections/usecases/create-channel-connection/create-channel-connection.usecase.ts
@@ -8,8 +8,6 @@ import {
   SubscriberRepository,
 } from '@novu/dal';
 import { parseResourceKey } from '@novu/shared';
-import { mapChannelConnectionEntityToDto } from '../../dtos/dto.mapper';
-import { GetChannelConnectionResponseDto } from '../../dtos/get-channel-connection-response.dto';
 import { CreateChannelConnectionCommand } from './create-channel-connection.command';
 
 @Injectable()
@@ -21,7 +19,7 @@ export class CreateChannelConnection {
   ) {}
 
   @InstrumentUsecase()
-  async execute(command: CreateChannelConnectionCommand): Promise<GetChannelConnectionResponseDto> {
+  async execute(command: CreateChannelConnectionCommand): Promise<ChannelConnectionEntity> {
     const integration = await this.findIntegration(command);
 
     await this.assertSingleConnectionPerResourceAndIntegration(command, integration);
@@ -44,7 +42,7 @@ export class CreateChannelConnection {
 
     const channelConnection = await this.createChannelConnection(command, identifier, integration);
 
-    return mapChannelConnectionEntityToDto(channelConnection);
+    return channelConnection;
   }
 
   private async assertSingleConnectionPerResourceAndIntegration(

--- a/apps/api/src/app/channel-connections/usecases/get-channel-connection/get-channel-connection.usecase.ts
+++ b/apps/api/src/app/channel-connections/usecases/get-channel-connection/get-channel-connection.usecase.ts
@@ -1,8 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InstrumentUsecase } from '@novu/application-generic';
-import { ChannelConnectionRepository } from '@novu/dal';
-import { mapChannelConnectionEntityToDto } from '../../dtos/dto.mapper';
-import { GetChannelConnectionResponseDto } from '../../dtos/get-channel-connection-response.dto';
+import { ChannelConnectionEntity, ChannelConnectionRepository } from '@novu/dal';
 import { GetChannelConnectionCommand } from './get-channel-connection.command';
 
 @Injectable()
@@ -10,7 +8,7 @@ export class GetChannelConnection {
   constructor(private readonly channelConnectionRepository: ChannelConnectionRepository) {}
 
   @InstrumentUsecase()
-  async execute(command: GetChannelConnectionCommand): Promise<GetChannelConnectionResponseDto> {
+  async execute(command: GetChannelConnectionCommand): Promise<ChannelConnectionEntity> {
     const channelConnection = await this.channelConnectionRepository.findOne({
       _organizationId: command.organizationId,
       _environmentId: command.environmentId,
@@ -24,6 +22,6 @@ export class GetChannelConnection {
       );
     }
 
-    return mapChannelConnectionEntityToDto(channelConnection);
+    return channelConnection;
   }
 }

--- a/apps/api/src/app/channel-connections/usecases/get-channel-connections/get-channel-connections.usecase.ts
+++ b/apps/api/src/app/channel-connections/usecases/get-channel-connections/get-channel-connections.usecase.ts
@@ -8,8 +8,6 @@ import {
 } from '@novu/dal';
 import { ProvidersIdEnum } from '@novu/shared';
 import { FilterQuery } from 'mongoose';
-import { mapChannelConnectionEntityToDto } from '../../dtos/dto.mapper';
-import { GetChannelConnectionResponseDto } from '../../dtos/get-channel-connection-response.dto';
 import { GetChannelConnectionsCommand } from './get-channel-connections.command';
 
 @Injectable()
@@ -17,14 +15,10 @@ export class GetChannelConnections {
   constructor(private readonly channelConnectionRepository: ChannelConnectionRepository) {}
 
   @InstrumentUsecase()
-  async execute(command: GetChannelConnectionsCommand): Promise<GetChannelConnectionResponseDto[]> {
+  async execute(command: GetChannelConnectionsCommand): Promise<ChannelConnectionEntity[]> {
     const channelConnections = await this.fetchChannelConnections(command);
 
-    if (channelConnections.length === 0) {
-      return [];
-    }
-
-    return this.mapAndFilterConnections(channelConnections);
+    return channelConnections;
   }
 
   private async fetchChannelConnections(command: GetChannelConnectionsCommand): Promise<ChannelConnectionEntity[]> {
@@ -43,9 +37,5 @@ export class GetChannelConnections {
     }
 
     return await this.channelConnectionRepository.find(query);
-  }
-
-  private mapAndFilterConnections(channelConnections: ChannelConnectionEntity[]): GetChannelConnectionResponseDto[] {
-    return channelConnections.map((conn) => mapChannelConnectionEntityToDto(conn));
   }
 }

--- a/apps/api/src/app/channel-connections/usecases/update-channel-connection/update-channel-connection.usecase.ts
+++ b/apps/api/src/app/channel-connections/usecases/update-channel-connection/update-channel-connection.usecase.ts
@@ -1,8 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InstrumentUsecase } from '@novu/application-generic';
 import { ChannelConnectionEntity, ChannelConnectionRepository } from '@novu/dal';
-import { mapChannelConnectionEntityToDto } from '../../dtos/dto.mapper';
-import { GetChannelConnectionResponseDto } from '../../dtos/get-channel-connection-response.dto';
 import { UpdateChannelConnectionCommand } from './update-channel-connection.command';
 
 @Injectable()
@@ -10,10 +8,10 @@ export class UpdateChannelConnection {
   constructor(private readonly channelConnectionRepository: ChannelConnectionRepository) {}
 
   @InstrumentUsecase()
-  async execute(command: UpdateChannelConnectionCommand): Promise<GetChannelConnectionResponseDto> {
+  async execute(command: UpdateChannelConnectionCommand): Promise<ChannelConnectionEntity> {
     const updatedChannelConnection = await this.updateChannelConnection(command);
 
-    return mapChannelConnectionEntityToDto(updatedChannelConnection);
+    return updatedChannelConnection;
   }
 
   private async updateChannelConnection(command: UpdateChannelConnectionCommand): Promise<ChannelConnectionEntity> {

--- a/apps/api/src/app/channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase.ts
+++ b/apps/api/src/app/channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase.ts
@@ -10,8 +10,6 @@ import {
   SubscriberRepository,
 } from '@novu/dal';
 import { parseResourceKey } from '@novu/shared';
-import { mapChannelEndpointEntityToDto } from '../../dtos/dto.mapper';
-import { GetChannelEndpointResponseDto } from '../../dtos/get-channel-endpoint-response.dto';
 import { CreateChannelEndpointCommand } from './create-channel-endpoint.command';
 
 @Injectable()
@@ -24,7 +22,7 @@ export class CreateChannelEndpoint {
   ) {}
 
   @InstrumentUsecase()
-  async execute(command: CreateChannelEndpointCommand): Promise<GetChannelEndpointResponseDto> {
+  async execute(command: CreateChannelEndpointCommand): Promise<ChannelEndpointEntity> {
     const integration = await this.findIntegration(command);
 
     await this.assertResourceExists(command);
@@ -52,7 +50,7 @@ export class CreateChannelEndpoint {
 
     const channelEndpoint = await this.createChannelEndpoint(command, identifier, integration, connection);
 
-    return mapChannelEndpointEntityToDto(channelEndpoint);
+    return channelEndpoint;
   }
 
   private async createChannelEndpoint(

--- a/apps/api/src/app/channel-endpoints/usecases/get-channel-endpoint/get-channel-endpoint.usecase.ts
+++ b/apps/api/src/app/channel-endpoints/usecases/get-channel-endpoint/get-channel-endpoint.usecase.ts
@@ -1,8 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InstrumentUsecase } from '@novu/application-generic';
-import { ChannelEndpointRepository } from '@novu/dal';
-import { mapChannelEndpointEntityToDto } from '../../dtos/dto.mapper';
-import { GetChannelEndpointResponseDto } from '../../dtos/get-channel-endpoint-response.dto';
+import { ChannelEndpointEntity, ChannelEndpointRepository } from '@novu/dal';
 import { GetChannelEndpointCommand } from './get-channel-endpoint.command';
 
 @Injectable()
@@ -10,7 +8,7 @@ export class GetChannelEndpoint {
   constructor(private readonly channelEndpointRepository: ChannelEndpointRepository) {}
 
   @InstrumentUsecase()
-  async execute(command: GetChannelEndpointCommand): Promise<GetChannelEndpointResponseDto> {
+  async execute(command: GetChannelEndpointCommand): Promise<ChannelEndpointEntity> {
     const channelEndpoint = await this.channelEndpointRepository.findOne({
       identifier: command.identifier,
       _organizationId: command.organizationId,
@@ -21,6 +19,6 @@ export class GetChannelEndpoint {
       throw new NotFoundException(`Channel endpoint with identifier '${command.identifier}' not found`);
     }
 
-    return mapChannelEndpointEntityToDto(channelEndpoint);
+    return channelEndpoint;
   }
 }

--- a/apps/api/src/app/channel-endpoints/usecases/get-channel-endpoints/get-channel-endpoints.usecase.ts
+++ b/apps/api/src/app/channel-endpoints/usecases/get-channel-endpoints/get-channel-endpoints.usecase.ts
@@ -4,8 +4,6 @@ import type { EnforceEnvOrOrgIds } from '@novu/dal';
 import { ChannelEndpointDBModel, ChannelEndpointEntity, ChannelEndpointRepository } from '@novu/dal';
 import { ProvidersIdEnum } from '@novu/shared';
 import { FilterQuery } from 'mongoose';
-import { mapChannelEndpointEntityToDto } from '../../dtos/dto.mapper';
-import { GetChannelEndpointResponseDto } from '../../dtos/get-channel-endpoint-response.dto';
 import { GetChannelEndpointsCommand } from './get-channel-endpoints.command';
 
 @Injectable()
@@ -13,14 +11,10 @@ export class GetChannelEndpoints {
   constructor(private readonly channelEndpointRepository: ChannelEndpointRepository) {}
 
   @InstrumentUsecase()
-  async execute(command: GetChannelEndpointsCommand): Promise<GetChannelEndpointResponseDto[]> {
+  async execute(command: GetChannelEndpointsCommand): Promise<ChannelEndpointEntity[]> {
     const channelEndpoints = await this.fetchChannelEndpoints(command);
 
-    if (channelEndpoints.length === 0) {
-      return [];
-    }
-
-    return this.mapAndFilterEndpoints(channelEndpoints);
+    return channelEndpoints;
   }
 
   private async fetchChannelEndpoints(command: GetChannelEndpointsCommand): Promise<ChannelEndpointEntity[]> {
@@ -46,9 +40,5 @@ export class GetChannelEndpoints {
     }
 
     return await this.channelEndpointRepository.find(query);
-  }
-
-  private mapAndFilterEndpoints(channelEndpoints: ChannelEndpointEntity[]): GetChannelEndpointResponseDto[] {
-    return channelEndpoints.map((endpoint) => mapChannelEndpointEntityToDto(endpoint));
   }
 }

--- a/apps/api/src/app/channel-endpoints/usecases/update-channel-endpoint/update-channel-endpoint.usecase.ts
+++ b/apps/api/src/app/channel-endpoints/usecases/update-channel-endpoint/update-channel-endpoint.usecase.ts
@@ -1,8 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InstrumentUsecase, validateEndpointForType } from '@novu/application-generic';
 import { ChannelEndpointEntity, ChannelEndpointRepository } from '@novu/dal';
-import { mapChannelEndpointEntityToDto } from '../../dtos/dto.mapper';
-import { GetChannelEndpointResponseDto } from '../../dtos/get-channel-endpoint-response.dto';
 import { UpdateChannelEndpointCommand } from './update-channel-endpoint.command';
 
 @Injectable()
@@ -10,7 +8,7 @@ export class UpdateChannelEndpoint {
   constructor(private readonly channelEndpointRepository: ChannelEndpointRepository) {}
 
   @InstrumentUsecase()
-  async execute(command: UpdateChannelEndpointCommand): Promise<GetChannelEndpointResponseDto> {
+  async execute(command: UpdateChannelEndpointCommand): Promise<ChannelEndpointEntity> {
     // Check if the channel endpoint exists
     const existingChannelEndpoint = await this.channelEndpointRepository.findOne({
       identifier: command.identifier,
@@ -29,7 +27,7 @@ export class UpdateChannelEndpoint {
 
     const updatedChannelEndpoint = await this.updateChannelEndpoint(command);
 
-    return mapChannelEndpointEntityToDto(updatedChannelEndpoint);
+    return updatedChannelEndpoint;
   }
 
   private async updateChannelEndpoint(command: UpdateChannelEndpointCommand): Promise<ChannelEndpointEntity> {

--- a/apps/api/src/app/subscribers-v2/channel-connections.controller.ts
+++ b/apps/api/src/app/subscribers-v2/channel-connections.controller.ts
@@ -24,6 +24,7 @@ import {
 } from '@novu/shared';
 import { RequireAuthentication } from '../auth/framework/auth.decorator';
 import { CreateChannelConnectionRequestDto } from '../channel-connections/dtos/create-channel-connection-request.dto';
+import { mapChannelConnectionEntityToDto } from '../channel-connections/dtos/dto.mapper';
 import { GetChannelConnectionResponseDto } from '../channel-connections/dtos/get-channel-connection-response.dto';
 import { GetChannelConnectionsQueryDto } from '../channel-connections/dtos/get-channel-connections-query.dto';
 import { UpdateChannelConnectionRequestDto } from '../channel-connections/dtos/update-channel-connection-request.dto';
@@ -84,7 +85,7 @@ export class ChannelConnectionsController {
   ): Promise<GetChannelConnectionResponseDto> {
     await this.checkFeatureEnabled(user);
 
-    return await this.getChannelConnectionUsecase.execute(
+    const channelConnection = await this.getChannelConnectionUsecase.execute(
       GetChannelConnectionCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
@@ -92,6 +93,8 @@ export class ChannelConnectionsController {
         integrationIdentifier,
       })
     );
+
+    return mapChannelConnectionEntityToDto(channelConnection);
   }
 
   @Get('/:subscriberId/channel-connections')
@@ -109,7 +112,7 @@ export class ChannelConnectionsController {
   ): Promise<GetChannelConnectionResponseDto[]> {
     await this.checkFeatureEnabled(user);
 
-    return await this.getChannelConnectionsUsecase.execute(
+    const channelConnections = await this.getChannelConnectionsUsecase.execute(
       GetChannelConnectionsCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
@@ -118,6 +121,8 @@ export class ChannelConnectionsController {
         provider: query.provider,
       })
     );
+
+    return channelConnections.map((connection) => mapChannelConnectionEntityToDto(connection));
   }
 
   @Post('/:subscriberId/channel-connections')
@@ -135,7 +140,7 @@ export class ChannelConnectionsController {
   ): Promise<GetChannelConnectionResponseDto> {
     await this.checkFeatureEnabled(user);
 
-    return await this.createChannelConnectionUsecase.execute(
+    const channelConnection = await this.createChannelConnectionUsecase.execute(
       CreateChannelConnectionCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
@@ -146,6 +151,8 @@ export class ChannelConnectionsController {
         auth: body.auth,
       })
     );
+
+    return mapChannelConnectionEntityToDto(channelConnection);
   }
 
   @Patch('channel-connections/:identifier')
@@ -164,7 +171,7 @@ export class ChannelConnectionsController {
   ): Promise<GetChannelConnectionResponseDto> {
     await this.checkFeatureEnabled(user);
 
-    return await this.updateChannelConnectionUsecase.execute(
+    const channelConnection = await this.updateChannelConnectionUsecase.execute(
       UpdateChannelConnectionCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
@@ -173,6 +180,8 @@ export class ChannelConnectionsController {
         auth: body.auth,
       })
     );
+
+    return mapChannelConnectionEntityToDto(channelConnection);
   }
 
   @Delete('channel-connections/:identifier')

--- a/apps/api/src/app/subscribers-v2/channel-endpoints.controller.ts
+++ b/apps/api/src/app/subscribers-v2/channel-endpoints.controller.ts
@@ -24,6 +24,7 @@ import {
 } from '@novu/shared';
 import { RequireAuthentication } from '../auth/framework/auth.decorator';
 import { CreateChannelEndpointRequestDto } from '../channel-endpoints/dtos/create-channel-endpoint-request.dto';
+import { mapChannelEndpointEntityToDto } from '../channel-endpoints/dtos/dto.mapper';
 import { GetChannelEndpointResponseDto } from '../channel-endpoints/dtos/get-channel-endpoint-response.dto';
 import { GetChannelEndpointsQueryDto } from '../channel-endpoints/dtos/get-channel-endpoints-query.dto';
 import { UpdateChannelEndpointRequestDto } from '../channel-endpoints/dtos/update-channel-endpoint-request.dto';
@@ -84,7 +85,7 @@ export class ChannelEndpointsController {
   ): Promise<GetChannelEndpointResponseDto[]> {
     await this.checkFeatureEnabled(user);
 
-    return await this.getChannelEndpointsUsecase.execute(
+    const channelEndpoints = await this.getChannelEndpointsUsecase.execute(
       GetChannelEndpointsCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
@@ -94,6 +95,8 @@ export class ChannelEndpointsController {
         type: query.type,
       })
     );
+
+    return channelEndpoints.map((endpoint) => mapChannelEndpointEntityToDto(endpoint));
   }
 
   @Get('/channel-endpoints/:identifier')
@@ -111,13 +114,15 @@ export class ChannelEndpointsController {
   ): Promise<GetChannelEndpointResponseDto> {
     await this.checkFeatureEnabled(user);
 
-    return await this.getChannelEndpointUsecase.execute(
+    const channelEndpoint = await this.getChannelEndpointUsecase.execute(
       GetChannelEndpointCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
         identifier,
       })
     );
+
+    return mapChannelEndpointEntityToDto(channelEndpoint);
   }
 
   @Post('/:subscriberId/channel-endpoints')
@@ -135,7 +140,7 @@ export class ChannelEndpointsController {
   ): Promise<GetChannelEndpointResponseDto> {
     await this.checkFeatureEnabled(user);
 
-    return await this.createChannelEndpointUsecase.execute(
+    const channelEndpoint = await this.createChannelEndpointUsecase.execute(
       CreateChannelEndpointCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
@@ -147,6 +152,8 @@ export class ChannelEndpointsController {
         endpoint: body.endpoint,
       })
     );
+
+    return mapChannelEndpointEntityToDto(channelEndpoint);
   }
 
   @Patch('/channel-endpoints/:identifier')
@@ -165,7 +172,7 @@ export class ChannelEndpointsController {
   ): Promise<GetChannelEndpointResponseDto> {
     await this.checkFeatureEnabled(user);
 
-    return await this.updateChannelEndpointUsecase.execute(
+    const channelEndpoint = await this.updateChannelEndpointUsecase.execute(
       UpdateChannelEndpointCommand.create({
         environmentId: user.environmentId,
         organizationId: user.organizationId,
@@ -173,6 +180,8 @@ export class ChannelEndpointsController {
         endpoint: body.endpoint,
       })
     );
+
+    return mapChannelEndpointEntityToDto(channelEndpoint);
   }
 
   @Delete('/channel-endpoints/:identifier')


### PR DESCRIPTION
- Channel-connections and channel-endpoints usecases now return entities instead of DTOs
- Controllers handle the mapping from entities to DTOs using existing mapper functions
- This separates business logic (usecases) from presentation logic (controllers)
- Maintains the same API contract while improving code organization

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
