### PR TITLE
chore(docker): update service images and enhance health checks in docker-compose.yml

### DIFF
--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -1,14 +1,14 @@
 name: novu
 services:
   redis:
-    image: 'redis:alpine'
+    image: "redis:alpine"
     container_name: redis
     restart: unless-stopped
     logging:
-      driver: 'json-file' # Enabled json-file logging with limits for consistency
+      driver: "json-file" # Enabled json-file logging with limits for consistency
       options:
-        max-size: '50m'
-        max-file: '5'
+        max-size: "50m"
+        max-file: "5"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -20,10 +20,10 @@ services:
     container_name: mongodb
     restart: unless-stopped
     logging:
-      driver: 'json-file'
+      driver: "json-file"
       options:
-        max-size: '50m'
-        max-file: '5'
+        max-size: "50m"
+        max-file: "5"
     environment:
       - PUID=1000
       - PGID=1000
@@ -34,23 +34,37 @@ services:
     ports:
       - 27017:27017
     healthcheck:
-      test: ["CMD", "mongo", "--eval", "db.adminCommand('ping')"]
-      interval: 10s
+      test:
+        [
+          "CMD",
+          "mongosh",
+          "--quiet",
+          "--username",
+          "${MONGO_INITDB_ROOT_USERNAME}",
+          "--password",
+          "${MONGO_INITDB_ROOT_PASSWORD}",
+          "--eval",
+          "db.adminCommand('ping').ok",
+        ]
+      interval: 20s
       timeout: 5s
       retries: 5
+      start_period: 20s
 
   api:
-    image: 'ghcr.io/novuhq/novu/api:2.3.0'
+    image: "ghcr.io/novuhq/novu/api:3.11.0"
     depends_on:
-      - mongodb
-      - redis
+      mongodb:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     container_name: api
     restart: unless-stopped
     logging:
-      driver: 'json-file'
+      driver: "json-file"
       options:
-        max-size: '50m'
-        max-file: '5'
+        max-size: "50m"
+        max-file: "5"
     environment:
       NODE_ENV: ${NODE_ENV}
       API_ROOT_URL: ${API_ROOT_URL}
@@ -78,7 +92,7 @@ services:
       NEW_RELIC_ENABLED: ${NEW_RELIC_ENABLED}
       NEW_RELIC_APP_NAME: ${NEW_RELIC_APP_NAME}
       NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY}
-      API_CONTEXT_PATH: ${API_CONTEXT_PATH}
+      API_CONTEXT_PATH: ${API_CONTEXT_PATH:-}
       MONGO_AUTO_CREATE_INDEXES: ${MONGO_AUTO_CREATE_INDEXES}
       IS_API_IDEMPOTENCY_ENABLED: ${IS_API_IDEMPOTENCY_ENABLED}
       IS_API_RATE_LIMITING_ENABLED: ${IS_API_RATE_LIMITING_ENABLED}
@@ -86,21 +100,34 @@ services:
       IS_V2_ENABLED: ${IS_V2_ENABLED}
     ports:
       - ${API_PORT}:${API_PORT}
-  
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget --no-verbose --tries=1 --spider http://localhost:$${PORT}/v1/health-check || exit 1",
+        ]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
   worker:
-    image: 'ghcr.io/novuhq/novu/worker:2.3.0'
+    image: "ghcr.io/novuhq/novu/worker:3.11.0"
     depends_on:
-      - mongodb
-      - redis
+      mongodb:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     container_name: worker
     restart: unless-stopped
     logging:
-      driver: 'json-file'
+      driver: "json-file"
       options:
-        max-size: '50m'
-        max-file: '5'
+        max-size: "50m"
+        max-file: "5"
     environment:
       NODE_ENV: ${NODE_ENV}
+      PORT: ${WORKER_PORT:-3004}
       MONGO_URL: ${MONGO_URL}
       MONGO_MAX_POOL_SIZE: ${MONGO_MAX_POOL_SIZE}
       REDIS_HOST: ${REDIS_HOST}
