### PR TITLE
fix(api-service): Mongo duplicate error handling 

### DIFF
--- a/apps/api/src/app/subscriptions/usecases/create-subscription-preferences/create-subscription-preferences.usecase.ts
+++ b/apps/api/src/app/subscriptions/usecases/create-subscription-preferences/create-subscription-preferences.usecase.ts
@@ -48,16 +48,35 @@ export class CreateSubscriptionPreferencesUsecase {
         continue;
       }
 
-      const createdPreference = await this.preferencesRepository.create({
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-        _subscriberId: command._subscriberId,
-        _templateId: workflow._id,
-        _topicSubscriptionId: command._topicSubscriptionId,
-        type: PreferencesTypeEnum.SUBSCRIPTION_SUBSCRIBER_WORKFLOW,
-        preferences: workflowPreferences,
-        contextKeys: command.contextKeys,
-      });
+      let createdPreference;
+      try {
+        createdPreference = await this.preferencesRepository.create({
+          _environmentId: command.environmentId,
+          _organizationId: command.organizationId,
+          _subscriberId: command._subscriberId,
+          _templateId: workflow._id,
+          _topicSubscriptionId: command._topicSubscriptionId,
+          type: PreferencesTypeEnum.SUBSCRIPTION_SUBSCRIBER_WORKFLOW,
+          preferences: workflowPreferences,
+          contextKeys: command.contextKeys,
+        });
+      } catch (error) {
+        const isDuplicateKeyError = error && typeof error === 'object' && 'code' in error && error.code === 11000;
+
+        if (isDuplicateKeyError) {
+          createdPreference = await this.preferencesRepository.findOne({
+            _environmentId: command.environmentId,
+            _subscriberId: command._subscriberId,
+            _templateId: workflow._id,
+            _topicSubscriptionId: command._topicSubscriptionId,
+            type: PreferencesTypeEnum.SUBSCRIPTION_SUBSCRIBER_WORKFLOW,
+          });
+        }
+
+        if (!isDuplicateKeyError || !createdPreference) {
+          throw error;
+        }
+      }
 
       if (createdPreference) {
         preferencesResult.push({

--- a/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/upsert-preferences/upsert-preferences.usecase.ts
@@ -180,18 +180,31 @@ export class UpsertPreferences {
       PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
     ].includes(command.type);
 
-    return await this.preferencesRepository.create({
-      _subscriberId: command._subscriberId,
-      _userId: command.userId,
-      _environmentId: command.environmentId,
-      _organizationId: command.organizationId,
-      _templateId: command.templateId,
-      _topicSubscriptionId: command.topicSubscriptionId,
-      preferences: command.preferences,
-      type: command.type,
-      schedule: command.schedule,
-      contextKeys: useContextFiltering && isContextScoped ? (command.contextKeys ?? []) : undefined,
-    });
+    try {
+      return await this.preferencesRepository.create({
+        _subscriberId: command._subscriberId,
+        _userId: command.userId,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+        _templateId: command.templateId,
+        _topicSubscriptionId: command.topicSubscriptionId,
+        preferences: command.preferences,
+        type: command.type,
+        schedule: command.schedule,
+        contextKeys: useContextFiltering && isContextScoped ? (command.contextKeys ?? []) : undefined,
+      });
+    } catch (error) {
+      const isDuplicateKeyError = error && typeof error === 'object' && 'code' in error && error.code === 11000;
+
+      if (isDuplicateKeyError) {
+        const existingPreference = await this.getPreference(command);
+        if (existingPreference) {
+          return existingPreference;
+        }
+      }
+
+      throw error;
+    }
   }
 
   private async updatePreferences(


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR implements graceful handling for MongoDB E11000 duplicate key errors in the preferences system. Previously, concurrent requests attempting to create identical preference records would result in a 500 error.

Now, when a `MongoServerError` with `code === 11000` occurs during preference creation (specifically in `UpsertPreferences` and `CreateSubscriptionPreferences` usecases), the system will catch the error and attempt to find and return the existing preference document instead of failing. This ensures idempotency and prevents unnecessary errors for operations that are effectively trying to create an already existing resource.

This change aligns with existing patterns for handling race conditions, such as in `ContextRepository.findOrCreateContext()`.

### Screenshots

N/A

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1771162186813889?thread_ts=1771162186.813889&cid=D0919LNRWE7)

<p><a href="https://cursor.com/background-agent?bcId=bc-2a3b0159-d1b7-556a-aeae-e1ddacd15cc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a3b0159-d1b7-556a-aeae-e1ddacd15cc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

