### PR TITLE
chore(js): polishing subscription after bug-bashing session part 2 fixes NV-6954

### DIFF
--- a/packages/js/src/subscriptions/types.ts
+++ b/packages/js/src/subscriptions/types.ts
@@ -1,4 +1,5 @@
 import type { RulesLogic } from 'json-logic-js';
+import { NonEmptyArray } from '../types';
 import type { TopicSubscription } from './subscription';
 import { SubscriptionPreference } from './subscription-preference';
 
@@ -34,20 +35,20 @@ export type CreateSubscriptionArgs = {
   topicName?: string;
   identifier?: string;
   name?: string;
-  preferences: Array<PreferenceFilter>;
+  preferences: NonEmptyArray<PreferenceFilter>;
 };
 
 export type BaseUpdateSubscriptionArgs = {
   topicKey: string;
   subscriptionId: string;
   name?: string;
-  preferences?: Array<PreferenceFilter>;
+  preferences?: NonEmptyArray<PreferenceFilter>;
 };
 
 export type InstanceUpdateSubscriptionArgs = {
   subscription: TopicSubscription;
   name?: string;
-  preferences?: Array<PreferenceFilter>;
+  preferences?: NonEmptyArray<PreferenceFilter>;
 };
 
 export type UpdateSubscriptionArgs = BaseUpdateSubscriptionArgs | InstanceUpdateSubscriptionArgs;

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -298,3 +298,5 @@ export type StandardNovuOptions = {
 export type NovuOptions = KeylessNovuOptions | StandardNovuOptions;
 
 export type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+export type NonEmptyArray<T> = [T, ...T[]];

--- a/packages/js/src/ui/components/elements/Preferences/ChannelRow.tsx
+++ b/packages/js/src/ui/components/elements/Preferences/ChannelRow.tsx
@@ -34,6 +34,7 @@ export const ChannelRow = (props: ChannelRowProps) => {
 
   const state = () => props.channel.state;
   const channel = () => props.channel.channel;
+  const channelId = () => `channel-${props.workflowId ?? ''}-${channel()}`;
 
   return (
     <div
@@ -49,7 +50,7 @@ export const ChannelRow = (props: ChannelRowProps) => {
       <div
         class={style({
           key: 'channelLabelContainer',
-          className: 'nt-flex nt-items-center nt-gap-2 nt-text-foreground',
+          className: 'nt-flex nt-items-center nt-gap-2 nt-text-foreground nt-w-full',
           context: { preference: props.preference, preferenceGroup: props.preferenceGroup } satisfies Parameters<
             InboxAppearanceCallback['channelLabelContainer']
           >[0],
@@ -72,17 +73,18 @@ export const ChannelRow = (props: ChannelRowProps) => {
             preferenceGroup={props.preferenceGroup}
           />
         </div>
-        <span
+        <label
+          for={channelId()}
           class={style({
             key: 'channelLabel',
-            className: 'nt-text-sm nt-font-semibold',
+            className: 'nt-text-sm nt-font-semibold nt-w-full nt-cursor-pointer',
             context: { preference: props.preference, preferenceGroup: props.preferenceGroup } satisfies Parameters<
               InboxAppearanceCallback['channelLabel']
             >[0],
           })}
         >
           {getLabel(channel())}
-        </span>
+        </label>
       </div>
       <div
         class={style({
@@ -94,6 +96,7 @@ export const ChannelRow = (props: ChannelRowProps) => {
         })}
       >
         <Switch
+          id={channelId()}
           state={state()}
           onChange={(newState) => onChange(newState === 'enabled')}
           disabled={props.preference?.workflow?.critical}

--- a/packages/js/src/ui/components/primitives/Checkbox.tsx
+++ b/packages/js/src/ui/components/primitives/Checkbox.tsx
@@ -9,10 +9,10 @@ type CheckboxRootProps<T extends ValidComponent = 'div'> = CheckboxPrimitive.Che
 };
 
 const Checkbox = <T extends ValidComponent = 'div'>(props: PolymorphicProps<T, CheckboxRootProps<T>>) => {
-  const [local, others] = splitProps(props as CheckboxRootProps, ['class']);
+  const [local, others] = splitProps(props as CheckboxRootProps, ['id', 'class']);
   return (
     <CheckboxPrimitive.Root class={cn('nt-items-top nt-group nt-relative nt-flex', local.class)} {...others}>
-      <CheckboxPrimitive.Input class="nt-peer" />
+      <CheckboxPrimitive.Input class="nt-peer" id={local.id} />
       <CheckboxPrimitive.Control class="nt-size-4 nt-shrink-0 nt-rounded-sm nt-border nt-border-primary nt-ring-offset-background data-[disabled]:nt-cursor-not-allowed data-[disabled]:nt-opacity-50 peer-focus-visible:nt-outline-none peer-focus-visible:nt-ring-2 peer-focus-visible:ntring-ring peer-focus-visible:nt-ring-offset-2 data-[checked]:nt-border-none data-[indeterminate]:nt-border-none data-[checked]:nt-bg-primary data-[indeterminate]:nt-bg-primary data-[checked]:nt-text-primary-foreground data-[indeterminate]:nt-text-primary-foreground">
         <CheckboxPrimitive.Indicator>
           <Switch>

--- a/packages/js/src/ui/components/primitives/Popover/PopoverContent.tsx
+++ b/packages/js/src/ui/components/primitives/Popover/PopoverContent.tsx
@@ -15,7 +15,7 @@ export const popoverContentVariants = cva(
     variants: {
       size: {
         inbox: 'nt-w-[400px] nt-h-[600px]',
-        subscription: 'nt-w-[400px] nt-h-auto',
+        subscription: 'nt-w-[350px] nt-h-auto',
       },
     },
     defaultVariants: {

--- a/packages/js/src/ui/components/primitives/Switch.tsx
+++ b/packages/js/src/ui/components/primitives/Switch.tsx
@@ -6,6 +6,7 @@ export type SwitchProps = {
   state?: SwitchState;
   onChange: (state: SwitchState) => void;
   disabled?: boolean;
+  id?: string;
 };
 
 export const Switch = (props: SwitchProps) => {
@@ -45,7 +46,14 @@ export const Switch = (props: SwitchProps) => {
         }),
       })}
     >
-      <input type="checkbox" class="nt-sr-only" checked={isChecked()} disabled={disabled()} onChange={handleChange} />
+      <input
+        type="checkbox"
+        class="nt-sr-only"
+        id={props.id}
+        checked={isChecked()}
+        disabled={disabled()}
+        onChange={handleChange}
+      />
       <div
         class={style({
           key: 'channelSwitchThumb',

--- a/packages/js/src/ui/components/subscription/Subscription.tsx
+++ b/packages/js/src/ui/components/subscription/Subscription.tsx
@@ -1,5 +1,6 @@
 import { OffsetOptions, Placement } from '@floating-ui/dom';
 import type { PreferenceFilter, TopicSubscription, WorkflowIdentifierOrId } from '../../../subscriptions';
+import { NonEmptyArray } from '../../../types';
 import { useSubscription } from '../../api/hooks/useSubscription';
 import { useInboxContext } from '../../context';
 import { cn } from '../../helpers';
@@ -25,6 +26,7 @@ export type GroupPreference = {
   label: string;
   filter: {
     workflowIds?: Array<WorkflowIdentifierOrId>;
+    workflows?: Array<{ label: string; workflowId: WorkflowIdentifierOrId }>;
     tags?: string[];
   };
   enabled?: boolean;
@@ -39,7 +41,7 @@ export type SubscriptionProps = {
   placementOffset?: OffsetOptions;
   topicKey: string;
   identifier?: string;
-  preferences: Array<UIPreference>;
+  preferences: NonEmptyArray<UIPreference>;
   renderPreferences?: SubscriptionPreferencesRenderer;
 };
 
@@ -58,14 +60,15 @@ export const Subscription = (props: SubscriptionProps) => {
     if (currentSubscription) {
       remove({ subscription: currentSubscription });
     } else {
-      const preferences: Array<PreferenceFilter> = props.preferences.map((preference) => {
+      const preferences = props.preferences.map((preference) => {
         if (typeof preference === 'object' && 'workflowId' in preference && preference.workflowId) {
           return { workflowId: preference.workflowId, enabled: preference.enabled };
         } else if (typeof preference === 'object' && 'filter' in preference && preference.filter) {
           return { filter: preference.filter, enabled: preference.enabled };
         }
+
         return preference;
-      });
+      }) as NonEmptyArray<PreferenceFilter>;
       create({ topicKey: props.topicKey, identifier: props.identifier, preferences: preferences });
     }
   };

--- a/packages/js/src/ui/components/subscription/SubscriptionButtonWrapper.tsx
+++ b/packages/js/src/ui/components/subscription/SubscriptionButtonWrapper.tsx
@@ -1,4 +1,5 @@
 import type { PreferenceFilter, TopicSubscription } from '../../../subscriptions';
+import { NonEmptyArray } from '../../../types';
 import { useSubscription } from '../../api/hooks/useSubscription';
 import { UIPreference } from './Subscription';
 import { SubscriptionButton } from './SubscriptionButton';
@@ -6,7 +7,7 @@ import { SubscriptionButton } from './SubscriptionButton';
 export type SubscriptionButtonWrapperProps = {
   topicKey: string;
   identifier?: string;
-  preferences: Array<UIPreference>;
+  preferences: NonEmptyArray<UIPreference>;
   onClick?: (args: { subscription?: TopicSubscription }) => void;
   onDeleteError?: (error: unknown) => void;
   onDeleteSuccess?: () => void;
@@ -32,14 +33,14 @@ export const SubscriptionButtonWrapper = (props: SubscriptionButtonWrapperProps)
       }
       props.onDeleteSuccess?.();
     } else {
-      const preferences: Array<PreferenceFilter> = props.preferences.map((preference) => {
+      const preferences = props.preferences.map((preference) => {
         if (typeof preference === 'object' && 'workflowId' in preference && preference.workflowId) {
           return { workflowId: preference.workflowId, enabled: preference.enabled };
         } else if (typeof preference === 'object' && 'filter' in preference && preference.filter) {
           return { filter: preference.filter, enabled: preference.enabled };
         }
         return preference;
-      });
+      }) as NonEmptyArray<PreferenceFilter>;
       const { data, error } = await create({
         topicKey: props.topicKey,
         identifier: props.identifier,

--- a/packages/js/src/ui/components/subscription/SubscriptionCog.tsx
+++ b/packages/js/src/ui/components/subscription/SubscriptionCog.tsx
@@ -2,6 +2,7 @@ import { OffsetOptions, Placement } from '@floating-ui/dom';
 import { createMemo, Show } from 'solid-js';
 import { Motion, Presence } from 'solid-motionone';
 import { TopicSubscription } from '../../../subscriptions';
+import { NonEmptyArray } from '../../../types';
 import { useStyle } from '../../helpers/useStyle';
 import { Cogs } from '../../icons';
 import { SubscriptionAppearanceCallback } from '../../types';
@@ -22,7 +23,7 @@ export const SubscriptionCog = (props: {
   isOpen: boolean;
   placement: Placement;
   placementOffset?: OffsetOptions;
-  preferences: Array<UIPreference>;
+  preferences: NonEmptyArray<UIPreference>;
   onOpenChange?: (isOpen: boolean) => void;
   onSubscribeClick: () => void;
   renderPreferences?: SubscriptionPreferencesRenderer;

--- a/packages/js/src/ui/components/subscription/SubscriptionPreferenceGroupRow.tsx
+++ b/packages/js/src/ui/components/subscription/SubscriptionPreferenceGroupRow.tsx
@@ -188,20 +188,22 @@ export const SubscriptionPreferenceGroupRow = (props: {
                   >[0],
                 })}
               >
-                <span
+                <label
+                  for={`subscription-preference-${el.preference.workflow.identifier}`}
                   class={style({
                     key: 'subscriptionPreferenceGroupWorkflowLabel',
-                    className: 'nt-text-sm nt-truncate nt-text-start',
+                    className: 'nt-text-sm nt-truncate nt-text-start nt-w-full nt-cursor-pointer',
                     context: { preference: el } satisfies Parameters<
                       SubscriptionAppearanceCallback['subscriptionPreferenceGroupWorkflowLabel']
                     >[0],
                   })}
                   data-localization={el.preference.workflow.identifier as StringLocalizationKey}
-                  title={t(el.preference.workflow.identifier as StringLocalizationKey) ?? el.label}
+                  title={el.label ?? t(el.preference.workflow.identifier as StringLocalizationKey)}
                 >
-                  {t(el.preference.workflow.identifier as StringLocalizationKey) ?? el.label}
-                </span>
+                  {el.label ?? t(el.preference.workflow.identifier as StringLocalizationKey)}
+                </label>
                 <Checkbox
+                  id={`subscription-preference-${el.preference.workflow.identifier}`}
                   checked={getPreferenceChecked(el.preference)}
                   onChange={handlePreferenceChange(el.preference)}
                 />

--- a/packages/js/src/ui/components/subscription/SubscriptionPreferenceRow.tsx
+++ b/packages/js/src/ui/components/subscription/SubscriptionPreferenceRow.tsx
@@ -31,20 +31,25 @@ export const SubscriptionPreferenceRow = (props: {
         >[0],
       })}
     >
-      <span
+      <label
+        for={`subscription-preference-${preference().workflow.identifier}`}
         class={style({
           key: 'subscriptionPreferenceLabel',
-          className: 'nt-text-sm nt-font-medium nt-truncate nt-text-start',
+          className: 'nt-text-sm nt-font-medium nt-truncate nt-text-start nt-w-full nt-cursor-pointer',
           context: { preference: props.preference } satisfies Parameters<
             SubscriptionAppearanceCallback['subscriptionPreferenceLabel']
           >[0],
         })}
         data-localization={preference().workflow.identifier as StringLocalizationKey}
-        title={t(preference().workflow.identifier as StringLocalizationKey) ?? props.preference.label}
+        title={props.preference.label ?? t(preference().workflow.identifier as StringLocalizationKey)}
       >
-        {t(preference().workflow.identifier as StringLocalizationKey) ?? props.preference.label}
-      </span>
-      <Checkbox checked={isChecked()} onChange={handleChange} />
+        {props.preference.label ?? t(preference().workflow.identifier as StringLocalizationKey)}
+      </label>
+      <Checkbox
+        id={`subscription-preference-${preference().workflow.identifier}`}
+        checked={isChecked()}
+        onChange={handleChange}
+      />
     </div>
   );
 };

--- a/packages/js/src/ui/components/subscription/SubscriptionPreferences.tsx
+++ b/packages/js/src/ui/components/subscription/SubscriptionPreferences.tsx
@@ -1,6 +1,7 @@
 import { createEffect, createMemo, Index, Show } from 'solid-js';
 import { TopicSubscription } from '../../../subscriptions';
 import { SubscriptionPreference } from '../../../subscriptions/subscription-preference';
+import { NonEmptyArray } from '../../../types';
 import { setDynamicLocalization } from '../../config/defaultLocalization';
 import { useInboxContext, useLocalization } from '../../context';
 import { cn, useStyle } from '../../helpers';
@@ -18,7 +19,7 @@ import { SubscriptionPreferencesFallback } from './SubscriptionPreferencesFallba
 export const SubscriptionPreferences = (props: {
   loading?: boolean;
   subscription?: TopicSubscription | null;
-  preferences: Array<UIPreference>;
+  preferences: NonEmptyArray<UIPreference>;
   renderPreferences?: SubscriptionPreferencesRenderer;
   onSubscribeClick: () => void;
 }) => {
@@ -58,7 +59,26 @@ export const SubscriptionPreferences = (props: {
               preference: SubscriptionPreference;
             }> = [];
 
-            if (
+            if (typeof preferenceFilter.filter === 'object' && 'workflows' in preferenceFilter.filter) {
+              const { workflows } = preferenceFilter.filter;
+              foundPreferences = subscriptionPreferences
+                .filter((pref) => {
+                  return workflows?.some(
+                    (workflow) =>
+                      workflow.workflowId === pref.workflow?.id || workflow.workflowId === pref.workflow?.identifier
+                  );
+                })
+                .map((pref) => {
+                  const workflow = workflows?.find(
+                    (workflow) =>
+                      workflow.workflowId === pref.workflow?.id || workflow.workflowId === pref.workflow?.identifier
+                  );
+                  return {
+                    label: workflow?.label ?? pref.workflow.name,
+                    preference: pref,
+                  };
+                });
+            } else if (
               typeof preferenceFilter.filter === 'object' &&
               ('workflowIds' in preferenceFilter.filter || 'tags' in preferenceFilter.filter)
             ) {

--- a/packages/js/src/ui/components/subscription/SubscriptionPreferencesWrapper.tsx
+++ b/packages/js/src/ui/components/subscription/SubscriptionPreferencesWrapper.tsx
@@ -1,4 +1,5 @@
 import type { PreferenceFilter, TopicSubscription } from '../../../subscriptions';
+import { NonEmptyArray } from '../../../types';
 import { useSubscription } from '../../api/hooks/useSubscription';
 import { UIPreference } from './Subscription';
 import { SubscriptionPreferences } from './SubscriptionPreferences';
@@ -6,7 +7,7 @@ import { SubscriptionPreferences } from './SubscriptionPreferences';
 export type SubscriptionPreferencesWrapperProps = {
   topicKey: string;
   identifier?: string;
-  preferences: Array<UIPreference>;
+  preferences: NonEmptyArray<UIPreference>;
   onClick?: (args: { subscription?: TopicSubscription }) => void;
   onDeleteError?: (error: unknown) => void;
   onDeleteSuccess?: () => void;
@@ -32,14 +33,15 @@ export const SubscriptionPreferencesWrapper = (props: SubscriptionPreferencesWra
       }
       props.onDeleteSuccess?.();
     } else {
-      const preferences: Array<PreferenceFilter> = props.preferences.map((preference) => {
+      const preferences = props.preferences.map((preference) => {
         if (typeof preference === 'object' && 'workflowId' in preference && preference.workflowId) {
           return { workflowId: preference.workflowId, enabled: preference.enabled };
         } else if (typeof preference === 'object' && 'filter' in preference && preference.filter) {
           return { filter: preference.filter, enabled: preference.enabled };
         }
+
         return preference;
-      });
+      }) as NonEmptyArray<PreferenceFilter>;
       const { data, error } = await create({
         topicKey: props.topicKey,
         identifier: props.identifier,


### PR DESCRIPTION
### What changed? Why was the change needed?

Subscription component polishing bugs after bug-bashing session part 2:
- https://linear.app/novu/issue/NV-6954/specifying-a-label-to-a-workflow-doesnt-work
- https://linear.app/novu/issue/NV-6968/not-allow-empty-preference-list
- https://linear.app/novu/issue/NV-6960/ui-whole-workflow-row-should-be-clickable
- https://linear.app/novu/issue/NV-6959/visual-spacing-is-quite-wide

### Screenshots
<img width="865" height="409" alt="Screenshot 2025-12-11 at 17 12 00" src="https://github.com/user-attachments/assets/9d1d1df4-3ff3-40ee-8140-cbf45a1e4a88" />
<img width="605" height="636" alt="Screenshot 2025-12-11 at 16 36 45" src="https://github.com/user-attachments/assets/15eee8c4-7502-400a-8c65-b76ce2449b78" />
<img width="979" height="498" alt="Screenshot 2025-12-11 at 16 36 36" src="https://github.com/user-attachments/assets/ba8c744e-5f61-4af7-84bf-c0a8a54bbcdd" />


