### PR TITLE
Github actions contributor access

### DIFF
--- a/.github/workflows/contributor-checks.yml
+++ b/.github/workflows/contributor-checks.yml
@@ -65,6 +65,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Disable Nx Cloud
+        run: |
+          node -e "
+            const fs = require('fs');
+            const nx = JSON.parse(fs.readFileSync('nx.json', 'utf-8'));
+            delete nx.tasksRunnerOptions;
+            delete nx.nxCloudId;
+            delete nx.nxCloudAccessToken;
+            delete nx.nxCloudUrl;
+            delete nx.nxCloudEncryptionKey;
+            nx.neverConnectToCloud = true;
+            fs.writeFileSync('nx.json', JSON.stringify(nx, null, 2));
+          "
+
       - name: Reset Nx cache
         run: npx nx reset || true
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Added a step to the `contributor-checks.yml` workflow to patch `nx.json` before running lint/build. This patch removes all Nx Cloud-related configuration (e.g., `tasksRunnerOptions`, `nxCloudId`) and sets `neverConnectToCloud: true`.

This change is needed because contributor checks were failing for read-only contributors due to Nx Cloud authorization errors. While `NX_NO_CLOUD=true` was set, Nx's runner selection logic would still load the `nx-cloud` light client if cloud configuration was present in `nx.json`. The light client's authorization check occurs *before* it processes `NX_NO_CLOUD`, leading to the 'Workspace is unable to be authorized' error. By stripping the cloud configuration from `nx.json`, we ensure the default local tasks runner is used, completely bypassing the cloud authorization process.

### Screenshots

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

### Special notes for your reviewer

</details>

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773049552272819?thread_ts=1773049552.272819&cid=D0919LNRWE7)

<p><a href="https://cursor.com/agents/bc-af417dfc-f5c5-5192-9c07-c32cd6765e86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af417dfc-f5c5-5192-9c07-c32cd6765e86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->