### PR TITLE
feat(dashboard): update step resolver UI fixes NV-7244

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/base-node.tsx
+++ b/apps/dashboard/src/components/workflow-editor/base-node.tsx
@@ -38,8 +38,8 @@ const nodeBadgeVariants = cva(
 
 export interface NodeIconProps extends React.HTMLAttributes<HTMLSpanElement>, VariantProps<typeof nodeBadgeVariants> {}
 
-export const NodeIcon = ({ children, variant }: NodeIconProps) => {
-  return <span className={nodeBadgeVariants({ variant })}>{children}</span>;
+export const NodeIcon = ({ children, variant, className }: NodeIconProps) => {
+  return <span className={cn(nodeBadgeVariants({ variant }), className)}>{children}</span>;
 };
 
 export const NodeName = ({ children }: { children: ReactNode }) => {

--- a/apps/dashboard/src/components/workflow-editor/node-utils.ts
+++ b/apps/dashboard/src/components/workflow-editor/node-utils.ts
@@ -139,6 +139,7 @@ export const createNode = ({
   controlValues,
   isPending,
   type,
+  stepResolverHash,
 }: {
   x: number;
   y: number;
@@ -150,6 +151,7 @@ export const createNode = ({
   controlValues: Record<string, unknown>;
   isPending?: boolean;
   type: StepTypeEnum;
+  stepResolverHash?: string;
 }): Node<NodeData, keyof typeof nodeTypes> => {
   return {
     // the random id is used to identify the node and to be able to re-render the nodes and edges
@@ -163,6 +165,7 @@ export const createNode = ({
       error,
       controlValues,
       isPending,
+      stepResolverHash,
     },
     type,
   };
@@ -195,6 +198,7 @@ export const mapStepToNode = ({
     error: error?.message ?? '',
     controlValues: step.controls.values,
     type: step.type,
+    stepResolverHash: step.stepResolverHash,
   });
 };
 

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -1,7 +1,8 @@
 import { Slug } from '@novu/shared';
 import { Node as FlowNode, Handle, NodeProps, Position } from '@xyflow/react';
+import { FileCode2 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { ComponentProps, KeyboardEventHandler, useCallback, useState } from 'react';
+import { ComponentProps, ComponentType, KeyboardEventHandler, useCallback, useState } from 'react';
 import { RiInsertRowTop, RiPlayCircleLine } from 'react-icons/ri';
 import { RQBJsonLogic } from 'react-querybuilder';
 import { Link } from 'react-router-dom';
@@ -26,6 +27,7 @@ export type NodeData = {
   controlValues?: Record<string, unknown>;
   isPending?: boolean;
   triggerLink?: string;
+  stepResolverHash?: string;
 };
 
 export type NodeType = FlowNode<NodeData>;
@@ -33,6 +35,44 @@ export type NodeType = FlowNode<NodeData>;
 const topHandleClasses = `data-[handlepos=top]:w-2! data-[handlepos=top]:h-2! data-[handlepos=top]:bg-transparent! data-[handlepos=top]:rounded-none! data-[handlepos=top]:before:absolute! data-[handlepos=top]:before:top-0! data-[handlepos=top]:before:left-0! data-[handlepos=top]:before:w-full! data-[handlepos=top]:before:h-full! data-[handlepos=top]:before:bg-neutral-alpha-200! data-[handlepos=top]:before:rotate-45!`;
 const bottomHandleClasses = `data-[handlepos=bottom]:w-2! data-[handlepos=bottom]:h-2! data-[handlepos=bottom]:bg-transparent! data-[handlepos=bottom]:rounded-none! data-[handlepos=bottom]:before:absolute! data-[handlepos=bottom]:before:bottom-0! data-[handlepos=bottom]:before:left-0! data-[handlepos=bottom]:before:w-full! data-[handlepos=bottom]:before:h-full! data-[handlepos=bottom]:before:bg-neutral-alpha-200! data-[handlepos=bottom]:before:rotate-45!`;
 const handleClassName = `${topHandleClasses} ${bottomHandleClasses}`;
+
+const VARIANT_TO_TEXT_CLASS: Record<string, string> = {
+  neutral: 'text-neutral-500',
+  feature: 'text-feature',
+  information: 'text-information',
+  highlighted: 'text-highlighted',
+  stable: 'text-stable',
+  verified: 'text-verified',
+  destructive: 'text-destructive',
+  success: 'text-success',
+  warning: 'text-warning',
+  alert: 'text-alert',
+};
+
+const StepNodeIcon = ({
+  stepResolverHash,
+  color,
+  Icon,
+}: {
+  stepResolverHash?: string;
+  color: string;
+  Icon: ComponentType;
+}) => {
+  if (stepResolverHash) {
+    return (
+      <FileCode2
+        className={cn('size-4 shrink-0 opacity-40', VARIANT_TO_TEXT_CLASS[color] ?? 'text-neutral-500')}
+        strokeWidth={1.5}
+      />
+    );
+  }
+
+  return (
+    <NodeIcon variant={color as any}>
+      <Icon />
+    </NodeIcon>
+  );
+};
 
 export const TriggerNode = ({ data }: NodeProps<FlowNode<{ triggerLink?: string }>>) => {
   const { isReadOnly, showStepPreview } = useCanvasContext();
@@ -246,9 +286,11 @@ export const EmailNode = ({ id, data }: NodeProps<NodeType>) => {
     <NodeWrapper id={id} type={StepTypeEnum.EMAIL}>
       <StepNode id={id} data={data} type={StepTypeEnum.EMAIL}>
         <NodeHeader type={StepTypeEnum.EMAIL}>
-          <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.EMAIL]}>
-            <Icon />
-          </NodeIcon>
+          <StepNodeIcon
+            stepResolverHash={data.stepResolverHash}
+            color={STEP_TYPE_TO_COLOR[StepTypeEnum.EMAIL]}
+            Icon={Icon}
+          />
 
           <NodeName>{data.name || 'Email Step'}</NodeName>
         </NodeHeader>
@@ -275,9 +317,11 @@ export const SmsNode = (props: NodeProps<NodeType>) => {
     <NodeWrapper id={id} type={StepTypeEnum.SMS}>
       <StepNode id={id} data={data} type={StepTypeEnum.SMS}>
         <NodeHeader type={StepTypeEnum.SMS}>
-          <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.SMS]}>
-            <Icon />
-          </NodeIcon>
+          <StepNodeIcon
+            stepResolverHash={data.stepResolverHash}
+            color={STEP_TYPE_TO_COLOR[StepTypeEnum.SMS]}
+            Icon={Icon}
+          />
           <NodeName>{data.name || 'SMS Step'}</NodeName>
         </NodeHeader>
         <NodeBody showPreview={showStepPreview} type={StepTypeEnum.SMS} controlValues={data.controlValues ?? {}}>
@@ -302,9 +346,11 @@ export const InAppNode = (props: NodeProps<NodeType>) => {
     <NodeWrapper id={id} type={StepTypeEnum.IN_APP}>
       <StepNode id={id} data={data} type={StepTypeEnum.IN_APP}>
         <NodeHeader type={StepTypeEnum.IN_APP}>
-          <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.IN_APP]}>
-            <Icon />
-          </NodeIcon>
+          <StepNodeIcon
+            stepResolverHash={data.stepResolverHash}
+            color={STEP_TYPE_TO_COLOR[StepTypeEnum.IN_APP]}
+            Icon={Icon}
+          />
           <NodeName>{data.name || 'In-App Step'}</NodeName>
         </NodeHeader>
         <NodeBody showPreview={showStepPreview} type={StepTypeEnum.IN_APP} controlValues={data.controlValues ?? {}}>
@@ -329,9 +375,11 @@ export const PushNode = (props: NodeProps<NodeType>) => {
     <NodeWrapper id={id} type={StepTypeEnum.PUSH}>
       <StepNode id={id} data={data} type={StepTypeEnum.PUSH}>
         <NodeHeader type={StepTypeEnum.PUSH}>
-          <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.PUSH]}>
-            <Icon />
-          </NodeIcon>
+          <StepNodeIcon
+            stepResolverHash={data.stepResolverHash}
+            color={STEP_TYPE_TO_COLOR[StepTypeEnum.PUSH]}
+            Icon={Icon}
+          />
           <NodeName>{data.name || 'Push Step'}</NodeName>
         </NodeHeader>
         <NodeBody showPreview={showStepPreview} type={StepTypeEnum.PUSH} controlValues={data.controlValues ?? {}}>
@@ -356,9 +404,11 @@ export const ChatNode = (props: NodeProps<NodeType>) => {
     <NodeWrapper id={id} type={StepTypeEnum.CHAT}>
       <StepNode id={id} data={data} type={StepTypeEnum.CHAT}>
         <NodeHeader type={StepTypeEnum.CHAT}>
-          <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.CHAT]}>
-            <Icon />
-          </NodeIcon>
+          <StepNodeIcon
+            stepResolverHash={data.stepResolverHash}
+            color={STEP_TYPE_TO_COLOR[StepTypeEnum.CHAT]}
+            Icon={Icon}
+          />
           <NodeName>{data.name || 'Chat Step'}</NodeName>
         </NodeHeader>
         <NodeBody showPreview={showStepPreview} type={StepTypeEnum.CHAT} controlValues={data.controlValues ?? {}}>
@@ -382,9 +432,11 @@ export const DelayNode = (props: NodeProps<NodeType>) => {
     <NodeWrapper id={id} type={StepTypeEnum.DELAY}>
       <StepNode id={id} data={data} type={StepTypeEnum.DELAY}>
         <NodeHeader type={StepTypeEnum.DELAY}>
-          <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.DELAY]}>
-            <Icon />
-          </NodeIcon>
+          <StepNodeIcon
+            stepResolverHash={data.stepResolverHash}
+            color={STEP_TYPE_TO_COLOR[StepTypeEnum.DELAY]}
+            Icon={Icon}
+          />
           <NodeName>{data.name || 'Delay Step'}</NodeName>
         </NodeHeader>
         <NodeBody type={StepTypeEnum.DELAY} controlValues={data.controlValues ?? {}}>
@@ -408,9 +460,11 @@ export const DigestNode = (props: NodeProps<NodeType>) => {
     <NodeWrapper id={id} type={StepTypeEnum.DIGEST}>
       <StepNode id={id} data={data} type={StepTypeEnum.DIGEST}>
         <NodeHeader type={StepTypeEnum.DIGEST}>
-          <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.DIGEST]}>
-            <Icon />
-          </NodeIcon>
+          <StepNodeIcon
+            stepResolverHash={data.stepResolverHash}
+            color={STEP_TYPE_TO_COLOR[StepTypeEnum.DIGEST]}
+            Icon={Icon}
+          />
           <NodeName>{data.name || 'Digest Step'}</NodeName>
         </NodeHeader>
         <NodeBody type={StepTypeEnum.DIGEST} controlValues={data.controlValues ?? {}}>
@@ -434,9 +488,11 @@ export const ThrottleNode = (props: NodeProps<NodeType>) => {
     <NodeWrapper id={id} type={StepTypeEnum.THROTTLE}>
       <StepNode id={id} data={data} type={StepTypeEnum.THROTTLE}>
         <NodeHeader type={StepTypeEnum.THROTTLE}>
-          <NodeIcon variant={STEP_TYPE_TO_COLOR[StepTypeEnum.THROTTLE]}>
-            <Icon />
-          </NodeIcon>
+          <StepNodeIcon
+            stepResolverHash={data.stepResolverHash}
+            color={STEP_TYPE_TO_COLOR[StepTypeEnum.THROTTLE]}
+            Icon={Icon}
+          />
           <NodeName>{data.name || 'Throttle Step'}</NodeName>
         </NodeHeader>
         <NodeBody type={StepTypeEnum.THROTTLE} controlValues={data.controlValues ?? {}}>
@@ -461,9 +517,7 @@ export const HttpRequestNode = (props: NodeProps<NodeType>) => {
     <NodeWrapper id={id} type={StepTypeEnum.HTTP_REQUEST}>
       <StepNode id={id} data={data} type={StepTypeEnum.HTTP_REQUEST}>
         <NodeHeader type={StepTypeEnum.HTTP_REQUEST} badgeLabel="API" badgeColor={color}>
-          <NodeIcon variant={color}>
-            <Icon />
-          </NodeIcon>
+          <StepNodeIcon stepResolverHash={data.stepResolverHash} color={color} Icon={Icon} />
           <NodeName>{data.name || 'HTTP Request Step'}</NodeName>
         </NodeHeader>
         <NodeBody type={StepTypeEnum.HTTP_REQUEST} controlValues={data.controlValues ?? {}}>
@@ -488,9 +542,7 @@ export const CustomNode = (props: NodeProps<NodeType>) => {
     <NodeWrapper id={id} type={StepTypeEnum.CUSTOM}>
       <StepNode id={id} data={data} type={StepTypeEnum.CUSTOM}>
         <NodeHeader type={StepTypeEnum.CUSTOM} badgeColor={color}>
-          <NodeIcon variant={color}>
-            <Icon />
-          </NodeIcon>
+          <StepNodeIcon stepResolverHash={data.stepResolverHash} color={color} Icon={Icon} />
           <NodeName>{data.name || 'Custom Step'}</NodeName>
         </NodeHeader>
         <NodeBody type={StepTypeEnum.CUSTOM} controlValues={data.controlValues ?? {}}>

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/step-editor-mode-toggle.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/step-editor-mode-toggle.tsx
@@ -1,12 +1,15 @@
 import { EnvironmentTypeEnum, FeatureFlagsKeysEnum } from '@novu/shared';
+import { ArrowRight, Check, DraftingCompass, FileCode2 } from 'lucide-react';
 import { useState } from 'react';
 import { ConfirmationModal } from '@/components/confirmation-modal';
-import { Tabs, TabsList, TabsTrigger } from '@/components/primitives/tabs';
+import { Switch } from '@/components/primitives/switch';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { useStepEditor } from '@/components/workflow-editor/steps/context/step-editor-context';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useDisconnectStepResolver } from '@/hooks/use-disconnect-step-resolver';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { TEMPLATE_CONFIGURABLE_STEP_TYPES } from '@/utils/constants';
+import { cn } from '@/utils/ui';
 
 export function StepEditorModeToggle() {
   const { step, isPendingResolverActivation, setIsPendingResolverActivation } = useStepEditor();
@@ -25,12 +28,10 @@ export function StepEditorModeToggle() {
   }
 
   const isActive = Boolean(step.stepResolverHash);
-  const mode = isActive || isPendingResolverActivation ? 'code' : 'novu';
+  const isCodeMode = isActive || isPendingResolverActivation;
 
-  const handleValueChange = (value: string) => {
-    if (value === mode) return;
-
-    if (value === 'code') {
+  const handleToggle = (checked: boolean) => {
+    if (checked) {
       setIsPendingResolverActivation(true);
     } else if (isActive) {
       setIsDisconnectModalOpen(true);
@@ -60,16 +61,87 @@ export function StepEditorModeToggle() {
         isLoading={isDisconnecting}
       />
 
-      <Tabs value={mode} onValueChange={handleValueChange}>
-        <TabsList>
-          <TabsTrigger value="novu" size="xs">
-            Novu
-          </TabsTrigger>
-          <TabsTrigger value="code" size="xs">
-            Code
-          </TabsTrigger>
-        </TabsList>
-      </Tabs>
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={() => handleToggle(false)}
+          className={cn(
+            'flex cursor-pointer items-center gap-0.5 rounded border px-1 py-0.5 transition-colors',
+            isCodeMode
+              ? 'border-stroke-weak bg-bg-weak text-text-sub hover:border-stroke-soft hover:bg-bg-white hover:text-text-strong'
+              : 'border-stroke-soft bg-bg-white text-text-strong'
+          )}
+        >
+          <DraftingCompass className="size-3" />
+          <span className="text-code-xs">EDITOR</span>
+        </button>
+
+        <Switch checked={isCodeMode} onCheckedChange={handleToggle} />
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => handleToggle(true)}
+              className={cn(
+                'flex cursor-pointer items-center gap-0.5 rounded border px-1 py-0.5 transition-colors',
+                isCodeMode
+                  ? 'border-stroke-soft bg-bg-white text-text-strong'
+                  : 'border-stroke-weak bg-bg-weak text-text-sub hover:border-stroke-soft hover:bg-bg-white hover:text-text-strong'
+              )}
+            >
+              <FileCode2 className="size-3" />
+              <span className="text-code-xs">CUSTOM CODE</span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent
+            variant="light"
+            side="bottom"
+            align="end"
+            className="w-[340px] overflow-hidden border-stroke-weak p-0 shadow-[0px_12px_24px_0px_rgba(14,18,27,0.06),0px_1px_2px_0px_rgba(14,18,27,0.03)]"
+          >
+            <div className="flex items-center gap-1 border-b border-stroke-weak bg-bg-weak px-2 py-1.5">
+              <FileCode2 className="size-3 shrink-0 text-text-strong" />
+              <span className="text-label-xs text-text-strong">Manage this step in your code</span>
+            </div>
+            <div className="flex flex-col gap-3 px-2 py-2">
+              <p className="text-paragraph-xs text-text-sub">
+                Write and deploy this step as a serverless function from your repository.
+              </p>
+              <ul className="flex flex-col gap-1.5">
+                {[
+                  { label: 'Use any template engine', detail: 'React Email, MJML...' },
+                  { label: 'Code-first', detail: 'define content and logic in TypeScript' },
+                  { label: 'Version controlled', detail: 'your handler lives in your repo' },
+                ].map(({ label, detail }) => (
+                  <li key={label} className="flex items-center gap-1">
+                    <Check className="size-3 shrink-0 text-text-sub" />
+                    <span className="text-paragraph-xs">
+                      <span className="font-medium text-text-strong">{label}:</span>
+                      <span className="text-text-sub"> {detail}</span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="flex items-center justify-between border-t border-stroke-weak bg-bg-weak px-2 py-1.5">
+              <div className="flex items-center gap-1">
+                <Check className="size-3 shrink-0 text-text-soft" />
+                <span className="text-paragraph-xs text-text-soft">You can switch back anytime</span>
+              </div>
+              <a
+                href="https://docs.novu.co/framework/overview"
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-0.5 text-label-xs text-text-strong hover:underline"
+              >
+                Learn more
+                <ArrowRight className="size-3" />
+              </a>
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      </div>
     </>
   );
 }

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/step-resolver-not-published.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/step-resolver-not-published.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
-import { RiCheckLine, RiCodeSSlashLine, RiFileCopyLine, RiLoaderLine } from 'react-icons/ri';
+import { FileCode2 } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useEffect, useId, useRef, useState } from 'react';
+import { RiCheckLine, RiCloseLine, RiFileCopyLine, RiLoaderLine } from 'react-icons/ri';
 import { Skeleton } from '@/components/primitives/skeleton';
+import { ExternalLink } from '@/components/shared/external-link';
 import { useFetchApiKeys } from '@/hooks/use-fetch-api-keys';
 import { apiHostnameManager } from '@/utils/api-hostname-manager';
 
@@ -69,8 +72,8 @@ function CodeBlock({ displayCommand, copyCommand }: { displayCommand: string; co
   };
 
   return (
-    <div className="relative w-full overflow-hidden rounded-xl shadow-[inset_0px_0px_0px_1px_#18181b,inset_0px_0px_0px_1.5px_rgba(255,255,255,0.1)]">
-      <div className="flex items-center justify-between bg-[rgba(14,18,27,0.9)] px-4 py-2">
+    <div className="relative w-full overflow-hidden rounded-lg shadow-[inset_0px_0px_0px_1px_#18181b,inset_0px_0px_0px_1.5px_rgba(255,255,255,0.1)]">
+      <div className="flex items-center justify-between bg-[rgba(14,18,27,0.9)] px-4 py-1.5">
         <span className="text-label-xs text-[#99a0ae]">Terminal</span>
         <button
           type="button"
@@ -85,7 +88,7 @@ function CodeBlock({ displayCommand, copyCommand }: { displayCommand: string; co
         </button>
       </div>
       <div className="bg-[rgba(14,18,27,0.9)] px-[5px] pb-[5px]">
-        <div className="flex gap-4 rounded-lg border border-[rgba(14,18,27,0.9)] bg-[rgba(14,18,27,0.9)] p-3">
+        <div className="flex gap-4 rounded-md border border-[rgba(14,18,27,0.9)] bg-[rgba(14,18,27,0.9)] p-3">
           <span className="shrink-0 font-mono text-xs text-[#525866]">❯</span>
           <span className="whitespace-pre font-mono text-xs text-white">{displayCommand}</span>
         </div>
@@ -94,12 +97,198 @@ function CodeBlock({ displayCommand, copyCommand }: { displayCommand: string; co
   );
 }
 
+function StepResolverIllustration() {
+  const gid = useId();
+
+  return (
+    <svg
+      width="100%"
+      viewBox="0 0 544 96"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      opacity="0.8"
+    >
+      <defs>
+        <linearGradient id={`${gid}-a`} x1="0" y1="0" x2="1" y2="0" gradientUnits="objectBoundingBox">
+          <stop stopColor="#F1EFEF" />
+          <stop offset="0.48" stopColor="#F9F8F8" />
+          <stop offset="0.992" stopColor="#F9F8F8" stopOpacity="0.75" />
+        </linearGradient>
+      </defs>
+
+      {/* ─── Card 1: Handler File ─── */}
+      <rect x="0.5" y="0.5" width="158" height="95" rx="7.5" stroke="#CACFD8" />
+      <rect x="4.5" y="4.5" width="150" height="87" rx="5.5" fill="white" stroke="#F2F5F8" />
+      {/* File tab */}
+      <rect x="8" y="9" width="142" height="19" rx="2.5" fill="#F8F8F8" stroke="#EFEFEF" strokeWidth="0.75" />
+      {/* < / > icon */}
+      <path
+        d="M16 14.5L13.5 18L16 21.5"
+        stroke="#C8C8C8"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M20 14.5L22.5 18L20 21.5"
+        stroke="#C8C8C8"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Filename bar */}
+      <rect x="27" y="16" width="38" height="4" rx="2" fill="#E8E8E8" />
+      {/* Code skeleton */}
+      <rect x="8" y="34" width="30" height="4" rx="2" fill={`url(#${gid}-a)`} />
+      <rect x="42" y="34" width="46" height="4" rx="2" fill="#F3F4F6" />
+      <rect x="14" y="43" width="70" height="4" rx="2" fill="#F3F4F6" />
+      <rect x="14" y="52" width="44" height="4" rx="2" fill={`url(#${gid}-a)`} />
+      <rect x="62" y="52" width="38" height="4" rx="2" fill="#F3F4F6" />
+      <rect x="14" y="61" width="56" height="4" rx="2" fill="#F3F4F6" />
+      <rect x="8" y="70" width="22" height="4" rx="2" fill="#F3F4F6" />
+      {/* Label */}
+      <text
+        x="79"
+        y="86"
+        textAnchor="middle"
+        fontFamily="ui-monospace,monospace"
+        fontSize="6.5"
+        fill="#C8C8C8"
+        letterSpacing="0.6"
+      >
+        YOUR CODE
+      </text>
+
+      {/* ─── Connector 1 ─── */}
+      <line x1="160" y1="48" x2="190" y2="48" stroke="#E1E4EA" strokeWidth="1" strokeDasharray="4 3" />
+      <path d="M186 44L192 48L186 52Z" fill="#CACFD8" />
+
+      {/* ─── Card 2: CLI Terminal ─── */}
+      <rect x="193.5" y="0.5" width="157" height="95" rx="7.5" stroke="#CACFD8" />
+      <rect x="197.5" y="4.5" width="149" height="87" rx="5.5" fill="#F8F8F8" stroke="#F2F5F8" />
+      {/* Traffic dots */}
+      <circle cx="208" cy="14" r="3" fill="#E2E2E2" />
+      <circle cx="218" cy="14" r="3" fill="#E2E2E2" />
+      <circle cx="228" cy="14" r="3" fill="#E2E2E2" />
+      <line x1="197" y1="22" x2="350" y2="22" stroke="#EFEFEF" strokeWidth="1" />
+      {/* Prompt */}
+      <text x="207" y="35" fontFamily="ui-monospace,monospace" fontSize="8" fill="#C0C0C0">
+        ❯
+      </text>
+      <text x="218" y="35" fontFamily="ui-monospace,monospace" fontSize="8" fill="#ABABAB">
+        npx novu
+      </text>
+      <text x="218" y="46" fontFamily="ui-monospace,monospace" fontSize="8" fill="#C8C8C8">
+        step publish
+      </text>
+      {/* Checkmark */}
+      <path
+        d="M208 56L211 59.5L217.5 53"
+        stroke="#C0C0C0"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <text x="221" y="59" fontFamily="ui-monospace,monospace" fontSize="8" fill="#C0C0C0">
+        Published!
+      </text>
+      {/* Label */}
+      <text
+        x="272"
+        y="86"
+        textAnchor="middle"
+        fontFamily="ui-monospace,monospace"
+        fontSize="6.5"
+        fill="#C8C8C8"
+        letterSpacing="0.6"
+      >
+        CLI PUBLISH
+      </text>
+
+      {/* ─── Connector 2 ─── */}
+      <line x1="352" y1="48" x2="382" y2="48" stroke="#E1E4EA" strokeWidth="1" strokeDasharray="4 3" />
+      <path d="M378 44L384 48L378 52Z" fill="#CACFD8" />
+
+      {/* ─── Card 3: Novu Cloud ─── */}
+      <rect x="385.5" y="0.5" width="158" height="95" rx="7.5" stroke="#CACFD8" strokeDasharray="5 3" />
+      <rect x="389.5" y="4.5" width="150" height="87" rx="5.5" fill="white" stroke="#F2F5F8" />
+      {/* Novu logo (300×300 → 26px: scale≈0.0867, centered at x=464, top at y=16) */}
+      <g transform="translate(451,16) scale(0.0867)">
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          fill="#D4D4D4"
+          d="M231 120.241C231 128.307 221.208 132.301 215.567 126.536L100.084 8.50548C115.699 2.9969 132.5 0 150 0C179.836 0 207.638 8.711 231 23.7285V120.241ZM273 64.1228V120.241C273 165.946 217.51 188.577 185.546 155.908L61.3582 28.9807C24.1534 56.2779 0 100.318 0 150C0 181.941 9.98339 211.55 27 235.877V180.059C27 134.354 82.4899 111.723 114.454 144.392L238.471 271.145C275.773 243.857 300 199.758 300 150C300 118.059 290.017 88.45 273 64.1228ZM84.433 173.764L199.697 291.571C184.144 297.031 167.419 300 150 300C120.164 300 92.3624 291.289 69 276.272V180.059C69 171.993 78.7923 167.999 84.433 173.764Z"
+        />
+      </g>
+      {/* Novu Cloud label */}
+      <text
+        x="464"
+        y="54"
+        textAnchor="middle"
+        fontFamily="ui-monospace,monospace"
+        fontSize="6.5"
+        fill="#C8C8C8"
+        letterSpacing="0.6"
+      >
+        NOVU CLOUD
+      </text>
+      {/* Serverless badge */}
+      <rect x="432" y="59" width="64" height="14" rx="7" fill="#F4F5F6" stroke="#EFEFEF" strokeWidth="0.75" />
+      <circle cx="442" cy="66" r="2.5" fill="#D4D4D4" />
+      <text x="448" y="69.5" fontFamily="ui-monospace,monospace" fontSize="7" fill="#ABABAB">
+        Serverless
+      </text>
+      {/* Bottom label */}
+      <text
+        x="464"
+        y="86"
+        textAnchor="middle"
+        fontFamily="ui-monospace,monospace"
+        fontSize="6.5"
+        fill="#C8C8C8"
+        letterSpacing="0.6"
+      >
+        DEPLOYED
+      </text>
+    </svg>
+  );
+}
+
+const FEATURE_BULLETS = [
+  'The CLI auto-scaffolds a handler file in your project — no manual setup needed.',
+  'Write your step output in TypeScript using any library or template engine.',
+  'Subscriber data, trigger payload, and dashboard controls are all available at runtime.',
+  'Commit the file to your repo and re-publish to deploy updates at any time.',
+];
+
 type StepResolverNotPublishedProps = {
   workflowId: string;
   stepId: string;
 };
 
+const INFO_CARD_DISMISSED_KEY = 'novu:step-resolver-info-card-dismissed';
+
+const BLOCK_TRANSITION = { duration: 0.22, ease: [0.25, 0.1, 0.25, 1] };
+
+function blockAnimation(delay: number) {
+  return {
+    initial: { opacity: 0, y: 8 },
+    animate: { opacity: 1, y: 0 },
+    transition: { ...BLOCK_TRANSITION, delay },
+  };
+}
+
 export const StepResolverNotPublished = ({ workflowId, stepId }: StepResolverNotPublishedProps) => {
+  const [infoCardDismissed, setInfoCardDismissed] = useState(
+    () => localStorage.getItem(INFO_CARD_DISMISSED_KEY) === 'true'
+  );
+
+  const handleDismissInfoCard = () => {
+    localStorage.setItem(INFO_CARD_DISMISSED_KEY, 'true');
+    setInfoCardDismissed(true);
+  };
   const apiKeysQuery = useFetchApiKeys();
   const secretKey = apiKeysQuery.data?.data?.[0]?.key;
 
@@ -117,35 +306,101 @@ export const StepResolverNotPublished = ({ workflowId, stepId }: StepResolverNot
   const fallbackCopy = `npx novu step publish --workflow=${workflowId} --step=${stepId} --secret-key=<your-secret-key>${apiUrl ? ` --api-url=${apiUrl}` : ''}`;
 
   return (
-    <div className="h-full overflow-y-auto bg-[#fbfbfb] px-16 pt-16">
-      <div className="flex flex-col">
-        <div className="flex w-full flex-col">
-          <div className="flex gap-0">
-            <div className="flex flex-col items-center">
-              <div className="z-10 flex size-5 shrink-0 items-center justify-center rounded-full bg-[#f4f5f6] shadow-[0px_0px_0px_1px_white,0px_0px_0px_2px_#e1e4ea]">
-                <RiCodeSSlashLine className="size-3 text-[#0e121b]" />
+    <div className="h-full overflow-y-auto bg-[#fbfbfb]">
+      <div className="mx-auto flex w-full max-w-[780px] flex-col p-6">
+        <AnimatePresence>
+          {!infoCardDismissed && (
+            <motion.div
+              className="relative mb-4 overflow-hidden rounded-[6px] border border-[#e1e4ea] bg-white shadow-[0px_1px_2px_0px_rgba(10,13,20,0.03)]"
+              initial={{ opacity: 0, y: -6, scale: 0.99 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -6, scale: 0.98 }}
+              transition={{ duration: 0.2, ease: 'easeOut' }}
+            >
+              {/* Novu logomark watermark — partially clipped at bottom-right */}
+              <svg
+                viewBox="0 0 300 300"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="pointer-events-none absolute size-[169px] opacity-[0.35]"
+                style={{ bottom: -71, right: 19 }}
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M231 120.241C231 128.307 221.208 132.301 215.567 126.536L100.084 8.50548C115.699 2.9969 132.5 0 150 0C179.836 0 207.638 8.711 231 23.7285V120.241ZM273 64.1228V120.241C273 165.946 217.51 188.577 185.546 155.908L61.3582 28.9807C24.1534 56.2779 0 100.318 0 150C0 181.941 9.98339 211.55 27 235.877V180.059C27 134.354 82.4899 111.723 114.454 144.392L238.471 271.145C275.773 243.857 300 199.758 300 150C300 118.059 290.017 88.45 273 64.1228ZM84.433 173.764L199.697 291.571C184.144 297.031 167.419 300 150 300C120.164 300 92.3624 291.289 69 276.272V180.059C69 171.993 78.7923 167.999 84.433 173.764Z"
+                  fill="#e1e4ea"
+                />
+              </svg>
+              <button
+                type="button"
+                onClick={handleDismissInfoCard}
+                className="absolute right-3 top-3 flex size-5 items-center justify-center rounded text-[#99a0ae] transition-colors hover:bg-[#f4f5f6] hover:text-[#525866]"
+              >
+                <RiCloseLine className="size-4" />
+              </button>
+              <div className="flex flex-col gap-3 p-3">
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center gap-1">
+                    <FileCode2 className="size-[14px] shrink-0 text-[#525866]" strokeWidth={1.5} />
+                    <span className="text-label-sm text-[#525866]">Resolve this step from your code</span>
+                  </div>
+                  <p className="text-label-xs text-[#99a0ae]">
+                    Instead of defining content in the editor, your application generates the output for this step.
+                  </p>
+                </div>
+                <ul className="flex flex-col gap-1.5">
+                  {FEATURE_BULLETS.map((bullet) => (
+                    <li key={bullet} className="flex items-center gap-1">
+                      <RiCheckLine className="size-3 shrink-0 text-[#525866]" />
+                      <span className="text-label-xs text-[#525866]">{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="w-fit">
+                  <ExternalLink
+                    variant="documentation"
+                    href="https://docs.novu.co/platform/concepts/step-resolvers"
+                    underline={false}
+                    className="cursor-pointer"
+                  >
+                    Read the docs
+                  </ExternalLink>
+                </div>
               </div>
-              <div className="w-px flex-1 bg-gradient-to-b from-neutral-200 to-neutral-100" />
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        <motion.div className="mb-4 py-3" {...blockAnimation(0.1)}>
+          <StepResolverIllustration />
+        </motion.div>
+
+        <motion.div className="flex flex-col" {...blockAnimation(0.2)}>
+          <div className="relative pl-8">
+            <div
+              className="absolute left-8 top-0 h-full w-px"
+              style={{ background: 'linear-gradient(to bottom, transparent, #e1e4ea 32px, #e1e4ea 75%, transparent)' }}
+            />
+            <div className="absolute left-[22px] top-8 z-10 flex size-5 items-center justify-center rounded-full bg-[#f4f5f6] shadow-[0px_0px_0px_1px_white,0px_0px_0px_2px_#e1e4ea]">
+              <span className="text-label-xs text-[#0e121b]">1</span>
             </div>
-            <div className="flex flex-col gap-6 pb-8 pl-6">
+            <div className="flex max-w-[560px] flex-col gap-6 pb-8 pl-8 pt-8">
               <div className="flex flex-col gap-1.5">
-                <p className="text-label-sm text-[#2f3037]">Deploy your step resolver</p>
-                <p className="text-label-xs max-w-[440px] text-[#99a0ae]">
-                  Run this from your project root. A step file will be scaffolded at{' '}
-                  <code className="rounded bg-neutral-100 px-1 py-0.5 font-mono text-[11px] text-[#0e121b]">
-                    novu/{workflowId}/{stepId}.step.ts
+                <p className="text-label-sm text-[#2f3037]">Publish your step handler</p>
+                <p className="text-label-xs text-[#99a0ae]">
+                  Run this from your project root. The CLI scaffolds{' '}
+                  <code className="rounded bg-neutral-100 px-1 py-0.5 font-mono text-[10px] text-[#525866]">
+                    novu/{workflowId}/{stepId}.step.tsx
                   </code>{' '}
-                  — customize the resolver logic there anytime and re-run to redeploy.
+                  if it doesn't exist yet — edit it with your logic and re-run to redeploy anytime.
                   <br />
-                  <br />💡 This bundles your handler, links it to this step, and deploys it to our{' '}
-                  <span className="cursor-default decoration-dotted underline underline-offset-2">
-                    managed infrastructure
-                  </span>
-                  .
+                  <br />💡 Your handler is bundled and deployed to Novu's serverless infrastructure on every publish.
                 </p>
               </div>
               {apiKeysQuery.isLoading ? (
-                <Skeleton className="h-[120px] w-full rounded-xl" />
+                <Skeleton className="h-[120px] rounded-lg" />
               ) : (
                 <CodeBlock
                   displayCommand={
@@ -162,22 +417,21 @@ export const StepResolverNotPublished = ({ workflowId, stepId }: StepResolverNot
               )}
             </div>
           </div>
-        </div>
 
-        <div className="flex gap-0">
-          <div className="flex shrink-0 flex-col items-center">
-            <RiLoaderLine className="size-5 animate-spin text-pink-500" />
+          <div className="flex gap-2 pb-8 pl-[26px]">
+            <RiLoaderLine className="mt-0.5 size-4 shrink-0 animate-spin text-[#dd2476]" />
+            <div className="flex flex-col gap-1.5">
+              <span className="text-label-sm bg-gradient-to-r from-[#dd2476] to-[#ff512f] bg-clip-text text-transparent">
+                Waiting for first deployment…
+              </span>
+              <p className="text-label-xs text-[#99a0ae]">
+                Run the command above from your project to publish this step.
+                <br />
+                Once deployed, you'll be able to preview and trigger notifications here.
+              </p>
+            </div>
           </div>
-          <div className="flex flex-col gap-1.5 pb-8 pl-6">
-            <span className="text-label-sm bg-gradient-to-r from-[#dd2476] to-[#ff512f] bg-clip-text text-transparent">
-              Waiting for step resolver...
-            </span>
-            <p className="text-label-xs text-[#99a0ae]">
-              Once your step resolver is deployed, you'll be able to preview it here and trigger your first
-              notification.
-            </p>
-          </div>
-        </div>
+        </motion.div>
       </div>
     </div>
   );

--- a/apps/dashboard/src/utils/types.ts
+++ b/apps/dashboard/src/utils/types.ts
@@ -20,7 +20,10 @@ export type RuntimeIssue = {
   message: string;
 };
 
-export type Step = Pick<StepResponseDto, 'name' | 'type' | '_id' | 'stepId' | 'issues' | 'slug' | 'controls'>;
+export type Step = Pick<
+  StepResponseDto,
+  'name' | 'type' | '_id' | 'stepId' | 'issues' | 'slug' | 'controls' | 'stepResolverHash'
+>;
 
 /**
  * Omit the `environment` field from the parameters of a function.


### PR DESCRIPTION
### What changed? Why was the change needed?

This pull request introduces support for "custom code" steps in the workflow editor, improving both the UI and the underlying data model. The main changes include adding the `stepResolverHash` property to nodes and steps, updating the node rendering logic to visually indicate custom code steps, and redesigning the step editor mode toggle to provide a clearer and more informative user experience.

**Custom Code Step Support and Visual Indicators:**

* Added `stepResolverHash` property to the `NodeData` type and updated node creation and mapping utilities to handle this property, enabling identification of custom code steps throughout the workflow editor. [[1]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fR30) [[2]](diffhunk://#diff-e916375f4d6f9575870a6e6807c97df7b1258a11c49353e4f87350483b8d4de9R142) [[3]](diffhunk://#diff-e916375f4d6f9575870a6e6807c97df7b1258a11c49353e4f87350483b8d4de9R154) [[4]](diffhunk://#diff-e916375f4d6f9575870a6e6807c97df7b1258a11c49353e4f87350483b8d4de9R168) [[5]](diffhunk://#diff-e916375f4d6f9575870a6e6807c97df7b1258a11c49353e4f87350483b8d4de9R201)
* Introduced the `StepNodeIcon` component, which displays a special icon (`FileCode2`) for nodes with `stepResolverHash`, visually distinguishing custom code steps from regular steps. All step node components now use `StepNodeIcon` instead of `NodeIcon`. [[1]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fR39-R76) [[2]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fL249-R293) [[3]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fL278-R324) [[4]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fL305-R353) [[5]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fL332-R382) [[6]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fL359-R411) [[7]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fL385-R439) [[8]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fL411-R467) [[9]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fL437-R495) [[10]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fL464-R520) [[11]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fL491-R545)

**Step Editor Mode Toggle Redesign:**

* Replaced the old tab-based mode toggle with a new UI featuring two buttons, a switch, and an informative tooltip. This makes it easier for users to switch between the Novu editor and custom code mode, and provides helpful information about custom code steps. [[1]](diffhunk://#diff-cf4a55b5854c7303639641998f2fa72f93c448f98e8c4795954c05a0a2991ccdR2-R12) [[2]](diffhunk://#diff-cf4a55b5854c7303639641998f2fa72f93c448f98e8c4795954c05a0a2991ccdL28-R34) [[3]](diffhunk://#diff-cf4a55b5854c7303639641998f2fa72f93c448f98e8c4795954c05a0a2991ccdL63-R144)

**Component and Icon Updates:**

* Updated imports and usage of icons throughout the workflow editor components, replacing older icon libraries with `lucide-react` where appropriate, and ensuring consistent styling for step icons. [[1]](diffhunk://#diff-48c96dc66f1c2bf75025736866173912faf73351b46ec759ced3a4f1b713879fR3-R5) [[2]](diffhunk://#diff-cf4a55b5854c7303639641998f2fa72f93c448f98e8c4795954c05a0a2991ccdR2-R12) [[3]](diffhunk://#diff-cd4054580f0f1c25141ff8f33f4e14f399ef694c878728ba2e64983189fd6087L1-R6)

**Refactoring and Code Quality:**

* Improved the `NodeIcon` component to accept a `className` prop, allowing for more flexible styling and easier integration with the new icon logic.

These changes collectively enhance the workflow editor's support for custom code steps, improve visual clarity, and provide a more user-friendly interface for managing step modes.
