### PR TITLE
feat(api-service): Preference webhook subscriber ID fixes NV-7110

### DIFF
--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -80,6 +80,7 @@ export class UpdatePreferences {
       objectType: WebhookObjectTypeEnum.PREFERENCE,
       payload: {
         object: newPreference,
+        subscriberId: command.subscriberId,
       },
       organizationId: command.organizationId,
       environmentId: command.environmentId,

--- a/apps/api/src/app/outbound-webhooks/webhooks.const.ts
+++ b/apps/api/src/app/outbound-webhooks/webhooks.const.ts
@@ -75,6 +75,9 @@ export class WebhookMessageFailedDto {
 export class WebhookPreferenceDto {
   @ApiProperty({ description: 'Current preference state' })
   object: InboxPreference;
+
+  @ApiProperty({ description: 'Subscriber ID' })
+  subscriberId: string;
 }
 
 // Create the webhook events as a record to ensure all enum values are covered

--- a/libs/application-generic/src/webhooks/usecases/send-webhook-message/send-webhook-message.command.ts
+++ b/libs/application-generic/src/webhooks/usecases/send-webhook-message/send-webhook-message.command.ts
@@ -11,12 +11,11 @@ export class SendWebhookMessageCommand extends EnvironmentCommand {
   @IsEnum(WebhookObjectTypeEnum)
   objectType: WebhookObjectTypeEnum;
 
-  // todo: investigate if we can create generic type that depends on the objectType, (e.g. map objectType to WebhookMessageSentDto, WebhookMessageFailedDto, etc.)
   @IsDefined()
   payload: {
     object: Record<string, unknown>;
     previousObject?: Record<string, unknown>;
-    [key: string]: Record<string, unknown> | undefined;
+    [key: string]: unknown;
   };
 
   @IsOptional()


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves [NV-7110](https://linear.app/novu/issue/NV-7110).

The `subscriberId` has been added to the `preference.updated` webhook payload. This change allows consumers of the webhook to identify which specific subscriber's preferences were updated, eliminating the need for full synchronizations of all subscriber preferences and reducing load on the user preferences endpoint.

Specifically:
*   The `WebhookPreferenceDto` now includes a `subscriberId` field.
*   The `UpdatePreferences` use case now includes the `subscriberId` in the `preference.updated` webhook payload.
*   The `SendWebhookMessageCommand` payload type was updated to allow primitive values for additional fields, accommodating the `subscriberId` string.

### Screenshots

N/A

---
Linear Issue: [NV-7110](https://linear.app/novu/issue/NV-7110/include-subscriberid-in-preference-updated-webhook-payload)

<p><a href="https://cursor.com/background-agent?bcId=bc-fe1f0ddf-3314-4984-a220-939aeece3abc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe1f0ddf-3314-4984-a220-939aeece3abc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

