### PR TITLE
perf(framework): cache transformed schemas

### DIFF
--- a/packages/framework/src/resources/workflow/discover-custom-step-factory.ts
+++ b/packages/framework/src/resources/workflow/discover-custom-step-factory.ts
@@ -19,19 +19,24 @@ export async function discoverCustomStepFactory(
     const controlSchema = options?.controlSchema || emptySchema;
     const outputSchema = options?.outputSchema || emptySchema;
 
+    const [transformedControlSchema, transformedOutputSchema] = await Promise.all([
+      transformSchema(controlSchema),
+      transformSchema(outputSchema),
+    ]);
+
     await discoverStep(targetWorkflow, stepId, {
       stepId,
       type,
       controls: {
-        schema: await transformSchema(controlSchema),
+        schema: transformedControlSchema,
         unknownSchema: controlSchema,
       },
       outputs: {
-        schema: await transformSchema(outputSchema),
+        schema: transformedOutputSchema,
         unknownSchema: outputSchema,
       },
       results: {
-        schema: await transformSchema(outputSchema),
+        schema: transformedOutputSchema,
         unknownSchema: outputSchema,
       },
       resolve: resolve as (controls: Record<string, unknown>) => Awaitable<Record<string, unknown>>,


### PR DESCRIPTION
## Summary
- cache transformed control and output schemas before discovering custom steps

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d0073a1f0c832e9af67af12d2595dc