### PR TITLE
refactor(api-service): Email block default font fixes NV-7055

### DIFF
--- a/libs/maily-render/src/maily.tsx
+++ b/libs/maily-render/src/maily.tsx
@@ -10,7 +10,6 @@ import {
   Button,
   Column,
   Container,
-  Font,
   Head,
   Heading,
   Hr,
@@ -550,16 +549,6 @@ export class Maily {
     ) : (
       <Html {...htmlProps}>
         <Head>
-          <Font
-            fallbackFontFamily={['system-ui', 'sans-serif'] as any}
-            fontFamily="Inter"
-            fontStyle="normal"
-            fontWeight={400}
-            webFont={{
-              url: 'https://rsms.me/inter/font-files/Inter-Regular.woff2?v=3.19',
-              format: 'woff2',
-            }}
-          />
           <style
             dangerouslySetInnerHTML={{
               __html: `blockquote,h1,h2,h3,img,li,ol,p,ul{margin-top:0;margin-bottom:0}@media only screen and (max-width:425px){.tab-row-full{width:100%!important}.tab-col-full{display:block!important;width:100%!important}.tab-pad{padding:0!important}}`,


### PR DESCRIPTION
### What changed? Why was the change needed?

Removed the explicit loading of the 'Inter' font via an external URL (`https://rsms.me/inter/font-files/Inter-Regular.woff2?v=3.19`) in block-based email content. This was done to address customer concerns (NV-7055) about suspicious external URLs in email HTML, which could potentially flag emails as insecure. Emails will now rely on system default fonts.

*   **Linear Ticket:** [NV-7055](https://linear.app/novu/issue/NV-7055/review-removing-default-font-family-in-email-blocks)

### Screenshots

N/A (No visual changes, font will default to system fonts)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer
The change removes the `<Font>` component from `@react-email/components` which was responsible for injecting the `rsms.me/inter` font URL. This should result in emails using the default sans-serif font of the recipient's email client. All `maily-render` tests passed after this change.
</details>

---
Linear Issue: [NV-7055](https://linear.app/novu/issue/NV-7055/review-removing-default-font-family-in-email-blocks)

<a href="https://cursor.com/background-agent?bcId=bc-a9b203f3-db1e-4b81-8983-7bd11b1fdecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9b203f3-db1e-4b81-8983-7bd11b1fdecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

