### PR TITLE
feat(novu,framework): align step resolver handlers with framework steps fixes NV-7235

### DIFF
--- a/libs/application-generic/src/usecases/execute-step-resolver/execute-step-resolver-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-step-resolver/execute-step-resolver-request.usecase.ts
@@ -5,6 +5,7 @@ import got, { HTTPError } from 'got';
 import { InstrumentUsecase } from '../../instrumentation';
 import { PinoLogger } from '../../logging';
 import { RETRYABLE_ERROR_CODES } from '../../services/http-client';
+import { sanitizeHtmlInObject } from '../../services/sanitize/sanitizer.service';
 import {
   BridgeError,
   ExecuteBridgeRequestCommand,
@@ -63,7 +64,18 @@ class StepResolverRequestError extends HttpException {
   }
 }
 
-type StepResolverResponse = Record<string, unknown>;
+type StepResolverResponse = {
+  outputs: Record<string, unknown>;
+  providers?: Record<string, unknown>;
+  options: { skip: boolean };
+  metadata: {
+    status: string;
+    error: boolean;
+    duration: number;
+    stepType?: string;
+    disableOutputSanitization?: boolean;
+  };
+};
 
 @Injectable()
 export class ExecuteStepResolverRequest {
@@ -131,17 +143,44 @@ export class ExecuteStepResolverRequest {
 
       const duration = Math.round(performance.now() - startTime);
 
-      return this.transformToExecuteOutput(response, duration);
+      const executeOutput = this.transformToExecuteOutput(response, duration);
+
+      return this.sanitizeOutputsIfNeeded(
+        executeOutput,
+        response.metadata.stepType,
+        response.metadata.disableOutputSanitization
+      );
     } catch (error) {
       await this.handleResponseError(error, url, command.stepResolverHash, command.processError);
     }
   }
 
+  private sanitizeOutputsIfNeeded(
+    result: ExecuteOutput,
+    stepType?: string,
+    disableOutputSanitization?: boolean
+  ): ExecuteOutput {
+    if (disableOutputSanitization) {
+      return result;
+    }
+
+    const sanitizableTypes = ['email', 'in_app'];
+    if (stepType && sanitizableTypes.includes(stepType)) {
+      return {
+        ...result,
+        outputs: sanitizeHtmlInObject(result.outputs as Record<string, unknown>),
+      };
+    }
+
+    return result;
+  }
+
   private transformToExecuteOutput(response: StepResolverResponse, duration: number): ExecuteOutput {
     return {
-      outputs: { ...response },
+      outputs: response.outputs,
+      providers: (response.providers ?? {}) as ExecuteOutput['providers'],
       options: {
-        skip: false,
+        skip: response.options?.skip === true,
       },
       metadata: {
         status: 'success',

--- a/packages/framework/src/resources/step-resolver/step.ts
+++ b/packages/framework/src/resources/step-resolver/step.ts
@@ -1,4 +1,7 @@
+import { providerSchemas } from '../../schemas/providers';
 import type { FromSchema, Schema } from '../../types';
+import type { ContextResolved } from '../../types/context.types';
+import type { WithPassthrough } from '../../types/provider.types';
 import type {
   ChatOutputUnvalidated,
   EmailOutputUnvalidated,
@@ -6,19 +9,42 @@ import type {
   PushOutputUnvalidated,
   SmsOutputUnvalidated,
 } from '../../types/step.types';
+import type { Subscriber } from '../../types/subscriber.types';
+import type { Awaitable } from '../../types/util.types';
 
 type StepResolverContext<TPayload extends Record<string, unknown> = Record<string, unknown>> = {
   payload: TPayload;
-  subscriber: Record<string, unknown>;
-  context: Record<string, unknown>;
+  subscriber: Subscriber;
+  context: ContextResolved;
   steps: Record<string, unknown>;
 };
 
 type ResolveControls<T extends Schema | undefined> = T extends Schema ? FromSchema<T> : Record<string, unknown>;
 
-type StepResolverOptions<TControlSchema extends Schema | undefined, TPayloadSchema extends Schema | undefined> = {
+type StepResolverProviders<T_StepType extends keyof typeof providerSchemas, T_Controls, T_Output> = {
+  [K in keyof (typeof providerSchemas)[T_StepType]]?: (
+    step: { controls: T_Controls; outputs: T_Output },
+    ctx: StepResolverContext
+  ) => Awaitable<WithPassthrough<Record<string, unknown>>>;
+};
+
+type BaseStepResolverOptions<TControlSchema extends Schema | undefined, TPayloadSchema extends Schema | undefined> = {
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
+  skip?: (
+    controls: ResolveControls<TControlSchema>,
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+  ) => Awaitable<boolean>;
+};
+
+type ChannelStepResolverOptions<
+  T_StepType extends keyof typeof providerSchemas,
+  TControlSchema extends Schema | undefined,
+  TPayloadSchema extends Schema | undefined,
+  T_Output extends Record<string, unknown>,
+> = BaseStepResolverOptions<TControlSchema, TPayloadSchema> & {
+  providers?: StepResolverProviders<T_StepType, ResolveControls<TControlSchema>, T_Output>;
+  disableOutputSanitization?: boolean;
 };
 
 export type EmailStepResolver<
@@ -33,6 +59,9 @@ export type EmailStepResolver<
   ) => Promise<EmailOutputUnvalidated>;
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
+  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
+  providers?: StepResolverProviders<'email', ResolveControls<TControlSchema>, EmailOutputUnvalidated>;
+  disableOutputSanitization?: boolean;
 };
 
 export type SmsStepResolver<
@@ -47,6 +76,9 @@ export type SmsStepResolver<
   ) => Promise<SmsOutputUnvalidated>;
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
+  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
+  providers?: StepResolverProviders<'sms', ResolveControls<TControlSchema>, SmsOutputUnvalidated>;
+  disableOutputSanitization?: boolean;
 };
 
 export type ChatStepResolver<
@@ -61,6 +93,9 @@ export type ChatStepResolver<
   ) => Promise<ChatOutputUnvalidated>;
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
+  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
+  providers?: StepResolverProviders<'chat', ResolveControls<TControlSchema>, ChatOutputUnvalidated>;
+  disableOutputSanitization?: boolean;
 };
 
 export type PushStepResolver<
