### PR TITLE
Activity feed resend context overrides

### DIFF
--- a/apps/api/src/app/activity/dtos/workflow-run-response.dto.ts
+++ b/apps/api/src/app/activity/dtos/workflow-run-response.dto.ts
@@ -108,4 +108,9 @@ export class GetWorkflowRunResponseDto extends GetWorkflowRunResponseBaseDto {
   @ApiProperty({ description: 'Trigger payload' })
   @IsObject()
   payload: Record<string, unknown>;
+
+  @ApiPropertyOptional({ description: 'Trigger overrides from the original workflow trigger' })
+  @IsOptional()
+  @IsObject()
+  overrides?: Record<string, unknown>;
 }

--- a/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
@@ -146,8 +146,11 @@ export class GetWorkflowRun {
       }
 
       const workflowRun = workflowRunResult.data;
-      const stepRuns = await this.getStepRunsForWorkflowRun(command, workflowRun);
-      const workflowRunDto = this.mapWorkflowRunToDto(workflowRun, stepRuns);
+      const [stepRuns, overrides] = await Promise.all([
+        this.getStepRunsForWorkflowRun(command, workflowRun),
+        this.getOverridesForWorkflowRun(workflowRun.transaction_id, command),
+      ]);
+      const workflowRunDto = this.mapWorkflowRunToDto(workflowRun, stepRuns, overrides);
 
       return workflowRunDto;
     } catch (error) {
@@ -284,9 +287,40 @@ export class GetWorkflowRun {
     };
   }
 
+  private async getOverridesForWorkflowRun(
+    transactionId: string,
+    command: GetWorkflowRunCommand
+  ): Promise<Record<string, unknown> | undefined> {
+    try {
+      const jobs: Pick<JobEntity, '_id' | 'overrides'>[] = await this.jobRepository.find(
+        {
+          transactionId,
+          _environmentId: command.environmentId,
+        },
+        '_id overrides',
+        { limit: 1, sort: { createdAt: 1 } }
+      );
+
+      const firstJob = jobs[0];
+      if (firstJob?.overrides && Object.keys(firstJob.overrides).length > 0) {
+        return firstJob.overrides as Record<string, unknown>;
+      }
+
+      return undefined;
+    } catch (error) {
+      this.logger.warn({
+        error: error.message,
+        transactionId,
+      }, 'Failed to get overrides for workflow run');
+
+      return undefined;
+    }
+  }
+
   private mapWorkflowRunToDto(
     workflowRun: WorkflowRunFetchResult,
-    stepRuns: IStepRunWithDetails[]
+    stepRuns: IStepRunWithDetails[],
+    overrides?: Record<string, unknown>
   ): GetWorkflowRunResponseDto {
     return {
       id: workflowRun.workflow_run_id,
@@ -308,6 +342,7 @@ export class GetWorkflowRun {
       critical: workflowRun.critical,
       contextKeys: workflowRun.context_keys,
       topics: workflowRun.topics ? JSON.parse(workflowRun.topics) : [],
+      overrides,
     };
   }
 }

