### PR TITLE
feat(api-service): expose workflow step preview endpoint via external API fixes NV-7282

### DIFF
--- a/apps/api/src/app/workflows-v2/workflow.controller.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.ts
@@ -283,6 +283,7 @@ export class WorkflowController {
   }
 
   @Post('/:workflowId/step/:stepId/preview')
+  @ExternalApiAccessible()
   @ApiOperation({
     summary: 'Generate step preview',
     description: 'Generates a preview for a specific workflow step by its unique identifier **stepId**',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Added the `@ExternalApiAccessible()` decorator to the `POST /v2/workflows/:workflowId/step/:stepId/preview` endpoint in the workflow controller.

The endpoint was returning 401 when called externally with an API key because it was missing the `ExternalApiAccessible()` decorator. This decorator:
1. Sets `external_api_accessible` metadata to allow API key-based authentication (bypassing the bearer-token-only auth guard)
2. Adds `ApiSecurity` Swagger metadata for the API key security scheme

The body params (`GeneratePreviewRequestDto` and `PreviewPayloadDto`) already had proper OpenAPI decorators (`@ApiPropertyOptional`, `@ApiProperty`, `@IsOptional`, etc.), so no DTO changes were needed.

Reference: The layout preview endpoint (`POST /v2/layouts/:layoutId/preview`) already had this decorator applied correctly.

### Screenshots

N/A - backend-only change

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- All 71 generate-preview E2E tests pass with this change
- The single failing test (`Workflow Controller E2E API Testing`) is a pre-existing issue unrelated to this change

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7282](https://linear.app/novu/issue/NV-7282/expose-workflow-step-preview-endpoint-via-external-api)

<div><a href="https://cursor.com/agents/bc-31aa2b6e-950a-4402-baa9-e76e69454b26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31aa2b6e-950a-4402-baa9-e76e69454b26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Added the `@ExternalApiAccessible()` decorator to the POST `/v2/workflows/:workflowId/step/:stepId/preview` endpoint in the workflow controller. This single-line change enables the endpoint to accept API key authentication for external API consumers, resolving 401 authentication errors when the endpoint was called externally with an API key.

## Affected areas

- **api**: Added `@ExternalApiAccessible()` decorator to the generatePreview method in the workflow controller, enabling API key-based authentication for external callers while bypassing the bearer-token-only auth guard.

## Testing

All 71 existing generate-preview E2E tests pass with this change, confirming backward compatibility and correct functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->