### PR TITLE
chore(root): bumps checkout action from v4 to v5

### DIFF
--- a/.github/actions/checkout-submodules/action.yml
+++ b/.github/actions/checkout-submodules/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Checkout submodule
       if: ${{ inputs.enabled == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         token: ${{ inputs.submodule_token }}
         repository: novuhq/packages-enterprise

--- a/.github/workflows/check-only.yml
+++ b/.github/workflows/check-only.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check for .only flags
         run: |

--- a/.github/workflows/check-submodule-sync-merge.yaml
+++ b/.github/workflows/check-submodule-sync-merge.yaml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/check-submodule-sync-pr.yaml
+++ b/.github/workflows/check-submodule-sync-pr.yaml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout main repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/community-label.yml
+++ b/.github/workflows/community-label.yml
@@ -15,7 +15,7 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: useblacksmith/setup-node@v5
         with:

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
         uses: pnpm/action-setup@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -230,7 +230,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0
@@ -341,7 +341,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get NPM Version
         id: package-version

--- a/.github/workflows/deployment-summary.yml
+++ b/.github/workflows/deployment-summary.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dev-deploy-inbound-mail.yml
+++ b/.github/workflows/dev-deploy-inbound-mail.yml
@@ -47,7 +47,7 @@ jobs:
         name: ['novu/inbound-mail-ee']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-project
 
       - name: Set Up Docker Buildx

--- a/.github/workflows/issue-label.yml
+++ b/.github/workflows/issue-label.yml
@@ -13,7 +13,7 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/jarvis.yml
+++ b/.github/workflows/jarvis.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: get-comment-body
         run: |
           ls -la

--- a/.github/workflows/manual-post-release.yml
+++ b/.github/workflows/manual-post-release.yml
@@ -34,7 +34,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/milestone-assign.yml
+++ b/.github/workflows/milestone-assign.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: useblacksmith/setup-node@v5
         with:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -17,7 +17,7 @@ jobs:
     environment: Linting
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
 
@@ -26,7 +26,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: Linting
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run Spell Check
         uses: streetsidesoftware/cspell-action@v6
         with:
@@ -40,7 +40,7 @@ jobs:
     environment: Linting
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Find flags
         uses: launchdarkly/find-code-references-in-pull-request@v2
@@ -81,7 +81,7 @@ jobs:
           else
             echo "branch=main" >> $GITHUB_OUTPUT
           fi
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Fetch enough history to find the merge base between base and head
           # This is typically much faster than fetch-depth: 0
@@ -133,7 +133,7 @@ jobs:
     timeout-minutes: 80
     steps:
       - run: echo '${{ needs.get-affected.outputs.test-providers }}'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-project
         with:
           slim: 'true'
@@ -158,7 +158,7 @@ jobs:
       - name: Affected packages
         run: echo '${{ needs.get-affected.outputs.test-packages }}'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-project
         with:
@@ -189,7 +189,7 @@ jobs:
     steps:
       - name: Affected libs
         run: echo '${{ needs.get-affected.outputs.test-libs }}'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-project
 
@@ -216,7 +216,7 @@ jobs:
       id-token: write
     steps:
       - run: echo ${{ matrix.projectName }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout with submodules
         with:
           submodules: true
@@ -254,7 +254,7 @@ jobs:
       deployments: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-project
       - uses: ./.github/actions/setup-redis-cluster
       - uses: ./.github/actions/run-api

--- a/.github/workflows/on-push-trigger.yml
+++ b/.github/workflows/on-push-trigger.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Trigger Deploy Workflow via GitHub CLI
         env:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,7 +11,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: PR Labels
         uses: actions/labeler@v4

--- a/.github/workflows/prepare-cloud-release.yaml
+++ b/.github/workflows/prepare-cloud-release.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/prepare-enterprise-self-hosted-release.yml
+++ b/.github/workflows/prepare-enterprise-self-hosted-release.yml
@@ -99,7 +99,7 @@ jobs:
         name: ${{ fromJson(needs.setup_matrix.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/prepare-self-hosted-release.yml
+++ b/.github/workflows/prepare-self-hosted-release.yml
@@ -25,7 +25,7 @@ jobs:
         name: ['novu/api', 'novu/worker', 'novu/dashboard', 'novu/webhook', 'novu/ws']
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Variables
         shell: bash

--- a/.github/workflows/preview-packages.yml
+++ b/.github/workflows/preview-packages.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         name: ['novu/inbound-mail-ee', 'novu/inbound-mail']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-project
 
       - name: build api

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -34,7 +34,7 @@ jobs:
       pr_number: ${{ !github.event.inputs.nightly && steps.create-pr.outputs.pull-request-number || '' }}
       pr_url: ${{ !github.event.inputs.nightly && steps.create-pr.outputs.pull-request-url || '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/reusable-api-e2e.yml
+++ b/.github/workflows/reusable-api-e2e.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout with submodules
         if: ${{ inputs.ee }}
         with:
@@ -32,7 +32,7 @@ jobs:
           token: ${{ secrets.SUBMODULES_TOKEN }}
 
       # Else checkout without submodules if the token is not provided
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout
         if: ${{ !inputs.ee }}
 

--- a/.github/workflows/reusable-dashboard-deploy.yml
+++ b/.github/workflows/reusable-dashboard-deploy.yml
@@ -42,7 +42,7 @@ jobs:
       deployments: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout with submodules
         with:
           submodules: true

--- a/.github/workflows/reusable-dashboard-e2e.yml
+++ b/.github/workflows/reusable-dashboard-e2e.yml
@@ -53,7 +53,7 @@ jobs:
 
       - id: checkout-enterprise-code
         name: Checkout enterprise code from the submodule
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: steps.determine_run_type.outputs.enterprise_run == 'true'
         with:
           submodules: true
@@ -61,7 +61,7 @@ jobs:
 
       - id: checkout-community-code
         name: Checkout community code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: steps.determine_run_type.outputs.enterprise_run != 'true'
 
       - uses: ./.github/actions/setup-project
@@ -171,7 +171,7 @@ jobs:
     needs: [e2e_dashboard]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 20.19.0

--- a/.github/workflows/reusable-inbound-mail-e2e.yml
+++ b/.github/workflows/reusable-inbound-mail-e2e.yml
@@ -37,13 +37,13 @@ jobs:
              echo "has_token=false" >> $GITHUB_OUTPUT
           fi
       # checkout with submodules if token is provided
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: steps.setup.outputs.has_token == 'true'
         with:
           submodules: ${{ inputs.ee }}
           token: ${{ secrets.SUBMODULES_TOKEN }}
       # else checkout without submodules if the token is not provided
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: steps.setup.outputs.has_token != 'true'
       - uses: ./.github/actions/setup-project
       - uses: ./.github/actions/setup-redis-cluster

--- a/.github/workflows/reusable-web-deploy.yml
+++ b/.github/workflows/reusable-web-deploy.yml
@@ -69,7 +69,7 @@ jobs:
       deployments: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         name: Checkout with submodules
         with:
           submodules: true

--- a/.github/workflows/reusable-web-e2e.yml
+++ b/.github/workflows/reusable-web-e2e.yml
@@ -53,7 +53,7 @@ jobs:
 
       - id: checkout-enterprise-code
         name: Checkout enterprise code from the submodule
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: steps.determine_run_type.outputs.enterprise_run == 'true'
         with:
           submodules: true
@@ -61,7 +61,7 @@ jobs:
 
       - id: checkout-community-code
         name: Checkout community code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         if: steps.determine_run_type.outputs.enterprise_run != 'true'
 
       - uses: ./.github/actions/setup-project
@@ -126,7 +126,7 @@ jobs:
     needs: [e2e_web]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 20.19.0

--- a/.github/workflows/reusable-webhook-e2e.yml
+++ b/.github/workflows/reusable-webhook-e2e.yml
@@ -17,7 +17,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-project
 

--- a/.github/workflows/reusable-worker-e2e.yml
+++ b/.github/workflows/reusable-worker-e2e.yml
@@ -37,13 +37,13 @@ jobs:
              echo "has_token=false" >> $GITHUB_OUTPUT
           fi
       # checkout with submodules if token is provided
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: steps.setup.outputs.has_token == 'true'
         with:
           submodules: ${{ inputs.ee }}
           token: ${{ secrets.SUBMODULES_TOKEN }}
         # else checkout without submodules if the token is not provided
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: steps.setup.outputs.has_token != 'true'
 
       - uses: ./.github/actions/setup-project

--- a/.github/workflows/reusable-ws-e2e.yml
+++ b/.github/workflows/reusable-ws-e2e.yml
@@ -37,13 +37,13 @@ jobs:
              echo "has_token=false" >> $GITHUB_OUTPUT
           fi
       # checkout with submodules if token is provided
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: steps.setup.outputs.has_token == 'true'
         with:
           submodules: ${{ inputs.ee }}
           token: ${{ secrets.SUBMODULES_TOKEN }}
       # else checkout without submodules if the token is not provided
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: steps.setup.outputs.has_token != 'true'
       - uses: ./.github/actions/setup-project
 

--- a/.github/workflows/tag-images.yml
+++ b/.github/workflows/tag-images.yml
@@ -21,7 +21,7 @@ jobs:
       deployments: write
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup kernel for react native, increase watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - uses: useblacksmith/setup-node@v5


### PR DESCRIPTION
### What changed? Why was the change needed?

Bumps Github's checkout action from v4 to [v5](https://github.com/actions/checkout/releases/tag/v5.0.0). 

