### PR TITLE
Novu community images 3.14.0

### DIFF
--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       start_period: 20s
 
   api:
-    image: "ghcr.io/novuhq/novu/api:3.11.0"
+    image: "ghcr.io/novuhq/novu/api:3.14.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -112,7 +112,7 @@ services:
       start_period: 40s
 
   worker:
-    image: "ghcr.io/novuhq/novu/worker:3.11.0"
+    image: "ghcr.io/novuhq/novu/worker:3.14.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -164,7 +164,7 @@ services:
       start_period: 20s
 
   ws:
-    image: "ghcr.io/novuhq/novu/ws:3.11.0"
+    image: "ghcr.io/novuhq/novu/ws:3.14.0"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -204,7 +204,7 @@ services:
       start_period: 40s
 
   dashboard:
-    image: "ghcr.io/novuhq/novu/dashboard:3.11.0"
+    image: "ghcr.io/novuhq/novu/dashboard:3.14.0"
     depends_on:
       api:
         condition: service_healthy


### PR DESCRIPTION
### What changed? Why was the change needed?

Updated all Novu image versions in `docker/community/docker-compose.yml` from `3.11.0` to `3.14.0`. This change was needed to ensure the community Docker Compose setup uses the specified Novu version `3.14.0`.

### Screenshots

N/A

---
[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1772088749578739?thread_ts=1772088749.578739&cid=C06GS20SPE0)

<p><a href="https://cursor.com/agents/bc-d81365f3-bfdf-5a7c-a0d2-f2937d249aee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d81365f3-bfdf-5a7c-a0d2-f2937d249aee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

