### PR TITLE
fix(novu): resolve zod bundling error and adapt step scaffolding to project setup fixes NV-7257

### DIFF
--- a/packages/novu/src/commands/step/bundler/bundler.ts
+++ b/packages/novu/src/commands/step/bundler/bundler.ts
@@ -1,9 +1,9 @@
 import * as esbuild from 'esbuild';
-import * as fs from 'fs';
 import * as path from 'path';
 import { generateWorkerWrapper } from '../templates/worker-wrapper';
 import type { DiscoveredStep, StepResolverReleaseBundle } from '../types';
 import { getBundlerConfig } from './config';
+import { getCliNodeModulesPaths } from './node-paths';
 
 const MAX_BUNDLE_SIZE = 10 * 1024 * 1024; // 10MB in bytes
 const BUNDLE_LABEL = 'step-resolver-release';
@@ -67,23 +67,6 @@ function formatBundlingError(bundleLabel: string, error: unknown): Error {
 
 function isBuildFailure(error: unknown): error is esbuild.BuildFailure {
   return typeof error === 'object' && error !== null && 'errors' in error && Array.isArray(error.errors);
-}
-
-function getCliNodeModulesPaths(): string[] {
-  const paths: string[] = [];
-  let dir = __dirname;
-
-  while (true) {
-    const nodeModules = path.join(dir, 'node_modules');
-    if (fs.existsSync(nodeModules)) {
-      paths.push(nodeModules);
-    }
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-
-  return paths;
 }
 
 async function bundleSteps(

--- a/packages/novu/src/commands/step/bundler/node-paths.ts
+++ b/packages/novu/src/commands/step/bundler/node-paths.ts
@@ -1,0 +1,19 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function getCliNodeModulesPaths(): string[] {
+  const paths: string[] = [];
+  let dir = __dirname;
+
+  while (true) {
+    const nodeModules = path.join(dir, 'node_modules');
+    if (fs.existsSync(nodeModules)) {
+      paths.push(nodeModules);
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return paths;
+}

--- a/packages/novu/src/commands/step/bundler/schema-extractor.ts
+++ b/packages/novu/src/commands/step/bundler/schema-extractor.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { zodToJsonSchema } from 'zod-to-json-schema';
+import { getCliNodeModulesPaths } from './node-paths';
 
 export interface ExtractedSchemas {
   controlSchema?: Record<string, unknown>;
@@ -22,6 +23,7 @@ export async function extractStepSchemas(filePath: string): Promise<ExtractedSch
       write: false,
       jsx: 'automatic',
       jsxImportSource: 'react',
+      nodePaths: getCliNodeModulesPaths(),
       loader: {
         '.ts': 'ts',
         '.tsx': 'tsx',

--- a/packages/novu/src/commands/step/publish.ts
+++ b/packages/novu/src/commands/step/publish.ts
@@ -19,6 +19,7 @@ import type {
 import {
   detectPackageManager,
   getInstallCommand,
+  hasZodV3,
   installPackageSync,
   isPackageInstalled,
   renderTable,
@@ -99,7 +100,8 @@ export async function stepPublish(options: PublishOptions): Promise<void> {
         workflowIds[0],
         stepIds[0],
         rootDir,
-        effectiveOutDir
+        effectiveOutDir,
+        hasZodV3(rootDir)
       );
     }
 
@@ -387,7 +389,8 @@ async function scaffoldStepFileIfNeeded(
   workflowId: string,
   stepId: string,
   rootDir: string,
-  configOutDir?: string
+  configOutDir?: string,
+  useZod = false
 ): Promise<boolean> {
   const outDir = configOutDir || './novu';
   const outDirPath = path.resolve(rootDir, outDir);
@@ -420,9 +423,9 @@ async function scaffoldStepFileIfNeeded(
       process.exit(1);
     }
     const templateImportPath = pathResolver.getTemplateImportPath(workflowId, templatePath);
-    stepFileContent = generateReactEmailStepFile(stepId, templateImportPath);
+    stepFileContent = generateReactEmailStepFile(stepId, templateImportPath, useZod);
   } else {
-    stepFileContent = generateStepFileForType(stepId, scaffoldResult.stepType);
+    stepFileContent = generateStepFileForType(stepId, scaffoldResult.stepType, useZod);
   }
 
   fsSync.writeFileSync(stepFilePath, stepFileContent, 'utf8');

--- a/packages/novu/src/commands/step/templates/__snapshots__/step-file.spec.ts.snap
+++ b/packages/novu/src/commands/step/templates/__snapshots__/step-file.spec.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`generateChatStepFile > should match snapshot 1`] = `
+exports[`generateChatStepFile > should match snapshot with zod 1`] = `
 "import { step } from '@novu/framework/step-resolver';
 import { z } from 'zod';
 
@@ -19,7 +19,29 @@ export default step.chat(
 "
 `;
 
-exports[`generateEmailStepFile > should match snapshot 1`] = `
+exports[`generateChatStepFile > should match snapshot without zod 1`] = `
+"import { step } from '@novu/framework/step-resolver';
+
+export default step.chat(
+  'send-chat',
+  async (controls, { payload, subscriber }) => ({
+    body: \`Hi \${subscriber.firstName ?? 'there'}, \${controls.message}\`,
+  }),
+  {
+    controlSchema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string', default: 'You have a new message.' },
+      },
+      additionalProperties: false,
+    } as const,
+    // skip: (_controls, { subscriber }) => !subscriber.channels?.chat,
+  }
+);
+"
+`;
+
+exports[`generateEmailStepFile > with zod > should match snapshot 1`] = `
 "import { step } from '@novu/framework/step-resolver';
 import { z } from 'zod';
 
@@ -53,7 +75,44 @@ export default step.email(
 "
 `;
 
-exports[`generateInAppStepFile > should match snapshot 1`] = `
+exports[`generateEmailStepFile > without zod > should match snapshot 1`] = `
+"import { step } from '@novu/framework/step-resolver';
+
+export default step.email(
+  'plain-email',
+  async (controls, { payload, subscriber }) => ({
+    subject: controls.subject,
+    body: \`
+      <html>
+        <body>
+          <h1>\${controls.heading}</h1>
+          <p>Hi \${subscriber.firstName ?? 'there'},</p>
+          <p>\${controls.body}</p>
+          <p><a href="\${controls.ctaUrl}">View details</a></p>
+        </body>
+      </html>
+    \`,
+    // Optionally override the sender for this step:
+    // from: { email: 'noreply@example.com', name: 'My App' },
+  }),
+  {
+    controlSchema: {
+      type: 'object',
+      properties: {
+        subject: { type: 'string', default: 'You have a new notification' },
+        heading: { type: 'string', default: 'New activity' },
+        body: { type: 'string', default: 'You have a new message.' },
+        ctaUrl: { type: 'string', default: '/' },
+      },
+      additionalProperties: false,
+    } as const,
+    // skip: (_controls, { subscriber }) => !subscriber.email,
+  }
+);
+"
+`;
+
+exports[`generateInAppStepFile > should match snapshot with zod 1`] = `
 "import { step } from '@novu/framework/step-resolver';
 import { z } from 'zod';
 
@@ -82,7 +141,39 @@ export default step.inApp(
 "
 `;
 
-exports[`generatePushStepFile > should match snapshot 1`] = `
+exports[`generateInAppStepFile > should match snapshot without zod 1`] = `
+"import { step } from '@novu/framework/step-resolver';
+
+export default step.inApp(
+  'in-app-notify',
+  async (controls, { payload, subscriber }) => ({
+    subject: controls.subject,
+    body: controls.body,
+    // avatar: subscriber.avatar,
+    primaryAction: {
+      label: controls.ctaLabel,
+      redirect: { url: controls.ctaUrl, target: '_blank' },
+    },
+    // secondaryAction: { label: 'Dismiss' },
+  }),
+  {
+    controlSchema: {
+      type: 'object',
+      properties: {
+        subject: { type: 'string', default: 'New activity' },
+        body: { type: 'string', default: 'You have a new notification.' },
+        ctaLabel: { type: 'string', default: 'View details' },
+        ctaUrl: { type: 'string', default: '/' },
+      },
+      additionalProperties: false,
+    } as const,
+    // skip: (_controls, { subscriber }) => !subscriber.channels?.in_app,
+  }
+);
+"
+`;
+
+exports[`generatePushStepFile > should match snapshot with zod 1`] = `
 "import { step } from '@novu/framework/step-resolver';
 import { z } from 'zod';
 
@@ -103,10 +194,34 @@ export default step.push(
 "
 `;
 
-exports[`generateReactEmailStepFile > should match snapshot 1`] = `
+exports[`generatePushStepFile > should match snapshot without zod 1`] = `
 "import { step } from '@novu/framework/step-resolver';
-import { render } from '@react-email/components';
+
+export default step.push(
+  'send-push',
+  async (controls, { payload, subscriber }) => ({
+    subject: controls.title,
+    body: controls.body,
+  }),
+  {
+    controlSchema: {
+      type: 'object',
+      properties: {
+        title: { type: 'string', default: 'New activity' },
+        body: { type: 'string', default: 'You have a new notification.' },
+      },
+      additionalProperties: false,
+    } as const,
+    // skip: (_controls, { subscriber }) => !subscriber.channels?.push,
+  }
+);
+"
+`;
+
+exports[`generateReactEmailStepFile > with zod > should match snapshot 1`] = `
+"import { step } from '@novu/framework/step-resolver';
 import { z } from 'zod';
+import { render } from '@react-email/components';
 import EmailTemplate from '../emails/welcome';
 
 export default step.email(
@@ -130,10 +245,10 @@ export default step.email(
 "
 `;
 
-exports[`generateReactEmailStepFile > should match snapshot with different import paths > nested-import 1`] = `
+exports[`generateReactEmailStepFile > with zod > should match snapshot with different import paths > nested-import 1`] = `
 "import { step } from '@novu/framework/step-resolver';
-import { render } from '@react-email/components';
 import { z } from 'zod';
+import { render } from '@react-email/components';
 import EmailTemplate from '../../src/emails/welcome';
 
 export default step.email(
@@ -157,10 +272,10 @@ export default step.email(
 "
 `;
 
-exports[`generateReactEmailStepFile > should match snapshot with different import paths > relative-import 1`] = `
+exports[`generateReactEmailStepFile > with zod > should match snapshot with different import paths > relative-import 1`] = `
 "import { step } from '@novu/framework/step-resolver';
-import { render } from '@react-email/components';
 import { z } from 'zod';
+import { render } from '@react-email/components';
 import EmailTemplate from './emails/welcome';
 
 export default step.email(
@@ -184,7 +299,37 @@ export default step.email(
 "
 `;
 
-exports[`generateSmsStepFile > should match snapshot 1`] = `
+exports[`generateReactEmailStepFile > without zod > should match snapshot 1`] = `
+"import { step } from '@novu/framework/step-resolver';
+import { render } from '@react-email/components';
+import EmailTemplate from '../emails/welcome';
+
+export default step.email(
+  'welcome-email',
+  async (controls, { payload, subscriber, steps }) => ({
+    subject: controls.subject,
+    body: await render(
+      <EmailTemplate
+        controls={controls}
+        subscriber={subscriber}
+        steps={steps}
+      />
+    ),
+  }),
+  {
+    controlSchema: {
+      type: 'object',
+      properties: {
+        subject: { type: 'string', default: 'You have a new notification' },
+      },
+      additionalProperties: false,
+    } as const,
+  }
+);
+"
+`;
+
+exports[`generateSmsStepFile > should match snapshot with zod 1`] = `
 "import { step } from '@novu/framework/step-resolver';
 import { z } from 'zod';
 
@@ -197,6 +342,28 @@ export default step.sms(
     controlSchema: z.object({
       message: z.string().default('You have a new notification. Reply STOP to unsubscribe.'),
     }),
+    // skip: (_controls, { subscriber }) => !subscriber.phone,
+  }
+);
+"
+`;
+
+exports[`generateSmsStepFile > should match snapshot without zod 1`] = `
+"import { step } from '@novu/framework/step-resolver';
+
+export default step.sms(
+  'send-sms',
+  async (controls, { payload, subscriber }) => ({
+    body: \`Hi \${subscriber.firstName ?? 'there'}, \${controls.message}\`,
+  }),
+  {
+    controlSchema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string', default: 'You have a new notification. Reply STOP to unsubscribe.' },
+      },
+      additionalProperties: false,
+    } as const,
     // skip: (_controls, { subscriber }) => !subscriber.phone,
   }
 );

--- a/packages/novu/src/commands/step/templates/step-file.spec.ts
+++ b/packages/novu/src/commands/step/templates/step-file.spec.ts
@@ -12,75 +12,137 @@ import {
 describe('generateReactEmailStepFile', () => {
   const stepId = 'welcome-email';
 
-  it('should match snapshot', () => {
-    expect(generateReactEmailStepFile(stepId, '../emails/welcome')).toMatchSnapshot();
+  describe('with zod', () => {
+    it('should match snapshot', () => {
+      expect(generateReactEmailStepFile(stepId, '../emails/welcome', true)).toMatchSnapshot();
+    });
+
+    it('should match snapshot with different import paths', () => {
+      expect(generateReactEmailStepFile(stepId, './emails/welcome', true)).toMatchSnapshot('relative-import');
+      expect(generateReactEmailStepFile(stepId, '../../src/emails/welcome', true)).toMatchSnapshot('nested-import');
+    });
+
+    it('imports render from @react-email/components and calls it', () => {
+      const result = generateReactEmailStepFile(stepId, '../emails/welcome', true);
+      expect(result).toContain('step.email(');
+      expect(result).toContain("'welcome-email'");
+      expect(result).toContain("from '@react-email/components'");
+      expect(result).toContain('await render(');
+      expect(result).toContain("from 'zod'");
+    });
+
+    it('escapes single quotes in stepId and templatePath', () => {
+      const result = generateReactEmailStepFile("it's-a-step", "../emails/it's-template", true);
+      expect(result).toContain("it\\'s-a-step");
+      expect(result).toContain("it\\'s-template");
+    });
   });
 
-  it('should match snapshot with different import paths', () => {
-    expect(generateReactEmailStepFile(stepId, './emails/welcome')).toMatchSnapshot('relative-import');
-    expect(generateReactEmailStepFile(stepId, '../../src/emails/welcome')).toMatchSnapshot('nested-import');
-  });
+  describe('without zod', () => {
+    it('should match snapshot', () => {
+      expect(generateReactEmailStepFile(stepId, '../emails/welcome', false)).toMatchSnapshot();
+    });
 
-  it('imports render from @react-email/components and calls it', () => {
-    const result = generateReactEmailStepFile(stepId, '../emails/welcome');
-    expect(result).toContain('step.email(');
-    expect(result).toContain("'welcome-email'");
-    expect(result).toContain("from '@react-email/components'");
-    expect(result).toContain('await render(');
-  });
-
-  it('escapes single quotes in stepId and templatePath', () => {
-    const result = generateReactEmailStepFile("it's-a-step", "../emails/it's-template");
-    expect(result).toContain("it\\'s-a-step");
-    expect(result).toContain("it\\'s-template");
+    it('imports render from @react-email/components and calls it', () => {
+      const result = generateReactEmailStepFile(stepId, '../emails/welcome', false);
+      expect(result).toContain('step.email(');
+      expect(result).toContain("from '@react-email/components'");
+      expect(result).toContain('await render(');
+      expect(result).not.toContain("from 'zod'");
+      expect(result).toContain('as const');
+    });
   });
 });
 
 describe('generateEmailStepFile', () => {
-  it('should match snapshot', () => {
-    expect(generateEmailStepFile('plain-email')).toMatchSnapshot();
+  describe('with zod', () => {
+    it('should match snapshot', () => {
+      expect(generateEmailStepFile('plain-email', true)).toMatchSnapshot();
+    });
+
+    it('does not use React Email', () => {
+      const result = generateEmailStepFile('plain-email', true);
+      expect(result).toContain('step.email(');
+      expect(result).toContain("'plain-email'");
+      expect(result).not.toContain('@react-email');
+      expect(result).not.toContain('await render(');
+      expect(result).toContain("from 'zod'");
+    });
   });
 
-  it('does not use React Email', () => {
-    const result = generateEmailStepFile('plain-email');
-    expect(result).toContain('step.email(');
-    expect(result).toContain("'plain-email'");
-    expect(result).not.toContain('@react-email');
-    expect(result).not.toContain('await render(');
+  describe('without zod', () => {
+    it('should match snapshot', () => {
+      expect(generateEmailStepFile('plain-email', false)).toMatchSnapshot();
+    });
+
+    it('does not use React Email or zod', () => {
+      const result = generateEmailStepFile('plain-email', false);
+      expect(result).toContain('step.email(');
+      expect(result).not.toContain('@react-email');
+      expect(result).not.toContain("from 'zod'");
+      expect(result).toContain('as const');
+    });
   });
 });
 
 describe('generateSmsStepFile', () => {
-  it('should match snapshot', () => {
-    expect(generateSmsStepFile('send-sms')).toMatchSnapshot();
+  it('should match snapshot with zod', () => {
+    expect(generateSmsStepFile('send-sms', true)).toMatchSnapshot();
+  });
+
+  it('should match snapshot without zod', () => {
+    expect(generateSmsStepFile('send-sms', false)).toMatchSnapshot();
   });
 });
 
 describe('generatePushStepFile', () => {
-  it('should match snapshot', () => {
-    expect(generatePushStepFile('send-push')).toMatchSnapshot();
+  it('should match snapshot with zod', () => {
+    expect(generatePushStepFile('send-push', true)).toMatchSnapshot();
+  });
+
+  it('should match snapshot without zod', () => {
+    expect(generatePushStepFile('send-push', false)).toMatchSnapshot();
   });
 });
 
 describe('generateChatStepFile', () => {
-  it('should match snapshot', () => {
-    expect(generateChatStepFile('send-chat')).toMatchSnapshot();
+  it('should match snapshot with zod', () => {
+    expect(generateChatStepFile('send-chat', true)).toMatchSnapshot();
+  });
+
+  it('should match snapshot without zod', () => {
+    expect(generateChatStepFile('send-chat', false)).toMatchSnapshot();
   });
 });
 
 describe('generateInAppStepFile', () => {
-  it('should match snapshot', () => {
-    expect(generateInAppStepFile('in-app-notify')).toMatchSnapshot();
+  it('should match snapshot with zod', () => {
+    expect(generateInAppStepFile('in-app-notify', true)).toMatchSnapshot();
+  });
+
+  it('should match snapshot without zod', () => {
+    expect(generateInAppStepFile('in-app-notify', false)).toMatchSnapshot();
   });
 });
 
 describe('generateStepFileForType', () => {
   it('throws for unknown type', () => {
-    expect(() => generateStepFileForType('my-step', 'custom')).toThrow();
+    expect(() => generateStepFileForType('my-step', 'custom', false)).toThrow();
   });
 
   it('escapes single quotes in stepId', () => {
-    const result = generateStepFileForType("it's", 'sms');
+    const result = generateStepFileForType("it's", 'sms', false);
     expect(result).toContain("it\\'s");
+  });
+
+  it('uses zod when useZod is true', () => {
+    const result = generateStepFileForType('my-step', 'sms', true);
+    expect(result).toContain("from 'zod'");
+  });
+
+  it('uses json schema when useZod is false', () => {
+    const result = generateStepFileForType('my-step', 'sms', false);
+    expect(result).not.toContain("from 'zod'");
+    expect(result).toContain('as const');
   });
 });

--- a/packages/novu/src/commands/step/templates/step-file.ts
+++ b/packages/novu/src/commands/step/templates/step-file.ts
@@ -8,11 +8,47 @@ function escapeString(value: string): string {
     .replace(/\u2029/g, '\\u2029');
 }
 
-export function generateReactEmailStepFile(stepId: string, templateImportPath: string): string {
-  return `import { step } from '@novu/framework/step-resolver';
-import { render } from '@react-email/components';
-import { z } from 'zod';
-import EmailTemplate from '${escapeString(templateImportPath)}';
+type ControlFields = Record<string, { default: string }>;
+
+function zodSchema(fields: ControlFields): string {
+  const entries = Object.entries(fields)
+    .map(([key, { default: def }]) => `      ${key}: z.string().default('${escapeString(def)}')`)
+    .join(',\n');
+
+  return `z.object({\n${entries},\n    })`;
+}
+
+function jsonSchema(fields: ControlFields): string {
+  const props = Object.entries(fields)
+    .map(([key, { default: def }]) => `        ${key}: { type: 'string', default: '${escapeString(def)}' }`)
+    .join(',\n');
+
+  return `{\n      type: 'object',\n      properties: {\n${props},\n      },\n      additionalProperties: false,\n    } as const`;
+}
+
+function controlSchema(fields: ControlFields, useZod: boolean): string {
+  return useZod ? zodSchema(fields) : jsonSchema(fields);
+}
+
+function stepImports(useZod: boolean, extras: string[] = []): string {
+  const lines = ["import { step } from '@novu/framework/step-resolver';"];
+
+  if (useZod) lines.push("import { z } from 'zod';");
+
+  lines.push(...extras);
+
+  return lines.join('\n');
+}
+
+const reactEmailFields: ControlFields = {
+  subject: { default: 'You have a new notification' },
+};
+
+export function generateReactEmailStepFile(stepId: string, templateImportPath: string, useZod: boolean): string {
+  return `${stepImports(useZod, [
+    "import { render } from '@react-email/components';",
+    `import EmailTemplate from '${escapeString(templateImportPath)}';`,
+  ])}
 
 export default step.email(
   '${escapeString(stepId)}',
@@ -27,17 +63,21 @@ export default step.email(
     ),
   }),
   {
-    controlSchema: z.object({
-      subject: z.string().default('You have a new notification'),
-    }),
+    controlSchema: ${controlSchema(reactEmailFields, useZod)},
   }
 );
 `;
 }
 
-export function generateEmailStepFile(stepId: string): string {
-  return `import { step } from '@novu/framework/step-resolver';
-import { z } from 'zod';
+const emailFields: ControlFields = {
+  subject: { default: 'You have a new notification' },
+  heading: { default: 'New activity' },
+  body: { default: 'You have a new message.' },
+  ctaUrl: { default: '/' },
+};
+
+export function generateEmailStepFile(stepId: string, useZod: boolean): string {
+  return `${stepImports(useZod)}
 
 export default step.email(
   '${escapeString(stepId)}',
@@ -57,21 +97,19 @@ export default step.email(
     // from: { email: 'noreply@example.com', name: 'My App' },
   }),
   {
-    controlSchema: z.object({
-      subject: z.string().default('You have a new notification'),
-      heading: z.string().default('New activity'),
-      body: z.string().default('You have a new message.'),
-      ctaUrl: z.string().default('/'),
-    }),
+    controlSchema: ${controlSchema(emailFields, useZod)},
     // skip: (_controls, { subscriber }) => !subscriber.email,
   }
 );
 `;
 }
 
-export function generateSmsStepFile(stepId: string): string {
-  return `import { step } from '@novu/framework/step-resolver';
-import { z } from 'zod';
+const smsFields: ControlFields = {
+  message: { default: 'You have a new notification. Reply STOP to unsubscribe.' },
+};
+
+export function generateSmsStepFile(stepId: string, useZod: boolean): string {
+  return `${stepImports(useZod)}
 
 export default step.sms(
   '${escapeString(stepId)}',
@@ -79,18 +117,20 @@ export default step.sms(
     body: \`Hi \${subscriber.firstName ?? 'there'}, \${controls.message}\`,
   }),
   {
-    controlSchema: z.object({
-      message: z.string().default('You have a new notification. Reply STOP to unsubscribe.'),
-    }),
+    controlSchema: ${controlSchema(smsFields, useZod)},
     // skip: (_controls, { subscriber }) => !subscriber.phone,
   }
 );
 `;
 }
 
-export function generatePushStepFile(stepId: string): string {
-  return `import { step } from '@novu/framework/step-resolver';
-import { z } from 'zod';
+const pushFields: ControlFields = {
+  title: { default: 'New activity' },
+  body: { default: 'You have a new notification.' },
+};
+
+export function generatePushStepFile(stepId: string, useZod: boolean): string {
+  return `${stepImports(useZod)}
 
 export default step.push(
   '${escapeString(stepId)}',
@@ -99,19 +139,19 @@ export default step.push(
     body: controls.body,
   }),
   {
-    controlSchema: z.object({
-      title: z.string().default('New activity'),
-      body: z.string().default('You have a new notification.'),
-    }),
+    controlSchema: ${controlSchema(pushFields, useZod)},
     // skip: (_controls, { subscriber }) => !subscriber.channels?.push,
   }
 );
 `;
 }
 
-export function generateChatStepFile(stepId: string): string {
-  return `import { step } from '@novu/framework/step-resolver';
-import { z } from 'zod';
+const chatFields: ControlFields = {
+  message: { default: 'You have a new message.' },
+};
+
+export function generateChatStepFile(stepId: string, useZod: boolean): string {
+  return `${stepImports(useZod)}
 
 export default step.chat(
   '${escapeString(stepId)}',
@@ -119,18 +159,22 @@ export default step.chat(
     body: \`Hi \${subscriber.firstName ?? 'there'}, \${controls.message}\`,
   }),
   {
-    controlSchema: z.object({
-      message: z.string().default('You have a new message.'),
-    }),
+    controlSchema: ${controlSchema(chatFields, useZod)},
     // skip: (_controls, { subscriber }) => !subscriber.channels?.chat,
   }
 );
 `;
 }
 
-export function generateInAppStepFile(stepId: string): string {
-  return `import { step } from '@novu/framework/step-resolver';
-import { z } from 'zod';
+const inAppFields: ControlFields = {
+  subject: { default: 'New activity' },
+  body: { default: 'You have a new notification.' },
+  ctaLabel: { default: 'View details' },
+  ctaUrl: { default: '/' },
+};
+
+export function generateInAppStepFile(stepId: string, useZod: boolean): string {
+  return `${stepImports(useZod)}
 
 export default step.inApp(
   '${escapeString(stepId)}',
@@ -145,19 +189,14 @@ export default step.inApp(
     // secondaryAction: { label: 'Dismiss' },
   }),
   {
-    controlSchema: z.object({
-      subject: z.string().default('New activity'),
-      body: z.string().default('You have a new notification.'),
-      ctaLabel: z.string().default('View details'),
-      ctaUrl: z.string().default('/'),
-    }),
+    controlSchema: ${controlSchema(inAppFields, useZod)},
     // skip: (_controls, { subscriber }) => !subscriber.channels?.in_app,
   }
 );
 `;
 }
 
-const STEP_GENERATORS: Record<string, (stepId: string) => string> = {
+const STEP_GENERATORS: Record<string, (stepId: string, useZod: boolean) => string> = {
   email: generateEmailStepFile,
   sms: generateSmsStepFile,
   push: generatePushStepFile,
@@ -165,11 +204,11 @@ const STEP_GENERATORS: Record<string, (stepId: string) => string> = {
   in_app: generateInAppStepFile,
 };
 
-export function generateStepFileForType(stepId: string, stepType: string): string {
+export function generateStepFileForType(stepId: string, stepType: string, useZod: boolean): string {
   const generator = STEP_GENERATORS[stepType];
   if (!generator) {
     throw new Error(`No generator available for step type '${stepType}'.`);
   }
 
-  return generator(stepId);
+  return generator(stepId, useZod);
 }

--- a/packages/novu/src/commands/step/utils/index.ts
+++ b/packages/novu/src/commands/step/utils/index.ts
@@ -1,5 +1,11 @@
 export { isCI, isInteractive } from './environment';
 export { StepFilePathResolver } from './file-paths';
-export { detectPackageManager, getInstallCommand, installPackageSync, isPackageInstalled } from './package-manager';
+export {
+  detectPackageManager,
+  getInstallCommand,
+  hasZodV3,
+  installPackageSync,
+  isPackageInstalled,
+} from './package-manager';
 export { withSpinner } from './spinner';
 export { renderTable } from './table';

--- a/packages/novu/src/commands/step/utils/package-manager.ts
+++ b/packages/novu/src/commands/step/utils/package-manager.ts
@@ -2,6 +2,21 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 
+export function hasZodV3(rootDir: string): boolean {
+  try {
+    const zodPkgPath = path.join(rootDir, 'node_modules', 'zod', 'package.json');
+
+    if (!fs.existsSync(zodPkgPath)) return false;
+
+    const pkg = JSON.parse(fs.readFileSync(zodPkgPath, 'utf8')) as { version?: string };
+    const major = parseInt((pkg.version ?? '').split('.')[0], 10);
+
+    return major === 3;
+  } catch {
+    return false;
+  }
+}
+
 type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
 
 export function detectPackageManager(rootDir: string): PackageManager {


### PR DESCRIPTION
### What changed? Why was the change needed?

When running `novu step publish` in a project without `zod` installed, the CLI would crash with:

```
Error: Build failed with 1 error: Could not resolve "zod"
```

Two root causes:

1. **`schema-extractor.ts`** ran its own esbuild pass without `nodePaths`, so it couldn't find `zod` from the CLI's own `node_modules` (unlike the main bundler which already had `nodePaths` set up correctly)
2. **Generated step files** (`*.step.tsx`) always imported `zod`, causing TypeScript/IDE errors for users who don't have it in their project

## Changes

- **Fix `schema-extractor.ts`**: Added `nodePaths` pointing to the CLI's own `node_modules`, matching what the main bundler already does. `zod` is now resolved transparently from the CLI's installation during schema extraction
- **Conditional step file generation**: At scaffold time, detect if the user has Zod v3 installed (`node_modules/zod/package.json`). If yes, generate step files with Zod schemas. If no, generate with `as const` JSON schema — which has zero external dependencies and provides the same TypeScript inference quality via `json-schema-to-ts`
- **Extract shared `getCliNodeModulesPaths`** into `bundler/node-paths.ts` to avoid duplication between `bundler.ts` and `schema-extractor.ts`
- **Refactor `step-file.ts`**: Replace duplicated template strings with a field-based approach — each step type declares its control fields once, and `zodSchema()`/`jsonSchema()` helpers compose the correct schema block
