### PR TITLE
fix(ci): Cursor bot community check

### DIFF
--- a/.github/workflows/contributor-checks.yml
+++ b/.github/workflows/contributor-checks.yml
@@ -22,6 +22,12 @@ jobs:
           author="${{ github.event.pull_request.user.login }}"
           echo "Checking if $author is a team member..."
 
+          if [[ "$author" == *"[bot]" ]]; then
+            echo "is_community=false" >> $GITHUB_OUTPUT
+            echo "$author is a bot account - skipping contributor checks"
+            exit 0
+          fi
+
           response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ github.repository }}/collaborators/$author/permission")
 

--- a/.github/workflows/scripts/is-community-contributor.js
+++ b/.github/workflows/scripts/is-community-contributor.js
@@ -4,6 +4,7 @@ const octokit = new Octokit();
 
 const isCommunityContributor = async (owner, repo, username) => {
   if (!username) return false;
+  if (username.endsWith('[bot]')) return false;
 
   const {
     data: { permission },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The `contributor-checks.yml` GitHub Action was failing for PRs created by bot accounts (e.g., `cursor[bot]`) due to a URL malformation error when `curl` attempted to fetch permissions for usernames containing square brackets.

To resolve this, the following changes were made:

*   `.github/workflows/contributor-checks.yml`: Added an early check to identify PR authors whose usernames end with `[bot]`. For these accounts, community checks are skipped, and `is_community` is set to `false`.
*   `.github/workflows/scripts/is-community-contributor.js`: Implemented a similar check to return `false` for bot accounts, ensuring consistency across community-related workflows.

### Screenshots

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773232668688019?thread_ts=1773232668.688019&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-41278fd8-bb72-5dcd-a22b-d6ee33be774a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41278fd8-bb72-5dcd-a22b-d6ee33be774a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->