### PR TITLE
fix(js): undefined access when severity is not provided

### DIFF
--- a/packages/js/src/ui/components/Notification/DefaultNotification.tsx
+++ b/packages/js/src/ui/components/Notification/DefaultNotification.tsx
@@ -55,6 +55,8 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
   const { navigate, status } = useInboxContext();
   const [minutesPassed, setMinutesPassed] = createSignal(0);
 
+  const severity = createMemo(() => props.notification.severity ?? SeverityLevelEnum.NONE);
+
   const createdAt = createMemo(() => {
     minutesPassed(); // register as dep
 
@@ -120,18 +122,18 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
   return (
     <a
       class={style({
-        key: SEVERITY_TO_NOTIFICATION_KEYS[props.notification.severity],
+        key: SEVERITY_TO_NOTIFICATION_KEYS[severity()],
         className: cn(
           'nt-transition nt-w-full nt-text-sm hover:nt-bg-primary-alpha-25 nt-group nt-relative nt-flex nt-items-start nt-p-4 nt-gap-2',
           '[&:not(:first-child)]:nt-border-t nt-border-neutral-alpha-100',
           {
             'nt-cursor-pointer': !props.notification.isRead || !!props.notification.redirect?.url,
             'nt-bg-severity-high-alpha-100 hover:nt-bg-severity-high-alpha-50':
-              props.notification.severity === SeverityLevelEnum.HIGH,
+              severity() === SeverityLevelEnum.HIGH,
             'nt-bg-severity-medium-alpha-100 hover:nt-bg-severity-medium-alpha-50':
-              props.notification.severity === SeverityLevelEnum.MEDIUM,
+              severity() === SeverityLevelEnum.MEDIUM,
             'nt-bg-severity-low-alpha-100 hover:nt-bg-severity-low-alpha-50':
-              props.notification.severity === SeverityLevelEnum.LOW,
+              severity() === SeverityLevelEnum.LOW,
           }
         ),
         context: { notification: props.notification } satisfies Parameters<InboxAppearanceCallback['notification']>[0],
@@ -140,14 +142,14 @@ export const DefaultNotification = (props: DefaultNotificationProps) => {
     >
       <div
         class={style({
-          key: SEVERITY_TO_BAR_KEYS[props.notification.severity],
+          key: SEVERITY_TO_BAR_KEYS[severity()],
           className: cn('nt-transition nt-absolute nt-left-0 nt-top-0 nt-bottom-0 nt-w-[3px]', {
             'nt-bg-severity-high group-hover:nt-bg-severity-high-alpha-500':
-              props.notification.severity === SeverityLevelEnum.HIGH,
+              severity() === SeverityLevelEnum.HIGH,
             'nt-bg-severity-medium group-hover:nt-bg-severity-medium-alpha-500':
-              props.notification.severity === SeverityLevelEnum.MEDIUM,
+              severity() === SeverityLevelEnum.MEDIUM,
             'nt-bg-severity-low group-hover:nt-bg-severity-low-alpha-500':
-              props.notification.severity === SeverityLevelEnum.LOW,
+              severity() === SeverityLevelEnum.LOW,
           }),
           context: { notification: props.notification } satisfies Parameters<
             InboxAppearanceCallback['notificationBar']

--- a/packages/js/src/ui/helpers/useStyle.ts
+++ b/packages/js/src/ui/helpers/useStyle.ts
@@ -25,6 +25,10 @@ export const useStyle = () => {
         iconKey?: AllIconKey;
         context?: any;
       }) => {
+        if (!key) {
+          return cn(className);
+        }
+
         const appearanceKeyParts = key.split('__');
         let finalAppearanceKeys: (keyof AllElements)[] = [];
         for (let i = 0; i < appearanceKeyParts.length; i += 1) {


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves a `TypeError: Cannot read properties of undefined (reading 'split')` (https://github.com/novuhq/novu/issues/9437) that occurred when rendering notifications with a missing or `undefined` `severity` field.

The `DefaultNotification` component now defaults `notification.severity` to `SeverityLevelEnum.NONE` if it's `undefined`, ensuring backward compatibility and preventing crashes for older notifications or API responses. A defensive check was also added to `useStyle.ts` to gracefully handle `undefined` keys.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

The primary fix is in `DefaultNotification.tsx` to ensure `severity` is always defined. The change in `useStyle.ts` provides an additional safeguard against `undefined` keys.

</details>

---
<a href="https://cursor.com/background-agent?bcId=bc-ad9062ae-90d0-42c6-8e84-a0e9de482e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad9062ae-90d0-42c6-8e84-a0e9de482e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

