### PR TITLE
fix(root): use latest npm to able to use npm trusted publishing

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -118,24 +118,85 @@ jobs:
             echo "Skipping build for stable release (will be built after PR merge)"
           fi
 
-      - name: Debug - Verify OIDC-only configuration
+      # #region agent log - Debug OIDC authentication setup
+      - name: Debug - OIDC Authentication Investigation
         if: github.event.inputs.release_type != 'stable'
         run: |
-          echo "🔍 DEBUG: Verifying OIDC-only configuration"
-          echo "Branch: ${{ github.ref_name }}"
-          echo "Workflow: ${{ github.workflow_ref }}"
+          echo "🔍 HYPOTHESIS A: Check npm registry configuration"
+          echo "=== Root .npmrc ==="
+          if [ -f ".npmrc" ]; then
+            cat .npmrc
+          else
+            echo "No .npmrc in repo root"
+          fi
+
           echo ""
-          echo "Checking for NODE_AUTH_TOKEN (should NOT be present):"
+          echo "=== Home .npmrc ==="
+          if [ -f "$HOME/.npmrc" ]; then
+            cat $HOME/.npmrc
+          else
+            echo "No .npmrc in home directory"
+          fi
+
+          echo ""
+          echo "=== Temp .npmrc ==="
           if [ -f "/home/runner/work/_temp/.npmrc" ]; then
             cat /home/runner/work/_temp/.npmrc
-            echo ""
-            echo "⚠️ WARNING: .npmrc file exists - this should NOT happen with pure OIDC"
           else
-            echo "✅ No .npmrc file - OIDC-only mode active"
+            echo "No .npmrc in temp directory (expected for OIDC)"
           fi
+
           echo ""
-          echo "OIDC environment variables:"
-          env | grep -E "ACTIONS_ID_TOKEN|NPM_CONFIG" || echo "✅ Only OIDC env vars present"
+          echo "🔍 HYPOTHESIS B: Check npm version and OIDC support"
+          npm --version
+          npm config get registry
+
+          echo ""
+          echo "🔍 HYPOTHESIS C: Test OIDC from different directories"
+          echo "Current directory: $(pwd)"
+          echo "OIDC env vars present:"
+          env | grep ACTIONS_ID_TOKEN_REQUEST_URL || echo "❌ ACTIONS_ID_TOKEN_REQUEST_URL not found"
+
+          echo ""
+          echo "From subdirectory (packages/react):"
+          cd packages/react
+          pwd
+          env | grep ACTIONS_ID_TOKEN_REQUEST_URL || echo "❌ ACTIONS_ID_TOKEN_REQUEST_URL not found in subdir"
+          cd ../..
+
+          echo ""
+          echo "🔍 HYPOTHESIS D: Check if npm has OIDC config"
+          npm config list 2>&1 | head -30
+
+          echo ""
+          echo "🔍 HYPOTHESIS E: Verify Trusted Publisher context"
+          echo "Workflow file: ${{ github.workflow }}"
+          echo "Workflow path: .github/workflows/$(basename ${{ github.workflow_ref }} | cut -d'@' -f1)"
+          echo "Branch: ${{ github.ref_name }}"
+          echo "Event: ${{ github.event_name }}"
+
+          echo ""
+          echo "🔍 Test: Attempt npm pack with --dry-run from subdirectory"
+          cd packages/react
+          npm pack --dry-run 2>&1 | head -15 || true
+          cd ../..
+      # #endregion
+      # #region agent log - Test manual npm publish with OIDC
+      - name: Test - Manual npm publish from root with OIDC
+        if: github.event.inputs.release_type != 'stable'
+        run: |
+          echo "🔍 HYPOTHESIS C+D: Test npm publish with explicit OIDC from root"
+          cd packages/react
+
+          echo "Current directory: $(pwd)"
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL present: $(env | grep ACTIONS_ID_TOKEN_REQUEST_URL | wc -l)"
+
+          echo ""
+          echo "Attempting: npm publish --dry-run --provenance --registry https://registry.npmjs.org --loglevel silly"
+          npm publish --dry-run --provenance --registry https://registry.npmjs.org --loglevel silly 2>&1 | tail -50 || true
+
+          cd ../..
+      # #endregion
       - name: Publish packages (nightly and rc only)
         if: github.event.inputs.release_type != 'stable'
         run: |

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           node-version: "20.19.0"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies
         shell: bash
@@ -118,103 +119,70 @@ jobs:
             echo "Skipping build for stable release (will be built after PR merge)"
           fi
 
-      # #region agent log - Debug OIDC authentication setup
-      - name: Debug - OIDC Authentication Investigation
+      # #region agent log - Debug authentication mode
+      - name: Debug - Check authentication mode (Token vs OIDC)
         if: github.event.inputs.release_type != 'stable'
         run: |
-          echo "🔍 HYPOTHESIS A: Check npm registry configuration"
-          echo "=== Root .npmrc ==="
-          if [ -f ".npmrc" ]; then
-            cat .npmrc
-          else
-            echo "No .npmrc in repo root"
-          fi
+          echo "🔍 DEBUG: Checking authentication configuration"
 
           echo ""
