### PR TITLE
feat(dashboard): Onboarding cursor deeplink

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -141,6 +141,7 @@
     "decompile",
     "dedup",
     "deduplicated",
+    "deeplink",
     "deepmerge",
     "Deepmerge",
     "defexps",

--- a/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/angular-prompt.ts
+++ b/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/angular-prompt.ts
@@ -7,68 +7,29 @@ import { environment } from '../environments/environment';
 @Component({
   selector: 'app-notification-center',
   template: \`
-    <!-- Ensure the environment variable is available -->
     <div *ngIf="applicationIdentifier" id="novu-notification-center"></div>
-    <div *ngIf="!applicationIdentifier">
-      <p>NOVU_APP_IDENTIFIER is not defined in environment</p>
-    </div>
   \`
 })
 export class NotificationCenterComponent implements OnInit {
   applicationIdentifier = environment.novuAppIdentifier;
   subscriberId = environment.novuSubscriberId;
-
-  // Backend configuration (for EU region use https://eu.api.novu.co and https://eu.ws.novu.co)
   backendUrl = '';
   socketUrl = '';
 
-  // Appearance configuration
   appearance = {
-    // Base theme configuration
-    baseTheme: 'dark', // Or undefined for light theme
-
-    // Variables for global styling
-    variables: {
-      colorPrimary: '',
-      colorPrimaryForeground: '',
-      colorSecondary: '',
-      colorSecondaryForeground: '',
-      colorCounter: '',
-      colorCounterForeground: '',
-      colorBackground: '',
-      colorRing: '',
-      colorForeground: '',
-      colorNeutral: '',
-      colorShadow: '',
-
-      // Typography and Layout
-      fontSize: '',
-    },
-    elements: {
-      bellIcon: {
-        color: '',
-      },
-    },
+    variables: {},
+    elements: {},
   };
-
-  // Layout configuration
-  placement = '';
-  placementOffset = {};
 
   constructor(private novuService: NovuService) {}
 
   async ngOnInit() {
-    if (!this.applicationIdentifier || !this.subscriberId) {
-      console.error('Required environment variables are not defined');
-      return;
-    }
+    if (!this.applicationIdentifier || !this.subscriberId) return;
 
     await this.novuService.initialize({
       backendUrl: this.backendUrl,
       socketUrl: this.socketUrl,
       appearance: this.appearance,
-      placement: this.placement,
-      placementOffset: this.placementOffset,
     });
 
     this.novuService.showNotificationCenter('novu-notification-center');
@@ -93,19 +54,19 @@ const ANGULAR_PROMPT = `You are an AI agent specialized in integrating the Novu 
 Before starting the integration, analyze the host application to understand:
 
 **Project Structure Analysis**:
-- [ ] Package manager (pnpm, yarn, npm, bun)
-- [ ] Angular version and configuration
-- [ ] Existing authentication system (Auth0, Firebase, Supabase, custom)
-- [ ] UI framework/library (Angular Material, PrimeNG, Tailwind, etc.)
-- [ ] Existing component patterns and naming conventions
-- [ ] State management solution (NgRx, NGXS, Akita, etc.)
-- [ ] Module structure (feature modules, shared modules, etc.)
+- Package manager (pnpm, yarn, npm, bun)
+- Angular version and configuration
+- Existing authentication system (Auth0, Firebase, Supabase, custom)
+- UI framework/library (Angular Material, PrimeNG, Tailwind, etc.)
+- Existing component patterns and naming conventions
+- State management solution (NgRx, NGXS, Akita, etc.)
+- Module structure (feature modules, shared modules, etc.)
 
 **UI Placement Analysis**:
 Potential common places where the inbox could be integrated in the UI:
-- [ ] Header/navbar structure and positioning
-- [ ] User menu or profile dropdown location
-- [ ] Sidebar layout and available space
+- Header/navbar structure and positioning
+- User menu or profile dropdown location
+- Sidebar layout and available space
 
 ## Critical Constraints & Requirements
 
@@ -144,10 +105,6 @@ pnpm add @novu/js
 # or
 bun add @novu/js
 \`\`\`
-
-**Verification**:
-- [ ] Package installed successfully
-- [ ] No peer dependency conflicts
 
 ### Step 2: Environment Configuration
 **Objective**: Set up the required environment configuration for Novu
@@ -194,8 +151,6 @@ export class NovuService {
     backendUrl?: string;
     socketUrl?: string;
     appearance?: any;
-    placement?: string;
-    placementOffset?: any;
   }) {
     if (!environment.novuAppIdentifier) return;
 
@@ -223,98 +178,11 @@ export class NovuService {
 **Implementation**:
 \`\`\`typescript
 const appearance = {
-  variables: {
-    // Optional: define colors, typography, spacing, border-radius, etc.
-  },
-  elements: {
-    // Optional: customize container, notifications, badges, buttons, etc.
-  },
+  variables: {},
+  elements: {},
 };
+// Extract the host app's design tokens (colors, typography, spacing) from its styling system and map them to the appearance variables.
 \`\`\`
-
-### Step 4.0 — Styling Integration Principles
-
-Extract styling variables from the host application first.
-
-Customize only what's necessary to achieve visual consistency.
-
-Avoid introducing new styles that don't exist in the host application.
-
-### Step 4.1 — Extract Styling Variables
-
-**Objective**:
-- Collect and prepare the host application's design tokens for the appearance configuration.
-
-**Actions**:
-
-- Identify styling system:
-
-- Angular Material → check theme configuration
-
-- Tailwind CSS → check tailwind.config.js
-
-- CSS custom properties → check :root {}
-
-- SCSS/SASS → look for _variables.scss
-
-- Locate variables: Extract values such as primary/secondary colors, background, text, borders, shadows, radii, and fonts.
-
-- Create variables object: Map them to the appearance configuration.
-
-- Validate: Ensure the object is correctly referenced.
-
-
-**Suggested Variables to Extract**:
-
-- colorBackground → main background
-- colorForeground → base text color
-- colorPrimary, colorPrimaryForeground
-- colorSecondary, colorSecondaryForeground
-- colorNeutral → borders/dividers
-- fontSize → base font size
-
-**Fallback Guidelines**:
-
-- If variables are missing, infer equivalents from the app's design.
-
-- Use the most prominent brand colors as primary/secondary.
-
-- Stick to values consistent with existing patterns.
-
-- Document any assumptions.
-
-### Step 4.2 — Apply Variables
-
-**Objective**:    
-Integrate the extracted variables into the appearance configuration.
-
-**Actions**:
-
-- Apply the variables object to the appearance configuration.
-
-- [ ] Confirm the variables are applied and override correctly.
-
-**Verification**:
-
-- [ ] The variables object is applied and functional.
-
-### Step 4.3 — Validate Visual Integration
-
-**Objective**:
-- Ensure the notification center aligns visually with the host application.
-
-**Actions**:
-1. Extract design tokens from the host application:
-   - **Angular Material**: Check theme configuration.
-   - **Tailwind CSS**: Check tailwind.config.js.
-   - **CSS Variables**: Inspect :root {}.
-   - **SCSS/SASS**: Look for _variables.scss.
-
-2. Map the extracted tokens to the appearance configuration.
-
-3. Validate the integration:
-   - [ ] Ensure the variables are applied correctly.
-   - [ ] Confirm visual consistency with the host application.
 
 ### Step 5: Component Creation
 **Objective**: Create a self-contained component for the Inbox integration
@@ -341,47 +209,16 @@ ${KITCHEN_SINK_INBOX_SNIPPET}
 ### Step 7: Validation & Testing
 **Objective**: Ensure the integration meets all quality standards
 
-**Visual Validation**:
-- [ ] Proper spacing and typography
-- [ ] Consistent with host application design system
+- Proper spacing and typography
+- Consistent with host application design system
+- No JavaScript errors
+- No TypeScript compilation errors
+- No Angular template errors
 
-**Console Validation**:
-- [ ] No JavaScript errors
-- [ ] No TypeScript compilation errors
-- [ ] No Angular template errors
-
-### Step 8: AI Model Verification (Internal Process)
-**Objective**: Perform final verification before returning code
-
-**Verification Checklist**:
-- [ ] Package installation confirmed
-- [ ] Environment configuration properly set up
-- [ ] Service created and properly injected
-- [ ] Component uses proper Angular patterns
-- [ ] Appearance configuration is inline and type-safe
-- [ ] Component is properly placed in the UI
-
-**Action**: If any check fails → stop and revise the implementation
-
-### Step 9: Iterative Refinement Process
-**Objective**: Fine-tune the integration based on validation results
-
-**Refinement Areas**:
-- Adjust inline appearance properties
-- Optimize service logic
-- Improve placement positioning
-- Preserve validated design tokens and placement
-
-### Step 10: Final Output Requirements
-**Objective**: Deliver a complete, production-ready integration
-
-**Required Deliverables**:
-- Self-contained NotificationCenterComponent
-- NovuService with proper typing
-- Inline appearance configuration with empty placeholders
-- Environment configuration
-- TypeScript compliance with proper typing
-- Dark mode support (if any)
+### Step 8: Verify & Deliver
+- Confirm package installation, env vars, component configuration, and UI placement
+- Ensure TypeScript compliance and no console errors
+- Deliver a self-contained component with inline appearance, subscriber detection, and env var references
 `;
 
 /**

--- a/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/javascript-prompt.ts
+++ b/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/javascript-prompt.ts
@@ -9,6 +9,10 @@ const novu = new NovuUI({
     backendUrl: '',
     socketUrl: '',
   },
+  appearance: {
+    variables: {},
+    elements: {},
+  },
 });
 
 novu.mountComponent({
@@ -35,19 +39,19 @@ const JAVASCRIPT_PROMPT = `You are an AI agent specialized in integrating the No
 Before starting the integration, analyze the host application to understand:
 
 **Project Structure Analysis**:
-- [ ] Package manager (pnpm, yarn, npm, bun)
-- [ ] Build tool (Webpack, Vite, Parcel, etc.)
-- [ ] Module system (ESM, CommonJS)
-- [ ] Existing authentication system (custom, third-party)
-- [ ] UI patterns (vanilla DOM, Web Components)
-- [ ] Existing component patterns and naming conventions
-- [ ] State management approach (custom, third-party)
+- Package manager (pnpm, yarn, npm, bun)
+- Build tool (Webpack, Vite, Parcel, etc.)
+- Module system (ESM, CommonJS)
+- Existing authentication system (custom, third-party)
+- UI patterns (vanilla DOM, Web Components)
+- Existing component patterns and naming conventions
+- State management approach (custom, third-party)
 
 **UI Placement Analysis**:
 Potential common places where the inbox could be integrated in the UI:
-- [ ] Header/navbar structure and positioning
-- [ ] User menu or profile dropdown location
-- [ ] Sidebar layout and available space
+- Header/navbar structure and positioning
+- User menu or profile dropdown location
+- Sidebar layout and available space
 
 ## Critical Constraints & Requirements
 
@@ -86,10 +90,6 @@ pnpm add @novu/js
 # or
 bun add @novu/js
 \`\`\`
-
-**Verification**:
-- [ ] Package installed successfully
-- [ ] No peer dependency conflicts
 
 ### Step 2: Environment Variable Configuration
 **Objective**: Set up the required environment variables for Novu
@@ -146,100 +146,16 @@ export const novuManager = new NovuManager();
 \`\`\`
 
 ### Step 4: Inline Appearance Configuration
-**Objective**: Create type-safe appearance configuration
+**Objective**: Create appearance configuration
 
 **Implementation**:
 \`\`\`javascript
 const appearance = {
-  variables: {
-    // Optional: define colors, typography, spacing, border-radius, etc.
-  },
-  elements: {
-    // Optional: customize container, notifications, badges, buttons, etc.
-  },
+  variables: {},
+  elements: {},
 };
+// Extract the host app's design tokens (colors, typography, spacing) from its styling system and map them to the appearance variables.
 \`\`\`
-
-### Step 4.0 — Styling Integration Principles
-
-Extract styling variables from the host application first.
-
-Customize only what's necessary to achieve visual consistency.
-
-Avoid introducing new styles that don't exist in the host application.
-
-### Step 4.1 — Extract Styling Variables
-
-**Objective**:
-- Collect and prepare the host application's design tokens for the appearance configuration.
-
-**Actions**:
-
-- Identify styling system:
-
-- CSS custom properties → check :root {}
-
-- SCSS/SASS → look for _variables.scss
-
-- CSS-in-JS → inspect theme objects
-
-- Locate variables: Extract values such as primary/secondary colors, background, text, borders, shadows, radii, and fonts.
-
-- Create variables object: Map them to the appearance configuration.
-
-- Validate: Ensure the object is correctly referenced.
-
-
-**Suggested Variables to Extract**:
-
-- colorBackground → main background
-- colorForeground → base text color
-- colorPrimary, colorPrimaryForeground
-- colorSecondary, colorSecondaryForeground
-- colorNeutral → borders/dividers
-- fontSize → base font size
-
-**Fallback Guidelines**:
-
-- If variables are missing, infer equivalents from the app's design.
-
-- Use the most prominent brand colors as primary/secondary.
-
-- Stick to values consistent with existing patterns.
-
-- Document any assumptions.
-
-### Step 4.2 — Apply Variables
-
-**Objective**:    
-Integrate the extracted variables into the appearance configuration.
-
-**Actions**:
-
-- Apply the variables object to the appearance configuration.
-
-- [ ] Confirm the variables are applied and override correctly.
-
-**Verification**:
-
-- [ ] The variables object is applied and functional.
-
-### Step 4.3 — Validate Visual Integration
-
-**Objective**:
-- Ensure the notification center aligns visually with the host application.
-
-**Actions**:
-1. Extract design tokens from the host application:
-   - **CSS Variables**: Inspect :root {}.
-   - **SCSS/SASS**: Look for _variables.scss.
-   - **CSS-in-JS**: Review theme objects.
-
-2. Map the extracted tokens to the appearance configuration.
-
-3. Validate the integration:
-   - [ ] Ensure the variables are applied correctly.
-   - [ ] Confirm visual consistency with the host application.
 
 ### Step 5: Integration Implementation
 **Objective**: Create a self-contained implementation for the Inbox integration
@@ -266,47 +182,16 @@ ${KITCHEN_SINK_INBOX_SNIPPET}
 ### Step 7: Validation & Testing
 **Objective**: Ensure the integration meets all quality standards
 
-**Visual Validation**:
-- [ ] Proper spacing and typography
-- [ ] Consistent with host application design system
+- Proper spacing and typography
+- Consistent with host application design system
+- No JavaScript errors
+- No module loading errors
+- No DOM manipulation errors
 
-**Console Validation**:
-- [ ] No JavaScript errors
-- [ ] No module loading errors
-- [ ] No DOM manipulation errors
-
-### Step 8: AI Model Verification (Internal Process)
-**Objective**: Perform final verification before returning code
-
-**Verification Checklist**:
-- [ ] Package installation confirmed
-- [ ] Environment variables properly configured
-- [ ] Module properly initialized
-- [ ] DOM ready state handled
-- [ ] Appearance configuration is inline
-- [ ] Component is properly placed in the UI
-
-**Action**: If any check fails → stop and revise the implementation
-
-### Step 9: Iterative Refinement Process
-**Objective**: Fine-tune the integration based on validation results
-
-**Refinement Areas**:
-- Adjust inline appearance properties
-- Optimize initialization logic
-- Improve placement positioning
-- Preserve validated design tokens and placement
-
-### Step 10: Final Output Requirements
-**Objective**: Deliver a complete, production-ready integration
-
-**Required Deliverables**:
-- Self-contained JavaScript module
-- DOM ready state handling
-- Inline appearance configuration with empty placeholders
-- Environment variable configuration
-- Error handling and fallbacks
-- Dark mode support (if any)
+### Step 8: Verify & Deliver
+- Confirm package installation, env vars, component configuration, and UI placement
+- Ensure TypeScript compliance and no console errors
+- Deliver a self-contained component with inline appearance, subscriber detection, and env var references
 `;
 
 /**

--- a/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/nextjs-prompt.ts
+++ b/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/nextjs-prompt.ts
@@ -4,51 +4,19 @@ const KITCHEN_SINK_INBOX_SNIPPET = `'use client';
 import { Inbox } from '@novu/nextjs';
 
 export default function NotificationInbox({ subscriberId }: { subscriberId: string }) {
-  // Ensure the environment variable is available
   const applicationIdentifier = process.env.NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER;
 
   return (
     <Inbox
-      // Required core configuration
       applicationIdentifier={applicationIdentifier}
       subscriberId={subscriberId}
-
-      // Backend configuration (for EU region use https://eu.api.novu.co and wss://eu.ws.novu.co)
+      // For EU region use https://eu.api.novu.co and wss://eu.ws.novu.co
       backendUrl="https://eu.api.novu.co"
       socketUrl="wss://eu.ws.novu.co"
-
-      // Appearance configuration
       appearance={{
-        // Base theme configuration
-        baseTheme: 'dark', // Or undefined for light theme
-
-        // Variables for global styling
-        variables: {
-          colorPrimary: '',
-          colorPrimaryForeground: '',
-          colorSecondary: '',
-          colorSecondaryForeground: '',
-          colorCounter: '',
-          colorCounterForeground: '',
-          colorBackground: '',
-          colorRing: '',
-          colorForeground: '',
-          colorNeutral: '',
-          colorShadow: '',
-
-          // Typography and Layout
-          fontSize: '',
-        },
-        elements: {
-          bellIcon: {
-            color: '',
-          },
-        },
+        variables: {},
+        elements: {},
       }}
-
-      // Layout configuration
-      placement=""
-      placementOffset={}
     />
   );
 }
@@ -72,18 +40,18 @@ const NEXTJS_PROMPT = `You are an AI agent specialized in integrating the Novu I
 Before starting the integration, analyze the host application to understand:
 
 **Project Structure Analysis**:
-- [ ] Package manager (pnpm, yarn, npm, bun)
-- [ ] Next.js version and configuration
-- [ ] Existing authentication system (Clerk, NextAuth, Firebase, Supabase, custom)
-- [ ] UI framework/library (Tailwind, styled-components, CSS modules, etc.)
-- [ ] Existing component patterns and naming conventions
-- [ ] Router type (App Router vs Pages Router)
+- Package manager (pnpm, yarn, npm, bun)
+- Next.js version and configuration
+- Existing authentication system (Clerk, NextAuth, Firebase, Supabase, custom)
+- UI framework/library (Tailwind, styled-components, CSS modules, etc.)
+- Existing component patterns and naming conventions
+- Router type (App Router vs Pages Router)
 
 **UI Placement Analysis**:
 Potential common places where the inbox could be integrated in the UI:
-- [ ] Header/navbar structure and positioning
-- [ ] User menu or profile dropdown location
-- [ ] Sidebar layout and available space
+- Header/navbar structure and positioning
+- User menu or profile dropdown location
+- Sidebar layout and available space
 
 ## Critical Constraints & Requirements
 
@@ -93,7 +61,7 @@ Potential common places where the inbox could be integrated in the UI:
 - **Subscriber ID Management**: Extract subscriber IDs using authentication hooks for seamless integration.
 - **Environment Variables**: Verify the presence of .env.local or .env files with correct configurations to support the application environment.
 - **TypeScript Compliance**: Adhere to Novu Inbox props and follow TypeScript best practices to ensure type safety and maintainable code.
-- **Backend and Socket URL**: Only override 'backendUrl'/'socketUrl' when targeting a non-default region (e.g., EU) based on workspace/tenant configuration — not end-user location. Read from 'NEXT_PUBLIC_NOVU_BACKEND_URL' and 'NEXT_PUBLIC_NOVU_SOCKET_URL' when set; otherwise omit these props to use defaults.   
+- **Backend and Socket URL**: Only override 'backendUrl'/'socketUrl' when targeting a non-default region (e.g., EU) based on workspace/tenant configuration — not end-user location. Read from 'NEXT_PUBLIC_NOVU_BACKEND_URL' and 'NEXT_PUBLIC_NOVU_SOCKET_URL' when set; otherwise omit these props to use defaults.
 
 ### Never Do:
 - **External Files**: Use external appearance objects or separate files to manage styling and design elements.
@@ -112,11 +80,7 @@ Potential common places where the inbox could be integrated in the UI:
 
 **Actions**:
 1. Detect the project's package manager (pnpm, yarn, npm, bun)
-2. Install @novu/nextjs using the appropriate command:
-
-**Verification**:
-- [ ] Package installed successfully
-- [ ] No peer dependency conflicts
+2. Install @novu/nextjs using the appropriate command
 
 ### Step 2: Environment Variable Configuration
 **Objective**: Set up the required environment variable for Novu application identifier
@@ -144,114 +108,17 @@ NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER=YOUR_APP_IDENTIFIER
 subscriberId="YOUR_SUBSCRIBER_ID"
 \`\`\`
 
-**Validation**:
-- [ ] Subscriber ID is properly extracted from auth system
-- [ ] Fallback placeholder is used when auth is not available
-- [ ] No undefined or null values passed to component
-
 ### Step 4: Inline Appearance Configuration
-**Objective**: Embed empty appearance objects to demonstrate customization capabilities
+**Objective**: Embed appearance objects matching the host application's design
 
 **Implementation**:
 \`\`\`typescript
 appearance={{
-  variables: {
-    // Optional: define colors, typography, spacing, border-radius, etc.
-    // Example: colors: { primary: '#007bff', secondary: '#6c757d' }
-  },
-  elements: {
-    // Optional: customize container, notifications, badges, buttons, etc.
-    // Example: container: { backgroundColor: 'var(--bg-color)' }
-  },
-  icons: {
-    // Optional: override icons, e.g.
-  },
+  variables: {},
+  elements: {},
 }}
 \`\`\`
-
-### Step 4.0 — Styling Integration Principles
-
-Extract styling variables from the host application first.
-
-Customize only what's necessary to achieve visual consistency.
-
-Avoid introducing new styles that don't exist in the host application.
-
-### Step 4.1 — Extract Styling Variables
-
-**Objective**:
-- Collect and prepare the host application's design tokens (colors, typography, spacing) for the <Inbox /> component appearance.variables object.
-
-**Actions**:
-
-- Identify styling system:
-
-- Tailwind CSS → check tailwind.config.js
-
-- CSS custom properties → check :root {}
-
-- SCSS/SASS → look for _variables.scss
-
-- CSS-in-JS → inspect theme objects or styled-components
-
-- Locate variables: Extract values such as primary/secondary colors, background, text, borders, shadows, radii, and fonts.
-
-- Create variables object: Map them to the appearance.variables object on <Inbox />.
-
-- Validate: Ensure the object is correctly referenced inside the appearance prop.
-
-
-**Suggested Variables to Extract**:
-
-- colorBackground → main background
-- colorForeground → base text color
-- colorPrimary, colorPrimaryForeground
-- colorSecondary, colorSecondaryForeground
-- colorNeutral → borders/dividers
-- fontSize → base font size
-
-**Fallback Guidelines**:
-
-- If variables are missing, infer equivalents from the app's design.
-
-- Use the most prominent brand colors as primary/secondary.
-
-- Stick to values consistent with existing patterns.
-
-- Document any assumptions.
-
-### Step 4.2 — Apply Variables
-
-**Objective**:    
-Integrate the extracted variables into <Inbox />.
-
-**Actions**:
-
-- Apply the variables object to the <Inbox appearance={{ variables: {...} }} />.
-
-- [ ] Confirm the variables are applied and override correctly.
-
-**Verification**:
-
-- [ ] The variables object is applied and functional.
-
-### Step 4.3 — Validate Visual Integration
-
-**Objective**:
-- Ensure <Inbox /> aligns visually with the host application.
-
-**Actions**:
-1. Extract design tokens (e.g., colors, typography, spacing) from the host application:
-   - **Tailwind CSS**: Check tailwind.config.js.
-   - **CSS Variables**: Inspect :root {}.
-   - **SCSS/SASS**: Look for _variables.scss.
-   - **CSS-in-JS**: Review theme objects or styled-components.
-
-2. Map the extracted tokens to the appearance.variables object.
-
-3. Validate the integration:
-   - [ ] Ensure the variables are applied correctly.
-   - [ ] Confirm visual consistency with the host application.
+Extract the host app's design tokens (colors, typography, spacing) from its styling system (Tailwind config, CSS variables, SCSS, theme objects) and map them to the appearance.variables object.
 
 ### Step 5: Component Creation
 **Objective**: Create a self-contained component for the Inbox integration
@@ -278,45 +145,15 @@ ${KITCHEN_SINK_INBOX_SNIPPET}
 ### Step 7: Validation & Testing
 **Objective**: Ensure the integration meets all quality standards
 
-**Visual Validation**:
-- [ ] Proper spacing and typography
-- [ ] Consistent with host application design system
+- Proper spacing and typography
+- Consistent with host application design system
+- No JavaScript errors
+- No TypeScript compilation errors
 
-**Console Validation**:
-- [ ] No JavaScript errors
-- [ ] No TypeScript compilation errors
-
-### Step 8: AI Model Verification (Internal Process)
-**Objective**: Perform final verification before returning code
-
-**Verification Checklist**:
-- [ ] Package installation confirmed
-- [ ] <Inbox /> component is inline with no wrappers/triggers
-- [ ] <Inbox /> component is properly configured with all required props
-- [ ] <Inbox /> component is properly styled and aligned with the host application's design system
-- [ ] <Inbox /> component is properly placed in the appropriate UI location
-
-**Action**: If any check fails → stop and revise the implementation
-
-### Step 9: Iterative Refinement Process
-**Objective**: Fine-tune the integration based on validation results
-
-**Refinement Areas**:
-- Adjust inline appearance properties
-- Optimize subscriber detection logic
-- Improve placement positioning
-- Preserve validated design tokens and placement
-
-### Step 10: Final Output Requirements
-**Objective**: Deliver a complete, production-ready integration
-
-**Required Deliverables**:
-- Self-contained NotificationInbox.tsx component
-- Inline appearance prop with empty placeholders
-- Subscriber detection with fallback mechanism
-- Environment variable reference via .env.local
-- TypeScript compliance with proper typing
-- Dark mode support (if any)
+### Step 8: Verify & Deliver
+- Confirm package installation, env vars, component props, and UI placement
+- Ensure TypeScript compliance and no console errors
+- Deliver a self-contained component with inline appearance, subscriber detection, and env var references
 `;
 
 /**

--- a/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/react-native-prompt.ts
+++ b/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/react-native-prompt.ts
@@ -4,58 +4,24 @@ import { NotificationCenter } from '@novu/react-native';
 import Config from 'react-native-config';
 
 export default function NotificationInbox() {
-  // Ensure the environment variables are available
   const applicationIdentifier = Config.NOVU_APP_IDENTIFIER;
   const subscriberId = Config.NOVU_SUBSCRIBER_ID;
 
   if (!applicationIdentifier || !subscriberId) {
-    console.error('Required environment variables are not defined');
     return null;
   }
 
   return (
     <View style={styles.container}>
       <NotificationCenter
-        // Required core configuration
         applicationIdentifier={applicationIdentifier}
         subscriberId={subscriberId}
-
-        // Backend configuration (for EU region use https://eu.api.novu.co and https://eu.ws.novu.co)
         backendUrl=""
         socketUrl=""
-
-        // Appearance configuration
         appearance={{
-          // Base theme configuration
-          baseTheme: dark, // Or undefined for light theme
-
-          // Variables for global styling
-          variables: {
-            colorPrimary: '',
-            colorPrimaryForeground: '',
-            colorSecondary: '',
-            colorSecondaryForeground: '',
-            colorCounter: '',
-            colorCounterForeground: '',
-            colorBackground: '',
-            colorRing: '',
-            colorForeground: '',
-            colorNeutral: '',
-            colorShadow: '',
-
-            // Typography and Layout
-            fontSize: '',
-          },
-          elements: {
-            bellIcon: {
-              color: '',
-            },
-          },
+          variables: {},
+          elements: {},
         }}
-
-        // Layout configuration
-        placement=""
-        placementOffset={{}}
       />
     </View>
   );
@@ -85,21 +51,21 @@ const REACT_NATIVE_PROMPT = `You are an AI agent specialized in integrating the 
 Before starting the integration, analyze the host application to understand:
 
 **Project Structure Analysis**:
-- [ ] Package manager (pnpm, yarn, npm, bun)
-- [ ] React Native version and configuration
-- [ ] Navigation system (React Navigation, Expo Router)
-- [ ] Existing authentication system (Auth0, Firebase, Supabase, custom)
-- [ ] UI framework/library (React Native Paper, Native Base, etc.)
-- [ ] Existing component patterns and naming conventions
-- [ ] State management solution (Redux, MobX, Zustand, etc.)
-- [ ] Environment variable handling (react-native-config, dotenv)
+- Package manager (pnpm, yarn, npm, bun)
+- React Native version and configuration
+- Navigation system (React Navigation, Expo Router)
+- Existing authentication system (Auth0, Firebase, Supabase, custom)
+- UI framework/library (React Native Paper, Native Base, etc.)
+- Existing component patterns and naming conventions
+- State management solution (Redux, MobX, Zustand, etc.)
+- Environment variable handling (react-native-config, dotenv)
 
 **UI Placement Analysis**:
 Potential common places where the inbox could be integrated in the UI:
-- [ ] Header/navbar structure and positioning
-- [ ] Tab bar or drawer menu location
-- [ ] Screen layout and available space
-- [ ] Platform-specific considerations (iOS vs Android)
+- Header/navbar structure and positioning
+- Tab bar or drawer menu location
+- Screen layout and available space
+- Platform-specific considerations (iOS vs Android)
 
 ## Critical Constraints & Requirements
 
@@ -138,11 +104,6 @@ pnpm add @novu/react-native react-native-config
 # or
 bun add @novu/react-native react-native-config
 \`\`\`
-
-**Verification**:
-- [ ] Package installed successfully
-- [ ] No peer dependency conflicts
-- [ ] Native modules linked properly
 
 ### Step 2: Environment Variable Configuration
 **Objective**: Set up the required environment variables for Novu
@@ -195,95 +156,11 @@ export default function App() {
 **Implementation**:
 \`\`\`typescript
 const appearance = {
-  variables: {
-    // Optional: define colors, typography, spacing, border-radius, etc.
-  },
-  elements: {
-    // Optional: customize container, notifications, badges, buttons, etc.
-  },
+  variables: {},
+  elements: {},
 };
 \`\`\`
-
-### Step 4.0 — Styling Integration Principles
-
-Extract styling variables from the host application first.
-
-Customize only what's necessary to achieve visual consistency.
-
-Avoid introducing new styles that don't exist in the host application.
-
-### Step 4.1 — Extract Styling Variables
-
-**Objective**:
-- Collect and prepare the host application's design tokens for the appearance configuration.
-
-**Actions**:
-
-- Identify styling system:
-
-- Theme configuration → check theme files
-
-- StyleSheet definitions → check style files
-
-- UI library → check theme configuration
-
-- Locate variables: Extract values such as primary/secondary colors, background, text, borders, shadows, radii, and fonts.
-
-- Create variables object: Map them to the appearance configuration.
-
-- Validate: Ensure the object is correctly referenced.
-
-
-**Suggested Variables to Extract**:
-
-- colorBackground → main background
-- colorForeground → base text color
-- colorPrimary, colorPrimaryForeground
-- colorSecondary, colorSecondaryForeground
-- colorNeutral → borders/dividers
-- fontSize → base font size
-
-**Fallback Guidelines**:
-
-- If variables are missing, infer equivalents from the app's design.
-
-- Use the most prominent brand colors as primary/secondary.
-
-- Stick to values consistent with existing patterns.
-
-- Document any assumptions.
-
-### Step 4.2 — Apply Variables
-
-**Objective**:    
-Integrate the extracted variables into the appearance configuration.
-
-**Actions**:
-
-- Apply the variables object to the appearance configuration.
-
-- [ ] Confirm the variables are applied and override correctly.
-
-**Verification**:
-
-- [ ] The variables object is applied and functional.
-
-### Step 4.3 — Validate Visual Integration
-
-**Objective**:
-- Ensure the notification center aligns visually with the host application.
-
-**Actions**:
-1. Extract design tokens from the host application:
-   - **Theme Configuration**: Check theme files.
-   - **StyleSheet**: Review style definitions.
-   - **UI Library**: Check theme settings.
-
-2. Map the extracted tokens to the appearance configuration.
-
-3. Validate the integration:
-   - [ ] Ensure the variables are applied correctly.
-   - [ ] Confirm visual consistency with the host application.
+Extract the host app's design tokens (colors, typography, spacing) from its styling system and map them to the appearance variables.
 
 ### Step 5: Component Creation
 **Objective**: Create a self-contained component for the Inbox integration
@@ -310,51 +187,17 @@ ${KITCHEN_SINK_INBOX_SNIPPET}
 ### Step 7: Validation & Testing
 **Objective**: Ensure the integration meets all quality standards
 
-**Visual Validation**:
-- [ ] Proper spacing and typography
-- [ ] Consistent with host application design system
-- [ ] Platform-specific UI guidelines followed
+- Proper spacing and typography
+- Consistent with host application design system
+- Platform-specific UI guidelines followed
+- No JavaScript errors
+- No native module errors
+- No layout warnings
 
-**Console Validation**:
-- [ ] No JavaScript errors
-- [ ] No native module errors
-- [ ] No layout warnings
-
-### Step 8: AI Model Verification (Internal Process)
-**Objective**: Perform final verification before returning code
-
-**Verification Checklist**:
-- [ ] Package installation confirmed
-- [ ] Environment variables properly configured
-- [ ] NovuProvider properly set up in App.tsx
-- [ ] Component uses proper React Native patterns
-- [ ] Appearance configuration is inline and type-safe
-- [ ] Component is properly placed in the UI
-- [ ] Platform-specific considerations handled
-
-**Action**: If any check fails → stop and revise the implementation
-
-### Step 9: Iterative Refinement Process
-**Objective**: Fine-tune the integration based on validation results
-
-**Refinement Areas**:
-- Adjust inline appearance properties
-- Optimize native module usage
-- Improve placement positioning
-- Preserve validated design tokens and placement
-- Handle platform-specific edge cases
-
-### Step 10: Final Output Requirements
-**Objective**: Deliver a complete, production-ready integration
-
-**Required Deliverables**:
-- Self-contained NotificationInbox component
-- App root with NovuProvider
-- Inline appearance configuration with empty placeholders
-- Environment variable configuration
-- TypeScript compliance with proper typing
-- Platform-specific handling
-- Dark mode support (if any)
+### Step 8: Verify & Deliver
+- Confirm package installation, env vars, component configuration, and UI placement
+- Ensure TypeScript compliance and no console errors
+- Deliver a self-contained component with inline appearance, subscriber detection, and env var references
 `;
 
 interface PromptConfig {

--- a/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/react-prompt.ts
+++ b/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/react-prompt.ts
@@ -3,56 +3,19 @@ import { PromptConfig, replaceConfigVariables } from './types';
 const KITCHEN_SINK_INBOX_SNIPPET = `import { Inbox } from '@novu/react';
 
 function NotificationInbox() {
-  // Ensure the environment variable is available
   const applicationIdentifier = process.env.REACT_APP_NOVU_APPLICATION_IDENTIFIER;
-  
-  if (!applicationIdentifier) {
-    console.error('REACT_APP_NOVU_APPLICATION_IDENTIFIER is not defined');
-    return null;
-  }
 
   return (
     <Inbox
-      // Required core configuration
       applicationIdentifier={applicationIdentifier}
       subscriberId={subscriberId}
-
-      // Backend configuration (for EU region use https://eu.api.novu.co and https://eu.ws.novu.co)
-      backendUrl=process.env.NOVU_BACKEND_URL
-      socketUrl=process.env.NOVU_SOCKET_URL
-
-      // Appearance configuration
+      // For EU region use https://eu.api.novu.co and https://eu.ws.novu.co
+      backendUrl={process.env.NOVU_BACKEND_URL}
+      socketUrl={process.env.NOVU_SOCKET_URL}
       appearance={{
-        // Base theme configuration
-        baseTheme: dark, // Or undefined for light theme
-
-        // Variables for global styling
-        variables: {
-          colorPrimary: '',
-          colorPrimaryForeground: '',
-          colorSecondary: '',
-          colorSecondaryForeground: '',
-          colorCounter: '',
-          colorCounterForeground: '',
-          colorBackground: '',
-          colorRing: '',
-          colorForeground: '',
-          colorNeutral: '',
-          colorShadow: '',
-
-          // Typography and Layout
-          fontSize: '',
-        },
-        elements: {
-          bellIcon: {
-            color: '',
-          },
-        },
-      },
-
-      // Layout configuration
-      placement=""
-      placementOffset={}
+        variables: {},
+        elements: {},
+      }}
     />
   );
 }
@@ -78,19 +41,19 @@ const REACT_PROMPT = `You are an AI agent specialized in integrating the Novu In
 Before starting the integration, analyze the host application to understand:
 
 **Project Structure Analysis**:
-- [ ] Package manager (pnpm, yarn, npm, bun)
-- [ ] React version and configuration
-- [ ] Existing authentication system (Auth0, Firebase, Supabase, custom)
-- [ ] UI framework/library (Tailwind, styled-components, CSS modules, etc.)
-- [ ] Existing component patterns and naming conventions
-- [ ] State management solution (Redux, MobX, Zustand, React Query, etc.)
-- [ ] Routing solution (React Router, TanStack Router, etc.)
+- Package manager (pnpm, yarn, npm, bun)
+- React version and configuration
+- Existing authentication system (Auth0, Firebase, Supabase, custom)
+- UI framework/library (Tailwind, styled-components, CSS modules, etc.)
+- Existing component patterns and naming conventions
+- State management solution (Redux, MobX, Zustand, React Query, etc.)
+- Routing solution (React Router, TanStack Router, etc.)
 
 **UI Placement Analysis**:
 Potential common places where the inbox could be integrated in the UI:
-- [ ] Header/navbar structure and positioning
-- [ ] User menu or profile dropdown location
-- [ ] Sidebar layout and available space
+- Header/navbar structure and positioning
+- User menu or profile dropdown location
+- Sidebar layout and available space
 
 ## Critical Constraints & Requirements
 
@@ -119,20 +82,7 @@ Potential common places where the inbox could be integrated in the UI:
 
 **Actions**:
 1. Detect the project's package manager (pnpm, yarn, npm, bun)
-2. Install @novu/react using the appropriate command:
-\`\`\`bash
-npm install @novu/react
-# or
-yarn add @novu/react
-# or
-pnpm add @novu/react
-# or
-bun add @novu/react
-\`\`\`
-
-**Verification**:
-- [ ] Package installed successfully
-- [ ] No peer dependency conflicts
+2. Install @novu/react using the appropriate command
 
 ### Step 2: Environment Variable Configuration
 **Objective**: Set up the required environment variable for Novu application identifier
@@ -161,114 +111,17 @@ REACT_APP_NOVU_APPLICATION_IDENTIFIER=YOUR_APP_IDENTIFIER
 subscriberId="YOUR_SUBSCRIBER_ID"
 \`\`\`
 
-**Validation**:
-- [ ] Subscriber ID is properly extracted from auth system
-- [ ] Fallback placeholder is used when auth is not available
-- [ ] No undefined or null values passed to component
-
 ### Step 4: Inline Appearance Configuration
-**Objective**: Embed empty appearance objects to demonstrate customization capabilities
+**Objective**: Embed appearance objects matching the host application's design
 
 **Implementation**:
 \`\`\`typescript
 appearance={{
-  variables: {
-    // Optional: define colors, typography, spacing, border-radius, etc.
-    // Example: colors: { primary: '#007bff', secondary: '#6c757d' }
-  },
-  elements: {
-    // Optional: customize container, notifications, badges, buttons, etc.
-    // Example: container: { backgroundColor: 'var(--bg-color)' }
-  },
-  icons: {
-    // Optional: override icons, e.g.
-  },
+  variables: {},
+  elements: {},
 }}
 \`\`\`
-
-### Step 4.0 — Styling Integration Principles
-
-Extract styling variables from the host application first.
-
-Customize only what's necessary to achieve visual consistency.
-
-Avoid introducing new styles that don't exist in the host application.
-
-### Step 4.1 — Extract Styling Variables
-
-**Objective**:
-- Collect and prepare the host application's design tokens (colors, typography, spacing) for the <Inbox /> component appearance.variables object.
-
-**Actions**:
-
-- Identify styling system:
-
-- Tailwind CSS → check tailwind.config.js
-
-- CSS custom properties → check :root {}
-
-- SCSS/SASS → look for _variables.scss
-
-- CSS-in-JS → inspect theme objects or styled-components
-
-- Locate variables: Extract values such as primary/secondary colors, background, text, borders, shadows, radii, and fonts.
-
-- Create variables object: Map them to the appearance.variables object on <Inbox />.
-
-- Validate: Ensure the object is correctly referenced inside the appearance prop.
-
-
-**Suggested Variables to Extract**:
-
-- colorBackground → main background
-- colorForeground → base text color
-- colorPrimary, colorPrimaryForeground
-- colorSecondary, colorSecondaryForeground
-- colorNeutral → borders/dividers
-- fontSize → base font size
-
-**Fallback Guidelines**:
-
-- If variables are missing, infer equivalents from the app's design.
-
-- Use the most prominent brand colors as primary/secondary.
-
-- Stick to values consistent with existing patterns.
-
-- Document any assumptions.
-
-### Step 4.2 — Apply Variables
-
-**Objective**:    
-Integrate the extracted variables into <Inbox />.
-
-**Actions**:
-
-- Apply the variables object to the <Inbox appearance={{ variables: {...} }} />.
-
-- [ ] Confirm the variables are applied and override correctly.
-
-**Verification**:
-
-- [ ] The variables object is applied and functional.
-
-### Step 4.3 — Validate Visual Integration
-
-**Objective**:
-- Ensure <Inbox /> aligns visually with the host application.
-
-**Actions**:
-1. Extract design tokens (e.g., colors, typography, spacing) from the host application:
-   - **Tailwind CSS**: Check tailwind.config.js.
-   - **CSS Variables**: Inspect :root {}.
-   - **SCSS/SASS**: Look for _variables.scss.
-   - **CSS-in-JS**: Review theme objects or styled-components.
-
-2. Map the extracted tokens to the appearance.variables object.
-
-3. Validate the integration:
-   - [ ] Ensure the variables are applied correctly.
-   - [ ] Confirm visual consistency with the host application.
+Extract the host app's design tokens (colors, typography, spacing) from its styling system (Tailwind config, CSS variables, SCSS, theme objects) and map them to the appearance.variables object.
 
 ### Step 5: Component Creation
 **Objective**: Create a self-contained component for the Inbox integration
@@ -295,45 +148,15 @@ ${KITCHEN_SINK_INBOX_SNIPPET}
 ### Step 7: Validation & Testing
 **Objective**: Ensure the integration meets all quality standards
 
-**Visual Validation**:
-- [ ] Proper spacing and typography
-- [ ] Consistent with host application design system
+- Proper spacing and typography
+- Consistent with host application design system
+- No JavaScript errors
+- No TypeScript compilation errors
 
-**Console Validation**:
-- [ ] No JavaScript errors
-- [ ] No TypeScript compilation errors
-
-### Step 8: AI Model Verification (Internal Process)
-**Objective**: Perform final verification before returning code
-
-**Verification Checklist**:
-- [ ] Package installation confirmed
-- [ ] <Inbox /> component is inline with no wrappers/triggers
-- [ ] <Inbox /> component is properly configured with all required props
-- [ ] <Inbox /> component is properly styled and aligned with the host application's design system
-- [ ] <Inbox /> component is properly placed in the appropriate UI location
-
-**Action**: If any check fails → stop and revise the implementation
-
-### Step 9: Iterative Refinement Process
-**Objective**: Fine-tune the integration based on validation results
-
-**Refinement Areas**:
-- Adjust inline appearance properties
-- Optimize subscriber detection logic
-- Improve placement positioning
-- Preserve validated design tokens and placement
-
-### Step 10: Final Output Requirements
-**Objective**: Deliver a complete, production-ready integration
-
-**Required Deliverables**:
-- Self-contained NotificationInbox.tsx component
-- Inline appearance prop with empty placeholders
-- Subscriber detection with fallback mechanism
-- Environment variable reference via .env
-- TypeScript compliance with proper typing
-- Dark mode support (if any)
+### Step 8: Verify & Deliver
+- Confirm package installation, env vars, component props, and UI placement
+- Ensure TypeScript compliance and no console errors
+- Deliver a self-contained component with inline appearance, subscriber detection, and env var references
 `;
 
 /**

--- a/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/remix-prompt.ts
+++ b/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/remix-prompt.ts
@@ -1,10 +1,9 @@
 import { PromptConfig, replaceConfigVariables } from './types';
 
-const KITCHEN_SINK_INBOX_SNIPPET = `import { useLoaderData, Outlet } from '@remix-run/react';
+const KITCHEN_SINK_INBOX_SNIPPET = `import { useLoaderData } from '@remix-run/react';
 import { Inbox } from '@novu/react';
 import type { LoaderFunction } from '@remix-run/node';
 
-// Ensure the environment variables are available
 export const loader: LoaderFunction = async () => {
   const applicationIdentifier = process.env.NOVU_APP_IDENTIFIER;
   const subscriberId = process.env.NOVU_SUBSCRIBER_ID;
@@ -21,46 +20,14 @@ export default function NotificationInbox() {
 
   return (
     <Inbox
-      // Required core configuration
       applicationIdentifier={applicationIdentifier}
       subscriberId={subscriberId}
-
-      // Backend configuration (for EU region use https://eu.api.novu.co and https://eu.ws.novu.co)
       backendUrl=""
       socketUrl=""
-
-      // Appearance configuration
       appearance={{
-        // Base theme configuration
-        baseTheme: dark, // Or undefined for light theme
-
-        // Variables for global styling
-        variables: {
-          colorPrimary: '',
-          colorPrimaryForeground: '',
-          colorSecondary: '',
-          colorSecondaryForeground: '',
-          colorCounter: '',
-          colorCounterForeground: '',
-          colorBackground: '',
-          colorRing: '',
-          colorForeground: '',
-          colorNeutral: '',
-          colorShadow: '',
-
-          // Typography and Layout
-          fontSize: '',
-        },
-        elements: {
-          bellIcon: {
-            color: '',
-          },
-        },
-      },
-
-      // Layout configuration
-      placement="bottom"
-      placementOffset={0}
+        variables: {},
+        elements: {},
+      }}
     />
   );
 }`;
@@ -83,19 +50,19 @@ const REMIX_PROMPT = `You are an AI agent specialized in integrating the Novu In
 Before starting the integration, analyze the host application to understand:
 
 **Project Structure Analysis**:
-- [ ] Package manager (pnpm, yarn, npm, bun)
-- [ ] Remix version and configuration
-- [ ] Existing authentication system (Auth0, Firebase, Supabase, custom)
-- [ ] UI framework/library (Tailwind, styled-components, CSS modules, etc.)
-- [ ] Existing component patterns and naming conventions
-- [ ] State management approach (loaders, actions, context)
-- [ ] Routing structure (nested routes, resource routes)
+- Package manager (pnpm, yarn, npm, bun)
+- Remix version and configuration
+- Existing authentication system (Auth0, Firebase, Supabase, custom)
+- UI framework/library (Tailwind, styled-components, CSS modules, etc.)
+- Existing component patterns and naming conventions
+- State management approach (loaders, actions, context)
+- Routing structure (nested routes, resource routes)
 
 **UI Placement Analysis**:
 Potential common places where the inbox could be integrated in the UI:
-- [ ] Header/navbar structure and positioning
-- [ ] User menu or profile dropdown location
-- [ ] Sidebar layout and available space
+- Header/navbar structure and positioning
+- User menu or profile dropdown location
+- Sidebar layout and available space
 
 ## Critical Constraints & Requirements
 
@@ -134,10 +101,6 @@ pnpm add @novu/react
 # or
 bun add @novu/react
 \`\`\`
-
-**Verification**:
-- [ ] Package installed successfully
-- [ ] No peer dependency conflicts
 
 ### Step 2: Environment Variable Configuration
 **Objective**: Set up the required environment variables for Novu
@@ -211,98 +174,11 @@ export default function App() {
 **Implementation**:
 \`\`\`typescript
 const appearance = {
-  variables: {
-    // Optional: define colors, typography, spacing, border-radius, etc.
-  },
-  elements: {
-    // Optional: customize container, notifications, badges, buttons, etc.
-  },
+  variables: {},
+  elements: {},
 };
 \`\`\`
-
-### Step 4.0 — Styling Integration Principles
-
-Extract styling variables from the host application first.
-
-Customize only what's necessary to achieve visual consistency.
-
-Avoid introducing new styles that don't exist in the host application.
-
-### Step 4.1 — Extract Styling Variables
-
-**Objective**:
-- Collect and prepare the host application's design tokens for the appearance configuration.
-
-**Actions**:
-
-- Identify styling system:
-
-- Tailwind CSS → check tailwind.config.js
-
-- CSS custom properties → check :root {}
-
-- SCSS/SASS → look for _variables.scss
-
-- CSS-in-JS → inspect theme objects or styled-components
-
-- Locate variables: Extract values such as primary/secondary colors, background, text, borders, shadows, radii, and fonts.
-
-- Create variables object: Map them to the appearance configuration.
-
-- Validate: Ensure the object is correctly referenced.
-
-
-**Suggested Variables to Extract**:
-
-- colorBackground → main background
-- colorForeground → base text color
-- colorPrimary, colorPrimaryForeground
-- colorSecondary, colorSecondaryForeground
-- colorNeutral → borders/dividers
-- fontSize → base font size
-
-**Fallback Guidelines**:
-
-- If variables are missing, infer equivalents from the app's design.
-
-- Use the most prominent brand colors as primary/secondary.
-
-- Stick to values consistent with existing patterns.
-
-- Document any assumptions.
-
-### Step 4.2 — Apply Variables
-
-**Objective**:    
-Integrate the extracted variables into the appearance configuration.
-
-**Actions**:
-
-- Apply the variables object to the appearance configuration.
-
-- [ ] Confirm the variables are applied and override correctly.
-
-**Verification**:
-
-- [ ] The variables object is applied and functional.
-
-### Step 4.3 — Validate Visual Integration
-
-**Objective**:
-- Ensure the notification center aligns visually with the host application.
-
-**Actions**:
-1. Extract design tokens from the host application:
-   - **Tailwind CSS**: Check tailwind.config.js.
-   - **CSS Variables**: Inspect :root {}.
-   - **SCSS/SASS**: Look for _variables.scss.
-   - **CSS-in-JS**: Review theme objects or styled-components.
-
-2. Map the extracted tokens to the appearance configuration.
-
-3. Validate the integration:
-   - [ ] Ensure the variables are applied correctly.
-   - [ ] Confirm visual consistency with the host application.
+Extract the host app's design tokens (colors, typography, spacing) from its styling system and map them to the appearance variables.
 
 ### Step 5: Component Creation
 **Objective**: Create a self-contained component for the Inbox integration
@@ -329,47 +205,16 @@ ${KITCHEN_SINK_INBOX_SNIPPET}
 ### Step 7: Validation & Testing
 **Objective**: Ensure the integration meets all quality standards
 
-**Visual Validation**:
-- [ ] Proper spacing and typography
-- [ ] Consistent with host application design system
+- Proper spacing and typography
+- Consistent with host application design system
+- No JavaScript errors
+- No TypeScript compilation errors
+- No Remix hydration warnings
 
-**Console Validation**:
-- [ ] No JavaScript errors
-- [ ] No TypeScript compilation errors
-- [ ] No Remix hydration warnings
-
-### Step 8: AI Model Verification (Internal Process)
-**Objective**: Perform final verification before returning code
-
-**Verification Checklist**:
-- [ ] Package installation confirmed
-- [ ] Environment variables properly configured
-- [ ] NovuProvider properly set up in root.tsx
-- [ ] Component uses proper Remix patterns
-- [ ] Appearance configuration is inline and type-safe
-- [ ] Component is properly placed in the UI
-
-**Action**: If any check fails → stop and revise the implementation
-
-### Step 9: Iterative Refinement Process
-**Objective**: Fine-tune the integration based on validation results
-
-**Refinement Areas**:
-- Adjust inline appearance properties
-- Optimize loader logic
-- Improve placement positioning
-- Preserve validated design tokens and placement
-
-### Step 10: Final Output Requirements
-**Objective**: Deliver a complete, production-ready integration
-
-**Required Deliverables**:
-- Self-contained notification route component
-- Root layout with NovuProvider
-- Inline appearance configuration with empty placeholders
-- Environment variable configuration
-- TypeScript compliance with proper typing
-- Dark mode support (if any)
+### Step 8: Verify & Deliver
+- Confirm package installation, env vars, component configuration, and UI placement
+- Ensure TypeScript compliance and no console errors
+- Deliver a self-contained component with inline appearance, subscriber detection, and env var references
 `;
 
 /**

--- a/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/vue-prompt.ts
+++ b/apps/dashboard/src/components/welcome/ai-prompts/framework-prompts/vue-prompt.ts
@@ -2,11 +2,8 @@ import { PromptConfig, replaceConfigVariables } from './types';
 
 const KITCHEN_SINK_INBOX_SNIPPET = `<template>
   <div>
-    <!-- Ensure the environment variable is available -->
     <div v-if="applicationIdentifier" id="novu-notification-center"></div>
-    <div v-else>
-      <p>VITE_NOVU_APP_IDENTIFIER is not defined</p>
-    </div>
+    <div v-else><p>VITE_NOVU_APP_IDENTIFIER is not defined</p></div>
   </div>
 </template>
 
@@ -14,49 +11,17 @@ const KITCHEN_SINK_INBOX_SNIPPET = `<template>
 import { onMounted, ref } from 'vue';
 import { Novu } from '@novu/js';
 
-// Core configuration
 const applicationIdentifier = import.meta.env.VITE_NOVU_APP_IDENTIFIER;
 const subscriberId = import.meta.env.VITE_NOVU_SUBSCRIBER_ID;
-
-// Backend configuration (for EU region use https://eu.api.novu.co and https://eu.ws.novu.co)
 const backendUrl = '';
 const socketUrl = '';
 
-// Appearance configuration
 const appearance = {
-  // Base theme configuration
-  baseTheme: 'dark', // Or undefined for light theme
-
-  // Variables for global styling
-  variables: {
-    colorPrimary: '',
-    colorPrimaryForeground: '',
-    colorSecondary: '',
-    colorSecondaryForeground: '',
-    colorCounter: '',
-    colorCounterForeground: '',
-    colorBackground: '',
-    colorRing: '',
-    colorForeground: '',
-    colorNeutral: '',
-    colorShadow: '',
-
-    // Typography and Layout
-    fontSize: '',
-  },
-  elements: {
-    bellIcon: {
-      color: '',
-    },
-  },
+  variables: {},
+  elements: {},
 };
 
-// Layout configuration
-const placement = '';
-const placementOffset = {};
-
 const novu = ref<Novu | null>(null);
-const isInitialized = ref(false);
 
 onMounted(async () => {
   if (!applicationIdentifier || !subscriberId) return;
@@ -67,15 +32,11 @@ onMounted(async () => {
   });
 
   await novu.value.init();
-  
+
   novu.value.showNotificationCenter('#novu-notification-center', {
     subscriberId,
     appearance,
-    placement,
-    placementOffset,
   });
-
-  isInitialized.value = true;
 });
 </script>`;
 
@@ -97,20 +58,20 @@ const VUE_PROMPT = `You are an AI agent specialized in integrating the Novu Inbo
 Before starting the integration, analyze the host application to understand:
 
 **Project Structure Analysis**:
-- [ ] Package manager (pnpm, yarn, npm, bun)
-- [ ] Vue version and configuration (Vue 2 vs Vue 3)
-- [ ] Build tool (Vite, Vue CLI, etc.)
-- [ ] Existing authentication system (Auth0, Firebase, Supabase, custom)
-- [ ] UI framework/library (Tailwind, Vuetify, Element Plus, etc.)
-- [ ] Existing component patterns and naming conventions
-- [ ] State management solution (Pinia, Vuex, etc.)
-- [ ] Routing solution (Vue Router)
+- Package manager (pnpm, yarn, npm, bun)
+- Vue version and configuration (Vue 2 vs Vue 3)
+- Build tool (Vite, Vue CLI, etc.)
+- Existing authentication system (Auth0, Firebase, Supabase, custom)
+- UI framework/library (Tailwind, Vuetify, Element Plus, etc.)
+- Existing component patterns and naming conventions
+- State management solution (Pinia, Vuex, etc.)
+- Routing solution (Vue Router)
 
 **UI Placement Analysis**:
 Potential common places where the inbox could be integrated in the UI:
-- [ ] Header/navbar structure and positioning
-- [ ] User menu or profile dropdown location
-- [ ] Sidebar layout and available space
+- Header/navbar structure and positioning
+- User menu or profile dropdown location
+- Sidebar layout and available space
 
 ## Critical Constraints & Requirements
 
@@ -149,10 +110,6 @@ pnpm add @novu/js
 # or
 bun add @novu/js
 \`\`\`
-
-**Verification**:
-- [ ] Package installed successfully
-- [ ] No peer dependency conflicts
 
 ### Step 2: Environment Variable Configuration
 **Objective**: Set up the required environment variables for Novu
@@ -215,98 +172,11 @@ export function useNovu() {
 **Implementation**:
 \`\`\`typescript
 const appearance = {
-  variables: {
-    // Optional: define colors, typography, spacing, border-radius, etc.
-  },
-  elements: {
-    // Optional: customize container, notifications, badges, buttons, etc.
-  },
+  variables: {},
+  elements: {},
 };
 \`\`\`
-
-### Step 4.0 — Styling Integration Principles
-
-Extract styling variables from the host application first.
-
-Customize only what's necessary to achieve visual consistency.
-
-Avoid introducing new styles that don't exist in the host application.
-
-### Step 4.1 — Extract Styling Variables
-
-**Objective**:
-- Collect and prepare the host application's design tokens for the appearance configuration.
-
-**Actions**:
-
-- Identify styling system:
-
-- Tailwind CSS → check tailwind.config.js
-
-- CSS custom properties → check :root {}
-
-- SCSS/SASS → look for _variables.scss
-
-- UI Framework → check theme configuration
-
-- Locate variables: Extract values such as primary/secondary colors, background, text, borders, shadows, radii, and fonts.
-
-- Create variables object: Map them to the appearance.variables object.
-
-- Validate: Ensure the object is correctly referenced.
-
-
-**Suggested Variables to Extract**:
-
-- colorBackground → main background
-- colorForeground → base text color
-- colorPrimary, colorPrimaryForeground
-- colorSecondary, colorSecondaryForeground
-- colorNeutral → borders/dividers
-- fontSize → base font size
-
-**Fallback Guidelines**:
-
-- If variables are missing, infer equivalents from the app's design.
-
-- Use the most prominent brand colors as primary/secondary.
-
-- Stick to values consistent with existing patterns.
-
-- Document any assumptions.
-
-### Step 4.2 — Apply Variables
-
-**Objective**:    
-Integrate the extracted variables into the appearance configuration.
-
-**Actions**:
-
-- Apply the variables object to the appearance configuration.
-
-- [ ] Confirm the variables are applied and override correctly.
-
-**Verification**:
-
-- [ ] The variables object is applied and functional.
-
-### Step 4.3 — Validate Visual Integration
-
-**Objective**:
-- Ensure the notification center aligns visually with the host application.
-
-**Actions**:
-1. Extract design tokens from the host application:
-   - **Tailwind CSS**: Check tailwind.config.js.
-   - **CSS Variables**: Inspect :root {}.
-   - **SCSS/SASS**: Look for _variables.scss.
-   - **UI Framework**: Review theme configuration.
-
-2. Map the extracted tokens to the appearance.variables object.
-
-3. Validate the integration:
-   - [ ] Ensure the variables are applied correctly.
-   - [ ] Confirm visual consistency with the host application.
+Extract the host app's design tokens (colors, typography, spacing) from its styling system and map them to the appearance variables.
 
 ### Step 5: Component Creation
 **Objective**: Create a self-contained component for the Inbox integration
@@ -333,47 +203,16 @@ ${KITCHEN_SINK_INBOX_SNIPPET}
 ### Step 7: Validation & Testing
 **Objective**: Ensure the integration meets all quality standards
 
-**Visual Validation**:
-- [ ] Proper spacing and typography
-- [ ] Consistent with host application design system
+- Proper spacing and typography
+- Consistent with host application design system
+- No JavaScript errors
+- No TypeScript compilation errors
+- No Vue warnings
 
-**Console Validation**:
-- [ ] No JavaScript errors
-- [ ] No TypeScript compilation errors
-- [ ] No Vue warnings
-
-### Step 8: AI Model Verification (Internal Process)
-**Objective**: Perform final verification before returning code
-
-**Verification Checklist**:
-- [ ] Package installation confirmed
-- [ ] Environment variables properly configured with VITE_ prefix
-- [ ] Composable created and properly typed
-- [ ] Component uses Composition API
-- [ ] Appearance configuration is inline and type-safe
-- [ ] Component is properly placed in the UI
-
-**Action**: If any check fails → stop and revise the implementation
-
-### Step 9: Iterative Refinement Process
-**Objective**: Fine-tune the integration based on validation results
-
-**Refinement Areas**:
-- Adjust inline appearance properties
-- Optimize composable logic
-- Improve placement positioning
-- Preserve validated design tokens and placement
-
-### Step 10: Final Output Requirements
-**Objective**: Deliver a complete, production-ready integration
-
-**Required Deliverables**:
-- Self-contained NotificationCenter.vue component
-- useNovu composable with proper typing
-- Inline appearance configuration with empty placeholders
-- Environment variable reference via .env
-- TypeScript compliance with proper typing
-- Dark mode support (if any)
+### Step 8: Verify & Deliver
+- Confirm package installation, env vars, component configuration, and UI placement
+- Ensure TypeScript compliance and no console errors
+- Deliver a self-contained component with inline appearance, subscriber detection, and env var references
 `;
 
 /**

--- a/apps/dashboard/src/components/welcome/framework-guides.tsx
+++ b/apps/dashboard/src/components/welcome/framework-guides.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useState } from 'react';
-import { RiSparklingLine } from 'react-icons/ri';
+import { RiExternalLinkLine, RiSparklingLine } from 'react-icons/ri';
 import { useTelemetry } from '../../hooks/use-telemetry';
 import { TelemetryEvent } from '../../utils/telemetry';
 import { CodeBlock, Language } from '../primitives/code-block';
@@ -189,6 +189,29 @@ function StepCodeBlock({
   );
 }
 
+function buildCursorDeeplink(promptText: string): string {
+  return `https://cursor.com/link/prompt?text=${encodeURIComponent(promptText)}`;
+}
+
+const PROMPT_BUTTON_STYLE = {
+  boxSizing: 'border-box' as const,
+  padding: '6px 8px',
+  background: 'linear-gradient(180deg, rgba(255, 255, 255, 0.16) 0%, rgba(255, 255, 255, 0) 100%), #0E121B',
+  boxShadow: '0px 1px 2px rgba(27, 28, 29, 0.48), 0px 0px 0px 1px #242628',
+  borderRadius: '8px',
+  fontFamily: 'Inter',
+  fontWeight: 500,
+  fontSize: '12px',
+  lineHeight: '16px',
+  fontFeatureSettings: "'cv09' on, 'ss11' on, 'calt' off, 'liga' off",
+  transition: 'background 150ms ease, box-shadow 150ms ease',
+};
+
+const PROMPT_BUTTON_STYLE_COPIED = {
+  ...PROMPT_BUTTON_STYLE,
+  background: 'linear-gradient(180deg, rgba(255, 255, 255, 0.28) 0%, rgba(255, 255, 255, 0.12) 100%), #151A22',
+};
+
 function StepButton({
   buttonText,
   copyText,
@@ -214,43 +237,42 @@ function StepButton({
     }
   };
 
+  const handleCursorDeeplink = () => {
+    track(TelemetryEvent.CURSOR_DEEPLINK_CLICKED, { framework: frameworkName });
+    window.open(buildCursorDeeplink(copyText), '_blank');
+  };
+
   return (
     <motion.div {...codeBlockAnimation(index)} className="w-full max-w-[500px]">
       <div className="flex flex-col gap-3">
-        <button
-          onClick={handleCopy}
-          className="relative flex flex-row justify-center items-center gap-1 w-[126px] h-7 text-white font-medium text-xs leading-4"
-          style={{
-            boxSizing: 'border-box',
-            padding: '6px 4px 6px 6px',
-            background: copied
-              ? 'linear-gradient(180deg, rgba(255, 255, 255, 0.28) 0%, rgba(255, 255, 255, 0.12) 100%), #151A22'
-              : 'linear-gradient(180deg, rgba(255, 255, 255, 0.16) 0%, rgba(255, 255, 255, 0) 100%), #0E121B',
-            boxShadow: '0px 1px 2px rgba(27, 28, 29, 0.48), 0px 0px 0px 1px #242628',
-            borderRadius: '8px',
-            fontFamily: 'Inter',
-            fontWeight: 500,
-            fontSize: '12px',
-            lineHeight: '16px',
-            fontFeatureSettings: "'cv09' on, 'ss11' on, 'calt' off, 'liga' off",
-            transition: 'background 150ms ease, box-shadow 150ms ease',
-          }}
-        >
-          <div
-            className={`${copied ? 'opacity-0' : 'opacity-100'} flex flex-row items-center gap-1 transition-opacity`}
-            aria-hidden={copied}
+        <div className="flex flex-row items-center gap-2">
+          <button
+            onClick={handleCopy}
+            className="relative flex flex-row justify-center items-center gap-1 h-7 text-white font-medium text-xs leading-4"
+            style={copied ? PROMPT_BUTTON_STYLE_COPIED : PROMPT_BUTTON_STYLE}
           >
-            <RiSparklingLine className="w-3.5 h-3.5 flex-none order-0" />
-            <span className="px-1 w-[98px] h-4 flex flex-row justify-center items-center flex-none order-1">
-              <span className="w-[90px] h-4 flex items-center flex-none order-0">{buttonText}</span>
-            </span>
-          </div>
-          <div
-            className={`absolute inset-0 flex items-center justify-center transition-opacity ${copied ? 'opacity-100' : 'opacity-0'}`}
+            <div
+              className={`${copied ? 'opacity-0' : 'opacity-100'} flex flex-row items-center gap-1 transition-opacity`}
+              aria-hidden={copied}
+            >
+              <RiSparklingLine className="w-3.5 h-3.5 flex-none" />
+              <span>{buttonText}</span>
+            </div>
+            <div
+              className={`absolute inset-0 flex items-center justify-center transition-opacity ${copied ? 'opacity-100' : 'opacity-0'}`}
+            >
+              Copied!
+            </div>
+          </button>
+          <button
+            onClick={handleCursorDeeplink}
+            className="flex flex-row items-center gap-1 h-7 text-white font-medium text-xs leading-4 hover:opacity-90 active:scale-[0.98]"
+            style={PROMPT_BUTTON_STYLE}
           >
-            Copied!
-          </div>
-        </button>
+            <RiExternalLinkLine className="w-3.5 h-3.5 flex-none" />
+            <span>Open in Cursor</span>
+          </button>
+        </div>
         <p className="text-foreground-400 text-xs">(No terminal, no docs — just let your pair programmer handle it.)</p>
       </div>
     </motion.div>

--- a/apps/dashboard/src/components/welcome/framework-guides.tsx
+++ b/apps/dashboard/src/components/welcome/framework-guides.tsx
@@ -190,7 +190,7 @@ function StepCodeBlock({
 }
 
 function buildCursorDeeplink(promptText: string): string {
-  return `https://cursor.com/link/prompt?text=${encodeURIComponent(promptText)}`;
+  return `cursor://anysphere.cursor-deeplink/prompt?text=${encodeURIComponent(promptText)}`;
 }
 
 const PROMPT_BUTTON_STYLE = {
@@ -237,10 +237,13 @@ function StepButton({
     }
   };
 
-  const handleCursorDeeplink = () => {
+  const handleCursorDeeplink = async () => {
     track(TelemetryEvent.AI_PROMPT_COPIED, { framework: frameworkName });
     track(TelemetryEvent.CURSOR_DEEPLINK_CLICKED, { framework: frameworkName });
-    window.open(buildCursorDeeplink(copyText), '_blank');
+    try {
+      await navigator.clipboard.writeText(copyText);
+    } catch {}
+    window.location.href = buildCursorDeeplink(copyText);
   };
 
   return (

--- a/apps/dashboard/src/components/welcome/framework-guides.tsx
+++ b/apps/dashboard/src/components/welcome/framework-guides.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import { useState } from 'react';
-import { RiExternalLinkLine, RiSparklingLine } from 'react-icons/ri';
+import { RiSparklingLine } from 'react-icons/ri';
 import { useTelemetry } from '../../hooks/use-telemetry';
 import { TelemetryEvent } from '../../utils/telemetry';
 import { CodeBlock, Language } from '../primitives/code-block';
@@ -238,6 +238,7 @@ function StepButton({
   };
 
   const handleCursorDeeplink = () => {
+    track(TelemetryEvent.AI_PROMPT_COPIED, { framework: frameworkName });
     track(TelemetryEvent.CURSOR_DEEPLINK_CLICKED, { framework: frameworkName });
     window.open(buildCursorDeeplink(copyText), '_blank');
   };
@@ -269,7 +270,9 @@ function StepButton({
             className="flex flex-row items-center gap-1 h-7 text-white font-medium text-xs leading-4 hover:opacity-90 active:scale-[0.98]"
             style={PROMPT_BUTTON_STYLE}
           >
-            <RiExternalLinkLine className="w-3.5 h-3.5 flex-none" />
+            <svg className="w-3.5 h-3.5 flex-none" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+              <path d="M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23" />
+            </svg>
             <span>Open in Cursor</span>
           </button>
         </div>

--- a/apps/dashboard/src/utils/telemetry.ts
+++ b/apps/dashboard/src/utils/telemetry.ts
@@ -19,6 +19,7 @@ export enum TelemetryEvent {
   INBOX_PREVIEW_STYLE_CHANGED = 'Inbox preview style changed - [Onboarding]',
   INBOX_FRAMEWORK_SELECTED = 'Inbox framework selected - [Onboarding]',
   AI_PROMPT_COPIED = 'AI prompt copied - [Onboarding]',
+  CURSOR_DEEPLINK_CLICKED = 'Cursor deeplink clicked - [Onboarding]',
   SKIP_ONBOARDING_CLICKED = 'Skip onboarding clicked - [Onboarding]',
   ONBOARDING_COMPLETED = 'Onboarding completed - [Onboarding]',
   USECASE_SELECT_PAGE_VIEWED = 'Use case select page viewed - [Onboarding]',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Added an "Open in Cursor" button alongside the existing "Copy AI prompt" button in the dashboard onboarding flow. This provides Cursor users with a direct deeplink to open the generated AI prompt in their editor, streamlining their onboarding experience.

A `CURSOR_DEEPLINK_CLICKED` telemetry event was added to track usage.

### Screenshots

<img src="/opt/cursor/artifacts/screenshot_cursor_deeplink_button.webp" />
<img src="/opt/cursor/artifacts/screenshot_cursor_deeplink_opened.webp" />

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773079970241879?thread_ts=1773079970.241879&cid=D0919LNRWE7)

<p><a href="https://cursor.com/agents/bc-2b9ea107-2977-5673-a1ee-ef01edf9e49b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b9ea107-2977-5673-a1ee-ef01edf9e49b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->