### PR TITLE
fix(application-generic): remove environmentId fallback from analytics track in get-layout

### DIFF
--- a/libs/application-generic/src/usecases/get-layout-v2/get-layout.use-case.ts
+++ b/libs/application-generic/src/usecases/get-layout-v2/get-layout.use-case.ts
@@ -28,7 +28,7 @@ export class GetLayoutUseCase {
       })
     );
 
-    this.analyticsService.track('Get layout - [Layouts]', command.userId ?? command.environmentId, {
+    this.analyticsService.track('Get layout - [Layouts]', command.userId, {
       _organizationId: command.organizationId,
       _environmentId: command.environmentId,
       layoutId: layout._id!,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the `?? command.environmentId` fallback from the `analyticsService.track` call in `GetLayoutUseCase`, so the user ID field is passed directly without falling back to the environment ID.

## Changes

- `libs/application-generic/src/usecases/get-layout-v2/get-layout.use-case.ts`: Changed `command.userId ?? command.environmentId` to `command.userId` in the analytics track call.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1773925832223579?thread_ts=1773925832.223579&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-ba97457e-0217-5a44-8490-7bf92c9e68ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba97457e-0217-5a44-8490-7bf92c9e68ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
Removed the `environmentId` fallback from the analytics tracking call in `GetLayoutUseCase`. Previously, the analytics service would fall back to using `environmentId` if `userId` was unavailable. Now it passes `userId` directly to ensure accurate user identification in analytics events.

## Affected areas
**application-generic**: Updated the analytics tracking in `GetLayoutUseCase.execute` to pass `userId` directly instead of falling back to `environmentId` as a fallback identifier.

## Testing
This one-line fix does not require new unit tests. The change corrects the analytics event metadata, and existing tests should validate that the use case continues to function correctly. Manual verification may be helpful to confirm analytics events now track the correct user identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->