-          echo "=== Home .npmrc ==="
-          if [ -f "$HOME/.npmrc" ]; then
-            cat $HOME/.npmrc
-          else
-            echo "No .npmrc in home directory"
-          fi
-
-          echo ""
-          echo "=== Temp .npmrc ==="
+          echo "=== .npmrc created by setup-node ==="
           if [ -f "/home/runner/work/_temp/.npmrc" ]; then
+            echo "✅ .npmrc exists"
             cat /home/runner/work/_temp/.npmrc
           else
-            echo "No .npmrc in temp directory (expected for OIDC)"
+            echo "❌ .npmrc NOT found"
           fi
 
           echo ""
-          echo "🔍 HYPOTHESIS B: Check npm version and OIDC support"
-          npm --version
+          echo "=== Authentication Mode Detection ==="
+          if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "🔑 MODE: Token-based authentication (NPM_TOKEN secret is set)"
+            echo "   This run will use traditional npm token auth"
+          else
+            echo "🆔 MODE: OIDC authentication (NPM_TOKEN secret is empty)"
+            echo "   This run will attempt OIDC with GitHub Actions"
+          fi
+
+          echo ""
+          echo "=== OIDC environment variables ==="
+          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "✅ ACTIONS_ID_TOKEN_REQUEST_URL is available"
+          else
+            echo "❌ ACTIONS_ID_TOKEN_REQUEST_URL not available"
+          fi
+
+          echo ""
+          echo "=== npm configuration ==="
           npm config get registry
 
           echo ""
-          echo "🔍 HYPOTHESIS C: Test OIDC from different directories"
-          echo "Current directory: $(pwd)"
-          echo "OIDC env vars present:"
-          env | grep ACTIONS_ID_TOKEN_REQUEST_URL || echo "❌ ACTIONS_ID_TOKEN_REQUEST_URL not found"
-
-          echo ""
-          echo "From subdirectory (packages/react):"
-          cd packages/react
-          pwd
-          env | grep ACTIONS_ID_TOKEN_REQUEST_URL || echo "❌ ACTIONS_ID_TOKEN_REQUEST_URL not found in subdir"
-          cd ../..
-
-          echo ""
-          echo "🔍 HYPOTHESIS D: Check if npm has OIDC config"
-          npm config list 2>&1 | head -30
-
-          echo ""
-          echo "🔍 HYPOTHESIS E: Verify Trusted Publisher context"
-          echo "Workflow file: ${{ github.workflow }}"
-          echo "Workflow path: .github/workflows/$(basename ${{ github.workflow_ref }} | cut -d'@' -f1)"
+          echo "=== Context ==="
           echo "Branch: ${{ github.ref_name }}"
-          echo "Event: ${{ github.event_name }}"
-
-          echo ""
-          echo "🔍 Test: Attempt npm pack with --dry-run from subdirectory"
-          cd packages/react
-          npm pack --dry-run 2>&1 | head -15 || true
-          cd ../..
+          echo "Workflow: ${{ github.workflow_ref }}"
       # #endregion
-      # #region agent log - Test manual npm publish with OIDC
-      - name: Test - Manual npm publish from root with OIDC
-        if: github.event.inputs.release_type != 'stable'
-        run: |
-          echo "🔍 HYPOTHESIS C+D: Test npm publish with explicit OIDC from root"
-          cd packages/react
-
-          echo "Current directory: $(pwd)"
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL present: $(env | grep ACTIONS_ID_TOKEN_REQUEST_URL | wc -l)"
-
-          echo ""
-          echo "Attempting: npm publish --dry-run --provenance --registry https://registry.npmjs.org --loglevel silly"
-          npm publish --dry-run --provenance --registry https://registry.npmjs.org --loglevel silly 2>&1 | tail -50 || true
-
-          cd ../..
-      # #endregion
-      # #region agent log - Post-fix verification
+      # #region agent log - Test with NPM_TOKEN first, then OIDC
       - name: Publish packages (nightly and rc only)
         if: github.event.inputs.release_type != 'stable'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "🔍 POST-FIX: Publishing with explicit --registry flag"
-          echo "Expected: npm publish should now use OIDC authentication via explicit registry"
+          echo "🔍 TEST: Publishing with NPM_TOKEN to verify mechanism works"
+          echo "NODE_AUTH_TOKEN present: $( [ -n "${NODE_AUTH_TOKEN}" ] && echo 'YES' || echo 'NO' )"
+          echo ""
 
           if [ "${{ github.event.inputs.release_type }}" = "nightly" ]; then
-            echo "Publishing nightly with tag=nightly, provenance=true, registry=https://registry.npmjs.org"
+            echo "Publishing nightly with --tag=nightly --provenance"
             pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=nightly --provenance --verbose
           elif [ "${{ github.event.inputs.release_type }}" = "rc" ]; then
