### PR TITLE
fix(api): restore concurrent unread and severity queries

### DIFF
--- a/apps/ws/src/socket/usecases/external-services-route/external-services-route.usecase.ts
+++ b/apps/ws/src/socket/usecases/external-services-route/external-services-route.usecase.ts
@@ -71,6 +71,16 @@ export class ExternalServicesRoute {
       environment: { _id: command._environmentId },
     });
 
+    const severityCountsPromise = isNotificationSeverityEnabled
+      ? this.messageRepository.getCountBySeverity(
+          command._environmentId,
+          command.userId,
+          ChannelTypeEnum.IN_APP,
+          { read: false, snoozed: false },
+          { limit: 99 }
+        )
+      : Promise.resolve([]);
+
     const [unreadCount, severityCounts] = await Promise.all([
       this.messageRepository.getCount(
         command._environmentId,
@@ -81,15 +91,7 @@ export class ExternalServicesRoute {
         undefined,
         'primary'
       ),
-      isNotificationSeverityEnabled
-        ? await this.messageRepository.getCountBySeverity(
-            command._environmentId,
-            command.userId,
-            ChannelTypeEnum.IN_APP,
-            { read: false, snoozed: false },
-            { limit: 99 }
-          )
-        : [],
+      severityCountsPromise,
     ]);
 
     const paginationIndication: IUnreadCountPaginationIndication =


### PR DESCRIPTION
## Summary
- ensure unread and severity count queries execute concurrently by deferring severity promise resolution

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68cb177ee7ac832ea20be0b73fa8b59d