### PR TITLE
fix(application-generic): improve LaunchDarkly client initialization and error handling

### DIFF
--- a/libs/application-generic/src/services/feature-flags/launch-darkly.service.ts
+++ b/libs/application-generic/src/services/feature-flags/launch-darkly.service.ts
@@ -1,20 +1,27 @@
 import { init, LDClient, LDMultiKindContext } from '@launchdarkly/node-server-sdk';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import type { FeatureFlagContext, FeatureFlagContextBase, IFeatureFlagsService } from './types';
+
+const LOG_CONTEXT = 'LaunchDarklyFeatureFlagsService';
+const INITIALIZATION_TIMEOUT_SECONDS = 10;
 
 @Injectable()
 export class LaunchDarklyFeatureFlagsService implements IFeatureFlagsService {
   private client: LDClient;
-  public isEnabled: boolean;
+  public isEnabled = false;
 
   public async initialize(): Promise<void> {
-    const launchDarklySdkKey = process.env.LAUNCH_DARKLY_SDK_KEY;
-    if (!launchDarklySdkKey) {
-      throw new Error('Missing Launch Darkly SDK key');
+    try {
+      this.client = init(process.env.LAUNCH_DARKLY_SDK_KEY as string);
+      await this.client.waitForInitialization({ timeout: INITIALIZATION_TIMEOUT_SECONDS });
+      this.isEnabled = true;
+    } catch (error) {
+      Logger.error(
+        `Failed to initialize LaunchDarkly client, feature flags will use default values. SDK will retry to initialize in the next tick.`,
+        (error as Error).stack || (error as Error).message,
+        LOG_CONTEXT
+      );
     }
-    this.client = init(launchDarklySdkKey);
-    await this.client.waitForInitialization({ timeout: 10000 });
-    this.isEnabled = true;
   }
 
   public async gracefullyShutdown(): Promise<void> {
@@ -32,10 +39,13 @@ export class LaunchDarklyFeatureFlagsService implements IFeatureFlagsService {
     user,
     component,
   }: FeatureFlagContext<T_Result>): Promise<T_Result> {
-    const context = this.buildLDContext({ user, organization, environment, component });
-    const newVar = await this.client.variation(key, context, defaultValue);
+    if (!this.isEnabled) {
+      return defaultValue;
+    }
 
-    return newVar;
+    const context = this.buildLDContext({ user, organization, environment, component });
+
+    return await this.client.variation(key, context, defaultValue);
   }
 
   private buildLDContext({ user, organization, environment, component }: FeatureFlagContextBase): LDMultiKindContext {


### PR DESCRIPTION
## What changed

The LaunchDarkly feature flags service was refactored to improve error resilience and initialization handling. Instead of throwing errors when the LaunchDarkly client fails to initialize, the service now logs the error and gracefully degrades by using default flag values. The initialization status is tracked via an `isEnabled` flag that starts as `false` and is only set to `true` after successful initialization, with a configurable 10-second timeout.

## Affected areas

**application-generic**: Updated the LaunchDarkly feature flags service to handle initialization failures gracefully, logging errors without throwing and allowing the system to fall back to default values when the service is unavailable.

## Key technical decisions

- Changed error handling strategy from throwing exceptions to logging errors and gracefully degrading — when LaunchDarkly fails to initialize, the service continues operation and returns default values for all flag checks instead of crashing.
- Introduced `INITIALIZATION_TIMEOUT_SECONDS` constant (10 seconds) to replace hard-coded timeout value, making the initialization timeout configurable.
- Added early exit in `getFlag()` to immediately return default values when `isEnabled` is false, avoiding unnecessary client calls.

## Testing

No new tests were mentioned in the PR. Testing should verify that the service gracefully handles missing or invalid SDK keys, that initialization failures are logged appropriately, and that flag checks return default values when the service is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
