### PR TITLE
feat(dashboard, api-service, worker): Payload tags containsAny condition fixes NV-7178

### DIFF
--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -3789,6 +3789,212 @@ describe('Trigger event - /v1/events/trigger (POST) #novu-v2', () => {
       expect(executionDetails?.raw).to.contain('Failed to evaluate rule');
       expect(executionDetails?.raw).to.contain('Unrecognized operation invalidOp');
     });
+
+    it('should skip step when containsAny condition does not match with literal values', async () => {
+      const workflowBody: CreateWorkflowDto = {
+        name: 'Test ContainsAny Literal',
+        workflowId: 'test-contains-any-literal',
+        __source: WorkflowCreationSourceEnum.DASHBOARD,
+        steps: [
+          {
+            type: StepTypeEnum.IN_APP,
+            name: 'Message Name',
+            controlValues: {
+              body: 'Hello!',
+              skip: {
+                containsAny: [{ var: 'payload.tags' }, ['urgent', 'important']],
+              },
+            },
+          },
+        ],
+      };
+
+      const response = await session.testAgent.post('/v2/workflows').send(workflowBody);
+      expect(response.status).to.equal(201);
+      const workflow: WorkflowResponseDto = response.body.data;
+
+      await novuClient.trigger({
+        workflowId: workflow.workflowId,
+        to: [subscriber.subscriberId],
+        payload: { tags: ['info', 'low'] },
+      });
+      await session.waitForJobCompletion(workflow._id);
+
+      const skippedMessages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _subscriberId: subscriber._id,
+      });
+      expect(skippedMessages.length).to.equal(0);
+
+      await novuClient.trigger({
+        workflowId: workflow.workflowId,
+        to: [subscriber.subscriberId],
+        payload: { tags: ['urgent', 'info'] },
+      });
+      await session.waitForJobCompletion(workflow._id);
+
+      const executedMessages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _subscriberId: subscriber._id,
+      });
+      expect(executedMessages.length).to.equal(1);
+    });
+
+    it('should execute step when containsAny matches with var reference to another payload array', async () => {
+      const workflowBody: CreateWorkflowDto = {
+        name: 'Test ContainsAny Var Ref',
+        workflowId: 'test-contains-any-var-ref',
+        __source: WorkflowCreationSourceEnum.DASHBOARD,
+        steps: [
+          {
+            type: StepTypeEnum.IN_APP,
+            name: 'Message Name',
+            controlValues: {
+              body: 'Hello!',
+              skip: {
+                containsAny: [{ var: 'payload.items' }, { var: 'payload.tags' }],
+              },
+            },
+          },
+        ],
+      };
+
+      const response = await session.testAgent.post('/v2/workflows').send(workflowBody);
+      expect(response.status).to.equal(201);
+      const workflow: WorkflowResponseDto = response.body.data;
+
+      await novuClient.trigger({
+        workflowId: workflow.workflowId,
+        to: [subscriber.subscriberId],
+        payload: { items: ['a', 'b'], tags: ['x', 'y'] },
+      });
+      await session.waitForJobCompletion(workflow._id);
+
+      const skippedMessages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _subscriberId: subscriber._id,
+      });
+      expect(skippedMessages.length).to.equal(0);
+
+      await novuClient.trigger({
+        workflowId: workflow.workflowId,
+        to: [subscriber.subscriberId],
+        payload: { items: ['dima'], tags: ['dima'] },
+      });
+      await session.waitForJobCompletion(workflow._id);
+
+      const executedMessages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _subscriberId: subscriber._id,
+      });
+      expect(executedMessages.length).to.equal(1);
+    });
+
+    it('should skip step when doesNotContainAny condition does not match', async () => {
+      const workflowBody: CreateWorkflowDto = {
+        name: 'Test DoesNotContainAny',
+        workflowId: 'test-does-not-contain-any',
+        __source: WorkflowCreationSourceEnum.DASHBOARD,
+        steps: [
+          {
+            type: StepTypeEnum.IN_APP,
+            name: 'Message Name',
+            controlValues: {
+              body: 'Hello!',
+              skip: {
+                doesNotContainAny: [{ var: 'payload.tags' }, ['blocked', 'spam']],
+              },
+            },
+          },
+        ],
+      };
+
+      const response = await session.testAgent.post('/v2/workflows').send(workflowBody);
+      expect(response.status).to.equal(201);
+      const workflow: WorkflowResponseDto = response.body.data;
+
+      await novuClient.trigger({
+        workflowId: workflow.workflowId,
+        to: [subscriber.subscriberId],
+        payload: { tags: ['info', 'blocked'] },
+      });
+      await session.waitForJobCompletion(workflow._id);
+
+      const skippedMessages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _subscriberId: subscriber._id,
+      });
+      expect(skippedMessages.length).to.equal(0);
+
+      await novuClient.trigger({
+        workflowId: workflow.workflowId,
+        to: [subscriber.subscriberId],
+        payload: { tags: ['info', 'update'] },
+      });
+      await session.waitForJobCompletion(workflow._id);
+
+      const executedMessages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _subscriberId: subscriber._id,
+      });
+      expect(executedMessages.length).to.equal(1);
+    });
+
+    it('should execute step when containsAny with var reference to subscriber data', async () => {
+      subscriber = await subscriberService.createSubscriber({
+        firstName: 'John',
+        lastName: 'Doe',
+        data: { tags: ['vip', 'premium'] },
+      });
+
+      const workflowBody: CreateWorkflowDto = {
+        name: 'Test ContainsAny Subscriber Data',
+        workflowId: 'test-contains-any-subscriber-data',
+        __source: WorkflowCreationSourceEnum.DASHBOARD,
+        steps: [
+          {
+            type: StepTypeEnum.IN_APP,
+            name: 'Message Name',
+            controlValues: {
+              body: 'Hello!',
+              skip: {
+                containsAny: [{ var: 'payload.tags' }, { var: 'subscriber.data.tags' }],
+              },
+            },
+          },
+        ],
+      };
+
+      const response = await session.testAgent.post('/v2/workflows').send(workflowBody);
+      expect(response.status).to.equal(201);
+      const workflow: WorkflowResponseDto = response.body.data;
+
+      await novuClient.trigger({
+        workflowId: workflow.workflowId,
+        to: [subscriber.subscriberId],
+        payload: { tags: ['basic', 'free'] },
+      });
+      await session.waitForJobCompletion(workflow._id);
+
+      const skippedMessages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _subscriberId: subscriber._id,
+      });
+      expect(skippedMessages.length).to.equal(0);
+
+      await novuClient.trigger({
+        workflowId: workflow.workflowId,
+        to: [subscriber.subscriberId],
+        payload: { tags: ['vip', 'other'] },
+      });
+      await session.waitForJobCompletion(workflow._id);
+
+      const executedMessages = await messageRepository.find({
+        _environmentId: session.environment._id,
+        _subscriberId: subscriber._id,
+      });
+      expect(executedMessages.length).to.equal(1);
+    });
   });
 
   describe('Subscriber Schedule Logic', () => {

--- a/apps/api/src/app/shared/services/query-parser/query-parser.service.spec.ts
+++ b/apps/api/src/app/shared/services/query-parser/query-parser.service.spec.ts
@@ -265,6 +265,106 @@ describe('QueryParserService', () => {
       });
     });
 
