### PR TITLE
refactor(api-service): add type annotations to updateServices method parameters

### DIFF
--- a/apps/api/src/app/widgets/usecases/remove-messages-bulk/remove-messages-bulk.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/remove-messages-bulk/remove-messages-bulk.usecase.ts
@@ -6,7 +6,7 @@ import {
   InvalidateCacheService,
   WebSocketsQueueService,
 } from '@novu/application-generic';
-import { DalException, MessageRepository, SubscriberRepository } from '@novu/dal';
+import { DalException, MessageRepository, SubscriberEntity, SubscriberRepository } from '@novu/dal';
 import { ChannelTypeEnum, WebSocketEventEnum } from '@novu/shared';
 
 import { MarkEnum } from '../mark-message-as/mark-message-as.command';
@@ -55,7 +55,7 @@ export class RemoveMessagesBulk {
     }
   }
 
-  private async updateServices(subscriber, marked: string): Promise<void> {
+  private async updateServices(subscriber: SubscriberEntity, marked: MarkEnum): Promise<void> {
     const eventMessage = marked === MarkEnum.READ ? WebSocketEventEnum.UNREAD : WebSocketEventEnum.UNSEEN;
 
     await this.webSocketsQueueService.add({


### PR DESCRIPTION
This pull request makes minor improvements to type safety and code clarity in the `remove-messages-bulk.usecase.ts` file by refining imports and function signatures.

- Type safety improvements:
  * Added the `SubscriberEntity` type to imports and updated the `updateServices` method signature to explicitly type the `subscriber` parameter as `SubscriberEntity` and the `marked` parameter as `MarkEnum` for better type checking and code clarity. [[1]](diffhunk://#diff-4a8fc36cad832260f7af68eaff0fb4491960a51cab7683cfe00a8a1d044f88a4L9-R9) [[2]](diffhunk://#diff-4a8fc36cad832260f7af68eaff0fb4491960a51cab7683cfe00a8a1d044f88a4L58-R58)

This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-b1fc97f4-2f64-48c2-936c-7abe96f957c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1fc97f4-2f64-48c2-936c-7abe96f957c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

