### PR TITLE
test(api): update v1 translations e2e test to run in #novu-v2 suite

### DIFF
--- a/apps/api/src/app/translations/e2e/v1/create-translation.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/create-translation.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('Create translation group - /translations/groups (POST) #novu-v2', async () => {
+describe('[V1 Translations] Create translation group - /translations/groups (POST) #novu-v2', async () => {
   let session: UserSession;
 
   beforeEach(async () => {

--- a/apps/api/src/app/translations/e2e/v1/create-translation.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/create-translation.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('Create translation group - /translations/groups (POST) #novu-v1', async () => {
+describe('Create translation group - /translations/groups (POST) #novu-v2', async () => {
   let session: UserSession;
 
   beforeEach(async () => {

--- a/apps/api/src/app/translations/e2e/v1/delete-translation-group.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/delete-translation-group.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('Delete a Translation group - /translations/group/:id (Delete) #novu-v1', async () => {
+describe('Delete a Translation group - /translations/group/:id (Delete) #novu-v2', async () => {
   let session: UserSession;
 
   beforeEach(async () => {

--- a/apps/api/src/app/translations/e2e/v1/delete-translation-group.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/delete-translation-group.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('Delete a Translation group - /translations/group/:id (Delete) #novu-v2', async () => {
+describe('[V1 Translations] Delete a Translation group - /translations/group/:id (Delete) #novu-v2', async () => {
   let session: UserSession;
 
   beforeEach(async () => {

--- a/apps/api/src/app/translations/e2e/v1/delete-translation.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/delete-translation.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('Delete a Translation - /translations/group/:id/locale/:locale (Delete) #novu-v2', async () => {
+describe('[V1 Translations] Delete a Translation - /translations/group/:id/locale/:locale (Delete) #novu-v2', async () => {
   let session: UserSession;
 
   beforeEach(async () => {

--- a/apps/api/src/app/translations/e2e/v1/delete-translation.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/delete-translation.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('Delete a Translation - /translations/group/:id/locale/:locale (Delete) #novu-v1', async () => {
+describe('Delete a Translation - /translations/group/:id/locale/:locale (Delete) #novu-v2', async () => {
   let session: UserSession;
 
   beforeEach(async () => {

--- a/apps/api/src/app/translations/e2e/v1/edit-translation.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/edit-translation.e2e-ee.ts
@@ -7,7 +7,7 @@ const createTranslationGroup = {
   locales: ['hi_IN'],
 };
 
-describe('Edit translation - /translations/groups/:identifier/locales/:locale (PATCH) #novu-v1', async () => {
+describe('Edit translation - /translations/groups/:identifier/locales/:locale (PATCH) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/edit-translation.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/edit-translation.e2e-ee.ts
@@ -7,7 +7,7 @@ const createTranslationGroup = {
   locales: ['hi_IN'],
 };
 
-describe('Edit translation - /translations/groups/:identifier/locales/:locale (PATCH) #novu-v2', async () => {
+describe('[V1 Translations] Edit translation - /translations/groups/:identifier/locales/:locale (PATCH) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/get-locales-from-content.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/get-locales-from-content.e2e-ee.ts
@@ -9,7 +9,7 @@ const createTranslationGroup = {
 
 const content = 'Hello {{i18n "test.key1"}}, {{i18n "test.key2"}}, {{i18n "test.key3"}}';
 
-describe('Get locales from content - /translations/groups/:identifier/locales/:locale (PATCH) #novu-v2', async () => {
+describe('[V1 Translations] Get locales from content - /translations/groups/:identifier/locales/:locale (PATCH) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/get-locales-from-content.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/get-locales-from-content.e2e-ee.ts
@@ -9,7 +9,7 @@ const createTranslationGroup = {
 
 const content = 'Hello {{i18n "test.key1"}}, {{i18n "test.key2"}}, {{i18n "test.key3"}}';
 
-describe('Get locales from content - /translations/groups/:identifier/locales/:locale (PATCH) #novu-v1', async () => {
+describe('Get locales from content - /translations/groups/:identifier/locales/:locale (PATCH) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/get-locales.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/get-locales.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('get locales - /translations/locales (GET) #novu-v2', async () => {
+describe('[V1 Translations] get locales - /translations/locales (GET) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/get-locales.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/get-locales.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('get locales - /translations/locales (GET) #novu-v1', async () => {
+describe('get locales - /translations/locales (GET) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/get-translation-group.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/get-translation-group.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('get translation group - /translations/groups/:identifier (GET) #novu-v2', async () => {
+describe('[V1 Translations] get translation group - /translations/groups/:identifier (GET) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/get-translation-group.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/get-translation-group.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('get translation group - /translations/groups/:identifier (GET) #novu-v1', async () => {
+describe('get translation group - /translations/groups/:identifier (GET) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/get-translation-groups.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/get-translation-groups.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('get translation groups - /translations/groups (GET) #novu-v1', async () => {
+describe('get translation groups - /translations/groups (GET) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/get-translation-groups.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/get-translation-groups.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('get translation groups - /translations/groups (GET) #novu-v2', async () => {
+describe('[V1 Translations] get translation groups - /translations/groups (GET) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/get-translation.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/get-translation.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('GET translation - /translations/groups/:identifier/locales/:locale (GET) #novu-v1', async () => {
+describe('GET translation - /translations/groups/:identifier/locales/:locale (GET) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/get-translation.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/get-translation.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('GET translation - /translations/groups/:identifier/locales/:locale (GET) #novu-v2', async () => {
+describe('[V1 Translations] GET translation - /translations/groups/:identifier/locales/:locale (GET) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/update-default-locale.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/update-default-locale.e2e-ee.ts
@@ -2,7 +2,7 @@ import { OrganizationRepository } from '@novu/dal';
 import { getEERepository, UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('Update default locale and add new translations - /translations/language (PATCH) #novu-v1', async () => {
+describe('Update default locale and add new translations - /translations/language (PATCH) #novu-v2', async () => {
   let session: UserSession;
   const organizationRepository = getEERepository<OrganizationRepository>('OrganizationRepository');
 

--- a/apps/api/src/app/translations/e2e/v1/update-default-locale.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/update-default-locale.e2e-ee.ts
@@ -2,7 +2,7 @@ import { OrganizationRepository } from '@novu/dal';
 import { getEERepository, UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('Update default locale and add new translations - /translations/language (PATCH) #novu-v2', async () => {
+describe('[V1 Translations] Update default locale and add new translations - /translations/language (PATCH) #novu-v2', async () => {
   let session: UserSession;
   const organizationRepository = getEERepository<OrganizationRepository>('OrganizationRepository');
 

--- a/apps/api/src/app/translations/e2e/v1/update-translation.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/update-translation.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('Update translation - /translations/groups (PATCH) #novu-v1', async () => {
+describe('Update translation - /translations/groups (PATCH) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {

--- a/apps/api/src/app/translations/e2e/v1/update-translation.e2e-ee.ts
+++ b/apps/api/src/app/translations/e2e/v1/update-translation.e2e-ee.ts
@@ -1,7 +1,7 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe('Update translation - /translations/groups (PATCH) #novu-v2', async () => {
+describe('[V1 Translations] Update translation - /translations/groups (PATCH) #novu-v2', async () => {
   let session: UserSession;
 
   before(async () => {


### PR DESCRIPTION
### What changed? Why was the change needed?

Updated the `describe()` strings in all e2e tests within `apps/api/src/app/translations/e2e/v1`.

Specifically:
*   Replaced `#novu-v1` with `#novu-v2` to align with new test categorization.
*   Prepended `[V1 Translations]` to each `describe()` string. This is to clearly identify these as legacy V1 tests that must continue to run, ensuring backward compatibility for existing customers.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

---
[Slack Thread](https://novu.slack.com/archives/D0919LNS89H/p1758053280308669?thread_ts=1758053280.308669&cid=D0919LNS89H)

<a href="https://cursor.com/background-agent?bcId=bc-d9df61d1-fd7d-40b7-81b6-8b5172649078">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d9df61d1-fd7d-40b7-81b6-8b5172649078">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

