### PR TITLE
fix(api): remove duplicate widgets module entry

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -129,7 +129,6 @@ const baseModules: Array<Type | DynamicModule | Promise<DynamicModule> | Forward
   StorageModule,
   WorkflowOverridesModule,
   RateLimitingModule,
-  WidgetsModule,
   TracingModule.register(packageJson.name, packageJson.version),
   BridgeModule,
   PreferencesModule,


### PR DESCRIPTION
## Summary
- remove the duplicate WidgetsModule entry from the base module list

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df7a1aa78832eb284e3663aa45e03)