### PR TITLE
fix(api-service): Add bulk workflow queueing for event triggers fixes NV-6908

### DIFF
--- a/apps/api/src/app/events/dtos/trigger-event-response.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IWorkflowDataDto } from '@novu/application-generic';
 import { TriggerEventStatusEnum } from '@novu/shared';
 import { IsBoolean, IsDefined, IsEnum, IsOptional, IsString } from 'class-validator';
 
@@ -29,10 +30,13 @@ export class TriggerEventResponseDto {
 
   @ApiProperty({
     description: 'The returned transaction ID of the trigger',
-    type: String, // Specify that this is a string
-    required: false, // Not required since it's optional
+    type: String,
+    required: false,
   })
   @IsOptional()
   @IsString()
   transactionId?: string;
+
+  @IsOptional()
+  jobData?: IWorkflowDataDto;
 }

--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.command.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.command.ts
@@ -63,6 +63,9 @@ export class ParseEventRequestBaseCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @IsValidContextPayload({ maxCount: 5 })
   context?: ContextPayload;
+
+  @IsOptional()
+  skipQueueInsertion?: boolean;
 }
 
 export class ParseEventRequestMulticastCommand extends ParseEventRequestBaseCommand {

--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
@@ -380,16 +380,19 @@ export class ParseEventRequest {
       requestId,
     };
 
-    await this.workflowQueueService.add({ name: transactionId, data: jobData, groupId: command.organizationId });
-    this.logger.info(
-      { ...command, transactionId, discoveredWorkflowId: discoveredWorkflow?.workflowId },
-      'Event dispatched to [Workflow] Queue'
-    );
+    if (!command.skipQueueInsertion) {
+      await this.workflowQueueService.add({ name: transactionId, data: jobData, groupId: command.organizationId });
+      this.logger.info(
+        { ...command, transactionId, discoveredWorkflowId: discoveredWorkflow?.workflowId },
+        'Event dispatched to [Workflow] Queue'
+      );
+    }
 
     return {
       acknowledged: true,
       status: TriggerEventStatusEnum.PROCESSED,
       transactionId,
+      jobData: command.skipQueueInsertion ? jobData : undefined,
     };
   }
 

--- a/apps/api/src/app/events/usecases/process-bulk-trigger/process-bulk-trigger.usecase.ts
+++ b/apps/api/src/app/events/usecases/process-bulk-trigger/process-bulk-trigger.usecase.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { IWorkflowBulkJobDto, WorkflowQueueService } from '@novu/application-generic';
 import { NotificationTemplateRepository } from '@novu/dal';
 import { AddressingTypeEnum, TriggerEventStatusEnum, TriggerRequestCategoryEnum } from '@novu/shared';
 import { TriggerEventResponseDto } from '../../dtos';
@@ -10,7 +11,8 @@ import { ProcessBulkTriggerCommand } from './process-bulk-trigger.command';
 export class ProcessBulkTrigger {
   constructor(
     private parseEventRequest: ParseEventRequest,
-    private notificationTemplateRepository: NotificationTemplateRepository
+    private notificationTemplateRepository: NotificationTemplateRepository,
+    private workflowQueueService: WorkflowQueueService
   ) {}
 
   async execute(command: ProcessBulkTriggerCommand) {
@@ -54,6 +56,7 @@ export class ProcessBulkTrigger {
             bridgeUrl: event.bridgeUrl,
             requestId: command.requestId,
             workflow,
+            skipQueueInsertion: true,
           })
         )) as unknown as TriggerEventResponseDto;
 
@@ -75,6 +78,21 @@ export class ProcessBulkTrigger {
     });
 
     const results = await Promise.all(eventPromises);
+
+    const jobsToQueue: IWorkflowBulkJobDto[] = results
+      .filter(
+        (result): result is TriggerEventResponseDto & { jobData: NonNullable<typeof result.jobData> } =>
+          result.status === TriggerEventStatusEnum.PROCESSED && result.jobData !== undefined
+      )
+      .map((result) => ({
+        name: result.jobData.transactionId,
+        data: result.jobData,
+        groupId: result.jobData.organizationId,
+      }));
+
+    if (jobsToQueue.length > 0) {
+      await this.workflowQueueService.addBulk(jobsToQueue);
+    }
 
     return results;
   }


### PR DESCRIPTION
Introduces a skipQueueInsertion flag to control queue insertion during event parsing, and updates bulk trigger processing to collect job data and enqueue jobs in bulk. Also extends the TriggerEventResponseDto to optionally include jobData for processed events.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