-            echo "Publishing rc with tag=next, provenance=true, registry=https://registry.npmjs.org"
+            echo "Publishing rc with --tag=next --provenance"
             pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=next --provenance --verbose
           fi
 
-          echo "🔍 POST-FIX: Publish completed with exit code: $?"
+          echo ""
+          echo "🔍 Publish exit code: $?"
+          echo "If successful, next test will be without NPM_TOKEN to verify OIDC"
       # #endregion
-
       - name: Create Pull Request
         if: github.event.inputs.release_type == 'stable'
         id: create-pr
@@ -287,6 +255,7 @@ jobs:
         with:
           node-version: "20.19.0"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies
         shell: bash
@@ -297,6 +266,8 @@ jobs:
         run: pnpm run build:packages
 
       - name: Publish packages to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           pnpm nx run-many -t nx-release-publish --projects=${{ steps.extract-info.outputs.packages }} -- --tag=latest --provenance
 

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -63,7 +63,6 @@ jobs:
         with:
           node-version: "20.19.0"
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies
         shell: bash
@@ -119,50 +118,26 @@ jobs:
             echo "Skipping build for stable release (will be built after PR merge)"
           fi
 
-      # #region agent log - Debug npm/pnpm OIDC configuration
-      - name: Debug - Check npm configuration before publish
+      - name: Debug - Verify OIDC-only configuration
         if: github.event.inputs.release_type != 'stable'
         run: |
-          echo "🔍 DEBUG_LOG_START"
-          echo "=== HYPOTHESIS F: Branch/Environment Validation ==="
-
-          echo "--- Git context (may affect Trusted Publisher) ---"
+          echo "🔍 DEBUG: Verifying OIDC-only configuration"
           echo "Branch: ${{ github.ref_name }}"
-          echo "Ref: ${{ github.ref }}"
-          echo "SHA: ${{ github.sha }}"
-          echo "Workflow ref: ${{ github.workflow_ref }}"
-          echo "Event name: ${{ github.event_name }}"
-
+          echo "Workflow: ${{ github.workflow_ref }}"
           echo ""
-          echo "--- npm config with _authToken ---"
-          echo "Auth token location: /home/runner/work/_temp/.npmrc"
-          cat /home/runner/work/_temp/.npmrc || echo "File not found"
-
+          echo "Checking for NODE_AUTH_TOKEN (should NOT be present):"
+          if [ -f "/home/runner/work/_temp/.npmrc" ]; then
+            cat /home/runner/work/_temp/.npmrc
+            echo ""
+            echo "⚠️ WARNING: .npmrc file exists - this should NOT happen with pure OIDC"
+          else
+            echo "✅ No .npmrc file - OIDC-only mode active"
+          fi
           echo ""
-          echo "--- Test: Can we use npm directly (not pnpm)? ---"
-          cd packages/react
-          echo "Current directory: $(pwd)"
-          echo "Attempting npm pack (dry run)..."
-          npm pack --dry-run 2>&1 | head -20 || true
-
-          echo ""
-          echo "--- Test: Check if pnpm respects npm config ---"
-          echo "pnpm config list:"
-          pnpm config list 2>&1 | grep -E "(registry|_authToken)" || echo "No auth config in pnpm"
-
-          cd ../..
-
-          echo ""
-          echo "⚠️  CRITICAL: Running from branch '${{ github.ref_name }}'"
-          echo "⚠️  Trusted Publisher may only allow publishes from 'main' or 'next' branches"
-          echo "⚠️  This could explain why provenance works but publish fails"
-
-          echo "🔍 DEBUG_LOG_END"
-      # #endregion
+          echo "OIDC environment variables:"
+          env | grep -E "ACTIONS_ID_TOKEN|NPM_CONFIG" || echo "✅ Only OIDC env vars present"
       - name: Publish packages (nightly and rc only)
         if: github.event.inputs.release_type != 'stable'
-        env:
-          NPM_CONFIG_PROVENANCE: true
         run: |
           echo "🔍 PUBLISH_DEBUG_START"
           echo "Attempting to publish with OIDC..."
@@ -247,7 +222,6 @@ jobs:
         with:
           node-version: "20.19.0"
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies
         shell: bash
@@ -258,8 +232,6 @@ jobs:
         run: pnpm run build:packages
 
       - name: Publish packages to NPM
-        env:
-          NPM_CONFIG_PROVENANCE: true
         run: |
           pnpm nx run-many -t nx-release-publish --projects=${{ steps.extract-info.outputs.packages }} -- --tag=latest --provenance
 

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -63,7 +63,13 @@ jobs:
         with:
           node-version: "20.19.0"
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm for Trusted Publishing
+        run: |
+          echo "Current npm version: $(npm --version)"
+          npm install -g npm@latest
+          echo "Upgraded npm version: $(npm --version)"
+          echo "✅ npm CLI >= 11.5.1 required for trusted publishing"
 
       - name: Install Dependencies
         shell: bash
@@ -153,13 +159,25 @@ jobs:
           fi
 
           echo ""
