### PR TITLE
feat(dashboard): Dashboard sender inputs autocomplete

### DIFF
--- a/apps/dashboard/src/components/step-preview-hover-card.tsx
+++ b/apps/dashboard/src/components/step-preview-hover-card.tsx
@@ -46,11 +46,11 @@ export function StepPreview({ type, controlValues }: StepPreviewProps) {
   }
 
   if (type === StepTypeEnum.EMAIL) {
-    const { subject, body } = controlValues;
+    const { subject, body, from } = controlValues;
 
     return (
       <div className="bg-background p-3">
-        <EmailPreviewHeader />
+        <EmailPreviewHeader previewFrom={from} />
         <EmailPreviewSubject className="px-3 py-2" subject={subject} />
         <div className="mx-auto w-full overflow-auto">
           <Maily value={body} translationValueInput={() => null} />

--- a/apps/dashboard/src/components/workflow-editor/steps/email/configure-email-step-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/configure-email-step-preview.tsx
@@ -9,10 +9,15 @@ import { useWorkflow } from '@/components/workflow-editor/workflow-provider';
 import { usePreviewStep } from '@/hooks/use-preview-step';
 import { cn } from '@/utils/ui';
 
-type MiniEmailPreviewProps = HTMLAttributes<HTMLDivElement>;
+type MiniEmailPreviewProps = HTMLAttributes<HTMLDivElement> & {
+  previewFrom?: {
+    email?: string;
+    name?: string;
+  };
+};
 
 const MiniEmailPreview = (props: MiniEmailPreviewProps) => {
-  const { className, children, ...rest } = props;
+  const { className, children, previewFrom, ...rest } = props;
   return (
     <div
       className={cn(
@@ -22,7 +27,7 @@ const MiniEmailPreview = (props: MiniEmailPreviewProps) => {
       {...rest}
     >
       <div className="flex flex-col gap-1 py-1">
-        <EmailPreviewHeader className="px-2 text-sm" />
+        <EmailPreviewHeader className="px-2 text-sm" previewFrom={previewFrom} />
         <Separator className="before:bg-neutral-alpha-100" />
         <div className="relative z-10 line-clamp-3 space-y-1 px-2 pt-2 text-xs">{children}</div>
       </div>
@@ -106,7 +111,7 @@ export function ConfigureEmailStepPreview(props: ConfigureEmailStepPreviewProps)
 
   if (previewData.result.type === 'email') {
     return (
-      <MiniEmailPreview className={className} {...rest}>
+      <MiniEmailPreview className={className} previewFrom={previewData.result.preview.from} {...rest}>
         <span className="text-foreground-600 max-w-[20ch] truncate">{previewData.result.preview.subject}</span>
         <span> - </span>
         <span className="text-foreground-400">{getPlainText(previewData.result.preview.body)}</span>

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-editor-preview.tsx
@@ -46,10 +46,13 @@ export const EmailEditorPreview = ({
 }: EmailEditorPreviewProps) => {
   const [activeTab, setActiveTab] = useState('desktop');
 
+  const previewFrom =
+    previewData?.result?.type === ChannelTypeEnum.EMAIL ? previewData.result.preview.from : undefined;
+
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full">
       <div className="flex w-full items-center justify-between px-4 pb-0 pt-4">
-        <EmailPreviewHeader />
+        <EmailPreviewHeader previewFrom={previewFrom} />
         <div>
           <TabsList>
             <TabsTrigger value="mobile">

--- a/apps/dashboard/src/components/workflow-editor/steps/email/email-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/email-preview.tsx
@@ -12,17 +12,21 @@ import { NovuBranding } from './novu-branding';
 type EmailPreviewHeaderProps = HTMLAttributes<HTMLDivElement> & {
   minimalHeader?: boolean;
   onEditSenderClick?: () => void;
+  previewFrom?: {
+    email?: string;
+    name?: string;
+  };
 };
 
 export const EmailPreviewHeader = (props: EmailPreviewHeaderProps) => {
-  const { className, children, minimalHeader = false, onEditSenderClick, ...rest } = props;
+  const { className, children, minimalHeader = false, onEditSenderClick, previewFrom, ...rest } = props;
   const { senderEmail, senderName, isLoading } = usePrimaryEmailIntegration();
   const formContext = useFormContext();
   const fromEmail = formContext?.watch('from.email');
   const fromName = formContext?.watch('from.name');
 
-  const displaySenderName = fromName || senderName || 'Acme Inc.';
-  const displaySenderEmail = fromEmail || senderEmail || 'noreply@novu.co';
+  const displaySenderName = previewFrom?.name || fromName || senderName || 'Acme Inc.';
+  const displaySenderEmail = previewFrom?.email || fromEmail || senderEmail || 'noreply@novu.co';
 
   return (
     <div className={cn('flex gap-2', className)} {...rest}>

--- a/apps/dashboard/src/components/workflow-editor/steps/email/sender-config-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/sender-config-drawer.tsx
@@ -135,7 +135,7 @@ export function SenderConfigDrawer({ open, onOpenChange }: SenderConfigDrawerPro
               </FormLabel>
               <FormControl>
                 <InputRoot>
-                  <InputWrapper className="flex h-[2.35rem] items-center">
+                  <InputWrapper className="flex h-[2.35rem] items-center px-0">
                     <ControlInput
                       placeholder={
                         localUseDefaults ? integrationName || 'Acme Inc.' : integrationName || 'e.g. Acme Security'
@@ -170,7 +170,7 @@ export function SenderConfigDrawer({ open, onOpenChange }: SenderConfigDrawerPro
               </FormLabel>
               <FormControl>
                 <InputRoot hasError={!!emailError}>
-                  <InputWrapper className="flex h-[2.35rem] items-center">
+                  <InputWrapper className="flex h-[2.35rem] items-center px-0">
                     <ControlInput
                       placeholder={
                         localUseDefaults

--- a/apps/dashboard/src/components/workflow-editor/steps/email/sender-config-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/sender-config-drawer.tsx
@@ -3,7 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import { RiInformation2Line } from 'react-icons/ri';
 import { Button } from '@/components/primitives/button';
 import { FormControl, FormItem, FormLabel, FormMessage } from '@/components/primitives/form/form';
-import { Input } from '@/components/primitives/input';
+import { InputRoot, InputWrapper } from '@/components/primitives/input';
 import { Separator } from '@/components/primitives/separator';
 import {
   Sheet,
@@ -16,7 +16,10 @@ import {
 } from '@/components/primitives/sheet';
 import { Switch } from '@/components/primitives/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
+import { ControlInput } from '@/components/workflow-editor/control-input';
 import { useSaveForm } from '@/components/workflow-editor/steps/save-form-context';
+import { useWorkflow } from '@/components/workflow-editor/workflow-provider';
+import { useParseVariables } from '@/hooks/use-parse-variables';
 import { usePrimaryEmailIntegration } from '@/hooks/use-primary-email-integration';
 
 type SenderConfigDrawerProps = {
@@ -28,6 +31,8 @@ export function SenderConfigDrawer({ open, onOpenChange }: SenderConfigDrawerPro
   const { getValues, setValue } = useFormContext();
   const { saveForm } = useSaveForm();
   const { senderEmail: integrationEmail, senderName: integrationName } = usePrimaryEmailIntegration();
+  const { step, digestStepBeforeCurrent } = useWorkflow();
+  const { variables, isAllowedVariable } = useParseVariables(step?.variables, digestStepBeforeCurrent?.stepId);
 
   const [localEmail, setLocalEmail] = useState('');
   const [localName, setLocalName] = useState('');
@@ -129,16 +134,22 @@ export function SenderConfigDrawer({ open, onOpenChange }: SenderConfigDrawerPro
                 </Tooltip>
               </FormLabel>
               <FormControl>
-                <Input
-                  placeholder={
-                    localUseDefaults ? integrationName || 'Acme Inc.' : integrationName || 'e.g. Acme Security'
-                  }
-                  disabled={localUseDefaults}
-                  value={localName}
-                  onChange={(e) => {
-                    setLocalName(e.target.value);
-                  }}
-                />
+                <InputRoot>
+                  <InputWrapper className="flex h-[2.35rem] items-center">
+                    <ControlInput
+                      placeholder={
+                        localUseDefaults ? integrationName || 'Acme Inc.' : integrationName || 'e.g. Acme Security'
+                      }
+                      disabled={localUseDefaults}
+                      value={localName}
+                      onChange={setLocalName}
+                      variables={variables}
+                      isAllowedVariable={isAllowedVariable}
+                      size="sm"
+                      indentWithTab={false}
+                    />
+                  </InputWrapper>
+                </InputRoot>
               </FormControl>
             </FormItem>
 
@@ -158,24 +169,29 @@ export function SenderConfigDrawer({ open, onOpenChange }: SenderConfigDrawerPro
                 </Tooltip>
               </FormLabel>
               <FormControl>
-                <Input
-                  type="email"
-                  placeholder={
-                    localUseDefaults
-                      ? integrationEmail || 'noreply@novu.co'
-                      : integrationEmail || 'e.g. noreply@acme.com'
-                  }
-                  disabled={localUseDefaults}
-                  value={localEmail}
-                  onChange={(e) => {
-                    const newEmail = e.target.value;
-                    setLocalEmail(newEmail);
-                    if (emailError && (!newEmail || validateEmail(newEmail))) {
-                      setEmailError('');
-                    }
-                  }}
-                  hasError={!!emailError}
-                />
+                <InputRoot hasError={!!emailError}>
+                  <InputWrapper className="flex h-[2.35rem] items-center">
+                    <ControlInput
+                      placeholder={
+                        localUseDefaults
+                          ? integrationEmail || 'noreply@novu.co'
+                          : integrationEmail || 'e.g. noreply@acme.com'
+                      }
+                      disabled={localUseDefaults}
+                      value={localEmail}
+                      onChange={(newEmail) => {
+                        setLocalEmail(newEmail);
+                        if (emailError && (!newEmail || validateEmail(newEmail))) {
+                          setEmailError('');
+                        }
+                      }}
+                      variables={variables}
+                      isAllowedVariable={isAllowedVariable}
+                      size="sm"
+                      indentWithTab={false}
+                    />
+                  </InputWrapper>
+                </InputRoot>
               </FormControl>
               {emailError && <FormMessage>{emailError}</FormMessage>}
             </FormItem>

--- a/apps/dashboard/src/components/workflow-editor/steps/preview/previews/email-preview-wrapper.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/preview/previews/email-preview-wrapper.tsx
@@ -43,6 +43,7 @@ export function EmailCorePreview({
     return {
       subject: previewData.result.preview?.subject || '',
       body: previewData.result.preview?.body || '',
+      from: previewData.result.preview?.from,
     };
   }, [previewData?.result]);
 
@@ -76,7 +77,7 @@ export function EmailCorePreview({
       <div className="">
         <div className="bg-bg-white overflow-auto rounded-lg border border-neutral-200">
           <div className="flex w-full items-center justify-between px-3 pb-0 pt-3">
-            <EmailPreviewHeader />
+            <EmailPreviewHeader previewFrom={emailPreviewContent?.from} />
             <div>
               <TabsList>
                 <TabsTrigger value="mobile">


### PR DESCRIPTION
### What changed? Why was the change needed?

The sender name and sender email input fields in the sender configuration modal have been updated to use the `ControlInput` component, wrapped in `InputRoot` and `InputWrapper`. This change integrates variable autocomplete functionality, allowing users to easily insert dynamic variables (e.g., `{{firstName}}`). It also ensures visual and functional consistency with other control inputs in the workflow editor.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->
Please include screenshots or a screencast demonstrating the autocomplete functionality for both the sender name and email fields.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1770652648179019?thread_ts=1770652648.179019&cid=D0919LNRWE7)

<p><a href="https://cursor.com/background-agent?bcId=bc-6da4ee12-796f-5bef-b623-baed63ab522d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6da4ee12-796f-5bef-b623-baed63ab522d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

