### PR TITLE
perf(api-service): Conditional preference fetches in GetPreferences for global

### DIFF
--- a/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
@@ -156,30 +156,26 @@ export class GetPreferences {
 
     const queryOptions = { readPreference: 'secondaryPreferred' as const };
 
-    const result: PreferenceSet = {};
-
-    const workflowQueries = command.templateId
-      ? Promise.all([
-          this.preferencesRepository.findOne(
-            {
-              ...baseQuery,
-              _templateId: command.templateId,
-              type: PreferencesTypeEnum.WORKFLOW_RESOURCE,
-            },
-            undefined,
-            queryOptions
-          ),
-          this.preferencesRepository.findOne(
-            {
-              ...baseQuery,
-              _templateId: command.templateId,
-              type: PreferencesTypeEnum.USER_WORKFLOW,
-            },
-            undefined,
-            queryOptions
-          ),
-        ])
-      : Promise.resolve([null, null] as const);
+    const queries = [
+      this.preferencesRepository.findOne(
+        {
+          ...baseQuery,
+          _templateId: command.templateId,
+          type: PreferencesTypeEnum.WORKFLOW_RESOURCE,
+        },
+        undefined,
+        queryOptions
+      ),
+      this.preferencesRepository.findOne(
+        {
+          ...baseQuery,
+          _templateId: command.templateId,
+          type: PreferencesTypeEnum.USER_WORKFLOW,
+        },
+        undefined,
+        queryOptions
+      ),
+    ];
 
     if (command.subscriberId) {
       const useContextFiltering = await this.featureFlagsService.getFlag({
@@ -192,20 +188,18 @@ export class GetPreferences {
         enabled: useContextFiltering,
       });
 
-      const subscriberQueries = [
-        command.templateId
-          ? this.preferencesRepository.findOne(
-              {
-                ...baseQuery,
-                _subscriberId: command.subscriberId,
-                _templateId: command.templateId,
-                type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
-                ...contextQuery,
-              },
-              undefined,
-              queryOptions
-            )
-          : Promise.resolve(null),
+      queries.push(
+        this.preferencesRepository.findOne(
+          {
+            ...baseQuery,
+            _subscriberId: command.subscriberId,
+            _templateId: command.templateId,
+            type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
+            ...contextQuery,
+          },
+          undefined,
+          queryOptions
+        ),
         this.preferencesRepository.findOne(
           {
             ...baseQuery,
@@ -215,38 +209,34 @@ export class GetPreferences {
           },
           undefined,
           queryOptions
-        ),
-      ];
+        )
+      );
+    }
 
-      const [[workflowResourcePreference, workflowUserPreference], [subscriberWorkflowPreference, subscriberGlobalPreference]] =
-        await Promise.all([workflowQueries, Promise.all(subscriberQueries)]);
+    const [
+      workflowResourcePreference,
+      workflowUserPreference,
+      subscriberWorkflowPreference,
+      subscriberGlobalPreference,
+    ] = await Promise.all(queries);
 
-      if (workflowResourcePreference) {
-        result.workflowResourcePreference = workflowResourcePreference as PreferenceSet['workflowResourcePreference'];
-      }
+    const result: PreferenceSet = {};
 
-      if (workflowUserPreference) {
-        result.workflowUserPreference = workflowUserPreference as PreferenceSet['workflowUserPreference'];
-      }
+    if (workflowResourcePreference) {
+      result.workflowResourcePreference = workflowResourcePreference as PreferenceSet['workflowResourcePreference'];
+    }
 
-      if (subscriberWorkflowPreference) {
-        result.subscriberWorkflowPreference =
-          subscriberWorkflowPreference as PreferenceSet['subscriberWorkflowPreference'];
-      }
+    if (workflowUserPreference) {
+      result.workflowUserPreference = workflowUserPreference as PreferenceSet['workflowUserPreference'];
+    }
 
-      if (subscriberGlobalPreference) {
-        result.subscriberGlobalPreference = subscriberGlobalPreference as PreferenceSet['subscriberGlobalPreference'];
-      }
-    } else {
-      const [workflowResourcePreference, workflowUserPreference] = await workflowQueries;
+    if (subscriberWorkflowPreference) {
+      result.subscriberWorkflowPreference =
+        subscriberWorkflowPreference as PreferenceSet['subscriberWorkflowPreference'];
+    }
 
-      if (workflowResourcePreference) {
-        result.workflowResourcePreference = workflowResourcePreference as PreferenceSet['workflowResourcePreference'];
-      }
-
-      if (workflowUserPreference) {
-        result.workflowUserPreference = workflowUserPreference as PreferenceSet['workflowUserPreference'];
-      }
+    if (subscriberGlobalPreference) {
+      result.subscriberGlobalPreference = subscriberGlobalPreference as PreferenceSet['subscriberGlobalPreference'];
     }
 
     return result;

--- a/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
@@ -156,26 +156,30 @@ export class GetPreferences {
 
     const queryOptions = { readPreference: 'secondaryPreferred' as const };
 
-    const queries = [
-      this.preferencesRepository.findOne(
-        {
-          ...baseQuery,
-          _templateId: command.templateId,
-          type: PreferencesTypeEnum.WORKFLOW_RESOURCE,
-        },
-        undefined,
-        queryOptions
-      ),
-      this.preferencesRepository.findOne(
-        {
-          ...baseQuery,
-          _templateId: command.templateId,
-          type: PreferencesTypeEnum.USER_WORKFLOW,
-        },
-        undefined,
-        queryOptions
-      ),
-    ];
+    const result: PreferenceSet = {};
+
+    const workflowQueries = command.templateId
+      ? Promise.all([
+          this.preferencesRepository.findOne(
+            {
+              ...baseQuery,
+              _templateId: command.templateId,
+              type: PreferencesTypeEnum.WORKFLOW_RESOURCE,
+            },
+            undefined,
+            queryOptions
+          ),
+          this.preferencesRepository.findOne(
+            {
+              ...baseQuery,
+              _templateId: command.templateId,
+              type: PreferencesTypeEnum.USER_WORKFLOW,
+            },
+            undefined,
+            queryOptions
+          ),
+        ])
+      : Promise.resolve([null, null] as const);
 
     if (command.subscriberId) {
       const useContextFiltering = await this.featureFlagsService.getFlag({
@@ -188,18 +192,20 @@ export class GetPreferences {
         enabled: useContextFiltering,
       });
 
-      queries.push(
-        this.preferencesRepository.findOne(
-          {
-            ...baseQuery,
-            _subscriberId: command.subscriberId,
-            _templateId: command.templateId,
-            type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
-            ...contextQuery,
-          },
-          undefined,
-          queryOptions
-        ),
+      const subscriberQueries = [
+        command.templateId
+          ? this.preferencesRepository.findOne(
+              {
+                ...baseQuery,
+                _subscriberId: command.subscriberId,
+                _templateId: command.templateId,
+                type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
+                ...contextQuery,
+              },
+              undefined,
+              queryOptions
+            )
+          : Promise.resolve(null),
         this.preferencesRepository.findOne(
           {
             ...baseQuery,
@@ -209,34 +215,38 @@ export class GetPreferences {
           },
           undefined,
           queryOptions
-        )
-      );
-    }
+        ),
+      ];
 
-    const [
-      workflowResourcePreference,
-      workflowUserPreference,
-      subscriberWorkflowPreference,
-      subscriberGlobalPreference,
-    ] = await Promise.all(queries);
+      const [[workflowResourcePreference, workflowUserPreference], [subscriberWorkflowPreference, subscriberGlobalPreference]] =
+        await Promise.all([workflowQueries, Promise.all(subscriberQueries)]);
 
-    const result: PreferenceSet = {};
+      if (workflowResourcePreference) {
+        result.workflowResourcePreference = workflowResourcePreference as PreferenceSet['workflowResourcePreference'];
+      }
 
-    if (workflowResourcePreference) {
-      result.workflowResourcePreference = workflowResourcePreference as PreferenceSet['workflowResourcePreference'];
-    }
+      if (workflowUserPreference) {
+        result.workflowUserPreference = workflowUserPreference as PreferenceSet['workflowUserPreference'];
+      }
 
-    if (workflowUserPreference) {
-      result.workflowUserPreference = workflowUserPreference as PreferenceSet['workflowUserPreference'];
-    }
+      if (subscriberWorkflowPreference) {
+        result.subscriberWorkflowPreference =
+          subscriberWorkflowPreference as PreferenceSet['subscriberWorkflowPreference'];
+      }
 
-    if (subscriberWorkflowPreference) {
-      result.subscriberWorkflowPreference =
-        subscriberWorkflowPreference as PreferenceSet['subscriberWorkflowPreference'];
-    }
+      if (subscriberGlobalPreference) {
+        result.subscriberGlobalPreference = subscriberGlobalPreference as PreferenceSet['subscriberGlobalPreference'];
+      }
+    } else {
+      const [workflowResourcePreference, workflowUserPreference] = await workflowQueries;
 
-    if (subscriberGlobalPreference) {
-      result.subscriberGlobalPreference = subscriberGlobalPreference as PreferenceSet['subscriberGlobalPreference'];
+      if (workflowResourcePreference) {
+        result.workflowResourcePreference = workflowResourcePreference as PreferenceSet['workflowResourcePreference'];
+      }
+
+      if (workflowUserPreference) {
+        result.workflowUserPreference = workflowUserPreference as PreferenceSet['workflowUserPreference'];
+      }
     }
 
     return result;
@@ -256,30 +266,35 @@ export class GetPreferences {
       organizationId: command.organizationId,
     };
 
-    const workflowPreferences = await this.inMemoryLRUCacheService.get(
-      InMemoryLRUCacheStore.WORKFLOW_PREFERENCES,
-      `${command.environmentId}:${command.templateId}`,
-      async (): Promise<[PreferencesEntity | null, PreferencesEntity | null]> => {
-        const preferences = await this.preferencesRepository.find(
-          {
-            ...baseQuery,
-            _templateId: command.templateId,
-            type: { $in: [PreferencesTypeEnum.WORKFLOW_RESOURCE, PreferencesTypeEnum.USER_WORKFLOW] },
-          },
-          undefined,
-          queryOptions
-        );
+    let workflowResourcePreference: PreferencesEntity | null = null;
+    let workflowUserPreference: PreferencesEntity | null = null;
 
-        const workflowResourcePreference =
-          preferences.find((p) => p.type === PreferencesTypeEnum.WORKFLOW_RESOURCE) ?? null;
-        const workflowUserPreference = preferences.find((p) => p.type === PreferencesTypeEnum.USER_WORKFLOW) ?? null;
+    if (command.templateId) {
+      const workflowPreferences = await this.inMemoryLRUCacheService.get(
+        InMemoryLRUCacheStore.WORKFLOW_PREFERENCES,
+        `${command.environmentId}:${command.templateId}`,
+        async (): Promise<[PreferencesEntity | null, PreferencesEntity | null]> => {
+          const preferences = await this.preferencesRepository.find(
+            {
+              ...baseQuery,
+              _templateId: command.templateId,
+              type: { $in: [PreferencesTypeEnum.WORKFLOW_RESOURCE, PreferencesTypeEnum.USER_WORKFLOW] },
+            },
+            undefined,
+            queryOptions
+          );
 
-        return [workflowResourcePreference, workflowUserPreference];
-      },
-      cacheOptions
-    );
+          const workflowResourcePref =
+            preferences.find((p) => p.type === PreferencesTypeEnum.WORKFLOW_RESOURCE) ?? null;
+          const workflowUserPref = preferences.find((p) => p.type === PreferencesTypeEnum.USER_WORKFLOW) ?? null;
 
-    const [workflowResourcePreference, workflowUserPreference] = workflowPreferences;
+          return [workflowResourcePref, workflowUserPref];
+        },
+        cacheOptions
+      );
+
+      [workflowResourcePreference, workflowUserPreference] = workflowPreferences;
+    }
 
     let subscriberWorkflowPreference: PreferencesEntity | null = null;
     let subscriberGlobalPreference: PreferencesEntity | null = null;
@@ -295,18 +310,20 @@ export class GetPreferences {
         enabled: useContextFiltering,
       });
 
-      [subscriberWorkflowPreference, subscriberGlobalPreference] = await Promise.all([
-        this.preferencesRepository.findOne(
-          {
-            ...baseQuery,
-            _subscriberId: command.subscriberId,
-            _templateId: command.templateId,
-            type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
-            ...contextQuery,
-          },
-          undefined,
-          queryOptions
-        ),
+      const [workflowPref, globalPref] = await Promise.all([
+        command.templateId
+          ? this.preferencesRepository.findOne(
+              {
+                ...baseQuery,
+                _subscriberId: command.subscriberId,
+                _templateId: command.templateId,
+                type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
+                ...contextQuery,
+              },
+              undefined,
+              queryOptions
+            )
+          : Promise.resolve(null),
         this.preferencesRepository.findOne(
           {
             ...baseQuery,
@@ -318,6 +335,9 @@ export class GetPreferences {
           queryOptions
         ),
       ]);
+
+      subscriberWorkflowPreference = workflowPref;
+      subscriberGlobalPreference = globalPref;
     }
 
     const result: PreferenceSet = {};


### PR DESCRIPTION
Refactor GetPreferences to avoid unnecessary DB reads when templateId is missing. Queries are split into workflowQueries and subscriberQueries that resolve to nulls if command.templateId is absent, and results are awaited with Promise.all in grouped form. Cache lookup for workflow preferences is now performed only when templateId exists, and result fields are populated conditionally. Overall this reduces redundant repository calls and simplifies preference assembly logic.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
