### PR TITLE
feat(dashboard,ee-auth): add Hello world paragraph and console.log

### DIFF
--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -316,6 +316,7 @@ export const WorkflowsPage = () => {
           {shouldShowStartWithTemplatesSection && (
             <div className="text-label-xs text-text-soft my-2">Your Workflows</div>
           )}
+          <p>Hello world!</p>
           <WorkflowList
             hasActiveFilters={!!hasActiveFilters}
             onClearFilters={clearFilters}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Two changes:
1. **Dashboard (`apps/dashboard/src/pages/workflows.tsx`)**: Added a `<p>Hello world!</p>` paragraph above the `WorkflowList` component on the Workflows page.
2. **Enterprise Auth (`.source/auth/src/better-auth/better-auth.service.ts`)**: Added `console.log('Hello world from auth!')` in the `BetterAuthService` constructor.

### Screenshots

Both changes verified:
- Dashboard: "Hello world!" text visible on the Workflows page under "Your Workflows"
- API logs: `Hello world from auth!` printed during API startup

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

Enterprise submodule branch: `cursor/dashboard-auth-service-content-bde2` on `novuhq/packages-enterprise`

### Special notes for your reviewer

The enterprise submodule pointer was updated to include the console.log change in `better-auth.service.ts`.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f66aec3-874e-4b10-b60a-c2fff3e4652e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f66aec3-874e-4b10-b60a-c2fff3e4652e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

