### PR TITLE
fix(api-service,dal): copilot revert and retry on appropriate checkpoint fixes NV-7212

### DIFF
--- a/libs/dal/src/repositories/ai-chat/ai-chat.entity.ts
+++ b/libs/dal/src/repositories/ai-chat/ai-chat.entity.ts
@@ -1,4 +1,4 @@
-import { AiResourceTypeEnum } from '@novu/shared';
+import { AiResourceTypeEnum, AiResumeActionEnum } from '@novu/shared';
 import type { ChangePropsValueType } from '../../types/helpers';
 import type { EnvironmentId } from '../environment';
 import type { OrganizationId } from '../organization';
@@ -23,6 +23,7 @@ export class AiChatEntity {
 
   snapshots?: AiChatSnapshotRef[];
   resumeCheckpointId?: string;
+  resumeAction?: AiResumeActionEnum | null;
 
   hasPendingChanges: boolean;
 

--- a/libs/dal/src/repositories/ai-chat/ai-chat.schema.ts
+++ b/libs/dal/src/repositories/ai-chat/ai-chat.schema.ts
@@ -1,3 +1,4 @@
+import { AiResumeActionEnum } from '@novu/shared';
 import mongoose, { Schema } from 'mongoose';
 import { schemaOptions } from '../schema-default.options';
 import { AiChatDBModel } from './ai-chat.entity';
@@ -50,6 +51,12 @@ const aiChatSchema = new Schema<AiChatDBModel>(
     },
     resumeCheckpointId: {
       type: Schema.Types.String,
+      required: false,
+      default: null,
+    },
+    resumeAction: {
+      type: Schema.Types.String,
+      enum: Object.values(AiResumeActionEnum),
       required: false,
       default: null,
     },

--- a/packages/shared/src/types/ai.ts
+++ b/packages/shared/src/types/ai.ts
@@ -45,3 +45,8 @@ export enum AiWorkflowToolsNameEnum {
   REMOVE_STEP = 'tool-removeStep',
   MOVE_STEP = 'tool-moveStep',
 }
+
+export enum AiResumeActionEnum {
+  TRY_AGAIN = 'tryAgain',
+  REVERT = 'revert',
+}


### PR DESCRIPTION
### What changed? Why was the change needed?
Related EE repo PR: https://github.com/novuhq/packages-enterprise/pull/412

Novu Copilot: fixed the revert and retry functionality that was pointing on the wrong checkpoint remembering the last user message. Now it forks from the last user message and updates the message with new user input.

### Screenshots


https://github.com/user-attachments/assets/4edd4284-7c65-494e-9571-f3a3da422ed4


https://github.com/user-attachments/assets/a1de2ab6-3459-48cb-ad55-2cf0440e1b76


