### PR TITLE
fix(dashboard): email activity tracking doc links

### DIFF
--- a/packages/shared/src/consts/providers/configurations/provider-configuration.ts
+++ b/packages/shared/src/consts/providers/configurations/provider-configuration.ts
@@ -15,8 +15,8 @@ const sendgridConfigurations: ConfigConfiguration[] = [
     required: false,
     links: [
       {
-        text: 'set-up guide',
-        url: 'https://docs.novu.co/platform/integrations/email/sendgrid#manual-setup',
+        text: 'manual set-up guide',
+        url: 'https://docs.novu.co/platform/integrations/email/activity-tracking/manual-configuration/sendgrid',
       },
     ],
   },
@@ -37,8 +37,8 @@ const resendConfigurations: ConfigConfiguration[] = [
     required: false,
     links: [
       {
-        text: 'set-up guide',
-        url: 'https://docs.novu.co/platform/integrations/email/resend#manual-setup',
+        text: 'manual set-up guide',
+        url: 'https://docs.novu.co/platform/integrations/email/activity-tracking/manual-configuration/resend',
       },
     ],
   },
@@ -59,8 +59,8 @@ const mailgunConfigurations: ConfigConfiguration[] = [
     required: false,
     links: [
       {
-        text: 'set-up guide',
-        url: 'https://docs.novu.co/platform/integrations/email/mailgun#manual-setup',
+        text: 'manual set-up guide',
+        url: 'https://docs.novu.co/platform/integrations/email/activity-tracking/manual-configuration/mailgun',
       },
     ],
   },
@@ -81,8 +81,8 @@ const sesConfigurations: ConfigConfiguration[] = [
     required: false,
     links: [
       {
-        text: 'set-up guide',
-        url: 'https://docs.novu.co/platform/integrations/email/amazon-ses#manual-setup',
+        text: 'manual set-up guide',
+        url: 'https://docs.novu.co/platform/integrations/email/activity-tracking/manual-configuration/ses',
       },
     ],
   },
@@ -116,7 +116,7 @@ export const sendgridGroupConfigurations: ConfigConfigurationGroup[] = [
     configurations: sendgridConfigurations,
     enabler: 'inboundWebhookEnabled',
     setupWebhookUrlGuide:
-      'https://www.twilio.com/docs/sendgrid/for-developers/tracking-events/getting-started-event-webhook#add-an-event-webhook',
+      'https://docs.novu.co/platform/integrations/email/activity-tracking/manual-configuration/sendgrid',
   },
 ];
 
@@ -125,7 +125,7 @@ export const resendGroupConfigurations: ConfigConfigurationGroup[] = [
     groupType: 'inboundWebhook',
     configurations: resendConfigurations,
     enabler: 'inboundWebhookEnabled',
-    setupWebhookUrlGuide: 'https://resend.com/docs/dashboard/webhooks/introduction#what-is-a-webhook%3F',
+    setupWebhookUrlGuide: 'https://docs.novu.co/platform/integrations/email/activity-tracking/manual-configuration/resend',
   },
 ];
 
@@ -134,7 +134,7 @@ export const mailgunGroupConfigurations: ConfigConfigurationGroup[] = [
     groupType: 'inboundWebhook',
     configurations: mailgunConfigurations,
     enabler: 'inboundWebhookEnabled',
-    setupWebhookUrlGuide: 'https://documentation.mailgun.com/docs/mailgun/user-manual/events/webhooks',
+    setupWebhookUrlGuide: 'https://docs.novu.co/platform/integrations/email/activity-tracking/manual-configuration/mailgun',
   },
 ];
 
@@ -144,7 +144,7 @@ export const sesGroupConfigurations: ConfigConfigurationGroup[] = [
     configurations: sesConfigurations,
     enabler: 'inboundWebhookEnabled',
     setupWebhookUrlGuide:
-      'https://www.twilio.com/docs/sendgrid/for-developers/tracking-events/getting-started-event-webhook#add-an-event-webhook',
+      'https://docs.novu.co/platform/integrations/email/activity-tracking/manual-configuration/ses',
   },
 ];
 


### PR DESCRIPTION
Fix incorrect documentation links for Email Activity Tracking manual setup in the integration store sidebar.

The previous links were outdated and pointed to incorrect documentation sections. This PR updates both the descriptive links and the "View Guide" button links for SendGrid, Resend, Mailgun, and SES to the new, correct manual configuration guides.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1759848598494609?thread_ts=1759848598.494609&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-6539d763-d31c-4f34-83e5-f0c7c2ae3d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6539d763-d31c-4f34-83e5-f0c7c2ae3d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

