### PR TITLE
feat(api-service): Workflow id casing update

### DIFF
--- a/apps/api/src/app/workflows-v2/dtos/create-step.dto.ts
+++ b/apps/api/src/app/workflows-v2/dtos/create-step.dto.ts
@@ -26,8 +26,8 @@ export class BaseStepConfigDto {
 
   @ApiPropertyOptional({ description: 'Unique identifier for the step' })
   @IsString()
-  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
-    message: 'stepId must be a valid slug format (lowercase letters, numbers, and hyphens only)',
+  @Matches(/^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/, {
+    message: 'stepId must be a valid slug format (letters, numbers, and hyphens only)',
   })
   @IsOptional()
   stepId?: string;

--- a/apps/api/src/app/workflows-v2/dtos/create-workflow.dto.ts
+++ b/apps/api/src/app/workflows-v2/dtos/create-workflow.dto.ts
@@ -51,8 +51,8 @@ import { WorkflowCommonsFields } from './workflow-commons.dto';
 export class CreateWorkflowDto extends WorkflowCommonsFields {
   @ApiProperty({ description: 'Unique identifier for the workflow' })
   @IsString()
-  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
-    message: 'workflowId must be a valid slug format (lowercase letters, numbers, and hyphens only)',
+  @Matches(/^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/, {
+    message: 'workflowId must be a valid slug format (letters, numbers, and hyphens only)',
   })
   workflowId: string;
 

--- a/apps/api/src/app/workflows-v2/dtos/duplicate-workflow.dto.ts
+++ b/apps/api/src/app/workflows-v2/dtos/duplicate-workflow.dto.ts
@@ -16,8 +16,8 @@ export class DuplicateWorkflowDto {
   })
   @IsOptional()
   @IsString()
-  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
-    message: 'workflowId must be a valid slug format (lowercase letters, numbers, and hyphens only)',
+  @Matches(/^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/, {
+    message: 'workflowId must be a valid slug format (letters, numbers, and hyphens only)',
   })
   workflowId?: string;
 

--- a/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
@@ -47,7 +47,7 @@ describe('Upsert Workflow #novu-v2', () => {
         expect(error.message).to.contain('Validation Error');
         expect(error.errors).to.exist;
         expect(error.errors.general.messages[0]).to.contain(
-          'must be a valid slug format (lowercase letters, numbers, and hyphens only)'
+          'must be a valid slug format (letters, numbers, and hyphens only)'
         );
       }
     });

--- a/apps/dashboard/src/components/workflow-editor/schema.ts
+++ b/apps/dashboard/src/components/workflow-editor/schema.ts
@@ -13,8 +13,8 @@ import * as z from 'zod';
 export const workflowSchema = z.object({
   active: z.boolean().optional(),
   name: z.string().min(1).max(MAX_NAME_LENGTH),
-  workflowId: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
-    message: 'workflowId must be a valid slug format (lowercase letters, numbers, and hyphens only)',
+  workflowId: z.string().regex(/^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/, {
+    message: 'workflowId must be a valid slug format (letters, numbers, and hyphens only)',
   }),
   tags: z
     .array(z.string().min(0).max(MAX_TAG_LENGTH))


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR updates the validation for workflow IDs and step IDs to allow uppercase letters. Previously, only lowercase letters were permitted. This change addresses [NV-7013](https://linear.app/novu/issue/NV-7013), enabling more flexible naming conventions for v2 workflows and steps across the API and dashboard. The regex pattern and associated error messages have been updated accordingly.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---
Linear Issue: [NV-7013](https://linear.app/novu/issue/NV-7013/new-workflow-id-structure)

<a href="https://cursor.com/background-agent?bcId=bc-4f96f80d-cf96-4e13-a9da-20b64077e351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f96f80d-cf96-4e13-a9da-20b64077e351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

