### PR TITLE
fix(web): Remove lodash.set dependency

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -100,7 +100,6 @@
     "lodash.debounce": "^4.0.8",
     "lodash.get": "^4.3.2",
     "lodash.isequal": "^4.5.0",
-    "lodash.set": "^4.3.2",
     "mdx-bundler": "10.0.2",
     "mixpanel-browser": "^2.52.0",
     "monaco-editor": "^0.39.0",

--- a/apps/web/src/hooks/useProcessVariables.ts
+++ b/apps/web/src/hooks/useProcessVariables.ts
@@ -1,6 +1,6 @@
 import { TemplateVariableTypeEnum, IMustacheVariable, ITemplateVariable } from '@novu/shared';
 import { useMemo } from 'react';
-import set from 'lodash.set';
+import { safeSet } from '../utils/safe-set';
 import get from 'lodash.get';
 
 const processVariables = (variables: IMustacheVariable[]) => {
@@ -9,13 +9,13 @@ const processVariables = (variables: IMustacheVariable[]) => {
   variables
     .filter((variable) => variable.type !== TemplateVariableTypeEnum.ARRAY)
     .forEach((variable) => {
-      set(varsObj, variable.name, getVariableValue(variable));
+      safeSet(varsObj, variable.name, getVariableValue(variable));
     });
 
   variables
     .filter((variable) => variable.type === TemplateVariableTypeEnum.ARRAY)
     .forEach((variable) => {
-      set(varsObj, variable.name, [get(varsObj, variable.name, [])]);
+      safeSet(varsObj, variable.name, [get(varsObj, variable.name, [])]);
     });
 
   return JSON.stringify(varsObj, null, 2);

--- a/apps/web/src/pages/templates/components/TriggerSnippetTabs.tsx
+++ b/apps/web/src/pages/templates/components/TriggerSnippetTabs.tsx
@@ -1,6 +1,6 @@
 import { Prism } from '@mantine/prism';
 import { useMemo } from 'react';
-import set from 'lodash.set';
+import { safeSet } from '../../../utils/safe-set';
 import get from 'lodash.get';
 
 import { INotificationTrigger, INotificationTriggerVariable, TemplateVariableTypeEnum } from '@novu/shared';
@@ -75,12 +75,12 @@ export const getPayloadValue = (variables: INotificationTriggerVariable[]) => {
   variables
     .filter((variable) => variable?.type !== TemplateVariableTypeEnum.ARRAY)
     .forEach((variable) => {
-      set(varsObj, variable.name, variable.value || '<REPLACE_WITH_DATA>');
+      safeSet(varsObj, variable.name, variable.value || '<REPLACE_WITH_DATA>');
     });
   variables
     .filter((variable) => variable?.type === TemplateVariableTypeEnum.ARRAY)
     .forEach((variable) => {
-      set(varsObj, variable.name, [get(varsObj, variable.name, '<REPLACE_WITH_DATA>')]);
+      safeSet(varsObj, variable.name, [get(varsObj, variable.name, '<REPLACE_WITH_DATA>')]);
     });
 
   return varsObj;
@@ -91,7 +91,7 @@ export const getSubscriberValue = (
 ) => {
   const varsObj: Record<string, any> = {};
   variables.forEach((variable) => {
-    set(varsObj, variable.name, getValue(variable));
+    safeSet(varsObj, variable.name, getValue(variable));
   });
 
   return varsObj;

--- a/apps/web/src/pages/templates/components/email-editor/variables-management/VariablesManagement.tsx
+++ b/apps/web/src/pages/templates/components/email-editor/variables-management/VariablesManagement.tsx
@@ -1,7 +1,7 @@
 import { useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import React, { useEffect, useState } from 'react';
-import set from 'lodash.set';
+import { safeSet } from '../../../../../utils/safe-set';
 import styled from '@emotion/styled';
 import { Group, useMantineColorScheme } from '@mantine/core';
 
@@ -41,7 +41,7 @@ function searchByKey(object, searchString) {
 
   Object.keys(object).forEach((key) => {
     if (key.toLowerCase().includes(searchString.toLowerCase())) {
-      set(varsObj, key, object[key]);
+      safeSet(varsObj, key, object[key]);
     }
   });
 

--- a/apps/web/src/utils/safe-set.ts
+++ b/apps/web/src/utils/safe-set.ts
@@ -1,0 +1,81 @@
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isUnsafeKey(key: string): boolean {
+  return UNSAFE_KEYS.has(key);
+}
+
+function toPathArray(path: string | string[]): string[] {
+  if (Array.isArray(path)) {
+    return path;
+  }
+
+  const result: string[] = [];
+  let current = '';
+  let inBracket = false;
+
+  for (let i = 0; i < path.length; i++) {
+    const char = path[i];
+
+    if (char === '[' && !inBracket) {
+      if (current) {
+        result.push(current);
+        current = '';
+      }
+      inBracket = true;
+    } else if (char === ']' && inBracket) {
+      if (current) {
+        result.push(current);
+        current = '';
+      }
+      inBracket = false;
+    } else if (char === '.' && !inBracket) {
+      if (current) {
+        result.push(current);
+        current = '';
+      }
+    } else {
+      current += char;
+    }
+  }
+
+  if (current) {
+    result.push(current);
+  }
+
+  return result;
+}
+
+export function safeSet<T extends object>(object: T, path: string | string[], value: unknown): T {
+  if (object === null || typeof object !== 'object') {
+    return object;
+  }
+
+  const keys = toPathArray(path);
+
+  if (keys.length === 0) {
+    return object;
+  }
+
+  if (keys.some(isUnsafeKey)) {
+    return object;
+  }
+
+  let current: Record<string, unknown> = object as Record<string, unknown>;
+
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i];
+    const nextKey = keys[i + 1];
+    const isNextKeyNumeric = /^\d+$/.test(nextKey);
+
+    if (current[key] === null || typeof current[key] !== 'object') {
+      current[key] = isNextKeyNumeric ? [] : {};
+    }
+
+    current = current[key] as Record<string, unknown>;
+  }
+
+  const lastKey = keys[keys.length - 1];
+  current[lastKey] = value;
+
+  return object;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1335,9 +1335,6 @@ importers:
       lodash.isequal:
         specifier: ^4.5.0
         version: 4.5.0
-      lodash.set:
-        specifier: ^4.3.2
-        version: 4.3.2
       mdx-bundler:
         specifier: 10.0.2
         version: 10.0.2(esbuild@0.23.1)
@@ -23561,9 +23558,6 @@ packages:
 
   lodash.partial@4.2.1:
     resolution: {integrity: sha512-qsiGr0kiA31O7chhmKSUiEGtxXnYtwmaJF00TPAUW79C5PCfaVeLTUN3sLT+rEPcqZooPtiFcGhnphQzFhkqmg==}
-
-  lodash.set@4.3.2:
-    resolution: {integrity: sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==}
 
   lodash.snakecase@4.1.1:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
@@ -51874,6 +51868,7 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
+    optional: true
 
   debug@4.3.1(supports-color@8.1.1):
     dependencies:
@@ -52994,7 +52989,7 @@ snapshots:
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       is-core-module: 2.15.1
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -53002,7 +52997,7 @@ snapshots:
 
   eslint-module-utils@2.8.2(@typescript-eslint/parser@5.62.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@9.19.0(jiti@2.4.2)):
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.6.2)
       eslint: 9.19.0(jiti@2.4.2)
@@ -53024,7 +53019,7 @@ snapshots:
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
       array.prototype.flatmap: 1.3.2
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       doctrine: 2.1.0
       eslint: 9.19.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
@@ -58073,8 +58068,6 @@ snapshots:
 
   lodash.partial@4.2.1: {}
 
-  lodash.set@4.3.2: {}
-
   lodash.snakecase@4.1.1: {}
 
   lodash.sortby@4.7.0: {}
@@ -59582,7 +59575,7 @@ snapshots:
 
   needle@2.4.0:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       iconv-lite: 0.4.24
       sax: 1.4.1
     transitivePeerDependencies:
@@ -59590,7 +59583,7 @@ snapshots:
 
   needle@3.2.0:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       iconv-lite: 0.6.3
       sax: 1.2.4
     transitivePeerDependencies:
@@ -61114,7 +61107,7 @@ snapshots:
   portfinder@1.0.32:
     dependencies:
       async: 2.6.4
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       mkdirp: 0.5.6
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
### What changed? Why was the change needed?

Removed the vulnerable `lodash.set` dependency and replaced it with a custom `safeSet` utility. This change addresses Dependabot alert #243 regarding Prototype Pollution in `lodash.set` by preventing malicious modification of `Object.prototype`.

The new `safeSet` utility provides similar functionality to `lodash.set` but includes checks to block unsafe keys (`__proto__`, `constructor`, `prototype`), mitigating the vulnerability.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

The `safeSet` utility supports both dot-notation (`foo.bar.baz`) and bracket-notation (`foo[0].bar`) and automatically creates nested objects/arrays as needed, mirroring the behavior of `lodash.set`.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1767552979812589?thread_ts=1767552979.812589&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-b50c9601-dc01-47eb-8ace-963dd89ebe8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b50c9601-dc01-47eb-8ace-963dd89ebe8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

