### PR TITLE
fix(dashboard): context dropdown page refresh

### DIFF
--- a/apps/dashboard/src/components/primitives/autocomplete.tsx
+++ b/apps/dashboard/src/components/primitives/autocomplete.tsx
@@ -70,6 +70,7 @@ export function Autocomplete<T extends AutocompleteItem>({
   // Form submission handler
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    e.stopPropagation();
 
     if (open && hasResults && highlightedIndex >= 0) {
       // Select highlighted item
@@ -141,9 +142,12 @@ export function Autocomplete<T extends AutocompleteItem>({
         setOpen(false);
         break;
       case 'Enter':
+        e.preventDefault();
         if (highlightedIndex >= 0) {
-          e.preventDefault();
           handleSelectItem(items[highlightedIndex]);
+        } else if (items.length > 0) {
+          // If no item is highlighted but there are results, select the first item
+          handleSelectItem(items[0]);
         }
         break;
     }


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR fixes an issue where pressing Enter in the context dropdown in the in-app editor would refresh the page instead of selecting a context.

The root cause was that the `Autocomplete` component's form would submit and refresh the page if `e.preventDefault()` was not explicitly called when the Enter key was pressed without a highlighted item.

The changes ensure:
- The `Enter` key always prevents default form submission when the dropdown is open with results.
- If no item is highlighted, the first available item in the list is now selected upon pressing `Enter`.
- `e.stopPropagation()` was added to the `handleSubmit` function to prevent event bubbling.

**Relevant Linear ticket:** [NV-6819](https://linear.app/novuhq/issue/NV-6819)

---
Linear Issue: [NV-6819](https://linear.app/novu/issue/NV-6819/dashboard-clicking-enter-on-the-context-dropdown-in-the-editor)

<a href="https://cursor.com/background-agent?bcId=bc-ca9880b2-c624-4b1a-9cb7-96ef3485cc4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca9880b2-c624-4b1a-9cb7-96ef3485cc4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

