### PR TITLE
chore(root): update cspell ignore list

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -770,7 +770,9 @@
     "BLKTM",
     "Novuand",
     "kobalte",
-    "jsonrepair"
+    "jsonrepair",
+    "xoxb",
+    "fanout"
   ],
   "flagWords": [],
   "patterns": [


### PR DESCRIPTION
### What changed? Why was the change needed?

Added "xoxb" and "fanout" to the cspell ignore list in `.cspell.json` to prevent them from being flagged as misspelled words.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ab65091-eaf1-4f47-89c1-1d92106b4c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ab65091-eaf1-4f47-89c1-1d92106b4c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

