### PR TITLE
feat(dashboard): change sync workflow action to publish workflow fixes NV-7265

### DIFF
--- a/apps/dashboard/src/components/header-navigation/publish-button.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-button.tsx
@@ -28,6 +28,7 @@ type PublishState = {
   modalState: ModalState;
   selectedEnvironment: IEnvironment | null;
   publishResult: IEnvironmentPublishResponse | null;
+  preSelectedWorkflowId: string | null;
 };
 
 export const PublishButton = () => {
@@ -79,16 +80,14 @@ export const PublishButton = () => {
     [queryClient, actions]
   );
 
-  // Listen for custom event from command palette
+  // Listen for custom event from command palette or workflow actions
   useEffect(() => {
     const handleOpenPublishModal = (event: CustomEvent) => {
-      const { targetEnvironment: eventTargetEnv } = event.detail;
+      const { targetEnvironment: eventTargetEnv, preSelectedWorkflowId } = event.detail;
       if (eventTargetEnv) {
-        // Force refetch diff data to get latest changes
         queryClient.invalidateQueries({ queryKey: ['diff-environments'] });
 
-        // Check if there are changes and open appropriate modal
-        handleEnvironmentSelect(eventTargetEnv, true); // Assume there are changes for now
+        actions.openPublishModal(eventTargetEnv, preSelectedWorkflowId);
       }
     };
 
@@ -97,7 +96,7 @@ export const PublishButton = () => {
     return () => {
       window.removeEventListener('open-publish-modal', handleOpenPublishModal as EventListener);
     };
-  }, [queryClient, handleEnvironmentSelect]);
+  }, [queryClient, actions]);
 
   const handlePublish = async (selectedResources?: ResourceToPublish[]) => {
     if (!state.selectedEnvironment?._id || !currentEnvironment?._id) {
@@ -155,6 +154,7 @@ export const PublishButton = () => {
           currentEnvironmentId={currentEnvironment?._id}
           onConfirm={handlePublish}
           isPublishing={publishMutation.isPending}
+          preSelectedWorkflowId={state.preSelectedWorkflowId ?? undefined}
         />
 
         <PublishSuccessModal
@@ -219,6 +219,7 @@ export const PublishButton = () => {
             currentEnvironmentId={currentEnvironment?._id}
             onConfirm={handlePublish}
             isPublishing={publishMutation.isPending}
+            preSelectedWorkflowId={state.preSelectedWorkflowId ?? undefined}
           />
 
           <PublishSuccessModal
@@ -253,19 +254,31 @@ const usePublishState = () => {
     modalState: 'closed',
     selectedEnvironment: null,
     publishResult: null,
+    preSelectedWorkflowId: null,
   });
 
   const actions = {
-    openPublishModal: (environment: IEnvironment) =>
-      setState({ modalState: 'publish', selectedEnvironment: environment, publishResult: null }),
+    openPublishModal: (environment: IEnvironment, preSelectedWorkflowId?: string) =>
+      setState({
+        modalState: 'publish',
+        selectedEnvironment: environment,
+        publishResult: null,
+        preSelectedWorkflowId: preSelectedWorkflowId ?? null,
+      }),
 
     openNoChangesModal: (environment: IEnvironment) =>
-      setState({ modalState: 'no-changes', selectedEnvironment: environment, publishResult: null }),
+      setState({
+        modalState: 'no-changes',
+        selectedEnvironment: environment,
+        publishResult: null,
+        preSelectedWorkflowId: null,
+      }),
 
     showSuccess: (result: IEnvironmentPublishResponse) =>
       setState((prev) => ({ ...prev, modalState: 'success', publishResult: result })),
 
-    close: () => setState({ modalState: 'closed', selectedEnvironment: null, publishResult: null }),
+    close: () =>
+      setState({ modalState: 'closed', selectedEnvironment: null, publishResult: null, preSelectedWorkflowId: null }),
   };
 
   return { state, actions };

--- a/apps/dashboard/src/components/header-navigation/publish-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-modal.tsx
@@ -31,6 +31,7 @@ type PublishModalProps = {
   currentEnvironmentId?: string;
   onConfirm: (selectedResources: ResourceToPublish[]) => void;
   isPublishing?: boolean;
+  preSelectedWorkflowId?: string;
 };
 
 type ResourceSelection = {
@@ -48,6 +49,7 @@ export function PublishModal({
   currentEnvironmentId,
   onConfirm,
   isPublishing = false,
+  preSelectedWorkflowId,
 }: PublishModalProps) {
   const [resourceSelection, setResourceSelection] = useState<ResourceSelection>({});
   const [workflowsExpanded, setWorkflowsExpanded] = useState(true);
@@ -71,18 +73,22 @@ export function PublishModal({
       const resourceId = resource.sourceResource?.id || resource.targetResource?.id;
 
       if (resourceId) {
+        const shouldBeSelected = preSelectedWorkflowId
+          ? resource.resourceType === 'workflow' && resourceId === preSelectedWorkflowId
+          : true;
+
         initialSelection[resourceId] = {
-          selected: true, // Start with all selected
+          selected: shouldBeSelected,
           disabled: false,
           resource,
         };
       }
     });
 
-    // Apply dependency rules to the initial selection
+    // Apply dependency rules to the initial selection (this will auto-select dependent layouts)
     const selectionWithDependencies = calculateDependencyState(initialSelection);
     setResourceSelection(selectionWithDependencies);
-  }, [diffData, calculateDependencyState]);
+  }, [diffData, calculateDependencyState, preSelectedWorkflowId]);
 
   const handleResourceToggle = (resourceId: string) => {
     setResourceSelection((prev) => {

--- a/apps/dashboard/src/components/workflow-row.tsx
+++ b/apps/dashboard/src/components/workflow-row.tsx
@@ -50,7 +50,6 @@ import { useDeleteWorkflow } from '@/hooks/use-delete-workflow';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { usePatchWorkflow } from '@/hooks/use-patch-workflow';
-import { useSyncWorkflow } from '@/hooks/use-sync-workflow';
 import { LocalizationResourceEnum } from '@/types/translations';
 import { ResourceOriginEnum, WorkflowStatusEnum } from '@/utils/enums';
 import { formatDateSimple } from '@/utils/format-date';
@@ -128,7 +127,6 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
   const { currentEnvironment } = useEnvironment();
   const { isUserLoaded } = useAuth();
   const has = useHasPermission();
-  const { safeSync, PromoteConfirmModal } = useSyncWorkflow(workflow);
   const isHttpLogsPageEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_HTTP_LOGS_PAGE_ENABLED, false);
   const isV0Workflow = workflow.origin === ResourceOriginEnum.NOVU_CLOUD_V1;
   const isDuplicable =
@@ -418,11 +416,9 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
                     </Link>
                   </Protect>
                   <Protect permission={PermissionsEnum.WORKFLOW_WRITE}>
-                    <SyncWorkflowMenuItem
+                    <PublishWorkflowMenuItem
                       currentEnvironment={currentEnvironment}
-                      isSyncable={false}
-                      tooltipContent="Syncing workflows is now performed in the top right corner of the navigation bar as Publish changes."
-                      onSync={safeSync}
+                      workflowId={workflow.workflowId}
                     />
                   </Protect>
                   <Protect permission={PermissionsEnum.NOTIFICATION_READ}>
@@ -542,37 +538,44 @@ export const WorkflowRow = ({ workflow }: WorkflowRowProps) => {
         confirmButtonText="Proceed"
         isLoading={isPauseWorkflowPending}
       />
-      <PromoteConfirmModal />
     </>
   );
 };
 
-const SyncWorkflowMenuItem = ({
+const PublishWorkflowMenuItem = ({
   currentEnvironment,
-  isSyncable,
-  tooltipContent,
-  onSync,
+  workflowId,
 }: {
   currentEnvironment: IEnvironment | undefined;
-  isSyncable: boolean;
-  tooltipContent: string | undefined;
-  onSync: (targetEnvironmentId: string) => void;
+  workflowId: string;
 }) => {
   const { currentOrganization } = useAuth();
   const { environments = [] } = useFetchEnvironments({ organizationId: currentOrganization?._id });
   const otherEnvironments = environments.filter((env: IEnvironment) => env._id !== currentEnvironment?._id);
 
-  if (!isSyncable) {
+  const handlePublishClick = (targetEnvironment: IEnvironment) => {
+    window.dispatchEvent(
+      new CustomEvent('open-publish-modal', {
+        detail: { targetEnvironment, preSelectedWorkflowId: workflowId },
+      })
+    );
+  };
+
+  if (currentEnvironment?.type !== EnvironmentTypeEnum.DEV) {
+    return null;
+  }
+
+  if (otherEnvironments.length === 0) {
     return (
       <Tooltip>
         <TooltipTrigger>
           <DropdownMenuItem disabled>
             <LuBookUp2 />
-            Sync workflow
+            Publish workflow
           </DropdownMenuItem>
         </TooltipTrigger>
         <TooltipPortal>
-          <TooltipContent>{tooltipContent}</TooltipContent>
+          <TooltipContent>No other environments available</TooltipContent>
         </TooltipPortal>
       </Tooltip>
     );
@@ -580,9 +583,9 @@ const SyncWorkflowMenuItem = ({
 
   if (otherEnvironments.length === 1) {
     return (
-      <DropdownMenuItem onClick={() => onSync(otherEnvironments[0]._id)}>
+      <DropdownMenuItem onClick={() => handlePublishClick(otherEnvironments[0])}>
         <LuBookUp2 />
-        {`Sync to ${otherEnvironments[0].name}`}
+        {`Publish to ${otherEnvironments[0].name}`}
       </DropdownMenuItem>
     );
   }
@@ -591,12 +594,12 @@ const SyncWorkflowMenuItem = ({
     <DropdownMenuSub>
       <DropdownMenuSubTrigger className="gap-2">
         <LuBookUp2 />
-        Sync workflow
+        Publish workflow
       </DropdownMenuSubTrigger>
       <DropdownMenuPortal>
         <DropdownMenuSubContent>
           {otherEnvironments.map((env) => (
-            <DropdownMenuItem key={env._id} onClick={() => onSync(env._id)}>
+            <DropdownMenuItem key={env._id} onClick={() => handlePublishClick(env)}>
               {env.name}
             </DropdownMenuItem>
           ))}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR changes the "Sync workflow" action in the workflow row dropdown menu to "Publish workflow". When clicked, it opens the publish changes modal with only the selected workflow pre-selected by default.

Fixes NV-7265

**Changes made:**
- Replaced `SyncWorkflowMenuItem` with `PublishWorkflowMenuItem` in `workflow-row.tsx`
- Added `preSelectedWorkflowId` prop to `PublishModal` component  
- Updated publish modal initialization logic to only select the specified workflow when `preSelectedWorkflowId` is provided
- The existing logic for auto-selecting dependent layouts is preserved via `calculateDependencyState`
- Removed unused `useSyncWorkflow` hook usage

**Behavior:**
- Clicking "Publish to Production" (or "Publish workflow" if multiple environments) from a workflow's dropdown menu opens the publish modal
- Only the clicked workflow is pre-selected by default
- Other workflows in the modal are unchecked
- Dependent layouts are still auto-selected based on the selected workflow

### Screenshots

Screenshots and a demo video are available in the [Cursor Agent artifacts](https://cursor.com/agents/bc-188b55db-f576-4b69-8dee-726b1632f4e8).

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- The feature was tested manually with both single and multiple workflows
- When clicking "Publish workflow" on different workflows, only the clicked workflow is pre-selected
- The auto-selection of dependent layouts (via `calculateDependencyState`) continues to work as expected

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-188b55db-f576-4b69-8dee-726b1632f4e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-188b55db-f576-4b69-8dee-726b1632f4e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

