### PR TITLE
fix(dashboard): Email validation template variables for send email fixes NV-7194

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/email/sender-config-drawer.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/sender-config-drawer.tsx
@@ -57,6 +57,10 @@ export function SenderConfigDrawer({ open, onOpenChange }: SenderConfigDrawerPro
       return true;
     }
 
+    if (/\{\{.*?\}\}/.test(email)) {
+      return true;
+    }
+
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
     return emailRegex.test(email);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The `validateEmail` function in `apps/dashboard/src/components/workflow-editor/steps/email/sender-config-drawer.tsx` was updated to skip email regex validation if the input contains template variable syntax (e.g., `{{...}}`).

This change resolves [NV-7194](https://linear.app/novu/issue/NV-7194), which prevented users from saving sender configurations when the "Sender email" field contained template variables, as the client-side validation incorrectly flagged them as invalid email addresses. The update allows dynamic email addresses to be used, aligning the behavior with the "Sender name" field.

### Screenshots

N/A, see [NV-7194](https://linear.app/novu/issue/NV-7194) for the original bug screenshot.

---
Linear Issue: [NV-7194](https://linear.app/novu/issue/NV-7194/sender-email-validation-rejects-template-variables-in-sender-config)

<p><a href="https://cursor.com/agents/bc-088b5752-f4a5-438e-a98b-4c7bdb7ef0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-088b5752-f4a5-438e-a98b-4c7bdb7ef0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->