### PR TITLE
feat(api): add oauth scopes option to chat url fixes NV-6895

### DIFF
--- a/apps/api/src/app/integrations/dtos/generate-chat-oauth-url.dto.ts
+++ b/apps/api/src/app/integrations/dtos/generate-chat-oauth-url.dto.ts
@@ -1,8 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsValidContextPayload } from '@novu/application-generic';
 import { ContextPayload } from '@novu/shared';
-import { IsDefined, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsDefined, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { ApiContextPayload } from '../../shared/framework/swagger/context-payload.decorator';
+import { SLACK_DEFAULT_OAUTH_SCOPES } from '../usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase';
 
 export class GenerateChatOauthUrlRequestDto {
   @ApiProperty({
@@ -37,4 +38,22 @@ export class GenerateChatOauthUrlRequestDto {
   @IsOptional()
   @IsValidContextPayload({ maxCount: 5 })
   context?: ContextPayload;
+
+  @ApiProperty({
+    type: [String],
+    description: `OAuth scopes to request during authorization. These define the permissions your chat integration will have. If not specified, default scopes will be used: ${SLACK_DEFAULT_OAUTH_SCOPES.join(', ')}.`,
+    example: [
+      'chat:write',
+      'chat:write.public',
+      'channels:read',
+      'groups:read',
+      'users:read',
+      'users:read.email',
+      'incoming-webhook',
+    ],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  scope?: string[];
 }

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -408,7 +408,9 @@ export class IntegrationsController {
   @ApiOperation({
     summary: 'Generate chat OAuth URL',
     description: `Generate an OAuth URL for chat integrations like Slack. 
-    The subscriber will use this URL to authorize the chat integration.`,
+    This URL allows subscribers to authorize the integration, enabling the system to send messages 
+    through their chat workspace. The authorization process creates either a workspace connection 
+    for broader access or an incoming webhook endpoint for direct message delivery.`,
   })
   @ApiResponse(String)
   @ApiExcludeEndpoint()
@@ -430,6 +432,7 @@ export class IntegrationsController {
         integrationIdentifier: body.integrationIdentifier,
         connectionIdentifier: body.connectionIdentifier,
         context: body.context,
+        scope: body.scope,
       })
     );
   }

--- a/apps/api/src/app/integrations/integrations.module.ts
+++ b/apps/api/src/app/integrations/integrations.module.ts
@@ -7,6 +7,7 @@ import {
 } from '@novu/application-generic';
 import {
   ChannelConnectionRepository,
+  ChannelEndpointRepository,
   CommunityOrganizationRepository,
   CommunityUserRepository,
   ContextRepository,
@@ -26,6 +27,7 @@ const PROVIDERS = [ChannelFactory, CompileTemplate, GetNovuProviderCredentials, 
     CommunityOrganizationRepository,
     CommunityUserRepository,
     ChannelConnectionRepository,
+    ChannelEndpointRepository,
     ContextRepository,
     ...PROVIDERS,
   ],

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
@@ -11,10 +11,12 @@ import {
   IntegrationEntity,
   IntegrationRepository,
 } from '@novu/dal';
-import { ChatProviderIdEnum } from '@novu/shared';
+import { ChatProviderIdEnum, ENDPOINT_TYPES } from '@novu/shared';
 import axios from 'axios';
 import { CreateChannelConnectionCommand } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.command';
 import { CreateChannelConnection } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
+import { CreateChannelEndpointCommand } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
+import { CreateChannelEndpoint } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
 import {
   GenerateSlackOauthUrl,
   StateData,
@@ -31,7 +33,8 @@ export class SlackOauthCallback {
     private integrationRepository: IntegrationRepository,
     private environmentRepository: EnvironmentRepository,
     private getNovuProviderCredentials: GetNovuProviderCredentials,
-    private createChannelConnection: CreateChannelConnection
+    private createChannelConnection: CreateChannelConnection,
+    private createChannelEndpoint: CreateChannelEndpoint
   ) {}
 
   async execute(command: SlackOauthCallbackCommand): Promise<ChatOauthCallbackResult> {
@@ -40,29 +43,70 @@ export class SlackOauthCallback {
     const credentials = await this.getIntegrationCredentials(integration);
 
     const authData = await this.exchangeCodeForAuthData(command.providerCode, credentials);
+    const isIncomingWebhook = authData.incoming_webhook;
 
-    await this.createChannelConnection.execute(
-      CreateChannelConnectionCommand.create({
-        identifier: stateData.identifier,
-        organizationId: stateData.organizationId,
-        environmentId: stateData.environmentId,
-        integrationIdentifier: integration.identifier,
-        subscriberId: stateData.subscriberId,
-        context: stateData.context,
-        auth: {
-          accessToken: authData.access_token,
-        },
-        workspace: {
-          id: authData.team.id,
-          name: authData.team.name,
-        },
-      })
-    );
+    if (isIncomingWebhook) {
+      /*
+       * Incoming webhooks are handled differently from workspace connections:
+       *
+       * - Incoming webhook: Creates a stateless endpoint tied to a specific subscriber
+       *   using only the webhook URL. This provides direct message delivery.
+       *
+       * - Workspace connection: Uses access_token for broader workspace access
+       *   and is not tied to a specific subscriber.
+       *
+       * While authData contains both access_token and channel_id, we intentionally
+       * use only the webhook URL to maintain clear separation of concerns.
+       */
+      await this.createIncomingWebhookEndpoint(stateData, integration, authData);
+    } else {
+      await this.createChannelConnection.execute(
+        CreateChannelConnectionCommand.create({
+          identifier: stateData.identifier,
+          organizationId: stateData.organizationId,
+          environmentId: stateData.environmentId,
+          integrationIdentifier: integration.identifier,
+          subscriberId: stateData.subscriberId,
+          context: stateData.context,
+          auth: {
+            accessToken: authData.access_token,
+          },
+          workspace: {
+            id: authData.team.id,
+            name: authData.team.name,
+          },
+        })
+      );
+    }
 
     return {
       type: ResponseTypeEnum.HTML,
       result: this.SCRIPT_CLOSE_TAB,
     };
+  }
+
+  private async createIncomingWebhookEndpoint(
+    stateData: StateData,
+    integration: IntegrationEntity,
+    authData: any
+  ): Promise<void> {
+    if (!stateData.subscriberId) {
+      throw new BadRequestException('subscriberId is required for incoming webhook');
+    }
+
+    await this.createChannelEndpoint.execute(
+      CreateChannelEndpointCommand.create({
+        organizationId: stateData.organizationId,
+        environmentId: stateData.environmentId,
+        context: stateData.context,
+        integrationIdentifier: integration.identifier,
+        subscriberId: stateData.subscriberId,
+        type: ENDPOINT_TYPES.WEBHOOK,
+        endpoint: {
+          url: authData.incoming_webhook.url,
+        },
+      })
+    );
   }
 
   private async getIntegration(stateData: StateData): Promise<IntegrationEntity> {

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-chat-oauth-url.command.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-chat-oauth-url.command.ts
@@ -1,6 +1,6 @@
 import { IsValidContextPayload } from '@novu/application-generic';
 import { ContextPayload } from '@novu/shared';
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class GenerateChatOauthUrlCommand extends EnvironmentCommand {
@@ -19,4 +19,9 @@ export class GenerateChatOauthUrlCommand extends EnvironmentCommand {
   @IsOptional()
   @IsValidContextPayload({ maxCount: 5 })
   readonly context?: ContextPayload;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  readonly scope?: string[];
 }

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-chat-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-chat-oauth-url.usecase.ts
@@ -26,6 +26,7 @@ export class GenerateChatOauthUrl {
             subscriberId: command.subscriberId,
             integration,
             context: command.context,
+            scope: command.scope,
           })
         );
 

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.command.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.command.ts
@@ -1,7 +1,7 @@
 import { IsValidContextPayload } from '@novu/application-generic';
 import { IntegrationEntity } from '@novu/dal';
 import { ContextPayload } from '@novu/shared';
-import { IsOptional, IsString } from 'class-validator';
+import { IsArray, IsOptional, IsString } from 'class-validator';
 import { EnvironmentCommand } from '../../../../shared/commands/project.command';
 
 export class GenerateSlackOauthUrlCommand extends EnvironmentCommand {
@@ -18,4 +18,9 @@ export class GenerateSlackOauthUrlCommand extends EnvironmentCommand {
   @IsOptional()
   @IsValidContextPayload({ maxCount: 5 })
   context?: ContextPayload;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  readonly scope?: string[];
 }

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
@@ -16,18 +16,18 @@ export type StateData = {
   timestamp: number;
 };
 
+export const SLACK_DEFAULT_OAUTH_SCOPES = [
+  'chat:write',
+  'chat:write.public',
+  'channels:read',
+  'groups:read',
+  'users:read',
+  'users:read.email',
+] as const;
+
 @Injectable()
 export class GenerateSlackOauthUrl {
   private readonly SLACK_OAUTH_URL = 'https://slack.com/oauth/v2/authorize?';
-
-  private readonly SLACK_OAUTH_SCOPES = [
-    'chat:write',
-    'chat:write.public',
-    'channels:read',
-    'groups:read',
-    'users:read',
-    'users:read.email',
-  ] as const;
 
   constructor(
     private environmentRepository: EnvironmentRepository,
@@ -47,11 +47,17 @@ export class GenerateSlackOauthUrl {
       command.connectionIdentifier
     );
 
-    return this.getOAuthUrl(clientId!, secureState);
+    return this.getOAuthUrl(clientId!, secureState, command.scope);
   }
 
   private validateSubscriberIdOrContext(command: GenerateSlackOauthUrlCommand): void {
-    const { subscriberId, context } = command;
+    const { subscriberId, context, scope } = command;
+
+    if (scope?.includes('incoming-webhook')) {
+      if (!subscriberId) {
+        throw new BadRequestException('subscriberId is required for incoming webhook');
+      }
+    }
 
     if (!subscriberId && !context) {
       throw new BadRequestException('Either subscriberId or context must be provided');
@@ -76,11 +82,11 @@ export class GenerateSlackOauthUrl {
     return;
   }
 
-  private async getOAuthUrl(clientId: string, secureState: string): Promise<string> {
+  private async getOAuthUrl(clientId: string, secureState: string, scope?: string[]): Promise<string> {
     const oauthParams = new URLSearchParams({
       state: secureState,
       client_id: clientId,
-      scope: this.SLACK_OAUTH_SCOPES.join(','),
+      scope: scope?.join(',') ?? SLACK_DEFAULT_OAUTH_SCOPES.join(','),
       redirect_uri: GenerateSlackOauthUrl.buildRedirectUri(),
     });
 

--- a/apps/api/src/app/integrations/usecases/index.ts
+++ b/apps/api/src/app/integrations/usecases/index.ts
@@ -2,11 +2,11 @@ import {
   CalculateLimitNovuIntegration,
   ConditionsFilter,
   GetDecryptedIntegrations,
-  GetNovuProviderCredentials,
   NormalizeVariables,
   SelectIntegration,
 } from '@novu/application-generic';
 import { CreateChannelConnection } from '../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
+import { CreateChannelEndpoint } from '../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
 import { AutoConfigureIntegration } from './auto-configure-integration/auto-configure-integration.usecase';
 import { ChatOauthCallback } from './chat-oauth-callback/chat-oauth-callback.usecase';
 import { SlackOauthCallback } from './chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase';
@@ -47,4 +47,5 @@ export const USE_CASES = [
   SlackOauthCallback,
   ChatOauthCallback,
   CreateChannelConnection,
+  CreateChannelEndpoint,
 ];


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OAuth scope customization for chat integrations, allowing fine-tuned permission control with sensible defaults.
  * Enabled webhook-based endpoints for incoming OAuth callbacks as an alternative to standard channel connections.

* **Documentation**
  * Expanded API documentation for OAuth authorization, clarifying workspace connection and incoming webhook configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->