### PR TITLE
feat(worker, api-service): Analytic logs batching condition

### DIFF
--- a/libs/application-generic/src/services/analytic-logs/log.repository.ts
+++ b/libs/application-generic/src/services/analytic-logs/log.repository.ts
@@ -314,7 +314,7 @@ export abstract class LogRepository<TSchema extends ClickhouseSchema<any>, TEnha
     environmentId?: string;
     userId?: string;
   }): Promise<boolean> {
-    if (!this.batchService || !this.clickhouseService.client || this.table !== 'traces') {
+    if (!this.batchService || !this.clickhouseService.client) {
       return false;
     }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Removed the `this.table !== 'traces'` check from the `shouldUseBatching` method in `LogRepository`.

This change enables batching functionality for all tables, not just 'traces', when the `IS_CLICKHOUSE_BATCHING_ENABLED` feature flag is active. This allows for more consistent batching behavior across different log types.

---
[Slack Thread](https://novu.slack.com/archives/D092998U7KR/p1770727907405799?thread_ts=1770727907.405799&cid=D092998U7KR)

<p><a href="https://cursor.com/background-agent?bcId=bc-423ac038-430e-5f95-8b07-0a259238be07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-423ac038-430e-5f95-8b07-0a259238be07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

