### PR TITLE
Dashboard preview data persistence

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/hooks/use-preview-data-initialization.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/hooks/use-preview-data-initialization.ts
@@ -30,11 +30,19 @@ export function usePreviewDataInitialization({
   loadPersistedContext,
 }: InitializationProps) {
   const isInitializedRef = useRef(false);
-  const lastValueRef = useRef(value);
+  const lastInitKeyRef = useRef<string>('');
 
   const initializeData = useCallback(() => {
-    // Skip if already initialized or missing required props
-    if (isInitializedRef.current || !workflowId || !stepId || !environmentId) {
+    // Skip if missing required props
+    if (!workflowId || !stepId || !environmentId) {
+      return;
+    }
+
+    // Create a unique key for this workflow/step/environment combination
+    const initKey = `${workflowId}-${stepId}-${environmentId}`;
+
+    // Skip if already initialized for this specific combination
+    if (isInitializedRef.current && lastInitKeyRef.current === initKey) {
       return;
     }
 
@@ -99,9 +107,11 @@ export function usePreviewDataInitialization({
       }
 
       isInitializedRef.current = true;
+      lastInitKeyRef.current = initKey;
     } catch (error) {
       console.warn('Failed to initialize preview context data:', error);
       isInitializedRef.current = true;
+      lastInitKeyRef.current = `${workflowId}-${stepId}-${environmentId}`;
     }
   }, [
     workflowId,
@@ -116,18 +126,18 @@ export function usePreviewDataInitialization({
     onChange,
   ]);
 
+  // Reset initialization when workflow/step/environment changes
+  useEffect(() => {
+    const currentKey = `${workflowId}-${stepId}-${environmentId}`;
+    if (lastInitKeyRef.current !== currentKey) {
+      isInitializedRef.current = false;
+    }
+  }, [workflowId, stepId, environmentId]);
+
   // Initialize data when dependencies are ready
   useEffect(() => {
     initializeData();
   }, [initializeData]);
-
-  // Reset initialization when key props change
-  useEffect(() => {
-    if (value !== lastValueRef.current && value === '{}') {
-      isInitializedRef.current = false;
-      lastValueRef.current = value;
-    }
-  }, [value]);
 
   return { isInitialized: isInitializedRef.current };
 }

--- a/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/test-workflow/test-workflow-drawer.tsx
@@ -60,10 +60,11 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
   const [transactionId, setTransactionId] = useState<string>();
   const [isActivityDrawerOpen, setIsActivityDrawerOpen] = useState(false);
   const [isSubscriberDrawerOpen, setIsSubscriberDrawerOpen] = useState(false);
-  const [payloadData, setPayloadData] = useState<PayloadData>({});
+  const [payloadData, setPayloadData] = useState<PayloadData | null>(null);
   const [subscriberData, setSubscriberData] = useState<PreviewSubscriberData | null>(null);
   const [contextData, setContextData] = useState<ContextPayload | null>(null);
   const [currentFormData, setCurrentFormData] = useState<{ to: unknown; payload: PayloadData } | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
 
   // Cleanup expired storage data on component mount
   useEffect(() => {
@@ -82,45 +83,40 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
   const { data: apiKeysResponse } = useFetchApiKeys({ enabled: canReadApiKeys });
   const apiKey = canReadApiKeys ? (apiKeysResponse?.data?.[0]?.key ?? 'your-api-key-here') : 'your-api-key-here';
 
-  // Reset state when drawer closes to ensure fresh data on next open
+  // Reset initialization flag when drawer closes to allow fresh load on next open
   useEffect(() => {
     if (!isOpen) {
-      setPayloadData({});
-      setSubscriberData(null);
-      setContextData(null);
+      setIsInitialized(false);
     }
   }, [isOpen]);
 
-  // Initialize data when drawer opens
+  // Initialize data when drawer opens - load from localStorage
   useEffect(() => {
-    if (!isOpen || !workflow?.workflowId || !currentEnvironment?._id) return;
+    if (!isOpen || !workflow?.workflowId || !currentEnvironment?._id || isInitialized) return;
 
-    if (Object.keys(payloadData).length === 0) {
-      const initialData =
-        initialPayload && Object.keys(initialPayload).length > 0
-          ? initialPayload
-          : getInitialPayload(workflow.workflowId, currentEnvironment._id, workflow, isPayloadSchemaEnabled);
-      setPayloadData(initialData);
-    }
+    // Load payload from localStorage or use initialPayload/server defaults
+    const loadedPayload =
+      initialPayload && Object.keys(initialPayload).length > 0
+        ? initialPayload
+        : getInitialPayload(workflow.workflowId, currentEnvironment._id, workflow, isPayloadSchemaEnabled);
+    setPayloadData(loadedPayload);
 
-    if (!subscriberData && currentUser) {
-      const initialSubscriber = getInitialSubscriber(workflow.workflowId, currentEnvironment._id, {
+    // Load subscriber from localStorage or use current user
+    if (currentUser) {
+      const loadedSubscriber = getInitialSubscriber(workflow.workflowId, currentEnvironment._id, {
         _id: currentUser._id,
         firstName: currentUser.firstName ?? undefined,
         lastName: currentUser.lastName ?? undefined,
         email: currentUser.email ?? undefined,
       });
-      if (initialSubscriber) {
-        setSubscriberData(initialSubscriber);
-      }
+      setSubscriberData(loadedSubscriber);
     }
 
-    if (!contextData) {
-      const initialContext = getInitialContext(workflow.workflowId, currentEnvironment._id);
-      if (initialContext) {
-        setContextData(initialContext);
-      }
-    }
+    // Load context from localStorage
+    const loadedContext = getInitialContext(workflow.workflowId, currentEnvironment._id);
+    setContextData(loadedContext);
+
+    setIsInitialized(true);
   }, [
     isOpen,
     workflow?.workflowId,
@@ -129,9 +125,7 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
     initialPayload,
     isPayloadSchemaEnabled,
     workflow,
-    payloadData,
-    subscriberData,
-    contextData,
+    isInitialized,
   ]);
 
   const subscriberIdToFetch = subscriberData?.subscriberId || '';
@@ -259,7 +253,7 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
       } = await triggerWorkflow({
         name: workflow?.workflowId ?? '',
         to: subscriberData,
-        payload: payloadData,
+        payload: payloadData ?? {},
         ...getContextSpread(contextData),
       });
 
@@ -286,7 +280,7 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
       }
 
       setTransactionId(newTransactionId);
-      setCurrentFormData({ to: subscriberData, payload: payloadData });
+      setCurrentFormData({ to: subscriberData, payload: payloadData ?? {} });
       setIsActivityDrawerOpen(true);
     } catch (e) {
       showErrorToast(
@@ -306,7 +300,7 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
       const curlCommand = generateTriggerCurlCommand({
         workflowId: workflow.workflowId,
         to: subscriberData,
-        payload: payloadData,
+        payload: payloadData ?? {},
         ...getContextSpread(contextData),
         apiKey: apiKey,
       });
@@ -339,7 +333,7 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
       const postmanCollection = generatePostmanCollection({
         workflowId: workflow.workflowId,
         to: subscriberData,
-        payload: payloadData,
+        payload: payloadData ?? {},
         ...getContextSpread(contextData),
         apiKey,
       });
@@ -412,7 +406,7 @@ export const TestWorkflowDrawer = forwardRef<HTMLDivElement, TestWorkflowDrawerP
         <div className="flex h-full flex-col">
           <TestWorkflowContent
             workflow={workflow}
-            payloadData={payloadData}
+            payloadData={payloadData ?? {}}
             subscriberData={subscriberData}
             contextData={contextData}
             isLoadingSubscriber={isLoadingSubscriber}


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR fixes a bug (NV-6709) where payload, subscriber, and context data in the test workflow drawer and step editor sidebar did not persist across refreshes or navigation.

The issue was twofold:
1.  In `test-workflow-drawer.tsx`, the state was incorrectly reset when the drawer closed, preventing proper re-initialization from local storage on reopen.
2.  In `use-preview-data-initialization.ts`, the initialization flag was not reset when navigating between different workflows, steps, or environments, causing persisted data to not be loaded.

The changes ensure that:
*   The `TestWorkflowDrawer` correctly loads persisted data from local storage each time it opens, without prematurely resetting the state.
*   The `usePreviewDataInitialization` hook properly detects changes in workflow, step, or environment, and resets its initialization state to allow fresh loading of persisted data.

Relevant links: [NV-6709](https://linear.app/novu/issue/NV-6709)

### Screenshots

N/A

---
Linear Issue: [NV-6709](https://linear.app/novu/issue/NV-6709/dashboard-payloadsubscriber-data-doesnt-persist-in-test-workflow)

<a href="https://cursor.com/background-agent?bcId=bc-7f255d0e-a4bf-48a3-acb2-4615402410b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f255d0e-a4bf-48a3-acb2-4615402410b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

