### PR TITLE
fix(dashboard): Translations page docs link fixes NV-7139

### DIFF
--- a/apps/api/src/app/shared/framework/swagger/swagger.controller.ts
+++ b/apps/api/src/app/shared/framework/swagger/swagger.controller.ts
@@ -77,7 +77,7 @@ function buildBaseOptions() {
       url: 'https://docs.novu.co/platform/workflow/layouts',
     })
     .addTag('Translations', `Used to localize your notifications to different languages.`, {
-      url: 'https://docs.novu.co/platform/workflow/translations',
+      url: 'https://docs.novu.co/platform/workflow/advanced-features/translations',
     });
 
   return options;

--- a/apps/dashboard/src/components/translations/translation-list-upgrade-cta.tsx
+++ b/apps/dashboard/src/components/translations/translation-list-upgrade-cta.tsx
@@ -47,7 +47,7 @@ export const TranslationListUpgradeCta = () => {
         >
           {IS_SELF_HOSTED ? 'Contact Sales' : 'Upgrade now'}
         </Button>
-        <Link to={'https://docs.novu.co/platform/workflow/translations'} target="_blank">
+        <Link to={'https://docs.novu.co/platform/workflow/advanced-features/translations'} target="_blank">
           <LinkButton size="sm" leadingIcon={RiBookMarkedLine}>
             How does this help?
           </LinkButton>

--- a/apps/dashboard/src/components/translations/translation-onboarding-page.tsx
+++ b/apps/dashboard/src/components/translations/translation-onboarding-page.tsx
@@ -130,7 +130,7 @@ export const TranslationOnboardingPage = () => {
                     description={
                       <>
                         Don't worry about getting this perfect — you can add more languages anytime.{' '}
-                        <Link to="https://docs.novu.co/platform/workflow/translations" className="underline">
+                        <Link to="https://docs.novu.co/platform/workflow/advanced-features/translations" className="underline">
                           Learn more.
                         </Link>
                       </>
@@ -201,7 +201,7 @@ export const TranslationOnboardingPage = () => {
               View workflows
             </Button>
 
-            <Link to="https://docs.novu.co/platform/workflow/translations" target="_blank">
+            <Link to="https://docs.novu.co/platform/workflow/advanced-features/translations" target="_blank">
               <LinkButton variant="gray" leadingIcon={RiBookMarkedLine} size="sm">
                 Learn more in docs
               </LinkButton>

--- a/packages/novu/src/commands/translations/pull.ts
+++ b/packages/novu/src/commands/translations/pull.ts
@@ -42,7 +42,7 @@ export async function pullTranslations(options: TranslationCommandOptions): Prom
     console.log('  2. Navigate to the Translations page');
     console.log('  3. Enable translations and configure your target locales');
     console.log('  4. Set your default locale');
-    console.log('\n📖 Learn more: https://docs.novu.co/platform/workflow/translations');
+    console.log('\n📖 Learn more: https://docs.novu.co/platform/workflow/advanced-features/translations');
 
     throw new Error('Translations not configured. Please enable translations in your dashboard first.');
   }

--- a/packages/novu/src/commands/translations/push.ts
+++ b/packages/novu/src/commands/translations/push.ts
@@ -42,7 +42,7 @@ export async function pushTranslations(options: TranslationCommandOptions): Prom
     console.log('  2. Navigate to the Translations page');
     console.log('  3. Enable translations and configure your target locales');
     console.log('  4. Set your default locale');
-    console.log('\n📖 Learn more: https://docs.novu.co/platform/workflow/translations');
+    console.log('\n📖 Learn more: https://docs.novu.co/platform/workflow/advanced-features/translations');
 
     throw new Error('Translations not configured. Please enable translations in your dashboard first.');
   }


### PR DESCRIPTION
### What changed? Why was the change needed?

Updated the dead documentation link `docs.novu.co/platform/workflow/translations` to the correct `docs.novu.co/platform/workflow/advanced-features/translations`.

This change was needed to fix a broken link on the Translations (beta) page and other related areas, as reported in Linear issue [NV-7139](https://linear.app/novu/issue/NV-7139/fix-dead-docs-link-on-translations-beta-page).

The link was updated in 6 occurrences across 5 files:
- `apps/dashboard/src/components/translations/translation-list-upgrade-cta.tsx`
- `apps/dashboard/src/components/translations/translation-onboarding-page.tsx`
- `apps/api/src/app/shared/framework/swagger/swagger.controller.ts`
- `packages/novu/src/commands/translations/pull.ts`
- `packages/novu/src/commands/translations/push.ts`

### Screenshots

N/A - This is a URL update, not a visual change.

---
Linear Issue: [NV-7139](https://linear.app/novu/issue/NV-7139/fix-dead-docs-link-on-translations-beta-page)

<p><a href="https://cursor.com/agents/bc-f01ee1e8-0b84-45cb-a469-02cdc6cec3f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f01ee1e8-0b84-45cb-a469-02cdc6cec3f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