@@ -75,6 +110,9 @@ export type PushStepResolver<
   ) => Promise<PushOutputUnvalidated>;
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
+  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
+  providers?: StepResolverProviders<'push', ResolveControls<TControlSchema>, PushOutputUnvalidated>;
+  disableOutputSanitization?: boolean;
 };
 
 export type InAppStepResolver<
@@ -89,6 +127,9 @@ export type InAppStepResolver<
   ) => Promise<InAppOutputUnvalidated>;
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
+  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
+  providers?: StepResolverProviders<'in_app', ResolveControls<TControlSchema>, InAppOutputUnvalidated>;
+  disableOutputSanitization?: boolean;
 };
 
 export type AnyStepResolver =
@@ -107,7 +148,7 @@ function email<
     controls: ResolveControls<TControlSchema>,
     ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
   ) => Promise<EmailOutputUnvalidated>,
-  options?: StepResolverOptions<TControlSchema, TPayloadSchema>
+  options?: ChannelStepResolverOptions<'email', TControlSchema, TPayloadSchema, EmailOutputUnvalidated>
 ): EmailStepResolver<TControlSchema, TPayloadSchema> {
   return {
     type: 'email',
@@ -115,6 +156,9 @@ function email<
     resolve: resolve as EmailStepResolver<TControlSchema, TPayloadSchema>['resolve'],
     controlSchema: options?.controlSchema,
     payloadSchema: options?.payloadSchema,
+    skip: options?.skip,
+    providers: options?.providers as EmailStepResolver<TControlSchema, TPayloadSchema>['providers'],
+    disableOutputSanitization: options?.disableOutputSanitization,
   };
 }
 
@@ -127,7 +171,7 @@ function sms<
     controls: ResolveControls<TControlSchema>,
     ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
   ) => Promise<SmsOutputUnvalidated>,
-  options?: StepResolverOptions<TControlSchema, TPayloadSchema>
+  options?: ChannelStepResolverOptions<'sms', TControlSchema, TPayloadSchema, SmsOutputUnvalidated>
 ): SmsStepResolver<TControlSchema, TPayloadSchema> {
   return {
     type: 'sms',
@@ -135,6 +179,9 @@ function sms<
     resolve: resolve as SmsStepResolver<TControlSchema, TPayloadSchema>['resolve'],
     controlSchema: options?.controlSchema,
     payloadSchema: options?.payloadSchema,
+    skip: options?.skip,
+    providers: options?.providers as SmsStepResolver<TControlSchema, TPayloadSchema>['providers'],
+    disableOutputSanitization: options?.disableOutputSanitization,
   };
 }
 
@@ -147,7 +194,7 @@ function chat<
     controls: ResolveControls<TControlSchema>,
     ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
   ) => Promise<ChatOutputUnvalidated>,
-  options?: StepResolverOptions<TControlSchema, TPayloadSchema>
+  options?: ChannelStepResolverOptions<'chat', TControlSchema, TPayloadSchema, ChatOutputUnvalidated>
 ): ChatStepResolver<TControlSchema, TPayloadSchema> {
   return {
     type: 'chat',
@@ -155,6 +202,9 @@ function chat<
     resolve: resolve as ChatStepResolver<TControlSchema, TPayloadSchema>['resolve'],
     controlSchema: options?.controlSchema,
     payloadSchema: options?.payloadSchema,
+    skip: options?.skip,
+    providers: options?.providers as ChatStepResolver<TControlSchema, TPayloadSchema>['providers'],
+    disableOutputSanitization: options?.disableOutputSanitization,
   };
 }
 
@@ -167,7 +217,7 @@ function push<
     controls: ResolveControls<TControlSchema>,
     ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
   ) => Promise<PushOutputUnvalidated>,
-  options?: StepResolverOptions<TControlSchema, TPayloadSchema>
+  options?: ChannelStepResolverOptions<'push', TControlSchema, TPayloadSchema, PushOutputUnvalidated>
 ): PushStepResolver<TControlSchema, TPayloadSchema> {
   return {
     type: 'push',
@@ -175,6 +225,9 @@ function push<
     resolve: resolve as PushStepResolver<TControlSchema, TPayloadSchema>['resolve'],
     controlSchema: options?.controlSchema,
     payloadSchema: options?.payloadSchema,
+    skip: options?.skip,
+    providers: options?.providers as PushStepResolver<TControlSchema, TPayloadSchema>['providers'],
+    disableOutputSanitization: options?.disableOutputSanitization,
   };
 }
 
@@ -187,7 +240,7 @@ function inApp<
     controls: ResolveControls<TControlSchema>,
     ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
   ) => Promise<InAppOutputUnvalidated>,
