### PR TITLE
style(dashboard): canvas metadata UI improvements

### DIFF
--- a/apps/dashboard/src/components/primitives/badge.tsx
+++ b/apps/dashboard/src/components/primitives/badge.tsx
@@ -1,11 +1,13 @@
 // AlignUI Badge v0.0.0
 
 import { Slot } from '@radix-ui/react-slot';
+import { motion } from 'motion/react';
 import * as React from 'react';
 
 import type { PolymorphicComponentProps } from '@/utils/polymorphic';
 import { recursiveCloneChildren } from '@/utils/recursive-clone-children';
 import { tv, type VariantProps } from '@/utils/tv';
+import { cn } from '@/utils/ui';
 
 const BADGE_ROOT_NAME = 'BadgeRoot';
 const BADGE_ICON_NAME = 'BadgeIcon';
@@ -457,4 +459,115 @@ function BadgeDot({ size, variant, color, className, ...rest }: BadgeDotProps) {
 
 BadgeDot.displayName = BADGE_DOT_NAME;
 
-export { BadgeRoot as Badge, BadgeIcon, BadgeDot as Dot, BadgeRoot as Root };
+type AnimatedBadgeDotProps = BadgeSharedProps & Omit<React.HTMLAttributes<HTMLDivElement>, 'color'>;
+
+const COLOR_TO_BASE_CLASSES: Record<
+  NonNullable<BadgeSharedProps['color']>,
+  { text: string; base25: string; base15: string }
+> = {
+  gray: {
+    text: 'text-faded-base',
+    base25: 'bg-faded-base/25',
+    base15: 'bg-faded-base/15',
+  },
+  blue: {
+    text: 'text-information-base',
+    base25: 'bg-information-base/25',
+    base15: 'bg-information-base/15',
+  },
+  orange: {
+    text: 'text-warning-base',
+    base25: 'bg-warning-base/25',
+    base15: 'bg-warning-base/15',
+  },
+  red: {
+    text: 'text-error-base',
+    base25: 'bg-error-base/25',
+    base15: 'bg-error-base/15',
+  },
+  green: {
+    text: 'text-success-base',
+    base25: 'bg-success-base/25',
+    base15: 'bg-success-base/15',
+  },
+  yellow: {
+    text: 'text-away-base',
+    base25: 'bg-away-base/25',
+    base15: 'bg-away-base/15',
+  },
+  purple: {
+    text: 'text-feature-base',
+    base25: 'bg-feature-base/25',
+    base15: 'bg-feature-base/15',
+  },
+  sky: {
+    text: 'text-verified-base',
+    base25: 'bg-verified-base/25',
+    base15: 'bg-verified-base/15',
+  },
+  pink: {
+    text: 'text-highlighted-base',
+    base25: 'bg-highlighted-base/25',
+    base15: 'bg-highlighted-base/15',
+  },
+  teal: {
+    text: 'text-stable-base',
+    base25: 'bg-stable-base/25',
+    base15: 'bg-stable-base/15',
+  },
+};
+
+function AnimatedBadgeDot({ size, variant, color = 'gray', className, ...rest }: AnimatedBadgeDotProps) {
+  const { dot } = badgeVariants({ size, variant, color });
+  const colorClasses = COLOR_TO_BASE_CLASSES[color];
+
+  return (
+    <div className={dot({ class: cn('relative', colorClasses.text, className) })} {...rest}>
+      <motion.div
+        animate={{
+          scale: [1.8, 2, 1.8],
+          opacity: [1, 0.7, 1],
+        }}
+        transition={{
+          duration: 2.4,
+          repeat: Infinity,
+          ease: [0.34, 1.56, 0.64, 1],
+        }}
+        style={{ transformOrigin: 'center' }}
+        className="absolute inset-0 flex items-center justify-center before:size-[2.5px] before:rounded-full before:bg-current"
+      />
+      <motion.div
+        animate={{
+          scale: [0.4, 1.2, 0.4],
+          opacity: [0.3, 0, 0.3],
+        }}
+        transition={{
+          duration: 2.4,
+          repeat: Infinity,
+          ease: [0.25, 0.46, 0.45, 0.94],
+          delay: 0.1,
+        }}
+        className={cn('absolute inset-0 rounded-full', colorClasses.base25)}
+        style={{ transformOrigin: 'center' }}
+      />
+      <motion.div
+        animate={{
+          scale: [0.6, 1.2, 0.6],
+          opacity: [0.2, 0, 0.2],
+        }}
+        transition={{
+          duration: 2.4,
+          repeat: Infinity,
+          ease: [0.25, 0.46, 0.45, 0.94],
+          delay: 0.2,
+        }}
+        className={cn('absolute inset-0 rounded-full', colorClasses.base15)}
+        style={{ transformOrigin: 'center' }}
+      />
+    </div>
+  );
+}
+
+AnimatedBadgeDot.displayName = 'AnimatedBadgeDot';
+
+export { BadgeRoot as Badge, BadgeIcon, BadgeDot as Dot, BadgeRoot as Root, AnimatedBadgeDot };

--- a/apps/dashboard/src/components/primitives/command.tsx
+++ b/apps/dashboard/src/components/primitives/command.tsx
@@ -42,19 +42,41 @@ const CommandInput = React.forwardRef<
     inputWrapperClassName?: string;
     inputRootClassName?: string;
     inlineLeadingNode?: React.ReactNode;
+    hasError?: boolean;
   }
->(({ className, size = 'md', inputRootClassName, inputWrapperClassName, inlineLeadingNode, ...props }, ref) => (
-  <InputRoot className={inputRootClassName}>
-    <InputWrapper className={cn('h-9', size === 'sm' && 'h-8', size === 'xs' && 'h-7', inputWrapperClassName)}>
-      {inlineLeadingNode}
-      <CommandPrimitive.Input
-        ref={ref}
-        className={cn('text-paragraph-xs placeholder:text-text-soft h-9 w-full bg-transparent outline-none', className)}
-        {...props}
-      />
-    </InputWrapper>
-  </InputRoot>
-));
+>(
+  (
+    { className, size = 'md', inputRootClassName, inputWrapperClassName, inlineLeadingNode, hasError, ...props },
+    ref
+  ) => (
+    <InputRoot className={inputRootClassName} size={size as 'sm' | 'md' | 'xs' | '2xs'} hasError={hasError}>
+      <InputWrapper
+        className={cn(
+          size === 'md' && 'h-10',
+          size === 'sm' && 'h-[2.35rem]',
+          size === 'xs' && 'h-8',
+          inputWrapperClassName
+        )}
+      >
+        {inlineLeadingNode}
+        <CommandPrimitive.Input
+          ref={ref}
+          className={cn(
+            'w-full bg-transparent outline-none text-text-strong',
+            'placeholder:select-none placeholder:text-text-soft placeholder:transition placeholder:duration-200 placeholder:ease-out',
+            'group-hover/input-wrapper:placeholder:text-text-sub',
+            'focus:placeholder:text-text-sub',
+            size === 'md' && 'h-10 text-paragraph-sm',
+            size === 'sm' && 'h-[2.35rem] text-paragraph-xs',
+            size === 'xs' && 'h-8 text-paragraph-xs',
+            className
+          )}
+          {...props}
+        />
+      </InputWrapper>
+    </InputRoot>
+  )
+);
 
 CommandInput.displayName = CommandPrimitive.Input.displayName;
 

--- a/apps/dashboard/src/components/primitives/tag-input.tsx
+++ b/apps/dashboard/src/components/primitives/tag-input.tsx
@@ -5,17 +5,29 @@ import { Popover, PopoverAnchor, PopoverContent } from '@/components/primitives/
 import { cn } from '@/utils/ui';
 import { Tag } from './tag';
 
-type TagInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> & {
+type TagInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'size'> & {
   value: string[];
   suggestions: string[];
   onChange: (tags: string[]) => void;
   size?: 'sm' | 'md' | 'xs';
   hideTags?: boolean;
   onAddTag?: (tag: string) => void;
+  hasError?: boolean;
 };
 
 const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
-  const { className, suggestions = [], value = [], onChange, onBlur, hideTags = false, onAddTag, ...rest } = props;
+  const {
+    className,
+    suggestions = [],
+    value = [],
+    onChange,
+    onBlur,
+    hideTags = false,
+    onAddTag,
+    size = 'xs',
+    hasError,
+    ...rest
+  } = props;
   const [tags, setTags] = useState<string[]>(Array.isArray(value) ? value : []);
   const [inputValue, setInputValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
@@ -156,7 +168,8 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
                   autoComplete="off"
                   value={inputValue}
                   className={cn('flex-grow', className)}
-                  placeholder="Type a tag and press Enter"
+                  size={size}
+                  hasError={hasError}
                   onValueChange={(value) => {
                     setInputValue(value);
                     if (value) {

--- a/apps/dashboard/src/components/primitives/tag-input.tsx
+++ b/apps/dashboard/src/components/primitives/tag-input.tsx
@@ -44,6 +44,13 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
     );
   }, [inputValue, suggestions, tags]);
 
+  const shouldShowPopover = useMemo(() => {
+    if (!isOpen) return false;
+    const trimmed = (inputValue || '').trim();
+    if (!trimmed) return validSuggestions.length > 0;
+    return filteredSuggestions.length > 0 || isNewTag;
+  }, [isOpen, inputValue, validSuggestions.length, filteredSuggestions.length, isNewTag]);
+
   useEffect(() => {
     setTags(value || []);
   }, [value]);
@@ -85,7 +92,7 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
 
   return (
     <div className="w-full">
-      <Popover open={isOpen}>
+      <Popover open={shouldShowPopover}>
         <Command loop shouldFilter={false}>
           <div className="flex flex-col gap-2 pb-0.5">
             <PopoverAnchor asChild>
@@ -99,6 +106,8 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
                   setInputValue(value || '');
                   if (value) {
                     setIsOpen(true);
+                  } else {
+                    setIsOpen(false);
                   }
                 }}
                 onClick={() => setIsOpen(true)}
@@ -144,53 +153,51 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
               </div>
             )}
           </div>
