### PR TITLE
Liquid condition quotes

### DIFF
--- a/apps/api/src/app/shared/services/control-value-sanitizer.service.ts
+++ b/apps/api/src/app/shared/services/control-value-sanitizer.service.ts
@@ -5,7 +5,7 @@ import {
   PinoLogger,
   SanitizationType,
 } from '@novu/application-generic';
-import { actionStepSchemas, channelStepSchemas } from '@novu/framework/internal';
+import { actionStepSchemas, channelStepSchemas, fixLiquidDoubleQuotes } from '@novu/framework/internal';
 import { ResourceOriginEnum } from '@novu/shared';
 import Ajv, { ErrorObject } from 'ajv';
 import addFormats from 'ajv-formats';
@@ -172,7 +172,8 @@ export class ControlValueSanitizerService {
     const parserEngine = buildLiquidParser();
 
     try {
-      parserEngine.parse(JSON.stringify(value));
+      const templateString = fixLiquidDoubleQuotes(JSON.stringify(value));
+      parserEngine.parse(templateString);
 
       return value;
     } catch (error) {

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -40,7 +40,7 @@ import type {
 } from './types';
 import { WithPassthrough } from './types/provider.types';
 import { EMOJI, log, resolveApiUrl, resolveSecretKey, sanitizeHtmlInObject } from './utils';
-import { createLiquidEngine } from './utils/liquid.utils';
+import { createLiquidEngine, fixLiquidDoubleQuotes } from './utils/liquid.utils';
 import { normalizeControlData } from './utils/normalize-controls.utils';
 import { deepMerge } from './utils/object.utils';
 import { validateData } from './validators';
@@ -699,6 +699,7 @@ export class Client {
     try {
       let templateString = this.preprocessTranslationPatterns(JSON.stringify(templateControls));
       templateString = this.preprocessFilterTranslationArgs(templateString);
+      templateString = fixLiquidDoubleQuotes(templateString);
       const parsedTemplate = this.templateEngine.parse(templateString);
       const discoveredWorkflow = this.getWorkflow(event.workflowId);
 

--- a/packages/framework/src/internal/index.ts
+++ b/packages/framework/src/internal/index.ts
@@ -3,4 +3,4 @@ export * from '../errors';
 export * from '../filters';
 export { actionStepSchemas, channelStepSchemas } from '../schemas';
 export * from '../types';
-export { createLiquidEngine } from '../utils/liquid.utils';
+export { createLiquidEngine, fixLiquidDoubleQuotes } from '../utils/liquid.utils';

--- a/packages/framework/src/utils/liquid.utils.test.ts
+++ b/packages/framework/src/utils/liquid.utils.test.ts
@@ -1,6 +1,11 @@
 import { Liquid } from 'liquidjs';
 import { describe, expect, it } from 'vitest';
-import { createLiquidEngine, defaultOutputEscape, stringifyDataStructureWithSingleQuotes } from './liquid.utils';
+import {
+  createLiquidEngine,
+  defaultOutputEscape,
+  fixLiquidDoubleQuotes,
+  stringifyDataStructureWithSingleQuotes,
+} from './liquid.utils';
 
 describe('createLiquidEngine', () => {
   it('should create a Liquid instance with default configuration', () => {
@@ -449,5 +454,132 @@ describe('stringifyDataStructureWithSingleQuotes', () => {
     const myTestUndefined = undefined;
     const converted = stringifyDataStructureWithSingleQuotes(myTestUndefined);
     expect(converted).toStrictEqual('');
+  });
+});
+
+describe('fixLiquidDoubleQuotes', () => {
+  const engine = new Liquid({
+    strictVariables: true,
+    strictFilters: true,
+    greedy: false,
+    catchAllErrors: true,
+  });
+
+  it('should fix escaped double quotes in Liquid if conditions', async () => {
+    const controls = { body: `{% if payload.CommentType == "CommentReply" %}found{% endif %}` };
+    let templateString = JSON.stringify(controls);
+
+    expect(templateString).toBe('{"body":"{% if payload.CommentType == \\"CommentReply\\" %}found{% endif %}"}');
+
+    templateString = fixLiquidDoubleQuotes(templateString);
+
+    expect(templateString).toBe('{"body":"{% if payload.CommentType == "CommentReply" %}found{% endif %}"}');
+
+    const parsed = engine.parse(templateString);
+    const result = await engine.render(parsed, { payload: { CommentType: 'CommentReply' } });
+    const parsedResult = JSON.parse(result);
+
+    expect(parsedResult.body).toBe('found');
+  });
+
+  it('should fix escaped double quotes in Liquid elsif conditions', async () => {
+    const controls = {
+      body: `{% if payload.type == "reply" %}Reply{% elsif payload.type == "mention" %}Mention{% endif %}`,
+    };
+    let templateString = JSON.stringify(controls);
+    templateString = fixLiquidDoubleQuotes(templateString);
+
+    const parsed = engine.parse(templateString);
+    const result = await engine.render(parsed, { payload: { type: 'reply' } });
+    const parsedResult = JSON.parse(result);
+
+    expect(parsedResult.body).toBe('Reply');
+  });
+
+  it('should not break templates with single quotes', async () => {
+    const controls = { body: `{% if payload.type == 'reply' %}Reply{% endif %}` };
+    let templateString = JSON.stringify(controls);
+    templateString = fixLiquidDoubleQuotes(templateString);
+
+    const parsed = engine.parse(templateString);
+    const result = await engine.render(parsed, { payload: { type: 'reply' } });
+    const parsedResult = JSON.parse(result);
+
+    expect(parsedResult.body).toBe('Reply');
+  });
+
+  it('should fix escaped double quotes in Liquid output expressions', async () => {
+    const controls = { body: `Value: "{{payload.value}}"` };
+    let templateString = JSON.stringify(controls);
+    templateString = fixLiquidDoubleQuotes(templateString);
+
+    const parsed = engine.parse(templateString);
+    const result = await engine.render(parsed, { payload: { value: 'test' } });
+    const parsedResult = JSON.parse(result);
+
+    expect(parsedResult.body).toBe('Value: "test"');
+  });
+
+  it('should handle complex templates with mixed single and double quotes', async () => {
+    const controls = {
+      body: `{% if payload.type == "reply" %}{{payload.message}}{% elsif payload.type == 'mention' %}Mentioned{% endif %}`,
+    };
+    let templateString = JSON.stringify(controls);
+    templateString = fixLiquidDoubleQuotes(templateString);
+
+    const parsed = engine.parse(templateString);
+    const result = await engine.render(parsed, { payload: { type: 'reply', message: 'Hello!' } });
+    const parsedResult = JSON.parse(result);
+
+    expect(parsedResult.body).toBe('Hello!');
+  });
+
+  it('should preserve double quotes outside of Liquid tags', async () => {
+    const controls = { body: `Static "text" here` };
+    let templateString = JSON.stringify(controls);
+    templateString = fixLiquidDoubleQuotes(templateString);
+
+    const parsed = engine.parse(templateString);
+    const result = await engine.render(parsed, {});
+    const parsedResult = JSON.parse(result);
+
+    expect(parsedResult.body).toBe('Static "text" here');
+  });
+
+  it('should handle multiline Liquid templates', async () => {
+    const controls = {
+      body: `{% if payload.type == "reply" %}
+        Reply message
+      {% elsif payload.type == "mention" %}
+        Mention message
+      {% endif %}`,
+    };
+    let templateString = JSON.stringify(controls);
+    templateString = fixLiquidDoubleQuotes(templateString);
+
+    const parsed = engine.parse(templateString);
+    const result = await engine.render(parsed, { payload: { type: 'reply' } });
+    const parsedResult = JSON.parse(result);
+
+    expect(parsedResult.body).toContain('Reply message');
+  });
+
+  it('should return unchanged string if no Liquid tags present', () => {
+    const templateString = '{"body":"Hello World"}';
+    const result = fixLiquidDoubleQuotes(templateString);
+
+    expect(result).toBe(templateString);
+  });
+
+  it('should handle contains operator with double quotes', async () => {
+    const controls = { body: `{% if payload.tags contains "important" %}Tagged{% endif %}` };
+    let templateString = JSON.stringify(controls);
+    templateString = fixLiquidDoubleQuotes(templateString);
+
+    const parsed = engine.parse(templateString);
+    const result = await engine.render(parsed, { payload: { tags: ['important', 'urgent'] } });
+    const parsedResult = JSON.parse(result);
+
+    expect(parsedResult.body).toBe('Tagged');
   });
 });

--- a/packages/framework/src/utils/liquid.utils.ts
+++ b/packages/framework/src/utils/liquid.utils.ts
@@ -67,3 +67,28 @@ export function createLiquidEngine(options?: LiquidOptions): Liquid {
 
   return liquidEngine;
 }
+
+/**
+ * Fixes escaped double quotes inside Liquid tags in a JSON-stringified template string.
+ *
+ * When control values containing Liquid templates with double quotes are passed through
+ * JSON.stringify, the double quotes get escaped as `\"`. This escaped form is not valid
+ * Liquid syntax and causes parsing errors.
+ *
+ * This function unescapes double quotes inside Liquid tags (`{% %}`) and output expressions
+ * (`{{ }}`) to restore valid Liquid syntax.
+ *
+ * @example
+ * // Input (after JSON.stringify):
+ * // {"body":"{% if payload.type == \"reply\" %}Reply{% endif %}"}
+ * // Output:
+ * // {"body":"{% if payload.type == "reply" %}Reply{% endif %}"}
+ *
+ * @param templateString - The JSON-stringified template string
+ * @returns The template string with unescaped double quotes inside Liquid expressions
+ */
+export function fixLiquidDoubleQuotes(templateString: string): string {
+  return templateString.replace(/({%.*?%})|({{.*?}})/gs, (match) => {
+    return match.replace(/\\"/g, '"');
+  });
+}


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves [NV-7101](https://linear.app/novu/issue/NV-7101/double-quotes-break-liquid-js-helper-ifelse-conditions).

Previously, Liquid conditions using double quotes (e.g., `{% if payload.type == "reply" %}`) would fail to parse because `JSON.stringify` was escaping the double quotes to `\"`. This resulted in invalid Liquid syntax.

A new utility function, `fixLiquidDoubleQuotes`, has been introduced to unescape these double quotes within Liquid tags (`{% %}`) and output expressions (`{{ }}`). This function is now applied in both the framework client's `compileControls` method and the API's `sanitizeControlValuesByLiquidCompilationFailure` method, ensuring that double quotes in Liquid templates are correctly parsed and rendered.

### Screenshots

N/A

---
Linear Issue: [NV-7101](https://linear.app/novu/issue/NV-7101/double-quotes-break-liquid-js-helper-ifelse-conditions)

<p><a href="https://cursor.com/background-agent?bcId=bc-a63fb32c-1a09-4ad6-a139-43f043f908a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a63fb32c-1a09-4ad6-a139-43f043f908a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

