### PR TITLE
style(dashboard): redundant globe icon from region selector

### DIFF
--- a/apps/dashboard/src/context/region/region-selector.tsx
+++ b/apps/dashboard/src/context/region/region-selector.tsx
@@ -4,7 +4,6 @@ import { useRegion } from '@/context/region';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { useLDClient } from 'launchdarkly-react-client-sdk';
-import { Globe } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { REGIONS } from './region-config';
 
@@ -55,10 +54,7 @@ export function RegionSelector() {
   return (
     <Select value={selectedRegion} onValueChange={setSelectedRegion}>
       <SelectTrigger className={triggerClassName}>
-        <div className="flex items-center gap-1.5">
-          <Globe size={12} className="text-muted-foreground" />
-          <SelectValue placeholder="Select Region" />
-        </div>
+        <SelectValue placeholder="Select Region" />
       </SelectTrigger>
       <SelectContent>
         {REGION_OPTIONS.map((option) => (


### PR DESCRIPTION
### What changed? Why was the change needed?

Removed the redundant globe icon from the `RegionSelector` component's trigger in the apps dashboard.

### Screenshots

[Include a screenshot of the apps dashboard with the updated region selector, showing the absence of the globe icon.]

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1763993201571999?thread_ts=1763993201.571999&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-157ee919-3017-4cac-b365-ab628c08ee71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-157ee919-3017-4cac-b365-ab628c08ee71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

