### PR TITLE
refactor(worker): workflow trigger update logic to avoid hot items

### DIFF
--- a/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
@@ -306,6 +306,7 @@ export class TriggerEvent {
       activeWorkerName: getActiveWorker(),
     });
   }
+
   private async getAndUpdateWorkflowById(command: {
     triggerIdentifier: string;
     environmentId: string;
@@ -315,15 +316,15 @@ export class TriggerEvent {
   }) {
     const lastTriggeredAt = new Date();
 
-    const workflow = await this.notificationTemplateRepository.findByTriggerIdentifierAndUpdate(
+    const workflow = await this.notificationTemplateRepository.findByTriggerIdentifier(
       command.environmentId,
-      command.triggerIdentifier,
-      lastTriggeredAt
+      command.triggerIdentifier
     );
 
     if (workflow) {
-      // We only consider trigger when it's coming from the backend SDK
-      if (!command.payload?.__source) {
+      const isBackendSDK = !command.payload?.__source;
+
+      if (isBackendSDK) {
         if (!workflow.lastTriggeredAt) {
           this.analyticsService.track('Workflow Connected to Backend SDK - [API]', command.userId, {
             name: workflow.name,
@@ -333,9 +334,21 @@ export class TriggerEvent {
           });
         }
 
-        /**
-         * Update the entry to cache it with the new lastTriggeredAt
-         */
+        const shouldUpdate =
+          !workflow.lastTriggeredAt ||
+          new Date(workflow.lastTriggeredAt).getTime() < lastTriggeredAt.getTime() - 5 * 60 * 1000;
+
+        if (shouldUpdate) {
+          const previousLastTriggeredAt = workflow.lastTriggeredAt ? new Date(workflow.lastTriggeredAt) : null;
+
+          this.notificationTemplateRepository.updateLastTriggeredAt(
+            command.environmentId,
+            command.triggerIdentifier,
+            lastTriggeredAt,
+            previousLastTriggeredAt
+          );
+        }
+
         workflow.lastTriggeredAt = lastTriggeredAt.toISOString();
       }
     }

--- a/libs/dal/src/repositories/notification-template/notification-template.repository.ts
+++ b/libs/dal/src/repositories/notification-template/notification-template.repository.ts
@@ -134,14 +134,18 @@ export class NotificationTemplateRepository extends BaseRepository<
     return this.mapEntity(item);
   }
 
-  async findByTriggerIdentifierAndUpdate(environmentId: string, triggerIdentifier: string, lastTriggeredAt: Date) {
-    const requestQuery: NotificationTemplateQuery = {
-      _environmentId: environmentId,
-      'triggers.identifier': triggerIdentifier,
-    };
-
-    const item = await this.MongooseModel.findOneAndUpdate(
-      requestQuery,
+  async updateLastTriggeredAt(
+    environmentId: string,
+    triggerIdentifier: string,
+    lastTriggeredAt: Date,
+    previousLastTriggeredAt: Date | null
+  ) {
+    const updateResult = await this.MongooseModel.updateOne(
+      {
+        _environmentId: environmentId,
+        'triggers.identifier': triggerIdentifier,
+        $or: [{ lastTriggeredAt: null }, { lastTriggeredAt: previousLastTriggeredAt }],
+      },
       {
         $set: {
           lastTriggeredAt,
@@ -149,10 +153,11 @@ export class NotificationTemplateRepository extends BaseRepository<
       },
       {
         timestamps: false,
+        writeConcern: { w: 1 },
       }
-    ).populate('steps.template');
+    );
 
-    return this.mapEntity(item);
+    return updateResult.modifiedCount > 0;
   }
 
   async updatePublishFields(workflowId: string, environmentId: string, userId: string, session?: ClientSession | null) {

--- a/libs/dal/src/repositories/notification-template/notification-template.repository.ts
+++ b/libs/dal/src/repositories/notification-template/notification-template.repository.ts
@@ -87,7 +87,10 @@ export class NotificationTemplateRepository extends BaseRepository<
       'triggers.identifier': identifier,
     };
 
-    const query = this.MongooseModel.findOne(requestQuery, undefined, { session }).populate('steps.template');
+    const query = this.MongooseModel.findOne(requestQuery, undefined, {
+      session,
+      readPreference: 'secondaryPreferred',
+    }).populate('steps.template');
 
     if (includeUpdatedBy) {
       query.populate('updatedBy');


### PR DESCRIPTION
Replaces findByTriggerIdentifierAndUpdate with separate find and updateLastTriggeredAt methods. Updates lastTriggeredAt only if not set or older than 5 minutes, improving cache and update efficiency for workflow triggers.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
