### PR TITLE
fix(dashboard): Improve CopyButton error handling with fallback mechanismmm

### DIFF
--- a/apps/dashboard/src/components/primitives/copy-button.tsx
+++ b/apps/dashboard/src/components/primitives/copy-button.tsx
@@ -21,7 +21,23 @@ export const CopyButton = (props: CopyButtonProps) => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch (err) {
-      console.error('Failed to copy text: ', err);
+      // Fallback to legacy clipboard API for older browsers
+      try {
+        const textArea = document.createElement('textarea');
+        textArea.value = valueToCopy;
+        textArea.style.position = 'fixed';
+        textArea.style.opacity = '0';
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      } catch (fallbackErr) {
+        // Both clipboard methods failed - this is rare but possible
+        // Could integrate with toast notification system here if available
+        console.warn('Copy operation failed. Please copy manually:', valueToCopy);
+      }
     }
   };
 
@@ -75,7 +91,7 @@ export const CopyButton = (props: CopyButtonProps) => {
         </button>
       </TooltipTrigger>
       <TooltipContent className="px-2 py-1 text-xs" sideOffset={4}>
-        {copied ? 'Copied!' : 'Click to copy'}
+        {copied ? 'Copied to clipboard!' : 'Copy to clipboard'}
       </TooltipContent>
     </Tooltip>
   );


### PR DESCRIPTION


- Add fallback clipboard implementation using legacy document.execCommand for older browsers
- Replace console.error with console.warn and more informative messaging
- Improve tooltip text for better UX clarity
- Ensure copy functionality works across different browser environments
- Handle edge cases where both modern and legacy clipboard APIs fail

Fixes potential copy functionality failures in older browsers and provides better error messaging when clipboard operations are not available.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
