### PR TITLE
fix(api-service): Update includeInactiveChannels defaults in subscribers v1 controllers

### DIFF
--- a/apps/api/src/app/subscribers-v2/subscribers.controller.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.controller.ts
@@ -285,7 +285,7 @@ export class SubscribersController {
         organizationId: user.organizationId,
         environmentId: user.environmentId,
         subscriberId: subscriberId,
-        includeInactiveChannels: true,
+        includeInactiveChannels: false,
       })
     );
 

--- a/apps/api/src/app/subscribers/subscribersV1.controller.ts
+++ b/apps/api/src/app/subscribers/subscribersV1.controller.ts
@@ -480,7 +480,7 @@ export class SubscribersV1Controller {
       subscriberId,
       environmentId: user.environmentId,
       level: parameter,
-      includeInactiveChannels: includeInactiveChannels ?? false,
+      includeInactiveChannels: includeInactiveChannels ?? true,
     });
 
     return await this.getPreferenceUsecase.execute(command);


### PR DESCRIPTION
Changed the default value of includeInactiveChannels to false in subscribers-v2 controller and to true in subscribersV1 controller to align with updated requirements for channel inclusion.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
