### PR TITLE
refactor(worker): Send message primary find

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -484,16 +484,10 @@ export class SendMessage {
     subscriberId: string;
     _environmentId: string;
   }) {
-    return await this.subscriberRepository.findOne(
-      {
-        _environmentId,
-        subscriberId,
-      },
-      undefined,
-      {
-        readPreference: 'secondaryPreferred',
-      }
-    );
+    return await this.subscriberRepository.findOne({
+      _environmentId,
+      subscriberId,
+    });
   }
 
   @Instrument()


### PR DESCRIPTION
### What changed? Why was the change needed?

Removed `readPreference: 'secondaryPreferred'` from the `subscriberRepository.findOne` call within the `getSubscriberBySubscriberId` method in `send-message.usecase.ts`. This ensures that subscriber lookups are always performed against the primary MongoDB node, guaranteeing strong consistency for these queries. The `findOne` call was also simplified by removing an unused `undefined` parameter.

### Screenshots

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1769690838130019?thread_ts=1769690838.130019&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-03ee212a-0d48-427f-8b24-4b0d35efe830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-03ee212a-0d48-427f-8b24-4b0d35efe830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

