### PR TITLE
feat(providers): Sendgrid eu region support fixes NV-7028

### DIFF
--- a/libs/application-generic/src/factories/mail/handlers/sendgrid.handler.ts
+++ b/libs/application-generic/src/factories/mail/handlers/sendgrid.handler.ts
@@ -15,6 +15,7 @@ export class SendgridHandler extends BaseEmailHandler {
       senderName: credentials.senderName,
       ipPoolName: credentials.ipPoolName,
       webhookPublicKey: credentials.inboundWebhookSigningKey,
+      baseUrl: credentials.baseUrl,
     });
   }
 }

--- a/libs/application-generic/src/factories/mail/handlers/sendgrid.handler.ts
+++ b/libs/application-generic/src/factories/mail/handlers/sendgrid.handler.ts
@@ -15,7 +15,7 @@ export class SendgridHandler extends BaseEmailHandler {
       senderName: credentials.senderName,
       ipPoolName: credentials.ipPoolName,
       webhookPublicKey: credentials.inboundWebhookSigningKey,
-      baseUrl: credentials.baseUrl,
+      region: credentials.region,
     });
   }
 }

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
@@ -170,22 +170,25 @@ test('should override credentials with mail data', async () => {
   expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({ ipPoolName: 'ip_from_mail_data' }));
 });
 
