### PR TITLE
style(dashboard): Remove beta from analytics page

### DIFF
--- a/apps/dashboard/src/components/side-navigation/side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/side-navigation.tsx
@@ -182,12 +182,7 @@ export const SideNavigation = () => {
                       to={buildRoute(ROUTES.ANALYTICS, { environmentSlug: currentEnvironment?.slug ?? '' })}
                     >
                       <RiLineChartLine className="size-4" />
-                      <span>
-                        Analytics{' '}
-                        <Badge variant="lighter" className="text-xs">
-                          BETA
-                        </Badge>
-                      </span>
+                      <span>Analytics</span>
                     </NavigationLink>
                   </Protect>
                 )}

--- a/apps/dashboard/src/pages/analytics.tsx
+++ b/apps/dashboard/src/pages/analytics.tsx
@@ -101,9 +101,6 @@ export function AnalyticsPage() {
         headerStartItems={
           <h1 className="text-foreground-950 flex items-center gap-1">
             <span>Analytics</span>
-            <Badge variant="lighter" className="text-xs">
-              BETA
-            </Badge>
             {isDevMockMode && (
               <Badge variant="filled" color="orange" className="text-xs">
                 DEV MOCK DATA


### PR DESCRIPTION
### What changed? Why was the change needed?

Removed the "Beta" badge from the Analytics page side navigation link and the Analytics page header title. This change was requested to reflect that the Analytics feature is no longer considered in beta.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1759920460412959?thread_ts=1759920460.412959&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-d5c05406-7945-456e-ad2f-4c21ff1bf131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5c05406-7945-456e-ad2f-4c21ff1bf131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

