### PR TITLE
feat(framework): export param types fixes NV-7261

### DIFF
--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -9,7 +9,11 @@ export type {
   InAppStepResolver,
   PushStepResolver,
   SmsStepResolver,
+  StepResolverContext,
 } from './resources/step-resolver/step';
 export { step } from './resources/step-resolver/step';
 export { providerSchemas } from './schemas';
 export { ClientOptions, SeverityLevelEnum, Workflow } from './types';
+export type { ContextResolved } from './types/context.types';
+export type { Subscriber } from './types/subscriber.types';
+export type { ExecuteInput } from './types/workflow.types';

--- a/packages/framework/src/resources/step-resolver/step.ts
+++ b/packages/framework/src/resources/step-resolver/step.ts
@@ -12,7 +12,7 @@ import type {
 import type { Subscriber } from '../../types/subscriber.types';
 import type { Awaitable } from '../../types/util.types';
 
-type StepResolverContext<TPayload extends Record<string, unknown> = Record<string, unknown>> = {
+export type StepResolverContext<TPayload extends Record<string, unknown> = Record<string, unknown>> = {
   payload: TPayload;
   subscriber: Subscriber;
   context: ContextResolved;

--- a/packages/framework/src/step-resolver.ts
+++ b/packages/framework/src/step-resolver.ts
@@ -5,8 +5,11 @@ export type {
   InAppStepResolver,
   PushStepResolver,
   SmsStepResolver,
+  StepResolverContext,
 } from './resources/step-resolver/step';
 export { step } from './resources/step-resolver/step';
 export { providerSchemas } from './schemas/providers';
 export { channelStepSchemas } from './schemas/steps/channels';
+export type { ContextResolved } from './types/context.types';
 export type { WithPassthrough } from './types/provider.types';
+export type { Subscriber } from './types/subscriber.types';


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The framework now exports four commonly-used types from its public API: `StepResolverContext`, `ContextResolved`, `Subscriber`, and `ExecuteInput`. These types are essential for developers using the framework to properly type their step resolvers and workflow implementations. The `StepResolverContext` type was marked for export at its definition point, and all four types are now re-exported from both the main entry point and the step-resolver module for easier access.

## Affected areas

**@framework**: Types are now exported from `packages/framework/src/index.ts` and `packages/framework/src/step-resolver.ts`, making them available to developers building workflows and step resolvers with the framework.

## Testing

No tests were added, as type exports do not require runtime testing — TypeScript compilation validates that the types are correctly defined and exported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
