### PR TITLE
fix(dashboard): Add security header to netlify toml fixes NV-6885

### DIFF
--- a/apps/dashboard/netlify.toml
+++ b/apps/dashboard/netlify.toml
@@ -25,6 +25,7 @@
     X-XSS-Protection = "1; mode=block"
     Referrer-Policy = "no-referrer-when-downgrade"
     X-Content-Type-Options = "nosniff"
+    Content-Security-Policy = "frame-ancestors 'none';"
     Permissions-Policy = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()"
     Strict-Transport-Security = '''
     max-age=63072000;


### PR DESCRIPTION
### What changed? Why was the change needed?

Added `Content-Security-Policy: frame-ancestors 'none';` to `apps/dashboard/netlify.toml`. This change addresses Linear issue NV-6885 (Section 7.1) by preventing clickjacking attacks, instructing browsers to disallow embedding the dashboard application in iframes.

Linear ticket: [NV-6885](https://linear.app/novu/issue/NV-6885/missing-security-headers-section-71)

### Screenshots

N/A (security header change)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

The header is configured via Netlify's `netlify.toml` and applies globally to all routes (`/*`).

</details>

---
Linear Issue: [NV-6885](https://linear.app/novu/issue/NV-6885/missing-security-headers-section-71)

<a href="https://cursor.com/background-agent?bcId=bc-175252e4-a2aa-4fe4-a1e0-74d563b5eac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-175252e4-a2aa-4fe4-a1e0-74d563b5eac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

