### PR TITLE
refactor(worker): Transaction ID logging level

### DIFF
--- a/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts
@@ -209,6 +209,8 @@ export class TriggerEvent {
       }
     } catch (e) {
       const error = e as Error;
+      const isBadRequest = e instanceof BadRequestException;
+
       await this.createWorkflowTrace({
         command,
         eventType: 'workflow_execution_failed',
@@ -218,16 +220,19 @@ export class TriggerEvent {
         workflowId: storedWorkflow?._id,
       });
 
-      Logger.error(
-        {
-          transactionId: command.transactionId,
-          organization: command.organizationId,
-          triggerIdentifier: command.identifier,
-          userId: command.userId,
-          error: e,
-        },
-        'Unexpected error has occurred when triggering event'
-      );
+      const logPayload = {
+        transactionId: command.transactionId,
+        organization: command.organizationId,
+        triggerIdentifier: command.identifier,
+        userId: command.userId,
+        error: e,
+      };
+
+      if (isBadRequest) {
+        Logger.debug(logPayload, 'Bad request when triggering event');
+      } else {
+        Logger.error(logPayload, 'Unexpected error has occurred when triggering event');
+      }
 
       throw e;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The catch block in `libs/application-generic/src/usecases/trigger-event/trigger-event.usecase.ts` was updated to log `BadRequestException` instances at `debug` level instead of `error`.

This change was needed because `BadRequestException` errors (e.g., "transactionId property is not unique") are user validation errors, not unexpected system failures. Logging them as `error` was polluting error monitoring systems like NewRelic with non-critical alerts. Downgrading the log level provides appropriate visibility without triggering unnecessary alerts.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1772638672472399?thread_ts=1772638672.472399&cid=D0919LNRWE7)

<p><a href="https://cursor.com/agents/bc-85eb5e3a-43bb-59d9-b28b-c462ca562286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85eb5e3a-43bb-59d9-b28b-c462ca562286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->