### PR TITLE
fix(api-service,worker): downgrade subscriberId validation error log from error to debug

### DIFF
--- a/apps/worker/src/app/workflow/services/subscriber-process.worker.ts
+++ b/apps/worker/src/app/workflow/services/subscriber-process.worker.ts
@@ -19,6 +19,11 @@ import { SubscriberJobBound } from '../usecases/subscriber-job-bound/subscriber-
 const nr = require('newrelic');
 
 const LOG_CONTEXT = 'SubscriberProcessWorker';
+const SUBSCRIBER_ID_VALIDATION_PREFIX = 'subscriberId under property to';
+
+function isSubscriberIdValidationError(e: unknown): boolean {
+  return e instanceof BadRequestException && typeof e.message === 'string' && e.message.startsWith(SUBSCRIBER_ID_VALIDATION_PREFIX);
+}
 
 @Injectable()
 export class SubscriberProcessWorker extends SubscriberProcessWorkerService {
@@ -69,7 +74,7 @@ export class SubscriberProcessWorker extends SubscriberProcessWorkerService {
                 .execute(data)
                 .then(resolve)
                 .catch((e) => {
-                  if (e instanceof BadRequestException) {
+                  if (isSubscriberIdValidationError(e)) {
                     Logger.debug(e, e.message, 'SubscriberProcessWorkerService - getWorkerProcessor');
                   } else {
                     Logger.error(e, 'unexpected error', 'SubscriberProcessWorkerService - getWorkerProcessor');

--- a/apps/worker/src/app/workflow/services/subscriber-process.worker.ts
+++ b/apps/worker/src/app/workflow/services/subscriber-process.worker.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { HttpException, Injectable, Logger } from '@nestjs/common';
 import {
   BullMqService,
   FeatureFlagsService,
@@ -69,8 +69,12 @@ export class SubscriberProcessWorker extends SubscriberProcessWorkerService {
                 .execute(data)
                 .then(resolve)
                 .catch((e) => {
-                  Logger.error(e, 'unexpected error', 'SubscriberProcessWorkerService - getWorkerProcessor');
-                  nr.noticeError(e);
+                  if (e instanceof HttpException) {
+                    Logger.debug(e, e.message, 'SubscriberProcessWorkerService - getWorkerProcessor');
+                  } else {
+                    Logger.error(e, 'unexpected error', 'SubscriberProcessWorkerService - getWorkerProcessor');
+                    nr.noticeError(e);
+                  }
                   reject(e);
                 })
 

--- a/apps/worker/src/app/workflow/services/subscriber-process.worker.ts
+++ b/apps/worker/src/app/workflow/services/subscriber-process.worker.ts
@@ -1,4 +1,4 @@
-import { HttpException, Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import {
   BullMqService,
   FeatureFlagsService,
@@ -69,7 +69,7 @@ export class SubscriberProcessWorker extends SubscriberProcessWorkerService {
                 .execute(data)
                 .then(resolve)
                 .catch((e) => {
-                  if (e instanceof HttpException) {
+                  if (e instanceof BadRequestException) {
                     Logger.debug(e, e.message, 'SubscriberProcessWorkerService - getWorkerProcessor');
                   } else {
                     Logger.error(e, 'unexpected error', 'SubscriberProcessWorkerService - getWorkerProcessor');

--- a/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -188,7 +188,7 @@ export class TriggerMulticast extends TriggerBase {
         error: e,
       };
 
-      if (e instanceof BadRequestException) {
+      if (isSubscriberIdValidationError(e)) {
         this.logger.debug(logData, error.message);
       } else {
         this.logger.error(logData, 'Unexpected error has occurred when processing multicast');
@@ -329,6 +329,12 @@ export const buildSubscriberDefine = (recipient: TriggerRecipientSubscriber): IS
     return recipient;
   }
 };
+
+const SUBSCRIBER_ID_VALIDATION_PREFIX = 'subscriberId under property to';
+
+function isSubscriberIdValidationError(e: unknown): boolean {
+  return e instanceof BadRequestException && typeof e.message === 'string' && e.message.startsWith(SUBSCRIBER_ID_VALIDATION_PREFIX);
+}
 
 export const validateSubscriberDefine = (recipient: ISubscribersDefine) => {
   if (!recipient) {

--- a/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, HttpException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { TopicEntity, TopicRepository, TopicSubscribersRepository } from '@novu/dal';
 import {
   FeatureFlagsKeysEnum,
@@ -188,7 +188,7 @@ export class TriggerMulticast extends TriggerBase {
         error: e,
       };
 
-      if (e instanceof HttpException) {
+      if (e instanceof BadRequestException) {
         this.logger.debug(logData, error.message);
       } else {
         this.logger.error(logData, 'Unexpected error has occurred when processing multicast');

--- a/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
+++ b/libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, HttpException, Injectable } from '@nestjs/common';
 import { TopicEntity, TopicRepository, TopicSubscribersRepository } from '@novu/dal';
 import {
   FeatureFlagsKeysEnum,
@@ -180,16 +180,19 @@ export class TriggerMulticast extends TriggerBase {
         }
       );
 
-      this.logger.error(
-        {
-          transactionId: command.transactionId,
-          organization: command.organizationId,
-          triggerIdentifier: command.identifier,
-          userId: command.userId,
-          error: e,
-        },
-        'Unexpected error has occurred when processing multicast'
-      );
+      const logData = {
+        transactionId: command.transactionId,
+        organization: command.organizationId,
+        triggerIdentifier: command.identifier,
+        userId: command.userId,
+        error: e,
+      };
+
+      if (e instanceof HttpException) {
+        this.logger.debug(logData, error.message);
+      } else {
+        this.logger.error(logData, 'Unexpected error has occurred when processing multicast');
+      }
 
       throw e;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The `subscriberId under property to is not configured` error was being logged at `error` level in production (via New Relic), causing noise in error monitoring. This is a **user input validation error** (bad request), not a system error, and should not trigger error-level alerts.

**Changes:**
- **`libs/application-generic/src/usecases/trigger-multicast/trigger-multicast.usecase.ts`**: In the `TriggerMulticast.execute()` catch block, subscriberId validation errors are now logged at `debug` level, while all other errors (including other `BadRequestException`s) continue to log at `error` level.
- **`apps/worker/src/app/workflow/services/subscriber-process.worker.ts`**: In the `SubscriberProcessWorker` processor catch block, subscriberId validation errors are now logged at `debug` level and excluded from New Relic via `nr.noticeError()`, while all other errors retain the original `error` level logging and New Relic reporting.

Both files use a message-based predicate (`isSubscriberIdValidationError`) that matches only errors starting with `"subscriberId under property to"`, ensuring other `BadRequestException`s (e.g., `Workflow id was not found`) remain visible at error level.

### Screenshots

N/A - logging-only change

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

Per CodeRabbit feedback, the check was narrowed from a broad `BadRequestException` class check to a specific message-based predicate. This ensures only the known subscriberId user-input validation errors are downgraded, while other `BadRequestException`s that may represent contract/data issues remain at error level and are reported to New Relic.

</details>

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773737520659089?thread_ts=1773737520.659089&cid=D0919LNRWE7)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773737520659089?thread_ts=1773737520.659089&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-ef45b7a8-fa12-5cee-8a77-295b637f852f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef45b7a8-fa12-5cee-8a77-295b637f852f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

