### PR TITLE
fix(dashboard): clear stale step control errors when field has a value fixes NV-7264

### DIFF
--- a/apps/api/src/app/step-resolvers/step-resolvers.module.ts
+++ b/apps/api/src/app/step-resolvers/step-resolvers.module.ts
@@ -1,5 +1,13 @@
 import { Module } from '@nestjs/common';
-import { DisconnectStepResolverUsecase, GetWorkflowByIdsUseCase } from '@novu/application-generic';
+import {
+  BuildStepIssuesUsecase,
+  BuildVariableSchemaUsecase,
+  CreateVariablesObject,
+  DisconnectStepResolverUsecase,
+  GetWorkflowByIdsUseCase,
+  TierRestrictionsValidateUsecase,
+} from '@novu/application-generic';
+import { CommunityOrganizationRepository } from '@novu/dal';
 import { SharedModule } from '../shared/shared.module';
 import { CloudflareStepResolverDeployService } from './services/cloudflare-step-resolver-deploy.service';
 import { StepResolversController } from './step-resolvers.controller';
@@ -12,7 +20,16 @@ const SERVICES = [CloudflareStepResolverDeployService];
 @Module({
   imports: [SharedModule],
   controllers: [StepResolversController],
-  providers: [...USE_CASES, ...SERVICES, GetWorkflowByIdsUseCase],
+  providers: [
+    ...USE_CASES,
+    ...SERVICES,
+    GetWorkflowByIdsUseCase,
+    BuildStepIssuesUsecase,
+    BuildVariableSchemaUsecase,
+    TierRestrictionsValidateUsecase,
+    CreateVariablesObject,
+    CommunityOrganizationRepository,
+  ],
   exports: [...USE_CASES],
 })
 export class StepResolversModule {}

--- a/apps/api/src/app/step-resolvers/usecases/deploy-step-resolver/deploy-step-resolver.usecase.ts
+++ b/apps/api/src/app/step-resolvers/usecases/deploy-step-resolver/deploy-step-resolver.usecase.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
 import {
+  BuildStepIssuesUsecase,
   FeatureFlagsService,
   GetWorkflowByIdsCommand,
   GetWorkflowByIdsUseCase,
@@ -8,7 +9,13 @@ import {
   PinoLogger,
   reconcileStepResolverControlValues,
 } from '@novu/application-generic';
-import { ClientSession, ControlValuesEntity, ControlValuesRepository, MessageTemplateRepository } from '@novu/dal';
+import {
+  ClientSession,
+  ControlValuesEntity,
+  ControlValuesRepository,
+  MessageTemplateRepository,
+  NotificationTemplateRepository,
+} from '@novu/dal';
 import { ControlValuesLevelEnum, FeatureFlagsKeysEnum, StepTypeEnum } from '@novu/shared';
 import { createHash } from 'crypto';
 import { DeployStepResolverResponseDto } from '../../dtos';
@@ -47,6 +54,8 @@ export class DeployStepResolverUsecase {
     private cloudflareStepResolverDeployService: CloudflareStepResolverDeployService,
     private controlValuesRepository: ControlValuesRepository,
     private messageTemplateRepository: MessageTemplateRepository,
+    private notificationTemplateRepository: NotificationTemplateRepository,
+    private buildStepIssuesUsecase: BuildStepIssuesUsecase,
     private featureFlagsService: FeatureFlagsService,
     private logger: PinoLogger
   ) {
@@ -97,6 +106,8 @@ export class DeployStepResolverUsecase {
       await this.upsertControlValues(command, resolvedManifestSteps, session);
       await this.updateStepControlSchemas(command, resolvedManifestSteps, session);
     });
+
+    await this.recalculateAndPersistStepIssues(command, resolvedManifestSteps);
 
     return {
       stepResolverHash,
@@ -251,6 +262,47 @@ export class DeployStepResolverUsecase {
         { $set: { 'controls.schema': step.controlSchema }, $unset: { 'controls.uiSchema': 1 } },
         { session }
       );
+    }
+  }
+
+  private async recalculateAndPersistStepIssues(
+    command: DeployStepResolverCommand,
+    resolvedSteps: ResolvedManifestStep[]
+  ): Promise<void> {
+    const workflowInternalIds = [...new Set(resolvedSteps.map((s) => s.workflowInternalId))];
+
+    for (const workflowInternalId of workflowInternalIds) {
+      const workflow = await this.getWorkflowByIdsUseCase.execute(
+        GetWorkflowByIdsCommand.create({
+          workflowIdOrInternalId: workflowInternalId,
+          environmentId: command.user.environmentId,
+          organizationId: command.user.organizationId,
+          userId: command.user._id,
+        })
+      );
+
+      for (const step of resolvedSteps.filter((s) => s.workflowInternalId === workflowInternalId)) {
+        const workflowStep = workflow.steps.find((s) => s._templateId === step.stepInternalId);
+        if (!workflowStep?._templateId || !workflowStep.template?.type || !workflow.origin) continue;
+
+        const issues = await this.buildStepIssuesUsecase.execute({
+          workflowOrigin: workflow.origin,
+          user: command.user,
+          stepInternalId: workflowStep._templateId,
+          workflow,
+          controlSchema: workflowStep.template.controls?.schema ?? step.controlSchema,
+          stepType: workflowStep.template.type,
+        });
+
+        await this.notificationTemplateRepository.update(
+          {
+            _id: workflowInternalId,
+            _environmentId: command.user.environmentId,
+            'steps._templateId': step.stepInternalId,
+          },
+          { $set: { 'steps.$.issues': issues } }
+        );
+      }
     }
   }
 

