### PR TITLE
fix(dashboard): Billing page view role for billing tab fixes NV-7046

### DIFF
--- a/apps/dashboard/src/components/command-palette/commands/settings-commands.tsx
+++ b/apps/dashboard/src/components/command-palette/commands/settings-commands.tsx
@@ -1,10 +1,16 @@
+import { PermissionsEnum } from '@novu/shared';
 import { RiDatabase2Line, RiMoneyDollarCircleLine, RiSettings4Line, RiUserAddLine } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
+import { IS_SELF_HOSTED } from '@/config';
+import { useHasPermission } from '@/hooks/use-has-permission';
 import { ROUTES } from '@/utils/routes';
 import { Command, CommandExecutionContext } from '../command-types';
 
 export function useSettingsCommands(_context: CommandExecutionContext): Command[] {
   const navigate = useNavigate();
+  const hasPermission = useHasPermission();
+  const hasBillingPermission = hasPermission({ permission: PermissionsEnum.BILLING_WRITE });
+  const canShowBilling = !IS_SELF_HOSTED && hasBillingPermission;
 
   const commands: Command[] = [
     {
@@ -37,7 +43,10 @@ export function useSettingsCommands(_context: CommandExecutionContext): Command[
       keywords: ['team', 'members', 'invite', 'settings'],
       execute: () => navigate(ROUTES.SETTINGS_TEAM),
     },
-    {
+  ];
+
+  if (canShowBilling) {
+    commands.push({
       id: 'settings-billing',
       label: 'Billing Settings',
       description: 'Manage billing and subscription settings',
@@ -46,8 +55,8 @@ export function useSettingsCommands(_context: CommandExecutionContext): Command[
       priority: 'medium',
       keywords: ['billing', 'subscription', 'payment', 'invoice', 'settings'],
       execute: () => navigate(ROUTES.SETTINGS_BILLING),
-    },
-  ];
+    });
+  }
 
   return commands;
 }

--- a/apps/dashboard/src/pages/settings.tsx
+++ b/apps/dashboard/src/pages/settings.tsx
@@ -6,8 +6,10 @@ import {
   FeatureNameEnum,
   GetSubscriptionDto,
   getFeatureForTierAsBoolean,
+  PermissionsEnum,
 } from '@novu/shared';
 import { motion } from 'motion/react';
+import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Card } from '@/components/primitives/card';
 import { InlineToast } from '@/components/primitives/inline-toast';
@@ -15,6 +17,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitive
 import { OrganizationSettings } from '@/components/settings/organization-settings';
 import { IS_SELF_HOSTED } from '@/config';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { useHasPermission } from '@/hooks/use-has-permission';
 import { ROUTES } from '@/utils/routes';
 import { Plan } from '../components/billing/plan';
 import { DashboardLayout } from '../components/dashboard-layout';
