### PR TITLE
feat(worker): Subscriber job bound lru cache

### DIFF
--- a/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
@@ -86,6 +86,7 @@ export class SubscriberJobBound {
           _id: templateId,
           environmentId,
           organizationId,
+          source: command.payload?.__source,
         });
 
     if (!template) {
@@ -285,10 +286,12 @@ export class SubscriberJobBound {
     _id,
     environmentId,
     organizationId,
+    source,
   }: {
     _id: string;
     environmentId: string;
     organizationId: string;
+    source?: string;
   }): Promise<NotificationTemplateEntity | null> {
     const cacheKey = `${environmentId}:${_id}`;
 
@@ -300,7 +303,9 @@ export class SubscriberJobBound {
       component: 'worker-workflow',
     });
 
-    if (isFeatureFlagEnabled) {
+    const isCacheEnabled = isFeatureFlagEnabled && !source;
+
+    if (isCacheEnabled) {
       const cached = workflowCache.get(cacheKey);
       if (cached) {
         return cached;
@@ -315,19 +320,19 @@ export class SubscriberJobBound {
     const fetchPromise = this.notificationTemplateRepository
       .findById(_id, environmentId)
       .then((workflow) => {
-        if (workflow && isFeatureFlagEnabled) {
+        if (workflow && isCacheEnabled) {
           workflowCache.set(cacheKey, workflow);
         }
 
         return workflow;
       })
       .finally(() => {
-        if (isFeatureFlagEnabled) {
+        if (isCacheEnabled) {
           workflowInflightRequests.delete(cacheKey);
         }
       });
 
-    if (isFeatureFlagEnabled) {
+    if (isCacheEnabled) {
       workflowInflightRequests.set(cacheKey, fetchPromise);
     }
 

--- a/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
@@ -6,6 +6,7 @@ import {
   CreateNotificationJobsCommand,
   CreateOrUpdateSubscriberCommand,
   CreateOrUpdateSubscriberUseCase,
+  FeatureFlagsService,
   GetPreferences,
   GetPreferencesCommand,
   Instrument,
@@ -19,6 +20,7 @@ import { IntegrationRepository, NotificationTemplateEntity, NotificationTemplate
 import {
   buildWorkflowPreferences,
   ChannelTypeEnum,
+  FeatureFlagsKeysEnum,
   InAppProviderIdEnum,
   ISubscribersDefine,
   ProvidersIdEnum,
@@ -26,10 +28,18 @@ import {
   SeverityLevelEnum,
   STEP_TYPE_TO_CHANNEL_TYPE,
 } from '@novu/shared';
+import { LRUCache } from 'lru-cache';
 import { StoreSubscriberJobs, StoreSubscriberJobsCommand } from '../store-subscriber-jobs';
 import { SubscriberJobBoundCommand } from './subscriber-job-bound.command';
 
 const LOG_CONTEXT = 'SubscriberJobBoundUseCase';
+
+const workflowCache = new LRUCache<string, NotificationTemplateEntity>({
+  max: 1000,
+  ttl: 1000 * 30,
+});
+
+const workflowInflightRequests = new Map<string, Promise<NotificationTemplateEntity | null>>();
 
 @Injectable()
 export class SubscriberJobBound {
@@ -42,7 +52,8 @@ export class SubscriberJobBound {
     private logger: PinoLogger,
     private analyticsService: AnalyticsService,
     private traceLogRepository: TraceLogRepository,
-    private getPreferences: GetPreferences
+    private getPreferences: GetPreferences,
+    private featureFlagsService: FeatureFlagsService
   ) {}
 
   @InstrumentUsecase()
@@ -74,6 +85,7 @@ export class SubscriberJobBound {
       : await this.getWorkflow({
           _id: templateId,
           environmentId,
+          organizationId,
         });
 
     if (!template) {
@@ -268,8 +280,58 @@ export class SubscriberJobBound {
     return true;
   }
 
-  private async getWorkflow({ _id, environmentId }: { _id: string; environmentId: string }) {
-    return await this.notificationTemplateRepository.findById(_id, environmentId);
+  @Instrument()
+  private async getWorkflow({
+    _id,
+    environmentId,
+    organizationId,
+  }: {
+    _id: string;
+    environmentId: string;
+    organizationId: string;
+  }): Promise<NotificationTemplateEntity | null> {
+    const cacheKey = `${environmentId}:${_id}`;
+
+    const isFeatureFlagEnabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_LRU_CACHE_ENABLED,
+      defaultValue: false,
+      environment: { _id: environmentId },
+      organization: { _id: organizationId },
+      component: 'worker-workflow',
+    });
+
+    if (isFeatureFlagEnabled) {
+      const cached = workflowCache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const inflightRequest = workflowInflightRequests.get(cacheKey);
+      if (inflightRequest) {
+        return inflightRequest;
+      }
+    }
+
+    const fetchPromise = this.notificationTemplateRepository
+      .findById(_id, environmentId)
+      .then((workflow) => {
+        if (workflow && isFeatureFlagEnabled) {
+          workflowCache.set(cacheKey, workflow);
+        }
+
+        return workflow;
+      })
+      .finally(() => {
+        if (isFeatureFlagEnabled) {
+          workflowInflightRequests.delete(cacheKey);
+        }
+      });
+
+    if (isFeatureFlagEnabled) {
+      workflowInflightRequests.set(cacheKey, fetchPromise);
+    }
+
+    return fetchPromise;
   }
 
   @InstrumentUsecase()


### PR DESCRIPTION
### What changed? Why was the change needed?

Implemented an LRU cache for fetching non-code-based workflows within `SubscriberJobBoundUseCase`. This change introduces caching for `getWorkflow` to reduce database load and improve performance for frequently accessed workflows, aligning with the caching mechanism recently added to `run-job.usecase.ts`.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

The LRU cache functionality is gated by the `IS_LRU_CACHE_ENABLED` feature flag, specifically for the `worker-workflow` component.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1767955357688459?thread_ts=1767955357.688459&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-ea531425-b3bd-4584-a730-a2603b1e78f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ea531425-b3bd-4584-a730-a2603b1e78f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

