### PR TITLE
fix(dashboard): context binding when adding subscribers to topics

### DIFF
--- a/apps/dashboard/src/api/topics.ts
+++ b/apps/dashboard/src/api/topics.ts
@@ -1,6 +1,7 @@
 import { RulesLogic } from '@novu/js';
 import type { CustomDataType, DirectionEnum, IEnvironment, SeverityLevelEnum } from '@novu/shared';
 import { Topic } from '@/components/topics/types';
+import { convertContextKeysToPayload } from '@/utils/context-variable-utils';
 import { delV2, getV2, patchV2, postV2 } from './api.client';
 
 export type ListTopicsResponse = {
@@ -113,24 +114,7 @@ export const addSubscribersToTopic = async ({
   subscribers: string[];
   contextKeys?: string[];
 }) => {
-  // Convert contextKeys array to ContextPayload object
-  // contextKeys format: ["tenant:org-acme", "app:jira"]
-  // ContextPayload format: { tenant: "org-acme", app: "jira" }
-  let context: Record<string, string> | undefined;
-  if (contextKeys && contextKeys.length > 0) {
-    const contextObj = contextKeys.reduce(
-      (acc, key) => {
-        const [type, id] = key.split(':');
-        if (type && id) {
-          acc[type] = id;
-        }
-        return acc;
-      },
-      {} as Record<string, string>
-    );
-    // Only set context if we have at least one valid key-value pair
-    context = Object.keys(contextObj).length > 0 ? contextObj : undefined;
-  }
+  const context = convertContextKeysToPayload(contextKeys);
 
   const { data } = await postV2<{
     data: {

--- a/apps/dashboard/src/api/topics.ts
+++ b/apps/dashboard/src/api/topics.ts
@@ -106,11 +106,30 @@ export const addSubscribersToTopic = async ({
   environment,
   topicKey,
   subscribers,
+  contextKeys,
 }: {
   environment: IEnvironment;
   topicKey: string;
   subscribers: string[];
+  contextKeys?: string[];
 }) => {
+  // Convert contextKeys array to ContextPayload object
+  // contextKeys format: ["tenant:org-acme", "app:jira"]
+  // ContextPayload format: { tenant: "org-acme", app: "jira" }
+  const context =
+    contextKeys && contextKeys.length > 0
+      ? contextKeys.reduce(
+          (acc, key) => {
+            const [type, id] = key.split(':');
+            if (type && id) {
+              acc[type] = id;
+            }
+            return acc;
+          },
+          {} as Record<string, string>
+        )
+      : undefined;
+
   const { data } = await postV2<{
     data: {
       succeeded: string[];
@@ -120,7 +139,10 @@ export const addSubscribersToTopic = async ({
     };
   }>(`/topics/${encodeURIComponent(topicKey)}/subscriptions`, {
     environment,
-    body: { subscriberIds: subscribers },
+    body: {
+      subscriberIds: subscribers,
+      ...(context && { context }),
+    },
   });
 
   return data;

--- a/apps/dashboard/src/api/topics.ts
+++ b/apps/dashboard/src/api/topics.ts
@@ -116,19 +116,21 @@ export const addSubscribersToTopic = async ({
   // Convert contextKeys array to ContextPayload object
   // contextKeys format: ["tenant:org-acme", "app:jira"]
   // ContextPayload format: { tenant: "org-acme", app: "jira" }
-  const context =
-    contextKeys && contextKeys.length > 0
-      ? contextKeys.reduce(
-          (acc, key) => {
-            const [type, id] = key.split(':');
-            if (type && id) {
-              acc[type] = id;
-            }
-            return acc;
-          },
-          {} as Record<string, string>
-        )
-      : undefined;
+  let context: Record<string, string> | undefined;
+  if (contextKeys && contextKeys.length > 0) {
+    const contextObj = contextKeys.reduce(
+      (acc, key) => {
+        const [type, id] = key.split(':');
+        if (type && id) {
+          acc[type] = id;
+        }
+        return acc;
+      },
+      {} as Record<string, string>
+    );
+    // Only set context if we have at least one valid key-value pair
+    context = Object.keys(contextObj).length > 0 ? contextObj : undefined;
+  }
 
   const { data } = await postV2<{
     data: {

--- a/apps/dashboard/src/components/topics/add-subscriber-form.tsx
+++ b/apps/dashboard/src/components/topics/add-subscriber-form.tsx
@@ -6,10 +6,11 @@ import { useAddTopicSubscribers } from './hooks/use-topic-subscribers';
 
 type AddSubscriberFormProps = {
   topicKey: string;
+  contextKeys?: string[];
   onSuccess?: () => void;
 };
 
-export function AddSubscriberForm({ topicKey, onSuccess }: AddSubscriberFormProps) {
+export function AddSubscriberForm({ topicKey, contextKeys, onSuccess }: AddSubscriberFormProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const { mutate: addSubscribers, isPending } = useAddTopicSubscribers();
 
@@ -20,6 +21,7 @@ export function AddSubscriberForm({ topicKey, onSuccess }: AddSubscriberFormProp
       {
         topicKey,
         subscribers: [subscriber.subscriberId.trim()],
+        contextKeys,
       },
       {
         onSuccess: () => {

--- a/apps/dashboard/src/components/topics/hooks/use-topic-subscribers.ts
+++ b/apps/dashboard/src/components/topics/hooks/use-topic-subscribers.ts
@@ -55,7 +55,15 @@ export function useAddTopicSubscribers() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ topicKey, subscribers }: { topicKey: string; subscribers: string[] }) => {
+    mutationFn: ({
+      topicKey,
+      subscribers,
+      contextKeys,
+    }: {
+      topicKey: string;
+      subscribers: string[];
+      contextKeys?: string[];
+    }) => {
       if (!currentEnvironment) {
         throw new Error('Environment not found');
       }
@@ -64,6 +72,7 @@ export function useAddTopicSubscribers() {
         environment: currentEnvironment,
         topicKey,
         subscribers,
+        contextKeys,
       });
     },
     onSuccess: (_, variables) => {

--- a/apps/dashboard/src/components/topics/topic-drawer.tsx
+++ b/apps/dashboard/src/components/topics/topic-drawer.tsx
@@ -117,7 +117,7 @@ const TopicSubscribers = (props: TopicSubscribersProps) => {
           'flex flex-col gap-4': !readOnly,
         })}
       >
-        {!readOnly && <AddSubscriberForm topicKey={topicKey} />}
+        {!readOnly && <AddSubscriberForm topicKey={topicKey} contextKeys={contextKeys} />}
       </div>
       <div
         className={cn('border-b border-b-neutral-200 px-3 py-2', {


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request enhances the process of adding subscribers to a topic by introducing support for passing contextual information (via `contextKeys`) throughout the API and component layers. This allows additional metadata (such as tenant or app identifiers) to be associated with each subscription, improving flexibility and integration with multi-tenant or multi-app scenarios.

Fixes NV-7088

**API and Data Handling Improvements:**

* Updated the `addSubscribersToTopic` API function to accept an optional `contextKeys` array, converting it into a `context` object that maps key types to their values for use in the request payload.
* Modified the API request body to include the `context` object if provided, ensuring that contextual data is sent to the backend when adding subscribers.

**Component and Hook Updates:**

* Updated the `AddSubscriberForm` component and its props to accept and forward `contextKeys`, enabling UI-level support for context-aware subscriptions. [[1]](diffhunk://#diff-512d42aaee26cad9a28dac635b41af6d4f91a0260f6afbfd53f5846cbfc9cfb9R9-R13) [[2]](diffhunk://#diff-512d42aaee26cad9a28dac635b41af6d4f91a0260f6afbfd53f5846cbfc9cfb9R24)
* Enhanced the `useAddTopicSubscribers` hook to accept and pass through the `contextKeys` parameter, ensuring that context is handled consistently throughout the data flow. [[1]](diffhunk://#diff-1c0e0db69e12e1494b6bbdba4130dc99254699faf4bcb19add1206f176bdd02dL58-R66) [[2]](diffhunk://#diff-1c0e0db69e12e1494b6bbdba4130dc99254699faf4bcb19add1206f176bdd02dR75)
* Modified the `TopicSubscribers` component to pass `contextKeys` to the `AddSubscriberForm`, ensuring the context is available when adding new subscribers from the topic drawer.
