### PR TITLE
refactor(api-service): centralize context retrieval queries & sort fixes NV-7058

### DIFF
--- a/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/bulk-update-preferences/bulk-update-preferences.usecase.ts
@@ -163,6 +163,6 @@ export class BulkUpdatePreferences {
       context
     );
 
-    return contexts.map((ctx) => ctx.key).sort();
+    return contexts.map((ctx) => ctx.key);
   }
 }

--- a/apps/api/src/app/inbox/usecases/delete-subscription/delete-subscription.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/delete-subscription/delete-subscription.usecase.ts
@@ -36,7 +36,15 @@ export class DeleteTopicSubscription {
       throw new NotFoundException(`Topic with key ${command.topicKey} not found`);
     }
 
-    const contextQuery = await this.buildContextExactMatchQuery(command.contextKeys, command.organizationId);
+    const useContextFiltering = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+      defaultValue: false,
+      organization: { _id: command.organizationId },
+    });
+
+    const contextQuery = this.topicSubscribersRepository.buildContextExactMatchQuery(command.contextKeys, {
+      enabled: useContextFiltering,
+    });
 
     const subscription = await this.topicSubscribersRepository.findOne({
       _environmentId: command.environmentId,
@@ -69,32 +77,5 @@ export class DeleteTopicSubscription {
     });
 
     return { success: true };
-  }
-
-  private async buildContextExactMatchQuery(
-    contextKeys: string[] | undefined,
-    organizationId: string
-  ): Promise<Record<string, unknown>> {
-    const useContextFiltering = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
-      defaultValue: false,
-      organization: { _id: organizationId },
-    });
-
-    if (!useContextFiltering) {
-      return {}; // FF OFF: no context filtering (pre-feature behavior)
-    }
-
-    // undefined or empty array = match only "no context" subscriptions/preferences
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    // non-empty array = exact match
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
   }
 }

