### PR TITLE
fix(dashboard): Allow null controlValues and update restore behavior fixrs NV-7112 fixes NV-7112

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/step-utils.ts
+++ b/apps/dashboard/src/components/workflow-editor/step-utils.ts
@@ -105,7 +105,9 @@ export const updateStepInWorkflow = (
     steps: workflow.steps.map((step) => {
       if (step.stepId === stepId) {
         const existingControlValues = step.controls?.values || {};
-        const updatedControlValues = updateStep.controlValues || existingControlValues;
+        const updatedControlValues = updateStep.controlValues !== undefined 
+          ? updateStep.controlValues 
+          : existingControlValues;
 
         return {
           ...step,

--- a/apps/dashboard/src/components/workflow-editor/steps/controls/custom-step-controls.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/controls/custom-step-controls.tsx
@@ -11,6 +11,7 @@ import { InlineToast } from '@/components/primitives/inline-toast';
 import { Separator } from '@/components/primitives/separator';
 import { Switch } from '@/components/primitives/switch';
 import { SidebarContent } from '@/components/side-navigation/sidebar';
+import { updateStepInWorkflow } from '@/components/workflow-editor/step-utils';
 import { useSaveForm } from '@/components/workflow-editor/steps/save-form-context';
 import { ResourceOriginEnum } from '@/utils/enums';
 import { buildDefaultValuesOfDataSchema } from '@/utils/schema';
@@ -29,7 +30,7 @@ const CONTROLS_DOCS_LINK = 'https://docs.novu.co/framework/controls';
 export const CustomStepControls = (props: CustomStepControlsProps) => {
   const { className, dataSchema, origin } = props;
   const [isRestoreDefaultModalOpen, setIsRestoreDefaultModalOpen] = useState(false);
-  const { step } = useWorkflow();
+  const { step, workflow, update } = useWorkflow();
   const [isOverridden, setIsOverridden] = useState(() => Object.keys(step?.controls.values ?? {}).length > 0);
   const { reset } = useFormContext();
   const { saveForm } = useSaveForm();
@@ -98,9 +99,11 @@ export const CustomStepControls = (props: CustomStepControlsProps) => {
         open={isRestoreDefaultModalOpen}
         onOpenChange={setIsRestoreDefaultModalOpen}
         onConfirm={async () => {
-          const defaultValues = buildDefaultValuesOfDataSchema(step?.controls.dataSchema ?? {});
+          if (!workflow || !step) return;
+
+          const defaultValues = buildDefaultValuesOfDataSchema(step.controls.dataSchema ?? {});
           reset(defaultValues);
-          saveForm({ forceSubmit: true });
+          update(updateStepInWorkflow(workflow, step.stepId, { controlValues: null }));
           setIsRestoreDefaultModalOpen(false);
           setIsOverridden(false);
         }}
@@ -149,7 +152,12 @@ export const CustomStepControls = (props: CustomStepControlsProps) => {
           </AccordionTrigger>
 
           <AccordionContent>
-            <div className="bg-background rounded-md border border-dashed p-3">
+            <div
+              className={cn(
+                'bg-background rounded-md border border-dashed p-3',
+                !isOverridden && 'opacity-60 pointer-events-none'
+              )}
+            >
               <JsonForm schema={(dataSchema as RJSFSchema) || {}} disabled={!isOverridden} />
             </div>
           </AccordionContent>


### PR DESCRIPTION
Treat controlValues === undefined as the only case to keep existing values (so null is now accepted) in updateStepInWorkflow. In the custom step controls component, import and use updateStepInWorkflow and workflow.update; when restoring defaults reset the form and update the workflow with controlValues: null (instead of calling saveForm). Add a guard for missing workflow/step and visually disable the JSON form when the controls are not overridden.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
