### PR TITLE
chore(root): update spellcheck ignore list

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -730,6 +730,7 @@
     "Unvalidated",
     "upsert",
     "upserted",
+    "upserting",
     "unstub",
     "upstash",
     "Upstash",


### PR DESCRIPTION
### What changed? Why was the change needed?

Added 'upserting' to the `words` array in `.cspell.json`. This change was needed to prevent the spell checker from flagging 'upserting' as a typo, as it is a valid technical term used in the codebase. This aligns with existing entries like 'upsert' and 'upserted'.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNS89H/p1759312002424039?thread_ts=1759312002.424039&cid=D0919LNS89H)

<a href="https://cursor.com/background-agent?bcId=bc-9617aec4-851b-49a6-ab29-773de5554f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9617aec4-851b-49a6-ab29-773de5554f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

