### PR TITLE
fix: correct sender name for iSendPro sms provider

### DIFF
--- a/libs/application-generic/src/factories/sms/handlers/isendpro-sms.handler.ts
+++ b/libs/application-generic/src/factories/sms/handlers/isendpro-sms.handler.ts
@@ -10,7 +10,7 @@ export class ISendProSmsHandler extends BaseSmsHandler {
   buildProvider(credentials: ICredentials) {
     const config = {
       apiKey: credentials.apiKey ?? '',
-      sender: credentials.senderId ?? 'NOVU', // optional
+      sender: credentials.from ?? 'NOVU', // optional
     };
 
     this.provider = new ISendProSmsProvider(config);


### PR DESCRIPTION
## 🐛 Bug

The iSendPro SMS provider was not using the configured sender name.
Even when a sender was defined in the integration,
messages were sent with an incorrect or default sender.

## ✅ Fix

- Correctly map the `from` / `sender` field to the iSendPro API payload
- Ensure the configured sender name is always used when sending SMS

## 🔍 Impact

- Fixes incorrect sender name in outgoing SMS
- No breaking changes
- No behavior change for other SMS providers
