### PR TITLE
Websocket contextKeys undefined

### DIFF
--- a/enterprise/workers/socket/src/durable-objects/websocket-room.ts
+++ b/enterprise/workers/socket/src/durable-objects/websocket-room.ts
@@ -260,7 +260,7 @@ export class WebSocketRoom extends DurableObject<IEnv> {
       environmentId,
       connectedAt: attachment.connectedAt || Date.now(),
       jwtToken: attachment.jwtToken,
-      contextKeys: attachment.contextKeys,
+      contextKeys: attachment.contextKeys ?? [],
     };
   }
 

--- a/enterprise/workers/socket/src/middleware/auth.ts
+++ b/enterprise/workers/socket/src/middleware/auth.ts
@@ -42,7 +42,7 @@ export async function authenticateJWT(context: Context, next: Next) {
     const userId = userPayload._id;
     const subscriberId = userPayload.subscriberId || userId;
     const { organizationId, environmentId } = userPayload;
-    const contextKeys = userPayload.contextKeys;
+    const contextKeys = userPayload.contextKeys ?? [];
 
     if (!userId || !subscriberId || !organizationId || !environmentId) {
       return context.json({ error: 'Unauthorized: Missing required user information in JWT' }, 401);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR adds defensive nullish coalescing (`?? []`) to `contextKeys` in the enterprise websocket service to prevent crashes when `contextKeys` is `undefined`.

The change was needed to address `TypeError: Cannot read properties of undefined (reading 'length')` in `WSGateway.processConnectionRequest` (Linear issue NV-7172). This bug occurs because `contextKeys` can be `undefined` in two main scenarios:

1.  **Old JWTs:** When users upgrade, JWTs issued by older API versions (pre-`contextKeys` feature) may still be valid and lack the `contextKeys` field.
2.  **Durable Object hibernation:** When a Durable Object wakes from hibernation, deserialized attachments from old connections might not contain `contextKeys`.

The community `ws` service already received a similar fix (PR #10130). This PR applies the same robust handling to the enterprise websocket worker.

The changes are in:
*   `enterprise/workers/socket/src/middleware/auth.ts`: Guards `userPayload.contextKeys` when extracting from JWT.
*   `enterprise/workers/socket/src/durable-objects/websocket-room.ts`: Guards `attachment.contextKeys` when deserializing hibernated attachment data.

### Screenshots

N/A

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

This PR addresses the enterprise counterpart of the fix already merged in the community `ws` service (PR #10130).

### Special notes for your reviewer

The core issue stems from the assumption that `contextKeys` would always be present, which is not true for JWTs issued by older API versions or for deserialized Durable Object attachments from before the `contextKeys` feature was introduced. The `?? []` guards ensure graceful handling in these edge cases.

</details>

---
Linear Issue: [NV-7172](https://linear.app/novu/issue/NV-7172/bug-report-ws3140-crashes-on-connection-in)

<p><a href="https://cursor.com/agents/bc-2f777cf1-de31-49bb-b7d9-47fdcaf5d292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f777cf1-de31-49bb-b7d9-47fdcaf5d292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->