### PR TITLE
fix(sdk): add Next.js peer dependency to prevent version conflicts

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -52,6 +52,14 @@
       "types": "./h3.d.ts"
     }
   },
+  "peerDependencies": {
+    "next": ">=13.0.0"
+  },
+  "peerDependenciesMeta": {
+    "next": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@types/express": "^4.17.13",
@@ -61,7 +69,7 @@
     "@vercel/node": "^2.15.9",
     "express": "^4.18.2",
     "jest": "^29.7.0",
-    "next": "^13.5.4",
+    "next": "^15.5.0",
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Problem
Users upgrading to Next.js 15.5 experience build failures when using \`novu.serve()\` due to type incompatibilities between different Next.js versions in the dependency tree.

## Root Cause  
The issue occurs when package managers install multiple versions of Next.js dependencies, creating type conflicts in the framework handlers.

## Solution
Add Next.js as an optional peer dependency to ensure consistent version resolution and prevent type conflicts.

## Testing
- ✅ Builds successfully with Next.js 15.4.x
- ✅ Builds successfully with Next.js 15.5.x  
- ✅ No breaking changes for existing users

Fixes #9227