### PR TITLE
fix(worker): error message formatting in standard worker

### DIFF
--- a/apps/worker/src/app/workflow/services/standard.worker.ts
+++ b/apps/worker/src/app/workflow/services/standard.worker.ts
@@ -74,7 +74,7 @@ export class StandardWorker extends StandardWorkerService {
       const message = data.payload?.message;
 
       if (!message) {
-        throw new Error(`Job data is missing required fields${JSON.stringify(data)}`);
+        throw new Error(`Job data is missing required fields: ${JSON.stringify(data)}`);
       }
 
       return {


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request makes a minor improvement to error handling in the `StandardWorker` service. The error message thrown when required job data is missing is now more readable and clear. 

- Improved the error message in the `StandardWorker` class to include a colon and space before the serialized job data, making it easier to read and debug.
