### PR TITLE
fix(worker): Xss sanitization improvement

### DIFF
--- a/libs/application-generic/src/services/sanitize/sanitizer.service.spec.ts
+++ b/libs/application-generic/src/services/sanitize/sanitizer.service.spec.ts
@@ -69,6 +69,27 @@ describe('HTML Sanitizer - XSS Prevention', () => {
       expect(sanitized).to.include('id="main"');
     });
 
+    it('should strip oncontentvisibilityautostatechange attribute', () => {
+      const maliciousHtml =
+        '<a oncontentvisibilityautostatechange="alert(window.origin)" style="display:block;content-visibility:auto">click</a>';
+      const sanitized = sanitizeHTML(maliciousHtml);
+
+      expect(sanitized).to.not.include('oncontentvisibilityautostatechange');
+      expect(sanitized).to.not.include('alert');
+      expect(sanitized).to.include('<a');
+      expect(sanitized).to.include('style="display:block;content-visibility:auto"');
+    });
+
+    it('should strip any attribute starting with "on" as event handlers', () => {
+      const maliciousHtml = '<div onfutureevent="alert(1)" data-value="safe">Content</div>';
+      const sanitized = sanitizeHTML(maliciousHtml);
+
+      expect(sanitized).to.not.include('onfutureevent');
+      expect(sanitized).to.not.include('alert');
+      expect(sanitized).to.include('data-value="safe"');
+      expect(sanitized).to.include('Content');
+    });
+
     it('should remove script tags', () => {
       const maliciousHtml = '<div>Safe content</div><script>alert("XSS")</script>';
       const sanitized = sanitizeHTML(maliciousHtml);

--- a/libs/application-generic/src/services/sanitize/sanitizer.service.ts
+++ b/libs/application-generic/src/services/sanitize/sanitizer.service.ts
@@ -27,73 +27,9 @@ const SAFE_IMG_ATTRIBUTES = [
   'lang',
 ];
 
-const DANGEROUS_ATTRIBUTES = [
-  'onerror',
-  'onload',
-  'onclick',
-  'onmouseover',
-  'onmouseout',
-  'onmouseenter',
-  'onmouseleave',
-  'onfocus',
-  'onblur',
-  'onsubmit',
-  'onreset',
-  'onchange',
-  'oninput',
-  'onkeydown',
-  'onkeyup',
-  'onkeypress',
-  'ondblclick',
-  'oncontextmenu',
-  'ondrag',
-  'ondragend',
-  'ondragenter',
-  'ondragleave',
-  'ondragover',
-  'ondragstart',
-  'ondrop',
-  'onscroll',
-  'onwheel',
-  'oncopy',
-  'oncut',
-  'onpaste',
-  'onabort',
-  'oncanplay',
-  'oncanplaythrough',
-  'ondurationchange',
-  'onemptied',
-  'onended',
-  'onloadeddata',
-  'onloadedmetadata',
-  'onloadstart',
-  'onpause',
-  'onplay',
-  'onplaying',
-  'onprogress',
-  'onratechange',
-  'onseeked',
-  'onseeking',
-  'onstalled',
-  'onsuspend',
-  'ontimeupdate',
-  'onvolumechange',
-  'onwaiting',
-  'onanimationstart',
-  'onanimationend',
-  'onanimationiteration',
-  'ontransitionend',
-  'onpointerdown',
-  'onpointerup',
-  'onpointermove',
-  'onpointerenter',
-  'onpointerleave',
-  'onpointercancel',
-  'ontouchstart',
-  'ontouchend',
-  'ontouchmove',
-  'ontouchcancel',
-];
+function isEventHandlerAttribute(name: string): boolean {
+  return name.toLowerCase().startsWith('on');
+}
 
 const sanitizeOptions: IOptions = {
   /**
@@ -119,7 +55,7 @@ const sanitizeOptions: IOptions = {
       const safeAttribs: Record<string, string> = {};
 
       for (const [key, value] of Object.entries(attribs)) {
-        if (!DANGEROUS_ATTRIBUTES.includes(key.toLowerCase())) {
+        if (!isEventHandlerAttribute(key)) {
           safeAttribs[key] = value;
         }
       }

--- a/packages/framework/src/utils/sanitize.utils.test.ts
+++ b/packages/framework/src/utils/sanitize.utils.test.ts
@@ -136,6 +136,42 @@ describe('sanitize util', () => {
     });
   });
 
+  it('should strip oncontentvisibilityautostatechange attribute', () => {
+    const myTestObject = {
+      input:
+        '<a oncontentvisibilityautostatechange="alert(window.origin)" style="display:block;content-visibility:auto">click</a>',
+    };
+    const result = sanitizeHtmlInObject(myTestObject);
+
+    expect(result.input).not.toContain('oncontentvisibilityautostatechange');
+    expect(result.input).not.toContain('alert');
+    expect(result.input).toContain('<a');
+    expect(result.input).toContain('style="display:block;content-visibility:auto"');
+  });
+
+  it('should strip any attribute starting with "on" as event handlers', () => {
+    const myTestObject = {
+      input: '<div onfutureevent="alert(1)" data-value="safe">Content</div>',
+    };
+    const result = sanitizeHtmlInObject(myTestObject);
+
+    expect(result.input).not.toContain('onfutureevent');
+    expect(result.input).not.toContain('alert');
+    expect(result.input).toContain('data-value="safe"');
+    expect(result.input).toContain('Content');
+  });
+
+  it('should strip onclick from non-img tags', () => {
+    const myTestObject = {
+      input: '<a href="https://example.com" onclick="alert(1)">Link</a>',
+    };
+    const result = sanitizeHtmlInObject(myTestObject);
+
+    expect(result.input).not.toContain('onclick');
+    expect(result.input).toContain('href="https://example.com"');
+    expect(result.input).toContain('Link');
+  });
+
   const removeTagTestCases: TestCase[] = [
     {
       tag: 'script',

--- a/packages/framework/src/utils/sanitize.utils.ts
+++ b/packages/framework/src/utils/sanitize.utils.ts
@@ -10,6 +10,10 @@ import sanitizeTypes, { IOptions } from 'sanitize-html';
  */
 const SAFE_IMG_ATTRIBUTES = ['src', 'alt', 'width', 'height', 'loading', 'srcset', 'sizes', 'crossorigin', 'usemap', 'ismap', 'class', 'id', 'style', 'title', 'dir', 'lang'];
 
+function isEventHandlerAttribute(name: string): boolean {
+  return name.toLowerCase().startsWith('on');
+}
+
 const sanitizeOptions: IOptions = {
   /**
    * Additional tags to allow.
@@ -30,6 +34,20 @@ const sanitizeOptions: IOptions = {
    * while keeping all other attributes permissive for other tags.
    */
   transformTags: {
+    '*': (tagName, attribs) => {
+      const safeAttribs: Record<string, string> = {};
+
+      for (const [key, value] of Object.entries(attribs)) {
+        if (!isEventHandlerAttribute(key)) {
+          safeAttribs[key] = value;
+        }
+      }
+
+      return {
+        tagName,
+        attribs: safeAttribs,
+      };
+    },
     img: (tagName, attribs) => {
       const safeAttribs: Record<string, string> = {};
 


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR fixes an XSS vulnerability in the HTML sanitization process used for email previews and other content.

Previously, both sanitizers relied on an incomplete denylist (`DANGEROUS_ATTRIBUTES`) to block event handler attributes. This list missed newer attributes like `oncontentvisibilityautostatechange`, allowing arbitrary JavaScript execution.

The fix replaces the denylist with a pattern-based check (`isEventHandlerAttribute()`) that strips **any** attribute whose name starts with `on` (case-insensitive). This approach is future-proof as all JavaScript event handler attributes follow the `on*` naming convention.

**Files changed:**
- `libs/application-generic/src/services/sanitize/sanitizer.service.ts`
- `packages/framework/src/utils/sanitize.utils.ts`
- Their respective test files.

**PoC (before fix):**
`<a oncontentvisibilityautostatechange="alert(window.origin)" style="display:block;content-visibility:auto">`

### Screenshots

N/A (Security fix, no visual changes)

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1772131994999439?thread_ts=1772131994.999439&cid=D0919LNRWE7)

<p><a href="https://cursor.com/agents/bc-a9b958b0-8d62-5daf-bac3-91c12020d659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9b958b0-8d62-5daf-bac3-91c12020d659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

