### PR TITLE
fix(dashboard): add white background layer to inline tip overlay fixes NV-7280

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
@@ -216,7 +216,7 @@ export const WorkflowCanvas = ({
                 transition: 'border 0.3s ease-in-out, background 0.3s ease-in-out',
               }}
             />
-            <div className="absolute left-4 top-4 z-50">
+            <div className="absolute left-4 top-4 z-50 rounded-lg bg-white">
               <InlineToast
                 className="bg-warning/10 border shadow-md"
                 variant={'warning'}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR fixes an issue where the inline tip overlay text in the workflow editor was overlapping with underlying content. The "View-only" warning toast displayed in non-development environments had a semi-transparent orange background (`bg-warning/10`), which allowed workflow canvas content (dots, nodes, edges) to show through and visually collide with the toast text.

**The fix:**
- Added `rounded-lg bg-white` classes to the wrapper div around the `InlineToast` component in the workflow canvas
- This creates an opaque white background layer behind the semi-transparent orange tint
- The `rounded-lg` class ensures the white background matches the InlineToast's border radius for a clean appearance

**File changed:**
- `apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx` - Added white background layer to the read-only overlay toast wrapper

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7280](https://linear.app/novu/issue/NV-7280/inline-tip-overlay-text-overlaps-underlying-content)

<div><a href="https://cursor.com/agents/bc-3c5ea44f-1211-4931-8c4e-07e3aded4836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c5ea44f-1211-4931-8c4e-07e3aded4836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The inline tip overlay in the workflow canvas editor now includes an opaque white background layer behind the semi-transparent orange warning toast. This prevents canvas elements (nodes, dots, edges) from visually colliding with the overlay text. The fix adds `rounded-lg` and `bg-white` classes to the toast wrapper div, ensuring the toast border radius matches its new background styling.

## Affected areas

**@novu/dashboard**: Updated the workflow canvas component to apply white background and border radius styling to the view-only warning overlay toast wrapper, eliminating visual overlap issues with the underlying workflow canvas.

## Testing

No new tests are required for this change, as it is a pure styling fix with no functional or behavioral modifications to the component logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->