### PR TITLE
feat(api): allow to pass a custom MixPanel host via env var

### DIFF
--- a/libs/application-generic/src/services/analytics.service.ts
+++ b/libs/application-generic/src/services/analytics.service.ts
@@ -31,7 +31,9 @@ export class AnalyticsService {
     }
 
     if (process.env.MIXPANEL_TOKEN) {
-      this.mixpanel = Mixpanel.init(process.env.MIXPANEL_TOKEN);
+      this.mixpanel = Mixpanel.init(process.env.MIXPANEL_TOKEN, {
+        host: process.env.MIXPANEL_HOST,
+      });
     }
   }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

Allow to customize the MixPanel host via an env variable

https://github.com/novuhq/novu/issues/10174