--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
@@ -193,26 +193,24 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
   );
 
   const setControlValuesIssues = useCallback(() => {
-    const stepIssues = flattenIssues(step.issues?.controls);
-    const currentErrors = form.formState.errors;
+    // @ts-expect-error - isNew is set by useUpdateWorkflow, see that file for details
+    if (step.isNew) {
+      form.clearErrors();
+      return;
+    }
 
-    // Clear errors that are not in stepIssues
-    Object.values(currentErrors).forEach((controlValues) => {
-      Object.keys(controlValues).forEach((key) => {
-        if (!stepIssues[`${key}`]) {
-          // @ts-expect-error - dynamic key
-          form.clearErrors(`controlValues.${key}`);
-        }
-      });
-    });
+    const issues = flattenIssues(step.issues?.controls);
+    const formValues = form.getValues() as unknown as Record<string, Record<string, unknown>>;
+    const controlValues = formValues.controlValues ?? {};
+    const formErrors = form.formState.errors as Record<string, Record<string, unknown>>;
+    const setError = form.setError as (key: string, error: { message: string }) => void;
+    const clearError = form.clearErrors as (key: string) => void;
 
-    // @ts-expect-error - isNew doesn't exist on StepResponseDto and it's too much work to override the @novu/shared types now. See useUpdateWorkflow.ts for more details
-    if (!step.isNew) {
-      // Set new errors from stepIssues
-      Object.entries(stepIssues).forEach(([key, value]) => {
-        // @ts-expect-error - dynamic key
-        form.setError(`controlValues.${key}`, { message: value });
-      });
+    for (const key of new Set([...Object.keys(formErrors.controlValues ?? {}), ...Object.keys(issues)])) {
+      const hasValue = controlValues[key] != null && controlValues[key] !== '';
+
+      if (issues[key] && !hasValue) setError(`controlValues.${key}`, { message: issues[key] });
+      else clearError(`controlValues.${key}`);
     }
   }, [form, step]);
 

--- a/apps/dashboard/src/components/workflow-editor/steps/step-editor-layout.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/step-editor-layout.tsx
@@ -1,5 +1,5 @@
-import { PermissionsEnum, StepResponseDto, WorkflowResponseDto } from '@novu/shared';
-import { useState } from 'react';
+import { ContentIssueEnum, PermissionsEnum, StepResponseDto, WorkflowResponseDto } from '@novu/shared';
+import { useMemo, useState } from 'react';
 import { RiCodeBlock, RiEdit2Line, RiEyeLine, RiGitCommitFill, RiPlayCircleLine } from 'react-icons/ri';
 import { useParams } from 'react-router-dom';
 import { IssuesPanel } from '@/components/issues-panel';
@@ -33,7 +33,8 @@ type StepEditorLayoutProps = {
 };
 
 function StepEditorContent() {
-  const { step, isSubsequentLoad, editorValue, workflow, selectedLocale, setSelectedLocale } = useStepEditor();
+  const { step, isSubsequentLoad, editorValue, workflow, selectedLocale, setSelectedLocale, controlValues } =
+    useStepEditor();
   const stepResolverHint = useStepResolverHint();
   const editorTitle = getEditorTitle(step.type);
   const { workflowSlug = '' } = useParams<{ workflowSlug: string }>();
@@ -57,6 +58,29 @@ function StepEditorContent() {
   const handleTestWorkflowClick = () => {
     setIsTestDrawerOpen(true);
   };
+
+  const filteredIssues = useMemo(() => {
+    if (!step.issues?.controls) return step.issues;
+
+    const flatValues = (controlValues ?? {}) as Record<string, unknown>;
+    const nestedValues = (flatValues.controlValues ?? {}) as Record<string, unknown>;
+
+    const filteredControls = Object.fromEntries(
+      Object.entries(step.issues.controls).filter(([key, issues]) => {
+        const val = flatValues[key] ?? nestedValues[key];
+        const hasValue = val !== undefined && val !== null && val !== '';
+
+        if (!hasValue) return true;
+
+        return !issues.every((issue) => issue.issueType === ContentIssueEnum.MISSING_VALUE);
+      })
+    );
+
+    return {
+      ...step.issues,
+      controls: Object.keys(filteredControls).length > 0 ? filteredControls : undefined,
+    };
+  }, [step.issues, controlValues]);
 
   const currentPayload = parseJsonValue(editorValue).payload;
 
@@ -143,7 +167,7 @@ function StepEditorContent() {
         </div>
 
         <IssuesPanel
-          issues={step.issues}
+          issues={filteredIssues}
           isTranslationEnabled={workflow.isTranslationEnabled}
           hintMessage={stepResolverHint}
         />

--- a/apps/dashboard/src/pages/edit-step-template-v2.tsx
+++ b/apps/dashboard/src/pages/edit-step-template-v2.tsx
@@ -59,23 +59,22 @@ export function EditStepTemplateV2Page() {
   const setIssuesFromStep = useCallback(() => {
     if (!step) return;
 
-    const stepIssues = flattenIssues(step.issues?.controls);
-    const currentErrors = form.formState.errors;
+    // @ts-expect-error - isNew is set by useUpdateWorkflow, see that file for details
+    if (step.isNew) {
+      form.clearErrors();
+      return;
+    }
 
-    // Clear errors that are not in stepIssues
-    Object.keys(currentErrors).forEach((key) => {
-      if (!stepIssues[key]) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        form.clearErrors(key as any);
-      }
-    });
+    const issues = flattenIssues(step.issues?.controls);
+    const values = form.getValues() as Record<string, unknown>;
+    const setError = form.setError as (key: string, error: { message: string }) => void;
+    const clearError = form.clearErrors as (key: string) => void;
 
-    // @ts-expect-error - isNew doesn't exist on StepResponseDto and it's too much work to override the @novu/shared types now. See useUpdateWorkflow.ts for more details
-    if (!step.isNew) {
-      Object.entries(stepIssues).forEach(([key, value]) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        form.setError(key as any, { message: value });
-      });
+    for (const key of new Set([...Object.keys(form.formState.errors), ...Object.keys(issues)])) {
+      const hasValue = values[key] != null && values[key] !== '';
+
+      if (issues[key] && !hasValue) setError(key, { message: issues[key] });
+      else clearError(key);
     }
   }, [form, step]);
 


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The PR fixes stale step control validation errors that persist even after a user provides a value for a required field. The fix clears errors when fields have values, recalculates step issues during step resolver deployment, and filters error display based on current form values to prevent displaying outdated validation messages.

## Affected areas

**api**: Expanded the step resolvers module to register `BuildStepIssuesUsecase` and `NotificationTemplateRepository`, and added a new method in `DeployStepResolverUsecase` to recalculate and persist step-level validation issues after deployment.

**dashboard**: Updated error synchronization logic across multiple form components to clear stale validation errors when fields have values, filter displayed issues based on current control values, and ensure form errors stay in sync with actual step issues.

## Key technical decisions

- Introduced `recalculateAndPersistStepIssues()` method to rebuild step validation state during deployment, ensuring persisted issues reflect the current step configuration.
- Unified error-handling approach using a single loop that synchronizes form errors with current issues and form values, replacing previous per-control error tracking logic.
- Added filtering of displayed issues in the issues panel to only show relevant validation problems based on whether control fields have values, preventing "missing value" errors from appearing for populated fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
