### PR TITLE
Activity feed resend context overrides

### DIFF
--- a/apps/api/src/app/activity/dtos/workflow-run-response.dto.ts
+++ b/apps/api/src/app/activity/dtos/workflow-run-response.dto.ts
@@ -108,4 +108,14 @@ export class GetWorkflowRunResponseDto extends GetWorkflowRunResponseBaseDto {
   @ApiProperty({ description: 'Trigger payload' })
   @IsObject()
   payload: Record<string, unknown>;
+
+  @ApiPropertyOptional({ description: 'Trigger overrides', type: 'object' })
+  @IsOptional()
+  @IsObject()
+  overrides?: Record<string, unknown>;
+
+  @ApiPropertyOptional({ description: 'Context payload used in the original trigger', type: 'object' })
+  @IsOptional()
+  @IsObject()
+  context?: Record<string, unknown>;
 }

--- a/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
@@ -10,7 +10,7 @@ import {
   WorkflowRunRepository,
 } from '@novu/application-generic';
 import { JobEntity, JobRepository } from '@novu/dal';
-import { SeverityLevelEnum, StepTypeEnum } from '@novu/shared';
+import { ContextPayload, SeverityLevelEnum, StepTypeEnum } from '@novu/shared';
 import { GetWorkflowRunResponseDto, StepRunDto } from '../../dtos/workflow-run-response.dto';
 import { mapTraceToExecutionDetailDto, mapWorkflowRunStatusToDto } from '../../shared/mappers';
 import { GetWorkflowRunCommand } from './get-workflow-run.command';
@@ -146,8 +146,13 @@ export class GetWorkflowRun {
       }
 
       const workflowRun = workflowRunResult.data;
-      const stepRuns = await this.getStepRunsForWorkflowRun(command, workflowRun);
-      const workflowRunDto = this.mapWorkflowRunToDto(workflowRun, stepRuns);
+      const [stepRuns, overrides] = await Promise.all([
+        this.getStepRunsForWorkflowRun(command, workflowRun),
+        this.getOverridesForWorkflowRun(workflowRun, command),
+      ]);
+
+      const context = this.reconstructContextFromKeys(workflowRun.context_keys);
+      const workflowRunDto = this.mapWorkflowRunToDto(workflowRun, stepRuns, overrides, context);
 
       return workflowRunDto;
     } catch (error) {
@@ -284,9 +289,64 @@ export class GetWorkflowRun {
     };
   }
 
+  private async getOverridesForWorkflowRun(
+    workflowRun: WorkflowRunFetchResult,
+    command: GetWorkflowRunCommand
+  ): Promise<Record<string, unknown> | undefined> {
+    try {
+      const firstJob: Pick<JobEntity, 'overrides'> | null = await this.jobRepository.findOne(
+        {
+          _notificationId: workflowRun.workflow_run_id,
+          _environmentId: command.environmentId,
+        },
+        'overrides',
+        { sort: { createdAt: 1 } }
+      );
+
+      if (firstJob?.overrides && Object.keys(firstJob.overrides).length > 0) {
+        return firstJob.overrides as Record<string, unknown>;
+      }
+
+      return undefined;
+    } catch (error) {
+      this.logger.warn('Failed to get overrides for workflow run', {
+        error: error.message,
+        workflowRunId: workflowRun.workflow_run_id,
+      });
+
+      return undefined;
+    }
+  }
+
+  private reconstructContextFromKeys(contextKeys: string[] | undefined): ContextPayload | undefined {
+    if (!contextKeys || contextKeys.length === 0) {
+      return undefined;
+    }
+
+    const context: ContextPayload = {};
+    for (const key of contextKeys) {
+      const separatorIndex = key.indexOf(':');
+      if (separatorIndex === -1) continue;
+
+      const type = key.substring(0, separatorIndex);
+      const id = key.substring(separatorIndex + 1);
+      if (type && id) {
+        context[type] = id;
+      }
+    }
+
+    if (Object.keys(context).length === 0) {
+      return undefined;
+    }
+
+    return context;
+  }
+
   private mapWorkflowRunToDto(
     workflowRun: WorkflowRunFetchResult,
-    stepRuns: IStepRunWithDetails[]
+    stepRuns: IStepRunWithDetails[],
+    overrides?: Record<string, unknown>,
+    context?: ContextPayload
   ): GetWorkflowRunResponseDto {
     return {
       id: workflowRun.workflow_run_id,
@@ -308,6 +368,8 @@ export class GetWorkflowRun {
       critical: workflowRun.critical,
       contextKeys: workflowRun.context_keys,
       topics: workflowRun.topics ? JSON.parse(workflowRun.topics) : [],
+      overrides,
+      context,
     };
   }
 }

