### PR TITLE
test(worker): Workflow skip logic e2e

### DIFF
--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -248,6 +248,67 @@ describe('Workflow Controller E2E API Testing #novu-v2', () => {
       expect(workflowCreated.validatePayload).to.be.false;
     });
 
+    it('should create workflow with skip condition on a step using payload variable', async () => {
+      const skipCondition = {
+        '!=': [{ var: 'payload.skipStep' }, 'true'],
+      };
+
+      const steps = [
+        buildEmailStep({
+          controlValues: {
+            subject: 'Test Email Subject',
+            body: 'Test Email Body',
+            disableOutputSanitization: false,
+            skip: skipCondition,
+          },
+        }),
+        buildInAppStep({
+          controlValues: {
+            body: 'In-App Body',
+          },
+        }),
+      ];
+
+      const payloadSchema = {
+        type: 'object',
+        properties: {
+          skipStep: { type: 'string' },
+        },
+        required: ['skipStep'],
+        additionalProperties: false,
+      };
+
+      const createWorkflowDto: CreateWorkflowDto = buildWorkflow({
+        name: `Skip Logic Workflow ${new Date().toISOString()}`,
+        steps: steps as any,
+        payloadSchema,
+      });
+
+      const workflow = await createWorkflow(apiClient, createWorkflowDto);
+
+      expect(workflow).to.be.ok;
+      expect(workflow.steps).to.have.lengthOf(2);
+      expect(Object.keys(workflow.issues || {}).length).to.equal(0);
+
+      const emailStep = workflow.steps[0] as EmailStepResponseDto;
+      expect(emailStep.type).to.equal('email');
+      expect(emailStep.controls.values.skip).to.deep.equal(skipCondition);
+      expect(emailStep.controls.values.subject).to.equal('Test Email Subject');
+
+      const inAppStep = workflow.steps[1] as InAppStepResponseDto;
+      expect(inAppStep.type).to.equal('in_app');
+      expect(inAppStep.controls.values.skip).to.be.undefined;
+
+      const retrievedWorkflow = await getWorkflow(workflow.id);
+      const retrievedEmailStep = retrievedWorkflow.steps[0] as EmailStepResponseDto;
+      expect(retrievedEmailStep.controls.values.skip).to.deep.equal(skipCondition);
+
+      const retrievedInAppStep = retrievedWorkflow.steps[1] as InAppStepResponseDto;
+      expect(retrievedInAppStep.controls.values.skip).to.be.undefined;
+
+      expect(retrievedWorkflow.payloadSchema).to.deep.equal(payloadSchema);
+    });
+
     it('should reject workflow creation with invalid JSON schema', async () => {
       const invalidPayloadSchema = {
         type: 'invalid-type',


### PR DESCRIPTION
### What changed? Why was the change needed?

Added a new E2E test for the v2 workflow API to validate the creation and retrieval of workflows with a payload schema and step-level skip conditions using JSONLogic. This ensures that complex workflow structures, including conditional step skipping, are correctly handled and persisted.

The test creates a workflow with a `skipStep: string` in its payload schema and two steps: an email step with a `skipStep != "true"` condition and an in-app step without a skip condition. It then verifies the workflow's successful creation and the proper storage of the skip logic.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1772131994999439?thread_ts=1772131994.999439&cid=D0919LNRWE7)

<p><a href="https://cursor.com/agents/bc-1a48ccf0-f5fe-57de-a40f-327a049d568e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a48ccf0-f5fe-57de-a40f-327a049d568e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

