### PR TITLE
docs(root): fix typo in cursor dashboard rules

### DIFF
--- a/.cursor/rules/dashboard.mdc
+++ b/.cursor/rules/dashboard.mdc
@@ -3,6 +3,6 @@ description:
 globs: apps/dashboard/**/*
 alwaysApply: false
 ---
-- Do not attempt to to build or run the dashboard as the user will be already running it, to check types you should be able to access the eslint results in cursor.
+- Do not attempt to build or run the dashboard as the user will be already running it, to check types you should be able to access the eslint results in cursor.
 - Use lowercase with dashes for directories and files (e.g., components/auth-wizard).
 - Favor named exports for components.


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixed a typo in the dashboard rules documentation (`.cursor/rules/dashboard.mdc`). Removed duplicate "to" in line 6, changing "Do not attempt to **to** build" to "Do not attempt to build".

This corrects a grammatical error in the documentation that explains developers should not attempt to build or run the dashboard locally, as it's already running.

### Screenshots

N/A - Documentation-only change (text correction in markdown file)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
<!-- A link to a dependent pull request  -->

### Special notes for your reviewer
This is a minor documentation fix with no functional changes to the codebase.

</details>