### PR TITLE
fix(novu): update init step id

### DIFF
--- a/packages/novu/src/commands/init/templates/app-react-email/ts/app/novu/workflows/welcome-onboarding-email/workflow.ts
+++ b/packages/novu/src/commands/init/templates/app-react-email/ts/app/novu/workflows/welcome-onboarding-email/workflow.ts
@@ -18,7 +18,7 @@ export const welcomeOnboardingEmail = workflow(
       }
     );
 
-    await step.inApp('In-App Step', async () => {
+    await step.inApp('in-app-step', async () => {
       return {
         subject: payload.inAppSubject,
         body: payload.inAppBody,


### PR DESCRIPTION
### What changed? Why was the change needed?

The step ID in the `welcome-onboarding-email/workflow.ts` template was updated from `'In-App Step'` to `'in-app-step'`.

This change was needed to resolve a 422 validation error (NV-7102) that occurred when updating workflows created via `npx novu init`. The Novu API requires step IDs to be in a valid slug format (letters, numbers, hyphens, and underscores only), which the original ID with spaces did not meet.

### Screenshots

---
Linear Issue: [NV-7102](https://linear.app/novu/issue/NV-7102/cli-npx-novu-init-from-docs-produce-step-id-with-space)

<p><a href="https://cursor.com/background-agent?bcId=bc-8116b71e-93bb-406f-883f-1c7a19cb11cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8116b71e-93bb-406f-883f-1c7a19cb11cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