@@ -125,19 +152,31 @@ services:
       API_ROOT_URL: http://api:${API_PORT}
       IS_EMAIL_INLINE_CSS_DISABLED: ${IS_EMAIL_INLINE_CSS_DISABLED}
       IS_USE_MERGED_DIGEST_ID_ENABLED: ${IS_USE_MERGED_DIGEST_ID_ENABLED}
-  
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget --no-verbose --tries=1 --spider http://localhost:$${PORT:-3004}/v1/health-check || exit 1",
+        ]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
   ws:
-    image: 'ghcr.io/novuhq/novu/ws:2.3.0'
+    image: "ghcr.io/novuhq/novu/ws:3.11.0"
     depends_on:
-      - mongodb
-      - redis
+      mongodb:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     container_name: ws
     restart: unless-stopped
     logging:
-      driver: 'json-file'
+      driver: "json-file"
       options:
-        max-size: '50m'
-        max-file: '5'
+        max-size: "50m"
+        max-file: "5"
     environment:
       PORT: ${WS_PORT}
       NODE_ENV: ${NODE_ENV}
@@ -147,25 +186,37 @@ services:
       REDIS_PORT: ${REDIS_PORT}
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       JWT_SECRET: ${JWT_SECRET}
-      WS_CONTEXT_PATH: ${WS_CONTEXT_PATH}
+      WS_CONTEXT_PATH: ${WS_CONTEXT_PATH:-}
       NEW_RELIC_ENABLED: ${NEW_RELIC_ENABLED}
       NEW_RELIC_APP_NAME: ${NEW_RELIC_APP_NAME}
       NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY}
     ports:
       - ${WS_PORT}:${WS_PORT}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget --no-verbose --tries=1 --spider http://localhost:$${PORT}/v1/health-check || exit 1",
+        ]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
   dashboard:
-    image: 'ghcr.io/novuhq/novu/dashboard:2.3.0'
+    image: "ghcr.io/novuhq/novu/dashboard:3.11.0"
     depends_on:
-      - api
-      - worker
+      api:
+        condition: service_healthy
+      worker:
+        condition: service_healthy
     container_name: dashboard
     restart: unless-stopped
     logging:
-      driver: 'json-file'
+      driver: "json-file"
       options:
-        max-size: '50m'
-        max-file: '5'
+        max-size: "50m"
+        max-file: "5"
     environment:
       VITE_API_HOSTNAME: ${VITE_API_HOSTNAME}
       VITE_SELF_HOSTED: true
@@ -173,6 +224,16 @@ services:
       VITE_LEGACY_DASHBOARD_URL: ${VITE_LEGACY_DASHBOARD_URL}
     ports:
       - 4000:4000
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'node -e "const http = require(''http''); const req = http.get({hostname: ''localhost'', port: 4000, path: ''/'', timeout: 5000}, (res) => { process.exit(res.statusCode === 200 ? 0 : 1); }); req.on(''error'', () => process.exit(1)); req.on(''timeout'', () => { req.destroy(); process.exit(1); });"',
+        ]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
 
 volumes:
   mongodb: ~


### PR DESCRIPTION
### What changed? Why was the change needed
This fixes concern discussed in #7953

- MongoDB & Redis: Already had health checks, updated MongoDB to use mongosh (v8.0.3 requirement)
- API, Worker, WS: Use wget (already in alpine images)
  - Health check: wget --no-verbose --tries=1 --spider http://localhost:$${PORT}/v1/health-check
  - Key fix: Use $${PORT} (container's env var), not $${API_PORT}
- Dashboard: Use Node.js http module (backward compatible, no wget in image)
  - Health check: Node.js one-liner checking port 4000
- Dependencies: Added condition: service_healthy so services wait for their dependencies:
  - API/Worker/WS → wait for MongoDB + Redis
  - Dashboard → waits for API + Worker
- Configuration:
  - Intervals: 20s
  - Timeouts: 10s
  - Retries: 3
  - Start periods: 20-40s (longer for API/WS)

Result: All services have working health checks with zero Docker image changes needed (100% backward compatible).

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
