### PR TITLE
refactor(dashboard): Get started link URL update

### DIFF
--- a/apps/dashboard/src/components/auth/region-picker.tsx
+++ b/apps/dashboard/src/components/auth/region-picker.tsx
@@ -24,10 +24,10 @@ export function RegionPicker() {
   function handleRegionChange(value: RegionType) {
     switch (value) {
       case REGION_MAP.US:
-        window.location.href = 'https://dashboard-v2.novu.co';
+        window.location.href = 'https://dashboard.novu.co';
         break;
       case REGION_MAP.EU:
-        window.location.href = 'https://eu.dashboard-v2.novu.co';
+        window.location.href = 'https://eu.dashboard.novu.co';
         break;
     }
   }


### PR DESCRIPTION
### What changed? Why was the change needed?

Updated the "Get Started" links in the region picker component to point to the new dashboard URLs.

-   US region URL: `https://dashboard-v2.novu.co` → `https://dashboard.novu.co`
-   EU region URL: `https://eu.dashboard-v2.novu.co` → `https://eu.dashboard.novu.co`

This change was needed to reflect the updated dashboard domain.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1769712767732029?thread_ts=1769712767.732029&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-9186711e-c329-4f19-bc9c-ed370214ce6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9186711e-c329-4f19-bc9c-ed370214ce6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

