### PR TITLE
chore(api-service): logger request method order

### DIFF
--- a/apps/api/src/app/activity/usecases/build-workflow-runs-count-chart/build-workflow-runs-count-chart.usecase.ts
+++ b/apps/api/src/app/activity/usecases/build-workflow-runs-count-chart/build-workflow-runs-count-chart.usecase.ts
@@ -34,10 +34,10 @@ export class BuildWorkflowRunsCountChart {
       topicKey,
     } = command;
 
-    this.logger.debug('Getting workflow runs count for chart', {
+    this.logger.debug({
       organizationId: command.organizationId,
       environmentId: command.environmentId,
-    });
+    }, 'Getting workflow runs count for chart');
 
     try {
       const queryBuilder = new QueryBuilder<WorkflowRun>({
@@ -103,11 +103,11 @@ export class BuildWorkflowRunsCountChart {
         count: result,
       };
     } catch (error) {
-      this.logger.error('Failed to get workflow runs count for chart', {
+      this.logger.error({
         error: error.message,
         organizationId: command.organizationId,
         environmentId: command.environmentId,
-      });
+      }, 'Failed to get workflow runs count for chart');
       throw error;
     }
   }

--- a/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
@@ -110,21 +110,21 @@ export class GetWorkflowRun {
 
       return digestDataByStepId;
     } catch (error) {
-      this.logger.warn('Failed to get job digest data', {
+      this.logger.warn({
         error: error.message,
         transactionId,
-      });
+      }, 'Failed to get job digest data');
 
       return new Map();
     }
   }
 
   async execute(command: GetWorkflowRunCommand): Promise<GetWorkflowRunResponseDto> {
-    this.logger.debug('Getting workflow run from ClickHouse', {
+    this.logger.debug({
       organizationId: command.organizationId,
       environmentId: command.environmentId,
       workflowRunId: command.workflowRunId,
-    });
+    }, 'Getting workflow run from ClickHouse');
 
     try {
       const workflowRunQuery = new QueryBuilder<WorkflowRun>({
@@ -151,12 +151,12 @@ export class GetWorkflowRun {
 
       return workflowRunDto;
     } catch (error) {
-      this.logger.error('Failed to get workflow run', {
+      this.logger.error({
         error: error.message,
         organizationId: command.organizationId,
         environmentId: command.environmentId,
         workflowRunId: command.workflowRunId,
-      });
+      }, 'Failed to get workflow run');
       throw error;
     }
   }
@@ -260,10 +260,10 @@ export class GetWorkflowRun {
 
       return executionDetailsByEntityId;
     } catch (error) {
-      this.logger.warn('Failed to get execution details from traces', {
+      this.logger.warn({
         error: error.message,
         entityIds,
-      });
+      }, 'Failed to get execution details from traces');
 
       return new Map();
     }

--- a/apps/api/src/app/activity/usecases/get-workflow-runs/get-workflow-runs.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-runs/get-workflow-runs.usecase.ts
@@ -72,12 +72,12 @@ export class GetWorkflowRuns {
   }
 
   async execute(command: GetWorkflowRunsCommand): Promise<GetWorkflowRunsResponseDto> {
-    this.logger.debug('Getting workflow runs with compound cursor-based pagination', {
+    this.logger.debug({
       organizationId: command.organizationId,
       environmentId: command.environmentId,
       limit: command.limit,
       cursor: command.cursor ? 'present' : 'not-present',
-    });
+    }, 'Getting workflow runs with compound cursor-based pagination');
 
     try {
       const queryBuilder = new QueryBuilder<WorkflowRun>({
@@ -189,10 +189,10 @@ export class GetWorkflowRuns {
       if (command.cursor) {
         try {
           cursor = this.decodeCursor(command.cursor);
-          this.logger.debug('Using compound cursor pagination', {
+          this.logger.debug({
             timestamp: cursor.created_at,
             workflowRunId: cursor.workflow_run_id,
-          });
+          }, 'Using compound cursor pagination');
         } catch (error) {
           throw new BadRequestException('Invalid cursor format');
         }
@@ -246,11 +246,11 @@ export class GetWorkflowRuns {
         previous: previousCursor,
       };
     } catch (error) {
-      this.logger.error('Failed to get workflow runs', {
+      this.logger.error({
         error: error.message,
         organizationId: command.organizationId,
         environmentId: command.environmentId,
-      });
+      }, 'Failed to get workflow runs');
       throw error;
     }
   }
@@ -305,10 +305,10 @@ export class GetWorkflowRuns {
         workflow_run_id: lastItemOfPreviousPage.workflow_run_id,
       });
     } catch (error) {
-      this.logger.error('Failed to generate previous cursor', {
+      this.logger.error({
         error: error.message,
         currentCursor,
-      });
+      }, 'Failed to generate previous cursor');
 
       return null;
     }
@@ -388,11 +388,11 @@ export class GetWorkflowRuns {
 
       return stepRunsByCompositeKey;
     } catch (error) {
-      this.logger.warn('Failed to get step runs for workflow runs', {
+      this.logger.warn({
         error: error.message,
         transactionIds: workflowRuns.map((run) => run.transaction_id),
         subscriberIds: workflowRuns.map((run) => run.subscriber_id),
-      });
+      }, 'Failed to get step runs for workflow runs');
 
       return new Map();
     }

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/base-translation-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/base-translation-renderer.usecase.ts
@@ -141,7 +141,7 @@ export abstract class BaseTranslationRendererUsecase {
         errorMessage.includes('No translation found');
 
       if (!isExpectedError) {
-        this.logger.error('Unexpected error during translation context creation', {
+        this.logger.error({
           error: errorMessage,
           resourceId,
           resourceType,
@@ -149,7 +149,7 @@ export abstract class BaseTranslationRendererUsecase {
           environmentId,
           locale,
           stack: error?.stack,
-        });
+        }, 'Unexpected error during translation context creation');
       }
 
       return null;
@@ -174,12 +174,12 @@ export abstract class BaseTranslationRendererUsecase {
 
       return await translate.executeWithContext(context, content, variables);
     } catch (error) {
-      this.logger.error('Translation with context failed', {
+      this.logger.error({
         error: error?.message || error,
         resourceId: context.resourceId,
         locale: context.locale,
         stack: error?.stack,
-      });
+      }, 'Translation with context failed');
 
       throw new InternalServerErrorException(
         `Translation processing failed for resource ${context.resourceId}: ${error?.message || String(error)}`
@@ -209,13 +209,13 @@ export abstract class BaseTranslationRendererUsecase {
     organization?: OrganizationEntity;
   }): Promise<string | Record<string, unknown>> {
     if (!resourceId) {
-      this.logger.warn('Resource ID is required for translation module', {
+      this.logger.warn({
         resourceId,
         resourceType,
         organizationId,
         environmentId,
         locale,
-      });
+      }, 'Resource ID is required for translation module');
 
       return content;
     }
@@ -242,7 +242,7 @@ export abstract class BaseTranslationRendererUsecase {
 
       return typeof content === 'string' ? translatedContent : JSON.parse(translatedContent);
     } catch (error) {
-      this.logger.error('Translation processing failed', {
+      this.logger.error({
         error: error?.message || error,
         resourceId,
         resourceType,
@@ -250,7 +250,7 @@ export abstract class BaseTranslationRendererUsecase {
         environmentId,
         locale,
         stack: error?.stack,
-      });
+      }, 'Translation processing failed');
 
       throw new InternalServerErrorException(
         `Translation processing failed for resource ${resourceId}: ${error?.message || String(error)}`
@@ -267,10 +267,10 @@ export abstract class BaseTranslationRendererUsecase {
 
       return this.moduleRef.get(translationModule, { strict: false });
     } catch (error) {
-      this.logger.error('Translation module loading failed', {
+      this.logger.error({
         error: error?.message || error,
         stack: error?.stack,
-      });
+      }, 'Translation module loading failed');
 
       throw new InternalServerErrorException(`Unable to load Translation module: ${error?.message || String(error)}`);
     }

--- a/apps/api/src/app/integrations/usecases/auto-configure-integration/auto-configure-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/auto-configure-integration/auto-configure-integration.usecase.ts
@@ -56,11 +56,11 @@ export class AutoConfigureIntegration {
           }
         );
 
-        this.logger.trace('Auto-configuration completed successfully', {
+        this.logger.trace({
           integrationId: command.integrationId,
           organizationId: command.organizationId,
           webhookUrl,
-        });
+        }, 'Auto-configuration completed successfully');
 
         return {
           success: true,
@@ -68,11 +68,11 @@ export class AutoConfigureIntegration {
           integration: { ...encryptedIntegration, configurations: updatedConfigurations },
         };
       } else {
-        this.logger.warn('Auto-configuration failed', {
+        this.logger.warn({
           integrationId: command.integrationId,
           organizationId: command.organizationId,
           message: result.message,
-        });
+        }, 'Auto-configuration failed');
 
         return {
           success: false,

--- a/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
@@ -281,11 +281,11 @@ export class GetActivityFeed {
         };
       });
 
-      this.logger.debug('Successfully enhanced notifications with ClickHouse execution details', {
+      this.logger.debug({
         notificationCount: notifications.length,
         jobCount: allJobIds.length,
         executionDetailsCount: Array.from(executionDetailsByJobId.values()).flat().length,
-      });
+      }, 'Successfully enhanced notifications with ClickHouse execution details');
 
       return enhancedNotifications;
     } catch (error) {

--- a/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
@@ -106,11 +106,11 @@ export class GetActivity {
       }),
     ]);
 
-    this.logger.debug('feature flags', {
+    this.logger.debug({
       tracesEnabled,
       stepRunsEnabled,
       workflowRunsEnabled,
-    });
+    }, 'feature flags');
 
     let feedItem: NotificationFeedItemEntity | null = null;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Corrected the argument order for Pino logger calls across 7 files, affecting 21 instances. Previously, logger calls were in the format `logger.level(message, object)`, which is incorrect for Pino. The fix aligns calls to the expected `logger.level(object, message)` format to prevent logging errors and ensure proper log data capture.

### Screenshots

---
[Slack Thread](https://novu.slack.com/archives/D092998U7KR/p1770727907405799?thread_ts=1770727907.405799&cid=D092998U7KR)

<p><a href="https://cursor.com/agents/bc-f5a61e87-0fc0-589e-bfb0-bdc826b600b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5a61e87-0fc0-589e-bfb0-bdc826b600b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->