### PR TITLE
feat(novu,dashboard): step resolver workflowId is implicit from generated folder fixes NV-7190

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/email/react-email-not-published.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/react-email-not-published.tsx
@@ -148,7 +148,12 @@ export const ReactEmailNotPublished = ({ workflowId, stepId }: ReactEmailNotPubl
       label: 'Link your React Email template to this step',
       description: (
         <>
-          Run this from your project root — you'll be prompted to choose a React Email template to link to this step.
+          Run this from your project root — you'll be prompted to choose a React Email template. A step file will be
+          scaffolded at{' '}
+          <code className="rounded bg-neutral-100 px-1 py-0.5 font-mono text-[11px] text-[#0e121b]">
+            novu/{workflowId}/{stepId}.step.tsx
+          </code>{' '}
+          — customize the resolver logic there anytime and re-run to redeploy.
           <br />
           <br />💡 This bundles your template, links it to this step, and deploys it to our{' '}
           <span className="cursor-default decoration-dotted underline underline-offset-2">managed infrastructure</span>.

--- a/packages/novu/src/commands/email/bundler/bundler.spec.ts
+++ b/packages/novu/src/commands/email/bundler/bundler.spec.ts
@@ -23,14 +23,15 @@ describe('bundleRelease', () => {
 
     fs.writeFileSync(path.join(sourceDir, 'utils.ts'), "export const body = 'Hello from alias';\n", 'utf8');
 
-    const stepFilePath = path.join(stepDir, 'welcome.step.ts');
+    const workflowDir = path.join(stepDir, 'onboarding');
+    fs.mkdirSync(workflowDir, { recursive: true });
+    const stepFilePath = path.join(workflowDir, 'welcome.step.ts');
     fs.writeFileSync(
       stepFilePath,
       `
 import { body } from '@emails/utils';
 
 export const stepId = 'welcome-email';
-export const workflowId = 'onboarding';
 export const type = 'email';
 
 export default async function () {
@@ -49,7 +50,7 @@ export default async function () {
         workflowId: 'onboarding',
         type: 'email',
         filePath: stepFilePath,
-        relativePath: 'welcome.step.ts',
+        relativePath: 'onboarding/welcome.step.ts',
       },
     ];
 
@@ -69,14 +70,15 @@ export default async function () {
     const stepDir = path.join(tempDir, 'novu');
     fs.mkdirSync(stepDir, { recursive: true });
 
-    const stepFilePath = path.join(stepDir, 'missing-alias.step.ts');
+    const workflowDir = path.join(stepDir, 'onboarding');
+    fs.mkdirSync(workflowDir, { recursive: true });
+    const stepFilePath = path.join(workflowDir, 'missing-alias.step.ts');
     fs.writeFileSync(
       stepFilePath,
       `
 import { body } from '@emails/utils';
 
 export const stepId = 'missing-alias';
-export const workflowId = 'onboarding';
 export const type = 'email';
 
 export default async function () {
@@ -95,7 +97,7 @@ export default async function () {
         workflowId: 'onboarding',
         type: 'email',
         filePath: stepFilePath,
-        relativePath: 'missing-alias.step.ts',
+        relativePath: 'onboarding/missing-alias.step.ts',
       },
     ];
 

--- a/packages/novu/src/commands/email/discovery/step-discovery.spec.ts
+++ b/packages/novu/src/commands/email/discovery/step-discovery.spec.ts
@@ -18,10 +18,7 @@ describe('step-discovery', () => {
   });
 
   it('discovers and validates a correct tsx step file', async () => {
-    writeStepFile(
-      'welcome-email.step.tsx',
-      createStepFileContent({ stepId: 'welcome-email', workflowId: 'onboarding' })
-    );
+    writeStepFile('onboarding/welcome-email.step.tsx', createStepFileContent({ stepId: 'welcome-email' }));
 
     const result = await discoverStepFiles(tempDir);
 
@@ -33,18 +30,15 @@ describe('step-discovery', () => {
       stepId: 'welcome-email',
       workflowId: 'onboarding',
       type: 'email',
-      relativePath: 'welcome-email.step.tsx',
+      relativePath: 'onboarding/welcome-email.step.tsx',
     });
   });
 
   it('discovers valid js and jsx step files', async () => {
+    writeStepFile('workflow-js/plain-js.step.js', createStepFileContent({ stepId: 'plain-js', useJsx: false }));
     writeStepFile(
-      'plain-js.step.js',
-      createStepFileContent({ stepId: 'plain-js', workflowId: 'workflow-js', useJsx: false })
-    );
-    writeStepFile(
-      'template-jsx.step.jsx',
-      createStepFileContent({ stepId: 'template-jsx', workflowId: 'workflow-jsx', useJsx: true })
+      'workflow-jsx/template-jsx.step.jsx',
+      createStepFileContent({ stepId: 'template-jsx', useJsx: true })
     );
 
     const result = await discoverStepFiles(tempDir);
@@ -56,14 +50,8 @@ describe('step-discovery', () => {
   });
 
   it('returns valid steps and errors when files are mixed', async () => {
-    writeStepFile(
-      'valid.step.tsx',
-      createStepFileContent({ stepId: 'valid-step', workflowId: 'workflow-valid', useJsx: true })
-    );
-    writeStepFile(
-      'invalid.step.tsx',
-      createStepFileContent({ includeStepId: false, workflowId: 'workflow-valid', useJsx: true })
-    );
+    writeStepFile('workflow-valid/valid.step.tsx', createStepFileContent({ stepId: 'valid-step', useJsx: true }));
+    writeStepFile('workflow-valid/invalid.step.tsx', createStepFileContent({ includeStepId: false, useJsx: true }));
 
     const result = await discoverStepFiles(tempDir);
 
@@ -77,26 +65,34 @@ describe('step-discovery', () => {
     expect(invalidError?.errors.some((error) => error.includes('stepId'))).toBe(true);
   });
 
-  it.each([
-    ['workflowId', { includeWorkflowId: false }, "Missing required export: 'workflowId' (must be a string literal)"],
-    [
-      'stepId',
-      { includeStepId: false },
-      "Missing step resolver: default export must be 'step.email(stepId, resolver, opts)'",
-    ],
-  ])('detects missing %s', async (_name, options, expectedError) => {
-    writeStepFile('missing-required.step.tsx', createStepFileContent(options));
+  it('detects missing workflow folder', async () => {
+    writeStepFile('missing-required.step.tsx', createStepFileContent({}));
 
     const result = await discoverStepFiles(tempDir);
 
     expect(result.valid).toBe(false);
     expect(result.steps).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].errors).toContain(expectedError);
+    expect(result.errors[0].errors).toContain(
+      'Step file must be inside a workflow folder (e.g., novu/{workflowId}/step-name.step.tsx)'
+    );
+  });
+
+  it('detects missing stepId', async () => {
+    writeStepFile('onboarding/missing-required.step.tsx', createStepFileContent({ includeStepId: false }));
+
+    const result = await discoverStepFiles(tempDir);
+
+    expect(result.valid).toBe(false);
+    expect(result.steps).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].errors).toContain(
+      "Missing step resolver: default export must be 'step.email(stepId, resolver, opts)'"
+    );
   });
 
   it('detects invalid step type', async () => {
-    writeStepFile('invalid-type.step.tsx', createStepFileContent({ type: 'sms' }));
+    writeStepFile('onboarding/invalid-type.step.tsx', createStepFileContent({ type: 'sms' }));
 
     const result = await discoverStepFiles(tempDir);
 
@@ -106,7 +102,7 @@ describe('step-discovery', () => {
   });
 
   it('detects missing default export', async () => {
-    writeStepFile('missing-default.step.tsx', createStepFileContent({ includeDefaultExport: false }));
+    writeStepFile('onboarding/missing-default.step.tsx', createStepFileContent({ includeDefaultExport: false }));
 
     const result = await discoverStepFiles(tempDir);
 
@@ -116,8 +112,8 @@ describe('step-discovery', () => {
   });
 
   it('allows duplicate step IDs across different workflows', async () => {
-    writeStepFile('first.step.tsx', createStepFileContent({ stepId: 'confirmation', workflowId: 'signup' }));
-    writeStepFile('second.step.tsx', createStepFileContent({ stepId: 'confirmation', workflowId: 'booking' }));
+    writeStepFile('signup/confirmation.step.tsx', createStepFileContent({ stepId: 'confirmation' }));
+    writeStepFile('booking/confirmation.step.tsx', createStepFileContent({ stepId: 'confirmation' }));
 
     const result = await discoverStepFiles(tempDir);
 
@@ -128,8 +124,8 @@ describe('step-discovery', () => {
   });
 
   it('detects duplicate step IDs within same workflow', async () => {
-    writeStepFile('first.step.tsx', createStepFileContent({ stepId: 'duplicate-step', workflowId: 'onboarding' }));
-    writeStepFile('second.step.tsx', createStepFileContent({ stepId: 'duplicate-step', workflowId: 'onboarding' }));
+    writeStepFile('onboarding/first.step.tsx', createStepFileContent({ stepId: 'duplicate-step' }));
+    writeStepFile('onboarding/second.step.tsx', createStepFileContent({ stepId: 'duplicate-step' }));
 
     const result = await discoverStepFiles(tempDir);
 
@@ -154,21 +150,18 @@ describe('step-discovery', () => {
   });
 
   it('returns discovered steps in deterministic path order', async () => {
-    writeStepFile('z-last.step.ts', createStepFileContent({ stepId: 'z-last', workflowId: 'wf-z', useJsx: false }));
-    writeStepFile(
-      'nested/m-middle.step.ts',
-      createStepFileContent({ stepId: 'm-middle', workflowId: 'wf-m', useJsx: false })
-    );
-    writeStepFile('a-first.step.ts', createStepFileContent({ stepId: 'a-first', workflowId: 'wf-a', useJsx: false }));
+    writeStepFile('wf-z/z-last.step.ts', createStepFileContent({ stepId: 'z-last', useJsx: false }));
+    writeStepFile('wf-m/m-middle.step.ts', createStepFileContent({ stepId: 'm-middle', useJsx: false }));
+    writeStepFile('wf-a/a-first.step.ts', createStepFileContent({ stepId: 'a-first', useJsx: false }));
 
     const result = await discoverStepFiles(tempDir);
 
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
     expect(result.steps.map((step) => step.relativePath.replace(/\\/g, '/'))).toEqual([
-      'a-first.step.ts',
-      'nested/m-middle.step.ts',
-      'z-last.step.ts',
+      'wf-a/a-first.step.ts',
+      'wf-m/m-middle.step.ts',
+      'wf-z/z-last.step.ts',
     ]);
   });
 
@@ -180,18 +173,14 @@ describe('step-discovery', () => {
 
   function createStepFileContent({
     stepId = 'welcome-email',
-    workflowId = 'onboarding',
     type = 'email',
     includeStepId = true,
-    includeWorkflowId = true,
     includeDefaultExport = true,
     useJsx = true,
   }: {
     stepId?: string;
-    workflowId?: string;
     type?: string;
     includeStepId?: boolean;
-    includeWorkflowId?: boolean;
     includeDefaultExport?: boolean;
     useJsx?: boolean;
   } = {}): string {
@@ -202,12 +191,6 @@ describe('step-discovery', () => {
 
     if (useJsx) {
       lines.push("import EmailTemplate from '../emails/welcome';");
-    }
-
-    lines.push('');
-
-    if (includeWorkflowId) {
-      lines.push(`export const workflowId = '${workflowId}';`);
     }
 
     lines.push('');

--- a/packages/novu/src/commands/email/discovery/step-discovery.ts
+++ b/packages/novu/src/commands/email/discovery/step-discovery.ts
@@ -6,7 +6,6 @@ import type { DiscoveredStep, StepDiscoveryResult, ValidationError } from '../ty
 
 interface StepMetadata {
   stepId?: string;
-  workflowId?: string;
   type?: string;
 }
 
@@ -31,13 +30,17 @@ export async function discoverStepFiles(stepsDir: string): Promise<StepDiscovery
   const analyses = relativeStepFiles.map((relativePath) =>
     analyzeStepFile(path.resolve(stepsDir, relativePath), relativePath)
   );
-  const duplicateStepIdErrors = buildDuplicateStepIdErrors(analyses);
+  const duplicateStepIdErrors = buildDuplicateStepIdErrors(analyses, (rp) => deriveWorkflowId(rp));
 
   const steps: DiscoveredStep[] = [];
   const errors: ValidationError[] = [];
 
   for (const analysis of analyses) {
-    const fileErrors = [...buildValidationErrors(analysis), ...(duplicateStepIdErrors.get(analysis.filePath) ?? [])];
+    const workflowId = deriveWorkflowId(analysis.relativePath);
+    const fileErrors = [
+      ...buildValidationErrors(analysis, workflowId),
+      ...(duplicateStepIdErrors.get(analysis.filePath) ?? []),
+    ];
     if (fileErrors.length > 0) {
       errors.push({
         filePath: path.relative(process.cwd(), analysis.filePath),
@@ -46,7 +49,7 @@ export async function discoverStepFiles(stepsDir: string): Promise<StepDiscovery
       continue;
     }
 
-    const { stepId, workflowId, type } = analysis.metadata;
+    const { stepId, type } = analysis.metadata;
     if (stepId && workflowId && type) {
       steps.push({
         stepId,
@@ -94,9 +97,6 @@ function extractStepMetadata(sourceFile: ts.SourceFile): StepMetadata {
   const metadata: StepMetadata = {};
 
   function visit(node: ts.Node) {
-    if (ts.isVariableStatement(node) && hasModifier(node.modifiers, ts.SyntaxKind.ExportKeyword)) {
-      extractWorkflowIdExport(node, metadata);
-    }
     if (ts.isExportAssignment(node) && !node.isExportEquals) {
       extractStepResolverCallMetadata(node.expression, metadata);
     }
@@ -108,20 +108,13 @@ function extractStepMetadata(sourceFile: ts.SourceFile): StepMetadata {
   return metadata;
 }
 
-function extractWorkflowIdExport(node: ts.VariableStatement, metadata: StepMetadata): void {
-  for (const declaration of node.declarationList.declarations) {
-    if (
-      !ts.isIdentifier(declaration.name) ||
-      !declaration.initializer ||
-      !ts.isStringLiteral(declaration.initializer)
-    ) {
-      continue;
-    }
-
-    if (declaration.name.text === 'workflowId') {
-      metadata.workflowId = declaration.initializer.text;
-    }
+function deriveWorkflowId(relativePath: string): string | undefined {
+  const parentDir = path.dirname(relativePath);
+  if (parentDir === '.' || parentDir === '') {
+    return undefined;
   }
+
+  return parentDir.split(path.sep)[0];
 }
 
 // Matches: step.email('stepId', resolver, opts) — also handles (step.email(...)), `as` casts, and `satisfies` expressions
@@ -187,15 +180,16 @@ function extractParseDiagnostics(sourceFile: ts.SourceFile): string[] {
   return (parseDiagnostics ?? []).map((diagnostic) => formatParseDiagnostic(sourceFile, diagnostic));
 }
 
-function buildValidationErrors(analysis: AnalyzedStepFile): string[] {
+function buildValidationErrors(analysis: AnalyzedStepFile, workflowId: string | undefined): string[] {
   const errors: string[] = [...analysis.parseErrors];
 
-  if (!analysis.metadata.workflowId) {
-    errors.push("Missing required export: 'workflowId' (must be a string literal)");
+  if (!workflowId) {
+    errors.push('Step file must be inside a workflow folder (e.g., novu/{workflowId}/step-name.step.tsx)');
   }
 
   if (!analysis.hasDefaultExport) {
     errors.push('Missing default export');
+
     return errors;
   }
 
@@ -210,20 +204,28 @@ function buildValidationErrors(analysis: AnalyzedStepFile): string[] {
   return errors;
 }
 
-function buildDuplicateStepIdErrors(analyses: AnalyzedStepFile[]): Map<string, string[]> {
-  const filesByCompositeKey = groupAnalysesByCompositeKey(analyses);
+function buildDuplicateStepIdErrors(
+  analyses: AnalyzedStepFile[],
+  getWorkflowId: (relativePath: string) => string | undefined
+): Map<string, string[]> {
+  const filesByCompositeKey = groupAnalysesByCompositeKey(analyses, getWorkflowId);
+
   return buildErrorsForDuplicates(filesByCompositeKey);
 }
 
-function groupAnalysesByCompositeKey(analyses: AnalyzedStepFile[]): Map<string, AnalyzedStepFile[]> {
+function groupAnalysesByCompositeKey(
+  analyses: AnalyzedStepFile[],
+  getWorkflowId: (relativePath: string) => string | undefined
+): Map<string, AnalyzedStepFile[]> {
   const grouped = new Map<string, AnalyzedStepFile[]>();
 
   for (const analysis of analyses) {
-    if (!analysis.metadata.stepId || !analysis.metadata.workflowId) {
+    const workflowId = getWorkflowId(analysis.relativePath);
+    if (!analysis.metadata.stepId || !workflowId) {
       continue;
     }
 
-    const key = `${analysis.metadata.workflowId}:${analysis.metadata.stepId}`;
+    const key = `${workflowId}:${analysis.metadata.stepId}`;
     const files = grouped.get(key) ?? [];
     files.push(analysis);
     grouped.set(key, files);

--- a/packages/novu/src/commands/email/discovery/step-discovery.ts
+++ b/packages/novu/src/commands/email/discovery/step-discovery.ts
@@ -114,7 +114,7 @@ function deriveWorkflowId(relativePath: string): string | undefined {
     return undefined;
   }
 
-  return parentDir.split(path.sep)[0];
+  return parentDir.split('/')[0];
 }
 
 // Matches: step.email('stepId', resolver, opts) — also handles (step.email(...)), `as` casts, and `satisfies` expressions

--- a/packages/novu/src/commands/email/publish.ts
+++ b/packages/novu/src/commands/email/publish.ts
@@ -294,12 +294,14 @@ async function scaffoldStepFileIfNeeded(
   fsSync.mkdirSync(workflowDir, { recursive: true });
 
   const templateImportPath = pathResolver.getTemplateImportPath(workflowId, templatePath);
-  const stepFileContent = generateStepFile(stepId, workflowId, templateImportPath, { template: templatePath });
+  const stepFileContent = generateStepFile(stepId, templateImportPath, { template: templatePath });
 
   fsSync.writeFileSync(stepFilePath, stepFileContent, 'utf8');
 
   const relPath = path.relative(rootDir, stepFilePath);
   console.log(`   ${green('✓')} Created ${relPath}`);
+  console.log('');
+  console.log(`   ${yellow('ℹ')}  Customize the resolver logic in this file anytime, then re-run publish to redeploy.`);
   console.log('');
   console.log(`   ${yellow('ℹ')}  For TypeScript types in your editor:`);
   console.log(`      npm install --save-dev @novu/framework`);
@@ -430,7 +432,7 @@ async function discoverAndValidateSteps(stepsDir: string, stepsDirLabel: string)
         console.error('');
         console.error('Expected *.step.tsx, *.step.ts, *.step.jsx, or *.step.js files.');
         console.error('');
-        console.error("Run 'npx novu email init' first to generate step handlers.");
+        console.error(`Run 'npx novu email publish --workflow=<id> --step=<id>' to scaffold your first step handler.`);
         console.error('');
         throw new Error('No step files found');
       }

--- a/packages/novu/src/commands/email/templates/__snapshots__/step-file.spec.ts.snap
+++ b/packages/novu/src/commands/email/templates/__snapshots__/step-file.spec.ts.snap
@@ -5,8 +5,6 @@ exports[`generateStepFile > should match snapshot 1`] = `
 import { render } from '@react-email/components';
 import EmailTemplate from '../emails/welcome';
 
-export const workflowId = 'onboarding';
-
 export default step.email('welcome-email', async (controls, { payload, subscriber, context, steps }) => ({
   subject: controls.subject ?? payload.subject ?? 'No Subject',
   body: await render(
@@ -26,8 +24,6 @@ exports[`generateStepFile > should match snapshot with different import paths > 
 "import { step } from '@novu/framework/step-resolver';
 import { render } from '@react-email/components';
 import EmailTemplate from '../../src/emails/welcome';
-
-export const workflowId = 'onboarding';
 
 export default step.email('welcome-email', async (controls, { payload, subscriber, context, steps }) => ({
   subject: controls.subject ?? payload.subject ?? 'No Subject',
@@ -49,8 +45,6 @@ exports[`generateStepFile > should match snapshot with different import paths > 
 import { render } from '@react-email/components';
 import EmailTemplate from './emails/welcome';
 
-export const workflowId = 'onboarding';
-
 export default step.email('welcome-email', async (controls, { payload, subscriber, context, steps }) => ({
   subject: controls.subject ?? payload.subject ?? 'No Subject',
   body: await render(
@@ -70,8 +64,6 @@ exports[`generateStepFile > should match snapshot with subject > with-subject 1`
 "import { step } from '@novu/framework/step-resolver';
 import { render } from '@react-email/components';
 import EmailTemplate from '../emails/welcome';
-
-export const workflowId = 'onboarding';
 
 export default step.email('welcome-email', async (controls, { payload, subscriber, context, steps }) => ({
   subject: controls.subject ?? payload.subject ?? 'Welcome to Acme!',

--- a/packages/novu/src/commands/email/templates/__snapshots__/worker-wrapper.spec.ts.snap
+++ b/packages/novu/src/commands/email/templates/__snapshots__/worker-wrapper.spec.ts.snap
@@ -106,10 +106,10 @@ export default {
 
 exports[`generateWorkerWrapper > should handle single step > single-step 1`] = `
 "import { validateData } from '@novu/framework/validators';
-import stepHandler0, { workflowId as workflowId0 } from "./novu/welcome-email.step";
+import stepHandler0 from "./novu/welcome-email.step";
 
 const stepHandlers = new Map([
-  [\`\${workflowId0}/\${stepHandler0.stepId}\`, stepHandler0]
+  ["onboarding" + '/' + stepHandler0.stepId, stepHandler0]
 ]);
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
@@ -210,12 +210,12 @@ export default {
 
 exports[`generateWorkerWrapper > should match snapshot 1`] = `
 "import { validateData } from '@novu/framework/validators';
-import stepHandler0, { workflowId as workflowId0 } from "./novu/welcome-email.step";
-import stepHandler1, { workflowId as workflowId1 } from "./novu/verify-email.step";
+import stepHandler0 from "./novu/welcome-email.step";
+import stepHandler1 from "./novu/verify-email.step";
 
 const stepHandlers = new Map([
-  [\`\${workflowId0}/\${stepHandler0.stepId}\`, stepHandler0],
-  [\`\${workflowId1}/\${stepHandler1.stepId}\`, stepHandler1]
+  ["onboarding" + '/' + stepHandler0.stepId, stepHandler0],
+  ["onboarding" + '/' + stepHandler1.stepId, stepHandler1]
 ]);
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };

--- a/packages/novu/src/commands/email/templates/step-file.spec.ts
+++ b/packages/novu/src/commands/email/templates/step-file.spec.ts
@@ -3,13 +3,12 @@ import { generateStepFile } from './step-file';
 
 describe('generateStepFile', () => {
   const stepId = 'welcome-email';
-  const workflowId = 'onboarding';
   const baseConfig = {
     template: 'emails/welcome.tsx',
   };
 
   it('should match snapshot', () => {
-    const result = generateStepFile(stepId, workflowId, '../emails/welcome', baseConfig);
+    const result = generateStepFile(stepId, '../emails/welcome', baseConfig);
     expect(result).toMatchSnapshot();
   });
 
@@ -18,15 +17,15 @@ describe('generateStepFile', () => {
       ...baseConfig,
       subject: 'Welcome to Acme!',
     };
-    const result = generateStepFile(stepId, workflowId, '../emails/welcome', config);
+    const result = generateStepFile(stepId, '../emails/welcome', config);
     expect(result).toMatchSnapshot('with-subject');
   });
 
   it('should match snapshot with different import paths', () => {
-    const result1 = generateStepFile(stepId, workflowId, './emails/welcome', baseConfig);
+    const result1 = generateStepFile(stepId, './emails/welcome', baseConfig);
     expect(result1).toMatchSnapshot('relative-import');
 
-    const result2 = generateStepFile(stepId, workflowId, '../../src/emails/welcome', baseConfig);
+    const result2 = generateStepFile(stepId, '../../src/emails/welcome', baseConfig);
     expect(result2).toMatchSnapshot('nested-import');
   });
 });

--- a/packages/novu/src/commands/email/templates/step-file.ts
+++ b/packages/novu/src/commands/email/templates/step-file.ts
@@ -13,19 +13,12 @@ function escapeString(value: string): string {
     .replace(/\u2029/g, '\\u2029');
 }
 
-export function generateStepFile(
-  stepId: string,
-  workflowId: string,
-  templateImportPath: string,
-  emailConfig: EmailStepConfig
-): string {
+export function generateStepFile(stepId: string, templateImportPath: string, emailConfig: EmailStepConfig): string {
   const defaultSubject = emailConfig.subject || 'No Subject';
 
   return `import { step } from '@novu/framework/step-resolver';
 import { render } from '@react-email/components';
 import EmailTemplate from '${escapeString(templateImportPath)}';
-
-export const workflowId = '${escapeString(workflowId)}';
 
 export default step.email('${escapeString(stepId)}', async (controls, { payload, subscriber, context, steps }) => ({
   subject: controls.subject ?? payload.subject ?? '${escapeString(defaultSubject)}',

--- a/packages/novu/src/commands/email/templates/worker-wrapper.spec.ts
+++ b/packages/novu/src/commands/email/templates/worker-wrapper.spec.ts
@@ -35,13 +35,13 @@ describe('generateWorkerWrapper', () => {
     expect(result).toMatchSnapshot('single-step');
   });
 
-  it('should use workflowId named imports and stepHandler.stepId for map keys', () => {
+  it('should use inline workflowId strings and stepHandler.stepId for map keys', () => {
     const result = generateWorkerWrapper(mockSteps, '/root');
 
-    expect(result).toContain('workflowId as workflowId0');
-    expect(result).toContain('workflowId as workflowId1');
+    expect(result).toContain('"onboarding"');
     expect(result).toContain('stepHandler0.stepId');
     expect(result).toContain('stepHandler1.stepId');
+    expect(result).not.toContain('workflowId as');
   });
 
   it('should call step.resolve with validatedControls as first arg and ctx as second', () => {

--- a/packages/novu/src/commands/email/templates/worker-wrapper.ts
+++ b/packages/novu/src/commands/email/templates/worker-wrapper.ts
@@ -12,10 +12,7 @@ export function generateWorkerWrapper(steps: DiscoveredStep[], rootDir: string):
 
 function generateImports(steps: DiscoveredStep[], rootDir: string): string {
   const stepImports = steps
-    .map(
-      (s, i) =>
-        `import stepHandler${i}, { workflowId as workflowId${i} } from ${JSON.stringify(getImportPath(s.filePath, rootDir))};`
-    )
+    .map((s, i) => `import stepHandler${i} from ${JSON.stringify(getImportPath(s.filePath, rootDir))};`)
     .join('\n');
 
   return `import { validateData } from '@novu/framework/validators';\n${stepImports}`;
@@ -23,7 +20,7 @@ function generateImports(steps: DiscoveredStep[], rootDir: string): string {
 
 function generateStepHandlersMap(steps: DiscoveredStep[]): string {
   const entries = steps
-    .map((_s, i) => `  [\`\${workflowId${i}}/\${stepHandler${i}.stepId}\`, stepHandler${i}]`)
+    .map((s, i) => `  [${JSON.stringify(s.workflowId)} + '/' + stepHandler${i}.stepId, stepHandler${i}]`)
     .join(',\n');
 
   return `const stepHandlers = new Map([\n${entries}\n]);`;


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request refactors how email step files are organized and discovered in the codebase. Steps are now required to be placed inside workflow-specific subfolders (e.g., `novu/{workflowId}/step-name.step.tsx`), and the workflow ID is inferred from the folder structure rather than an explicit export in the step file. The tests, validation logic, and scaffolding have all been updated to reflect this new convention, improving consistency and reducing boilerplate.

**Step file organization and workflow ID inference:**

- Step files must now reside inside a workflow-named folder, and the workflow ID is automatically derived from the folder name instead of requiring a `workflowId` export in the file. This affects both the implementation and validation logic. [[1]](diffhunk://#diff-f846e19e77bc58acf9c9edb66ad34d265c07e43b4e815a72eeac2e22cb86c2bdL111-R117) [[2]](diffhunk://#diff-f846e19e77bc58acf9c9edb66ad34d265c07e43b4e815a72eeac2e22cb86c2bdL34-R43) [[3]](diffhunk://#diff-f846e19e77bc58acf9c9edb66ad34d265c07e43b4e815a72eeac2e22cb86c2bdL49-R52) [[4]](diffhunk://#diff-f846e19e77bc58acf9c9edb66ad34d265c07e43b4e815a72eeac2e22cb86c2bdL190-R192) [[5]](diffhunk://#diff-f846e19e77bc58acf9c9edb66ad34d265c07e43b4e815a72eeac2e22cb86c2bdL213-R228)
- Validation errors will now be raised if a step file is not placed within a workflow folder, and duplicate step IDs are detected per workflow using the folder structure. [[1]](diffhunk://#diff-f846e19e77bc58acf9c9edb66ad34d265c07e43b4e815a72eeac2e22cb86c2bdL190-R192) [[2]](diffhunk://#diff-f846e19e77bc58acf9c9edb66ad34d265c07e43b4e815a72eeac2e22cb86c2bdL213-R228)

**Test updates:**

- All relevant tests have been updated so that step files are created inside workflow-specific folders, and the `workflowId` export has been removed from test step files. [[1]](diffhunk://#diff-bf65887f4c2e16cacfdaba47c3a43b9e03c12ad6ba56d524b9ca3c5e4d45ede4L21-R21) [[2]](diffhunk://#diff-bf65887f4c2e16cacfdaba47c3a43b9e03c12ad6ba56d524b9ca3c5e4d45ede4L36-R41) [[3]](diffhunk://#diff-bf65887f4c2e16cacfdaba47c3a43b9e03c12ad6ba56d524b9ca3c5e4d45ede4L59-R54) [[4]](diffhunk://#diff-bf65887f4c2e16cacfdaba47c3a43b9e03c12ad6ba56d524b9ca3c5e4d45ede4L80-R95) [[5]](diffhunk://#diff-bf65887f4c2e16cacfdaba47c3a43b9e03c12ad6ba56d524b9ca3c5e4d45ede4L109-R105) [[6]](diffhunk://#diff-bf65887f4c2e16cacfdaba47c3a43b9e03c12ad6ba56d524b9ca3c5e4d45ede4L119-R116) [[7]](diffhunk://#diff-bf65887f4c2e16cacfdaba47c3a43b9e03c12ad6ba56d524b9ca3c5e4d45ede4L131-R128) [[8]](diffhunk://#diff-bf65887f4c2e16cacfdaba47c3a43b9e03c12ad6ba56d524b9ca3c5e4d45ede4L157-R164) [[9]](diffhunk://#diff-bf65887f4c2e16cacfdaba47c3a43b9e03c12ad6ba56d524b9ca3c5e4d45ede4L183-L194) [[10]](diffhunk://#diff-bf65887f4c2e16cacfdaba47c3a43b9e03c12ad6ba56d524b9ca3c5e4d45ede4L209-L214)
- New and updated tests check for errors when step files are not inside a workflow folder or are missing required fields.

**Scaffolding and CLI improvements:**

- The step file scaffolding command (`publish`) now generates files in the correct workflow folder and omits the `workflowId` export. It also provides improved CLI output and guidance to the user. [[1]](diffhunk://#diff-4b97b2068ff0586b1101549803224c5cc91f4573b24431e518a71ca8856dbe7cL297-R305) [[2]](diffhunk://#diff-4b97b2068ff0586b1101549803224c5cc91f4573b24431e518a71ca8856dbe7cL433-R435) [[3]](diffhunk://#diff-4b0b3c2a259cf3a0fa41a5cd17e2be4f75d9a7fdb508bb28e51f8732cd5f208dL151-R156)

**Bundler and discovery logic:**

- The bundler and discovery logic now handle the new folder structure, ensuring that file paths and relative paths reflect the workflow subfolder. [[1]](diffhunk://#diff-d2be87fe5c044791cb94f254256d8a50895104598060beb3c0e823b16b15f730L26-L33) [[2]](diffhunk://#diff-d2be87fe5c044791cb94f254256d8a50895104598060beb3c0e823b16b15f730L52-R53) [[3]](diffhunk://#diff-d2be87fe5c044791cb94f254256d8a50895104598060beb3c0e823b16b15f730L72-L79) [[4]](diffhunk://#diff-d2be87fe5c044791cb94f254256d8a50895104598060beb3c0e823b16b15f730L98-R100)

**Internal code cleanup:**

- Removed all references to the `workflowId` export from step file metadata and related interfaces. [[1]](diffhunk://#diff-f846e19e77bc58acf9c9edb66ad34d265c07e43b4e815a72eeac2e22cb86c2bdL9) [[2]](diffhunk://#diff-f846e19e77bc58acf9c9edb66ad34d265c07e43b4e815a72eeac2e22cb86c2bdL97-L99)

These changes make the workflow and step organization more intuitive and reduce the need for redundant configuration inside each step file.