### PR TITLE
fix(api-service): Change log level from info to debug

### DIFF
--- a/apps/api/src/app/internal/usecases/update-subscriber-online-state/update-subscriber-online-state.usecase.ts
+++ b/apps/api/src/app/internal/usecases/update-subscriber-online-state/update-subscriber-online-state.usecase.ts
@@ -13,7 +13,7 @@ export class UpdateSubscriberOnlineState {
   }
 
   async execute(command: UpdateSubscriberOnlineStateCommand): Promise<{ success: boolean; message?: string }> {
-    this.logger.info(
+    this.logger.debug(
       `Updating subscriber online state: ${command.subscriberId} in environment ${command.environmentId} to ${command.isOnline}`
     );
 
@@ -32,7 +32,7 @@ export class UpdateSubscriberOnlineState {
       }
     );
 
-    this.logger.info(
+    this.logger.debug(
       `Subscriber ${command.subscriberId} is now ${command.isOnline ? 'online' : 'offline'} in environment ${command.environmentId}`
     );
 

--- a/libs/application-generic/src/logging/index.ts
+++ b/libs/application-generic/src/logging/index.ts
@@ -74,7 +74,10 @@ export function createNestLoggingModuleOptions(settings: {
   }
 
   return {
-    exclude: [{ path: '*/health-check', method: RequestMethod.GET }],
+    exclude: [
+      { path: '*/health-check', method: RequestMethod.GET },
+      { path: '/v1/internal/subscriber-online-state', method: RequestMethod.POST }
+    ],
     assignResponse: true,
     pinoHttp: {
       useOnlyCustomLevels: true,


### PR DESCRIPTION
### What changed? Why was the change needed?

Converted two log statements in `apps/api/src/app/internal/usecases/update-subscriber-online-state/update-subscriber-online-state.usecase.ts` from `info` to `debug` level.

This change reduces log verbosity in production environments, as these specific messages are more suitable for debug-level logging and will only appear when debug logging is explicitly enabled.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1759139726288089?thread_ts=1759139726.288089&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-90011c30-7fb8-4837-b411-7ebe5da6ca80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90011c30-7fb8-4837-b411-7ebe5da6ca80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

