### PR TITLE
fix(dashboard): update production empty state copy to use publish terminology fixes PRD-590

### DIFF
--- a/apps/dashboard/src/components/workflow-list-empty.tsx
+++ b/apps/dashboard/src/components/workflow-list-empty.tsx
@@ -43,8 +43,8 @@ const WorkflowListEmptyProd = ({ switchToDev }: { switchToDev: () => void }) => 
     <div className="flex flex-col items-center gap-2 text-center">
       <span className="text-foreground-900 block font-medium">No workflows in production</span>
       <p className="text-foreground-400 max-w-[60ch] text-sm">
-        To sync workflows to production, switch to Development environment, select a workflow and click on 'Sync to
-        Production,' or sync via novu CLI for code-first workflows.
+        To publish workflows to production, switch to Development environment and click 'Publish changes' in the
+        navigation bar, or use the Novu CLI for code-first workflows.
       </p>
     </div>
 

--- a/apps/dashboard/src/components/workflow-list-empty.tsx
+++ b/apps/dashboard/src/components/workflow-list-empty.tsx
@@ -43,7 +43,7 @@ const WorkflowListEmptyProd = ({ switchToDev }: { switchToDev: () => void }) => 
     <div className="flex flex-col items-center gap-2 text-center">
       <span className="text-foreground-900 block font-medium">No workflows in production</span>
       <p className="text-foreground-400 max-w-[60ch] text-sm">
-        To publish workflows to production, switch to Development environment and click 'Publish changes' in the
+        To publish workflows to production, switch to Development and click 'Publish changes'
         , or use the Novu CLI for code-first workflows.
       </p>
     </div>

--- a/apps/dashboard/src/components/workflow-list-empty.tsx
+++ b/apps/dashboard/src/components/workflow-list-empty.tsx
@@ -44,7 +44,7 @@ const WorkflowListEmptyProd = ({ switchToDev }: { switchToDev: () => void }) => 
       <span className="text-foreground-900 block font-medium">No workflows in production</span>
       <p className="text-foreground-400 max-w-[60ch] text-sm">
         To publish workflows to production, switch to Development environment and click 'Publish changes' in the
-        navigation bar, or use the Novu CLI for code-first workflows.
+        , or use the Novu CLI for code-first workflows.
       </p>
     </div>
 


### PR DESCRIPTION
Updated the production empty state copy in apps/dashboard/src/components/workflow-list-empty.tsx to use "publish" terminology instead of "sync":


<div><a href="https://cursor.com/agents/bc-4ca9700e-5236-4f2f-816e-d0b7b5e77676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ca9700e-5236-4f2f-816e-d0b7b5e77676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

