### PR TITLE
refactor(dashboard): Usage page charts fetching batch

### DIFF
--- a/apps/dashboard/src/pages/analytics.tsx
+++ b/apps/dashboard/src/pages/analytics.tsx
@@ -55,6 +55,7 @@ export function AnalyticsPage() {
   const { data: workflowTemplates } = useFetchWorkflows({ limit: 100 });
 
   // Define report types for each section
+  // Request 1: Metrics
   const metricsReportTypes = [
     ReportTypeEnum.MESSAGES_DELIVERED,
     ReportTypeEnum.ACTIVE_SUBSCRIBERS,
@@ -62,13 +63,18 @@ export function AnalyticsPage() {
     ReportTypeEnum.TOTAL_INTERACTIONS,
   ];
 
-  const chartsReportTypes = [
+  // Request 2: Trends and provider charts
+  const trendsReportTypes = [
     ReportTypeEnum.DELIVERY_TREND,
     ReportTypeEnum.INTERACTION_TREND,
-    ReportTypeEnum.WORKFLOW_BY_VOLUME,
     ReportTypeEnum.PROVIDER_BY_VOLUME,
-    ReportTypeEnum.WORKFLOW_RUNS_TREND,
     ReportTypeEnum.ACTIVE_SUBSCRIBERS_TREND,
+  ];
+
+  // Request 3: Workflow charts
+  const workflowReportTypes = [
+    ReportTypeEnum.WORKFLOW_BY_VOLUME,
+    ReportTypeEnum.WORKFLOW_RUNS_TREND,
   ];
 
   const { charts: metricsCharts, isLoading: isMetricsLoading } = useFetchCharts({
@@ -82,11 +88,11 @@ export function AnalyticsPage() {
   });
 
   const {
-    charts: chartsData,
-    isLoading: isChartsLoading,
-    error: chartsError,
+    charts: trendsCharts,
+    isLoading: isTrendsLoading,
+    error: trendsError,
   } = useFetchCharts({
-    reportType: chartsReportTypes,
+    reportType: trendsReportTypes,
     createdAtGte: chartsDateRange.createdAtGte,
     workflowIds: selectedWorkflows.length > 0 ? selectedWorkflows : undefined,
     enabled: true,
@@ -94,6 +100,24 @@ export function AnalyticsPage() {
     staleTime: CHART_CONFIG.staleTime,
     useMockData: isDevMockMode,
   });
+
+  const {
+    charts: workflowCharts,
+    isLoading: isWorkflowLoading,
+    error: workflowError,
+  } = useFetchCharts({
+    reportType: workflowReportTypes,
+    createdAtGte: chartsDateRange.createdAtGte,
+    workflowIds: selectedWorkflows.length > 0 ? selectedWorkflows : undefined,
+    enabled: true,
+    refetchInterval: CHART_CONFIG.refetchInterval,
+    staleTime: CHART_CONFIG.staleTime,
+    useMockData: isDevMockMode,
+  });
+
+  const chartsData = { ...trendsCharts, ...workflowCharts };
+  const isChartsLoading = isTrendsLoading || isWorkflowLoading;
+  const chartsError = trendsError || workflowError;
 
   const { messagesDeliveredData, activeSubscribersData, avgMessagesPerSubscriberData, totalInteractionsData } =
     useMetricData(metricsCharts);


### PR DESCRIPTION
### What changed? Why was the change needed?
The chart data fetching on the Usage page (`apps/dashboard/src/pages/analytics.tsx`) has been refactored from 2 parallel `useFetchCharts` calls to 3. This change splits the original "charts" query into separate requests for "trends/provider" and "workflow" related charts.

This was needed to better organize and provide more granular control over the different categories of chart data requests on the Usage page.

### Screenshots
N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
N/A

### Special notes for your reviewer
Existing chart components on the Usage page should continue to function as before, as the `chartsData`, `isChartsLoading`, and `chartsError` variables are merged from the new requests to maintain compatibility.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1768829044850919?thread_ts=1768829044.850919&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-436af740-3ccd-4b74-a1e9-2138ff6ac819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-436af740-3ccd-4b74-a1e9-2138ff6ac819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

