### PR TITLE
fix(api-service): Workflow sync environment check

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/sync-to-environment/sync-to-environment.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/sync-to-environment/sync-to-environment.usecase.ts
@@ -1,8 +1,9 @@
-import { BadRequestException, Injectable, Optional } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException, Optional } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { Instrument, InstrumentUsecase, SendWebhookMessage } from '@novu/application-generic';
 import {
   ClientSession,
+  EnvironmentRepository,
   LocalizationResourceEnum,
   NotificationTemplateRepository,
   PreferencesEntity,
@@ -52,6 +53,7 @@ export class SyncToEnvironmentUseCase {
     private layoutSyncToEnvironmentUseCase: LayoutSyncToEnvironmentUseCase,
     private moduleRef: ModuleRef,
     private notificationTemplateRepository: NotificationTemplateRepository,
+    private environmentRepository: EnvironmentRepository,
     @Optional()
     private sendWebhookMessage?: SendWebhookMessage
   ) {}
@@ -61,6 +63,8 @@ export class SyncToEnvironmentUseCase {
     if (command.user.environmentId === command.targetEnvironmentId) {
       throw new BadRequestException('Cannot sync workflow to the same environment');
     }
+
+    await this.validateTargetEnvironment(command.targetEnvironmentId, command.user.organizationId);
 
     const sourceWorkflow = await this.getWorkflowUseCase.execute(
       GetWorkflowCommand.create({
@@ -140,6 +144,14 @@ export class SyncToEnvironmentUseCase {
     }
 
     return upsertedWorkflow;
+  }
+
+  private async validateTargetEnvironment(targetEnvironmentId: string, organizationId: string): Promise<void> {
+    const environment = await this.environmentRepository.findByIdAndOrganization(targetEnvironmentId, organizationId);
+
+    if (!environment) {
+      throw new NotFoundException(`Environment ${targetEnvironmentId} not found`);
+    }
   }
 
   private async publishTranslationGroup(

--- a/apps/api/src/app/workflows-v2/usecases/sync-to-environment/sync-to-environment.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/sync-to-environment/sync-to-environment.usecase.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException, Optional } from '@n
 import { ModuleRef } from '@nestjs/core';
 import { Instrument, InstrumentUsecase, SendWebhookMessage } from '@novu/application-generic';
 import {
+  BaseRepository,
   ClientSession,
   EnvironmentRepository,
   LocalizationResourceEnum,
@@ -147,17 +148,13 @@ export class SyncToEnvironmentUseCase {
   }
 
   private async validateTargetEnvironment(targetEnvironmentId: string, organizationId: string): Promise<void> {
-    try {
-      const environment = await this.environmentRepository.findByIdAndOrganization(targetEnvironmentId, organizationId);
+    if (!BaseRepository.isInternalId(targetEnvironmentId)) {
+      throw new NotFoundException(`Environment ${targetEnvironmentId} not found`);
+    }
 
-      if (!environment) {
-        throw new NotFoundException(`Environment ${targetEnvironmentId} not found`);
-      }
-    } catch (error) {
-      if (error instanceof NotFoundException) {
-        throw error;
-      }
+    const environment = await this.environmentRepository.findByIdAndOrganization(targetEnvironmentId, organizationId);
 
+    if (!environment) {
       throw new NotFoundException(`Environment ${targetEnvironmentId} not found`);
     }
   }

--- a/apps/api/src/app/workflows-v2/usecases/sync-to-environment/sync-to-environment.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/sync-to-environment/sync-to-environment.usecase.ts
@@ -147,9 +147,17 @@ export class SyncToEnvironmentUseCase {
   }
 
   private async validateTargetEnvironment(targetEnvironmentId: string, organizationId: string): Promise<void> {
-    const environment = await this.environmentRepository.findByIdAndOrganization(targetEnvironmentId, organizationId);
+    try {
+      const environment = await this.environmentRepository.findByIdAndOrganization(targetEnvironmentId, organizationId);
 
-    if (!environment) {
+      if (!environment) {
+        throw new NotFoundException(`Environment ${targetEnvironmentId} not found`);
+      }
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+
       throw new NotFoundException(`Environment ${targetEnvironmentId} not found`);
     }
   }

--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -696,9 +696,22 @@ describe('Workflow Controller E2E API Testing #novu-v2', () => {
       expect(error?.message).to.equal('Cannot sync workflow to the same environment');
     });
 
-    it('should throw an error if the workflow to promote is not found', async () => {
+    it('should throw an error if the target environment is not found', async () => {
       const { error } = await expectSdkExceptionGeneric(() =>
         apiClient.workflows.sync({ targetEnvironmentId: '123' }, '123')
+      );
+
+      expect(error?.statusCode).to.equal(404);
+      expect(error?.message).to.equal('Environment 123 not found');
+    });
+
+    it('should throw an error if the workflow to promote is not found', async () => {
+      await session.switchToProdEnvironment();
+      const prodEnvironmentId = session.environment._id;
+      await session.switchToDevEnvironment();
+
+      const { error } = await expectSdkExceptionGeneric(() =>
+        apiClient.workflows.sync({ targetEnvironmentId: prodEnvironmentId }, '123')
       );
 
       expect(error?.statusCode).to.equal(404);


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR introduces an environment ID validation check for the `targetEnvironmentId` in the `PUT /v2/workflows/:workflowId/sync` endpoint.

This change was needed to prevent potential cross-organization environment access, ensuring that the `targetEnvironmentId` belongs to the user's organization. This aligns with the security enhancement introduced in PR #10063, which added similar validation for the `environmentId` in the `getWorkflow` endpoint.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

The validation logic mirrors the `environmentId` check implemented in PR #10063.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1771507969004219?thread_ts=1771507969.004219&cid=D0919LNRWE7)

<p><a href="https://cursor.com/background-agent?bcId=bc-268edf3b-7c7b-5603-8d68-54920eacf1ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-268edf3b-7c7b-5603-8d68-54920eacf1ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

