### PR TITLE
feat(shared): add tenant ID credential for MS Teams integration

### DIFF
--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -559,6 +559,13 @@ export const msTeamsConfig: IConfigCredential[] = [
     required: true,
   },
   {
+    key: CredentialsKeyEnum.TenantId,
+    displayName: 'Tenant ID',
+    description: 'Azure Bot Tenant ID',
+    type: 'string',
+    required: true,
+  },
+  {
     key: CredentialsKeyEnum.RedirectUrl,
     displayName: 'Redirect URL',
     description: 'Redirect after Teams OAuth flow finished (default behaviour will close the tab)',

--- a/packages/shared/src/entities/integration/credential.interface.ts
+++ b/packages/shared/src/entities/integration/credential.interface.ts
@@ -52,4 +52,5 @@ export interface ICredentials {
   AppIOBearerToken?: string;
   AppIOOriginalSignature?: string;
   servicePlanId?: string;
+  tenantId?: string;
 }

--- a/packages/shared/src/types/providers.ts
+++ b/packages/shared/src/types/providers.ts
@@ -51,6 +51,7 @@ export enum CredentialsKeyEnum {
   SenderId = 'senderId',
   AppIOBaseUrl = 'AppIOBaseUrl',
   ServicePlanId = 'servicePlanId',
+  TenantId = 'tenantId',
 }
 
 export type ConfigurationKey = keyof IConfigurations;


### PR DESCRIPTION
Add tenantId credential field to MS Teams configuration to support Azure Bot Tenant ID authentication. This credential is required for MS Teams OAuth flow.

Changes:
- Add TenantId to CredentialsKeyEnum
- Add tenantId field to ICredentials interface
- Add tenantId credential to msTeamsConfig with required validation

fixes NV-6910

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
