### PR TITLE
fix(dashboard): Last subscriber removal issue fixes NV-7079

### DIFF
--- a/apps/dashboard/src/components/subscribers/subscriber-row.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-row.tsx
@@ -1,4 +1,5 @@
 import { ISubscriberResponseDto, PermissionsEnum } from '@novu/shared';
+import { useQueryClient } from '@tanstack/react-query';
 import { ComponentProps, useState } from 'react';
 import { RiDeleteBin2Line, RiFileCopyLine, RiMore2Fill, RiPulseFill } from 'react-icons/ri';
 import { Link } from 'react-router-dom';
@@ -26,6 +27,7 @@ import { useEnvironment } from '@/context/environment/hooks';
 import { useDeleteSubscriber } from '@/hooks/use-delete-subscriber';
 import { formatDateSimple } from '@/utils/format-date';
 import { Protect } from '@/utils/protect';
+import { QueryKeys } from '@/utils/query-keys';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 import { useSubscribersUrlState } from './hooks/use-subscribers-url-state';
@@ -60,6 +62,7 @@ export const SubscriberRow = ({ subscriber, subscribersCount, firstTwoSubscriber
   const { currentEnvironment } = useEnvironment();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const subscriberTitle = getSubscriberTitle(subscriber);
+  const queryClient = useQueryClient();
   const { navigateToSubscribersFirstPage, navigateToEditSubscriberPage } = useSubscribersNavigate();
   const { handleNavigationAfterDelete } = useSubscribersUrlState();
 
@@ -104,7 +107,11 @@ export const SubscriberRow = ({ subscriber, subscribersCount, firstTwoSubscriber
     const hasSingleSubscriber = subscribersCount === 1;
 
     if (hasSingleSubscriber) {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKeys.fetchSubscribers],
+      });
       navigateToSubscribersFirstPage();
+
       return;
     }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixes NV-7079: The last subscriber was not removed from the list on delete due to stale cache data.

Previously, when deleting the last subscriber from `subscriber-row.tsx`, the query cache was not invalidated. The `navigateToSubscribersFirstPage` function only resets the query if pagination parameters are present in the URL. On the first page (without pagination params), the query remained un-invalidated, causing the deleted subscriber to still appear in the list.

This change adds `queryClient.invalidateQueries` before `navigateToSubscribersFirstPage()` when deleting the last subscriber, ensuring the cache is cleared and the UI reflects the deletion. This aligns the behavior with the existing logic in `subscriber-overview-form.tsx`.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

---
Linear Issue: [NV-7079](https://linear.app/novu/issue/NV-7079/last-subscriber-not-removed-from-subscribers-list-on-delete)

<a href="https://cursor.com/background-agent?bcId=bc-ab2de1be-9ceb-4c5f-96dd-5be1091a9668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab2de1be-9ceb-4c5f-96dd-5be1091a9668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

