### PR TITLE
fix(dashboard): don't add translation page command shortcut in self hosted

### DIFF
--- a/apps/dashboard/src/components/command-palette/commands/navigation-commands.tsx
+++ b/apps/dashboard/src/components/command-palette/commands/navigation-commands.tsx
@@ -13,6 +13,7 @@ import {
   RiTranslate2,
 } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
+import { IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { buildRoute, ROUTES } from '@/utils/routes';
@@ -24,6 +25,7 @@ export function useNavigationCommands(context: CommandExecutionContext): Command
   const hasWorkflowPermission = hasPermission({ permission: PermissionsEnum.WORKFLOW_READ });
   const hasSubscriberPermission = hasPermission({ permission: PermissionsEnum.SUBSCRIBER_READ });
   const isEmailLayoutsPageActive = useFeatureFlag(FeatureFlagsKeysEnum.IS_LAYOUTS_PAGE_ACTIVE);
+  const isEnterprise = !IS_SELF_HOSTED || IS_ENTERPRISE;
 
   const createNavigationCommand = useCallback(
     (id: string, label: string, route: string, icon: React.ReactNode, permission?: () => boolean) => ({
@@ -107,9 +109,17 @@ export function useNavigationCommands(context: CommandExecutionContext): Command
     );
   }
 
-  commands.push(
-    createNavigationCommand('nav-translations', 'Translations', ROUTES.TRANSLATIONS, <RiTranslate2 />)
-  );
+  if (isEnterprise) {
+    commands.push(
+      createNavigationCommand(
+        'nav-translations',
+        'Translations',
+        ROUTES.TRANSLATIONS,
+        <RiTranslate2 />,
+        () => isEnterprise
+      )
+    );
+  }
 
   return commands;
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

The `nav-translations` command in the command palette is now conditionally displayed. It will only be available if the instance is either Novu Cloud (`!IS_SELF_HOSTED`) or a self-hosted enterprise instance (`IS_ENTERPRISE`).

This change ensures that the translations feature is only accessible to enterprise customers, aligning with licensing requirements. This addresses the concern raised in the provided Slack context (referencing Image 1) where the feature was previously controlled by a removed feature flag and needed to be restricted for community edition self-hosted instances.

### Screenshots

No new visual changes are introduced. The command will simply not appear for instances that do not meet the `(!IS_SELF_HOSTED || IS_ENTERPRISE)` condition.

---
[Slack Thread](https://novu.slack.com/archives/C06DU7A7BPV/p1758803848981629?thread_ts=1758803848.981629&cid=C06DU7A7BPV)

<a href="https://cursor.com/background-agent?bcId=bc-5298762c-7791-4a85-a449-5665b6847332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5298762c-7791-4a85-a449-5665b6847332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

