### PR TITLE
fix(dashboard): hide add step button for code-first workflows fixes NV-7246

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -591,9 +591,8 @@ export const AddNode = (props: NodeProps<NodeType>) => {
           <RiInsertRowTop className="size-3.5 text-text-soft" />
           <span className="text-label-xs text-text-soft">Drop here</span>
         </div>
-        {!isIntersecting && (
+        {!isIntersecting && !isReadOnly && (
           <AddStepMenu
-            disabled={isReadOnly}
             visible
             className="-mt-1"
             onMenuItemClick={(selection) => addNode(data.index, selection)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Removed the "+" add step button from the workflow editor canvas for code-first (external origin) workflows. Since steps cannot be added through the dashboard editor for code-first workflows, the button should not be displayed.

The fix modifies the `AddNode` component in `nodes.tsx` to check the `isReadOnly` flag (which is already `true` for external origin workflows) and skip rendering the `AddStepMenu` entirely, matching the existing behavior in `edges.tsx` where the between-step add buttons are already hidden for read-only workflows.

Linear ticket: [NV-7246](https://linear.app/novu/issue/NV-7246)

### Screenshots

**Before (regular workflow - button visible):**
The "+" button correctly appears for dashboard-created workflows (origin: `novu-cloud`).

**After (code-first workflow - button hidden):**
The "+" button is no longer rendered for code-first workflows (origin: `external`).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7246](https://linear.app/novu/issue/NV-7246/remove-button-in-code-first-workflow)

<div><a href="https://cursor.com/agents/bc-f7af587a-10a5-4fdc-83c6-2cc5c72e25cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7af587a-10a5-4fdc-83c6-2cc5c72e25cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

