### PR TITLE
fix(api-service): add skipOutputEscape option to createLiquidEngine

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -85,7 +85,19 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
     private createExecutionDetails: CreateExecutionDetails
   ) {
     super(moduleRef, logger);
-    this.liquidEngine = createLiquidEngine({ skipOutputEscape: true });
+    this.liquidEngine = createLiquidEngine({
+      outputEscape: (output: unknown): string => {
+        if (Array.isArray(output) || (typeof output === 'object' && output !== null)) {
+          const valueStringified = JSON.stringify(output);
+          const valueSingleQuotes = valueStringified.replace(/"/g, "'");
+          const valueEscapedNewLines = valueSingleQuotes.replace(/\n/g, '\\n');
+
+          return valueEscapedNewLines;
+        }
+
+        return output === undefined || output === null ? '' : String(output as unknown);
+      },
+    });
   }
 
   @InstrumentUsecase()

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -85,7 +85,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
     private createExecutionDetails: CreateExecutionDetails
   ) {
     super(moduleRef, logger);
-    this.liquidEngine = createLiquidEngine();
+    this.liquidEngine = createLiquidEngine({ skipOutputEscape: true });
   }
 
   @InstrumentUsecase()

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -85,6 +85,22 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
     private createExecutionDetails: CreateExecutionDetails
   ) {
     super(moduleRef, logger);
+    /**
+     * Custom outputEscape function for email rendering that handles object serialization
+     * without escaping HTML content.
+     *
+     * The default outputEscape (from createLiquidEngine) escapes special characters in strings
+     * (quotes, newlines, etc.) which is needed for JSON context but breaks HTML attributes
+     * when rendering email content. For example, `style="color: red"` would become
+     * `style=\"color: red\"` causing malformed HTML.
+     *
+     * This custom implementation:
+     * 1. Serializes objects/arrays to JSON strings (required for Maily loops like {{ payload.items }})
+     * 2. Does NOT escape quotes/newlines in regular strings (preserves HTML attribute integrity)
+     *
+     * This allows HTML content like `{{ layout_content }}` to render properly with correct
+     * attributes while still supporting object iteration in email templates.
+     */
     this.liquidEngine = createLiquidEngine({
       outputEscape: (output: unknown): string => {
         if (Array.isArray(output) || (typeof output === 'object' && output !== null)) {

--- a/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
@@ -1395,6 +1395,76 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
       expect(previewResponseDto.previewPayloadExample.payload?.subject.test).to.have.property('payload');
     });
 
+    it('email: should render HTML without escaping quotes in attributes', async () => {
+      const { stepDatabaseId, workflowId } = await createWorkflowAndReturnId(novuClient, StepTypeEnum.EMAIL);
+
+      const controlValues = {
+        subject: 'Test HTML Rendering',
+        body: JSON.stringify({
+          type: 'doc',
+          content: [
+            {
+              type: 'button',
+              attrs: {
+                text: 'Click Me',
+                isTextVariable: false,
+                url: 'https://example.com',
+                isUrlVariable: false,
+                alignment: 'center',
+                variant: 'filled',
+                borderRadius: 'smooth',
+                buttonColor: '#FF5733',
+                textColor: '#FFFFFF',
+                showIfKey: null,
+                paddingTop: 12,
+                paddingRight: 24,
+                paddingBottom: 12,
+                paddingLeft: 24,
+                width: 'auto',
+                aliasFor: null,
+              },
+            },
+            {
+              type: 'paragraph',
+              attrs: { textAlign: 'center', showIfKey: null },
+              content: [
+                {
+                  type: 'text',
+                  text: 'Test content with special characters: "quotes" & symbols',
+                },
+              ],
+            },
+          ],
+        }),
+      };
+
+      const previewResponseDto = await generatePreview(novuClient, workflowId, stepDatabaseId, {
+        controlValues,
+      });
+
+      expect(previewResponseDto.result).to.exist;
+      if (!previewResponseDto.result || previewResponseDto.result.type !== 'email') {
+        throw new Error('Expected email preview');
+      }
+
+      const preview = previewResponseDto.result.preview as EmailRenderOutput;
+      expect(preview.body).to.exist;
+
+      expect(preview.body).to.not.contain('\\"');
+      expect(preview.body).to.not.contain('\\&quot;');
+      expect(preview.body).to.not.contain('&quot;center&quot;');
+      expect(preview.body).to.not.contain('align=\\"center\\"');
+
+      expect(preview.body).to.contain('#FF5733');
+      expect(preview.body).to.contain('#FFFFFF');
+      expect(preview.body).to.contain('Click Me');
+      expect(preview.body).to.contain('Test content with special characters');
+
+      expect(preview.body).to.match(/style="[^"]*color[^"]*"/);
+      expect(preview.body).to.match(/style="[^"]*background-color[^"]*"/);
+      expect(preview.body).to.match(/align="center"/);
+    });
+
     async function createWorkflowAndPreview(type: StepTypeEnum, description: string) {
       const { stepDatabaseId, workflowId } = await createWorkflowAndReturnId(novuClient, type);
       const requestDto = buildDtoNoPayload(type);

--- a/packages/framework/src/internal/index.ts
+++ b/packages/framework/src/internal/index.ts
@@ -3,4 +3,4 @@ export * from '../errors';
 export * from '../filters';
 export { actionStepSchemas, channelStepSchemas } from '../schemas';
 export * from '../types';
-export { createLiquidEngine, type CreateLiquidEngineOptions } from '../utils/liquid.utils';
+export { createLiquidEngine } from '../utils/liquid.utils';

--- a/packages/framework/src/internal/index.ts
+++ b/packages/framework/src/internal/index.ts
@@ -3,4 +3,4 @@ export * from '../errors';
 export * from '../filters';
 export { actionStepSchemas, channelStepSchemas } from '../schemas';
 export * from '../types';
-export { createLiquidEngine } from '../utils/liquid.utils';
+export { createLiquidEngine, type CreateLiquidEngineOptions } from '../utils/liquid.utils';

--- a/packages/framework/src/utils/liquid.utils.test.ts
+++ b/packages/framework/src/utils/liquid.utils.test.ts
@@ -280,7 +280,7 @@ describe('createLiquidEngine', () => {
     expect(jsonResult).toBe('Line 1\\nLine 2\\nLine 3');
   });
 
-  describe('skipOutputEscape option', () => {
+  describe('custom outputEscape override', () => {
     it('should escape quotes in output by default (for JSON context)', async () => {
       const engine = createLiquidEngine();
       const htmlContent = '<div style="color: red">Hello</div>';
@@ -291,8 +291,21 @@ describe('createLiquidEngine', () => {
       expect(result).toBe('<div style=\\"color: red\\">Hello</div>');
     });
 
-    it('should not escape quotes when skipOutputEscape is true (for HTML context)', async () => {
-      const engine = createLiquidEngine({ skipOutputEscape: true });
+    it('should allow overriding outputEscape to not escape quotes (for HTML context)', async () => {
+      const engine = createLiquidEngine({
+        outputEscape: (output: unknown): string => {
+          if (Array.isArray(output) || (typeof output === 'object' && output !== null)) {
+            const valueStringified = JSON.stringify(output);
+            const valueSingleQuotes = valueStringified.replace(/"/g, "'");
+            const valueEscapedNewLines = valueSingleQuotes.replace(/\n/g, '\\n');
+
+            return valueEscapedNewLines;
+          }
+
+          return output === undefined || output === null ? '' : String(output as unknown);
+        },
+      });
+
       const htmlContent = '<div style="color: red">Hello</div>';
       const template = '{{ content }}';
 
@@ -301,28 +314,44 @@ describe('createLiquidEngine', () => {
       expect(result).toBe('<div style="color: red">Hello</div>');
     });
 
-    it('should preserve HTML attributes when rendering layout content with skipOutputEscape', async () => {
-      const engine = createLiquidEngine({ skipOutputEscape: true });
-      const layoutContent = '<table align="center" width="100%" style="max-width:600px"><tr><td>Content</td></tr></table>';
+    it('should preserve HTML attributes when rendering layout content with custom outputEscape', async () => {
+      const engine = createLiquidEngine({
+        outputEscape: (output: unknown): string => {
+          if (Array.isArray(output) || (typeof output === 'object' && output !== null)) {
+            return JSON.stringify(output).replace(/"/g, "'");
+          }
+
+          return output === undefined || output === null ? '' : String(output as unknown);
+        },
+      });
+
+      const layoutContent =
+        '<table align="center" width="100%" style="max-width:600px"><tr><td>Content</td></tr></table>';
       const template = '<html><body>{{ layout_content }}</body></html>';
 
       const result = await engine.parseAndRender(template, { layout_content: layoutContent });
 
-      expect(result).toBe('<html><body><table align="center" width="100%" style="max-width:600px"><tr><td>Content</td></tr></table></body></html>');
+      expect(result).toBe(
+        '<html><body><table align="center" width="100%" style="max-width:600px"><tr><td>Content</td></tr></table></body></html>'
+      );
       expect(result).not.toContain('\\"');
     });
 
-    it('should still register all default filters when skipOutputEscape is true', async () => {
-      const engine = createLiquidEngine({ skipOutputEscape: true });
+    it('should still serialize objects when using custom outputEscape', async () => {
+      const engine = createLiquidEngine({
+        outputEscape: (output: unknown): string => {
+          if (Array.isArray(output) || (typeof output === 'object' && output !== null)) {
+            return JSON.stringify(output).replace(/"/g, "'");
+          }
 
-      const jsonResult = await engine.parseAndRender('{{ data | json }}', { data: { a: 1 } });
-      expect(jsonResult).toBe("{'a':1}");
+          return output === undefined || output === null ? '' : String(output as unknown);
+        },
+      });
 
-      const digestResult = await engine.parseAndRender('{{ names | digest }}', { names: ['A', 'B', 'C'] });
-      expect(digestResult).toBe('A, B and 1 other');
+      const template = '{{ items }}';
+      const result = await engine.parseAndRender(template, { items: [{ name: 'Item 1' }, { name: 'Item 2' }] });
 
-      const pluralizeResult = await engine.parseAndRender("{{ 2 | pluralize: 'item' }}", {});
-      expect(pluralizeResult).toBe('2 items');
+      expect(result).toBe("[{'name':'Item 1'},{'name':'Item 2'}]");
     });
   });
 });

--- a/packages/framework/src/utils/liquid.utils.test.ts
+++ b/packages/framework/src/utils/liquid.utils.test.ts
@@ -279,6 +279,52 @@ describe('createLiquidEngine', () => {
     const jsonResult = await engine.parseAndRender(jsonTemplate, data);
     expect(jsonResult).toBe('Line 1\\nLine 2\\nLine 3');
   });
+
+  describe('skipOutputEscape option', () => {
+    it('should escape quotes in output by default (for JSON context)', async () => {
+      const engine = createLiquidEngine();
+      const htmlContent = '<div style="color: red">Hello</div>';
+      const template = '{{ content }}';
+
+      const result = await engine.parseAndRender(template, { content: htmlContent });
+
+      expect(result).toBe('<div style=\\"color: red\\">Hello</div>');
+    });
+
+    it('should not escape quotes when skipOutputEscape is true (for HTML context)', async () => {
+      const engine = createLiquidEngine({ skipOutputEscape: true });
+      const htmlContent = '<div style="color: red">Hello</div>';
+      const template = '{{ content }}';
+
+      const result = await engine.parseAndRender(template, { content: htmlContent });
+
+      expect(result).toBe('<div style="color: red">Hello</div>');
+    });
+
+    it('should preserve HTML attributes when rendering layout content with skipOutputEscape', async () => {
+      const engine = createLiquidEngine({ skipOutputEscape: true });
+      const layoutContent = '<table align="center" width="100%" style="max-width:600px"><tr><td>Content</td></tr></table>';
+      const template = '<html><body>{{ layout_content }}</body></html>';
+
+      const result = await engine.parseAndRender(template, { layout_content: layoutContent });
+
+      expect(result).toBe('<html><body><table align="center" width="100%" style="max-width:600px"><tr><td>Content</td></tr></table></body></html>');
+      expect(result).not.toContain('\\"');
+    });
+
+    it('should still register all default filters when skipOutputEscape is true', async () => {
+      const engine = createLiquidEngine({ skipOutputEscape: true });
+
+      const jsonResult = await engine.parseAndRender('{{ data | json }}', { data: { a: 1 } });
+      expect(jsonResult).toBe("{'a':1}");
+
+      const digestResult = await engine.parseAndRender('{{ names | digest }}', { names: ['A', 'B', 'C'] });
+      expect(digestResult).toBe('A, B and 1 other');
+
+      const pluralizeResult = await engine.parseAndRender("{{ 2 | pluralize: 'item' }}", {});
+      expect(pluralizeResult).toBe('2 items');
+    });
+  });
 });
 
 describe('defaultOutputEscape', () => {

--- a/packages/framework/src/utils/liquid.utils.ts
+++ b/packages/framework/src/utils/liquid.utils.ts
@@ -44,13 +44,25 @@ export const stringifyDataStructureWithSingleQuotes = (value: unknown, spaces: n
   }
 };
 
+export type CreateLiquidEngineOptions = LiquidOptions & {
+  skipOutputEscape?: boolean;
+};
+
 /**
  * Creates a configured Liquid instance with Novu's default settings.
+ *
+ * @param options - LiquidJS options plus:
+ *   - skipOutputEscape: Set to true when rendering content that will be used as HTML output.
+ *     The default outputEscape is designed for JSON context (escaping quotes, newlines) which
+ *     breaks HTML attributes. Email rendering should set this to true since it handles its
+ *     own escaping and outputs HTML content.
  */
-export function createLiquidEngine(options?: LiquidOptions): Liquid {
+export function createLiquidEngine(options?: CreateLiquidEngineOptions): Liquid {
+  const { skipOutputEscape, ...liquidOptions } = options ?? {};
+
   const liquidEngine = new Liquid({
-    outputEscape: defaultOutputEscape,
-    ...options,
+    outputEscape: skipOutputEscape ? undefined : defaultOutputEscape,
+    ...liquidOptions,
   });
 
   // Register default filters

--- a/packages/framework/src/utils/liquid.utils.ts
+++ b/packages/framework/src/utils/liquid.utils.ts
@@ -44,25 +44,17 @@ export const stringifyDataStructureWithSingleQuotes = (value: unknown, spaces: n
   }
 };
 
-export type CreateLiquidEngineOptions = LiquidOptions & {
-  skipOutputEscape?: boolean;
-};
-
 /**
  * Creates a configured Liquid instance with Novu's default settings.
  *
- * @param options - LiquidJS options plus:
- *   - skipOutputEscape: Set to true when rendering content that will be used as HTML output.
- *     The default outputEscape is designed for JSON context (escaping quotes, newlines) which
- *     breaks HTML attributes. Email rendering should set this to true since it handles its
- *     own escaping and outputs HTML content.
+ * @param options - LiquidJS options. Note: By default, this uses a custom outputEscape function
+ *   that escapes special JSON characters. If you need different escaping behavior (e.g., for HTML
+ *   rendering), you can override the outputEscape function in the options.
  */
-export function createLiquidEngine(options?: CreateLiquidEngineOptions): Liquid {
-  const { skipOutputEscape, ...liquidOptions } = options ?? {};
-
+export function createLiquidEngine(options?: LiquidOptions): Liquid {
   const liquidEngine = new Liquid({
-    outputEscape: skipOutputEscape ? undefined : defaultOutputEscape,
-    ...liquidOptions,
+    outputEscape: defaultOutputEscape,
+    ...options,
   });
 
   // Register default filters


### PR DESCRIPTION
Introduces a CreateLiquidEngineOptions type with a skipOutputEscape flag to control output escaping in the Liquid engine. Updates email output renderer to use this option for proper HTML rendering, and re-exports the new type for external use.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
