### PR TITLE
feat(dashboard): rename analytics to usage

### DIFF
--- a/apps/dashboard/src/components/side-navigation/side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/side-navigation.tsx
@@ -182,7 +182,7 @@ export const SideNavigation = () => {
                       to={buildRoute(ROUTES.ANALYTICS, { environmentSlug: currentEnvironment?.slug ?? '' })}
                     >
                       <RiLineChartLine className="size-4" />
-                      <span>Analytics</span>
+                      <span>Usage</span>
                     </NavigationLink>
                   </Protect>
                 )}

--- a/apps/dashboard/src/pages/analytics.tsx
+++ b/apps/dashboard/src/pages/analytics.tsx
@@ -104,11 +104,11 @@ export function AnalyticsPage() {
 
   return (
     <>
-      <PageMeta title="Analytics" />
+      <PageMeta title="Usage" />
       <DashboardLayout
         headerStartItems={
           <h1 className="text-foreground-950 flex items-center gap-1">
-            <span>Analytics</span>
+            <span>Usage</span>
             {isDevMockMode && (
               <Badge variant="filled" color="orange" className="text-xs">
                 DEV MOCK DATA
@@ -190,7 +190,7 @@ export function AnalyticsPage() {
           </div>
           {currentEnvironment?.type === EnvironmentTypeEnum.DEV && (
             <InlineToast
-              title="You're viewing analytics for the Development environment"
+              title="You're viewing usage for the Development environment"
               variant="tip"
               ctaLabel="Switch to production"
               onCtaClick={() => {

--- a/apps/dashboard/src/utils/telemetry.ts
+++ b/apps/dashboard/src/utils/telemetry.ts
@@ -59,7 +59,7 @@ export enum TelemetryEvent {
   WORKFLOW_CHECKLIST_STEP_CLICKED = 'Workflow checklist step clicked - [Workflow Editor]',
   WORKFLOW_INSTRUCTIONS_OPENED = 'Workflow instructions opened - [Workflow Editor]',
   SUBSCRIBERS_PAGE_VISIT = 'Subscribers page visit',
-  ANALYTICS_PAGE_VISIT = 'Usage page visit',
+  ANALYTICS_PAGE_VISIT = 'Analytics page visit',
   SUBSCRIBER_CREATED = 'Subscriber created',
   SUBSCRIBER_EDITED = 'Subscriber edited',
   SUBSCRIBER_DELETED = 'Subscriber deleted',

--- a/apps/dashboard/src/utils/telemetry.ts
+++ b/apps/dashboard/src/utils/telemetry.ts
@@ -59,7 +59,7 @@ export enum TelemetryEvent {
   WORKFLOW_CHECKLIST_STEP_CLICKED = 'Workflow checklist step clicked - [Workflow Editor]',
   WORKFLOW_INSTRUCTIONS_OPENED = 'Workflow instructions opened - [Workflow Editor]',
   SUBSCRIBERS_PAGE_VISIT = 'Subscribers page visit',
-  ANALYTICS_PAGE_VISIT = 'Analytics page visit',
+  ANALYTICS_PAGE_VISIT = 'Usage page visit',
   SUBSCRIBER_CREATED = 'Subscriber created',
   SUBSCRIBER_EDITED = 'Subscriber edited',
   SUBSCRIBER_DELETED = 'Subscriber deleted',


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR renames all instances of "Analytics" to "Usage" across the dashboard UI and telemetry events.

Specifically:
*   The side navigation label for the analytics section was updated to "Usage".
*   The page title, main heading, and a development environment toast message on the analytics page were changed to reflect "Usage".
*   The telemetry event description for the analytics page visit was updated from "Analytics page visit" to "Usage page visit".

This change is needed to align with the product's new standardized terminology for usage tracking, improving overall user experience and consistency as outlined in [NV-6918](https://linear.app/novu/issue/NV-6918/rename-analytics-to-usage).

### Screenshots

---
Linear Issue: [NV-6918](https://linear.app/novu/issue/NV-6918/rename-analytics-to-usage)

<a href="https://cursor.com/background-agent?bcId=bc-ce5944db-3186-43b8-bdd0-6ddf4b09f6ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce5944db-3186-43b8-bdd0-6ddf4b09f6ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

