### PR TITLE
Mark notifications test

### DIFF
--- a/apps/api/src/app/inbox/usecases/mark-many-notifications-as/mark-many-notifications-as.spec.ts
+++ b/apps/api/src/app/inbox/usecases/mark-many-notifications-as/mark-many-notifications-as.spec.ts
@@ -142,6 +142,7 @@ describe('MarkManyNotificationsAs', () => {
           event: WebSocketEventEnum.UNREAD,
           userId: mockSubscriber._id,
           _environmentId: mockSubscriber._environmentId,
+          contextKeys: [],
         },
         groupId: mockSubscriber._organizationId,
       },


### PR DESCRIPTION
### What changed? Why was the change needed?

The CI was failing due to an `AssertionError` in the `MarkManyNotificationsAs` test. The test expected the websocket `unread_count_changed` event data to not include the `contextKeys` field, while the actual implementation correctly adds `contextKeys: []` when not explicitly provided.

This change updates the test's expected websocket event data to include `contextKeys: []` to align with the current implementation, resolving the failing CI.

### Screenshots

---
<a href="https://cursor.com/background-agent?bcId=bc-b0af4307-68ad-4f7d-bc86-7ad5904611e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0af4307-68ad-4f7d-bc86-7ad5904611e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

