### PR TITLE
fix(dashboard): Email layout name saving issue fixes NV-7084

### DIFF
--- a/apps/dashboard/src/components/layouts/layout-editor-settings-drawer.tsx
+++ b/apps/dashboard/src/components/layouts/layout-editor-settings-drawer.tsx
@@ -4,7 +4,7 @@ import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { EnvironmentTypeEnum, PermissionsEnum, ResourceOriginEnum } from '@novu/shared';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { formatDistanceToNow } from 'date-fns';
-import { forwardRef, useCallback, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { RiDeleteBin2Line, RiSettings4Line } from 'react-icons/ri';
 import { useBlocker, useNavigate } from 'react-router-dom';
@@ -81,12 +81,19 @@ export const LayoutEditorSettingsDrawer = forwardRef<HTMLDivElement, LayoutEdito
         layoutId: layout?.layoutId || '',
         isTranslationEnabled: layout?.isTranslationEnabled || false,
       },
-      values: {
-        name: layout?.name || '',
-        layoutId: layout?.layoutId || '',
-        isTranslationEnabled: layout?.isTranslationEnabled || false,
-      },
     });
+
+    const wasOpenRef = useRef(false);
+    useEffect(() => {
+      if (isOpen && !wasOpenRef.current && layout) {
+        form.reset({
+          name: layout.name || '',
+          layoutId: layout.layoutId || '',
+          isTranslationEnabled: layout.isTranslationEnabled || false,
+        });
+      }
+      wasOpenRef.current = isOpen;
+    }, [isOpen, layout, form]);
 
     const hasUnsavedChanges = form.formState.isDirty;
 
@@ -105,7 +112,12 @@ export const LayoutEditorSettingsDrawer = forwardRef<HTMLDivElement, LayoutEdito
     });
 
     const { updateLayout, isPending: isUpdating } = useUpdateLayout({
-      onSuccess: () => {
+      onSuccess: (data) => {
+        form.reset({
+          name: data.name || '',
+          layoutId: data.layoutId || '',
+          isTranslationEnabled: data.isTranslationEnabled || false,
+        });
         showSuccessToast('Layout updated successfully', '', toastOptions);
         onOpenChange(false);
       },
@@ -240,7 +252,10 @@ export const LayoutEditorSettingsDrawer = forwardRef<HTMLDivElement, LayoutEdito
                 id="layout-settings"
                 autoComplete="off"
                 noValidate
-                onSubmit={form.handleSubmit(onSubmit)}
+                onSubmit={(e) => {
+                  e.stopPropagation();
+                  form.handleSubmit(onSubmit)(e);
+                }}
                 className="flex h-full flex-col"
               >
                 <VisuallyHidden>


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves NV-7084, addressing the unreliable update of email layout names. Users reported that changes were often overridden, as the client sent duplicate API calls: one with the new name and another with the old name.

**Root Cause:**
1.  **Event Bubbling:** The settings drawer form (`layout-settings`) is rendered within the React component tree of the main editor form (`edit-layout`). Despite the settings drawer using a Radix Sheet portal (separate DOM), React's synthetic `submit` events bubble up the *component tree*. This caused both forms to submit simultaneously. The main form, always submitting the `layout?.name` (the old server value), would override the new name sent by the settings drawer.
2.  **Form Control & Race Conditions:** The `useForm` hook in the settings drawer was using the `values` prop, making it a "controlled" form that continuously re-synced with external `layout` data. This led to unexpected resets and race conditions during submission, potentially sending stale data.

**Changes:**
1.  **Prevented Event Bubbling:** Added `e.stopPropagation()` to the settings drawer form's `onSubmit` handler to stop the submit event from reaching the parent main form.
2.  **Improved Form State Management:**
    *   Removed the `values` prop from `useForm` in the settings drawer.
    *   Implemented a `useEffect` with `wasOpenRef` to reset the form only when the drawer transitions from closed to open, ensuring fresh data on open without interfering with mid-edit changes.
    *   Reset the form with the mutation response data upon successful save to maintain a clean state before the drawer closes.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->
N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->
The core issue was the interaction between nested forms in the React component tree, where synthetic events bubble, even when using portals that separate DOM elements. The `e.stopPropagation()` on the settings drawer's form submission is crucial to prevent the parent form from also submitting.

</details>

---
Linear Issue: [NV-7084](https://linear.app/novu/issue/NV-7084/cannot-reliably-update-email-layout-name)

<p><a href="https://cursor.com/background-agent?bcId=bc-e69b1422-d53e-4010-89aa-aa25478a2d1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e69b1422-d53e-4010-89aa-aa25478a2d1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

