### PR TITLE
fix(js): Inbox requestLock error when not available fixes NV-7033

### DIFF
--- a/packages/js/src/ui/helpers/browser.ts
+++ b/packages/js/src/ui/helpers/browser.ts
@@ -1,4 +1,10 @@
 export function requestLock(id: string, cb: (id: string) => void) {
+  if (typeof navigator === 'undefined' || !('locks' in navigator) || !navigator.locks) {
+    cb(id);
+
+    return () => {};
+  }
+
   let isFulfilled = false;
   let promiseResolve: () => void;
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixed a `TypeError: Cannot read properties of undefined (reading 'request')` that occurred in the `requestLock` function during Inbox component mount. This error happened when `navigator` or `navigator.locks` was unavailable (e.g., during SSR or in environments without Web Locks API support).

The change adds a guard to `packages/js/src/ui/helpers/browser.ts` to check for `navigator.locks` availability before attempting to use it. If unavailable, the callback is immediately invoked, preventing the crash.

Relevant Linear ticket: [NV-7033](https://linear.app/novu/issue/NV-7033)

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

The fallback behavior (immediately invoking the callback) aligns with the logic found in `packages/react/src/utils/requestLock.ts` for similar scenarios.

</details>

---
Linear Issue: [NV-7033](https://linear.app/novu/issue/NV-7033/bug-report-typeerror-cannot-read-properties-of-undefined-reading)

<a href="https://cursor.com/background-agent?bcId=bc-1c80184e-f3e4-4431-ad00-d17146f91083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c80184e-f3e4-4431-ad00-d17146f91083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


Fixes: #9823