### PR TITLE
Custom step overrides inputs

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/controls/text-widget.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/controls/text-widget.tsx
@@ -59,6 +59,7 @@ export function TextWidget(props: WidgetProps) {
                     variables={variables}
                     isAllowedVariable={isAllowedVariable}
                     size="sm"
+                    disabled={disabled}
                   />
                 </InputWrapper>
               </InputRoot>


### PR DESCRIPTION
### What changed? Why was the change needed?
The `TextWidget` in `apps/dashboard/src/components/workflow-editor/steps/controls/text-widget.tsx` was updated to pass the `disabled` prop to its `ControlInput` component for non-number text fields.

This change ensures that all inputs within the custom step controls are correctly disabled when overrides are not enabled. Previously, these specific text inputs remained editable even when the form was marked as disabled.

### Screenshots
<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->
The `JsonForm` correctly passes the `disabled` prop based on the override status; this fix ensures the `TextWidget` properly respects and propagates that prop.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1770971591819989?thread_ts=1770971591.819989&cid=D0919LNRWE7)

<p><a href="https://cursor.com/background-agent?bcId=bc-b38ab5c3-50ba-5334-acbb-e9eb4b3bbd86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b38ab5c3-50ba-5334-acbb-e9eb4b3bbd86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

