### PR TITLE
fix(root): Nx build without access to cloud

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -138,6 +138,8 @@ jobs:
         with:
           slim: 'true'
       - uses: mansagroup/nrwl-nx-action@v3
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
           targets: lint,build,test
           parallel: 5
@@ -168,6 +170,7 @@ jobs:
         uses: mansagroup/nrwl-nx-action@v3
         env:
           LOG_LEVEL: 'info'
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
           targets: build
           projects: '@novu/api'
@@ -176,6 +179,7 @@ jobs:
         uses: mansagroup/nrwl-nx-action@v3
         env:
           LOG_LEVEL: 'info'
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
           targets: lint,build,test
           projects: ${{join(fromJson(needs.get-affected.outputs.test-packages), ',')}}
@@ -195,6 +199,8 @@ jobs:
 
       - name: Run Lint, Build, Test
         uses: mansagroup/nrwl-nx-action@v3
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
           targets: lint,build,test
           projects: ${{join(fromJson(needs.get-affected.outputs.test-libs), ',')}}
@@ -230,6 +236,8 @@ jobs:
       - uses: ./.github/actions/setup-redis-cluster
       - uses: mansagroup/nrwl-nx-action@v3
         name: Lint and build and test
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
           targets: build
           projects: '@novu/api'
@@ -237,6 +245,8 @@ jobs:
 
       - uses: mansagroup/nrwl-nx-action@v3
         name: Lint and build and test
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
           targets: lint,build,test
           projects: ${{matrix.projectName}}

--- a/.github/workflows/preview-packages.yml
+++ b/.github/workflows/preview-packages.yml
@@ -41,6 +41,8 @@ jobs:
         run: pnpm run packages:set-latest
 
       - name: Build
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         run: pnpm run preview:pkg:build
 
       - name: Release package previews to pkg.pr.new

--- a/.github/workflows/prod-deploy-inbound-mail.yml
+++ b/.github/workflows/prod-deploy-inbound-mail.yml
@@ -36,6 +36,8 @@ jobs:
       - uses: ./.github/actions/setup-project
 
       - name: build api
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         run: pnpm build:inbound-mail
 
       - uses: crazy-max/ghaction-setup-docker@v2

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -120,6 +120,8 @@ jobs:
           fi
 
       - name: Build packages
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         run: |
           if [ "${{ github.event.inputs.release_type }}" != "stable" ]; then
             pnpm run build:packages
@@ -236,6 +238,8 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: Build packages
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         run: pnpm run build:packages
 
       - name: Publish packages to NPM

--- a/.github/workflows/reusable-api-e2e.yml
+++ b/.github/workflows/reusable-api-e2e.yml
@@ -45,6 +45,8 @@ jobs:
         name: Start localstack
 
       - name: Build API & Worker
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         run: CI='' pnpm nx run-many --target=build --all --projects=@novu/api-service,@novu/worker
 
       - name: Start Worker

--- a/.github/workflows/reusable-dashboard-deploy.yml
+++ b/.github/workflows/reusable-dashboard-deploy.yml
@@ -54,6 +54,8 @@ jobs:
           submodules: true
 
       - name: Build
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         run: CI='' pnpm build:dashboard --skip-nx-cache
 
       - name: Deploy Dashboard to Netlify

--- a/.github/workflows/reusable-dashboard-e2e.yml
+++ b/.github/workflows/reusable-dashboard-e2e.yml
@@ -93,6 +93,8 @@ jobs:
           echo NODE_ENV=test >> .env.playwright
 
       - uses: mansagroup/nrwl-nx-action@v3
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         with:
           targets: build
           projects: '@novu/dashboard,@novu/api-service,@novu/worker'

--- a/.github/workflows/reusable-inbound-mail-e2e.yml
+++ b/.github/workflows/reusable-inbound-mail-e2e.yml
@@ -50,6 +50,8 @@ jobs:
 
         # Runs a single command using the runners shell
       - name: Build Inbound Mail
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         run: CI='' pnpm build:inbound-mail
 
       - name: Run unit tests

--- a/.github/workflows/reusable-webhook-e2e.yml
+++ b/.github/workflows/reusable-webhook-e2e.yml
@@ -25,6 +25,8 @@ jobs:
 
         # Runs a single command using the runners shell
       - name: Build Webhook
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         run: CI='' pnpm build:webhook
 
       # Runs a set of commands using the runners shell

--- a/.github/workflows/reusable-worker-e2e.yml
+++ b/.github/workflows/reusable-worker-e2e.yml
@@ -54,6 +54,8 @@ jobs:
 
         # Runs a single command using the runners shell
       - name: Build worker
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         run: CI='' pnpm build:worker
 
       # Runs a set of commands using the runners shell

--- a/.github/workflows/reusable-ws-e2e.yml
+++ b/.github/workflows/reusable-ws-e2e.yml
@@ -49,6 +49,8 @@ jobs:
 
         # Runs a single command using the runners shell
       - name: Build WS
+        env:
+          NX_NO_CLOUD: ${{ secrets.NX_CLOUD_ACCESS_TOKEN == '' && 'true' || 'false' }}
         run: CI='' pnpm build:ws
 
       - name: Run unit tests


### PR DESCRIPTION
### What changed? Why was the change needed?

Previously, CI builds would fail for community PRs due to missing `NX_CLOUD_ACCESS_TOKEN`, causing Nx Cloud authentication to fail.

This change adds the `NX_NO_CLOUD` environment variable to all relevant Nx build steps in GitHub Actions workflows. It is set to `true` if `NX_CLOUD_ACCESS_TOKEN` is not available, allowing builds to proceed without Nx Cloud authentication. When the token is present, Nx Cloud will still be utilized.

This ensures that community contributions can be built and tested without requiring access to internal secrets.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1770805132122319?thread_ts=1770805132.122319&cid=D0919LNRWE7)

<p><a href="https://cursor.com/background-agent?bcId=bc-cc094ba9-80e0-5bd8-a457-63849336aa06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc094ba9-80e0-5bd8-a457-63849336aa06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

