### PR TITLE
fix(worker): Prototype pollution fix

### DIFF
--- a/libs/application-generic/src/utils/json-schema-utils.spec.ts
+++ b/libs/application-generic/src/utils/json-schema-utils.spec.ts
@@ -248,6 +248,57 @@ describe('keysToObject', () => {
   });
 });
 
+describe('prototype pollution guard', () => {
+  it('should not allow __proto__ pollution via digest payload properties', () => {
+    const paths = [
+      'steps.digest-step.events.payload',
+      'steps.digest-step.events.payload.__proto__.polluted',
+    ];
+
+    const before = ({} as any).polluted;
+    keysToObject(paths);
+    const after = ({} as any).polluted;
+
+    expect(before).to.equal(undefined);
+    expect(after).to.equal(undefined);
+  });
+
+  it('should not allow constructor pollution via digest payload properties', () => {
+    const paths = [
+      'steps.digest-step.events.payload',
+      'steps.digest-step.events.payload.constructor.prototype.polluted',
+    ];
+
+    const before = ({} as any).polluted;
+    keysToObject(paths);
+    const after = ({} as any).polluted;
+
+    expect(before).to.equal(undefined);
+    expect(after).to.equal(undefined);
+  });
+
+  it('should still set safe nested properties within digest payload', () => {
+    const paths = [
+      'steps.digest-step.events.payload',
+      'steps.digest-step.events.payload.user.name',
+    ];
+
+    const result = keysToObject(paths);
+
+    expect(result).to.deep.equal({
+      steps: {
+        'digest-step': {
+          events: {
+            payload: {
+              user: { name: 'name' },
+            },
+          },
+        },
+      },
+    });
+  });
+});
+
 describe('mockSchemaDefaults', () => {
   it('should preserve falsy default values (0, false, null, empty string)', () => {
     const schema: JSONSchemaDto = {

--- a/libs/application-generic/src/utils/json-schema-utils.ts
+++ b/libs/application-generic/src/utils/json-schema-utils.ts
@@ -235,9 +235,17 @@ function buildObjectFromPaths(
   return result;
 }
 
-// Helper function to set nested properties in an object
+const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isPrototypePollutionKey(key: string): boolean {
+  return PROTOTYPE_POLLUTION_KEYS.has(key);
+}
+
 function setNestedProperty(obj: Record<string, unknown>, path: string, value: string) {
   const keys = path.split('.');
+
+  if (keys.some(isPrototypePollutionKey)) return;
+
   let current = obj;
 
   for (let i = 0; i < keys.length - 1; i += 1) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Fixed a prototype pollution vulnerability in the `setNestedProperty` utility function.

The `setNestedProperty` function was vulnerable to prototype pollution, as reported by CodeQL. It allowed an attacker to modify `Object.prototype` by crafting specific key paths (e.g., `__proto__`, `constructor`, `prototype`).

The change introduces a guard that prevents assignment if any key in the provided path is `__proto__`, `constructor`, or `prototype`. New test cases were added to cover this fix.

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773246927602969?thread_ts=1773246927.602969&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-be4b0a58-55ac-5cc6-b24e-3b82bedda43f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be4b0a58-55ac-5cc6-b24e-3b82bedda43f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->