+    describe('containsAny operator', () => {
+      it('should return true when array contains at least one of the given values', () => {
+        const rule: RulesLogic<AdditionalOperation> = { containsAny: [{ var: 'tags' }, ['a', 'b', 'c']] };
+        const data = { tags: ['a', 'x', 'y'] };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.true;
+      });
+
+      it('should return true when array contains all of the given values', () => {
+        const rule: RulesLogic<AdditionalOperation> = { containsAny: [{ var: 'tags' }, ['a', 'b']] };
+        const data = { tags: ['a', 'b', 'c'] };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.true;
+      });
+
+      it('should return false when array contains none of the given values', () => {
+        const rule: RulesLogic<AdditionalOperation> = { containsAny: [{ var: 'tags' }, ['x', 'y', 'z']] };
+        const data = { tags: ['a', 'b', 'c'] };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.false;
+      });
+
+      it('should return false when data input is not an array', () => {
+        const rule: RulesLogic<AdditionalOperation> = { containsAny: [{ var: 'tags' }, ['a', 'b']] };
+        const data = { tags: 'not an array' };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.false;
+      });
+
+      it('should return false when rule value is not an array', () => {
+        const rule: RulesLogic<AdditionalOperation> = { containsAny: [{ var: 'tags' }, 'not an array'] };
+        const data = { tags: ['a', 'b'] };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.false;
+      });
+
+      it('should return false when data array is empty', () => {
+        const rule: RulesLogic<AdditionalOperation> = { containsAny: [{ var: 'tags' }, ['a', 'b']] };
+        const data = { tags: [] };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.false;
+      });
+
+      it('should return false when rule array is empty', () => {
+        const rule: RulesLogic<AdditionalOperation> = { containsAny: [{ var: 'tags' }, []] };
+        const data = { tags: ['a', 'b'] };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('doesNotContainAny operator', () => {
+      it('should return true when array contains none of the given values', () => {
+        const rule: RulesLogic<AdditionalOperation> = { doesNotContainAny: [{ var: 'tags' }, ['x', 'y', 'z']] };
+        const data = { tags: ['a', 'b', 'c'] };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.true;
+      });
+
+      it('should return false when array contains at least one of the given values', () => {
+        const rule: RulesLogic<AdditionalOperation> = { doesNotContainAny: [{ var: 'tags' }, ['a', 'x']] };
+        const data = { tags: ['a', 'b', 'c'] };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.false;
+      });
+
+      it('should return false when data input is not an array', () => {
+        const rule: RulesLogic<AdditionalOperation> = { doesNotContainAny: [{ var: 'tags' }, ['a']] };
+        const data = { tags: 'not an array' };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.false;
+      });
+
+      it('should return false when rule value is not an array', () => {
+        const rule: RulesLogic<AdditionalOperation> = { doesNotContainAny: [{ var: 'tags' }, 'not an array'] };
+        const data = { tags: ['a', 'b'] };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.false;
+      });
+
+      it('should return true when data array is empty', () => {
+        const rule: RulesLogic<AdditionalOperation> = { doesNotContainAny: [{ var: 'tags' }, ['a']] };
+        const data = { tags: [] };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.true;
+      });
+    });
+
     describe('between operator', () => {
       it('should return true when number is between min and max', () => {
         const rule: RulesLogic<AdditionalOperation> = { between: [{ var: 'value' }, [5, 10]] };

--- a/apps/api/src/app/shared/services/query-parser/query-parser.service.spec.ts
+++ b/apps/api/src/app/shared/services/query-parser/query-parser.service.spec.ts
@@ -321,6 +321,26 @@ describe('QueryParserService', () => {
         expect(error).to.be.undefined;
         expect(result).to.be.false;
       });
+
+      it('should resolve var references and compare two array variables', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          containsAny: [{ var: 'payload.items' }, { var: 'payload.tags' }],
+        };
+        const data = { payload: { items: ['dima'], tags: ['dima'] } };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.true;
+      });
+
+      it('should return false when var-referenced arrays have no overlap', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          containsAny: [{ var: 'payload.items' }, { var: 'subscriber.data.tags' }],
+        };
+        const data = { payload: { items: ['a', 'b'] }, subscriber: { data: { tags: ['x', 'y'] } } };
+        const { result, error } = evaluateRules(rule, data);
+        expect(error).to.be.undefined;
+        expect(result).to.be.false;
+      });
     });
 
     describe('doesNotContainAny operator', () => {

--- a/apps/api/src/app/shared/services/query-parser/query-parser.service.ts
+++ b/apps/api/src/app/shared/services/query-parser/query-parser.service.ts
@@ -217,6 +217,18 @@ const initializeCustomOperators = (): void => {
     createStringOperator((input, value) => !input.endsWith(value))
   );
 
+  jsonLogic.add_operation('containsAny', (dataInput: unknown, ruleValue: unknown): boolean => {
+    if (!Array.isArray(dataInput) || !Array.isArray(ruleValue)) return false;
+
+    return dataInput.some((item) => ruleValue.includes(item));
+  });
+
+  jsonLogic.add_operation('doesNotContainAny', (dataInput: unknown, ruleValue: unknown): boolean => {
+    if (!Array.isArray(dataInput) || !Array.isArray(ruleValue)) return false;
+
+    return !dataInput.some((item) => ruleValue.includes(item));
+  });
+
   jsonLogic.add_operation('null', (dataInput: unknown): boolean => dataInput === null);
 
   jsonLogic.add_operation('notNull', (dataInput: unknown): boolean => dataInput !== null);

--- a/apps/api/src/app/shared/services/query-parser/query-validator.service.spec.ts
+++ b/apps/api/src/app/shared/services/query-parser/query-validator.service.spec.ts
@@ -171,6 +171,102 @@ describe('QueryValidatorService', () => {
       });
     });
 
+    describe('containsAny operation', () => {
+      it('should validate valid containsAny operation', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          containsAny: [{ var: 'payload.foo' }, ['value1', 'value2']],
+        };
+
+        const issues = queryValidatorService.validateQueryRules(rule);
+
+        expect(issues).to.be.empty;
+      });
+
+      it('should detect invalid containsAny structure', () => {
+        const rule: any = {
+          containsAny: [],
+        };
+
+        const issues = queryValidatorService.validateQueryRules(rule);
+
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].message).to.include('Invalid operation structure');
+        expect(issues[0].type).to.equal(QueryIssueTypeEnum.INVALID_STRUCTURE);
+      });
+
+      it('should detect invalid field reference in containsAny operation', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          containsAny: [{}, ['value1', 'value2']],
+        };
+
+        const issues = queryValidatorService.validateQueryRules(rule);
+
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].message).to.include('Invalid field reference in comparison');
+        expect(issues[0].type).to.equal(QueryIssueTypeEnum.INVALID_STRUCTURE);
+      });
+
+      it('should detect empty array in containsAny operation', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          containsAny: [{ var: 'payload.foo' }, []],
+        };
+
+        const issues = queryValidatorService.validateQueryRules(rule);
+
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].message).to.include('Value is required');
+        expect(issues[0].type).to.equal(QueryIssueTypeEnum.MISSING_VALUE);
+      });
+
+      it('should detect null value in containsAny operation', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          containsAny: [{ var: 'payload.foo' }, null],
+        };
+
+        const issues = queryValidatorService.validateQueryRules(rule);
+
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].message).to.include('Value is required');
+        expect(issues[0].type).to.equal(QueryIssueTypeEnum.MISSING_VALUE);
+      });
+    });
+
+    describe('doesNotContainAny operation', () => {
+      it('should validate valid doesNotContainAny operation', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          doesNotContainAny: [{ var: 'payload.foo' }, ['value1', 'value2']],
+        };
+
+        const issues = queryValidatorService.validateQueryRules(rule);
+
+        expect(issues).to.be.empty;
+      });
+
+      it('should detect invalid field reference in doesNotContainAny operation', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          doesNotContainAny: [{}, ['value1']],
+        };
+
+        const issues = queryValidatorService.validateQueryRules(rule);
+
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].message).to.include('Invalid field reference in comparison');
+        expect(issues[0].type).to.equal(QueryIssueTypeEnum.INVALID_STRUCTURE);
+      });
+
+      it('should detect empty array in doesNotContainAny operation', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          doesNotContainAny: [{ var: 'payload.foo' }, []],
+        };
+
+        const issues = queryValidatorService.validateQueryRules(rule);
+
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].message).to.include('Value is required');
+        expect(issues[0].type).to.equal(QueryIssueTypeEnum.MISSING_VALUE);
+      });
+    });
+
     describe('between operation', () => {
       it('should validate valid between operation', () => {
         const rule: RulesLogic<AdditionalOperation> = {

--- a/apps/api/src/app/shared/services/query-parser/query-validator.service.spec.ts
+++ b/apps/api/src/app/shared/services/query-parser/query-validator.service.spec.ts
@@ -229,6 +229,28 @@ describe('QueryValidatorService', () => {
         expect(issues[0].message).to.include('Value is required');
         expect(issues[0].type).to.equal(QueryIssueTypeEnum.MISSING_VALUE);
       });
+
+      it('should validate containsAny with a var reference as second operand', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          containsAny: [{ var: 'payload.foo' }, { var: 'subscriber.data.tags' }],
+        };
+
+        const issues = queryValidatorService.validateQueryRules(rule);
+
+        expect(issues).to.be.empty;
+      });
+
+      it('should detect invalid var reference in containsAny second operand', () => {
+        const rule: RulesLogic<AdditionalOperation> = {
+          containsAny: [{ var: 'payload.foo' }, { var: 'invalid.field' }],
+        };
+
+        const issues = queryValidatorService.validateQueryRules(rule);
+
+        expect(issues).to.have.lengthOf(1);
+        expect(issues[0].message).to.include('Value is not valid');
+        expect(issues[0].type).to.equal(QueryIssueTypeEnum.INVALID_FIELD_VALUE);
+      });
     });
 
     describe('doesNotContainAny operation', () => {

--- a/apps/api/src/app/shared/services/query-parser/query-validator.service.ts
+++ b/apps/api/src/app/shared/services/query-parser/query-validator.service.ts
@@ -143,6 +143,12 @@ export class QueryValidatorService {
         continue;
       }
 
+      // handle 'containsAny' and 'doesNotContainAny' operators
+      if (key === 'containsAny' || key === 'doesNotContainAny') {
+        this.validateContainsAnyOperation({ operator: key, value, issues, path });
+        continue;
+      }
+
       const isBetween =
         key === JsonComparisonOperatorEnum.LESS_THAN_OR_EQUAL && Array.isArray(value) && value.length === 3;
       if (isBetween) {
@@ -280,6 +286,36 @@ export class QueryValidatorService {
       if (secondOperandEmpty) {
         issues.push(this.getValueIssue(path));
       }
+    }
+  }
+
+  private validateContainsAnyOperation({
+    operator,
+    value,
+    issues,
+    path,
+  }: {
+    operator: string;
+    value: unknown;
+    issues: QueryIssue[];
+    path: number[];
+  }) {
+    if (!Array.isArray(value) || value.length !== 2) {
+      issues.push(this.getOperationIssue(operator, path));
+
+      return;
+    }
+
+    const [field, comparisonValue] = value;
+
+    this.validateFieldReference(field, issues, path);
+
+    const isEmpty =
+      comparisonValue === undefined ||
+      comparisonValue === null ||
+      (Array.isArray(comparisonValue) && comparisonValue.length === 0);
+    if (isEmpty) {
+      issues.push(this.getValueIssue(path));
     }
   }
 

--- a/apps/api/src/app/shared/services/query-parser/query-validator.service.ts
+++ b/apps/api/src/app/shared/services/query-parser/query-validator.service.ts
@@ -310,6 +310,15 @@ export class QueryValidatorService {
 
     this.validateFieldReference(field, issues, path);
 
+    const isVarReference =
+      comparisonValue && typeof comparisonValue === 'object' && !Array.isArray(comparisonValue) && 'var' in comparisonValue;
+
+    if (isVarReference) {
+      this.validateFieldReference(comparisonValue, issues, path);
+
+      return;
+    }
+
     const isEmpty =
       comparisonValue === undefined ||
       comparisonValue === null ||

--- a/apps/dashboard/src/components/conditions-editor/field-type-editors.ts
+++ b/apps/dashboard/src/components/conditions-editor/field-type-editors.ts
@@ -61,7 +61,10 @@ export function getPlaceholderForField(
     case 'datetime':
       return '2024-01-01T00:00:00Z';
     case 'array':
-      return operator === 'contains' ? 'item' : 'item1, item2';
+      if (operator === 'contains') return 'item';
+      if (operator === 'containsAny' || operator === 'doesNotContainAny') return 'item1, item2, item3';
+
+      return 'item1, item2';
     case 'object':
       return '{"key": "value"}';
     default:
@@ -254,6 +257,24 @@ export function getHelpTextForField(operator: string, { fieldData }: { fieldData
           description:
             'Check if the array contains the specified item. You can also use dynamic values from the payload.',
           examples: ['item1', '{{payload.requiredTag}}'],
+        };
+      }
+
+      if (operator === 'containsAny') {
+        return {
+          title: 'Array contains any of',
+          description:
+            'Check if the array contains at least one of the specified items. Separate multiple values with commas. You can also use dynamic values from the payload.',
+          examples: ['tag1, tag2, tag3', '{{subscriber.data.tags}}'],
+        };
+      }
+
+      if (operator === 'doesNotContainAny') {
+        return {
+          title: 'Array does not contain any of',
+          description:
+            'Check if the array does not contain any of the specified items. Separate multiple values with commas. You can also use dynamic values from the payload.',
+          examples: ['tag1, tag2, tag3', '{{subscriber.data.tags}}'],
         };
       }
 

--- a/apps/dashboard/src/components/conditions-editor/field-type-operators.ts
+++ b/apps/dashboard/src/components/conditions-editor/field-type-operators.ts
@@ -71,6 +71,8 @@ export const FIELD_TYPE_OPERATORS: Record<FieldDataType, Operator[]> = {
   array: [
     { name: 'contains', label: 'contains' },
     { name: 'doesNotContain', label: 'does not contain' },
+    { name: 'containsAny', label: 'contains any of' },
+    { name: 'doesNotContainAny', label: 'does not contain any of' },
     { name: 'null', label: 'is null' },
     { name: 'notNull', label: 'is not null' },
   ],

--- a/apps/dashboard/src/components/workflow-editor/steps/conditions/edit-step-conditions-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/conditions/edit-step-conditions-form.tsx
@@ -62,7 +62,16 @@ const customRuleProcessor = (rule: RuleType, options: any) => {
   }
 
   if (isContainsAnyOperator(rule.operator)) {
-    const values = (rule.value as string)
+    const trimmedValue = (rule.value as string).trim();
+    const variableMatch = trimmedValue.match(/^\{\{(.+?)\}\}$/);
+
+    if (variableMatch) {
+      return {
+        [rule.operator]: [{ var: rule.field }, { var: variableMatch[1].trim() }],
+      };
+    }
+
+    const values = trimmedValue
       .split(',')
       .map((v) => v.trim())
       .filter(Boolean);

--- a/apps/dashboard/src/components/workflow-editor/steps/conditions/edit-step-conditions-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/conditions/edit-step-conditions-form.tsx
@@ -36,9 +36,13 @@ const PAYLOAD_FIELD_PREFIX = 'payload.';
 const SUBSCRIBER_DATA_FIELD_PREFIX = 'subscriber.data.';
 const CONTEXT_FIELD_PREFIX = 'context.';
 
-// Custom rule processor to handle relative date operators
+const CONTAINS_ANY_OPERATORS = ['containsAny', 'doesNotContainAny'] as const;
+
+function isContainsAnyOperator(operator: string): boolean {
+  return (CONTAINS_ANY_OPERATORS as readonly string[]).includes(operator);
+}
+
 const customRuleProcessor = (rule: RuleType, options: any) => {
-  // Handle relative date operators
   if (isRelativeDateOperator(rule.operator)) {
     try {
       const parsedValue = JSON.parse(rule.value as string);
@@ -48,18 +52,26 @@ const customRuleProcessor = (rule: RuleType, options: any) => {
         (typeof parsedValue.amount === 'number' || typeof parsedValue.amount === 'string') &&
         parsedValue.unit
       ) {
-        const result = {
+        return {
           [rule.operator]: [{ var: rule.field }, parsedValue],
         };
-
-        return result;
       }
     } catch (error) {
       console.warn('Failed to parse relative date value:', rule.value, error);
     }
   }
 
-  // Fall back to the default rule processor for all other operators
+  if (isContainsAnyOperator(rule.operator)) {
+    const values = (rule.value as string)
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
+
+    return {
+      [rule.operator]: [{ var: rule.field }, values],
+    };
+  }
+
   return defaultRuleProcessorJsonLogic(rule, options);
 };
 

--- a/apps/dashboard/src/utils/conditions.ts
+++ b/apps/dashboard/src/utils/conditions.ts
@@ -1,63 +1,40 @@
 import { RQBJsonLogic, RuleGroupType } from 'react-querybuilder';
 import { parseJsonLogic } from 'react-querybuilder/parseJsonLogic';
 
-// Custom JsonLogic operations for parsing relative date operators
+function parseArrayOperatorArgs(val: any, operator: string) {
+  if (!val || !Array.isArray(val) || val.length < 2) {
+    return false;
+  }
+
+  const values = Array.isArray(val[1]) ? val[1].join(', ') : String(val[1]);
+
+  return {
+    field: val[0]?.var,
+    operator,
+    value: values,
+  };
+}
+
+function parseRelativeDateArgs(val: any, operator: string) {
+  if (!val || !Array.isArray(val) || val.length < 2) {
+    return false;
+  }
+
+  return {
+    field: val[0]?.var,
+    operator,
+    value: JSON.stringify(val[1]),
+  };
+}
+
 const customJsonLogicOperations = {
-  moreThanXAgo: (val: any) => {
-    if (!val || !Array.isArray(val) || val.length < 2) {
-      return false;
-    }
-
-    return {
-      field: val[0]?.var,
-      operator: 'moreThanXAgo',
-      value: JSON.stringify(val[1]),
-    };
-  },
-  lessThanXAgo: (val: any) => {
-    if (!val || !Array.isArray(val) || val.length < 2) {
-      return false;
-    }
-
-    return {
-      field: val[0]?.var,
-      operator: 'lessThanXAgo',
-      value: JSON.stringify(val[1]),
-    };
-  },
-  exactlyXAgo: (val: any) => {
-    if (!val || !Array.isArray(val) || val.length < 2) {
-      return false;
-    }
-
-    return {
-      field: val[0]?.var,
-      operator: 'exactlyXAgo',
-      value: JSON.stringify(val[1]),
-    };
-  },
-  withinLast: (val: any) => {
-    if (!val || !Array.isArray(val) || val.length < 2) {
-      return false;
-    }
-
-    return {
-      field: val[0]?.var,
-      operator: 'withinLast',
-      value: JSON.stringify(val[1]),
-    };
-  },
-  notWithinLast: (val: any) => {
-    if (!val || !Array.isArray(val) || val.length < 2) {
-      return false;
-    }
-
-    return {
-      field: val[0]?.var,
-      operator: 'notWithinLast',
-      value: JSON.stringify(val[1]),
-    };
-  },
+  moreThanXAgo: (val: any) => parseRelativeDateArgs(val, 'moreThanXAgo'),
+  lessThanXAgo: (val: any) => parseRelativeDateArgs(val, 'lessThanXAgo'),
+  exactlyXAgo: (val: any) => parseRelativeDateArgs(val, 'exactlyXAgo'),
+  withinLast: (val: any) => parseRelativeDateArgs(val, 'withinLast'),
+  notWithinLast: (val: any) => parseRelativeDateArgs(val, 'notWithinLast'),
+  containsAny: (val: any) => parseArrayOperatorArgs(val, 'containsAny'),
+  doesNotContainAny: (val: any) => parseArrayOperatorArgs(val, 'doesNotContainAny'),
 };
 
 // Shared parse options for consistency

--- a/apps/dashboard/src/utils/conditions.ts
+++ b/apps/dashboard/src/utils/conditions.ts
@@ -6,7 +6,16 @@ function parseArrayOperatorArgs(val: any, operator: string) {
     return false;
   }
 
-  const values = Array.isArray(val[1]) ? val[1].join(', ') : String(val[1]);
+  const secondOperand = val[1];
+  let values: string;
+
+  if (secondOperand && typeof secondOperand === 'object' && 'var' in secondOperand) {
+    values = `{{${secondOperand.var}}}`;
+  } else if (Array.isArray(secondOperand)) {
+    values = secondOperand.join(', ');
+  } else {
+    values = String(secondOperand);
+  }
 
   return {
     field: val[0]?.var,


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR introduces `containsAny` and `doesNotContainAny` operators for array fields in step conditions. This change addresses Linear issue [NV-7178](https://linear.app/novu/issue/NV-7178/add-containsany-step-condition-for-payload-tags), which was a customer request to support conditions like `payload.tags.containsAny(subscriber.data.tags)`. Previously, only `contains` for a single array element was supported.

**Backend (API):**
*   Implemented `containsAny` and `doesNotContainAny` JSON-Logic operators in `query-parser.service.ts`.
*   Added validation for these new operators in `query-validator.service.ts`.
*   Added comprehensive unit tests for both the parser and validator services.

**Frontend (Dashboard):**
*   Added "contains any of" and "does not contain any of" to the array operator list in `field-type-operators.ts`.
*   Updated `field-type-editors.ts` with placeholder text and help descriptions for the new operators.
*   Modified `edit-step-conditions-form.tsx` to process comma-separated input values into an array for JSON-Logic conversion.
*   Added parsers in `conditions.ts` to convert JSON-Logic `containsAny`/`doesNotContainAny` back to react-querybuilder format.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->
Screenshots of the dashboard UI showing the new operators and their input fields would be included here.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

The changes span both the API (backend evaluation engine and validation) and the Dashboard UI (operator selection, input handling, and JSON-Logic conversion). All existing and new unit tests (20 new tests) pass.

</details>

---
Linear Issue: [NV-7178](https://linear.app/novu/issue/NV-7178/add-containsany-step-condition-for-payload-tags)

<p><a href="https://cursor.com/agents/bc-a980fc30-8f5d-4e7e-b281-beee73dbb413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a980fc30-8f5d-4e7e-b281-beee73dbb413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

