### PR TITLE
fix(framework): Liquid output escaping for special JSON characters including "

### DIFF
--- a/apps/api/src/app/events/e2e/bridge-trigger.e2e.ts
+++ b/apps/api/src/app/events/e2e/bridge-trigger.e2e.ts
@@ -2007,6 +2007,52 @@ describe('Novu-Hosted Bridge Trigger #novu-v2', () => {
 
     expect(sentMessages.length).to.be.eq(2);
   });
+
+  it('should render control values with payload containing double quotes', async () => {
+    const createWorkflowDto: CreateWorkflowDto = {
+      tags: [],
+      active: true,
+      name: 'Test Quotes Workflow',
+      description: 'Test Workflow with Quotes',
+      __source: WorkflowCreationSourceEnum.DASHBOARD,
+      workflowId: 'test-quotes-workflow',
+      steps: [
+        {
+          type: StepTypeEnum.IN_APP,
+          name: 'In App Step',
+          controlValues: {
+            subject: '{{payload.title}}',
+            body: '{{payload.body}}',
+          },
+        },
+      ],
+    };
+
+    const response = await session.testAgent.post(`/v2/workflows`).send(createWorkflowDto);
+    expect(response.status).to.be.eq(201);
+
+    const responseData = response.body.data as WorkflowResponseDto;
+
+    const payloadWithQuotes = {
+      title: 'Test message with "quotes"',
+      body: 'This content has "double quotes" and "special characters" in the text',
+    };
+
+    await triggerEvent(session, responseData.workflowId, subscriber._id, payloadWithQuotes);
+    await session.waitForJobCompletion();
+
+    const sentMessages = await messageRepository.find({
+      _environmentId: session.environment._id,
+      _subscriberId: session.subscriberProfile?._id,
+      templateIdentifier: responseData.workflowId,
+      channel: StepTypeEnum.IN_APP,
+    });
+
+    expect(sentMessages.length).to.be.eq(1);
+    expect(sentMessages[0].subject).to.equal('Test message with "quotes"');
+    expect(sentMessages[0].content).to.include('"double quotes"');
+    expect(sentMessages[0].content).to.include('"special characters"');
+  });
 });
 
 async function syncWorkflow(

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -1014,9 +1014,7 @@ describe('Novu Client', () => {
       const emailExecutionResult = await client.executeWorkflow(event);
 
       expect(emailExecutionResult.outputs).toEqual({
-        body: `{
-  'text': 'cat'
-}`,
+        body: `{\\n  'text': 'cat'\\n}`,
         subject: 'Hello',
       });
     });

--- a/packages/framework/src/utils/liquid.utils.ts
+++ b/packages/framework/src/utils/liquid.utils.ts
@@ -13,9 +13,14 @@ export function defaultOutputEscape(output: unknown): string {
   if (Array.isArray(output) || (typeof output === 'object' && output !== null)) {
     return stringifyDataStructureWithSingleQuotes(output);
   }
-  // For strings that might contain newlines, ensure proper escaping
-  else if (typeof output === 'string' && output.includes('\n')) {
-    return output.replace(/\n/g, '\\n');
+  // For strings, escape special JSON characters: backslashes, double quotes, and newlines
+  else if (typeof output === 'string') {
+    return output
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/\t/g, '\\t');
   } else {
     return output === undefined || output === null ? '' : String(output as unknown);
   }


### PR DESCRIPTION
Enhanced the defaultOutputEscape function to properly escape backslashes, double quotes, newlines, carriage returns, and tabs in string outputs. Added an E2E test to verify correct rendering of control values when payload contains double quotes.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
