### PR TITLE
fix(dashboard): remove duplicate close icon in publish success modal fixes PRD-589

### DIFF
--- a/apps/dashboard/src/components/header-navigation/publish-success-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-success-modal.tsx
@@ -1,9 +1,9 @@
 import type { IEnvironment } from '@novu/shared';
-import { RiArrowRightSLine, RiCheckboxCircleFill, RiCloseFill } from 'react-icons/ri';
+import { RiArrowRightSLine, RiCheckboxCircleFill } from 'react-icons/ri';
 import type { IEnvironmentPublishResponse } from '@/api/environments';
 import { useEnvironment } from '@/context/environment/hooks';
 import { Button } from '../primitives/button';
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from '../primitives/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../primitives/dialog';
 import { VisuallyHidden } from '../primitives/visually-hidden';
 
 type PublishSuccessModalProps = {
@@ -59,15 +59,8 @@ export function PublishSuccessModal({
             {buildSummaryText()} have been published to {environment?.name}.
           </DialogDescription>
         </VisuallyHidden>
-        <div className="flex items-start justify-between">
-          <div className="bg-success-lighter rounded-full p-2">
-            <RiCheckboxCircleFill className="text-success-base size-6" />
-          </div>
-          <DialogClose asChild>
-            <button className="opacity-70 transition-opacity hover:opacity-100">
-              <RiCloseFill className="size-4" />
-            </button>
-          </DialogClose>
+        <div className="bg-success-lighter w-fit rounded-full p-2">
+          <RiCheckboxCircleFill className="text-success-base size-6" />
         </div>
 
         <div className="space-y-2">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes the duplicate close icon in the publish success modal. The modal was showing two close icons in the top-right corner - one from the custom implementation and one from the built-in `DialogContent` component.

## Changes
- Removed the custom close button from `PublishSuccessModal` that was rendering `RiCloseFill` icon
- The modal now relies on the built-in close button provided by `DialogContent`, which matches the styling and alignment used in other UI modals
- Removed unused `RiCloseFill` import and `DialogClose` component import

## Before
The modal had two close (X) icons in the top-right corner - one custom and one from the Dialog primitive.

## After
The modal now has a single close icon in the top-right corner, matching the standard Dialog styling used throughout the application.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [PRD-589](https://linear.app/novu/issue/PRD-589/fix-duplicate-close-icon-in-publish-success-modal)

<div><a href="https://cursor.com/agents/bc-ffc6033e-bdd8-41ad-8258-02517644c449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffc6033e-bdd8-41ad-8258-02517644c449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

