### PR TITLE
fix(dashboard): Dashboard team org tabs order

### DIFF
--- a/apps/dashboard/src/components/settings/organization-settings.tsx
+++ b/apps/dashboard/src/components/settings/organization-settings.tsx
@@ -82,7 +82,7 @@ export function OrganizationSettings({ clerkAppearance }: { clerkAppearance: App
         <h1 className="text-label-sm text-text-strong mb-3">Organization Settings</h1>
         {EE_AUTH_PROVIDER === 'clerk' ? (
           <OrganizationProfile appearance={clerkAppearance}>
-            <OrganizationProfile.Page label="general" />
+            <OrganizationProfile.Page label="members" />
           </OrganizationProfile>
         ) : (
           <BetterAuthOrganizationSettings />

--- a/apps/dashboard/src/pages/settings.tsx
+++ b/apps/dashboard/src/pages/settings.tsx
@@ -212,7 +212,7 @@ export function SettingsPage() {
                   )}
                   {EE_AUTH_PROVIDER === 'clerk' ? (
                     <OrganizationProfile appearance={clerkAppearance}>
-                      <OrganizationProfile.Page label="members" />
+                      <OrganizationProfile.Page label="general" />
                     </OrganizationProfile>
                   ) : (
                     <TeamMembers appearance={clerkAppearance} />


### PR DESCRIPTION
### What changed? Why was the change needed?

The content for the "Team" and "Organization" tabs on the settings page was flipped in the Clerk authentication flow. This PR swaps the `OrganizationProfile.Page` labels to correctly display team invitation components under the "Team" tab and organization settings under the "Organization" tab.

### Screenshots

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1772033451771369?thread_ts=1772033451.771369&cid=D0919LNRWE7)

<p><a href="https://cursor.com/agents/bc-30f22edf-fc89-5ada-b9cf-2d8481193df5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30f22edf-fc89-5ada-b9cf-2d8481193df5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

