### PR TITLE
feat(dashboard): Integration store validation errors fixes NV-7196

### DIFF
--- a/apps/dashboard/src/api/api.client.ts
+++ b/apps/dashboard/src/api/api.client.ts
@@ -118,6 +118,10 @@ function parseErrorMessage(errorData: any): string {
     return DEFAULT_ERROR;
   }
 
+  if (Array.isArray(errorData.message)) {
+    return errorData.message.filter(Boolean).join('. ') || DEFAULT_ERROR;
+  }
+
   if (typeof errorData.message !== 'string') {
     return errorData.message?.message || DEFAULT_ERROR;
   }

--- a/apps/dashboard/src/api/integrations.ts
+++ b/apps/dashboard/src/api/integrations.ts
@@ -4,7 +4,7 @@ import { del, get, post, put } from './api.client';
 export type CreateIntegrationData = {
   providerId: string;
   channel: ChannelTypeEnum;
-  credentials: Record<string, string>;
+  credentials: Record<string, unknown>;
   configurations: Record<string, string>;
   name: string;
   identifier: string;
@@ -25,7 +25,7 @@ export type UpdateIntegrationData = {
   identifier: string;
   active: boolean;
   primary: boolean;
-  credentials: Record<string, string>;
+  credentials: Record<string, unknown>;
   configurations: Record<string, string>;
   check: boolean;
 };

--- a/apps/dashboard/src/components/integrations/components/create-integration-sidebar.tsx
+++ b/apps/dashboard/src/components/integrations/components/create-integration-sidebar.tsx
@@ -17,6 +17,7 @@ import { IntegrationSettings } from './integration-settings';
 import { IntegrationSheet } from './integration-sheet';
 import { SelectPrimaryIntegrationModal } from './modals/select-primary-integration-modal';
 import { handleIntegrationError } from './utils/handle-integration-error';
+import { cleanCredentials } from './utils/helpers';
 
 export type CreateIntegrationSidebarProps = {
   isOpened: boolean;
@@ -73,7 +74,7 @@ export function CreateIntegrationSidebar({ isOpened }: CreateIntegrationSidebarP
       const integration = await createIntegration({
         providerId: provider.id,
         channel: provider.channel,
-        credentials: data.credentials,
+        credentials: cleanCredentials(data.credentials),
         configurations: data.configurations,
         name: data.name,
         identifier: data.identifier,

--- a/apps/dashboard/src/components/integrations/components/update-integration-sidebar.tsx
+++ b/apps/dashboard/src/components/integrations/components/update-integration-sidebar.tsx
@@ -17,7 +17,7 @@ import { IntegrationSheet } from './integration-sheet';
 import { DeleteIntegrationModal } from './modals/delete-integration-modal';
 import { SelectPrimaryIntegrationModal } from './modals/select-primary-integration-modal';
 import { handleIntegrationError } from './utils/handle-integration-error';
-import { isDemoIntegration } from './utils/helpers';
+import { cleanCredentials, isDemoIntegration } from './utils/helpers';
 
 type UpdateIntegrationSidebarProps = {
   isOpened: boolean;
@@ -88,7 +88,7 @@ export function UpdateIntegrationSidebar({ isOpened }: UpdateIntegrationSidebarP
           identifier: data.identifier,
           active: data.active,
           primary: data.primary,
-          credentials: data.credentials,
+          credentials: cleanCredentials(data.credentials),
           check: data.check,
           configurations: data.configurations,
         },

--- a/apps/dashboard/src/components/integrations/components/utils/handle-integration-error.ts
+++ b/apps/dashboard/src/components/integrations/components/utils/handle-integration-error.ts
@@ -2,16 +2,64 @@ import * as Sentry from '@sentry/react';
 import { CheckIntegrationResponseEnum } from '@/api/integrations';
 import { showErrorToast } from '../../../../components/primitives/sonner-helpers';
 
+function extractCheckIntegrationCode(rawError: unknown): string | undefined {
+  const errorData = rawError as Record<string, unknown> | undefined;
+  if (!errorData?.message || typeof errorData.message !== 'string') return undefined;
+
+  try {
+    const parsed = JSON.parse(errorData.message);
+
+    return parsed?.code;
+  } catch {
+    return undefined;
+  }
+}
+
+function formatValidationMessages(rawError: unknown): string | undefined {
+  const errorData = rawError as Record<string, unknown> | undefined;
+  if (!errorData) return undefined;
+
+  const errors = errorData.errors as Record<string, { messages?: string[] }> | undefined;
+  const generalMessages = errors?.general?.messages;
+
+  if (Array.isArray(generalMessages) && generalMessages.length > 0) {
+    return generalMessages
+      .map((msg) => msg.replace(/^credentials\./, ''))
+      .filter(Boolean)
+      .join('. ');
+  }
+
+  if (Array.isArray(errorData.message)) {
+    const messages = (errorData.message as string[])
+      .map((msg) => msg.replace(/^credentials\./, ''))
+      .filter(Boolean);
+
+    return messages.length > 0 ? messages.join('. ') : undefined;
+  }
+
+  return undefined;
+}
+
 export function handleIntegrationError(error: any, operation: 'update' | 'create' | 'delete') {
-  if (error?.message?.code === CheckIntegrationResponseEnum.INVALID_EMAIL) {
-    showErrorToast(error.message?.message, 'Invalid sender email');
-  } else if (error?.message?.code === CheckIntegrationResponseEnum.BAD_CREDENTIALS) {
-    showErrorToast(error.message?.message, 'Invalid credentials or credentials expired');
+  const rawError = error?.rawError;
+  const checkCode = extractCheckIntegrationCode(rawError);
+
+  if (checkCode === CheckIntegrationResponseEnum.INVALID_EMAIL) {
+    showErrorToast(error.message, 'Invalid sender email');
+  } else if (checkCode === CheckIntegrationResponseEnum.BAD_CREDENTIALS) {
+    showErrorToast(error.message, 'Invalid credentials or credentials expired');
   } else {
+    const validationMessage = formatValidationMessages(rawError);
+    if (validationMessage) {
+      showErrorToast(validationMessage, 'Validation Error');
+
+      return;
+    }
+
     Sentry.captureException(error);
 
     showErrorToast(
-      error?.message?.message || error?.message || `There was an error ${operation}ing the integration.`,
+      error?.message || `There was an error ${operation}ing the integration.`,
       `Failed to ${operation} integration`
     );
   }

--- a/apps/dashboard/src/components/integrations/components/utils/helpers.ts
+++ b/apps/dashboard/src/components/integrations/components/utils/helpers.ts
@@ -31,3 +31,29 @@ export function configurationToCredential(config: ConfigConfiguration): IConfigC
     },
   } as IConfigCredential;
 }
+
+const OBJECT_CREDENTIAL_KEYS = new Set<string>([CredentialsKeyEnum.TlsOptions]);
+
+export function cleanCredentials(credentials: Record<string, unknown>): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(credentials)) {
+    if (value === '' || value === undefined || value === null) continue;
+
+    if (OBJECT_CREDENTIAL_KEYS.has(key) && typeof value === 'string') {
+      try {
+        const parsed = JSON.parse(value);
+        if (typeof parsed === 'object' && parsed !== null) {
+          cleaned[key] = parsed;
+          continue;
+        }
+      } catch {
+        // leave as string, API validation will catch it
+      }
+    }
+
+    cleaned[key] = value;
+  }
+
+  return cleaned;
+}

--- a/libs/application-generic/src/decorators/to-boolean.spec.ts
+++ b/libs/application-generic/src/decorators/to-boolean.spec.ts
@@ -45,4 +45,9 @@ describe('@TransformToBoolean() transformer', () => {
     const result = transform({ isSomething: null });
     expect(typeof result.isSomething).not.equal('boolean');
   });
+
+  it('should transform empty string to undefined', () => {
+    const result = transform({ isSomething: '' });
+    expect(result.isSomething).to.equal(undefined);
+  });
 });

--- a/libs/application-generic/src/decorators/to-boolean.ts
+++ b/libs/application-generic/src/decorators/to-boolean.ts
@@ -6,6 +6,7 @@ export const TransformToBoolean = () =>
   Transform(({ value }) => {
     if (value === 'true') return true;
     if (value === 'false') return false;
+    if (value === '') return undefined;
 
     return value; // @IsBoolean validator should reject non-boolean value.
   });

--- a/libs/application-generic/src/dtos/credentials.dto.ts
+++ b/libs/application-generic/src/dtos/credentials.dto.ts
@@ -1,5 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ICredentials } from '@novu/shared';
+import { Transform } from 'class-transformer';
 import { IsBoolean, IsObject, IsOptional, IsString } from 'class-validator';
 import { TransformToBoolean } from '../decorators/to-boolean';
 
