### PR TITLE
chore(api-service,js,react): subscription component polishing after bug-bashing part 1 fixes NV-6957

### DIFF
--- a/apps/api/src/app/inbox/dtos/create-topic-subscription-request.dto.ts
+++ b/apps/api/src/app/inbox/dtos/create-topic-subscription-request.dto.ts
@@ -1,6 +1,6 @@
-import { ApiExtraModels, ApiProperty, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
+import { ApiExtraModels, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsArray, IsDefined, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsOptional, IsString, ValidateNested } from 'class-validator';
 import {
   GroupPreferenceFilterDto,
   WorkflowPreferenceRequestDto,
@@ -18,13 +18,13 @@ export class TopicIdentifierDto {
 
 @ApiExtraModels(WorkflowPreferenceRequestDto, GroupPreferenceFilterDto, TopicIdentifierDto)
 export class CreateTopicSubscriptionRequestDto {
-  @ApiProperty({
-    description: 'Unique identifier for this subscription',
+  @ApiPropertyOptional({
+    description: 'Unique identifier for this subscription. If not provided, a default identifier will be generated.',
     example: 'subscriber-123-subscription-a',
   })
   @IsString()
-  @IsDefined()
-  identifier: string;
+  @IsOptional()
+  identifier?: string;
 
   @ApiPropertyOptional({
     description: 'The name of the subscription',

--- a/libs/dal/src/repositories/topic/topic-subscribers.entity.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.entity.ts
@@ -19,7 +19,7 @@ export class TopicSubscribersEntity {
   // TODO: Rename to subscriberId, to align with workflowId and stepId that are also externally provided identifiers by Novu users
   externalSubscriberId: ExternalSubscriberId;
   name?: string;
-  identifier?: string;
+  identifier: string;
   createdAt?: string;
   updatedAt?: string;
 }

--- a/libs/dal/src/repositories/topic/topic-subscribers.entity.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.entity.ts
@@ -19,7 +19,7 @@ export class TopicSubscribersEntity {
   // TODO: Rename to subscriberId, to align with workflowId and stepId that are also externally provided identifiers by Novu users
   externalSubscriberId: ExternalSubscriberId;
   name?: string;
-  identifier: string;
+  identifier?: string;
   createdAt?: string;
   updatedAt?: string;
 }

--- a/libs/dal/src/repositories/topic/topic-subscribers.schema.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.schema.ts
@@ -40,7 +40,6 @@ const topicSubscribersSchema = new Schema<TopicSubscribersDBModel>(
     },
     identifier: {
       type: Schema.Types.String,
-      required: false,
     },
   },
   schemaOptions

--- a/packages/js/src/api/inbox-service.ts
+++ b/packages/js/src/api/inbox-service.ts
@@ -338,7 +338,7 @@ export class InboxService {
     return this.#httpClient.get(`${INBOX_ROUTE}/topics/${topicKey}/subscriptions`);
   }
 
-  getSubscription(topicKey: string, identifier: string): Promise<SubscriptionResponse> {
+  getSubscription({ topicKey, identifier }: { topicKey: string; identifier: string }): Promise<SubscriptionResponse> {
     return this.#httpClient.get(`${INBOX_ROUTE}/topics/${topicKey}/subscriptions/${identifier}`);
   }
 

--- a/packages/js/src/cache/subscriptions-cache.ts
+++ b/packages/js/src/cache/subscriptions-cache.ts
@@ -42,6 +42,20 @@ export class SubscriptionsCache {
       }
     });
 
+    this.#emitter.on('subscription.update.resolved', ({ data }) => {
+      if (data) {
+        this.handleUpdate(data);
+      }
+    });
+
+    this.#emitter.on('subscription.delete.resolved', ({ args }) => {
+      if ('subscription' in args) {
+        this.handleDelete(args.subscription);
+      } else if ('subscriptionId' in args) {
+        this.handleDeleteById(args.subscriptionId);
+      }
+    });
+
     this.#emitter.on('subscription.preference.update.pending', ({ data }) => {
       if (data) {
         this.handlePreferenceUpdate(data);
@@ -58,14 +72,6 @@ export class SubscriptionsCache {
         this.handleBulkPreferenceUpdate(data);
       }
     });
-
-    this.#emitter.on('subscription.delete.resolved', ({ args }) => {
-      if ('subscription' in args) {
-        this.handleDelete(args.subscription);
-      } else if ('subscriptionId' in args) {
-        this.handleDeleteById(args.subscriptionId);
-      }
-    });
   }
 
   private handleCreate = (subscription: TopicSubscription): void => {
@@ -74,6 +80,25 @@ export class SubscriptionsCache {
 
     if (subscriptions) {
       const updatedSubscriptions = [...subscriptions, subscription];
+      this.#cache.set(listKey, updatedSubscriptions);
+
+      this.#emitter.emit('subscriptions.list.updated', {
+        data: { topicKey: subscription.topicKey, subscriptions: updatedSubscriptions },
+      });
+    }
+
+    this.#itemCache.set(
+      getItemCacheKey({ topicKey: subscription.topicKey, identifier: subscription.identifier }),
+      subscription
+    );
+  };
+
+  private handleUpdate = (subscription: TopicSubscription): void => {
+    const listKey = getListCacheKey({ topicKey: subscription.topicKey });
+    const subscriptions = this.#cache.get(listKey);
+
+    if (subscriptions) {
+      const updatedSubscriptions = subscriptions.map((el) => (el.id === subscription.id ? subscription : el));
       this.#cache.set(listKey, updatedSubscriptions);
 
       this.#emitter.emit('subscriptions.list.updated', {
@@ -196,9 +221,9 @@ export class SubscriptionsCache {
     for (const listKey of allListKeys) {
       const subscriptions = this.#cache.get(listKey);
       if (subscriptions) {
-        const subscription = subscriptions.find((el) => el.id === subscriptionId);
+        const subscription = subscriptions.find((el) => el.id === subscriptionId || el.identifier === subscriptionId);
         if (subscription) {
-          const updatedSubscriptions = subscriptions.filter((el) => el.id !== subscriptionId);
+          const updatedSubscriptions = subscriptions.filter((el) => el.id !== subscription.id);
           this.#cache.set(listKey, updatedSubscriptions);
 
           this.#emitter.emit('subscriptions.list.updated', {
@@ -217,7 +242,7 @@ export class SubscriptionsCache {
     const allItemKeys = this.#itemCache.keys();
     for (const key of allItemKeys) {
       const subscription = this.#itemCache.get(key);
-      if (subscription && subscription.id === subscriptionId) {
+      if (subscription && (subscription.id === subscriptionId || subscription.identifier === subscriptionId)) {
         this.#itemCache.remove(key);
 
         return;

--- a/packages/js/src/novu.ts
+++ b/packages/js/src/novu.ts
@@ -55,11 +55,12 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
       userAgent: options.__userAgent,
     });
     this.#emitter = new NovuEventEmitter();
+    const subscriber = buildSubscriber({ subscriberId: options.subscriberId, subscriber: options.subscriber });
     this.#session = new Session(
       {
         applicationIdentifier: options.applicationIdentifier || '',
         subscriberHash: options.subscriberHash,
-        subscriber: buildSubscriber({ subscriberId: options.subscriberId, subscriber: options.subscriber }),
+        subscriber,
         defaultSchedule: options.defaultSchedule,
         context: options.context,
         contextHash: options.contextHash,
@@ -80,6 +81,7 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
       eventEmitterInstance: this.#emitter,
     });
     this.subscriptions = new Subscriptions({
+      subscriber,
       useCache: options.useCache ?? true,
       inboxServiceInstance: this.#inboxService,
       eventEmitterInstance: this.#emitter,

--- a/packages/js/src/subscriptions/helpers.ts
+++ b/packages/js/src/subscriptions/helpers.ts
@@ -65,7 +65,7 @@ export const getSubscription = async ({
   apiService: InboxService;
   cache: SubscriptionsCache;
   options: Options;
-  args: GetSubscriptionArgs;
+  args: GetSubscriptionArgs & { identifier: string };
 }): Result<TopicSubscription | null> => {
   try {
     const { useCache, refetch } = options;
@@ -73,7 +73,10 @@ export const getSubscription = async ({
     emitter.emit('subscription.get.pending', { args, data });
 
     if (!data || refetch) {
-      const response = await apiService.getSubscription(args.topicKey, args.identifier ?? '');
+      const response = await apiService.getSubscription({
+        topicKey: args.topicKey,
+        identifier: args.identifier,
+      });
       if (!response) {
         emitter.emit('subscription.get.resolved', { args, data: null });
 

--- a/packages/js/src/subscriptions/subscriptions.ts
+++ b/packages/js/src/subscriptions/subscriptions.ts
@@ -2,7 +2,8 @@ import { InboxService } from '../api';
 import { BaseModule } from '../base-module';
 import { SubscriptionsCache } from '../cache/subscriptions-cache';
 import { NovuEventEmitter } from '../event-emitter';
-import { Options, Result } from '../types';
+import { Options, Result, Subscriber } from '../types';
+import { buildSubscriptionIdentifier } from '../ui/internal';
 import {
   createSubscription,
   deleteSubscription,
@@ -25,6 +26,7 @@ import type {
 
 export class Subscriptions extends BaseModule {
   #useCache: boolean;
+  #subscriber: Subscriber;
 
   readonly cache: SubscriptionsCache;
 
@@ -32,10 +34,12 @@ export class Subscriptions extends BaseModule {
     useCache,
     inboxServiceInstance,
     eventEmitterInstance,
+    subscriber,
   }: {
     useCache: boolean;
     inboxServiceInstance: InboxService;
     eventEmitterInstance: NovuEventEmitter;
+    subscriber: Subscriber;
   }) {
     super({
       eventEmitterInstance,
@@ -47,6 +51,7 @@ export class Subscriptions extends BaseModule {
       useCache,
     });
     this.#useCache = useCache;
+    this.#subscriber = subscriber;
   }
 
   async list(args: ListSubscriptionsArgs, options?: Options): Result<TopicSubscription[]> {
@@ -74,7 +79,12 @@ export class Subscriptions extends BaseModule {
           ...options,
           useCache: options?.useCache ?? this.#useCache,
         },
-        args,
+        args: {
+          ...args,
+          identifier:
+            args.identifier ??
+            buildSubscriptionIdentifier({ topicKey: args.topicKey, subscriberId: this.#subscriber.subscriberId }),
+        },
       })
     );
   }

--- a/packages/js/src/subscriptions/types.ts
+++ b/packages/js/src/subscriptions/types.ts
@@ -8,12 +8,14 @@ export type WorkflowFilter = {
   workflowId: WorkflowIdentifierOrId;
   enabled?: boolean;
   condition?: RulesLogic;
+  filter?: never;
 };
 
 export type WorkflowGroupFilter = {
   filter: { workflowIds?: Array<WorkflowIdentifierOrId>; tags?: string[] };
   enabled?: boolean;
   condition?: RulesLogic;
+  workflowId?: never;
 };
 
 export type PreferenceFilter = WorkflowIdentifierOrId | WorkflowFilter | WorkflowGroupFilter;

--- a/packages/js/src/ui/api/hooks/useSubscription.ts
+++ b/packages/js/src/ui/api/hooks/useSubscription.ts
@@ -6,14 +6,19 @@ import {
   TopicSubscription,
 } from '../../../subscriptions';
 import { useNovu } from '../../context';
+import { buildSubscriptionIdentifier } from '../../internal';
 
 export const useSubscription = (options: GetSubscriptionArgs) => {
   const novuAccessor = useNovu();
+  const identifier = () => {
+    const subscriberId = novuAccessor().subscriberId;
+    return options.identifier ?? buildSubscriptionIdentifier({ topicKey: options.topicKey, subscriberId });
+  };
 
   const [loading, setLoading] = createSignal(true);
-  const [subscription, { mutate, refetch }] = createResource(options || {}, async ({ topicKey, identifier }) => {
+  const [subscription, { mutate, refetch }] = createResource(options || {}, async ({ topicKey }) => {
     try {
-      const response = await novuAccessor().subscriptions.get({ topicKey, identifier });
+      const response = await novuAccessor().subscriptions.get({ topicKey, identifier: identifier() });
 
       return response.data;
     } catch (error) {
@@ -49,7 +54,7 @@ export const useSubscription = (options: GetSubscriptionArgs) => {
 
   onMount(() => {
     const listener = ({ data }: { data?: TopicSubscription }) => {
-      if (!data || data.topicKey !== options.topicKey || data.identifier !== options.identifier) {
+      if (!data || data.topicKey !== options.topicKey || data.identifier !== identifier()) {
         return;
       }
 
@@ -59,7 +64,7 @@ export const useSubscription = (options: GetSubscriptionArgs) => {
 
     const currentNovu = novuAccessor();
     const cleanupCreatePending = currentNovu.on('subscription.create.pending', ({ args }) => {
-      if (!args || args.topicKey !== options.topicKey || args.identifier !== options.identifier) {
+      if (!args || args.topicKey !== options.topicKey || args.identifier !== identifier()) {
         return;
       }
       setLoading(true);
@@ -82,7 +87,21 @@ export const useSubscription = (options: GetSubscriptionArgs) => {
       }
       setLoading(true);
     });
-    const cleanupDelete = currentNovu.on('subscription.delete.resolved', () => {
+    const cleanupDelete = currentNovu.on('subscription.delete.resolved', ({ args }) => {
+      const subscriptionId = subscription()?.id;
+      const subscriptionIdentifier = subscription()?.identifier;
+      if (
+        !args ||
+        ('subscriptionId' in args &&
+          args.subscriptionId !== subscriptionId &&
+          args.subscriptionId !== subscriptionIdentifier) ||
+        ('subscription' in args &&
+          args.subscription.id !== subscriptionId &&
+          args.subscription.identifier !== subscriptionIdentifier)
+      ) {
+        return;
+      }
+
       mutate(null);
       setLoading(false);
     });

--- a/packages/js/src/ui/components/subscription/Subscription.tsx
+++ b/packages/js/src/ui/components/subscription/Subscription.tsx
@@ -18,6 +18,7 @@ export type WorkflowPreference = {
   label?: string;
   workflowId: WorkflowIdentifierOrId;
   enabled?: boolean;
+  filter?: never;
 };
 
 export type GroupPreference = {
@@ -27,6 +28,7 @@ export type GroupPreference = {
     tags?: string[];
   };
   enabled?: boolean;
+  workflowId?: never;
 };
 
 export type UIPreference = WorkflowIdentifierOrId | WorkflowPreference | GroupPreference;
@@ -36,7 +38,7 @@ export type SubscriptionProps = {
   placement?: Placement;
   placementOffset?: OffsetOptions;
   topicKey: string;
-  identifier: string;
+  identifier?: string;
   preferences: Array<UIPreference>;
   renderPreferences?: SubscriptionPreferencesRenderer;
 };
@@ -57,9 +59,9 @@ export const Subscription = (props: SubscriptionProps) => {
       remove({ subscription: currentSubscription });
     } else {
       const preferences: Array<PreferenceFilter> = props.preferences.map((preference) => {
-        if (typeof preference === 'object' && 'workflowId' in preference) {
+        if (typeof preference === 'object' && 'workflowId' in preference && preference.workflowId) {
           return { workflowId: preference.workflowId, enabled: preference.enabled };
-        } else if (typeof preference === 'object' && 'filter' in preference) {
+        } else if (typeof preference === 'object' && 'filter' in preference && preference.filter) {
           return { filter: preference.filter, enabled: preference.enabled };
         }
         return preference;

--- a/packages/js/src/ui/components/subscription/SubscriptionButtonWrapper.tsx
+++ b/packages/js/src/ui/components/subscription/SubscriptionButtonWrapper.tsx
@@ -5,7 +5,7 @@ import { SubscriptionButton } from './SubscriptionButton';
 
 export type SubscriptionButtonWrapperProps = {
   topicKey: string;
-  identifier: string;
+  identifier?: string;
   preferences: Array<UIPreference>;
   onClick?: (args: { subscription?: TopicSubscription }) => void;
   onDeleteError?: (error: unknown) => void;
@@ -33,9 +33,9 @@ export const SubscriptionButtonWrapper = (props: SubscriptionButtonWrapperProps)
       props.onDeleteSuccess?.();
     } else {
       const preferences: Array<PreferenceFilter> = props.preferences.map((preference) => {
-        if (typeof preference === 'object' && 'workflowId' in preference) {
+        if (typeof preference === 'object' && 'workflowId' in preference && preference.workflowId) {
           return { workflowId: preference.workflowId, enabled: preference.enabled };
-        } else if (typeof preference === 'object' && 'filter' in preference) {
+        } else if (typeof preference === 'object' && 'filter' in preference && preference.filter) {
           return { filter: preference.filter, enabled: preference.enabled };
         }
         return preference;

--- a/packages/js/src/ui/components/subscription/SubscriptionPreferenceGroupRow.tsx
+++ b/packages/js/src/ui/components/subscription/SubscriptionPreferenceGroupRow.tsx
@@ -110,12 +110,13 @@ export const SubscriptionPreferenceGroupRow = (props: {
           <span
             class={style({
               key: 'subscriptionPreferenceGroupLabel',
-              className: 'nt-text-sm nt-font-semibold nt-truncate nt-text-start',
+              className: 'nt-text-sm nt-font-semibold nt-truncate nt-text-start nt-mr-2',
               context: { group: props.group } satisfies Parameters<
                 SubscriptionAppearanceCallback['subscriptionPreferenceGroupLabel']
               >[0],
             })}
             data-open={isOpened()}
+            title={props.group.label}
           >
             {props.group.label}
           </span>
@@ -181,7 +182,7 @@ export const SubscriptionPreferenceGroupRow = (props: {
               <div
                 class={style({
                   key: 'subscriptionPreferenceGroupWorkflowRow',
-                  className: 'nt-flex nt-items-center nt-justify-between nt-p-2 nt-rounded',
+                  className: 'nt-flex nt-items-center nt-justify-between nt-p-2 nt-rounded nt-gap-2',
                   context: { preference: el } satisfies Parameters<
                     SubscriptionAppearanceCallback['subscriptionPreferenceGroupWorkflowRow']
                   >[0],
@@ -190,12 +191,13 @@ export const SubscriptionPreferenceGroupRow = (props: {
                 <span
                   class={style({
                     key: 'subscriptionPreferenceGroupWorkflowLabel',
-                    className: 'nt-text-sm',
+                    className: 'nt-text-sm nt-truncate nt-text-start',
                     context: { preference: el } satisfies Parameters<
                       SubscriptionAppearanceCallback['subscriptionPreferenceGroupWorkflowLabel']
                     >[0],
                   })}
                   data-localization={el.preference.workflow.identifier as StringLocalizationKey}
+                  title={t(el.preference.workflow.identifier as StringLocalizationKey) ?? el.label}
                 >
                   {t(el.preference.workflow.identifier as StringLocalizationKey) ?? el.label}
                 </span>

--- a/packages/js/src/ui/components/subscription/SubscriptionPreferenceRow.tsx
+++ b/packages/js/src/ui/components/subscription/SubscriptionPreferenceRow.tsx
@@ -25,7 +25,7 @@ export const SubscriptionPreferenceRow = (props: {
     <div
       class={style({
         key: 'subscriptionPreferenceRow',
-        className: 'nt-flex nt-items-center nt-justify-between nt-p-2 nt-rounded-lg',
+        className: 'nt-flex nt-items-center nt-justify-between nt-p-2 nt-rounded-lg nt-gap-2',
         context: { preference: props.preference } satisfies Parameters<
           SubscriptionAppearanceCallback['subscriptionPreferenceRow']
         >[0],
@@ -34,12 +34,13 @@ export const SubscriptionPreferenceRow = (props: {
       <span
         class={style({
           key: 'subscriptionPreferenceLabel',
-          className: 'nt-text-sm nt-font-medium',
+          className: 'nt-text-sm nt-font-medium nt-truncate nt-text-start',
           context: { preference: props.preference } satisfies Parameters<
             SubscriptionAppearanceCallback['subscriptionPreferenceLabel']
           >[0],
         })}
         data-localization={preference().workflow.identifier as StringLocalizationKey}
+        title={t(preference().workflow.identifier as StringLocalizationKey) ?? props.preference.label}
       >
         {t(preference().workflow.identifier as StringLocalizationKey) ?? props.preference.label}
       </span>

--- a/packages/js/src/ui/components/subscription/SubscriptionPreferencesWrapper.tsx
+++ b/packages/js/src/ui/components/subscription/SubscriptionPreferencesWrapper.tsx
@@ -5,7 +5,7 @@ import { SubscriptionPreferences } from './SubscriptionPreferences';
 
 export type SubscriptionPreferencesWrapperProps = {
   topicKey: string;
-  identifier: string;
+  identifier?: string;
   preferences: Array<UIPreference>;
   onClick?: (args: { subscription?: TopicSubscription }) => void;
   onDeleteError?: (error: unknown) => void;
@@ -33,9 +33,9 @@ export const SubscriptionPreferencesWrapper = (props: SubscriptionPreferencesWra
       props.onDeleteSuccess?.();
     } else {
       const preferences: Array<PreferenceFilter> = props.preferences.map((preference) => {
-        if (typeof preference === 'object' && 'workflowId' in preference) {
+        if (typeof preference === 'object' && 'workflowId' in preference && preference.workflowId) {
           return { workflowId: preference.workflowId, enabled: preference.enabled };
-        } else if (typeof preference === 'object' && 'filter' in preference) {
+        } else if (typeof preference === 'object' && 'filter' in preference && preference.filter) {
           return { filter: preference.filter, enabled: preference.enabled };
         }
         return preference;

--- a/packages/js/src/ui/internal/buildSubscriptionIdentifier.ts
+++ b/packages/js/src/ui/internal/buildSubscriptionIdentifier.ts
@@ -1,0 +1,3 @@
+export function buildSubscriptionIdentifier({ topicKey, subscriberId }: { topicKey: string; subscriberId?: string }) {
+  return `tk_${topicKey}:si_${subscriberId}`;
+}

--- a/packages/js/src/ui/internal/index.ts
+++ b/packages/js/src/ui/internal/index.ts
@@ -1,3 +1,4 @@
 export * from './buildContextKey';
 export * from './buildSubscriber';
+export * from './buildSubscriptionIdentifier';
 export * from './parseMarkdown';

--- a/packages/react/src/components/subscription/SubscriptionButton.tsx
+++ b/packages/react/src/components/subscription/SubscriptionButton.tsx
@@ -20,7 +20,7 @@ export const SubscriptionButton = React.memo(
 
     const mount = React.useCallback(
       (element: HTMLElement) => {
-        if (!topicKey || !identifier || !preferences) {
+        if (!topicKey || !preferences) {
           return;
         }
 

--- a/packages/react/src/components/subscription/SubscriptionPreferences.tsx
+++ b/packages/react/src/components/subscription/SubscriptionPreferences.tsx
@@ -20,7 +20,7 @@ export const SubscriptionPreferences = React.memo(
 
     const mount = React.useCallback(
       (element: HTMLElement) => {
-        if (!topicKey || !identifier || !preferences) {
+        if (!topicKey || !preferences) {
           return;
         }
 

--- a/packages/react/src/hooks/useSubscription.ts
+++ b/packages/react/src/hooks/useSubscription.ts
@@ -1,4 +1,5 @@
 import { NovuError, TopicSubscription } from '@novu/js';
+import { buildSubscriptionIdentifier } from '@novu/js/internal';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNovu } from './NovuProvider';
 
@@ -23,7 +24,11 @@ export type UseSubscriptionResult = {
 export const useSubscription = (props: UseSubscriptionProps): UseSubscriptionResult => {
   const novu = useNovu();
   const propsRef = useRef<UseSubscriptionProps>(props);
-  propsRef.current = props;
+  propsRef.current = {
+    ...props,
+    identifier:
+      props.identifier ?? buildSubscriptionIdentifier({ topicKey: props.topicKey, subscriberId: novu.subscriberId }),
+  };
   const [subscription, setSubscription] = useState<TopicSubscription | null>();
   const subscriptionRef = useRef<TopicSubscription | null>(null);
   subscriptionRef.current = subscription ?? null;

--- a/playground/nextjs/src/pages/subscription-components/index.tsx
+++ b/playground/nextjs/src/pages/subscription-components/index.tsx
@@ -20,7 +20,6 @@ export default function SubscriptionComponentsPage() {
         <NovuProvider {...novuConfig}>
           <Subscription
             topicKey="test"
-            identifier="test"
             preferences={[
               { workflowId: 'test-workflow3' },
               { label: 'Test Group', filter: { tags: [] } },


### PR DESCRIPTION
### What changed? Why was the change needed?

Subscription component polishing after bug bashing includes fixes for:
- https://linear.app/novu/issue/NV-6957/preferences-checkbox-is-not-optimistically-updated-in-the-subscription
- https://linear.app/novu/issue/NV-6952/remove-the-required-identifier-prop-and-fallback-to-topic-key
- https://linear.app/novu/issue/NV-6958/using-2-subscription-components-clicking-one-one-changes-the-other
- https://linear.app/novu/issue/NV-6964/confusing-prop-filter-when-using-workflowid
- https://linear.app/novu/issue/NV-6956/long-workflow-name-could-be-a-little-more-elegant

### Screenshots
<img width="873" height="570" alt="Screenshot 2025-12-10 at 23 20 32" src="https://github.com/user-attachments/assets/8b233758-2458-40a2-9314-9af88448c887" />


https://github.com/user-attachments/assets/73548d2d-c0ee-4f67-9ade-e476aae14845


