### PR TITLE
fix(dashboard): DialogTitle requirement error dashboard fixes NV-7062

### DIFF
--- a/apps/dashboard/src/components/header-navigation/no-changes-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/no-changes-modal.tsx
@@ -1,6 +1,7 @@
 import type { IEnvironment } from '@novu/shared';
 import { Button } from '../primitives/button';
-import { Dialog, DialogContent } from '../primitives/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../primitives/dialog';
+import { VisuallyHidden } from '../primitives/visually-hidden';
 
 type NoChangesModalProps = {
   isOpen: boolean;
@@ -12,6 +13,12 @@ export function NoChangesModal({ isOpen, onClose }: NoChangesModalProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-md gap-4 p-3">
+        <VisuallyHidden>
+          <DialogTitle>No changes to publish</DialogTitle>
+          <DialogDescription>
+            There are no workflows or layouts pending for publishing right now.
+          </DialogDescription>
+        </VisuallyHidden>
         <div className="flex items-start justify-start">
           <svg width="116" height="44" viewBox="0 0 116 44" fill="none" xmlns="http://www.w3.org/2000/svg">
             <rect x="0.5" y="0.5" width="115" height="43" rx="7.5" stroke="#E1E4EA" strokeDasharray="5 3" />

--- a/apps/dashboard/src/components/header-navigation/publish-success-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-success-modal.tsx
@@ -3,7 +3,8 @@ import { RiArrowRightSLine, RiCheckboxCircleFill, RiCloseFill } from 'react-icon
 import type { IEnvironmentPublishResponse } from '@/api/environments';
 import { useEnvironment } from '@/context/environment/hooks';
 import { Button } from '../primitives/button';
-import { Dialog, DialogClose, DialogContent } from '../primitives/dialog';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from '../primitives/dialog';
+import { VisuallyHidden } from '../primitives/visually-hidden';
 
 type PublishSuccessModalProps = {
   isOpen: boolean;
@@ -52,6 +53,12 @@ export function PublishSuccessModal({
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-sm gap-4 p-4">
+        <VisuallyHidden>
+          <DialogTitle>Environment Published to {environment?.name}</DialogTitle>
+          <DialogDescription>
+            {buildSummaryText()} have been published to {environment?.name}.
+          </DialogDescription>
+        </VisuallyHidden>
         <div className="flex items-start justify-between">
           <div className="bg-success-lighter rounded-full p-2">
             <RiCheckboxCircleFill className="text-success-base size-6" />

--- a/apps/dashboard/src/components/primitives/command.tsx
+++ b/apps/dashboard/src/components/primitives/command.tsx
@@ -2,7 +2,8 @@ import { type DialogProps } from '@radix-ui/react-dialog';
 import { Command as CommandPrimitive } from 'cmdk';
 import * as React from 'react';
 
-import { Dialog, DialogContent } from '@/components/primitives/dialog';
+import { Dialog, DialogContent, DialogTitle } from '@/components/primitives/dialog';
+import { VisuallyHidden } from '@/components/primitives/visually-hidden';
 import { InputRoot, InputWrapper } from '@/components/primitives/input';
 import { cn } from '@/utils/ui';
 
@@ -27,6 +28,9 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0">
+        <VisuallyHidden>
+          <DialogTitle>Command</DialogTitle>
+        </VisuallyHidden>
         <Command className="**:[[cmdk-group-heading]]:text-foreground-400 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 **:[[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 **:[[cmdk-input]]:h-12 **:[[cmdk-item]]:px-2 **:[[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves the accessibility issue (NV-7062) where several `DialogContent` components were missing a `DialogTitle`, which is required for screen reader users.

To address this, `DialogTitle` (and `DialogDescription` where appropriate) components have been added and wrapped with `VisuallyHidden`. This ensures that the dialogs are properly announced to screen readers while maintaining the existing visual design, following Radix UI's recommendations.

### Screenshots

N/A - These changes are not visual.

---
Linear Issue: [NV-7062](https://linear.app/novu/issue/NV-7062/dialogcontent-requires-a-dialogtitle-for-the-component-to-be)

<a href="https://cursor.com/background-agent?bcId=bc-2afe13a9-3852-47a2-b272-f51d0580930f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2afe13a9-3852-47a2-b272-f51d0580930f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

