### PR TITLE
feat(dashboard): add cimode warning fixes NV-6914

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -92,6 +92,7 @@
     "cidrmatch",
     "cidrmax",
     "cimg",
+    "cimode",
     "circleci",
     "cirdmatch",
     "classpath",

--- a/apps/dashboard/src/components/primitives/locale-select.tsx
+++ b/apps/dashboard/src/components/primitives/locale-select.tsx
@@ -1,6 +1,6 @@
 import { getAllLocales, getCommonLocales, getLocaleByIso } from '@novu/shared';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { RiArrowDownSLine, RiCheckLine } from 'react-icons/ri';
+import { RiArrowDownSLine, RiCheckLine, RiErrorWarningFill } from 'react-icons/ri';
 import { cn } from '@/utils/ui';
 import { FlagCircle, StackedFlagCircles } from '../flag-circle';
 import TruncatedText from '../truncated-text';
@@ -90,6 +90,8 @@ function SingleSelectTrigger({ value, placeholder }: { value?: string; placehold
           <TruncatedText>
             {currentLocale.langIso} - {currentLocale.langName}
           </TruncatedText>
+        ) : value ? (
+          <TruncatedText>{value}</TruncatedText>
         ) : (
           <span className="text-neutral-400">{placeholder}</span>
         )}
