### PR TITLE
fix(dashboard):  UserButton re-rendering for legacy dashboard option

### DIFF
--- a/apps/dashboard/src/components/user-profile.tsx
+++ b/apps/dashboard/src/components/user-profile.tsx
@@ -1,5 +1,6 @@
 import { UserButton, useOrganization } from '@clerk/clerk-react';
 import { FeatureFlagsKeysEnum } from '@novu/shared';
+import { useMemo } from 'react';
 import { RiSignpostFill } from 'react-icons/ri';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useNewDashboardOptIn } from '@/hooks/use-new-dashboard-opt-in';
@@ -7,23 +8,30 @@ import { ROUTES } from '../utils/routes';
 
 export function UserProfile() {
   const { organization } = useOrganization();
-  const { optOut } = useNewDashboardOptIn();
   const isLegacySelectorButtonVisible = useFeatureFlag(FeatureFlagsKeysEnum.IS_LEGACY_SELECTOR_BUTTON_VISIBLE);
 
-  const shouldShowLegacyButton =
-    organization && (organization.createdAt < new Date('2024-12-24') || isLegacySelectorButtonVisible);
+  const shouldShowLegacyButton = useMemo(
+    () => organization && (organization.createdAt < new Date('2024-12-24') || isLegacySelectorButtonVisible),
+    [organization, isLegacySelectorButtonVisible]
+  );
 
-  return (
-    <UserButton
-      userProfileUrl={ROUTES.SETTINGS_ACCOUNT}
-      appearance={{
-        elements: {
-          avatarBox: 'h-6 w-6',
-          userButtonTrigger: 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        },
-      }}
-    >
-      {shouldShowLegacyButton && (
+  const { optOut } = useNewDashboardOptIn();
+
+  /**
+   * Required duplication due to clerk fails to re-render based on child components changes
+   */
+  if (shouldShowLegacyButton) {
+    return (
+      <UserButton
+        key="legacy"
+        userProfileUrl={ROUTES.SETTINGS_ACCOUNT}
+        appearance={{
+          elements: {
+            avatarBox: 'h-6 w-6',
+            userButtonTrigger: 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          },
+        }}
+      >
         <UserButton.MenuItems>
           <UserButton.Action
             label="Go back to legacy V0 Dashboard"
@@ -31,7 +39,20 @@ export function UserProfile() {
             onClick={optOut}
           />
         </UserButton.MenuItems>
-      )}
-    </UserButton>
-  );
+      </UserButton>
+    );
+  } else {
+    return (
+      <UserButton
+        key="new"
+        userProfileUrl={ROUTES.SETTINGS_ACCOUNT}
+        appearance={{
+          elements: {
+            avatarBox: 'h-6 w-6',
+            userButtonTrigger: 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          },
+        }}
+      ></UserButton>
+    );
+  }
 }


### PR DESCRIPTION
Refactored UserProfile to conditionally render UserButton with distinct keys based on legacy dashboard visibility. This resolves issues with Clerk failing to re-render child components when feature flags or organization state change.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
