### PR TITLE
feat(dashboard,api-service): surface step resolver runtime errors to preview fixes NV-7136

### DIFF
--- a/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
@@ -86,8 +86,6 @@ export class PreviewUsecase {
           schema: context.variableSchema,
         };
       } catch (error) {
-        this.logger.error({ err: error }, 'Error executing preview');
-
         const isStepResolverEmail = context.stepData.type === StepTypeEnum.EMAIL && stepResolverHash !== undefined;
 
         /*

--- a/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/preview/preview.usecase.ts
@@ -7,7 +7,7 @@ import {
   PinoLogger,
 } from '@novu/application-generic';
 import { ContextResolved } from '@novu/framework/internal';
-import { ChannelTypeEnum, ResourceOriginEnum } from '@novu/shared';
+import { ChannelTypeEnum, ResourceOriginEnum, StepTypeEnum } from '@novu/shared';
 import { PreviewStep, PreviewStepCommand } from '../../../bridge/usecases/preview-step';
 // Import new services
 import { ControlValueSanitizerService } from '../../../shared/services/control-value-sanitizer.service';
@@ -63,12 +63,18 @@ export class PreviewUsecase {
 
       const cleanedPayloadExample = this.payloadProcessor.cleanPreviewExamplePayload(payloadExample);
 
+      const stepResolverHash =
+        typeof context.stepData.controls.values?.stepResolverHash === 'string'
+          ? context.stepData.controls.values.stepResolverHash
+          : undefined;
+
       try {
         const executeOutput = await this.executePreviewUsecase(
           command,
           context.stepData,
           payloadExample,
-          previewTemplateData.controlValues
+          previewTemplateData.controlValues,
+          stepResolverHash
         );
 
         return {
@@ -82,13 +88,21 @@ export class PreviewUsecase {
       } catch (error) {
         this.logger.error({ err: error }, 'Error executing preview');
 
+        const isStepResolverEmail = context.stepData.type === StepTypeEnum.EMAIL && stepResolverHash !== undefined;
+
         /*
          * If preview execution fails, still return valid schema and payload example
-         * but with an empty preview result
+         * but with an empty preview result.
+         * For step resolver email steps, since its a runtime error, surface the error
+         * as HTML rendered in the preview panel.
          */
+        const previewResult = isStepResolverEmail
+          ? { subject: '', body: this.errorHandler.buildPreviewErrorHtml(error) }
+          : {};
+
         return {
           result: {
-            preview: {},
+            preview: previewResult,
             type: context.stepData.type as unknown as ChannelTypeEnum,
           },
           previewPayloadExample: cleanedPayloadExample,
@@ -147,14 +161,10 @@ export class PreviewUsecase {
     command: PreviewCommand,
     stepData: StepResponseDto,
     previewPayloadExample: PreviewPayloadDto,
-    controlValues: Record<string, unknown>
+    controlValues: Record<string, unknown>,
+    stepResolverHash: string | undefined
   ) {
     const state = this.payloadProcessor.buildState(previewPayloadExample.steps);
-
-    const stepResolverHash =
-      typeof stepData.controls.values?.stepResolverHash === 'string'
-        ? stepData.controls.values.stepResolverHash
-        : undefined;
 
     return await this.previewStepUsecase.execute(
       PreviewStepCommand.create({

--- a/apps/api/src/app/workflows-v2/usecases/preview/utils/preview-error-handler.ts
+++ b/apps/api/src/app/workflows-v2/usecases/preview/utils/preview-error-handler.ts
@@ -1,9 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import { captureException } from '@sentry/node';
 import { GeneratePreviewResponseDto } from '../../../dtos';
 import { LOG_CONTEXT } from '../preview.constants';
 import { FrameworkError, GeneratePreviewError } from '../preview.types';
+
+const PLATFORM_ERROR_MESSAGES: Record<string, string> = {
+  STEP_RESOLVER_UNAVAILABLE:
+    'Your email template code is unavailable. Try running "npx novu email publish" to redeploy.',
+  STEP_RESOLVER_NOT_FOUND:
+    'No published email template code found. Run "npx novu email publish" to deploy your templates.',
+  STEP_RESOLVER_AUTHENTICATION_FAILED:
+    'Preview failed due to an authentication error. Please contact support if this persists.',
+  STEP_RESOLVER_PAYLOAD_TOO_LARGE: 'The preview payload is too large to process.',
+  STEP_RESOLVER_TIMEOUT:
+    'Your email template took too long to render. Check for slow operations in your template code.',
+  STEP_RESOLVER_ERROR: 'Failed to reach your email template code. Try running "npx novu email publish" to redeploy.',
+  STEP_RESOLVER_HTTP_ERROR:
+    'An unexpected error occurred while rendering your email template. Please contact support if this persists.',
+};
 
 @Injectable()
 export class PreviewErrorHandler {
@@ -56,5 +71,68 @@ export class PreviewErrorHandler {
     } else {
       throw error;
     }
+  }
+
+  buildPreviewErrorHtml(error: unknown): string {
+    const { title, message, hint } = this.extractErrorContent(error);
+
+    return `<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f8f9fc; padding: 40px 24px; min-height: 320px; display: flex; align-items: flex-start; justify-content: center;">
+  <div style="max-width: 480px; width: 100%; background: #ffffff; border: 1px solid #e3e7ee; border-radius: 8px; box-shadow: 0px 1px 2px 0px rgba(10, 13, 20, 0.03); overflow: hidden;">
+    <div style="padding: 16px; border-bottom: 1px solid #e3e7ee; display: flex; align-items: center; gap: 8px;">
+      <div style="width: 20px; height: 20px; border-radius: 50%; background: hsl(355 96% 60% / 10%); display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Z" fill="hsl(355, 70%, 48%)"/>
+          <path d="M8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" fill="hsl(355, 70%, 48%)"/>
+        </svg>
+      </div>
+      <span style="color: #0f1117; font-weight: 500; font-size: 13px; letter-spacing: -0.005em;">${title}</span>
+    </div>
+    <div style="padding: 16px;">
+      <pre style="margin: 0 0 12px; background: #f8f9fc; border: 1px solid #e3e7ee; border-radius: 6px; padding: 12px; font-size: 12px; color: #525866; white-space: pre-wrap; word-break: break-word; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; line-height: 1.6;">${this.escapeHtml(message)}</pre>
+      <p style="margin: 0; font-size: 12px; color: #717784; line-height: 1.5;">${hint}</p>
+    </div>
+  </div>
+</div>`;
+  }
+
+  private extractErrorContent(error: unknown): { title: string; message: string; hint: string } {
+    if (error instanceof HttpException) {
+      const response = error.getResponse() as Record<string, unknown>;
+      const code = typeof response?.code === 'string' ? response.code : '';
+      const message = typeof response?.message === 'string' ? response.message : error.message;
+
+      if (code === 'STEP_HANDLER_ERROR') {
+        return {
+          title: 'Template error',
+          message,
+          hint: 'Fix the error in your template code and run "npx novu email publish" to redeploy.',
+        };
+      }
+
+      const platformMessage = PLATFORM_ERROR_MESSAGES[code];
+
+      if (platformMessage) {
+        return {
+          title: 'Preview unavailable',
+          message: platformMessage,
+          hint: 'This is not a problem with your template code.',
+        };
+      }
+    }
+
+    return {
+      title: 'Preview failed',
+      message: 'An unexpected error occurred while rendering the preview.',
+      hint: 'Please try again. If the issue persists, contact support.',
+    };
+  }
+
+  private escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#x27;');
   }
 }

--- a/libs/application-generic/src/usecases/execute-step-resolver/execute-step-resolver-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-step-resolver/execute-step-resolver-request.usecase.ts
@@ -37,6 +37,10 @@ const HTTP_ERROR_MAPPINGS: Record<number, { code: string; message: string }> = {
     code: 'STEP_RESOLVER_PAYLOAD_TOO_LARGE',
     message: 'Step resolver payload too large',
   },
+  500: {
+    code: 'STEP_RESOLVER_HTTP_ERROR',
+    message: 'Step resolver returned an internal error',
+  },
   502: {
     code: 'STEP_RESOLVER_UNAVAILABLE',
     message: 'Step resolver worker unavailable',
@@ -198,9 +202,22 @@ export class ExecuteStepResolverRequest {
   private buildErrorResponse(error: unknown, url: string, stepResolverHash: string): BridgeError {
     if (error instanceof HTTPError) {
       const statusCode = error.response.statusCode;
-      const shouldLog = statusCode >= 500;
 
-      if (shouldLog) {
+      if (statusCode === 500) {
+        const parsedBody = this.tryParseBody(error.response.body);
+
+        if (parsedBody?.error === 'STEP_HANDLER_ERROR') {
+          return {
+            url,
+            code: 'STEP_HANDLER_ERROR',
+            message: parsedBody.message ?? 'An error occurred in your template code',
+            statusCode,
+            cause: error,
+          };
+        }
+      }
+
+      if (statusCode >= 500) {
         this.logger.error({ error, statusCode, url, stepResolverHash }, `Step resolver HTTP error: ${statusCode}`);
       }
 
@@ -229,5 +246,19 @@ export class ExecuteStepResolverRequest {
       statusCode: isTimeout ? HttpStatus.REQUEST_TIMEOUT : HttpStatus.INTERNAL_SERVER_ERROR,
       cause: error,
     };
+  }
+
+  private tryParseBody(body: unknown): Record<string, string> | null {
+    try {
+      const parsed = typeof body === 'string' ? JSON.parse(body) : body;
+
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        return parsed as Record<string, string>;
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
   }
 }

--- a/packages/novu/src/commands/email/templates/__snapshots__/worker-wrapper.spec.ts.snap
+++ b/packages/novu/src/commands/email/templates/__snapshots__/worker-wrapper.spec.ts.snap
@@ -82,7 +82,10 @@ export default {
       );
     } catch (error) {
       console.error('Error executing step handler:', error);
-      return jsonResponse({ error: 'Step execution failed', message: 'Internal server error' }, 500);
+      return jsonResponse({
+        error: 'STEP_HANDLER_ERROR',
+        message: error instanceof Error ? error.message : String(error),
+      }, 500);
     }
   },
 };"
@@ -170,7 +173,10 @@ export default {
       );
     } catch (error) {
       console.error('Error executing step handler:', error);
-      return jsonResponse({ error: 'Step execution failed', message: 'Internal server error' }, 500);
+      return jsonResponse({
+        error: 'STEP_HANDLER_ERROR',
+        message: error instanceof Error ? error.message : String(error),
+      }, 500);
     }
   },
 };"
@@ -260,7 +266,10 @@ export default {
       );
     } catch (error) {
       console.error('Error executing step handler:', error);
-      return jsonResponse({ error: 'Step execution failed', message: 'Internal server error' }, 500);
+      return jsonResponse({
+        error: 'STEP_HANDLER_ERROR',
+        message: error instanceof Error ? error.message : String(error),
+      }, 500);
     }
   },
 };"

