### PR TITLE
test(api): add comprehensive e2e tests for contexts API fixes NV-6762

### DIFF
--- a/apps/api/src/app/contexts/e2e/create-context.e2e.ts
+++ b/apps/api/src/app/contexts/e2e/create-context.e2e.ts
@@ -1,0 +1,177 @@
+import { ContextRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import axios, { AxiosResponse } from 'axios';
+import { expect } from 'chai';
+
+describe('Create Context - /contexts (POST) #novu-v2', () => {
+  let session: UserSession;
+  const contextRepository = new ContextRepository();
+
+  before(() => {
+    // @ts-expect-error process.env is not typed
+    process.env.IS_CONTEXT_ENABLED = 'true';
+  });
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  after(() => {
+    // @ts-expect-error process.env is not typed
+    delete process.env.IS_CONTEXT_ENABLED;
+  });
+
+  it('should create a new context', async () => {
+    const response = await createContext({
+      session,
+      type: 'tenant',
+      id: 'create-test-org-acme',
+      data: { tenantName: 'Acme Corp', region: 'us-east-1' },
+    });
+
+    expect(response.status).to.equal(201);
+    expect(response.data).to.be.ok;
+
+    const createdContext = await contextRepository.findOne({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'create-test-org-acme',
+    });
+
+    expect(createdContext?.type).to.equal('tenant');
+    expect(createdContext?.id).to.equal('create-test-org-acme');
+    expect(createdContext?.data).to.deep.equal({ tenantName: 'Acme Corp', region: 'us-east-1' });
+  });
+
+  it('should create a context without data', async () => {
+    const response = await createContext({
+      session,
+      type: 'workspace',
+      id: 'create-test-workspace-123',
+    });
+
+    expect(response.status).to.equal(201);
+    expect(response.data).to.be.ok;
+
+    const createdContext = await contextRepository.findOne({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'workspace',
+      id: 'create-test-workspace-123',
+    });
+
+    expect(createdContext?.type).to.equal('workspace');
+    expect(createdContext?.id).to.equal('create-test-workspace-123');
+    expect(createdContext?.data).to.deep.equal({});
+  });
+
+  it('should throw error if a context already exists', async () => {
+    await createContext({
+      session,
+      type: 'tenant',
+      id: 'create-test-duplicate',
+      data: { tenantName: 'Acme Corp' },
+    });
+
+    try {
+      await createContext({
+        session,
+        type: 'tenant',
+        id: 'create-test-duplicate',
+        data: { tenantName: 'Acme Corp Updated' },
+      });
+
+      throw new Error('Should not succeed');
+    } catch (e) {
+      expect(e.response.status).to.equal(409);
+      expect(e.response.data.message).to.contains(
+        `Context with type 'tenant' and id 'create-test-duplicate' already exists`
+      );
+    }
+  });
+
+  it('should throw error if type is missing', async () => {
+    try {
+      await createContext({
+        session,
+        id: 'org-acme',
+      });
+
+      throw new Error('Should not succeed');
+    } catch (e) {
+      expect(e.response.status).to.equal(422);
+    }
+  });
+
+  it('should throw error if id is missing', async () => {
+    try {
+      await createContext({
+        session,
+        type: 'tenant',
+      });
+
+      throw new Error('Should not succeed');
+    } catch (e) {
+      expect(e.response.status).to.equal(422);
+    }
+  });
+
+  it('should throw error if type has invalid format', async () => {
+    try {
+      await createContext({
+        session,
+        type: 'Invalid_Type!',
+        id: 'create-test-invalid-type',
+      });
+
+      throw new Error('Should not succeed');
+    } catch (e) {
+      expect(e.response.status).to.equal(422);
+    }
+  });
+
+  it('should throw error if id has invalid format', async () => {
+    try {
+      await createContext({
+        session,
+        type: 'tenant',
+        id: 'Invalid ID!',
+      });
+
+      throw new Error('Should not succeed');
+    } catch (e) {
+      expect(e.response.status).to.equal(422);
+    }
+  });
+});
+
+// biome-ignore lint/suspicious/noExportsInTest: helper function used by other tests
+export async function createContext({
+  session,
+  type,
+  id,
+  data,
+}: {
+  session;
+  type?: string;
+  id?: string;
+  data?: any;
+}): Promise<AxiosResponse> {
+  const axiosInstance = axios.create();
+
+  return await axiosInstance.post(
+    `${session.serverUrl}/v2/contexts`,
+    {
+      type,
+      id,
+      data,
+    },
+    {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    }
+  );
+}

--- a/apps/api/src/app/contexts/e2e/delete-context.e2e.ts
+++ b/apps/api/src/app/contexts/e2e/delete-context.e2e.ts
@@ -1,0 +1,100 @@
+import { ContextRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import axios, { AxiosResponse } from 'axios';
+import { expect } from 'chai';
+
+describe('Delete Context - /contexts/:type/:id (DELETE) #novu-v2', () => {
+  let session: UserSession;
+  const contextRepository = new ContextRepository();
+
+  before(() => {
+    // @ts-expect-error process.env is not typed
+    process.env.IS_CONTEXT_ENABLED = 'true';
+  });
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  after(() => {
+    // @ts-expect-error process.env is not typed
+    delete process.env.IS_CONTEXT_ENABLED;
+  });
+
+  it('should delete newly created context', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'delete-test-org-acme',
+      key: 'tenant:delete-test-org-acme',
+      data: { tenantName: 'Acme Corp', region: 'us-east-1' },
+    });
+
+    const existingContext = await contextRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      type: 'tenant',
+      id: 'delete-test-org-acme',
+    });
+
+    expect(existingContext).to.be.ok;
+
+    const response = await deleteContext({
+      session,
+      type: 'tenant',
+      id: 'delete-test-org-acme',
+    });
+
+    expect(response.status).to.equal(204);
+
+    const deletedContext = await contextRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      type: 'tenant',
+      id: 'delete-test-org-acme',
+    });
+
+    expect(deletedContext).to.equal(null);
+  });
+
+  it('should throw exception while trying to delete non-existing context', async () => {
+    const type = 'tenant';
+    const id = 'non-existent-context';
+
+    try {
+      await deleteContext({
+        session,
+        type,
+        id,
+      });
+
+      throw new Error('Should not succeed');
+    } catch (e) {
+      expect(e.response.status).to.equal(404);
+      expect(e?.response?.data?.message || e?.message).to.contains(
+        `Context with id '${id}' and type '${type}' not found in environment ${session.environment._id}`
+      );
+    }
+  });
+});
+
+// biome-ignore lint/suspicious/noExportsInTest: helper function used by other tests
+export async function deleteContext({
+  session,
+  type,
+  id,
+}: {
+  session;
+  type?: string;
+  id?: string;
+}): Promise<AxiosResponse> {
+  const axiosInstance = axios.create();
+
+  return await axiosInstance.delete(`${session.serverUrl}/v2/contexts/${type}/${id}`, {
+    headers: {
+      authorization: `ApiKey ${session.apiKey}`,
+    },
+  });
+}

