### PR TITLE
fix(dashboard): layouts pagination default size

### DIFF
--- a/apps/dashboard/src/components/layouts/hooks/use-layouts-url-state.tsx
+++ b/apps/dashboard/src/components/layouts/hooks/use-layouts-url-state.tsx
@@ -17,7 +17,7 @@ export const defaultLayoutsFilter: LayoutsFilter = {
   orderBy: 'createdAt',
   orderDirection: DirectionEnum.DESC,
   offset: 0,
-  limit: 12,
+  limit: 10,
 };
 
 export type LayoutsUrlState = {


### PR DESCRIPTION
### What changed? Why was the change needed?

Changed the default pagination limit for the layouts page from 12 to 10 in `apps/dashboard/src/components/layouts/hooks/use-layouts-url-state.tsx`. This was needed to standardize the layouts page pagination to 10 items per page by default, matching other list pages in the dashboard (e.g., topics, translations, contexts) as per [NV-6780](https://linear.app/NV-6780).

### Screenshots

The layouts page will now display 10 items per page by default, consistent with other list pages.

---
Linear Issue: [NV-6780](https://linear.app/novu/issue/NV-6780/layouts-pagination-has-12-item-size-by-default)

<a href="https://cursor.com/background-agent?bcId=bc-c0413241-9cb7-463c-a80a-7c065e000fa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0413241-9cb7-463c-a80a-7c065e000fa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