--- a/packages/novu/src/commands/email/templates/worker-wrapper.spec.ts
+++ b/packages/novu/src/commands/email/templates/worker-wrapper.spec.ts
@@ -49,6 +49,6 @@ describe('generateWorkerWrapper', () => {
     expect(result).toContain('function jsonResponse(body, status, extraHeaders = {})');
     expect(result).toContain("Allow: 'POST'");
     expect(result).toContain("error: 'Invalid JSON body'");
-    expect(result).toContain("message: 'Internal server error'");
+    expect(result).toContain("error: 'STEP_HANDLER_ERROR'");
   });
 });

--- a/packages/novu/src/commands/email/templates/worker-wrapper.ts
+++ b/packages/novu/src/commands/email/templates/worker-wrapper.ts
@@ -52,7 +52,10 @@ function generateFetchHandler(): string {
       ${generateRequestHandler()}
     } catch (error) {
       console.error('Error executing step handler:', error);
-      return jsonResponse({ error: 'Step execution failed', message: 'Internal server error' }, 500);
+      return jsonResponse({
+        error: 'STEP_HANDLER_ERROR',
+        message: error instanceof Error ? error.message : String(error),
+      }, 500);
     }
   },
 };`;


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR implements end-to-end error surfacing for custom step resolvers. It ensures that when a user's template code throws a runtime exception in a Cloudflare Worker, the actual error message is captured and rendered as a user-friendly HTML card directly within the dashboard's preview panel.

```mermaid
sequenceDiagram
    participant Dash as Dashboard
    participant API as Novu API (PreviewUsecase)
    participant Dispatch as Cloudflare Dispatcher
    participant Worker as User Worker (Wrapper)
    participant Handler as User Template Code

    Dash->>API: POST /v2/workflows/.../preview
    API->>Dispatch: POST /resolve/...
    Dispatch->>Worker: Forward Request
    Worker->>Handler: Execute step handler
    
    Note over Handler: Runtime Error!<br/>(e.g. TypeError)
    
    Handler-->>Worker: Throw Exception
    Worker-->>Dispatch: 500 { error: "STEP_HANDLER_ERROR", message: "..." }
    Dispatch-->>API: Forward 500 JSON
    
    Note over API: Detect STEP_HANDLER_ERROR<br/>Generate Error HTML
    
    API-->>Dash: 200 { preview: { body: "<html>...error card...</html>" } }
    
    Note over Dash: Render HTML in<br/>Shadow DOM
```

**Key highlights:**
- **Edge Capture:** Updated worker wrapper to return actual error messages with a `STEP_HANDLER_ERROR` sentinel.
- **Normalization:** Enhanced API logic to parse these errors and suppress infrastructure logging for user-code failures.
- **Contextual Rendering:** Added a dashboard-aligned HTML error renderer in the API to provide clear, actionable feedback (with CLI-specific instructions) exactly where the email content would normally appear.
- **Safety:** Scoped specifically to email steps using the step resolver to ensure zero impact on standard Novu Cloud workflows.