### PR TITLE
feat(js): allow passing socket options to the novu js configuration

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -81,3 +81,20 @@ const novu = new Novu({
 ```
 
 > Note: When HMAC encryption is enabled and `context` is provided, the `contextHash` is required. The hash is order-independent, so `{a:1, b:2}` produces the same hash as `{b:2, a:1}`.
+
+## Socket Options
+
+You can provide custom socket configuration options using the `socketOptions` parameter. These options will be merged with the default socket configuration when initializing the WebSocket connection.
+
+```ts
+const novu = new Novu({
+  applicationIdentifier: 'YOUR_NOVU_APPLICATION_IDENTIFIER',
+  subscriber: 'YOUR_INTERNAL_SUBSCRIBER_ID',
+  socketOptions: {
+    reconnectionDelay: 5000,
+    timeout: 20000,
+    path: '/my-custom-path',
+    // ... other socket.io-client options
+  },
+});
+```

--- a/packages/js/src/novu.test.ts
+++ b/packages/js/src/novu.test.ts
@@ -1,6 +1,7 @@
 import { Novu } from './novu';
 
-const mockSessionResponse = { data: { token: 'cafebabe' } };
+const sessionToken = 'cafebabe';
+const mockSessionResponse = { data: { token: sessionToken } };
 
 const mockNotificationsResponse = {
   data: [],
@@ -25,6 +26,17 @@ async function mockFetch(url: string, reqInit: Request) {
   }
   throw new Error(`Unmocked request: ${url}`);
 }
+
+jest.mock('socket.io-client', () => {
+  const mockIOFn = jest.fn(() => ({
+    on: jest.fn(),
+    disconnect: jest.fn(),
+  }));
+  return {
+    __esModule: true,
+    default: mockIOFn,
+  };
+});
 
 beforeAll(() => jest.spyOn(global, 'fetch'));
 afterAll(() => jest.restoreAllMocks());
@@ -73,6 +85,41 @@ describe('Novu', () => {
         hasMore: mockNotificationsResponse.hasMore,
         filter: mockNotificationsResponse.filter,
       });
+    });
+  });
+
+  describe('socket options', () => {
+    test('should initialize socket.io with socketOptions when provided', async () => {
+      const socketUrl = 'https://custom-socket.example.com';
+      const socketOptions = {
+        path: '/custom-socket-path',
+        reconnectionDelay: 5000,
+      };
+
+      const novu = new Novu({
+        applicationIdentifier,
+        subscriberId,
+        socketUrl,
+        socketOptions,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      await novu.socket.connect();
+
+      const mockIO = jest.requireMock('socket.io-client').default;
+      expect(mockIO).toHaveBeenCalledWith(
+        socketUrl,
+        expect.objectContaining({
+          path: '/custom-socket-path',
+          reconnectionDelay: 5000,
+          reconnectionDelayMax: 10000,
+          transports: ['websocket'],
+          query: {
+            token: sessionToken,
+          },
+        })
+      );
     });
   });
 });

--- a/packages/js/src/novu.ts
+++ b/packages/js/src/novu.ts
@@ -90,6 +90,7 @@ export class Novu implements Pick<NovuEventEmitter, 'on'> {
     });
     this.socket = createSocket({
       socketUrl: options.socketUrl,
+      socketOptions: options.socketOptions,
       eventEmitterInstance: this.#emitter,
       inboxServiceInstance: this.#inboxService,
     });

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -280,7 +280,12 @@ export type StandardNovuOptions = {
   contextHash?: string;
   apiUrl?: string;
   socketUrl?: string;
-  socketOptions?: Record<string, any>;
+  /**
+   * Custom socket configuration options. These options will be merged with the default socket configuration.
+   * For socket.io-client connections, supports all socket.io-client options (e.g., `path`, `reconnectionDelay`, `timeout`, etc.).
+   * For PartySocket connections, options are applied to the WebSocket instance.
+   */
+  socketOptions?: Record<string, unknown>;
   useCache?: boolean;
   defaultSchedule?: DefaultSchedule;
   context?: Context;

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -280,6 +280,7 @@ export type StandardNovuOptions = {
   contextHash?: string;
   apiUrl?: string;
   socketUrl?: string;
+  socketOptions?: Record<string, any>;
   useCache?: boolean;
   defaultSchedule?: DefaultSchedule;
   context?: Context;

--- a/packages/js/src/ws/party-socket.ts
+++ b/packages/js/src/ws/party-socket.ts
@@ -128,13 +128,16 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
   #emitter: NovuEventEmitter;
   #partySocket: WebSocket | undefined;
   #socketUrl: string;
+  #socketOptions?: Record<string, unknown>;
 
   constructor({
     socketUrl,
+    socketOptions,
     inboxServiceInstance,
     eventEmitterInstance,
   }: {
     socketUrl?: string;
+    socketOptions?: Record<string, unknown>;
     inboxServiceInstance: InboxService;
     eventEmitterInstance: NovuEventEmitter;
   }) {
@@ -144,6 +147,7 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
     });
     this.#emitter = eventEmitterInstance;
     this.#socketUrl = socketUrl ?? PRODUCTION_SOCKET_URL;
+    this.#socketOptions = socketOptions;
   }
 
   protected onSessionSuccess({ token }: Session): void {
@@ -223,7 +227,7 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
     const url = new URL(this.#socketUrl);
     url.searchParams.set('token', this.#token);
 
-    this.#partySocket = new WebSocket(url.toString());
+    this.#partySocket = new WebSocket(url.toString(), undefined, this.#socketOptions);
 
     this.#partySocket.addEventListener('open', () => {
       this.#emitter.emit('socket.connect.resolved', { args });

--- a/packages/js/src/ws/socket-factory.ts
+++ b/packages/js/src/ws/socket-factory.ts
@@ -30,10 +30,12 @@ function shouldUsePartySocket(socketUrl?: string): boolean {
 
 export function createSocket({
   socketUrl,
+  socketOptions,
   inboxServiceInstance,
   eventEmitterInstance,
 }: {
   socketUrl?: string;
+  socketOptions?: Record<string, unknown>;
   inboxServiceInstance: InboxService;
   eventEmitterInstance: NovuEventEmitter;
 }): BaseSocketInterface {
@@ -44,6 +46,7 @@ export function createSocket({
     case SocketType.PARTY_SOCKET:
       return new PartySocketClient({
         socketUrl: transformedSocketUrl,
+        socketOptions,
         inboxServiceInstance,
         eventEmitterInstance,
       });
@@ -51,6 +54,7 @@ export function createSocket({
     default:
       return new Socket({
         socketUrl: transformedSocketUrl,
+        socketOptions,
         inboxServiceInstance,
         eventEmitterInstance,
       });

--- a/packages/js/src/ws/socket.ts
+++ b/packages/js/src/ws/socket.ts
@@ -127,13 +127,16 @@ export class Socket extends BaseModule implements BaseSocketInterface {
   #emitter: NovuEventEmitter;
   #socketIo: SocketIO | undefined;
   #socketUrl: string;
+  #socketOptions?: Record<string, unknown>;
 
   constructor({
     socketUrl,
+    socketOptions,
     inboxServiceInstance,
     eventEmitterInstance,
   }: {
     socketUrl?: string;
+    socketOptions?: Record<string, unknown>;
     inboxServiceInstance: InboxService;
     eventEmitterInstance: NovuEventEmitter;
   }) {
@@ -143,6 +146,7 @@ export class Socket extends BaseModule implements BaseSocketInterface {
     });
     this.#emitter = eventEmitterInstance;
     this.#socketUrl = socketUrl ?? PRODUCTION_SOCKET_URL;
+    this.#socketOptions = socketOptions;
   }
 
   protected onSessionSuccess({ token }: Session): void {
@@ -181,6 +185,7 @@ export class Socket extends BaseModule implements BaseSocketInterface {
       query: {
         token: `${this.#token}`,
       },
+      ...(this.#socketOptions ?? {}),
     });
 
     this.#socketIo.on('connect', () => {


### PR DESCRIPTION
### What changed? Why was the change needed?

Adds support for `socketOptions` parameter to customize socket.io-client configuration. Users can now pass additional socket configuration options that will be merged with the default socket settings.

**Features:**
- Supports all socket.io-client options (e.g., `path`, `reconnectionDelay`, `timeout`, etc.)
- Options are merged with default configuration
- Works for both socket.io-client and PartySocket connections
- Includes test coverage to validate options are passed correctly

Resolves: 
- https://github.com/novuhq/novu/issues/2994

### Screenshots

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

## Example Usage

```
const novu = new Novu({
  applicationIdentifier: 'YOUR_APP_ID',
  subscriber: 'SUBSCRIBER_ID',
  socketUrl: 'https://my-server-url.com',
  socketOptions: {
    path: '/custom-socket-path',
    reconnectionDelay: 5000,
  },
});
```
</details>
