### PR TITLE
fix(api-service): layout identifier bug fixes NV-6720

### DIFF
--- a/apps/api/src/app/layouts-v2/usecases/sync-to-environment/layout-sync-to-environment.usecase.ts
+++ b/apps/api/src/app/layouts-v2/usecases/sync-to-environment/layout-sync-to-environment.usecase.ts
@@ -53,7 +53,6 @@ export class LayoutSyncToEnvironmentUseCase {
 
     const upsertedLayout = await this.upsertLayoutUseCase.execute(
       UpsertLayoutCommand.create({
-        preserveLayoutId: true,
         environmentId: command.targetEnvironmentId,
         organizationId: command.user.organizationId,
         userId: command.user._id,

--- a/apps/api/src/app/layouts-v2/usecases/upsert-layout/upsert-layout.command.ts
+++ b/apps/api/src/app/layouts-v2/usecases/upsert-layout/upsert-layout.command.ts
@@ -31,8 +31,4 @@ export class UpsertLayoutCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @IsString()
   layoutIdOrInternalId?: string;
-
-  @IsOptional()
-  @IsBoolean()
-  preserveLayoutId?: boolean;
 }

--- a/apps/api/src/app/layouts-v2/usecases/upsert-layout/upsert-layout.usecase.spec.ts
+++ b/apps/api/src/app/layouts-v2/usecases/upsert-layout/upsert-layout.usecase.spec.ts
@@ -210,6 +210,28 @@ describe('UpsertLayoutUseCase', () => {
         expect(createCommand.isDefault).to.be.true;
       });
 
+      it('should use custom layoutId when provided instead of slugified name', async () => {
+        const customLayoutId = 'custom-layout-identifier';
+        const layoutDtoWithCustomId = {
+          ...mockLayoutDto,
+          layoutId: customLayoutId,
+        };
+
+        const command = UpsertLayoutCommand.create({
+          userId: mockUser._id,
+          environmentId: mockUser.environmentId,
+          organizationId: mockUser.organizationId,
+          layoutDto: layoutDtoWithCustomId,
+        });
+
+        await upsertLayoutUseCase.execute(command);
+
+        expect(createLayoutUseCaseMock.execute.calledOnce).to.be.true;
+        const createCommand = createLayoutUseCaseMock.execute.firstCall.args[0];
+        expect(createCommand.identifier).to.equal(customLayoutId);
+        expect(createCommand.name).to.equal(mockLayoutDto.name);
+      });
+
       it('should set isDefault to false when a default layout already exists', async () => {
         const existingDefaultLayout = { ...mockExistingLayout, isDefault: true };
         layoutRepositoryMock.findOne.resolves(existingDefaultLayout as any);

--- a/apps/api/src/app/layouts-v2/usecases/upsert-layout/upsert-layout.usecase.ts
+++ b/apps/api/src/app/layouts-v2/usecases/upsert-layout/upsert-layout.usecase.ts
@@ -99,7 +99,7 @@ export class UpsertLayout {
           organizationId: command.organizationId,
           userId: command.userId,
           name: command.layoutDto.name,
-          identifier: command.preserveLayoutId ? (command.layoutDto.layoutId ?? '') : slugify(command.layoutDto.name),
+          identifier: command.layoutDto.layoutId || slugify(command.layoutDto.name),
           type: ResourceTypeEnum.BRIDGE,
           origin: ResourceOriginEnum.NOVU_CLOUD,
           isDefault: !defaultLayout,


### PR DESCRIPTION
### What changed? Why was the change needed?

The `UpsertLayoutUseCase` was updated to prioritize a custom `layoutId` provided in the `layoutDto` during layout creation.

Previously, the system would always generate an identifier from the layout name, ignoring custom `layoutId` values, because the `preserveLayoutId` flag was not consistently set. This resolves a bug (NV-6720) where custom layout identifiers were not respected.

Relevant links: [NV-6720](https://linear.app/novu/issue/NV-6720)

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

N/A

</details>

---
Linear Issue: [NV-6720](https://linear.app/novu/issue/NV-6720/autogenerated-layouts-identifier-is-used-even-if-custom-identifier-is)

<a href="https://cursor.com/background-agent?bcId=bc-559f8aae-7c21-4be4-95f2-b55ac95aa477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-559f8aae-7c21-4be4-95f2-b55ac95aa477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

