### PR TITLE
fix(api-service): strip rawData.payload.unknownSchema before persisting bridge sync

### DIFF
--- a/apps/api/src/app/bridge/e2e/sync.e2e.ts
+++ b/apps/api/src/app/bridge/e2e/sync.e2e.ts
@@ -118,6 +118,10 @@ describe('Bridge Sync - /bridge/sync (POST) #novu-v2', async () => {
     expect(workflowData.steps[0].stepId).to.equal('send-email');
     expect(workflowData.steps[0].uuid).to.equal('send-email');
     expect(workflowData.steps[0].template?.name).to.equal('send-email');
+
+    expect(workflowData.rawData.payload).to.be.ok;
+    expect((workflowData.rawData.payload as any).schema).to.be.ok;
+    expect((workflowData.rawData.payload as any).unknownSchema).to.not.exist;
   });
 
   it('should create a workflow identified by a space-separated identifier', async () => {

--- a/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
@@ -243,7 +243,7 @@ export class Sync {
         controls: {
           schema: workflow.controls?.schema as unknown as JSONSchema,
         },
-        rawData: workflow as unknown as Record<string, unknown>,
+        rawData: this.buildRawData(workflow),
         payloadSchema: workflow.payload?.schema as unknown as JSONSchema,
         active: workflowActive,
         status: computeWorkflowStatus(workflowActive, steps),
@@ -276,7 +276,7 @@ export class Sync {
       controls: {
         schema: workflow.controls?.schema as unknown as JSONSchemaDto,
       },
-      rawData: workflow,
+      rawData: this.buildRawData(workflow),
       payloadSchema: workflow.payload?.schema as unknown as JSONSchemaDto,
       type: ResourceTypeEnum.BRIDGE,
       description: this.getWorkflowDescription(workflow),
@@ -379,6 +379,17 @@ export class Sync {
 
   private getWorkflowTags(workflow: DiscoverWorkflowOutput): string[] {
     return workflow.tags || [];
+  }
+
+  private buildRawData(workflow: DiscoverWorkflowOutput): Record<string, unknown> {
+    const rawData = { ...workflow } as Record<string, unknown>;
+
+    if (rawData.payload && typeof rawData.payload === 'object') {
+      const { unknownSchema, ...payloadRest } = rawData.payload as Record<string, unknown>;
+      rawData.payload = payloadRest;
+    }
+
+    return rawData;
   }
 
   private castToAnyNotSupportedParam(param: any): any {

--- a/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
@@ -385,8 +385,13 @@ export class Sync {
     const rawData = { ...workflow } as Record<string, unknown>;
 
     if (rawData.payload && typeof rawData.payload === 'object') {
-      const { unknownSchema, ...payloadRest } = rawData.payload as Record<string, unknown>;
+      const { unknownSchema: _payloadUnknownSchema, ...payloadRest } = rawData.payload as Record<string, unknown>;
       rawData.payload = payloadRest;
+    }
+
+    if (rawData.controls && typeof rawData.controls === 'object') {
+      const { unknownSchema: _controlsUnknownSchema, ...controlsRest } = rawData.controls as Record<string, unknown>;
+      rawData.controls = controlsRest;
     }
 
     return rawData;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

During the bridge sync flow, the `rawData` object stored on workflows includes `payload.unknownSchema` and `controls.unknownSchema`, which are parsed Zod/schema representations that can be very large and are not needed after sync. This PR strips both `rawData.payload.unknownSchema` and `rawData.controls.unknownSchema` before persisting to MongoDB, reducing document size.

**Changes:**
- Added `buildRawData()` helper in the `Sync` usecase that shallow-clones the workflow and removes `unknownSchema` from both `payload` and `controls` before returning the rawData
- Applied it to both the create and update workflow paths
- Added e2e test assertions to verify `rawData.payload.schema` is preserved while `rawData.payload.unknownSchema` is stripped

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

The change is minimal and surgical — only the `rawData` field passed to create/update commands is affected. The original `workflow` object is not mutated, so all other fields (like `payloadSchema`) that reference `workflow.payload.schema` continue to work correctly.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773756751421049?thread_ts=1773756751.421049&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-3f153271-d0fc-5a07-81e9-aefa7511aa1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f153271-d0fc-5a07-81e9-aefa7511aa1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

