### PR TITLE
fix(api-service): OpenSSL API vulnerability

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.20 AS dev_base
+FROM node:20-alpine3.21 AS dev_base
 RUN apk add --no-cache g++ make py3-pip
 ENV NX_DAEMON=false
 
@@ -46,7 +46,7 @@ WORKDIR /usr/src/app
 RUN pnpm recursive exec -- rm -rf ./src
 
 # ------- PRODUCTION BUILD ----------
-FROM node:20-alpine3.20 AS prod
+FROM node:20-alpine3.21 AS prod
 
 ARG PACKAGE_PATH
 

--- a/apps/dashboard/dockerfile
+++ b/apps/dashboard/dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.20 AS builder
+FROM node:20-alpine3.21 AS builder
 RUN apk add g++ make py3-pip
 ENV NX_DAEMON=false
 
@@ -25,7 +25,7 @@ RUN --mount=type=cache,id=pnpm-store-dashboard,target=/root/.pnpm-store\
 
 RUN CI='' pnpm build:dashboard --skip-nx-cache
 
-FROM node:20-alpine3.20
+FROM node:20-alpine3.21
 
 RUN npm install -g http-server --loglevel notice
 

--- a/apps/inbound-mail/Dockerfile
+++ b/apps/inbound-mail/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.20 as dev_base
+FROM node:20-alpine3.21 as dev_base
 RUN apk add g++ make py3-pip
 
 ENV NX_DAEMON=false

--- a/apps/webhook/Dockerfile
+++ b/apps/webhook/Dockerfile
@@ -1,5 +1,5 @@
 # Use the base image for development
-FROM node:20-alpine3.20 AS dev_base
+FROM node:20-alpine3.21 AS dev_base
 RUN apk add --no-cache g++ make py3-pip
 ENV NX_DAEMON=false
 
@@ -42,7 +42,7 @@ RUN pnpm recursive exec -- rm -rf ./src
 
 # ------- PRODUCTION BUILD ----------
 # Use clean base for production (NO Python)
-FROM node:20-alpine3.20 AS prod
+FROM node:20-alpine3.21 AS prod
 ARG PACKAGE_PATH
 
 # Set environment variables for production

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.20 AS dev_base
+FROM node:20-alpine3.21 AS dev_base
 RUN apk --update --no-cache add curl g++ make py3-pip
 ENV NX_DAEMON=false
 
@@ -49,7 +49,7 @@ WORKDIR /usr/src/app
 RUN pnpm recursive exec -- rm -rf ./src
 
 # ------- PRODUCTION BUILD ----------
-FROM node:20-alpine3.20 AS prod
+FROM node:20-alpine3.21 AS prod
 ARG PACKAGE_PATH
 
 ENV CI=true

--- a/apps/ws/Dockerfile
+++ b/apps/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.20 AS dev_base
+FROM node:20-alpine3.21 AS dev_base
 RUN apk add --no-cache g++ make py3-pip
 ENV NX_DAEMON=false
 
@@ -47,7 +47,7 @@ WORKDIR /usr/src/app
 RUN pnpm recursive exec -- rm -rf ./src
 
 # ------- PRODUCTION BUILD ----------
-FROM node:20-alpine3.20 AS prod
+FROM node:20-alpine3.21 AS prod
 
 ARG PACKAGE_PATH
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Bumped the Alpine base image from `3.20` to `3.21` across all service Dockerfiles (`api`, `worker`, `ws`, `webhook`, `inbound-mail`, `dashboard`).

This change was needed to address CVE-2025-9230, an OpenSSL vulnerability present in `node:20-alpine3.20` (which ships with OpenSSL `3.3.3-r0`). The `node:20-alpine3.21` base image includes the patched OpenSSL `3.3.5-r0`.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1772638672472399?thread_ts=1772638672.472399&cid=D0919LNRWE7)

<p><a href="https://cursor.com/agents/bc-0e887ff8-83ad-5aec-a30e-189f8480bdaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e887ff8-83ad-5aec-a30e-189f8480bdaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->