-          <CommandList>
-            {(filteredSuggestions.length > 0 || isNewTag || inputValue === '') && (
-              <PopoverContent
-                className="max-h-64 w-[var(--radix-popover-trigger-width)] overflow-hidden p-1"
-                portal={false}
-                onOpenAutoFocus={(e) => {
-                  e.preventDefault();
-                }}
-                align="start"
-                sideOffset={4}
-                onPointerDownOutside={(e) => {
-                  const target = e.target as HTMLElement;
-                  if (!target.closest('[cmdk-input-wrapper]')) {
-                    setIsOpen(false);
-                  }
-                }}
-              >
-                <CommandGroup>
-                  {isNewTag && (
-                    <CommandItem
-                      value={inputValue.trim()}
-                      onSelect={() => {
-                        addTag(inputValue);
-                      }}
-                    >
-                      <span className="text-foreground-400 text-xs font-medium">create: </span>
-                      <span className="truncate font-mono text-xs">{inputValue.trim()}</span>
-                    </CommandItem>
-                  )}
+          <PopoverContent
+            className="bg-background text-foreground-600 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 relative z-50 max-h-96 min-w-[8rem] w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-md border shadow-md p-1"
+            portal={false}
+            onOpenAutoFocus={(e) => {
+              e.preventDefault();
+            }}
+            align="start"
+            sideOffset={12}
+            onPointerDownOutside={(e) => {
+              const target = e.target as HTMLElement;
+              if (!target.closest('[cmdk-input-wrapper]')) {
+                setIsOpen(false);
+              }
+            }}
+          >
+            <CommandList className="max-h-[inherit] overflow-auto">
+              <CommandGroup className="!p-0">
+                {isNewTag && (
+                  <CommandItem
+                    value={inputValue.trim()}
+                    onSelect={() => {
+                      addTag(inputValue);
+                    }}
+                  >
+                    <span className="text-foreground-400 text-xs font-medium">create: </span>
+                    <span className="truncate font-mono text-xs">{inputValue.trim()}</span>
+                  </CommandItem>
+                )}
 
-                  {isNewTag && filteredSuggestions.length > 0 && <div className="bg-muted -mx-1 my-1 h-px" />}
+                {isNewTag && filteredSuggestions.length > 0 && <div className="bg-muted my-1 h-px" />}
 
-                  {filteredSuggestions.map((tag) => (
-                    <CommandItem
-                      key={tag}
-                      value={`${tag}-suggestion`}
-                      onSelect={() => {
-                        addTag(tag);
-                      }}
-                    >
-                      <span className="truncate">{tag}</span>
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </PopoverContent>
-            )}
-          </CommandList>
+                {filteredSuggestions.map((tag) => (
+                  <CommandItem
+                    key={tag}
+                    value={`${tag}-suggestion`}
+                    onSelect={() => {
+                      addTag(tag);
+                    }}
+                  >
+                    <span className="truncate">{tag}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </PopoverContent>
         </Command>
       </Popover>
     </div>

--- a/apps/dashboard/src/components/primitives/tag-input.tsx
+++ b/apps/dashboard/src/components/primitives/tag-input.tsx
@@ -162,7 +162,7 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
               e.preventDefault();
             }}
             align="start"
-            sideOffset={4}
+            sideOffset={1}
             onPointerDownOutside={(e) => {
               const target = e.target as HTMLElement;
               if (!target.closest('[cmdk-input-wrapper]')) {

--- a/apps/dashboard/src/components/primitives/tag-input.tsx
+++ b/apps/dashboard/src/components/primitives/tag-input.tsx
@@ -91,76 +91,78 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
   };
 
   return (
-    <div className="w-full">
+    <div className="w-full overflow-visible">
       <Popover open={shouldShowPopover}>
-        <Command loop shouldFilter={false}>
-          <div className="flex flex-col gap-2 pb-0.5">
-            <PopoverAnchor asChild>
-              <CommandInput
-                ref={ref}
-                autoComplete="off"
-                value={inputValue || ''}
-                className={cn('flex-grow', className)}
-                placeholder="Type a tag and press Enter"
-                onValueChange={(value) => {
-                  setInputValue(value || '');
-                  if (value) {
-                    setIsOpen(true);
-                  } else {
-                    setIsOpen(false);
-                  }
-                }}
-                onClick={() => setIsOpen(true)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Escape') {
-                    setIsOpen(false);
-                  }
-                }}
-                onBlur={(e) => {
-                  setTimeout(() => {
-                    setIsOpen(false);
-                    onBlur?.(e);
-                  }, 150);
-                }}
-                {...rest}
-              />
-            </PopoverAnchor>
-            {!hideTags && (
-              <div className="flex flex-wrap gap-2">
-                {(tags || []).map((tag, index) => (
-                  <Tag
-                    key={index}
-                    variant="stroke"
-                    className="max-w-[12rem] shrink-0"
-                    onDismiss={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-
-                      removeTag(tag);
-                    }}
-                    dismissTestId={`tags-badge-remove-${tag}`}
-                  >
-                    <span
-                      className="block max-w-full truncate"
-                      style={{ wordBreak: 'break-all' }}
-                      data-testid="tags-badge-value"
-                      title={tag}
-                    >
-                      {tag}
-                    </span>
-                  </Tag>
-                ))}
+        <Command loop shouldFilter={false} className="overflow-visible">
+          <PopoverAnchor asChild>
+            <div className="flex flex-col gap-2 pb-0.5 overflow-visible">
+              <div className="p-1 -m-1 mb-0">
+                <CommandInput
+                  ref={ref}
+                  autoComplete="off"
+                  value={inputValue || ''}
+                  className={cn('flex-grow', className)}
+                  placeholder="Type a tag and press Enter"
+                  onValueChange={(value) => {
+                    setInputValue(value || '');
+                    if (value) {
+                      setIsOpen(true);
+                    } else {
+                      setIsOpen(false);
+                    }
+                  }}
+                  onClick={() => setIsOpen(true)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Escape') {
+                      setIsOpen(false);
+                    }
+                  }}
+                  onBlur={(e) => {
+                    setTimeout(() => {
+                      setIsOpen(false);
+                      onBlur?.(e);
+                    }, 150);
+                  }}
+                  {...rest}
+                />
               </div>
-            )}
-          </div>
+              {!hideTags && (
+                <div className="flex flex-wrap gap-2">
+                  {(tags || []).map((tag, index) => (
+                    <Tag
+                      key={index}
+                      variant="stroke"
+                      className="max-w-[12rem] shrink-0"
+                      onDismiss={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+
+                        removeTag(tag);
+                      }}
+                      dismissTestId={`tags-badge-remove-${tag}`}
+                    >
+                      <span
+                        className="block max-w-full truncate"
+                        style={{ wordBreak: 'break-all' }}
+                        data-testid="tags-badge-value"
+                        title={tag}
+                      >
+                        {tag}
+                      </span>
+                    </Tag>
+                  ))}
+                </div>
+              )}
+            </div>
+          </PopoverAnchor>
           <PopoverContent
-            className="bg-background text-foreground-600 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 relative z-50 max-h-96 min-w-[8rem] w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-md border shadow-md p-1"
+            className="bg-background text-foreground-600 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 relative z-50 max-h-96 w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-md border shadow-md p-1"
             portal={false}
             onOpenAutoFocus={(e) => {
               e.preventDefault();
             }}
             align="start"
-            sideOffset={12}
+            sideOffset={4}
             onPointerDownOutside={(e) => {
               const target = e.target as HTMLElement;
               if (!target.closest('[cmdk-input-wrapper]')) {
@@ -177,12 +179,12 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
                       addTag(inputValue);
                     }}
                   >
-                    <span className="text-foreground-400 text-xs font-medium">create: </span>
+                    <span className="text-foreground-400 text-xs font-medium">Create: </span>
                     <span className="truncate font-mono text-xs">{inputValue.trim()}</span>
                   </CommandItem>
                 )}
 
