### PR TITLE
fix(shared): include validation details in CommandValidationException message

### DIFF
--- a/libs/application-generic/src/commands/base.command.ts
+++ b/libs/application-generic/src/commands/base.command.ts
@@ -87,6 +87,15 @@ export class CommandValidationException extends BadRequestException {
     public className: string,
     public constraintsViolated: Record<string, ConstraintValidation>
   ) {
-    super({ message: 'Validation failed', className, constraintsViolated });
+    const message = formatValidationMessage(className, constraintsViolated);
+    super({ message, className, constraintsViolated });
   }
+}
+
+function formatValidationMessage(className: string, constraints: Record<string, ConstraintValidation>): string {
+  const details = Object.entries(constraints)
+    .map(([field, constraint]) => `${field}: ${constraint.messages.join(', ')}`)
+    .join('; ');
+
+  return `Validation failed for ${className}: ${details}`;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The `CommandValidationException` error message was just `"Validation failed"` with no details about which fields failed or what the constraint violations were. When this exception is caught and logged in the worker (e.g. `SubscriberProcessWorkerService - getWorkerProcessor`), the logs only showed `"error.message": "Validation failed"` — making it impossible to diagnose what actually went wrong.

The message now includes the command class name and all specific field-level validation failures. For example:

**Before:** `Validation failed`

**After:** `Validation failed for CreateOrUpdateSubscriberCommand: subscriberId: subscriberId should not be empty; environmentId: environmentId must be a string, environmentId should not be empty`

This applies to both worker error logs and API error responses (via the exception filter), improving debuggability across the board.

### Screenshots

N/A — this is a log/error message improvement, not a visual change.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- The structured `constraintsViolated` field on the response body is unchanged — only the `message` string is now more descriptive.
- No tests assert on the exact `"Validation failed"` string, so this is a safe change.
- The API exception filter's `handleCommandValidation` method reads `exception.message` for the error DTO, so the API response will also benefit from the more descriptive message.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773738174339939?thread_ts=1773738174.339939&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-8bdbbfba-41bf-5d9a-bca8-cc67b8d19158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bdbbfba-41bf-5d9a-bca8-cc67b8d19158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

