### PR TITLE
fix(api-service): Optimize subscriber search endpoint fixes NV-6899

### DIFF
--- a/apps/api/src/app/subscribers-v2/subscribers.controller.e2e.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.e2e.ts
@@ -165,19 +165,6 @@ describe('Subscriber Controller E2E API Testing #novu-v2', () => {
         expect(subscribers[0].firstName).to.contain(uuid.substring(0, 5));
         expect(subscribers[0].lastName).to.equal('Subscriber');
       });
-
-      it('should find subscriber by partial subscriberId match', async () => {
-        const uuid = generateUUID();
-        await createSubscriberAndValidate(uuid);
-
-        const subscribers = await getAllAndValidate({
-          searchParams: { subscriberId: `test-sub` },
-          expectedTotalResults: 1,
-          expectedArraySize: 1,
-        });
-
-        expect(subscribers[0].subscriberId).to.equal(`test-subscriber-${uuid}`);
-      });
     });
 
     describe('List Subscriber Cursor Pagination', () => {

--- a/libs/dal/src/repositories/subscriber/subscriber.repository.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.repository.ts
@@ -235,10 +235,7 @@ export class SubscriberRepository extends BaseRepository<SubscriberDBModel, Subs
               },
             }),
             ...(query.subscriberId && {
-              subscriberId: {
-                $regex: regExpEscape(query.subscriberId),
-                $options: 'i',
-              },
+              subscriberId: query.subscriberId,
             }),
             ...(query.name && {
               $expr: {


### PR DESCRIPTION
### What changed? Why was the change needed?

The `subscriberId` search in the `listSubscribers` method (`libs/dal/src/repositories/subscriber/subscriber.repository.ts`) was changed from a regex-based search to an exact match.

This change was needed to resolve Linear issue [NV-6899](https://linear.app/plain/issue/NV-6899), where the subscriber search option was extremely slow. Using an exact match allows the database to leverage indexes on `subscriberId`, significantly improving search performance, especially for large subscriber bases. It also aligns the behavior with the API documentation, which states the search is case-sensitive.

### Screenshots

N/A

---
Linear Issue: [NV-6899](https://linear.app/novu/issue/NV-6899/subscriber-search-option-on-test-workflow-sidebar-is-slow)

<a href="https://cursor.com/background-agent?bcId=bc-fd3fe6a2-9bfc-45d2-ad34-89d633b95f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd3fe6a2-9bfc-45d2-ad34-89d633b95f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

