### PR TITLE
feat(application-generic): batch service transaction wrap

### DIFF
--- a/libs/application-generic/jest.setup.js
+++ b/libs/application-generic/jest.setup.js
@@ -1,1 +1,13 @@
 require('dotenv').config({ path: './src/.env.test' });
+
+jest.mock('newrelic', () => ({
+  startBackgroundTransaction: jest.fn((name, group, handler) => {
+    if (typeof handler === 'function') {
+      return handler();
+    }
+  }),
+  getTransaction: jest.fn(() => ({
+    end: jest.fn(),
+  })),
+  noticeError: jest.fn(),
+}));

--- a/libs/application-generic/src/services/analytic-logs/clickhouse-batch.service.ts
+++ b/libs/application-generic/src/services/analytic-logs/clickhouse-batch.service.ts
@@ -1,8 +1,11 @@
 import { BeforeApplicationShutdown, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { ObservabilityBackgroundTransactionEnum } from '@novu/shared';
 import { PinoLogger } from 'nestjs-pino';
 import PQueue from 'p-queue';
 import { QueueBaseService } from '../queues';
 import { ClickHouseService, InsertOptions } from './clickhouse.service';
+
+const nr = require('newrelic');
 
 type Row = Record<string, unknown>;
 
@@ -221,44 +224,62 @@ export class ClickHouseBatchService implements OnModuleDestroy, OnModuleInit, Be
     const maxRetries = buffer.config.maxRetries ?? DEFAULT_MAX_RETRIES;
     const retryDelayMs = buffer.config.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
 
-    try {
-      await this.flushBatchWithRetry(table, batchToFlush, buffer.config.insertOptions, maxRetries, retryDelayMs);
+    const _this = this;
 
-      buffer.metrics.totalFlushed += batchToFlush.length;
+    return new Promise<void>((resolve) => {
+      nr.startBackgroundTransaction(
+        ObservabilityBackgroundTransactionEnum.CLICKHOUSE_BATCH_FLUSH,
+        `ClickHouse-${table}`,
+        function processFlush() {
+          const transaction = nr.getTransaction();
 
-      this.logger.debug(
-        {
-          table,
-          rowCount: batchToFlush.length,
-          totalFlushed: buffer.metrics.totalFlushed,
-        },
-        'Successfully flushed batch to ClickHouse'
+          _this
+            .flushBatchWithRetry(table, batchToFlush, buffer.config.insertOptions, maxRetries, retryDelayMs)
+            .then(() => {
+              buffer.metrics.totalFlushed += batchToFlush.length;
+
+              _this.logger.debug(
+                {
+                  table,
+                  rowCount: batchToFlush.length,
+                  totalFlushed: buffer.metrics.totalFlushed,
+                },
+                'Successfully flushed batch to ClickHouse'
+              );
+            })
+            .catch((error) => {
+              nr.noticeError(error);
+              buffer.metrics.totalFailed += batchToFlush.length;
+
+              _this.logger.error(
+                {
+                  err: error,
+                  table,
+                  rowCount: batchToFlush.length,
+                  totalFailed: buffer.metrics.totalFailed,
+                  errorMessage: error instanceof Error ? error.message : 'Unknown error',
+                },
+                'Failed to flush batch to ClickHouse after retries'
+              );
+
+              buffer.rows = [...batchToFlush, ...buffer.rows];
+
+              _this.logger.warn(
+                {
+                  table,
+                  rowCount: batchToFlush.length,
+                  bufferSize: buffer.rows.length,
+                },
+                'Re-queued failed batch back into buffer'
+              );
+            })
+            .finally(() => {
+              transaction.end();
+              resolve();
+            });
+        }
       );
-    } catch (error) {
-      buffer.metrics.totalFailed += batchToFlush.length;
-
-      this.logger.error(
-        {
-          err: error,
-          table,
-          rowCount: batchToFlush.length,
-          totalFailed: buffer.metrics.totalFailed,
-          errorMessage: error instanceof Error ? error.message : 'Unknown error',
-        },
-        'Failed to flush batch to ClickHouse after retries'
-      );
-
-      buffer.rows = [...batchToFlush, ...buffer.rows];
-
-      this.logger.warn(
-        {
-          table,
-          rowCount: batchToFlush.length,
-          bufferSize: buffer.rows.length,
-        },
-        'Re-queued failed batch back into buffer'
-      );
-    }
+    });
   }
 
   private async flushBatchWithRetry(

--- a/packages/shared/src/config/job-queue.ts
+++ b/packages/shared/src/config/job-queue.ts
@@ -21,6 +21,7 @@ export enum ObservabilityBackgroundTransactionEnum {
   WS_SOCKET_SOCKET_CONNECTION = 'ws_socket_handle_connection',
   WS_SOCKET_HANDLE_DISCONNECT = 'ws_socket_handle_disconnect',
   CRON_JOB_QUEUE = 'cron-job-queue',
+  CLICKHOUSE_BATCH_FLUSH = 'clickhouse-batch-flush',
 }
 
 export enum JobCronNameEnum {


### PR DESCRIPTION
### What changed? Why was the change needed?

Added New Relic background transaction instrumentation to the `ClickHouseBatchService`'s `flushTable` method. This change was needed because ClickHouse batch flush operations were not being properly instrumented, leading to a lack of observability for these critical background tasks. By wrapping them in New Relic transactions, we ensure they are visible for performance monitoring and error tracking.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

*   A new enum value `CLICKHOUSE_BATCH_FLUSH` was added to `ObservabilityBackgroundTransactionEnum`.
*   A Jest mock for `newrelic` was added to `jest.setup.js` to ensure tests pass without actual New Relic agent interaction.
*   The `flushTable` method now uses `nr.startBackgroundTransaction` to wrap the asynchronous flush operation, ensuring proper transaction lifecycle management and error reporting.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1770735324708839?thread_ts=1770735324.708839&cid=D0919LNRWE7)

<p><a href="https://cursor.com/background-agent?bcId=bc-f68e7ba8-f4c8-578e-a9fc-4996fb53f7c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f68e7ba8-f4c8-578e-a9fc-4996fb53f7c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