--- a/apps/api/src/app/inbox/usecases/get-topic-subscriptions/get-topic-subscriptions.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/get-topic-subscriptions/get-topic-subscriptions.usecase.ts
@@ -27,7 +27,7 @@ export class GetTopicSubscriptions {
 
   @InstrumentUsecase()
   async execute(command: GetTopicSubscriptionsCommand): Promise<SubscriptionDetailsResponseDto[]> {
-    const contextQuery = await this.buildContextExactMatchQuery(command.contextKeys, command.organizationId);
+    const contextQuery = await this.buildContextQuery(command.contextKeys, command.organizationId);
 
     const subscriptions = await this.topicSubscribersRepository.find({
       _environmentId: command.environmentId,
@@ -46,7 +46,7 @@ export class GetTopicSubscriptions {
   ): Promise<SubscriptionDetailsResponseDto[]> {
     const subscriptionPreferencesMap = new Map<TopicSubscribersEntity, PreferencesEntity[]>();
 
-    const contextQuery = await this.buildContextExactMatchQuery(contextKeys, organizationId);
+    const contextQuery = await this.buildContextQuery(contextKeys, organizationId);
 
     for (const subscription of subscriptions) {
       const preferences = await this.preferencesRepository.find({
@@ -109,10 +109,7 @@ export class GetTopicSubscriptions {
     return workflowsMap;
   }
 
-  private async buildContextExactMatchQuery(
-    contextKeys: string[] | undefined,
-    organizationId?: string
-  ): Promise<Record<string, unknown>> {
+  private async buildContextQuery(contextKeys?: string[], organizationId?: string): Promise<Record<string, unknown>> {
     if (!organizationId) {
       return {};
     }
@@ -123,20 +120,8 @@ export class GetTopicSubscriptions {
       organization: { _id: organizationId },
     });
 
-    if (!useContextFiltering) {
-      return {}; // FF OFF: no context filtering (pre-feature behavior)
-    }
-
-    // undefined or empty array = match only "no context" subscriptions/preferences
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    // non-empty array = exact match
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
+    return this.topicSubscribersRepository.buildContextExactMatchQuery(contextKeys, {
+      enabled: useContextFiltering,
+    });
   }
 }

--- a/apps/api/src/app/inbox/usecases/session/session.spec.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.spec.ts
@@ -374,7 +374,7 @@ describe('Session', () => {
     const subscriber = { _id: 'subscriber-id' };
     const notificationCount = { data: [{ count: 10, filter: {} }] };
     const token = 'token';
-    const mockContexts = [{ key: 'teamId:team-123' }, { key: 'projectId:project-456' }];
+    const mockContexts = [{ key: 'projectId:project-456' }, { key: 'teamId:team-123' }];
 
     environmentRepository.findEnvironmentByIdentifier.resolves(environment as any);
     organizationRepository.findById.resolves(organization as any);

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -421,7 +421,7 @@ export class Session {
       context
     );
 
-    return contexts.map((context) => context.key).sort();
+    return contexts.map((context) => context.key);
   }
 
   private async getMaxSnoozeDurationHours(apiServiceLevel: ApiServiceLevelEnum) {

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -127,7 +127,15 @@ export class UpdatePreferences {
       identifier = stripContextFromIdentifier(identifier);
     }
 
-    const contextQuery = await this.buildContextExactMatchQuery(command.contextKeys, command.organizationId);
+    const useContextFiltering = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+      defaultValue: false,
+      organization: { _id: command.organizationId },
+    });
+
+    const contextQuery = this.topicSubscribersRepository.buildContextExactMatchQuery(command.contextKeys, {
+      enabled: useContextFiltering,
+    });
 
     // Try to find by identifier first
     let subscription = await this.topicSubscribersRepository.findOne({
@@ -195,7 +203,15 @@ export class UpdatePreferences {
       command.workflowIdOrIdentifier &&
       workflow
     ) {
-      const contextQuery = await this.buildContextExactMatchQuery(command.contextKeys, command.organizationId);
+      const useContextFiltering = await this.featureFlagsService.getFlag({
+        key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+        defaultValue: false,
+        organization: { _id: command.organizationId },
+      });
+
+      const contextQuery = this.preferencesRepository.buildContextExactMatchQuery(command.contextKeys, {
+        enabled: useContextFiltering,
+      });
 
       const query: FilterQuery<PreferencesDBModel> & EnforceEnvOrOrgIds = {
         _environmentId: command.environmentId,
@@ -347,30 +363,5 @@ export class UpdatePreferences {
         contextKeys: item.contextKeys,
       })
     );
-  }
-
-  private async buildContextExactMatchQuery(
-    contextKeys: string[] | undefined,
-    organizationId: string
-  ): Promise<Record<string, unknown>> {
-    const useContextFiltering = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
-      defaultValue: false,
-      organization: { _id: organizationId },
-    });
-
-    if (!useContextFiltering) {
-      return {};
-    }
-
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
   }
 }

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
@@ -264,7 +264,15 @@ export class GetSubscriberPreference {
     };
 
     const readOptions = { readPreference: 'secondaryPreferred' as const };
-    const contextQuery = await this.buildContextExactMatchQuery(contextKeys, organizationId);
+    const useContextFiltering = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+      defaultValue: false,
+      organization: { _id: organizationId },
+    });
+
+    const contextQuery = this.preferencesRepository.buildContextExactMatchQuery(contextKeys, {
+      enabled: useContextFiltering,
+    });
 
     const [
       workflowResourcePreferences,
@@ -318,33 +326,6 @@ export class GetSubscriberPreference {
       workflowUserPreferences,
       subscriberWorkflowPreferences,
       subscriberGlobalPreference: subscriberGlobalPreferences[0] ?? null,
-    };
-  }
-
-  private async buildContextExactMatchQuery(
-    contextKeys: string[] | undefined,
-    organizationId: string
-  ): Promise<Record<string, unknown>> {
-    const useContextFiltering = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
-      defaultValue: false,
-      organization: { _id: organizationId },
-    });
-
-    if (!useContextFiltering) {
-      return {}; // FF OFF: no context filtering (pre-feature behavior)
-    }
-
-    // undefined or empty array = match only "no context" preferences
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    // non-empty array = exact match
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
     };
   }
 }

--- a/apps/api/src/app/subscriptions/usecases/create-subscriptions/create-subscriptions.usecase.ts
+++ b/apps/api/src/app/subscriptions/usecases/create-subscriptions/create-subscriptions.usecase.ts
@@ -56,13 +56,13 @@ export class CreateSubscriptionsUsecase {
 
   @InstrumentUsecase()
   async execute(command: CreateSubscriptionsCommand): Promise<CreateSubscriptionsResponseDto> {
-    const isContextEnabled = await this.featureFlagsService.getFlag({
+    const useContextFiltering = await this.featureFlagsService.getFlag({
       key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
       defaultValue: false,
       organization: { _id: command.organizationId },
     });
 
-    const contextKeys = isContextEnabled
+    const contextKeys = useContextFiltering
       ? (command.contextKeys ??
         (await this.resolveContexts(command.environmentId, command.organizationId, command.context)))
       : undefined; // FF OFF: always ignore context
@@ -113,12 +113,6 @@ export class CreateSubscriptionsUsecase {
         command.subscriptions.find((s) => s.subscriberId === sub.subscriberId)?.identifier ||
         buildDefaultSubscriptionIdentifier(command.topicKey, sub.subscriberId, contextKeys),
     }));
-
-    const useContextFiltering = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
-      defaultValue: false,
-      organization: { _id: command.organizationId },
-    });
 
     const contextQuery = this.topicSubscribersRepository.buildContextExactMatchQuery(contextKeys, {
       enabled: useContextFiltering,

--- a/apps/api/src/app/subscriptions/usecases/create-subscriptions/create-subscriptions.usecase.ts
+++ b/apps/api/src/app/subscriptions/usecases/create-subscriptions/create-subscriptions.usecase.ts
@@ -114,7 +114,16 @@ export class CreateSubscriptionsUsecase {
         buildDefaultSubscriptionIdentifier(command.topicKey, sub.subscriberId, contextKeys),
     }));
 
