### PR TITLE
fix(worker): Channel step logic for bridge execution

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -565,7 +565,12 @@ export class SendMessage {
   }
 }
 
-const NON_BRIDGE_STEPS: StepTypeEnum[] = [StepTypeEnum.DIGEST, StepTypeEnum.DELAY, StepTypeEnum.TRIGGER];
+const NON_BRIDGE_STEPS: StepTypeEnum[] = [
+  StepTypeEnum.DIGEST,
+  StepTypeEnum.DELAY,
+  StepTypeEnum.TRIGGER,
+  StepTypeEnum.HTTP_REQUEST,
+];
 
 function isBridgeStep(stepType: StepTypeEnum | undefined): boolean {
   if (!stepType) return false;

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -98,7 +98,7 @@ export class SendMessage {
     const stepType = command.step?.template?.type;
 
     let bridgeResponse: ExecuteOutput | null = null;
-    if (isChannelStep(stepType)) {
+    if (isBridgeStep(stepType)) {
       bridgeResponse = await this.executeBridgeJob.execute({
         ...command,
         variables,
@@ -565,22 +565,10 @@ export class SendMessage {
   }
 }
 
-const CHANNEL_STEP_MAP: Record<StepTypeEnum, boolean> = {
-  [StepTypeEnum.IN_APP]: true,
-  [StepTypeEnum.EMAIL]: true,
-  [StepTypeEnum.SMS]: true,
-  [StepTypeEnum.CHAT]: true,
-  [StepTypeEnum.PUSH]: true,
-  [StepTypeEnum.CUSTOM]: false,
-  [StepTypeEnum.HTTP_REQUEST]: false,
-  [StepTypeEnum.DIGEST]: false,
-  [StepTypeEnum.DELAY]: false,
-  [StepTypeEnum.TRIGGER]: false,
-  [StepTypeEnum.THROTTLE]: false,
-};
+const NON_BRIDGE_STEPS: StepTypeEnum[] = [StepTypeEnum.DIGEST, StepTypeEnum.DELAY, StepTypeEnum.TRIGGER];
 
-function isChannelStep(stepType: StepTypeEnum | undefined): boolean {
+function isBridgeStep(stepType: StepTypeEnum | undefined): boolean {
   if (!stepType) return false;
 
-  return CHANNEL_STEP_MAP[stepType];
+  return !NON_BRIDGE_STEPS.includes(stepType);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR fixes a regression where `CUSTOM` and `THROTTLE` steps were not being executed by the bridge.

The standalone `isChannelStep` function, which gates bridge execution, was incorrectly returning `false` for these step types.

To resolve this:
*   The standalone function `isChannelStep` was renamed to `isBridgeStep` to clarify its purpose (determining if a step should go through the bridge).
*   Its logic was refactored from an allowlist (`CHANNEL_STEP_MAP`) to an exclusion list (`NON_BRIDGE_STEPS`).
*   `isBridgeStep` now returns `true` for all steps except `DIGEST`, `DELAY`, and `TRIGGER`, ensuring `CUSTOM`, `HTTP_REQUEST`, and `THROTTLE` steps are correctly processed.
*   The class method `this.isChannelStep` (used for notification channel preference evaluation) remains unchanged.

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773677403556349?thread_ts=1773677403.556349&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-f89dc22a-6f71-57be-be55-a3873de10dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f89dc22a-6f71-57be-be55-a3873de10dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->