### PR TITLE
Email layout name reliability

### DIFF
--- a/apps/dashboard/src/components/layouts/layout-editor-provider.tsx
+++ b/apps/dashboard/src/components/layouts/layout-editor-provider.tsx
@@ -442,7 +442,8 @@ export const LayoutEditorProvider = ({
     }
   }, [blocker]);
 
-  const onSubmit = (formData: Record<string, unknown>) => {
+  const onSubmit = (formData: Record<string, unknown>, event?: React.BaseSyntheticEvent) => {
+    event?.stopPropagation();
     updateLayout({
       layout: {
         name: layout?.name ?? '',

--- a/apps/dashboard/src/components/layouts/layout-editor-settings-drawer.tsx
+++ b/apps/dashboard/src/components/layouts/layout-editor-settings-drawer.tsx
@@ -170,7 +170,8 @@ export const LayoutEditorSettingsDrawer = forwardRef<HTMLDivElement, LayoutEdito
       });
     };
 
-    const onSubmit = async (data: LayoutSettingsFormData) => {
+    const onSubmit = async (data: LayoutSettingsFormData, event?: React.BaseSyntheticEvent) => {
+      event?.stopPropagation();
       if (!layout) return;
 
       await updateLayout({

--- a/apps/dashboard/src/components/layouts/layout-editor-settings-drawer.tsx
+++ b/apps/dashboard/src/components/layouts/layout-editor-settings-drawer.tsx
@@ -4,7 +4,7 @@ import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { EnvironmentTypeEnum, PermissionsEnum, ResourceOriginEnum } from '@novu/shared';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { formatDistanceToNow } from 'date-fns';
-import { forwardRef, useCallback, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { RiDeleteBin2Line, RiSettings4Line } from 'react-icons/ri';
 import { useBlocker, useNavigate } from 'react-router-dom';
@@ -81,12 +81,21 @@ export const LayoutEditorSettingsDrawer = forwardRef<HTMLDivElement, LayoutEdito
         layoutId: layout?.layoutId || '',
         isTranslationEnabled: layout?.isTranslationEnabled || false,
       },
-      values: {
-        name: layout?.name || '',
-        layoutId: layout?.layoutId || '',
-        isTranslationEnabled: layout?.isTranslationEnabled || false,
-      },
     });
+
+    const wasOpenRef = useRef(false);
+    useEffect(() => {
+      const isOpening = isOpen && !wasOpenRef.current;
+      wasOpenRef.current = isOpen;
+
+      if (isOpening && layout) {
+        form.reset({
+          name: layout.name || '',
+          layoutId: layout.layoutId || '',
+          isTranslationEnabled: layout.isTranslationEnabled || false,
+        });
+      }
+    }, [isOpen, layout, form]);
 
     const hasUnsavedChanges = form.formState.isDirty;
 
@@ -105,7 +114,12 @@ export const LayoutEditorSettingsDrawer = forwardRef<HTMLDivElement, LayoutEdito
     });
 
     const { updateLayout, isPending: isUpdating } = useUpdateLayout({
-      onSuccess: () => {
+      onSuccess: (data) => {
+        form.reset({
+          name: data.name || '',
+          layoutId: data.layoutId || '',
+          isTranslationEnabled: data.isTranslationEnabled || false,
+        });
         showSuccessToast('Layout updated successfully', '', toastOptions);
         onOpenChange(false);
       },


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves [NV-7084](https://linear.app/novu/issue/NV-7084/cannot-reliably-update-email-layout-name), which reported unreliable updates to email layout names due to duplicate API calls where the old name would override the new one.

The root cause was a race condition in the `LayoutEditorSettingsDrawer`:
1.  The `useForm` hook was initialized with the `values` prop, making the form "controlled" by the external `layout` state.
2.  During an update, if the `layout` object was refetched or invalidated, the form would unexpectedly reset to potentially stale data.
3.  This allowed for a second API call with the old layout name to be sent, overriding the intended update.

To fix this:
*   The `values` prop was removed from `useForm` in `LayoutEditorSettingsDrawer` to prevent unintended resets from external state changes during asynchronous operations.
*   A `useEffect` was added to explicitly reset the form only when the drawer *opens*, ensuring it initializes with the latest layout data without interrupting ongoing edits.
*   The form is now reset with the *response data* upon a successful layout update, ensuring its internal state is consistent with the newly saved values before the drawer closes.

These changes eliminate the race condition and ensure layout name updates are reliably persisted.

### Screenshots

<!-- No visual changes -->

---
Linear Issue: [NV-7084](https://linear.app/novu/issue/NV-7084/cannot-reliably-update-email-layout-name)

<a href="https://cursor.com/background-agent?bcId=bc-cb632db8-4bcd-48c0-8fa7-4e0b780df2ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb632db8-4bcd-48c0-8fa7-4e0b780df2ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