-    const contextQuery = await this.buildContextExactMatchQuery(contextKeys, command.organizationId);
+    const useContextFiltering = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+      defaultValue: false,
+      organization: { _id: command.organizationId },
+    });
+
+    const contextQuery = this.topicSubscribersRepository.buildContextExactMatchQuery(contextKeys, {
+      enabled: useContextFiltering,
+    });
+
     const existingSubscriptions = await this.topicSubscribersRepository.find({
       _environmentId: command.environmentId,
       _organizationId: command.organizationId,
@@ -412,7 +421,9 @@ export class CreateSubscriptionsUsecase {
       return undefined;
     }
 
-    const contextQuery = await this.buildContextExactMatchQuery(subscription.contextKeys, command.organizationId);
+    const contextQuery = this.preferencesRepository.buildContextExactMatchQuery(subscription.contextKeys, {
+      enabled: useContextFiltering,
+    });
 
     const preferencesEntities = await this.preferencesRepository.find({
       _environmentId: command.environmentId,
@@ -645,30 +656,5 @@ export class CreateSubscriptionsUsecase {
     );
 
     return contexts.map((ctx) => ctx.key).sort();
-  }
-
-  private async buildContextExactMatchQuery(
-    contextKeys: string[] | undefined,
-    organizationId: string
-  ): Promise<Record<string, unknown>> {
-    const useContextFiltering = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
-      defaultValue: false,
-      organization: { _id: organizationId },
-    });
-
-    if (!useContextFiltering) {
-      return {};
-    }
-
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
   }
 }

