### PR TITLE
fix(api-service): workflowId duplication bug fixes NV-6946

### DIFF
--- a/apps/api/src/app/workflows-v2/dtos/duplicate-workflow.dto.ts
+++ b/apps/api/src/app/workflows-v2/dtos/duplicate-workflow.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsBoolean, IsOptional, IsString, Matches } from 'class-validator';
 
 export class DuplicateWorkflowDto {
   @ApiProperty({
@@ -9,6 +9,17 @@ export class DuplicateWorkflowDto {
   @IsOptional()
   @IsString()
   name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Custom workflow identifier for the duplicated workflow',
+    type: String,
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+    message: 'workflowId must be a valid slug format (lowercase letters, numbers, and hyphens only)',
+  })
+  workflowId?: string;
 
   @ApiPropertyOptional({
     description: 'Tags associated with the workflow',

--- a/apps/api/src/app/workflows-v2/usecases/duplicate-workflow/duplicate-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/duplicate-workflow/duplicate-workflow.usecase.ts
@@ -70,6 +70,7 @@ export class DuplicateWorkflowUseCase {
     preferences: PreferencesEntity[]
   ): Promise<UpsertWorkflowDataCommand> {
     return {
+      workflowId: overrides.workflowId,
       name: overrides.name ?? `${originWorkflow.name} (Copy)`,
       description: overrides.description ?? originWorkflow.description,
       tags: overrides.tags ?? originWorkflow.tags,

--- a/apps/api/src/app/workflows-v2/usecases/duplicate-workflow/duplicate-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/duplicate-workflow/duplicate-workflow.usecase.ts
@@ -46,6 +46,7 @@ export class DuplicateWorkflowUseCase {
       UpsertWorkflowCommand.create({
         workflowDto: duplicateWorkflowDto,
         user: command.user,
+        preserveWorkflowId: !!command.overrides.workflowId,
       })
     );
 

--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -778,23 +778,6 @@ describe('Workflow Controller E2E API Testing #novu-v2', () => {
       expect(duplicatedWorkflow?.tags).to.deep.equal(['tag1', 'tag2']);
     });
 
-    it('should duplicate a workflow with custom workflowId', async () => {
-      const workflowCreated = await createWorkflowAndValidate('XYZ');
-      const customWorkflowId = 'my-custom-workflow-id';
-      const duplicatedWorkflow = (
-        await apiClient.workflows.duplicate(
-          {
-            name: 'Duplicated Workflow',
-            workflowId: customWorkflowId,
-          } as any,
-          workflowCreated.id
-        )
-      ).result;
-      expect(duplicatedWorkflow?.id).to.not.equal(workflowCreated.id);
-      expect(duplicatedWorkflow?.workflowId).to.equal(customWorkflowId);
-      expect(duplicatedWorkflow?.name).to.equal('Duplicated Workflow');
-    });
-
     it('should throw an error if the workflow to duplicate is not found', async () => {
       const res = await expectSdkExceptionGeneric(() =>
         apiClient.workflows.duplicate({ name: 'Duplicated Workflow' }, '123')

--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -778,6 +778,23 @@ describe('Workflow Controller E2E API Testing #novu-v2', () => {
       expect(duplicatedWorkflow?.tags).to.deep.equal(['tag1', 'tag2']);
     });
 
+    it('should duplicate a workflow with custom workflowId', async () => {
+      const workflowCreated = await createWorkflowAndValidate('XYZ');
+      const customWorkflowId = 'my-custom-workflow-id';
+      const duplicatedWorkflow = (
+        await apiClient.workflows.duplicate(
+          {
+            name: 'Duplicated Workflow',
+            workflowId: customWorkflowId,
+          } as any,
+          workflowCreated.id
+        )
+      ).result;
+      expect(duplicatedWorkflow?.id).to.not.equal(workflowCreated.id);
+      expect(duplicatedWorkflow?.workflowId).to.equal(customWorkflowId);
+      expect(duplicatedWorkflow?.name).to.equal('Duplicated Workflow');
+    });
+
     it('should throw an error if the workflow to duplicate is not found', async () => {
       const res = await expectSdkExceptionGeneric(() =>
         apiClient.workflows.duplicate({ name: 'Duplicated Workflow' }, '123')

--- a/apps/dashboard/src/hooks/use-duplicate-workflow.ts
+++ b/apps/dashboard/src/hooks/use-duplicate-workflow.ts
@@ -53,6 +53,7 @@ export function useDuplicateWorkflow({ workflowSlug, onSuccess }: UseDuplicateWo
 
   const submit = (values: z.infer<typeof workflowSchema>) => {
     return mutation.mutateAsync({
+      workflowId: values.workflowId,
       name: values.name,
       description: values.description || undefined,
       tags: values.tags || [],

--- a/packages/shared/src/dto/workflows/workflow.dto.ts
+++ b/packages/shared/src/dto/workflows/workflow.dto.ts
@@ -124,7 +124,10 @@ export type UpsertStepBody = StepCreateBody | UpdateStepBody;
 export type StepCreateBody = StepCreateDto;
 export type UpdateStepBody = StepUpdateDto;
 
-export type DuplicateWorkflowDto = Pick<CreateWorkflowDto, 'name' | 'tags' | 'description' | 'isTranslationEnabled'>;
+export type DuplicateWorkflowDto = Pick<
+  CreateWorkflowDto,
+  'name' | 'tags' | 'description' | 'isTranslationEnabled' | 'workflowId'
+>;
 
 export function isStepCreateBody(step: UpsertStepBody): step is StepCreateDto {
   return step && typeof step === 'object' && !(step as UpdateStepBody)._id;

--- a/packages/shared/src/dto/workflows/workflow.dto.ts
+++ b/packages/shared/src/dto/workflows/workflow.dto.ts
@@ -126,8 +126,10 @@ export type UpdateStepBody = StepUpdateDto;
 
 export type DuplicateWorkflowDto = Pick<
   CreateWorkflowDto,
-  'name' | 'tags' | 'description' | 'isTranslationEnabled' | 'workflowId'
->;
+  'name' | 'tags' | 'description' | 'isTranslationEnabled'
+> & {
+  workflowId?: string;
+};
 
 export function isStepCreateBody(step: UpsertStepBody): step is StepCreateDto {
   return step && typeof step === 'object' && !(step as UpdateStepBody)._id;


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR fixes an issue (NV-6946) where changing the `workflowId` during workflow duplication from the dashboard did not work.

The `workflowId` field was not being passed through the entire duplication flow. This fix addresses the issue by:

*   Adding `workflowId` to the `DuplicateWorkflowDto` in both the shared package and the API DTO.
*   Modifying the API's `DuplicateWorkflowUseCase` to pass the provided `workflowId` to the upsert command.
*   Updating the dashboard's `useDuplicateWorkflow` hook to send the `workflowId` with the duplication request.
*   Adding an E2E test to verify that duplicating a workflow with a custom `workflowId` now functions correctly.

**Relevant links:** [NV-6946](https://linear.app/novu/issue/NV-6946)

### Screenshots

N/A

---
Linear Issue: [NV-6946](https://linear.app/novu/issue/NV-6946/changing-workflowid-during-workflow-duplication-does-not-work)

<a href="https://cursor.com/background-agent?bcId=bc-fb0f974e-cf23-426c-b167-62fb691d5001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb0f974e-cf23-426c-b167-62fb691d5001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

