### PR TITLE
chore(): Mongodb docker version update

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   db:
-    image: mongo:8.0.3
+    image: mongo:8.0.17
     restart: unless-stopped
     volumes:
       - mongodb-content:/data/db

--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   mongodb:
-    image: mongo:8.0.3
+    image: mongo:8.0.17
     container_name: mongodb
     restart: unless-stopped
     logging:

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   mongo:
     container_name: '${MONGO_DOCKER_NAME-mongo_main}'
-    image: mongo:8.0.3
+    image: mongo:8.0.17
     network_mode: bridge
     ports:
       - '${DOCKER_MONGO_PORT:-27017}:27017'


### PR DESCRIPTION
### What changed? Why was the change needed?

Updated the MongoDB Docker image version from `8.0.3` to `8.0.17` in the following `docker-compose.yml` files:
- `.devcontainer/docker-compose.yml`
- `docker/local/docker-compose.yml`
- `docker/community/docker-compose.yml`

This change was needed to apply a patched hotfix for MongoDB.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

This update addresses a requested hotfix for the MongoDB version.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1767016397784909?thread_ts=1767016397.784909&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-7690c661-9029-4824-86ed-8f4086bff340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7690c661-9029-4824-86ed-8f4086bff340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

