### PR TITLE
fix(api-service): resolve repeat block image src repeating first item in maily renderer

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -659,7 +659,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
     index: number
   ): Array<MailyJSONContent | MailyJSONMarks> {
     return nodes.map((node) => {
-      const processedNode = { ...node };
+      const processedNode = structuredClone(node);
 
       if (isVariableNode(processedNode)) {
         this.processVariableNodeTypes(processedNode);


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR fixes the image not displaying properly

The change was to create proper copy of node

### Screenshots

Before
<img width="1366" height="768" alt="before" src="https://github.com/user-attachments/assets/178ba2ae-9d63-47c8-96ce-e12788763c49" />

After
<img width="1366" height="768" alt="after" src="https://github.com/user-attachments/assets/1ea8131a-1000-4ff7-abff-4bfb0bb5d437" />

Fixes #9140