### PR TITLE
feat(dal): ensure uniqueness on ctx prefs via hash fixes NV-7077

### DIFF
--- a/libs/dal/src/repositories/preferences/preferences.entity.ts
+++ b/libs/dal/src/repositories/preferences/preferences.entity.ts
@@ -35,6 +35,8 @@ export class PreferencesEntity {
 
   contextKeys?: string[];
 
+  contextKeysHash?: string;
+
   createdAt?: string;
 
   updatedAt?: string;

--- a/libs/dal/src/repositories/preferences/preferences.schema.ts
+++ b/libs/dal/src/repositories/preferences/preferences.schema.ts
@@ -1,6 +1,6 @@
 import { ChannelTypeEnum, PreferencesTypeEnum } from '@novu/shared';
 import { createHash } from 'crypto';
-import mongoose, { Schema, UpdateQuery } from 'mongoose';
+import mongoose, { Schema } from 'mongoose';
 import { schemaOptions } from '../schema-default.options';
 import { PreferencesDBModel } from './preferences.entity';
 
@@ -93,16 +93,41 @@ preferencesSchema.plugin(mongooseDelete, {
   use$neOperator: false,
 });
 
-preferencesSchema.pre('save', function (next) {
-  // Generate a hash from contextKeys to enforce uniqueness, since MongoDB cannot create unique indexes directly on arrays the way we need.
-  // See: https://www.mongodb.com/docs/manual/core/indexes/index-types/index-multikey/#unique-multikey-indexes
-  // The hash ensures each unique combination of contextKeys is properly indexed.
-  if (this.contextKeys && this.contextKeys.length > 0) {
-    const sorted = [...this.contextKeys].sort();
-    this.contextKeysHash = createHash('sha256').update(JSON.stringify(sorted)).digest('hex').substring(0, 16);
-  } else {
-    this.contextKeysHash = undefined;
+const CONTEXT_FILTERING_PREFERENCE_TYPES = [
+  PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
+  PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
+  PreferencesTypeEnum.SUBSCRIPTION_SUBSCRIBER_WORKFLOW,
+] as const;
+
+function shouldApplyContextKeysHash(type: PreferencesTypeEnum): boolean {
+  return CONTEXT_FILTERING_PREFERENCE_TYPES.includes(type as (typeof CONTEXT_FILTERING_PREFERENCE_TYPES)[number]);
+}
+
+function generateContextKeysHash(contextKeys: string[] | undefined): string {
+  if (!contextKeys || contextKeys.length === 0) {
+    return 'DEFAULT_CONTEXT';
   }
+
+  const sorted = [...contextKeys].sort();
+
+  return createHash('sha256').update(JSON.stringify(sorted)).digest('hex').substring(0, 16);
+}
+
+preferencesSchema.pre('save', function (next) {
+  if (shouldApplyContextKeysHash(this.type)) {
+    this.contextKeysHash = generateContextKeysHash(this.contextKeys);
+  }
+
+  next();
+});
+
+preferencesSchema.pre('insertMany', (next, docs: PreferencesDBModel[]) => {
+  for (const doc of docs) {
+    if (shouldApplyContextKeysHash(doc.type)) {
+      doc.contextKeysHash = generateContextKeysHash(doc.contextKeys);
+    }
+  }
+
   next();
 });
 
@@ -122,6 +147,7 @@ preferencesSchema.index(
     unique: true,
     partialFilterExpression: {
       type: PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
+      contextKeysHash: { $exists: true },
     },
   }
 );
@@ -143,6 +169,7 @@ preferencesSchema.index(
     unique: true,
     partialFilterExpression: {
       type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
+      contextKeysHash: { $exists: true },
     },
   }
 );
@@ -181,6 +208,7 @@ preferencesSchema.index(
     unique: true,
     partialFilterExpression: {
       type: PreferencesTypeEnum.SUBSCRIPTION_SUBSCRIBER_WORKFLOW,
+      contextKeysHash: { $exists: true },
     },
   }
 );

--- a/libs/dal/src/repositories/preferences/preferences.schema.ts
+++ b/libs/dal/src/repositories/preferences/preferences.schema.ts
@@ -1,5 +1,6 @@
 import { ChannelTypeEnum, PreferencesTypeEnum } from '@novu/shared';
-import mongoose, { Schema } from 'mongoose';
+import { createHash } from 'crypto';
+import mongoose, { Schema, UpdateQuery } from 'mongoose';
 import { schemaOptions } from '../schema-default.options';
 import { PreferencesDBModel } from './preferences.entity';
 
@@ -77,6 +78,10 @@ const preferencesSchema = new Schema<PreferencesDBModel>(
       type: [Schema.Types.String],
       default: undefined,
     },
+    contextKeysHash: {
+      type: Schema.Types.String,
+      default: undefined,
+    },
   },
   { ...schemaOptions, minimize: false }
 );
@@ -88,9 +93,22 @@ preferencesSchema.plugin(mongooseDelete, {
   use$neOperator: false,
 });
 
