### PR TITLE
Implement create subscriber dry run validation

### DIFF
--- a/apps/api/src/app/subscribers-v2/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.ts
@@ -183,6 +183,7 @@ export class SubscribersController {
          * channels: body.channels || [],
          */
         failIfExists,
+        userId: user._id,
       })
     );
 

--- a/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.command.ts
+++ b/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.command.ts
@@ -80,4 +80,8 @@ export class CreateOrUpdateSubscriberCommand extends EnvironmentCommand {
   @IsOptional()
   @IsBoolean()
   failIfExists?: boolean = false;
+
+  @IsOptional()
+  @IsString()
+  userId?: string;
 }

--- a/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.spec.ts
+++ b/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.spec.ts
@@ -1,7 +1,15 @@
 import { Test } from '@nestjs/testing';
-import { SubscriberRepository } from '@novu/dal';
+import { CommunityOrganizationRepository, EnvironmentRepository, SubscriberRepository } from '@novu/dal';
 import { UserSession } from '@novu/testing';
-import { CacheInMemoryProviderService, CacheService, InvalidateCacheService } from '../../services';
+import {
+  AnalyticsService,
+  CacheInMemoryProviderService,
+  CacheService,
+  FeatureFlagsService,
+  InvalidateCacheService,
+} from '../../services';
+import { PinoLogger } from '../../logging';
+import { UpdateSubscriberChannel } from '../subscribers';
 import { UpdateSubscriber } from '../update-subscriber';
 import { CreateOrUpdateSubscriberCommand } from './create-or-update-subscriber.command';
 import { CreateOrUpdateSubscriberUseCase } from './create-or-update-subscriber.usecase';
