### PR TITLE
style(dashboard): Topics empty state copy fixes NV-7105

### DIFF
--- a/apps/dashboard/src/components/subscribers/subscriber-activity-list.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-activity-list.tsx
@@ -22,18 +22,23 @@ const statusToTooltipStyles: Record<string, string> = {
   disabled: 'before:bg-faded-lighter before:border before:border-faded-light text-faded-base',
 };
 
+const DEFAULT_EMPTY_DESCRIPTION =
+  "This subscriber hasn't received any notifications yet. Once a workflow is triggered for them, you'll see their notification history and delivery details here.";
+
 export const SubscriberActivityList = ({
   isLoading,
   activities,
   hasChangesInFilters,
   onClearFilters,
   onActivitySelect,
+  emptyFiltersDescription = DEFAULT_EMPTY_DESCRIPTION,
 }: {
   isLoading: boolean;
   activities: IActivity[];
   hasChangesInFilters: boolean;
   onClearFilters: () => void;
   onActivitySelect: (activityId: string) => void;
+  emptyFiltersDescription?: string;
 }) => {
   if (!isLoading && activities.length === 0) {
     return (
@@ -48,7 +53,7 @@ export const SubscriberActivityList = ({
         <ActivityEmptyState
           emptySearchResults={hasChangesInFilters}
           onClearFilters={onClearFilters}
-          emptyFiltersDescription="This subscriber hasn't received any notifications yet. Once a workflow is triggered for them, you'll see their notification history and delivery details here."
+          emptyFiltersDescription={emptyFiltersDescription}
         />
       </motion.div>
     );

--- a/apps/dashboard/src/components/topics/topic-activity.tsx
+++ b/apps/dashboard/src/components/topics/topic-activity.tsx
@@ -128,6 +128,7 @@ export const TopicActivity = ({ topicKey }: { topicKey: string }) => {
             hasChangesInFilters={hasChangesInFilters}
             onClearFilters={handleClearFilters}
             onActivitySelect={handleActivitySelect}
+            emptyFiltersDescription="Subscribers in this topic haven't received any notifications yet. Once a workflow is triggered for this topic, you'll see their notification history and delivery details here."
           />
           <span className="text-paragraph-2xs text-text-soft border-border-soft mt-auto border-t p-3 text-center">
             To view more detailed activity, View{' '}


### PR DESCRIPTION
### What changed? Why was the change needed?

The empty state copy for the Topics activity feed has been updated. The shared `SubscriberActivityList` component now accepts an optional `emptyFiltersDescription` prop, allowing `TopicActivity` to provide the new topic-specific message: "Subscribers in this topic haven’t received any notifications yet. Once a workflow is triggered for this topic, you’ll see their notification history and delivery details here." This change ensures the correct message is displayed for topics without impacting the subscriber view.

Linear ticket: [NV-7105](https://linear.app/NV-7105)

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

---
Linear Issue: [NV-7105](https://linear.app/novu/issue/NV-7105/update-topics-activity-feed-empty-state-copy)

<p><a href="https://cursor.com/background-agent?bcId=bc-f8fbd205-48a2-4285-b869-d9c3ff10f22f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8fbd205-48a2-4285-b869-d9c3ff10f22f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

