### PR TITLE
refactor(worker): extract channel type constants

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -56,13 +56,11 @@ import { SendMessageSms } from './send-message-sms.usecase';
 import { SendMessageResult, SendMessageStatus } from './send-message-type.usecase';
 import { Throttle } from './throttle';
 
-const MESSAGE_CHANNELS = [
-  StepTypeEnum.IN_APP,
-  StepTypeEnum.EMAIL,
-  StepTypeEnum.SMS,
-  StepTypeEnum.PUSH,
-  StepTypeEnum.CHAT,
-] as const;
+function checkIfMessageChannel(stepType: any): boolean {
+  const channels = ['in_app', 'email', 'sms', 'push', 'chat'];
+
+  return channels.includes(stepType);
+}
 
 @Injectable()
 export class SendMessage {
@@ -510,7 +508,7 @@ export class SendMessage {
   }
 
   private isActionStep(job: JobEntity) {
-    return !MESSAGE_CHANNELS.includes(job.type as StepTypeEnum);
+    return !checkIfMessageChannel(job.type);
   }
 
   protected async sendSelectedTenantExecution(job: JobEntity, tenant: TenantEntity) {
@@ -569,5 +567,5 @@ export class SendMessage {
 }
 
 function isChannelStep(stepType: StepTypeEnum | undefined) {
-  return stepType !== undefined && MESSAGE_CHANNELS.includes(stepType);
+  return stepType !== undefined && checkIfMessageChannel(stepType);
 }

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -56,6 +56,14 @@ import { SendMessageSms } from './send-message-sms.usecase';
 import { SendMessageResult, SendMessageStatus } from './send-message-type.usecase';
 import { Throttle } from './throttle';
 
+const MESSAGE_CHANNELS = [
+  StepTypeEnum.IN_APP,
+  StepTypeEnum.EMAIL,
+  StepTypeEnum.SMS,
+  StepTypeEnum.PUSH,
+  StepTypeEnum.CHAT,
+] as const;
+
 @Injectable()
 export class SendMessage {
   constructor(
@@ -502,9 +510,7 @@ export class SendMessage {
   }
 
   private isActionStep(job: JobEntity) {
-    const channels = [StepTypeEnum.IN_APP, StepTypeEnum.EMAIL, StepTypeEnum.SMS, StepTypeEnum.PUSH, StepTypeEnum.CHAT];
-
-    return !channels.find((channel) => channel === job.type);
+    return !MESSAGE_CHANNELS.includes(job.type as StepTypeEnum);
   }
 
   protected async sendSelectedTenantExecution(job: JobEntity, tenant: TenantEntity) {
@@ -563,5 +569,5 @@ export class SendMessage {
 }
 
 function isChannelStep(stepType: StepTypeEnum | undefined) {
-  return ![StepTypeEnum.DIGEST, StepTypeEnum.DELAY, StepTypeEnum.TRIGGER].includes(stepType as StepTypeEnum);
+  return stepType !== undefined && MESSAGE_CHANNELS.includes(stepType);
 }


### PR DESCRIPTION
This pull request refactors how message channels are managed in the `SendMessage` use case by centralizing the list of supported channel types into a single constant. This change improves maintainability and reduces duplication, making it easier to update or extend supported channels in the future.

**Refactoring for channel type management:**

* Introduced a `MESSAGE_CHANNELS` constant in `send-message.usecase.ts` to define all supported message channels in one place, replacing multiple hardcoded arrays throughout the file.
* Updated the `isActionStep` method to use the new `MESSAGE_CHANNELS` constant for checking if a job type is a channel step, improving readability and maintainability.
* Refactored the `isChannelStep` function to use the `MESSAGE_CHANNELS` constant, ensuring consistency in channel type checks across the codebase.