### PR TITLE
fix(dashboard): Production translation toggle fixes NV-7098

### DIFF
--- a/apps/dashboard/src/components/translations/translation-switch.tsx
+++ b/apps/dashboard/src/components/translations/translation-switch.tsx
@@ -22,8 +22,9 @@ export function TranslationSwitch({ id, value, onChange, isReadOnly }: Translati
     ) &&
     (!IS_SELF_HOSTED || IS_ENTERPRISE);
 
-  const disabled = !canUseTranslationFeature || isLoading || isReadOnly;
-  const checked = disabled ? false : value;
+  const isFeatureUnavailable = !canUseTranslationFeature || isLoading;
+  const disabled = isFeatureUnavailable || isReadOnly;
+  const checked = isFeatureUnavailable ? false : value;
 
   return (
     <div className="flex items-center">


### PR DESCRIPTION
### What changed? Why was the change needed?

The `TranslationSwitch` component was updated to correctly reflect the translation status in read-only environments (e.g., production workflows).

Previously, the translation toggle would always appear "off" in read-only contexts, even when translations were enabled in the database. This was due to the UI logic forcing the toggle's `checked` state to `false` when the switch was disabled (which includes being read-only).

The change ensures the toggle visually displays the correct database state for translation enablement, while still remaining disabled and non-interactive in read-only environments.

**Relevant links:** [NV-7098](https://linear.app/NV-7098)

### Screenshots

This change addresses the visual discrepancy shown in the screenshots attached to the Linear ticket.

---
Linear Issue: [NV-7098](https://linear.app/novu/issue/NV-7098/enable-translation-toggle-is-of-in-production-workflow-after-sync)

<p><a href="https://cursor.com/agents/bc-49dac61a-db23-4eb9-9525-9035ab063269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49dac61a-db23-4eb9-9525-9035ab063269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

