### PR TITLE
feat(worker): Job queue environment cache

### DIFF
--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
@@ -6,12 +6,14 @@ import {
   dashboardSanitizeControlValues,
   ExecuteBridgeRequest,
   ExecuteBridgeRequestCommand,
+  FeatureFlagsService,
   Instrument,
   InstrumentUsecase,
   PinoLogger,
 } from '@novu/application-generic';
 import {
   ControlValuesRepository,
+  EnvironmentEntity,
   EnvironmentRepository,
   JobEntity,
   JobRepository,
@@ -33,12 +35,23 @@ import {
   ControlValuesLevelEnum,
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
+  FeatureFlagsKeysEnum,
   ITriggerPayload,
   JobStatusEnum,
   ResourceOriginEnum,
   ResourceTypeEnum,
 } from '@novu/shared';
+import { LRUCache } from 'lru-cache';
 import { ExecuteBridgeJobCommand } from './execute-bridge-job.command';
+
+type EnvironmentCacheData = Pick<EnvironmentEntity, '_id' | 'echo' | 'apiKeys'>;
+
+const environmentCache = new LRUCache<string, EnvironmentCacheData>({
+  max: 500,
+  ttl: 1000 * 60,
+});
+
+const environmentInflightRequests = new Map<string, Promise<EnvironmentCacheData | null>>();
 
 @Injectable()
 export class ExecuteBridgeJob {
@@ -50,7 +63,8 @@ export class ExecuteBridgeJob {
     private controlValuesRepository: ControlValuesRepository,
     private createExecutionDetails: CreateExecutionDetails,
     private executeBridgeRequest: ExecuteBridgeRequest,
-    private logger: PinoLogger
+    private logger: PinoLogger,
+    private featureFlagsService: FeatureFlagsService
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -90,13 +104,7 @@ export class ExecuteBridgeJob {
       throw new Error('Step id is not set');
     }
 
-    const environment = await this.environmentRepository.findOne(
-      {
-        _id: command.environmentId,
-        _organizationId: command.organizationId,
-      },
-      'echo apiKeys _id'
-    );
+    const environment = await this.getEnvironment(command.environmentId, command.organizationId);
 
     if (!environment) {
       throw new Error(`Environment id ${command.environmentId} is not found`);
@@ -333,5 +341,60 @@ export class ExecuteBridgeJob {
         error: job?.error,
       },
     };
+  }
+
+  @Instrument()
+  private async getEnvironment(
+    environmentId: string,
+    organizationId: string
+  ): Promise<EnvironmentCacheData | null> {
+    const cacheKey = `${organizationId}:${environmentId}`;
+
+    const isFeatureFlagEnabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_LRU_CACHE_ENABLED,
+      defaultValue: false,
+      environment: { _id: environmentId },
+      organization: { _id: organizationId },
+      component: 'worker-environment',
+    });
+
+    if (isFeatureFlagEnabled) {
+      const cached = environmentCache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const inflightRequest = environmentInflightRequests.get(cacheKey);
+      if (inflightRequest) {
+        return inflightRequest;
+      }
+    }
+
+    const fetchPromise = this.environmentRepository
+      .findOne(
+        {
+          _id: environmentId,
+          _organizationId: organizationId,
+        },
+        'echo apiKeys _id'
+      )
+      .then((environment) => {
+        if (environment && isFeatureFlagEnabled) {
+          environmentCache.set(cacheKey, environment);
+        }
+
+        return environment;
+      })
+      .finally(() => {
+        if (isFeatureFlagEnabled) {
+          environmentInflightRequests.delete(cacheKey);
+        }
+      });
+
+    if (isFeatureFlagEnabled) {
+      environmentInflightRequests.set(cacheKey, fetchPromise);
+    }
+
+    return fetchPromise;
   }
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

Introduced an LRU cache for fetching environment data from MongoDB within the `execute-bridge-job` use case in the worker. This change reduces database load and improves performance by caching frequently accessed environments, mirroring existing caching patterns for workflows.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

The cache has a 60-second TTL and a maximum size of 500 items. It is enabled via the `IS_LRU_CACHE_ENABLED` feature flag, specifically for the `worker-environment` component. The implementation pattern, including handling inflight requests, is consistent with existing LRU cache usage in the codebase.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1767968791734299?thread_ts=1767968791.734299&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-c8b8127a-949e-4c17-8cb7-04ce3573862c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8b8127a-949e-4c17-8cb7-04ce3573862c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