+preferencesSchema.pre('save', function (next) {
+  // Generate a hash from contextKeys to enforce uniqueness, since MongoDB cannot create unique indexes directly on arrays the way we need.
+  // See: https://www.mongodb.com/docs/manual/core/indexes/index-types/index-multikey/#unique-multikey-indexes
+  // The hash ensures each unique combination of contextKeys is properly indexed.
+  if (this.contextKeys && this.contextKeys.length > 0) {
+    const sorted = [...this.contextKeys].sort();
+    this.contextKeysHash = createHash('sha256').update(JSON.stringify(sorted)).digest('hex').substring(0, 16);
+  } else {
+    this.contextKeysHash = undefined;
+  }
+  next();
+});
+
 // Subscriber Global Preferences
 // Ensures one global preference per subscriber per context (SUBSCRIBER_GLOBAL type)
-// Includes contextKeys to allow multiple preferences for different contexts
+// Includes contextKeysHash to allow multiple preferences for different contexts
 // Partial filter ensures this only applies to SUBSCRIBER_GLOBAL type,
 // preventing conflicts with other preference types
 preferencesSchema.index(
@@ -98,7 +116,7 @@ preferencesSchema.index(
     _environmentId: 1,
     _subscriberId: 1,
     type: 1,
-    contextKeys: 1,
+    contextKeysHash: 1,
   },
   {
     unique: true,
@@ -110,7 +128,7 @@ preferencesSchema.index(
 
 // Subscriber Workflow Preferences
 // Ensures one workflow preference per subscriber per template per context (SUBSCRIBER_WORKFLOW type)
-// Includes contextKeys to allow multiple preferences for different contexts
+// Includes contextKeysHash to allow multiple preferences for different contexts
 // Partial filter ensures this only applies to SUBSCRIBER_WORKFLOW type,
 // preventing conflicts with other preference types
 preferencesSchema.index(
@@ -119,7 +137,7 @@ preferencesSchema.index(
     _subscriberId: 1,
     _templateId: 1,
     type: 1,
-    contextKeys: 1,
+    contextKeysHash: 1,
   },
   {
     unique: true,
@@ -148,7 +166,7 @@ preferencesSchema.index(
 );
 
 // Ensures one workflow preference per subscriber per template per topic subscription per context (SUBSCRIPTION_SUBSCRIBER_WORKFLOW type)
-// Includes contextKeys to allow multiple preferences for different contexts
+// Includes contextKeysHash to allow multiple preferences for different contexts
 // Only for this type (via partial filter).
 preferencesSchema.index(
   {
@@ -157,7 +175,7 @@ preferencesSchema.index(
     _topicSubscriptionId: 1,
     _templateId: 1,
     type: 1,
-    contextKeys: 1,
+    contextKeysHash: 1,
   },
   {
     unique: true,


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request introduces a new mechanism for handling preference uniqueness when `contextKeys` are present by adding a `contextKeysHash` field to the preferences schema. Instead of using the raw `contextKeys` array for uniqueness, a hash of the sorted `contextKeys` is now computed and used in unique indexes. This change ensures consistent and efficient handling of context-based preferences.

Schema and indexing improvements for context-based preferences:

* Added a new optional `contextKeysHash` field to the `PreferencesEntity` and its schema, which stores a hash of the sorted `contextKeys` array. [[1]](diffhunk://#diff-4b426cec6f9134d3c59bcc08528a4ed76838555f257b8dd2053d24907e108f0eR38-R39) [[2]](diffhunk://#diff-d62dfdd56b9d078f422d32bd9d04546c138d063ca4898ef6b4768a04634eb9e6R81-R84)
* Implemented pre-save and pre-insertMany hooks on the preferences schema to automatically generate and assign `contextKeysHash` for relevant preference types when documents are created or updated.
* Updated unique indexes for `SUBSCRIBER_GLOBAL`, `SUBSCRIBER_WORKFLOW`, and `SUBSCRIPTION_SUBSCRIBER_WORKFLOW` preference types to use `contextKeysHash` instead of the raw `contextKeys` array, ensuring proper uniqueness and index efficiency. [[1]](diffhunk://#diff-d62dfdd56b9d078f422d32bd9d04546c138d063ca4898ef6b4768a04634eb9e6R96-R157) [[2]](diffhunk://#diff-d62dfdd56b9d078f422d32bd9d04546c138d063ca4898ef6b4768a04634eb9e6L122-R172) [[3]](diffhunk://#diff-d62dfdd56b9d078f422d32bd9d04546c138d063ca4898ef6b4768a04634eb9e6L151-R196) [[4]](diffhunk://#diff-d62dfdd56b9d078f422d32bd9d04546c138d063ca4898ef6b4768a04634eb9e6L160-R211)

Utility and code clarity:

* Added utility functions `shouldApplyContextKeysHash` and `generateContextKeysHash` to determine when to apply the hash and to generate it in a consistent way.
* Updated comments throughout the schema file to reflect the switch from `contextKeys` to `contextKeysHash` for uniqueness and context filtering. [[1]](diffhunk://#diff-d62dfdd56b9d078f422d32bd9d04546c138d063ca4898ef6b4768a04634eb9e6R96-R157) [[2]](diffhunk://#diff-d62dfdd56b9d078f422d32bd9d04546c138d063ca4898ef6b4768a04634eb9e6L151-R196)