--- a/apps/api/src/app/contexts/e2e/get-context.e2e.ts
+++ b/apps/api/src/app/contexts/e2e/get-context.e2e.ts
@@ -1,0 +1,94 @@
+import { ContextRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import axios from 'axios';
+import { expect } from 'chai';
+
+describe('Get Context - /contexts/:type/:id (GET) #novu-v2', () => {
+  let session: UserSession;
+  const contextRepository = new ContextRepository();
+
+  before(() => {
+    // @ts-expect-error process.env is not typed
+    process.env.IS_CONTEXT_ENABLED = 'true';
+  });
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  afterEach(async () => {
+    await contextRepository.delete({
+      _environmentId: session.environment._id,
+    });
+  });
+
+  after(() => {
+    // @ts-expect-error process.env is not typed
+    delete process.env.IS_CONTEXT_ENABLED;
+  });
+
+  it('should get a newly created context', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'get-test-org-acme',
+      key: 'tenant:get-test-org-acme',
+      data: { tenantName: 'Acme Corp', region: 'us-east-1' },
+    });
+
+    const getContextResult = await getContext({ session, type: 'tenant', id: 'get-test-org-acme' });
+
+    expect(getContextResult.data.type).to.equal('tenant');
+    expect(getContextResult.data.id).to.equal('get-test-org-acme');
+    expect(getContextResult.data.data).to.deep.equal({ tenantName: 'Acme Corp', region: 'us-east-1' });
+    expect(getContextResult.data.createdAt).to.be.ok;
+    expect(getContextResult.data.updatedAt).to.be.ok;
+  });
+
+  it('should get a context with empty data', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'workspace',
+      id: 'get-test-workspace-123',
+      key: 'workspace:get-test-workspace-123',
+      data: {},
+    });
+
+    const getContextResult = await getContext({ session, type: 'workspace', id: 'get-test-workspace-123' });
+
+    expect(getContextResult.data.type).to.equal('workspace');
+    expect(getContextResult.data.id).to.equal('get-test-workspace-123');
+    expect(getContextResult.data.data).to.deep.equal({});
+  });
+
+  it('should throw exception if context does not exist', async () => {
+    const incorrectType = 'tenant';
+    const incorrectId = 'non-existent';
+
+    try {
+      await getContext({ session, type: incorrectType, id: incorrectId });
+
+      throw new Error('Should not succeed');
+    } catch (e) {
+      expect(e.response.status).to.equal(404);
+      expect(e?.response?.data?.message || e?.message).to.contains(
+        `Context with id '${incorrectId}' and type '${incorrectType}' not found in environment ${session.environment._id}`
+      );
+    }
+  });
+});
+
+async function getContext({ session, type, id }: { session; type: string; id: string }) {
+  const axiosInstance = axios.create();
+
+  return (
+    await axiosInstance.get(`${session.serverUrl}/v2/contexts/${type}/${id}`, {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    })
+  ).data;
+}

