### PR TITLE
fix(api): replace context upsert with findOrCreate fixes NV-6826

### DIFF
--- a/apps/api/src/app/events/e2e/context-events.e2e.ts
+++ b/apps/api/src/app/events/e2e/context-events.e2e.ts
@@ -163,7 +163,7 @@ describe('Context functionality - /v1/events/trigger (POST) #novu-v2', () => {
     expect(regionContext?.key).to.equal('region:us-east-1');
   });
 
-  it('should handle context upsert logic correctly', async () => {
+  it('should handle context find-or-create logic correctly (no updates)', async () => {
     const initialData = { name: 'Acme Corp', plan: 'basic' };
     const context1: ContextPayload = {
       tenant: {
@@ -203,12 +203,13 @@ describe('Context functionality - /v1/events/trigger (POST) #novu-v2', () => {
 
     expect(storedContext?.data).to.deep.equal(initialData);
 
-    // Third trigger with explicit data update
-    const updatedData = { name: 'Acme Corporation', plan: 'enterprise', region: 'us-west' };
+    // Third trigger with different data - should NOT update existing context
+    // this is to prevent accidental updates and overwrites
+    const attemptedUpdateData = { name: 'Acme Corporation', plan: 'enterprise', region: 'us-west' };
     const context3: ContextPayload = {
       tenant: {
         id: 'org-acme',
-        data: updatedData,
+        data: attemptedUpdateData,
       },
     };
 
@@ -216,7 +217,7 @@ describe('Context functionality - /v1/events/trigger (POST) #novu-v2', () => {
 
     await session.waitForJobCompletion(workflow._id);
 
-    // Verify context was updated, not duplicated
+    // Verify context was NOT updated - original data should remain
     const contexts = await contextRepository.find({
       _environmentId: session.environment._id,
       type: 'tenant',
@@ -224,27 +225,7 @@ describe('Context functionality - /v1/events/trigger (POST) #novu-v2', () => {
     });
 
     expect(contexts).to.have.length(1); // Still only one context
-    expect(contexts[0].data).to.deep.equal(updatedData); // Data should be updated
-
-    // Fourth trigger with empty data object (should update to empty)
-    const context4: ContextPayload = {
-      tenant: {
-        id: 'org-acme',
-        data: {},
-      },
-    };
-
-    await sendTrigger(workflow, subscriber.subscriberId, {}, {}, undefined, undefined, context4);
-
-    await session.waitForJobCompletion(workflow._id);
-
-    storedContext = await contextRepository.findOne({
-      _environmentId: session.environment._id,
-      type: 'tenant',
-      id: 'org-acme',
-    });
-
-    expect(storedContext?.data).to.deep.equal({}); // Should be updated to empty object
+    expect(contexts[0].data).to.deep.equal(initialData); // Data should NOT be updated - original data preserved
   });
 
   it('should reject invalid context payload', async () => {

--- a/apps/api/src/app/inbox/usecases/session/session.spec.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.spec.ts
@@ -387,13 +387,13 @@ describe('Session', () => {
       defaultLocale: 'en_US',
     });
     featureFlagsService.getFlag.resolves(true);
-    contextRepository.upsertContextsFromPayload.resolves(mockContexts as any);
+    contextRepository.findOrCreateContextsFromPayload.resolves(mockContexts as any);
 
     const response: SubscriberSessionResponseDto = await session.execute(command);
 
-    expect(contextRepository.upsertContextsFromPayload.calledOnce).to.be.true;
+    expect(contextRepository.findOrCreateContextsFromPayload.calledOnce).to.be.true;
     expect(
-      contextRepository.upsertContextsFromPayload.calledWith(
+      contextRepository.findOrCreateContextsFromPayload.calledWith(
         environment._id,
         environment._organizationId,
         command.requestData.context
@@ -437,7 +437,7 @@ describe('Session', () => {
       defaultLocale: 'en_US',
     });
     featureFlagsService.getFlag.resolves(true);
-    contextRepository.upsertContextsFromPayload.resolves(mockContexts as any);
+    contextRepository.findOrCreateContextsFromPayload.resolves(mockContexts as any);
 
     const validateHmacEncryptionStub = sinon.stub(encryption, 'validateHmacEncryption');
     const validateContextHmacEncryptionStub = sinon.stub(encryption, 'validateContextHmacEncryption');
@@ -492,7 +492,7 @@ describe('Session', () => {
 
     const response: SubscriberSessionResponseDto = await session.execute(command);
 
-    expect(contextRepository.upsertContextsFromPayload.called).to.be.false;
+    expect(contextRepository.findOrCreateContextsFromPayload.called).to.be.false;
 
     expect(response.contextKeys).to.deep.equal([]);
   });

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -420,7 +420,11 @@ export class Session {
       return [];
     }
 
-    const contexts = await this.contextRepository.upsertContextsFromPayload(environmentId, organizationId, context);
+    const contexts = await this.contextRepository.findOrCreateContextsFromPayload(
+      environmentId,
+      organizationId,
+      context
+    );
 
     return contexts.map((context) => context.key);
   }

--- a/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
@@ -380,7 +380,7 @@ export class TriggerEvent {
     }
 
     try {
-      const contexts = await this.contextRepository.upsertContextsFromPayload(
+      const contexts = await this.contextRepository.findOrCreateContextsFromPayload(
         command.environmentId,
         command.organizationId,
         command.context

--- a/libs/dal/src/repositories/context/context.repository.ts
+++ b/libs/dal/src/repositories/context/context.repository.ts
@@ -10,7 +10,26 @@ export class ContextRepository extends BaseRepository<ContextDBModel, ContextEnt
     super(Context, ContextEntity);
   }
 
-  async upsertContext(
+  async findOrCreateContextsFromPayload(
+    environmentId: string,
+    organizationId: string,
+    contextPayload: ContextPayload
+  ): Promise<ContextEntity[]> {
+    const findOrCreatePromises = Object.entries(contextPayload).map(([type, value]) => {
+      if (!value) return null;
+
+      const { id, data } =
+        typeof value === 'string' ? { id: value, data: undefined } : { id: value.id, data: value.data };
+
+      return this.findOrCreateContext(environmentId, organizationId, type, id, data);
+    });
+
+    const validPromises = findOrCreatePromises.filter((promise): promise is Promise<ContextEntity> => promise !== null);
+
+    return Promise.all(validPromises);
+  }
+
+  async findOrCreateContext(
     environmentId: string,
     organizationId: string,
     type: ContextType,
@@ -24,55 +43,22 @@ export class ContextRepository extends BaseRepository<ContextDBModel, ContextEnt
       type,
     };
 
-    // Try to find existing context first
     const existingContext = await this.findOne(query);
 
     if (existingContext) {
-      // Update path: context already exists
-      const updateFields: Partial<ContextEntity> = {};
-
-      // Only update data if explicitly provided (even if empty object or null)
-      if (data !== undefined) {
-        updateFields.data = data;
-      }
-
-      const updatedContext = await this.findOneAndUpdate(query, { $set: updateFields }, { new: true });
-
-      // biome-ignore lint/style/noNonNullAssertion: we know it exists since we found it
-      return updatedContext!;
-    } else {
-      // Create path: context doesn't exist, create new one
-      const newContext: FilterQuery<ContextDBModel> & EnforceEnvOrOrgIds = {
-        _environmentId: environmentId,
-        _organizationId: organizationId,
-        id,
-        type,
-        key: createContextKey(type, id),
-        data: data || {},
-      };
-
-      return this.create(newContext);
+      return existingContext;
     }
-  }
 
-  async upsertContextsFromPayload(
-    environmentId: string,
-    organizationId: string,
-    contextPayload: ContextPayload
-  ): Promise<ContextEntity[]> {
-    const upsertPromises = Object.entries(contextPayload).map(([type, value]) => {
-      if (!value) return null; // Skip undefined values
+    const newContext: FilterQuery<ContextDBModel> & EnforceEnvOrOrgIds = {
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+      id,
+      type,
+      key: createContextKey(type, id),
+      data: data || {},
+    };
 
-      const { id, data } =
-        typeof value === 'string' ? { id: value, data: undefined } : { id: value.id, data: value.data };
-
-      return this.upsertContext(environmentId, organizationId, type, id, data);
-    });
-
-    // Filter out null promises and execute in parallel
-    const validPromises = upsertPromises.filter((promise): promise is Promise<ContextEntity> => promise !== null);
-
-    return Promise.all(validPromises);
+    return this.create(newContext);
   }
 
   async findByKeys(environmentId: string, organizationId: string, contextKeys: string[]): Promise<ContextEntity[]> {


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified context event handling to use find-or-create semantics instead of update-on-duplicate, preventing existing context data from being inadvertently modified when the same event is triggered multiple times. This ensures data integrity across repeated event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->