### PR TITLE
Billing cron worker isolation

### DIFF
--- a/apps/worker/src/config/worker-init.config.ts
+++ b/apps/worker/src/config/worker-init.config.ts
@@ -10,7 +10,8 @@ type WorkerClass =
   | typeof StandardWorker
   | typeof WorkflowWorker
   | typeof SubscriberProcessWorker
-  | typeof InboundParseWorker;
+  | typeof InboundParseWorker
+  | null;
 
 type WorkerModuleTree = { workerClass: WorkerClass; queueDependencies: JobTopicNameEnum[] };
 
@@ -31,6 +32,10 @@ export const WORKER_MAPPING: WorkerDepTree = {
   },
   [JobTopicNameEnum.INBOUND_PARSE_MAIL]: {
     workerClass: InboundParseWorker,
+    queueDependencies: [],
+  },
+  [JobTopicNameEnum.ACTIVE_JOBS_METRIC]: {
+    workerClass: null,
     queueDependencies: [],
   },
 };

--- a/libs/application-generic/src/modules/cron.module.ts
+++ b/libs/application-generic/src/modules/cron.module.ts
@@ -15,7 +15,8 @@ import { MetricsModule } from './metrics.module';
  * the job names. This would allow us to specify the cron jobs in a more explicit way for each worker.
  */
 const cronJobsFromWorkers: Partial<Record<JobTopicNameEnum, Array<JobCronNameEnum>>> = {
-  [JobTopicNameEnum.STANDARD]: [JobCronNameEnum.CREATE_BILLING_USAGE_RECORDS, JobCronNameEnum.SEND_CRON_METRICS],
+  [JobTopicNameEnum.STANDARD]: [JobCronNameEnum.SEND_CRON_METRICS],
+  [JobTopicNameEnum.ACTIVE_JOBS_METRIC]: [JobCronNameEnum.CREATE_BILLING_USAGE_RECORDS],
 };
 
 export const cronService = {


### PR DESCRIPTION
### What changed? Why was the change needed?

Moved the `CREATE_BILLING_USAGE_RECORDS` cron job from the `STANDARD` worker to the `ACTIVE_JOBS_METRIC` worker. This enables the billing cron to run independently from the standard notification processing worker, offering greater flexibility in worker deployment.

Specifically:
- The `cronJobsFromWorkers` mapping was updated to associate `CREATE_BILLING_USAGE_RECORDS` with `ACTIVE_JOBS_METRIC`.
- The `WORKER_MAPPING` was extended to include `ACTIVE_JOBS_METRIC` with a `null` worker class, and the `WorkerClass` type was updated to permit `null`.

### Screenshots

N/A

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1769104049130599?thread_ts=1769104049.130599&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-63ca6218-18f9-478d-bb67-1e24fcf439da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63ca6218-18f9-478d-bb67-1e24fcf439da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

