### PR TITLE
fix(root): Cursor bot permissions

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -32,9 +32,18 @@ jobs:
       - name: Check if PR author is team member
         id: check_team_member
         run: |
-          # Check if the PR author has write access to the repository (indicating team membership)
           author="${{ github.event.pull_request.user.login }}"
           echo "Checking if $author is a team member..."
+
+          # Trusted bot accounts are treated as team members
+          trusted_bots=("cursor[bot]")
+          for bot in "${trusted_bots[@]}"; do
+            if [[ "$author" == "$bot" ]]; then
+              echo "is_team_member=true" >> $GITHUB_OUTPUT
+              echo "$author is a trusted bot, treating as team member"
+              exit 0
+            fi
+          done
 
           # Use GitHub API to check user permissions
           response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The `conventional-commit.yml` workflow was updated to correctly handle PRs opened by bot accounts.

Previously, the "Check if PR author is team member" step failed for `cursor[bot]` because the GitHub API call to check collaborator permissions does not work for bot accounts with square brackets in their username.

This change introduces a `trusted_bots` list. If the PR author is a trusted bot (e.g., `cursor[bot]`), the `is_team_member` check now passes automatically, skipping the failing API call.

### Screenshots

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773245329366539?thread_ts=1773245329.366539&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-34e5a6f4-e22f-5788-936c-78c148b5919a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34e5a6f4-e22f-5788-936c-78c148b5919a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->