### PR TITLE
feat(worker): Cache workflow preferences in LRU store

### DIFF
--- a/libs/application-generic/src/services/in-memory-lru-cache/in-memory-lru-cache.store.ts
+++ b/libs/application-generic/src/services/in-memory-lru-cache/in-memory-lru-cache.store.ts
@@ -1,4 +1,4 @@
-import type { EnvironmentEntity, NotificationTemplateEntity, OrganizationEntity } from '@novu/dal';
+import type { EnvironmentEntity, NotificationTemplateEntity, OrganizationEntity, PreferencesEntity } from '@novu/dal';
 import type { UserSessionData } from '@novu/shared';
 
 export enum InMemoryLRUCacheStore {
@@ -8,6 +8,7 @@ export enum InMemoryLRUCacheStore {
   API_KEY_USER = 'api-key-user',
   VALIDATOR = 'validator',
   ACTIVE_WORKFLOWS = 'active-workflows',
+  WORKFLOW_PREFERENCES = 'workflow-preferences',
 }
 
 export type WorkflowCacheData = NotificationTemplateEntity | null;
@@ -16,6 +17,7 @@ export type EnvironmentCacheData = Pick<EnvironmentEntity, '_id' | 'echo' | 'api
 export type ApiKeyUserCacheData = UserSessionData | null;
 export type ValidatorCacheData = unknown;
 export type ActiveWorkflowsCacheData = NotificationTemplateEntity[];
+export type WorkflowPreferencesCacheData = [PreferencesEntity | null, PreferencesEntity | null];
 
 export type CacheStoreDataTypeMap = {
   [InMemoryLRUCacheStore.WORKFLOW]: WorkflowCacheData;
@@ -24,6 +26,7 @@ export type CacheStoreDataTypeMap = {
   [InMemoryLRUCacheStore.API_KEY_USER]: ApiKeyUserCacheData;
   [InMemoryLRUCacheStore.VALIDATOR]: ValidatorCacheData;
   [InMemoryLRUCacheStore.ACTIVE_WORKFLOWS]: ActiveWorkflowsCacheData;
+  [InMemoryLRUCacheStore.WORKFLOW_PREFERENCES]: WorkflowPreferencesCacheData;
 };
 
 export type StoreConfig = {
@@ -64,5 +67,10 @@ export const STORE_CONFIGS: Record<InMemoryLRUCacheStore, StoreConfig> = {
     max: 300,
     ttl: 1000 * 60,
     featureFlagComponent: 'active-workflows',
+  },
+  [InMemoryLRUCacheStore.WORKFLOW_PREFERENCES]: {
+    max: 1000,
+    ttl: 1000 * 60,
+    featureFlagComponent: 'workflow-preferences',
   },
 };

--- a/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
@@ -11,6 +11,7 @@ import {
 } from '@novu/shared';
 import { Instrument, InstrumentUsecase } from '../../instrumentation';
 import { FeatureFlagsService } from '../../services/feature-flags';
+import { InMemoryLRUCacheService, InMemoryLRUCacheStore } from '../../services/in-memory-lru-cache';
 import { MergePreferencesCommand } from '../merge-preferences/merge-preferences.command';
 import { MergePreferences } from '../merge-preferences/merge-preferences.usecase';
 import { GetPreferencesCommand } from './get-preferences.command';
@@ -41,7 +42,8 @@ class PreferencesNotFoundException extends BadRequestException {
 export class GetPreferences {
   constructor(
     private preferencesRepository: PreferencesRepository,
-    private featureFlagsService: FeatureFlagsService
+    private featureFlagsService: FeatureFlagsService,
+    private inMemoryLRUCacheService: InMemoryLRUCacheService
   ) {}
 
   @InstrumentUsecase()
@@ -249,12 +251,38 @@ export class GetPreferences {
 
     const queryOptions = { readPreference: 'secondaryPreferred' as const };
 
-    const orConditions: Array<Record<string, unknown>> = [
-      {
-        _templateId: command.templateId,
-        type: { $in: [PreferencesTypeEnum.WORKFLOW_RESOURCE, PreferencesTypeEnum.USER_WORKFLOW] },
+    const cacheOptions = {
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+    };
+
+    const workflowPreferences = await this.inMemoryLRUCacheService.get(
+      InMemoryLRUCacheStore.WORKFLOW_PREFERENCES,
+      `${command.environmentId}:${command.templateId}`,
+      async (): Promise<[PreferencesEntity | null, PreferencesEntity | null]> => {
+        const preferences = await this.preferencesRepository.find(
+          {
+            ...baseQuery,
+            _templateId: command.templateId,
+            type: { $in: [PreferencesTypeEnum.WORKFLOW_RESOURCE, PreferencesTypeEnum.USER_WORKFLOW] },
+          },
+          undefined,
+          queryOptions
+        );
+
+        const workflowResourcePreference =
+          preferences.find((p) => p.type === PreferencesTypeEnum.WORKFLOW_RESOURCE) ?? null;
+        const workflowUserPreference = preferences.find((p) => p.type === PreferencesTypeEnum.USER_WORKFLOW) ?? null;
+
+        return [workflowResourcePreference, workflowUserPreference];
       },
-    ];
+      cacheOptions
+    );
+
+    const [workflowResourcePreference, workflowUserPreference] = workflowPreferences;
+
+    let subscriberWorkflowPreference: PreferencesEntity | null = null;
+    let subscriberGlobalPreference: PreferencesEntity | null = null;
 
     if (command.subscriberId) {
       const useContextFiltering = await this.featureFlagsService.getFlag({
@@ -267,47 +295,48 @@ export class GetPreferences {
         enabled: useContextFiltering,
       });
 
-      orConditions.push(
-        {
-          _subscriberId: command.subscriberId,
-          _templateId: command.templateId,
-          type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
-          ...contextQuery,
-        },
-        {
-          _subscriberId: command.subscriberId,
-          type: PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
-          ...contextQuery,
-        }
-      );
+      [subscriberWorkflowPreference, subscriberGlobalPreference] = await Promise.all([
+        this.preferencesRepository.findOne(
+          {
+            ...baseQuery,
+            _subscriberId: command.subscriberId,
+            _templateId: command.templateId,
+            type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
+            ...contextQuery,
+          },
+          undefined,
+          queryOptions
+        ),
+        this.preferencesRepository.findOne(
+          {
+            ...baseQuery,
+            _subscriberId: command.subscriberId,
+            type: PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
+            ...contextQuery,
+          },
+          undefined,
+          queryOptions
+        ),
+      ]);
     }
-
-    const allPreferences = await this.preferencesRepository.find(
-      {
-        ...baseQuery,
-        $or: orConditions,
-      },
-      undefined,
-      queryOptions
-    );
 
     const result: PreferenceSet = {};
 
-    for (const preference of allPreferences) {
-      switch (preference.type) {
-        case PreferencesTypeEnum.WORKFLOW_RESOURCE:
-          result.workflowResourcePreference = preference as PreferenceSet['workflowResourcePreference'];
-          break;
-        case PreferencesTypeEnum.USER_WORKFLOW:
-          result.workflowUserPreference = preference as PreferenceSet['workflowUserPreference'];
-          break;
-        case PreferencesTypeEnum.SUBSCRIBER_WORKFLOW:
-          result.subscriberWorkflowPreference = preference as PreferenceSet['subscriberWorkflowPreference'];
-          break;
-        case PreferencesTypeEnum.SUBSCRIBER_GLOBAL:
-          result.subscriberGlobalPreference = preference as PreferenceSet['subscriberGlobalPreference'];
-          break;
-      }
+    if (workflowResourcePreference) {
+      result.workflowResourcePreference = workflowResourcePreference as PreferenceSet['workflowResourcePreference'];
+    }
+
+    if (workflowUserPreference) {
+      result.workflowUserPreference = workflowUserPreference as PreferenceSet['workflowUserPreference'];
+    }
+
+    if (subscriberWorkflowPreference) {
+      result.subscriberWorkflowPreference =
+        subscriberWorkflowPreference as PreferenceSet['subscriberWorkflowPreference'];
+    }
+
+    if (subscriberGlobalPreference) {
+      result.subscriberGlobalPreference = subscriberGlobalPreference as PreferenceSet['subscriberGlobalPreference'];
     }
 
     return result;


### PR DESCRIPTION
Add WORKFLOW_PREFERENCES to the in-memory LRU store with types and config, and import PreferencesEntity. Update GetPreferences usecase to use InMemoryLRUCacheService to cache workflow-level preferences (workflow resource and user preferences) keyed by `${environmentId}:${templateId}`. Replace the previous bulk find/$or approach with a cached lookup for workflow prefs and separate repository lookups for subscriber-specific prefs when needed, then assemble the PreferenceSet from the retrieved values. This reduces DB reads and centralizes workflow preference caching (max/ttl set in STORE_CONFIGS).

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
