### PR TITLE
fix(worker): smtp timeout fix default time out bug

### DIFF
--- a/packages/providers/src/lib/email/nodemailer/nodemailer.provider.spec.ts
+++ b/packages/providers/src/lib/email/nodemailer/nodemailer.provider.spec.ts
@@ -55,6 +55,8 @@ describe.skip('NodemailerProvider', () => {
         host: config.host,
         port: config.port,
         secure: config.secure,
+        connectionTimeout: 10000,
+        socketTimeout: 10000,
         auth: undefined,
         dkim: undefined,
         ignoreTls: undefined,
@@ -107,6 +109,8 @@ describe.skip('NodemailerProvider', () => {
         host: mockConfig.host,
         port: mockConfig.port,
         secure: mockConfig.secure,
+        connectionTimeout: 10000,
+        socketTimeout: 10000,
         auth: {
           user: mockConfig.user,
           pass: mockConfig.password,

--- a/packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts
+++ b/packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts
@@ -53,6 +53,8 @@ export class NodemailerProvider extends BaseProvider implements IEmailProvider {
       host: this.config.host,
       port: this.config.port,
       secure: this.config.secure,
+      connectionTimeout: 10000,
+      socketTimeout: 10000,
       auth: authEnabled
         ? {
             user: this.config.user,


### PR DESCRIPTION
### What changed? Why was the change needed?

The SMTP email provider timeout for `NodemailerProvider` has been changed from the default 120 seconds to 10 seconds.

This was achieved by explicitly setting `connectionTimeout` and `socketTimeout` to 10000ms (10 seconds) in `packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts`. Previously, these timeouts were not set, causing Nodemailer to use its default 2-minute timeout.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1769097902714999?thread_ts=1769097902.714999&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-6ebec13c-3bce-4af9-aee4-35e43c30e115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ebec13c-3bce-4af9-aee4-35e43c30e115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

