### PR TITLE
fix(worker, dal): Zod deviceTokens validation type fix fixes NV-7242

### DIFF
--- a/libs/dal/src/repositories/message/message.repository.ts
+++ b/libs/dal/src/repositories/message/message.repository.ts
@@ -1088,10 +1088,15 @@ export class MessageRepository extends BaseRepository<MessageDBModel, MessageEnt
     return this.normalizeDeviceTokens(entities);
   }
 
+  /**
+   * Legacy Mongoose schema defined deviceTokens as [Schema.Types.Array] instead of [Schema.Types.String],
+   * causing tokens to be stored as nested arrays (e.g. [["token1"]] instead of ["token1"]).
+   * This normalizes existing corrupted data so the API returns a flat string array matching the Zod schema.
+   */
   private normalizeDeviceTokens(messages: MessageEntity[]): MessageEntity[] {
     for (const message of messages) {
-      if (message.deviceTokens) {
-        message.deviceTokens = (message.deviceTokens as unknown[]).flat(Infinity).filter(
+      if (Array.isArray(message.deviceTokens)) {
+        message.deviceTokens = message.deviceTokens.flat(Infinity).filter(
           (token): token is string => typeof token === 'string'
         );
       }

--- a/libs/dal/src/repositories/message/message.repository.ts
+++ b/libs/dal/src/repositories/message/message.repository.ts
@@ -1083,7 +1083,21 @@ export class MessageRepository extends BaseRepository<MessageDBModel, MessageEnt
         '_id firstName lastName avatar subscriberId createdAt updatedAt _organizationId _environmentId deleted'
       );
 
-    return this.mapEntities(data);
+    const entities = this.mapEntities(data);
+
+    return this.normalizeDeviceTokens(entities);
+  }
+
+  private normalizeDeviceTokens(messages: MessageEntity[]): MessageEntity[] {
+    for (const message of messages) {
+      if (message.deviceTokens) {
+        message.deviceTokens = (message.deviceTokens as unknown[]).flat(Infinity).filter(
+          (token): token is string => typeof token === 'string'
+        );
+      }
+    }
+
+    return messages;
   }
 
   async deleteMessagesByIds({

--- a/libs/dal/src/repositories/message/message.schema.ts
+++ b/libs/dal/src/repositories/message/message.schema.ts
@@ -72,7 +72,7 @@ const messageSchema = new Schema<MessageDBModel>(
     phone: Schema.Types.String,
     directWebhookUrl: Schema.Types.String,
     providerId: Schema.Types.String,
-    deviceTokens: [Schema.Types.Array],
+    deviceTokens: [Schema.Types.String],
     title: Schema.Types.String,
     seen: {
       type: Schema.Types.Boolean,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR resolves a Zod validation error in SDK calls (e.g., `novu.message.retrieve()`) when retrieving messages with `deviceTokens`.

The issue stemmed from an incorrect Mongoose schema definition for `deviceTokens` in `libs/dal/src/repositories/message/message.schema.ts`, which caused device tokens to be stored as nested arrays (e.g., `[["token"]]`) instead of flat arrays (`["token"]`). The SDK's Zod validation correctly rejected this invalid structure.

The fix addresses this in two ways:
1.  The `deviceTokens` schema in `libs/dal/src/repositories/message/message.schema.ts` has been updated to `[Schema.Types.String]` to prevent new messages from being stored with the incorrect nested array structure.
2.  A `normalizeDeviceTokens` function has been added to `libs/dal/src/repositories/message/message.repository.ts`. This function flattens any existing nested `deviceTokens` arrays when messages are retrieved, ensuring backward compatibility for already stored data without requiring a data migration.

fixes NV-7242

### Screenshots

<!-- Not applicable -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

Unit tests for the `normalizeDeviceTokens` function confirm it correctly handles various scenarios, including deeply nested arrays and already flat arrays. E2E tests were attempted but failed due to unrelated infrastructure issues.

</details>

Linear Issue: [NV-7242](https://linear.app/novu/issue/NV-7242/zod-validation-error-on-devicetokens-in-sdk-call)

<div><a href="https://cursor.com/agents/bc-e38d6acb-e30e-4154-988e-d9329c8d4018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e38d6acb-e30e-4154-988e-d9329c8d4018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->