### PR TITLE
fix: set preferences data directly on fetch to prevent undefined on re-mount

### DIFF
--- a/packages/react/src/hooks/usePreferences.ts
+++ b/packages/react/src/hooks/usePreferences.ts
@@ -55,8 +55,9 @@ export const usePreferences = (props?: UsePreferencesProps): UsePreferencesResul
     if (response.error) {
       setError(response.error);
       onError?.(response.error);
-    } else {
-      onSuccess?.(response.data!);
+    } else if (response.data) {
+      setData(response.data);
+      onSuccess?.(response.data);
     }
     setIsLoading(false);
     setIsFetching(false);


### PR DESCRIPTION
## Summary

Fix `usePreferences` hook returning `undefined` for `preferences` when a component unmounts and re-mounts.

## Root Cause

The `fetchPreferences` function was not calling `setData()` with the API response data. It relied solely on event listeners (`preferences.list.updated`, `preferences.list.pending`, `preferences.list.resolved`) to update the state via the `sync` callback.

On first mount, the event fires and `sync` sets the data correctly. However, when the component unmounts and re-mounts, the event listeners are re-registered but the cached response may not trigger a new event, leaving `preferences` as `undefined` permanently (with `isLoading: false` and no error).

## Fix

Added `setData(response.data)` in the success branch of `fetchPreferences`, consistent with how `useNotifications` handles its fetch response. This ensures the data is always set directly from the API response, regardless of whether events fire.

## Comparison with useNotifications

`useNotifications` correctly calls `setData(responseData.notifications)` in its `fetchNotifications` callback — this PR aligns `usePreferences` with that pattern.

Fixes #10057
