### PR TITLE
Fix workflow id sluggification for p2p

### DIFF
--- a/packages/shared/src/utils/slugify/slugify.spec.ts
+++ b/packages/shared/src/utils/slugify/slugify.spec.ts
@@ -541,4 +541,16 @@ describe('slugify', () => {
   it('replaces leading and trailing separator chars', () => {
     expect(slugify('! Come on, fhqwhgads !'), 'Come-on-fhqwhgads');
   });
+
+  it('should handle strings with spaces by decamelizing individual words while preserving acronyms', () => {
+    expect(slugify('New InApp Step')).toBe('new-in-app-step');
+    expect(slugify('P2P TESTING')).toBe('p2p-testing');
+    expect(slugify('API Step')).toBe('api-step');
+    expect(slugify('B2B Testing')).toBe('b2b-testing');
+  });
+
+  it('should still decamelize camelCase strings without spaces', () => {
+    expect(slugify('newInAppStep')).toBe('new-in-app-step');
+    expect(slugify('p2pTesting')).toBe('p2p-testing');
+  });
 });

--- a/packages/shared/src/utils/slugify/slugify.ts
+++ b/packages/shared/src/utils/slugify/slugify.ts
@@ -249,7 +249,21 @@ export const slugify = (string: string, options?: Options) => {
   string = transliterate(string, { customReplacements: Array.from(customReplacements) });
 
   if (options.decamelize) {
-    string = decamelize(string);
+    if (string.includes(' ')) {
+      // Apply decamelization to individual words, but preserve acronyms
+      string = string
+        .split(' ')
+        .map((word) => {
+          // Don't decamelize pure acronyms (all caps) or short words
+          if (word.length <= 3 && /^[A-Z0-9]+$/.test(word)) {
+            return word;
+          }
+          return decamelize(word);
+        })
+        .join(' ');
+    } else {
+      string = decamelize(string);
+    }
   }
 
   let patternSlug = /[^a-zA-Z\d]+/g;


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves `NV-6721` by fixing an issue with workflow ID sluggification. Previously, the `slugify` utility incorrectly processed strings, leading to:
- "P2P TESTING" being sluggified as "p2-p-testing" instead of "p2p-testing".
- "New InApp Step" being sluggified as "new-inapp-step" instead of "new-in-app-step", causing an E2E test failure.

The `slugify` function in `packages/shared/src/utils/slugify/slugify.ts` has been updated to apply decamelization more intelligently:
- For strings containing spaces, `decamelize` is now applied to individual words. Short acronyms (e.g., "P2P", "API") are preserved within these words to prevent incorrect splitting.
- For strings without spaces, the standard `decamelize` logic is applied as before.

This ensures that both the original "P2P" issue and the "InApp" test failure are resolved, while maintaining correct behavior for other camelCase strings.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- The core change is in how `decamelize` is conditionally applied based on whether the input string contains spaces.
- New test cases have been added to `packages/shared/src/utils/slugify/slugify.spec.ts` to validate the corrected behavior for strings with spaces and acronyms.

</details>

---
Linear Issue: [NV-6721](https://linear.app/novu/issue/NV-6721/dashboard-workflow-id-is-created-with-dash-after-digit)

<a href="https://cursor.com/background-agent?bcId=bc-fc8826cf-0bdc-47c2-bcf6-051b823c738a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fc8826cf-0bdc-47c2-bcf6-051b823c738a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

