### PR TITLE
refactor(api-service): make contex required parameter for subscriber JWT

### DIFF
--- a/apps/api/src/app/auth/services/auth.service.ts
+++ b/apps/api/src/app/auth/services/auth.service.ts
@@ -36,7 +36,7 @@ export class AuthService implements IAuthService {
     return this.authService.getUserByApiKey(apiKey);
   }
 
-  getSubscriberWidgetToken(subscriber: SubscriberEntity, contextKeys?: string[]): Promise<string> {
+  getSubscriberWidgetToken(subscriber: SubscriberEntity, contextKeys: string[]): Promise<string> {
     return this.authService.getSubscriberWidgetToken(subscriber, contextKeys);
   }
 

--- a/apps/api/src/app/auth/services/community.auth.service.ts
+++ b/apps/api/src/app/auth/services/community.auth.service.ts
@@ -196,7 +196,7 @@ export class CommunityAuthService implements IAuthService {
     };
   }
 
-  public async getSubscriberWidgetToken(subscriber: SubscriberEntity, contextKeys?: string[]): Promise<string> {
+  public async getSubscriberWidgetToken(subscriber: SubscriberEntity, contextKeys: string[]): Promise<string> {
     return this.jwtService.sign(
       {
         _id: subscriber._id,

--- a/apps/api/src/app/inbox/dtos/subscriber-session-response.dto.ts
+++ b/apps/api/src/app/inbox/dtos/subscriber-session-response.dto.ts
@@ -22,5 +22,5 @@ export class SubscriberSessionResponseDto {
   readonly isDevelopmentMode: boolean;
   readonly applicationIdentifier?: string;
   readonly schedule?: Schedule;
-  readonly contextKeys?: string[];
+  readonly contextKeys: string[];
 }

--- a/apps/api/src/app/shared/framework/user.decorator.ts
+++ b/apps/api/src/app/shared/framework/user.decorator.ts
@@ -9,7 +9,7 @@ export { UserSession };
 export interface SubscriberSession extends SubscriberEntity {
   organizationId: string;
   environmentId: string;
-  contextKeys?: string[];
+  contextKeys: string[];
   scheme: ApiAuthSchemeEnum;
 }
 

--- a/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/initialize-session/initialize-session.usecase.ts
@@ -75,7 +75,7 @@ export class InitializeSession {
     });
 
     return {
-      token: await this.authService.getSubscriberWidgetToken(subscriber),
+      token: await this.authService.getSubscriberWidgetToken(subscriber, []),
       profile: {
         _id: subscriber._id,
         firstName: subscriber.firstName,

--- a/libs/application-generic/src/services/auth/auth.service.interface.ts
+++ b/libs/application-generic/src/services/auth/auth.service.interface.ts
@@ -19,7 +19,7 @@ export interface IAuthService {
   refreshToken(userId: string): Promise<string>;
   isAuthenticatedForOrganization(userId: string, organizationId: string): Promise<boolean>;
   getUserByApiKey(apiKey: string): Promise<UserSessionData>;
-  getSubscriberWidgetToken(subscriber: SubscriberEntity, contextKeys?: string[]): Promise<string>;
+  getSubscriberWidgetToken(subscriber: SubscriberEntity, contextKeys: string[]): Promise<string>;
   generateUserToken(user: UserEntity): Promise<string>;
   getSignedToken(
     user: UserEntity,

--- a/packages/shared/src/dto/session/session.dto.ts
+++ b/packages/shared/src/dto/session/session.dto.ts
@@ -6,7 +6,7 @@ export interface ISubscriberJwtDto {
   subscriberId: string;
   organizationId: string;
   environmentId: string;
-  contextKeys?: string[];
+  contextKeys: string[];
   aud: 'widget_user';
 }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request standardizes the handling of the `contextKeys` property across multiple interfaces, DTOs, and service methods by making it a required field instead of optional. This change ensures consistency and reduces ambiguity when passing or accessing `contextKeys` throughout the authentication and session management code.

> [!NOTE]
> The expiration of subscriber JWT is 15 days, the context was introduced 3 months ago - all token should have the contextKeys, therefore it doesn't need to be optional anymore.  

**Standardization of `contextKeys` property:**

* Updated `contextKeys` from optional to required in the following interfaces and DTOs: `SubscriberSession`, `ISubscriberJwtDto`, and `SubscriberSessionResponseDto`. [[1]](diffhunk://#diff-3c7606fc670b0bc098136d08ed26005d836e61c986e6e361859147df61eb79c9L12-R12) [[2]](diffhunk://#diff-f635c1e432bb93184c2b362894b6ff3820dec0c33b43e5f197830416cbd84d4eL9-R9) [[3]](diffhunk://#diff-9dca2c1cb5da1014a28d4cc5dd49e70c3145c40355d5e0e7d985258f6b5e584cL25-R25)
* Modified `IAuthService` interface and its implementations (`AuthService`, `CommunityAuthService`) to require `contextKeys` as a parameter in `getSubscriberWidgetToken`. [[1]](diffhunk://#diff-2e279bd7594cfd01dcd71d3fbf06bcb66c6a3652d0a206e3e9536ca369e13bccL22-R22) [[2]](diffhunk://#diff-7b90561f1765cc8061f3065abde564abfdf3891dac81d2e99577cd44285b8061L39-R39) [[3]](diffhunk://#diff-1cc608bff26090f9e9dc6a14576f618a17031f2cd04ac1a111defd73a42ed3eeL199-R199)

**Refactoring for method invocation:**

* Changed the invocation of `getSubscriberWidgetToken` in `InitializeSession` use case to always pass an array for `contextKeys`, even if empty.

**Submodule update:**

* Updated the submodule reference in `.source` to a newer commit, likely to sync with upstream changes.
