### PR TITLE
Hide context schema if feature flag is off

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
@@ -67,7 +67,15 @@ export class PreviewUsecase {
       }
 
       const cleanedPayloadExample = this.payloadProcessor.cleanPreviewExamplePayload(payloadExample);
-      const schema = await this.schemaBuilder.buildPreviewPayloadSchema(payloadExample, context.workflow.payloadSchema);
+      const schema = await this.schemaBuilder.buildPreviewPayloadSchema(
+        payloadExample,
+        context.workflow.payloadSchema,
+        {
+          organizationId: command.user.organizationId,
+          environmentId: command.user.environmentId,
+          userId: command.user._id,
+        }
+      );
 
       try {
         const executeOutput = await this.executePreviewUsecase(

--- a/apps/api/src/app/workflows-v2/usecases/preview/services/schema-builder.service.ts
+++ b/apps/api/src/app/workflows-v2/usecases/preview/services/schema-builder.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
+import { FeatureFlagsService } from '@novu/application-generic';
 import { JsonSchemaFormatEnum, JsonSchemaTypeEnum } from '@novu/dal';
-import { ContextPayload } from '@novu/shared';
+import { ContextPayload, FeatureFlagsKeysEnum } from '@novu/shared';
 import { merge } from 'es-toolkit/compat';
 import { JSONSchemaDto } from '../../../../shared/dtos/json-schema.dto';
 import { buildVariablesSchema } from '../../../../shared/utils/create-schema';
@@ -9,6 +10,7 @@ import { PreviewPayloadDto } from '../../../dtos';
 
 @Injectable()
 export class SchemaBuilderService {
+  constructor(private readonly featureFlagsService: FeatureFlagsService) {}
   async buildVariablesSchema(
     variablesObject: Record<string, unknown>,
     variables: JSONSchemaDto
@@ -25,7 +27,8 @@ export class SchemaBuilderService {
 
   async buildPreviewPayloadSchema(
     previewPayloadExample: PreviewPayloadDto,
-    workflowPayloadSchema?: JSONSchemaDto
+    workflowPayloadSchema?: JSONSchemaDto,
+    userContext?: { organizationId: string; environmentId: string; userId: string }
   ): Promise<JSONSchemaDto | null> {
     if (!workflowPayloadSchema) {
       return null;
@@ -37,22 +40,38 @@ export class SchemaBuilderService {
       additionalProperties: false,
     };
 
+    if (!schema.properties) {
+      schema.properties = {};
+    }
+
     if (previewPayloadExample.payload) {
-      schema.properties!.payload = workflowPayloadSchema || {
+      schema.properties.payload = workflowPayloadSchema || {
         type: JsonSchemaTypeEnum.OBJECT,
         additionalProperties: true,
       };
     }
 
-    // Always include context schema
-    schema.properties!.context = previewPayloadExample.context 
-      ? this.buildContextSchema(previewPayloadExample.context)
-      : this.getDefaultContextSchema();
+    // Include context schema only if feature flag is enabled
+    if (userContext) {
+      const isContextEnabled = await this.featureFlagsService.getFlag({
+        key: FeatureFlagsKeysEnum.IS_CONTEXT_ENABLED,
+        organization: { _id: userContext.organizationId },
+        environment: { _id: userContext.environmentId },
+        user: { _id: userContext.userId },
+        defaultValue: false,
+      });
+
+      if (isContextEnabled) {
+        schema.properties.context = previewPayloadExample.context
+          ? this.buildContextSchema(previewPayloadExample.context)
+          : this.getDefaultContextSchema();
+      }
+    }
 
     // Build dynamic subscriber schema based on actual subscriber data
-    schema.properties!.subscriber = this.buildSubscriberSchema(previewPayloadExample.subscriber);
+    schema.properties.subscriber = this.buildSubscriberSchema(previewPayloadExample.subscriber);
 
-    schema.properties!.steps = this.getStepsSchema();
+    schema.properties.steps = this.getStepsSchema();
 
     return schema;
   }


### PR DESCRIPTION
### What changed? Why was the change needed?

The context schema for workflow previews is now conditionally included based on the `IS_CONTEXT_ENABLED` feature flag. Previously, the `SchemaBuilderService.buildPreviewPayloadSchema` always included the context schema, regardless of the feature flag status.

This change ensures that the new context feature is not exposed in the API surface when the `IS_CONTEXT_ENABLED` flag is disabled.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNS89H/p1759165799381299?thread_ts=1759165799.381299&cid=D0919LNS89H)

<a href="https://cursor.com/background-agent?bcId=bc-27cfe26d-8ceb-414e-ac6b-ab9df0f34cc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-27cfe26d-8ceb-414e-ac6b-ab9df0f34cc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

