### PR TITLE
chore(root): add biome plugin to validate Record types in DTOs fixes NV-6905

### DIFF
--- a/biome-plugins/api-property-record-type.grit
+++ b/biome-plugins/api-property-record-type.grit
@@ -1,0 +1,14 @@
+// Plugin to detect Record<string, ...> types in DTO files
+// Reminds developers to verify proper OpenAPI configuration for SDK generation
+
+engine biome(1.0)
+language js(typescript)
+
+// Match any Record<string, ...> type usage
+`Record<string, $_>` where {
+  register_diagnostic(
+    span = $match,
+    severity = "warn",
+    message = "Verify @ApiProperty includes type: 'object' and additionalProperties: true for proper SDK generation"
+  )
+}

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+  "plugins": ["./biome-plugins/api-property-record-type.grit"],
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request introduces a new Biome plugin to help developers ensure proper OpenAPI configuration when using `Record<string, ...>` types in DTO files. The plugin automatically warns developers to verify that `@ApiProperty` includes the correct settings for SDK generation. Additionally, the plugin is registered in the Biome configuration.

**Biome plugin addition and configuration:**

* Added `biome-plugins/api-property-record-type.grit` plugin to detect usage of `Record<string, ...>` types and warn developers to verify `@ApiProperty` includes `type: 'object'` and `additionalProperties: true` for SDK generation.
* Registered the new plugin in `biome.json` by adding it to the `plugins` array.