-          echo "=== Test 3: Check OIDC env vars from shell ==="
+          echo "=== Test 3: Verify OIDC environment and npm version ==="
           cd /home/runner/work/novu/novu/packages/react
+          echo "npm version: $(npm --version)"
+          NPM_MAJOR=$(npm --version | cut -d. -f1)
+          if [ "$NPM_MAJOR" -ge 11 ]; then
+            echo "✅ npm >= 11.5.1 (supports trusted publishing)"
+          else
+            echo "❌ npm < 11.5.1 (trusted publishing requires >= 11.5.1)"
+          fi
+          echo ""
           echo "ACTIONS_ID_TOKEN_REQUEST_URL: ${ACTIONS_ID_TOKEN_REQUEST_URL:-NOT_SET}"
           echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: $([ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] && echo 'SET' || echo 'NOT_SET')"
-          echo "NODE_AUTH_TOKEN: $([ -n "${NODE_AUTH_TOKEN:-}" ] && echo 'SET' || echo 'NOT_SET')"
+          echo "NODE_AUTH_TOKEN: $([ -z "${NODE_AUTH_TOKEN:-}" ] && echo 'NOT_SET (GOOD - OIDC can work)' || echo 'SET (BAD - blocks OIDC)')"
           echo ""
-          echo "If OIDC vars are NOT_SET, that confirms environment issue"
+          if [ -z "${NODE_AUTH_TOKEN:-}" ] && [ "$NPM_MAJOR" -ge 11 ]; then
+            echo "✅ All requirements met - OIDC trusted publishing should work!"
+          else
+            echo "❌ Requirements not met - check errors above"
+          fi
 
           echo ""
           echo "=== Test 4: Simulate what nx does ==="
@@ -281,7 +299,13 @@ jobs:
         with:
           node-version: "20.19.0"
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm for Trusted Publishing
+        run: |
+          echo "Current npm version: $(npm --version)"
+          npm install -g npm@latest
+          echo "Upgraded npm version: $(npm --version)"
+          echo "✅ npm CLI >= 11.5.1 required for trusted publishing"
 
       - name: Install Dependencies
         shell: bash

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -119,47 +119,58 @@ jobs:
             echo "Skipping build for stable release (will be built after PR merge)"
           fi
 
-      # #region agent log - Debug authentication mode
-      - name: Debug - Check authentication mode (Token vs OIDC)
+      # #region agent log - Hypothesis F: Test if nx is interfering with OIDC
+      - name: "DEBUG F: Test direct npm publish vs nx"
         if: github.event.inputs.release_type != 'stable'
+        continue-on-error: true
         run: |
-          echo "🔍 DEBUG: Checking authentication configuration"
+          echo "🔬 HYPOTHESIS F (USER): Does nx interfere with OIDC authentication?"
+          echo ""
+          echo "=== Test 1: Direct npm publish (no nx) ==="
+          cd packages/react
+          echo "Running: npm publish --dry-run --provenance"
+          npm publish --dry-run --provenance 2>&1 | grep -E "(Publishing|Signed provenance|OIDC|authToken|authenticated|login)" || echo "No auth-related output"
+          DIRECT_EXIT=$?
+          echo "Exit code: $DIRECT_EXIT"
 
           echo ""
-          echo "=== .npmrc created by setup-node ==="
-          if [ -f "/home/runner/work/_temp/.npmrc" ]; then
-            echo "✅ .npmrc exists"
-            cat /home/runner/work/_temp/.npmrc
+          echo "=== Test 2: Via nx (current method) ==="
+          cd /home/runner/work/novu/novu
+          echo "Running: pnpm nx run @novu/react:nx-release-publish -- --tag=nightly --provenance --dry-run"
+          pnpm nx run @novu/react:nx-release-publish -- --tag=nightly --provenance --dry-run 2>&1 | grep -E "(Publishing|Signed provenance|OIDC|authToken|authenticated|login)" || echo "No auth-related output"
+          NX_EXIT=$?
+          echo "Exit code: $NX_EXIT"
+
+          echo ""
+          echo "=== Comparison ==="
+          if [ $DIRECT_EXIT -eq 0 ] && [ $NX_EXIT -ne 0 ]; then
+            echo "⚠️ HYPOTHESIS F: CONFIRMED - Direct npm works but nx fails!"
+            echo "Problem: nx is interfering with OIDC"
+          elif [ $DIRECT_EXIT -ne 0 ] && [ $NX_EXIT -ne 0 ]; then
+            echo "Both methods fail - nx might not be the problem"
           else
-            echo "❌ .npmrc NOT found"
+            echo "Results are similar"
           fi
 
           echo ""
