### PR TITLE
feat(dashboard, application-generic): introduce new regions and regioncontext to launchdarkly fixes NV-6852

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,10 +28,14 @@ on:
         default: staging
         options:
           - staging
-          - staging-apse1
+          - staging-lon
           - production-us
           - production-eu
-          - production-apse1
+          - production-sg
+          - production-au
+          - production-lon
+          - production-jp
+          - production-kr
           - production-us-and-eu
 
       deploy_api:
@@ -89,7 +93,7 @@ jobs:
           if [ "${{ github.event.inputs.environment }}" == "staging" ]; then
             envs+=("\"staging-eu\"")
           fi
-          if [ "${{ github.event.inputs.environment }}" == "staging-apse1" ]; then
+          if [ "${{ github.event.inputs.environment }}" == "staging-lon" ]; then
             envs+=("\"staging-apse1\"")
           fi
           if [ "${{ github.event.inputs.environment }}" == "production-us" ]; then
@@ -98,8 +102,20 @@ jobs:
           if [ "${{ github.event.inputs.environment }}" == "production-eu" ]; then
             envs+=("\"prod-eu\"")
           fi
-          if [ "${{ github.event.inputs.environment }}" == "production-apse1" ]; then
+          if [ "${{ github.event.inputs.environment }}" == "production-sg" ]; then
             envs+=("\"prod-apse1\"")
+          fi
+          if [ "${{ github.event.inputs.environment }}" == "production-au" ]; then
+            envs+=("\"prod-apse2\"")
+          fi
+          if [ "${{ github.event.inputs.environment }}" == "production-lon" ]; then
+            envs+=("\"prod-ew2\"")
+          fi
+          if [ "${{ github.event.inputs.environment }}" == "production-jp" ]; then
+            envs+=("\"prod-apne1\"")
+          fi
+          if [ "${{ github.event.inputs.environment }}" == "production-kr" ]; then
+            envs+=("\"prod-apne2\"")
           fi
           if [ "${{ github.event.inputs.environment }}" == "production-us-and-eu" ]; then
             envs+=("\"prod-us\"")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,12 +28,12 @@ on:
         default: staging
         options:
           - staging
-          - staging-lon
+          - staging-sg
           - production-us
           - production-eu
           - production-sg
           - production-au
-          - production-lon
+          - production-uk
           - production-jp
           - production-kr
           - production-us-and-eu
@@ -93,7 +93,7 @@ jobs:
           if [ "${{ github.event.inputs.environment }}" == "staging" ]; then
             envs+=("\"staging-eu\"")
           fi
-          if [ "${{ github.event.inputs.environment }}" == "staging-lon" ]; then
+          if [ "${{ github.event.inputs.environment }}" == "staging-uk" ]; then
             envs+=("\"staging-apse1\"")
           fi
           if [ "${{ github.event.inputs.environment }}" == "production-us" ]; then
@@ -108,7 +108,7 @@ jobs:
           if [ "${{ github.event.inputs.environment }}" == "production-au" ]; then
             envs+=("\"prod-apse2\"")
           fi
-          if [ "${{ github.event.inputs.environment }}" == "production-lon" ]; then
+          if [ "${{ github.event.inputs.environment }}" == "production-uk" ]; then
             envs+=("\"prod-ew2\"")
           fi
           if [ "${{ github.event.inputs.environment }}" == "production-jp" ]; then

