### PR TITLE
fix(root): Github actions contributor access

### DIFF
--- a/.github/workflows/contributor-checks.yml
+++ b/.github/workflows/contributor-checks.yml
@@ -42,6 +42,8 @@ jobs:
     if: needs.check-contributor.outputs.is_community == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      NX_NO_CLOUD: "true"
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Added `NX_NO_CLOUD: "true"` as an environment variable to the `contributor-install-build-lint` job in `.github/workflows/contributor-checks.yml`.

This change is needed because contributor checks were failing for external contributors due to "Nx Cloud: Workspace is unable to be authorized" errors. The `nx.json` configures Nx Cloud as the default task runner, and external contributors lack the necessary access. Setting `NX_NO_CLOUD=true` bypasses Nx Cloud authentication for these checks, allowing lint and build tasks to run locally and complete successfully.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

Locally verified that with `NX_NO_CLOUD=true`, Nx outputs "Nx Cloud manually disabled" and proceeds to run tasks without authentication errors.
</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773049552272819?thread_ts=1773049552.272819&cid=D0919LNRWE7)

<p><a href="https://cursor.com/agents/bc-4df8f30c-dda9-5f9b-a67d-dcaa3432b182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4df8f30c-dda9-5f9b-a67d-dcaa3432b182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->