-  options?: StepResolverOptions<TControlSchema, TPayloadSchema>
+  options?: ChannelStepResolverOptions<'in_app', TControlSchema, TPayloadSchema, InAppOutputUnvalidated>
 ): InAppStepResolver<TControlSchema, TPayloadSchema> {
   return {
     type: 'in_app',
@@ -195,6 +248,9 @@ function inApp<
     resolve: resolve as InAppStepResolver<TControlSchema, TPayloadSchema>['resolve'],
     controlSchema: options?.controlSchema,
     payloadSchema: options?.payloadSchema,
+    skip: options?.skip,
+    providers: options?.providers as InAppStepResolver<TControlSchema, TPayloadSchema>['providers'],
+    disableOutputSanitization: options?.disableOutputSanitization,
   };
 }
 

--- a/packages/framework/src/resources/step-resolver/step.ts
+++ b/packages/framework/src/resources/step-resolver/step.ts
@@ -21,10 +21,15 @@ type StepResolverContext<TPayload extends Record<string, unknown> = Record<strin
 
 type ResolveControls<T extends Schema | undefined> = T extends Schema ? FromSchema<T> : Record<string, unknown>;
 
-type StepResolverProviders<T_StepType extends keyof typeof providerSchemas, T_Controls, T_Output> = {
+type StepResolverProviders<
+  T_StepType extends keyof typeof providerSchemas,
+  T_Controls,
+  T_Output,
+  T_Payload extends Record<string, unknown> = Record<string, unknown>,
+> = {
   [K in keyof (typeof providerSchemas)[T_StepType]]?: (
     step: { controls: T_Controls; outputs: T_Output },
-    ctx: StepResolverContext
+    ctx: StepResolverContext<T_Payload>
   ) => Awaitable<WithPassthrough<Record<string, unknown>>>;
 };
 
@@ -43,7 +48,12 @@ type ChannelStepResolverOptions<
   TPayloadSchema extends Schema | undefined,
   T_Output extends Record<string, unknown>,
 > = BaseStepResolverOptions<TControlSchema, TPayloadSchema> & {
-  providers?: StepResolverProviders<T_StepType, ResolveControls<TControlSchema>, T_Output>;
+  providers?: StepResolverProviders<
+    T_StepType,
+    ResolveControls<TControlSchema>,
+    T_Output,
+    ResolveControls<TPayloadSchema>
+  >;
   disableOutputSanitization?: boolean;
 };
 
@@ -60,7 +70,12 @@ export type EmailStepResolver<
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
   skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
-  providers?: StepResolverProviders<'email', ResolveControls<TControlSchema>, EmailOutputUnvalidated>;
+  providers?: StepResolverProviders<
+    'email',
+    ResolveControls<TControlSchema>,
+    EmailOutputUnvalidated,
+    ResolveControls<TPayloadSchema>
+  >;
   disableOutputSanitization?: boolean;
 };
 
@@ -77,7 +92,12 @@ export type SmsStepResolver<
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
   skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
-  providers?: StepResolverProviders<'sms', ResolveControls<TControlSchema>, SmsOutputUnvalidated>;
+  providers?: StepResolverProviders<
+    'sms',
+    ResolveControls<TControlSchema>,
+    SmsOutputUnvalidated,
+    ResolveControls<TPayloadSchema>
+  >;
   disableOutputSanitization?: boolean;
 };
 
@@ -94,7 +114,12 @@ export type ChatStepResolver<
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
   skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
-  providers?: StepResolverProviders<'chat', ResolveControls<TControlSchema>, ChatOutputUnvalidated>;
+  providers?: StepResolverProviders<
+    'chat',
+    ResolveControls<TControlSchema>,
+    ChatOutputUnvalidated,
+    ResolveControls<TPayloadSchema>
+  >;
   disableOutputSanitization?: boolean;
 };
 
@@ -111,7 +136,12 @@ export type PushStepResolver<
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
   skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
-  providers?: StepResolverProviders<'push', ResolveControls<TControlSchema>, PushOutputUnvalidated>;
+  providers?: StepResolverProviders<
+    'push',
+    ResolveControls<TControlSchema>,
+    PushOutputUnvalidated,
+    ResolveControls<TPayloadSchema>
+  >;
   disableOutputSanitization?: boolean;
 };
 
@@ -128,7 +158,12 @@ export type InAppStepResolver<
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
   skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
-  providers?: StepResolverProviders<'in_app', ResolveControls<TControlSchema>, InAppOutputUnvalidated>;
+  providers?: StepResolverProviders<
+    'in_app',
+    ResolveControls<TControlSchema>,
+    InAppOutputUnvalidated,
+    ResolveControls<TPayloadSchema>
+  >;
   disableOutputSanitization?: boolean;
 };
 

--- a/packages/framework/src/step-resolver.ts
+++ b/packages/framework/src/step-resolver.ts
@@ -7,4 +7,6 @@ export type {
   SmsStepResolver,
 } from './resources/step-resolver/step';
 export { step } from './resources/step-resolver/step';
+export { providerSchemas } from './schemas/providers';
 export { channelStepSchemas } from './schemas/steps/channels';
+export type { WithPassthrough } from './types/provider.types';

--- a/packages/novu/src/commands/step/publish.ts
+++ b/packages/novu/src/commands/step/publish.ts
@@ -136,8 +136,8 @@ export async function stepPublish(options: PublishOptions): Promise<void> {
       return;
     }
 
