### PR TITLE
refactor(providers): reuse axios instance in KannelSmsProvider

### DIFF
--- a/packages/providers/src/lib/sms/kannel/kannel.provider.ts
+++ b/packages/providers/src/lib/sms/kannel/kannel.provider.ts
@@ -1,12 +1,13 @@
 import { SmsProviderIdEnum } from '@novu/shared';
 import { ChannelTypeEnum, ISendMessageSuccessResponse, ISmsOptions, ISmsProvider } from '@novu/stateless';
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
 
 export class KannelSmsProvider extends BaseProvider implements ISmsProvider {
   id = SmsProviderIdEnum.Kannel;
   apiBaseUrl: string;
+  private axiosInstance: AxiosInstance;
   channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
   protected casing = CasingEnum.SNAKE_CASE;
 
@@ -21,6 +22,7 @@ export class KannelSmsProvider extends BaseProvider implements ISmsProvider {
   ) {
     super();
     this.apiBaseUrl = `http://${config.host}:${config.port}/cgi-bin`;
+    this.axiosInstance = axios.create();
   }
 
   async sendMessage(
@@ -36,7 +38,7 @@ export class KannelSmsProvider extends BaseProvider implements ISmsProvider {
       text: options.content,
     }).body;
 
-    const result = await axios.create().get(url, {
+    const result = await this.axiosInstance.get(url, {
       params: queryParameters,
     });
 


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR refactors the `KannelSmsProvider` to reuse a single `axios` instance instead of creating a new one for each `sendMessage` call.

The change was needed to:
*   Improve performance by avoiding unnecessary HTTP client recreation.
*   Reduce resource waste.
*   Follow `axios` best practices.

This is a behavior-preserving refactor with no changes to the provider's public API or functionality.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

---
<p><a href="https://cursor.com/background-agent?bcId=bc-32cd586d-3a36-4bc0-88ee-96b381e1282d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-32cd586d-3a36-4bc0-88ee-96b381e1282d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

