### PR TITLE
fix(api-service): Workflow schema duplication fixes NV-7040

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/duplicate-workflow/duplicate-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/duplicate-workflow/duplicate-workflow.usecase.ts
@@ -81,6 +81,9 @@ export class DuplicateWorkflowUseCase {
       steps: this.mapStepsToDuplicate(originWorkflow.steps),
       preferences: this.mapPreferences(preferences),
       isTranslationEnabled: overrides.isTranslationEnabled ?? originWorkflow.isTranslationEnabled,
+      payloadSchema: originWorkflow.payloadSchema || null,
+      validatePayload: originWorkflow.validatePayload,
+      severity: originWorkflow.severity,
     };
   }
 

--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -787,6 +787,37 @@ describe('Workflow Controller E2E API Testing #novu-v2', () => {
       expect(res.error!.message).to.contain('Workflow');
       expect(res.error!.ctx?.workflowId).to.contain('123');
     });
+
+    it('should duplicate a workflow with payloadSchema, validatePayload, and severity', async () => {
+      const payloadSchema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          email: { type: 'string' },
+        },
+        required: ['name'],
+      };
+      const createWorkflowDto: CreateWorkflowDto = buildWorkflow({
+        name: 'Test Workflow with Schema',
+        payloadSchema,
+        validatePayload: true,
+      });
+      const workflowCreated = await createWorkflow(apiClient, createWorkflowDto);
+
+      const duplicatedWorkflow = (
+        await apiClient.workflows.duplicate(
+          {
+            name: 'Duplicated Workflow with Schema',
+          },
+          workflowCreated.id
+        )
+      ).result;
+
+      expect(duplicatedWorkflow?.id).to.not.equal(workflowCreated.id);
+      expect(duplicatedWorkflow?.payloadSchema).to.deep.equal(payloadSchema);
+      expect(duplicatedWorkflow?.validatePayload).to.equal(true);
+      expect(duplicatedWorkflow?.severity).to.equal(workflowCreated.severity);
+    });
   });
 
   describe('Get step data', () => {


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves [NV-7040](https://linear.app/novu/issue/NV-7040), where the workflow schema (`payloadSchema`, `validatePayload`, and `severity`) was not being duplicated when a workflow was copied.

The `duplicate-workflow.usecase.ts` has been updated to include these missing fields during the duplication process. A new e2e test case has also been added to `workflow.controller.e2e.ts` to ensure the correct duplication of these properties.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

The approach for duplicating these fields aligns with the existing logic in `sync-to-environment.usecase.ts`.

</details>

---
Linear Issue: [NV-7040](https://linear.app/novu/issue/NV-7040/workflow-schema-not-duplicated-when-duplicating-workflow)

<a href="https://cursor.com/background-agent?bcId=bc-9c1a882c-383c-4dc7-a98f-29c2709acbe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c1a882c-383c-4dc7-a98f-29c2709acbe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

