### PR TITLE
Novu js solid-js issue

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -94,6 +94,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
+    "@kobalte/core": "^0.13.10",
     "@types/jest": "^29.2.3",
     "@types/node": "^20.15.0",
     "autoprefixer": "^10.4.0",
@@ -105,6 +106,7 @@
     "esbuild-plugin-compress": "^1.0.1",
     "esbuild-plugin-inline-import": "^1.0.4",
     "esbuild-plugin-solid": "^0.6.0",
+    "solid-motionone": "^1.0.3",
     "http-server": "^0.13.0",
     "jest": "^29.3.1",
     "postcss": "^8.4.38",
@@ -127,7 +129,6 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.6.13",
-    "@kobalte/core": "^0.13.10",
     "@types/json-logic-js": "^2.0.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
@@ -137,7 +138,6 @@
     "socket.io-client": "4.7.2",
     "solid-floating-ui": "^0.3.1",
     "solid-js": "^1.9.4",
-    "solid-motionone": "^1.0.3",
     "tailwind-merge": "^2.4.0"
   },
   "nx": {

--- a/packages/js/tsup.config.ts
+++ b/packages/js/tsup.config.ts
@@ -58,6 +58,7 @@ const baseModuleConfig: Options = {
   ...baseConfig,
   treeshake: true,
   dts: true,
+  noExternal: ['solid-motionone', '@kobalte/core'],
   entry: {
     index: './src/index.ts',
     'ui/index': './src/ui/index.ts',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The `@novu/js` package was causing a `ReferenceError: React is not defined` when used in Solid.js applications (fixes NV-7126). This happened because `solid-motionone` and `@kobalte/core` (dependencies of `@novu/js`) were being resolved by Solid.js bundlers to their raw `.jsx` files. These raw JSX files were then incorrectly processed by a React JSX runtime, leading to the error.

To resolve this, `solid-motionone` and `@kobalte/core` are now bundled directly into `@novu/js` via `tsup.config.ts`. This ensures consumers always receive pre-compiled JavaScript, preventing JSX runtime conflicts. As a result, these packages have been moved from `dependencies` to `devDependencies` in `package.json`.

### Screenshots

Linear Issue: [NV-7126](https://linear.app/novu/issue/NV-7126/bug-report-not-able-to-use-novujs-with-solid-js)

<div><a href="https://cursor.com/agents/bc-d006fe46-da38-42f6-a5c1-3db93113a22c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d006fe46-da38-42f6-a5c1-3db93113a22c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->