### PR TITLE
refactor(application-generic): simplify event handling in SocketWorker

### DIFF
--- a/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
+++ b/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
@@ -35,7 +35,20 @@ export class SocketWorkerService {
     this.socketWorkerApiKey = process.env.INTERNAL_SERVICES_API_KEY;
   }
 
-  async sendMessage({
+  async sendMessage(params: SendMessageParams): Promise<void> {
+    switch (params.event) {
+      case WebSocketEventEnum.RECEIVED:
+        return this.handleReceivedEvent(params);
+      case WebSocketEventEnum.UNREAD:
+        return this.handleUnreadEvent(params);
+      case WebSocketEventEnum.UNSEEN:
+        return this.handleUnseenEvent(params);
+      default:
+        return this.sendMessageInternal(params);
+    }
+  }
+
+  private async handleReceivedEvent({
     userId,
     event,
     data,
@@ -44,51 +57,53 @@ export class SocketWorkerService {
     subscriberId,
     contextKeys,
   }: SendMessageParams): Promise<void> {
-    if (event === WebSocketEventEnum.RECEIVED) {
-      const { messageId } = data || {};
-      const storedMessage = await this.messageRepository.findOne({
-        _id: messageId,
-        _environmentId: environmentId,
-      });
+    const { messageId } = data || {};
+    const storedMessage = await this.messageRepository.findOne({
+      _id: messageId,
+      _environmentId: environmentId,
+    });
 
-      if (!storedMessage) {
-        Logger.error(`Message with id ${messageId} not found in environment ${environmentId}`, LOG_CONTEXT);
+    if (!storedMessage) {
+      Logger.error(`Message with id ${messageId} not found in environment ${environmentId}`, LOG_CONTEXT);
 
-        return;
-      }
-
-      await this.sendMessageInternal({
-        userId,
-        event,
-        data: { message: storedMessage },
-        organizationId,
-        environmentId,
-        subscriberId,
-        contextKeys,
-      });
-
-      // Only recalculate the counts if we send a messageId/message.
-      if (messageId) {
-        await Promise.all([
-          this.sendUnseenCount(userId, environmentId, organizationId, contextKeys),
-          this.sendUnreadCount(userId, environmentId, organizationId, contextKeys),
-        ]);
-      }
-    } else if (event === WebSocketEventEnum.UNREAD) {
-      await this.sendUnreadCount(userId, environmentId, organizationId, contextKeys);
-    } else if (event === WebSocketEventEnum.UNSEEN) {
-      await this.sendUnseenCount(userId, environmentId, organizationId, contextKeys);
-    } else {
-      await this.sendMessageInternal({
-        userId,
-        event,
-        data,
-        organizationId,
-        environmentId,
-        subscriberId,
-        contextKeys,
-      });
+      return;
     }
+
+    await this.sendMessageInternal({
+      userId,
+      event,
+      data: { message: storedMessage },
+      organizationId,
+      environmentId,
+      subscriberId,
+      contextKeys,
+    });
+
+    // Only recalculate the counts if we send a messageId/message.
+    if (messageId) {
+      await Promise.all([
+        this.sendUnseenCount(userId, environmentId, organizationId, contextKeys),
+        this.sendUnreadCount(userId, environmentId, organizationId, contextKeys),
+      ]);
+    }
+  }
+
+  private async handleUnreadEvent({
+    userId,
+    environmentId,
+    organizationId,
+    contextKeys,
+  }: SendMessageParams): Promise<void> {
+    await this.sendUnreadCount(userId, environmentId, organizationId, contextKeys);
+  }
+
+  private async handleUnseenEvent({
+    userId,
+    environmentId,
+    organizationId,
+    contextKeys,
+  }: SendMessageParams): Promise<void> {
+    await this.sendUnseenCount(userId, environmentId, organizationId, contextKeys);
   }
 
   private async sendMessageInternal({


### PR DESCRIPTION
This pull request refactors the `SocketWorkerService` to improve the handling of different WebSocket events by introducing dedicated handler methods for each event type. The main logic for processing `RECEIVED`, `UNREAD`, and `UNSEEN` events has been separated into their own private methods, making the code more modular and easier to maintain.

**Refactoring event handling in `SocketWorkerService`:**

* The `sendMessage` method now uses a `switch` statement to delegate event-specific logic to dedicated handler methods for `RECEIVED`, `UNREAD`, and `UNSEEN` events, improving readability and maintainability.
* Introduced three new private methods: `handleReceivedEvent`, `handleUnreadEvent`, and `handleUnseenEvent`, each encapsulating the logic for their respective event types. This replaces the previous approach of using multiple `if-else` statements within `sendMessage`. [[1]](diffhunk://#diff-ebe1d2b59cdbe32a6558ab02c2ddba09dee91f406afb9e0b327451aaf3fef7b5L47) [[2]](diffhunk://#diff-ebe1d2b59cdbe32a6558ab02c2ddba09dee91f406afb9e0b327451aaf3fef7b5L77-R106)

This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-4ea57755-4bda-4cd4-b08d-1668f6d524af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ea57755-4bda-4cd4-b08d-1668f6d524af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

