### PR TITLE
fix(ws): contextKeys undefined fixes NV-7172

### DIFF
--- a/apps/ws/src/socket/services/web-socket.worker.ts
+++ b/apps/ws/src/socket/services/web-socket.worker.ts
@@ -58,7 +58,7 @@ export class WebSocketWorker extends WebSocketsWorkerService {
                 event: data.event,
                 payload: data.payload,
                 _environmentId: data._environmentId,
-                contextKeys: data.contextKeys,
+                contextKeys: data.contextKeys ?? [],
               })
             )
             .then(() => resolve())

--- a/apps/ws/src/socket/usecases/external-services-route/external-services-route.command.ts
+++ b/apps/ws/src/socket/usecases/external-services-route/external-services-route.command.ts
@@ -26,7 +26,8 @@ export class ExternalServicesRouteCommand extends BaseCommand {
   @IsString()
   _environmentId: string;
 
+  @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  contextKeys: string[];
+  contextKeys: string[] = [];
 }

--- a/apps/ws/src/socket/ws.gateway.ts
+++ b/apps/ws/src/socket/ws.gateway.ts
@@ -152,13 +152,13 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect, IDes
       LOG_CONTEXT
     );
 
-    // Store contexts in socket metadata for filtering
-    connection.data.contextKeys = subscriber.contextKeys;
+    const contextKeys = subscriber.contextKeys ?? [];
 
-    // Join single user room (no per-context rooms needed)
+    connection.data.contextKeys = contextKeys;
+
     await connection.join(subscriber._id);
 
-    const contextDisplay = subscriber.contextKeys.length === 0 ? 'no context' : subscriber.contextKeys.join(', ');
+    const contextDisplay = contextKeys.length === 0 ? 'no context' : contextKeys.join(', ');
     Logger.debug(
       `Connection ${connection.id} accepted for ${subscriber._id} with contexts: ${contextDisplay}`,
       LOG_CONTEXT
@@ -174,17 +174,18 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect, IDes
       return;
     }
 
+    const safeContextKeys = contextKeys ?? [];
     const sockets = await this.server.in(userId).fetchSockets();
 
     Logger.log(
-      `Sending event ${event} to ${userId} with message contexts: ${contextKeys.length === 0 ? 'none' : contextKeys.join(', ')} (${sockets.length} socket(s))`,
+      `Sending event ${event} to ${userId} with message contexts: ${safeContextKeys.length === 0 ? 'none' : safeContextKeys.join(', ')} (${sockets.length} socket(s))`,
       LOG_CONTEXT
     );
 
     for (const socket of sockets) {
-      const inboxContextKeys = socket.data.contextKeys;
+      const inboxContextKeys = socket.data.contextKeys ?? [];
 
-      if (this.isExactMatch(contextKeys, inboxContextKeys)) {
+      if (this.isExactMatch(safeContextKeys, inboxContextKeys)) {
         socket.emit(event, data);
         Logger.debug(
           `Delivered to socket ${socket.id} with inbox contexts: ${inboxContextKeys.length === 0 ? 'none' : inboxContextKeys.join(', ')}`,
@@ -192,7 +193,7 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect, IDes
         );
       } else {
         Logger.log(
-          `Skipped socket ${socket.id} - contexts mismatch. Message: [${contextKeys.join(', ') || 'none'}], Inbox: [${inboxContextKeys.join(', ') || 'none'}]`,
+          `Skipped socket ${socket.id} - contexts mismatch. Message: [${safeContextKeys.join(', ') || 'none'}], Inbox: [${inboxContextKeys.join(', ') || 'none'}]`,
           LOG_CONTEXT
         );
       }
@@ -224,7 +225,7 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect, IDes
     Logger.log(`Sending individualized unread counts to ${sockets.length} socket(s) for user ${userId}`, LOG_CONTEXT);
 
     for (const socket of sockets) {
-      const contextKeys = socket.data.contextKeys;
+      const contextKeys = socket.data.contextKeys ?? [];
 
       try {
         const [unreadCount, severityCounts] = await Promise.all([
@@ -297,7 +298,7 @@ export class WSGateway implements OnGatewayConnection, OnGatewayDisconnect, IDes
     Logger.log(`Sending individualized unseen counts to ${sockets.length} socket(s) for user ${userId}`, LOG_CONTEXT);
 
     for (const socket of sockets) {
-      const contextKeys = socket.data.contextKeys;
+      const contextKeys = socket.data.contextKeys ?? [];
 
       try {
         const unseenCount = await messageRepository.getCount(


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR resolves NV-7172, addressing a bug where the `ws` service would crash on connection attempts when `subscriber.contextKeys` was `undefined`. This typically occurred with tokens from older API versions or when `contextKeys` was stripped by an interceptor.

The changes guard against `undefined` `contextKeys` by defaulting to an empty array (`[]`) in all relevant locations within the `ws` service:

*   **`apps/ws/src/socket/ws.gateway.ts`**: Added `?? []` fallbacks where `contextKeys` is read (e.g., `processConnectionRequest`, `sendMessage`, `sendUnreadCountToAllConnections`, `sendUnseenCountToAllConnections`).
*   **`apps/ws/src/socket/services/web-socket.worker.ts`**: Defaults `data.contextKeys` to `[]` when constructing `ExternalServicesRouteCommand` to handle stale queued jobs.
*   **`apps/ws/src/socket/usecases/external-services-route/external-services-route.command.ts`**: Made `contextKeys` optional with `@IsOptional()` and a default of `[]` to prevent validation failures for commands missing the field.

These changes ensure the `ws` service robustly handles connections without crashing due to missing `contextKeys`.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

All changes are scoped exclusively to the `apps/ws` service. Existing tests for the `ws` service pass with these changes.
</details>

---
Linear Issue: [NV-7172](https://linear.app/novu/issue/NV-7172/bug-report-ws3140-crashes-on-connection-in)

<p><a href="https://cursor.com/agents/bc-a345d613-d633-40b7-bf3f-111046394b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a345d613-d633-40b7-bf3f-111046394b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

