### PR TITLE
chore(root): remove push triggers for next and main branches in dev-deploy-web.yml

### DIFF
--- a/.github/workflows/dev-deploy-web.yml
+++ b/.github/workflows/dev-deploy-web.yml
@@ -10,13 +10,6 @@ on:
         required: false
         type: boolean
         default: false
-  push:
-    branches:
-      - next
-      - main
-    paths:
-      - "apps/web/**"
-      - "packages/shared/**"
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}


### PR DESCRIPTION
### What changed? Why was the change needed?
We only want to deploy `web` occasionally. It hoards up resources for no reason everytime. 

