### PR TITLE
style(dashboard): preview sandbox UI improvements, text fade 

### DIFF
--- a/apps/dashboard/src/components/preview-context-section.tsx
+++ b/apps/dashboard/src/components/preview-context-section.tsx
@@ -9,7 +9,7 @@ import { ContextSectionProps } from './workflow-editor/steps/types/preview-conte
 
 export function PreviewContextSection({ error, context, schema, onUpdate, onClearPersisted }: ContextSectionProps) {
   return (
-    <AccordionItem value="context" className={ACCORDION_STYLES.item}>
+    <AccordionItem value="context" className={ACCORDION_STYLES.itemLast}>
       <AccordionTrigger className={ACCORDION_STYLES.trigger}>
         <div className="flex w-full items-center justify-between">
           <div className="flex items-center gap-2">

--- a/apps/dashboard/src/components/primitives/input.tsx
+++ b/apps/dashboard/src/components/primitives/input.tsx
@@ -48,6 +48,11 @@ export const inputVariants = tv({
       // base
       'w-full bg-transparent bg-none text-paragraph-sm text-text-strong outline-none',
       'transition duration-200 ease-out',
+      // horizontal scroll with fade gradient - only affects text content
+      'overflow-x-auto scrollbar-thin',
+      '[mask-image:linear-gradient(to_right,black_calc(100%-1.5rem),transparent)]',
+      '[mask-size:100%_100%]',
+      '[mask-repeat:no-repeat]',
       // placeholder
       'placeholder:select-none placeholder:text-text-soft placeholder:transition placeholder:duration-200 placeholder:ease-out',
       // hover placeholder

--- a/apps/dashboard/src/components/primitives/input.tsx
+++ b/apps/dashboard/src/components/primitives/input.tsx
@@ -48,7 +48,7 @@ export const inputVariants = tv({
       // base
       'w-full bg-transparent bg-none text-paragraph-sm text-text-strong outline-none',
       'transition duration-200 ease-out',
-      // horizontal scroll with fade gradient - only affects text content
+      // horizontal scroll with fade gradient
       'overflow-x-auto scrollbar-thin',
       '[mask-image:linear-gradient(to_right,black_calc(100%-1.5rem),transparent)]',
       '[mask-size:100%_100%]',

--- a/apps/dashboard/src/components/workflow-editor/steps/components/preview-step-results-section.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/components/preview-step-results-section.tsx
@@ -59,7 +59,7 @@ export function PreviewStepResultsSection({
   const stepEntries = Object.entries(localParsedData.steps || {});
 
   return (
-    <AccordionItem value="step-results" className={ACCORDION_STYLES.itemLast}>
+    <AccordionItem value="step-results" className={ACCORDION_STYLES.item}>
       <AccordionTrigger className={ACCORDION_STYLES.trigger}>
         <div className="flex items-center gap-0.5">
           Step results
@@ -76,9 +76,10 @@ export function PreviewStepResultsSection({
         </div>
       </AccordionTrigger>
       <AccordionContent className="flex flex-col gap-2">
-        {stepEntries.length > 0 ? (
-          <div className="w-full">
-            {stepEntries.map(([stepId, stepData]) => {
+        <div className="flex flex-1 flex-col gap-2 overflow-auto">
+          {stepEntries.length > 0 ? (
+            <>
+              {stepEntries.map(([stepId, stepData]) => {
               const stepType = getStepType(workflow, stepId);
               const StepIcon = getStepTypeIcon(stepType);
               const stepName = getStepName(workflow, stepId);
@@ -133,11 +134,12 @@ export function PreviewStepResultsSection({
                     ))}
                 </div>
               );
-            })}
-          </div>
-        ) : (
-          <p className="text-xs italic text-neutral-500">no step results</p>
-        )}
+              })}
+            </>
+          ) : (
+            <p className="text-xs italic text-neutral-500">no step results</p>
+          )}
+        </div>
       </AccordionContent>
     </AccordionItem>
   );

--- a/apps/dashboard/src/components/workflow-editor/steps/layout/resizable-layout.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/layout/resizable-layout.tsx
@@ -17,7 +17,7 @@ type PanelProps = {
   maxSize?: number;
 };
 
-function ContextPanel({ children, className, defaultSize = 25, minSize = 20, maxSize = 40 }: PanelProps) {
+function ContextPanel({ children, className, defaultSize = 20, minSize = 20, maxSize = 40 }: PanelProps) {
   return (
     <ResizablePanel defaultSize={defaultSize} minSize={minSize} maxSize={maxSize} className="h-full">
       <div className={cn('flex h-full flex-col border-neutral-200', className)}>{children}</div>

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/editable-json-viewer/editable-json-viewer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/editable-json-viewer/editable-json-viewer.tsx
@@ -148,14 +148,15 @@ export function EditableJsonViewer({
       className={cn(
         'border-neutral-alpha-200 bg-background text-foreground-600',
         'mx-0 mt-0 rounded-lg border border-dashed',
-        'max-h-[400px] min-h-[100px] overflow-auto',
+        'max-h-[400px] min-h-[100px] overflow-hidden',
         'font-mono text-xs',
+        'flex flex-col',
         isReadOnly && 'pointer-events-none',
         className
       )}
     >
       {validationErrors.length > 0 && (
-        <div className="p-1.5 pb-0">
+        <div className="p-1.5 pb-0 shrink-0">
           <InlineToast
             variant="error"
             title={`Payload validation issue${validationErrors.length > 1 ? 's' : ''}`}
@@ -172,29 +173,38 @@ export function EditableJsonViewer({
           />
         </div>
       )}
-      <JsonEditor
-        data={value}
-        onUpdate={handleUpdate}
-        onError={handleError}
-        theme={CUSTOM_THEME}
-        TextEditor={CustomTextEditor}
-        customNodeDefinitions={customNodeDefinitions}
-        jsonParse={JSON5.parse}
-        jsonStringify={(data) => JSON5.stringify(data, null, 2)}
-        icons={JSON_EDITOR_ICONS}
-        showErrorMessages={false}
-        showStringQuotes={true}
-        showCollectionCount={!isReadOnly}
-        showArrayIndices={false}
-        enableClipboard={!isReadOnly}
-        restrictEdit={isReadOnly}
-        restrictDelete
-        restrictAdd
-        rootName={'nv-root-node'}
-        defaultValue={undefined}
-        restrictTypeSelection
-        collapseAnimationTime={100}
-      />
+      <div
+        className={cn(
+          'flex-1 overflow-auto overflow-x-auto scrollbar-thin',
+          '[mask-image:linear-gradient(to_right,black_calc(100%-1.5rem),transparent)]',
+          '[mask-size:100%_100%]',
+          '[mask-repeat:no-repeat]'
+        )}
+      >
+        <JsonEditor
+          data={value}
+          onUpdate={handleUpdate}
+          onError={handleError}
+          theme={CUSTOM_THEME}
+          TextEditor={CustomTextEditor}
+          customNodeDefinitions={customNodeDefinitions}
+          jsonParse={JSON5.parse}
+          jsonStringify={(data) => JSON5.stringify(data, null, 2)}
+          icons={JSON_EDITOR_ICONS}
+          showErrorMessages={false}
+          showStringQuotes={true}
+          showCollectionCount={!isReadOnly}
+          showArrayIndices={false}
+          enableClipboard={!isReadOnly}
+          restrictEdit={isReadOnly}
+          restrictDelete
+          restrictAdd
+          rootName={'nv-root-node'}
+          defaultValue={undefined}
+          restrictTypeSelection
+          collapseAnimationTime={100}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### What changed? Why was the change needed?
Brings in minor UI improvements to the preivew sandbox, with fade effects on text cutoff, etc. 

### Screenshots
<table style="width:100%; border-collapse:collapse; text-align:center;">
  <thead>
    <tr>
      <th style="padding:10px; border:1px solid #ddd;">Before</th>
      <th style="padding:10px; border:1px solid #ddd;">After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td style="padding:10px; border:1px solid #ddd;">
        <img src="https://github.com/user-attachments/assets/86344d45-ffa6-4e0e-8140-636a71a151c8"
             alt="Before"
             style="max-width:100%; height:auto; border-radius:6px;" />
      </td>
      <td style="padding:10px; border:1px solid #ddd;">
        <img src="https://github.com/user-attachments/assets/2cf5b472-1723-426f-a676-490c391356e4"
             alt="After"
             style="max-width:100%; height:auto; border-radius:6px;" />
      </td>
    </tr>
  </tbody>
</table>





