### PR TITLE
Fix duplicate email steps in workflow duplication

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/duplicate-workflow/duplicate-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/duplicate-workflow/duplicate-workflow.usecase.ts
@@ -74,6 +74,7 @@ export class DuplicateWorkflowUseCase {
       name: step.name ?? '',
       type: step.type,
       controlValues: step.controls.values ?? null,
+      // Explicitly exclude stepId to ensure new unique IDs are generated for duplicated steps
     }));
   }
 

--- a/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/upsert-workflow/upsert-workflow.usecase.ts
@@ -215,7 +215,7 @@ export class UpsertWorkflowUseCase {
 
     // Build optimistic step information for sync scenarios
     const optimisticSteps = command.workflowDto.steps.map((step) => ({
-      stepId: step.stepId || this.generateUniqueStepId(step, command.workflowDto.steps),
+      stepId: step.stepId || this.generateUniqueStepIdFromStepCommands(step, command.workflowDto.steps),
       type: step.type,
     }));
 
@@ -252,7 +252,7 @@ export class UpsertWorkflowUseCase {
         stepId:
           updateStepId ||
           syncToEnvironmentCreateStepId ||
-          this.generateUniqueStepId(step, existingWorkflow ? existingWorkflow.steps : command.workflowDto.steps),
+          this.generateUniqueStepId(step, existingWorkflow ? existingWorkflow.steps : steps),
         name: step.name,
         issues,
       };
@@ -288,6 +288,42 @@ export class UpsertWorkflowUseCase {
     }, []);
 
     const isStepIdUnique = (stepId: string) => !previousStepIds.includes(stepId);
+
+    while (attempts < maxAttempts) {
+      if (isStepIdUnique(finalStepId)) {
+        break;
+      }
+
+      finalStepId = `${slug}-${shortId()}`;
+      attempts += 1;
+    }
+
+    if (attempts === maxAttempts && !isStepIdUnique(finalStepId)) {
+      throw new BadRequestException({
+        message: 'Failed to generate unique stepId',
+        stepId: finalStepId,
+      });
+    }
+
+    return finalStepId;
+  }
+
+  @Instrument()
+  private generateUniqueStepIdFromStepCommands(step: UpsertStepDataCommand, allSteps: UpsertStepDataCommand[]): string {
+    const slug = slugify(step.name);
+
+    let finalStepId = slug;
+    let attempts = 0;
+    const maxAttempts = 5;
+
+    const existingStepIds = allSteps.reduce<string[]>((acc, s) => {
+      if (s.stepId && s !== step) {
+        acc.push(s.stepId);
+      }
+      return acc;
+    }, []);
+
+    const isStepIdUnique = (stepId: string) => !existingStepIds.includes(stepId);
 
     while (attempts < maxAttempts) {
       if (isStepIdUnique(finalStepId)) {


### PR DESCRIPTION
### What changed? Why was the change needed?

When duplicating a v2 workflow, steps with identical names (e.g., two email steps) were being created with the same `stepId` in the new workflow, instead of generating unique, auto-suffixed IDs.

This was due to a type mismatch in the `generateUniqueStepId` method within `UpsertWorkflowUseCase`. During the duplication and optimistic step generation process, this method was incorrectly passed `UpsertStepDataCommand[]` (which lacks populated `stepId`s at that stage) instead of `NotificationStep[]` (which contains existing `stepId`s for uniqueness checks). This prevented the unique ID generation logic from correctly identifying and resolving conflicts.

The fix introduces a new method, `generateUniqueStepIdFromStepCommands`, specifically designed to handle `UpsertStepDataCommand[]` inputs for unique ID generation during duplication. Calls to the ID generation methods in `UpsertWorkflowUseCase.buildSteps` have been updated to use the appropriate method based on the input step type, ensuring all duplicated steps receive unique identifiers.

### Screenshots

N/A

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1758194208568919?thread_ts=1758194208.568919&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-0616673e-f362-496e-9f9d-d13cc0f8ed64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0616673e-f362-496e-9f9d-d13cc0f8ed64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

