### PR TITLE
feat(dashboard): Dashboard mobile responsiveness

### DIFF
--- a/apps/dashboard/src/components/auth-layout.tsx
+++ b/apps/dashboard/src/components/auth-layout.tsx
@@ -3,7 +3,7 @@ import { Toaster } from './primitives/sonner';
 
 export const AuthLayout = ({ children }: { children: ReactNode }) => {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[url('/images/auth/background.svg')] bg-cover bg-no-repeat">
+    <div className="flex min-h-screen items-center justify-center overflow-auto bg-[url('/images/auth/background.svg')] bg-cover bg-no-repeat p-4 md:p-0">
       <Toaster />
 
       <div className="flex w-full flex-1 flex-row items-center justify-center">{children}</div>

--- a/apps/dashboard/src/components/auth/auth-card.tsx
+++ b/apps/dashboard/src/components/auth/auth-card.tsx
@@ -2,5 +2,9 @@ import { cn } from '../../utils/ui';
 import { Card } from '../primitives/card';
 
 export function AuthCard({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <Card className={cn('flex min-h-[692px] w-full max-w-[1100px] overflow-hidden', className)}>{children}</Card>;
+  return (
+    <Card className={cn('flex min-h-0 w-full max-w-[1100px] overflow-hidden md:min-h-[692px]', className)}>
+      {children}
+    </Card>
+  );
 }

--- a/apps/dashboard/src/components/auth/create-organization.tsx
+++ b/apps/dashboard/src/components/auth/create-organization.tsx
@@ -54,8 +54,8 @@ interface IllustrationProps {
 // Small Components
 function FormContainer({ children }: FormContainerProps) {
   return (
-    <div className="flex min-w-[564px] max-w-[564px] items-center p-[60px]">
-      <div className="flex flex-col gap-[4px]">{children}</div>
+    <div className="flex w-full items-center p-6 md:min-w-[564px] md:max-w-[564px] md:p-[60px]">
+      <div className="flex w-full flex-col gap-[4px]">{children}</div>
     </div>
   );
 }
@@ -118,7 +118,7 @@ function Illustration({ src, alt, className }: IllustrationProps) {
 
 function IllustrationSection() {
   return (
-    <div className="flex flex-1 items-center justify-center">
+    <div className="hidden flex-1 items-center justify-center md:flex">
       <Illustration {...ILLUSTRATION_CONFIG} />
     </div>
   );
@@ -126,7 +126,7 @@ function IllustrationSection() {
 
 function MainContent() {
   return (
-    <div className="flex flex-1">
+    <div className="flex flex-1 flex-col md:flex-row">
       <OrganizationFormSection />
       <IllustrationSection />
     </div>

--- a/apps/dashboard/src/components/auth/inbox-playground.tsx
+++ b/apps/dashboard/src/components/auth/inbox-playground.tsx
@@ -136,9 +136,8 @@ export function InboxPlayground({ appId, subscriberId }: { appId: string; subscr
           backgroundRepeat: 'no-repeat',
         }}
       >
-        <div className="flex flex-1">
-          {/* App Name Section - Show immediately */}
-          <div className="flex flex-1 items-start justify-start">
+        <div className="flex flex-1 flex-col md:flex-row">
+          <div className="hidden flex-1 items-start justify-start md:flex">
             <div className="ml-10 mt-9">
               <div className="text-1xl font-medium text-gray-500">
                 {organization?.name ? `${organization.name} App` : 'ACME App'}
@@ -146,10 +145,9 @@ export function InboxPlayground({ appId, subscriberId }: { appId: string; subscr
             </div>
           </div>
 
-          {/* Inbox Preview Section - Show with optimized loading */}
-          <div className="flex flex-1 flex-col">
-            <div className="flex items-start justify-end">
-              <div className="nv-no-scrollbar mr-20 mt-16 h-[470px] w-[375px] rounded-lg border border-gray-200 bg-white shadow-[0_8px_25px_-8px_rgba(0,0,0,0.15)]">
+          <div className="flex flex-1 flex-col items-center md:items-end">
+            <div className="flex items-start justify-center px-4 py-6 md:justify-end md:px-0">
+              <div className="nv-no-scrollbar h-[380px] w-full max-w-[375px] rounded-lg border border-gray-200 bg-white shadow-[0_8px_25px_-8px_rgba(0,0,0,0.15)] md:mr-20 md:mt-16 md:h-[470px] md:w-[375px]">
                 <InboxPreviewContent />
               </div>
             </div>

--- a/apps/dashboard/src/components/auth/inbox-playground.tsx
+++ b/apps/dashboard/src/components/auth/inbox-playground.tsx
@@ -147,7 +147,7 @@ export function InboxPlayground({ appId, subscriberId }: { appId: string; subscr
 
           <div className="flex flex-1 flex-col items-center md:items-end">
             <div className="flex items-start justify-center px-4 py-6 md:justify-end md:px-0">
-              <div className="nv-no-scrollbar h-[380px] w-full max-w-[375px] rounded-lg border border-gray-200 bg-white shadow-[0_8px_25px_-8px_rgba(0,0,0,0.15)] md:mr-20 md:mt-16 md:h-[470px] md:w-[375px]">
+              <div className="nv-no-scrollbar h-[380px] w-full max-w-[375px] overflow-hidden rounded-lg border border-gray-200 bg-white shadow-[0_8px_25px_-8px_rgba(0,0,0,0.15)] md:mr-20 md:mt-16 md:h-[470px] md:w-[375px]">
                 <InboxPreviewContent />
               </div>
             </div>

--- a/apps/dashboard/src/components/auth/inbox-preview-content.tsx
+++ b/apps/dashboard/src/components/auth/inbox-preview-content.tsx
@@ -52,7 +52,7 @@ export function InboxPreviewContent() {
           backgroundColor: 'white',
         },
         inboxContent: {
-          maxHeight: '460px',
+          maxHeight: '100%',
         },
         notificationListContainer: {
           minHeight: '100%',
@@ -69,7 +69,7 @@ export function InboxPreviewContent() {
   };
 
   return (
-    <div className="hide-inbox-footer nv-no-scrollbar mt-1 h-[470px] w-[370px] overflow-y-auto overflow-x-hidden">
+    <div className="hide-inbox-footer nv-no-scrollbar mt-1 h-full w-full overflow-y-auto overflow-x-hidden">
       <Inbox {...configuration}>
         <InboxContent />
       </Inbox>

--- a/apps/dashboard/src/components/auth/questionnaire-form.tsx
+++ b/apps/dashboard/src/components/auth/questionnaire-form.tsx
@@ -83,9 +83,9 @@ export function QuestionnaireForm() {
 
   return (
     <>
-      <div className="w-full max-w-[564px] px-0 pt-[80px]">
+      <div className="w-full max-w-[564px] px-4 pt-10 md:px-0 md:pt-[80px]">
         <div className="flex flex-col items-center gap-8">
-          <div className="flex w-[350px] flex-col gap-1">
+          <div className="flex w-full max-w-[350px] flex-col gap-1">
             <div className="flex w-full items-center gap-1.5">
               <div className="flex flex-1 flex-col gap-1">
                 <StepIndicator step={2} />
@@ -100,7 +100,7 @@ export function QuestionnaireForm() {
           </div>
 
           <Form {...form}>
-            <FormRoot onSubmit={handleSubmit(onSubmit)} className="flex w-[350px] flex-col gap-8">
+            <FormRoot onSubmit={handleSubmit(onSubmit)} className="flex w-full max-w-[350px] flex-col gap-8">
               <div className="flex flex-col gap-7">
                 <div className="flex flex-col gap-[4px]">
                   <label className="text-foreground-600 text-xs font-medium">Job title</label>
@@ -227,7 +227,7 @@ export function QuestionnaireForm() {
         </div>
       </div>
 
-      <div className="w-full max-w-[564px] flex-1">
+      <div className="hidden w-full max-w-[564px] flex-1 md:block">
         <img src="/images/auth/ui-org.svg" alt="create-org-illustration" />
       </div>
     </>

--- a/apps/dashboard/src/components/dashboard-layout.tsx
+++ b/apps/dashboard/src/components/dashboard-layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { HeaderNavigation } from '@/components/header-navigation/header-navigation';
+import { MobileDesktopPrompt } from '@/components/mobile-desktop-prompt';
 // @ts-ignore
 import { SideNavigation } from '@/components/side-navigation/side-navigation';
 
@@ -16,12 +17,21 @@ export const DashboardLayout = ({
 }) => {
   return (
     <div className="relative flex h-full w-full">
-      {showSideNavigation && <SideNavigation />}
+      {showSideNavigation && (
+        <div className="hidden md:block">
+          <SideNavigation />
+        </div>
+      )}
       <div className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden">
-        <HeaderNavigation startItems={headerStartItems} hideBridgeUrl={!showBridgeUrl} />
+        <HeaderNavigation
+          startItems={headerStartItems}
+          hideBridgeUrl={!showBridgeUrl}
+          showMobileNav={showSideNavigation}
+        />
 
         <div className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden p-2">{children}</div>
       </div>
+      <MobileDesktopPrompt />
     </div>
   );
 };

--- a/apps/dashboard/src/components/full-page-layout.tsx
+++ b/apps/dashboard/src/components/full-page-layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { HeaderNavigation } from '@/components/header-navigation/header-navigation';
+import { MobileDesktopPrompt } from '@/components/mobile-desktop-prompt';
 
 export const FullPageLayout = ({
   children,
@@ -15,6 +16,7 @@ export const FullPageLayout = ({
 
         <div className="relative flex flex-1 flex-col overflow-y-auto overflow-x-hidden">{children}</div>
       </div>
+      <MobileDesktopPrompt />
     </div>
   );
 };

--- a/apps/dashboard/src/components/header-navigation/header-navigation.tsx
+++ b/apps/dashboard/src/components/header-navigation/header-navigation.tsx
@@ -3,6 +3,7 @@ import { HTMLAttributes, ReactNode } from 'react';
 import { RiSearchLine } from 'react-icons/ri';
 import { useCommandPalette } from '@/components/command-palette/hooks/use-command-palette';
 import { InboxButton } from '@/components/inbox-button';
+import { MobileSideNavigation } from '@/components/side-navigation/mobile-side-navigation';
 import { UserProfile } from '@/components/user-profile';
 import { RegionSelector } from '@/context/region';
 import { cn } from '@/utils/ui';
@@ -18,10 +19,11 @@ import { PublishButton } from './publish-button';
 type HeaderNavigationProps = HTMLAttributes<HTMLDivElement> & {
   startItems?: ReactNode;
   hideBridgeUrl?: boolean;
+  showMobileNav?: boolean;
 };
 
 export const HeaderNavigation = (props: HeaderNavigationProps) => {
-  const { startItems, hideBridgeUrl = false, className, ...rest } = props;
+  const { startItems, hideBridgeUrl = false, showMobileNav = false, className, ...rest } = props;
   const { currentEnvironment } = useEnvironment();
   const has = useHasPermission();
   const canPublish = has({ permission: PermissionsEnum.ENVIRONMENT_WRITE });
@@ -35,25 +37,41 @@ export const HeaderNavigation = (props: HeaderNavigationProps) => {
       )}
       {...rest}
     >
-      {startItems}
+      <div className="flex items-center gap-1">
+        {showMobileNav && <MobileSideNavigation />}
+        {startItems}
+      </div>
       <div className="text-foreground-600 ml-auto flex items-center gap-2">
         <Button
           variant="secondary"
           mode="outline"
-          className="h-[26px] px-[5px]"
+          className="hidden h-[26px] px-[5px] md:inline-flex"
           size="2xs"
           onClick={openCommandPalette}
         >
           <RiSearchLine className="size-3 text-text-sub" />
           <Kbd className="bg-bg-weak rounded-4 h-[16px]">⌘K</Kbd>
         </Button>
-        {currentEnvironment?.type === EnvironmentTypeEnum.DEV && canPublish && <PublishButton />}
-        {!hideBridgeUrl ? <EditBridgeUrlButton /> : null}
-        {!(IS_SELF_HOSTED && IS_ENTERPRISE) && <CustomerSupportButton />}
+        <Button
+          variant="secondary"
+          mode="outline"
+          className="h-[26px] px-[5px] md:hidden"
+          size="2xs"
+          onClick={openCommandPalette}
+        >
+          <RiSearchLine className="size-3 text-text-sub" />
+        </Button>
+        <span className="hidden md:contents">
+          {currentEnvironment?.type === EnvironmentTypeEnum.DEV && canPublish && <PublishButton />}
+          {!hideBridgeUrl ? <EditBridgeUrlButton /> : null}
+          {!(IS_SELF_HOSTED && IS_ENTERPRISE) && <CustomerSupportButton />}
+        </span>
         <div className="flex items-center gap-2">
           <InboxButton />
-          <div className="h-4 w-px bg-neutral-200" />
-          <RegionSelector />
+          <div className="hidden h-4 w-px bg-neutral-200 md:block" />
+          <span className="hidden md:inline-flex">
+            <RegionSelector />
+          </span>
         </div>
         <UserProfile />
       </div>

--- a/apps/dashboard/src/components/mobile-desktop-prompt.tsx
+++ b/apps/dashboard/src/components/mobile-desktop-prompt.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { RiCloseLine, RiComputerLine, RiArrowRightLine } from 'react-icons/ri';
+import { LogoCircle } from '@/components/icons/logo-circle';
+import { cn } from '@/utils/ui';
+
+const MOBILE_PROMPT_DISMISSED_KEY = 'novu-mobile-prompt-dismissed';
+
+export function MobileDesktopPrompt() {
+  const [isDismissed, setIsDismissed] = useState(() => {
+    try {
+      return sessionStorage.getItem(MOBILE_PROMPT_DISMISSED_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const handleDismiss = () => {
+    setIsDismissed(true);
+    try {
+      sessionStorage.setItem(MOBILE_PROMPT_DISMISSED_KEY, 'true');
+    } catch {}
+  };
+
+  if (isDismissed) return null;
+
+  return (
+    <div className="animate-in slide-in-from-bottom-4 fade-in fixed inset-x-0 bottom-0 z-[100] p-3 duration-500 md:hidden">
+      <div
+        className={cn(
+          'relative mx-auto max-w-md overflow-hidden rounded-2xl',
+          'bg-background border border-neutral-200 shadow-[0_8px_30px_rgb(0,0,0,0.12)]'
+        )}
+      >
+        <button
+          onClick={handleDismiss}
+          className="absolute right-3 top-3 z-10 rounded-full p-1 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600"
+          aria-label="Dismiss"
+        >
+          <RiCloseLine className="size-4" />
+        </button>
+
+        <div className="relative px-5 pb-5 pt-4">
+          <div className="mb-3 flex items-center gap-2.5">
+            <div className="flex size-8 items-center justify-center rounded-lg bg-gradient-to-br from-pink-500/10 to-purple-500/10">
+              <LogoCircle className="size-5" />
+            </div>
+            <span className="text-sm font-semibold text-neutral-900">Novu</span>
+          </div>
+
+          <div className="mb-4">
+            <h3 className="mb-1.5 text-base font-semibold text-neutral-900">Best on desktop</h3>
+            <p className="text-sm leading-relaxed text-neutral-500">
+              Novu's dashboard is designed for desktop screens. Switch to your computer for the full experience with
+              workflow editing, code integration, and more.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3 rounded-xl bg-neutral-50 px-4 py-3">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white shadow-sm ring-1 ring-neutral-200/60">
+              <RiComputerLine className="size-5 text-neutral-700" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-neutral-800">Open on your computer</p>
+              <p className="truncate text-xs text-neutral-400">dashboard.novu.co</p>
+            </div>
+            <RiArrowRightLine className="size-4 shrink-0 text-neutral-400" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/side-navigation/mobile-side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/mobile-side-navigation.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { RiMenuLine } from 'react-icons/ri';
+import { useLocation } from 'react-router-dom';
+import { Sheet, SheetContent, SheetTitle } from '@/components/primitives/sheet';
+import { SideNavigation } from './side-navigation';
+import { useEffect } from 'react';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+
+export function MobileSideNavigation() {
+  const [isOpen, setIsOpen] = useState(false);
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    setIsOpen(false);
+  }, [pathname]);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className="flex size-8 items-center justify-center rounded-lg text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-neutral-900 md:hidden"
+        aria-label="Open navigation"
+      >
+        <RiMenuLine className="size-5" />
+      </button>
+
+      <Sheet open={isOpen} onOpenChange={setIsOpen}>
+        <SheetContent side="left" className="w-[275px] p-0 sm:max-w-[275px]">
+          <VisuallyHidden>
+            <SheetTitle>Navigation</SheetTitle>
+          </VisuallyHidden>
+          <SideNavigation />
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/apps/dashboard/src/components/side-navigation/mobile-side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/mobile-side-navigation.tsx
@@ -1,10 +1,9 @@
-import { useState } from 'react';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+import { useEffect, useState } from 'react';
 import { RiMenuLine } from 'react-icons/ri';
 import { useLocation } from 'react-router-dom';
 import { Sheet, SheetContent, SheetTitle } from '@/components/primitives/sheet';
 import { SideNavigation } from './side-navigation';
-import { useEffect } from 'react';
-import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
 export function MobileSideNavigation() {
   const [isOpen, setIsOpen] = useState(false);

--- a/apps/dashboard/src/components/usecase-playground-header.tsx
+++ b/apps/dashboard/src/components/usecase-playground-header.tsx
@@ -48,8 +48,8 @@ export function UsecasePlaygroundHeader({
   const skipButtonText = getSkipButtonText();
 
   return (
-    <div className="flex items-center justify-between gap-4 border-b pr-6">
-      <div className="flex pl-3">
+    <div className="flex flex-col gap-2 border-b px-3 py-2 md:flex-row md:items-center md:justify-between md:gap-4 md:py-0 md:pl-0 md:pr-6">
+      <div className="flex pl-0 md:pl-3">
         {showBackButton && (
           <CompactButton
             icon={RiArrowLeftSLine}
@@ -59,9 +59,9 @@ export function UsecasePlaygroundHeader({
           />
         )}
 
-        <div className="flex-1 py-3 pr-3 pt-3">
-          <h2 className="text-lg font-medium">{title}</h2>
-          <p className="text-foreground-400 pb-1.5 text-sm">{description}</p>
+        <div className="flex-1 py-2 pr-3 md:py-3 md:pt-3">
+          <h2 className="text-base font-medium md:text-lg">{title}</h2>
+          <p className="text-foreground-400 pb-1.5 text-xs md:text-sm">{description}</p>
         </div>
       </div>
 

--- a/apps/dashboard/src/components/welcome/progress-section.tsx
+++ b/apps/dashboard/src/components/welcome/progress-section.tsx
@@ -29,13 +29,13 @@ export function ProgressSection({ isNewHomePageEnabled }: { isNewHomePageEnabled
       <Card
         className={cn(
           'relative flex items-stretch gap-2 rounded-xl border-neutral-100 shadow-none w-full',
-          isNewHomePageEnabled ? 'flex-col bg-transparent' : ''
+          isNewHomePageEnabled ? 'flex-col bg-transparent' : 'flex-col md:flex-row'
         )}
       >
         {isNewHomePageEnabled ? <HomePageHeader /> : <WelcomeHeader />}
 
         <motion.div
-          className={cn('flex flex-1 flex-col gap-3', isNewHomePageEnabled ? 'p-3 pt-0' : 'p-6')}
+          className={cn('flex flex-1 flex-col gap-3', isNewHomePageEnabled ? 'p-3 pt-0' : 'p-4 md:p-6')}
           variants={stepsList}
         >
           {steps.map((step, index) => (
@@ -44,7 +44,7 @@ export function ProgressSection({ isNewHomePageEnabled }: { isNewHomePageEnabled
         </motion.div>
 
         {!isNewHomePageEnabled && (
-          <motion.div variants={logo} className="absolute bottom-0 right-0">
+          <motion.div variants={logo} className="absolute bottom-0 right-0 hidden md:block">
             <NovuLogo />
           </motion.div>
         )}
@@ -74,7 +74,7 @@ function StepItem({ step, environmentSlug }: StepItemProps) {
   };
 
   return (
-    <motion.div className="flex max-w-[370px] items-center gap-1.5" variants={stepItem}>
+    <motion.div className="flex w-full items-center gap-1.5 md:max-w-[370px]" variants={stepItem}>
       <div
         className={`${step.status === 'completed' ? 'bg-success' : 'shadow-xs'} flex h-6 w-6 min-w-6 items-center justify-center rounded-full`}
       >
@@ -115,22 +115,22 @@ function WelcomeHeader() {
   return (
     <motion.div
       variants={leftSection}
-      className="flex w-full max-w-[380px] grow flex-col items-start justify-between gap-2 rounded-l-xl bg-[#FBFBFB] p-6"
+      className="flex w-full grow flex-col items-start justify-between gap-2 rounded-t-xl bg-[#FBFBFB] p-4 md:max-w-[380px] md:rounded-l-xl md:rounded-tr-none md:p-6"
     >
       <div className="flex w-full flex-col gap-2">
         <motion.h2 variants={textItem} className="font-label-medium text-base font-medium">
           You're doing great work! 💪
         </motion.h2>
 
-        <div className="text-foreground-400 flex flex-col gap-6 text-sm">
+        <div className="text-foreground-400 flex flex-col gap-4 text-sm md:gap-6">
           <motion.p variants={textItem}>Set up Novu to send notifications your users will love.</motion.p>
-          <motion.p variants={textItem}>
+          <motion.p variants={textItem} className="hidden md:block">
             Streamline all your customer messaging in one tool and delight them at every touchpoint.
           </motion.p>
         </div>
       </div>
 
-      <motion.div variants={textItem} className="space-between flex items-center gap-0">
+      <motion.div variants={textItem} className="hidden items-center gap-0 md:flex">
         <p className="text-foreground-400 text-sm">Get started with our setup guide.</p>
         <PointingArrow className="relative left-[15px] top-[-10px]" />
       </motion.div>

--- a/apps/dashboard/src/components/welcome/resources-list.tsx
+++ b/apps/dashboard/src/components/welcome/resources-list.tsx
@@ -74,7 +74,7 @@ export function ResourcesList({ resources, title, icon }: ResourcesListProps) {
           {resources.map((resource, index) => (
             <motion.div key={index} variants={itemVariants}>
               <Link to={resource.url} target="_blank" rel="noopener" onClick={() => handleResourceClick(resource)}>
-                <Card className="w-60 shrink-0 overflow-hidden border-none shadow-[0px_12px_12px_0px_rgba(0,0,0,0.02),0px_0px_0px_1px_rgba(0,0,0,0.05)] transition-all duration-200">
+                <Card className="w-48 shrink-0 overflow-hidden border-none shadow-[0px_12px_12px_0px_rgba(0,0,0,0.02),0px_0px_0px_1px_rgba(0,0,0,0.05)] transition-all duration-200 md:w-60">
                   <motion.div
                     className="bg-foreground-50 h-[95px] overflow-hidden"
                     whileHover={{ scale: 1.03 }}

--- a/apps/dashboard/src/hooks/use-is-mobile.ts
+++ b/apps/dashboard/src/hooks/use-is-mobile.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') return false;
+
+    return window.innerWidth < MOBILE_BREAKPOINT;
+  });
+
+  const handleResize = useCallback(() => {
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+  }, []);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setIsMobile(e.matches);
+    };
+
+    setIsMobile(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, [handleResize]);
+
+  return isMobile;
+}

--- a/apps/dashboard/src/hooks/use-is-mobile.ts
+++ b/apps/dashboard/src/hooks/use-is-mobile.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const MOBILE_BREAKPOINT = 768;
 
@@ -8,10 +8,6 @@ export function useIsMobile() {
 
     return window.innerWidth < MOBILE_BREAKPOINT;
   });
-
-  const handleResize = useCallback(() => {
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-  }, []);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
@@ -26,7 +22,7 @@ export function useIsMobile() {
     return () => {
       mediaQuery.removeEventListener('change', handleChange);
     };
-  }, [handleResize]);
+  }, []);
 
   return isMobile;
 }

--- a/apps/dashboard/src/pages/inbox-embed-page.tsx
+++ b/apps/dashboard/src/pages/inbox-embed-page.tsx
@@ -1,8 +1,12 @@
 import { ChannelTypeEnum } from '@novu/shared';
 import { useEffect, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { RiComputerLine, RiArrowRightSLine } from 'react-icons/ri';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { AnimatedPage } from '@/components/onboarding/animated-page';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { AuthCard } from '../components/auth/auth-card';
+import { LogoCircle } from '../components/icons/logo-circle';
+import { Button } from '../components/primitives/button';
 import { UsecasePlaygroundHeader } from '../components/usecase-playground-header';
 import { InboxEmbed } from '../components/welcome/inbox-embed';
 import { useEnvironment } from '../context/environment/hooks';
@@ -11,8 +15,53 @@ import { useTelemetry } from '../hooks/use-telemetry';
 import { ROUTES } from '../utils/routes';
 import { TelemetryEvent } from '../utils/telemetry';
 
+function MobileEmbedSkip() {
+  const navigate = useNavigate();
+  const telemetry = useTelemetry();
+
+  const handleGoToDashboard = () => {
+    telemetry(TelemetryEvent.SKIP_ONBOARDING_CLICKED, { skippedFrom: 'mobile-embed-skip' });
+    navigate(ROUTES.WELCOME);
+  };
+
+  return (
+    <AnimatedPage>
+      <AuthCard className="mx-4 max-w-md">
+        <div className="flex flex-1 flex-col items-center justify-center gap-6 p-8 text-center">
+          <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-pink-500/10 to-purple-500/10">
+            <LogoCircle className="size-8" />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <h2 className="text-foreground-950 text-xl font-semibold">Continue on desktop</h2>
+            <p className="text-foreground-400 text-sm leading-relaxed">
+              Embedding the Inbox component requires a code editor and development environment. Open Novu on your
+              computer to complete this step.
+            </p>
+          </div>
+
+          <div className="flex w-full items-center gap-3 rounded-xl bg-neutral-50 px-4 py-3">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white shadow-sm ring-1 ring-neutral-200/60">
+              <RiComputerLine className="size-5 text-neutral-700" />
+            </div>
+            <div className="min-w-0 flex-1 text-left">
+              <p className="text-sm font-medium text-neutral-800">Open on your computer</p>
+              <p className="truncate text-xs text-neutral-400">Complete the Inbox integration</p>
+            </div>
+          </div>
+
+          <Button variant="primary" className="mt-2 w-full" trailingIcon={RiArrowRightSLine} onClick={handleGoToDashboard}>
+            Skip to Dashboard
+          </Button>
+        </div>
+      </AuthCard>
+    </AnimatedPage>
+  );
+}
+
 export function InboxEmbedPage() {
   const telemetry = useTelemetry();
+  const isMobile = useIsMobile();
   const { environments } = useEnvironment();
   const [searchParams] = useSearchParams();
   const environmentHint = searchParams.get('environmentId');
@@ -43,6 +92,10 @@ export function InboxEmbedPage() {
   useEffect(() => {
     telemetry(TelemetryEvent.INBOX_EMBED_PAGE_VIEWED);
   }, [telemetry]);
+
+  if (isMobile) {
+    return <MobileEmbedSkip />;
+  }
 
   return (
     <AnimatedPage>

--- a/apps/dashboard/src/pages/inbox-embed-success-page.tsx
+++ b/apps/dashboard/src/pages/inbox-embed-success-page.tsx
@@ -20,8 +20,8 @@ export function InboxEmbedSuccessPage() {
   }
 
   return (
-    <AnimatedPage className="flex flex-col items-center justify-center">
-      <AuthCard className="relative mt-10 block max-h-[366px] min-h-[380px] w-full max-w-[366px] border-none bg-transparent bg-[linear-gradient(180deg,rgba(255,255,255,0.35)_0%,rgba(255,255,255,0.15)_39.37%)]">
+    <AnimatedPage className="flex flex-col items-center justify-center px-4 md:px-0">
+      <AuthCard className="relative mt-4 block max-h-[366px] min-h-[380px] w-full max-w-[366px] border-none bg-transparent bg-[linear-gradient(180deg,rgba(255,255,255,0.35)_0%,rgba(255,255,255,0.15)_39.37%)] md:mt-10">
         <div className="flex w-full flex-col justify-center p-0">
           <div className="relative mb-[50px] flex w-full flex-row items-end justify-end p-2">
             <img src="/images/auth/success-usecase-hint.svg" alt="Onboarding succcess hint to look for inbox" />

--- a/apps/dashboard/src/pages/welcome-page.tsx
+++ b/apps/dashboard/src/pages/welcome-page.tsx
@@ -92,7 +92,7 @@ export function WelcomePage(): ReactElement {
     <>
       <PageMeta title="Get Started with Novu" />
       <DashboardLayout>
-        <motion.div className="flex flex-col gap-8 p-9 pt-4" variants={pageVariants} initial="hidden" animate="show">
+        <motion.div className="flex flex-col gap-6 p-4 pt-2 md:gap-8 md:p-9 md:pt-4" variants={pageVariants} initial="hidden" animate="show">
           <motion.div variants={sectionVariants}>
             <ProgressSection />
           </motion.div>

--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -203,8 +203,8 @@ export const WorkflowsPage = () => {
       <PageMeta title="Workflows" />
       <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows</h1>}>
         <div className="flex h-full w-full flex-col">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2 py-2.5">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-2 py-2.5">
               <FacetedFormFilter
                 type="text"
                 size="small"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR introduces mobile responsiveness to the dashboard, addressing the current lack of optimization for mobile devices. The goal is to provide a functional mobile experience while guiding users towards the desktop for the optimal experience.

Key changes include:

*   **`useIsMobile` hook:** A new hook for reactive mobile viewport detection.
*   **`MobileDesktopPrompt` component:** A dismissible bottom banner on mobile encouraging desktop usage, with persistence via `sessionStorage`.
*   **`MobileSideNavigation` component:** Implements a hamburger menu and a Sheet-based collapsible sidebar for mobile navigation.
*   **Layout updates:** `DashboardLayout` and `FullPageLayout` have been updated to be responsive, incorporating the mobile prompt and conditionally rendering the sidebar.
*   **`HeaderNavigation` adjustments:** The header now includes a hamburger menu, displays an icon-only search on mobile, and hides desktop-specific actions on smaller screens.
*   **`Workflows` page improvements:** The filter and action bar on the workflows page has been made more mobile-friendly.

The desktop experience remains unchanged, with all responsive behaviors applied specifically to mobile breakpoints.

### Screenshots

_Screenshots are needed to demonstrate the mobile responsiveness and the new components (mobile desktop prompt, mobile sidebar)._

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773406582866109?thread_ts=1773406582.866109&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-a68d0433-9626-515f-8ed6-740b95ff9d15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a68d0433-9626-515f-8ed6-740b95ff9d15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->