@@ -102,19 +104,28 @@ function SingleSelectTrigger({ value, placeholder }: { value?: string; placehold
 function MultiSelectTrigger({ value, placeholder }: { value?: string[]; placeholder: string }) {
   const allLocales = getAllLocales();
   const selectedLocales = value ? allLocales.filter((locale) => value.includes(locale.langIso)) : [];
+  const customLocales = value ? value.filter((val) => !allLocales.some((locale) => locale.langIso === val)) : [];
+  const totalSelectedCount = selectedLocales.length + customLocales.length;
 
-  if (selectedLocales.length === 0) {
+  if (totalSelectedCount === 0) {
     return <span className="text-xs font-normal text-neutral-400">{placeholder}</span>;
   }
 
-  if (selectedLocales.length <= 4) {
+  if (totalSelectedCount <= 4) {
     return (
       <div className="flex items-center gap-1.5 overflow-hidden">
         {selectedLocales.map((locale, index) => (
           <div key={locale.langIso} className="flex shrink-0 items-center gap-1">
             <FlagCircle locale={locale.langIso} size="sm" />
             <span className="text-xs font-normal text-neutral-950">{locale.langIso}</span>
-            {index < selectedLocales.length - 1 && <span className="text-neutral-400">•</span>}
+            {index < totalSelectedCount - 1 && <span className="text-neutral-400">•</span>}
+          </div>
+        ))}
+        {customLocales.map((locale, index) => (
+          <div key={locale} className="flex shrink-0 items-center gap-1">
+            <FlagCircle locale={locale} size="sm" />
+            <span className="text-xs font-normal text-neutral-950">{locale}</span>
+            {selectedLocales.length + index < totalSelectedCount - 1 && <span className="text-neutral-400">•</span>}
           </div>
         ))}
       </div>
@@ -123,8 +134,12 @@ function MultiSelectTrigger({ value, placeholder }: { value?: string[]; placehol
 
   return (
     <div className="flex items-center gap-1.5">
-      <StackedFlagCircles locales={selectedLocales.map((locale) => locale.langIso)} maxVisible={10} size="md" />
-      <span className="text-xs font-normal text-neutral-950">{selectedLocales.length} locales selected</span>
+      <StackedFlagCircles
+        locales={[...selectedLocales.map((locale) => locale.langIso), ...customLocales]}
+        maxVisible={10}
+        size="md"
+      />
+      <span className="text-xs font-normal text-neutral-950">{totalSelectedCount} locales selected</span>
     </div>
   );
 }
@@ -209,6 +224,8 @@ export function LocaleSelect(props: LocaleSelectProps) {
     }
   };
 
+  const showCimodeWarning = !multiSelect && value === 'cimode';
+
   return (
     <div ref={containerRef} className="relative">
       <Button
@@ -230,6 +247,16 @@ export function LocaleSelect(props: LocaleSelectProps) {
           className={cn('ml-auto size-4 opacity-50', disabled || readOnly ? 'hidden' : 'opacity-100')}
         />
       </Button>
+
+      {showCimodeWarning && (
+        <div className="mt-2 flex gap-2 rounded-lg border border-amber-200 bg-amber-50 p-2.5">
+          <RiErrorWarningFill className="mt-0.5 size-4 shrink-0 text-amber-600" />
+          <p className="text-xs text-amber-900">
+            <span className="font-medium">cimode</span> will return translation keys without translating them. This
+            locale is used for debugging purposes.
+          </p>
+        </div>
+      )}
 
       {isOpen && (
         <div

--- a/apps/dashboard/src/components/primitives/locale-select.tsx
+++ b/apps/dashboard/src/components/primitives/locale-select.tsx
@@ -6,6 +6,7 @@ import { FlagCircle, StackedFlagCircles } from '../flag-circle';
 import TruncatedText from '../truncated-text';
 import { Button, ButtonProps } from './button';
 import { Input } from './input';
+import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip';
 
 type BaseLocaleSelectProps = {
   disabled?: boolean;
@@ -227,44 +228,35 @@ export function LocaleSelect(props: LocaleSelectProps) {
   const showCimodeWarning = !multiSelect && value === 'cimode';
 
   return (
-    <div ref={containerRef} className="relative">
-      <Button
-        variant="secondary"
-        mode="outline"
-        className={cn('flex h-8 w-full items-center justify-between gap-1 rounded-lg px-3 focus:z-10', className)}
-        disabled={disabled || readOnly}
-        onClick={handleToggle}
-        type="button"
-        {...rest}
-      >
-        {multiSelect ? (
-          <MultiSelectTrigger value={value as string[]} placeholder={placeholder} />
-        ) : (
-          <SingleSelectTrigger value={value as string} placeholder={placeholder} />
-        )}
-
-        <RiArrowDownSLine
-          className={cn('ml-auto size-4 opacity-50', disabled || readOnly ? 'hidden' : 'opacity-100')}
-        />
-      </Button>
-
-      {showCimodeWarning && (
-        <div className="mt-2 flex gap-2 rounded-lg border border-amber-200 bg-amber-50 p-2.5">
-          <RiErrorWarningFill className="mt-0.5 size-4 shrink-0 text-amber-600" />
-          <p className="text-xs text-amber-900">
-            <span className="font-medium">cimode</span> will return translation keys without translating them. This
-            locale is used for debugging purposes.
-          </p>
-        </div>
-      )}
-
-      {isOpen && (
-        <div
-          className={cn(
-            'border-border bg-background absolute z-[9999] mt-1 w-full min-w-[320px] rounded-lg border shadow-lg',
-            dropdownPosition === 'right' ? 'right-0' : 'left-0'
-          )}
+    <div className="flex items-center gap-1.5">
+      <div ref={containerRef} className="relative flex-1">
+        <Button
+          variant="secondary"
+          mode="outline"
+          className={cn('flex h-8 w-full items-center justify-between gap-1 rounded-lg px-3 focus:z-10', className)}
+          disabled={disabled || readOnly}
+          onClick={handleToggle}
+          type="button"
+          {...rest}
         >
+          {multiSelect ? (
+            <MultiSelectTrigger value={value as string[]} placeholder={placeholder} />
+          ) : (
+            <SingleSelectTrigger value={value as string} placeholder={placeholder} />
+          )}
+
+          <RiArrowDownSLine
+            className={cn('ml-auto size-4 opacity-50', disabled || readOnly ? 'hidden' : 'opacity-100')}
+          />
+        </Button>
+
+        {isOpen && (
+          <div
+            className={cn(
+              'border-border bg-background absolute z-[9999] mt-1 w-full min-w-[320px] rounded-lg border shadow-lg',
+              dropdownPosition === 'right' ? 'right-0' : 'left-0'
+            )}
+          >
           <div className="border-border border-b p-2">
             <Input
               ref={inputRef}
@@ -318,6 +310,21 @@ export function LocaleSelect(props: LocaleSelectProps) {
             )}
           </div>
         </div>
+      )}
+      </div>
+
+      {showCimodeWarning && (
+        <Tooltip>
+          <TooltipTrigger type="button">
+            <RiErrorWarningFill className="size-4 shrink-0 text-amber-600" />
+          </TooltipTrigger>
+          <TooltipContent className="max-w-[260px]">
+            <p className="text-xs">
+              <span className="font-medium">cimode</span> will return translation keys without translating them. This
+              locale is used for debugging purposes.
+            </p>
+          </TooltipContent>
+        </Tooltip>
       )}
     </div>
   );

--- a/apps/dashboard/src/components/primitives/locale-select.tsx
+++ b/apps/dashboard/src/components/primitives/locale-select.tsx
@@ -316,7 +316,7 @@ export function LocaleSelect(props: LocaleSelectProps) {
       {showCimodeWarning && (
         <Tooltip>
           <TooltipTrigger type="button">
-            <RiErrorWarningFill className="size-4 shrink-0 text-amber-600" />
+            <RiErrorWarningFill className="size-4 shrink-0 text-warning" />
           </TooltipTrigger>
           <TooltipContent className="max-w-[260px]">
             <p className="text-xs">


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves NV-6914 by improving the `LocaleSelect` component in the dashboard:

*   **Display of unexpected locales:** When a locale not present in the predefined list is set on a subscriber, the UI now correctly displays the actual custom locale value instead of showing an empty field. This enhances observability for unexpected locale settings.
*   **`cimode` warning:** A warning banner is now displayed when `cimode` is selected, informing the user that it returns translation keys for debugging purposes.

### Screenshots

*   Screenshot showing a custom locale value displayed in the select component.
*   Screenshot showing the `cimode` warning banner.

---
Linear Issue: [NV-6914](https://linear.app/novu/issue/NV-6914/i-also-noticed-than-whenver-an-un-expected-locale-field-is-set-on-the)

<a href="https://cursor.com/background-agent?bcId=bc-859bd6c7-d3c3-4350-87e8-197ab1e66837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-859bd6c7-d3c3-4350-87e8-197ab1e66837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

