### PR TITLE
fix(ws): Sentry fetchsockets timeout filter

### DIFF
--- a/apps/ws/src/instrument.ts
+++ b/apps/ws/src/instrument.ts
@@ -8,6 +8,6 @@ if (process.env.SENTRY_DSN) {
     dsn: process.env.SENTRY_DSN,
     environment: process.env.NODE_ENV,
     release: `v${version}`,
-    ignoreErrors: ['Non-Error exception captured'],
+    ignoreErrors: ['Non-Error exception captured', 'timeout reached while waiting for fetchSockets response'],
   });
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

Filtered out the "timeout reached while waiting for fetchSockets response" error from Sentry in the `apps/ws` service. This error, originating from the `@socket.io/redis-adapter`, was causing noise in Sentry and is not actionable.

Relevant Sentry issue: [https://novu-r9.sentry.io/issues/6130035483/events/](https://novu-r9.sentry.io/issues/6130035483/events/)

### Screenshots

N/A

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1769071350445839?thread_ts=1769071350.445839&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-7a07fa1e-cf03-497d-a9a8-b99080e2cddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7a07fa1e-cf03-497d-a9a8-b99080e2cddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

