### PR TITLE
feat(framework,worker,api): workflow execution with context & variable parsing fixes NV-6697

### DIFF
--- a/apps/api/src/app/bridge/usecases/preview-step/preview-step.command.ts
+++ b/apps/api/src/app/bridge/usecases/preview-step/preview-step.command.ts
@@ -1,4 +1,5 @@
 import { EnvironmentWithUserCommand } from '@novu/application-generic';
+import { ContextResolved } from '@novu/framework/internal';
 import { JobStatusEnum, ResourceOriginEnum } from '@novu/shared';
 import { SubscriberResponseDtoOptional } from '../../../subscribers/dtos';
 
@@ -7,6 +8,7 @@ export class PreviewStepCommand extends EnvironmentWithUserCommand {
   stepId: string;
   controls: Record<string, unknown>;
   payload: Record<string, unknown>;
+  context?: ContextResolved;
   subscriber?: SubscriberResponseDtoOptional;
   workflowOrigin: ResourceOriginEnum;
   state?: FrameworkPreviousStepsOutputState[];

--- a/apps/api/src/app/bridge/usecases/preview-step/preview-step.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/preview-step/preview-step.usecase.ts
@@ -39,6 +39,7 @@ export class PreviewStep {
       payload: command.payload || {},
       state: command.state || [],
       subscriber: command.subscriber || {},
+      context: command.context || {},
       stepId: command.stepId,
       workflowId: command.workflowId,
       action: PostActionEnum.PREVIEW,

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/render-command.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/render-command.ts
@@ -1,4 +1,5 @@
 import { BaseCommand } from '@novu/application-generic';
+import type { ContextResolved } from '@novu/framework/internal';
 import { LAYOUT_CONTENT_VARIABLE } from '@novu/shared';
 
 export class RenderCommand extends BaseCommand {
@@ -9,6 +10,7 @@ export class FullPayloadForRender {
   workflow?: Record<string, unknown>;
   subscriber: Record<string, unknown>;
   payload: Record<string, unknown>;
+  context?: ContextResolved;
   steps: Record<string, unknown>; // step.stepId.unknown
   // this variable is used to pass the layout content to the renderer
   [LAYOUT_CONTENT_VARIABLE]?: string;

--- a/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
@@ -346,6 +346,7 @@ export class TriggerEventRequestDto {
   //           data: {
   //             type: 'object',
   //             description: 'Optional additional context data',
+  //             additionalProperties: true,
   //             example: { name: 'Acme Corp', region: 'us-east-1' },
   //           },
   //         },

--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
@@ -98,7 +98,7 @@ export class ExecuteBridgeJob {
       throw new Error(`Bridge URL is not set for environment id: ${environment._id}`);
     }
 
-    const { subscriber, payload: originalPayload } = command.variables || {};
+    const { subscriber, payload: originalPayload, context } = command.variables || {};
     const payload = this.normalizePayload(originalPayload);
 
     const state = await this.generateState(command);
@@ -112,6 +112,7 @@ export class ExecuteBridgeJob {
       controls: variablesStores ?? {},
       state,
       subscriber: subscriber ?? {},
+      context: context ?? {},
     };
 
     const workflowId = isStateful

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -246,6 +246,7 @@ export class RunJob {
           tags: notification.tags || [],
           severity: notification.severity,
           statelessPreferences: job.preferences,
+          contextKeys: job.contextKeys,
         })
       );
 

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-channel.command.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-channel.command.ts
@@ -1,5 +1,5 @@
 import type { SubscriberEntity, TenantEntity } from '@novu/dal';
-import type { ExecuteOutput } from '@novu/framework/internal';
+import type { ContextResolved, ExecuteOutput } from '@novu/framework/internal';
 import type { ITriggerPayload, SeverityLevelEnum } from '@novu/shared';
 import { IsDefined, IsOptional } from 'class-validator';
 import { SendMessageCommand } from './send-message.command';
@@ -12,6 +12,7 @@ export class SendMessageChannelCommand extends SendMessageCommand {
     actor?: SubscriberEntity;
     webhook?: Record<string, unknown>;
     tenant?: TenantEntity;
+    context?: ContextResolved;
     step: {
       digest: boolean;
       events: any[] | undefined;

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
@@ -642,6 +642,7 @@ export class SendMessageChat extends SendMessageBase {
       _jobId: command.jobId,
       tags: command.tags,
       severity: command.severity,
+      ...(command.contextKeys && { contextKeys: command.contextKeys }),
       ...(channelData &&
         channelData.length > 0 && { channelData: channelData.map((data) => this.redactChannelData(data)) }),
       ...additionalFields,

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -212,6 +212,7 @@ export class SendMessageEmail extends SendMessageBase {
       _jobId: command.jobId,
       tags: command.tags,
       severity: command.severity,
+      ...(command.contextKeys && { contextKeys: command.contextKeys }),
     });
 
     let replyToAddress: string | undefined;

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
@@ -236,12 +236,12 @@ export class SendMessageInApp extends SendMessageBase {
         _feedId: step.template._feedId,
         channel: ChannelTypeEnum.IN_APP,
         _jobId: command.jobId,
+        ...(command.contextKeys && { contextKeys: command.contextKeys }),
         ...(actor &&
           actor.type !== ActorTypeEnum.NONE && {
             actor,
             _actorId: command.job?._actorId,
           }),
-        contextKeys: command.contextKeys,
         ...additionalFields,
       });
     }

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
@@ -209,7 +209,7 @@ export class SendMessageInApp extends SendMessageBase {
     const bridgeOutputs = command.bridgeData?.outputs as InAppOutput;
     const inAppMessage = inAppMessageFromBridgeOutputs(bridgeOutputs);
 
-    const channelData: Partial<
+    const additionalFields: Partial<
       Pick<MessageEntity, 'content' | 'subject' | 'avatar' | 'payload' | 'cta' | 'tags' | 'data' | 'severity'>
     > = {
       content: (this.storeContent() ? inAppMessage.content || content : null) as string,
@@ -241,7 +241,8 @@ export class SendMessageInApp extends SendMessageBase {
             actor,
             _actorId: command.job?._actorId,
           }),
-        ...channelData,
+        contextKeys: command.contextKeys,
+        ...additionalFields,
       });
     }
 
@@ -253,7 +254,7 @@ export class SendMessageInApp extends SendMessageBase {
             seen: false,
             createdAt: new Date(),
             updatedAt: new Date(),
-            ...channelData,
+            ...additionalFields,
           },
         },
         {

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
@@ -595,6 +595,7 @@ export class SendMessagePush extends SendMessageBase {
       _jobId: command.jobId,
       tags: command.tags,
       severity: command.severity,
+      ...(command.contextKeys && { contextKeys: command.contextKeys }),
     });
 
     await this.createExecutionDetails.execute(

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-sms.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-sms.usecase.ts
@@ -15,7 +15,7 @@ import {
   SmsFactory,
 } from '@novu/application-generic';
 
-import {  IntegrationEntity, MessageEntity, MessageRepository, SubscriberRepository } from '@novu/dal';
+import { IntegrationEntity, MessageEntity, MessageRepository, SubscriberRepository } from '@novu/dal';
 import { SmsOutput } from '@novu/framework/internal';
 import {
   ChannelTypeEnum,
@@ -174,6 +174,7 @@ export class SendMessageSms extends SendMessageBase {
       _jobId: command.jobId,
       tags: command.tags,
       severity: command.severity,
+      ...(command.contextKeys && { contextKeys: command.contextKeys }),
     });
 
     await this.createExecutionDetails.execute(

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.command.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.command.ts
@@ -1,6 +1,6 @@
 import { EnvironmentWithUserCommand } from '@novu/application-generic';
 import type { JobEntity, NotificationStepEntity } from '@novu/dal';
-import type { SeverityLevelEnum, TriggerOverrides, WorkflowPreferences } from '@novu/shared';
+import type { ContextKey, SeverityLevelEnum, TriggerOverrides, WorkflowPreferences } from '@novu/shared';
 import { IsDefined, IsOptional, IsString } from 'class-validator';
 
 export class SendMessageCommand extends EnvironmentWithUserCommand {
@@ -50,4 +50,7 @@ export class SendMessageCommand extends EnvironmentWithUserCommand {
 
   @IsOptional()
   statelessPreferences?: WorkflowPreferences;
+
+  @IsOptional()
+  contextKeys?: ContextKey[];
 }

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -19,6 +19,8 @@ import {
   NormalizeVariables,
   NormalizeVariablesCommand,
   PlatformException,
+  ResolveContextFromKeys,
+  ResolveContextFromKeysCommand,
 } from '@novu/application-generic';
 import {
   JobEntity,
@@ -27,7 +29,7 @@ import {
   TenantEntity,
   TenantRepository,
 } from '@novu/dal';
-import { ExecuteOutput } from '@novu/framework/internal';
+import { ContextResolved, ExecuteOutput } from '@novu/framework/internal';
 import {
   DeliveryLifecycleDetail,
   DeliveryLifecycleStatus,
@@ -73,6 +75,7 @@ export class SendMessage {
     private tenantRepository: TenantRepository,
     private analyticsService: AnalyticsService,
     private normalizeVariablesUsecase: NormalizeVariables,
+    private resolveContextFromKeys: ResolveContextFromKeys,
     private executeBridgeJob: ExecuteBridgeJob,
     private featureFlagsService: FeatureFlagsService
   ) {}
@@ -407,7 +410,7 @@ export class SendMessage {
 
   @Instrument()
   private async buildCompileContext(command: SendMessageCommand): Promise<SendMessageChannelCommand['compileContext']> {
-    const [subscriber, actor, tenant] = await Promise.all([
+    const [subscriber, actor, tenant, context] = await Promise.all([
       this.getSubscriberBySubscriberId({
         subscriberId: command.subscriberId,
         _environmentId: command.environmentId,
@@ -418,6 +421,7 @@ export class SendMessage {
           _environmentId: command.environmentId,
         }),
       this.handleTenantExecution(command.job),
+      this.resolveContext(command),
     ]);
 
     if (!subscriber) throw new PlatformException('Subscriber not found');
@@ -432,7 +436,30 @@ export class SendMessage {
       },
       ...(tenant && { tenant }),
       ...(actor && { actor }),
+      ...(context && { context }),
     };
+  }
+
+  @Instrument()
+  private async resolveContext(command: SendMessageCommand): Promise<ContextResolved> {
+    const { contextKeys, environmentId, organizationId } = command;
+
+    const contexts = await this.resolveContextFromKeys.execute(
+      ResolveContextFromKeysCommand.create({
+        environmentId,
+        organizationId,
+        userId: command.userId,
+        contextKeys: contextKeys || [],
+      })
+    );
+
+    return contexts.reduce((acc, context) => {
+      acc[context.type] = {
+        id: context.id,
+        data: context.data,
+      };
+      return acc;
+    }, {} as ContextResolved);
   }
 
   private async getWorkflow({ _id, environmentId }: { _id: string; environmentId: string }) {

--- a/apps/worker/src/app/workflow/workflow.module.ts
+++ b/apps/worker/src/app/workflow/workflow.module.ts
@@ -18,7 +18,8 @@ import {
   GetTopicSubscribersUseCase,
   NormalizeVariables,
   ProcessTenant,
-  ResolveContext,
+  ResolveContextFromKeys,
+  ResolveContextFromPayload,
   SelectIntegration,
   SelectVariant,
   SendWebhookMessage,
@@ -188,7 +189,8 @@ const USE_CASES = [
   ExecuteBridgeJob,
   GetPreferences,
   WorkflowRunService,
-  ResolveContext,
+  ResolveContextFromKeys,
+  ResolveContextFromPayload,
   GetSubscriberSchedule,
 ];
 

--- a/libs/application-generic/src/services/analytic-logs/trace-log/trace-log.schema.ts
+++ b/libs/application-generic/src/services/analytic-logs/trace-log/trace-log.schema.ts
@@ -1,4 +1,5 @@
 import {
+  CHArray,
   CHDateTime64,
   CHLowCardinality,
   CHNullable,
@@ -21,7 +22,6 @@ const schemaDefinition = {
   user_id: { type: CHNullable(CHString()) },
   external_subscriber_id: { type: CHNullable(CHString()) },
   subscriber_id: { type: CHNullable(CHString()) },
-  // TODO: add context_id
 
   // Trace metadata
   event_type: { type: CHLowCardinality(CHString()) }, // e.g., "message:seen", "step_run:start", "step_run:end"

--- a/libs/application-generic/src/usecases/normalize-variables/normalize-variables.usecase.ts
+++ b/libs/application-generic/src/usecases/normalize-variables/normalize-variables.usecase.ts
@@ -38,6 +38,7 @@ export class NormalizeVariables {
 
     filterVariables.step = command.variables?.step ?? undefined;
     filterVariables.actor = command.variables?.actor ?? undefined;
+    filterVariables.context = command.variables?.context ?? undefined;
 
     return filterVariables;
   }

--- a/libs/application-generic/src/usecases/resolve-context/index.ts
+++ b/libs/application-generic/src/usecases/resolve-context/index.ts
@@ -1,2 +1,4 @@
-export * from './resolve-context.command';
-export * from './resolve-context.usecase';
+export * from './resolve-context-from-keys.command';
+export * from './resolve-context-from-keys.usecase';
+export * from './resolve-context-from-payload.command';
+export * from './resolve-context-from-payload.usecase';

--- a/libs/application-generic/src/usecases/resolve-context/resolve-context-from-keys.command.ts
+++ b/libs/application-generic/src/usecases/resolve-context/resolve-context-from-keys.command.ts
@@ -1,0 +1,12 @@
+import { ContextKey } from '@novu/shared';
+import { ArrayMaxSize, IsArray, IsDefined, IsString } from 'class-validator';
+
+import { EnvironmentWithUserCommand } from '../../commands';
+
+export class ResolveContextFromKeysCommand extends EnvironmentWithUserCommand {
+  @IsDefined()
+  @IsArray()
+  @ArrayMaxSize(5)
+  @IsString({ each: true })
+  contextKeys: ContextKey[];
+}

--- a/libs/application-generic/src/usecases/resolve-context/resolve-context-from-keys.usecase.ts
+++ b/libs/application-generic/src/usecases/resolve-context/resolve-context-from-keys.usecase.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { ContextEntity, ContextRepository } from '@novu/dal';
+import { InstrumentUsecase } from '../../instrumentation';
+import { PinoLogger } from '../../logging';
+import { ResolveContextFromKeysCommand } from './resolve-context-from-keys.command';
+
+@Injectable()
+export class ResolveContextFromKeys {
+  constructor(
+    private logger: PinoLogger,
+    private contextRepository: ContextRepository
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  @InstrumentUsecase()
+  public async execute(command: ResolveContextFromKeysCommand): Promise<ContextEntity[]> {
+    if (command.contextKeys.length === 0) {
+      return [];
+    }
+
+    return this.contextRepository.findByKeys(command.environmentId, command.organizationId, command.contextKeys);
+  }
+}

--- a/libs/application-generic/src/usecases/resolve-context/resolve-context-from-payload.command.ts
+++ b/libs/application-generic/src/usecases/resolve-context/resolve-context-from-payload.command.ts
@@ -4,7 +4,7 @@ import { IsDefined } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../commands';
 import { IsValidContextPayload } from '../../decorators';
 
-export class ResolveContextCommand extends EnvironmentWithUserCommand {
+export class ResolveContextFromPayloadCommand extends EnvironmentWithUserCommand {
   @IsDefined()
   @IsValidContextPayload({ maxCount: 5 })
   context: ContextPayload;

--- a/libs/application-generic/src/usecases/resolve-context/resolve-context-from-payload.usecase.ts
+++ b/libs/application-generic/src/usecases/resolve-context/resolve-context-from-payload.usecase.ts
@@ -3,10 +3,10 @@ import { ContextEntity, ContextRepository } from '@novu/dal';
 import { ContextData, ContextType, ContextValue } from '@novu/shared';
 import { InstrumentUsecase } from '../../instrumentation';
 import { PinoLogger } from '../../logging';
-import { ResolveContextCommand } from './resolve-context.command';
+import { ResolveContextFromPayloadCommand } from './resolve-context-from-payload.command';
 
 @Injectable()
-export class ResolveContext {
+export class ResolveContextFromPayload {
   constructor(
     private logger: PinoLogger,
     private contextRepository: ContextRepository
@@ -15,8 +15,7 @@ export class ResolveContext {
   }
 
   @InstrumentUsecase()
-  public async execute(command: ResolveContextCommand): Promise<ContextEntity[]> {
-    // Process all context type-value pairs in parallel to avoid N+1 queries
+  public async execute(command: ResolveContextFromPayloadCommand): Promise<ContextEntity[]> {
     const contexts = await Promise.all(
       Object.entries(command.context).map(([contextType, contextValue]) =>
         this.resolveContextTypeAndValue(command, contextType, contextValue)
@@ -27,7 +26,7 @@ export class ResolveContext {
   }
 
   private async resolveContextTypeAndValue(
-    command: ResolveContextCommand,
+    command: ResolveContextFromPayloadCommand,
     contextType: ContextType,
     contextValue: ContextValue
   ): Promise<ContextEntity> {
@@ -39,7 +38,7 @@ export class ResolveContext {
   }
 
   private async handleStringValue(
-    command: ResolveContextCommand,
+    command: ResolveContextFromPayloadCommand,
     contextType: ContextType,
     id: string
   ): Promise<ContextEntity> {
@@ -47,7 +46,7 @@ export class ResolveContext {
   }
 
   private async handleObjectValue(
-    command: ResolveContextCommand,
+    command: ResolveContextFromPayloadCommand,
     contextType: ContextType,
     contextValue: { id: string; data?: ContextData }
   ): Promise<ContextEntity> {

--- a/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
@@ -25,7 +25,7 @@ import { LogRepository, mapEventTypeToTitle, TraceLogRepository } from '../../se
 import { AnalyticsService } from '../../services/analytics.service';
 import { CreateOrUpdateSubscriberCommand, CreateOrUpdateSubscriberUseCase } from '../create-or-update-subscriber';
 import { ProcessTenant, ProcessTenantCommand } from '../process-tenant';
-import { ResolveContext, ResolveContextCommand } from '../resolve-context';
+import { ResolveContextFromPayload, ResolveContextFromPayloadCommand } from '../resolve-context';
 import { TriggerBroadcastCommand } from '../trigger-broadcast/trigger-broadcast.command';
 import { TriggerBroadcast } from '../trigger-broadcast/trigger-broadcast.usecase';
 import { TriggerMulticast, TriggerMulticastCommand } from '../trigger-multicast';
@@ -48,7 +48,7 @@ export class TriggerEvent {
     private triggerMulticast: TriggerMulticast,
     private analyticsService: AnalyticsService,
     private traceLogRepository: TraceLogRepository,
-    private resolveContext: ResolveContext,
+    private resolveContextFromPayload: ResolveContextFromPayload,
     private featureFlagsService: FeatureFlagsService
   ) {
     this.logger.setContext(this.constructor.name);
@@ -381,8 +381,8 @@ export class TriggerEvent {
     }
 
     try {
-      const contexts = await this.resolveContext.execute(
-        ResolveContextCommand.create({
+      const contexts = await this.resolveContextFromPayload.execute(
+        ResolveContextFromPayloadCommand.create({
           environmentId: command.environmentId,
           organizationId: command.organizationId,
           userId: command.userId,

--- a/libs/application-generic/src/utils/filter-processing-details.ts
+++ b/libs/application-generic/src/utils/filter-processing-details.ts
@@ -1,4 +1,5 @@
 import { SubscriberEntity, TenantEntity } from '@novu/dal';
+import type { ContextResolved } from '@novu/framework/internal';
 import { ICondition, IMessageFilter, ITriggerPayload } from '@novu/shared';
 
 export interface IFilterVariables {
@@ -7,6 +8,7 @@ export interface IFilterVariables {
   actor?: SubscriberEntity;
   webhook?: Record<string, unknown>;
   tenant?: TenantEntity;
+  context?: ContextResolved;
   step?: {
     digest: boolean;
     events: any[] | undefined;

--- a/libs/application-generic/src/webhooks/dtos/message-webhook.response.dto.ts
+++ b/libs/application-generic/src/webhooks/dtos/message-webhook.response.dto.ts
@@ -27,6 +27,7 @@ export type MessageWebhookResponseDto = Pick<
   | 'status'
   | 'errorId'
   | 'errorText'
+  | 'contextKeys'
 > & {
   providerResponseId?: string;
   deviceToken?: string;

--- a/libs/application-generic/src/webhooks/mappers/message.mapper.ts
+++ b/libs/application-generic/src/webhooks/mappers/message.mapper.ts
@@ -29,6 +29,7 @@ export const messageWebhookMapper = (
     | 'status'
     | 'errorId'
     | 'errorText'
+    | 'contextKeys'
   >,
   subscriberId: string,
   context?: {
@@ -71,5 +72,6 @@ export const messageWebhookMapper = (
     webhookUrl: context?.webhookUrl,
     channelData: context?.channelData,
     providerResponseId: context?.providerResponseId,
+    contextKeys: message.contextKeys,
   };
 };

--- a/libs/dal/src/repositories/context/context.repository.ts
+++ b/libs/dal/src/repositories/context/context.repository.ts
@@ -1,4 +1,4 @@
-import { ContextData, ContextId, ContextType, createContextKey } from '@novu/shared';
+import { ContextData, ContextId, ContextKey, ContextType, createContextKey } from '@novu/shared';
 import { FilterQuery } from 'mongoose';
 import type { EnforceEnvOrOrgIds } from '../../types';
 import { BaseRepository } from '../base-repository';
@@ -53,5 +53,19 @@ export class ContextRepository extends BaseRepository<ContextDBModel, ContextEnt
 
       return this.create(newContext);
     }
+  }
+
+  async findByKeys(environmentId: string, organizationId: string, contextKeys: ContextKey[]): Promise<ContextEntity[]> {
+    if (contextKeys.length === 0) {
+      return [];
+    }
+
+    const query = {
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+      key: { $in: contextKeys },
+    };
+
+    return this.find(query);
   }
 }

--- a/libs/dal/src/repositories/job/job.schema.ts
+++ b/libs/dal/src/repositories/job/job.schema.ts
@@ -31,7 +31,7 @@ const jobSchema = new Schema<JobDBModel>(
       type: Schema.Types.Mixed,
     },
     contextKeys: {
-      type: Schema.Types.Array,
+      type: [Schema.Types.String],
       default: undefined,
     },
     step: {

--- a/libs/dal/src/repositories/message/message.entity.ts
+++ b/libs/dal/src/repositories/message/message.entity.ts
@@ -2,6 +2,7 @@ import {
   ChannelEndpointByType,
   ChannelEndpointType,
   ChannelTypeEnum,
+  ContextKey,
   IActor,
   IMessageCTA,
   SeverityLevelEnum,
@@ -132,6 +133,8 @@ export class MessageEntity {
   severity?: SeverityLevelEnum;
 
   channelData?: MessageChannelData[];
+
+  contextKeys?: ContextKey[];
 }
 
 export type MessageDBModel = ChangePropsValueType<

--- a/libs/dal/src/repositories/message/message.schema.ts
+++ b/libs/dal/src/repositories/message/message.schema.ts
@@ -149,6 +149,10 @@ const messageSchema = new Schema<MessageDBModel>(
       ],
       default: undefined,
     },
+    contextKeys: {
+      type: [Schema.Types.String],
+      default: undefined,
+    },
   },
   schemaOptions
 );

--- a/libs/dal/src/repositories/notification/notification.schema.ts
+++ b/libs/dal/src/repositories/notification/notification.schema.ts
@@ -64,7 +64,7 @@ const notificationSchema = new Schema<NotificationDBModel>(
       type: Schema.Types.Boolean,
     },
     contextKeys: {
-      type: Schema.Types.Array,
+      type: [Schema.Types.String],
       default: undefined,
     },
   },

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -374,6 +374,7 @@ describe('Novu Client', () => {
         },
         state: [],
         controls: {},
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(emailEvent);
@@ -466,6 +467,7 @@ describe('Novu Client', () => {
           },
         ],
         controls: {},
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(emailEvent);
@@ -496,6 +498,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -536,6 +539,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -564,6 +568,7 @@ describe('Novu Client', () => {
         subscriber: {},
         state: [],
         controls: {},
+        context: {},
       };
 
       await client.addWorkflows([newWorkflow]);
@@ -600,6 +605,7 @@ describe('Novu Client', () => {
           },
         ],
         controls: {},
+        context: {},
       };
 
       const delayExecutionResult = await client.executeWorkflow(delayEvent);
@@ -674,6 +680,7 @@ describe('Novu Client', () => {
         },
         state: [],
         controls: {},
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(emailEvent);
@@ -744,6 +751,7 @@ describe('Novu Client', () => {
           body: '{{payload.comments}}',
           subject: '{{payload.subject}}',
         },
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(event);
@@ -810,6 +818,7 @@ describe('Novu Client', () => {
           body: '{{payload.comments | json}}',
           subject: '{{payload.subject}}',
         },
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(event);
@@ -873,6 +882,7 @@ describe('Novu Client', () => {
           body: '{{payload.comment}}',
           subject: '{{payload.subject}}',
         },
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(event);
@@ -936,6 +946,7 @@ describe('Novu Client', () => {
           body: '{{payload.comment | json}}',
           subject: '{{payload.subject}}',
         },
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(event);
@@ -999,6 +1010,7 @@ describe('Novu Client', () => {
           body: '{{payload.comment | json: 2}}',
           subject: '{{payload.subject}}',
         },
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(event);
@@ -1046,6 +1058,7 @@ describe('Novu Client', () => {
           body: 'Hi {{payload.does_not_exist}}',
           subject: 'Test subject',
         },
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(event);
@@ -1092,6 +1105,7 @@ describe('Novu Client', () => {
           body: 'body {{controls.subject}}',
           subject: 'subject',
         },
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(emailEvent);
@@ -1141,6 +1155,7 @@ describe('Novu Client', () => {
           body: 'body',
           subject: 'subject {{controls.subject}}',
         },
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(emailEvent);
@@ -1203,6 +1218,7 @@ describe('Novu Client', () => {
           subject:
             'Hello subject {{payload.name}}! {{t.nested.single}} {{t.nested-with-dash.single}} {{t.nested_with_underscore.single}} {{t.123.single}} {{t.你好.single}}', // with nesting
         },
+        context: {},
       };
 
       const emailExecutionResult = await client.executeWorkflow(event);
@@ -1212,6 +1228,76 @@ describe('Novu Client', () => {
         body: 'Hello body John! {{t.single}} {{t.with-dash}} {{t.with_underscore}} {{t.123}} {{t.你好}}',
         subject:
           'Hello subject John! {{t.nested.single}} {{t.nested-with-dash.single}} {{t.nested_with_underscore.single}} {{t.123.single}} {{t.你好.single}}',
+      });
+    });
+
+    it('should compile context variables correctly', async () => {
+      const newWorkflow = workflow(
+        'test-workflow',
+        async ({ step }) => {
+          await step.email(
+            'send-email',
+            async (controls) => ({
+              body: controls.body,
+              subject: controls.subject,
+            }),
+            {
+              controlSchema: {
+                type: 'object',
+                properties: {
+                  body: { type: 'string' },
+                  subject: { type: 'string' },
+                },
+                required: ['body', 'subject'],
+                additionalProperties: false,
+              } as const,
+            }
+          );
+        },
+        {
+          payloadSchema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+            required: [],
+            additionalProperties: false,
+          } as const,
+        }
+      );
+
+      await client.addWorkflows([newWorkflow]);
+
+      const event: Event = {
+        action: PostActionEnum.EXECUTE,
+        payload: { name: 'John' },
+        workflowId: 'test-workflow',
+        stepId: 'send-email',
+        subscriber: {},
+        state: [],
+        controls: {
+          body: 'Hello {{payload.name}} from {{context.app.id}}!',
+          subject: 'Context test: {{context.tenant.id}} - {{context.app.id}}',
+        },
+        context: {
+          tenant: {
+            id: 'test-tenant',
+            data: {
+              name: 'Test Tenant',
+            },
+          },
+          app: {
+            id: 'test-app',
+            data: {},
+          },
+        },
+      };
+
+      const emailExecutionResult = await client.executeWorkflow(event);
+
+      expect(emailExecutionResult.outputs).toEqual({
+        body: 'Hello John from test-app!',
+        subject: 'Context test: test-tenant - test-app',
       });
     });
 
@@ -1271,6 +1357,7 @@ describe('Novu Client', () => {
         controls: {
           foo: 'foo',
         },
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -1324,6 +1411,7 @@ describe('Novu Client', () => {
         controls: {
           foo: 'foo',
         },
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -1376,6 +1464,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -1418,6 +1507,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       await client.executeWorkflow(event);
@@ -1446,6 +1536,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       await client.executeWorkflow(event);
@@ -1475,6 +1566,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       await client.executeWorkflow(event);
@@ -1521,6 +1613,7 @@ describe('Novu Client', () => {
         ],
         payload: {},
         controls: {},
+        context: {},
       };
 
       await client.executeWorkflow(event);
@@ -1555,6 +1648,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -1579,6 +1673,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -1638,6 +1733,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -1677,6 +1773,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -1765,6 +1862,7 @@ describe('Novu Client', () => {
         ],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -1794,6 +1892,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       await expect(client.executeWorkflow(event)).rejects.toThrow(WorkflowNotFoundError);
@@ -1829,6 +1928,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       await expect(client.executeWorkflow(event)).rejects.toThrow(ExecutionStateCorruptError);
@@ -1870,6 +1970,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       await expect(client.executeWorkflow(event)).rejects.toThrow(
@@ -1907,6 +2008,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       await expect(client.executeWorkflow(event)).rejects.toThrow(
@@ -1934,6 +2036,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -1968,6 +2071,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -2005,6 +2109,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);
@@ -2044,6 +2149,7 @@ describe('Novu Client', () => {
         state: [],
         payload: {},
         controls: {},
+        context: {},
       };
 
       const executionResult = await client.executeWorkflow(event);

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -448,6 +448,7 @@ export class Client {
           environment: {},
           controls: {},
           subscriber: event.subscriber,
+          context: event.context,
           step: {
             email: this.executeStepFactory(validatedEvent, setResult, hasResult),
             sms: this.executeStepFactory(validatedEvent, setResult, hasResult),
@@ -691,6 +692,7 @@ export class Client {
         },
         payload: event.payload,
         subscriber: event.subscriber,
+        context: event.context,
         steps: buildSteps(event.state),
         t: {}, // Empty object so t.* properties are undefined and trigger default filters
       };

--- a/packages/framework/src/client.validation.test.ts
+++ b/packages/framework/src/client.validation.test.ts
@@ -70,6 +70,7 @@ describe('validation', () => {
         stepId: 'test-email',
         state: [],
         subscriber: {},
+        context: {},
       });
     } catch (error) {
       expect(error).to.be.instanceOf(ExecutionStateControlsInvalidError);

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -208,6 +208,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
         ...(triggerEvent.actor && { actor: triggerEvent.actor }),
         ...(triggerEvent.bridgeUrl && { bridgeUrl: triggerEvent.bridgeUrl }),
         ...(triggerEvent.controls && { controls: triggerEvent.controls }),
+        ...(triggerEvent.context && { context: triggerEvent.context }),
       };
 
       const result = await this.http.post('/events/trigger', requestPayload);

--- a/packages/framework/src/resources/workflow/workflow.resource.ts
+++ b/packages/framework/src/resources/workflow/workflow.resource.ts
@@ -62,6 +62,7 @@ export function workflow<
       ...(event.transactionId && { transactionId: event.transactionId }),
       ...(event.overrides && { overrides: event.overrides }),
       ...(event.actor && { actor: event.actor }),
+      ...(event.context && { context: event.context }),
       ...(bridgeUrl && { bridgeUrl }),
     };
 
@@ -103,6 +104,7 @@ export function workflow<
       subscriber: {},
       environment: {},
       controls: {} as T_Controls,
+      context: {},
       step: {
         push: await discoverChannelStepFactory(
           newWorkflow,

--- a/packages/framework/src/resources/workflow/workflow.test.ts
+++ b/packages/framework/src/resources/workflow/workflow.test.ts
@@ -496,5 +496,115 @@ describe('workflow function', () => {
         })
       );
     });
+
+    it('should handle various context payload formats', async () => {
+      const testWorkflow = workflow('test-workflow', async ({ step }) => {
+        await step.custom('custom', async () => ({
+          foo: 'bar',
+        }));
+      });
+
+      const fetchMock = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => {
+          return Promise.resolve({
+            transactionId: '123',
+          });
+        },
+      });
+      global.fetch = fetchMock;
+
+      await testWorkflow.trigger({
+        to: 'test@test.com',
+        payload: {
+          name: 'John',
+        },
+        context: {
+          // Simple string value
+          user: 'john-doe',
+
+          // Rich object with full data
+          tenant: {
+            id: 'org-acme',
+            data: { name: 'Acme Corp', plan: 'enterprise', region: 'us-east' },
+          },
+          // Rich object without data field
+          app: {
+            id: 'jira',
+          },
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching('/events/trigger'),
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'test-workflow',
+            to: 'test@test.com',
+            payload: {
+              name: 'John',
+            },
+            context: {
+              user: 'john-doe',
+              tenant: {
+                id: 'org-acme',
+                data: { name: 'Acme Corp', plan: 'enterprise', region: 'us-east' },
+              },
+              app: {
+                id: 'jira',
+              },
+            },
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `ApiKey ${process.env.NOVU_SECRET_KEY}`,
+          },
+          method: 'POST',
+        })
+      );
+    });
+
+    it('should work without context properties', async () => {
+      const testWorkflow = workflow('test-workflow', async ({ step }) => {
+        await step.custom('custom', async () => ({
+          foo: 'bar',
+        }));
+      });
+
+      const fetchMock = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => {
+          return Promise.resolve({
+            transactionId: '123',
+          });
+        },
+      });
+      global.fetch = fetchMock;
+
+      await testWorkflow.trigger({
+        to: 'test@test.com',
+        payload: {
+          name: 'John',
+        },
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching('/events/trigger'),
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'test-workflow',
+            to: 'test@test.com',
+            payload: {
+              name: 'John',
+            },
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `ApiKey ${process.env.NOVU_SECRET_KEY}`,
+          },
+          method: 'POST',
+        })
+      );
+    });
   });
 });

--- a/packages/framework/src/types/context.types.ts
+++ b/packages/framework/src/types/context.types.ts
@@ -1,0 +1,104 @@
+type ContextType = string;
+type ContextId = string;
+type ContextData = Record<string, unknown>;
+
+/**
+ * Context value can be either a simple string identifier or a rich object with additional data
+ *
+ * @example
+ * // Simple string value
+ * "org-acme"
+ *
+ * @example
+ * // Rich object with optional data
+ * {
+ *   id: "org-acme",
+ *   data: { name: "Acme Corp", plan: "enterprise" }
+ * }
+ */
+export type ContextValue =
+  | string
+  | {
+      id: ContextId;
+      data?: ContextData;
+    };
+
+/**
+ * Context payload represents the raw context data provided by users when triggering workflows.
+ * It's a flexible structure that maps context types to their values.
+ *
+ * This is the input format that gets processed and resolved into ContextResolved.
+ *
+ * @example
+ * // Single context with string value
+ * { tenant: "org-acme" }
+ *
+ * @example
+ * // Multiple contexts with string values
+ * { tenant: "org-acme", app: "jira", user: "john-doe" }
+ *
+ * @example
+ * // Context with rich object containing additional data
+ * {
+ *   tenant: {
+ *     id: "org-acme",
+ *     data: { name: "Acme Corp", plan: "enterprise" }
+ *   }
+ * }
+ *
+ * @example
+ * // Mixed context values (string and object)
+ * {
+ *   tenant: { id: "org-acme", data: { name: "Acme Corp" } },
+ *   app: "jira",
+ *   user: "john-doe"
+ * }
+ */
+export type ContextPayload = Partial<Record<ContextType, ContextValue>>;
+
+/**
+ * Resolved contexts represent the normalized, fully-processed context data used internally
+ * throughout the application and framework. This ensures consistent structure regardless
+ * of the input format in ContextPayload.
+ *
+ * All contexts are normalized to have both an `id` and `data` field, even if the original
+ * payload only provided a string value (in which case `data` will be an empty object).
+ *
+ * This type is used to:
+ * - Pass context data between services without exposing full entity details
+ * - Ensure consistent context structure in workflow execution
+ * - Provide type safety for context access in templates and conditions
+ *
+ * @example
+ * // Resolved from payload: { tenant: "org-acme", app: "jira" }
+ * {
+ *   tenant: {
+ *     id: "org-acme",
+ *     data: {} // Empty data since only ID was provided
+ *   },
+ *   app: {
+ *     id: "jira",
+ *     data: {} // Empty data since only ID was provided
+ *   }
+ * }
+ *
+ * @example
+ * // Resolved from payload with rich data
+ * {
+ *   tenant: {
+ *     id: "org-acme",
+ *     data: { name: "Acme Corp", plan: "enterprise", region: "us-east" }
+ *   },
+ *   app: {
+ *     id: "jira",
+ *     data: { version: "8.0", environment: "production" }
+ *   }
+ * }
+ */
+export type ContextResolved = Record<
+  ContextType,
+  {
+    id: ContextId;
+    data: ContextData;
+  }
+>;

--- a/packages/framework/src/types/event.types.ts
+++ b/packages/framework/src/types/event.types.ts
@@ -1,4 +1,5 @@
 import type { ISubscriberPayload, ITriggerPayload, TriggerEventStatusEnum, TriggerRecipientsPayload } from '../shared';
+import { ContextPayload } from './context.types';
 import { ConditionalPartial, PickRequiredKeys } from './util.types';
 
 type EventPayload = ITriggerPayload;
@@ -31,6 +32,10 @@ export type EventTriggerParams<T_Payload = EventPayload> = {
    * Actor to trigger the workflow from
    */
   actor?: Actor;
+  /**
+   * Context to trigger the workflow with
+   */
+  context?: ContextPayload;
   /**
    * Bridge url to trigger the workflow to
    */

--- a/packages/framework/src/types/execution.types.ts
+++ b/packages/framework/src/types/execution.types.ts
@@ -1,4 +1,5 @@
 import { PostActionEnum } from '../constants';
+import type { ContextResolved } from './context.types';
 import { WithPassthrough } from './provider.types';
 import type { Subscriber } from './subscriber.types';
 
@@ -10,6 +11,7 @@ export type Event = {
   state: State[];
   action: Exclude<PostActionEnum, PostActionEnum.TRIGGER>;
   subscriber: Subscriber;
+  context: ContextResolved;
 };
 
 export type State = {

--- a/packages/framework/src/types/index.ts
+++ b/packages/framework/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './code.types';
 export * from './config.types';
+export * from './context.types';
 export * from './discover.types';
 export * from './event.types';
 export * from './execution.types';

--- a/packages/framework/src/types/workflow.types.ts
+++ b/packages/framework/src/types/workflow.types.ts
@@ -1,4 +1,5 @@
 import { WorkflowChannelEnum } from '../constants';
+import { ContextResolved } from './context.types';
 import type { Schema } from './schema.types';
 import type { Step } from './step.types';
 import type { Subscriber } from './subscriber.types';
@@ -28,6 +29,8 @@ export type ExecuteInput<T_Payload extends Record<string, unknown>, T_Controls e
   environment: Record<string, unknown>;
   /** The controls for the event. Provided via the Dashboard. */
   controls: T_Controls;
+  /** The resolved context for the event. */
+  context: ContextResolved;
 };
 
 /**

--- a/packages/shared/src/types/context.ts
+++ b/packages/shared/src/types/context.ts
@@ -32,7 +32,7 @@ export const CONTEXT_IDENTIFIER_REGEX = /^[a-zA-Z0-9_-]+$/;
 export type ContextValue =
   | string
   | {
-      id: string;
+      id: ContextId;
       data?: ContextData;
     };
 


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support sending an optional context with event triggers; context is resolved and available during workflow execution, previews, and template rendering.
  - Accept and resolve contextKeys to enrich message compile context.
  - Persist contextKeys on messages and include them in message webhook responses.
  - Context is propagated across bridge events and discovery flows for consistent availability.
- Documentation
  - Clarified context payload example to allow additional arbitrary fields in the OpenAPI/Swagger example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->