### PR TITLE
fix(dashboard): activity filters overflow

### DIFF
--- a/apps/dashboard/src/components/activity/activity-filters.tsx
+++ b/apps/dashboard/src/components/activity/activity-filters.tsx
@@ -109,7 +109,7 @@ export function ActivityFilters({
 
   return (
     <Form {...form}>
-      <FormRoot className={cn('nv-no-scrollbar w-full flex items-center gap-2 overflow-x-auto pb-2.5', className)}>
+        <FormRoot className={cn('w-full flex flex-wrap items-center gap-2 pb-2.5', className)}>
         {!hide.includes('dateRange') && (
           <FormField
             control={form.control}

--- a/apps/dashboard/src/components/contexts/context-activity.tsx
+++ b/apps/dashboard/src/components/contexts/context-activity.tsx
@@ -99,7 +99,7 @@ export const ContextActivity = ({ type, id }: { type: ContextType; id: ContextId
           onFiltersChange={setFilters}
           onReset={handleClearFilters}
           hide={['dateRange', 'contextKeys']}
-          className="min-h-max overflow-x-auto py-2 px-2"
+          className="py-2 px-2"
         />
         <SubscriberActivityList
           isLoading={isLoading}

--- a/apps/dashboard/src/components/subscribers/subscriber-activity.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-activity.tsx
@@ -117,7 +117,7 @@ export const SubscriberActivity = ({ subscriberId }: { subscriberId: string }) =
           onFiltersChange={setFilters}
           onReset={handleClearFilters}
           hide={['dateRange', 'subscriberId']}
-          className="min-h-max overflow-x-auto py-2 px-2"
+          className="py-2 px-2"
         />
         <SubscriberActivityList
           isLoading={isLoading}

--- a/apps/dashboard/src/components/topics/topic-activity.tsx
+++ b/apps/dashboard/src/components/topics/topic-activity.tsx
@@ -118,7 +118,7 @@ export const TopicActivity = ({ topicKey }: { topicKey: string }) => {
             onFiltersChange={setFilters}
             onReset={handleClearFilters}
             hide={['dateRange', 'topicKey']}
-            className="min-h-max overflow-x-auto px-2.5 pt-2.5"
+            className="px-2.5 pt-2.5"
           />
           <SubscriberActivityList
             isLoading={isLoading}


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves [NV-7068](https://linear.app/no-project/issue/NV-7068).

The `ActivityFilters` component previously used `overflow-x-auto`, which caused filters to be cut off in drawer contexts (e.g., Topic, Subscriber, Context Activity drawers) where horizontal scrolling was not effectively visible or accessible.

This change modifies the `ActivityFilters` component to use `flex-wrap`, allowing filters to wrap to a new line when they exceed the available horizontal space. Additionally, the `overflow-x-auto` class has been removed from the `ActivityFilters` component and its usages in `topic-activity.tsx`, `subscriber-activity.tsx`, and `context-activity.tsx` to ensure the new wrapping behavior functions correctly.

### Screenshots

See the original Linear issue for a screenshot demonstrating the problem.

---
Linear Issue: [NV-7068](https://linear.app/novu/issue/NV-7068/dashboard-not-all-filters-are-visible)

<a href="https://cursor.com/background-agent?bcId=bc-cad2c5c4-dd18-4f16-98fb-4c3295cd1d51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cad2c5c4-dd18-4f16-98fb-4c3295cd1d51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