--- a/apps/api/src/app/subscriptions/usecases/create-subscriptions/create-subscriptions.usecase.ts
+++ b/apps/api/src/app/subscriptions/usecases/create-subscriptions/create-subscriptions.usecase.ts
@@ -146,7 +146,12 @@ export class CreateSubscriptionsUsecase {
 
     for (const subscription of existingSubscriptions) {
       const subscriber = foundSubscribers.find((sub) => sub._id.toString() === subscription._subscriberId.toString());
-      const preferences = await this.fetchPreferencesForSubscription(command, subscription, workflows);
+      const preferences = await this.fetchPreferencesForSubscription(
+        command,
+        subscription,
+        workflows,
+        useContextFiltering
+      );
 
       subscriptionData.push({
         _id: subscription._id.toString(),
@@ -246,7 +251,12 @@ export class CreateSubscriptionsUsecase {
       for (const subscription of newSubscriptions.updated) {
         const subscriber = foundSubscribers.find((sub) => sub._id.toString() === subscription._subscriberId.toString());
 
-        const preferences = await this.fetchPreferencesForSubscription(command, subscription, workflows);
+        const preferences = await this.fetchPreferencesForSubscription(
+          command,
+          subscription,
+          workflows,
+          useContextFiltering
+        );
 
         subscriptionData.push({
           _id: subscription._id.toString(),
@@ -415,7 +425,8 @@ export class CreateSubscriptionsUsecase {
   private async fetchPreferencesForSubscription(
     command: CreateSubscriptionsCommand,
     subscription: TopicSubscribersEntity,
-    workflows: NotificationTemplateEntity[]
+    workflows: NotificationTemplateEntity[],
+    useContextFiltering: boolean
   ): Promise<SubscriptionPreferenceDto[] | undefined> {
     if (!command.preferences || command.preferences.length === 0 || workflows.length === 0) {
       return undefined;

--- a/apps/api/src/app/subscriptions/usecases/create-subscriptions/create-subscriptions.usecase.ts
+++ b/apps/api/src/app/subscriptions/usecases/create-subscriptions/create-subscriptions.usecase.ts
@@ -655,6 +655,6 @@ export class CreateSubscriptionsUsecase {
       context
     );
 
-    return contexts.map((ctx) => ctx.key).sort();
+    return contexts.map((ctx) => ctx.key);
   }
 }

--- a/apps/api/src/app/subscriptions/usecases/get-subscription/get-subscription.usecase.ts
+++ b/apps/api/src/app/subscriptions/usecases/get-subscription/get-subscription.usecase.ts
@@ -47,7 +47,19 @@ export class GetSubscription {
       command.identifier = stripContextFromIdentifier(command.identifier);
     }
 
-    const contextQuery = await this.buildContextExactMatchQuery(command.contextKeys, command.organizationId);
+    const useContextFiltering = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+      defaultValue: false,
+      organization: { _id: command.organizationId },
+    });
+
+    // Admin API (topics-v2): contextKeys undefined → no context filtering (identifier is sufficient)
+    const contextQuery =
+      command.contextKeys === undefined
+        ? {}
+        : this.topicSubscribersRepository.buildContextExactMatchQuery(command.contextKeys, {
+            enabled: useContextFiltering,
+          });
 
     const subscription = await this.topicSubscribersRepository.findOne({
       _environmentId: command.environmentId,
@@ -174,38 +186,5 @@ export class GetSubscription {
     );
 
     return computedPreferences.filter((pref): pref is NonNullable<typeof pref> => pref !== null);
-  }
-
-  private async buildContextExactMatchQuery(
-    contextKeys: string[] | undefined,
-    organizationId: string
-  ): Promise<Record<string, unknown>> {
-    const useContextFiltering = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
-      defaultValue: false,
-      organization: { _id: organizationId },
-    });
-
-    if (!useContextFiltering) {
-      return {}; // FF OFF: no context filtering (pre-feature behavior)
-    }
-
-    // Admin API (topics-v2): contextKeys undefined → no context filtering (identifier is sufficient)
-    if (contextKeys === undefined) {
-      return {};
-    }
-
-    // Subscriber API (inbox): contextKeys always provided as array
-    // Empty array → match only subscriptions with no context
-    if (contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    // Non-empty array → exact context match for security
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
   }
 }

--- a/apps/api/src/app/subscriptions/usecases/update-subscription/update-subscription.usecase.ts
+++ b/apps/api/src/app/subscriptions/usecases/update-subscription/update-subscription.usecase.ts
@@ -73,7 +73,7 @@ export class UpdateSubscriptionUsecase {
       throw new NotFoundException(`Topic with key ${command.topicKey} not found`);
     }
 
-    const contextQuery = await this.buildContextExactMatchQuery(command.contextKeys, command.organizationId);
+    const contextQuery = await this.buildContextQuery(command.contextKeys, command.organizationId);
 
     const subscription = await this.topicSubscribersRepository.findOne({
       identifier: command.identifier,
@@ -137,39 +137,12 @@ export class UpdateSubscriptionUsecase {
     return this.mapSubscriptionToDto(updatedSubscription, subscriber, topic, preferences);
   }
 
-  private async buildContextExactMatchQuery(
-    contextKeys: string[] | undefined,
-    organizationId: string
-  ): Promise<Record<string, unknown>> {
-    const useContextFiltering = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
-      defaultValue: false,
-      organization: { _id: organizationId },
-    });
-
-    if (!useContextFiltering) {
-      return {}; // FF OFF: no context filtering (pre-feature behavior)
-    }
-
-    // undefined or empty array = match only "no context" subscriptions/preferences
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    // non-empty array = exact match
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
-  }
-
   private async updatePreferencesForSubscription(
     command: UpdateSubscriptionCommand,
     subscription: TopicSubscribersEntity,
     workflows: NotificationTemplateEntity[]
   ): Promise<void> {
-    const contextQuery = await this.buildContextExactMatchQuery(command.contextKeys, command.organizationId);
+    const contextQuery = await this.buildContextQuery(command.contextKeys, command.organizationId);
 
     await this.preferencesRepository.delete({
       _environmentId: command.environmentId,
@@ -212,7 +185,7 @@ export class UpdateSubscriptionUsecase {
       return undefined;
     }
 
-    const contextQuery = await this.buildContextExactMatchQuery(contextKeys, organizationId);
+    const contextQuery = await this.buildContextQuery(contextKeys, organizationId);
 
     const preferencesEntities = await this.preferencesRepository.find({
       _environmentId: environmentId,
@@ -428,5 +401,21 @@ export class UpdateSubscriptionUsecase {
       createdAt: subscription.createdAt ?? '',
       updatedAt: subscription.updatedAt ?? '',
     };
+  }
+
+  private async buildContextQuery(contextKeys?: string[], organizationId?: string): Promise<Record<string, unknown>> {
+    if (!organizationId) {
+      return {};
+    }
+
+    const useContextFiltering = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+      defaultValue: false,
+      organization: { _id: organizationId },
+    });
+
+    return this.topicSubscribersRepository.buildContextExactMatchQuery(contextKeys, {
+      enabled: useContextFiltering,
+    });
   }
 }

--- a/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
@@ -168,7 +168,15 @@ export class GetPreferences {
     ];
 
     if (command.subscriberId) {
-      const contextQuery = await this.buildContextExactMatchQuery(command.contextKeys, command.organizationId);
+      const useContextFiltering = await this.featureFlagsService.getFlag({
+        key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+        defaultValue: false,
+        organization: { _id: command.organizationId },
+      });
+
+      const contextQuery = this.preferencesRepository.buildContextExactMatchQuery(command.contextKeys, {
+        enabled: useContextFiltering,
+      });
 
       queries.push(
         this.preferencesRepository.findOne(
@@ -222,32 +230,5 @@ export class GetPreferences {
     }
 
     return result;
-  }
-
-  private async buildContextExactMatchQuery(
-    contextKeys: string[] | undefined,
-    organizationId: string
-  ): Promise<Record<string, unknown>> {
-    const useContextFiltering = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
-      defaultValue: false,
-      organization: { _id: organizationId },
-    });
-
-    if (!useContextFiltering) {
-      return {}; // FF OFF: no context filtering (pre-feature behavior)
-    }
-
-    // undefined or empty array = match only "no context" preferences
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    // non-empty array = exact match
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
   }
 }

--- a/libs/application-generic/src/usecases/get-subscriber-schedule/get-subscriber-schedule.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-schedule/get-subscriber-schedule.usecase.ts
@@ -14,7 +14,15 @@ export class GetSubscriberSchedule {
 
   @InstrumentUsecase()
   async execute(command: GetSubscriberScheduleCommand): Promise<Schedule | undefined> {
-    const contextQuery = await this.buildContextExactMatchQuery(command.contextKeys, command.organizationId);
+    const useContextFiltering = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+      defaultValue: false,
+      organization: { _id: command.organizationId },
+    });
+
+    const contextQuery = this.preferencesRepository.buildContextExactMatchQuery(command.contextKeys, {
+      enabled: useContextFiltering,
+    });
 
     const subscriberGlobalPreference = await this.preferencesRepository.findOne(
       {
@@ -29,31 +37,5 @@ export class GetSubscriberSchedule {
     );
 
     return subscriberGlobalPreference?.schedule;
-  }
-
-  @Instrument()
-  private async buildContextExactMatchQuery(
-    contextKeys: string[] | undefined,
-    organizationId: string
-  ): Promise<Record<string, unknown>> {
-    const useContextFiltering = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
-      defaultValue: false,
-      organization: { _id: organizationId },
-    });
-
-    if (!useContextFiltering) {
-      return {};
-    }
-
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
   }
 }

--- a/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -235,7 +235,7 @@ export class TriggerMulticast extends TriggerBase {
       });
 
       const contextQuery = this.preferencesRepository.buildContextExactMatchQuery(command.contextKeys, {
-        enabled: useContextFiltering && !!command.contextKeys,
+        enabled: useContextFiltering,
       });
 
       const subscriptionPreference = await this.preferencesRepository.findOne({

--- a/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -234,8 +234,9 @@ export class TriggerMulticast extends TriggerBase {
         organization: { _id: command.organizationId },
       });
 
-      const contextQuery =
-        useContextFiltering && command.contextKeys ? this.buildContextExactMatchQuery(command.contextKeys) : {};
+      const contextQuery = this.preferencesRepository.buildContextExactMatchQuery(command.contextKeys, {
+        enabled: useContextFiltering && !!command.contextKeys,
+      });
 
       const subscriptionPreference = await this.preferencesRepository.findOne({
         _environmentId: command.environmentId,
@@ -279,20 +280,6 @@ export class TriggerMulticast extends TriggerBase {
 
       return { result: true, subscriptionIdentifier };
     }
-  }
-
-  private buildContextExactMatchQuery(contextKeys?: string[]): Record<string, unknown> {
-    // undefined or empty array = match only "no context" preferences
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    // non-empty array = exact match filtering (order-insensitive)
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
   }
 
   private async evaluatePreferenceCondition(

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
@@ -235,11 +235,19 @@ export class UpsertPreferences {
   }
 
   private async getPreference(command: UpsertPreferencesCommand): Promise<PreferencesEntity | undefined> {
-    const contextQuery = await this.buildContextExactMatchQuery(
-      command.contextKeys,
-      command.type,
-      command.organizationId
-    );
+    // Non-context-scoped types (universal/workflow-level) - no context filter
+    const nonContextScopedTypes = [PreferencesTypeEnum.WORKFLOW_RESOURCE, PreferencesTypeEnum.USER_WORKFLOW];
+    const useContextFiltering = nonContextScopedTypes.includes(command.type)
+      ? false
+      : await this.featureFlagsService.getFlag({
+          key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+          defaultValue: false,
+          organization: { _id: command.organizationId },
+        });
+
+    const contextQuery = this.preferencesRepository.buildContextExactMatchQuery(command.contextKeys, {
+      enabled: useContextFiltering,
+    });
 
     const query: FilterQuery<PreferencesDBModel> & EnforceEnvOrOrgIds = {
       _environmentId: command.environmentId,
@@ -252,36 +260,5 @@ export class UpsertPreferences {
     };
 
     return await this.preferencesRepository.findOne(query);
-  }
-
-  private async buildContextExactMatchQuery(
-    contextKeys: string[] | undefined,
-    type: PreferencesTypeEnum,
-    organizationId: string
-  ): Promise<Record<string, unknown>> {
-    // Non-context-scoped types (universal/workflow-level) - no context filter
-    const nonContextScopedTypes = [PreferencesTypeEnum.WORKFLOW_RESOURCE, PreferencesTypeEnum.USER_WORKFLOW];
-
-    if (nonContextScopedTypes.includes(type)) {
-      return {};
-    }
-
-    const useContextFiltering = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
-      defaultValue: false,
-      organization: { _id: organizationId },
-    });
-
-    if (!useContextFiltering) {
-      return {};
-    }
-
-    // undefined or empty array = match only "no context" preferences
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return { $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }] };
-    }
-
-    // Match records with exact same context keys (order-independent)
-    return { contextKeys: { $all: contextKeys, $size: contextKeys.length } };
   }
 }

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -62,25 +62,29 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
       return {};
     }
 
