### PR TITLE
feat(dashboard): add Hello world paragraph above WorkflowList

### DIFF
--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -316,6 +316,7 @@ export const WorkflowsPage = () => {
           {shouldShowStartWithTemplatesSection && (
             <div className="text-label-xs text-text-soft my-2">Your Workflows</div>
           )}
+          <p>Hello world!</p>
           <WorkflowList
             hasActiveFilters={!!hasActiveFilters}
             onClearFilters={clearFilters}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Added a `<p>Hello world!</p>` paragraph element above the `WorkflowList` component in `apps/dashboard/src/pages/workflows.tsx`.

### Screenshots

The "Hello world!" text is visible on the workflows page above the workflow table.


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-479d6d20-e49e-4406-a8c3-0951feb5d819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-479d6d20-e49e-4406-a8c3-0951feb5d819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

