### PR TITLE
fix(api-service): update URLs to fallback to FRONT_BASE_URL if DASHBOARD_URL is not set

### DIFF
--- a/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.usecase.ts
+++ b/apps/api/src/app/auth/usecases/password-reset-request/password-reset-request.usecase.ts
@@ -49,7 +49,7 @@ export class PasswordResetRequest {
   private static getResetRedirectLink(token: string, user: UserEntity, src?: PasswordResetFlowEnum): string {
     // ensure that only users without passwords are allowed to reset
     if (src === PasswordResetFlowEnum.USER_PROFILE && !user.password) {
-      return `${process.env.DASHBOARD_URL}/settings/profile?token=${token}&view=password`;
+      return `${process.env.DASHBOARD_URL || process.env.FRONT_BASE_URL}/settings/profile?token=${token}&view=password`;
     }
 
     /**
@@ -58,7 +58,7 @@ export class PasswordResetRequest {
      * 2. When src is explicitly FORGOT_PASSWORD
      * 3. User already has a password
      */
-    return `${process.env.DASHBOARD_URL}/auth/reset/${token}`;
+    return `${process.env.DASHBOARD_URL || process.env.FRONT_BASE_URL}/auth/reset/${token}`;
   }
 
   private isRequestBlocked(user: UserEntity) {

--- a/apps/api/src/app/invites/usecases/invite-member/invite-member.usecase.ts
+++ b/apps/api/src/app/invites/usecases/invite-member/invite-member.usecase.ts
@@ -44,7 +44,7 @@ export class InviteMember {
           inviteeName: capitalize(command.email.split('@')[0]),
           organizationName: capitalize(organization.name),
           inviterName: capitalize(inviterUser.firstName ?? ''),
-          acceptInviteUrl: `${process.env.DASHBOARD_URL}/auth/invitation/${token}`,
+          acceptInviteUrl: `${process.env.DASHBOARD_URL || process.env.FRONT_BASE_URL}/auth/invitation/${token}`,
         },
       });
     }

--- a/apps/api/src/app/invites/usecases/resend-invite/resend-invite.usecase.ts
+++ b/apps/api/src/app/invites/usecases/resend-invite/resend-invite.usecase.ts
@@ -49,7 +49,7 @@ export class ResendInvite {
           inviteeName: capitalize(foundInvitee.invite.email.split('@')[0]),
           organizationName: capitalize(organization.name),
           inviterName: capitalize(inviterUser.firstName ?? ''),
-          acceptInviteUrl: `${process.env.DASHBOARD_URL}/auth/invitation/${token}`,
+          acceptInviteUrl: `${process.env.DASHBOARD_URL || process.env.FRONT_BASE_URL}/auth/invitation/${token}`,
         },
       });
     }

--- a/apps/api/src/config/env.validators.ts
+++ b/apps/api/src/config/env.validators.ts
@@ -26,7 +26,7 @@ export const envValidators = {
   LOG_LEVEL: str({ choices: ['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'none'] }),
   PORT: port(),
   FRONT_BASE_URL: str(),
-  DASHBOARD_URL: str(),
+  DASHBOARD_URL: str({ default: '' }),
   DISABLE_USER_REGISTRATION: bool({ default: false }),
   REDIS_HOST: str(),
   REDIS_PORT: port(),

--- a/libs/application-generic/src/services/auth/shared.ts
+++ b/libs/application-generic/src/services/auth/shared.ts
@@ -1,5 +1,5 @@
 export const buildOauthRedirectUrl = (request): string => {
-  let url = `${process.env.DASHBOARD_URL}/auth/login`;
+  let url = `${process.env.DASHBOARD_URL || process.env.FRONT_BASE_URL}/auth/login`;
 
   if (!request.user || !request.user.token) {
     return `${url}?error=AuthenticationError`;


### PR DESCRIPTION

[EE-PR](https://github.com/novuhq/packages-enterprise/pull/421)

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
DASHBOARD_URL is no longer required: URL-building now falls back to FRONT_BASE_URL when DASHBOARD_URL is unset. This makes redirect links (password reset, invites, OAuth) resilient in environments that don't provide a separate DASHBOARD_URL and preserves existing behavior when it is set. The env validator was updated so DASHBOARD_URL may be empty instead of failing validation.

## Affected areas
- api: Password reset, invite send/resend, and related flows now construct redirect links using DASHBOARD_URL || FRONT_BASE_URL; env.validators updated to make DASHBOARD_URL optional (default '').
- application-generic: Shared auth helper that builds OAuth/login redirect URLs now falls back to FRONT_BASE_URL when DASHBOARD_URL is not provided.
- enterprise: This change references an enterprise PR (packages-enterprise#421) for related e2e/enterprise flows — reviewers should check enterprise integration tests and EE-specific tests.

## Key technical decisions
- Use process.env.DASHBOARD_URL || process.env.FRONT_BASE_URL for runtime URL selection to maintain backward compatibility without requiring DASHBOARD_URL.
- Change env validation for DASHBOARD_URL to str({ default: '' }) to avoid startup failures when it is unset.

## Testing
No new tests were added in this PR; verify via existing integration/e2e tests that exercise password reset, invite, and OAuth flows both with and without DASHBOARD_URL set, and ensure enterprise e2e (EE) scenarios continue to pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