-    // Match only "no context" (default context) records
-
+    // Match records with no context (default/empty context)
     if (contextKeys === undefined || contextKeys.length === 0) {
-      // for collections created after context was introduced, we always wrote contextKeys: [] so we
-      // dont need to check for $exists: false
+      // For collections created after context was introduced, we always write contextKeys: []
+      // For older collections, the field may not exist (treated as default context)
       if (strictEmpty) {
         return { contextKeys: [] };
       }
 
-      // the $or is here because old records before context was introduced dont have that field and thats counted
-      // as default context. After migration we can simplify the query to check just contextKeys: []
+      // Match both missing field (legacy) and empty array (current)
       return {
         $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
       };
     }
 
-    // order independent matching - after sort migration we can simplify
+    // Sort defensively to ensure consistent matching regardless of input order
+    // This protects against unsorted input and enables future query optimization
+    const sortedKeys = [...contextKeys].sort();
+
+    // Use $all + $size for order-independent array matching
+    // After data migration to guarantee sorted storage, this can be simplified to:
+    // return { contextKeys: sortedKeys };  // Direct equality (faster, uses index)
     return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
+      contextKeys: { $all: sortedKeys, $size: sortedKeys.length },
     };
   }
 

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -45,6 +45,45 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
     return new Types.ObjectId(value);
   }
 
