### PR TITLE
API security headers

### DIFF
--- a/apps/api/netlify.toml
+++ b/apps/api/netlify.toml
@@ -1,0 +1,12 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-XSS-Protection = "1; mode=block"
+    Referrer-Policy = "no-referrer-when-downgrade"
+    X-Content-Type-Options = "nosniff"
+    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' https:; img-src 'self' data: https:; font-src 'self' https:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+    Permissions-Policy = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()"
+    Strict-Transport-Security = '''
+    max-age=63072000;
+    includeSubDomains;
+    preload'''

--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -84,7 +84,24 @@ export async function bootstrap(
   server.headersTimeout = 65 * 1000;
   logger.trace(`Server headersTimeout: ${server.headersTimeout / 1000}s `);
 
-  app.use(helmet());
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'", 'https:'],
+          imgSrc: ["'self'", 'data:', 'https:'],
+          fontSrc: ["'self'", 'https:'],
+          objectSrc: ["'none'"],
+          frameAncestors: ["'none'"],
+          baseUri: ["'self'"],
+          formAction: ["'self'"],
+          upgradeInsecureRequests: [],
+        },
+      },
+    })
+  );
   app.enableCors(corsOptionsDelegate);
 
   app.use(passport.initialize());


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR addresses NV-6884, "Missing Security Headers (Section 7.2)," by removing `'unsafe-inline'` from the `style-src` directive in the Content Security Policy (CSP).

Specifically:
*   A `netlify.toml` file was created for `apps/api` to apply security headers, including a `Content-Security-Policy` that disallows `'unsafe-inline'` for `style-src`.
*   The `helmet()` configuration in `apps/api/src/bootstrap.ts` was updated to use explicit CSP directives, removing `'unsafe-inline'` from `style-src` and allowing `'self' https:` to ensure compatibility with Swagger UI.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

---
Linear Issue: [NV-6884](https://linear.app/novu/issue/NV-6884/missing-security-headers-section-72)

<p><a href="https://cursor.com/background-agent?bcId=bc-8cc5a81b-f77b-47a7-944e-4f64471c8ae6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8cc5a81b-f77b-47a7-944e-4f64471c8ae6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

