### PR TITLE
fix(dashboard): Allow status toggle in channel preferences fixes NV-7113

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/channel-preferences-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/channel-preferences-form.tsx
@@ -242,7 +242,6 @@ export const ChannelPreferencesForm = (props: ConfigureWorkflowFormProps) => {
                               new_status: checked,
                             });
                           }}
-                          disabled={isReadOnly}
                         />
                       </FormControl>
                     </FormItem>

--- a/apps/dashboard/src/components/workflow-editor/channel-preferences.tsx
+++ b/apps/dashboard/src/components/workflow-editor/channel-preferences.tsx
@@ -11,8 +11,7 @@ export function ChannelPreferences() {
     return null;
   }
 
-  const isReadOnly =
-    workflow.origin === ResourceOriginEnum.EXTERNAL || currentEnvironment?.type !== EnvironmentTypeEnum.DEV;
+  const isReadOnly = currentEnvironment?.type !== EnvironmentTypeEnum.DEV;
 
   return <ChannelPreferencesForm workflow={workflow} update={update} isReadOnly={isReadOnly} />;
 }


### PR DESCRIPTION
Remove the disabled={isReadOnly} prop from the status checkbox in ChannelPreferencesForm so the control is not forcibly disabled by the isReadOnly flag. This restores interaction with the status toggle and fixes cases where the checkbox could not be changed due to the read-only prop.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