--- a/apps/dashboard/src/api/activity.ts
+++ b/apps/dashboard/src/api/activity.ts
@@ -58,6 +58,7 @@ export interface GetWorkflowRunsDto {
 
 export type GetWorkflowRunResponse = GetWorkflowRunsDto & {
   payload: Record<string, unknown>;
+  overrides?: Record<string, unknown>;
 };
 
 export interface GetWorkflowRunsResponseDto {
@@ -81,6 +82,7 @@ function mapWorkflowRunToActivity(workflowRun: GetWorkflowRunResponse | GetWorkf
       subscriberId: workflowRun.subscriberId || workflowRun.internalSubscriberId,
     },
     payload: 'payload' in workflowRun ? workflowRun.payload : {},
+    overrides: 'overrides' in workflowRun ? workflowRun.overrides : undefined,
     tags: [], // Not available in workflow runs, empty array for compatibility
     createdAt: workflowRun.createdAt,
     updatedAt: workflowRun.updatedAt,

--- a/apps/dashboard/src/api/workflows.ts
+++ b/apps/dashboard/src/api/workflows.ts
@@ -100,12 +100,14 @@ export async function triggerWorkflow({
   payload,
   to,
   context,
+  overrides,
 }: {
   environment: IEnvironment;
   name: string;
   payload: unknown;
   to: unknown;
   context?: unknown;
+  overrides?: Record<string, unknown>;
 }) {
   return post<{ data: { transactionId?: string } }>(`/events/trigger`, {
     environment,
@@ -114,6 +116,7 @@ export async function triggerWorkflow({
       to,
       payload: { ...(payload ?? {}), __source: (payload as any)?.__source ?? 'dashboard' },
       context: context ?? undefined,
+      overrides: overrides ?? undefined,
     },
   });
 }

--- a/apps/dashboard/src/components/activity/activity-header.tsx
+++ b/apps/dashboard/src/components/activity/activity-header.tsx
@@ -1,4 +1,4 @@
-import { IActivity, IEnvironment } from '@novu/shared';
+import { type ContextPayload, IActivity, IEnvironment } from '@novu/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { motion } from 'motion/react';
 import { RiCloseLine, RiRouteFill } from 'react-icons/ri';
@@ -11,6 +11,32 @@ import { QueryKeys } from '@/utils/query-keys';
 import { cn } from '@/utils/ui';
 import { triggerWorkflow } from '../../api/workflows';
 import { RepeatPlay } from '../icons/repeat-play';
+
+function reconstructContextFromKeys(contextKeys?: string[]): ContextPayload | undefined {
+  if (!contextKeys || contextKeys.length === 0) return undefined;
+
+  const context: ContextPayload = {};
+  for (const key of contextKeys) {
+    const separatorIndex = key.indexOf(':');
+    if (separatorIndex === -1) continue;
+
+    const type = key.substring(0, separatorIndex);
+    const id = key.substring(separatorIndex + 1);
+    if (type && id) {
+      context[type] = id;
+    }
+  }
+
+  return Object.keys(context).length > 0 ? context : undefined;
+}
+
+function getOverridesFromJobs(activity: IActivity): Record<string, unknown> | undefined {
+  const firstJobWithOverrides = activity.jobs?.find(
+    (job) => job.overrides && Object.keys(job.overrides).length > 0
+  );
+
+  return firstJobWithOverrides?.overrides as Record<string, unknown> | undefined;
+}
 
 type ActivityHeaderProps = {
   className?: string;
@@ -37,6 +63,9 @@ export const ActivityHeader = ({ className, activity, onTransactionIdChange, onC
     mutationFn: async () => {
       if (!activity) throw new Error('No activity data available');
 
+      const context = reconstructContextFromKeys(activity.contextKeys);
+      const overrides = activity.overrides ?? getOverridesFromJobs(activity);
+
       const {
         data: { transactionId: newTransactionId },
       } = await triggerWorkflow({
@@ -44,6 +73,8 @@ export const ActivityHeader = ({ className, activity, onTransactionIdChange, onC
         to: activity.subscriber?.subscriberId,
         payload: resentPayload,
         environment: currentEnvironment!,
+        context,
+        overrides,
       });
 
       if (!newTransactionId) {

--- a/packages/shared/src/entities/activity-feed/activity.interface.ts
+++ b/packages/shared/src/entities/activity-feed/activity.interface.ts
@@ -22,6 +22,7 @@ export interface IActivity {
     subscriberId: string;
   };
   payload: Record<string, unknown>;
+  overrides?: Record<string, unknown>;
   tags: string[];
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR resolves NV-7111 by ensuring the "Resend" option in the activity feed correctly includes the original `context` and `overrides` when re-triggering a workflow.

Previously, the resend functionality would only reuse the payload, ignoring the associated context and overrides. This change addresses that by:

*   **API:** Enhancing the `GetWorkflowRun` use case to fetch and expose `overrides` (from the first Job entity) and `context` (reconstructed from `contextKeys`) in the workflow run detail response.
*   **Dashboard:** Updating the activity feed to consume these new `context` and `overrides` fields and pass them to the `triggerWorkflow` API call when resending an event.
*   **Shared:** Updating the `IActivity` interface to include the new `overrides` field.

### Screenshots

Manual end-to-end testing was impacted by a pre-existing ClickHouse data propagation issue in the local development environment, which prevented the activity feed from displaying data. Therefore, no screenshots are available.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

*   The API service builds successfully with `nx build api-service`.
*   The dashboard builds successfully with `nx build dashboard`.
*   The local ClickHouse data propagation issue prevented full manual verification of the "Resend" button's functionality in the browser. The code changes are purely additive and logically sound based on the data flow.

</details>

---
Linear Issue: [NV-7111](https://linear.app/novu/issue/NV-7111/resend-option-in-activity-feed-missing-context-and-overrides-in)

<p><a href="https://cursor.com/agents/bc-13ceaab3-13bf-4735-8c5d-70a7c5cfbfc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13ceaab3-13bf-4735-8c5d-70a7c5cfbfc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->