### PR TITLE
perf(api-service): Optimize bridge sync endpoint timing fixes NV-7182

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -785,7 +785,8 @@
     "Checkpointer",
     "checkpointer",
     "langchain",
-    "langgraph"
+    "langgraph",
+    "Vitest"
   ],
   "flagWords": [],
   "patterns": [

--- a/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
@@ -1,6 +1,8 @@
 import { BadRequestException, HttpException, Injectable } from '@nestjs/common';
 import { AnalyticsService, ExecuteBridgeRequest, JSONSchema, NotificationStep } from '@novu/application-generic';
 import {
+  ControlValuesEntity,
+  ControlValuesRepository,
   EnvironmentEntity,
   EnvironmentRepository,
   NotificationGroupRepository,
@@ -10,6 +12,7 @@ import {
 import { DiscoverOutput, DiscoverStepOutput, DiscoverWorkflowOutput, GetActionEnum } from '@novu/framework/internal';
 import {
   buildWorkflowPreferences,
+  ControlValuesLevelEnum,
   ResourceOriginEnum,
   ResourceTypeEnum,
   SeverityLevelEnum,
@@ -42,7 +45,8 @@ export class Sync {
     private environmentRepository: EnvironmentRepository,
     private executeBridgeRequest: ExecuteBridgeRequest,
     private buildStepIssuesUsecase: BuildStepIssuesUsecase,
-    private analyticsService: AnalyticsService
+    private analyticsService: AnalyticsService,
+    private controlValuesRepository: ControlValuesRepository
   ) {}
   async execute(command: SyncCommand): Promise<CreateBridgeResponseDto> {
     const environment = await this.findEnvironment(command);
@@ -160,10 +164,13 @@ export class Sync {
     command: SyncCommand,
     workflowsFromBridge: DiscoverWorkflowOutput[]
   ): Promise<NotificationTemplateEntity[]> {
-    const existingFrameworkWorkflows = await Promise.all(
-      workflowsFromBridge.map((workflow) =>
-        this.notificationTemplateRepository.findByTriggerIdentifier(command.environmentId, workflow.workflowId)
-      )
+    const identifiers = workflowsFromBridge.map((w) => w.workflowId);
+    const bulkResults = await this.notificationTemplateRepository.findByTriggerIdentifierBulk(
+      command.environmentId,
+      identifiers
+    );
+    const existingFrameworkWorkflows = workflowsFromBridge.map(
+      (workflow) => bulkResults.find((r) => r.triggers.some((t) => t.identifier === workflow.workflowId)) ?? null
     );
 
     existingFrameworkWorkflows.forEach((workflow, index) => {
@@ -254,6 +261,7 @@ export class Sync {
 
     return {
       id: workflowExist._id,
+      existingWorkflow: workflowExist,
       environmentId: command.environmentId,
       organizationId: command.organizationId,
       userId: command.userId,
@@ -279,6 +287,17 @@ export class Sync {
     commandWorkflowSteps: DiscoverStepOutput[],
     workflow?: NotificationTemplateEntity | undefined
   ): Promise<NotificationStep[]> {
+    let preloadedControlValues: ControlValuesEntity[] | undefined;
+
+    if (workflow?._id) {
+      preloadedControlValues = await this.controlValuesRepository.find({
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+        _workflowId: workflow._id,
+        level: ControlValuesLevelEnum.STEP_CONTROLS,
+      });
+    }
+
     return Promise.all(
       commandWorkflowSteps.map(async (step: DiscoverStepOutput) => {
         const foundStep = workflow?.steps?.find((workflowStep) => workflowStep.stepId === step.stepId);
@@ -294,6 +313,7 @@ export class Sync {
           workflow,
           stepType: step.type as StepTypeEnum,
           controlSchema: step.controls?.schema as unknown as JSONSchemaDto,
+          ...(preloadedControlValues ? { preloadedControlValues } : {}),
         });
 
         const template = {

--- a/apps/api/src/app/workflows-v1/usecases/update-workflow/update-workflow.command.ts
+++ b/apps/api/src/app/workflows-v1/usecases/update-workflow/update-workflow.command.ts
@@ -6,7 +6,7 @@ import {
   NotificationStep,
   PreferencesRequired,
 } from '@novu/application-generic';
-import { ClientSession } from '@novu/dal';
+import { ClientSession, NotificationTemplateEntity } from '@novu/dal';
 import {
   CustomDataType,
   MAX_DESCRIPTION_LENGTH,
@@ -139,6 +139,10 @@ export class UpdateWorkflowCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @Exclude()
   session?: ClientSession | null;
+
+  @IsOptional()
+  @Exclude()
+  existingWorkflow?: NotificationTemplateEntity;
 
   @IsOptional()
   @IsEnum(SeverityLevelEnum)

--- a/apps/api/src/app/workflows-v1/usecases/update-workflow/update-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v1/usecases/update-workflow/update-workflow.usecase.ts
@@ -80,13 +80,15 @@ export class UpdateWorkflow {
   async execute(command: UpdateWorkflowCommand): Promise<WorkflowWithPreferencesResponseDto> {
     await this.validatePayload(command);
 
-    const existingTemplate = await this.getWorkflowWithPreferencesUseCase.execute(
-      GetWorkflowWithPreferencesCommand.create({
-        workflowIdOrInternalId: command.id,
-        environmentId: command.environmentId,
-        organizationId: command.organizationId,
-      })
-    );
+    const existingTemplate =
+      command.existingWorkflow ??
+      (await this.getWorkflowWithPreferencesUseCase.execute(
+        GetWorkflowWithPreferencesCommand.create({
+          workflowIdOrInternalId: command.id,
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+        })
+      ));
     if (!existingTemplate) throw new NotFoundException(`Notification template with id ${command.id} not found`);
 
     let updatePayload: Partial<WorkflowWithPreferencesResponseDto> = {};
@@ -107,16 +109,20 @@ export class UpdateWorkflow {
     }
 
     if (command.workflowId) {
-      const isExistingIdentifier = await this.notificationTemplateRepository.findByTriggerIdentifier(
-        command.environmentId,
-        command.workflowId
-      );
+      const existingIdentifier = existingTemplate.triggers?.[0]?.identifier;
 
-      if (isExistingIdentifier && isExistingIdentifier._id !== command.id) {
-        throw new BadRequestException(`Workflow with identifier ${command.workflowId} already exists`);
-      } else {
-        updatePayload['triggers.0.identifier'] = command.workflowId;
+      if (existingIdentifier !== command.workflowId) {
+        const isExistingIdentifier = await this.notificationTemplateRepository.findByTriggerIdentifier(
+          command.environmentId,
+          command.workflowId
+        );
+
+        if (isExistingIdentifier && isExistingIdentifier._id !== command.id) {
+          throw new BadRequestException(`Workflow with identifier ${command.workflowId} already exists`);
+        }
       }
+
+      updatePayload['triggers.0.identifier'] = command.workflowId;
     }
 
     if (command.notificationGroupId) {

--- a/apps/api/src/app/workflows-v1/usecases/update-workflow/update-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v1/usecases/update-workflow/update-workflow.usecase.ts
@@ -42,6 +42,7 @@ import {
   buildWorkflowPreferences,
   ChangeEntityTypeEnum,
   ControlValuesLevelEnum,
+  DEFAULT_WORKFLOW_PREFERENCES,
   isBridgeWorkflow,
   PreferencesTypeEnum,
   ResourceOriginEnum,
@@ -80,15 +81,15 @@ export class UpdateWorkflow {
   async execute(command: UpdateWorkflowCommand): Promise<WorkflowWithPreferencesResponseDto> {
     await this.validatePayload(command);
 
-    const existingTemplate =
-      command.existingWorkflow ??
-      (await this.getWorkflowWithPreferencesUseCase.execute(
-        GetWorkflowWithPreferencesCommand.create({
-          workflowIdOrInternalId: command.id,
-          environmentId: command.environmentId,
-          organizationId: command.organizationId,
-        })
-      ));
+    const existingTemplate: WorkflowWithPreferencesResponseDto = command.existingWorkflow
+      ? { ...command.existingWorkflow, userPreferences: null, defaultPreferences: DEFAULT_WORKFLOW_PREFERENCES }
+      : await this.getWorkflowWithPreferencesUseCase.execute(
+          GetWorkflowWithPreferencesCommand.create({
+            workflowIdOrInternalId: command.id,
+            environmentId: command.environmentId,
+            organizationId: command.organizationId,
+          })
+        );
     if (!existingTemplate) throw new NotFoundException(`Notification template with id ${command.id} not found`);
 
     let updatePayload: Partial<WorkflowWithPreferencesResponseDto> = {};

--- a/libs/dal/src/repositories/notification-template/notification-template.repository.ts
+++ b/libs/dal/src/repositories/notification-template/notification-template.repository.ts
@@ -69,10 +69,7 @@ export class NotificationTemplateRepository extends BaseRepository<
       'triggers.identifier': { $in: identifiers },
     };
 
-    const query = this.MongooseModel.find(requestQuery, undefined, {
-      session,
-      readPreference: 'secondaryPreferred',
-    }).populate('steps.template');
+    const query = this.MongooseModel.find(requestQuery, undefined, { session }).populate('steps.template');
 
     const items = await query;
 

--- a/libs/dal/src/repositories/notification-template/notification-template.repository.ts
+++ b/libs/dal/src/repositories/notification-template/notification-template.repository.ts
@@ -69,7 +69,10 @@ export class NotificationTemplateRepository extends BaseRepository<
       'triggers.identifier': { $in: identifiers },
     };
 
-    const query = this.MongooseModel.find(requestQuery, undefined, { session }).populate('steps.template');
+    const query = this.MongooseModel.find(requestQuery, undefined, {
+      session,
+      readPreference: 'secondaryPreferred',
+    }).populate('steps.template');
 
     const items = await query;
 


### PR DESCRIPTION
Preload step control values and reduce DB calls during sync and update flows. Changes include: add ControlValuesEntity and ControlValuesRepository to Sync usecase and preload step-level control values for workflows; switch to bulk lookup for notification templates by trigger identifiers in Sync to avoid N+1 queries; include existingWorkflow in Sync response and pass an optional existingWorkflow into UpdateWorkflowCommand to skip an extra fetch; improve identifier uniqueness check in UpdateWorkflow to avoid unnecessary lookups; set readPreference to secondaryPreferred on the notification template bulk query to reduce primary load. Minor import and DI updates to support these changes.

### What changed? Why was the change needed?

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
