### PR TITLE
feat(novu,dashboard): interactive react email template selector in CLI fixes NV-7185

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/email/react-email-not-published.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/react-email-not-published.tsx
@@ -31,7 +31,6 @@ function buildPublishCommand({
       `npx novu email publish \\`,
       `  --workflow=${workflowId} \\`,
       `  --step=${stepId} \\`,
-      `  --template=./emails/your-template.tsx \\`,
       `  --secret-key=${maskedKey}${apiUrlFlag ? ' \\' : ''}`,
       ...(apiUrlFlag ? [`  ${apiUrlFlag}`] : []),
     ];
@@ -42,7 +41,6 @@ function buildPublishCommand({
   const flags = [
     `--workflow=${workflowId}`,
     `--step=${stepId}`,
-    `--template=./emails/your-template.tsx`,
     `--secret-key=${secretKey}`,
     ...(apiUrlFlag ? [apiUrlFlag] : []),
   ];
@@ -119,12 +117,11 @@ export const ReactEmailNotPublished = ({ workflowId, stepId }: ReactEmailNotPubl
     `npx novu email publish \\`,
     `  --workflow=${workflowId} \\`,
     `  --step=${stepId} \\`,
-    `  --template=./emails/your-template.tsx \\`,
     `  --secret-key=<your-secret-key>${apiUrl ? ' \\' : ''}`,
     ...(apiUrl ? [`  --api-url=${apiUrl}`] : []),
   ].join('\n');
 
-  const fallbackPublishCopy = `npx novu email publish --workflow=${workflowId} --step=${stepId} --template=./emails/your-template.tsx --secret-key=<your-secret-key>${apiUrl ? ` --api-url=${apiUrl}` : ''}`;
+  const fallbackPublishCopy = `npx novu email publish --workflow=${workflowId} --step=${stepId} --secret-key=<your-secret-key>${apiUrl ? ` --api-url=${apiUrl}` : ''}`;
 
   const steps: Step[] = [
     {
@@ -151,11 +148,7 @@ export const ReactEmailNotPublished = ({ workflowId, stepId }: ReactEmailNotPubl
       label: 'Link your React Email template to this step',
       description: (
         <>
-          Replace{' '}
-          <code className="rounded bg-neutral-100 px-1 py-0.5 font-mono text-[11px] text-neutral-600">
-            ./emails/your-template.tsx
-          </code>{' '}
-          with the path to your React Email component.
+          Run this from your project root — you'll be prompted to choose a React Email template to link to this step.
           <br />
           <br />💡 This bundles your template, links it to this step, and deploys it to our{' '}
           <span className="cursor-default decoration-dotted underline underline-offset-2">managed infrastructure</span>.

--- a/packages/novu/src/commands/email/discovery/email-template-discovery.ts
+++ b/packages/novu/src/commands/email/discovery/email-template-discovery.ts
@@ -3,10 +3,10 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-export type DiscoveredTemplate = {
+export interface DiscoveredTemplate {
   filePath: string;
   relativePath: string;
-};
+}
 
 const DEFAULT_IGNORES = [
   '**/node_modules/**',
@@ -106,6 +106,15 @@ async function checkIsReactEmailTemplate(filePath: string): Promise<boolean> {
     }
 
     if (ts.isFunctionDeclaration(node) && node.modifiers?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword)) {
+      hasDefaultExport = true;
+    }
+
+    if (
+      ts.isExportDeclaration(node) &&
+      node.exportClause &&
+      ts.isNamedExports(node.exportClause) &&
+      node.exportClause.elements.some((e) => e.name.text === 'default')
+    ) {
       hasDefaultExport = true;
     }
 

--- a/packages/novu/src/commands/email/discovery/email-template-discovery.ts
+++ b/packages/novu/src/commands/email/discovery/email-template-discovery.ts
@@ -1,0 +1,135 @@
+import fg from 'fast-glob';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as ts from 'typescript';
+
+export type DiscoveredTemplate = {
+  filePath: string;
+  relativePath: string;
+};
+
+const DEFAULT_IGNORES = [
+  '**/node_modules/**',
+  '**/.git/**',
+  '**/.next/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/out/**',
+  '**/coverage/**',
+  '**/.turbo/**',
+  '**/.vercel/**',
+  '**/.cache/**',
+  '**/tmp/**',
+  '**/*.test.{ts,tsx,js,jsx}',
+  '**/*.spec.{ts,tsx,js,jsx}',
+  '**/__tests__/**',
+  '**/__mocks__/**',
+  '**/test/**',
+  '**/tests/**',
+  '**/*.stories.{ts,tsx,js,jsx}',
+  '**/*.story.{ts,tsx,js,jsx}',
+  '**/.storybook/**',
+  '**/*.config.{ts,js}',
+  '**/*.d.ts',
+];
+
+const CONCURRENCY = 32;
+
+export async function discoverEmailTemplates(rootDir: string = process.cwd()): Promise<DiscoveredTemplate[]> {
+  const files = await fg(['**/*.{tsx,jsx,ts,js}'], {
+    cwd: rootDir,
+    dot: true,
+    absolute: false,
+    ignore: DEFAULT_IGNORES,
+    followSymbolicLinks: true,
+  });
+
+  const out: DiscoveredTemplate[] = [];
+
+  for (let i = 0; i < files.length; i += CONCURRENCY) {
+    const batch = files.slice(i, i + CONCURRENCY);
+    const batchResults = await Promise.all(
+      batch.map(async (relativePath) => {
+        const filePath = path.join(rootDir, relativePath);
+        const isTemplate = await checkIsReactEmailTemplate(filePath);
+        if (!isTemplate) return null;
+
+        return { filePath, relativePath } satisfies DiscoveredTemplate;
+      })
+    );
+
+    for (const result of batchResults) {
+      if (result) out.push(result);
+    }
+  }
+
+  return out;
+}
+
+async function checkIsReactEmailTemplate(filePath: string): Promise<boolean> {
+  let text: string;
+  try {
+    text = await fs.readFile(filePath, 'utf8');
+  } catch {
+    return false;
+  }
+
+  if (!text.includes('@react-email/') && !text.includes('react-email')) {
+    return false;
+  }
+
+  const scriptKind = getScriptKind(filePath);
+  const sf = ts.createSourceFile(filePath, text, ts.ScriptTarget.Latest, true, scriptKind);
+
+  let hasReactEmailImport = false;
+  let hasJsx = false;
+  let hasDefaultExport = false;
+
+  function visit(node: ts.Node): void {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const specifier = node.moduleSpecifier.text;
+      if (
+        specifier === '@react-email/components' ||
+        specifier.startsWith('@react-email/') ||
+        specifier === 'react-email'
+      ) {
+        hasReactEmailImport = true;
+      }
+    }
+
+    if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node) || ts.isJsxFragment(node)) {
+      hasJsx = true;
+    }
+
+    if (ts.isExportAssignment(node) && !node.isExportEquals) {
+      hasDefaultExport = true;
+    }
+
+    if (ts.isFunctionDeclaration(node) && node.modifiers?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword)) {
+      hasDefaultExport = true;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sf);
+
+  return hasReactEmailImport && hasJsx && hasDefaultExport;
+}
+
+function getScriptKind(filePath: string): ts.ScriptKind {
+  const ext = path.extname(filePath).toLowerCase();
+
+  switch (ext) {
+    case '.tsx':
+      return ts.ScriptKind.TSX;
+    case '.ts':
+      return ts.ScriptKind.TS;
+    case '.jsx':
+      return ts.ScriptKind.JSX;
+    case '.js':
+      return ts.ScriptKind.JS;
+    default:
+      return ts.ScriptKind.JS;
+  }
+}

--- a/packages/novu/src/commands/email/discovery/index.ts
+++ b/packages/novu/src/commands/email/discovery/index.ts
@@ -1,1 +1,3 @@
+export type { DiscoveredTemplate } from './email-template-discovery';
+export { discoverEmailTemplates } from './email-template-discovery';
 export { discoverStepFiles } from './step-discovery';

--- a/packages/novu/src/commands/email/publish.ts
+++ b/packages/novu/src/commands/email/publish.ts
@@ -194,7 +194,7 @@ async function promptForTemplate(templates: DiscoveredTemplate[]): Promise<strin
   if (selectResponse.template !== MANUAL_ENTRY_VALUE) {
     console.log('');
 
-    return selectResponse.template as string;
+    return selectResponse.template;
   }
 
   const textResponse = await prompts(
@@ -215,7 +215,7 @@ async function promptForTemplate(templates: DiscoveredTemplate[]): Promise<strin
 
   console.log('');
 
-  return textResponse.template as string | undefined;
+  return textResponse.template;
 }
 
 function assertTemplateRequiresWorkflowAndStep(

--- a/packages/novu/src/commands/email/publish.ts
+++ b/packages/novu/src/commands/email/publish.ts
@@ -3,12 +3,14 @@ import * as fs from 'fs/promises';
 import ora from 'ora';
 import * as path from 'path';
 import { green, red, yellow } from 'picocolors';
+import prompts from 'prompts';
 import type { RendererConflictStep } from './api';
 import { RendererConflictError, StepResolverClient } from './api';
 import { bundleRelease, formatBundleSize } from './bundler';
 import { extractStepSchemas } from './bundler/schema-extractor';
 import { loadConfig } from './config/loader';
-import { discoverStepFiles } from './discovery';
+import type { DiscoveredTemplate } from './discovery';
+import { discoverEmailTemplates, discoverStepFiles } from './discovery';
 import { generateStepFile } from './templates/step-file';
 import type {
   DeploymentResult,
@@ -53,10 +55,12 @@ export async function emailPublish(options: PublishOptions): Promise<void> {
     assertStepRequiresWorkflow(options.step, options.workflow);
     assertTemplateRequiresWorkflowAndStep(options.template, options.workflow, options.step);
 
-    if (options.template) {
+    const templatePath = options.template ?? (await resolveTemplateInteractively(options, rootDir, config?.outDir));
+
+    if (templatePath) {
       const workflowIds = normalizeRequestedWorkflows(options.workflow);
       const stepIds = normalizeRequestedWorkflows(options.step);
-      await scaffoldStepFileIfNeeded(options.template, workflowIds[0], stepIds[0], rootDir, config?.outDir);
+      await scaffoldStepFileIfNeeded(templatePath, workflowIds[0], stepIds[0], rootDir, config?.outDir);
     }
 
     const discoveredSteps = await discoverAndValidateSteps(stepsDir, stepsDirLabel);
@@ -105,6 +109,113 @@ export async function emailPublish(options: PublishOptions): Promise<void> {
     console.error('');
     process.exit(1);
   }
+}
+
+async function resolveTemplateInteractively(
+  options: PublishOptions,
+  rootDir: string,
+  configOutDir?: string
+): Promise<string | undefined> {
+  const workflowIds = normalizeRequestedWorkflows(options.workflow);
+  const stepIds = normalizeRequestedWorkflows(options.step);
+
+  if (workflowIds.length !== 1 || stepIds.length !== 1) {
+    return undefined;
+  }
+
+  const outDir = configOutDir || './novu';
+  const outDirPath = path.resolve(rootDir, outDir);
+  const pathResolver = new StepFilePathResolver(rootDir, outDirPath);
+  const stepFilePath = pathResolver.getStepFilePath(workflowIds[0], stepIds[0]);
+
+  if (fsSync.existsSync(stepFilePath)) {
+    return undefined;
+  }
+
+  if (!process.stdout.isTTY) {
+    console.log(yellow('ℹ  No --template provided. Use --template=<path> to scaffold a step file.'));
+    console.log('');
+
+    return undefined;
+  }
+
+  const templates = await withSpinner('Discovering React Email templates...', () => discoverEmailTemplates(rootDir), {
+    successMessage: 'Template discovery complete',
+    failMessage: 'Template discovery failed',
+  });
+
+  if (templates.length === 0) {
+    console.log(yellow('ℹ  No React Email templates found in this project.'));
+    console.log('');
+    console.log(
+      `   Templates must import from ${yellow('@react-email/components')}, use JSX, and have a default export.`
+    );
+    console.log('');
+    console.log(`   To specify a template path manually, re-run with:`);
+    console.log(
+      `   npx novu email publish --workflow=${workflowIds[0]} --step=${stepIds[0]} --template=<path-to-template>`
+    );
+    console.log('');
+
+    return undefined;
+  }
+
+  return promptForTemplate(templates);
+}
+
+const MANUAL_ENTRY_VALUE = '__manual__';
+
+async function promptForTemplate(templates: DiscoveredTemplate[]): Promise<string | undefined> {
+  console.log('');
+
+  const selectResponse = await prompts(
+    {
+      type: 'select',
+      name: 'template',
+      message: 'Select a React Email template for this step',
+      choices: [
+        ...templates.map((t) => ({ title: t.relativePath, value: t.relativePath })),
+        { title: 'Enter path manually...', value: MANUAL_ENTRY_VALUE },
+      ],
+    },
+    {
+      onCancel: () => {
+        console.log('');
+        console.log(yellow('ℹ  Template selection cancelled. Step file will not be scaffolded.'));
+        console.log('');
+      },
+    }
+  );
+
+  if (!selectResponse.template) {
+    return undefined;
+  }
+
+  if (selectResponse.template !== MANUAL_ENTRY_VALUE) {
+    console.log('');
+
+    return selectResponse.template as string;
+  }
+
+  const textResponse = await prompts(
+    {
+      type: 'text',
+      name: 'template',
+      message: 'Template path (relative to project root)',
+      initial: './emails/your-template.tsx',
+    },
+    {
+      onCancel: () => {
+        console.log('');
+        console.log(yellow('ℹ  Template selection cancelled. Step file will not be scaffolded.'));
+        console.log('');
+      },
+    }
+  );
+
+  console.log('');
+
+  return textResponse.template as string | undefined;
 }
 
 function assertTemplateRequiresWorkflowAndStep(

--- a/packages/novu/src/commands/email/publish.ts
+++ b/packages/novu/src/commands/email/publish.ts
@@ -55,12 +55,13 @@ export async function emailPublish(options: PublishOptions): Promise<void> {
     assertStepRequiresWorkflow(options.step, options.workflow);
     assertTemplateRequiresWorkflowAndStep(options.template, options.workflow, options.step);
 
-    const templatePath = options.template ?? (await resolveTemplateInteractively(options, rootDir, config?.outDir));
+    const effectiveOutDir = options.out || config?.outDir;
+    const templatePath = options.template ?? (await resolveTemplateInteractively(options, rootDir, effectiveOutDir));
 
     if (templatePath) {
       const workflowIds = normalizeRequestedWorkflows(options.workflow);
       const stepIds = normalizeRequestedWorkflows(options.step);
-      await scaffoldStepFileIfNeeded(templatePath, workflowIds[0], stepIds[0], rootDir, config?.outDir);
+      await scaffoldStepFileIfNeeded(templatePath, workflowIds[0], stepIds[0], rootDir, effectiveOutDir);
     }
 
     const discoveredSteps = await discoverAndValidateSteps(stepsDir, stepsDirLabel);
@@ -215,7 +216,12 @@ async function promptForTemplate(templates: DiscoveredTemplate[]): Promise<strin
 
   console.log('');
 
-  return textResponse.template;
+  const manualTemplatePath = textResponse.template?.trim();
+  if (!manualTemplatePath) {
+    return undefined;
+  }
+
+  return manualTemplatePath;
 }
 
 function assertTemplateRequiresWorkflowAndStep(


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request introduces a major usability improvement to the React Email publishing workflow. The CLI now automatically discovers React Email templates in the project and prompts the user to select one interactively if the `--template` flag is not provided, streamlining the process and removing the need to manually specify the template path. The dashboard UI and documentation are also updated to reflect this simplified workflow.

**Key changes:**

### CLI: React Email template discovery and interactive selection

* Added a new utility (`email-template-discovery.ts`) that scans the project for valid React Email templates by analyzing imports, JSX usage, and default exports. This enables automatic detection of templates. [[1]](diffhunk://#diff-7df2e04b54fe2b78cb9fb44474263f781df4bad372eeb5a309b8cfa5d47e2276R1-R135) [[2]](diffhunk://#diff-97f8cb795a801e42ff9b484da159ed9302caa16c3dd8acfe0a431ef2f2f14a76R1-R2)
* Updated the `emailPublish` command to prompt the user to select a template if `--template` is not provided, using the discovered templates. If no templates are found, the CLI provides helpful guidance. [[1]](diffhunk://#diff-4b97b2068ff0586b1101549803224c5cc91f4573b24431e518a71ca8856dbe7cL56-R63) [[2]](diffhunk://#diff-4b97b2068ff0586b1101549803224c5cc91f4573b24431e518a71ca8856dbe7cR114-R220)
* Integrated the new discovery and prompt logic into the CLI, replacing the previous requirement to always specify the template path manually.

### Dashboard UI and documentation updates

* Removed references to manually specifying the template path (e.g., `--template=./emails/your-template.tsx`) in both the dashboard UI and fallback copy, reflecting the new interactive selection flow. [[1]](diffhunk://#diff-4b0b3c2a259cf3a0fa41a5cd17e2be4f75d9a7fdb508bb28e51f8732cd5f208dL34) [[2]](diffhunk://#diff-4b0b3c2a259cf3a0fa41a5cd17e2be4f75d9a7fdb508bb28e51f8732cd5f208dL45) [[3]](diffhunk://#diff-4b0b3c2a259cf3a0fa41a5cd17e2be4f75d9a7fdb508bb28e51f8732cd5f208dL122-R124)
* Updated instructional text to explain that users will now be prompted to choose a template, further clarifying the improved workflow.