--- a/apps/dashboard/src/context/feature-flags-provider.tsx
+++ b/apps/dashboard/src/context/feature-flags-provider.tsx
@@ -1,6 +1,16 @@
+import { IS_ENTERPRISE, IS_SELF_HOSTED, LAUNCH_DARKLY_CLIENT_SIDE_ID } from '@/config';
 import { AsyncProviderConfig, asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
 import { lazy, Suspense } from 'react';
-import { IS_ENTERPRISE, IS_SELF_HOSTED, LAUNCH_DARKLY_CLIENT_SIDE_ID } from '@/config';
+import { getRegionConfig } from './region/region-config';
+import { detectRegionFromURL } from './region/region-utils';
+
+function getAwsRegion(): string {
+  const currentRegion = detectRegionFromURL();
+  const regionConfig = getRegionConfig(currentRegion);
+  return regionConfig?.awsRegion || '';
+}
+
+const awsRegion = getAwsRegion();
 
 const LD_CONFIG: AsyncProviderConfig = {
   clientSideID: LAUNCH_DARKLY_CLIENT_SIDE_ID,
@@ -8,8 +18,14 @@ const LD_CONFIG: AsyncProviderConfig = {
     useCamelCaseFlagKeys: false,
   },
   context: {
-    kind: 'user',
-    anonymous: true,
+    kind: 'multi',
+    user: {
+      anonymous: true,
+    },
+    region: {
+      key: awsRegion || 'unknown',
+      awsRegion: awsRegion,
+    },
   },
   options: {
     bootstrap: 'localStorage',

--- a/apps/dashboard/src/context/identity-provider.tsx
+++ b/apps/dashboard/src/context/identity-provider.tsx
@@ -2,12 +2,15 @@ import { setUser as sentrySetUser, setTags as setSentryTags } from '@sentry/reac
 import { useLDClient } from 'launchdarkly-react-client-sdk';
 import { useEffect, useRef } from 'react';
 import { useAuth } from './auth/hooks';
+import { getRegionConfig } from './region/region-config';
+import { useRegion } from './region/region-context';
 import { useSegment } from './segment/hooks';
 
 export function IdentityProvider({ children }: { children: React.ReactNode }) {
   const ldClient = useLDClient();
   const segment = useSegment();
   const { currentUser, currentOrganization } = useAuth();
+  const { selectedRegion } = useRegion();
   const hasIdentifiedUser = useRef(false);
   const hasIdentifiedOrg = useRef(false);
 
@@ -26,30 +29,37 @@ export function IdentityProvider({ children }: { children: React.ReactNode }) {
   }, [ldClient, currentUser]);
 
   useEffect(() => {
-    if (!currentOrganization || !currentUser || hasIdentifiedOrg.current) return;
+    if (!currentOrganization || !currentUser) return;
 
     const hasExternalId = currentUser._id;
     const hasOrganization = currentOrganization._id;
     const shouldMonitor = hasExternalId && hasOrganization;
 
     if (shouldMonitor) {
-      segment.identify(currentUser);
+      if (!hasIdentifiedOrg.current) {
+        segment.identify(currentUser);
 
-      sentrySetUser({
-        email: currentUser.email ?? '',
-        username: `${currentUser.firstName} ${currentUser.lastName}`,
-        id: currentUser._id,
-      });
+        sentrySetUser({
+          email: currentUser.email ?? '',
+          username: `${currentUser.firstName} ${currentUser.lastName}`,
+          id: currentUser._id,
+        });
 
-      setSentryTags({
-        'user.createdAt': currentUser.createdAt,
-        'organization.id': currentOrganization._id,
-        'organization.name': currentOrganization.name,
-        'organization.tier': currentOrganization.apiServiceLevel,
-        'organization.createdAt': currentOrganization.createdAt,
-      });
+        setSentryTags({
+          'user.createdAt': currentUser.createdAt,
+          'organization.id': currentOrganization._id,
+          'organization.name': currentOrganization.name,
+          'organization.tier': currentOrganization.apiServiceLevel,
+          'organization.createdAt': currentOrganization.createdAt,
+        });
+
+        hasIdentifiedOrg.current = true;
+      }
 
       if (ldClient) {
+        const regionConfig = getRegionConfig(selectedRegion);
+        const awsRegion = regionConfig?.awsRegion || '';
+
         ldClient.identify({
           kind: 'multi',
           organization: {
@@ -64,14 +74,16 @@ export function IdentityProvider({ children }: { children: React.ReactNode }) {
             lastName: currentUser.lastName,
             email: currentUser.email,
           },
+          region: {
+            key: awsRegion || 'unknown',
+            awsRegion: awsRegion,
+          },
         });
       }
     } else {
       sentrySetUser(null);
     }
-
-    hasIdentifiedOrg.current = true;
-  }, [ldClient, currentOrganization, currentUser, segment]);
+  }, [ldClient, currentOrganization, currentUser, segment, selectedRegion]);
 
   return <>{children}</>;
 }

--- a/apps/dashboard/src/routes/root.tsx
+++ b/apps/dashboard/src/routes/root.tsx
@@ -67,8 +67,8 @@ const RootRouteInternal = () => {
         <ClerkProvider>
           <SegmentProvider>
             <AuthProvider>
-              <IdentityProvider>
-                <RegionProvider>
+              <RegionProvider>
+                <IdentityProvider>
                   <HelmetProvider>
                     <TooltipProvider delayDuration={100}>
                       <EscapeKeyManagerProvider>
@@ -76,8 +76,8 @@ const RootRouteInternal = () => {
                       </EscapeKeyManagerProvider>
                     </TooltipProvider>
                   </HelmetProvider>
-                </RegionProvider>
-              </IdentityProvider>
+                </IdentityProvider>
+              </RegionProvider>
             </AuthProvider>
           </SegmentProvider>
         </ClerkProvider>

--- a/libs/application-generic/src/services/feature-flags/launch-darkly.service.ts
+++ b/libs/application-generic/src/services/feature-flags/launch-darkly.service.ts
@@ -69,6 +69,14 @@ export class LaunchDarklyFeatureFlagsService implements IFeatureFlagsService {
       };
     }
 
+    const region = process.env.NOVU_REGION;
+    if (region) {
+      mappedContext.region = {
+        key: region,
+        awsRegion: region,
+      };
+    }
+
     /*
      * LaunchDarkly requires at least one context kind in multi-kind contexts
      * Add a fallback global context to prevent "A multi-kind context must contain at least one kind" error


### PR DESCRIPTION
This pull request introduces significant improvements to how regional context is handled for feature flagging and deployment, particularly with LaunchDarkly and AWS regions. The changes ensure that region information is consistently passed through both the frontend and backend, and expand deployment environment support to additional AWS regions.

Key changes include:

**Feature flag context improvements:**

* The LaunchDarkly context in `feature-flags-provider.tsx` now includes a `region` object, with `awsRegion` dynamically detected from the URL and region config, and the context kind switched to `'multi'` for better multi-dimensional targeting.
* In `identity-provider.tsx`, user and organization identification for LaunchDarkly now includes the current region, using `selectedRegion` from context and `getRegionConfig`, ensuring LaunchDarkly receives accurate region data on user/org identification. [[1]](diffhunk://#diff-a069f090f9ec44aa937d778c11f5c0ebcb40d6c0cb54e93fa9b422aeed9a17beR5-R13) [[2]](diffhunk://#diff-a069f090f9ec44aa937d778c11f5c0ebcb40d6c0cb54e93fa9b422aeed9a17beL29-R39) [[3]](diffhunk://#diff-a069f090f9ec44aa937d778c11f5c0ebcb40d6c0cb54e93fa9b422aeed9a17beR56-R62) [[4]](diffhunk://#diff-a069f090f9ec44aa937d778c11f5c0ebcb40d6c0cb54e93fa9b422aeed9a17beR77-R86)
* The LaunchDarkly service on the backend (`launch-darkly.service.ts`) now adds a `region` context if `NOVU_REGION` is set in the environment, aligning backend and frontend context structure.

**Deployment workflow enhancements:**

* The GitHub Actions deployment workflow (`deploy.yml`) adds support for new AWS regions—London, Singapore, Australia, Japan, and Korea—across both staging and production, and updates environment mappings accordingly. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L31-R38) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L92-R96) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L101-R119)

**Provider context composition fix:**

* The provider order in `root.tsx` was corrected so that `IdentityProvider` is now nested inside `RegionProvider`, ensuring region context is available when identifying users and organizations.