### PR TITLE
style(worker): Log levels debug updates of verbose logs

### DIFF
--- a/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
@@ -121,7 +121,11 @@ export class AddJob {
       };
     }
 
-    this.logger.info(`Scheduling New Job ${job._id} of type: ${job.type}`);
+    if (job.type === StepTypeEnum.TRIGGER) {
+      this.logger.debug(`Scheduling New Job ${job._id} of type: ${job.type}`);
+    } else {
+      this.logger.info(`Scheduling New Job ${job._id} of type: ${job.type}`);
+    }
 
     const notification =
       command.notification ??

--- a/libs/application-generic/src/services/queues/queue-base.service.ts
+++ b/libs/application-generic/src/services/queues/queue-base.service.ts
@@ -85,7 +85,7 @@ export class QueueBaseService implements OnModuleDestroy {
     };
 
     const payloadSize = this.calculatePayloadSize(params.data);
-    Logger.log(
+    Logger.debug(
       `Adding job to queue. Topic: ${this.topic}, Job: ${params.name}, Payload size: ${payloadSize} bytes`,
       LOG_CONTEXT
     );
@@ -107,7 +107,7 @@ export class QueueBaseService implements OnModuleDestroy {
       );
     }
 
-    Logger.log(
+    Logger.debug(
       `Adding bulk jobs to queue. Topic: ${this.topic}, Count: ${data.length}, Total payload size: ${totalPayloadSize} bytes, Avg payload size: ${avgPayloadSize} bytes`,
       LOG_CONTEXT
     );

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.usecase.ts
@@ -191,7 +191,7 @@ export class ExecuteBridgeRequest {
       command.action
     );
 
-    this.logger.info(
+    this.logger.debug(
       `Resolved bridge URL: ${bridgeUrl} for environment ${command.environmentId} and origin ${command.workflowOrigin}`
     );
 
@@ -260,7 +260,7 @@ export class ExecuteBridgeRequest {
 
     const headers = await this.buildRequestHeaders(command);
 
-    this.logger.info(`Making bridge request to \`${url}\``);
+    this.logger.debug(`Making bridge request to \`${url}\``);
     try {
       return await request(url, {
         ...options,

--- a/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
@@ -162,7 +162,7 @@ export class TriggerEvent {
       // We might have a single actor for every trigger, so we only need to check for it once
       let actorProcessed: SubscriberEntity | undefined;
       if (mappedCommand.actor) {
-        this.logger.info(mappedCommand, 'Processing actor');
+        this.logger.debug(mappedCommand, 'Processing actor');
 
         try {
           actorProcessed = await this.createOrUpdateSubscriberUsecase.execute(


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR changes the log level for several specific messages from `info`/`log` to `debug`. This was done to reduce log verbosity at standard levels and provide more granular detail for debugging purposes.

The following log messages are now at `debug` level:
*   "Adding job to queue. Topic *"
*   "Resolved bridge URL"
*   "Making bridge request to"
*   "Adding bulk jobs to queue"
*   "Processing actor"
*   "Scheduling New Job of type: trigger" (only for trigger type jobs)

### Screenshots

N/A

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1770637531384839?thread_ts=1770637531.384839&cid=D0919LNRWE7)

<p><a href="https://cursor.com/background-agent?bcId=bc-76a7eb33-6247-5eb0-bfea-3e773c26ded7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-76a7eb33-6247-5eb0-bfea-3e773c26ded7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

