### PR TITLE
feat(js): allow not setting user agent

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -81,3 +81,17 @@ const novu = new Novu({
 ```
 
 > Note: When HMAC encryption is enabled and `context` is provided, the `contextHash` is required. The hash is order-independent, so `{a:1, b:2}` produces the same hash as `{b:2, a:1}`.
+
+## Custom User Agent
+
+You can remove the User-Agent header sent with requests by providing the `__userAgent` option set to `null`:
+
+```ts
+const novu = new Novu({
+  applicationIdentifier: 'YOUR_NOVU_APPLICATION_IDENTIFIER',
+  subscriber: 'YOUR_INTERNAL_SUBSCRIBER_ID',
+  __userAgent: null,
+});
+```
+
+If `__userAgent` is set to `null`, the SDK will not add a User-Agent header to requests, allowing the browser's default user agent to be used instead. This is done since some client's block adding user agent headers to requests.

--- a/packages/js/src/api/http-client.test.ts
+++ b/packages/js/src/api/http-client.test.ts
@@ -39,6 +39,20 @@ describe('HttpClient', () => {
       expect((client as any).apiVersion).toBe('v2');
       expect((client as any).headers['User-Agent']).toBe('custom-agent');
     });
+
+    it('should not add User-Agent header when userAgent is null', () => {
+      const client = new HttpClient({
+        userAgent: null as any,
+      });
+      expect((client as any).headers['User-Agent']).toBeUndefined();
+    });
+
+    it('should use default User-Agent when userAgent is undefined', () => {
+      const client = new HttpClient({
+        userAgent: undefined,
+      });
+      expect((client as any).headers['User-Agent']).toBe(`${PACKAGE_NAME}@${PACKAGE_VERSION}`);
+    });
   });
 
   describe('setAuthorizationToken', () => {

--- a/packages/js/src/api/http-client.ts
+++ b/packages/js/src/api/http-client.ts
@@ -29,7 +29,7 @@ export class HttpClient {
     this.headers = {
       'Novu-API-Version': NOVU_API_VERSION,
       'Content-Type': 'application/json',
-      'User-Agent': userAgent,
+      ...(userAgent !== null && { 'User-Agent': userAgent }),
       ...headers,
     };
   }
@@ -121,7 +121,8 @@ export class HttpClient {
 
     if (!response.ok) {
       const errorData = await response.json();
-      throw new Error(`${this.headers['User-Agent']} error. Status: ${response.status}, Message: ${errorData.message}`);
+      const userAgent = this.headers['User-Agent'] || DEFAULT_USER_AGENT;
+      throw new Error(`${userAgent} error. Status: ${response.status}, Message: ${errorData.message}`);
     }
     if (response.status === 204) {
       return undefined as unknown as T;


### PR DESCRIPTION
### What changed? Why was the change needed?

This allows users to not send the `User-Agent` parameter when self-hosting the project, since some fetch clients abort the connection if the user-agent is customized.


### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

Even though the `__userAgent` is used for testing only, it would be useful for some specific conditions to override the http client that it's being used. This way if the user sends null, the header is not sent. Its skipped.

</details>
