### PR TITLE
perf(dashboard): memoize template store tags

### DIFF
--- a/apps/dashboard/src/hooks/use-template-store.ts
+++ b/apps/dashboard/src/hooks/use-template-store.ts
@@ -1,5 +1,5 @@
 import { StepCreateDto, StepTypeEnum, WorkflowCreationSourceEnum } from '@novu/shared';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { IWorkflowSuggestion } from '@/components/template-store/types';
 import { extractApiItems } from '@/utils/api-response-normalizer';
 
@@ -270,7 +270,7 @@ export function useTemplateStore() {
     };
   }, []);
 
-  const availableTags = extractUniqueTags(suggestions);
+  const availableTags = useMemo(() => extractUniqueTags(suggestions), [suggestions]);
 
   return {
     suggestions,


### PR DESCRIPTION
## Summary
- memoize available template tags from suggestions in the template store hook

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dbd7b706e8832eb9c0b5d48d88c093