### PR TITLE
Workflow list tags filter

### DIFF
--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -112,23 +112,9 @@ export const WorkflowsPage = () => {
   };
 
   useEffect(() => {
-    const subscription = form.watch((value) => {
-      const updates: Partial<{ query: string; tags: string[]; status: string[] }> = {};
-
-      if (value.query !== undefined) {
+    const subscription = form.watch((value, { name }) => {
+      if (name === 'query' && value.query !== undefined) {
         debouncedSearch(value.query || '');
-      }
-
-      if (value.tags !== undefined) {
-        updates.tags = value.tags as string[];
-      }
-
-      if (value.status !== undefined) {
-        updates.status = value.status as string[];
-      }
-
-      if (Object.keys(updates).length > 0) {
-        updateSearchParams(updates);
       }
     });
 
@@ -136,7 +122,7 @@ export const WorkflowsPage = () => {
       subscription.unsubscribe();
       debouncedSearch.cancel();
     };
-  }, [form, debouncedSearch, updateSearchParams]);
+  }, [form, debouncedSearch]);
 
   const { quickTemplates, isLoading: isLoadingQuickStart } = useTemplateStore();
 
@@ -224,6 +210,7 @@ export const WorkflowsPage = () => {
                 selected={form.watch('tags')}
                 onSelect={(values) => {
                   form.setValue('tags', values, { shouldDirty: true, shouldTouch: true });
+                  updateSearchParams({ tags: values });
                 }}
               />
               <FacetedFormFilter
@@ -239,6 +226,7 @@ export const WorkflowsPage = () => {
                 selected={form.watch('status')}
                 onSelect={(values) => {
                   form.setValue('status', values, { shouldDirty: true, shouldTouch: true });
+                  updateSearchParams({ status: values });
                 }}
               />
 


### PR DESCRIPTION
### What changed? Why was the change needed?

The tags and status filters on the workflow list page were not reliably updating the URL query parameters, preventing filtering from working correctly (NV-6816). This was due to an unreliable `form.watch()` subscription for these fields, likely affected by React's batching behavior.

The fix involves directly calling `updateSearchParams` within the `onSelect` callbacks for the tags and status filters, ensuring immediate URL updates. The `useEffect` `form.watch` subscription was simplified to only handle the debounced search query.

### Screenshots

N/A (Functionality fix)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

This provides a more robust solution to a previously reported issue (similar to `ccbe7cf9bd`). The direct `updateSearchParams` calls make the filter behavior more explicit and reliable.

</details>

---
Linear Issue: [NV-6816](https://linear.app/novu/issue/NV-6816/functionality-of-filtering-by-tags-not-working-on-the-workflow-list)

<a href="https://cursor.com/background-agent?bcId=bc-eeb3de30-f6e4-424a-9665-de26cf809b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eeb3de30-f6e4-424a-9665-de26cf809b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

