### PR TITLE
Throttle tier limits

### DIFF
--- a/packages/shared/src/consts/feature-tiers-constants.ts
+++ b/packages/shared/src/consts/feature-tiers-constants.ts
@@ -322,8 +322,8 @@ const novuServiceTiers: Record<FeatureNameEnum, Record<ApiServiceLevelEnum, Feat
   },
   [FeatureNameEnum.PLATFORM_MAX_THROTTLE_WINDOW_TIME]: {
     [ApiServiceLevelEnum.FREE]: { label: '1 hour max throttle window', value: 1, timeSuffix: 'h' },
-    [ApiServiceLevelEnum.PRO]: { label: '24 hours max throttle window', value: 24, timeSuffix: 'h' },
-    [ApiServiceLevelEnum.BUSINESS]: { label: '7 days max throttle window', value: 7, timeSuffix: 'd' },
+    [ApiServiceLevelEnum.PRO]: { label: '7 days max throttle window', value: 7, timeSuffix: 'd' },
+    [ApiServiceLevelEnum.BUSINESS]: { label: '30 days max throttle window', value: 30, timeSuffix: 'd' },
     [ApiServiceLevelEnum.ENTERPRISE]: { label: 'Custom throttle window', value: UNLIMITED_VALUE, timeSuffix: 'd' },
     [ApiServiceLevelEnum.UNLIMITED]: { label: 'Unlimited', value: UNLIMITED_VALUE, timeSuffix: 'd' },
   },


### PR DESCRIPTION
### What changed? Why was the change needed?

Updated the throttle step tier limits for Pro and Business plans to align with new product requirements.

*   **Pro**: Changed from 24 hours to 7 days.
*   **Business**: Changed from 7 days to 30 days.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1769332976103429?thread_ts=1769332976.103429&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-8fc22dc2-aada-4696-9ca5-949a5a85c497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8fc22dc2-aada-4696-9ca5-949a5a85c497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

