### PR TITLE
fix(dashboard): email step block editor content not saved after refresh fixes NV-7106

### DIFF
--- a/apps/dashboard/src/pages/edit-step-template-v2.tsx
+++ b/apps/dashboard/src/pages/edit-step-template-v2.tsx
@@ -73,7 +73,9 @@ export function EditStepTemplateV2Page() {
 
   const value = useMemo(() => ({ saveForm }), [saveForm]);
 
-  if (!workflow || !step) {
+  const formHasValues = Object.keys(form.getValues()).length > 0;
+
+  if (!workflow || !step || !formHasValues) {
     return null;
   }
 

--- a/apps/dashboard/src/pages/edit-step-template-v2.tsx
+++ b/apps/dashboard/src/pages/edit-step-template-v2.tsx
@@ -73,9 +73,24 @@ export function EditStepTemplateV2Page() {
 
   const value = useMemo(() => ({ saveForm }), [saveForm]);
 
-  const formHasValues = Object.keys(form.getValues()).length > 0;
+  if (!workflow || !step) {
+    return null;
+  }
 
-  if (!workflow || !step || !formHasValues) {
+  const formValues = form.getValues();
+  const hasFormValues = Object.keys(formValues).length > 0;
+  const stepControlValues = step.controls.values;
+  const hasStepControlValues = stepControlValues && Object.keys(stepControlValues).length > 0;
+
+  // Wait for form to sync with step values when step has values to sync
+  // If stepControlValues is undefined, step hasn't loaded yet - don't render
+  // If stepControlValues is defined but has values, wait for form to sync - don't render until hasFormValues is true
+  // If stepControlValues is defined but empty {}, that's valid - render immediately
+  if (stepControlValues === undefined) {
+    return null;
+  }
+
+  if (hasStepControlValues && !hasFormValues) {
     return null;
   }
 

--- a/libs/maily-core/src/editor/extensions/slash-command/slash-command-item.tsx
+++ b/libs/maily-core/src/editor/extensions/slash-command/slash-command-item.tsx
@@ -139,6 +139,7 @@ export function SlashCommandItem(props: SlashCommandItemProps) {
           onClick={() => selectItem(groupIndex, commandIndex)}
           onMouseEnter={() => onHover(true)}
           onMouseLeave={() => onHover(false)}
+          onMouseDown={(e) => e.preventDefault()}
           type="button"
           ref={isActive ? activeCommandRef : null}
           data-item-key={itemKey}


### PR DESCRIPTION
### What changed? Why was the change needed?
This fixes the issue when tippy is closed, it's saving the wrong content prior the population of the block, currently ave will happen on blur of the editor.

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
