### PR TITLE
fix(shared): replace <a> with <Link> for dashboard URL in usage report email

### DIFF
--- a/libs/notifications/src/workflows/usage-report/email.tsx
+++ b/libs/notifications/src/workflows/usage-report/email.tsx
@@ -892,10 +892,8 @@ function FooterCta({ dashboardUrl }: { dashboardUrl: string }) {
 
       <Row style={{ marginTop: '20px' }}>
         <Column>
-          <a
+          <Link
             href={dashboardUrl || 'https://dashboard.novu.co'}
-            target="_blank"
-            rel="noopener noreferrer"
             style={{
               background: '#DF2E5B',
               color: COLORS.white,
@@ -911,7 +909,7 @@ function FooterCta({ dashboardUrl }: { dashboardUrl: string }) {
             }}
           >
             View dashboard
-          </a>
+          </Link>
         </Column>
       </Row>
     </Card>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Replaced the raw `<a>` HTML tag with the `<Link>` component from `@react-email/components` for the "View dashboard" button in the usage report email template.

## Why

The `<a>` tag was producing a broken URL in the rendered email. The `<Link>` component (already used elsewhere in the same file, e.g. for the LinkedIn link) properly handles href rendering in react-email templates.

## Changes

- `libs/notifications/src/workflows/usage-report/email.tsx` — swapped `<a>` → `<Link>` for the dashboard CTA button, removed unnecessary `target` and `rel` attributes (handled by `<Link>`).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D092998U7KR/p1773735656177739?thread_ts=1773735656.177739&cid=D092998U7KR)

<div><a href="https://cursor.com/agents/bc-365c1a13-d56c-5c05-a4d4-cf118f7f263d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-365c1a13-d56c-5c05-a4d4-cf118f7f263d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

