### PR TITLE
fix(js): Size limit adjustments

### DIFF
--- a/packages/js/scripts/size-limit.mjs
+++ b/packages/js/scripts/size-limit.mjs
@@ -15,12 +15,12 @@ const modules = [
   {
     name: 'UMD minified',
     filePath: umdPath,
-    limitInBytes: 190_000,
+    limitInBytes: 200_000,
   },
   {
     name: 'UMD gzip',
     filePath: umdGzipPath,
-    limitInBytes: 55_000,
+    limitInBytes: 60_000,
   },
 ];
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Adjusted the size limits in `packages/js/scripts/size-limit.mjs` as requested:
- UMD minified limit increased from `190_000` to `200_000` bytes.
- UMD gzip limit increased from `55_000` to `60_000` bytes.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1767696688729309?thread_ts=1767696688.729309&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-34100cf0-8f4b-4a1e-bfe1-8761c233a666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-34100cf0-8f4b-4a1e-bfe1-8761c233a666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

