### PR TITLE
fix(dashboard): remove the error tooltip when the pill widget gets destroyed

### DIFF
--- a/apps/dashboard/src/components/primitives/translation-plugin/pill-widget.ts
+++ b/apps/dashboard/src/components/primitives/translation-plugin/pill-widget.ts
@@ -150,10 +150,7 @@ export class TranslationPillWidget extends WidgetType {
         this.tooltipElement.setAttribute('data-state', 'closed');
 
         setTimeout(() => {
-          if (this.tooltipElement) {
-            document.body.removeChild(this.tooltipElement);
-            this.tooltipElement = null;
-          }
+          this.destroyTooltip();
         }, 150);
       }
 
@@ -208,14 +205,17 @@ export class TranslationPillWidget extends WidgetType {
     return tooltip;
   }
 
-  destroy(dom: HTMLElement) {
-    dom.removeEventListener('mousedown', this.clickHandler);
-
-    // Clean up tooltip if it exists
+  destroyTooltip() {
     if (this.tooltipElement) {
+      this.tooltipElement.replaceChildren();
       document.body.removeChild(this.tooltipElement);
       this.tooltipElement = null;
     }
+  }
+
+  destroy(dom: HTMLElement) {
+    this.destroyTooltip();
+    dom.removeEventListener('mousedown', this.clickHandler);
   }
 
   ignoreEvent() {

--- a/apps/dashboard/src/components/primitives/variable-plugin/variable-pill-widget.ts
+++ b/apps/dashboard/src/components/primitives/variable-plugin/variable-pill-widget.ts
@@ -94,7 +94,7 @@ export class VariablePillWidget extends WidgetType {
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
 
-      // @ts-ignore
+      // @ts-expect-error
       '-webkit-font-smoothing': 'antialiased',
       '-moz-osx-font-smoothing': 'grayscale',
     };
@@ -112,7 +112,7 @@ export class VariablePillWidget extends WidgetType {
       lineHeight: '1.2',
       color: 'hsl(var(--text-soft))',
 
-      // @ts-ignore
+      // @ts-expect-error
       '-webkit-font-smoothing': 'antialiased',
       '-moz-osx-font-smoothing': 'grayscale',
     };
@@ -189,10 +189,7 @@ export class VariablePillWidget extends WidgetType {
         this.tooltipElement.setAttribute('data-state', 'closed');
 
         setTimeout(() => {
-          if (this.tooltipElement) {
-            document.body.removeChild(this.tooltipElement);
-            this.tooltipElement = null;
-          }
+          this.destroyTooltip();
         }, 150);
       }
 
@@ -250,10 +247,7 @@ export class VariablePillWidget extends WidgetType {
             this.tooltipElement.setAttribute('data-state', 'closed');
 
             setTimeout(() => {
-              if (this.tooltipElement) {
-                document.body.removeChild(this.tooltipElement);
-                this.tooltipElement = null;
-              }
+              this.destroyTooltip();
             }, 150);
           }
         });
@@ -317,6 +311,14 @@ export class VariablePillWidget extends WidgetType {
     return tooltip;
   }
 
+  destroyTooltip() {
+    if (this.tooltipElement) {
+      this.tooltipElement.replaceChildren();
+      document.body.removeChild(this.tooltipElement);
+      this.tooltipElement = null;
+    }
+  }
+
   getVariableIssues() {
     if (this.isDigestEventsVariable && this.isDigestEventsVariable(this.variableName)) {
       const issues = validateEnhancedDigestFilters(this.filters);
@@ -345,6 +347,7 @@ export class VariablePillWidget extends WidgetType {
    * Removes event listeners to prevent memory leaks.
    */
   destroy(dom: HTMLElement) {
+    this.destroyTooltip();
     dom.removeEventListener('mousedown', this.clickHandler);
   }
 

--- a/apps/dashboard/src/components/primitives/variable-plugin/variable-pill-widget.ts
+++ b/apps/dashboard/src/components/primitives/variable-plugin/variable-pill-widget.ts
@@ -332,7 +332,12 @@ export class VariablePillWidget extends WidgetType {
    * Used by CodeMirror to optimize re-rendering.
    */
   eq(other: VariablePillWidget) {
-    return other.fullVariableName === this.fullVariableName && other.start === this.start && other.end === this.end;
+    return (
+      other.fullVariableName === this.fullVariableName &&
+      other.start === this.start &&
+      other.end === this.end &&
+      other.isNotInSchema === this.isNotInSchema
+    );
   }
 
   /**

--- a/apps/dashboard/src/components/variable/hooks/use-variable-validation.ts
+++ b/apps/dashboard/src/components/variable/hooks/use-variable-validation.ts
@@ -77,5 +77,5 @@ export const useVariableValidation = (
       variableKey,
       variableName: variableName,
     };
-  }, [variableName, aliasFor, isAllowedVariable, getSchemaPropertyByKey]);
+  }, [variableName, aliasFor, isAllowedVariable, getSchemaPropertyByKey, isPayloadSchemaEnabled]);
 };

--- a/apps/dashboard/src/components/variable/hooks/use-variable-validation.ts
+++ b/apps/dashboard/src/components/variable/hooks/use-variable-validation.ts
@@ -77,5 +77,5 @@ export const useVariableValidation = (
       variableKey,
       variableName: variableName,
     };
-  }, [variableName, aliasFor, isAllowedVariable, getSchemaPropertyByKey, isPayloadSchemaEnabled]);
+  }, [variableName, aliasFor, isAllowedVariable, getSchemaPropertyByKey]);
 };


### PR DESCRIPTION
Control Value Input: fixed the issue with the variable pill tooltip still being shown despite the mouse not being hovered over the variable.


### Screenshots

https://github.com/user-attachments/assets/968828c8-428f-4fe7-9295-425946715a51



---

This pull request contains changes generated by Cursor background composer.

<a href="https://cursor.com/background-agent?bcId=bc-faeb8b3f-4a12-49b9-80d5-da9347c8c540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-faeb8b3f-4a12-49b9-80d5-da9347c8c540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


