### PR TITLE
feat(api,dal,shared): add tenantId to MS Teams credentials

### DIFF
--- a/apps/api/src/app/integrations/dtos/credentials.dto.ts
+++ b/apps/api/src/app/integrations/dtos/credentials.dto.ts
@@ -226,6 +226,11 @@ export class CredentialsDto implements ICredentials {
   @IsString()
   @IsOptional()
   senderId?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  tenantId?: string;
   
   @ApiPropertyOptional()
   @IsOptional()

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -65,6 +65,7 @@ const integrationSchema = new Schema<IntegrationDBModel>(
       appSid: Schema.Types.String,
       senderId: Schema.Types.String,
       servicePlanId: Schema.Types.String,
+      tenantId: Schema.Types.String,
       AppIOBaseUrl: Schema.Types.String,
       AppIOSubscriptionId: Schema.Types.String,
       AppIOBearerToken: Schema.Types.String,

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -559,6 +559,13 @@ export const msTeamsConfig: IConfigCredential[] = [
     required: true,
   },
   {
+    key: CredentialsKeyEnum.TenantId,
+    displayName: 'Tenant ID',
+    description: 'Azure Bot Tenant ID',
+    type: 'string',
+    required: true,
+  },
+  {
     key: CredentialsKeyEnum.RedirectUrl,
     displayName: 'Redirect URL',
     description: 'Redirect after Teams OAuth flow finished (default behaviour will close the tab)',


### PR DESCRIPTION
Add tenantId credential field to MS Teams configuration to support Azure Bot Tenant ID authentication. This credential is required for MS Teams OAuth flow.

Changes:
- Add TenantId to CredentialsKeyEnum (shared/types)
- Add tenantId to ICredentials interface (shared/entities)
- Add tenantId credential to msTeamsConfig with required validation (shared/credentials)
- Add tenantId to integration.schema.ts (MongoDB credentials schema)
- Add tenantId to credentials.dto.ts (API validation)

fixes NV-6910

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
