### PR TITLE
Email verification optional default

### DIFF
--- a/apps/api/src/config/env.validators.ts
+++ b/apps/api/src/config/env.validators.ts
@@ -15,6 +15,7 @@ export const envValidators = {
   PORT: port(),
   FRONT_BASE_URL: str(),
   DISABLE_USER_REGISTRATION: bool({ default: false }),
+  DISABLE_EMAIL_VERIFICATION: bool({ default: false }),
   REDIS_HOST: str(),
   REDIS_PORT: port(),
   REDIS_TLS: json({ default: undefined }),

--- a/apps/dashboard/src/config/index.ts
+++ b/apps/dashboard/src/config/index.ts
@@ -44,6 +44,9 @@ export const IS_SELF_HOSTED = (window._env_?.VITE_SELF_HOSTED || import.meta.env
 
 export const IS_ENTERPRISE = (window._env_?.VITE_NOVU_ENTERPRISE || import.meta.env.VITE_NOVU_ENTERPRISE) === 'true';
 
+export const IS_EMAIL_VERIFICATION_DISABLED =
+  (window._env_?.VITE_DISABLE_EMAIL_VERIFICATION || import.meta.env.VITE_DISABLE_EMAIL_VERIFICATION) === 'true';
+
 if (!IS_SELF_HOSTED && EE_AUTH_PROVIDER === 'clerk' && !CLERK_PUBLISHABLE_KEY) {
   throw new Error('Missing Clerk Publishable Key');
 }

--- a/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
-import { IS_ENTERPRISE } from '@/config';
+import { IS_EMAIL_VERIFICATION_DISABLED, IS_ENTERPRISE } from '@/config';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
 
@@ -47,7 +47,7 @@ export function SignIn() {
       });
 
       if (authError) {
-        if (authError.status === 403) {
+        if (authError.status === 403 && !IS_EMAIL_VERIFICATION_DISABLED) {
           setShowResendVerification(true);
           throw new Error('Please verify your email address before signing in.');
         }

--- a/apps/dashboard/src/utils/better-auth/components/sign-up.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sign-up.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
+import { IS_EMAIL_VERIFICATION_DISABLED } from '@/config';
 import { ROUTES } from '@/utils/routes';
 import { authClient } from '../client';
 import { useAuth } from '../index';
@@ -104,7 +105,7 @@ export function SignUp() {
         throw new Error('Sign up failed');
       }
 
-      if (!signUpData.token) {
+      if (!signUpData.token && !IS_EMAIL_VERIFICATION_DISABLED) {
         navigate(`${ROUTES.VERIFY_EMAIL}?email=${encodeURIComponent(email)}`);
 
         return;

--- a/packages/shared/src/utils/env.ts
+++ b/packages/shared/src/utils/env.ts
@@ -67,3 +67,5 @@ export const getEEAuthProvider = (): EEAuthProvider => {
 export const isClerkEnabled = () => isEEAuthEnabled() && getEEAuthProvider() === 'clerk';
 
 export const isBetterAuthEnabled = () => isEEAuthEnabled() && getEEAuthProvider() === 'better-auth';
+
+export const isEmailVerificationDisabled = () => process.env.DISABLE_EMAIL_VERIFICATION === 'true';


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR introduces the ability to disable email verification in the better-auth flow via an environment variable. Previously, email verification was always required.

The change was needed to provide flexibility, allowing email verification to be optional while remaining enabled by default.

Specifically:
- A new environment variable `DISABLE_EMAIL_VERIFICATION` (default `false`) has been added.
- A helper `isEmailVerificationDisabled()` was added to `@novu/shared` to read this variable.
- The Dashboard's sign-up component now conditionally redirects to the email verification page.
- The Dashboard's sign-in component conditionally handles 403 errors related to email verification.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

A separate PR will be needed in the `@novu/ee-auth` package to fully integrate this change on the server-side, allowing the `betterAuth()` configuration to respect the `isEmailVerificationDisabled()` flag.

### Special notes for your reviewer

This PR handles the client-side (Dashboard) and shared environment variable setup. The server-side integration within `@novu/ee-auth` is a follow-up task.

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1772014561101269?thread_ts=1772014561.101269&cid=D0919LNRWE7)

<p><a href="https://cursor.com/agents/bc-703572f7-49d5-53ee-8c1c-02bdbd811198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-703572f7-49d5-53ee-8c1c-02bdbd811198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