-          echo "=== Authentication Mode Detection ==="
-          if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
-            echo "🔑 MODE: Token-based authentication (NPM_TOKEN secret is set)"
-            echo "   This run will use traditional npm token auth"
-          else
-            echo "🆔 MODE: OIDC authentication (NPM_TOKEN secret is empty)"
-            echo "   This run will attempt OIDC with GitHub Actions"
-          fi
+          echo "=== Test 3: Check OIDC env vars from shell ==="
+          cd /home/runner/work/novu/novu/packages/react
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL: ${ACTIONS_ID_TOKEN_REQUEST_URL:-NOT_SET}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: $([ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] && echo 'SET' || echo 'NOT_SET')"
+          echo "NODE_AUTH_TOKEN: $([ -n "${NODE_AUTH_TOKEN:-}" ] && echo 'SET' || echo 'NOT_SET')"
+          echo ""
+          echo "If OIDC vars are NOT_SET, that confirms environment issue"
 
           echo ""
-          echo "=== OIDC environment variables ==="
-          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
-            echo "✅ ACTIONS_ID_TOKEN_REQUEST_URL is available"
-          else
-            echo "❌ ACTIONS_ID_TOKEN_REQUEST_URL not available"
-          fi
-
+          echo "=== Test 4: Simulate what nx does ==="
+          cd /home/runner/work/novu/novu
+          echo "project.json command: cd packages/react && npm publish --access public \${NX_PUBLISH_ARGS:-}"
           echo ""
-          echo "=== npm configuration ==="
-          npm config get registry
-
-          echo ""
-          echo "=== Context ==="
-          echo "Branch: ${{ github.ref_name }}"
-          echo "Workflow: ${{ github.workflow_ref }}"
+          echo "Simulating with NX_PUBLISH_ARGS set:"
+          export NX_PUBLISH_ARGS="--tag=nightly --provenance --dry-run"
+          bash -c 'echo "ACTIONS_ID_TOKEN_REQUEST_URL in subshell: ${ACTIONS_ID_TOKEN_REQUEST_URL:-NOT_SET}"'
+          bash -c 'cd packages/react && npm publish --access public ${NX_PUBLISH_ARGS:-}' 2>&1 | tail -20
+          echo "Exit code: $?"
       # #endregion
       # #region agent log - PHASE 2: Test OIDC without token
       - name: Publish packages (nightly and rc only)

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -197,19 +197,23 @@ jobs:
 
           cd ../..
       # #endregion
+      # #region agent log - Post-fix verification
       - name: Publish packages (nightly and rc only)
         if: github.event.inputs.release_type != 'stable'
         run: |
-          echo "🔍 PUBLISH_DEBUG_START"
-          echo "Attempting to publish with OIDC..."
+          echo "🔍 POST-FIX: Publishing with explicit --registry flag"
+          echo "Expected: npm publish should now use OIDC authentication via explicit registry"
 
           if [ "${{ github.event.inputs.release_type }}" = "nightly" ]; then
+            echo "Publishing nightly with tag=nightly, provenance=true, registry=https://registry.npmjs.org"
             pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=nightly --provenance --verbose
           elif [ "${{ github.event.inputs.release_type }}" = "rc" ]; then
+            echo "Publishing rc with tag=next, provenance=true, registry=https://registry.npmjs.org"
             pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=next --provenance --verbose
           fi
 
-          echo "🔍 PUBLISH_DEBUG_END"
+          echo "🔍 POST-FIX: Publish completed with exit code: $?"
+      # #endregion
 
       - name: Create Pull Request
         if: github.event.inputs.release_type == 'stable'

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -66,10 +66,8 @@ jobs:
 
       - name: Upgrade npm for Trusted Publishing
         run: |
-          echo "Current npm version: $(npm --version)"
           npm install -g npm@latest
-          echo "Upgraded npm version: $(npm --version)"
-          echo "✅ npm CLI >= 11.5.1 required for trusted publishing"
+          echo "npm version: $(npm --version) (>= 11.5.1 required for trusted publishing)"
 
       - name: Install Dependencies
         shell: bash
@@ -125,108 +123,16 @@ jobs:
             echo "Skipping build for stable release (will be built after PR merge)"
           fi
 
