### PR TITLE
fix(api-service): Environment ID organization check

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/get-workflow/get-workflow.command.ts
+++ b/apps/api/src/app/workflows-v2/usecases/get-workflow/get-workflow.command.ts
@@ -1,8 +1,12 @@
 import { EnvironmentWithUserObjectCommand } from '@novu/application-generic';
-import { IsDefined, IsString } from 'class-validator';
+import { IsDefined, IsOptional, IsString } from 'class-validator';
 
 export class GetWorkflowCommand extends EnvironmentWithUserObjectCommand {
   @IsString()
   @IsDefined()
   workflowIdOrInternalId: string;
+
+  @IsString()
+  @IsOptional()
+  environmentId?: string;
 }

--- a/apps/api/src/app/workflows-v2/usecases/get-workflow/get-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/get-workflow/get-workflow.usecase.ts
@@ -1,6 +1,7 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { Instrument, InstrumentUsecase, PinoLogger } from '@novu/application-generic';
 import {
+  EnvironmentRepository,
   IntegrationEntity,
   IntegrationRepository,
   NotificationStepEntity,
@@ -29,6 +30,7 @@ export class GetWorkflowUseCase {
     private getWorkflowWithPreferencesUseCase: GetWorkflowWithPreferencesUseCase,
     private buildStepDataUsecase: BuildStepDataUsecase,
     private integrationsRepository: IntegrationRepository,
+    private environmentRepository: EnvironmentRepository,
     private logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -39,11 +41,15 @@ export class GetWorkflowUseCase {
     command: GetWorkflowCommand,
     workflowDataContainer?: WorkflowDataContainer
   ): Promise<WorkflowResponseDto> {
+    const effectiveEnvironmentId = await this.resolveEnvironmentId(command);
+
+    const user: UserSessionData = {
+      ...command.user,
+      environmentId: effectiveEnvironmentId,
+    };
+
     if (workflowDataContainer) {
-      const cachedDto = workflowDataContainer.getWorkflowDto(
-        command.workflowIdOrInternalId,
-        command.user.environmentId
-      );
+      const cachedDto = workflowDataContainer.getWorkflowDto(command.workflowIdOrInternalId, effectiveEnvironmentId);
 
       if (cachedDto) {
         this.logger.debug(`Using cached workflow DTO for ${command.workflowIdOrInternalId}`);
@@ -54,19 +60,38 @@ export class GetWorkflowUseCase {
 
     const workflowWithPreferences = await this.getWorkflowWithPreferencesUseCase.execute(
       GetWorkflowWithPreferencesCommand.create({
-        environmentId: command.user.environmentId,
+        environmentId: effectiveEnvironmentId,
         organizationId: command.user.organizationId,
         workflowIdOrInternalId: command.workflowIdOrInternalId,
         userId: command.user._id,
       })
     );
 
-    const fullSteps = await this.getFullWorkflowSteps(workflowWithPreferences, command.user);
+    const fullSteps = await this.getFullWorkflowSteps(workflowWithPreferences, user);
     const payloadExample = await generatePayloadExample(workflowWithPreferences);
 
     const workflowDto = toResponseWorkflowDto(workflowWithPreferences, fullSteps, payloadExample);
 
     return workflowDto;
+  }
+
+  private async resolveEnvironmentId(command: GetWorkflowCommand): Promise<string> {
+    const { environmentId } = command;
+
+    if (!environmentId || environmentId === command.user.environmentId) {
+      return command.user.environmentId;
+    }
+
+    const environment = await this.environmentRepository.findByIdAndOrganization(
+      environmentId,
+      command.user.organizationId
+    );
+
+    if (!environment) {
+      throw new NotFoundException(`Environment ${environmentId} not found`);
+    }
+
+    return environmentId;
   }
 
   private async getFullWorkflowSteps(

--- a/apps/api/src/app/workflows-v2/workflow.controller.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.ts
@@ -197,10 +197,8 @@ export class WorkflowController {
     return this.getWorkflowUseCase.execute(
       GetWorkflowCommand.create({
         workflowIdOrInternalId,
-        user: {
-          ...user,
-          environmentId: environmentId || user.environmentId,
-        },
+        user,
+        environmentId,
       })
     );
   }


### PR DESCRIPTION
### What changed? Why was the change needed?

This change introduces a validation mechanism for the `environmentId` when it's provided as a query parameter to the `getWorkflow` endpoint.

Previously, a custom `environmentId` from the query parameter would directly override the user's session `environmentId`. This could lead to unauthorized access or incorrect data retrieval if the provided `environmentId` did not belong to the user's organization.

Now, if a custom `environmentId` is passed and differs from the session's `environmentId`, the system verifies that this custom `environmentId` belongs to the current user's organization. If the environment is not found within the organization, a `NotFoundException` is thrown, enhancing security and data integrity.

Specifically:
- The `GetWorkflowCommand` now includes an optional `environmentId` field.
- The `WorkflowController` passes the query `environmentId` to the command as this new, separate field.
- The `GetWorkflowUseCase` injects `EnvironmentRepository` to perform the necessary validation.

### Screenshots

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1771491725112189?thread_ts=1771491725.112189&cid=D0919LNRWE7)

<p><a href="https://cursor.com/background-agent?bcId=bc-a1f36204-fc91-5ca1-848c-364f99f5577f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1f36204-fc91-5ca1-848c-364f99f5577f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

