### PR TITLE
perf(api): bulk unset layoutId from control values

### DIFF
--- a/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.spec.ts
+++ b/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.spec.ts
@@ -91,8 +91,7 @@ describe('DeleteLayoutUseCase', () => {
 
     // Default mocks
     getLayoutUseCaseMock.execute.resolves(mockLayout as any);
-    controlValuesRepositoryMock.findMany.resolves(mockStepControlValues as any);
-    controlValuesRepositoryMock.updateOne.resolves({} as any);
+    controlValuesRepositoryMock.update.resolves({ matched: 2, modified: 2 } as any);
     controlValuesRepositoryMock.delete.resolves({} as any);
     layoutRepositoryMock.deleteLayout.resolves();
   });
@@ -166,41 +165,21 @@ describe('DeleteLayoutUseCase', () => {
 
       await deleteLayoutUseCase.execute(command);
 
-      // Verify findMany was called to get step controls
-      expect(controlValuesRepositoryMock.findMany.calledOnce).to.be.true;
-      expect(controlValuesRepositoryMock.findMany.firstCall.args[0]).to.deep.equal({
+      // Verify update was called to remove layout references
+      expect(controlValuesRepositoryMock.update.calledOnce).to.be.true;
+      expect(controlValuesRepositoryMock.update.firstCall.args[0]).to.deep.equal({
+        level: ControlValuesLevelEnum.STEP_CONTROLS,
         _environmentId: 'env_id',
         _organizationId: 'org_id',
-        level: ControlValuesLevelEnum.STEP_CONTROLS,
         'controls.layoutId': 'layout_id',
       });
-
-      // Verify updateOne was called for each step control
-      expect(controlValuesRepositoryMock.updateOne.callCount).to.equal(2);
-
-      // Check first update call
-      expect(controlValuesRepositoryMock.updateOne.firstCall.args[0]).to.deep.equal({
-        _id: 'step_control_1',
-        _environmentId: 'env_id',
-        _organizationId: 'org_id',
-      });
-      expect(controlValuesRepositoryMock.updateOne.firstCall.args[1]).to.deep.equal({
-        $unset: { 'controls.layoutId': '' },
-      });
-
-      // Check second update call
-      expect(controlValuesRepositoryMock.updateOne.secondCall.args[0]).to.deep.equal({
-        _id: 'step_control_2',
-        _environmentId: 'env_id',
-        _organizationId: 'org_id',
-      });
-      expect(controlValuesRepositoryMock.updateOne.secondCall.args[1]).to.deep.equal({
+      expect(controlValuesRepositoryMock.update.firstCall.args[1]).to.deep.equal({
         $unset: { 'controls.layoutId': '' },
       });
     });
 
     it('should handle case where no step controls reference the layout', async () => {
-      controlValuesRepositoryMock.findMany.resolves([]);
+      controlValuesRepositoryMock.update.resolves({ matched: 0, modified: 0 } as any);
 
       const command = DeleteLayoutCommand.create({
         layoutIdOrInternalId: 'layout_identifier',
@@ -211,11 +190,8 @@ describe('DeleteLayoutUseCase', () => {
 
       await deleteLayoutUseCase.execute(command);
 
-      // Verify findMany was still called
-      expect(controlValuesRepositoryMock.findMany.calledOnce).to.be.true;
-
-      // Verify updateOne was not called since no step controls exist
-      expect(controlValuesRepositoryMock.updateOne.called).to.be.false;
+      // Verify update was still called (even if no documents matched)
+      expect(controlValuesRepositoryMock.update.calledOnce).to.be.true;
 
       // Verify layout was still deleted
       expect(layoutRepositoryMock.deleteLayout.calledOnce).to.be.true;
@@ -262,7 +238,7 @@ describe('DeleteLayoutUseCase', () => {
 
     it('should propagate error from step controls cleanup', async () => {
       const error = new Error('Database error');
-      controlValuesRepositoryMock.findMany.rejects(error);
+      controlValuesRepositoryMock.update.rejects(error);
 
       const command = DeleteLayoutCommand.create({
         layoutIdOrInternalId: 'layout_identifier',
@@ -281,7 +257,7 @@ describe('DeleteLayoutUseCase', () => {
 
     it('should propagate error from step controls update', async () => {
       const error = new Error('Update error');
-      controlValuesRepositoryMock.updateOne.rejects(error);
+      controlValuesRepositoryMock.update.rejects(error);
 
       const command = DeleteLayoutCommand.create({
         layoutIdOrInternalId: 'layout_identifier',
@@ -327,9 +303,8 @@ describe('DeleteLayoutUseCase', () => {
 
       await deleteLayoutUseCase.execute(command);
 
-      // Verify step controls operations were called before layout deletion
-      expect(controlValuesRepositoryMock.findMany.calledBefore(layoutRepositoryMock.deleteLayout)).to.be.true;
-      expect(controlValuesRepositoryMock.updateOne.calledBefore(layoutRepositoryMock.deleteLayout)).to.be.true;
+      // Verify step controls update was called before layout deletion
+      expect(controlValuesRepositoryMock.update.calledBefore(layoutRepositoryMock.deleteLayout)).to.be.true;
     });
   });
 });

--- a/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.ts
+++ b/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.ts
@@ -69,23 +69,15 @@ export class DeleteLayoutUseCase {
     environmentId: string;
     organizationId: string;
   }): Promise<void> {
-    const stepControlValues = await this.controlValuesRepository.findMany({
-      level: ControlValuesLevelEnum.STEP_CONTROLS,
-      _environmentId: environmentId,
-      _organizationId: organizationId,
-      'controls.layoutId': layoutId,
-    });
-
-    for (const controlValue of stepControlValues) {
-      await this.controlValuesRepository.updateOne(
-        {
-          _id: controlValue._id,
-          _environmentId: environmentId,
-          _organizationId: organizationId,
-        },
-        { $unset: { 'controls.layoutId': '' } }
-      );
-    }
+    await this.controlValuesRepository.update(
+      {
+        level: ControlValuesLevelEnum.STEP_CONTROLS,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        'controls.layoutId': layoutId,
+      },
+      { $unset: { 'controls.layoutId': '' } }
+    );
   }
 
   private async deleteTranslationGroup(layout: LayoutResponseDto, command: DeleteLayoutCommand) {


### PR DESCRIPTION
## Summary

A single updateMany call removes all matching layout references at once, eliminating N individual update round-trips when deleting layouts.