### PR TITLE
Email subject sanitization

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -2548,4 +2548,94 @@ describe('EmailOutputRendererUsecase', () => {
       expect(result.body).to.include('<p></p>');
     });
   });
+
+  describe('Subject handling (no HTML sanitization)', () => {
+    beforeEach(() => {
+      getOrganizationSettingsMock.execute.resolves({
+        removeNovuBranding: true,
+        defaultLocale: 'en_US',
+      });
+    });
+
+    it('should preserve ampersand characters in subject without HTML encoding', async () => {
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Welcome to I&B monitoring platform!',
+          body: '<p>Test content</p>',
+        },
+        fullPayloadForRender: mockFullPayload,
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.subject).to.equal('Welcome to I&B monitoring platform!');
+      expect(result.subject).to.not.include('&amp;');
+    });
+
+    it('should preserve less-than and greater-than characters in subject', async () => {
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Test <important> subject',
+          body: '<p>Test content</p>',
+        },
+        fullPayloadForRender: mockFullPayload,
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.subject).to.equal('Test <important> subject');
+      expect(result.subject).to.not.include('&lt;');
+      expect(result.subject).to.not.include('&gt;');
+    });
+
+    it('should preserve special characters in subject with variables', async () => {
+      const mockTipTapNode = {
+        type: 'doc',
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Test content' }] }],
+      };
+
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Order #{{payload.orderId}} from A&B Corp',
+          body: JSON.stringify(mockTipTapNode),
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { orderId: '12345' },
+        },
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.subject).to.include('A&B Corp');
+      expect(result.subject).to.not.include('&amp;');
+    });
+
+    it('should not apply HTML sanitization to subject even when body is sanitized', async () => {
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Price: $100 & shipping <$10>',
+          body: '<p>Content with & and <script>bad</script></p>',
+          disableOutputSanitization: false,
+        },
+        fullPayloadForRender: mockFullPayload,
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.subject).to.equal('Price: $100 & shipping <$10>');
+      expect(result.subject).to.not.include('&amp;');
+      expect(result.subject).to.not.include('&lt;');
+      expect(result.subject).to.not.include('&gt;');
+      expect(result.body).to.not.include('<script>');
+    });
+  });
 });

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -519,7 +519,7 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
           organization,
         });
 
-    return decodeHTML(this.unescapeJsonString(translatedSubject));
+    return this.unescapeJsonString(translatedSubject);
   }
 
   private async processMailyTranslations({


### PR DESCRIPTION
### What changed? Why was the change needed?

The email subject was incorrectly being HTML-decoded, causing special characters (e.g., `&`) to be rendered as HTML entities (e.g., `&amp;`) in the subject line. Email subjects are plain text and should not undergo HTML sanitization.

This change removes the `decodeHTML` call from the subject processing in `EmailOutputRendererUsecase`, ensuring subjects are treated as plain text. New tests have been added to verify that special characters are preserved correctly in the subject.

Relevant link: [NV-6836](https://linear.app/novu/issue/NV-6836/remove-email-sanitization-on-subject)

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

---
Linear Issue: [NV-6836](https://linear.app/novu/issue/NV-6836/remove-email-sanitization-on-subject)

<a href="https://cursor.com/background-agent?bcId=bc-4c1ab807-0ee7-48bf-b5aa-177df0842b89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c1ab807-0ee7-48bf-b5aa-177df0842b89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

