### PR TITLE
fix(api-service): Investigate user last name object in v2 api fixes NV-6693

### DIFF
--- a/apps/api/src/app/environments-v2/dtos/diff-environment.dto.ts
+++ b/apps/api/src/app/environments-v2/dtos/diff-environment.dto.ts
@@ -18,16 +18,16 @@ export class UserInfoDto {
   @IsString()
   _id: string;
 
-  @ApiProperty({ description: 'User first name' })
+  @ApiProperty({ type: 'string', description: 'User first name' })
   @IsString()
   firstName: string;
 
-  @ApiPropertyOptional({ description: 'User last name' })
+  @ApiPropertyOptional({ type: 'string', description: 'User last name' })
   @IsOptional()
   @IsString()
   lastName?: string | null;
 
-  @ApiPropertyOptional({ description: 'User external ID' })
+  @ApiPropertyOptional({ type: 'string', description: 'User external ID' })
   @IsOptional()
   @IsString()
   externalId?: string;

--- a/apps/api/src/app/workflows-v2/dtos/user-response.dto.ts
+++ b/apps/api/src/app/workflows-v2/dtos/user-response.dto.ts
@@ -6,17 +6,17 @@ export class UserResponseDto {
   @IsString()
   _id: string;
 
-  @ApiPropertyOptional({ description: 'User first name', nullable: true })
+  @ApiPropertyOptional({ type: 'string', description: 'User first name', nullable: true })
   @IsOptional()
   @IsString()
   firstName?: string;
 
-  @ApiPropertyOptional({ description: 'User last name', nullable: true })
+  @ApiPropertyOptional({ type: 'string', description: 'User last name', nullable: true })
   @IsOptional()
   @IsString()
   lastName?: string | null;
 
-  @ApiPropertyOptional({ description: 'User external ID', nullable: true })
+  @ApiPropertyOptional({ type: 'string', description: 'User external ID', nullable: true })
   @IsOptional()
   @IsString()
   externalId?: string;


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR addresses Linear ticket [NV-6693](https://linear.app/no-project/issue/NV-6693).

The OpenAPI schema was incorrectly inferring `lastName` (and other user-related fields) as `type: object` instead of `type: string`. This change explicitly adds `type: 'string'` to the `@ApiProperty` and `@ApiPropertyOptional` decorators for `firstName`, `lastName`, and `externalId` in the following DTOs:

*   `apps/api/src/app/workflows-v2/dtos/user-response.dto.ts`
*   `apps/api/src/app/environments-v2/dtos/diff-environment.dto.ts` (specifically `UserInfoDto`)

This ensures the OpenAPI documentation accurately reflects the string type of these fields.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

This change is purely for OpenAPI schema generation accuracy and does not alter any runtime behavior.

</details>

---
Linear Issue: [NV-6693](https://linear.app/novu/issue/NV-6693/clarify-if-last-name-as-object-in-v2-api-is-intentional)

<a href="https://cursor.com/background-agent?bcId=bc-d338da6f-3959-4ee7-b0d7-fad0f1aae971">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d338da6f-3959-4ee7-b0d7-fad0f1aae971">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

