### PR TITLE
refactor(api-service): simplify context key types to string

### DIFF
--- a/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
@@ -20,7 +20,6 @@ import {
   NotificationStepEntity,
 } from '@novu/dal';
 import {
-  ContextKey,
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
   FeatureFlagsKeysEnum,

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.command.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.command.ts
@@ -1,6 +1,6 @@
 import { EnvironmentWithUserCommand } from '@novu/application-generic';
 import type { JobEntity, NotificationStepEntity } from '@novu/dal';
-import type { ContextKey, SeverityLevelEnum, TriggerOverrides, WorkflowPreferences } from '@novu/shared';
+import type { SeverityLevelEnum, TriggerOverrides, WorkflowPreferences } from '@novu/shared';
 import { IsDefined, IsOptional, IsString } from 'class-validator';
 
 export class SendMessageCommand extends EnvironmentWithUserCommand {
@@ -52,5 +52,5 @@ export class SendMessageCommand extends EnvironmentWithUserCommand {
   statelessPreferences?: WorkflowPreferences;
 
   @IsOptional()
-  contextKeys?: ContextKey[];
+  contextKeys?: string[];
 }

--- a/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.command.ts
+++ b/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.command.ts
@@ -2,7 +2,6 @@ import { EnvironmentWithUserCommand } from '@novu/application-generic';
 import { SubscriberEntity, TopicEntity } from '@novu/dal';
 import { DiscoverWorkflowOutput } from '@novu/framework/internal';
 import {
-  ContextKey,
   ISubscribersDefine,
   ITenantDefine,
   StatelessControls,
@@ -42,7 +41,7 @@ export class SubscriberJobBoundCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  contextKeys?: ContextKey[];
+  contextKeys?: string[];
 
   @IsDefined()
   @IsMongoId()

--- a/libs/application-generic/src/dtos/process-subscriber-job.dto.ts
+++ b/libs/application-generic/src/dtos/process-subscriber-job.dto.ts
@@ -1,7 +1,6 @@
 import { SubscriberEntity, TopicEntity } from '@novu/dal';
 import { DiscoverWorkflowOutput } from '@novu/framework/internal';
 import {
-  ContextKey,
   ISubscribersDefine,
   ITenantDefine,
   StatelessControls,
@@ -24,7 +23,7 @@ export interface IProcessSubscriberDataDto {
   overrides: TriggerOverrides;
   tenant?: ITenantDefine;
   actor?: SubscriberEntity;
-  contextKeys?: ContextKey[];
+  contextKeys?: string[];
   subscriber: ISubscribersDefine;
   templateId: string;
   _subscriberSource: SubscriberSourceEnum;

--- a/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.command.ts
+++ b/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.command.ts
@@ -2,7 +2,6 @@
 import { NotificationTemplateEntity, SubscriberEntity, TopicEntity } from '@novu/dal';
 import {
   ChannelTypeEnum,
-  ContextKey,
   ISubscribersDefine,
   ITenantDefine,
   ProvidersIdEnum,
@@ -54,7 +53,7 @@ export class CreateNotificationJobsCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  contextKeys?: ContextKey[];
+  contextKeys?: string[];
 
   bridgeUrl?: string;
 

--- a/libs/application-generic/src/usecases/resolve-context/resolve-context-from-keys.command.ts
+++ b/libs/application-generic/src/usecases/resolve-context/resolve-context-from-keys.command.ts
@@ -1,4 +1,3 @@
-import { ContextKey } from '@novu/shared';
 import { ArrayMaxSize, IsArray, IsDefined, IsString } from 'class-validator';
 
 import { EnvironmentWithUserCommand } from '../../commands';
@@ -8,5 +7,5 @@ export class ResolveContextFromKeysCommand extends EnvironmentWithUserCommand {
   @IsArray()
   @ArrayMaxSize(5)
   @IsString({ each: true })
-  contextKeys: ContextKey[];
+  contextKeys: string[];
 }

--- a/libs/application-generic/src/usecases/trigger-base/trigger-base.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-base/trigger-base.usecase.ts
@@ -8,7 +8,6 @@ import {
   UserEntity,
 } from '@novu/dal';
 import {
-  ContextKey,
   FeatureFlagsKeysEnum,
   ISubscribersDefine,
   ITenantDefine,
@@ -39,7 +38,7 @@ export type BaseTriggerCommand = {
   overrides: TriggerOverrides;
   template: NotificationTemplateEntity;
   actor?: SubscriberEntity | undefined;
-  contextKeys?: ContextKey[];
+  contextKeys?: string[];
   tenant: ITenantDefine | null;
   environmentName: string;
   requestCategory?: TriggerRequestCategoryEnum;

--- a/libs/application-generic/src/usecases/trigger-broadcast/trigger-broadcast.command.ts
+++ b/libs/application-generic/src/usecases/trigger-broadcast/trigger-broadcast.command.ts
@@ -1,5 +1,5 @@
 import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
-import { ContextKey, ITenantDefine } from '@novu/shared';
+import { ITenantDefine } from '@novu/shared';
 import { IsArray, IsDefined, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import { TriggerEventBroadcastCommand } from '../trigger-event';
@@ -17,7 +17,7 @@ export class TriggerBroadcastCommand extends TriggerEventBroadcastCommand {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  contextKeys?: ContextKey[];
+  contextKeys?: string[];
 
   @IsDefined()
   @IsString()

--- a/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
@@ -10,7 +10,6 @@ import {
 } from '@novu/dal';
 import {
   AddressingTypeEnum,
-  ContextKey,
   FeatureFlagsKeysEnum,
   ISubscribersDefine,
   ITenantDefine,
@@ -375,7 +374,7 @@ export class TriggerEvent {
     return subscriber;
   }
 
-  private async resolveContextKeys(command: TriggerEventCommand): Promise<ContextKey[] | undefined> {
+  private async resolveContextKeys(command: TriggerEventCommand): Promise<string[] | undefined> {
     if (!command.context) {
       return undefined;
     }

--- a/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.command.ts
+++ b/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.command.ts
@@ -1,5 +1,5 @@
 import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
-import { ContextKey, ITenantDefine } from '@novu/shared';
+import { ITenantDefine } from '@novu/shared';
 import { IsArray, IsDefined, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 import { TriggerEventMulticastCommand } from '../trigger-event';
@@ -17,7 +17,7 @@ export class TriggerMulticastCommand extends TriggerEventMulticastCommand {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  contextKeys?: ContextKey[];
+  contextKeys?: string[];
 
   @IsDefined()
   @IsString()

--- a/libs/dal/src/repositories/context/context.entity.ts
+++ b/libs/dal/src/repositories/context/context.entity.ts
@@ -1,4 +1,4 @@
-import { Context, ContextData, ContextId, ContextKey, ContextType } from '@novu/shared';
+import { Context, ContextData, ContextId, ContextType } from '@novu/shared';
 import type { ChangePropsValueType } from '../../types/helpers';
 import type { EnvironmentId } from '../environment';
 import type { OrganizationId } from '../organization';
@@ -12,7 +12,7 @@ export class ContextEntity implements Context {
   type: ContextType;
   data: ContextData;
 
-  key: ContextKey;
+  key: string;
 
   createdAt: string;
   updatedAt: string;

--- a/libs/dal/src/repositories/context/context.repository.ts
+++ b/libs/dal/src/repositories/context/context.repository.ts
@@ -1,4 +1,4 @@
-import { ContextData, ContextId, ContextKey, ContextPayload, ContextType, createContextKey } from '@novu/shared';
+import { ContextData, ContextId, ContextPayload, ContextType, createContextKey } from '@novu/shared';
 import { FilterQuery } from 'mongoose';
 import type { EnforceEnvOrOrgIds } from '../../types';
 import { BaseRepository } from '../base-repository';
@@ -75,7 +75,7 @@ export class ContextRepository extends BaseRepository<ContextDBModel, ContextEnt
     return Promise.all(validPromises);
   }
 
-  async findByKeys(environmentId: string, organizationId: string, contextKeys: ContextKey[]): Promise<ContextEntity[]> {
+  async findByKeys(environmentId: string, organizationId: string, contextKeys: string[]): Promise<ContextEntity[]> {
     if (contextKeys.length === 0) {
       return [];
     }

--- a/libs/dal/src/repositories/job/job.entity.ts
+++ b/libs/dal/src/repositories/job/job.entity.ts
@@ -1,5 +1,4 @@
 import {
-  ContextKey,
   DeliveryLifecycleDetail,
   DeliveryLifecycleStatus,
   ITenantDefine,
@@ -54,7 +53,7 @@ export class JobEntity {
   actorId?: string;
   stepOutput?: Record<string, unknown>;
   preferences?: WorkflowPreferences;
-  contextKeys?: ContextKey[];
+  contextKeys?: string[];
   /**
    * used to track the number of times a step has been extended to the next available time in the subscriber schedule
    */

--- a/libs/dal/src/repositories/message/message.entity.ts
+++ b/libs/dal/src/repositories/message/message.entity.ts
@@ -2,7 +2,6 @@ import {
   ChannelEndpointByType,
   ChannelEndpointType,
   ChannelTypeEnum,
-  ContextKey,
   IActor,
   IMessageCTA,
   SeverityLevelEnum,
@@ -134,7 +133,7 @@ export class MessageEntity {
 
   channelData?: MessageChannelData[];
 
-  contextKeys?: ContextKey[];
+  contextKeys?: string[];
 }
 
 export type MessageDBModel = ChangePropsValueType<

--- a/libs/dal/src/repositories/notification/notification.entity.ts
+++ b/libs/dal/src/repositories/notification/notification.entity.ts
@@ -1,4 +1,4 @@
-import { ContextKey, ISubscribersDefine, SeverityLevelEnum, StatelessControls, StepTypeEnum } from '@novu/shared';
+import { ISubscribersDefine, SeverityLevelEnum, StatelessControls, StepTypeEnum } from '@novu/shared';
 
 import type { ChangePropsValueType } from '../../types/helpers';
 import type { EnvironmentId } from '../environment';

--- a/packages/shared/src/types/context.ts
+++ b/packages/shared/src/types/context.ts
@@ -10,7 +10,7 @@ export type Context = {
   type: ContextType;
   data: ContextData;
 
-  key: ContextKey;
+  key: string;
 
   createdAt: string;
   updatedAt: string;
@@ -20,9 +20,7 @@ export type ContextType = string;
 
 export type ContextId = string;
 
-export type ContextKey = `${ContextType}:${ContextId}`;
-
-export const createContextKey = (type: ContextType, id: ContextId): ContextKey => `${type}:${id}`;
+export const createContextKey = (type: ContextType, id: ContextId): string => `${type}:${id}`;
 
 export type ContextData = Record<string, unknown>;
 


### PR DESCRIPTION
Replace `ContextKey` type with `string` and remove its definition to simplify the type system.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9cceb2a-37f7-4955-bc2e-c437b08c64f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9cceb2a-37f7-4955-bc2e-c437b08c64f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized context identifiers to plain strings across notification, workflow, and data layers for consistency and easier integration.
  - Updated commands and payloads to accept string-based context keys with unchanged validation and behavior.

- Chores
  - Removed unused imports and legacy typings related to context keys.

Impact
  - No functional changes expected. Existing integrations should continue to work without modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->