-      # #region agent log - Hypothesis F: Test if nx is interfering with OIDC
-      - name: "DEBUG F: Test direct npm publish vs nx"
-        if: github.event.inputs.release_type != 'stable'
-        continue-on-error: true
-        run: |
-          echo "🔬 HYPOTHESIS F (USER): Does nx interfere with OIDC authentication?"
-          echo ""
-          echo "=== Test 1: Direct npm publish (no nx) ==="
-          cd packages/react
-          echo "Running: npm publish --dry-run --provenance"
-          npm publish --dry-run --provenance 2>&1 | grep -E "(Publishing|Signed provenance|OIDC|authToken|authenticated|login)" || echo "No auth-related output"
-          DIRECT_EXIT=$?
-          echo "Exit code: $DIRECT_EXIT"
-
-          echo ""
-          echo "=== Test 2: Via nx (current method) ==="
-          cd /home/runner/work/novu/novu
-          echo "Running: pnpm nx run @novu/react:nx-release-publish -- --tag=nightly --provenance --dry-run"
-          pnpm nx run @novu/react:nx-release-publish -- --tag=nightly --provenance --dry-run 2>&1 | grep -E "(Publishing|Signed provenance|OIDC|authToken|authenticated|login)" || echo "No auth-related output"
-          NX_EXIT=$?
-          echo "Exit code: $NX_EXIT"
-
-          echo ""
-          echo "=== Comparison ==="
-          if [ $DIRECT_EXIT -eq 0 ] && [ $NX_EXIT -ne 0 ]; then
-            echo "⚠️ HYPOTHESIS F: CONFIRMED - Direct npm works but nx fails!"
-            echo "Problem: nx is interfering with OIDC"
-          elif [ $DIRECT_EXIT -ne 0 ] && [ $NX_EXIT -ne 0 ]; then
-            echo "Both methods fail - nx might not be the problem"
-          else
-            echo "Results are similar"
-          fi
-
-          echo ""
-          echo "=== Test 3: Verify OIDC environment and npm version ==="
-          cd /home/runner/work/novu/novu/packages/react
-          echo "npm version: $(npm --version)"
-          NPM_MAJOR=$(npm --version | cut -d. -f1)
-          if [ "$NPM_MAJOR" -ge 11 ]; then
-            echo "✅ npm >= 11.5.1 (supports trusted publishing)"
-          else
-            echo "❌ npm < 11.5.1 (trusted publishing requires >= 11.5.1)"
-          fi
-          echo ""
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL: ${ACTIONS_ID_TOKEN_REQUEST_URL:-NOT_SET}"
-          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: $([ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] && echo 'SET' || echo 'NOT_SET')"
-          echo "NODE_AUTH_TOKEN: $([ -z "${NODE_AUTH_TOKEN:-}" ] && echo 'NOT_SET (GOOD - OIDC can work)' || echo 'SET (BAD - blocks OIDC)')"
-          echo ""
-          if [ -z "${NODE_AUTH_TOKEN:-}" ] && [ "$NPM_MAJOR" -ge 11 ]; then
-            echo "✅ All requirements met - OIDC trusted publishing should work!"
-          else
-            echo "❌ Requirements not met - check errors above"
-          fi
-
-          echo ""
-          echo "=== Test 4: Simulate what nx does ==="
-          cd /home/runner/work/novu/novu
-          echo "project.json command: cd packages/react && npm publish --access public \${NX_PUBLISH_ARGS:-}"
-          echo ""
-          echo "Simulating with NX_PUBLISH_ARGS set:"
-          export NX_PUBLISH_ARGS="--tag=nightly --provenance --dry-run"
-          bash -c 'echo "ACTIONS_ID_TOKEN_REQUEST_URL in subshell: ${ACTIONS_ID_TOKEN_REQUEST_URL:-NOT_SET}"'
-          bash -c 'cd packages/react && npm publish --access public ${NX_PUBLISH_ARGS:-}' 2>&1 | tail -20
-          echo "Exit code: $?"
-      # #endregion
-      # #region agent log - PHASE 2: Test OIDC without token
       - name: Publish packages (nightly and rc only)
         if: github.event.inputs.release_type != 'stable'
         run: |
-          echo "🆔 PHASE 2: Testing OIDC authentication (NO TOKEN)"
-          echo "Expected: npm detects OIDC env vars and uses GitHub Actions OIDC"
-          echo ""
-
-          echo "=== Pre-publish verification ==="
-          echo "NODE_AUTH_TOKEN set: $( [ -n "${NODE_AUTH_TOKEN:-}" ] && echo 'YES (BAD)' || echo 'NO (GOOD)' )"
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: $( [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] && echo 'YES (GOOD)' || echo 'NO (BAD)' )"
-          echo ""
-
           if [ "${{ github.event.inputs.release_type }}" = "nightly" ]; then
-            echo "Publishing nightly with --tag=nightly --provenance"
-            echo "Watch for: 'Signed provenance statement' and 'Provenance statement published to transparency log'"
-            echo ""
-            pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=nightly --provenance --verbose
+            echo "📦 Publishing nightly release with OIDC trusted publishing..."
+            pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=nightly --provenance
           elif [ "${{ github.event.inputs.release_type }}" = "rc" ]; then
-            echo "Publishing rc with --tag=next --provenance"
-            echo "Watch for: 'Signed provenance statement' and 'Provenance statement published to transparency log'"
-            echo ""
-            pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=next --provenance --verbose
+            echo "📦 Publishing RC release with OIDC trusted publishing..."
+            pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=next --provenance
           fi
-
-          EXIT_CODE=$?
-          echo ""
-          echo "🔍 Publish exit code: $EXIT_CODE"
-
-          if [ $EXIT_CODE -eq 0 ]; then
-            echo "✅ SUCCESS: OIDC authentication worked!"
-          else
-            echo "❌ FAILED: Check logs above for authentication errors"
-          fi
-
-          exit $EXIT_CODE
-      # #endregion
       - name: Create Pull Request
         if: github.event.inputs.release_type == 'stable'
         id: create-pr
@@ -302,10 +208,8 @@ jobs:
 
       - name: Upgrade npm for Trusted Publishing
         run: |
-          echo "Current npm version: $(npm --version)"
           npm install -g npm@latest