-                {isNewTag && filteredSuggestions.length > 0 && <div className="bg-muted my-1 h-px" />}
+                {isNewTag && filteredSuggestions.length > 0 && <div className="bg-muted  h-px" />}
 
                 {filteredSuggestions.map((tag) => (
                   <CommandItem

--- a/apps/dashboard/src/components/primitives/tag-input.tsx
+++ b/apps/dashboard/src/components/primitives/tag-input.tsx
@@ -1,5 +1,5 @@
-import { Command } from 'cmdk';
-import { forwardRef, useEffect, useMemo, useState } from 'react';
+import { Command as CommandPrimitive } from 'cmdk';
+import { forwardRef, type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/primitives/command';
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/primitives/popover';
 import { cn } from '@/utils/ui';
@@ -16,127 +16,189 @@ type TagInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange
 
 const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
   const { className, suggestions = [], value = [], onChange, onBlur, hideTags = false, onAddTag, ...rest } = props;
-  const [tags, setTags] = useState<string[]>(value || []);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [tags, setTags] = useState<string[]>(Array.isArray(value) ? value : []);
   const [inputValue, setInputValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
+  const blurTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const validSuggestions = useMemo(
-    () => (suggestions || []).filter((suggestion) => !(tags || []).includes(suggestion)),
-    [tags, suggestions]
-  );
+  useEffect(() => {
+    if (Array.isArray(value)) {
+      setTags(value);
+    }
+  }, [value]);
+
+  useEffect(() => {
+    return () => {
+      if (blurTimeoutRef.current) {
+        clearTimeout(blurTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const validSuggestions = useMemo(() => {
+    const safeSuggestions = Array.isArray(suggestions) ? suggestions.filter(Boolean) : [];
+    const safeTags = Array.isArray(tags) ? tags.filter(Boolean) : [];
+    return safeSuggestions.filter((suggestion) => !safeTags.includes(suggestion));
+  }, [tags, suggestions]);
 
   const filteredSuggestions = useMemo(() => {
-    const trimmed = (inputValue || '').trim();
-    if (!trimmed) {
-      return validSuggestions;
-    }
+    const trimmed = inputValue.trim();
+    if (!trimmed) return validSuggestions;
     const searchLower = trimmed.toLowerCase();
-    return validSuggestions.filter((s) => s?.toLowerCase().includes(searchLower));
+    return validSuggestions.filter((s) => s.toLowerCase().includes(searchLower));
   }, [inputValue, validSuggestions]);
 
   const isNewTag = useMemo(() => {
-    const trimmed = (inputValue || '').trim();
+    const trimmed = inputValue.trim();
     if (!trimmed) return false;
-
-    return (
-      !suggestions.some((s) => s?.toLowerCase() === trimmed.toLowerCase()) &&
-      !(tags || []).some((t) => t?.toLowerCase() === trimmed.toLowerCase())
-    );
+    const trimmedLower = trimmed.toLowerCase();
+    const existsInSuggestions = suggestions.some((s) => s?.toLowerCase() === trimmedLower);
+    const existsInTags = tags.some((t) => t?.toLowerCase() === trimmedLower);
+    return !existsInSuggestions && !existsInTags;
   }, [inputValue, suggestions, tags]);
 
   const shouldShowPopover = useMemo(() => {
     if (!isOpen) return false;
-    const trimmed = (inputValue || '').trim();
+    const trimmed = inputValue.trim();
     if (!trimmed) return validSuggestions.length > 0;
     return filteredSuggestions.length > 0 || isNewTag;
   }, [isOpen, inputValue, validSuggestions.length, filteredSuggestions.length, isNewTag]);
 
-  useEffect(() => {
-    setTags(value || []);
-  }, [value]);
+  const addTag = useCallback(
+    (tag: string) => {
+      if (!tag) return;
 
-  const addTag = (tag: string) => {
-    const newTag = (tag || '').trim();
+      const newTag = tag.trim();
+      if (!newTag || tags.includes(newTag)) return;
 
-    if (newTag === '') {
-      return;
-    }
+      const newTags = [...tags, newTag];
+      if (onAddTag) {
+        onAddTag(newTag);
+      } else {
+        onChange(newTags);
+      }
 
-    const newTags = [...(tags || []), newTag];
+      setInputValue('');
+      setIsOpen(false);
 
-    if (new Set(newTags).size !== newTags.length) {
-      return;
-    }
+      setTimeout(() => {
+        inputRef.current?.blur();
+      }, 0);
+    },
+    [tags, onChange, onAddTag]
+  );
 
-    if (onAddTag) {
-      onAddTag(newTag);
-    } else {
+  const removeTag = useCallback(
+    (tag: string) => {
+      if (!tag) return;
+      const newTags = tags.filter((t) => t !== tag);
       onChange(newTags);
+      setInputValue('');
+    },
+    [tags, onChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const input = inputRef.current;
+      if (!input) return;
+
+      if (!isOpen && inputValue.trim()) {
+        setIsOpen(true);
+      }
+
+      if (event.key === 'Enter' && input.value.trim() !== '') {
+        const trimmed = input.value.trim();
+        if (trimmed) {
+          event.preventDefault();
+          event.stopPropagation();
+          addTag(trimmed);
+        }
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setIsOpen(false);
+        input.blur();
+        return;
+      }
+    },
+    [isOpen, inputValue, addTag]
+  );
+
+  const handleValueChange = useCallback((value: string) => {
+    setInputValue(value);
+    if (value.trim()) {
+      setIsOpen(true);
     }
+  }, []);
 
-    setInputValue('');
-    setIsOpen(false);
-  };
+  const handleBlur = useCallback(
+    (e: React.FocusEvent<HTMLInputElement>) => {
+      if (blurTimeoutRef.current) {
+        clearTimeout(blurTimeoutRef.current);
+      }
+      blurTimeoutRef.current = setTimeout(() => {
+        setIsOpen(false);
+        onBlur?.(e);
+      }, 150);
+    },
+    [onBlur]
+  );
 
-  const removeTag = (tag: string) => {
-    const newTags = [...(tags || [])];
-    const index = newTags.indexOf(tag);
+  const handleSelectOption = useCallback(
+    (tag: string) => {
+      addTag(tag);
+      setTimeout(() => {
+        inputRef.current?.blur();
+      }, 0);
+    },
+    [addTag]
+  );
 
-    if (index !== -1) {
-      newTags.splice(index, 1);
+  const handlePointerDownOutside = useCallback((e: Event) => {
+    const target = e.target as HTMLElement;
+    if (target?.closest && !target.closest('[cmdk-input-wrapper]')) {
+      setIsOpen(false);
     }
-
-    onChange(newTags);
-    setInputValue('');
-  };
+  }, []);
 
   return (
     <div className="w-full overflow-visible">
       <Popover open={shouldShowPopover}>
-        <Command loop shouldFilter={false} className="overflow-visible">
+        <CommandPrimitive onKeyDown={handleKeyDown} loop shouldFilter={false} className="overflow-visible">
           <PopoverAnchor asChild>
             <div className="flex flex-col gap-2 pb-0.5 overflow-visible">
               <div className="p-1 -m-1 mb-0">
                 <CommandInput
-                  ref={ref}
+                  ref={(node) => {
+                    inputRef.current = node as HTMLInputElement;
+                    if (typeof ref === 'function') {
+                      ref(node);
+                    }
+                  }}
                   autoComplete="off"
-                  value={inputValue || ''}
+                  value={inputValue}
                   className={cn('flex-grow', className)}
                   placeholder="Type a tag and press Enter"
-                  onValueChange={(value) => {
-                    setInputValue(value || '');
-                    if (value) {
-                      setIsOpen(true);
-                    } else {
-                      setIsOpen(false);
-                    }
-                  }}
-                  onClick={() => setIsOpen(true)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Escape') {
-                      setIsOpen(false);
-                    }
-                  }}
-                  onBlur={(e) => {
-                    setTimeout(() => {
-                      setIsOpen(false);
-                      onBlur?.(e);
-                    }, 150);
-                  }}
+                  onValueChange={handleValueChange}
+                  onFocus={() => setIsOpen(true)}
+                  onBlur={handleBlur}
                   {...rest}
                 />
               </div>
               {!hideTags && (
                 <div className="flex flex-wrap gap-2">
-                  {(tags || []).map((tag, index) => (
+                  {tags.map((tag, index) => (
                     <Tag
-                      key={index}
+                      key={`${tag}-${index}`}
                       variant="stroke"
                       className="max-w-[12rem] shrink-0"
                       onDismiss={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-
+                        e?.preventDefault();
+                        e?.stopPropagation();
                         removeTag(tag);
                       }}
                       dismissTestId={`tags-badge-remove-${tag}`}
@@ -158,41 +220,38 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
           <PopoverContent
             className="bg-background text-foreground-600 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 relative z-50 max-h-96 w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-md border shadow-md p-1"
             portal={false}
-            onOpenAutoFocus={(e) => {
-              e.preventDefault();
-            }}
+            onOpenAutoFocus={(e) => e.preventDefault()}
             align="start"
-            sideOffset={1}
-            onPointerDownOutside={(e) => {
-              const target = e.target as HTMLElement;
-              if (!target.closest('[cmdk-input-wrapper]')) {
-                setIsOpen(false);
-              }
-            }}
+            sideOffset={0}
+            onPointerDownOutside={handlePointerDownOutside}
           >
             <CommandList className="max-h-[inherit] overflow-auto">
               <CommandGroup className="!p-0">
-                {isNewTag && (
+                {isNewTag && inputValue.trim() && (
                   <CommandItem
                     value={inputValue.trim()}
-                    onSelect={() => {
-                      addTag(inputValue);
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
                     }}
+                    onSelect={() => handleSelectOption(inputValue)}
                   >
                     <span className="text-foreground-400 text-xs font-medium">Create: </span>
                     <span className="truncate font-mono text-xs">{inputValue.trim()}</span>
                   </CommandItem>
                 )}
 
-                {isNewTag && filteredSuggestions.length > 0 && <div className="bg-muted  h-px" />}
+                {isNewTag && filteredSuggestions.length > 0 && <div className="bg-muted h-px" />}
 
                 {filteredSuggestions.map((tag) => (
                   <CommandItem
                     key={tag}
                     value={`${tag}-suggestion`}
-                    onSelect={() => {
-                      addTag(tag);
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
                     }}
+                    onSelect={() => handleSelectOption(tag)}
                   >
                     <span className="truncate">{tag}</span>
                   </CommandItem>
@@ -200,7 +259,7 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
               </CommandGroup>
             </CommandList>
           </PopoverContent>
-        </Command>
+        </CommandPrimitive>
       </Popover>
     </div>
   );

--- a/apps/dashboard/src/components/primitives/tag-input.tsx
+++ b/apps/dashboard/src/components/primitives/tag-input.tsx
@@ -10,42 +10,69 @@ type TagInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange
   suggestions: string[];
   onChange: (tags: string[]) => void;
   size?: 'sm' | 'md' | 'xs';
+  hideTags?: boolean;
+  onAddTag?: (tag: string) => void;
 };
 
 const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
-  const { className, suggestions, value, onChange, ...rest } = props;
-  const [tags, setTags] = useState<string[]>(value);
+  const { className, suggestions = [], value = [], onChange, onBlur, hideTags = false, onAddTag, ...rest } = props;
+  const [tags, setTags] = useState<string[]>(value || []);
   const [inputValue, setInputValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
+
   const validSuggestions = useMemo(
-    () => suggestions.filter((suggestion) => !tags.includes(suggestion)),
+    () => (suggestions || []).filter((suggestion) => !(tags || []).includes(suggestion)),
     [tags, suggestions]
   );
 
+  const filteredSuggestions = useMemo(() => {
+    const trimmed = (inputValue || '').trim();
+    if (!trimmed) {
+      return validSuggestions;
+    }
+    const searchLower = trimmed.toLowerCase();
+    return validSuggestions.filter((s) => s?.toLowerCase().includes(searchLower));
+  }, [inputValue, validSuggestions]);
+
+  const isNewTag = useMemo(() => {
+    const trimmed = (inputValue || '').trim();
+    if (!trimmed) return false;
+
+    return (
+      !suggestions.some((s) => s?.toLowerCase() === trimmed.toLowerCase()) &&
+      !(tags || []).some((t) => t?.toLowerCase() === trimmed.toLowerCase())
+    );
+  }, [inputValue, suggestions, tags]);
+
   useEffect(() => {
-    setTags(value);
+    setTags(value || []);
   }, [value]);
 
   const addTag = (tag: string) => {
-    const newTag = tag.trim();
+    const newTag = (tag || '').trim();
 
     if (newTag === '') {
       return;
     }
 
-    const newTags = [...tags, tag];
+    const newTags = [...(tags || []), newTag];
 
     if (new Set(newTags).size !== newTags.length) {
       return;
     }
 
-    onChange(newTags);
+    if (onAddTag) {
+      onAddTag(newTag);
+    } else {
+      onChange(newTags);
+    }
+
     setInputValue('');
     setIsOpen(false);
   };
 
   const removeTag = (tag: string) => {
-    const newTags = [...tags];
+    const newTags = [...(tags || [])];
     const index = newTags.indexOf(tag);
 
     if (index !== -1) {
@@ -57,110 +84,119 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
   };
 
   return (
-    <Popover open={isOpen}>
-      <Command loop>
-        <div className="flex flex-col gap-2 pb-0.5">
-          <PopoverAnchor asChild>
-            <CommandInput
-              ref={ref}
-              autoComplete="off"
-              value={inputValue}
-              className={cn('flex-grow', className)}
-              placeholder="Type a tag and press Enter"
-              onValueChange={(value) => {
-                setInputValue(value);
-
-                if (value) {
-                  setIsOpen(true);
-                }
-              }}
-              onClick={() => setIsOpen(true)}
-              onKeyDown={(e) => {
-                if (e.key === 'Escape') {
-                  setIsOpen(false);
-                }
-              }}
-              {...rest}
-            />
-          </PopoverAnchor>
-          <div className="flex flex-wrap gap-2">
-            {tags.map((tag, index) => (
-              <Tag
-                key={index}
-                variant="stroke"
-                className="max-w-[12rem] shrink-0"
-                onDismiss={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-
-                  removeTag(tag);
+    <div className="w-full">
+      <Popover open={isOpen}>
+        <Command loop shouldFilter={false}>
+          <div className="flex flex-col gap-2 pb-0.5">
+            <PopoverAnchor asChild>
+              <CommandInput
+                ref={ref}
+                autoComplete="off"
+                value={inputValue || ''}
+                className={cn('flex-grow', className)}
+                placeholder="Type a tag and press Enter"
+                onValueChange={(value) => {
+                  setInputValue(value || '');
+                  if (value) {
+                    setIsOpen(true);
+                  }
                 }}
-                dismissTestId={`tags-badge-remove-${tag}`}
-              >
-                <span
-                  className="block max-w-full truncate"
-                  style={{ wordBreak: 'break-all' }}
-                  data-testid="tags-badge-value"
-                  title={tag}
-                >
-                  {tag}
-                </span>
-              </Tag>
-            ))}
-          </div>
-        </div>
-        <CommandList>
-          {(validSuggestions.length > 0 || inputValue !== '') && (
-            <PopoverContent
-              className="max-h-64 w-32 p-1"
-              portal={false}
-              onOpenAutoFocus={(e) => {
-                e.preventDefault();
-              }}
-              align="start"
-              sideOffset={4}
-              onPointerDownOutside={(e) => {
-                const target = e.target as HTMLElement;
+                onClick={() => setIsOpen(true)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    setIsOpen(false);
+                  }
+                }}
+                onBlur={(e) => {
+                  setTimeout(() => {
+                    setIsOpen(false);
+                    onBlur?.(e);
+                  }, 150);
+                }}
+                {...rest}
+              />
+            </PopoverAnchor>
+            {!hideTags && (
+              <div className="flex flex-wrap gap-2">
+                {(tags || []).map((tag, index) => (
+                  <Tag
+                    key={index}
+                    variant="stroke"
+                    className="max-w-[12rem] shrink-0"
+                    onDismiss={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
 
-                if (!target.closest('[cmdk-input-wrapper]')) {
-                  setIsOpen(false);
-                }
-              }}
-            >
-              <CommandGroup>
-                {inputValue !== '' && !validSuggestions.includes(inputValue) && (
-                  <CommandItem
-                    value={inputValue}
-                    onSelect={() => {
-                      addTag(inputValue);
+                      removeTag(tag);
                     }}
-                    className="gap-1"
-                    disabled={inputValue === '' || tags.includes(inputValue)}
+                    dismissTestId={`tags-badge-remove-${tag}`}
                   >
-                    <span className="truncate">{inputValue}</span>
-                  </CommandItem>
-                )}
-
-                {validSuggestions.map((tag) => (
-                  <CommandItem
-                    key={tag}
-                    // We can't have duplicate keys in our list so adding a suffix
-                    // here to differentiate this from the value typed
-                    value={`${tag}-suggestion`}
-                    onSelect={() => {
-                      addTag(tag);
-                    }}
-                  >
-                    <span className="truncate">{tag}</span>
-                  </CommandItem>
+                    <span
+                      className="block max-w-full truncate"
+                      style={{ wordBreak: 'break-all' }}
+                      data-testid="tags-badge-value"
+                      title={tag}
+                    >
+                      {tag}
+                    </span>
+                  </Tag>
                 ))}
-              </CommandGroup>
-            </PopoverContent>
-          )}
-        </CommandList>
-      </Command>
-    </Popover>
+              </div>
+            )}
+          </div>
+          <CommandList>
+            {(filteredSuggestions.length > 0 || isNewTag || inputValue === '') && (
+              <PopoverContent
+                className="max-h-64 w-[var(--radix-popover-trigger-width)] overflow-hidden p-1"
+                portal={false}
+                onOpenAutoFocus={(e) => {
+                  e.preventDefault();
+                }}
+                align="start"
+                sideOffset={4}
+                onPointerDownOutside={(e) => {
+                  const target = e.target as HTMLElement;
+                  if (!target.closest('[cmdk-input-wrapper]')) {
+                    setIsOpen(false);
+                  }
+                }}
+              >
+                <CommandGroup>
+                  {isNewTag && (
+                    <CommandItem
+                      value={inputValue.trim()}
+                      onSelect={() => {
+                        addTag(inputValue);
+                      }}
+                    >
+                      <span className="text-foreground-400 text-xs font-medium">create: </span>
+                      <span className="truncate font-mono text-xs">{inputValue.trim()}</span>
+                    </CommandItem>
+                  )}
+
+                  {isNewTag && filteredSuggestions.length > 0 && <div className="bg-muted -mx-1 my-1 h-px" />}
+
+                  {filteredSuggestions.map((tag) => (
+                    <CommandItem
+                      key={tag}
+                      value={`${tag}-suggestion`}
+                      onSelect={() => {
+                        addTag(tag);
+                      }}
+                    >
+                      <span className="truncate">{tag}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </PopoverContent>
+            )}
+          </CommandList>
+        </Command>
+      </Popover>
+    </div>
   );
 });
+
+TagInput.displayName = 'TagInput';
 
 export { TagInput };

--- a/apps/dashboard/src/components/primitives/tag-input.tsx
+++ b/apps/dashboard/src/components/primitives/tag-input.tsx
@@ -1,5 +1,5 @@
-import { Command as CommandPrimitive } from 'cmdk';
-import { forwardRef, type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Command } from 'cmdk';
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/primitives/command';
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/primitives/popover';
 import { cn } from '@/utils/ui';
@@ -16,11 +16,11 @@ type TagInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange
 
 const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
   const { className, suggestions = [], value = [], onChange, onBlur, hideTags = false, onAddTag, ...rest } = props;
-  const inputRef = useRef<HTMLInputElement>(null);
   const [tags, setTags] = useState<string[]>(Array.isArray(value) ? value : []);
   const [inputValue, setInputValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const blurTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const isClickingInputRef = useRef(false);
 
   useEffect(() => {
     if (Array.isArray(value)) {
@@ -36,27 +36,27 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
     };
   }, []);
 
-  const validSuggestions = useMemo(() => {
-    const safeSuggestions = Array.isArray(suggestions) ? suggestions.filter(Boolean) : [];
-    const safeTags = Array.isArray(tags) ? tags.filter(Boolean) : [];
-    return safeSuggestions.filter((suggestion) => !safeTags.includes(suggestion));
-  }, [tags, suggestions]);
+  const validSuggestions = useMemo(
+    () => (suggestions || []).filter((suggestion) => !(value || []).includes(suggestion)),
+    [value, suggestions]
+  );
 
   const filteredSuggestions = useMemo(() => {
     const trimmed = inputValue.trim();
     if (!trimmed) return validSuggestions;
     const searchLower = trimmed.toLowerCase();
-    return validSuggestions.filter((s) => s.toLowerCase().includes(searchLower));
+    return validSuggestions.filter((s) => s?.toLowerCase().includes(searchLower));
   }, [inputValue, validSuggestions]);
 
   const isNewTag = useMemo(() => {
     const trimmed = inputValue.trim();
     if (!trimmed) return false;
     const trimmedLower = trimmed.toLowerCase();
-    const existsInSuggestions = suggestions.some((s) => s?.toLowerCase() === trimmedLower);
-    const existsInTags = tags.some((t) => t?.toLowerCase() === trimmedLower);
-    return !existsInSuggestions && !existsInTags;
-  }, [inputValue, suggestions, tags]);
+    return (
+      !suggestions.some((s) => s?.toLowerCase() === trimmedLower) &&
+      !(value || []).some((t) => t?.toLowerCase() === trimmedLower)
+    );
+  }, [inputValue, suggestions, value]);
 
   const shouldShowPopover = useMemo(() => {
     if (!isOpen) return false;
@@ -81,10 +81,6 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
 
       setInputValue('');
       setIsOpen(false);
-
-      setTimeout(() => {
-        inputRef.current?.blur();
-      }, 0);
     },
     [tags, onChange, onAddTag]
   );
@@ -100,43 +96,36 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
   );
 
   const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLDivElement>) => {
-      const input = inputRef.current;
-      if (!input) return;
-
-      if (!isOpen && inputValue.trim()) {
-        setIsOpen(true);
-      }
-
-      if (event.key === 'Enter' && input.value.trim() !== '') {
-        const trimmed = input.value.trim();
-        if (trimmed) {
-          event.preventDefault();
-          event.stopPropagation();
-          addTag(trimmed);
-        }
-        return;
-      }
-
-      if (event.key === 'Escape') {
-        event.preventDefault();
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
         setIsOpen(false);
-        input.blur();
-        return;
+      } else if (e.key === 'Enter' && inputValue.trim()) {
+        e.preventDefault();
+        addTag(inputValue);
       }
     },
-    [isOpen, inputValue, addTag]
+    [inputValue, addTag]
   );
 
-  const handleValueChange = useCallback((value: string) => {
-    setInputValue(value);
-    if (value.trim()) {
+  const handleClick = useCallback(() => {
+    isClickingInputRef.current = true;
+    if (blurTimeoutRef.current) {
+      clearTimeout(blurTimeoutRef.current);
+      blurTimeoutRef.current = null;
+    }
+    if (validSuggestions.length > 0 || inputValue.trim()) {
       setIsOpen(true);
     }
-  }, []);
+    setTimeout(() => {
+      isClickingInputRef.current = false;
+    }, 100);
+  }, [inputValue, validSuggestions.length]);
 
   const handleBlur = useCallback(
     (e: React.FocusEvent<HTMLInputElement>) => {
+      if (isClickingInputRef.current) {
+        return;
+      }
       if (blurTimeoutRef.current) {
         clearTimeout(blurTimeoutRef.current);
       }
@@ -146,16 +135,6 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
       }, 150);
     },
     [onBlur]
-  );
-
-  const handleSelectOption = useCallback(
-    (tag: string) => {
-      addTag(tag);
-      setTimeout(() => {
-        inputRef.current?.blur();
-      }, 0);
-    },
-    [addTag]
   );
 
   const handlePointerDownOutside = useCallback((e: Event) => {
@@ -168,23 +147,24 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
   return (
     <div className="w-full overflow-visible">
       <Popover open={shouldShowPopover}>
-        <CommandPrimitive onKeyDown={handleKeyDown} loop shouldFilter={false} className="overflow-visible">
+        <Command loop shouldFilter={false} className="overflow-visible">
           <PopoverAnchor asChild>
-            <div className="flex flex-col gap-2 pb-0.5 overflow-visible">
-              <div className="p-1 -m-1 mb-0">
+            <div className={cn('flex flex-col gap-2 overflow-visible', !hideTags && 'pb-0.5')}>
+              <div className="p-1 -m-1">
                 <CommandInput
-                  ref={(node) => {
-                    inputRef.current = node as HTMLInputElement;
-                    if (typeof ref === 'function') {
-                      ref(node);
-                    }
-                  }}
+                  ref={ref}
                   autoComplete="off"
                   value={inputValue}
                   className={cn('flex-grow', className)}
                   placeholder="Type a tag and press Enter"
-                  onValueChange={handleValueChange}
-                  onFocus={() => setIsOpen(true)}
+                  onValueChange={(value) => {
+                    setInputValue(value);
+                    if (value) {
+                      setIsOpen(true);
+                    }
+                  }}
+                  onClick={handleClick}
+                  onKeyDown={handleKeyDown}
                   onBlur={handleBlur}
                   {...rest}
                 />
@@ -217,49 +197,51 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>((props, ref) => {
               )}
             </div>
           </PopoverAnchor>
-          <PopoverContent
-            className="bg-background text-foreground-600 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 relative z-50 max-h-96 w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-md border shadow-md p-1"
-            portal={false}
-            onOpenAutoFocus={(e) => e.preventDefault()}
-            align="start"
-            sideOffset={0}
-            onPointerDownOutside={handlePointerDownOutside}
-          >
-            <CommandList className="max-h-[inherit] overflow-auto">
-              <CommandGroup className="!p-0">
-                {isNewTag && inputValue.trim() && (
-                  <CommandItem
-                    value={inputValue.trim()}
-                    onMouseDown={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                    }}
-                    onSelect={() => handleSelectOption(inputValue)}
-                  >
-                    <span className="text-foreground-400 text-xs font-medium">Create: </span>
-                    <span className="truncate font-mono text-xs">{inputValue.trim()}</span>
-                  </CommandItem>
-                )}
+          <CommandList>
+            {(filteredSuggestions.length > 0 || isNewTag) && (
+              <PopoverContent
+                className="bg-background text-foreground-600 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 relative z-50 max-h-96 w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-md border shadow-md p-1"
+                portal={false}
+                onOpenAutoFocus={(e) => e.preventDefault()}
+                align="start"
+                sideOffset={0}
+                onPointerDownOutside={handlePointerDownOutside}
+              >
+                <CommandGroup className="!p-0">
+                  {isNewTag && inputValue.trim() && (
+                    <CommandItem
+                      value={inputValue.trim()}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                      }}
+                      onSelect={() => addTag(inputValue)}
+                    >
+                      <span className="text-foreground-400 text-xs font-medium">Create: </span>
+                      <span className="truncate font-mono text-xs">{inputValue.trim()}</span>
+                    </CommandItem>
+                  )}
 
-                {isNewTag && filteredSuggestions.length > 0 && <div className="bg-muted h-px" />}
+                  {isNewTag && filteredSuggestions.length > 0 && <div className="bg-muted h-px" />}
 
-                {filteredSuggestions.map((tag) => (
-                  <CommandItem
-                    key={tag}
-                    value={`${tag}-suggestion`}
-                    onMouseDown={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                    }}
-                    onSelect={() => handleSelectOption(tag)}
-                  >
-                    <span className="truncate">{tag}</span>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </PopoverContent>
-        </CommandPrimitive>
+                  {filteredSuggestions.map((tag) => (
+                    <CommandItem
+                      key={tag}
+                      value={`${tag}-suggestion`}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                      }}
+                      onSelect={() => addTag(tag)}
+                    >
+                      <span className="truncate">{tag}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </PopoverContent>
+            )}
+          </CommandList>
+        </Command>
       </Popover>
     </div>
   );

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -7,7 +7,7 @@ import {
   UpdateWorkflowDto,
   WorkflowResponseDto,
 } from '@novu/shared';
-import { ChevronsUpDown, FilesIcon } from 'lucide-react';
+import { ChevronsUpDown, CircleDot, FilesIcon, FileText, Hash, Tags } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -404,7 +404,10 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                 render={({ field }) => (
                   <FormItem>
                     <div className="group flex items-center justify-between">
-                      <span className="text-text-soft font-code text-xs font-medium">STATUS</span>
+                      <div className="flex items-center gap-1.5">
+                        <CircleDot className="text-text-soft h-3.5 w-3.5 shrink-0" />
+                        <span className="text-text-soft font-code text-xs font-medium">STATUS</span>
+                      </div>
                       <div className="flex items-center gap-2">
                         {field.value ? (
                           <Badge variant="lighter" color="green" size="md" className="text-success-base gap-1.5">
@@ -445,7 +448,10 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                 render={({ field, fieldState }) => (
                   <FormItem>
                     <div className="group flex items-center justify-between gap-6">
-                      <span className="text-text-soft font-code text-xs font-medium">WORKFLOW</span>
+                      <div className="flex items-center gap-1.5">
+                        <RouteFill className="text-text-soft h-3.5 w-3.5 shrink-0" />
+                        <span className="text-text-soft font-code text-xs font-medium">WORKFLOW</span>
+                      </div>
                       <div className="relative flex items-center min-w-0 flex-1 justify-end h-8">
                         <AnimatePresence mode="wait">
                           {isEditingName && !isReadOnly ? (
@@ -525,7 +531,10 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                 render={({ field }) => (
                   <FormItem>
                     <div className="group flex items-center justify-between">
-                      <span className="text-text-soft font-code text-xs font-medium">ID</span>
+                      <div className="flex items-center gap-1.5">
+                        <Hash className="text-text-soft h-3.5 w-3.5 shrink-0" />
+                        <span className="text-text-soft font-code text-xs font-medium">ID</span>
+                      </div>
                       <div className="relative flex items-center gap-2">
                         <div className="opacity-0 transition-opacity duration-200 group-hover:opacity-100">
                           <CopyButton valueToCopy={field.value} size="2xs" className="h-1 p-0.5" />
@@ -554,7 +563,10 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                       onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
                       className="group flex w-full cursor-pointer items-center justify-between transition-colors hover:text-foreground-800"
                     >
-                      <span className="text-text-soft font-code text-xs font-medium">DESCRIPTION</span>
+                      <div className="flex items-center gap-1.5">
+                        <FileText className="text-text-soft h-3.5 w-3.5 shrink-0" />
+                        <span className="text-text-soft font-code text-xs font-medium">DESCRIPTION</span>
+                      </div>
                       <div className="relative flex items-center gap-2">
                         <motion.div
                           whileHover={{ scale: 1.05 }}
@@ -631,7 +643,10 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                           onClick={() => setIsAddingTag(!isAddingTag)}
                           className="group flex w-full cursor-pointer items-center justify-between transition-colors hover:text-foreground-800"
                         >
-                          <span className="text-text-soft font-code text-xs font-medium">TAGS</span>
+                          <div className="flex items-center gap-1.5">
+                            <Tags className="text-text-soft h-3.5 w-3.5 shrink-0" />
+                            <span className="text-text-soft font-code text-xs font-medium">TAGS</span>
+                          </div>
                           <div className="relative flex items-center gap-2">
                             <motion.div
                               whileHover={{ scale: 1.05 }}
@@ -645,7 +660,10 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                         </button>
                       ) : (
                         <div className="group flex items-center justify-between">
-                          <span className="text-text-soft font-code text-xs font-medium">TAGS</span>
+                          <div className="flex items-center gap-1.5">
+                            <Tags className="text-text-soft h-3.5 w-3.5 shrink-0" />
+                            <span className="text-text-soft font-code text-xs font-medium">TAGS</span>
+                          </div>
                         </div>
                       )}
 

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -7,12 +7,12 @@ import {
   UpdateWorkflowDto,
   WorkflowResponseDto,
 } from '@novu/shared';
-import { FilesIcon } from 'lucide-react';
-import { motion } from 'motion/react';
+import { ChevronsUpDown, FilesIcon } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { LuBookUp2 } from 'react-icons/lu';
 import {
+  RiAddLine,
   RiArrowRightSLine,
   RiCodeSSlashLine,
   RiDeleteBin2Line,
@@ -29,6 +29,7 @@ import { DeleteWorkflowDialog } from '@/components/delete-workflow-dialog';
 import { RouteFill } from '@/components/icons/route-fill';
 import { PageMeta } from '@/components/page-meta';
 import { PAUSE_MODAL_TITLE, PauseModalDescription } from '@/components/pause-workflow-dialog';
+import { Badge, Dot as BadgeDot } from '@/components/primitives/badge';
 import { Button } from '@/components/primitives/button';
 import { CompactButton } from '@/components/primitives/button-compact';
 import { CopyButton } from '@/components/primitives/copy-button';
@@ -37,22 +38,10 @@ import {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuPortal,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/primitives/dropdown-menu';
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-  FormRoot,
-} from '@/components/primitives/form/form';
+import { Form, FormField, FormItem, FormMessage, FormRoot } from '@/components/primitives/form/form';
 import { Input } from '@/components/primitives/input';
 import { Separator } from '@/components/primitives/separator';
 import { ToastIcon } from '@/components/primitives/sonner';
@@ -60,13 +49,11 @@ import { showToast } from '@/components/primitives/sonner-helpers';
 import { Switch } from '@/components/primitives/switch';
 import { TagInput } from '@/components/primitives/tag-input';
 import { Textarea } from '@/components/primitives/textarea';
-import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/components/primitives/tooltip';
 import { usePromotionalBanner } from '@/components/promotional/coming-soon-banner';
 import { SidebarContent, SidebarHeader } from '@/components/side-navigation/sidebar';
 import { workflowSchema } from '@/components/workflow-editor/schema';
 import { UpdateWorkflowFn } from '@/components/workflow-editor/workflow-provider';
-import { useAuth } from '@/context/auth/hooks';
-import { useEnvironment, useFetchEnvironments } from '@/context/environment/hooks';
+import { useEnvironment } from '@/context/environment/hooks';
 import { useDeleteWorkflow } from '@/hooks/use-delete-workflow';
 import { useFormAutosave } from '@/hooks/use-form-autosave';
 import { useSyncWorkflow } from '@/hooks/use-sync-workflow';
@@ -97,11 +84,12 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
   const [isPauseModalOpen, setIsPauseModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isPayloadSchemaDrawerOpen, setIsPayloadSchemaDrawerOpen] = useState(false);
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [isAddingTag, setIsAddingTag] = useState(false);
 
   const { tags } = useTags();
   const { currentEnvironment } = useEnvironment();
-  const { currentOrganization } = useAuth();
-  const { environments = [] } = useFetchEnvironments({ organizationId: currentOrganization?._id });
   const { isSyncable, PromoteConfirmModal } = useSyncWorkflow(workflow);
 
   const { show: showComingSoonBanner } = usePromotionalBanner({
@@ -195,7 +183,6 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
     });
   }, []);
 
-  const otherEnvironments = environments.filter((env) => env._id !== currentEnvironment?._id);
   const isDuplicable = useMemo(() => workflow.origin === ResourceOriginEnum.NOVU_CLOUD, [workflow.origin]);
 
   return (
@@ -294,120 +281,248 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
         </SidebarHeader>
         <Form {...form}>
           <FormRoot onBlur={onBlur}>
-            <SidebarContent size="md">
+            <SidebarContent size="md" className="space-y-2 py-2">
+              {/* STATUS Section */}
               <FormField
                 control={form.control}
                 name="active"
                 render={({ field }) => (
-                  <FormItem className="flex w-full items-center justify-between">
-                    <div className="flex items-center gap-4">
-                      <div
-                        className="bg-success/60 data-[active=false]:shadow-neutral-alpha-100 ml-2 h-1.5 w-1.5 rounded-full [--pulse-color:var(--success)] data-[active=true]:animate-[pulse-shadow_1s_ease-in-out_infinite] data-[active=false]:bg-neutral-300 data-[active=false]:shadow-[0_0px_0px_5px_var(--neutral-alpha-200),0_0px_0px_9px_var(--neutral-alpha-100)]"
-                        data-active={field.value}
-                      />
-                      <FormLabel>Active Workflow</FormLabel>
-                    </div>
-                    <FormControl>
-                      <Switch
-                        checked={field.value}
-                        onCheckedChange={(checked) => {
-                          if (!checked) {
-                            setIsPauseModalOpen(true);
-                            return;
-                          }
+                  <FormItem>
+                    <div className="group flex items-center justify-between">
+                      <span className="text-text-soft font-code text-xs font-medium">STATUS</span>
+                      <div className="flex items-center gap-3">
+                        {field.value ? (
+                          <motion.div
+                            initial={false}
+                            animate={{
+                              scale: [1, 1.02, 1],
+                            }}
+                            transition={{
+                              duration: 2,
+                              repeat: Infinity,
+                              ease: 'easeInOut',
+                            }}
+                          >
+                            <Badge
+                              variant="light"
+                              color="green"
+                              size="md"
+                              className="bg-success-lighter text-success-base gap-1.5"
+                            >
+                              <BadgeDot />
+                              <span className="font-code text-xs uppercase text-success">Active</span>
+                            </Badge>
+                          </motion.div>
+                        ) : (
+                          <Badge variant="light" color="gray" size="md" className="gap-1.5">
+                            <BadgeDot />
+                            <span className="font-code text-xs uppercase text-faded">Inactive</span>
+                          </Badge>
+                        )}
+                        <motion.div whileTap={{ scale: 0.95 }} transition={{ duration: 0.1 }}>
+                          <Switch
+                            checked={field.value}
+                            onCheckedChange={(checked) => {
+                              if (!checked) {
+                                setIsPauseModalOpen(true);
+                                return;
+                              }
 
-                          onPauseWorkflow(checked);
-                        }}
-                        disabled={isReadOnly}
-                      />
-                    </FormControl>
+                              onPauseWorkflow(checked);
+                            }}
+                            disabled={isReadOnly}
+                          />
+                        </motion.div>
+                      </div>
+                    </div>
                   </FormItem>
                 )}
               />
-            </SidebarContent>
-            <Separator />
-            <SidebarContent>
+
+              {/* WORKFLOW Section */}
               <FormField
                 control={form.control}
                 name="name"
                 defaultValue=""
                 render={({ field, fieldState }) => (
                   <FormItem>
-                    <FormLabel required>Name</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder="New workflow"
-                        {...field}
-                        disabled={isReadOnly}
-                        hasError={!!fieldState.error}
-                      />
-                    </FormControl>
-                    <FormMessage />
+                    <div className="group flex items-center justify-between">
+                      <span className="text-text-soft font-code text-xs font-medium">WORKFLOW</span>
+                      <div className="relative flex items-center gap-2 min-w-0 flex-1 justify-end">
+                        {isEditingName && !isReadOnly ? (
+                          <Input
+                            placeholder="New workflow"
+                            value={field.value}
+                            onChange={field.onChange}
+                            hasError={!!fieldState.error}
+                            className="min-w-[200px] [&>div]:before:hidden [&>div]:shadow-none [&>div]:focus-within:ring-1 [&>div]:focus-within:ring-stroke-soft [&>div]:focus-within:ring-offset-0 [&>div]:focus-within:border-stroke-soft"
+                            size="xs"
+                            autoFocus
+                            onBlur={() => {
+                              field.onBlur();
+                              setIsEditingName(false);
+                              saveForm();
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                e.currentTarget.blur();
+                              }
+                              if (e.key === 'Escape') {
+                                form.resetField('name');
+                                setIsEditingName(false);
+                              }
+                            }}
+                          />
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => !isReadOnly && setIsEditingName(true)}
+                            disabled={isReadOnly}
+                            className={cn(
+                              'text-foreground-600 text-right text-xs transition-colors',
+                              !isReadOnly && 'hover:text-foreground-800 cursor-pointer',
+                              isReadOnly && 'cursor-default'
+                            )}
+                          >
+                            {field.value || 'Untitled workflow'}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                    <FormMessage className="mt-1" />
                   </FormItem>
                 )}
               />
+
+              {/* ID Section */}
               <FormField
                 control={form.control}
                 name="workflowId"
                 defaultValue=""
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Identifier</FormLabel>
-                    <FormControl>
-                      <Input
-                        size="xs"
-                        trailingNode={<CopyButton valueToCopy={field.value} />}
-                        placeholder="Untitled"
-                        className="cursor-default"
-                        {...field}
-                        readOnly
-                      />
-                    </FormControl>
-                    <FormMessage />
+                    <div className="group flex items-center justify-between">
+                      <span className="text-text-soft font-code text-xs font-medium">ID</span>
+                      <div className="relative flex items-center gap-2">
+                        <div className="opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                          <CopyButton valueToCopy={field.value} size="2xs" className="h-1 p-0.5" />
+                        </div>
+                        <motion.span
+                          whileHover={{ x: -2 }}
+                          transition={{ duration: 0.15 }}
+                          className="text-foreground-600 font-mono text-xs"
+                        >
+                          {field.value}
+                        </motion.span>
+                      </div>
+                    </div>
                   </FormItem>
                 )}
               />
+
+              {/* DESCRIPTION Section */}
               <FormField
                 control={form.control}
                 name="description"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Description</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        className="min-h-36"
-                        placeholder="Describe what this workflow does"
-                        {...field}
-                        maxLength={MAX_DESCRIPTION_LENGTH}
-                        showCounter
-                        disabled={isReadOnly}
-                      />
-                    </FormControl>
-                    <FormMessage />
+                    <button
+                      type="button"
+                      onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
+                      className="group flex w-full items-center justify-between"
+                    >
+                      <span className="text-text-soft font-code text-xs font-medium">DESCRIPTION</span>
+                      <div className="relative flex items-center gap-2">
+                        <motion.div
+                          whileHover={{ scale: 1.1 }}
+                          whileTap={{ scale: 0.95 }}
+                          transition={{ duration: 0.15 }}
+                          className="text-foreground-400 group-hover:text-foreground-600 rounded p-1 transition-colors"
+                        >
+                          <ChevronsUpDown
+                            className={cn(
+                              'size-4 transition-transform duration-200',
+                              isDescriptionExpanded && 'rotate-180'
+                            )}
+                          />
+                        </motion.div>
+                      </div>
+                    </button>
+                    {isDescriptionExpanded && (
+                      <motion.div
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: 'auto', opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.2, ease: 'easeInOut' }}
+                        className="mt-2 overflow-hidden"
+                      >
+                        <Textarea
+                          className="min-h-24 text-sm"
+                          placeholder="Describe what this workflow does"
+                          value={field.value}
+                          onChange={field.onChange}
+                          maxLength={MAX_DESCRIPTION_LENGTH}
+                          showCounter
+                          disabled={isReadOnly}
+                          onBlur={() => {
+                            field.onBlur();
+                            saveForm();
+                          }}
+                        />
+                      </motion.div>
+                    )}
+                    <FormMessage className="mt-1" />
                   </FormItem>
                 )}
               />
+
+              {/* TAGS Section */}
               <FormField
                 control={form.control}
                 name="tags"
                 render={({ field }) => (
-                  <FormItem className="group" tabIndex={-1}>
-                    <div className="flex items-center gap-1">
-                      <FormLabel>Tags</FormLabel>
+                  <FormItem>
+                    <div className="group flex items-center justify-between">
+                      <span className="text-text-soft font-code text-xs font-medium">TAGS</span>
+                      <div className="relative flex items-center gap-2">
+                        {!isReadOnly && (
+                          <motion.button
+                            type="button"
+                            onClick={() => setIsAddingTag(!isAddingTag)}
+                            whileHover={{ scale: 1.05, rotate: 90 }}
+                            whileTap={{ scale: 0.95 }}
+                            transition={{ duration: 0.15 }}
+                            className="bg-bg-white hover:bg-bg-weak text-foreground-600 hover:text-foreground-800 flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors"
+                          >
+                            <RiAddLine className="size-3.5" />
+                          </motion.button>
+                        )}
+                      </div>
                     </div>
-                    <FormControl className="text-xs text-neutral-600">
-                      <TagInput
-                        {...field}
-                        onChange={(tags) => {
-                          form.setValue('tags', tags, { shouldValidate: true, shouldDirty: true });
-                          saveForm();
-                        }}
-                        disabled={isReadOnly}
-                        value={field.value ?? []}
-                        suggestions={tags.map((tag) => tag.name)}
-                      />
-                    </FormControl>
-                    <FormMessage />
+                    <AnimatePresence>
+                      {isAddingTag && !isReadOnly && (
+                        <motion.div
+                          initial={{ height: 0, opacity: 0 }}
+                          animate={{ height: 'auto', opacity: 1 }}
+                          exit={{ height: 0, opacity: 0 }}
+                          transition={{ duration: 0.2, ease: 'easeInOut' }}
+                          className="mt-2 overflow-hidden"
+                        >
+                          <TagInput
+                            value={field.value ?? []}
+                            onChange={(newTags) => {
+                              form.setValue('tags', newTags, { shouldValidate: true, shouldDirty: true });
+                              saveForm();
+                            }}
+                            disabled={isReadOnly}
+                            suggestions={tags.map((tag) => tag.name)}
+                            onBlur={() => setIsAddingTag(false)}
+                            className="h-6 text-xs"
+                          />
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                    <FormMessage className="mt-1" />
                   </FormItem>
                 )}
               />

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -107,7 +107,7 @@ function TagInputField({ currentTags, suggestions, onAddTag, onBlur }: TagInputF
           onAddTag={onAddTag}
           onBlur={onBlur}
           hideTags
-          className="h-6 text-xs"
+          size="xs"
           placeholder="Type a tag and press Enter"
         />
       </div>
@@ -325,7 +325,7 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                 name="active"
                 render={({ field }) => (
                   <FormItem>
-                    <div className="group flex items-center justify-between">
+                    <div className="group flex h-6 items-center justify-between">
                       <div className="flex items-center gap-1.5">
                         <CircleDot className="text-text-soft h-3.5 w-3.5 shrink-0" />
                         <span className="text-text-soft font-code text-xs font-medium">STATUS</span>
@@ -369,12 +369,12 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                 defaultValue=""
                 render={({ field, fieldState }) => (
                   <FormItem>
-                    <div className="group flex items-center justify-between gap-6">
+                    <div className="group flex h-6 items-center justify-between gap-6">
                       <div className="flex items-center gap-1.5">
                         <RouteFill className="text-text-soft h-3.5 w-3.5 shrink-0" />
                         <span className="text-text-soft font-code text-xs font-medium">WORKFLOW</span>
                       </div>
-                      <div className="relative flex items-center min-w-0 flex-1 justify-end h-8">
+                      <div className="relative flex min-w-0 flex-1 items-center justify-end">
                         <AnimatePresence mode="wait">
                           {isEditingName && !isReadOnly ? (
                             <motion.div
@@ -429,7 +429,7 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                               whileHover={!isReadOnly ? { x: 2 } : {}}
                               whileTap={!isReadOnly ? { scale: 0.98 } : {}}
                               className={cn(
-                                'text-foreground-600 text-right text-label-xs transition-colors h-8 flex items-center justify-end w-full min-w-0',
+                                'text-foreground-600 flex min-w-0 w-full items-center justify-end text-right text-label-xs transition-colors',
                                 !isReadOnly && 'hover:text-foreground-800 cursor-pointer',
                                 isReadOnly && 'cursor-default'
                               )}
@@ -452,7 +452,7 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                 defaultValue=""
                 render={({ field }) => (
                   <FormItem>
-                    <div className="group flex items-center justify-between">
+                    <div className="group flex h-6 items-center justify-between">
                       <div className="flex items-center gap-1.5">
                         <Hash className="text-text-soft h-3.5 w-3.5 shrink-0" />
                         <span className="text-text-soft font-code text-xs font-medium">ID</span>
@@ -483,7 +483,7 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                     <button
                       type="button"
                       onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
-                      className="group flex w-full cursor-pointer items-center justify-between transition-colors hover:text-foreground-800"
+                      className="group flex h-6 w-full cursor-pointer items-center justify-between transition-colors hover:text-foreground-800"
                     >
                       <div className="flex items-center gap-1.5">
                         <FileText className="text-text-soft h-3.5 w-3.5 shrink-0" />
@@ -563,7 +563,7 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                         <button
                           type="button"
                           onClick={() => setIsAddingTag(!isAddingTag)}
-                          className="group flex w-full cursor-pointer items-center justify-between transition-colors hover:text-foreground-800"
+                          className="group flex h-6 w-full cursor-pointer items-center justify-between transition-colors hover:text-foreground-800"
                         >
                           <div className="flex items-center gap-1.5">
                             <Tags className="text-text-soft h-3.5 w-3.5 shrink-0" />
@@ -581,7 +581,7 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                           </div>
                         </button>
                       ) : (
-                        <div className="group flex items-center justify-between">
+                        <div className="group flex h-6 items-center justify-between">
                           <div className="flex items-center gap-1.5">
                             <Tags className="text-text-soft h-3.5 w-3.5 shrink-0" />
                             <span className="text-text-soft font-code text-xs font-medium">TAGS</span>

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -50,6 +50,7 @@ import { ToastIcon } from '@/components/primitives/sonner';
 import { showToast } from '@/components/primitives/sonner-helpers';
 import { Switch } from '@/components/primitives/switch';
 import { Tag } from '@/components/primitives/tag';
+import { TagInput } from '@/components/primitives/tag-input';
 import { Textarea } from '@/components/primitives/textarea';
 import { usePromotionalBanner } from '@/components/promotional/coming-soon-banner';
 import { SidebarContent, SidebarHeader } from '@/components/side-navigation/sidebar';
@@ -88,21 +89,6 @@ type TagInputFieldProps = {
 };
 
 function TagInputField({ currentTags, suggestions, onAddTag, onBlur }: TagInputFieldProps) {
-  const [inputValue, setInputValue] = useState('');
-  const [isOpen, setIsOpen] = useState(false);
-
-  const validSuggestions = suggestions.filter((suggestion) => !currentTags.includes(suggestion));
-
-  const handleAddTag = (tag: string) => {
-    const trimmedTag = tag.trim();
-    if (trimmedTag === '' || currentTags.includes(trimmedTag)) {
-      return;
-    }
-    onAddTag(trimmedTag);
-    setInputValue('');
-    setIsOpen(false);
-  };
-
   return (
     <motion.div
       initial={{ height: 0, opacity: 0 }}
@@ -111,84 +97,18 @@ function TagInputField({ currentTags, suggestions, onAddTag, onBlur }: TagInputF
       transition={{ duration: 0.2, ease: 'easeInOut' }}
       className="mt-2 overflow-hidden"
     >
-      <Popover open={isOpen}>
-        <Command loop>
-          <PopoverAnchor asChild>
-            <CommandInput
-              autoComplete="off"
-              value={inputValue}
-              className="h-6 text-xs"
-              placeholder="Type a tag and press Enter"
-              onValueChange={(value) => {
-                setInputValue(value);
-                if (value) {
-                  setIsOpen(true);
-                }
-              }}
-              onClick={() => setIsOpen(true)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && inputValue.trim()) {
-                  e.preventDefault();
-                  handleAddTag(inputValue);
-                }
-                if (e.key === 'Escape') {
-                  setIsOpen(false);
-                  setInputValue('');
-                }
-              }}
-              onBlur={() => {
-                onBlur();
-                setIsOpen(false);
-              }}
-            />
-          </PopoverAnchor>
-          <CommandList>
-            {(validSuggestions.length > 0 || inputValue !== '') && (
-              <PopoverContent
-                className="max-h-64 w-32 p-1"
-                portal={false}
-                onOpenAutoFocus={(e) => {
-                  e.preventDefault();
-                }}
-                align="start"
-                sideOffset={4}
-                onPointerDownOutside={(e) => {
-                  const target = e.target as HTMLElement;
-                  if (!target.closest('[cmdk-input-wrapper]')) {
-                    setIsOpen(false);
-                  }
-                }}
-              >
-                <CommandGroup>
-                  {inputValue !== '' && !validSuggestions.includes(inputValue) && (
-                    <CommandItem
-                      value={inputValue}
-                      onSelect={() => {
-                        handleAddTag(inputValue);
-                      }}
-                      className="gap-1"
-                      disabled={inputValue === '' || currentTags.includes(inputValue)}
-                    >
-                      <span className="truncate">{inputValue}</span>
-                    </CommandItem>
-                  )}
-                  {validSuggestions.map((tag) => (
-                    <CommandItem
-                      key={tag}
-                      value={`${tag}-suggestion`}
-                      onSelect={() => {
-                        handleAddTag(tag);
-                      }}
-                    >
-                      <span className="truncate">{tag}</span>
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </PopoverContent>
-            )}
-          </CommandList>
-        </Command>
-      </Popover>
+      <TagInput
+        value={currentTags}
+        suggestions={suggestions}
+        onChange={() => {
+          // No-op since we use onAddTag instead
+        }}
+        onAddTag={onAddTag}
+        onBlur={onBlur}
+        hideTags
+        className="h-6 text-xs"
+        placeholder="Type a tag and press Enter"
+      />
     </motion.div>
   );
 }

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -32,6 +32,7 @@ import { PAUSE_MODAL_TITLE, PauseModalDescription } from '@/components/pause-wor
 import { AnimatedBadgeDot, Badge, Dot as BadgeDot } from '@/components/primitives/badge';
 import { Button } from '@/components/primitives/button';
 import { CompactButton } from '@/components/primitives/button-compact';
+import { Command, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/primitives/command';
 import { CopyButton } from '@/components/primitives/copy-button';
 import {
   DropdownMenu,
@@ -43,11 +44,12 @@ import {
 } from '@/components/primitives/dropdown-menu';
 import { Form, FormField, FormItem, FormMessage, FormRoot } from '@/components/primitives/form/form';
 import { Input } from '@/components/primitives/input';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/primitives/popover';
 import { Separator } from '@/components/primitives/separator';
 import { ToastIcon } from '@/components/primitives/sonner';
 import { showToast } from '@/components/primitives/sonner-helpers';
 import { Switch } from '@/components/primitives/switch';
-import { TagInput } from '@/components/primitives/tag-input';
+import { Tag } from '@/components/primitives/tag';
 import { Textarea } from '@/components/primitives/textarea';
 import { usePromotionalBanner } from '@/components/promotional/coming-soon-banner';
 import { SidebarContent, SidebarHeader } from '@/components/side-navigation/sidebar';
@@ -77,6 +79,119 @@ const toastOptions: ExternalToast = {
     toast: 'mb-4 right-0',
   },
 };
+
+type TagInputFieldProps = {
+  currentTags: string[];
+  suggestions: string[];
+  onAddTag: (tag: string) => void;
+  onBlur: () => void;
+};
+
+function TagInputField({ currentTags, suggestions, onAddTag, onBlur }: TagInputFieldProps) {
+  const [inputValue, setInputValue] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+
+  const validSuggestions = suggestions.filter((suggestion) => !currentTags.includes(suggestion));
+
+  const handleAddTag = (tag: string) => {
+    const trimmedTag = tag.trim();
+    if (trimmedTag === '' || currentTags.includes(trimmedTag)) {
+      return;
+    }
+    onAddTag(trimmedTag);
+    setInputValue('');
+    setIsOpen(false);
+  };
+
+  return (
+    <motion.div
+      initial={{ height: 0, opacity: 0 }}
+      animate={{ height: 'auto', opacity: 1 }}
+      exit={{ height: 0, opacity: 0 }}
+      transition={{ duration: 0.2, ease: 'easeInOut' }}
+      className="mt-2 overflow-hidden"
+    >
+      <Popover open={isOpen}>
+        <Command loop>
+          <PopoverAnchor asChild>
+            <CommandInput
+              autoComplete="off"
+              value={inputValue}
+              className="h-6 text-xs"
+              placeholder="Type a tag and press Enter"
+              onValueChange={(value) => {
+                setInputValue(value);
+                if (value) {
+                  setIsOpen(true);
+                }
+              }}
+              onClick={() => setIsOpen(true)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && inputValue.trim()) {
+                  e.preventDefault();
+                  handleAddTag(inputValue);
+                }
+                if (e.key === 'Escape') {
+                  setIsOpen(false);
+                  setInputValue('');
+                }
+              }}
+              onBlur={() => {
+                onBlur();
+                setIsOpen(false);
+              }}
+            />
+          </PopoverAnchor>
+          <CommandList>
+            {(validSuggestions.length > 0 || inputValue !== '') && (
+              <PopoverContent
+                className="max-h-64 w-32 p-1"
+                portal={false}
+                onOpenAutoFocus={(e) => {
+                  e.preventDefault();
+                }}
+                align="start"
+                sideOffset={4}
+                onPointerDownOutside={(e) => {
+                  const target = e.target as HTMLElement;
+                  if (!target.closest('[cmdk-input-wrapper]')) {
+                    setIsOpen(false);
+                  }
+                }}
+              >
+                <CommandGroup>
+                  {inputValue !== '' && !validSuggestions.includes(inputValue) && (
+                    <CommandItem
+                      value={inputValue}
+                      onSelect={() => {
+                        handleAddTag(inputValue);
+                      }}
+                      className="gap-1"
+                      disabled={inputValue === '' || currentTags.includes(inputValue)}
+                    >
+                      <span className="truncate">{inputValue}</span>
+                    </CommandItem>
+                  )}
+                  {validSuggestions.map((tag) => (
+                    <CommandItem
+                      key={tag}
+                      value={`${tag}-suggestion`}
+                      onSelect={() => {
+                        handleAddTag(tag);
+                      }}
+                    >
+                      <span className="truncate">{tag}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </PopoverContent>
+            )}
+          </CommandList>
+        </Command>
+      </Popover>
+    </motion.div>
+  );
+}
 
 export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
   const { workflow, update } = props;
@@ -437,7 +552,7 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                     <button
                       type="button"
                       onClick={() => setIsDescriptionExpanded(!isDescriptionExpanded)}
-                      className="group flex w-full items-center justify-between"
+                      className="group flex w-full cursor-pointer items-center justify-between transition-colors hover:text-foreground-800"
                     >
                       <span className="text-text-soft font-code text-xs font-medium">DESCRIPTION</span>
                       <div className="relative flex items-center gap-2">
@@ -488,51 +603,97 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
               <FormField
                 control={form.control}
                 name="tags"
-                render={({ field }) => (
-                  <FormItem>
-                    <div className="group flex items-center justify-between">
-                      <span className="text-text-soft font-code text-xs font-medium">TAGS</span>
-                      <div className="relative flex items-center gap-2">
-                        {!isReadOnly && (
-                          <motion.button
-                            type="button"
-                            onClick={() => setIsAddingTag(!isAddingTag)}
-                            whileHover={{ scale: 1.05 }}
-                            whileTap={{ scale: 0.95 }}
-                            transition={{ duration: 0.15 }}
-                            className="bg-bg-white hover:bg-bg-weak text-foreground-400 hover:text-foreground-600 flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors"
-                          >
-                            {isAddingTag ? <LuX className="size-3.5" /> : <LuPlus className="size-3.5" />}
-                          </motion.button>
-                        )}
-                      </div>
-                    </div>
-                    <AnimatePresence>
-                      {isAddingTag && !isReadOnly && (
-                        <motion.div
-                          initial={{ height: 0, opacity: 0 }}
-                          animate={{ height: 'auto', opacity: 1 }}
-                          exit={{ height: 0, opacity: 0 }}
-                          transition={{ duration: 0.2, ease: 'easeInOut' }}
-                          className="mt-2 overflow-hidden"
+                render={({ field }) => {
+                  const currentTags = field.value ?? [];
+                  const availableSuggestions = tags.map((tag) => tag.name).filter((tag) => !currentTags.includes(tag));
+
+                  const handleRemoveTag = (tagToRemove: string) => {
+                    const newTags = currentTags.filter((tag) => tag !== tagToRemove);
+                    form.setValue('tags', newTags, { shouldValidate: true, shouldDirty: true });
+                    saveForm();
+                  };
+
+                  const handleAddTag = (newTag: string) => {
+                    const trimmedTag = newTag.trim();
+                    if (trimmedTag === '' || currentTags.includes(trimmedTag)) {
+                      return;
+                    }
+                    const newTags = [...currentTags, trimmedTag];
+                    form.setValue('tags', newTags, { shouldValidate: true, shouldDirty: true });
+                    saveForm();
+                  };
+
+                  return (
+                    <FormItem>
+                      {!isReadOnly ? (
+                        <button
+                          type="button"
+                          onClick={() => setIsAddingTag(!isAddingTag)}
+                          className="group flex w-full cursor-pointer items-center justify-between transition-colors hover:text-foreground-800"
                         >
-                          <TagInput
-                            value={field.value ?? []}
-                            onChange={(newTags) => {
-                              form.setValue('tags', newTags, { shouldValidate: true, shouldDirty: true });
-                              saveForm();
-                            }}
-                            disabled={isReadOnly}
-                            suggestions={tags.map((tag) => tag.name)}
-                            onBlur={() => setIsAddingTag(false)}
-                            className="h-6 text-xs"
-                          />
-                        </motion.div>
+                          <span className="text-text-soft font-code text-xs font-medium">TAGS</span>
+                          <div className="relative flex items-center gap-2">
+                            <motion.div
+                              whileHover={{ scale: 1.05 }}
+                              whileTap={{ scale: 0.95 }}
+                              transition={{ duration: 0.15 }}
+                              className="bg-bg-white hover:bg-bg-weak text-foreground-400 hover:text-foreground-600 flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors"
+                            >
+                              {isAddingTag ? <LuX className="size-3.5" /> : <LuPlus className="size-3.5" />}
+                            </motion.div>
+                          </div>
+                        </button>
+                      ) : (
+                        <div className="group flex items-center justify-between">
+                          <span className="text-text-soft font-code text-xs font-medium">TAGS</span>
+                        </div>
                       )}
-                    </AnimatePresence>
-                    <FormMessage className="mt-1" />
-                  </FormItem>
-                )}
+
+                      {currentTags.length > 0 && (
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {currentTags.map((tag, index) => (
+                            <Tag
+                              key={index}
+                              variant="stroke"
+                              className="max-w-[12rem] shrink-0"
+                              onDismiss={
+                                !isReadOnly
+                                  ? (e) => {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                      handleRemoveTag(tag);
+                                    }
+                                  : undefined
+                              }
+                              dismissTestId={`tags-badge-remove-${tag}`}
+                            >
+                              <span
+                                className="block max-w-full truncate"
+                                style={{ wordBreak: 'break-all' }}
+                                data-testid="tags-badge-value"
+                                title={tag}
+                              >
+                                {tag}
+                              </span>
+                            </Tag>
+                          ))}
+                        </div>
+                      )}
+
+                      <AnimatePresence>
+                        {isAddingTag && !isReadOnly && (
+                          <TagInputField
+                            currentTags={currentTags}
+                            suggestions={availableSuggestions}
+                            onAddTag={handleAddTag}
+                            onBlur={() => setIsAddingTag(false)}
+                          />
+                        )}
+                      </AnimatePresence>
+                      <FormMessage className="mt-1" />
+                    </FormItem>
+                  );
+                }}
               />
             </SidebarContent>
           </FormRoot>

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -290,7 +290,7 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                   <FormItem>
                     <div className="group flex items-center justify-between">
                       <span className="text-text-soft font-code text-xs font-medium">STATUS</span>
-                      <div className="flex items-center gap-3">
+                      <div className="flex items-center gap-2">
                         {field.value ? (
                           <Badge variant="lighter" color="green" size="md" className="text-success-base gap-1.5">
                             <AnimatedBadgeDot size="md" variant="lighter" color="green" />
@@ -347,17 +347,24 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                                 value={field.value}
                                 onChange={field.onChange}
                                 hasError={!!fieldState.error}
-                                className="w-full [&>div]:before:hidden [&>div]:shadow-none [&>div]:focus-within:ring-1 [&>div]:focus-within:ring-stroke-soft [&>div]:focus-within:ring-offset-0 [&>div]:focus-within:border-stroke-soft [&_input]:text-right"
+                                maxLength={64}
+                                className="w-full [&>div]:before:hidden [&>div]:shadow-none [&>div]:focus-within:ring-1 [&>div]:focus-within:ring-stroke-soft [&>div]:focus-within:ring-offset-0 [&>div]:focus-within:border-stroke-soft [&_input]:text-right [&_input]:whitespace-nowrap [&_input]:[mask-image:linear-gradient(to_right,transparent,black_1rem,black_calc(100%-1rem),transparent)]"
                                 size="xs"
                                 autoFocus
                                 onBlur={() => {
                                   field.onBlur();
                                   setIsEditingName(false);
-                                  saveForm();
+                                  if (field.value?.trim()) {
+                                    saveForm();
+                                  }
                                 }}
                                 onKeyDown={(e) => {
                                   if (e.key === 'Enter') {
-                                    e.currentTarget.blur();
+                                    if (field.value?.trim()) {
+                                      e.currentTarget.blur();
+                                    } else {
+                                      form.setFocus('name');
+                                    }
                                   }
                                   if (e.key === 'Escape') {
                                     form.resetField('name');
@@ -379,12 +386,12 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                               whileHover={!isReadOnly ? { x: 2 } : {}}
                               whileTap={!isReadOnly ? { scale: 0.98 } : {}}
                               className={cn(
-                                'text-foreground-600 text-right text-label-xs transition-colors h-8 flex items-center justify-end w-full',
+                                'text-foreground-600 text-right text-label-xs transition-colors h-8 flex items-center justify-end w-full min-w-0',
                                 !isReadOnly && 'hover:text-foreground-800 cursor-pointer',
                                 isReadOnly && 'cursor-default'
                               )}
                             >
-                              {field.value || 'Untitled workflow'}
+                              <span className="truncate max-w-full">{field.value || 'Untitled workflow'}</span>
                             </motion.button>
                           )}
                         </AnimatePresence>
@@ -411,7 +418,7 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                         <motion.span
                           whileHover={{ x: -2 }}
                           transition={{ duration: 0.15 }}
-                          className="text-foreground-600 font-mono text-xs"
+                          className="text-foreground-600 text-right text-label-xs"
                         >
                           {field.value}
                         </motion.span>

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -95,20 +95,20 @@ function TagInputField({ currentTags, suggestions, onAddTag, onBlur }: TagInputF
       animate={{ height: 'auto', opacity: 1 }}
       exit={{ height: 0, opacity: 0 }}
       transition={{ duration: 0.2, ease: 'easeInOut' }}
-      className="mt-2 overflow-hidden"
+      className="mt-2"
     >
-      <TagInput
-        value={currentTags}
-        suggestions={suggestions}
-        onChange={() => {
-          // No-op since we use onAddTag instead
-        }}
-        onAddTag={onAddTag}
-        onBlur={onBlur}
-        hideTags
-        className="h-6 text-xs"
-        placeholder="Type a tag and press Enter"
-      />
+      <div className="p-1 -m-1">
+        <TagInput
+          value={currentTags}
+          suggestions={suggestions}
+          onChange={() => {}}
+          onAddTag={onAddTag}
+          onBlur={onBlur}
+          hideTags
+          className="h-6 text-xs"
+          placeholder="Type a tag and press Enter"
+        />
+      </div>
     </motion.div>
   );
 }

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -11,6 +11,7 @@ import { ChevronsUpDown, FilesIcon } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { LuCross, LuPlus, LuX } from 'react-icons/lu';
 import {
   RiAddLine,
   RiArrowRightSLine,
@@ -20,7 +21,6 @@ import {
   RiMore2Fill,
   RiSettingsLine,
 } from 'react-icons/ri';
-
 import { Link, useNavigate } from 'react-router-dom';
 import type { ExternalToast } from 'sonner';
 import { z } from 'zod';
@@ -29,7 +29,7 @@ import { DeleteWorkflowDialog } from '@/components/delete-workflow-dialog';
 import { RouteFill } from '@/components/icons/route-fill';
 import { PageMeta } from '@/components/page-meta';
 import { PAUSE_MODAL_TITLE, PauseModalDescription } from '@/components/pause-workflow-dialog';
-import { Badge, Dot as BadgeDot } from '@/components/primitives/badge';
+import { AnimatedBadgeDot, Badge, Dot as BadgeDot } from '@/components/primitives/badge';
 import { Button } from '@/components/primitives/button';
 import { CompactButton } from '@/components/primitives/button-compact';
 import { CopyButton } from '@/components/primitives/copy-button';
@@ -281,7 +281,7 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
         </SidebarHeader>
         <Form {...form}>
           <FormRoot onBlur={onBlur}>
-            <SidebarContent size="md" className="space-y-2 py-2">
+            <SidebarContent size="md">
               {/* STATUS Section */}
               <FormField
                 control={form.control}
@@ -292,31 +292,14 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                       <span className="text-text-soft font-code text-xs font-medium">STATUS</span>
                       <div className="flex items-center gap-3">
                         {field.value ? (
-                          <motion.div
-                            initial={false}
-                            animate={{
-                              scale: [1, 1.02, 1],
-                            }}
-                            transition={{
-                              duration: 2,
-                              repeat: Infinity,
-                              ease: 'easeInOut',
-                            }}
-                          >
-                            <Badge
-                              variant="light"
-                              color="green"
-                              size="md"
-                              className="bg-success-lighter text-success-base gap-1.5"
-                            >
-                              <BadgeDot />
-                              <span className="font-code text-xs uppercase text-success">Active</span>
-                            </Badge>
-                          </motion.div>
+                          <Badge variant="lighter" color="green" size="md" className="text-success-base gap-1.5">
+                            <AnimatedBadgeDot size="md" variant="lighter" color="green" />
+                            <span className="font-code text-xs uppercase">Active</span>
+                          </Badge>
                         ) : (
-                          <Badge variant="light" color="gray" size="md" className="gap-1.5">
+                          <Badge variant="lighter" color="gray" size="md" className="gap-1.5">
                             <BadgeDot />
-                            <span className="font-code text-xs uppercase text-faded">Inactive</span>
+                            <span className="font-code text-xs uppercase">Inactive</span>
                           </Badge>
                         )}
                         <motion.div whileTap={{ scale: 0.95 }} transition={{ duration: 0.1 }}>
@@ -346,50 +329,68 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                 defaultValue=""
                 render={({ field, fieldState }) => (
                   <FormItem>
-                    <div className="group flex items-center justify-between">
+                    <div className="group flex items-center justify-between gap-6">
                       <span className="text-text-soft font-code text-xs font-medium">WORKFLOW</span>
-                      <div className="relative flex items-center gap-2 min-w-0 flex-1 justify-end">
-                        {isEditingName && !isReadOnly ? (
-                          <Input
-                            placeholder="New workflow"
-                            value={field.value}
-                            onChange={field.onChange}
-                            hasError={!!fieldState.error}
-                            className="min-w-[200px] [&>div]:before:hidden [&>div]:shadow-none [&>div]:focus-within:ring-1 [&>div]:focus-within:ring-stroke-soft [&>div]:focus-within:ring-offset-0 [&>div]:focus-within:border-stroke-soft"
-                            size="xs"
-                            autoFocus
-                            onBlur={() => {
-                              field.onBlur();
-                              setIsEditingName(false);
-                              saveForm();
-                            }}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') {
-                                e.currentTarget.blur();
-                              }
-                              if (e.key === 'Escape') {
-                                form.resetField('name');
-                                setIsEditingName(false);
-                              }
-                            }}
-                          />
-                        ) : (
-                          <button
-                            type="button"
-                            onClick={() => !isReadOnly && setIsEditingName(true)}
-                            disabled={isReadOnly}
-                            className={cn(
-                              'text-foreground-600 text-right text-xs transition-colors',
-                              !isReadOnly && 'hover:text-foreground-800 cursor-pointer',
-                              isReadOnly && 'cursor-default'
-                            )}
-                          >
-                            {field.value || 'Untitled workflow'}
-                          </button>
-                        )}
+                      <div className="relative flex items-center min-w-0 flex-1 justify-end h-8">
+                        <AnimatePresence mode="wait">
+                          {isEditingName && !isReadOnly ? (
+                            <motion.div
+                              key="input"
+                              initial={{ opacity: 0, scale: 0.98 }}
+                              animate={{ opacity: 1, scale: 1 }}
+                              exit={{ opacity: 0, scale: 0.98 }}
+                              transition={{ duration: 0.15, ease: 'easeOut' }}
+                              className="absolute inset-0 flex items-center"
+                            >
+                              <Input
+                                placeholder="Workflow name"
+                                value={field.value}
+                                onChange={field.onChange}
+                                hasError={!!fieldState.error}
+                                className="w-full [&>div]:before:hidden [&>div]:shadow-none [&>div]:focus-within:ring-1 [&>div]:focus-within:ring-stroke-soft [&>div]:focus-within:ring-offset-0 [&>div]:focus-within:border-stroke-soft [&_input]:text-right"
+                                size="xs"
+                                autoFocus
+                                onBlur={() => {
+                                  field.onBlur();
+                                  setIsEditingName(false);
+                                  saveForm();
+                                }}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter') {
+                                    e.currentTarget.blur();
+                                  }
+                                  if (e.key === 'Escape') {
+                                    form.resetField('name');
+                                    setIsEditingName(false);
+                                  }
+                                }}
+                              />
+                            </motion.div>
+                          ) : (
+                            <motion.button
+                              key="button"
+                              type="button"
+                              onClick={() => !isReadOnly && setIsEditingName(true)}
+                              disabled={isReadOnly}
+                              initial={{ opacity: 0, scale: 0.98 }}
+                              animate={{ opacity: 1, scale: 1 }}
+                              exit={{ opacity: 0, scale: 0.98 }}
+                              transition={{ duration: 0.15, ease: 'easeOut' }}
+                              whileHover={!isReadOnly ? { x: 2 } : {}}
+                              whileTap={!isReadOnly ? { scale: 0.98 } : {}}
+                              className={cn(
+                                'text-foreground-600 text-right text-label-xs transition-colors h-8 flex items-center justify-end w-full',
+                                !isReadOnly && 'hover:text-foreground-800 cursor-pointer',
+                                isReadOnly && 'cursor-default'
+                              )}
+                            >
+                              {field.value || 'Untitled workflow'}
+                            </motion.button>
+                          )}
+                        </AnimatePresence>
                       </div>
                     </div>
-                    <FormMessage className="mt-1" />
+                    <FormMessage />
                   </FormItem>
                 )}
               />
@@ -434,14 +435,14 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                       <span className="text-text-soft font-code text-xs font-medium">DESCRIPTION</span>
                       <div className="relative flex items-center gap-2">
                         <motion.div
-                          whileHover={{ scale: 1.1 }}
+                          whileHover={{ scale: 1.05 }}
                           whileTap={{ scale: 0.95 }}
                           transition={{ duration: 0.15 }}
-                          className="text-foreground-400 group-hover:text-foreground-600 rounded p-1 transition-colors"
+                          className="bg-bg-white hover:bg-bg-weak text-foreground-400 hover:text-foreground-600 flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors"
                         >
                           <ChevronsUpDown
                             className={cn(
-                              'size-4 transition-transform duration-200',
+                              'size-3.5 transition-transform duration-200',
                               isDescriptionExpanded && 'rotate-180'
                             )}
                           />
@@ -489,12 +490,12 @@ export const ConfigureWorkflowForm = (props: ConfigureWorkflowFormProps) => {
                           <motion.button
                             type="button"
                             onClick={() => setIsAddingTag(!isAddingTag)}
-                            whileHover={{ scale: 1.05, rotate: 90 }}
+                            whileHover={{ scale: 1.05 }}
                             whileTap={{ scale: 0.95 }}
                             transition={{ duration: 0.15 }}
-                            className="bg-bg-white hover:bg-bg-weak text-foreground-600 hover:text-foreground-800 flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors"
+                            className="bg-bg-white hover:bg-bg-weak text-foreground-400 hover:text-foreground-600 flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors"
                           >
-                            <RiAddLine className="size-3.5" />
+                            {isAddingTag ? <LuX className="size-3.5" /> : <LuPlus className="size-3.5" />}
                           </motion.button>
                         )}
                       </div>

--- a/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/configure-workflow-form.tsx
@@ -101,7 +101,9 @@ function TagInputField({ currentTags, suggestions, onAddTag, onBlur }: TagInputF
         <TagInput
           value={currentTags}
           suggestions={suggestions}
-          onChange={() => {}}
+          onChange={() => {
+            // No-op since we use onAddTag instead
+          }}
           onAddTag={onAddTag}
           onBlur={onBlur}
           hideTags

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
@@ -8,6 +8,7 @@ import {
   StepUpdateDto,
   WorkflowResponseDto,
 } from '@novu/shared';
+import { Hash } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { HTMLAttributes, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -20,15 +21,7 @@ import { PageMeta } from '@/components/page-meta';
 import { Button } from '@/components/primitives/button';
 import { CompactButton } from '@/components/primitives/button-compact';
 import { CopyButton } from '@/components/primitives/copy-button';
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-  FormRoot,
-} from '@/components/primitives/form/form';
+import { Form, FormField, FormItem, FormMessage, FormRoot } from '@/components/primitives/form/form';
 import { Input } from '@/components/primitives/input';
 import { Separator } from '@/components/primitives/separator';
 import { SidebarContent, SidebarFooter, SidebarHeader } from '@/components/side-navigation/sidebar';
@@ -55,6 +48,8 @@ import { useFormAutosave } from '@/hooks/use-form-autosave';
 import { INLINE_CONFIGURABLE_STEP_TYPES, STEP_TYPE_LABELS, TEMPLATE_CONFIGURABLE_STEP_TYPES } from '@/utils/constants';
 import { getControlsDefaultValues } from '@/utils/default-values';
 import { buildRoute, ROUTES } from '@/utils/routes';
+import { cn } from '@/utils/ui';
+import { DEFAULT_STEP_ICON, STEP_TYPE_ICONS } from './constants/preview-context.constants';
 
 const STEP_TYPE_TO_INLINE_CONTROL_VALUES: Record<StepTypeEnum, () => React.JSX.Element | null> = {
   [StepTypeEnum.DELAY]: DelayControlValues,
@@ -93,6 +88,7 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
   const { step, workflow, update, environment } = props;
   const navigate = useNavigate();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(false);
   const supportedStepTypes = [
     StepTypeEnum.IN_APP,
     StepTypeEnum.SMS,
@@ -236,7 +232,13 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
                 <span className="sr-only">Back</span>
               </CompactButton>
             </Link>
-            <span>Configure Step</span>
+            <div className="flex items-center gap-1.5">
+              {(() => {
+                const StepIcon = STEP_TYPE_ICONS[step.type] || DEFAULT_STEP_ICON;
+                return <StepIcon className="h-4 w-4 shrink-0" />;
+              })()}
+              <span>Configure Step</span>
+            </div>
             <Link
               to={buildRoute(ROUTES.EDIT_WORKFLOW, {
                 environmentSlug: environment.slug!,
@@ -259,42 +261,118 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
           <Form {...form}>
             <FormRoot onBlur={onBlur}>
               <SaveFormContext.Provider value={value}>
-                <SidebarContent>
+                <SidebarContent size="md">
+                  {/* STEP Section */}
                   <FormField
                     control={form.control}
                     name="name"
-                    render={({ field, fieldState }) => (
-                      <FormItem>
-                        <FormLabel required>Name</FormLabel>
-                        <FormControl>
-                          <Input
-                            placeholder="Untitled"
-                            {...field}
-                            disabled={isReadOnly}
-                            hasError={!!fieldState.error}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
+                    defaultValue=""
+                    render={({ field, fieldState }) => {
+                      const StepIcon = STEP_TYPE_ICONS[step.type] || DEFAULT_STEP_ICON;
+                      return (
+                        <FormItem>
+                          <div className="group flex items-center justify-between gap-6">
+                            <div className="flex items-center gap-1.5">
+                              <StepIcon className="text-text-soft h-3.5 w-3.5 shrink-0" />
+                              <span className="text-text-soft font-code text-xs font-medium">STEP</span>
+                            </div>
+                            <div className="relative flex items-center min-w-0 flex-1 justify-end h-8">
+                              <AnimatePresence mode="wait">
+                                {isEditingName && !isReadOnly ? (
+                                  <motion.div
+                                    key="input"
+                                    initial={{ opacity: 0, scale: 0.98 }}
+                                    animate={{ opacity: 1, scale: 1 }}
+                                    exit={{ opacity: 0, scale: 0.98 }}
+                                    transition={{ duration: 0.15, ease: 'easeOut' }}
+                                    className="absolute inset-0 flex items-center"
+                                  >
+                                    <Input
+                                      placeholder="Step name"
+                                      value={field.value}
+                                      onChange={field.onChange}
+                                      hasError={!!fieldState.error}
+                                      maxLength={64}
+                                      className="w-full [&>div]:before:hidden [&>div]:shadow-none [&>div]:focus-within:ring-1 [&>div]:focus-within:ring-stroke-soft [&>div]:focus-within:ring-offset-0 [&>div]:focus-within:border-stroke-soft [&_input]:text-right [&_input]:whitespace-nowrap [&_input]:[mask-image:linear-gradient(to_right,transparent,black_1rem,black_calc(100%-1rem),transparent)]"
+                                      size="xs"
+                                      autoFocus
+                                      onBlur={() => {
+                                        field.onBlur();
+                                        setIsEditingName(false);
+                                        if (field.value?.trim()) {
+                                          saveForm();
+                                        }
+                                      }}
+                                      onKeyDown={(e) => {
+                                        if (e.key === 'Enter') {
+                                          if (field.value?.trim()) {
+                                            e.currentTarget.blur();
+                                          } else {
+                                            form.setFocus('name');
+                                          }
+                                        }
+                                        if (e.key === 'Escape') {
+                                          form.resetField('name');
+                                          setIsEditingName(false);
+                                        }
+                                      }}
+                                    />
+                                  </motion.div>
+                                ) : (
+                                  <motion.button
+                                    key="button"
+                                    type="button"
+                                    onClick={() => !isReadOnly && setIsEditingName(true)}
+                                    disabled={isReadOnly}
+                                    initial={{ opacity: 0, scale: 0.98 }}
+                                    animate={{ opacity: 1, scale: 1 }}
+                                    exit={{ opacity: 0, scale: 0.98 }}
+                                    transition={{ duration: 0.15, ease: 'easeOut' }}
+                                    whileHover={!isReadOnly ? { x: 2 } : {}}
+                                    whileTap={!isReadOnly ? { scale: 0.98 } : {}}
+                                    className={cn(
+                                      'text-foreground-600 text-right text-label-xs transition-colors h-8 flex items-center justify-end w-full min-w-0',
+                                      !isReadOnly && 'hover:text-foreground-800 cursor-pointer',
+                                      isReadOnly && 'cursor-default'
+                                    )}
+                                  >
+                                    <span className="truncate max-w-full">{field.value || 'Untitled step'}</span>
+                                  </motion.button>
+                                )}
+                              </AnimatePresence>
+                            </div>
+                          </div>
+                          <FormMessage />
+                        </FormItem>
+                      );
+                    }}
                   />
+
+                  {/* ID Section */}
                   <FormField
                     control={form.control}
-                    name={'stepId'}
+                    name="stepId"
+                    defaultValue=""
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel required>Identifier</FormLabel>
-                        <FormControl>
-                          <Input
-                            trailingNode={<CopyButton valueToCopy={field.value} />}
-                            placeholder="Untitled"
-                            className="cursor-default"
-                            {...field}
-                            readOnly
-                          />
-                        </FormControl>
-
-                        <FormMessage />
+                        <div className="group flex items-center justify-between">
+                          <div className="flex items-center gap-1.5">
+                            <Hash className="text-text-soft h-3.5 w-3.5 shrink-0" />
+                            <span className="text-text-soft font-code text-xs font-medium">ID</span>
+                          </div>
+                          <div className="relative flex items-center gap-2">
+                            <div className="opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                              <CopyButton valueToCopy={field.value} size="2xs" className="h-1 p-0.5" />
+                            </div>
+                            <motion.span
+                              whileHover={{ x: -2 }}
+                              transition={{ duration: 0.15 }}
+                              className="text-foreground-600 text-right text-label-xs"
+                            >
+                              {field.value}
+                            </motion.span>
+                          </div>
+                        </div>
                       </FormItem>
                     )}
                   />

--- a/apps/dashboard/src/components/workflow-editor/translation-toggle-section.tsx
+++ b/apps/dashboard/src/components/workflow-editor/translation-toggle-section.tsx
@@ -55,8 +55,8 @@ export function TranslationToggleSection({
 
   if (needsOnboarding) {
     return (
-      <div className="flex items-center justify-between border-t border-neutral-100 pt-4">
-        <div className="flex flex-col gap-2">
+      <div className="flex flex-col border-t border-neutral-100 pt-4">
+        <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <span className="text-label-xs text-text-strong">
               Enable Translations{' '}
@@ -77,20 +77,20 @@ export function TranslationToggleSection({
               </TooltipPortal>
             </Tooltip>
           </div>
-          <p className="text-foreground-400 text-2xs mb-1">Set up your target locales first to enable translations</p>
-        </div>
 
-        <motion.div whileHover={{ x: 2 }} transition={{ type: 'spring', stiffness: 300, damping: 20 }}>
-          <Button
-            variant="secondary"
-            mode="ghost"
-            size="xs"
-            onClick={() => navigate(translationsUrl)}
-            trailingIcon={RiArrowRightSLine}
-          >
-            Setup
-          </Button>
-        </motion.div>
+          <motion.div whileHover={{ x: 2 }} transition={{ type: 'spring', stiffness: 300, damping: 20 }}>
+            <Button
+              variant="secondary"
+              mode="ghost"
+              size="xs"
+              onClick={() => navigate(translationsUrl)}
+              trailingIcon={RiArrowRightSLine}
+            >
+              Setup
+            </Button>
+          </motion.div>
+        </div>
+        <p className="text-foreground-400 text-xs">Set up your target locales first to enable translations</p>
       </div>
     );
   }


### PR DESCRIPTION
### What changed? Why was the change needed?
- Workflow canvas UI layout improved
- Compact Description + Tag input component
- Step metadata UI layout improved
- Tag input refactor + improvements (autosuggestions, collapse, keyboard navigation)

### Screenshots
<table style="width:100%; border-collapse:collapse; text-align:center;">
  <thead>
    <tr>
      <th style="padding:10px; border:1px solid #ddd;">Before</th>
      <th style="padding:10px; border:1px solid #ddd;">After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td style="padding:10px; border:1px solid #ddd;">
        <img src="https://github.com/user-attachments/assets/983b84cf-5350-4d8c-a0d4-e7aa4c2381dd"
             alt="Before"
             style="max-width:100%; height:auto; border-radius:6px;" />
      </td>
      <td style="padding:10px; border:1px solid #ddd;">
        <img src="https://github.com/user-attachments/assets/90c2a37c-e587-4e5c-b126-dbb751d48b7f"
             alt="After"
             style="max-width:100%; height:auto; border-radius:6px;" />
      </td>
    </tr>
  </tbody>
</table>