### PR TITLE
refactor(worker): simplify step halt return condition

### DIFF
--- a/apps/worker/src/app/shared/utils/should-halt-on-step-failure.ts
+++ b/apps/worker/src/app/shared/utils/should-halt-on-step-failure.ts
@@ -5,7 +5,7 @@ export const shouldHaltOnStepFailure = (job: JobEntity): boolean => {
   /*
    * Action steps always stop on failure across all versions (v1 & v2)
    */
-  if (isActionStepType(job.type)) {
+  if (job.type && isActionStepType(job.type)) {
     return true;
   }
 

--- a/apps/worker/src/app/shared/utils/should-halt-on-step-failure.ts
+++ b/apps/worker/src/app/shared/utils/should-halt-on-step-failure.ts
@@ -2,10 +2,6 @@ import { isActionStepType } from '@novu/application-generic';
 import { JobEntity } from '@novu/dal';
 
 export const shouldHaltOnStepFailure = (job: JobEntity): boolean => {
-  if (!job.type) {
-    return job.step.shouldStopOnFail === true;
-  }
-
   /*
    * Action steps always stop on failure across all versions (v1 & v2)
    */


### PR DESCRIPTION
This pull request makes a small change to the `should-halt-on-step-failure.ts` utility function, improving the handling of jobs that may not have a defined `type` property. The update ensures that the function only checks for action step types when `job.type` is present, making the logic more robust.

This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-83c6bb47-0b34-4e16-804f-86804e5684a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83c6bb47-0b34-4e16-804f-86804e5684a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

