### PR TITLE
fix(dashboard): layout maily editor initial load fixes NV-6704

### DIFF
--- a/apps/dashboard/src/components/layouts/layout-editor-provider.tsx
+++ b/apps/dashboard/src/components/layouts/layout-editor-provider.tsx
@@ -40,15 +40,20 @@ export type LayoutContextType = {
 
 export const LayoutEditorContext = createContext<LayoutContextType>({} as LayoutContextType);
 
-export const LayoutEditorProvider = ({ children }: { children: React.ReactNode }) => {
+export const LayoutEditorProvider = ({
+  children,
+  layout,
+  layoutSlug,
+  isPending,
+}: {
+  children: React.ReactNode;
+  layout: LayoutResponseDto;
+  layoutSlug: string;
+  isPending: boolean;
+}) => {
   const [previewContextValue, setPreviewContextValue] = useState('{}');
   const previewContextValueRef = useDataRef(previewContextValue);
-  const { layoutSlug = '' } = useParams<{
-    layoutSlug?: string;
-  }>();
   const location = useLocation();
-
-  const { layout, isPending } = useFetchLayout({ layoutSlug });
 
   const defaultValues = useMemo(() => (layout ? getLayoutControlsDefaultValues(layout) : {}), [layout]);
   const values = useMemo(() => (layout?.controls.values.email ?? {}) as Record<string, unknown>, [layout]);

--- a/apps/dashboard/src/components/layouts/layout-editor-skeleton.tsx
+++ b/apps/dashboard/src/components/layouts/layout-editor-skeleton.tsx
@@ -1,0 +1,66 @@
+import { RiCodeBlock, RiEdit2Line, RiEyeLine, RiSettings4Line } from 'react-icons/ri';
+import { CompactButton } from '@/components/primitives/button-compact';
+import { Skeleton } from '@/components/primitives/skeleton';
+import { PanelHeader } from '@/components/workflow-editor/steps/layout/panel-header';
+import { ResizableLayout } from '@/components/workflow-editor/steps/layout/resizable-layout';
+
+export const LayoutEditorSkeleton = () => {
+  return (
+    <div className="flex h-full w-full">
+      <ResizableLayout autoSaveId="layout-editor-page-layout">
+        <ResizableLayout.ContextPanel>
+          <PanelHeader icon={RiCodeBlock} title="Preview Context" className="p-3" />
+          <div className="bg-bg-weak flex-1 overflow-hidden">
+            <div className="h-full overflow-y-auto p-3">
+              <Skeleton className="h-full w-full" />
+            </div>
+          </div>
+        </ResizableLayout.ContextPanel>
+
+        <ResizableLayout.Handle />
+
+        <ResizableLayout.MainContentPanel>
+          <div className="flex min-h-0 flex-1 flex-col">
+            <ResizableLayout autoSaveId="step-editor-content-layout">
+              <ResizableLayout.EditorPanel>
+                <div className="flex items-center justify-between">
+                  <PanelHeader icon={() => <RiEdit2Line />} title="Layout Editor" className="flex-1">
+                    <CompactButton
+                      size="md"
+                      variant="ghost"
+                      type="button"
+                      icon={RiSettings4Line}
+                      className="[&>svg]:size-4"
+                    />
+                  </PanelHeader>
+                </div>
+                <div className="flex-1 overflow-y-auto">
+                  <div className="h-full p-3">
+                    <Skeleton className="h-full w-full" />
+                  </div>
+                </div>
+              </ResizableLayout.EditorPanel>
+
+              <ResizableLayout.Handle />
+
+              <ResizableLayout.PreviewPanel>
+                <PanelHeader icon={RiEyeLine} title="Preview" isLoading />
+                <div className="flex-1 overflow-hidden">
+                  <div
+                    className="bg-bg-weak relative h-full overflow-y-auto p-3"
+                    style={{
+                      backgroundImage: 'radial-gradient(circle, hsl(var(--neutral-alpha-100)) 1px, transparent 1px)',
+                      backgroundSize: '20px 20px',
+                    }}
+                  >
+                    <Skeleton className="h-full w-full" />
+                  </div>
+                </div>
+              </ResizableLayout.PreviewPanel>
+            </ResizableLayout>
+          </div>
+        </ResizableLayout.MainContentPanel>
+      </ResizableLayout>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/layouts/layout-editor.tsx
+++ b/apps/dashboard/src/components/layouts/layout-editor.tsx
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/correctness/useUniqueElementIds: working correctly */
 import { ContentIssueEnum, EmailControlsDto, EnvironmentTypeEnum, RuntimeIssue } from '@novu/shared';
 import { useState } from 'react';
 import { RiArrowRightSLine, RiCodeBlock, RiEdit2Line, RiEyeLine, RiLockLine, RiSettings4Line } from 'react-icons/ri';

--- a/apps/dashboard/src/pages/edit-layout.tsx
+++ b/apps/dashboard/src/pages/edit-layout.tsx
@@ -7,10 +7,6 @@ import { PageMeta } from '@/components/page-meta';
 import { useFetchLayout } from '@/hooks/use-fetch-layout';
 import { LayoutEditorSkeleton } from '../components/layouts/layout-editor-skeleton';
 
-export const EditLayoutPageInternal = () => {
-  return <LayoutEditor />;
-};
-
 export const EditLayoutPage = () => {
   const { layoutSlug = '' } = useParams<{
     layoutSlug?: string;
@@ -33,7 +29,7 @@ export const EditLayoutPage = () => {
       <PageMeta title={`Edit ${layout?.name} Layout`} />
       <FullPageLayout headerStartItems={<LayoutBreadcrumbs />}>
         <LayoutEditorProvider layout={layout} layoutSlug={layoutSlug} isPending={isPending}>
-          <EditLayoutPageInternal />
+          <LayoutEditor />
         </LayoutEditorProvider>
       </FullPageLayout>
     </>

--- a/apps/dashboard/src/pages/edit-layout.tsx
+++ b/apps/dashboard/src/pages/edit-layout.tsx
@@ -1,26 +1,41 @@
+import { useParams } from 'react-router-dom';
 import { FullPageLayout } from '@/components/full-page-layout';
 import { LayoutBreadcrumbs } from '@/components/layouts/layout-breadcrumbs';
 import { LayoutEditor } from '@/components/layouts/layout-editor';
-import { LayoutEditorProvider, useLayoutEditor } from '@/components/layouts/layout-editor-provider';
+import { LayoutEditorProvider } from '@/components/layouts/layout-editor-provider';
 import { PageMeta } from '@/components/page-meta';
+import { useFetchLayout } from '@/hooks/use-fetch-layout';
+import { LayoutEditorSkeleton } from '../components/layouts/layout-editor-skeleton';
 
 export const EditLayoutPageInternal = () => {
-  const { layout } = useLayoutEditor();
+  return <LayoutEditor />;
+};
+
+export const EditLayoutPage = () => {
+  const { layoutSlug = '' } = useParams<{
+    layoutSlug?: string;
+  }>();
+  const { layout, isPending } = useFetchLayout({ layoutSlug });
+
+  if (!layout) {
+    return (
+      <>
+        <PageMeta title={`Edit Layout`} />
+        <FullPageLayout headerStartItems={<LayoutBreadcrumbs />}>
+          <LayoutEditorSkeleton />
+        </FullPageLayout>
+      </>
+    );
+  }
 
   return (
     <>
       <PageMeta title={`Edit ${layout?.name} Layout`} />
       <FullPageLayout headerStartItems={<LayoutBreadcrumbs />}>
-        <LayoutEditor />
+        <LayoutEditorProvider layout={layout} layoutSlug={layoutSlug} isPending={isPending}>
+          <EditLayoutPageInternal />
+        </LayoutEditorProvider>
       </FullPageLayout>
     </>
-  );
-};
-
-export const EditLayoutPage = () => {
-  return (
-    <LayoutEditorProvider>
-      <EditLayoutPageInternal />
-    </LayoutEditorProvider>
   );
 };


### PR DESCRIPTION
### What changed? Why was the change needed?

Layout Maily Editor - fixed the initial load issue with the form data set to `undefined`, resulting in the Maily component rendering an empty editor. Fixed by showing the skeleton for the editor until we load the layout data.

### Screenshots

https://github.com/user-attachments/assets/ef0ad5fa-a6e3-4974-9e69-085d1f15425f


