### PR TITLE
Debug context popover closing issue

### DIFF
--- a/apps/dashboard/src/components/contexts/context-drawer.tsx
+++ b/apps/dashboard/src/components/contexts/context-drawer.tsx
@@ -119,6 +119,7 @@ export const ContextDrawerButton = (props: ContextDrawerButtonProps) => {
       <button
         {...rest}
         onClick={(e) => {
+          e.stopPropagation();
           setOpen(true);
           onClick?.(e);
         }}


### PR DESCRIPTION
Add `e.stopPropagation()` to `ContextDrawerButton` to prevent the contexts popover from closing prematurely when opening the context drawer.

The popover was closing because the click event from the `ContextDrawerButton` was bubbling up to the popover, which interpreted it as a click outside its boundaries. This caused the popover to close while the context drawer was attempting to open. Stopping event propagation ensures the popover remains open.

---
<a href="https://cursor.com/background-agent?bcId=bc-79634ddd-a380-4be7-b6b5-f7d14d5f57f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79634ddd-a380-4be7-b6b5-f7d14d5f57f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

