### PR TITLE
 refactor(worker): add type annotation to getIntegrationHandler parameter

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
@@ -754,7 +754,7 @@ export class SendMessagePush extends SendMessageBase {
     return message;
   }
 
-  private getIntegrationHandler(integration): IPushHandler {
+  private getIntegrationHandler(integration: IntegrationEntity): IPushHandler {
     const pushFactory = new PushFactory();
     const pushHandler = pushFactory.getHandler(integration);
 


### PR DESCRIPTION
This pull request introduces a minor improvement to the type safety of the `SendMessagePush` use case. Specifically, it updates the type signature of the `getIntegrationHandler` method to explicitly require an `IntegrationEntity` parameter, clarifying expectations and helping prevent type-related errors.

- Type safety improvement:
  * Updated the `getIntegrationHandler` method in `SendMessagePush` to accept an explicit `IntegrationEntity` parameter instead of an untyped argument.

This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-ded793b1-b54f-43e0-bd7b-b8b120ee07f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ded793b1-b54f-43e0-bd7b-b8b120ee07f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

