### PR TITLE
refactor(application-generic): extract magic numbers to constants

### DIFF
--- a/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
+++ b/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
@@ -26,6 +26,11 @@ export interface SendMessageParams {
 export class SocketWorkerService {
   private readonly socketWorkerUrl: string | undefined;
   private readonly socketWorkerApiKey: string | undefined;
+  private readonly UNREAD_COUNT_LIMIT = 101;
+  private readonly UNREAD_COUNT_PAGINATION_THRESHOLD = 100;
+  private readonly SEVERITY_COUNT_LIMIT = 99;
+  private readonly HTTP_TIMEOUT_MS = 3000;
+  private readonly HTTP_RETRY_LIMIT = 2;
 
   constructor(
     private featureFlagsService: FeatureFlagsService,
@@ -133,9 +138,9 @@ export class SocketWorkerService {
         responseType: 'json',
         http2: true,
         dnsCache: true,
-        timeout: 3000,
+        timeout: this.HTTP_TIMEOUT_MS,
         retry: {
-          limit: 2,
+          limit: this.HTTP_RETRY_LIMIT,
           methods: ['POST'],
           statusCodes: [408, 429, 500, 502, 503, 504],
         },
@@ -179,7 +184,7 @@ export class SocketWorkerService {
           userId,
           ChannelTypeEnum.IN_APP,
           { read: false },
-          { limit: 101 },
+          { limit: this.UNREAD_COUNT_LIMIT },
           contextKeys,
           undefined,
           'primary'
@@ -189,7 +194,7 @@ export class SocketWorkerService {
           userId,
           ChannelTypeEnum.IN_APP,
           { read: false, snoozed: false },
-          { limit: 99 },
+          { limit: this.SEVERITY_COUNT_LIMIT },
           contextKeys
         ),
       ]);
@@ -211,7 +216,9 @@ export class SocketWorkerService {
       }
 
       const paginationIndication: UnreadCountPaginationIndication =
-        unreadCount > 100 ? { unreadCount: 100, hasMore: true } : { unreadCount, hasMore: false };
+        unreadCount > this.UNREAD_COUNT_PAGINATION_THRESHOLD
+          ? { unreadCount: this.UNREAD_COUNT_PAGINATION_THRESHOLD, hasMore: true }
+          : { unreadCount, hasMore: false };
 
       await this.sendMessageInternal({
         userId,


### PR DESCRIPTION
This pull request refactors the `SocketWorkerService` to centralize and clarify the use of various numeric constants related to unread counts, severity limits, and HTTP request configuration. By defining these values as private readonly class properties, the code becomes easier to maintain and reduces the risk of inconsistencies.

Key improvements include:

**Centralization of Constants:**

* Defined `UNREAD_COUNT_LIMIT`, `UNREAD_COUNT_PAGINATION_THRESHOLD`, `SEVERITY_COUNT_LIMIT`, `HTTP_TIMEOUT_MS`, and `HTTP_RETRY_LIMIT` as private readonly properties in `SocketWorkerService`, replacing hardcoded numeric literals throughout the class.

**Refactoring Usage of Constants:**

* Updated HTTP request configuration to use `HTTP_TIMEOUT_MS` and `HTTP_RETRY_LIMIT` instead of hardcoded values for timeout and retry limit.
* Replaced hardcoded limits in unread and severity count queries with `UNREAD_COUNT_LIMIT` and `SEVERITY_COUNT_LIMIT`. [[1]](diffhunk://#diff-ebe1d2b59cdbe32a6558ab02c2ddba09dee91f406afb9e0b327451aaf3fef7b5L182-R187) [[2]](diffhunk://#diff-ebe1d2b59cdbe32a6558ab02c2ddba09dee91f406afb9e0b327451aaf3fef7b5L192-R197)
* Modified the pagination indication logic to use `UNREAD_COUNT_PAGINATION_THRESHOLD` instead of the hardcoded value `100`.

This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-d341a4b7-8685-4e8a-981b-7eb49de66097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d341a4b7-8685-4e8a-981b-7eb49de66097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