-          echo "Upgraded npm version: $(npm --version)"
-          echo "✅ npm CLI >= 11.5.1 required for trusted publishing"
+          echo "npm version: $(npm --version) (>= 11.5.1 required for trusted publishing)"
 
       - name: Install Dependencies
         shell: bash
@@ -317,7 +221,7 @@ jobs:
 
       - name: Publish packages to NPM
         run: |
-          echo "Publishing stable release with OIDC authentication"
+          echo "📦 Publishing stable release with OIDC trusted publishing..."
           pnpm nx run-many -t nx-release-publish --projects=${{ steps.extract-info.outputs.packages }} -- --tag=latest --provenance
 
       - name: Create and push tags

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -161,27 +161,42 @@ jobs:
           echo "Branch: ${{ github.ref_name }}"
           echo "Workflow: ${{ github.workflow_ref }}"
       # #endregion
-      # #region agent log - Test with NPM_TOKEN first, then OIDC
+      # #region agent log - PHASE 2: Test OIDC without token
       - name: Publish packages (nightly and rc only)
         if: github.event.inputs.release_type != 'stable'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "🔍 TEST: Publishing with NPM_TOKEN to verify mechanism works"
-          echo "NODE_AUTH_TOKEN present: $( [ -n "${NODE_AUTH_TOKEN}" ] && echo 'YES' || echo 'NO' )"
+          echo "🆔 PHASE 2: Testing OIDC authentication (NO TOKEN)"
+          echo "Expected: npm detects OIDC env vars and uses GitHub Actions OIDC"
+          echo ""
+
+          echo "=== Pre-publish verification ==="
+          echo "NODE_AUTH_TOKEN set: $( [ -n "${NODE_AUTH_TOKEN:-}" ] && echo 'YES (BAD)' || echo 'NO (GOOD)' )"
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: $( [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] && echo 'YES (GOOD)' || echo 'NO (BAD)' )"
           echo ""
 
           if [ "${{ github.event.inputs.release_type }}" = "nightly" ]; then
             echo "Publishing nightly with --tag=nightly --provenance"
+            echo "Watch for: 'Signed provenance statement' and 'Provenance statement published to transparency log'"
+            echo ""
             pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=nightly --provenance --verbose
           elif [ "${{ github.event.inputs.release_type }}" = "rc" ]; then
             echo "Publishing rc with --tag=next --provenance"
+            echo "Watch for: 'Signed provenance statement' and 'Provenance statement published to transparency log'"
+            echo ""
             pnpm nx run-many -t nx-release-publish --projects=${{ github.event.inputs.packages }} -- --tag=next --provenance --verbose
           fi
 
+          EXIT_CODE=$?
           echo ""
-          echo "🔍 Publish exit code: $?"
-          echo "If successful, next test will be without NPM_TOKEN to verify OIDC"
+          echo "🔍 Publish exit code: $EXIT_CODE"
+
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "✅ SUCCESS: OIDC authentication worked!"
+          else
+            echo "❌ FAILED: Check logs above for authentication errors"
+          fi
+
+          exit $EXIT_CODE
       # #endregion
       - name: Create Pull Request
         if: github.event.inputs.release_type == 'stable'
