### PR TITLE
style(dashboard): Publish changes popup UI fixes NV-7003

### DIFF
--- a/apps/dashboard/src/components/header-navigation/publish-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-modal.tsx
@@ -329,14 +329,14 @@ function CompactResourceRow({
       <div className="min-w-0 flex-1">
         {resource.resourceType === 'layout' ? (
           // Layout: name and ID side by side
-          <div className="leading-0 flex w-full items-center gap-1 text-left min-w-0">
-            <span className="overflow-hidden truncate overflow-ellipsis text-xs font-medium leading-4 text-gray-900 flex-shrink min-w-0">
+          <div className="leading-0 flex w-full min-w-0 items-center gap-1 text-left">
+            <span className="min-w-0 flex-shrink truncate text-xs font-medium leading-4 text-gray-900">
               {displayName}
             </span>
             {hasDependencies && (
               <Tooltip>
                 <TooltipTrigger>
-                  <RiLinkUnlinkM className="h-3 w-3 text-orange-500" />
+                  <RiLinkUnlinkM className="h-3 w-3 flex-shrink-0 text-orange-500" />
                 </TooltipTrigger>
                 <TooltipContent>
                   {dependencies && dependencies.length > 0 && (
@@ -355,12 +355,12 @@ function CompactResourceRow({
           </div>
         ) : (
           <>
-            <div className="flex items-center gap-1">
-              <span className="truncate text-xs font-medium text-gray-900">{displayName}</span>
+            <div className="flex min-w-0 items-center gap-1">
+              <span className="min-w-0 truncate text-xs font-medium text-gray-900">{displayName}</span>
               {hasDependencies && (
                 <Tooltip>
                   <TooltipTrigger>
-                    <RiLinkUnlinkM className="h-3 w-3 text-orange-500" />
+                    <RiLinkUnlinkM className="h-3 w-3 flex-shrink-0 text-orange-500" />
                   </TooltipTrigger>
                   <TooltipContent>
                     {dependencies && dependencies.length > 0 && (
@@ -377,7 +377,7 @@ function CompactResourceRow({
                 </Tooltip>
               )}
             </div>
-            <div className="font-mono text-xs tracking-tight text-gray-400">{slug}</div>
+            <div className="truncate font-mono text-xs tracking-tight text-gray-400">{slug}</div>
           </>
         )}
 

--- a/apps/dashboard/src/components/header-navigation/publish-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-modal.tsx
@@ -143,11 +143,11 @@ export function PublishModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="w-full max-w-[486px] gap-4 p-3">
+      <DialogContent className="max-w-lg gap-4 p-3">
         <PublishModalHeader />
         <PublishModalContent environment={environment} />
 
-        <div className="space-y-1.5">
+        <div className="w-full max-w-[486px] space-y-1.5">
           {workflows.length > 0 && (
             <ResourceGroupCompact
               title="Workflows"

--- a/apps/dashboard/src/components/header-navigation/publish-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-modal.tsx
@@ -143,7 +143,7 @@ export function PublishModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-lg gap-4 p-3">
+      <DialogContent className="w-full max-w-[486px] gap-4 p-3">
         <PublishModalHeader />
         <PublishModalContent environment={environment} />
 


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves the UI overflow issue (NV-7003) in the "Publish Changes" modal when workflow names or IDs are excessively long.

The changes ensure that:
- Long workflow names and slugs/IDs now properly truncate with an ellipsis, preventing layout breakage.
- Dependency icons maintain their size and do not shrink when adjacent text truncates.

Specifically, `min-w-0` and `truncate` classes were added to relevant text containers, and `flex-shrink-0` was applied to dependency icons in `apps/dashboard/src/components/header-navigation/publish-modal.tsx`.

### Screenshots

This fix addresses the UI issue shown in the Linear ticket's screenshot: [https://uploads.linear.app/f13f1996-c9b0-4fea-8ee7-2c3faf6a832d/7631c96a-1d5f-41c1-8f9e-bff47f6bd8c0/1f79d809-7bf9-4d2c-9873-170818295613](https://uploads.linear.app/f13f1996-c9b0-4fea-8ee7-2c3faf6a832d/7631c96a-1d5f-41c1-8f9e-bff47f6bd8c0/1f79d809-7bf9-4d2c-9873-170818295613)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

The primary fix involved correctly applying `min-w-0` to flex containers and `truncate` to text elements, along with `flex-shrink-0` for icons, to ensure proper truncation behavior in flexbox layouts.

</details>

---
Linear Issue: [NV-7003](https://linear.app/novu/issue/NV-7003/ui-issues-for-long-workflow-names-on-publish-changes-popup)

<a href="https://cursor.com/background-agent?bcId=bc-a21cc922-447d-4948-a17f-c240edb26408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a21cc922-447d-4948-a17f-c240edb26408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

