### PR TITLE
fix(api-service): Adjust include channels on legacy preferences api fixes NV-7006

### DIFF
--- a/apps/api/src/app/subscribers/subscribersV1.controller.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.controller.ts
@@ -439,7 +439,7 @@ export class SubscribersV1Controller {
     type: Boolean,
     required: false,
     description:
-      'A flag which specifies if the inactive workflow channels should be included in the retrieved preferences. Default is true',
+      'A flag which specifies if the inactive workflow channels should be included in the retrieved preferences. Default is false',
   })
   @SdkGroupName('Subscribers.Preferences')
   @ApiExcludeEndpoint()
@@ -453,7 +453,7 @@ export class SubscribersV1Controller {
       subscriberId,
       environmentId: user.environmentId,
       level: PreferenceLevelEnum.TEMPLATE,
-      includeInactiveChannels: includeInactiveChannels ?? true,
+      includeInactiveChannels: includeInactiveChannels ?? false,
     });
 
     return (await this.getPreferenceUsecase.execute(command)) as UpdateSubscriberPreferenceResponseDto[];
@@ -480,7 +480,7 @@ export class SubscribersV1Controller {
       subscriberId,
       environmentId: user.environmentId,
       level: parameter,
-      includeInactiveChannels: includeInactiveChannels ?? true,
+      includeInactiveChannels: includeInactiveChannels ?? false,
     });
 
     return await this.getPreferenceUsecase.execute(command);
@@ -510,7 +510,7 @@ export class SubscribersV1Controller {
         subscriberId,
         workflowIdOrIdentifier: workflowId,
         level: PreferenceLevelEnum.TEMPLATE,
-        includeInactiveChannels: true,
+        includeInactiveChannels: false,
         ...(body.channel && { [body.channel.type]: body.channel.enabled }),
       })
     );
@@ -566,7 +566,7 @@ export class SubscribersV1Controller {
         organizationId: user.organizationId,
         subscriberId,
         level: PreferenceLevelEnum.GLOBAL,
-        includeInactiveChannels: true,
+        includeInactiveChannels: false,
         ...channels,
       })
     );


### PR DESCRIPTION
Updated the default value and documentation for the includeInactiveChannels flag in subscriber preferences endpoints to false instead of true. This affects preference retrieval and update logic to exclude inactive workflow channels by default.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
