### PR TITLE
fix(dal): remove embedded indexes from topic subscribers schema

### DIFF
--- a/libs/dal/src/repositories/topic/topic-subscribers.schema.ts
+++ b/libs/dal/src/repositories/topic/topic-subscribers.schema.ts
@@ -7,13 +7,11 @@ const topicSubscribersSchema = new Schema<TopicSubscribersDBModel>(
     _environmentId: {
       type: Schema.Types.ObjectId,
       ref: 'Environment',
-      index: true,
       required: true,
     },
     _organizationId: {
       type: Schema.Types.ObjectId,
       ref: 'Organization',
-      index: true,
       required: true,
     },
     _subscriberId: {
@@ -30,7 +28,6 @@ const topicSubscribersSchema = new Schema<TopicSubscribersDBModel>(
     },
     topicKey: {
       type: Schema.Types.String,
-      index: true,
       required: true,
     },
     externalSubscriberId: Schema.Types.String,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Removed the inline `index: true` from three fields in the topic subscribers schema:
- `topicKey`
- `_environmentId`
- `_organizationId`

These embedded single-field indexes are redundant because the fields are already covered by the compound indexes defined at the bottom of the schema file (e.g., `{ _subscriberId, _environmentId, topicKey }` and `{ _environmentId, identifier }`). Removing them reduces unnecessary index overhead.

### Screenshots

N/A — schema-only change, no visual impact.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773832230953419?thread_ts=1773832230.953419&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-0f602f8b-c61e-5d4a-9aab-32b08fa072b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f602f8b-c61e-5d4a-9aab-32b08fa072b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

