### PR TITLE
Idempotency key scope

### DIFF
--- a/apps/api/src/app/shared/framework/idempotency.e2e.ts
+++ b/apps/api/src/app/shared/framework/idempotency.e2e.ts
@@ -73,7 +73,7 @@ describe('Idempotency Test', async () => {
   it('should return cached and use correct cache key when apiKey is used', async () => {
     const key = `IdempotencyKey2`;
     const res1 = await testIdempotencyPost(IDEMPOTENCE_IMMEDIATE_RESPONSE, key);
-    const cacheKey = `test-${session.organization._id}-${key}`;
+    const cacheKey = `test-${session.environment._id}-${key}`;
     session.testServer?.getHttpServer();
 
     const cacheVal = JSON.stringify(JSON.parse(await cacheService?.get(cacheKey)!).data);
@@ -87,7 +87,7 @@ describe('Idempotency Test', async () => {
   it('should return cached and use correct cache key when authToken and apiKey combination is used', async () => {
     const key = `3`;
     const res1 = await testIdempotencyPost(IDEMPOTENCE_IMMEDIATE_RESPONSE, key);
-    const cacheKey = `test-${session.organization._id}-${key}`;
+    const cacheKey = `test-${session.environment._id}-${key}`;
     session.testServer?.getHttpServer();
 
     const cacheVal = JSON.stringify(JSON.parse(await cacheService?.get(cacheKey)!).data);

--- a/apps/api/src/app/shared/framework/idempotency.interceptor.ts
+++ b/apps/api/src/app/shared/framework/idempotency.interceptor.ts
@@ -150,7 +150,7 @@ export class IdempotencyInterceptor implements NestInterceptor {
     }
     const env = process.env.NODE_ENV;
 
-    return `${env}-${user.organizationId}-${this.getIdempotencyKey(context)}`;
+    return `${env}-${user.environmentId}-${this.getIdempotencyKey(context)}`;
   }
 
   async setCache(


### PR DESCRIPTION
### What changed? Why was the change needed?

The idempotency interceptor's Redis cache key generation has been updated to use the `environmentId` instead of the `organizationId`. Corresponding e2e tests were also updated.

This change was needed to ensure idempotency keys are unique per environment, allowing the same key to be used across different environments within the same organization without conflicts.

### Screenshots

---
[Slack Thread](https://novu.slack.com/archives/C06GFC06JS3/p1765722924524129?thread_ts=1765722924.524129&cid=C06GFC06JS3)

<a href="https://cursor.com/background-agent?bcId=bc-b5c749f5-0ee2-427d-b2d3-c668b923ddb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5c749f5-0ee2-427d-b2d3-c668b923ddb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

