### PR TITLE
refactor(worker): Delay error logging level adjustment

### DIFF
--- a/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
@@ -509,7 +509,7 @@ export class AddJob {
 
     if (tierValidationErrors && tierValidationErrors.length > 0) {
       const errorMessage = tierValidationErrors[0].message;
-      this.logger.error(`${stepTypeName} duration exceeds tier limits: ${errorMessage}, jobId: ${job._id}`);
+      this.logger.debug(`${stepTypeName} duration exceeds tier limits: ${errorMessage}, jobId: ${job._id}`);
 
       await this.createExecutionDetails.execute(
         CreateExecutionDetailsCommand.create({
@@ -535,7 +535,7 @@ export class AddJob {
     detail: DetailEnum
   ): Promise<AddJobResult> {
     const stepTypeName = stepType.toLowerCase();
-    this.logger.error(`${stepTypeName} validation failed for job ${job._id}: ${error.message}`);
+    this.logger.debug(`${stepTypeName} validation failed for job ${job._id}: ${error.message}`);
 
     await this.createExecutionDetails.execute(
       CreateExecutionDetailsCommand.create({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Changed two log statements in `apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts` from `this.logger.error` to `this.logger.debug`.

This change was needed because these logs (for "delay duration exceeds tier limits" and "delay validation failed for job") represent expected user-facing tier limit validations, not actual system errors. Therefore, `debug` is the more appropriate log level.

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773306690053899?thread_ts=1773306690.053899&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-3a0e2afb-0f86-5da3-b2e9-ae9f18fa5312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a0e2afb-0f86-5da3-b2e9-ae9f18fa5312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->