### PR TITLE
feat(novu): email publish - auto-install @novu/framework as devDependecy

### DIFF
--- a/packages/novu/src/commands/email/publish.ts
+++ b/packages/novu/src/commands/email/publish.ts
@@ -19,7 +19,15 @@ import type {
   StepResolverManifestStep,
   StepResolverReleaseBundle,
 } from './types';
-import { renderTable, StepFilePathResolver, withSpinner } from './utils';
+import {
+  detectPackageManager,
+  getInstallCommand,
+  installPackageSync,
+  isPackageInstalled,
+  renderTable,
+  StepFilePathResolver,
+  withSpinner,
+} from './utils';
 
 interface PublishOptions {
   secretKey?: string;
@@ -259,6 +267,31 @@ function assertTemplateRequiresWorkflowAndStep(
   }
 }
 
+const FRAMEWORK_PACKAGE = '@novu/framework';
+
+async function installFrameworkPackageIfNeeded(rootDir: string): Promise<void> {
+  if (isPackageInstalled(FRAMEWORK_PACKAGE, rootDir)) {
+    return;
+  }
+
+  const pm = detectPackageManager(rootDir);
+  const installCmd = getInstallCommand(pm, FRAMEWORK_PACKAGE);
+
+  try {
+    await withSpinner(
+      `Installing ${FRAMEWORK_PACKAGE} for TypeScript types...`,
+      async () => {
+        installPackageSync(FRAMEWORK_PACKAGE, rootDir);
+      },
+      { successMessage: `Installed ${FRAMEWORK_PACKAGE}`, failMessage: `Failed to install ${FRAMEWORK_PACKAGE}` }
+    );
+  } catch {
+    console.log(`   ${yellow('ℹ')}  For TypeScript types in your editor, run:`);
+    console.log(`      ${installCmd}`);
+    console.log('');
+  }
+}
+
 async function scaffoldStepFileIfNeeded(
   templatePath: string,
   workflowId: string,
@@ -301,9 +334,10 @@ async function scaffoldStepFileIfNeeded(
   const relPath = path.relative(rootDir, stepFilePath);
   console.log(`   ${green('✓')} Created ${relPath}`);
   console.log('');
-  console.log(`   ${yellow('ℹ')}  For TypeScript types in your editor:`);
-  console.log(`      npm install --save-dev @novu/framework`);
+  console.log(`   ${yellow('ℹ')}  Customize the resolver logic in this file anytime, then re-run publish to redeploy.`);
   console.log('');
+
+  await installFrameworkPackageIfNeeded(rootDir);
 }
 
 function assertNotProductionEnvironment(envInfo: EnvironmentInfo): void {

--- a/packages/novu/src/commands/email/utils/index.ts
+++ b/packages/novu/src/commands/email/utils/index.ts
@@ -1,4 +1,5 @@
 export { isCI, isInteractive } from './environment';
 export { StepFilePathResolver } from './file-paths';
+export { detectPackageManager, getInstallCommand, installPackageSync, isPackageInstalled } from './package-manager';
 export { withSpinner } from './spinner';
 export { renderTable } from './table';

--- a/packages/novu/src/commands/email/utils/package-manager.ts
+++ b/packages/novu/src/commands/email/utils/package-manager.ts
@@ -1,0 +1,45 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+export function detectPackageManager(rootDir: string): PackageManager {
+  if (fs.existsSync(path.join(rootDir, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (fs.existsSync(path.join(rootDir, 'yarn.lock'))) return 'yarn';
+  if (fs.existsSync(path.join(rootDir, 'bun.lockb')) || fs.existsSync(path.join(rootDir, 'bun.lock'))) return 'bun';
+
+  return 'npm';
+}
+
+export function isPackageInstalled(packageName: string, rootDir: string): boolean {
+  if (fs.existsSync(path.join(rootDir, 'node_modules', packageName))) return true;
+
+  try {
+    const pkgJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+
+    return !!(pkgJson.dependencies?.[packageName] || pkgJson.devDependencies?.[packageName]);
+  } catch {
+    return false;
+  }
+}
+
+export function getInstallCommand(packageManager: PackageManager, packageName: string): string {
+  switch (packageManager) {
+    case 'pnpm':
+      return `pnpm add --save-dev ${packageName}`;
+    case 'yarn':
+      return `yarn add --dev ${packageName}`;
+    case 'bun':
+      return `bun add --dev ${packageName}`;
+    default:
+      return `npm install --save-dev ${packageName}`;
+  }
+}
+
+export function installPackageSync(packageName: string, rootDir: string): void {
+  const pm = detectPackageManager(rootDir);
+  const cmd = getInstallCommand(pm, packageName);
+
+  execSync(cmd, { cwd: rootDir, stdio: 'pipe' });
+}


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request enhances the developer experience when publishing email templates by automating the installation of the `@novu/framework` package if it's not already present. It introduces utility functions for package management, ensuring TypeScript types are available without requiring manual steps. The most important changes are grouped below:

**Automated Framework Package Installation:**

* Added a new function `installFrameworkPackageIfNeeded` in `publish.ts` to automatically detect if `@novu/framework` is installed, and if not, install it using the appropriate package manager. This function also provides user guidance if installation fails.
* Updated the messaging in `scaffoldStepFileIfNeeded` to remove the manual install instruction and instead trigger the new automated installation process.

**Package Manager Utilities:**

* Created a new utility module `package-manager.ts` with functions to detect the package manager, check if a package is installed, get the correct install command, and perform a synchronous install.
* Re-exported the new package manager utility functions from `utils/index.ts` for use throughout the codebase.
* Updated imports in `publish.ts` to use the new package manager utility functions.
