### PR TITLE
fix(api-service): Subscriber inactive channels default

### DIFF
--- a/apps/api/src/app/subscribers-v2/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.ts
@@ -285,7 +285,7 @@ export class SubscribersController {
         organizationId: user.organizationId,
         environmentId: user.environmentId,
         subscriberId: subscriberId,
-        includeInactiveChannels: false,
+        includeInactiveChannels: true,
       })
     );
 


### PR DESCRIPTION
### What changed? Why was the change needed?

The `includeInactiveChannels` parameter in the `GET /:subscriberId/preferences/global` endpoint was changed to `true` by default. This change was requested to ensure inactive channels are included by default when fetching global preferences.

### Screenshots

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1768990770219449?thread_ts=1768990770.219449&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-af0be4d3-ada7-4e26-8718-db0364015c03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-af0be4d3-ada7-4e26-8718-db0364015c03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

