### PR TITLE
perf(dal): Set use$neOperator: false in mongooseDelete plugin configs

### DIFF
--- a/libs/dal/src/repositories/control-values/control-values.schema.ts
+++ b/libs/dal/src/repositories/control-values/control-values.schema.ts
@@ -38,7 +38,12 @@ const controlValuesSchema = new Schema<ControlValuesModel>(
   schemaOptions
 );
 
-controlValuesSchema.plugin(mongooseDelete, { deletedAt: true, deletedBy: true, overrideMethods: 'all' });
+controlValuesSchema.plugin(mongooseDelete, {
+  deletedAt: true,
+  deletedBy: true,
+  overrideMethods: 'all',
+  use$neOperator: false,
+});
 
 export const ControlValues =
   (mongoose.models.ControlValues as mongoose.Model<ControlValuesModel>) ||

--- a/libs/dal/src/repositories/notification-template/notification-template.schema.ts
+++ b/libs/dal/src/repositories/notification-template/notification-template.schema.ts
@@ -330,7 +330,12 @@ notificationTemplateSchema.index({
   name: 1,
 });
 
-notificationTemplateSchema.plugin(mongooseDelete, { deletedAt: true, deletedBy: true, overrideMethods: 'all' });
+notificationTemplateSchema.plugin(mongooseDelete, {
+  deletedAt: true,
+  deletedBy: true,
+  overrideMethods: 'all',
+  use$neOperator: false,
+});
 
 export const NotificationTemplate =
   (mongoose.models.NotificationTemplate as mongoose.Model<NotificationTemplateDBModel>) ||

--- a/libs/dal/src/repositories/preferences/preferences.schema.ts
+++ b/libs/dal/src/repositories/preferences/preferences.schema.ts
@@ -70,7 +70,12 @@ const preferencesSchema = new Schema<PreferencesDBModel>(
   { ...schemaOptions, minimize: false }
 );
 
-preferencesSchema.plugin(mongooseDelete, { deletedAt: true, deletedBy: true, overrideMethods: 'all' });
+preferencesSchema.plugin(mongooseDelete, {
+  deletedAt: true,
+  deletedBy: true,
+  overrideMethods: 'all',
+  use$neOperator: false,
+});
 
 // Subscriber Global Preferences
 // Ensures one global preference per subscriber (SUBSCRIBER_GLOBAL type)

--- a/libs/dal/src/repositories/subscriber/subscriber.schema.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.schema.ts
@@ -208,12 +208,13 @@ subscriberSchema.index(
   { name: 'unique_subscriber_per_environment', unique: true, partialFilterExpression: { deleted: false } }
 );
 
-subscriberSchema.plugin(mongooseDelete, { deletedAt: true, deletedBy: true, overrideMethods: 'all' });
+subscriberSchema.plugin(mongooseDelete, {
+  deletedAt: true,
+  deletedBy: true,
+  overrideMethods: 'all',
+  use$neOperator: false,
+});
 
 export const Subscriber =
   (mongoose.models.Subscriber as mongoose.Model<SubscriberDBModel>) ||
   mongoose.model<SubscriberDBModel>('Subscriber', subscriberSchema);
-
-function index(fields: IndexDefinition<SubscriberEntity>, options?: IndexOptions) {
-  subscriberSchema.index(fields, options);
-}


### PR DESCRIPTION
Updated mongooseDelete plugin configuration in control-values, notification-template, preferences, and subscriber schemas to explicitly set use$neOperator: false. This change ensures consistent soft-delete query behavior across these models.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