--- a/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
@@ -294,15 +294,16 @@ export class GetWorkflowRun {
     command: GetWorkflowRunCommand
   ): Promise<Record<string, unknown> | undefined> {
     try {
-      const firstJob: Pick<JobEntity, 'overrides'> | null = await this.jobRepository.findOne(
+      const jobs: Pick<JobEntity, 'overrides'>[] = await this.jobRepository.find(
         {
           _notificationId: workflowRun.workflow_run_id,
           _environmentId: command.environmentId,
         },
         'overrides',
-        { sort: { createdAt: 1 } }
+        { limit: 1, sort: { createdAt: 1 } }
       );
 
+      const firstJob = jobs[0];
       if (firstJob?.overrides && Object.keys(firstJob.overrides).length > 0) {
         return firstJob.overrides as Record<string, unknown>;
       }

--- a/apps/dashboard/src/api/activity.ts
+++ b/apps/dashboard/src/api/activity.ts
@@ -58,6 +58,8 @@ export interface GetWorkflowRunsDto {
 
 export type GetWorkflowRunResponse = GetWorkflowRunsDto & {
   payload: Record<string, unknown>;
+  overrides?: Record<string, unknown>;
+  context?: Record<string, unknown>;
 };
 
 export interface GetWorkflowRunsResponseDto {
@@ -67,6 +69,9 @@ export interface GetWorkflowRunsResponseDto {
 }
 
 function mapWorkflowRunToActivity(workflowRun: GetWorkflowRunResponse | GetWorkflowRunsDto): IActivity {
+  const overrides = 'overrides' in workflowRun ? workflowRun.overrides : undefined;
+  const context = 'context' in workflowRun ? workflowRun.context : undefined;
+
   return {
     _id: workflowRun.id,
     severity: workflowRun.severity,
@@ -76,12 +81,14 @@ function mapWorkflowRunToActivity(workflowRun: GetWorkflowRunResponse | GetWorkf
     _organizationId: workflowRun.organizationId,
     _subscriberId: workflowRun.internalSubscriberId,
     transactionId: workflowRun.transactionId,
-    channels: [], // Not available in workflow runs, empty array for compatibility
+    channels: [],
     to: {
       subscriberId: workflowRun.subscriberId || workflowRun.internalSubscriberId,
     },
     payload: 'payload' in workflowRun ? workflowRun.payload : {},
-    tags: [], // Not available in workflow runs, empty array for compatibility
+    overrides,
+    context,
+    tags: [],
     createdAt: workflowRun.createdAt,
     updatedAt: workflowRun.updatedAt,
     contextKeys: workflowRun.contextKeys || [],
@@ -145,13 +152,12 @@ function mapWorkflowRunToActivity(workflowRun: GetWorkflowRunResponse | GetWorkf
       _organizationId: workflowRun.organizationId,
       _environmentId: workflowRun.environmentId,
       _userId: '',
-      // delay: step.delay,
       _notificationId: workflowRun.id,
       status: step.status === 'queued' ? 'pending' : (step.status as any),
       _templateId: workflowRun.workflowId,
       payload: 'payload' in workflowRun ? workflowRun.payload : {},
       providerId: undefined,
-      overrides: {},
+      overrides: overrides ?? {},
       transactionId: workflowRun.transactionId,
       createdAt: workflowRun.createdAt,
       updatedAt: workflowRun.updatedAt,

--- a/apps/dashboard/src/api/workflows.ts
+++ b/apps/dashboard/src/api/workflows.ts
@@ -100,12 +100,14 @@ export async function triggerWorkflow({
   payload,
   to,
   context,
+  overrides,
 }: {
   environment: IEnvironment;
   name: string;
   payload: unknown;
   to: unknown;
   context?: unknown;
+  overrides?: unknown;
 }) {
   return post<{ data: { transactionId?: string } }>(`/events/trigger`, {
     environment,
@@ -114,6 +116,7 @@ export async function triggerWorkflow({
       to,
       payload: { ...(payload ?? {}), __source: (payload as any)?.__source ?? 'dashboard' },
       context: context ?? undefined,
+      overrides: overrides ?? undefined,
     },
   });
 }

--- a/apps/dashboard/src/components/activity/activity-header.tsx
+++ b/apps/dashboard/src/components/activity/activity-header.tsx
@@ -1,4 +1,4 @@
-import { IActivity, IEnvironment } from '@novu/shared';
+import { ContextPayload, IActivity } from '@novu/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { motion } from 'motion/react';
 import { RiCloseLine, RiRouteFill } from 'react-icons/ri';
@@ -11,6 +11,37 @@ import { QueryKeys } from '@/utils/query-keys';
 import { cn } from '@/utils/ui';
 import { triggerWorkflow } from '../../api/workflows';
 import { RepeatPlay } from '../icons/repeat-play';
+
+function reconstructContextFromKeys(contextKeys?: string[]): ContextPayload | undefined {
+  if (!contextKeys || contextKeys.length === 0) return undefined;
+
+  const context: ContextPayload = {};
+  for (const key of contextKeys) {
+    const separatorIndex = key.indexOf(':');
+    if (separatorIndex === -1) continue;
+
+    const type = key.substring(0, separatorIndex);
+    const id = key.substring(separatorIndex + 1);
+    if (type && id) {
+      context[type] = id;
+    }
+  }
+
+  return Object.keys(context).length > 0 ? context : undefined;
+}
+
+function getActivityOverrides(activity: IActivity): Record<string, unknown> | undefined {
+  if (activity.overrides && Object.keys(activity.overrides).length > 0) {
+    return activity.overrides;
+  }
+
+  const firstJobOverrides = activity.jobs?.[0]?.overrides;
+  if (firstJobOverrides && Object.keys(firstJobOverrides).length > 0) {
+    return firstJobOverrides as Record<string, unknown>;
+  }
+
+  return undefined;
+}
 
 type ActivityHeaderProps = {
   className?: string;
@@ -37,12 +68,17 @@ export const ActivityHeader = ({ className, activity, onTransactionIdChange, onC
     mutationFn: async () => {
       if (!activity) throw new Error('No activity data available');
 
+      const resendContext = activity.context ?? reconstructContextFromKeys(activity.contextKeys);
+      const resendOverrides = getActivityOverrides(activity);
+
       const {
         data: { transactionId: newTransactionId },
       } = await triggerWorkflow({
         name: activity.template?.triggers[0].identifier ?? '',
         to: activity.subscriber?.subscriberId,
         payload: resentPayload,
+        context: resendContext,
+        overrides: resendOverrides,
         environment: currentEnvironment!,
       });
 

--- a/packages/shared/src/entities/activity-feed/activity.interface.ts
+++ b/packages/shared/src/entities/activity-feed/activity.interface.ts
@@ -1,5 +1,6 @@
 import { SeverityLevelEnum } from '../../consts';
 import { ChannelTypeEnum, ISubscriber } from '../../types';
+import { ContextPayload } from '../../types/context';
 import { IExecutionDetail } from '../execution-details';
 import { IJob as IJobBase } from '../job';
 import { INotificationTemplate } from '../notification-template';
@@ -22,6 +23,8 @@ export interface IActivity {
     subscriberId: string;
   };
   payload: Record<string, unknown>;
+  overrides?: Record<string, unknown>;
+  context?: ContextPayload;
   tags: string[];
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
### What changed? Why was the change needed?

The "Resend" option in the activity feed now correctly includes the original `overrides` and `context` when retriggering a workflow.

This change was needed because previously, resending an activity would ignore these parameters, leading to inconsistent workflow runs compared to the initial trigger. This fix ensures that resending an activity accurately reproduces the original workflow run.

**Relevant links:**
*   Linear ticket: [NV-7111](https://linear.app/novu/issue/NV-7111)

### Screenshots

---
Linear Issue: [NV-7111](https://linear.app/novu/issue/NV-7111/resend-option-in-activity-feed-missing-context-and-overrides-in)

<p><a href="https://cursor.com/background-agent?bcId=bc-3817ca55-ea28-4c59-a33d-0213d0375ac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3817ca55-ea28-4c59-a33d-0213d0375ac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

