### PR TITLE
fix(dashboard): Templates widget non-dev dashboard fixes NV-7107

### DIFF
--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -178,10 +178,10 @@ export const WorkflowsPage = () => {
   const hasActiveFilters =
     queryParam.trim() !== '' || searchParams.getAll('tags').length > 0 || searchParams.getAll('status').length > 0;
 
-  const isProdEnv = currentEnvironment?.name === 'Production';
+  const isDevEnvironment = currentEnvironment?.type === EnvironmentTypeEnum.DEV;
 
   const shouldShowStartWithTemplatesSection =
-    workflowsData && workflowsData.totalCount < 5 && !hasActiveFilters && !isProdEnv;
+    workflowsData && workflowsData.totalCount < 5 && !hasActiveFilters && isDevEnvironment;
 
   useEffect(() => {
     track(TelemetryEvent.WORKFLOWS_PAGE_VISIT);


### PR DESCRIPTION
### What changed? Why was the change needed?

The "Quick Start" templates widget on the Workflows dashboard is now hidden in non-development environments. Previously, the widget was visible in staging/live environments because it only checked if the environment name was "Production". This allowed users to create new workflows from templates in environments where they could not be edited, leading to a confusing user experience.

This change aligns the widget's visibility with the `EnvironmentTypeEnum.DEV` check, ensuring it only appears in development environments where new workflows can be created and fully managed.

Relevant link: [NV-7107] Hide templates widget on dashboard in non-dev environments

### Screenshots

The templates widget will no longer be visible in non-development environments (e.g., staging, live). Refer to the reproduction video in the Linear ticket for the previous behavior.

---
Linear Issue: [NV-7107](https://linear.app/novu/issue/NV-7107/hide-templates-widget-on-dashboard-in-non-dev-environments)

<p><a href="https://cursor.com/background-agent?bcId=bc-bb593fbf-03f6-454b-919c-3269817eb246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb593fbf-03f6-454b-919c-3269817eb246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

