### PR TITLE
fix(api-service): run seed script API from build folder instead of dev mode

### DIFF
--- a/scripts/seed-agent-data.mjs
+++ b/scripts/seed-agent-data.mjs
@@ -1,9 +1,11 @@
 import { spawn } from 'node:child_process';
+import { copyFileSync, existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = resolve(__dirname, '..');
+const API_DIR = resolve(ROOT_DIR, 'apps', 'api');
 
 const API_URL = process.env.API_URL || 'http://localhost:3000';
 const BETTER_AUTH_URL = `${API_URL}/v1/better-auth`;
@@ -15,6 +17,8 @@ const SEED_USER_NAME = process.env.SEED_USER_NAME || 'Agent User';
 
 const MAX_HEALTH_RETRIES = 60;
 const HEALTH_RETRY_DELAY_MS = 2000;
+const STABILITY_CHECK_DELAY_MS = 2000;
+const STABILITY_CHECK_COUNT = 3;
 
 let managedApiProcess = null;
 
@@ -28,11 +32,30 @@ async function isApiRunning() {
   }
 }
 
-function startApiServer() {
-  console.log('API is not running. Starting it temporarily for seeding...');
+function ensureDistEnvFile() {
+  const srcEnv = resolve(API_DIR, 'src', '.env');
+  const distEnv = resolve(API_DIR, 'dist', '.env');
 
-  managedApiProcess = spawn('pnpm', ['start:api:dev'], {
-    cwd: ROOT_DIR,
+  if (existsSync(srcEnv) && !existsSync(distEnv)) {
+    copyFileSync(srcEnv, distEnv);
+  }
+}
+
+function startApiServer() {
+  const distMain = resolve(API_DIR, 'dist', 'main.js');
+
+  if (!existsSync(distMain)) {
+    throw new Error(
+      `API build output not found at ${distMain}. Run "pnpm build:api" first.`
+    );
+  }
+
+  ensureDistEnvFile();
+
+  console.log('API is not running. Starting it from the build folder...');
+
+  managedApiProcess = spawn('node', ['dist/main.js'], {
+    cwd: API_DIR,
     stdio: 'ignore',
     detached: true,
   });
@@ -82,7 +105,8 @@ async function waitForApi() {
     try {
       const res = await fetch(`${API_URL}/v1/health-check`);
       if (res.ok) {
-        console.log('API is ready.');
+        console.log('API is responding. Running stability checks...');
+        await verifyApiStability();
 
         return;
       }
@@ -94,6 +118,16 @@ async function waitForApi() {
   }
 
   throw new Error(`API did not become ready within ${(MAX_HEALTH_RETRIES * HEALTH_RETRY_DELAY_MS) / 1000}s`);
+}
+
+async function verifyApiStability() {
+  for (let i = 0; i < STABILITY_CHECK_COUNT; i++) {
+    await new Promise((r) => setTimeout(r, STABILITY_CHECK_DELAY_MS));
+    if (!(await isApiRunning())) {
+      throw new Error('API became unresponsive during stability check. It may have restarted.');
+    }
+  }
+  console.log('API is stable and ready.');
 }
 
 function extractSessionToken(res) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The `seed-agent-data.mjs` script was using `pnpm start:api:dev` (which runs `nest start --watch`) to start the API server temporarily for seeding. This caused intermittent failures because the dev server triggers a double build on startup, and the API could restart mid-seeding — leading to `fetch failed` errors (specifically during the "set active organization" step).

**Changes:**
- Replaced `pnpm start:api:dev` with `node dist/main.js` to run the API directly from the pre-built output, eliminating file watching and rebuild-related restarts
- Added build output validation — the script now checks that `dist/main.js` exists and throws a clear error if the API hasn't been built yet
- Added `ensureDistEnvFile()` to copy `src/.env` to `dist/.env` when missing, since the NestJS env loader resolves `.env` relative to the dist directory
- Added stability checks — after the initial health check passes, the script performs 3 consecutive health checks over 6 seconds to confirm the API won't restart before proceeding with seeding

### Screenshots

N/A — script-only change, no visual impact.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

This was identified from a cloud agent environment setup failure where the API restarted between the first and second build triggered by `nest start --watch`, causing the seed to fail at the "set active organization" step. Running from the build folder avoids this entirely since there's no file watching or recompilation.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06DU7A7BPV/p1773993320308589?thread_ts=1773993320.308589&cid=C06DU7A7BPV)

<div><a href="https://cursor.com/agents/bc-14adeeee-bc24-54bf-bfae-c48f8e2ff7b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14adeeee-bc24-54bf-bfae-c48f8e2ff7b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

