### PR TITLE
fix(api-service): Support whitespace control in Liquid assign tags fixes NV-6662

### DIFF
--- a/apps/api/src/app/shared/utils/template-parser/new-liquid-parser.spec.ts
+++ b/apps/api/src/app/shared/utils/template-parser/new-liquid-parser.spec.ts
@@ -368,6 +368,33 @@ describe('extractLiquidTemplateVariables', () => {
       expect(invalidVariables).to.have.lengthOf(0);
       expect(validVariables[0].name).to.equal('payload.firstName');
     });
+
+    it('should handle assign statements with whitespace control - both sides', () => {
+      const template = '{%- assign first_name = payload.first_name -%} Hello {{first_name}}';
+      const { validVariables, invalidVariables } = extractLiquidTemplateVariables({ template });
+
+      expect(validVariables).to.have.lengthOf(1);
+      expect(invalidVariables).to.have.lengthOf(0);
+      expect(validVariables[0].name).to.equal('payload.first_name');
+    });
+
+    it('should handle assign statements with whitespace control - left side only', () => {
+      const template = '{%- assign first_name = payload.first_name %} Hello {{first_name}}';
+      const { validVariables, invalidVariables } = extractLiquidTemplateVariables({ template });
+
+      expect(validVariables).to.have.lengthOf(1);
+      expect(invalidVariables).to.have.lengthOf(0);
+      expect(validVariables[0].name).to.equal('payload.first_name');
+    });
+
+    it('should handle assign statements with whitespace control - right side only', () => {
+      const template = '{% assign first_name = payload.first_name -%} Hello {{first_name}}';
+      const { validVariables, invalidVariables } = extractLiquidTemplateVariables({ template });
+
+      expect(validVariables).to.have.lengthOf(1);
+      expect(invalidVariables).to.have.lengthOf(0);
+      expect(validVariables[0].name).to.equal('payload.first_name');
+    });
   });
 
   describe('Capture tags', () => {

--- a/apps/api/src/app/shared/utils/template-parser/new-liquid-parser.ts
+++ b/apps/api/src/app/shared/utils/template-parser/new-liquid-parser.ts
@@ -538,8 +538,8 @@ function processTagToken({
       });
     }
   } else if (template instanceof AssignTag) {
-    // Extract assigned variable from token content: {% assign myVar = value %}
-    const assignMatch = output.match(/^\s*{%\s*assign\s+(\w+)\s*=\s*(.+?)\s*%}/);
+    // Extract assigned variable from token content: {% assign myVar = value %} or {%- assign myVar = value -%}
+    const assignMatch = output.match(/^\s*{%-?\s*assign\s+(\w+)\s*=\s*(.+?)\s*-?%}/);
     if (assignMatch) {
       const [, assignedVariable, valueExpression] = assignMatch;
 

--- a/apps/dashboard/src/utils/liquid-scope-analyzer.ts
+++ b/apps/dashboard/src/utils/liquid-scope-analyzer.ts
@@ -8,7 +8,7 @@ type Scope = {
 // Regex patterns for LiquidJS syntax
 const LIQUID_PATTERNS = {
   // Variable assignment
-  assign: /{%\s*assign\s+(\w+)\s*=[^%]+%}/g,
+  assign: /{%-?\s*assign\s+(\w+)\s*=[^%]+-?%}/g,
 
   // Loop constructs
   for: /{%\s*for\s+(\w+)\s+in\s+[^%]+%}/g,


### PR DESCRIPTION
Updated regex patterns in parser and scope analyzer to handle Liquid assign statements with whitespace control ({%- ... -%}). Added tests to verify correct variable extraction for assign tags with whitespace control on either or both sides.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
