### PR TITLE
Add upserting to spellcheck ignore list

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -730,6 +730,7 @@
     "Unvalidated",
     "upsert",
     "upserted",
+    "upserting",
     "unstub",
     "upstash",
     "Upstash",


### PR DESCRIPTION
### What changed? Why was the change needed?

Added the word `upserting` to the `words` array in the `.cspell.json` configuration file. This change was needed to prevent the spell checker from flagging "upserting" as a misspelling, as it is a valid technical term.

### Screenshots

---
[Slack Thread](https://novu.slack.com/archives/D0919LNS89H/p1759312002424039?thread_ts=1759312002.424039&cid=D0919LNS89H)

<a href="https://cursor.com/background-agent?bcId=bc-6e4e0636-4ab0-4734-a0a1-a998bd07ec52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e4e0636-4ab0-4734-a0a1-a998bd07ec52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

