### PR TITLE
feat(api): add context to bulk and broadcast trigger endpoints fixes NV-6902

### DIFF
--- a/apps/api/src/app/events/dtos/trigger-event-to-all-request.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-to-all-request.dto.ts
@@ -1,8 +1,9 @@
 import { ApiProperty, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
-import { TriggerRecipientSubscriber, TriggerTenantContext } from '@novu/shared';
+import { IsValidContextPayload } from '@novu/application-generic';
+import { ContextPayload, TriggerRecipientSubscriber, TriggerTenantContext } from '@novu/shared';
 import { Type } from 'class-transformer';
 import { IsDefined, IsObject, IsOptional, IsString, ValidateIf, ValidateNested } from 'class-validator';
-
+import { ApiContextPayload } from '../../shared/framework/swagger';
 import { SubscriberPayloadDto, TenantPayloadDto, TriggerOverrides } from './trigger-event-request.dto';
 
 export class TriggerEventToAllRequestDto {
@@ -87,4 +88,9 @@ export class TriggerEventToAllRequestDto {
   @ValidateNested()
   @Type(() => TenantPayloadDto)
   tenant?: TriggerTenantContext;
+
+  @ApiContextPayload()
+  @IsOptional()
+  @IsValidContextPayload({ maxCount: 5 })
+  context?: ContextPayload;
 }

--- a/apps/api/src/app/events/events.controller.ts
+++ b/apps/api/src/app/events/events.controller.ts
@@ -191,6 +191,7 @@ export class EventsController {
         transactionId,
         overrides: body.overrides || {},
         actor: body.actor,
+        context: body.context,
         requestId: req._nvRequestId,
       })
     );

--- a/apps/api/src/app/events/usecases/process-bulk-trigger/process-bulk-trigger.usecase.ts
+++ b/apps/api/src/app/events/usecases/process-bulk-trigger/process-bulk-trigger.usecase.ts
@@ -47,6 +47,7 @@ export class ProcessBulkTrigger {
             to: event.to,
             actor: event.actor,
             tenant: event.tenant,
+            context: event.context,
             transactionId: event.transactionId,
             addressingType: AddressingTypeEnum.MULTICAST,
             requestCategory: TriggerRequestCategoryEnum.BULK,

--- a/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.command.ts
+++ b/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.command.ts
@@ -1,4 +1,5 @@
-import { TriggerOverrides, TriggerRecipientSubscriber, TriggerTenantContext } from '@novu/shared';
+import { IsValidContextPayload } from '@novu/application-generic';
+import { ContextPayload, TriggerOverrides, TriggerRecipientSubscriber, TriggerTenantContext } from '@novu/shared';
 import { IsDefined, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
 
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
@@ -32,4 +33,8 @@ export class TriggerEventToAllCommand extends EnvironmentWithUserCommand {
   @IsString()
   @IsNotEmpty()
   requestId: string;
+
+  @IsOptional()
+  @IsValidContextPayload({ maxCount: 5 })
+  context?: ContextPayload;
 }

--- a/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.usecase.ts
+++ b/apps/api/src/app/events/usecases/trigger-event-to-all/trigger-event-to-all.usecase.ts
@@ -20,6 +20,7 @@ export class TriggerEventToAll {
         overrides: command.overrides || {},
         actor: command.actor,
         tenant: command.tenant,
+        context: command.context,
         requestCategory: TriggerRequestCategoryEnum.SINGLE,
         bridgeUrl: command.bridgeUrl,
         requestId: command.requestId,


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional context payload support to event triggering, allowing users to include contextual data when triggering events to all recipients. Context is limited to a maximum of 5 items and is propagated through the event processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->