### PR TITLE
refactor(worker): make contextKeys required in send-message flow fixes NV-7091

### DIFF
--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -304,7 +304,7 @@ export class RunJob {
           tags: notification.tags || [],
           severity: notification.severity,
           statelessPreferences: job.preferences,
-          contextKeys: job.contextKeys,
+          contextKeys: job.contextKeys || [],
           workflow,
         })
       );

--- a/apps/worker/src/app/workflow/usecases/send-message/channel-endpoint-resolution/resolve-channel-endpoints.command.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/channel-endpoint-resolution/resolve-channel-endpoints.command.ts
@@ -11,8 +11,7 @@ export class ResolveChannelEndpointsCommand extends EnvironmentWithUserCommand {
   @IsEnum(ChannelTypeEnum)
   channelType: ChannelTypeEnum;
 
-  @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  contextKeys?: string[];
+  contextKeys: string[];
 }

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-chat.usecase.ts
@@ -100,7 +100,7 @@ export class SendMessageChat extends SendMessageBase {
 
       // Check if there are any active channels
       if (channels.length === 0) {
-        if (command.contextKeys && command.contextKeys.length > 0) {
+        if (command.contextKeys.length > 0) {
           await this.createExecutionDetail(
             command,
             DetailEnum.SUBSCRIBER_CONTEXT_NO_ACTIVE_CHANNEL,
@@ -595,7 +595,7 @@ export class SendMessageChat extends SendMessageBase {
       tags: command.tags,
       severity: command.severity,
       stepId: command.step.stepId,
-      ...(command.contextKeys && { contextKeys: command.contextKeys }),
+      contextKeys: command.contextKeys,
       ...(channelData &&
         channelData.length > 0 && { channelData: channelData.map((data) => this.redactChannelData(data)) }),
       ...additionalFields,

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -214,7 +214,7 @@ export class SendMessageEmail extends SendMessageBase {
       _jobId: command.jobId,
       tags: command.tags,
       severity: command.severity,
-      ...(command.contextKeys && { contextKeys: command.contextKeys }),
+      contextKeys: command.contextKeys,
     });
 
     let replyToAddress: string | undefined;

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-in-app.usecase.ts
@@ -231,7 +231,7 @@ export class SendMessageInApp extends SendMessageBase {
         _feedId: step.template._feedId,
         channel: ChannelTypeEnum.IN_APP,
         _jobId: command.jobId,
-        ...(command.contextKeys && { contextKeys: command.contextKeys }),
+        contextKeys: command.contextKeys,
         ...(actor &&
           actor.type !== ActorTypeEnum.NONE && {
             actor,

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
@@ -732,7 +732,7 @@ export class SendMessagePush extends SendMessageBase {
       tags: command.tags,
       severity: command.severity,
       stepId: command.step?.stepId,
-      ...(command.contextKeys && { contextKeys: command.contextKeys }),
+      contextKeys: command.contextKeys,
     });
 
     await this.createExecutionDetails.execute(

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-sms.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-sms.usecase.ts
@@ -175,7 +175,7 @@ export class SendMessageSms extends SendMessageBase {
       _jobId: command.jobId,
       tags: command.tags,
       severity: command.severity,
-      ...(command.contextKeys && { contextKeys: command.contextKeys }),
+      contextKeys: command.contextKeys,
     });
 
     await this.createExecutionDetails.execute(

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.command.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.command.ts
@@ -1,7 +1,7 @@
 import { EnvironmentWithUserCommand } from '@novu/application-generic';
 import type { JobEntity, NotificationStepEntity, NotificationTemplateEntity } from '@novu/dal';
 import type { SeverityLevelEnum, TriggerOverrides, WorkflowPreferences } from '@novu/shared';
-import { IsDefined, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsDefined, IsOptional, IsString } from 'class-validator';
 
 export class SendMessageCommand extends EnvironmentWithUserCommand {
   @IsDefined()
@@ -51,8 +51,9 @@ export class SendMessageCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   statelessPreferences?: WorkflowPreferences;
 
-  @IsOptional()
-  contextKeys?: string[];
+  @IsArray()
+  @IsString({ each: true })
+  contextKeys: string[];
 
   @IsOptional()
   workflow?: NotificationTemplateEntity;

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -458,7 +458,7 @@ export class SendMessage {
   private async resolveContext(command: SendMessageCommand): Promise<ContextResolved> {
     const { contextKeys, environmentId, organizationId } = command;
 
-    if (!contextKeys || contextKeys.length === 0) {
+    if (contextKeys.length === 0) {
       return {} as ContextResolved;
     }
 

--- a/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.command.ts
+++ b/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.command.ts
@@ -38,10 +38,9 @@ export class SubscriberJobBoundCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   actor?: SubscriberEntity;
 
-  @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  contextKeys?: string[];
+  contextKeys: string[];
 
   @IsDefined()
   @IsMongoId()

--- a/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
@@ -227,7 +227,7 @@ export class SubscriberJobBound {
       }),
       severity,
       critical,
-      ...(contextKeys && { contextKeys }),
+      contextKeys,
     };
 
     if (actor) {

--- a/libs/application-generic/src/dtos/process-subscriber-job.dto.ts
+++ b/libs/application-generic/src/dtos/process-subscriber-job.dto.ts
@@ -23,7 +23,7 @@ export interface IProcessSubscriberDataDto {
   overrides: TriggerOverrides;
   tenant?: ITenantDefine;
   actor?: SubscriberEntity;
-  contextKeys?: string[];
+  contextKeys: string[];
   subscriber: ISubscribersDefine;
   templateId: string;
   _subscriberSource: SubscriberSourceEnum;

--- a/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.command.ts
+++ b/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.command.ts
@@ -50,10 +50,9 @@ export class CreateNotificationJobsCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   tenant?: ITenantDefine;
 
-  @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  contextKeys?: string[];
+  contextKeys: string[];
 
   bridgeUrl?: string;
 

--- a/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
+++ b/libs/application-generic/src/usecases/create-notification-jobs/create-notification-jobs.usecase.ts
@@ -102,7 +102,7 @@ export class CreateNotificationJobs {
       tags: command.template.tags,
       severity: command.severity,
       critical: command.critical,
-      ...(command.contextKeys && { contextKeys: command.contextKeys }),
+      contextKeys: command.contextKeys,
     });
 
     await this.createWorkflowRun(notification, command);
@@ -157,7 +157,7 @@ export class CreateNotificationJobs {
           delivery_lifecycle_detail: '',
           severity: notification.severity || SeverityLevelEnum.NONE,
           critical: notification.critical || false,
-          context_keys: notification.contextKeys || [],
+          context_keys: notification.contextKeys,
         };
         await this.traceLogRepository.createWorkflowRun([traceData]);
       }
@@ -194,7 +194,7 @@ export class CreateNotificationJobs {
       providerId,
       ...this.overloadActorData(command),
       preferences: command.preferences,
-      ...(command.contextKeys && { contextKeys: command.contextKeys }),
+      contextKeys: command.contextKeys,
     };
   }
 
@@ -293,7 +293,7 @@ export class CreateNotificationJobs {
         _actorId: command.actor?._id,
         actorId: command.actor?.subscriberId,
       }),
-      ...(command.contextKeys && { contextKeys: command.contextKeys }),
+      contextKeys: command.contextKeys,
     };
   }
 

--- a/libs/application-generic/src/usecases/trigger-base/trigger-base.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-base/trigger-base.usecase.ts
@@ -30,7 +30,7 @@ export type BaseTriggerCommand = {
   overrides: TriggerOverrides;
   template: NotificationTemplateEntity;
   actor?: SubscriberEntity | undefined;
-  contextKeys?: string[];
+  contextKeys: string[];
   tenant: ITenantDefine | null;
   requestCategory?: TriggerRequestCategoryEnum;
   controls?: StatelessControls;

--- a/libs/application-generic/src/usecases/trigger-broadcast/trigger-broadcast.command.ts
+++ b/libs/application-generic/src/usecases/trigger-broadcast/trigger-broadcast.command.ts
@@ -14,8 +14,7 @@ export class TriggerBroadcastCommand extends TriggerEventBroadcastCommand {
   @ValidateNested()
   tenant: ITenantDefine | null;
 
-  @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  contextKeys?: string[];
+  contextKeys: string[];
 }

--- a/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.command.ts
+++ b/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.command.ts
@@ -14,8 +14,7 @@ export class TriggerMulticastCommand extends TriggerEventMulticastCommand {
   @ValidateNested()
   tenant: ITenantDefine | null;
 
-  @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  contextKeys?: string[];
+  contextKeys: string[];
 }

--- a/libs/application-generic/src/utils/subscribers.utils.ts
+++ b/libs/application-generic/src/utils/subscribers.utils.ts
@@ -14,6 +14,7 @@ export function mapSubscribersToJobs(
         environmentId: command.environmentId,
         organizationId: command.organizationId,
         userId: command.userId,
+        contextKeys: command.contextKeys,
         transactionId: command.transactionId,
         requestId: command.requestId,
         identifier: command.identifier,
@@ -38,9 +39,6 @@ export function mapSubscribersToJobs(
     }
     if (command.tenant) {
       job.data.tenant = command.tenant;
-    }
-    if (command.contextKeys) {
-      job.data.contextKeys = command.contextKeys;
     }
 
     return job;


### PR DESCRIPTION
### What changed? Why was the change needed?

Remove optional flags and defensive null checks for `contextKeys` throughout 
the `send-message` pipeline. Context was introduced a while back and all new jobs should have `contextKeys` defined. One edge case is an old job being in queue for all this time, but we still guarantee contextKeys presence via 
fallback in `RunJob` (`job.contextKeys || []`), allowing downstream commands 
to safely require the field.

Changes:
- Make SendMessageCommand.contextKeys non-optional (string[])
- Make ResolveChannelEndpointsCommand.contextKeys non-optional
- Remove `!contextKeys ||` check in resolveContext()
- Remove conditional spreading in all channel usecases (email, sms, push, chat, in-app)
