### PR TITLE
feat(dashboard): Table pages new tab support fixes NV-7238

### DIFF
--- a/apps/dashboard/src/components/contexts/context-row.tsx
+++ b/apps/dashboard/src/components/contexts/context-row.tsx
@@ -22,7 +22,6 @@ import { formatDateSimple } from '@/utils/format-date';
 import { Protect } from '@/utils/protect';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
-import { useContextsNavigate } from './hooks/use-contexts-navigate';
 
 type ContextRowProps = {
   context: GetContextResponseDto;
@@ -41,10 +40,15 @@ const ContextTableCell = (props: ContextTableCellProps) => {
 };
 
 export const ContextRow = ({ context }: ContextRowProps) => {
-  const { navigateToEditContextPage } = useContextsNavigate();
   const { currentEnvironment } = useEnvironment();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { deleteContext, isPending: isDeleting } = useDeleteContext();
+
+  const contextLink = buildRoute(ROUTES.CONTEXTS_EDIT, {
+    environmentSlug: currentEnvironment?.slug ?? '',
+    type: context.type,
+    id: context.id,
+  });
 
   const stopPropagation = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -66,13 +70,15 @@ export const ContextRow = ({ context }: ContextRowProps) => {
     <>
       <TableRow
         className="group relative isolate cursor-pointer"
-        onClick={() => {
-          navigateToEditContextPage(context.type, context.id);
-        }}
       >
-        <ContextTableCell>
-          <span className="max-w-[300px] truncate font-medium">{context.type}</span>
-        </ContextTableCell>
+        <TableCell className="group-hover:bg-neutral-alpha-50 text-text-sub">
+          <Link to={contextLink} className="absolute inset-0" tabIndex={-1}>
+            <span className="sr-only">Edit context</span>
+          </Link>
+          <div className="relative">
+            <span className="max-w-[300px] truncate font-medium">{context.type}</span>
+          </div>
+        </TableCell>
         <ContextTableCell>
           <div className="flex items-center gap-1">
             <div className="font-code text-text-soft max-w-[300px] truncate">{context.id}</div>

--- a/apps/dashboard/src/components/contexts/context-row.tsx
+++ b/apps/dashboard/src/components/contexts/context-row.tsx
@@ -27,13 +27,20 @@ type ContextRowProps = {
   context: GetContextResponseDto;
 };
 
-type ContextTableCellProps = ComponentProps<typeof TableCell>;
+type ContextTableCellProps = ComponentProps<typeof TableCell> & {
+  to?: string;
+};
 
 const ContextTableCell = (props: ContextTableCellProps) => {
-  const { children, className, ...rest } = props;
+  const { children, className, to, ...rest } = props;
 
   return (
     <TableCell className={cn('group-hover:bg-neutral-alpha-50 text-text-sub relative', className)} {...rest}>
+      {to && (
+        <Link to={to} className="absolute inset-0" tabIndex={-1}>
+          <span className="sr-only">Edit context</span>
+        </Link>
+      )}
       {children}
     </TableCell>
   );
@@ -71,15 +78,10 @@ export const ContextRow = ({ context }: ContextRowProps) => {
       <TableRow
         className="group relative isolate cursor-pointer"
       >
-        <TableCell className="group-hover:bg-neutral-alpha-50 text-text-sub">
-          <Link to={contextLink} className="absolute inset-0" tabIndex={-1}>
-            <span className="sr-only">Edit context</span>
-          </Link>
-          <div className="relative">
-            <span className="max-w-[300px] truncate font-medium">{context.type}</span>
-          </div>
-        </TableCell>
-        <ContextTableCell>
+        <ContextTableCell to={contextLink}>
+          <span className="max-w-[300px] truncate font-medium">{context.type}</span>
+        </ContextTableCell>
+        <ContextTableCell to={contextLink}>
           <div className="flex items-center gap-1">
             <div className="font-code text-text-soft max-w-[300px] truncate">{context.id}</div>
             <CopyButton
@@ -89,12 +91,12 @@ export const ContextRow = ({ context }: ContextRowProps) => {
             />
           </div>
         </ContextTableCell>
-        <ContextTableCell>
+        <ContextTableCell to={contextLink}>
           {context.createdAt && (
             <TimeDisplayHoverCard date={context.createdAt}>{formatDateSimple(context.createdAt)}</TimeDisplayHoverCard>
           )}
         </ContextTableCell>
-        <ContextTableCell>
+        <ContextTableCell to={contextLink}>
           {context.updatedAt && (
             <TimeDisplayHoverCard date={context.updatedAt}>{formatDateSimple(context.updatedAt)}</TimeDisplayHoverCard>
           )}

--- a/apps/dashboard/src/components/subscribers/subscriber-row.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-row.tsx
@@ -165,7 +165,6 @@ export const SubscriberRow = ({ subscriber, subscribersCount, firstTwoSubscriber
               </div>
             </div>
           </div>
-          </div>
         </TableCell>
         <SubscriberTableCell>
           <TruncatedText className="relative z-10 max-w-[28ch]">{subscriber.email || '-'}</TruncatedText>

--- a/apps/dashboard/src/components/subscribers/subscriber-row.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-row.tsx
@@ -45,13 +45,20 @@ type SubscriberRowProps = {
   firstTwoSubscribersInternalIds: string[];
 };
 
-type SubscriberLinkTableCellProps = ComponentProps<typeof TableCell>;
+type SubscriberLinkTableCellProps = ComponentProps<typeof TableCell> & {
+  to?: string;
+};
 
 const SubscriberTableCell = (props: SubscriberLinkTableCellProps) => {
-  const { children, className, ...rest } = props;
+  const { children, className, to, ...rest } = props;
 
   return (
     <TableCell className={cn('group-hover:bg-neutral-alpha-50 text-text-sub relative', className)} {...rest}>
+      {to && (
+        <Link to={to} className="absolute inset-0" tabIndex={-1}>
+          <span className="sr-only">Edit subscriber</span>
+        </Link>
+      )}
       {children}
     </TableCell>
   );
@@ -142,11 +149,8 @@ export const SubscriberRow = ({ subscriber, subscribersCount, firstTwoSubscriber
         key={subscriber.subscriberId}
         className="group relative isolate cursor-pointer"
       >
-        <TableCell className="group-hover:bg-neutral-alpha-50 text-text-sub">
-          <Link to={subscriberLink} className="absolute inset-0" tabIndex={-1}>
-            <span className="sr-only">Edit subscriber</span>
-          </Link>
-          <div className="relative flex items-center gap-3">
+        <SubscriberTableCell to={subscriberLink}>
+          <div className="flex items-center gap-3">
             <Avatar>
               <AvatarImage src={subscriber.avatar || undefined} />
               <AvatarFallback>{subscriberTitle[0]}</AvatarFallback>
@@ -165,17 +169,17 @@ export const SubscriberRow = ({ subscriber, subscribersCount, firstTwoSubscriber
               </div>
             </div>
           </div>
-        </TableCell>
-        <SubscriberTableCell>
+        </SubscriberTableCell>
+        <SubscriberTableCell to={subscriberLink}>
           <TruncatedText className="relative z-10 max-w-[28ch]">{subscriber.email || '-'}</TruncatedText>
         </SubscriberTableCell>
-        <SubscriberTableCell>{subscriber.phone || '-'}</SubscriberTableCell>
-        <SubscriberTableCell>
+        <SubscriberTableCell to={subscriberLink}>{subscriber.phone || '-'}</SubscriberTableCell>
+        <SubscriberTableCell to={subscriberLink}>
           <TimeDisplayHoverCard date={new Date(subscriber.createdAt)}>
             {formatDateSimple(subscriber.createdAt)}
           </TimeDisplayHoverCard>
         </SubscriberTableCell>
-        <SubscriberTableCell>
+        <SubscriberTableCell to={subscriberLink}>
           <TimeDisplayHoverCard date={new Date(subscriber.updatedAt)}>
             {formatDateSimple(subscriber.updatedAt)}
           </TimeDisplayHoverCard>

--- a/apps/dashboard/src/components/subscribers/subscriber-row.tsx
+++ b/apps/dashboard/src/components/subscribers/subscriber-row.tsx
@@ -2,7 +2,7 @@ import { ISubscriberResponseDto, PermissionsEnum } from '@novu/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { ComponentProps, useState } from 'react';
 import { RiDeleteBin2Line, RiFileCopyLine, RiMore2Fill, RiPulseFill } from 'react-icons/ri';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { ExternalToast } from 'sonner';
 import { ConfirmationModal } from '@/components/confirmation-modal';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/primitives/avatar';
@@ -53,7 +53,6 @@ const SubscriberTableCell = (props: SubscriberLinkTableCellProps) => {
   return (
     <TableCell className={cn('group-hover:bg-neutral-alpha-50 text-text-sub relative', className)} {...rest}>
       {children}
-      <span className="sr-only">Edit subscriber</span>
     </TableCell>
   );
 };
@@ -63,8 +62,14 @@ export const SubscriberRow = ({ subscriber, subscribersCount, firstTwoSubscriber
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const subscriberTitle = getSubscriberTitle(subscriber);
   const queryClient = useQueryClient();
-  const { navigateToSubscribersFirstPage, navigateToEditSubscriberPage } = useSubscribersNavigate();
+  const location = useLocation();
+  const { navigateToSubscribersFirstPage } = useSubscribersNavigate();
   const { handleNavigationAfterDelete } = useSubscribersUrlState();
+
+  const subscriberLink = `${buildRoute(ROUTES.EDIT_SUBSCRIBER, {
+    environmentSlug: currentEnvironment?.slug ?? '',
+    subscriberId: encodeURIComponent(subscriber.subscriberId),
+  })}${location.search}`;
 
   const { deleteSubscriber, isPending: isDeleteSubscriberPending } = useDeleteSubscriber({
     onSuccess: () => {
@@ -136,12 +141,12 @@ export const SubscriberRow = ({ subscriber, subscribersCount, firstTwoSubscriber
       <TableRow
         key={subscriber.subscriberId}
         className="group relative isolate cursor-pointer"
-        onClick={() => {
-          navigateToEditSubscriberPage(subscriber.subscriberId);
-        }}
       >
-        <SubscriberTableCell>
-          <div className="flex items-center gap-3">
+        <TableCell className="group-hover:bg-neutral-alpha-50 text-text-sub">
+          <Link to={subscriberLink} className="absolute inset-0" tabIndex={-1}>
+            <span className="sr-only">Edit subscriber</span>
+          </Link>
+          <div className="relative flex items-center gap-3">
             <Avatar>
               <AvatarImage src={subscriber.avatar || undefined} />
               <AvatarFallback>{subscriberTitle[0]}</AvatarFallback>
@@ -160,7 +165,8 @@ export const SubscriberRow = ({ subscriber, subscribersCount, firstTwoSubscriber
               </div>
             </div>
           </div>
-        </SubscriberTableCell>
+          </div>
+        </TableCell>
         <SubscriberTableCell>
           <TruncatedText className="relative z-10 max-w-[28ch]">{subscriber.email || '-'}</TruncatedText>
         </SubscriberTableCell>

--- a/apps/dashboard/src/components/topics/topic-row.tsx
+++ b/apps/dashboard/src/components/topics/topic-row.tsx
@@ -2,7 +2,7 @@ import { PermissionsEnum } from '@novu/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { ComponentProps, useState } from 'react';
 import { RiDeleteBin2Line, RiFileCopyLine, RiMore2Fill, RiPulseFill } from 'react-icons/ri';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { ConfirmationModal } from '@/components/confirmation-modal';
 import { CompactButton } from '@/components/primitives/button-compact';
 import { CopyButton } from '@/components/primitives/copy-button';
@@ -24,7 +24,6 @@ import { buildRoute, ROUTES } from '../../utils/routes';
 import { cn } from '../../utils/ui';
 import { showErrorToast } from '../primitives/sonner-helpers';
 import { useDeleteTopic } from './hooks/use-delete-topic';
-import { useTopicsNavigate } from './hooks/use-topics-navigate';
 import { Topic } from './types';
 
 type TopicRowProps = {
@@ -39,7 +38,6 @@ const TopicTableCell = (props: TopicTableCellProps) => {
   return (
     <TableCell className={cn('group-hover:bg-neutral-alpha-50 text-text-sub relative', className)} {...rest}>
       {children}
-      <span className="sr-only">Edit topic</span>
     </TableCell>
   );
 };
@@ -49,7 +47,12 @@ export const TopicRow = ({ topic }: TopicRowProps) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { deleteTopic, isDeleting } = useDeleteTopic();
   const queryClient = useQueryClient();
-  const { navigateToEditTopicPage } = useTopicsNavigate();
+  const [searchParams] = useSearchParams();
+
+  const topicLink = `${buildRoute(ROUTES.TOPICS_EDIT, {
+    topicKey: topic.key,
+    environmentSlug: currentEnvironment?.slug ?? '',
+  })}?${searchParams.toString()}`;
 
   const stopPropagation = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -76,15 +79,15 @@ export const TopicRow = ({ topic }: TopicRowProps) => {
     <>
       <TableRow
         className="group relative isolate cursor-pointer"
-        onClick={() => {
-          navigateToEditTopicPage(topic.key);
-        }}
       >
-        <TopicTableCell>
-          <div className="flex items-center">
+        <TableCell className="group-hover:bg-neutral-alpha-50 text-text-sub">
+          <Link to={topicLink} className="absolute inset-0" tabIndex={-1}>
+            <span className="sr-only">Edit topic</span>
+          </Link>
+          <div className="relative flex items-center">
             <span className="max-w-[300px] truncate font-medium">{topic.name}</span>
           </div>
-        </TopicTableCell>
+        </TableCell>
         <TopicTableCell>
           <div className="flex items-center gap-1">
             <div className="font-code text-text-soft max-w-[300px] truncate">{topic.key}</div>

--- a/apps/dashboard/src/components/topics/topic-row.tsx
+++ b/apps/dashboard/src/components/topics/topic-row.tsx
@@ -30,13 +30,20 @@ type TopicRowProps = {
   topic: Topic;
 };
 
-type TopicTableCellProps = ComponentProps<typeof TableCell>;
+type TopicTableCellProps = ComponentProps<typeof TableCell> & {
+  to?: string;
+};
 
 const TopicTableCell = (props: TopicTableCellProps) => {
-  const { children, className, ...rest } = props;
+  const { children, className, to, ...rest } = props;
 
   return (
     <TableCell className={cn('group-hover:bg-neutral-alpha-50 text-text-sub relative', className)} {...rest}>
+      {to && (
+        <Link to={to} className="absolute inset-0" tabIndex={-1}>
+          <span className="sr-only">Edit topic</span>
+        </Link>
+      )}
       {children}
     </TableCell>
   );
@@ -80,15 +87,12 @@ export const TopicRow = ({ topic }: TopicRowProps) => {
       <TableRow
         className="group relative isolate cursor-pointer"
       >
-        <TableCell className="group-hover:bg-neutral-alpha-50 text-text-sub">
-          <Link to={topicLink} className="absolute inset-0" tabIndex={-1}>
-            <span className="sr-only">Edit topic</span>
-          </Link>
-          <div className="relative flex items-center">
+        <TopicTableCell to={topicLink}>
+          <div className="flex items-center">
             <span className="max-w-[300px] truncate font-medium">{topic.name}</span>
           </div>
-        </TableCell>
-        <TopicTableCell>
+        </TopicTableCell>
+        <TopicTableCell to={topicLink}>
           <div className="flex items-center gap-1">
             <div className="font-code text-text-soft max-w-[300px] truncate">{topic.key}</div>
             <CopyButton
@@ -98,12 +102,12 @@ export const TopicRow = ({ topic }: TopicRowProps) => {
             />
           </div>
         </TopicTableCell>
-        <TopicTableCell>
+        <TopicTableCell to={topicLink}>
           {topic.createdAt && (
             <TimeDisplayHoverCard date={topic.createdAt}>{formatDateSimple(topic.createdAt)}</TimeDisplayHoverCard>
           )}
         </TopicTableCell>
-        <TopicTableCell>
+        <TopicTableCell to={topicLink}>
           {topic.updatedAt && (
             <TimeDisplayHoverCard date={topic.updatedAt}>{formatDateSimple(topic.updatedAt)}</TimeDisplayHoverCard>
           )}

--- a/apps/dashboard/src/components/workflow-row.tsx
+++ b/apps/dashboard/src/components/workflow-row.tsx
@@ -97,13 +97,26 @@ const toastOptions: ExternalToast = {
   },
 };
 
-type WorkflowLinkTableCellProps = ComponentProps<typeof TableCell>;
+type WorkflowLinkTableCellProps = ComponentProps<typeof TableCell> & {
+  to?: string;
+  isExternal?: boolean;
+};
 
 const WorkflowLinkTableCell = (props: WorkflowLinkTableCellProps) => {
-  const { children, className, ...rest } = props;
+  const { children, className, to, isExternal, ...rest } = props;
 
   return (
     <TableCell className={cn('group-hover:bg-neutral-alpha-50 relative', className)} {...rest}>
+      {to &&
+        (isExternal ? (
+          <a href={to} className="absolute inset-0" tabIndex={-1}>
+            <span className="sr-only">Edit workflow</span>
+          </a>
+        ) : (
+          <Link to={to} className="absolute inset-0" tabIndex={-1}>
+            <span className="sr-only">Edit workflow</span>
+          </Link>
+        ))}
       {children}
     </TableCell>
   );
@@ -264,18 +277,11 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
             </TooltipPortal>
           </Tooltip>
         )}
-        <TableCell className="group-hover:bg-neutral-alpha-50">
-          {shouldRenderLink &&
-            (isV0Workflow ? (
-              <a href={workflowLink} className="absolute inset-0" tabIndex={-1}>
-                <span className="sr-only">Edit workflow</span>
-              </a>
-            ) : (
-              <Link to={workflowLink} className="absolute inset-0" tabIndex={-1}>
-                <span className="sr-only">Edit workflow</span>
-              </Link>
-            ))}
-          <div className="relative flex items-center gap-2 font-medium">
+        <WorkflowLinkTableCell
+          className="flex items-center gap-2 font-medium"
+          to={shouldRenderLink ? workflowLink : undefined}
+          isExternal={isV0Workflow}
+        >
           {workflow.origin === ResourceOriginEnum.EXTERNAL ? (
             <Tooltip delayDuration={300}>
               <TooltipTrigger>
@@ -339,19 +345,26 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
               />
             </div>
           </div>
-          </div>
-        </TableCell>
-        <WorkflowLinkTableCell className="min-w-[200px]">
+        </WorkflowLinkTableCell>
+        <WorkflowLinkTableCell
+          className="min-w-[200px]"
+          to={shouldRenderLink ? workflowLink : undefined}
+          isExternal={isV0Workflow}
+        >
           <WorkflowStatus status={workflow.status} steps={workflow.steps || []} />
         </WorkflowLinkTableCell>
-        <WorkflowLinkTableCell>
+        <WorkflowLinkTableCell to={shouldRenderLink ? workflowLink : undefined} isExternal={isV0Workflow}>
           <WorkflowSteps steps={workflow.stepTypeOverviews} />
         </WorkflowLinkTableCell>
-        <WorkflowLinkTableCell>
+        <WorkflowLinkTableCell to={shouldRenderLink ? workflowLink : undefined} isExternal={isV0Workflow}>
           <WorkflowTags tags={workflow.tags || []} />
         </WorkflowLinkTableCell>
 
-        <WorkflowLinkTableCell className="text-foreground-600 text-sm font-medium">
+        <WorkflowLinkTableCell
+          className="text-foreground-600 text-sm font-medium"
+          to={shouldRenderLink ? workflowLink : undefined}
+          isExternal={isV0Workflow}
+        >
           {workflow.lastTriggeredAt ? (
             <TimeDisplayHoverCard date={new Date(workflow.lastTriggeredAt)}>
               {formatDateSimple(workflow.lastTriggeredAt)}
@@ -360,7 +373,11 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
             <span className="text-foreground-400 text-sm font-normal">-</span>
           )}
         </WorkflowLinkTableCell>
-        <WorkflowLinkTableCell className="text-foreground-600 text-sm font-medium">
+        <WorkflowLinkTableCell
+          className="text-foreground-600 text-sm font-medium"
+          to={shouldRenderLink ? workflowLink : undefined}
+          isExternal={isV0Workflow}
+        >
           <TimeDisplayHoverCard date={new Date(workflow.updatedAt)}>
             {formatDateSimple(workflow.updatedAt)}
           </TimeDisplayHoverCard>

--- a/apps/dashboard/src/components/workflow-row.tsx
+++ b/apps/dashboard/src/components/workflow-row.tsx
@@ -22,7 +22,7 @@ import {
   RiTranslate2,
 } from 'react-icons/ri';
 
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { type ExternalToast } from 'sonner';
 import { PAUSE_MODAL_TITLE, PauseModalDescription } from '@/components/pause-workflow-dialog';
 import {
@@ -105,7 +105,6 @@ const WorkflowLinkTableCell = (props: WorkflowLinkTableCellProps) => {
   return (
     <TableCell className={cn('group-hover:bg-neutral-alpha-50 relative', className)} {...rest}>
       {children}
-      <span className="sr-only">Edit workflow</span>
     </TableCell>
   );
 };
@@ -116,7 +115,6 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
   const { currentEnvironment } = useEnvironment();
   const { isUserLoaded } = useAuth();
   const has = useHasPermission();
-  const navigate = useNavigate();
   const { safeSync, PromoteConfirmModal } = useSyncWorkflow(workflow);
   const isHttpLogsPageEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_HTTP_LOGS_PAGE_ENABLED, false);
   const isV0Workflow = workflow.origin === ResourceOriginEnum.NOVU_CLOUD_V1;
@@ -227,20 +225,9 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
     onPauseWorkflow();
   };
 
-  const handleRowClick = () => {
-    if (isV0Workflow && IS_SELF_HOSTED) {
-      return;
-    }
-
-    if (isV0Workflow) {
-      document.location.href = workflowLink;
-    } else {
-      navigate(workflowLink);
-    }
-  };
+  const shouldRenderLink = !(isV0Workflow && IS_SELF_HOSTED);
 
   const stopPropagation = (e: React.MouseEvent) => {
-    // don't propagate the click event to the row
     e.stopPropagation();
   };
 
@@ -253,7 +240,6 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
       <TableRow
         key={workflow._id}
         className={cn('group relative isolate cursor-pointer', isV0Workflow && IS_SELF_HOSTED && 'cursor-not-allowed')}
-        onClick={handleRowClick}
       >
         {isV0Workflow && IS_SELF_HOSTED && (
           <Tooltip delayDuration={300}>
@@ -278,7 +264,18 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
             </TooltipPortal>
           </Tooltip>
         )}
-        <WorkflowLinkTableCell className="flex items-center gap-2 font-medium">
+        <TableCell className="group-hover:bg-neutral-alpha-50">
+          {shouldRenderLink &&
+            (isV0Workflow ? (
+              <a href={workflowLink} className="absolute inset-0" tabIndex={-1}>
+                <span className="sr-only">Edit workflow</span>
+              </a>
+            ) : (
+              <Link to={workflowLink} className="absolute inset-0" tabIndex={-1}>
+                <span className="sr-only">Edit workflow</span>
+              </Link>
+            ))}
+          <div className="relative flex items-center gap-2 font-medium">
           {workflow.origin === ResourceOriginEnum.EXTERNAL ? (
             <Tooltip delayDuration={300}>
               <TooltipTrigger>
@@ -342,7 +339,8 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
               />
             </div>
           </div>
-        </WorkflowLinkTableCell>
+          </div>
+        </TableCell>
         <WorkflowLinkTableCell className="min-w-[200px]">
           <WorkflowStatus status={workflow.status} steps={workflow.steps || []} />
         </WorkflowLinkTableCell>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR enables native browser "Open in new tab" functionality (right-click, Cmd/Ctrl+click) for rows in the workflow, subscriber, topic, and context lists. Previously, navigation was handled via `onClick` handlers, which prevented this behavior.

The change implements a "per-cell link overlay" pattern: each navigable `TableCell` now contains an `<a>` or `<Link>` element positioned `absolute inset-0`. This allows the link to fill the cell, enabling native browser navigation while preserving the functionality of interactive elements (e.g., dropdowns, copy buttons) within the cells.

Fixes [NV-7238](https://linear.app/novu/issue/NV-7238/allow-opening-workflows-in-a-new-tab)

### Screenshots

<img src="/opt/cursor/artifacts/right_click_open_in_new_tab.webp" alt="Right-click showing Open link in new tab" />

Linear Issue: [NV-7238](https://linear.app/novu/issue/NV-7238/allow-opening-workflows-in-a-new-tab)

<div><a href="https://cursor.com/agents/bc-a90a9177-8092-4789-bf2f-e815100dbaba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a90a9177-8092-4789-bf2f-e815100dbaba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->