### PR TITLE
perf(api-service): bridge skip updated by join

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts
@@ -357,7 +357,7 @@ export class ConstructFrameworkWorkflow {
 
   @Instrument()
   private async getDbWorkflow(environmentId: string, workflowId: string): Promise<NotificationTemplateEntity> {
-    const foundWorkflow = await this.workflowsRepository.findByTriggerIdentifier(environmentId, workflowId);
+    const foundWorkflow = await this.workflowsRepository.findByTriggerIdentifier(environmentId, workflowId, null, false);
 
     if (!foundWorkflow) {
       throw new InternalServerErrorException(`Workflow ${workflowId} not found`);


### PR DESCRIPTION
### What changed? Why was the change needed?

Modified the `getDbWorkflow` method to pass `null` for the session and `false` for `includeUpdatedBy` to the `findByTriggerIdentifier` method. This prevents the `updatedBy` field from being joined and populated, optimizing data retrieval for this specific use case.

### Screenshots

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1767628638452389?thread_ts=1767628638.452389&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-9a73a1db-64e2-49a6-8a34-b1bde4f878da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9a73a1db-64e2-49a6-8a34-b1bde4f878da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

