### PR TITLE
perf(api): inline activity feature flag lookup

### DIFF
--- a/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
@@ -81,29 +81,29 @@ export class GetActivity {
       _organization: command.organizationId,
     });
 
-    const tracesEnabled = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_TRACE_LOGS_READ_ENABLED,
-      defaultValue: false,
+    const flagContext = {
       organization: { _id: command.organizationId },
       user: { _id: command.userId },
       environment: { _id: command.environmentId },
-    });
+    } as const;
 
-    const stepRunsEnabled = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_STEP_RUN_LOGS_READ_ENABLED,
-      defaultValue: false,
-      organization: { _id: command.organizationId },
-      user: { _id: command.userId },
-      environment: { _id: command.environmentId },
-    });
-
-    const workflowRunsEnabled = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_WORKFLOW_RUN_LOGS_READ_ENABLED,
-      defaultValue: false,
-      organization: { _id: command.organizationId },
-      user: { _id: command.userId },
-      environment: { _id: command.environmentId },
-    });
+    const [tracesEnabled, stepRunsEnabled, workflowRunsEnabled] = await Promise.all([
+      this.featureFlagsService.getFlag({
+        key: FeatureFlagsKeysEnum.IS_TRACE_LOGS_READ_ENABLED,
+        defaultValue: false,
+        ...flagContext,
+      }),
+      this.featureFlagsService.getFlag({
+        key: FeatureFlagsKeysEnum.IS_STEP_RUN_LOGS_READ_ENABLED,
+        defaultValue: false,
+        ...flagContext,
+      }),
+      this.featureFlagsService.getFlag({
+        key: FeatureFlagsKeysEnum.IS_WORKFLOW_RUN_LOGS_READ_ENABLED,
+        defaultValue: false,
+        ...flagContext,
+      }),
+    ]);
 
     this.logger.debug('feature flags', {
       tracesEnabled,


### PR DESCRIPTION
This pull request refactors how feature flags are fetched in the `GetActivity` use case to improve efficiency and code maintainability. The main change is batching the retrieval of multiple feature flags into a single asynchronous operation and reducing code duplication by using a shared context object.

Feature flag retrieval improvements:

* Consolidated the context for feature flag queries into a single `flagContext` object, reducing repetition and improving readability.
* Replaced separate `await` calls for each feature flag with a single `Promise.all` call, fetching `tracesEnabled`, `stepRunsEnabled`, and `workflowRunsEnabled` flags in parallel for better performance.