### PR TITLE
perf(api): seed novu integrations concurrently

### DIFF
--- a/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.usecase.ts
@@ -131,16 +131,20 @@ export class CreateNovuIntegrations {
   }
 
   async execute(command: CreateNovuIntegrationsCommand): Promise<void> {
+    const integrationPromises: Array<Promise<void>> = [];
+
     if (!command.channels || command.channels.includes(ChannelTypeEnum.EMAIL)) {
-      await this.createEmailIntegration(command);
+      integrationPromises.push(this.createEmailIntegration(command));
     }
 
     if (!command.channels || command.channels.includes(ChannelTypeEnum.IN_APP)) {
-      await this.createInAppIntegration(command);
+      integrationPromises.push(this.createInAppIntegration(command));
     }
 
     if (!command.channels || command.channels.includes(ChannelTypeEnum.CHAT)) {
-      await this.createSlackIntegration(command);
+      integrationPromises.push(this.createSlackIntegration(command));
     }
+
+    await Promise.all(integrationPromises);
   }
 }


### PR DESCRIPTION
**Rationale:** The Novu integration seeding use case currently awaits the email, in-app, and Slack setup branches one after another, even though each branch operates on distinct provider/channel combinations and can be scheduled concurrently to reduce bootstrap time for multi-channel environments.

**Risk:** Low
**Blast radius:** `apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.usecase.ts`