### PR TITLE
fix(api-service): Request log transaction ID fixes NV-7117

### DIFF
--- a/apps/api/src/app/events/usecases/process-bulk-trigger/process-bulk-trigger.usecase.ts
+++ b/apps/api/src/app/events/usecases/process-bulk-trigger/process-bulk-trigger.usecase.ts
@@ -79,6 +79,7 @@ export class ProcessBulkTrigger {
               acknowledged: true,
               status: TriggerEventStatusEnum.ERROR,
               error,
+              transactionId: event.transactionId,
             } as TriggerEventResponseDto;
           }
         })

--- a/apps/api/src/app/shared/utils/mappers.ts
+++ b/apps/api/src/app/shared/utils/mappers.ts
@@ -6,6 +6,21 @@ import { generateTransactionId } from '../helpers/generate-transaction-id';
 import { RequestWithReqId } from '../middleware/request-id.middleware';
 import { getRequestId } from './request-transaction.util';
 
+function extractTransactionIdFromBody(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+
+  const singleBody = body as { transactionId?: string };
+  if (singleBody.transactionId) return singleBody.transactionId;
+
+  const bulkBody = body as { events?: Array<{ transactionId?: string }> };
+  if (Array.isArray(bulkBody.events)) {
+    const ids = bulkBody.events.map((e) => e.transactionId).filter(Boolean);
+    if (ids.length > 0) return ids.join(',');
+  }
+
+  return undefined;
+}
+
 export function buildLog(
   req: RequestWithReqId,
   statusCode: number,
@@ -31,7 +46,7 @@ export function buildLog(
     hostname: req.hostname,
     status_code: statusCode,
     method: req.method,
-    transaction_id: generateTransactionId(),
+    transaction_id: extractTransactionIdFromBody(req.body) || generateTransactionId(),
     ip: getClientIp(req) || '',
     user_agent: req.headers['user-agent'] || '',
     request_body: sanitizePayload(req.body),


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR fixes an issue (NV-7117) where custom `transactionId` values were not being stored in the Requests tab logs when a workflow trigger failed.

The problem had two main causes:
1.  The `buildLog` function in `mappers.ts` always generated a new `transactionId` by default. While a successful response would override this with the correct `transactionId` via an interceptor, error paths did not, leading to the custom ID being lost.
2.  Error responses from the `process-bulk-trigger.usecase.ts` did not include the original `transactionId`, preventing the analytics interceptor from logging it for failed bulk events.

The changes address these issues by:
*   Modifying `apps/api/src/app/shared/utils/mappers.ts` to extract the `transactionId` directly from the request body (supporting both single and bulk triggers) before falling back to generating a new one.
*   Updating `apps/api/src/app/events/usecases/process-bulk-trigger/process-bulk-trigger.usecase.ts` to include the `transactionId` in error responses for individual events within a bulk trigger.

This ensures that custom `transactionId` values are correctly persisted in logs, even when events fail.

Relevant link: [NV-7117](https://linear.app/novu/issue/NV-7117/custom-transactionid-not-stored-in-requests-tab-logs)

### Screenshots

---
Linear Issue: [NV-7117](https://linear.app/novu/issue/NV-7117/custom-transactionid-not-stored-in-requests-tab-logs)

<p><a href="https://cursor.com/background-agent?bcId=bc-b7265d3f-3616-4a5b-82be-d38492c3c3af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7265d3f-3616-4a5b-82be-d38492c3c3af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

