### PR TITLE
feat(dashboard): Allow hyphens in payload schema keys fixes NV-6729

### DIFF
--- a/apps/dashboard/src/components/schema-editor/utils/validation-schema.ts
+++ b/apps/dashboard/src/components/schema-editor/utils/validation-schema.ts
@@ -61,10 +61,11 @@ const PropertyListItemSchema = z.object({
     .refine(
       (val) => {
         // For non-empty strings, enforce proper naming rules
-        return /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(val);
+        return /^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(val);
       },
       {
-        message: 'Name must start with a letter or underscore, and contain only letters, numbers, or underscores.',
+        message:
+          'Name must start with a letter or underscore, and contain only letters, numbers, underscores, or hyphens.',
       }
     ),
   definition: baseJsonSchema, // The schema definition for this property's value


### PR DESCRIPTION
### What changed? Why was the change needed?

The frontend validation for payload schema keys has been updated to allow hyphens (`-`). Previously, the regex `^[a-zA-Z_][a-zA-Z0-9_]*$` prevented users from creating payload variables with hyphens in their keys.

This change resolves [NV-6729](https://linear.app/novu/issue/NV-6729), enabling users to use hyphens in payload variable names, which is a common requirement for better readability and consistency. The regex in `apps/dashboard/src/components/schema-editor/utils/validation-schema.ts` has been updated to `^[a-zA-Z_][a-zA-Z0-9_-]*$`, and the associated validation message has been adjusted.

### Screenshots

<!-- Not applicable for this change as it's a validation logic update. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

The change is isolated to `apps/dashboard/src/components/schema-editor/utils/validation-schema.ts`. I've confirmed that other similar regex patterns in the codebase either already support hyphens or are used in contexts (e.g., database column names) where hyphens should remain restricted.
</details>

---
Linear Issue: [NV-6729](https://linear.app/novu/issue/NV-6729/cannot-create-payload-variable-with-dash-in-schema-key)

<a href="https://cursor.com/background-agent?bcId=bc-1be10ad8-5938-4594-aa49-057a282d4a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1be10ad8-5938-4594-aa49-057a282d4a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

