### PR TITLE
refactor(dashboard): dedupe params in useFetchLayouts

### DIFF
--- a/apps/dashboard/src/hooks/use-fetch-layouts.tsx
+++ b/apps/dashboard/src/hooks/use-fetch-layouts.tsx
@@ -22,12 +22,14 @@ export const useFetchLayouts = ({
   refetchOnWindowFocus = true,
 }: UseLayoutsParams = {}) => {
   const { currentEnvironment } = useEnvironment();
+  const environmentId = currentEnvironment?._id;
+  const params = { limit, offset, query, orderBy, orderDirection };
 
   const layoutsQuery = useQuery({
-    queryKey: [QueryKeys.fetchLayouts, currentEnvironment?._id, { limit, offset, query, orderBy, orderDirection }],
-    queryFn: () => getLayouts({ environment: currentEnvironment!, limit, offset, query, orderBy, orderDirection }),
+    queryKey: [QueryKeys.fetchLayouts, environmentId, params],
+    queryFn: () => getLayouts({ environment: currentEnvironment!, ...params }),
     placeholderData: keepPreviousData,
-    enabled: !!currentEnvironment?._id,
+    enabled: !!environmentId,
     refetchOnWindowFocus,
   });
 


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request refactors the `useFetchLayouts` hook to improve readability and maintainability by extracting common parameters and simplifying the query configuration.

**Refactoring and code simplification:**

* Extracted `environmentId` and combined query parameters into a single `params` object for cleaner code and easier maintenance.
* Updated `queryKey` and `queryFn` in the `useQuery` call to use the new `environmentId` and `params` variables, reducing repetition and potential for errors.
* Changed the `enabled` flag to use the extracted `environmentId`, improving clarity.
