### PR TITLE
chore(dashboard): UI polish - data object component

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/base/data-object.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/base/data-object.tsx
@@ -97,7 +97,7 @@ const InnerDataObject = ({ field }: { field: FieldValues }) => {
   };
 
   return (
-    <FormItem className="bg-bg-weak flex flex-col gap-2 rounded-lg border border-neutral-200 p-2">
+    <FormItem className="bg-bg-weak flex flex-col gap-1 rounded-lg border border-neutral-100 p-2">
       <div className="flex items-center gap-2">
         <RiInputField className="text-feature size-4" />
         <span className="text-xs">Data object</span>
@@ -116,7 +116,7 @@ const InnerDataObject = ({ field }: { field: FieldValues }) => {
           }
         />
       </div>
-      <Card className="rounded-md">
+      <Card className="rounded-md shadow-none">
         <CardContent className="flex flex-col gap-1 p-2">
           <div className="flex flex-col gap-1">
             {currentPairs.map((pair, index) => {

--- a/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/in-app/in-app-editor.tsx
@@ -77,17 +77,10 @@ export const InAppEditor = ({ uiSchema }: { uiSchema: UiSchema }) => {
         <>
           <Separator />
           <InAppTabsSection className="px-0 pb-0">
-            <div className="flex items-center gap-2.5 text-sm">
+            <div className="flex items-center gap-2 text-sm mb-3">
               <RiInstanceLine className="size-4" />
               <span>Developers</span>
             </div>
-          </InAppTabsSection>
-        </>
-      )}
-
-      {dataObject && (
-        <>
-          <InAppTabsSection className="px-0 pb-3">
             {getComponentByType({
               component: dataObject.component,
             })}


### PR DESCRIPTION
### What changed? Why was the change needed?
Aligned data object component better with the rest of the sections in the editor. 

Before:
<img width="802" height="527" alt="image" src="https://github.com/user-attachments/assets/2f995709-846a-404f-b0e4-0f380e302b50" />

After:
<img width="830" height="516" alt="image" src="https://github.com/user-attachments/assets/7d945e79-1706-44a7-8f2b-a9180eeac110" />