--- a/apps/api/src/app/contexts/e2e/list-contexts.e2e.ts
+++ b/apps/api/src/app/contexts/e2e/list-contexts.e2e.ts
@@ -1,0 +1,286 @@
+import { ContextRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import axios, { AxiosResponse } from 'axios';
+import { expect } from 'chai';
+
+describe('List Contexts - /contexts (GET) #novu-v2', () => {
+  let session: UserSession;
+  const contextRepository = new ContextRepository();
+
+  before(() => {
+    // @ts-expect-error process.env is not typed
+    process.env.IS_CONTEXT_ENABLED = 'true';
+  });
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  after(() => {
+    // @ts-expect-error process.env is not typed
+    delete process.env.IS_CONTEXT_ENABLED;
+  });
+
+  it('should get the newly created contexts', async () => {
+    for (let i = 0; i < 5; i += 1) {
+      await contextRepository.create({
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        type: 'tenant',
+        id: `list-test-1-org-${i}`,
+        key: `tenant:list-test-1-org-${i}`,
+        data: { index: i },
+      });
+
+      await timeout(5);
+    }
+
+    const response = await listContexts({ session });
+
+    expect(response.status).to.equal(200);
+    expect(response.data.data).to.be.an('array');
+    expect(response.data.data.length).to.equal(5);
+    expect(response.data.data[0].id).to.equal('list-test-1-org-4');
+    expect(response.data.data[4].id).to.equal('list-test-1-org-0');
+    expect(response.data.totalCount).to.equal(5);
+  });
+
+  it('should filter contexts by type', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'list-test-2-org-1',
+      key: 'tenant:list-test-2-org-1',
+      data: {},
+    });
+
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'workspace',
+      id: 'list-test-2-workspace-1',
+      key: 'workspace:list-test-2-workspace-1',
+      data: {},
+    });
+
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'list-test-2-org-2',
+      key: 'tenant:list-test-2-org-2',
+      data: {},
+    });
+
+    const response = await listContexts({ session, type: 'tenant' });
+
+    expect(response.status).to.equal(200);
+    expect(response.data.data.length).to.equal(2);
+    expect(response.data.data.every((ctx) => ctx.type === 'tenant')).to.be.true;
+  });
+
+  it('should filter contexts by id', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'list-test-3-org-acme',
+      key: 'tenant:list-test-3-org-acme',
+      data: {},
+    });
+
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'workspace',
+      id: 'list-test-3-org-acme',
+      key: 'workspace:list-test-3-org-acme',
+      data: {},
+    });
+
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'list-test-3-org-other',
+      key: 'tenant:list-test-3-org-other',
+      data: {},
+    });
+
+    const response = await listContexts({ session, id: 'list-test-3-org-acme' });
+
+    expect(response.status).to.equal(200);
+    expect(response.data.data.length).to.equal(2);
+    expect(response.data.data.every((ctx) => ctx.id === 'list-test-3-org-acme')).to.be.true;
+  });
+
+  it('should search contexts by key pattern', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'list-test-4-org-acme',
+      key: 'tenant:list-test-4-org-acme',
+      data: {},
+    });
+
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'workspace',
+      id: 'list-test-4-workspace-acme',
+      key: 'workspace:list-test-4-workspace-acme',
+      data: {},
+    });
+
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'list-test-4-org-other',
+      key: 'tenant:list-test-4-org-other',
+      data: {},
+    });
+
+    const response = await listContexts({ session, search: 'list-test-4.*acme' });
+
+    expect(response.status).to.equal(200);
+    expect(response.data.data.length).to.equal(2);
+  });
+
+  it('should support cursor-based pagination with limit', async () => {
+    for (let i = 0; i < 15; i += 1) {
+      await contextRepository.create({
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        type: 'tenant',
+        id: `list-test-5-org-${i}`,
+        key: `tenant:list-test-5-org-${i}`,
+        data: { index: i },
+      });
+
+      await timeout(5);
+    }
+
+    const page1 = await listContexts({ session, limit: 5 });
+
+    expect(page1.data.data.length).to.equal(5);
+    expect(page1.data.next).to.be.ok;
+    expect(page1.data.totalCount).to.equal(15);
+
+    const page2 = await listContexts({ session, limit: 5, after: page1.data.next });
+
+    expect(page2.data.data.length).to.equal(5);
+    expect(page2.data.next).to.be.ok;
+    expect(page2.data.previous).to.be.ok;
+
+    const page3 = await listContexts({ session, limit: 5, after: page2.data.next });
+
+    expect(page3.data.data.length).to.equal(5);
+    expect(page3.data.previous).to.be.ok;
+  });
+
+  it('should support orderBy and orderDirection', async () => {
+    await timeout(10);
+
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'list-test-6-org-1',
+      key: 'tenant:list-test-6-org-1',
+      data: {},
+    });
+
+    await timeout(10);
+
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'list-test-6-org-2',
+      key: 'tenant:list-test-6-org-2',
+      data: {},
+    });
+
+    await timeout(10);
+
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'list-test-6-org-3',
+      key: 'tenant:list-test-6-org-3',
+      data: {},
+    });
+
+    const responseDesc = await listContexts({ session, orderBy: 'createdAt', orderDirection: 'DESC' });
+
+    expect(responseDesc.data.data[0].id).to.equal('list-test-6-org-3');
+    expect(responseDesc.data.data[2].id).to.equal('list-test-6-org-1');
+
+    const responseAsc = await listContexts({ session, orderBy: 'createdAt', orderDirection: 'ASC' });
+
+    expect(responseAsc.data.data[0].id).to.equal('list-test-6-org-1');
+    expect(responseAsc.data.data[2].id).to.equal('list-test-6-org-3');
+  });
+
+  it('should return empty list when no contexts exist', async () => {
+    const response = await listContexts({ session });
+
+    expect(response.status).to.equal(200);
+    expect(response.data.data).to.be.an('array');
+    expect(response.data.data.length).to.equal(0);
+    expect(response.data.totalCount).to.equal(0);
+  });
+});
+
+async function listContexts({
+  session,
+  limit,
+  after,
+  before,
+  orderBy,
+  orderDirection,
+  type,
+  id,
+  search,
+}: {
+  session;
+  limit?: number;
+  after?: string;
+  before?: string;
+  orderBy?: string;
+  orderDirection?: string;
+  type?: string;
+  id?: string;
+  search?: string;
+}): Promise<AxiosResponse> {
+  const axiosInstance = axios.create();
+  const params = new URLSearchParams();
+
+  if (limit) params.append('limit', limit.toString());
+  if (after) params.append('after', after);
+  if (before) params.append('before', before);
+  if (orderBy) params.append('orderBy', orderBy);
+  if (orderDirection) params.append('orderDirection', orderDirection);
+  if (type) params.append('type', type);
+  if (id) params.append('id', id);
+  if (search) params.append('search', search);
+
+  const query = params.toString() ? `?${params.toString()}` : '';
+
+  return await axiosInstance.get(`${session.serverUrl}/v2/contexts${query}`, {
+    headers: {
+      authorization: `ApiKey ${session.apiKey}`,
+    },
+  });
+}
+
+function timeout(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/apps/api/src/app/contexts/e2e/update-context.e2e.ts
+++ b/apps/api/src/app/contexts/e2e/update-context.e2e.ts
@@ -1,0 +1,190 @@
+import { ContextRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import axios, { AxiosResponse } from 'axios';
+import { expect } from 'chai';
+
+describe('Update Context - /contexts/:type/:id (PATCH) #novu-v2', () => {
+  let session: UserSession;
+  const contextRepository = new ContextRepository();
+
+  before(() => {
+    // @ts-expect-error process.env is not typed
+    process.env.IS_CONTEXT_ENABLED = 'true';
+  });
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  afterEach(async () => {
+    await contextRepository.delete({
+      _environmentId: session.environment._id,
+    });
+  });
+
+  after(() => {
+    // @ts-expect-error process.env is not typed
+    delete process.env.IS_CONTEXT_ENABLED;
+  });
+
+  it('should update context data', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'update-test-org-1',
+      key: 'tenant:update-test-org-1',
+      data: { tenantName: 'Acme Corp', region: 'us-east-1' },
+    });
+
+    const response = await updateContext({
+      session,
+      type: 'tenant',
+      id: 'update-test-org-1',
+      data: { tenantName: 'Acme Corporation', region: 'us-west-2', settings: { theme: 'dark' } },
+    });
+
+    expect(response?.status).to.equal(200);
+
+    const updatedContext = await contextRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      type: 'tenant',
+      id: 'update-test-org-1',
+    });
+
+    expect(updatedContext?.data).to.deep.equal({
+      tenantName: 'Acme Corporation',
+      region: 'us-west-2',
+      settings: { theme: 'dark' },
+    });
+  });
+
+  it('should replace context data completely', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'update-test-org-2',
+      key: 'tenant:update-test-org-2',
+      data: { tenantName: 'Acme Corp', region: 'us-east-1', oldField: 'value' },
+    });
+
+    const response = await updateContext({
+      session,
+      type: 'tenant',
+      id: 'update-test-org-2',
+      data: { newField: 'newValue' },
+    });
+
+    expect(response?.status).to.equal(200);
+
+    const updatedContext = await contextRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      type: 'tenant',
+      id: 'update-test-org-2',
+    });
+
+    expect(updatedContext?.data).to.deep.equal({ newField: 'newValue' });
+    expect(updatedContext?.data).to.not.have.property('oldField');
+  });
+
+  it('should update context data to empty object', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'update-test-org-3',
+      key: 'tenant:update-test-org-3',
+      data: { tenantName: 'Acme Corp', region: 'us-east-1' },
+    });
+
+    const response = await updateContext({
+      session,
+      type: 'tenant',
+      id: 'update-test-org-3',
+      data: {},
+    });
+
+    expect(response?.status).to.equal(200);
+
+    const updatedContext = await contextRepository.findOne({
+      _environmentId: session.environment._id,
+      _organizationId: session.organization._id,
+      type: 'tenant',
+      id: 'update-test-org-3',
+    });
+
+    expect(updatedContext?.data).to.deep.equal({});
+  });
+
+  it('should throw exception if context does not exist', async () => {
+    try {
+      await updateContext({
+        session,
+        type: 'tenant',
+        id: 'non-existent',
+        data: { test: 'value' },
+      });
+
+      throw new Error('Should not succeed');
+    } catch (e) {
+      expect(e.response.status).to.equal(404);
+      expect(e?.response?.data?.message || e?.message).to.contains(
+        `Context with type 'tenant' and id 'non-existent' not found`
+      );
+    }
+  });
+
+  it('should throw error if data is missing', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'update-test-org-4',
+      key: 'tenant:update-test-org-4',
+      data: { tenantName: 'Acme Corp' },
+    });
+
+    try {
+      await updateContext({
+        session,
+        type: 'tenant',
+        id: 'update-test-org-4',
+      });
+
+      throw new Error('Should not succeed');
+    } catch (e) {
+      expect(e.response.status).to.equal(422);
+    }
+  });
+});
+
+// biome-ignore lint/suspicious/noExportsInTest: helper function used by other tests
+export async function updateContext({
+  session,
+  type,
+  id,
+  data,
+}: {
+  session;
+  type?: string;
+  id?: string;
+  data?: any;
+}): Promise<AxiosResponse> {
+  const axiosInstance = axios.create();
+
+  return await axiosInstance.patch(
+    `${session.serverUrl}/v2/contexts/${type}/${id}`,
+    {
+      data,
+    },
+    {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+    }
+  );
+}


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request adds comprehensive end-to-end test coverage for the new Contexts API endpoints in the Novu v2 API. It introduces tests for creating, retrieving, updating, deleting, and listing context entities, including validation and error scenarios. These tests ensure that all core context operations work as intended and handle edge cases properly.

**Contexts API E2E Test Coverage**

* CRUD Operations:
  - Added tests for creating contexts, including with and without data, and validation for duplicate, missing, or invalid fields (`create-context.e2e.ts`).
  - Added tests for retrieving contexts, including cases with empty data and handling non-existent contexts (`get-context.e2e.ts`).
  - Added tests for updating contexts, covering data replacement, empty data, and error handling for missing data or non-existent contexts (`update-context.e2e.ts`).
  - Added tests for deleting contexts, including successful deletion and error handling for non-existent contexts (`delete-context.e2e.ts`).

* Listing and Filtering:
  - Added tests for listing contexts with support for filtering by type, id, search patterns, cursor-based pagination, ordering, and handling empty results (`list-contexts.e2e.ts`).

