### PR TITLE
feat(api-service): finalize table migration and implement workflow run count analytics

### DIFF
--- a/apps/api/migrations/clickhouse-migrations/5_finalize_table_exchange.sql
+++ b/apps/api/migrations/clickhouse-migrations/5_finalize_table_exchange.sql
@@ -1,0 +1,88 @@
+-- Finalize table migration by exchanging old and new tables and recreating materialized views
+-- This migration completes the schema refactoring started in migration 4
+-- PREREQUISITE: All backfilling must be completed for traces_temp and delivery_trend_counts_temp
+
+-- =============================================================================
+-- Step 1: Exchange tables atomically (CRITICAL: Do this FIRST)
+-- After exchange, the main tables will have the new optimized schemas
+-- New inserts will immediately go to the new schema tables
+-- =============================================================================
+
+-- Exchange traces with traces_temp (swaps data and schema)
+-- After: traces has new ORDER BY, traces_temp has old data
+EXCHANGE TABLES traces AND traces_temp;
+
+-- Exchange delivery_trend_counts with delivery_trend_counts_temp
+-- After: delivery_trend_counts has TTL support, delivery_trend_counts_temp has old data
+EXCHANGE TABLES delivery_trend_counts AND delivery_trend_counts_temp;
+
+-- =============================================================================
+-- Step 2: Drop temporary migration materialized views immediately
+-- These MVs may error on schema mismatch after exchange, but that's acceptable
+-- The exchange happened first, so new data goes to the correct tables
+-- =============================================================================
+
+DROP VIEW IF EXISTS traces_to_traces_temp_mv;
+
+DROP VIEW IF EXISTS delivery_trend_counts_temp_mv;
+
+DROP VIEW IF EXISTS workflow_run_count_temp_mv;
+
+-- =============================================================================
+-- Step 3: Drop old materialized views that will be recreated
+-- delivery_trend_counts_mv needs to be recreated to change source from step_runs to traces
+-- =============================================================================
+
+DROP VIEW IF EXISTS delivery_trend_counts_mv;
+
+-- Note: trace_rollup_mv is NOT recreated as it continues to work with the new schema
+-- Note: workflow_run_count was created directly with its final name in migration 4
+
+-- =============================================================================
+-- Step 4: Create new permanent materialized views
+-- =============================================================================
+
+-- Materialized view: delivery_trend_counts_mv
+-- Aggregates message delivery counts by channel type for delivery trend analytics
+-- Source: traces table (now with new schema, previously used step_runs)
+CREATE MATERIALIZED VIEW IF NOT EXISTS delivery_trend_counts_mv
+TO delivery_trend_counts
+AS SELECT
+  toDate(created_at) AS date,
+  organization_id,
+  environment_id,
+  ifNull(workflow_id, '') AS workflow_id,
+  step_run_type AS step_type,
+  1 AS count,
+  toDate(expires_at) AS expires_at
+FROM traces
+WHERE
+  event_type = 'message_sent'
+  AND step_run_type IN ('in_app', 'email', 'sms', 'chat', 'push');
+
+-- Materialized view: workflow_run_count_mv
+-- Aggregates event counts by workflow run identifier for workflow analytics
+-- Source: traces table (now with new schema)
+-- IMPORTANT: Uses entity_type filter to match temp MV behavior from migration 4
+CREATE MATERIALIZED VIEW IF NOT EXISTS workflow_run_count_mv
+TO workflow_run_count
+AS SELECT
+  toDate(created_at) AS date,
+  organization_id,
+  environment_id,
+  event_type,
+  workflow_run_identifier AS workflow_run_id,
+  1 AS count,
+  toDate(expires_at) AS expires_at
+FROM traces
+WHERE entity_type = 'workflow_run';
+
+-- =============================================================================
+-- Step 5: Drop old tables (cleanup)
+-- After exchange, these tables contain the old data and are no longer needed
+-- =============================================================================
+
+-- We keep traces_temp table for historical data storage and do not drop it.
+-- DROP TABLE IF EXISTS traces_temp;
+
+DROP TABLE IF EXISTS delivery_trend_counts_temp;

--- a/libs/application-generic/src/services/analytic-logs/workflow-run-count/index.ts
+++ b/libs/application-generic/src/services/analytic-logs/workflow-run-count/index.ts
@@ -1,0 +1,2 @@
+export * from './workflow-run-count.repository';
+export * from './workflow-run-count.schema';