@@ -103,6 +104,20 @@ export class CredentialsDto implements ICredentials {
   ignoreTls?: boolean;
 
   @ApiPropertyOptional()
+  @Transform(({ value }) => {
+    if (value === '' || value === null) return undefined;
+    if (typeof value === 'string') {
+      try {
+        const parsed = JSON.parse(value);
+
+        return typeof parsed === 'object' && parsed !== null ? parsed : value;
+      } catch {
+        return value;
+      }
+    }
+
+    return value;
+  })
   @IsObject()
   @IsOptional()
   tlsOptions?: Record<string, unknown>;

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -142,7 +142,7 @@ export const nodemailerConfig: IConfigCredential[] = [
   {
     key: CredentialsKeyEnum.Secure,
     displayName: 'Secure',
-    type: 'boolean',
+    type: 'switch',
     required: false,
   },
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR addresses the issues outlined in [NV-7196](https://linear.app/novu/issue/NV-7196).

1.  **Improved Validation Error Messages**: The dashboard now displays specific field-level validation errors (e.g., "tlsOptions must be an object") instead of a generic "Validation Error". This was needed because the previous generic errors provided no actionable information to users.
2.  **Graceful Empty String Handling**: Empty string values for optional fields (like `tlsOptions` or `secure`) are now correctly handled. They are stripped before API submission on the frontend and converted to `undefined` on the backend, preventing validation errors when clearing fields. This resolves the issue where users could not return certain credential fields to an empty state.
3.  **Enhanced "Secure" Field UX**: The "Secure" field for Custom SMTP integration has been updated from a text input to a toggle switch for better usability, matching other boolean fields.
4.  **New Unit Test**: Added a unit test for the `TransformToBoolean` decorator to cover empty string handling.

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->
Screenshots/screencasts demonstrating the verbose validation errors, the "Secure" field as a switch, and the empty string handling will be attached.

---
Linear Issue: [NV-7196](https://linear.app/novu/issue/NV-7196/dashboard-integration-store-validation-error-need-to-be-more-verbose)

<p><a href="https://cursor.com/agents/bc-e630846d-3584-469e-9a4a-83f3e175e33d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e630846d-3584-469e-9a4a-83f3e175e33d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->