### PR TITLE
feat(api-service,js): ensure backwards compatibility for context prefs fixes NV-7072

### DIFF
--- a/apps/api/src/app/inbox/e2e/context-aware-topic-subscriptions.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/context-aware-topic-subscriptions.e2e.ts
@@ -25,6 +25,15 @@ describe('Context-aware topic subscriptions - /inbox/topics (with context) #novu
     session = new UserSession();
     await session.initialize();
 
+    // Wrap testAgent to include Novu-Client-Version header for context-aware behavior
+    const agent = session.testAgent;
+    session.testAgent = {
+      get: (url: string) => agent.get(url).set('Novu-Client-Version', '@novu/js@3.13.0'),
+      post: (url: string) => agent.post(url).set('Novu-Client-Version', '@novu/js@3.13.0'),
+      patch: (url: string) => agent.patch(url).set('Novu-Client-Version', '@novu/js@3.13.0'),
+      delete: (url: string) => agent.delete(url).set('Novu-Client-Version', '@novu/js@3.13.0'),
+    } as any;
+
     await setIntegrationConfig(session.environment._id, session.environment._organizationId);
 
     const sessionAResponse = await initializeSessionWithContext(session, CONTEXT_A);

--- a/apps/api/src/app/inbox/inbox.topic.controller.ts
+++ b/apps/api/src/app/inbox/inbox.topic.controller.ts
@@ -11,6 +11,7 @@ import {
   Query,
   Res,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiExcludeController } from '@nestjs/swagger';
@@ -29,6 +30,7 @@ import { GetSubscriptionCommand } from '../subscriptions/usecases/get-subscripti
 import { GetSubscription } from '../subscriptions/usecases/get-subscription/get-subscription.usecase';
 import { UpdateSubscriptionCommand, UpdateSubscriptionUsecase } from '../subscriptions/usecases/update-subscription';
 import { CreateTopicSubscriptionRequestDto } from './dtos/create-topic-subscription-request.dto';
+import { ContextCompatibilityInterceptor } from './interceptors/context-compatibility.interceptor';
 import { DeleteTopicSubscriptionCommand } from './usecases/delete-subscription/delete-subscription.command';
 import { DeleteTopicSubscription } from './usecases/delete-subscription/delete-subscription.usecase';
 import { GetTopicSubscriptionsCommand } from './usecases/get-topic-subscriptions/get-topic-subscriptions.command';
@@ -38,6 +40,7 @@ import { GetTopicSubscriptions } from './usecases/get-topic-subscriptions/get-to
 @Controller('/inbox')
 @ApiExcludeController()
 @ExcludeFromIdempotency()
+@UseInterceptors(ContextCompatibilityInterceptor)
 export class InboxTopicController {
   constructor(
     private getTopicSubscriptionsUsecase: GetTopicSubscriptions,

--- a/apps/api/src/app/inbox/interceptors/context-compatibility.interceptor.ts
+++ b/apps/api/src/app/inbox/interceptors/context-compatibility.interceptor.ts
@@ -1,0 +1,76 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+/**
+ * Parses @novu/js version from Novu-Client-Version header.
+ * Example: "@novu/js@3.13.0" -> "3.13.0"
+ */
+function parseClientVersion(clientVersion?: string): string | null {
+  if (!clientVersion) return null;
+  const match = clientVersion.match(/@novu\/js@(\d+\.\d+\.\d+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Checks if client version supports context in identifiers.
+ * Context support for preferences added in version 3.13.0
+ */
+function isContextAwareVersion(version: string): boolean {
+  const MIN_VERSION = '3.13.0';
+  const [major, minor, patch] = version.split('.').map(Number);
+  const [minMajor, minMinor, minPatch] = MIN_VERSION.split('.').map(Number);
+
+  if (major > minMajor) return true;
+  if (major < minMajor) return false;
+  if (minor > minMinor) return true;
+  if (minor < minMinor) return false;
+  return patch >= minPatch;
+}
+
+/**
+ * Determines if context should be disabled for this request.
+ * Only disables for old @novu/js client versions.
+ */
+function shouldDisableContextForOldClient(clientVersion?: string): boolean {
+  const version = parseClientVersion(clientVersion);
+  if (!version) {
+    return true; // No client version header = old client (before 3.13.0), disable context
+  }
+
+  return !isContextAwareVersion(version);
+}
+
+/**
+ * Interceptor that disables context features for old clients.
+ *
+ * Old @novu/js versions auto-generate identifiers without :ctx_,
+ * but if contextKeys exist in JWT, server would create subscriptions
+ * with :ctx_ causing identifier mismatches.
+ *
+ * This interceptor detects old clients via Novu-Client-Version header
+ * and strips contextKeys from the session to maintain consistency.
+ *
+ * @see https://linear.app/novu/issue/NV-7072/context-preferences-subscription-identifier-compatibility-issue
+ */
+@Injectable()
+export class ContextCompatibilityInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest();
+    const subscriberSession = request.user;
+
+    // No session or no contextKeys = nothing to do
+    if (!subscriberSession?.contextKeys || subscriberSession.contextKeys.length === 0) {
+      return next.handle();
+    }
+
+    const clientVersion = request.headers['novu-client-version'];
+
+    // Check if this is an old client
+    if (shouldDisableContextForOldClient(clientVersion)) {
+      // Disable context for old clients
+      subscriberSession.contextKeys = undefined;
+    }
+
+    return next.handle();
+  }
+}

--- a/libs/application-generic/src/http/headers.types.ts
+++ b/libs/application-generic/src/http/headers.types.ts
@@ -9,6 +9,7 @@ export enum HttpRequestHeaderKeysEnum {
   BAGGAGE = 'Baggage',
   NOVU_ENVIRONMENT_ID = 'Novu-Environment-Id',
   NOVU_API_VERSION = 'Novu-API-Version',
+  NOVU_CLIENT_VERSION = 'Novu-Client-Version',
   NOVU_USER_AGENT = 'Novu-User-Agent',
   BYPASS_TUNNEL_REMINDER = 'Bypass-Tunnel-Reminder',
   IDEMPOTENCY_KEY = 'Idempotency-Key',

--- a/packages/js/src/api/http-client.test.ts
+++ b/packages/js/src/api/http-client.test.ts
@@ -26,6 +26,7 @@ describe('HttpClient', () => {
       const client = new HttpClient();
       expect((client as any).apiUrl).toBe('https://api.novu.co/v1');
       expect((client as any).apiVersion).toBe('v1');
+      expect((client as any).headers['Novu-Client-Version']).toBe(`${PACKAGE_NAME}@${PACKAGE_VERSION}`);
       expect((client as any).headers['User-Agent']).toBe(`${PACKAGE_NAME}@${PACKAGE_VERSION}`);
     });
 
@@ -37,6 +38,7 @@ describe('HttpClient', () => {
       });
       expect((client as any).apiUrl).toBe('https://custom-api.example.com/v2');
       expect((client as any).apiVersion).toBe('v2');
+      expect((client as any).headers['Novu-Client-Version']).toBe(`${PACKAGE_NAME}@${PACKAGE_VERSION}`);
       expect((client as any).headers['User-Agent']).toBe('custom-agent');
     });
   });

--- a/packages/js/src/api/http-client.ts
+++ b/packages/js/src/api/http-client.ts
@@ -1,12 +1,15 @@
 export type HttpClientOptions = {
   apiVersion?: string;
   apiUrl?: string;
+  /**
+   * @deprecated User-Agent header is not reliable in browsers. Use Novu-Client-Version instead.
+   */
   userAgent?: string;
   headers?: Record<string, string>;
 };
 
 export const DEFAULT_API_VERSION = 'v1';
-const DEFAULT_USER_AGENT = `${PACKAGE_NAME}@${PACKAGE_VERSION}`;
+const DEFAULT_CLIENT_VERSION = `${PACKAGE_NAME}@${PACKAGE_VERSION}`;
 
 export class HttpClient {
   // Environment variable for local development that overrides the default API endpoint without affecting the Inbox DX
@@ -21,15 +24,16 @@ export class HttpClient {
     const {
       apiVersion = DEFAULT_API_VERSION,
       apiUrl = this.DEFAULT_BACKEND_URL,
-      userAgent = DEFAULT_USER_AGENT,
+      userAgent = DEFAULT_CLIENT_VERSION,
       headers = {},
     } = options || {};
     this.apiVersion = apiVersion;
     this.apiUrl = `${apiUrl}/${apiVersion}`;
     this.headers = {
       'Novu-API-Version': NOVU_API_VERSION,
+      'Novu-Client-Version': DEFAULT_CLIENT_VERSION,
       'Content-Type': 'application/json',
-      'User-Agent': userAgent,
+      'User-Agent': userAgent, // Deprecated: Doesn't work in browsers, kept for backward compatibility
       ...headers,
     };
   }
@@ -121,7 +125,9 @@ export class HttpClient {
 
     if (!response.ok) {
       const errorData = await response.json();
-      throw new Error(`${this.headers['User-Agent']} error. Status: ${response.status}, Message: ${errorData.message}`);
+      throw new Error(
+        `${this.headers['Novu-Client-Version']} error. Status: ${response.status}, Message: ${errorData.message}`
+      );
     }
     if (response.status === 204) {
       return undefined as unknown as T;

--- a/packages/js/src/novu.test.ts
+++ b/packages/js/src/novu.test.ts
@@ -34,7 +34,7 @@ describe('Novu', () => {
   const subscriberId = 'bar';
 
   beforeEach(() => {
-    // @ts-ignore
+    // @ts-expect-error
     global.fetch.mockImplementation(mockFetch) as jest.Mock;
   });
 
@@ -50,8 +50,9 @@ describe('Novu', () => {
         method: 'POST',
         body: JSON.stringify({ applicationIdentifier, subscriber: { subscriberId } }),
         headers: {
-          'Content-Type': 'application/json',
           'Novu-API-Version': '2024-06-26',
+          'Novu-Client-Version': '@novu/js@test',
+          'Content-Type': 'application/json',
           'User-Agent': '@novu/js@test',
         },
       });
@@ -61,10 +62,11 @@ describe('Novu', () => {
         method: 'GET',
         body: undefined,
         headers: {
-          Authorization: 'Bearer cafebabe',
-          'Content-Type': 'application/json',
           'Novu-API-Version': '2024-06-26',
+          'Novu-Client-Version': '@novu/js@test',
+          'Content-Type': 'application/json',
           'User-Agent': '@novu/js@test',
+          Authorization: 'Bearer cafebabe',
         },
       });
 


### PR DESCRIPTION
### What changed? Why was the change needed?

## Problem

Context preferences require `contextKeys` in **both** JWT and subscription identifier, but old clients only include them in JWT.

In more detail - https://linear.app/novu/issue/NV-7072/context-preferences-subscription-identifier-compatibility-issue

### Why Context Must Be in the Identifier

1. **Uniqueness**: Same subscriber can have multiple subscriptions to the same topic with different contexts
   - `tk_updates:si_user123:ctx_project:a` 
   - `tk_updates:si_user123:ctx_project:b`
2. **Client cache key**: Client uses identifier to cache and manage subscriptions locally
3. **API operations**: GET/PATCH/DELETE use identifier as the lookup key

### The Mismatch

```mermaid
sequenceDiagram
    participant Old Client
    participant API
    participant Database

    Note over Old Client: @novu/js < 3.13.0
    
    Old Client->>API: POST /subscriptions<br/>identifier: "tk_updates:si_user123"<br/>JWT contains: contextKeys=["project:a"]
    
    API->>API: Sees contextKeys in JWT<br/>Adds :ctx_ to identifier
    
    API->>Database: Store subscription<br/>identifier: "tk_updates:si_user123:ctx_project:a"
    
    Note over Old Client: Later: tries to fetch subscription
    
    Old Client->>API: GET /subscriptions/tk_updates:si_user123<br/>(auto-generated, no :ctx_)
    
    API->>Database: Find by identifier:<br/>"tk_updates:si_user123"
    
    Database-->>API: ❌ Not found
    API-->>Old Client: 404
```

**Root cause**: Old client generates identifier without `:ctx_`, but server adds it → permanent mismatch.

## Solution

**Context Compatibility Interceptor** detects old clients and strips `contextKeys` from JWT before processing:

```mermaid
sequenceDiagram
    participant Old Client
    participant Interceptor
    participant API
    participant Database

    Old Client->>Interceptor: POST /subscriptions<br/>No Novu-Client-Version header<br/>JWT: contextKeys=["project:a"]
    
    Interceptor->>Interceptor: Check header<br/>Missing → old client
    
    Interceptor->>Interceptor: Strip contextKeys from session
    
    Interceptor->>API: Continue request<br/>contextKeys=undefined
    
    API->>Database: Store subscription<br/>identifier: "tk_updates:si_user123"<br/>(no :ctx_)
    
    Note over Old Client: Later: fetch works!
    
    Old Client->>API: GET /subscriptions/tk_updates:si_user123
    API->>Database: Find: "tk_updates:si_user123"
    Database-->>API: ✅ Found
    API-->>Old Client: 200 OK
```

## Changes

- **Client**: Added `Novu-Client-Version` header
- **API**: Interceptor strips `contextKeys` for clients < 3.13.0 or missing header
- **Result**: Client-generated identifier matches server-stored identifier

## Deployment

⚠️ **Deploy API before releasing `@novu/js@3.13.0`**

---
