### PR TITLE
fix(dashboard): translation drawer freeze fixes NV-6739

### DIFF
--- a/apps/dashboard/src/components/translations/translation-drawer/editor-panel.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/editor-panel.tsx
@@ -39,7 +39,7 @@ export function EditorPanelSkeleton() {
 
       {/* JSON Editor skeleton - matches the actual editor */}
       <div className="flex-1 px-3 pb-3">
-        <div className="relative h-[calc(100%-10rem)] rounded-lg border border-neutral-200 bg-white p-4">
+        <div className="relative h-[calc(100%-24px)] rounded-lg border border-neutral-200 bg-white p-4">
           {/* Line numbers and content like real editor */}
           <div className="flex gap-4">
             <div className="text-neutral-400">
@@ -51,7 +51,7 @@ export function EditorPanelSkeleton() {
           </div>
         </div>
         {/* Footer timestamp */}
-        <div className="mt-2 px-1">
+        <div className="mt-2 px-1 h-6 flex items-center">
           <Skeleton className="h-3 w-60" /> {/* "Last updated at Jul 22, 2025 15:11:30 UTC" */}
         </div>
       </div>
@@ -68,12 +68,16 @@ type JSONEditorProps = {
   isReadOnly?: boolean;
 };
 
+const JSON_EXTENSIONS = [loadLanguage('json')?.extension ?? []];
+const BASIC_SETUP = { lineNumbers: true, defaultKeymap: true };
+
 function JSONEditor({ content, onChange, error, updatedAt, isOutdated, isReadOnly = false }: JSONEditorProps) {
   return (
-    <div className="flex-1 px-3 pb-3">
+    // 112px is the height of the actions section
+    <div className="flex-1 px-3 pb-3 flex flex-col max-h-[calc(100%-112px)]">
       <div
         className={cn(
-          'relative h-[calc(100%-10rem)] rounded-lg border bg-white p-4',
+          'relative overflow-hidden w-full rounded-lg border bg-white flex-1 ',
           error ? 'border-red-300' : 'border-neutral-200',
           isReadOnly && 'bg-neutral-50'
         )}
@@ -82,19 +86,19 @@ function JSONEditor({ content, onChange, error, updatedAt, isOutdated, isReadOnl
           value={content}
           onChange={onChange}
           lang="json"
-          extensions={[loadLanguage('json')?.extension ?? []]}
-          basicSetup={{ lineNumbers: true, defaultKeymap: true }}
+          extensions={JSON_EXTENSIONS}
+          basicSetup={BASIC_SETUP}
           placeholder="Enter JSON content..."
           className={cn(
-            'h-full overflow-y-auto overflow-x-hidden [&_.cm-content]:max-w-[calc(100%-2rem)]',
-            error ? 'pb-8' : ''
+            'flex-1 [&_.cm-scroller]:p-4 [&_div.cm-gutters]:bg-background [&_div.cm-gutters]:-translate-x-[16px] [&_div.cm-gutters]:pl-4 [&_div.cm-gutters]:-ml-4 [&_.cm-editor]:h-full rounded-lg [&_.cm-scroller]:!h-full [&_.cm-scroller]:overflow-auto [&_.cm-content]:max-w-[calc(100%-2rem)]',
+            error ? 'h-[calc(100%-32px)]' : 'h-full'
           )}
           foldGutter
           multiline
           readOnly={isReadOnly}
         />
         {error && (
-          <div className="absolute bottom-2 left-3 right-3 text-xs text-red-500">
+          <div className="px-4 py-2 text-xs text-red-500 h-min">
             <span className="font-medium">Invalid JSON:</span> {error}
           </div>
         )}
@@ -129,7 +133,8 @@ type EditorPanelProps = {
   selectedTranslation: TranslationWithPlaceholder | undefined;
   isLoadingTranslation: boolean;
   translationError: any;
-  modifiedContentString: string | null;
+  content: string;
+  modifiedContent: Record<string, any> | null;
   jsonError: string | null;
   onContentChange: (content: string) => void;
   outdatedLocales?: string[];
@@ -140,7 +145,8 @@ export function EditorPanel({
   selectedTranslation,
   isLoadingTranslation,
   translationError,
-  modifiedContentString,
+  content,
+  modifiedContent,
   jsonError,
   onContentChange,
   outdatedLocales,
@@ -161,29 +167,13 @@ export function EditorPanel({
     );
   }
 
-  // Use the modified string if available, otherwise format the original content
-  const contentToUse = modifiedContentString ?? JSON.stringify(selectedTranslation.content || {}, null, 2);
   const isOutdated = outdatedLocales?.includes(selectedTranslation.locale);
 
-  const parseContentForActions = () => {
-    if (!modifiedContentString || jsonError) {
-      return null;
-    }
-
-    try {
-      return JSON.parse(modifiedContentString);
-    } catch {
-      return null;
-    }
-  };
-
-  const modifiedContentForActions = parseContentForActions();
-
   return (
-    <div className="flex flex-1 flex-col bg-neutral-50">
+    <div className="flex flex-1 flex-col bg-neutral-50 max-w-[calc(100%-400px)]">
       <EditorActions
         selectedTranslation={selectedTranslation}
-        modifiedContent={modifiedContentForActions}
+        modifiedContent={modifiedContent}
         isReadOnly={isReadOnly}
       />
 
@@ -193,7 +183,7 @@ export function EditorPanel({
         </div>
       ) : selectedTranslation ? (
         <JSONEditor
-          content={contentToUse}
+          content={content}
           onChange={onContentChange}
           error={jsonError}
           updatedAt={selectedTranslation.updatedAt}

--- a/apps/dashboard/src/components/translations/translation-drawer/hooks/use-translation-editor.ts
+++ b/apps/dashboard/src/components/translations/translation-drawer/hooks/use-translation-editor.ts
@@ -1,12 +1,18 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Translation } from '@/api/translations';
 
 export function useTranslationEditor(selectedTranslation: Translation | undefined) {
   const [modifiedContentString, setModifiedContentString] = useState<string | null>(null);
+  const [modifiedContent, setModifiedContent] = useState<Record<string, any> | null>(null);
   const [jsonError, setJsonError] = useState<string | null>(null);
+  const originalContent = useMemo(
+    () => JSON.stringify(selectedTranslation?.content ?? {}, null, 2),
+    [selectedTranslation?.content]
+  );
 
   useEffect(() => {
     setModifiedContentString(null);
+    setModifiedContent(null);
     setJsonError(null);
   }, [selectedTranslation?.locale]);
 
@@ -16,43 +22,25 @@ export function useTranslationEditor(selectedTranslation: Translation | undefine
 
     try {
       // Only parse for validation, don't modify the content
-      JSON.parse(newContentString);
+      setModifiedContent(JSON.parse(newContentString));
       setJsonError(null);
     } catch (error) {
+      setModifiedContent(null);
       setJsonError(error instanceof Error ? error.message : 'Invalid JSON format');
     }
   }, []);
 
   const resetContent = useCallback(() => {
     setModifiedContentString(null);
+    setModifiedContent(null);
     setJsonError(null);
   }, []);
 
-  const parseModifiedContent = useCallback(() => {
-    if (!modifiedContentString || jsonError) {
-      return null;
-    }
-
-    try {
-      return JSON.parse(modifiedContentString);
-    } catch {
-      return null;
-    }
-  }, [modifiedContentString, jsonError]);
-
-  const checkIfContentChanged = useCallback(() => {
-    if (!modifiedContentString || !selectedTranslation) {
-      return false;
-    }
-
-    const originalContent = JSON.stringify(selectedTranslation.content, null, 2);
-    return modifiedContentString !== originalContent;
-  }, [modifiedContentString, selectedTranslation]);
-
-  const modifiedContent = parseModifiedContent();
-  const hasUnsavedChanges = checkIfContentChanged();
+  const hasUnsavedChanges =
+    !modifiedContentString || !selectedTranslation ? false : modifiedContentString !== originalContent;
 
   return {
+    originalContent,
     modifiedContent,
     modifiedContentString,
     jsonError,

--- a/apps/dashboard/src/components/translations/translation-drawer/locale-list.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/locale-list.tsx
@@ -176,7 +176,7 @@ export function LocaleList({
   }, [locales, actualDefaultLocale]);
 
   return (
-    <div className="w-[400px] border-r border-neutral-200">
+    <div className="min-w-[400px] border-r border-neutral-200">
       <TranslationStatusSection updatedAt={updatedAt} outdatedLocales={outdatedLocales} />
 
       <div className="p-4">

--- a/apps/dashboard/src/components/translations/translation-drawer/translation-drawer-content.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/translation-drawer-content.tsx
@@ -94,7 +94,8 @@ export const TranslationDrawerContent = forwardRef<TranslationDrawerContentRef, 
           </div>
         )}
 
-        <div className="flex h-full">
+        {/* 109px is the height of the header and footer */}
+        <div className="flex flex-1 h-[calc(100%-109px)]">
           <LocaleList
             locales={translationGroup.locales}
             selectedLocale={selectedLocale}
@@ -109,7 +110,8 @@ export const TranslationDrawerContent = forwardRef<TranslationDrawerContentRef, 
             selectedTranslation={selectedTranslation}
             isLoadingTranslation={isLoadingTranslation}
             translationError={translationError}
-            modifiedContentString={editor.modifiedContentString}
+            content={editor.modifiedContentString ?? editor.originalContent}
+            modifiedContent={editor.modifiedContent}
             jsonError={editor.jsonError}
             onContentChange={editor.handleContentChange}
             outdatedLocales={translationGroup.outdatedLocales}

--- a/apps/dashboard/src/components/translations/translation-drawer/translation-drawer.tsx
+++ b/apps/dashboard/src/components/translations/translation-drawer/translation-drawer.tsx
@@ -73,9 +73,10 @@ export const TranslationDrawer = forwardRef<HTMLDivElement, TranslationDrawerPro
     }, [onOpenChange]);
 
     return (
-      <div ref={ref}>
+      <>
         <Sheet open={isOpen} onOpenChange={onOpenChange}>
           <SheetContent
+            ref={ref}
             side="right"
             className="w-[1100px] !max-w-none"
             onInteractOutside={handleCloseAttempt}
@@ -109,7 +110,7 @@ export const TranslationDrawer = forwardRef<HTMLDivElement, TranslationDrawerPro
           onCancel={() => setShowUnsavedDialog(false)}
           onProceed={handleConfirmClose}
         />
-      </div>
+      </>
     );
   }
 );

--- a/apps/dashboard/src/components/unsaved-changes-alert-dialog.tsx
+++ b/apps/dashboard/src/components/unsaved-changes-alert-dialog.tsx
@@ -1,4 +1,4 @@
-import { RiAlertFill, RiArrowRightSLine } from 'react-icons/ri';
+import { RiAlertFill } from 'react-icons/ri';
 import {
   AlertDialog,
   AlertDialogAction,

--- a/apps/dashboard/src/pages/edit-translation.tsx
+++ b/apps/dashboard/src/pages/edit-translation.tsx
@@ -33,14 +33,6 @@ export const EditTranslationPage = () => {
     }
   };
 
-  const handleOpenChange = (isOpen: boolean) => {
-    setOpen(isOpen);
-
-    if (!isOpen) {
-      navigateToTranslationsPage();
-    }
-  };
-
   const handleLocaleChange = (newLocale: string) => {
     setCurrentLocale(newLocale);
 
@@ -69,7 +61,7 @@ export const EditTranslationPage = () => {
     <TranslationDrawer
       ref={unmountRef}
       isOpen={open}
-      onOpenChange={handleOpenChange}
+      onOpenChange={setOpen}
       resourceType={resourceType}
       resourceId={resourceId}
       initialLocale={currentLocale}


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixes a few issues with the Translation Drawer:
- it froze the whole translation page when the drawer editor changes were discarded
- there was a freeze when the user typed the locale value
- the UI issue with the editor content scrollbars not visible with the huge JSON locale is used

### Screenshots

https://github.com/user-attachments/assets/0d50d944-551e-47c4-b86b-aaf020e13849