+  /**
+   * Builds a MongoDB query for exact context key matching in READ operations.
+   * Uses $all and $size operators for order-independent array matching.
+   */
+  public buildContextExactMatchQuery(
+    contextKeys?: string[],
+    options?: {
+      enabled?: boolean;
+      strictEmpty?: boolean;
+    }
+  ): Record<string, unknown> {
+    const { enabled = true, strictEmpty = false } = options ?? {};
+
+    if (!enabled) {
+      return {};
+    }
+
+    // Match only "no context" (default context) records
+
+    if (contextKeys === undefined || contextKeys.length === 0) {
+      // for collections created after context was introduced, we always wrote contextKeys: [] so we
+      // dont need to check for $exists: false
+      if (strictEmpty) {
+        return { contextKeys: [] };
+      }
+
+      // the $or is here because old records before context was introduced dont have that field and thats counted
+      // as default context. After migration we can simplify the query to check just contextKeys: []
+      return {
+        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
+      };
+    }
+
+    // order independent matching - after sort migration we can simplify
+    return {
+      contextKeys: { $all: contextKeys, $size: contextKeys.length },
+    };
+  }
+
   async count(
     query: FilterQuery<T_DBModel> & T_Enforcement,
     limit?: number,

--- a/libs/dal/src/repositories/channel-connection/channel-connection.repository.ts
+++ b/libs/dal/src/repositories/channel-connection/channel-connection.repository.ts
@@ -11,16 +11,4 @@ export class ChannelConnectionRepository extends BaseRepository<
   constructor() {
     super(ChannelConnection, ChannelConnectionEntity);
   }
-
-  buildContextExactMatchQuery(contextKeys?: string[]) {
-    // empty array = no context, only match connections with no context
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return { contextKeys: [] };
-    }
-
-    // non-empty array = exact match filtering (order-insensitive)
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
-  }
 }

