### PR TITLE
fix(worker, ws): Notification unseen count value in event fixes NV-7038

### DIFF
--- a/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
+++ b/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
@@ -12,6 +12,11 @@ type UnreadCountPaginationIndication = {
   hasMore: boolean;
 };
 
+type UnseenCountPaginationIndication = {
+  unseenCount: number;
+  hasMore: boolean;
+};
+
 export interface SendMessageParams {
   userId: string;
   event: string;
@@ -262,10 +267,29 @@ export class SocketWorkerService {
     contextKeys?: string[]
   ): Promise<void> {
     try {
+      const unseenCount = await this.messageRepository.getCount(
+        environmentId,
+        userId,
+        ChannelTypeEnum.IN_APP,
+        { seen: false },
+        { limit: this.UNREAD_COUNT_LIMIT },
+        contextKeys,
+        undefined,
+        'primary'
+      );
+
+      const paginationIndication: UnseenCountPaginationIndication =
+        unseenCount > this.UNREAD_COUNT_PAGINATION_THRESHOLD
+          ? { unseenCount: this.UNREAD_COUNT_PAGINATION_THRESHOLD, hasMore: true }
+          : { unseenCount, hasMore: false };
+
       await this.sendMessageInternal({
         userId,
         event: WebSocketEventEnum.UNSEEN,
-        data: {},
+        data: {
+          unseenCount: paginationIndication.unseenCount,
+          hasMore: paginationIndication.hasMore,
+        },
         organizationId,
         environmentId,
         contextKeys,

--- a/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
+++ b/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
@@ -31,7 +31,7 @@ export interface SendMessageParams {
 export class SocketWorkerService {
   private readonly socketWorkerUrl: string | undefined;
   private readonly socketWorkerApiKey: string | undefined;
-  private readonly UNREAD_COUNT_LIMIT = 100;
+  private readonly UNREAD_COUNT_LIMIT = 101;
   private readonly UNREAD_COUNT_PAGINATION_THRESHOLD = 100;
   private readonly SEVERITY_COUNT_LIMIT = 99;
   private readonly HTTP_TIMEOUT_MS = 3000;

--- a/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
+++ b/libs/application-generic/src/services/socket-worker/socket-worker.service.ts
@@ -31,7 +31,7 @@ export interface SendMessageParams {
 export class SocketWorkerService {
   private readonly socketWorkerUrl: string | undefined;
   private readonly socketWorkerApiKey: string | undefined;
-  private readonly UNREAD_COUNT_LIMIT = 101;
+  private readonly UNREAD_COUNT_LIMIT = 100;
   private readonly UNREAD_COUNT_PAGINATION_THRESHOLD = 100;
   private readonly SEVERITY_COUNT_LIMIT = 99;
   private readonly HTTP_TIMEOUT_MS = 3000;


### PR DESCRIPTION
### What changed? Why was the change needed?
The `notifications.unseen_count_changed` WebSocket event was sending an `undefined` value for the unseen count when notifications were marked as seen. This was due to the `sendUnseenCountChange` method in `SocketWorkerService` sending an empty data object.

This change updates the `sendUnseenCountChange` method to correctly calculate and send the `unseenCount` and `hasMore` flags, mirroring the existing logic for `unreadCount` events. This ensures the client-side SDK receives the expected `{ unseenCount, hasMore }` payload, resolving the issue where the UI could not correctly display the unseen notification count.

**Relevant links:**
- Linear: [NV-7038](https://linear.app/novu/issue/NV-7038/undefined-value-sent-when-notifications-marked-as-seen)

### Screenshots
N/A (backend change)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR
N/A

### Special notes for your reviewer
The `UNREAD_COUNT_LIMIT` and `UNREAD_COUNT_PAGINATION_THRESHOLD` constants are reused for unseen count calculation to maintain consistency with existing pagination logic.
</details>

---
Linear Issue: [NV-7038](https://linear.app/novu/issue/NV-7038/undefined-value-sent-when-notifications-marked-as-seen)

<a href="https://cursor.com/background-agent?bcId=bc-308484a3-e893-488e-8a1c-6d66d1cacdb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-308484a3-e893-488e-8a1c-6d66d1cacdb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

