### PR TITLE
feat(dashboard): Add lookback window option to digest delay tabs fixes NV-7002

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/digest-delay-tabs/digest-delay-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/digest-delay-tabs/digest-delay-tabs.tsx
@@ -142,7 +142,7 @@ export const DigestDelayTabs = ({ isDigest = true }: { isDigest?: boolean }) => 
               <RegularType isReadOnly={isReadOnly} isDigest={isDigest} />
               {isDigest && (
                 <>
-                  <Separator className="my-2" />
+                  <Separator className="my-2 stroke-stroke-weak" />
                   <LookbackWindow isReadOnly={isReadOnly} />
                 </>
               )}

--- a/apps/dashboard/src/components/workflow-editor/steps/digest-delay-tabs/digest-delay-tabs.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/digest-delay-tabs/digest-delay-tabs.tsx
@@ -8,6 +8,7 @@ import { Separator } from '@/components/primitives/separator';
 import { TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { AMOUNT_KEY, CRON_KEY, TYPE_KEY, UNIT_KEY } from '@/components/workflow-editor/steps/digest-delay-tabs/keys';
+import { LookbackWindow } from '@/components/workflow-editor/steps/digest-delay-tabs/lookback-window';
 import { RegularType } from '@/components/workflow-editor/steps/digest-delay-tabs/regular-type';
 import { ScheduledType } from '@/components/workflow-editor/steps/digest-delay-tabs/scheduled-type';
 import { EVERY_MINUTE_CRON } from '@/components/workflow-editor/steps/digest-delay-tabs/utils';
@@ -136,11 +137,17 @@ export const DigestDelayTabs = ({ isDigest = true }: { isDigest?: boolean }) => 
             </TabsList>
           </div>
           <Separator className="before:bg-neutral-100" />
-          <div className="bg-background rounded-b-lg p-2">
-            <TabsContent value={REGULAR_TYPE}>
+          <div className="bg-background flex flex-col gap-2 rounded-b-lg p-2">
+            <TabsContent value={REGULAR_TYPE} className="m-0">
               <RegularType isReadOnly={isReadOnly} isDigest={isDigest} />
+              {isDigest && (
+                <>
+                  <Separator className="my-2" />
+                  <LookbackWindow isReadOnly={isReadOnly} />
+                </>
+              )}
             </TabsContent>
-            <TabsContent value={SCHEDULED_TYPE}>
+            <TabsContent value={SCHEDULED_TYPE} className="m-0">
               <FormField
                 control={control}
                 name={CRON_KEY}

--- a/apps/dashboard/src/components/workflow-editor/steps/digest-delay-tabs/keys.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/digest-delay-tabs/keys.ts
@@ -2,3 +2,5 @@ export const AMOUNT_KEY = 'controlValues.amount';
 export const UNIT_KEY = 'controlValues.unit';
 export const CRON_KEY = 'controlValues.cron';
 export const TYPE_KEY = 'controlValues.type';
+export const LOOKBACK_AMOUNT_KEY = 'controlValues.lookBackWindow.amount';
+export const LOOKBACK_UNIT_KEY = 'controlValues.lookBackWindow.unit';

--- a/apps/dashboard/src/components/workflow-editor/steps/digest-delay-tabs/lookback-window.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/digest-delay-tabs/lookback-window.tsx
@@ -1,0 +1,118 @@
+import { TimeUnitEnum } from '@novu/shared';
+import { useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { AmountInput } from '@/components/amount-input';
+import { FormControl, FormField, FormItem, FormLabel } from '@/components/primitives/form/form';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/primitives/select';
+import { LOOKBACK_AMOUNT_KEY, LOOKBACK_UNIT_KEY } from '@/components/workflow-editor/steps/digest-delay-tabs/keys';
+import { useSaveForm } from '@/components/workflow-editor/steps/save-form-context';
+import { TIME_UNIT_OPTIONS } from '@/components/workflow-editor/steps/time-units';
+
+type LookbackType = 'immediately' | '5min' | '30min' | 'custom';
+
+const LOOKBACK_OPTIONS = [
+  { label: 'Immediately', value: 'immediately' },
+  { label: 'When events repeat within 5 minutes', value: '5min' },
+  { label: 'When events repeat within 30 minutes', value: '30min' },
+  { label: 'Custom', value: 'custom' },
+];
+
+function deriveLookbackType(lookBackWindow?: { amount?: number; unit?: string }): LookbackType {
+  if (!lookBackWindow?.amount || !lookBackWindow?.unit) {
+    return 'immediately';
+  }
+
+  if (lookBackWindow.amount === 5 && lookBackWindow.unit === TimeUnitEnum.MINUTES) {
+    return '5min';
+  }
+
+  if (lookBackWindow.amount === 30 && lookBackWindow.unit === TimeUnitEnum.MINUTES) {
+    return '30min';
+  }
+
+  return 'custom';
+}
+
+export const LookbackWindow = ({ isReadOnly }: { isReadOnly: boolean }) => {
+  const { control, setValue, getValues, trigger, watch } = useFormContext();
+  const { saveForm } = useSaveForm();
+
+  const lookBackWindowWatch = watch('controlValues.lookBackWindow');
+
+  const lookbackType = useMemo(() => {
+    return deriveLookbackType(lookBackWindowWatch);
+  }, [lookBackWindowWatch]);
+
+  const handleLookbackTypeChange = async (value: LookbackType) => {
+    if (value === 'immediately') {
+      setValue('controlValues.lookBackWindow', undefined, { shouldDirty: true });
+    } else if (value === '5min') {
+      setValue(LOOKBACK_AMOUNT_KEY, 5, { shouldDirty: true });
+      setValue(LOOKBACK_UNIT_KEY, TimeUnitEnum.MINUTES, { shouldDirty: true });
+    } else if (value === '30min') {
+      setValue(LOOKBACK_AMOUNT_KEY, 30, { shouldDirty: true });
+      setValue(LOOKBACK_UNIT_KEY, TimeUnitEnum.MINUTES, { shouldDirty: true });
+    } else if (value === 'custom') {
+      const currentAmount = getValues(LOOKBACK_AMOUNT_KEY);
+      const currentUnit = getValues(LOOKBACK_UNIT_KEY);
+
+      if (!currentAmount || !currentUnit || currentAmount === 5 || currentAmount === 30) {
+        setValue(LOOKBACK_AMOUNT_KEY, 10, { shouldDirty: true });
+        setValue(LOOKBACK_UNIT_KEY, TimeUnitEnum.MINUTES, { shouldDirty: true });
+      }
+    }
+
+    await trigger(['controlValues.lookBackWindow']);
+    saveForm();
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <FormLabel
+        tooltip="Immediately: Start collecting events right away. Time window: Check if a notification was sent recently, if yes, start a digest; if no, deliver immediately."
+        className="text-text-sub"
+      >
+        Start digest
+      </FormLabel>
+      <FormField
+        control={control}
+        name="lookbackType"
+        render={() => (
+          <FormItem>
+            <FormControl>
+              <Select value={lookbackType} onValueChange={handleLookbackTypeChange} disabled={isReadOnly}>
+                <SelectTrigger className="w-full" size="2xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {LOOKBACK_OPTIONS.map(({ label, value }) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FormControl>
+          </FormItem>
+        )}
+      />
+      {lookbackType === 'custom' && (
+        <div className="flex items-center justify-between">
+          <span className="text-foreground-600 text-xs font-medium">When events repeat within</span>
+          <AmountInput
+            fields={{ inputKey: LOOKBACK_AMOUNT_KEY, selectKey: LOOKBACK_UNIT_KEY }}
+            options={TIME_UNIT_OPTIONS}
+            defaultOption={TimeUnitEnum.MINUTES}
+            className="w-min [&_input]:!w-[5ch] [&_input]:!min-w-[5ch]"
+            onValueChange={() => saveForm()}
+            showError={false}
+            min={1}
+            dataTestId="lookback-window-amount-input"
+            isReadOnly={isReadOnly}
+          />
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
Introduces a LookbackWindow component for digest steps, allowing users to configure when to start collecting events (immediately, 5min, 30min, or custom). Updates keys.ts with new lookback keys and integrates the component into digest-delay-tabs.tsx for improved workflow flexibility.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