-    if (process.stdout.isTTY) {
-      const confirmed = await confirmDeploy(selectedSteps.length, isFirstTimeScaffold);
+    if (process.stdout.isTTY && isFirstTimeScaffold) {
+      const confirmed = await confirmDeploy(selectedSteps.length);
       if (!confirmed) {
         console.log('');
         console.log(yellow('ℹ  Publish cancelled.'));
@@ -310,14 +310,11 @@ async function promptForEmailTemplate(rootDir: string): Promise<ScaffoldResult |
   return { mode: 'react-email', templatePath: selectResponse.template };
 }
 
-async function confirmDeploy(stepCount: number, isFirstTimeScaffold: boolean): Promise<boolean> {
+async function confirmDeploy(stepCount: number): Promise<boolean> {
   const stepText = stepCount === 1 ? '1 step' : `${stepCount} steps`;
   console.log('');
-
-  if (isFirstTimeScaffold) {
-    console.log(yellow(`⚠  Publishing will override any existing editor content for ${stepText}.`));
-    console.log('');
-  }
+  console.log(yellow(`⚠  Publishing will override any existing editor content for ${stepText}.`));
+  console.log('');
 
   const response = await prompts({
     type: 'confirm',
@@ -724,7 +721,7 @@ function printSuccessSummary(deployment: DeploymentResult, steps: DiscoveredStep
   );
   console.log('');
   console.log(
-    `   ${green(`${steps.length} ${stepText}`)} live in ${workflowCount} ${workflowText}${dim(` · Version ${deployment.stepResolverHash.slice(0, 8)} · ${elapsed}`)}`
+    `   ${green(`${steps.length} ${stepText}`)} live in ${workflowCount} ${workflowText}${dim(` · Version ${deployment.stepResolverHash} · ${elapsed}`)}`
   );
   console.log('');
 }

--- a/packages/novu/src/commands/step/templates/__snapshots__/worker-wrapper.spec.ts.snap
+++ b/packages/novu/src/commands/step/templates/__snapshots__/worker-wrapper.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`generateWorkerWrapper > should handle empty steps array > empty-steps 1`] = `
 "import { validateData } from '@novu/framework/validators';
-import { channelStepSchemas } from '@novu/framework/step-resolver';
+import { channelStepSchemas, providerSchemas } from '@novu/framework/step-resolver';
 
 
 // Pre-compile all JSON Schema validators during the startup phase.
@@ -13,9 +13,17 @@ await Promise.all([
   ...Object.values(channelStepSchemas).map(({ output }) =>
     validateData(output, {})
   ),
-  ...[].flatMap(handler =>
-    handler.controlSchema ? [validateData(handler.controlSchema, {})] : []
-  ),
+  ...[].flatMap(handler => {
+    const schemas = [];
+    if (handler.controlSchema) schemas.push(validateData(handler.controlSchema, {}));
+    if (handler.providers && providerSchemas[handler.type]) {
+      for (const key of Object.keys(handler.providers)) {
+        const providerSchema = providerSchemas[handler.type]?.[key]?.output;
+        if (providerSchema) schemas.push(validateData(providerSchema, {}));
+      }
+    }
+    return schemas;
+  }),
 ]);
 
 const stepHandlers = new Map([
@@ -62,6 +70,8 @@ export default {
         );
       }
 
+      const startTime = Date.now();
+
       let body = {};
       const rawBody = await request.text();
       if (rawBody) {
@@ -82,6 +92,7 @@ export default {
       const stateArray = Array.isArray(body.state) ? body.state : [];
       const stepOutputs = stateArray.reduce((acc, s) => { if (s && typeof s.stepId === 'string') acc[s.stepId] = s.outputs ?? {}; return acc; }, {});
       const controls = body.controls ?? {};
+      const isPreview = body.action === 'preview';
 
       if (!isObject(payload) || !isObject(subscriber) || !isObject(context) || !isObject(stepOutputs) || !isObject(controls)) {
         return jsonResponse(
@@ -102,6 +113,27 @@ export default {
         validatedControls = controlsResult.data;
       }
 
+      if (!isPreview && step.skip) {
+        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+        if (shouldSkip) {
+          return jsonResponse(
+            {
+              outputs: {},
+              providers: {},
+              options: { skip: true },
+              metadata: {
+                status: 'success',
+                error: false,
+                duration: Date.now() - startTime,
+                stepType: step.type,
+                disableOutputSanitization: step.disableOutputSanitization === true,
+              },
+            },
+            200
+          );
+        }
+      }
+
       const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs });
 
       const outputSchema = channelStepSchemas[step.type]?.output;
@@ -117,8 +149,40 @@ export default {
         validatedResult = outputResult.data ?? result;
       }
 
+      const providers = {};
+      if (step.providers) {
+        const ctx = { payload, subscriber, context, steps: stepOutputs };
+        for (const [providerKey, providerResolve] of Object.entries(step.providers)) {
+          const providerResult = await providerResolve({ controls: validatedControls, outputs: validatedResult }, ctx);
+          const providerOutputSchema = providerSchemas[step.type]?.[providerKey]?.output;
+          if (providerOutputSchema) {
+            const providerValidation = await validateData(providerOutputSchema, providerResult);
+            if (!providerValidation.success) {
+              return jsonResponse(
+                { error: 'INVALID_PROVIDER_OUTPUT', provider: providerKey, message: 'Provider output failed schema validation', details: providerValidation.errors },
+                400
+              );
+            }
+            providers[providerKey] = providerValidation.data ?? providerResult;
+          } else {
+            providers[providerKey] = providerResult;
+          }
+        }
+      }
+
       return jsonResponse(
-        { stepId: step.stepId, workflowId: workflowId, ...validatedResult },
+        {
+          outputs: validatedResult,
+          providers,
+          options: { skip: false },
+          metadata: {
+            status: 'success',
+            error: false,
+            duration: Date.now() - startTime,
+            stepType: step.type,
+            disableOutputSanitization: step.disableOutputSanitization === true,
+          },
+        },
         200
       );
     } catch (error) {
@@ -134,7 +198,7 @@ export default {
 
 exports[`generateWorkerWrapper > should handle single step > single-step 1`] = `
 "import { validateData } from '@novu/framework/validators';
-import { channelStepSchemas } from '@novu/framework/step-resolver';
+import { channelStepSchemas, providerSchemas } from '@novu/framework/step-resolver';
 import stepHandler0 from "./novu/welcome-email.step";
 
 // Pre-compile all JSON Schema validators during the startup phase.
@@ -145,9 +209,17 @@ await Promise.all([
   ...Object.values(channelStepSchemas).map(({ output }) =>
     validateData(output, {})
   ),
-  ...[stepHandler0].flatMap(handler =>
-    handler.controlSchema ? [validateData(handler.controlSchema, {})] : []
-  ),
+  ...[stepHandler0].flatMap(handler => {
+    const schemas = [];
+    if (handler.controlSchema) schemas.push(validateData(handler.controlSchema, {}));
+    if (handler.providers && providerSchemas[handler.type]) {
+      for (const key of Object.keys(handler.providers)) {
+        const providerSchema = providerSchemas[handler.type]?.[key]?.output;
+        if (providerSchema) schemas.push(validateData(providerSchema, {}));
+      }
+    }
+    return schemas;
+  }),
 ]);
 
 const stepHandlers = new Map([
@@ -194,6 +266,8 @@ export default {
         );
       }
 
+      const startTime = Date.now();
+
       let body = {};
       const rawBody = await request.text();
       if (rawBody) {
@@ -214,6 +288,7 @@ export default {
       const stateArray = Array.isArray(body.state) ? body.state : [];
       const stepOutputs = stateArray.reduce((acc, s) => { if (s && typeof s.stepId === 'string') acc[s.stepId] = s.outputs ?? {}; return acc; }, {});
       const controls = body.controls ?? {};
+      const isPreview = body.action === 'preview';
 
       if (!isObject(payload) || !isObject(subscriber) || !isObject(context) || !isObject(stepOutputs) || !isObject(controls)) {
         return jsonResponse(
@@ -234,6 +309,27 @@ export default {
         validatedControls = controlsResult.data;
       }
 
+      if (!isPreview && step.skip) {
+        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+        if (shouldSkip) {
+          return jsonResponse(
+            {
+              outputs: {},
+              providers: {},
+              options: { skip: true },
+              metadata: {
+                status: 'success',
+                error: false,
+                duration: Date.now() - startTime,
+                stepType: step.type,
+                disableOutputSanitization: step.disableOutputSanitization === true,
+              },
+            },
+            200
+          );
+        }
+      }
+
       const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs });
 
       const outputSchema = channelStepSchemas[step.type]?.output;
@@ -249,8 +345,40 @@ export default {
         validatedResult = outputResult.data ?? result;
       }
 
+      const providers = {};
+      if (step.providers) {
+        const ctx = { payload, subscriber, context, steps: stepOutputs };
+        for (const [providerKey, providerResolve] of Object.entries(step.providers)) {
+          const providerResult = await providerResolve({ controls: validatedControls, outputs: validatedResult }, ctx);
+          const providerOutputSchema = providerSchemas[step.type]?.[providerKey]?.output;
+          if (providerOutputSchema) {
+            const providerValidation = await validateData(providerOutputSchema, providerResult);
+            if (!providerValidation.success) {
+              return jsonResponse(
+                { error: 'INVALID_PROVIDER_OUTPUT', provider: providerKey, message: 'Provider output failed schema validation', details: providerValidation.errors },
+                400
+              );
+            }
+            providers[providerKey] = providerValidation.data ?? providerResult;
+          } else {
+            providers[providerKey] = providerResult;
+          }
+        }
+      }
+
       return jsonResponse(
-        { stepId: step.stepId, workflowId: workflowId, ...validatedResult },
+        {
+          outputs: validatedResult,
+          providers,
+          options: { skip: false },
+          metadata: {
+            status: 'success',
+            error: false,
+            duration: Date.now() - startTime,
+            stepType: step.type,
+            disableOutputSanitization: step.disableOutputSanitization === true,
+          },
+        },
         200
       );
     } catch (error) {
@@ -266,7 +394,7 @@ export default {
 
 exports[`generateWorkerWrapper > should match snapshot 1`] = `
 "import { validateData } from '@novu/framework/validators';
-import { channelStepSchemas } from '@novu/framework/step-resolver';
+import { channelStepSchemas, providerSchemas } from '@novu/framework/step-resolver';
 import stepHandler0 from "./novu/welcome-email.step";
 import stepHandler1 from "./novu/verify-email.step";
 
@@ -278,9 +406,17 @@ await Promise.all([
   ...Object.values(channelStepSchemas).map(({ output }) =>
     validateData(output, {})
   ),
-  ...[stepHandler0, stepHandler1].flatMap(handler =>
-    handler.controlSchema ? [validateData(handler.controlSchema, {})] : []
-  ),
+  ...[stepHandler0, stepHandler1].flatMap(handler => {
+    const schemas = [];
+    if (handler.controlSchema) schemas.push(validateData(handler.controlSchema, {}));
+    if (handler.providers && providerSchemas[handler.type]) {
+      for (const key of Object.keys(handler.providers)) {
+        const providerSchema = providerSchemas[handler.type]?.[key]?.output;
+        if (providerSchema) schemas.push(validateData(providerSchema, {}));
+      }
+    }
+    return schemas;
+  }),
 ]);
 
 const stepHandlers = new Map([
@@ -328,6 +464,8 @@ export default {
         );
       }
 
+      const startTime = Date.now();
+
       let body = {};
       const rawBody = await request.text();
       if (rawBody) {
@@ -348,6 +486,7 @@ export default {
       const stateArray = Array.isArray(body.state) ? body.state : [];
       const stepOutputs = stateArray.reduce((acc, s) => { if (s && typeof s.stepId === 'string') acc[s.stepId] = s.outputs ?? {}; return acc; }, {});
       const controls = body.controls ?? {};
+      const isPreview = body.action === 'preview';
 
       if (!isObject(payload) || !isObject(subscriber) || !isObject(context) || !isObject(stepOutputs) || !isObject(controls)) {
         return jsonResponse(
@@ -368,6 +507,27 @@ export default {
         validatedControls = controlsResult.data;
       }
 
+      if (!isPreview && step.skip) {
+        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+        if (shouldSkip) {
+          return jsonResponse(
+            {
+              outputs: {},
+              providers: {},
+              options: { skip: true },
+              metadata: {
+                status: 'success',
+                error: false,
+                duration: Date.now() - startTime,
+                stepType: step.type,
+                disableOutputSanitization: step.disableOutputSanitization === true,
+              },
+            },
+            200
+          );
+        }
+      }
+
       const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs });
 
       const outputSchema = channelStepSchemas[step.type]?.output;
@@ -383,8 +543,40 @@ export default {
         validatedResult = outputResult.data ?? result;
       }
 
+      const providers = {};
+      if (step.providers) {
+        const ctx = { payload, subscriber, context, steps: stepOutputs };
+        for (const [providerKey, providerResolve] of Object.entries(step.providers)) {
+          const providerResult = await providerResolve({ controls: validatedControls, outputs: validatedResult }, ctx);
+          const providerOutputSchema = providerSchemas[step.type]?.[providerKey]?.output;
+          if (providerOutputSchema) {
+            const providerValidation = await validateData(providerOutputSchema, providerResult);
+            if (!providerValidation.success) {
+              return jsonResponse(
+                { error: 'INVALID_PROVIDER_OUTPUT', provider: providerKey, message: 'Provider output failed schema validation', details: providerValidation.errors },
+                400
+              );
+            }
+            providers[providerKey] = providerValidation.data ?? providerResult;
+          } else {
+            providers[providerKey] = providerResult;
+          }
+        }
+      }
+
       return jsonResponse(
-        { stepId: step.stepId, workflowId: workflowId, ...validatedResult },
+        {
+          outputs: validatedResult,
+          providers,
+          options: { skip: false },
+          metadata: {
+            status: 'success',
+            error: false,
+            duration: Date.now() - startTime,
+            stepType: step.type,
+            disableOutputSanitization: step.disableOutputSanitization === true,
+          },
+        },
         200
       );
     } catch (error) {

--- a/packages/novu/src/commands/step/templates/__snapshots__/worker-wrapper.spec.ts.snap
+++ b/packages/novu/src/commands/step/templates/__snapshots__/worker-wrapper.spec.ts.snap
@@ -163,7 +163,10 @@ export default {
                 400
               );
             }
-            providers[providerKey] = providerValidation.data ?? providerResult;
+            const validated = providerValidation.data ?? providerResult;
+            providers[providerKey] = providerResult._passthrough !== undefined
+              ? { ...validated, _passthrough: providerResult._passthrough }
+              : validated;
           } else {
             providers[providerKey] = providerResult;
           }
@@ -359,7 +362,10 @@ export default {
                 400
               );
             }
-            providers[providerKey] = providerValidation.data ?? providerResult;
+            const validated = providerValidation.data ?? providerResult;
+            providers[providerKey] = providerResult._passthrough !== undefined
+              ? { ...validated, _passthrough: providerResult._passthrough }
+              : validated;
           } else {
             providers[providerKey] = providerResult;
           }
@@ -557,7 +563,10 @@ export default {
                 400
               );
             }
-            providers[providerKey] = providerValidation.data ?? providerResult;
+            const validated = providerValidation.data ?? providerResult;
+            providers[providerKey] = providerResult._passthrough !== undefined
+              ? { ...validated, _passthrough: providerResult._passthrough }
+              : validated;
           } else {
             providers[providerKey] = providerResult;
           }

--- a/packages/novu/src/commands/step/templates/worker-wrapper.spec.ts
+++ b/packages/novu/src/commands/step/templates/worker-wrapper.spec.ts
@@ -96,6 +96,13 @@ describe('generateWorkerWrapper', () => {
     expect(result).toContain("error: 'INVALID_PROVIDER_OUTPUT'");
   });
 
+  it('should preserve _passthrough metadata from provider result after schema validation', () => {
+    const result = generateWorkerWrapper(mockSteps, '/root');
+
+    expect(result).toContain('providerResult._passthrough !== undefined');
+    expect(result).toContain('_passthrough: providerResult._passthrough');
+  });
+
   it('should return ExecuteOutput-shaped response with outputs, providers, options, and metadata', () => {
     const result = generateWorkerWrapper(mockSteps, '/root');
 

--- a/packages/novu/src/commands/step/templates/worker-wrapper.spec.ts
+++ b/packages/novu/src/commands/step/templates/worker-wrapper.spec.ts
@@ -35,6 +35,12 @@ describe('generateWorkerWrapper', () => {
     expect(result).toMatchSnapshot('single-step');
   });
 
+  it('should import providerSchemas from @novu/framework/step-resolver', () => {
+    const result = generateWorkerWrapper(mockSteps, '/root');
+
+    expect(result).toContain("import { channelStepSchemas, providerSchemas } from '@novu/framework/step-resolver'");
+  });
+
   it('should use inline workflowId strings and stepHandler.stepId for map keys', () => {
     const result = generateWorkerWrapper(mockSteps, '/root');
 
@@ -64,5 +70,60 @@ describe('generateWorkerWrapper', () => {
     expect(result).toContain("Allow: 'POST'");
     expect(result).toContain("error: 'Invalid JSON body'");
     expect(result).toContain("error: 'STEP_HANDLER_ERROR'");
+  });
+
+  it('should evaluate step.skip before calling step.resolve but not in preview mode', () => {
+    const result = generateWorkerWrapper(mockSteps, '/root');
+
+    expect(result).toContain("body.action === 'preview'");
+    expect(result).toContain('if (!isPreview && step.skip)');
+    expect(result).toContain('const shouldSkip = await step.skip(validatedControls,');
+    expect(result).toContain('if (shouldSkip)');
+  });
+
+  it('should return skip response with ExecuteOutput shape when skipped', () => {
+    const result = generateWorkerWrapper(mockSteps, '/root');
+
+    expect(result).toContain('options: { skip: true }');
+  });
+
+  it('should execute provider overrides and collect results', () => {
+    const result = generateWorkerWrapper(mockSteps, '/root');
+
+    expect(result).toContain('if (step.providers)');
+    expect(result).toContain('for (const [providerKey, providerResolve] of Object.entries(step.providers))');
+    expect(result).toContain('await providerResolve(');
+    expect(result).toContain("error: 'INVALID_PROVIDER_OUTPUT'");
+  });
+
+  it('should return ExecuteOutput-shaped response with outputs, providers, options, and metadata', () => {
+    const result = generateWorkerWrapper(mockSteps, '/root');
+
+    expect(result).toContain('outputs: validatedResult');
+    expect(result).toContain('providers,');
+    expect(result).toContain('options: { skip: false }');
+    expect(result).toContain("status: 'success'");
+    expect(result).toContain('error: false');
+    expect(result).toContain('duration: Date.now() - startTime');
+    expect(result).toContain('stepType: step.type');
+    expect(result).toContain('disableOutputSanitization: step.disableOutputSanitization === true');
+  });
+
+  it('should not return flat legacy response format', () => {
+    const result = generateWorkerWrapper(mockSteps, '/root');
+
+    expect(result).not.toContain('stepId: step.stepId, workflowId: workflowId, ...validatedResult');
+  });
+
+  it('should pre-compile provider validators during startup', () => {
+    const result = generateWorkerWrapper(mockSteps, '/root');
+
+    expect(result).toContain('handler.providers && providerSchemas[handler.type]');
+  });
+
+  it('should track startTime for duration calculation', () => {
+    const result = generateWorkerWrapper(mockSteps, '/root');
+
+    expect(result).toContain('const startTime = Date.now()');
   });
 });

--- a/packages/novu/src/commands/step/templates/worker-wrapper.ts
+++ b/packages/novu/src/commands/step/templates/worker-wrapper.ts
@@ -238,7 +238,10 @@ function generateProviderExecution(): string {
                 400
               );
             }
-            providers[providerKey] = providerValidation.data ?? providerResult;
+            const validated = providerValidation.data ?? providerResult;
+            providers[providerKey] = providerResult._passthrough !== undefined
+              ? { ...validated, _passthrough: providerResult._passthrough }
+              : validated;
           } else {
             providers[providerKey] = providerResult;
           }

--- a/packages/novu/src/commands/step/templates/worker-wrapper.ts
+++ b/packages/novu/src/commands/step/templates/worker-wrapper.ts
@@ -17,7 +17,7 @@ function generateImports(steps: DiscoveredStep[], rootDir: string): string {
     .join('\n');
 
   return `import { validateData } from '@novu/framework/validators';
-import { channelStepSchemas } from '@novu/framework/step-resolver';\n${stepImports}`;
+import { channelStepSchemas, providerSchemas } from '@novu/framework/step-resolver';\n${stepImports}`;
 }
 
 function generateValidatorPrecompilation(steps: DiscoveredStep[]): string {
@@ -31,9 +31,17 @@ await Promise.all([
   ...Object.values(channelStepSchemas).map(({ output }) =>
     validateData(output, {})
   ),
-  ...[${handlerRefs}].flatMap(handler =>
-    handler.controlSchema ? [validateData(handler.controlSchema, {})] : []
-  ),
+  ...[${handlerRefs}].flatMap(handler => {
+    const schemas = [];
+    if (handler.controlSchema) schemas.push(validateData(handler.controlSchema, {}));
+    if (handler.providers && providerSchemas[handler.type]) {
+      for (const key of Object.keys(handler.providers)) {
+        const providerSchema = providerSchemas[handler.type]?.[key]?.output;
+        if (providerSchema) schemas.push(validateData(providerSchema, {}));
+      }
+    }
+    return schemas;
+  }),
 ]);`;
 }
 
@@ -105,18 +113,35 @@ function generateRequestHandler(): string {
 
       ${generateSchemaValidation()}
 
+      ${generateSkipCheck()}
+
       const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs });
 
       ${generateOutputValidation()}
 
+      ${generateProviderExecution()}
+
       return jsonResponse(
-        { stepId: step.stepId, workflowId: workflowId, ...validatedResult },
+        {
+          outputs: validatedResult,
+          providers,
+          options: { skip: false },
+          metadata: {
+            status: 'success',
+            error: false,
+            duration: Date.now() - startTime,
+            stepType: step.type,
+            disableOutputSanitization: step.disableOutputSanitization === true,
+          },
+        },
         200
       );`;
 }
 
 function generateBodyValidation(): string {
-  return `let body = {};
+  return `const startTime = Date.now();
+
+      let body = {};
       const rawBody = await request.text();
       if (rawBody) {
         try {
@@ -136,12 +161,50 @@ function generateBodyValidation(): string {
       const stateArray = Array.isArray(body.state) ? body.state : [];
       const stepOutputs = stateArray.reduce((acc, s) => { if (s && typeof s.stepId === 'string') acc[s.stepId] = s.outputs ?? {}; return acc; }, {});
       const controls = body.controls ?? {};
+      const isPreview = body.action === 'preview';
 
       if (!isObject(payload) || !isObject(subscriber) || !isObject(context) || !isObject(stepOutputs) || !isObject(controls)) {
         return jsonResponse(
           { error: 'Invalid request body', message: 'payload, subscriber, context, steps, and controls must be JSON objects' },
           400
         );
+      }`;
+}
+
+function generateSchemaValidation(): string {
+  return `let validatedControls = controls;
+      if (step.controlSchema) {
+        const controlsResult = await validateData(step.controlSchema, controls);
+        if (!controlsResult.success) {
+          return jsonResponse(
+            { error: 'INVALID_CONTROLS', message: 'Controls failed schema validation', details: controlsResult.errors },
+            400
+          );
+        }
+        validatedControls = controlsResult.data;
+      }`;
+}
+
+function generateSkipCheck(): string {
+  return `if (!isPreview && step.skip) {
+        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+        if (shouldSkip) {
+          return jsonResponse(
+            {
+              outputs: {},
+              providers: {},
+              options: { skip: true },
+              metadata: {
+                status: 'success',
+                error: false,
+                duration: Date.now() - startTime,
+                stepType: step.type,
+                disableOutputSanitization: step.disableOutputSanitization === true,
+              },
+            },
+            200
+          );
+        }
       }`;
 }
 
@@ -160,17 +223,26 @@ function generateOutputValidation(): string {
       }`;
 }
 
-function generateSchemaValidation(): string {
-  return `let validatedControls = controls;
-      if (step.controlSchema) {
-        const controlsResult = await validateData(step.controlSchema, controls);
-        if (!controlsResult.success) {
-          return jsonResponse(
-            { error: 'INVALID_CONTROLS', message: 'Controls failed schema validation', details: controlsResult.errors },
-            400
-          );
+function generateProviderExecution(): string {
+  return `const providers = {};
+      if (step.providers) {
+        const ctx = { payload, subscriber, context, steps: stepOutputs };
+        for (const [providerKey, providerResolve] of Object.entries(step.providers)) {
+          const providerResult = await providerResolve({ controls: validatedControls, outputs: validatedResult }, ctx);
+          const providerOutputSchema = providerSchemas[step.type]?.[providerKey]?.output;
+          if (providerOutputSchema) {
+            const providerValidation = await validateData(providerOutputSchema, providerResult);
+            if (!providerValidation.success) {
+              return jsonResponse(
+                { error: 'INVALID_PROVIDER_OUTPUT', provider: providerKey, message: 'Provider output failed schema validation', details: providerValidation.errors },
+                400
+              );
+            }
+            providers[providerKey] = providerValidation.data ?? providerResult;
+          } else {
+            providers[providerKey] = providerResult;
+          }
         }
-        validatedControls = controlsResult.data;
       }`;
 }
 


### PR DESCRIPTION
### What changed? Why was the change needed?

- **Feature parity with framework steps**: step resolver handlers now support `skip` conditions, `providers` overrides, and `disableOutputSanitization` — matching the framework step interface 1:1
- **Improved TypeScript DX**: `StepResolverContext` subscriber and context fields are now typed with `Subscriber` and `ContextResolved` instead of `Record<string, unknown>`, providing proper autocomplete in handler files
- **Standardized response format**: the generated Cloudflare Worker now returns an `ExecuteOutput`-shaped response (`outputs`, `providers`, `options`, `metadata`) and the backend `transformToExecuteOutput` was updated accordingly
- **Output sanitization**: HTML sanitization for `email` and `in_app` step outputs is now applied Novu-side after receiving the resolver response, with `disableOutputSanitization` opt-out passed via worker metadata
- **Skip in preview mode**: `skip` is not evaluated during preview calls, consistent with framework step behavior
- **CLI improvements**: the "override editor content" confirmation prompt is only shown on first-time scaffold (not on re-deploys), and the full version hash is now displayed in the success summary