@@ -32,7 +40,29 @@ describe('Create Subscriber', () => {
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [SubscriberRepository, InvalidateCacheService],
-      providers: [UpdateSubscriber, cacheInMemoryProviderService, cacheService],
+      providers: [
+        CreateOrUpdateSubscriberUseCase,
+        UpdateSubscriber,
+        UpdateSubscriberChannel,
+        AnalyticsService,
+        cacheInMemoryProviderService,
+        cacheService,
+        EnvironmentRepository,
+        CommunityOrganizationRepository,
+        {
+          provide: FeatureFlagsService,
+          useValue: {
+            getFlag: jest.fn().mockResolvedValue(true),
+          },
+        },
+        {
+          provide: PinoLogger,
+          useValue: {
+            setContext: jest.fn(),
+            warn: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     session = new UserSession();

--- a/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.usecase.ts
+++ b/libs/application-generic/src/usecases/create-or-update-subscriber/create-or-update-subscriber.usecase.ts
@@ -1,11 +1,24 @@
-import { ConflictException, Injectable } from '@nestjs/common';
-import { SubscriberEntity, SubscriberRepository } from '@novu/dal';
+import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
+import {
+  CommunityOrganizationRepository,
+  EnvironmentEntity,
+  EnvironmentRepository,
+  OrganizationEntity,
+  SubscriberEntity,
+  SubscriberRepository,
+  UserEntity,
+} from '@novu/dal';
+import { FeatureFlagsKeysEnum, VALID_ID_REGEX } from '@novu/shared';
+import { z } from 'zod';
 import { RetryOnError } from '../../decorators/retry-on-error-decorator';
 import { InstrumentUsecase } from '../../instrumentation';
-import { AnalyticsService, buildSubscriberKey, InvalidateCacheService } from '../../services';
+import { PinoLogger } from '../../logging';
+import { AnalyticsService, buildSubscriberKey, FeatureFlagsService, InvalidateCacheService } from '../../services';
 import { OAuthHandlerEnum, UpdateSubscriberChannel, UpdateSubscriberChannelCommand } from '../subscribers';
 import { UpdateSubscriber, UpdateSubscriberCommand } from '../update-subscriber';
 import { CreateOrUpdateSubscriberCommand } from './create-or-update-subscriber.command';
+
+const subscriberIdSchema = z.string().trim().regex(VALID_ID_REGEX);
 
 @Injectable()
 export class CreateOrUpdateSubscriberUseCase {
@@ -14,8 +27,14 @@ export class CreateOrUpdateSubscriberUseCase {
     private subscriberRepository: SubscriberRepository,
     private updateSubscriberUseCase: UpdateSubscriber,
     private updateSubscriberChannel: UpdateSubscriberChannel,
-    private analyticsService: AnalyticsService
-  ) {}
+    private analyticsService: AnalyticsService,
+    private featureFlagService: FeatureFlagsService,
+    private environmentRepository: EnvironmentRepository,
+    private communityOrganizationRepository: CommunityOrganizationRepository,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   @RetryOnError('MongoServerError', {
     maxRetries: 3,
@@ -23,7 +42,19 @@ export class CreateOrUpdateSubscriberUseCase {
   })
   @InstrumentUsecase()
   async execute(command: CreateOrUpdateSubscriberCommand) {
-    const persistedSubscriber = await this.getExistingSubscriber(command);
+    const [environment, organization, persistedSubscriber] = await Promise.all([
+      this.environmentRepository.findOne({ _id: command.environmentId }),
+      this.communityOrganizationRepository.findOne({ _id: command.organizationId }),
+      this.getExistingSubscriber(command),
+    ]);
+
+    await this.validateItem({
+      itemId: command.subscriberId,
+      environment,
+      organization,
+      userId: command.userId,
+    });
+
     if (command.failIfExists && persistedSubscriber) {
       throw new ConflictException(`Subscriber with id "${command.subscriberId}" already exists`);
     }
@@ -149,5 +180,38 @@ export class CreateOrUpdateSubscriberUseCase {
     _environmentId: string;
   }): Promise<SubscriberEntity | null> {
     return await this.subscriberRepository.findBySubscriberId(_environmentId, subscriberId, false);
+  }
+
+  private async validateItem({
+    itemId,
+    userId,
+    environment,
+    organization,
+  }: {
+    itemId: string;
+    environment?: EnvironmentEntity;
+    organization?: OrganizationEntity;
+    userId?: string;
+  }) {
+    const isDryRun = await this.featureFlagService.getFlag({
+      environment,
+      organization,
+      user: userId ? ({ _id: userId } as UserEntity) : undefined,
+      key: FeatureFlagsKeysEnum.IS_SUBSCRIBER_ID_VALIDATION_DRY_RUN_ENABLED,
+      defaultValue: true,
+    });
+    const result = subscriberIdSchema.safeParse(itemId);
+
+    if (result.success) {
+      return;
+    }
+
+    if (isDryRun) {
+      this.logger.warn(`[Dry run] Invalid subscriberId: ${itemId}`);
+    } else {
+      throw new BadRequestException(
+        `Invalid subscriberId: ${itemId}, only alphanumeric characters, -, _, and . or valid email addresses are allowed`
+      );
+    }
   }
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

Implemented dry run validation logic for subscriber IDs on the `create subscriber` endpoint, mirroring the existing validation in the `patch subscriber` endpoint.

This change addresses the "Business Logic Bypass" issue (NV-6881) by ensuring consistent validation across subscriber creation and updates. The dry run mode allows for identifying invalid subscriber IDs without immediately breaking existing functionality, facilitating a gradual rollout of stricter validation.

Relevant link: [NV-6881](https://linear.app/novu/issue/NV-6881/business-logic-bypass-section-31)

---
Linear Issue: [NV-6881](https://linear.app/novu/issue/NV-6881/business-logic-bypass-section-31)

<a href="https://cursor.com/background-agent?bcId=bc-ea31e9ed-599a-4d4e-8b1f-ad1fc793bce8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ea31e9ed-599a-4d4e-8b1f-ad1fc793bce8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

