### PR TITLE
feat(dashboard, api-service): Identifier character set extension for workflow ids

### DIFF
--- a/apps/api/src/app/workflows-v2/dtos/create-step.dto.ts
+++ b/apps/api/src/app/workflows-v2/dtos/create-step.dto.ts
@@ -26,8 +26,8 @@ export class BaseStepConfigDto {
 
   @ApiPropertyOptional({ description: 'Unique identifier for the step' })
   @IsString()
-  @Matches(/^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/, {
-    message: 'stepId must be a valid slug format (letters, numbers, and hyphens only)',
+  @Matches(/^[a-zA-Z0-9]+(?:[-_][a-zA-Z0-9]+)*$/, {
+    message: 'stepId must be a valid slug format (letters, numbers, hyphens, and underscores only)',
   })
   @IsOptional()
   stepId?: string;

--- a/apps/api/src/app/workflows-v2/dtos/create-workflow.dto.ts
+++ b/apps/api/src/app/workflows-v2/dtos/create-workflow.dto.ts
@@ -51,8 +51,8 @@ import { WorkflowCommonsFields } from './workflow-commons.dto';
 export class CreateWorkflowDto extends WorkflowCommonsFields {
   @ApiProperty({ description: 'Unique identifier for the workflow' })
   @IsString()
-  @Matches(/^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/, {
-    message: 'workflowId must be a valid slug format (letters, numbers, and hyphens only)',
+  @Matches(/^[a-zA-Z0-9]+(?:[-_][a-zA-Z0-9]+)*$/, {
+    message: 'workflowId must be a valid slug format (letters, numbers, hyphens, and underscores only)',
   })
   workflowId: string;
 

--- a/apps/api/src/app/workflows-v2/dtos/duplicate-workflow.dto.ts
+++ b/apps/api/src/app/workflows-v2/dtos/duplicate-workflow.dto.ts
@@ -16,8 +16,8 @@ export class DuplicateWorkflowDto {
   })
   @IsOptional()
   @IsString()
-  @Matches(/^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/, {
-    message: 'workflowId must be a valid slug format (letters, numbers, and hyphens only)',
+  @Matches(/^[a-zA-Z0-9]+(?:[-_][a-zA-Z0-9]+)*$/, {
+    message: 'workflowId must be a valid slug format (letters, numbers, hyphens, and underscores only)',
   })
   workflowId?: string;
 

--- a/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/upsert-workflow.e2e.ts
@@ -47,7 +47,7 @@ describe('Upsert Workflow #novu-v2', () => {
         expect(error.message).to.contain('Validation Error');
         expect(error.errors).to.exist;
         expect(error.errors.general.messages[0]).to.contain(
-          'must be a valid slug format (letters, numbers, and hyphens only)'
+          'must be a valid slug format (letters, numbers, hyphens, and underscores only)'
         );
       }
     });

--- a/apps/dashboard/src/components/workflow-editor/schema.ts
+++ b/apps/dashboard/src/components/workflow-editor/schema.ts
@@ -13,8 +13,8 @@ import * as z from 'zod';
 export const workflowSchema = z.object({
   active: z.boolean().optional(),
   name: z.string().min(1).max(MAX_NAME_LENGTH),
-  workflowId: z.string().regex(/^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$/, {
-    message: 'workflowId must be a valid slug format (letters, numbers, and hyphens only)',
+  workflowId: z.string().regex(/^[a-zA-Z0-9]+(?:[-_][a-zA-Z0-9]+)*$/, {
+    message: 'workflowId must be a valid slug format (letters, numbers, hyphens, and underscores only)',
   }),
   tags: z
     .array(z.string().min(0).max(MAX_TAG_LENGTH))


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR updates the validation for workflow and step IDs to allow underscores (`_`) in addition to hyphens (`-`). Previously, only hyphens were permitted in these identifiers. This change provides more flexibility for naming conventions while maintaining a valid slug format. The regex pattern and corresponding error messages have been updated across relevant DTOs and schemas.

### Screenshots

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1767696704047569?thread_ts=1767696704.047569&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-e5276a94-552d-4651-8622-b23f101b54a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5276a94-552d-4651-8622-b23f101b54a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

