### PR TITLE
fix(dashboard): Workflow runs loading state usage page

### DIFF
--- a/apps/dashboard/src/components/analytics/components/charts-section.tsx
+++ b/apps/dashboard/src/components/analytics/components/charts-section.tsx
@@ -10,27 +10,35 @@ import { WorkflowsByVolume } from '../charts/workflows-by-volume';
 
 type ChartsSectionProps = {
   charts: Record<string, unknown> | undefined;
-  isLoading: boolean;
-  error: Error | null;
+  isTrendsLoading: boolean;
+  isWorkflowLoading: boolean;
+  trendsError: Error | null;
+  workflowError: Error | null;
 };
 
-export function ChartsSection({ charts, isLoading, error }: ChartsSectionProps) {
+export function ChartsSection({
+  charts,
+  isTrendsLoading,
+  isWorkflowLoading,
+  trendsError,
+  workflowError,
+}: ChartsSectionProps) {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-2">
       <DeliveryTrendsChart
         data={charts?.[ReportTypeEnum.DELIVERY_TREND] as ChartDataPoint[]}
-        isLoading={isLoading}
-        error={error}
+        isLoading={isTrendsLoading}
+        error={trendsError}
       />
       <WorkflowsByVolume
         data={charts?.[ReportTypeEnum.WORKFLOW_BY_VOLUME] as WorkflowVolumeDataPoint[]}
-        isLoading={isLoading}
-        error={error}
+        isLoading={isWorkflowLoading}
+        error={workflowError}
       />
       <InteractionTrendChart
         data={charts?.[ReportTypeEnum.INTERACTION_TREND] as InteractionTrendDataPoint[]}
-        isLoading={isLoading}
-        error={error}
+        isLoading={isTrendsLoading}
+        error={trendsError}
       />
     </div>
   );

--- a/apps/dashboard/src/pages/analytics.tsx
+++ b/apps/dashboard/src/pages/analytics.tsx
@@ -116,8 +116,6 @@ export function AnalyticsPage() {
   });
 
   const chartsData = { ...trendsCharts, ...workflowCharts };
-  const isChartsLoading = isTrendsLoading || isWorkflowLoading;
-  const chartsError = trendsError || workflowError;
 
   const { messagesDeliveredData, activeSubscribersData, avgMessagesPerSubscriberData, totalInteractionsData } =
     useMetricData(metricsCharts);
@@ -184,14 +182,20 @@ export function AnalyticsPage() {
             </motion.div>
 
             <motion.div variants={ANIMATION_VARIANTS.section}>
-              <ChartsSection charts={chartsData} isLoading={isChartsLoading} error={chartsError} />
+              <ChartsSection
+                charts={chartsData}
+                isTrendsLoading={isTrendsLoading}
+                isWorkflowLoading={isWorkflowLoading}
+                trendsError={trendsError}
+                workflowError={workflowError}
+              />
             </motion.div>
 
             <motion.div variants={ANIMATION_VARIANTS.section}>
               <WorkflowRunsTrendChart
                 data={chartsData?.[ReportTypeEnum.WORKFLOW_RUNS_TREND] as WorkflowRunsTrendDataPoint[]}
-                isLoading={isChartsLoading}
-                error={chartsError}
+                isLoading={isWorkflowLoading}
+                error={workflowError}
               />
             </motion.div>
 
@@ -199,15 +203,15 @@ export function AnalyticsPage() {
               <div className="lg:col-span-8">
                 <ActiveSubscribersTrendChart
                   data={chartsData?.[ReportTypeEnum.ACTIVE_SUBSCRIBERS_TREND] as ActiveSubscribersTrendDataPoint[]}
-                  isLoading={isChartsLoading}
-                  error={chartsError}
+                  isLoading={isTrendsLoading}
+                  error={trendsError}
                 />
               </div>
               <div className="lg:col-span-4 h-full">
                 <ProvidersByVolume
                   data={chartsData?.[ReportTypeEnum.PROVIDER_BY_VOLUME] as ProviderVolumeDataPoint[]}
-                  isLoading={isChartsLoading}
-                  error={chartsError}
+                  isLoading={isTrendsLoading}
+                  error={trendsError}
                 />
               </div>
             </motion.div>


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR addresses an issue on the Usage/Analytics page where charts displayed loading skeletons longer than necessary. In the previous PR (#9854), data fetching was split into multiple queries, but all charts continued to use a single, combined loading state. This meant charts would wait for all queries to resolve before rendering, even if their specific data was already available.

The change refactors the `ChartsSection` and individual chart components to use distinct loading states (`isTrendsLoading`, `isWorkflowLoading`) and error objects (`trendsError`, `workflowError`) based on the data each chart consumes. This ensures that charts render immediately once their specific data has loaded, improving perceived performance.

### Screenshots

<!-- No visual changes, only loading state behavior. -->

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1768922142589129?thread_ts=1768922142.589129&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-f3c7fdf4-3161-4fc9-947b-3ff0772ac574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3c7fdf4-3161-4fc9-947b-3ff0772ac574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

