### PR TITLE
feat(api): chat oauth - redirect uri & deprecate legacy fixes NV-6890

### DIFF
--- a/apps/api/src/app/channel-endpoints/channel-endpoints.module.ts
+++ b/apps/api/src/app/channel-endpoints/channel-endpoints.module.ts
@@ -37,6 +37,6 @@ const DAL_MODELS = [
 @Module({
   controllers: [ChannelEndpointsController],
   providers: [...USE_CASES, ...DAL_MODELS, featureFlagsService],
-  exports: [...USE_CASES],
+  exports: [...USE_CASES, ...DAL_MODELS],
 })
 export class ChannelEndpointsModule {}

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
@@ -79,6 +79,10 @@ export class SlackOauthCallback {
       );
     }
 
+    if (credentials.redirectUrl) {
+      return { type: ResponseTypeEnum.URL, result: credentials.redirectUrl };
+    }
+
     return {
       type: ResponseTypeEnum.HTML,
       result: this.SCRIPT_CLOSE_TAB,

--- a/apps/api/src/app/subscribers/subscribersV1.controller.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.controller.ts
@@ -776,12 +776,17 @@ export class SubscribersV1Controller {
     );
   }
 
+  /**
+   * @deprecated Use the new channel management approach.
+   * @see channel-endpoints and channel-connections modules
+   */
   @ExternalApiAccessible()
   @Get('/:subscriberId/credentials/:providerId/oauth/callback')
   @ApiExcludeEndpoint()
   @ApiOperation({
     summary: 'Handle slack oauth redirect',
     description: `Handle slack oauth redirect by its unique key identifier **subscriberId** and providerId **providerId**.`,
+    deprecated: true,
   })
   @ApiResponse(String, 200, false, false, {
     status: 200,
@@ -831,11 +836,16 @@ export class SubscribersV1Controller {
     res.redirect(callbackResult.resultString); // Return the URL to redirect to
   }
 
+  /**
+   * @deprecated Use the new channel management approach.
+   * @see channel-endpoints and channel-connections modules
+   */
   @ExternalApiAccessible()
   @ApiExcludeEndpoint()
   @Get('/:subscriberId/credentials/:providerId/oauth')
   @ApiOperation({
     summary: 'Handle chat oauth',
+    deprecated: true,
   })
   @SdkGroupName('Subscribers.Authentication')
   @SdkMethodName('chatAccessOauth')

--- a/apps/api/src/app/subscribers/subscribersV1.module.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.module.ts
@@ -1,7 +1,7 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { AuthModule } from '../auth/auth.module';
-
+import { ChannelEndpointsModule } from '../channel-endpoints/channel-endpoints.module';
 import { OutboundWebhooksModule } from '../outbound-webhooks/outbound-webhooks.module';
 import { PreferencesModule } from '../preferences';
 import { SharedModule } from '../shared/shared.module';
@@ -16,6 +16,7 @@ import { USE_CASES } from './usecases';
     TerminusModule,
     forwardRef(() => WidgetsModule),
     PreferencesModule,
+    ChannelEndpointsModule,
     OutboundWebhooksModule.forRoot(),
   ],
   controllers: [SubscribersV1Controller],

--- a/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
@@ -3,6 +3,7 @@ import {
   CreateOrUpdateSubscriberCommand,
   CreateOrUpdateSubscriberUseCase,
   decryptCredentials,
+  FeatureFlagsService,
   IChannelCredentialsCommand,
   OAuthHandlerEnum,
   UpdateSubscriberChannel,
@@ -15,12 +16,18 @@ import {
   IntegrationEntity,
   IntegrationRepository,
 } from '@novu/dal';
-import { ICredentialsDto } from '@novu/shared';
+import { ENDPOINT_TYPES, FeatureFlagsKeysEnum, ICredentialsDto } from '@novu/shared';
 import axios from 'axios';
+import { CreateChannelEndpointCommand } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
+import { CreateChannelEndpoint } from '../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
 import { validateEncryption } from '../chat-oauth/chat-oauth.usecase';
 import { ChatOauthCallbackCommand } from './chat-oauth-callback.command';
 import { ChatOauthCallbackResult, ResponseTypeEnum } from './chat-oauth-callback.result';
 
+/**
+ * @deprecated Use the new channel management approach.
+ * @see channel-endpoints and channel-connections modules
+ */
 @Injectable()
 export class ChatOauthCallback {
   readonly SLACK_ACCESS_URL = 'https://slack.com/api/oauth.v2.access';
@@ -30,11 +37,14 @@ export class ChatOauthCallback {
     private updateSubscriberChannelUsecase: UpdateSubscriberChannel,
     private integrationRepository: IntegrationRepository,
     private environmentRepository: EnvironmentRepository,
-    private createSubscriberUsecase: CreateOrUpdateSubscriberUseCase
+    private createSubscriberUsecase: CreateOrUpdateSubscriberUseCase,
+    private createChannelEndpoint: CreateChannelEndpoint,
+    private featureFlagsService: FeatureFlagsService
   ) {}
 
   async execute(command: ChatOauthCallbackCommand): Promise<ChatOauthCallbackResult> {
-    const integrationCredentials = await this.getIntegrationCredentials(command);
+    const integration = await this.getIntegration(command);
+    const integrationCredentials = integration.credentials;
 
     const { _organizationId, apiKeys } = await this.getEnvironment(command.environmentId);
 
@@ -47,7 +57,7 @@ export class ChatOauthCallback {
 
     const webhookUrl = await this.getWebhook(command, integrationCredentials);
 
-    await this.createSubscriber(_organizationId, command, webhookUrl);
+    await this.createSubscriber(_organizationId, command, webhookUrl, integration);
 
     if (integrationCredentials && integrationCredentials.redirectUrl) {
       return { typeOfResponse: ResponseTypeEnum.URL, resultString: integrationCredentials.redirectUrl };
@@ -59,7 +69,8 @@ export class ChatOauthCallback {
   private async createSubscriber(
     organizationId: string,
     command: ChatOauthCallbackCommand,
-    webhookUrl: string
+    webhookUrl: string,
+    integration: IntegrationEntity
   ): Promise<void> {
     await this.createSubscriberUsecase.execute(
       CreateOrUpdateSubscriberCommand.create({
@@ -68,6 +79,30 @@ export class ChatOauthCallback {
         subscriberId: command?.subscriberId,
       })
     );
+
+    const isSlackTeamsEnabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_SLACK_TEAMS_ENABLED,
+      defaultValue: false,
+      environment: { _id: command.environmentId },
+      organization: { _id: organizationId },
+    });
+
+    if (isSlackTeamsEnabled) {
+      await this.createChannelEndpoint.execute(
+        CreateChannelEndpointCommand.create({
+          organizationId: organizationId,
+          environmentId: command.environmentId,
+          integrationIdentifier: integration.identifier,
+          subscriberId: command.subscriberId,
+          type: ENDPOINT_TYPES.WEBHOOK,
+          endpoint: {
+            url: webhookUrl,
+          },
+        })
+      );
+
+      return;
+    }
 
     const subscriberCredentials: IChannelCredentialsCommand = { webhookUrl, channel: command.providerId };
 
@@ -136,7 +171,7 @@ export class ChatOauthCallback {
     return webhook;
   }
 
-  private async getIntegrationCredentials(command: ChatOauthCallbackCommand) {
+  private async getIntegration(command: ChatOauthCallbackCommand) {
     const query: Partial<IntegrationEntity> & { _environmentId: string } = {
       _environmentId: command.environmentId,
       channel: ChannelTypeEnum.CHAT,
@@ -160,7 +195,7 @@ export class ChatOauthCallback {
 
     integration.credentials = decryptCredentials(integration.credentials);
 
-    return integration.credentials;
+    return integration;
   }
 
   private async hmacValidation({

--- a/apps/dashboard/src/components/integrations/components/integration-settings.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-settings.tsx
@@ -1,5 +1,13 @@
-import { ChannelTypeEnum, IIntegration, IProviderConfig, PermissionsEnum } from '@novu/shared';
-import { useEffect } from 'react';
+import {
+  ChannelTypeEnum,
+  ChatProviderIdEnum,
+  FeatureFlagsKeysEnum,
+  IIntegration,
+  IProviderConfig,
+  PermissionsEnum,
+  slackConfig,
+} from '@novu/shared';
+import { useEffect, useMemo } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { RiInputField } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
@@ -7,6 +15,7 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/
 import { Form, FormRoot } from '@/components/primitives/form/form';
 import { Label } from '@/components/primitives/label';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { Protect } from '@/utils/protect';
 import { ROUTES } from '@/utils/routes';
 import { cn } from '../../../utils/ui';
@@ -106,6 +115,23 @@ export function IntegrationSettings({
   }, [name, mode, setValue]);
 
   const isDemo = integration && isDemoIntegration(integration.providerId);
+  const isSlackTeamsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_SLACK_TEAMS_ENABLED, false);
+
+  // Filter credentials for Slack: hide HMAC for new integrations when feature flag is enabled
+  // But keep HMAC visible for existing integrations (backward compatibility)
+  const providerCredentials = useMemo(() => {
+    if (provider.id !== ChatProviderIdEnum.Slack || !isSlackTeamsEnabled) {
+      return provider.credentials;
+    }
+
+    // For existing integrations (update mode), show HMAC if it is true in credentials
+    if (mode === 'update' && integration?.credentials?.hmac === true) {
+      return provider.credentials;
+    }
+
+    // For new integrations (create mode), use config without HMAC
+    return slackConfig;
+  }, [provider.id, provider.credentials, isSlackTeamsEnabled, mode, integration?.credentials]);
 
   return (
     <Form {...form}>
@@ -195,7 +221,7 @@ export function IntegrationSettings({
                   </AccordionTrigger>
                   <AccordionContent>
                     <div className="border-neutral-alpha-200 bg-background text-foreground-600 mx-0 mt-0 flex flex-col gap-2 rounded-lg border p-3">
-                      {provider.credentials.map((credential) => (
+                      {providerCredentials.map((credential) => (
                         <CredentialSection
                           key={`${credential.key}-${integration?._id || 'no-id'}`}
                           credential={credential}

--- a/packages/shared/src/consts/providers/channels/chat.ts
+++ b/packages/shared/src/consts/providers/channels/chat.ts
@@ -5,7 +5,7 @@ import {
   getstreamConfig,
   grafanaOnCallConfig,
   rocketChatConfig,
-  slackConfig,
+  slackConfigLegacy,
   whatsAppBusinessConfig,
 } from '../credentials';
 import { IConfigCredential, IProviderConfig } from '../provider.interface';
@@ -23,7 +23,7 @@ export const chatProviders: IProviderConfig[] = [
     id: ChatProviderIdEnum.Slack,
     displayName: 'Slack',
     channel: ChannelTypeEnum.CHAT,
-    credentials: slackConfig,
+    credentials: slackConfigLegacy,
     docReference: `https://docs.novu.co/platform/integrations/chat/slack${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'slack.svg', dark: 'slack.svg' },
   },

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -481,7 +481,7 @@ export const messagebirdConfig: IConfigCredential[] = [
   ...smsConfigBase,
 ];
 
-export const slackConfig: IConfigCredential[] = [
+export const slackConfigLegacy: IConfigCredential[] = [
   {
     key: CredentialsKeyEnum.ApplicationId,
     displayName: 'Application Id',
@@ -511,6 +511,34 @@ export const slackConfig: IConfigCredential[] = [
     key: CredentialsKeyEnum.Hmac,
     displayName: 'HMAC',
     type: 'switch',
+    required: false,
+  },
+];
+
+export const slackConfig: IConfigCredential[] = [
+  {
+    key: CredentialsKeyEnum.ApplicationId,
+    displayName: 'Application Id',
+    type: 'string',
+    required: true,
+  },
+  {
+    key: CredentialsKeyEnum.ClientId,
+    displayName: 'Client ID',
+    type: 'string',
+    required: true,
+  },
+  {
+    key: CredentialsKeyEnum.SecretKey,
+    displayName: 'Client Secret',
+    type: 'string',
+    required: true,
+  },
+  {
+    key: CredentialsKeyEnum.RedirectUrl,
+    displayName: 'Redirect URL',
+    description: 'Redirect after Slack OAuth flow finished (default behaviour will close the tab)',
+    type: 'string',
     required: false,
   },
 ];
@@ -1333,5 +1361,5 @@ export const ISendProProviderConfig: IConfigCredential[] = [
     description: 'The sender of sms',
     type: 'text',
     required: false,
-  }
-  ];
+  },
+];


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * OAuth callback endpoints marked as deprecated; users should migrate to the new channel management approach.

* **New Features**
  * Enhanced Slack integration configuration with improved credential management options.
  * Updated Slack credential handling with feature flag support for teams functionality.

* **Updates**
  * Refined dashboard credential filtering for Slack providers based on integration mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->