### PR TITLE
Email step subject controls

### DIFF
--- a/packages/novu/src/commands/email/templates/__snapshots__/step-file.spec.ts.snap
+++ b/packages/novu/src/commands/email/templates/__snapshots__/step-file.spec.ts.snap
@@ -10,7 +10,7 @@ export const type = 'email';
 
 export default async function({ payload, subscriber, context, steps, controls }) {
   return {
-    subject: payload.subject || 'No Subject',
+    subject: controls.subject ?? payload.subject ?? 'No Subject',
     body: await render(
       <EmailTemplate
         {...payload}
@@ -35,7 +35,7 @@ export const type = 'email';
 
 export default async function({ payload, subscriber, context, steps, controls }) {
   return {
-    subject: payload.subject || 'No Subject',
+    subject: controls.subject ?? payload.subject ?? 'No Subject',
     body: await render(
       <EmailTemplate
         {...payload}
@@ -60,7 +60,7 @@ export const type = 'email';
 
 export default async function({ payload, subscriber, context, steps, controls }) {
   return {
-    subject: payload.subject || 'No Subject',
+    subject: controls.subject ?? payload.subject ?? 'No Subject',
     body: await render(
       <EmailTemplate
         {...payload}
@@ -85,7 +85,7 @@ export const type = 'email';
 
 export default async function({ payload, subscriber, context, steps, controls }) {
   return {
-    subject: payload.subject || 'Welcome to Acme!',
+    subject: controls.subject ?? payload.subject ?? 'Welcome to Acme!',
     body: await render(
       <EmailTemplate
         {...payload}

--- a/packages/novu/src/commands/email/templates/step-file.ts
+++ b/packages/novu/src/commands/email/templates/step-file.ts
@@ -21,7 +21,7 @@ export const type = 'email';
 
 export default async function({ payload, subscriber, context, steps, controls }) {
   return {
-    subject: controls.subject || payload.subject || '${escapeString(defaultSubject)}',
+    subject: controls.subject ?? payload.subject ?? '${escapeString(defaultSubject)}',
     body: await render(
       <EmailTemplate
         {...payload}


### PR DESCRIPTION
### What changed? Why was the change needed?

Replaced the logical OR (`||`) operator with the nullish coalescing operator (`??`) in the subject assignment for generated email step templates (`packages/novu/src/commands/email/templates/step-file.ts`). This ensures that an explicit empty string (`""`) provided via `controls.subject` or `payload.subject` is honored as a valid subject, rather than being incorrectly treated as a falsy value and falling back to a default subject.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

This PR specifically addresses the subject assignment on line 24 of `step-file.ts`. Other potential changes discussed during development (e.g., handling of the `controls` prop or other `||` to `??` conversions) were intentionally excluded to focus solely on this specific fix as per instructions. Snapshot files have been updated to reflect the change in the generated template code.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNS89H/p1771868479352969?thread_ts=1771868479.352969&cid=D0919LNS89H)

<p><a href="https://cursor.com/agents/bc-9ef9355f-afd9-557d-b7e0-7b0596abeeb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ef9355f-afd9-557d-b7e0-7b0596abeeb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

