### PR TITLE
fix(api-service): Enhance sanitizer to remove dangerous HTML attributes fixes NV-6883

### DIFF
--- a/libs/application-generic/src/services/sanitize/sanitizer.service.ts
+++ b/libs/application-generic/src/services/sanitize/sanitizer.service.ts
@@ -8,7 +8,92 @@ import sanitizeTypes, { IOptions } from 'sanitize-html';
  *
  * @see https://www.npmjs.com/package/sanitize-html#default-options
  */
-const SAFE_IMG_ATTRIBUTES = ['src', 'alt', 'width', 'height', 'loading', 'srcset', 'sizes', 'crossorigin', 'usemap', 'ismap', 'class', 'id', 'style', 'title', 'dir', 'lang'];
+const SAFE_IMG_ATTRIBUTES = [
+  'src',
+  'alt',
+  'width',
+  'height',
+  'loading',
+  'srcset',
+  'sizes',
+  'crossorigin',
+  'usemap',
+  'ismap',
+  'class',
+  'id',
+  'style',
+  'title',
+  'dir',
+  'lang',
+];
+
+const DANGEROUS_ATTRIBUTES = [
+  'onerror',
+  'onload',
+  'onclick',
+  'onmouseover',
+  'onmouseout',
+  'onmouseenter',
+  'onmouseleave',
+  'onfocus',
+  'onblur',
+  'onsubmit',
+  'onreset',
+  'onchange',
+  'oninput',
+  'onkeydown',
+  'onkeyup',
+  'onkeypress',
+  'ondblclick',
+  'oncontextmenu',
+  'ondrag',
+  'ondragend',
+  'ondragenter',
+  'ondragleave',
+  'ondragover',
+  'ondragstart',
+  'ondrop',
+  'onscroll',
+  'onwheel',
+  'oncopy',
+  'oncut',
+  'onpaste',
+  'onabort',
+  'oncanplay',
+  'oncanplaythrough',
+  'ondurationchange',
+  'onemptied',
+  'onended',
+  'onloadeddata',
+  'onloadedmetadata',
+  'onloadstart',
+  'onpause',
+  'onplay',
+  'onplaying',
+  'onprogress',
+  'onratechange',
+  'onseeked',
+  'onseeking',
+  'onstalled',
+  'onsuspend',
+  'ontimeupdate',
+  'onvolumechange',
+  'onwaiting',
+  'onanimationstart',
+  'onanimationend',
+  'onanimationiteration',
+  'ontransitionend',
+  'onpointerdown',
+  'onpointerup',
+  'onpointermove',
+  'onpointerenter',
+  'onpointerleave',
+  'onpointercancel',
+  'ontouchstart',
+  'ontouchend',
+  'ontouchmove',
+  'ontouchcancel',
+];
 
 const sanitizeOptions: IOptions = {
   /**
@@ -30,6 +115,20 @@ const sanitizeOptions: IOptions = {
    * while keeping all other attributes permissive for other tags.
    */
   transformTags: {
+    '*': (tagName, attribs) => {
+      const safeAttribs: Record<string, string> = {};
+
+      for (const [key, value] of Object.entries(attribs)) {
+        if (!DANGEROUS_ATTRIBUTES.includes(key.toLowerCase())) {
+          safeAttribs[key] = value;
+        }
+      }
+
+      return {
+        tagName,
+        attribs: safeAttribs,
+      };
+    },
     img: (tagName, attribs) => {
       const safeAttribs: Record<string, string> = {};
 

--- a/package.json
+++ b/package.json
@@ -213,6 +213,7 @@
       "core-js",
       "core-js-pure",
       "cypress",
+      "es5-ext",
       "esbuild",
       "fsevents",
       "iframe-resizer",


### PR DESCRIPTION
Added a list of dangerous event handler attributes and updated the sanitizer to strip them from all tags, improving security against XSS attacks. Also updated package.json to include 'es5-ext' in the list of dependencies to ignore.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