-test('should set EU data residency when EU base url is provided', async () => {
-  const setDataResidencySpy = vi.spyOn(sgClient, 'setDataResidency');
+test('should set custom base url when provided', async () => {
+  const setDefaultRequestSpy = vi.spyOn(sgClient, 'setDefaultRequest');
 
   new SendgridEmailProvider({
     ...mockConfig,
-    baseUrl: 'https://api.eu.sendgrid.com',
+    baseUrl: 'https://api.eu.sendgrid.com/',
   });
 
-  expect(setDataResidencySpy).toHaveBeenCalledWith('eu');
+  expect(setDefaultRequestSpy).toHaveBeenCalledWith({ baseUrl: 'https://api.eu.sendgrid.com/' });
 });
 
-test('should not set data residency when base url is not provided', async () => {
-  const setDataResidencySpy = vi.spyOn(sgClient, 'setDataResidency');
-  setDataResidencySpy.mockClear();
+test('should not set custom base url when not provided', async () => {
+  const setDefaultRequestSpy = vi.spyOn(sgClient, 'setDefaultRequest');
+  setDefaultRequestSpy.mockClear();
 
   new SendgridEmailProvider(mockConfig);
 
-  expect(setDataResidencySpy).not.toHaveBeenCalled();
+  const customBaseUrlCall = setDefaultRequestSpy.mock.calls.find(
+    (call) => typeof call[0] === 'object' && 'baseUrl' in call[0]
+  );
+  expect(customBaseUrlCall).toBeUndefined();
 });

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
@@ -1,4 +1,4 @@
-import sgClient from '@sendgrid/client';
+import { Client } from '@sendgrid/client';
 import { MailService } from '@sendgrid/mail';
 import { expect, test, vi } from 'vitest';
 import { SendgridEmailProvider } from './sendgrid.provider';
@@ -171,7 +171,7 @@ test('should override credentials with mail data', async () => {
 });
 
 test('should set custom base url when provided', async () => {
-  const setDefaultRequestSpy = vi.spyOn(sgClient, 'setDefaultRequest');
+  const setDefaultRequestSpy = vi.spyOn(Client.prototype, 'setDefaultRequest');
 
   new SendgridEmailProvider({
     ...mockConfig,
@@ -182,7 +182,7 @@ test('should set custom base url when provided', async () => {
 });
 
 test('should not set custom base url when not provided', async () => {
-  const setDefaultRequestSpy = vi.spyOn(sgClient, 'setDefaultRequest');
+  const setDefaultRequestSpy = vi.spyOn(Client.prototype, 'setDefaultRequest');
   setDefaultRequestSpy.mockClear();
 
   new SendgridEmailProvider(mockConfig);

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
@@ -1,3 +1,4 @@
+import sgClient from '@sendgrid/client';
 import { MailService } from '@sendgrid/mail';
 import { expect, test, vi } from 'vitest';
 import { SendgridEmailProvider } from './sendgrid.provider';
@@ -167,4 +168,24 @@ test('should override credentials with mail data', async () => {
     ...{ ipPoolName: 'ip_from_mail_data' },
   });
   expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({ ipPoolName: 'ip_from_mail_data' }));
+});
+
+test('should set EU data residency when EU base url is provided', async () => {
+  const setDataResidencySpy = vi.spyOn(sgClient, 'setDataResidency');
+
+  new SendgridEmailProvider({
+    ...mockConfig,
+    baseUrl: 'https://api.eu.sendgrid.com',
+  });
+
+  expect(setDataResidencySpy).toHaveBeenCalledWith('eu');
+});
+
+test('should not set data residency when base url is not provided', async () => {
+  const setDataResidencySpy = vi.spyOn(sgClient, 'setDataResidency');
+  setDataResidencySpy.mockClear();
+
+  new SendgridEmailProvider(mockConfig);
+
+  expect(setDataResidencySpy).not.toHaveBeenCalled();
 });

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
@@ -170,25 +170,34 @@ test('should override credentials with mail data', async () => {
   expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({ ipPoolName: 'ip_from_mail_data' }));
 });
 
-test('should set custom base url when provided', async () => {
-  const setDefaultRequestSpy = vi.spyOn(Client.prototype, 'setDefaultRequest');
+test('should set EU data residency when region is eu', async () => {
+  const setDataResidencySpy = vi.spyOn(Client.prototype, 'setDataResidency');
 
   new SendgridEmailProvider({
     ...mockConfig,
-    baseUrl: 'https://api.eu.sendgrid.com/',
+    region: 'eu',
   });
 
-  expect(setDefaultRequestSpy).toHaveBeenCalledWith('baseUrl', 'https://api.eu.sendgrid.com/');
+  expect(setDataResidencySpy).toHaveBeenCalledWith('eu');
 });
 
-test('should not set custom base url when not provided', async () => {
-  const setDefaultRequestSpy = vi.spyOn(Client.prototype, 'setDefaultRequest');
-  setDefaultRequestSpy.mockClear();
+test('should not set data residency when region is global', async () => {
+  const setDataResidencySpy = vi.spyOn(Client.prototype, 'setDataResidency');
+  setDataResidencySpy.mockClear();
+
+  new SendgridEmailProvider({
+    ...mockConfig,
+    region: 'global',
+  });
+
+  expect(setDataResidencySpy).not.toHaveBeenCalled();
+});
+
+test('should not set data residency when region is not provided', async () => {
+  const setDataResidencySpy = vi.spyOn(Client.prototype, 'setDataResidency');
+  setDataResidencySpy.mockClear();
 
   new SendgridEmailProvider(mockConfig);
 
-  const customBaseUrlCall = setDefaultRequestSpy.mock.calls.find(
-    (call) => call[0] === 'baseUrl' && call[1]?.includes('eu.sendgrid')
-  );
-  expect(customBaseUrlCall).toBeUndefined();
+  expect(setDataResidencySpy).not.toHaveBeenCalled();
 });

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
@@ -178,7 +178,7 @@ test('should set custom base url when provided', async () => {
     baseUrl: 'https://api.eu.sendgrid.com/',
   });
 
-  expect(setDefaultRequestSpy).toHaveBeenCalledWith({ baseUrl: 'https://api.eu.sendgrid.com/' });
+  expect(setDefaultRequestSpy).toHaveBeenCalledWith('baseUrl', 'https://api.eu.sendgrid.com/');
 });
 
 test('should not set custom base url when not provided', async () => {
@@ -188,7 +188,7 @@ test('should not set custom base url when not provided', async () => {
   new SendgridEmailProvider(mockConfig);
 
   const customBaseUrlCall = setDefaultRequestSpy.mock.calls.find(
-    (call) => typeof call[0] === 'object' && 'baseUrl' in call[0]
+    (call) => call[0] === 'baseUrl' && call[1]?.includes('eu.sendgrid')
   );
   expect(customBaseUrlCall).toBeUndefined();
 });

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
@@ -32,14 +32,14 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
       senderName: string;
       ipPoolName?: string;
       webhookPublicKey?: string;
-      baseUrl?: string;
+      region?: string;
     }
   ) {
     super();
     this.client = new Client();
 
-    if (this.config.baseUrl) {
-      this.client.setDefaultRequest('baseUrl', this.config.baseUrl);
+    if (this.config.region === 'eu') {
+      this.client.setDataResidency('eu');
     }
 
     this.client.setApiKey(this.config.apiKey);

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
@@ -9,7 +9,7 @@ import {
   IEmailProvider,
   ISendMessageSuccessResponse,
 } from '@novu/stateless';
-import sgClient from '@sendgrid/client';
+import { Client } from '@sendgrid/client';
 // cspell:disable-next-line
 import { EventWebhook } from '@sendgrid/eventwebhook';
 import { MailDataRequired, MailService } from '@sendgrid/mail';
@@ -23,7 +23,7 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
   protected casing: CasingEnum = CasingEnum.CAMEL_CASE;
   channelType = ChannelTypeEnum.EMAIL as ChannelTypeEnum.EMAIL;
   private sendgridMail: MailService;
-  private sendgridClient: typeof sgClient;
+  private client: Client;
 
   constructor(
     private config: {
@@ -36,15 +36,16 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
     }
   ) {
     super();
-    this.sendgridMail = new MailService();
-    this.sendgridClient = sgClient;
+    this.client = new Client();
 
     if (this.config.baseUrl) {
-      this.sendgridClient.setDefaultRequest('baseUrl', this.config.baseUrl);
+      this.client.setDefaultRequest('baseUrl', this.config.baseUrl);
     }
 
-    this.sendgridClient.setApiKey(this.config.apiKey);
-    this.sendgridMail.setClient(this.sendgridClient);
+    this.client.setApiKey(this.config.apiKey);
+
+    this.sendgridMail = new MailService();
+    this.sendgridMail.setClient(this.client);
   }
 
   async sendMessage(
@@ -216,7 +217,7 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
   }> {
     try {
       // Step 1: Create a new Event Webhook
-      const [createResponse, createBody] = await this.sendgridClient.request({
+      const [createResponse, createBody] = await this.client.request({
         url: '/v3/user/webhooks/event/settings',
         method: 'POST' as const,
         body: {
@@ -243,7 +244,7 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
       const webhookId = createBody.id;
 
       // Step 2: Enable Signature Verification
-      const [enableSignatureResponse, enableSignatureBody] = await this.sendgridClient.request({
+      const [enableSignatureResponse, enableSignatureBody] = await this.client.request({
         url: `/v3/user/webhooks/event/settings/signed/${webhookId}`,
         method: 'PATCH' as const,
         body: {

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
@@ -32,13 +32,30 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
       senderName: string;
       ipPoolName?: string;
       webhookPublicKey?: string;
+      baseUrl?: string;
     }
   ) {
     super();
     this.sendgridMail = new MailService();
-    this.sendgridMail.setApiKey(this.config.apiKey);
     this.sendgridClient = sgClient;
+
+    const region = this.getRegionFromBaseUrl(this.config.baseUrl);
+    if (region) {
+      this.sendgridClient.setDataResidency(region);
+    }
+
     this.sendgridClient.setApiKey(this.config.apiKey);
+    this.sendgridMail.setClient(this.sendgridClient);
+  }
+
+  private getRegionFromBaseUrl(baseUrl?: string): string | null {
+    if (!baseUrl) return null;
+
+    if (baseUrl.includes('api.eu.sendgrid.com')) {
+      return 'eu';
+    }
+
+    return null;
   }
 
   async sendMessage(

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
@@ -39,23 +39,12 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
     this.sendgridMail = new MailService();
     this.sendgridClient = sgClient;
 
-    const region = this.getRegionFromBaseUrl(this.config.baseUrl);
-    if (region) {
-      this.sendgridClient.setDataResidency(region);
+    if (this.config.baseUrl) {
+      this.sendgridClient.setDefaultRequest({ baseUrl: this.config.baseUrl });
     }
 
     this.sendgridClient.setApiKey(this.config.apiKey);
     this.sendgridMail.setClient(this.sendgridClient);
-  }
-
-  private getRegionFromBaseUrl(baseUrl?: string): string | null {
-    if (!baseUrl) return null;
-
-    if (baseUrl.includes('api.eu.sendgrid.com')) {
-      return 'eu';
-    }
-
-    return null;
   }
 
   async sendMessage(

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
@@ -40,7 +40,7 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
     this.sendgridClient = sgClient;
 
     if (this.config.baseUrl) {
-      this.sendgridClient.setDefaultRequest({ baseUrl: this.config.baseUrl });
+      this.sendgridClient.setDefaultRequest('baseUrl', this.config.baseUrl);
     }
 
     this.sendgridClient.setApiKey(this.config.apiKey);

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -202,6 +202,13 @@ export const sendgridConfig: IConfigCredential[] = [
     required: true,
   },
   {
+    key: CredentialsKeyEnum.BaseUrl,
+    displayName: 'Base URL',
+    description: 'Use https://api.eu.sendgrid.com for EU region accounts',
+    type: 'string',
+    required: false,
+  },
+  {
     key: CredentialsKeyEnum.IpPoolName,
     displayName: 'IP Pool Name',
     type: 'string',

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -202,11 +202,16 @@ export const sendgridConfig: IConfigCredential[] = [
     required: true,
   },
   {
-    key: CredentialsKeyEnum.BaseUrl,
-    displayName: 'Base URL',
-    description: 'Use https://api.eu.sendgrid.com for EU region accounts',
-    type: 'string',
+    key: CredentialsKeyEnum.Region,
+    displayName: 'Region',
+    description: 'Select EU if your SendGrid account is hosted in the EU data center',
+    type: 'dropdown',
     required: false,
+    value: 'global',
+    dropdown: [
+      { name: 'Global (US)', value: 'global' },
+      { name: 'EU', value: 'eu' },
+    ],
   },
   {
     key: CredentialsKeyEnum.IpPoolName,


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR adds support for SendGrid's EU data residency. Users can now specify a "Base URL" in the SendGrid provider configuration. If `https://api.eu.sendgrid.com` is provided, the SendGrid SDK will be configured to use the EU region via `setDataResidency('eu')`. If no base URL is provided, it defaults to the US region.

This change was needed to allow users with SendGrid EU region accounts to properly integrate with the platform, ensuring compliance with data residency requirements.

### Screenshots

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1767799532177929?thread_ts=1767799532.177929&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-3c8c2a6d-e2c3-45bd-ae13-5b1aad4b0ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c8c2a6d-e2c3-45bd-ae13-5b1aad4b0ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

