### PR TITLE
Email subject sanitization

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -2548,4 +2548,107 @@ describe('EmailOutputRendererUsecase', () => {
       expect(result.body).to.include('<p></p>');
     });
   });
+
+  describe('Subject line handling', () => {
+    it('should not HTML-encode special characters in subject', async () => {
+      const mockTipTapNode: MailyJSONContent = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Hello World',
+              },
+            ],
+          },
+        ],
+      };
+
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Welcome to I&B monitoring platform!',
+          body: JSON.stringify(mockTipTapNode),
+        },
+        fullPayloadForRender: mockFullPayload,
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.subject).to.equal('Welcome to I&B monitoring platform!');
+      expect(result.subject).to.not.include('&amp;');
+    });
+
+    it('should preserve special characters in subject with liquid variables', async () => {
+      const mockTipTapNode: MailyJSONContent = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Hello',
+              },
+            ],
+          },
+        ],
+      };
+
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Order #{{payload.orderId}} - R&D Department',
+          body: JSON.stringify(mockTipTapNode),
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { orderId: '12345' },
+        },
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.subject).to.include('R&D Department');
+      expect(result.subject).to.not.include('&amp;');
+    });
+
+    it('should handle subject with multiple special characters', async () => {
+      const mockTipTapNode: MailyJSONContent = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Content',
+              },
+            ],
+          },
+        ],
+      };
+
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Tom & Jerry <3 Pizza > Pasta',
+          body: JSON.stringify(mockTipTapNode),
+        },
+        fullPayloadForRender: mockFullPayload,
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.subject).to.equal('Tom & Jerry <3 Pizza > Pasta');
+      expect(result.subject).to.not.include('&amp;');
+      expect(result.subject).to.not.include('&lt;');
+      expect(result.subject).to.not.include('&gt;');
+    });
+  });
 });

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -519,7 +519,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
           organization,
         });
 
-    return decodeHTML(this.unescapeJsonString(translatedSubject));
+    return this.unescapeJsonString(translatedSubject);
   }
 
   private async processMailyTranslations({


### PR DESCRIPTION
### What changed? Why was the change needed?

Email subjects were incorrectly being sanitized as HTML, causing characters like `&` to be encoded as `&amp;`. Subjects are plain text and should not undergo HTML entity decoding.

This PR removes the `decodeHTML` function call from the `processSubjectTranslations` method in `apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts` to ensure subjects are treated as plain text.

Related Linear ticket: [NV-6836](https://linear.app/novu/issue/NV-6836/remove-email-sanitization-on-subject)

### Screenshots

The original Linear issue description includes a screenshot demonstrating the problem.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

</details>

---
Linear Issue: [NV-6836](https://linear.app/novu/issue/NV-6836/remove-email-sanitization-on-subject)

<a href="https://cursor.com/background-agent?bcId=bc-d21173eb-752f-41cb-8be8-71b30fce407f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d21173eb-752f-41cb-8be8-71b30fce407f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

