### PR TITLE
feat(api,framework): translations - support liquid filters & nesting fixes NV-6870

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -2516,16 +2516,19 @@ describe('EmailOutputRendererUsecase', () => {
     });
 
     it('should not double-escape JSON characters from translation content', async () => {
-      const translatedContent = 'Visit <a style=\'color: #0C0D0D;\' href=\'https://sharefile.com/support\'>http://sharefile.com/support</a> and look for \\"Chat with Us.\\"';
-      
-      translateStub.restore();
-      translateStub = sinon.stub(require('@novu/ee-translation').Translate.prototype, 'execute').callsFake(async (command: any) => {
-        if (command.content.includes('{{t.footer}}')) {
-          return command.content.replace('{{t.footer}}', translatedContent);
-        }
+      const translatedContent =
+        "Visit <a style='color: #0C0D0D;' href='https://sharefile.com/support'>http://sharefile.com/support</a> and look for \\\"Chat with Us.\\\"";
 
-        return command.content || '';
-      });
+      translateStub.restore();
+      translateStub = sinon
+        .stub(require('@novu/ee-translation').Translate.prototype, 'execute')
+        .callsFake(async (command: any) => {
+          if (command.content.includes('{{t.footer}}')) {
+            return command.content.replace('{{t.footer}}', translatedContent);
+          }
+
+          return command.content || '';
+        });
 
       const mockTipTapNode: MailyJSONContent = {
         type: 'doc',
@@ -2564,15 +2567,17 @@ describe('EmailOutputRendererUsecase', () => {
 
     it('should handle translation content with multiple escaped characters', async () => {
       const translatedContent = 'Line 1\\nLine 2\\tTabbed\\r\\nAnd \\"quoted\\"';
-      
-      translateStub.restore();
-      translateStub = sinon.stub(require('@novu/ee-translation').Translate.prototype, 'execute').callsFake(async (command: any) => {
-        if (command.content.includes('{{t.multiline}}')) {
-          return command.content.replace('{{t.multiline}}', translatedContent);
-        }
 
-        return command.content || '';
-      });
+      translateStub.restore();
+      translateStub = sinon
+        .stub(require('@novu/ee-translation').Translate.prototype, 'execute')
+        .callsFake(async (command: any) => {
+          if (command.content.includes('{{t.multiline}}')) {
+            return command.content.replace('{{t.multiline}}', translatedContent);
+          }
+
+          return command.content || '';
+        });
 
       const mockTipTapNode: MailyJSONContent = {
         type: 'doc',
@@ -2621,16 +2626,19 @@ describe('EmailOutputRendererUsecase', () => {
     });
 
     it('should not double-escape JSON characters from translation content in plain HTML body', async () => {
-      const translatedContent = 'Visit <a style=\'color: #0C0D0D;\' href=\'https://sharefile.com/support\'>http://sharefile.com/support</a> and look for \\"Chat with Us.\\"';
-      
-      translateStub.restore();
-      translateStub = sinon.stub(require('@novu/ee-translation').Translate.prototype, 'execute').callsFake(async (command: any) => {
-        if (command.content.includes('{{t.footer}}')) {
-          return command.content.replace('{{t.footer}}', translatedContent);
-        }
+      const translatedContent =
+        "Visit <a style='color: #0C0D0D;' href='https://sharefile.com/support'>http://sharefile.com/support</a> and look for \\\"Chat with Us.\\\"";
 
-        return command.content || '';
-      });
+      translateStub.restore();
+      translateStub = sinon
+        .stub(require('@novu/ee-translation').Translate.prototype, 'execute')
+        .callsFake(async (command: any) => {
+          if (command.content.includes('{{t.footer}}')) {
+            return command.content.replace('{{t.footer}}', translatedContent);
+          }
+
+          return command.content || '';
+        });
 
       const plainHtmlBody = '<p>{{t.footer}}</p>';
 
@@ -2656,15 +2664,17 @@ describe('EmailOutputRendererUsecase', () => {
 
     it('should handle plain HTML body with multiple escaped characters', async () => {
       const translatedContent = 'Line 1\\nLine 2\\tTabbed\\r\\nAnd \\"quoted\\"';
-      
-      translateStub.restore();
-      translateStub = sinon.stub(require('@novu/ee-translation').Translate.prototype, 'execute').callsFake(async (command: any) => {
-        if (command.content.includes('{{t.multiline}}')) {
-          return command.content.replace('{{t.multiline}}', translatedContent);
-        }
 
-        return command.content || '';
-      });
+      translateStub.restore();
+      translateStub = sinon
+        .stub(require('@novu/ee-translation').Translate.prototype, 'execute')
+        .callsFake(async (command: any) => {
+          if (command.content.includes('{{t.multiline}}')) {
+            return command.content.replace('{{t.multiline}}', translatedContent);
+          }
+
+          return command.content || '';
+        });
 
       const plainHtmlBody = '<div>{{t.multiline}}</div>';
 
@@ -2692,15 +2702,17 @@ describe('EmailOutputRendererUsecase', () => {
 
     it('should handle email subject with escaped characters', async () => {
       const translatedSubject = 'Welcome to \\"Our Service\\" - You\\\'re all set!';
-      
-      translateStub.restore();
-      translateStub = sinon.stub(require('@novu/ee-translation').Translate.prototype, 'execute').callsFake(async (command: any) => {
-        if (command.content.includes('{{t.subject}}')) {
-          return command.content.replace('{{t.subject}}', translatedSubject);
-        }
 
-        return command.content || '';
-      });
+      translateStub.restore();
+      translateStub = sinon
+        .stub(require('@novu/ee-translation').Translate.prototype, 'execute')
+        .callsFake(async (command: any) => {
+          if (command.content.includes('{{t.subject}}')) {
+            return command.content.replace('{{t.subject}}', translatedSubject);
+          }
+
+          return command.content || '';
+        });
 
       const renderCommand: EmailOutputRendererCommand = {
         environmentId: 'fake_env_id',
@@ -2724,15 +2736,17 @@ describe('EmailOutputRendererUsecase', () => {
 
     it('should handle layout with plain HTML body containing escaped characters', async () => {
       const translatedLayoutContent = 'Footer: Visit us at \\"Main Street\\" \\nCall: 555-1234';
-      
-      translateStub.restore();
-      translateStub = sinon.stub(require('@novu/ee-translation').Translate.prototype, 'execute').callsFake(async (command: any) => {
-        if (command.content.includes('{{t.layoutFooter}}')) {
-          return command.content.replace('{{t.layoutFooter}}', translatedLayoutContent);
-        }
 
-        return command.content || '';
-      });
+      translateStub.restore();
+      translateStub = sinon
+        .stub(require('@novu/ee-translation').Translate.prototype, 'execute')
+        .callsFake(async (command: any) => {
+          if (command.content.includes('{{t.layoutFooter}}')) {
+            return command.content.replace('{{t.layoutFooter}}', translatedLayoutContent);
+          }
+
+          return command.content || '';
+        });
 
       const layoutContent = '<html><body>{{content}}<footer>{{t.layoutFooter}}</footer></body></html>';
       const stepContent = '<p>Step content</p>';
@@ -2896,6 +2910,268 @@ describe('EmailOutputRendererUsecase', () => {
       // Should have converted whitespace-only paragraphs to empty ones
       expect(result.body).to.not.include('> </p>');
       expect(result.body).to.include('<p></p>');
+    });
+  });
+
+  describe('Layout body translation preprocessing', () => {
+    beforeEach(() => {
+      getOrganizationSettingsMock.execute.resolves({
+        removeNovuBranding: false,
+        defaultLocale: 'en_US',
+      });
+    });
+
+    it('should transform translation keys in filter arguments for layouts', async () => {
+      translateStub.restore();
+      translateStub = sinon
+        .stub(require('@novu/ee-translation').Translate.prototype, 'execute')
+        .callsFake(async (command: any) => {
+          // Verify that filter arguments are transformed to {{t.key}} format
+          if (command.content.includes("'{{t.apple}}'") && command.content.includes("'{{t.apples}}'")) {
+            return command.content.replace("'{{t.apple}}'", "'1 apple'").replace("'{{t.apples}}'", "'5 apples'");
+          }
+
+          return command.content || '';
+        });
+
+      const layoutContent =
+        "<html><body>{{content}}<footer>You have {{ payload.count | pluralize: 't.apple', 't.apples' }}</footer></body></html>";
+      const stepContent = '<p>Step content</p>';
+
+      controlValuesRepositoryMock.findOne.resolves({
+        _id: 'test_layout_id',
+        _organizationId: 'fake_org_id',
+        _environmentId: 'fake_env_id',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+        priority: 0,
+        controls: {
+          email: {
+            body: layoutContent,
+          },
+        },
+      });
+
+      getLayoutUseCase.execute.resolves({
+        _id: 'test_layout_id',
+        isDefault: false,
+        name: 'test_layout_name',
+        layoutId: 'test_layout_id',
+      } as any);
+
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Layout Filter Test',
+          body: stepContent,
+          layoutId: 'test_layout_id',
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { count: 5 },
+        },
+        workflowId: mockDbWorkflow._id,
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('Step content');
+      // The pluralize filter should have processed with the translated values
+      expect(result.body).to.include('5 apples');
+    });
+
+    it('should handle layout with mixed translation keys and filter arguments', async () => {
+      translateStub.restore();
+      translateStub = sinon
+        .stub(require('@novu/ee-translation').Translate.prototype, 'execute')
+        .callsFake(async (command: any) => {
+          let content = command.content || '';
+
+          // Transform standalone translation keys
+          if (content.includes('{{t.greeting}}')) {
+            content = content.replace('{{t.greeting}}', 'Hello');
+          }
+
+          // Transform filter argument translation keys
+          if (content.includes("'{{t.item}}'")) {
+            content = content.replace("'{{t.item}}'", "'item'");
+          }
+          if (content.includes("'{{t.items}}'")) {
+            content = content.replace("'{{t.items}}'", "'items'");
+          }
+
+          return content;
+        });
+
+      const layoutContent =
+        "<html><body>{{content}}<footer>{{t.greeting}}! You have {{ payload.count | pluralize: 't.item', 't.items' }}</footer></body></html>";
+      const stepContent = '<p>Main content</p>';
+
+      controlValuesRepositoryMock.findOne.resolves({
+        _id: 'test_layout_id',
+        _organizationId: 'fake_org_id',
+        _environmentId: 'fake_env_id',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        level: ControlValuesLevelEnum.LAYOUT_CONTROLS,
+        priority: 0,
+        controls: {
+          email: {
+            body: layoutContent,
+          },
+        },
+      });
+
+      getLayoutUseCase.execute.resolves({
+        _id: 'test_layout_id',
+        isDefault: false,
+        name: 'test_layout_name',
+        layoutId: 'test_layout_id',
+      } as any);
+
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Mixed Layout Test',
+          body: stepContent,
+          layoutId: 'test_layout_id',
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { count: 3 },
+        },
+        workflowId: mockDbWorkflow._id,
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('Main content');
+      expect(result.body).to.include('Hello');
+      expect(result.body).to.include('3 items');
+    });
+  });
+
+  describe('Case-insensitive translation key matching', () => {
+    beforeEach(() => {
+      getOrganizationSettingsMock.execute.resolves({
+        removeNovuBranding: false,
+        defaultLocale: 'en_US',
+      });
+    });
+
+    it('should match uppercase translation keys from upcase filter', async () => {
+      translateStub.restore();
+      translateStub = sinon
+        .stub(require('@novu/ee-translation').Translate.prototype, 'execute')
+        .callsFake(async (command: any) => {
+          // Match both lowercase and uppercase translation keys
+          if (command.content.includes('{{T.GREETING}}')) {
+            return command.content.replace('{{T.GREETING}}', 'HELLO WORLD');
+          }
+          if (command.content.includes('{{t.greeting}}')) {
+            return command.content.replace('{{t.greeting}}', 'hello world');
+          }
+
+          return command.content || '';
+        });
+
+      const plainHtmlBody = '<p>{{T.GREETING}}</p>';
+
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Case Test',
+          body: plainHtmlBody,
+        },
+        fullPayloadForRender: mockFullPayload,
+        workflowId: mockDbWorkflow._id,
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('HELLO WORLD');
+    });
+
+    it('should match lowercase translation keys from downcase filter', async () => {
+      translateStub.restore();
+      translateStub = sinon
+        .stub(require('@novu/ee-translation').Translate.prototype, 'execute')
+        .callsFake(async (command: any) => {
+          if (command.content.includes('{{t.welcome}}')) {
+            return command.content.replace('{{t.welcome}}', 'welcome');
+          }
+
+          return command.content || '';
+        });
+
+      const plainHtmlBody = '<p>{{t.welcome}} to our service</p>';
+
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Lowercase Test',
+          body: plainHtmlBody,
+        },
+        fullPayloadForRender: mockFullPayload,
+        workflowId: mockDbWorkflow._id,
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('welcome to our service');
+    });
+
+    it('should handle mixed case translation keys in the same content', async () => {
+      translateStub.restore();
+      translateStub = sinon
+        .stub(require('@novu/ee-translation').Translate.prototype, 'execute')
+        .callsFake(async (command: any) => {
+          let content = command.content || '';
+
+          // Handle uppercase keys (from upcase filter)
+          if (content.includes('{{T.HEADER}}')) {
+            content = content.replace('{{T.HEADER}}', 'WELCOME');
+          }
+          // Handle lowercase keys (from downcase filter)
+          if (content.includes('{{t.footer}}')) {
+            content = content.replace('{{t.footer}}', 'thank you');
+          }
+          // Handle normal case keys
+          if (content.includes('{{t.body}}')) {
+            content = content.replace('{{t.body}}', 'This is the body');
+          }
+
+          return content;
+        });
+
+      const plainHtmlBody = '<header>{{T.HEADER}}</header><main>{{t.body}}</main><footer>{{t.footer}}</footer>';
+
+      const renderCommand: EmailOutputRendererCommand = {
+        environmentId: 'fake_env_id',
+        organizationId: 'fake_org_id',
+        controlValues: {
+          subject: 'Mixed Case Test',
+          body: plainHtmlBody,
+        },
+        fullPayloadForRender: mockFullPayload,
+        workflowId: mockDbWorkflow._id,
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('WELCOME');
+      expect(result.body).to.include('This is the body');
+      expect(result.body).to.include('thank you');
     });
   });
 });

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -331,8 +331,20 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
 
     const layoutControlValues = layoutControlsEntity.controls as LayoutControlType;
 
+    /**
+     * Preprocess layout body: transform 't.key' filter arguments to '{{t.key}}'
+     * so they can be resolved by the translation service.
+     *
+     * This preprocessing normally happens in the framework's client.ts (preprocessFilterTranslationArgs),
+     * but since layouts are fetched directly from the database and don't go through the framework,
+     * we need to apply the same transformation here.
+     *
+     * @see packages/framework/src/client.ts - preprocessFilterTranslationArgs
+     */
+    const layoutBody = (layoutControlValues.email?.body ?? '').replace(/'t\.([\p{L}\p{N}_.-]+)'/gu, "'{{t.$1}}'");
+
     return this.processBodyContent({
-      body: layoutControlValues.email?.body ?? '',
+      body: layoutBody,
       payload: {
         ...payload,
         [LAYOUT_CONTENT_VARIABLE]: removeBrandingFromHtml(cleanedStepBodyHtml.replace(/\n/g, '')),

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -1229,6 +1229,127 @@ describe('Novu Client', () => {
       });
     });
 
+    it('should preserve translation keys used as filter arguments', async () => {
+      const newWorkflow = workflow(
+        'test-workflow',
+        async ({ step }) => {
+          await step.email(
+            'send-email',
+            async (controls) => ({
+              body: controls.body,
+              subject: controls.subject,
+            }),
+            {
+              controlSchema: {
+                type: 'object',
+                properties: {
+                  body: { type: 'string' },
+                  subject: { type: 'string' },
+                },
+                required: ['body', 'subject'],
+                additionalProperties: false,
+              } as const,
+            }
+          );
+        },
+        {
+          payloadSchema: {
+            type: 'object',
+            properties: {
+              count: { type: 'number' },
+            },
+            required: ['count'],
+            additionalProperties: false,
+          } as const,
+        }
+      );
+
+      await client.addWorkflows([newWorkflow]);
+
+      const event: Event = {
+        action: PostActionEnum.EXECUTE,
+        payload: { count: 5 },
+        workflowId: 'test-workflow',
+        stepId: 'send-email',
+        subscriber: {},
+        state: [],
+        controls: {
+          body: "You have {{ payload.count | pluralize: 't.apple', 't.apples' }}",
+          subject: "{{ payload.count | pluralize: 't.itemSingular', 't.itemPlural' }} in your cart",
+        },
+        context: {},
+      };
+
+      const emailExecutionResult = await client.executeWorkflow(event);
+
+      // Translation keys used as filter arguments should be transformed to {{t.key}} format
+      expect(emailExecutionResult.outputs).toEqual({
+        body: 'You have 5 {{t.apples}}',
+        subject: '5 {{t.itemPlural}} in your cart',
+      });
+    });
+
+    it('should handle translation keys with mixed liquid expressions and filters', async () => {
+      const newWorkflow = workflow(
+        'test-workflow',
+        async ({ step }) => {
+          await step.email(
+            'send-email',
+            async (controls) => ({
+              body: controls.body,
+              subject: controls.subject,
+            }),
+            {
+              controlSchema: {
+                type: 'object',
+                properties: {
+                  body: { type: 'string' },
+                  subject: { type: 'string' },
+                },
+                required: ['body', 'subject'],
+                additionalProperties: false,
+              } as const,
+            }
+          );
+        },
+        {
+          payloadSchema: {
+            type: 'object',
+            properties: {
+              count: { type: 'number' },
+              name: { type: 'string' },
+            },
+            required: ['count', 'name'],
+            additionalProperties: false,
+          } as const,
+        }
+      );
+
+      await client.addWorkflows([newWorkflow]);
+
+      const event: Event = {
+        action: PostActionEnum.EXECUTE,
+        payload: { count: 1, name: 'Alice' },
+        workflowId: 'test-workflow',
+        stepId: 'send-email',
+        subscriber: {},
+        state: [],
+        controls: {
+          body: "Hello {{payload.name}}, you have {{ payload.count | pluralize: 't.item', 't.items' }}. {{t.footer}}",
+          subject: '{{t.greeting}} {{payload.name}}',
+        },
+        context: {},
+      };
+
+      const emailExecutionResult = await client.executeWorkflow(event);
+
+      // Mix of payload variables, translation filter args, and standalone translation keys
+      expect(emailExecutionResult.outputs).toEqual({
+        body: 'Hello Alice, you have 1 {{t.item}}. {{t.footer}}',
+        subject: '{{t.greeting}} Alice',
+      });
+    });
+
     it('should compile context variables correctly', async () => {
       const newWorkflow = workflow(
         'test-workflow',

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -680,7 +680,8 @@ export class Client {
 
   private async compileControls(templateControls: Record<string, unknown>, event: Event) {
     try {
-      const templateString = this.preprocessTranslationPatterns(JSON.stringify(templateControls));
+      let templateString = this.preprocessTranslationPatterns(JSON.stringify(templateControls));
+      templateString = this.preprocessFilterTranslationArgs(templateString);
       const parsedTemplate = this.templateEngine.parse(templateString);
       const discoveredWorkflow = this.getWorkflow(event.workflowId);
 
@@ -696,13 +697,14 @@ export class Client {
         subscriber: event.subscriber,
         context: event.context,
         steps: buildSteps(event.state),
-        t: {}, // Empty object so t.* properties are undefined and trigger default filters
       };
 
       const compiledString = await this.templateEngine.render(parsedTemplate, renderVariables);
+      // Post-process: convert [T:key] placeholders back to {{t.key}} markers
+      const withMarkers = this.postprocessTranslationMarkers(compiledString);
       // repair the string to fix invalid JSON, it could happen in the case when the control value
       // doesn't have escaped quotes like '"foo"' then compiled string '{"body":""foo""}' is not valid JSON and parse will fail
-      const repairedString = jsonrepair(compiledString);
+      const repairedString = jsonrepair(withMarkers);
       return JSON.parse(repairedString);
     } catch (error) {
       throw new StepControlCompilationFailedError(event.workflowId, event.stepId, error);
@@ -710,11 +712,28 @@ export class Client {
   }
 
   /**
-   * Preprocesses translation patterns to preserve them when values are undefined.
-   * Transforms {{t.key}} to {{t.key | default: "{{t.key}}"}}
+   * Preprocesses standalone translation patterns.
+   * Transforms {{t.key}} to [T:key] placeholder (not Liquid syntax, passes through unchanged).
    */
   private preprocessTranslationPatterns(template: string): string {
-    return template.replace(/\{\{\s*t\.([\p{L}\p{N}_.-]+)\s*\}\}/gu, '{{ t.$1 | default: "{{t.$1}}" }}');
+    return template.replace(/\{\{\s*t\.([\p{L}\p{N}_.-]+)\s*\}\}/gu, '[T:$1]');
+  }
+
+  /**
+   * Preprocesses translation keys used as filter arguments.
+   * Transforms 't.key' to '[T:key]' placeholder (not Liquid syntax, passes through unchanged).
+   * Example: pluralize: 't.apple', 't.apples' → pluralize: '[T:apple]', '[T:apples]'
+   */
+  private preprocessFilterTranslationArgs(template: string): string {
+    return template.replace(/'t\.([\p{L}\p{N}_.-]+)'/gu, "'[T:$1]'");
+  }
+
+  /**
+   * Post-processes placeholders back to translation markers after Liquid render.
+   * Transforms [T:key] back to {{t.key}} for the translation service.
+   */
+  private postprocessTranslationMarkers(content: string): string {
+    return content.replace(/\[T:([\p{L}\p{N}_.-]+)\]/gu, '{{t.$1}}');
   }
 
   /**

--- a/packages/shared/src/consts/translation/translation.constants.spec.ts
+++ b/packages/shared/src/consts/translation/translation.constants.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { TRANSLATION_KEY_SINGLE_REGEX } from './translation.constants';
+
+describe('TRANSLATION_KEY_SINGLE_REGEX', () => {
+  describe('case-insensitive matching', () => {
+    it('should match lowercase translation keys', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t.hello}}')).toBe(true);
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t.greeting}}')).toBe(true);
+    });
+
+    it('should match uppercase translation keys (case-insensitive)', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{T.HELLO}}')).toBe(true);
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{T.GREETING}}')).toBe(true);
+    });
+
+    it('should match mixed case translation keys', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{T.helloWorld}}')).toBe(true);
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t.HelloWorld}}')).toBe(true);
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{T.hello}}')).toBe(true);
+    });
+  });
+
+  describe('key extraction', () => {
+    it('should extract key from lowercase translation marker', () => {
+      const match = '{{t.greeting}}'.match(TRANSLATION_KEY_SINGLE_REGEX);
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe('greeting');
+    });
+
+    it('should extract key from uppercase translation marker', () => {
+      const match = '{{T.GREETING}}'.match(TRANSLATION_KEY_SINGLE_REGEX);
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe('GREETING');
+    });
+
+    it('should extract nested keys', () => {
+      const match = '{{t.nested.key.value}}'.match(TRANSLATION_KEY_SINGLE_REGEX);
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe('nested.key.value');
+    });
+  });
+
+  describe('whitespace handling', () => {
+    it('should match with spaces around the key', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{ t.hello }}')).toBe(true);
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{  t.hello  }}')).toBe(true);
+    });
+
+    it('should match with spaces around uppercase key', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{ T.HELLO }}')).toBe(true);
+    });
+  });
+
+  describe('special characters in keys', () => {
+    it('should match keys with dashes', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t.hello-world}}')).toBe(true);
+    });
+
+    it('should match keys with underscores', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t.hello_world}}')).toBe(true);
+    });
+
+    it('should match keys with numbers', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t.item123}}')).toBe(true);
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t.123}}')).toBe(true);
+    });
+  });
+
+  describe('non-matching cases', () => {
+    it('should not match regular liquid variables', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{payload.name}}')).toBe(false);
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{subscriber.email}}')).toBe(false);
+    });
+
+    it('should not match incomplete translation markers', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t.}}')).toBe(false);
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t}}')).toBe(false);
+    });
+
+    it('should not match translation markers without braces', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('t.hello')).toBe(false);
+    });
+  });
+
+  describe('global regex usage warning', () => {
+    it('should not have global flag to avoid state issues', () => {
+      expect(TRANSLATION_KEY_SINGLE_REGEX.global).toBe(false);
+    });
+
+    it('should be safe to use .test() multiple times', () => {
+      // Global regexes maintain state and cause inconsistent results
+      // This test verifies the regex works correctly for multiple consecutive calls
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t.hello}}')).toBe(true);
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t.hello}}')).toBe(true);
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{t.world}}')).toBe(true);
+      expect(TRANSLATION_KEY_SINGLE_REGEX.test('{{T.HELLO}}')).toBe(true);
+    });
+  });
+});

--- a/packages/shared/src/consts/translation/translation.constants.ts
+++ b/packages/shared/src/consts/translation/translation.constants.ts
@@ -12,11 +12,14 @@ export const TRANSLATION_NAMESPACE_SEPARATOR = 't.';
  * Regular expression to match a single translation key in the format {{t.key}} with optional spaces
  * (non-global version for single matches)
  *
+ * Case-insensitive to support keys transformed by upcase/downcase filters.
+ * E.g., {{t.appleSingular}} after upcase becomes {{T.APPLESINGULAR}}
+ *
  * ⚠️ WARNING: Do NOT add global flag (/g) to this regex! Global regexes maintain state
  * and cause inconsistent .test() results when shared across calls.
- * Use: new RegExp(TRANSLATION_KEY_SINGLE_REGEX.source, 'g') for global matching instead.
+ * Use: new RegExp(TRANSLATION_KEY_SINGLE_REGEX.source, 'gi') for global matching instead.
  */
-export const TRANSLATION_KEY_SINGLE_REGEX = /\{\{\s*t\.([^}]+?)\s*\}\}/;
+export const TRANSLATION_KEY_SINGLE_REGEX = /\{\{\s*t\.([^}]+?)\s*\}\}/i;
 
 /**
  * Translation trigger character (without spaces)


### PR DESCRIPTION
### What changed? Why was the change needed?

EE PR: https://github.com/novuhq/packages-enterprise/pull/379

Fixes NV-6937, NV-6870

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed translation filter handling in email layouts to ensure proper rendering of translated content
  * Improved translation placeholder preservation during framework processing

* **Improvements**
  * Translation keys are now matched case-insensitively for greater flexibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->