### PR TITLE
fix(api-service): exclude inbox from idempotency

### DIFF
--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -27,6 +27,7 @@ import { TriggerEventRequestDto } from '../events/dtos';
 import { TriggerEventResponseDto } from '../events/dtos/trigger-event-response.dto';
 import { ParseEventRequestMulticastCommand } from '../events/usecases/parse-event-request';
 import { ParseEventRequest } from '../events/usecases/parse-event-request/parse-event-request.usecase';
+import { ExcludeFromIdempotency } from '../shared/framework/exclude-from-idempotency';
 import { ApiCommonResponses } from '../shared/framework/response.decorator';
 import { KeylessAccessible } from '../shared/framework/swagger/keyless.security';
 import { SubscriberSession, UserSession } from '../shared/framework/user.decorator';
@@ -82,6 +83,7 @@ import type { InboxNotification, InboxPreference } from './utils/types';
 @ApiCommonResponses()
 @Controller('/inbox')
 @ApiExcludeController()
+@ExcludeFromIdempotency()
 export class InboxController {
   constructor(
     private initializeSessionUsecase: Session,

--- a/apps/api/src/app/shared/framework/exclude-from-idempotency.ts
+++ b/apps/api/src/app/shared/framework/exclude-from-idempotency.ts
@@ -1,0 +1,7 @@
+import { applyDecorators, SetMetadata } from '@nestjs/common';
+
+export const EXCLUDE_FROM_IDEMPOTENCY = 'exclude_from_idempotency';
+
+export function ExcludeFromIdempotency() {
+  return applyDecorators(SetMetadata(EXCLUDE_FROM_IDEMPOTENCY, true));
+}

--- a/apps/api/src/app/shared/framework/idempotency.interceptor.ts
+++ b/apps/api/src/app/shared/framework/idempotency.interceptor.ts
@@ -10,6 +10,7 @@ import {
   ServiceUnavailableException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import {
   CacheService,
   FeatureFlagsService,
@@ -21,6 +22,7 @@ import { ApiAuthSchemeEnum, FeatureFlagsKeysEnum, UserSessionData } from '@novu/
 import { createHash } from 'crypto';
 import { Observable, of, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
+import { EXCLUDE_FROM_IDEMPOTENCY } from './exclude-from-idempotency';
 
 const IDEMPOTENCY_CACHE_TTL = 60 * 60 * 24; // 24h
 const IDEMPOTENCY_PROGRESS_TTL = 60 * 5; // 5min
@@ -38,6 +40,7 @@ const ALLOWED_METHODS = ['post', 'patch'];
 @Injectable()
 export class IdempotencyInterceptor implements NestInterceptor {
   constructor(
+    private readonly reflector: Reflector,
     private readonly cacheService: CacheService,
     private featureFlagService: FeatureFlagsService,
     private logger: PinoLogger
@@ -46,6 +49,14 @@ export class IdempotencyInterceptor implements NestInterceptor {
   }
 
   protected async isEnabled(context: ExecutionContext): Promise<boolean> {
+    const isExcluded = this.reflector.getAllAndOverride<boolean>(EXCLUDE_FROM_IDEMPOTENCY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isExcluded) {
+      return false;
+    }
+
     const isAllowedAuthScheme = this.isAllowedAuthScheme(context);
     if (!isAllowedAuthScheme) {
       return true;


### PR DESCRIPTION
### What changed? Why was the change needed?

Exclude Inbox controller from Idempotency as we see the Sentry errors, [link](https://novu-r9.sentry.io/issues/6145063439/?project=6248811&query=is%3Aunresolved&referrer=issue-stream).

**Note:** To support idempotency in Inbox, we would have to get the "session data" instead of "user" data in the Idempotency interceptor and implement the support for idempotency header in the SDKs.

### Screenshots

https://github.com/user-attachments/assets/d00a6615-81e3-4820-b235-068bbd7e9e89



