### PR TITLE
Websocket contextKeys undefined

### DIFF
--- a/apps/api/src/app/auth/services/passport/subscriber-jwt.strategy.ts
+++ b/apps/api/src/app/auth/services/passport/subscriber-jwt.strategy.ts
@@ -33,7 +33,7 @@ export class JwtSubscriberStrategy extends PassportStrategy(Strategy, 'subscribe
       ...subscriber,
       organizationId: subscriber._organizationId,
       environmentId: subscriber._environmentId,
-      contextKeys: payload.contextKeys,
+      contextKeys: payload.contextKeys ?? [],
       scheme: ApiAuthSchemeEnum.BEARER,
     };
   }

--- a/apps/api/src/app/shared/framework/user.decorator.ts
+++ b/apps/api/src/app/shared/framework/user.decorator.ts
@@ -9,7 +9,7 @@ export { UserSession };
 export interface SubscriberSession extends SubscriberEntity {
   organizationId: string;
   environmentId: string;
-  contextKeys: string[];
+  contextKeys?: string[];
   scheme: ApiAuthSchemeEnum;
 }
 

--- a/apps/ws/src/socket/services/web-socket.worker.ts
+++ b/apps/ws/src/socket/services/web-socket.worker.ts
@@ -58,7 +58,7 @@ export class WebSocketWorker extends WebSocketsWorkerService {
                 event: data.event,
                 payload: data.payload,
                 _environmentId: data._environmentId,
-                contextKeys: data.contextKeys,
+                contextKeys: data.contextKeys ?? [],
               })
             )
             .then(() => resolve())

--- a/apps/ws/src/socket/ws.gateway.ts
+++ b/apps/ws/src/socket/ws.gateway.ts
@@ -152,13 +152,13 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect, IDes
       LOG_CONTEXT
     );
 
-    // Store contexts in socket metadata for filtering
-    connection.data.contextKeys = subscriber.contextKeys;
+    const contextKeys = subscriber.contextKeys ?? [];
 
-    // Join single user room (no per-context rooms needed)
+    connection.data.contextKeys = contextKeys;
+
     await connection.join(subscriber._id);
 
-    const contextDisplay = subscriber.contextKeys.length === 0 ? 'no context' : subscriber.contextKeys.join(', ');
+    const contextDisplay = contextKeys.length === 0 ? 'no context' : contextKeys.join(', ');
     Logger.debug(
       `Connection ${connection.id} accepted for ${subscriber._id} with contexts: ${contextDisplay}`,
       LOG_CONTEXT
@@ -174,17 +174,18 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect, IDes
       return;
     }
 
+    const safeContextKeys = contextKeys ?? [];
     const sockets = await this.server.in(userId).fetchSockets();
 
     Logger.log(
-      `Sending event ${event} to ${userId} with message contexts: ${contextKeys.length === 0 ? 'none' : contextKeys.join(', ')} (${sockets.length} socket(s))`,
+      `Sending event ${event} to ${userId} with message contexts: ${safeContextKeys.length === 0 ? 'none' : safeContextKeys.join(', ')} (${sockets.length} socket(s))`,
       LOG_CONTEXT
     );
 
     for (const socket of sockets) {
-      const inboxContextKeys = socket.data.contextKeys;
+      const inboxContextKeys = socket.data.contextKeys ?? [];
 
-      if (this.isExactMatch(contextKeys, inboxContextKeys)) {
+      if (this.isExactMatch(safeContextKeys, inboxContextKeys)) {
         socket.emit(event, data);
         Logger.debug(
           `Delivered to socket ${socket.id} with inbox contexts: ${inboxContextKeys.length === 0 ? 'none' : inboxContextKeys.join(', ')}`,
@@ -192,7 +193,7 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect, IDes
         );
       } else {
         Logger.log(
-          `Skipped socket ${socket.id} - contexts mismatch. Message: [${contextKeys.join(', ') || 'none'}], Inbox: [${inboxContextKeys.join(', ') || 'none'}]`,
+          `Skipped socket ${socket.id} - contexts mismatch. Message: [${safeContextKeys.join(', ') || 'none'}], Inbox: [${inboxContextKeys.join(', ') || 'none'}]`,
           LOG_CONTEXT
         );
       }
@@ -224,7 +225,7 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect, IDes
     Logger.log(`Sending individualized unread counts to ${sockets.length} socket(s) for user ${userId}`, LOG_CONTEXT);
 
     for (const socket of sockets) {
-      const contextKeys = socket.data.contextKeys;
+      const contextKeys = socket.data.contextKeys ?? [];
 
       try {
         const [unreadCount, severityCounts] = await Promise.all([
@@ -297,7 +298,7 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect, IDes
     Logger.log(`Sending individualized unseen counts to ${sockets.length} socket(s) for user ${userId}`, LOG_CONTEXT);
 
     for (const socket of sockets) {
-      const contextKeys = socket.data.contextKeys;
+      const contextKeys = socket.data.contextKeys ?? [];
 
       try {
         const unseenCount = await messageRepository.getCount(

--- a/packages/shared/src/dto/session/session.dto.ts
+++ b/packages/shared/src/dto/session/session.dto.ts
@@ -6,7 +6,7 @@ export interface ISubscriberJwtDto {
   subscriberId: string;
   organizationId: string;
   environmentId: string;
-  contextKeys: string[];
+  contextKeys?: string[];
   aud: 'widget_user';
 }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves a critical bug (NV-7172) where the `ws` service crashed when `subscriber.contextKeys` was `undefined` during connection processing. This could happen with older client JWTs or when the `ContextCompatibilityInterceptor` explicitly unset `contextKeys`.

The changes ensure `contextKeys` is safely handled by:
*   Adding nullish coalescing (`?? []`) to all access points of `subscriber.contextKeys` and `socket.data.contextKeys` in `apps/ws/src/socket/ws.gateway.ts` and `apps/ws/src/socket/services/web-socket.worker.ts`.
*   Marking `contextKeys` as optional in `ISubscriberJwtDto` (`packages/shared/src/dto/session/session.dto.ts`) and `SubscriberSession` (`apps/api/src/app/shared/framework/user.decorator.ts`).
*   Defaulting `payload.contextKeys` to `[]` in `apps/api/src/app/auth/services/passport/subscriber-jwt.strategy.ts`.

This prevents `ws` service crashes and improves robustness for websocket connections.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

---
Linear Issue: [NV-7172](https://linear.app/novu/issue/NV-7172/bug-report-ws3140-crashes-on-connection-in)

<p><a href="https://cursor.com/agents/bc-bcb16181-c76e-442d-a3e3-812d12989202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcb16181-c76e-442d-a3e3-812d12989202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

