### PR TITLE
fix(api): import context pagination DTO from within the module 

### DIFF
--- a/apps/api/src/app/contexts/dtos/cursor-pagination-query.dto.ts
+++ b/apps/api/src/app/contexts/dtos/cursor-pagination-query.dto.ts
@@ -1,0 +1,55 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { DirectionEnum } from '@novu/shared';
+import { Transform, Type } from 'class-transformer';
+import { IsOptional, IsString } from 'class-validator';
+
+export class CursorPaginationQueryDto<T, K extends keyof T> {
+  @ApiProperty({
+    description: 'Cursor for pagination indicating the starting point after which to fetch results.',
+    type: String,
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  after?: string;
+
+  @ApiProperty({
+    description: 'Cursor for pagination indicating the ending point before which to fetch results.',
+    type: String,
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  before?: string;
+
+  @ApiPropertyOptional({
+    description: 'Limit the number of items to return',
+    type: Number,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  limit?: number;
+
+  @ApiPropertyOptional({
+    description: 'Direction of sorting',
+    enum: DirectionEnum,
+  })
+  @IsOptional()
+  orderDirection?: DirectionEnum;
+
+  @ApiPropertyOptional({
+    description: 'Field to order by',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  orderBy?: K;
+
+  @ApiPropertyOptional({
+    description: 'Include cursor item in response',
+    type: Boolean,
+  })
+  @Transform(({ value }) => value === 'true')
+  @IsOptional()
+  includeCursor?: boolean;
+}

--- a/apps/api/src/app/contexts/dtos/index.ts
+++ b/apps/api/src/app/contexts/dtos/index.ts
@@ -1,4 +1,5 @@
 export * from './create-context-request.dto';
+export * from './cursor-pagination-query.dto';
 export * from './dto.mapper';
 export * from './get-context-response.dto';
 export * from './list-contexts-query.dto';

--- a/apps/api/src/app/contexts/dtos/list-contexts-query.dto.ts
+++ b/apps/api/src/app/contexts/dtos/list-contexts-query.dto.ts
@@ -1,7 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ContextType } from '@novu/shared';
 import { IsOptional, IsString } from 'class-validator';
-import { CursorPaginationQueryDto } from '../../subscribers-v2/dtos/cursor-pagination-query.dto';
+import { CursorPaginationQueryDto } from './cursor-pagination-query.dto';
 import { GetContextResponseDto } from './get-context-response.dto';
 
 export class ListContextsQueryDto extends CursorPaginationQueryDto<GetContextResponseDto, 'createdAt' | 'updatedAt'> {


### PR DESCRIPTION
This pull request introduces a new generic cursor-based pagination DTO and refactors its usage within the contexts module to improve code organization and reusability. The most important changes are grouped below:

### Pagination DTO introduction and usage

* Added a new generic `CursorPaginationQueryDto` class in `apps/api/src/app/contexts/dtos/cursor-pagination-query.dto.ts` to standardize cursor-based pagination parameters, including support for sorting, limiting, and cursor inclusion.
* Refactored `ListContextsQueryDto` to extend the new `CursorPaginationQueryDto` from the local contexts DTOs directory rather than the previous location, ensuring proper encapsulation and module boundaries.

### Exports and module organization

* Exported the new `CursorPaginationQueryDto` from the contexts DTOs index file, making it available for use throughout the module.