### PR TITLE
fix(dashboard): Override defaults toggle save fixes NV-7112

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/controls/custom-step-controls.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/controls/custom-step-controls.tsx
@@ -124,6 +124,7 @@ export const CustomStepControls = (props: CustomStepControlsProps) => {
             }
 
             setIsOverridden(checked);
+            saveForm({ forceSubmit: true });
           }}
           data-testid="override-defaults-switch"
         />


### PR DESCRIPTION
### What changed? Why was the change needed?

The "Override code defined defaults" toggle in `custom-step-controls.tsx` was not triggering a save action when switched ON, causing the change to not persist. This PR adds a call to `saveForm({ forceSubmit: true });` when the toggle is enabled to ensure the state is correctly saved.

### Screenshots

N/A

---
[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1770302886930639?thread_ts=1770302886.930639&cid=C06GS20SPE0)

<p><a href="https://cursor.com/background-agent?bcId=bc-77b38919-e11a-5af9-815c-d626a0bffb38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-77b38919-e11a-5af9-815c-d626a0bffb38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