@@ -79,6 +82,8 @@ export function SettingsPage() {
   const { subscription } = useFetchSubscription();
   const isRbacEnabledFlag = useFeatureFlag(FeatureFlagsKeysEnum.IS_RBAC_ENABLED, false);
   const isRbacEnabled = checkRbacEnabled(subscription, isRbacEnabledFlag);
+  const has = useHasPermission();
+  const hasBillingPermission = has({ permission: PermissionsEnum.BILLING_WRITE });
 
   const clerkAppearance = getClerkComponentAppearance(isRbacEnabled);
 
@@ -92,8 +97,16 @@ export function SettingsPage() {
     return rbacFeatureEnabled && featureFlag;
   }
 
+  const canShowBilling = !IS_SELF_HOSTED && hasBillingPermission;
+
   const currentTab =
     location.pathname === ROUTES.SETTINGS ? 'account' : location.pathname.split('/settings/')[1] || 'account';
+
+  useEffect(() => {
+    if (currentTab === 'billing' && !canShowBilling) {
+      navigate(ROUTES.SETTINGS_ACCOUNT, { replace: true });
+    }
+  }, [currentTab, canShowBilling, navigate]);
 
   const handleTabChange = (value: string) => {
     switch (value) {
@@ -107,7 +120,7 @@ export function SettingsPage() {
         navigate(ROUTES.SETTINGS_TEAM);
         break;
       case 'billing':
-        if (!IS_SELF_HOSTED) {
+        if (canShowBilling) {
           navigate(ROUTES.SETTINGS_BILLING);
         }
 
@@ -129,7 +142,7 @@ export function SettingsPage() {
             Team
           </TabsTrigger>
 
-          {!IS_SELF_HOSTED && (
+          {canShowBilling && (
             <TabsTrigger variant="regular" value="billing" size="xl">
               Billing
             </TabsTrigger>
@@ -137,7 +150,7 @@ export function SettingsPage() {
         </TabsList>
 
         <div
-          className={`mx-auto mt-1 px-1.5 ${currentTab === 'billing' && !IS_SELF_HOSTED ? 'max-w-[1400px]' : 'max-w-[700px]'}`}
+          className={`mx-auto mt-1 px-1.5 ${currentTab === 'billing' && canShowBilling ? 'max-w-[1400px]' : 'max-w-[700px]'}`}
         >
           <TabsContent value="account" className="rounded-lg">
             <motion.div {...FADE_ANIMATION}>
@@ -162,7 +175,7 @@ export function SettingsPage() {
             <motion.div {...FADE_ANIMATION}>
               <Card className="border-none shadow-none">
                 <div className="pb-6 pt-4 flex flex-col">
-                  {subscription?.apiServiceLevel === ApiServiceLevelEnum.FREE && (
+                  {subscription?.apiServiceLevel === ApiServiceLevelEnum.FREE && canShowBilling && (
                     <InlineToast
                       title="Tip:"
                       description="Hide Novu branding from your notification channels by upgrading to a paid plan."
@@ -184,7 +197,7 @@ export function SettingsPage() {
             <motion.div {...FADE_ANIMATION}>
               <Card className="border-none shadow-none">
                 <div className={`pb-6 pt-4 flex flex-col ${isRbacEnabled ? 'show-role-column' : 'hide-role-column'}`}>
-                  {isRbacEnabledFlag && !isRbacEnabled && (
+                  {isRbacEnabledFlag && !isRbacEnabled && canShowBilling && (
                     <InlineToast
                       title="Tip:"
                       description="Get role-based access control and add unlimited members by upgrading."
@@ -203,7 +216,7 @@ export function SettingsPage() {
             </motion.div>
           </TabsContent>
 
-          {!IS_SELF_HOSTED && (
+          {canShowBilling && (
             <TabsContent value="billing" className="rounded-lg">
               <motion.div {...FADE_ANIMATION}>
                 <Card className="border-none shadow-none">


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR restricts access to the billing page and related UI elements for users who do not have `org:billing:write` permission.

The change was needed to align the dashboard's behavior with Novu's roles and permissions documentation (NV-7046), which states that users with a "View" role on a Team plan should not be able to access the billing page.

Specifically:
*   The "Billing" tab in the settings page is now hidden.
*   The "Billing Settings" command is removed from the command palette.
*   Upgrade CTAs (InlineToast components) that navigate to the billing page are hidden.
*   Users attempting to directly navigate to `/settings/billing` without permission will be redirected to `/settings/account`.

Relevant link: [NV-7046](https://linear.app/novu/issue/NV-7046)

### Screenshots

Screenshots showing the absence of the billing tab and related CTAs for a user with "View" role would be relevant.

---
Linear Issue: [NV-7046](https://linear.app/novu/issue/NV-7046/billing-page-should-not-be-accessible-for-view-role-in-team-plan)

<a href="https://cursor.com/background-agent?bcId=bc-4b01e6fe-22ab-44ef-92b6-945b34ff68f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4b01e6fe-22ab-44ef-92b6-945b34ff68f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

