### PR TITLE
fix(dashboard): biome linting errors

### DIFF
--- a/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sign-in.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
@@ -8,6 +8,8 @@ import { authClient } from '../client';
 
 export function SignIn() {
   const navigate = useNavigate();
+  const emailId = useId();
+  const passwordId = useId();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -82,12 +84,12 @@ export function SignIn() {
       <h2 className="mb-6 text-center text-xl font-semibold">Sign In</h2>
       <form onSubmit={handleSubmit} className="space-y-6">
         <div>
-          <label htmlFor="email" className="mb-1 block text-sm font-medium text-foreground-700">
+          <label htmlFor={emailId} className="mb-1 block text-sm font-medium text-foreground-700">
             Email
           </label>
           <Input
             type="email"
-            id="email"
+            id={emailId}
             value={email}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
             placeholder="user@example.com"
@@ -97,7 +99,7 @@ export function SignIn() {
         </div>
         <div>
           <div className="mb-1 flex items-center justify-between">
-            <label htmlFor="password" className="block text-sm font-medium text-foreground-700">
+            <label htmlFor={passwordId} className="block text-sm font-medium text-foreground-700">
               Password
             </label>
             <span
@@ -114,7 +116,7 @@ export function SignIn() {
           </div>
           <Input
             type="password"
-            id="password"
+            id={passwordId}
             value={password}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
             placeholder="Password"

--- a/apps/dashboard/src/utils/better-auth/components/sso-sign-in.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/sso-sign-in.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
@@ -8,6 +8,7 @@ import { authClient } from '../client';
 export function SSOSignIn() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const ssoEmailId = useId();
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -62,12 +63,12 @@ export function SSOSignIn() {
       <h2 className="mb-6 text-center text-xl font-semibold">Sign In with SSO</h2>
       <form onSubmit={handleSubmit} className="space-y-6">
         <div>
-          <label htmlFor="sso-email" className="mb-1 block text-sm font-medium text-foreground-700">
+          <label htmlFor={ssoEmailId} className="mb-1 block text-sm font-medium text-foreground-700">
             Work Email
           </label>
           <Input
             type="email"
-            id="sso-email"
+            id={ssoEmailId}
             value={email}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
             placeholder="you@company.com"

--- a/apps/dashboard/src/utils/conditions.ts
+++ b/apps/dashboard/src/utils/conditions.ts
@@ -80,7 +80,9 @@ function recursiveGetUniqueFields(query: RuleGroupType): string[] {
     if ('rules' in rule) {
       // recursively get fields from nested rule groups
       const nestedFields = recursiveGetUniqueFields(rule);
-      nestedFields.forEach((field) => fields.add(field));
+      for (const field of nestedFields) {
+        fields.add(field);
+      }
     } else {
       // add field from individual rule
       const field = rule.field.split('.').shift();
@@ -109,7 +111,9 @@ function recursiveGetUniqueOperators(query: RuleGroupType): string[] {
     if ('rules' in rule) {
       // recursively get operators from nested rule groups
       const nestedOperators = recursiveGetUniqueOperators(rule);
-      nestedOperators.forEach((operator) => operators.add(operator));
+      for (const operator of nestedOperators) {
+        operators.add(operator);
+      }
     } else {
       // add operator from individual rule
       operators.add(rule.operator);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR resolves several Biome linting errors that were preventing pre-commit hooks from passing.

*   **`apps/dashboard/src/utils/better-auth/components/sign-in.tsx` & `sso-sign-in.tsx`**: Replaced static `id` attributes on `<Input>` elements with dynamically generated unique IDs using React's `useId()` hook. This addresses the `lint/correctness/useUniqueElementIds` error, which prevents duplicate IDs in the DOM.
*   **`apps/dashboard/src/utils/conditions.ts`**: Converted `forEach` loops that implicitly returned values from their callbacks into `for...of` loops. This fixes the `lint/suspicious/useIterableCallbackReturn` error, as `forEach` callbacks should not return values.

### Screenshots

[Slack Thread](https://novu.slack.com/archives/D092998U7KR/p1773314815787459?thread_ts=1773314815.787459&cid=D092998U7KR)

<div><a href="https://cursor.com/agents/bc-6f7df618-afe6-5159-b778-844c2d8d413b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f7df618-afe6-5159-b778-844c2d8d413b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->