--- a/libs/dal/src/repositories/channel-endpoint/channel-endpoint.repository.ts
+++ b/libs/dal/src/repositories/channel-endpoint/channel-endpoint.repository.ts
@@ -11,14 +11,4 @@ export class ChannelEndpointRepository extends BaseRepository<
   constructor() {
     super(ChannelEndpoint, ChannelEndpointEntity);
   }
-
-  buildContextExactMatchQuery(contextKeys?: string[]) {
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return { contextKeys: [] };
-    }
-
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
-  }
 }

--- a/libs/dal/src/repositories/context/context.repository.ts
+++ b/libs/dal/src/repositories/context/context.repository.ts
@@ -26,7 +26,9 @@ export class ContextRepository extends BaseRepository<ContextDBModel, ContextEnt
 
     const validPromises = findOrCreatePromises.filter((promise): promise is Promise<ContextEntity> => promise !== null);
 
-    return Promise.all(validPromises);
+    const contexts = await Promise.all(validPromises);
+
+    return contexts.sort((a, b) => a.key.localeCompare(b.key));
   }
 
   async findOrCreateContext(

--- a/libs/dal/src/repositories/message/message.repository.ts
+++ b/libs/dal/src/repositories/message/message.repository.ts
@@ -1170,18 +1170,4 @@ export class MessageRepository extends BaseRepository<MessageDBModel, MessageEnt
       ...this.buildContextExactMatchQuery(contextKeys),
     };
   }
-
-  private buildContextExactMatchQuery(contextKeys: string[]): MessageQuery {
-    // empty array = inbox has no (default) context, only match messages with no context
-    if (contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    // non-empty array = exact match filtering
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
-  }
 }

--- a/libs/dal/src/repositories/notification/notification.repository.ts
+++ b/libs/dal/src/repositories/notification/notification.repository.ts
@@ -346,18 +346,4 @@ export class NotificationRepository extends BaseRepository<
   estimatedDocumentCount() {
     return this.MongooseModel.estimatedDocumentCount();
   }
-
-  private buildContextExactMatchQuery(contextKeys: string[]) {
-    // empty array = inbox has no context, only match notifications with no context
-    if (contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    // non-empty array = exact match filtering
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
-  }
 }

--- a/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.repository.ts
@@ -382,20 +382,6 @@ export class TopicSubscribersRepository extends BaseRepository<
 
     return countMap;
   }
