### PR TITLE
feat(worker): SQS job logging levels

### DIFF
--- a/libs/application-generic/src/services/queues/queue-base.service.ts
+++ b/libs/application-generic/src/services/queues/queue-base.service.ts
@@ -265,14 +265,14 @@ export class QueueBaseService implements OnModuleDestroy {
 
     if (messages.length === 1) {
       await this.sqsService.send(this.topic, messages[0]);
-      Logger.log(
+      Logger.debug(
         { topic: this.topic, jobName: jobs[0].name, payloadSizeBytes: this.calculatePayloadSize(jobs[0].data) },
         'Added job to SQS',
         LOG_CONTEXT
       );
     } else {
       await this.sqsService.sendBulk(this.topic, messages);
-      Logger.log({ topic: this.topic, count: messages.length }, 'Added bulk jobs to SQS', LOG_CONTEXT);
+      Logger.debug({ topic: this.topic, count: messages.length }, 'Added bulk jobs to SQS', LOG_CONTEXT);
     }
   }
 

--- a/libs/application-generic/src/services/workers/worker-base.service.ts
+++ b/libs/application-generic/src/services/workers/worker-base.service.ts
@@ -88,7 +88,7 @@ export class WorkerBaseService implements INovuWorker, OnModuleDestroy {
 
   private shouldSkipProcessing(data: any, jobId: string): boolean {
     if (data?.skipProcessing) {
-      Logger.log({ topic: this.topic, jobId }, 'Skipping job - marked for skip during migration', LOG_CONTEXT);
+      Logger.debug({ topic: this.topic, jobId }, 'Skipping job - marked for skip during migration', LOG_CONTEXT);
 
       return true;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Changed the log level from `Logger.log` to `Logger.debug` for the following messages:

*   "Added job to SQS"
*   "Added bulk jobs to SQS"
*   "Skipping job - marked for skip during migration"

This change was needed to reduce noise in default production logs, as these messages are more appropriate for debug-level logging.

---
[Slack Thread](https://novu.slack.com/archives/C06SD5WHPD0/p1772627115352009?thread_ts=1772627115.352009&cid=C06SD5WHPD0)

<p><a href="https://cursor.com/agents/bc-1b03f0e9-ad33-586d-adc4-9321580acd69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b03f0e9-ad33-586d-adc4-9321580acd69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->