--- a/libs/application-generic/src/services/analytic-logs/workflow-run-count/workflow-run-count.repository.ts
+++ b/libs/application-generic/src/services/analytic-logs/workflow-run-count/workflow-run-count.repository.ts
@@ -1,0 +1,116 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
+import { FeatureFlagsService } from '../../feature-flags/feature-flags.service';
+import { ClickHouseService } from '../clickhouse.service';
+import { LogRepository } from '../log.repository';
+import {
+  WORKFLOW_RUN_COUNT_ORDER_BY,
+  WORKFLOW_RUN_COUNT_TABLE_NAME,
+  WorkflowRunCount,
+  workflowRunCountSchema,
+} from './workflow-run-count.schema';
+
+@Injectable()
+export class WorkflowRunCountRepository extends LogRepository<typeof workflowRunCountSchema, WorkflowRunCount> {
+  public readonly table = WORKFLOW_RUN_COUNT_TABLE_NAME;
+  public readonly identifierPrefix = 'wrc_';
+
+  constructor(
+    protected readonly clickhouseService: ClickHouseService,
+    protected readonly logger: PinoLogger,
+    protected readonly featureFlagsService: FeatureFlagsService
+  ) {
+    super(clickhouseService, logger, workflowRunCountSchema, WORKFLOW_RUN_COUNT_ORDER_BY, featureFlagsService);
+    this.logger.setContext(this.constructor.name);
+  }
+
+  async getWorkflowRunEventCounts(
+    environmentId: string,
+    organizationId: string,
+    startDate: Date,
+    endDate: Date,
+    workflowRunIds?: string[]
+  ): Promise<Array<{ workflow_run_id: string; event_type: string; count: string }>> {
+    const workflowRunFilter =
+      workflowRunIds && workflowRunIds.length > 0 ? 'AND workflow_run_id IN {workflowRunIds:Array(String)}' : '';
+
+    const query = `
+      SELECT 
+        workflow_run_id,
+        event_type,
+        sum(count) as count
+      FROM ${WORKFLOW_RUN_COUNT_TABLE_NAME}
+      WHERE 
+        environment_id = {environmentId:String} 
+        AND organization_id = {organizationId:String}
+        AND date >= {startDate:Date}
+        AND date <= {endDate:Date}
+        ${workflowRunFilter}
+      GROUP BY workflow_run_id, event_type
+      ORDER BY workflow_run_id, event_type
+    `;
+
+    const params: Record<string, unknown> = {
+      environmentId,
+      organizationId,
+      startDate: startDate.toISOString().split('T')[0],
+      endDate: endDate.toISOString().split('T')[0],
+    };
+
+    if (workflowRunIds && workflowRunIds.length > 0) {
+      params.workflowRunIds = workflowRunIds;
+    }
+
+    const result = await this.clickhouseService.query<{
+      workflow_run_id: string;
+      event_type: string;
+      count: string;
+    }>({
+      query,
+      params,
+    });
+
+    return result.data;
+  }
+
+  async getWorkflowRunEventTrend(
+    environmentId: string,
+    organizationId: string,
+    startDate: Date,
+    endDate: Date,
+    eventType: string
+  ): Promise<Array<{ date: string; count: string }>> {
+    const query = `
+      SELECT 
+        date,
+        sum(count) as count
+      FROM ${WORKFLOW_RUN_COUNT_TABLE_NAME}
+      WHERE 
+        environment_id = {environmentId:String} 
+        AND organization_id = {organizationId:String}
+        AND event_type = {eventType:String}
+        AND date >= {startDate:Date}
+        AND date <= {endDate:Date}
+      GROUP BY date
+      ORDER BY date
+    `;
+
+    const params: Record<string, unknown> = {
+      environmentId,
+      organizationId,
+      eventType,
+      startDate: startDate.toISOString().split('T')[0],
+      endDate: endDate.toISOString().split('T')[0],
+    };
+
+    const result = await this.clickhouseService.query<{
+      date: string;
+      count: string;
+    }>({
+      query,
+      params,
+    });
+
+    return result.data;
+  }
+}

--- a/libs/application-generic/src/services/analytic-logs/workflow-run-count/workflow-run-count.schema.ts
+++ b/libs/application-generic/src/services/analytic-logs/workflow-run-count/workflow-run-count.schema.ts
@@ -1,40 +1,40 @@
 import { CHDate, CHLowCardinality, CHString, CHUInt64, ClickhouseSchema } from 'clickhouse-schema';
 
-export const DELIVERY_TREND_COUNTS_TABLE_NAME = 'delivery_trend_counts';
+export const WORKFLOW_RUN_COUNT_TABLE_NAME = 'workflow_run_count';
 
 const schemaDefinition = {
   date: { type: CHDate() },
   organization_id: { type: CHString() },
   environment_id: { type: CHString() },
-  workflow_id: { type: CHString() },
-  step_type: { type: CHLowCardinality(CHString()) },
+  event_type: { type: CHLowCardinality(CHString()) },
+  workflow_run_id: { type: CHString() },
   count: { type: CHUInt64() },
   expires_at: { type: CHDate() },
 };
 
-export const DELIVERY_TREND_COUNTS_ORDER_BY: (keyof typeof schemaDefinition)[] = [
+export const WORKFLOW_RUN_COUNT_ORDER_BY: (keyof typeof schemaDefinition)[] = [
   'organization_id',
   'environment_id',
+  'event_type',
   'date',
-  'workflow_id',
-  'step_type',
+  'workflow_run_id',
 ];
 
 const clickhouseSchemaOptions = {
-  table_name: DELIVERY_TREND_COUNTS_TABLE_NAME,
+  table_name: WORKFLOW_RUN_COUNT_TABLE_NAME,
   engine: 'SummingMergeTree',
-  order_by: `(${DELIVERY_TREND_COUNTS_ORDER_BY.join(', ')})` as any,
+  order_by: `(${WORKFLOW_RUN_COUNT_ORDER_BY.join(', ')})` as any,
   additional_options: ['PARTITION BY toYYYYMM(date)', 'TTL expires_at'],
 };
 
-export const deliveryTrendCountsSchema = new ClickhouseSchema(schemaDefinition, clickhouseSchemaOptions);
+export const workflowRunCountSchema = new ClickhouseSchema(schemaDefinition, clickhouseSchemaOptions);
 
-export type DeliveryTrendCount = {
+export type WorkflowRunCount = {
   date: string;
   organization_id: string;
   environment_id: string;
-  workflow_id: string;
-  step_type: string;
+  event_type: string;
+  workflow_run_id: string;
   count: number;
   expires_at: string;
 };


### PR DESCRIPTION


- Added SQL migration to finalize table exchange and recreate materialized views for traces and delivery trend counts.
- Updated delivery trend counts schema to include `expires_at` field and added TTL support.
- Introduced new workflow run count repository and schema for tracking workflow run events.
- Implemented methods for retrieving workflow run event counts and trends.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