-
-  buildContextExactMatchQuery(contextKeys?: string[]): Record<string, unknown> {
-    // undefined or empty array = match only "no context" subscriptions
-    if (contextKeys === undefined || contextKeys.length === 0) {
-      return {
-        $or: [{ contextKeys: { $exists: false } }, { contextKeys: [] }],
-      };
-    }
-
-    // non-empty array = exact match filtering (order-insensitive)
-    return {
-      contextKeys: { $all: contextKeys, $size: contextKeys.length },
-    };
-  }
 }
 
 function isErrorWithWriteErrors(e: unknown): e is { writeErrors?: unknown; message?: string; result?: unknown } {


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request refactors how context-based queries are constructed and used throughout the codebase, centralizing the logic for building context queries and removing duplicated private methods from multiple use cases. The main improvement is the consistent use of repository-level `buildContextExactMatchQuery` methods, with feature flag checks handled in each use case before constructing the query. This results in cleaner, more maintainable code and ensures that context filtering is applied consistently across all relevant operations.

**Refactoring and centralization of context query logic:**

* Removed duplicated `buildContextExactMatchQuery` private methods from several use cases (`UpdatePreferences`, `GetSubscriberPreference`, `GetSubscription`, `CreateSubscriptionsUsecase`, `DeleteTopicSubscription`, `UpdateSubscriptionUsecase`) and replaced their usage with calls to repository-level `buildContextExactMatchQuery`, passing in the feature flag state as a parameter. [[1]](diffhunk://#diff-bd1f675c7c356e16f818b43c0e88f567cf4d85082f3951111474372eea3afec3L351-L375) [[2]](diffhunk://#diff-d0141c69c6966e85b09d4967ff9701a1349efb628175e5b955d8d89052003b18L323-L349) [[3]](diffhunk://#diff-74b4c953b8393edfef56d748bee28a842602d36a28913b2538df20b951980beaL178-L210) [[4]](diffhunk://#diff-b3f9da10d1c8825a11840c6eb2670ee32fa3f2f62ddf57892dbc07f6326a2124L647-R669) [[5]](diffhunk://#diff-014ca5a6ec0507311c051192fccf8838ef427f3d8271d7126231e8a785868480L73-L99) [[6]](diffhunk://#diff-b8ce0d8aab76d35a9684526d0c9d745636436f4c5cdc13eebef181cc2c26d472L140-R145)
* Updated all relevant use cases to check the `IS_CONTEXT_PREFERENCES_ENABLED` feature flag before building context queries, ensuring feature-flag-driven behavior is consistent. [[1]](diffhunk://#diff-bd1f675c7c356e16f818b43c0e88f567cf4d85082f3951111474372eea3afec3L130-R138) [[2]](diffhunk://#diff-bd1f675c7c356e16f818b43c0e88f567cf4d85082f3951111474372eea3afec3L198-R214) [[3]](diffhunk://#diff-d0141c69c6966e85b09d4967ff9701a1349efb628175e5b955d8d89052003b18L267-R275) [[4]](diffhunk://#diff-74b4c953b8393edfef56d748bee28a842602d36a28913b2538df20b951980beaL50-R62) [[5]](diffhunk://#diff-b3f9da10d1c8825a11840c6eb2670ee32fa3f2f62ddf57892dbc07f6326a2124L117-R126) [[6]](diffhunk://#diff-b3f9da10d1c8825a11840c6eb2670ee32fa3f2f62ddf57892dbc07f6326a2124L409-R437) [[7]](diffhunk://#diff-b3f9da10d1c8825a11840c6eb2670ee32fa3f2f62ddf57892dbc07f6326a2124L240-R259) [[8]](diffhunk://#diff-014ca5a6ec0507311c051192fccf8838ef427f3d8271d7126231e8a785868480L39-R47)

**API and method signature changes:**

* Changed method signatures and usages to pass the feature flag state explicitly to repository methods, rather than embedding flag logic within each use case. [[1]](diffhunk://#diff-bd1f675c7c356e16f818b43c0e88f567cf4d85082f3951111474372eea3afec3L130-R138) [[2]](diffhunk://#diff-bd1f675c7c356e16f818b43c0e88f567cf4d85082f3951111474372eea3afec3L198-R214) [[3]](diffhunk://#diff-d0141c69c6966e85b09d4967ff9701a1349efb628175e5b955d8d89052003b18L267-R275) [[4]](diffhunk://#diff-74b4c953b8393edfef56d748bee28a842602d36a28913b2538df20b951980beaL50-R62) [[5]](diffhunk://#diff-b3f9da10d1c8825a11840c6eb2670ee32fa3f2f62ddf57892dbc07f6326a2124L117-R126) [[6]](diffhunk://#diff-b3f9da10d1c8825a11840c6eb2670ee32fa3f2f62ddf57892dbc07f6326a2124L409-R437) [[7]](diffhunk://#diff-b3f9da10d1c8825a11840c6eb2670ee32fa3f2f62ddf57892dbc07f6326a2124L240-R259) [[8]](diffhunk://#diff-014ca5a6ec0507311c051192fccf8838ef427f3d8271d7126231e8a785868480L39-R47)

**Consistency improvements:**

* Standardized the naming of context query builder methods (e.g., `buildContextQuery` instead of `buildContextExactMatchQuery`) in `GetTopicSubscriptions` and `UpdateSubscriptionUsecase` for clarity and alignment with repository methods. [[1]](diffhunk://#diff-b262a879fc4dc7165b818e6842710e8eda1c61f53324260a4739e0e05684be4dL30-R30) [[2]](diffhunk://#diff-b262a879fc4dc7165b818e6842710e8eda1c61f53324260a4739e0e05684be4dL49-R49) [[3]](diffhunk://#diff-b262a879fc4dc7165b818e6842710e8eda1c61f53324260a4739e0e05684be4dL112-R112) [[4]](diffhunk://#diff-b262a879fc4dc7165b818e6842710e8eda1c61f53324260a4739e0e05684be4dL126-R125) [[5]](diffhunk://#diff-b8ce0d8aab76d35a9684526d0c9d745636436f4c5cdc13eebef181cc2c26d472L76-R76) [[6]](diffhunk://#diff-b8ce0d8aab76d35a9684526d0c9d745636436f4c5cdc13eebef181cc2c26d472L140-R145) [[7]](diffhunk://#diff-b8ce0d8aab76d35a9684526d0c9d745636436f4c5cdc13eebef181cc2c26d472L215-R188)
