### PR TITLE
feat(api-service): Inbox subscriber field update for locale fixes NV-7021

### DIFF
--- a/apps/api/src/app/inbox/e2e/session.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/session.e2e.ts
@@ -168,6 +168,107 @@ describe('Session - /inbox/session (POST) #novu-v2', async () => {
     expect(storedSubscriber.email).to.equal(newRandomSubscriber.email);
   });
 
+  it('should create a new subscriber with locale and data fields', async () => {
+    await setIntegrationConfig({
+      _environmentId: session.environment._id,
+      _organizationId: session.environment._organizationId,
+      hmac: false,
+    });
+    const subscriberId = `user-subscriber-id-${`${randomBytes(4).toString('hex')}`}`;
+
+    const newRandomSubscriber = {
+      subscriberId,
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john@example.com',
+      locale: 'de-DE',
+      data: { customKey: 'customValue', nestedData: { key: 'value' } },
+    };
+
+    const res = await initializeSession({
+      applicationIdentifier: session.environment.identifier,
+      subscriber: newRandomSubscriber,
+    });
+
+    const { status, body } = res;
+
+    expect(status).to.equal(201);
+    expect(body.data.token).to.be.ok;
+
+    const storedSubscriber = await subscriberRepository.findBySubscriberId(session.environment._id, subscriberId);
+    expect(storedSubscriber).to.exist;
+    if (!storedSubscriber) {
+      throw new Error('Subscriber exists but was not found');
+    }
+
+    expect(storedSubscriber.firstName).to.equal(newRandomSubscriber.firstName);
+    expect(storedSubscriber.lastName).to.equal(newRandomSubscriber.lastName);
+    expect(storedSubscriber.email).to.equal(newRandomSubscriber.email);
+    expect(storedSubscriber.locale).to.equal(newRandomSubscriber.locale);
+    expect(storedSubscriber.data).to.deep.equal(newRandomSubscriber.data);
+  });
+
+  it('should update locale and data fields when subscriber already exists with valid HMAC', async () => {
+    await setIntegrationConfig({
+      _environmentId: session.environment._id,
+      _organizationId: session.environment._organizationId,
+      hmac: false,
+    });
+    const subscriberId = `user-subscriber-id-${`${randomBytes(4).toString('hex')}`}`;
+
+    const initialSubscriber = {
+      subscriberId,
+      firstName: 'Jane',
+      lastName: 'Smith',
+      email: 'jane@example.com',
+      locale: 'en-US',
+      data: { initialKey: 'initialValue' },
+    };
+
+    const res = await initializeSession({
+      applicationIdentifier: session.environment.identifier,
+      subscriber: initialSubscriber,
+    });
+
+    expect(res.status).to.equal(201);
+
+    const storedSubscriber = await subscriberRepository.findBySubscriberId(session.environment._id, subscriberId);
+    expect(storedSubscriber).to.exist;
+    expect(storedSubscriber?.locale).to.equal('en-US');
+    expect(storedSubscriber?.data).to.deep.equal({ initialKey: 'initialValue' });
+
+    const updatedSubscriber = {
+      subscriberId,
+      firstName: 'Jane Updated',
+      lastName: 'Smith Updated',
+      email: 'jane.updated@example.com',
+      locale: 'fr-FR',
+      data: { updatedKey: 'updatedValue', nested: { key: 'value' } },
+    };
+
+    const secretKey = session.environment.apiKeys[0].key;
+    const subscriberHash = createHash(secretKey, subscriberId);
+
+    const updateRes = await initializeSession({
+      applicationIdentifier: session.environment.identifier,
+      subscriber: updatedSubscriber,
+      subscriberHash,
+    });
+
+    expect(updateRes.status).to.equal(201);
+
+    const updatedStoredSubscriber = await subscriberRepository.findBySubscriberId(
+      session.environment._id,
+      subscriberId
+    );
+    expect(updatedStoredSubscriber).to.exist;
+    expect(updatedStoredSubscriber?.firstName).to.equal(updatedSubscriber.firstName);
+    expect(updatedStoredSubscriber?.lastName).to.equal(updatedSubscriber.lastName);
+    expect(updatedStoredSubscriber?.email).to.equal(updatedSubscriber.email);
+    expect(updatedStoredSubscriber?.locale).to.equal(updatedSubscriber.locale);
+    expect(updatedStoredSubscriber?.data).to.deep.equal(updatedSubscriber.data);
+  });
+
   it('should upsert a subscriber', async () => {
     await setIntegrationConfig(
       {

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -167,6 +167,7 @@ export class Session {
         phone: subscriber.phone,
         email: subscriber.email,
         avatar: subscriber.avatar,
+        locale: subscriber.locale,
         data: subscriber.data as CustomDataType,
         timezone: subscriber.timezone,
         allowUpdate: isHmacValid(


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixed a bug (NV-7021) where the `locale` and `data` fields were not being saved for new subscribers during inbox session initialization. The `locale` field was missing from the `CreateOrUpdateSubscriberCommand` call in the `Session` use case, preventing it from being persisted. This change ensures that both `locale` and `data` provided during inbox session initialization are correctly stored.

New E2E tests have been added to verify that `locale` and `data` fields are correctly handled for both new subscriber creation and updates via the inbox session.

Relevant link: [NV-7021](https://linear.app/novu/issue/NV-7021/locale-and-data-field-not-set-for-new-subscriber-in-inbox)

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

-   The primary fix is in `apps/api/src/app/inbox/usecases/session/session.usecase.ts` where `locale` was added to the `CreateOrUpdateSubscriberCommand`.
-   Two new E2E tests have been added in `apps/api/src/app/inbox/e2e/session.e2e.ts` to cover `locale` and `data` field persistence and updates.

</details>

---
Linear Issue: [NV-7021](https://linear.app/novu/issue/NV-7021/locale-and-data-field-not-set-for-new-subscriber-in-inbox)

<a href="https://cursor.com/background-agent?bcId=bc-b64facf4-b597-443a-bb22-df48cd818562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b64facf4-b597-443a-bb22-df48cd818562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

