### PR TITLE
fix(api): normalize workflow step mapping

### DIFF
--- a/apps/api/src/app/workflows-v2/workflow.controller.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.ts
@@ -101,10 +101,7 @@ export class WorkflowController {
     @UserSession(ParseSlugEnvironmentIdPipe) user: UserSessionData,
     @Body() createWorkflowDto: CreateWorkflowDto
   ): Promise<WorkflowResponseDto> {
-    const upsertSteps: UpsertStepDataCommand[] = createWorkflowDto.steps.map((step: StepUpsertDto) => ({
-      ...step,
-      controlValues: (step.controlValues as Record<string, unknown> | null | undefined) ?? null,
-    }));
+    const upsertSteps = this.normalizeSteps(createWorkflowDto.steps);
 
     return this.upsertWorkflowUseCase.execute(
       UpsertWorkflowCommand.create({
@@ -157,10 +154,7 @@ export class WorkflowController {
     @Param('workflowId', ParseSlugIdPipe) workflowIdOrInternalId: string,
     @Body() updateWorkflowDto: UpdateWorkflowDto
   ): Promise<WorkflowResponseDto> {
-    const upsertSteps: UpsertStepDataCommand[] = updateWorkflowDto.steps.map((step: StepUpsertDto) => ({
-      ...step,
-      controlValues: (step.controlValues as Record<string, unknown> | null | undefined) ?? null,
-    }));
+    const upsertSteps = this.normalizeSteps(updateWorkflowDto.steps);
 
     return await this.upsertWorkflowUseCase.execute(
       UpsertWorkflowCommand.create({
@@ -172,6 +166,13 @@ export class WorkflowController {
         workflowIdOrInternalId,
       })
     );
+  }
+
+  private normalizeSteps(steps: StepUpsertDto[]): UpsertStepDataCommand[] {
+    return steps.map((step: StepUpsertDto) => ({
+      ...step,
+      controlValues: (step.controlValues as Record<string, unknown> | null | undefined) ?? null,
+    }));
   }
 
   @Get(':workflowId')


### PR DESCRIPTION
## Summary
- extract a helper to normalize workflow step control values
- reuse the helper from the create and update handlers

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68cb1129c044832eab49b908a75a8ac1