### PR TITLE
chore(dashboard): Terminology update events workflows

### DIFF
--- a/apps/dashboard/src/components/auth/auth-side-banner.tsx
+++ b/apps/dashboard/src/components/auth/auth-side-banner.tsx
@@ -37,7 +37,7 @@ export function AuthSideBanner() {
               <div className="inline-flex justify-start gap-1">
                 <CircleCheck className="h-3 w-3" color="#99a0ad" />
                 <div className="text-xs font-medium leading-none text-neutral-400">
-                  No credit card required, 10k events for free every month.
+                  No credit card required, 10k workflow runs for free every month.
                 </div>
               </div>
             </div>

--- a/apps/dashboard/src/components/billing/active-plan-banner.tsx
+++ b/apps/dashboard/src/components/billing/active-plan-banner.tsx
@@ -32,7 +32,7 @@ interface UsageMetric {
 }
 
 const USAGE_METRICS: UsageMetric[] = [
-  { type: 'events', icon: RiCalendarEventLine, label: 'Events' },
+  { type: 'events', icon: RiCalendarEventLine, label: 'Workflow Runs' },
   { type: 'workflows', icon: RiRouteFill, label: 'Workflows' },
   { type: 'teammates', icon: RiTeamLine, label: 'Teammates' },
 ];
@@ -57,10 +57,10 @@ function getEventsTooltipContent(
   const isFreePlan = currentPlan === ApiServiceLevelEnum.FREE;
 
   const limitMessage = isFreePlan
-    ? "Further events won't be allowed after the free limit is exceeded."
+    ? "Further workflow runs won't be allowed after the free limit is exceeded."
     : 'Pay as you grow. No hard limit.';
 
-  return `Includes ${formatLimit(usageData.included)} events — ${limitMessage}`;
+  return `Includes ${formatLimit(usageData.included)} workflow runs — ${limitMessage}`;
 }
 
 function formatDateRange(

--- a/apps/dashboard/src/components/billing/features-config.ts
+++ b/apps/dashboard/src/components/billing/features-config.ts
@@ -16,7 +16,7 @@ type FeatureConfig = FeatureNameEnum | string;
 
 export const FEATURE_SECTIONS: FeatureSectionConfig[] = [
   {
-    title: 'Events',
+    title: 'Workflow Runs',
     features: [
       FeatureNameEnum.PLATFORM_MONTHLY_EVENTS_INCLUDED,
       FeatureNameEnum.PLATFORM_COST_PER_ADDITIONAL_1K_EVENTS,
@@ -85,7 +85,7 @@ const PLAN_FEATURES_CONFIG: Record<ApiServiceLevelEnum, { included: FeatureConfi
       FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
     ],
     excluded: [
-      '30,000 events & more',
+      '30,000 workflow runs & more',
       'Unlimited workflows',
       FeatureNameEnum.CUSTOM_ENVIRONMENTS_BOOLEAN,
       'Dedicated support',
@@ -100,7 +100,7 @@ const PLAN_FEATURES_CONFIG: Record<ApiServiceLevelEnum, { included: FeatureConfi
       FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
     ],
     excluded: [
-      '250,000 events & more',
+      '250,000 workflow runs & more',
       'Unlimited workflows',
       FeatureNameEnum.CUSTOM_ENVIRONMENTS_BOOLEAN,
       FeatureNameEnum.WEBHOOKS,
@@ -115,7 +115,7 @@ const PLAN_FEATURES_CONFIG: Record<ApiServiceLevelEnum, { included: FeatureConfi
       FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,
     ],
     excluded: [
-      'Custom event amount',
+      'Custom workflow run amount',
       FeatureNameEnum.ACCOUNT_CUSTOM_SAML_SSO_OIDC_BOOLEAN,
       '24 hours support SLA',
       'Custom delay & snooze durations',
@@ -133,7 +133,7 @@ const PLAN_FEATURES_CONFIG: Record<ApiServiceLevelEnum, { included: FeatureConfi
   },
   [ApiServiceLevelEnum.UNLIMITED]: {
     included: [
-      'Custom events',
+      'Custom workflow runs',
       FeatureNameEnum.PLATFORM_MAX_WORKFLOWS,
       FeatureNameEnum.ACCOUNT_MAX_TEAM_MEMBERS,
       FeatureNameEnum.PLATFORM_ACTIVITY_FEED_RETENTION,

--- a/apps/dashboard/src/components/side-navigation/free-trial-card.tsx
+++ b/apps/dashboard/src/components/side-navigation/free-trial-card.tsx
@@ -44,7 +44,7 @@ const CardContent = ({
         <TooltipContent variant="light" size="lg" side="right" className="w-48">
           <TooltipArrow variant="light" className="-translate-y-[1px]" />
           <span className="text-foreground-600 text-xs">
-            After the trial ends, continue to enjoy Novu's free tier with up to 20 workflows and up to 10k events/month.
+            After the trial ends, continue to enjoy Novu's free tier with up to 20 workflows and up to 10k workflow runs/month.
           </span>
         </TooltipContent>
       </Tooltip>

--- a/apps/dashboard/src/components/side-navigation/usage-card.tsx
+++ b/apps/dashboard/src/components/side-navigation/usage-card.tsx
@@ -83,7 +83,7 @@ function CardContent({ currentEvents, maxEvents, resetDate }: CardContentProps) 
       <div className="flex items-center">
         {!isComplete ? (
           <>
-            <span className="text-label-xs">Events Used</span>
+            <span className="text-label-xs">Workflow Runs</span>
           </>
         ) : (
           <>


### PR DESCRIPTION
### What changed? Why was the change needed?
Updated all user-facing instances of "Events" to "Workflow Runs" within the `apps/dashboard` pricing and usage sections. This change was needed to align with the recent product terminology refactor from "Events" to "Workflow Runs".

### Screenshots
N/A - This PR involves text-only changes in the UI.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer
This PR specifically targets "Events" related to pricing and usage metrics. Technical references to "events" (e.g., API endpoints, digest events) and the "Events" category in the template store were intentionally left unchanged as they refer to distinct concepts.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1765723518205319?thread_ts=1765723518.205319&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-e1d67d59-a12b-4b75-80e4-8a9d0b58ef18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e1d67d59-a12b-4b75-80e4-8a9d0b58ef18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

