### PR TITLE
fix(api-service): Message response payload types 

### DIFF
--- a/apps/api/src/app/widgets/dtos/message-response.dto.ts
+++ b/apps/api/src/app/widgets/dtos/message-response.dto.ts
@@ -52,7 +52,8 @@ export class EmailBlock {
 class MessageActionResult {
   @ApiPropertyOptional({
     description: 'Payload of the action result',
-    type: Object,
+    type: 'object',
+    additionalProperties: true,
   })
   payload?: Record<string, unknown>;
 
@@ -349,13 +350,15 @@ export class MessageResponseDto implements IMessage {
 
   @ApiPropertyOptional({
     description: 'The payload that was used to send the notification trigger',
-    type: Object,
+    type: 'object',
+    additionalProperties: true,
   })
   payload: Record<string, unknown>;
 
   @ApiPropertyOptional({
     description: 'Provider specific overrides used when triggering the notification',
-    type: Object,
+    type: 'object',
+    additionalProperties: true,
   })
   overrides?: Record<string, unknown>;
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Updated Swagger annotations for `payload` and `overrides` properties in `message-response.dto.ts` to `type: 'object', additionalProperties: true`. This change ensures that the API documentation accurately reflects the dynamic and flexible nature of these object properties, allowing them to contain any additional fields.

### Screenshots

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1769420924244119?thread_ts=1769420924.244119&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-33a0eb29-5649-4a12-ae98-531ffd2b2d10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33a0eb29-5649-4a12-ae98-531ffd2b2d10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

