### PR TITLE
perf(api-service): reuse Ajv instance for payload validation

### DIFF
--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
@@ -48,6 +48,12 @@ import {
   ParseEventRequestMulticastCommand,
 } from './parse-event-request.command';
 
+const ajv = new Ajv({
+  allErrors: true,
+  useDefaults: true,
+});
+addFormats(ajv);
+
 @Injectable()
 export class ParseEventRequest {
   constructor(
@@ -511,12 +517,6 @@ export class ParseEventRequest {
   }
 
   private validateAndApplyPayloadDefaults(payload: any, schema: any): any {
-    const ajv = new Ajv({
-      allErrors: true,
-      useDefaults: true,
-    });
-    addFormats(ajv);
-
     const validate = ajv.compile(schema);
 
     // Create a deep copy of the payload to avoid mutating the original

--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
@@ -520,7 +520,7 @@ export class ParseEventRequest {
     const validate = ajv.compile(schema);
 
     // Create a deep copy of the payload to avoid mutating the original
-    const payloadWithDefaults = JSON.parse(JSON.stringify(payload));
+    const payloadWithDefaults = structuredClone(payload);
     const valid = validate(payloadWithDefaults);
 
     if (!valid && validate.errors) {

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -400,11 +400,22 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
   }
 
   protected mapEntity<TData>(data: TData): TData extends null ? null : T_MappedEntity {
-    return plainToInstance(this.entity, structuredClone(data)) as any;
+    const plainData =
+      data && typeof data === 'object' && 'toObject' in data && typeof data.toObject === 'function'
+        ? data.toObject()
+        : data;
+
+    return plainToInstance(this.entity, structuredClone(plainData)) as any;
   }
 
   protected mapEntities(data: any): T_MappedEntity[] {
-    return plainToInstance<T_MappedEntity, T_MappedEntity[]>(this.entity, JSON.parse(JSON.stringify(data)));
+    const plainData = Array.isArray(data)
+      ? data.map((item) => (item && typeof item === 'object' && 'toObject' in item && typeof item.toObject === 'function' 
+          ? item.toObject() 
+          : item))
+      : data;
+
+    return plainToInstance<T_MappedEntity, T_MappedEntity[]>(this.entity, structuredClone(plainData));
   }
 
   /*

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -404,7 +404,7 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
   }
 
   protected mapEntities(data: any): T_MappedEntity[] {
-    return plainToInstance<T_MappedEntity, T_MappedEntity[]>(this.entity, structuredClone(data));
+    return plainToInstance<T_MappedEntity, T_MappedEntity[]>(this.entity, JSON.parse(JSON.stringify(data)));
   }
 
   /*

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -410,9 +410,11 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
 
   protected mapEntities(data: any): T_MappedEntity[] {
     const plainData = Array.isArray(data)
-      ? data.map((item) => (item && typeof item === 'object' && 'toObject' in item && typeof item.toObject === 'function' 
-          ? item.toObject() 
-          : item))
+      ? data.map((item) =>
+          item && typeof item === 'object' && 'toObject' in item && typeof item.toObject === 'function'
+            ? item.toObject()
+            : item
+        )
       : data;
 
     return plainToInstance<T_MappedEntity, T_MappedEntity[]>(this.entity, structuredClone(plainData));

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -400,11 +400,11 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
   }
 
   protected mapEntity<TData>(data: TData): TData extends null ? null : T_MappedEntity {
-    return plainToInstance(this.entity, JSON.parse(JSON.stringify(data))) as any;
+    return plainToInstance(this.entity, structuredClone(data)) as any;
   }
 
   protected mapEntities(data: any): T_MappedEntity[] {
-    return plainToInstance<T_MappedEntity, T_MappedEntity[]>(this.entity, JSON.parse(JSON.stringify(data)));
+    return plainToInstance<T_MappedEntity, T_MappedEntity[]>(this.entity, structuredClone(data));
   }
 
   /*


### PR DESCRIPTION
Moves Ajv instance creation to a module-level constant and reuses it in validateAndApplyPayloadDefaults, instead of creating a new instance on each call. This improves performance and consistency in schema validation.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
