### PR TITLE
Dashboard variable schema error

### DIFF
--- a/apps/dashboard/src/components/primitives/variable-editor.tsx
+++ b/apps/dashboard/src/components/primitives/variable-editor.tsx
@@ -3,7 +3,7 @@ import { EditorView, Extension } from '@uiw/react-codemirror';
 import { JSONSchema7 } from 'json-schema';
 import { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Editor, EditorProps } from '@/components/primitives/editor';
-import { createVariableExtension } from '@/components/primitives/variable-plugin';
+import { createVariableExtension, schemaChangeEffect } from '@/components/primitives/variable-plugin';
 import { DEFAULT_VARIABLE_PILL_HEIGHT } from '@/components/primitives/variable-plugin/variable-pill-widget';
 import { variablePillTheme } from '@/components/primitives/variable-plugin/variable-theme';
 import { EditVariablePopover } from '@/components/variable/edit-variable-popover';
@@ -358,6 +358,15 @@ export function VariableEditor({
       setVariableTriggerPosition(null);
     }
   }, [selectedVariable, viewRef, containerRef]);
+
+  // Trigger decoration update when validation function changes (e.g., when schema changes)
+  useEffect(() => {
+    if (viewRef.current) {
+      viewRef.current.dispatch({
+        effects: schemaChangeEffect.of(undefined),
+      });
+    }
+  }, [isAllowedVariable, viewRef]);
 
   return (
     <div ref={containerRef} className={className} onClick={handleContainerClick}>

--- a/apps/dashboard/src/components/primitives/variable-plugin/index.ts
+++ b/apps/dashboard/src/components/primitives/variable-plugin/index.ts
@@ -1,5 +1,6 @@
 import { Decoration, EditorView, ViewPlugin } from '@uiw/react-codemirror';
 import { VariablePluginView } from './plugin-view';
+import { schemaChangeField } from './schema-change-effect';
 import type { PluginState } from './types';
 
 export function createVariableExtension({
@@ -10,7 +11,7 @@ export function createVariableExtension({
   isDigestEventsVariable,
   getVariableErrorMessage,
 }: PluginState) {
-  return ViewPlugin.fromClass(
+  const plugin = ViewPlugin.fromClass(
     class {
       private view: VariablePluginView;
 
@@ -42,9 +43,12 @@ export function createVariableExtension({
         }),
     }
   );
+
+  return [schemaChangeField, plugin];
 }
 
 export const VARIABLE_PILL_CLASS = 'cm-variable-pill';
 export const FILTERS_CLASS = 'has-filters';
 
+export * from './schema-change-effect';
 export * from './types';

--- a/apps/dashboard/src/components/primitives/variable-plugin/plugin-view.ts
+++ b/apps/dashboard/src/components/primitives/variable-plugin/plugin-view.ts
@@ -3,6 +3,7 @@ import { MutableRefObject } from 'react';
 import { parseVariable, VARIABLE_REGEX_STRING } from '@/utils/liquid';
 import { isVariableInLocalContext } from '@/utils/liquid-scope-analyzer';
 import { IsAllowedVariable } from '@/utils/parseStepVariables';
+import { schemaChangeEffect } from './schema-change-effect';
 import { isTypingVariable } from './utils';
 import { VariablePillWidget } from './variable-pill-widget';
 
@@ -27,7 +28,12 @@ export class VariablePluginView {
   }
 
   update(update: any) {
-    if (update.docChanged || update.viewportChanged || update.selectionSet) {
+    // Check if schema changed (via effect) or if document/viewport/selection changed
+    const hasSchemaChangeEffect = update.transactions?.some((tr: any) =>
+      tr.effects?.some((effect: any) => effect.is(schemaChangeEffect))
+    );
+
+    if (update.docChanged || update.viewportChanged || update.selectionSet || hasSchemaChangeEffect) {
       const pos = update.state.selection.main.head;
       const content = update.state.doc.toString();
 

--- a/apps/dashboard/src/components/primitives/variable-plugin/schema-change-effect.ts
+++ b/apps/dashboard/src/components/primitives/variable-plugin/schema-change-effect.ts
@@ -1,0 +1,23 @@
+import { StateEffect, StateField } from '@codemirror/state';
+
+/**
+ * State effect to signal that the schema has changed and decorations should be recalculated.
+ * This is used to force the variable plugin to update when the payload schema changes.
+ */
+export const schemaChangeEffect = StateEffect.define<void>();
+
+/**
+ * State field to track schema change effects.
+ * This doesn't store any state, but its presence ensures the effect triggers view updates.
+ */
+export const schemaChangeField = StateField.define<number>({
+  create: () => 0,
+  update: (value, tr) => {
+    for (const effect of tr.effects) {
+      if (effect.is(schemaChangeEffect)) {
+        return value + 1;
+      }
+    }
+    return value;
+  },
+});


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves [NV-6656](https://linear.app/novu/issue/NV-6656), where "variable schema does not exist" errors would persist in the CodeMirror editor even after users corrected their variables.

The issue stemmed from the CodeMirror variable plugin not re-evaluating its decorations when the underlying payload schema (and thus the `isAllowedVariable` validation logic) changed.

To fix this:
*   A new CodeMirror `StateEffect` (`schemaChangeEffect`) and `StateField` were introduced to explicitly signal schema updates.
*   The `VariablePluginView` was updated to listen for this effect and trigger a recalculation of variable decorations.
*   A `useEffect` hook was added to the `VariableEditor` to dispatch the `schemaChangeEffect` whenever the `isAllowedVariable` validation function changes, ensuring the editor's error states are correctly updated.

---
Linear Issue: [NV-6656](https://linear.app/novu/issue/NV-6656/variable-schema-does-not-exist-error-gets-stuck-on-the-dashboard)

<a href="https://cursor.com/background-agent?bcId=bc-6cfefa64-60bb-4b2e-be55-75ad744e3c3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6cfefa64-60bb-4b2e-be55-75ad744e3c3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

