### PR TITLE
chore(dashboard,js): novu branding in the console

### DIFF
--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -60,10 +60,12 @@ import { VercelIntegrationPage } from './pages/vercel-integration-page';
 import { AuthRoute, CatchAllRoute, DashboardRoute, RootRoute } from './routes';
 import { OnboardingParentRoute } from './routes/onboarding';
 import { ProtectedRoute } from './routes/protected-route';
+import { renderNovuBrandingInConsole } from './utils/novu-branding';
 import { ROUTES } from './utils/routes';
 import { initializeSentry } from './utils/sentry';
 import { overrideZodErrorMap } from './utils/validation';
 
+renderNovuBrandingInConsole();
 initializeSentry();
 overrideZodErrorMap();
 

--- a/apps/dashboard/src/utils/novu-branding.ts
+++ b/apps/dashboard/src/utils/novu-branding.ts
@@ -1,0 +1,28 @@
+export const renderNovuBrandingInConsole = () => {
+  const logo = `
+              @@@@@@@@@@@@@        
+      @@@       @@@@@@@@@@@        
+    @@@@@@@@       @@@@@@@@        
+  @@@@@@@@@@@@       @@@@@@     @@ 
+ @@@@@@@@@@@@@@@@      @@@@     @@@
+@@@@@@@@@@@@@@@@@@@       @     @@@
+@@@@@         @@@@@@@@         @@@@
+ @@@     @       @@@@@@@@@@@@@@@@@@
+ @@@     @@@@      @@@@@@@@@@@@@@@@
+  @@     @@@@@@       @@@@@@@@@@@@ 
+         @@@@@@@@       @@@@@@@@   
+         @@@@@@@@@@@       @@@     
+         @@@@@@@@@@@@@                  
+        `;
+
+  console.log(`%c${logo}`, `font-size: 8px;`);
+
+  console.log(
+    '%cWelcome to Novu Dashboard! 🚀\nCheck out our documentation at https://docs.novu.co',
+    `
+    font-size: 16px;
+    font-family: Inter, system-ui, sans-serif;
+    font-weight: 700;
+    `
+  );
+};

--- a/packages/js/src/session/session.ts
+++ b/packages/js/src/session/session.ts
@@ -1,7 +1,10 @@
 import type { InboxService } from '../api';
 import { NovuEventEmitter } from '../event-emitter';
 import { isBrowser } from '../utils/is-browser';
+import { renderNovuBrandingInConsole } from '../utils/novu-branding';
 import { InitializeSessionArgs } from './types';
+
+let wasSessionInitialized = false;
 
 export class Session {
   #emitter: NovuEventEmitter;
@@ -121,6 +124,11 @@ export class Session {
       if (!response?.applicationIdentifier?.startsWith('pk_keyless_')) {
         this.handleApplicationIdentifier('delete');
       }
+
+      if (!wasSessionInitialized && !response.removeNovuBranding) {
+        renderNovuBrandingInConsole();
+      }
+      wasSessionInitialized = true;
 
       this.#emitter.emit('session.initialize.resolved', { args: this.#options, data: response });
     } catch (error) {

--- a/packages/js/src/utils/novu-branding.ts
+++ b/packages/js/src/utils/novu-branding.ts
@@ -1,0 +1,28 @@
+export const renderNovuBrandingInConsole = () => {
+  const logo = `
+              @@@@@@@@@@@@@        
+      @@@       @@@@@@@@@@@        
+    @@@@@@@@       @@@@@@@@        
+  @@@@@@@@@@@@       @@@@@@     @@ 
+ @@@@@@@@@@@@@@@@      @@@@     @@@
+@@@@@@@@@@@@@@@@@@@       @     @@@
+@@@@@         @@@@@@@@         @@@@
+ @@@     @       @@@@@@@@@@@@@@@@@@
+ @@@     @@@@      @@@@@@@@@@@@@@@@
+  @@     @@@@@@       @@@@@@@@@@@@ 
+         @@@@@@@@       @@@@@@@@   
+         @@@@@@@@@@@       @@@     
+         @@@@@@@@@@@@@                  
+        `;
+
+  console.log(`%c${logo}`, `font-size: 8px;`);
+
+  console.log(
+    '%cThe Inbox is powered by Novu! 🔔\nhttps://novu.co',
+    `
+    font-size: 16px;
+    font-family: Inter, system-ui, sans-serif;
+    font-weight: 700;
+    `
+  );
+};


### PR DESCRIPTION
### What changed? Why was the change needed?

Added Novu branding information to the console in the Dashboard and Inbox code. It will always be rendered once.

### Screenshots
<img width="709" height="311" alt="Screenshot 2026-01-15 at 11 33 11" src="https://github.com/user-attachments/assets/a83950f5-fb9b-401d-b81e-412a9d497d71" />
<img width="689" height="314" alt="Screenshot 2026-01-15 at 11 33 24" src="https://github.com/user-attachments/assets/aff2803d-172a-43dd-90ee-7a003eb4924a" />


https://github.com/user-attachments/assets/a5273710-858a-4914-ad1f-ae82eee2b05b


