### PR TITLE
feat(dashboard): Onboarding sign up event

### DIFF
--- a/apps/dashboard/src/pages/inbox-usecase-page.tsx
+++ b/apps/dashboard/src/pages/inbox-usecase-page.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '../context/auth/hooks';
 import { useEnvironment, useFetchEnvironments } from '../context/environment/hooks';
 import { useTelemetry } from '../hooks/use-telemetry';
 import { TelemetryEvent } from '../utils/telemetry';
+import { sendGTMEvent } from '../utils/tracking';
 
 interface RequiredData {
   appId: string;
@@ -156,8 +157,9 @@ export function InboxUsecasePage() {
   const requiredData = getRequiredData(environment, currentUser?._id, currentOrganization?._id);
 
   useEffect(() => {
+    sendGTMEvent('sign_up');
+
     setTimeout(() => {
-      // this is a little workaround to prevent race conditions during initial sync flow of new organizations
       telemetry(TelemetryEvent.INBOX_USECASE_PAGE_VIEWED);
     }, 2000);
   }, [telemetry]);

--- a/apps/dashboard/src/utils/tracking.ts
+++ b/apps/dashboard/src/utils/tracking.ts
@@ -1,3 +1,10 @@
+export function sendGTMEvent(event: string, data?: Record<string, unknown>) {
+  const dataLayer = (window as { dataLayer?: Record<string, unknown>[] }).dataLayer;
+  if (!dataLayer) return;
+
+  dataLayer.push({ event, ...data });
+}
+
 export function getUtmParams(): Record<string, string> {
   const searchParams = new URLSearchParams(window.location.search);
   const utmParams: Record<string, string> = {};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

When a user creates an account and arrives at the `/onboarding/inbox` page, a `sign_up` event is now pushed to Google Tag Manager's `dataLayer`. This change was needed to track user sign-up events via GTM.

-   Added a `sendGTMEvent` utility in `apps/dashboard/src/utils/tracking.ts` to safely push events to `window.dataLayer`.
-   Called `sendGTMEvent('sign_up')` from `apps/dashboard/src/pages/inbox-usecase-page.tsx` on page load.

### Screenshots

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773158277166069?thread_ts=1773158277.166069&cid=D0919LNRWE7)

<p><a href="https://cursor.com/agents/bc-9cbf4a93-0336-530a-8237-2403e160f579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cbf4a93-0336-530a-8237-2403e160f579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->