### PR TITLE
fix(dashboard): workflow activity filter on view activity fixes NV-6726

### DIFF
--- a/apps/dashboard/src/components/workflow-row.tsx
+++ b/apps/dashboard/src/components/workflow-row.tsx
@@ -120,6 +120,7 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
   const { safeSync, isSyncable, tooltipContent, PromoteConfirmModal } = useSyncWorkflow(workflow);
 
   const isNewChangeManagementEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_NEW_CHANGE_MECHANISM_ENABLED);
+  const isHttpLogsPageEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_HTTP_LOGS_PAGE_ENABLED, false);
   const isV0Workflow = workflow.origin === ResourceOriginEnum.NOVU_CLOUD_V1;
   const isDuplicable =
     workflow.origin === ResourceOriginEnum.NOVU_CLOUD && currentEnvironment?.type === EnvironmentTypeEnum.DEV;
@@ -418,7 +419,7 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
                   <Protect permission={PermissionsEnum.NOTIFICATION_READ}>
                     <Link
                       to={
-                        buildRoute(ROUTES.ACTIVITY_FEED, {
+                        buildRoute(isHttpLogsPageEnabled ? ROUTES.ACTIVITY_WORKFLOW_RUNS : ROUTES.ACTIVITY_FEED, {
                           environmentSlug: currentEnvironment?.slug ?? '',
                         }) +
                         '?' +

--- a/apps/dashboard/src/pages/activity-feed.tsx
+++ b/apps/dashboard/src/pages/activity-feed.tsx
@@ -53,11 +53,12 @@ export function ActivityFeed() {
   // Redirect legacy activity-feed URLs to the new runs URL when feature flag is enabled
   useEffect(() => {
     if (isHttpLogsPageEnabled && location.pathname.includes('/activity-feed') && currentEnvironment?.slug) {
-      navigate(buildRoute(ROUTES.ACTIVITY_WORKFLOW_RUNS, { environmentSlug: currentEnvironment.slug }), {
+      const newPath = buildRoute(ROUTES.ACTIVITY_WORKFLOW_RUNS, { environmentSlug: currentEnvironment.slug });
+      navigate(`${newPath}${location.search}`, {
         replace: true,
       });
     }
-  }, [isHttpLogsPageEnabled, location.pathname, currentEnvironment?.slug, navigate]);
+  }, [isHttpLogsPageEnabled, location.pathname, location.search, currentEnvironment?.slug, navigate]);
 
   // Track page visit for requests tab
   useEffect(() => {


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves [NV-6726](https://linear.app/novu/issue/NV-6726), where clicking "View activity" on a workflow did not correctly filter the activity feed by the workflow ID.

The issue stemmed from two problems:
1.  **Redirect losing query parameters**: When the `IS_HTTP_LOGS_PAGE_ENABLED` feature flag was active, a redirect from `/activity-feed` to `/activity/workflow-runs` was not preserving URL query parameters, causing the workflow filter (`?workflows=:id`) to be lost.
2.  **Inconsistent routing**: The "View activity" link in the workflow list was still pointing to the legacy `ACTIVITY_FEED` route, relying on the redirect to reach `ACTIVITY_WORKFLOW_RUNS`.

To fix this:
1.  The redirect in `apps/dashboard/src/pages/activity-feed.tsx` now preserves `location.search` (query parameters).
2.  The "View activity" link in `apps/dashboard/src/components/workflow-row.tsx` was updated to conditionally navigate directly to `ROUTES.ACTIVITY_WORKFLOW_RUNS` when `IS_HTTP_LOGS_PAGE_ENABLED` is true, bypassing the redirect.

These changes ensure that the workflow activity feed is always correctly filtered by the selected workflow ID.

### Screenshots

N/A

---
Linear Issue: [NV-6726](https://linear.app/novu/issue/NV-6726/view-activity-option-in-workflow-should-show-only-workflow-events)

<a href="https://cursor.com/background-agent?bcId=bc-4e7ced03-38fc-415a-98eb-f2240bcfa654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e7ced03-38fc-415a-98eb-f2240bcfa654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

