### PR TITLE
Subject html sanitization

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -132,6 +132,73 @@ describe('EmailOutputRendererUsecase', () => {
   } as any;
 
   describe('general flow', () => {
+    it('should preserve special characters in subject without HTML encoding', async () => {
+      const mockTipTapNode: MailyJSONContent = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Hello World',
+              },
+            ],
+          },
+        ],
+      };
+
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Welcome to I&B monitoring platform! Let\'s get started!',
+          body: JSON.stringify(mockTipTapNode),
+        },
+        fullPayloadForRender: mockFullPayload,
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.subject).to.equal('Welcome to I&B monitoring platform! Let\'s get started!');
+      expect(result.subject).to.not.include('&amp;');
+    });
+
+    it('should handle subject with liquid variables and special characters', async () => {
+      const mockTipTapNode: MailyJSONContent = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: 'Hello World',
+              },
+            ],
+          },
+        ],
+      };
+
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Hello {{payload.name}} & welcome to {{payload.company}}!',
+          body: JSON.stringify(mockTipTapNode),
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { name: 'John', company: 'Acme & Co' },
+        },
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.subject).to.equal('Hello John & welcome to Acme & Co!');
+      expect(result.subject).to.not.include('&amp;');
+    });
+
     it('should return subject and body when body is not string', async () => {
       let renderCommand: EmailOutputRendererCommand = {
         dbWorkflow: mockDbWorkflow,

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -29,7 +29,7 @@ import {
   LAYOUT_CONTENT_VARIABLE,
   LAYOUT_PREVIEW_EMAIL_STEP,
 } from '@novu/shared';
-import { decodeHTML } from 'entities';
+import { decodeHTML as decodeHTMLEntities } from 'entities';
 import { Liquid } from 'liquidjs';
 import { GetLayoutCommand, GetLayoutUseCase } from '../../../layouts-v2/usecases/get-layout';
 import { GetOrganizationSettingsCommand } from '../../../organization/usecases/get-organization-settings/get-organization-settings.command';
@@ -472,7 +472,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
       });
       const parsedMaily = await this.parseMailyContentByLiquid(translatedMaily, escapedPayloadForJson);
       const renderedMaily = await mailyRender(parsedMaily, { noHtmlWrappingTags });
-      return decodeHTML(renderedMaily);
+      return decodeHTMLEntities(renderedMaily);
     } else {
       const processedHtml = await this.processTextTranslations({
         text: body,
@@ -519,7 +519,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
           organization,
         });
 
-    return decodeHTML(this.unescapeJsonString(translatedSubject));
+    return this.liquidEngine.parseAndRender(this.unescapeJsonString(translatedSubject), unescapedVariables);
   }
 
   private async processMailyTranslations({


### PR DESCRIPTION
### What changed? Why was the change needed?

The email subject was incorrectly being treated as HTML content, causing special characters (e.g., `&`) to be HTML-encoded (e.g., `&amp;`). This change removes the HTML decoding from the subject processing and instead uses the Liquid engine to correctly render the subject as plain text while supporting Liquid variables.

- Removed `decodeHTML` from the `processSubjectTranslations` method in `email-output-renderer.usecase.ts`.
- Replaced it with `liquidEngine.parseAndRender` to correctly process the subject as plain text with Liquid variable support.
- Renamed the `decodeHTML` import to `decodeHTMLEntities` to clarify its specific use for HTML body content.
- Added two new test cases to `email-output-renderer.spec.ts` to ensure special characters and Liquid variables in the subject are handled correctly.

This resolves [NV-6836](https://linear.app/novu/issue/NV-6836/remove-email-sanitization-on-subject).

### Screenshots

N/A

---
Linear Issue: [NV-6836](https://linear.app/novu/issue/NV-6836/remove-email-sanitization-on-subject)

<a href="https://cursor.com/background-agent?bcId=bc-edb4a4ad-9d24-4b05-a5e5-dcb79a7a219d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-edb4a4ad-9d24-4b05-a5e5-dcb79a7a219d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

