### PR TITLE
fix(dashboard): Integration store mandatory fields label fixes NV-7177

### DIFF
--- a/apps/dashboard/src/components/integrations/components/credential-section.tsx
+++ b/apps/dashboard/src/components/integrations/components/credential-section.tsx
@@ -31,7 +31,7 @@ const SECURE_CREDENTIALS = [
 
 function FormLabel({ credential, tooltip }: { credential: IConfigCredential; tooltip?: ReactNode }) {
   return (
-    <PrimitiveFormLabel htmlFor={credential.key} optional={!credential.required} tooltip={tooltip}>
+    <PrimitiveFormLabel htmlFor={credential.key} required={credential.required} optional={!credential.required} tooltip={tooltip}>
       {credential.displayName}
     </PrimitiveFormLabel>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Previously, mandatory credential fields in the integration store (e.g., for Slack) were not marked with a red asterisk, causing confusion for users as to why the "Create Integration" button remained disabled.

This change updates the `FormLabel` component in `credential-section.tsx` to correctly pass the `required` prop based on `credential.required`. This ensures that all mandatory credential fields now display a red asterisk (`*`), providing a clear visual indication to the user.

### Screenshots

![Slack integration form with required field indicators](slack_integration_required_fields.webp)

---
Linear Issue: [NV-7177](https://linear.app/novu/issue/NV-7177/dashboard-ux-integration-store-does-not-allow-to-store-new-provider)

<p><a href="https://cursor.com/agents/bc-3848fb3d-1684-4422-88ea-f709711af728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3848fb3d-1684-4422-88ea-f709711af728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->