### PR TITLE
feat(dashboard,shared,auth): add Hello world elements and email domain classification utilities

### DIFF
--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -316,6 +316,7 @@ export const WorkflowsPage = () => {
           {shouldShowStartWithTemplatesSection && (
             <div className="text-label-xs text-text-soft my-2">Your Workflows</div>
           )}
+          <p>Hello world!</p>
           <WorkflowList
             hasActiveFilters={!!hasActiveFilters}
             onClearFilters={clearFilters}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changes

**Dashboard**
- Added `<p>Hello world!</p>` paragraph above the `WorkflowList` component in `apps/dashboard/src/pages/workflows.tsx`

**Enterprise Auth**
- Added `console.log('Hello world from auth!')` in the `BetterAuthService` constructor

**Shared - Email Domain Classification** (`packages/shared/src/utils/freeEmailDomains.ts`)
- Created `FREE_EMAIL_DOMAINS` Set containing: gmail.com, googlemail.com, yahoo.com, hotmail.com, outlook.com, live.com, icloud.com, proton.me, protonmail.com, 163.com, qq.com, mail.ru, aol.com
- Created `DISPOSABLE_EMAIL_DOMAINS` Set containing: minitts.net, azsc.us, emaildisruptor.com, skymail.ink, tutamail.com, kksk.uk, gtempaccount.com, privaterelay.appleid.com
- Added `isFreeEmail()` — checks free email providers AND disallows `.edu.` university domains
- Added `isDisposableEmail()` — detects throwaway/disposable email domains
- Added `isBusinessEmail()` — convenience helper (not free AND not disposable)
- All utilities exported from `@novu/shared`

### Enterprise Submodule

The enterprise submodule (`.source`) has been updated with a corresponding branch `cursor/dashboard-auth-service-content-cde7` in `novuhq/packages-enterprise`.

### Testing

- 12 unit tests added and passing (`vitest`) covering all domain sets, `isFreeEmail`, `isDisposableEmail`, `isBusinessEmail`, case insensitivity, and `.edu.` detection
- TypeScript compilation passes cleanly
- Biome lint passes
- Dashboard manually verified — "Hello world!" visible on Workflows page
- API logs manually verified — "Hello world from auth!" appears at startup

### Verification

![Hello world on Workflows page](https://cursor.com/artifacts/c/art-c912be9d-f09a-41ca-b84b-a522098acaee)
![API logs showing Hello world from auth](https://cursor.com/artifacts/c/art-98e0000a-9cd4-43ed-bec9-3edcd7a0741b)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cae8dee-24f5-4bc9-ba33-5eb699b6ea4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cae8dee-24f5-4bc9-ba33-5eb699b6ea4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