@@ -266,9 +281,8 @@ jobs:
         run: pnpm run build:packages
 
       - name: Publish packages to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          echo "Publishing stable release with OIDC authentication"
           pnpm nx run-many -t nx-release-publish --projects=${{ steps.extract-info.outputs.packages }} -- --tag=latest --provenance
 
       - name: Create and push tags

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,21 +1,3 @@
-## v3.12.0-rc.1 (2025-12-12)
-
-### 🚀 Features
-
-- **react,nextjs:** subscription hooks fixes NV-6864 ([#9530](https://github.com/novuhq/novu/pull/9530))
-- **js,react,nextjs:** subscription button and preferences standalone components fixes NV-6909 ([#9527](https://github.com/novuhq/novu/pull/9527))
-- **js,react,nextjs:** subscription component fixes NV-6863 ([#9512](https://github.com/novuhq/novu/pull/9512))
-- **js:** subscriptions module fixes NV-6862 ([#9462](https://github.com/novuhq/novu/pull/9462))
-
-### 🩹 Fixes
-
-- **js:** undefined access when severity is not provided ([#9663](https://github.com/novuhq/novu/pull/9663))
-
-### ❤️ Thank You
-
-- Adam Chmara @ChmaraX
-- Paweł Tymczuk @LetItRock
-
 ## v3.11.0 (2025-10-27)
 
 ### 🚀 Features

--- a/packages/js/project.json
+++ b/packages/js/project.json
@@ -12,7 +12,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/js && npm publish --access public ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/js && pnpm publish --access public --no-git-checks ${NX_PUBLISH_ARGS:-}"
       }
     }
   }

--- a/packages/js/project.json
+++ b/packages/js/project.json
@@ -12,7 +12,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/js && npm publish --access public ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/js && npm publish --access public --registry https://registry.npmjs.org ${NX_PUBLISH_ARGS:-}"
       }
     }
   }

--- a/packages/js/project.json
+++ b/packages/js/project.json
@@ -12,7 +12,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/js && npm publish --access public --registry https://registry.npmjs.org ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/js && npm publish --access public ${NX_PUBLISH_ARGS:-}"
       }
     }
   }

--- a/packages/nextjs/CHANGELOG.md
+++ b/packages/nextjs/CHANGELOG.md
@@ -1,15 +1,3 @@
-## v3.12.0-rc.1 (2025-12-12)
-
-### 🚀 Features
-
-- **react,nextjs:** subscription hooks fixes NV-6864 ([#9530](https://github.com/novuhq/novu/pull/9530))
-- **js,react,nextjs:** subscription button and preferences standalone components fixes NV-6909 ([#9527](https://github.com/novuhq/novu/pull/9527))
-- **js,react,nextjs:** subscription component fixes NV-6863 ([#9512](https://github.com/novuhq/novu/pull/9512))
-
-### ❤️ Thank You
-
-- Paweł Tymczuk @LetItRock
-
 ## v3.11.0 (2025-10-27)
 
 ### 🚀 Features

--- a/packages/nextjs/project.json
+++ b/packages/nextjs/project.json
@@ -6,7 +6,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/nextjs && npm publish --access public ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/nextjs && pnpm publish --access public --no-git-checks ${NX_PUBLISH_ARGS:-}"
       }
     }
   }

--- a/packages/nextjs/project.json
+++ b/packages/nextjs/project.json
@@ -6,7 +6,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/nextjs && npm publish --access public ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/nextjs && npm publish --access public --registry https://registry.npmjs.org ${NX_PUBLISH_ARGS:-}"
       }
     }
   }

--- a/packages/nextjs/project.json
+++ b/packages/nextjs/project.json
@@ -6,7 +6,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/nextjs && npm publish --access public --registry https://registry.npmjs.org ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/nextjs && npm publish --access public ${NX_PUBLISH_ARGS:-}"
       }
     }
   }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,7 +1,3 @@
-## v3.12.0-rc.1 (2025-12-12)
-
-This was a version bump only for @novu/react-native to align it with other projects, there were no code changes.
-
 ## v3.11.0 (2025-10-27)
 
 This was a version bump only for @novu/react-native to align it with other projects, there were no code changes.

--- a/packages/react-native/project.json
+++ b/packages/react-native/project.json
@@ -6,7 +6,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/react-native && npm publish --access public ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/react-native && pnpm publish --access public --no-git-checks ${NX_PUBLISH_ARGS:-}"
       }
     }
   }

--- a/packages/react-native/project.json
+++ b/packages/react-native/project.json
@@ -6,7 +6,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/react-native && npm publish --access public --registry https://registry.npmjs.org ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/react-native && npm publish --access public ${NX_PUBLISH_ARGS:-}"
       }
     }
   }

--- a/packages/react-native/project.json
+++ b/packages/react-native/project.json
@@ -6,7 +6,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/react-native && npm publish --access public ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/react-native && npm publish --access public --registry https://registry.npmjs.org ${NX_PUBLISH_ARGS:-}"
       }
     }
   }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,20 +1,3 @@
-## v3.12.0-rc.1 (2025-12-12)
-
-### 🚀 Features
-
-- **react,nextjs:** subscription hooks fixes NV-6864 ([#9530](https://github.com/novuhq/novu/pull/9530))
-- **js,react,nextjs:** subscription button and preferences standalone components fixes NV-6909 ([#9527](https://github.com/novuhq/novu/pull/9527))
-- **js,react,nextjs:** subscription component fixes NV-6863 ([#9512](https://github.com/novuhq/novu/pull/9512))
-
-### 🩹 Fixes
-
-- **react:** update inbox links to point to the correct platform overview ([#9355](https://github.com/novuhq/novu/pull/9355))
-
-### ❤️ Thank You
-
-- Pawan Jain
-- Paweł Tymczuk @LetItRock
-
 ## v3.11.0 (2025-10-27)
 
 ### 🚀 Features

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -6,7 +6,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/react && npm publish --access public ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/react && pnpm publish --access public --no-git-checks ${NX_PUBLISH_ARGS:-}"
       }
     }
   }

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -6,7 +6,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/react && npm publish --access public ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/react && npm publish --access public --registry https://registry.npmjs.org ${NX_PUBLISH_ARGS:-}"
       }
     }
   }

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -6,7 +6,7 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd packages/react && npm publish --access public --registry https://registry.npmjs.org ${NX_PUBLISH_ARGS:-}"
+        "command": "cd packages/react && npm publish --access public ${NX_PUBLISH_ARGS:-}"
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publish pipeline to use pnpm instead of npm with Trusted Publishing (OIDC) support.
  * Added `--no-git-checks` flag to publish commands across packages.
  * Simplified release workflow with clearer status messages and removed verbose debug logs.

* **Revert**
  * Removed v3.12.0-rc.1 changelog entries from all packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->