### PR TITLE
fix(application-generic): resolve Liquid template variables in step resolver controls

### DIFF
--- a/libs/application-generic/src/usecases/execute-step-resolver/execute-step-resolver-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-step-resolver/execute-step-resolver-request.usecase.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'node:crypto';
 import { HttpException, HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
-import { ExecuteOutput, HttpQueryKeysEnum } from '@novu/framework/internal';
+import { createLiquidEngine, ExecuteOutput, HttpQueryKeysEnum, State } from '@novu/framework/internal';
 import got, { HTTPError } from 'got';
 import { InstrumentUsecase } from '../../instrumentation';
 import { PinoLogger } from '../../logging';
@@ -118,8 +118,9 @@ export class ExecuteStepResolverRequest {
       stepId
     );
     const retriesLimit = command.retriesLimit ?? DEFAULT_RETRIES_LIMIT;
-    const normalizedEvent = command.event ?? {};
-    const headers = this.buildRequestHeaders(normalizedEvent, hmacSecret);
+    const normalizedEvent = (command.event ?? {}) as Record<string, unknown>;
+    const compiledEvent = await this.compileControlValues(normalizedEvent, url, command.processError);
+    const headers = this.buildRequestHeaders(compiledEvent, hmacSecret);
 
     this.logger.debug(
       { url, stepResolverHash: command.stepResolverHash, workflowId, stepId },
@@ -129,7 +130,7 @@ export class ExecuteStepResolverRequest {
     try {
       const response = await got
         .post(url, {
-          json: normalizedEvent,
+          json: compiledEvent,
           headers,
           timeout: { request: DEFAULT_TIMEOUT },
           retry: {
@@ -188,6 +189,58 @@ export class ExecuteStepResolverRequest {
         duration,
       },
     };
+  }
+
+  private async compileControlValues(
+    event: Record<string, unknown>,
+    url: string,
+    processError?: ProcessError
+  ): Promise<Record<string, unknown>> {
+    const controls = (event.controls ?? {}) as Record<string, unknown>;
+
+    if (Object.keys(controls).length === 0) {
+      return event;
+    }
+
+    try {
+      const liquidEngine = createLiquidEngine();
+      const parsedTemplate = liquidEngine.parse(JSON.stringify(controls));
+
+      const stateArray = Array.isArray(event.state) ? (event.state as State[]) : [];
+      const stepsMap = stateArray.reduce<Record<string, Record<string, unknown>>>((acc, state) => {
+        acc[state.stepId] = state.outputs ?? {};
+
+        return acc;
+      }, {});
+
+      const renderVariables = {
+        payload: (event.payload ?? {}) as Record<string, unknown>,
+        subscriber: (event.subscriber ?? {}) as Record<string, unknown>,
+        context: (event.context ?? {}) as Record<string, unknown>,
+        steps: stepsMap,
+      };
+
+      const compiledString = await liquidEngine.render(parsedTemplate, renderVariables);
+
+      return { ...event, controls: JSON.parse(compiledString) };
+    } catch (cause) {
+      const compilationError: BridgeError = {
+        url,
+        code: 'STEP_RESOLVER_CONTROL_COMPILATION_FAILED',
+        message:
+          cause instanceof Error
+            ? `Step control compilation failed: ${cause.message}`
+            : 'Step control compilation failed: invalid template syntax in control values',
+        statusCode: HttpStatus.BAD_REQUEST,
+        cause,
+      };
+
+      if (processError) {
+        await processError(compilationError);
+      }
+
+      throw new StepResolverRequestError(compilationError);
+    }
   }
 
   private buildRequestHeaders(event: unknown, hmacSecret: string): Record<string, string> {

--- a/packages/novu/src/commands/step/discovery/step-discovery.ts
+++ b/packages/novu/src/commands/step/discovery/step-discovery.ts
@@ -138,18 +138,41 @@ function extractStepMetadata(body: unknown[]): StepMetadata {
   const metadata: StepMetadata = {};
 
   for (const node of body) {
-    if (!isAstNode(node) || node.type !== 'ExportDefaultDeclaration') continue;
+    if (!isAstNode(node)) continue;
 
-    extractFromDefaultExport(node.declaration, metadata);
+    if (node.type === 'ExportDefaultDeclaration') {
+      extractFromDefaultExport(node.declaration, body, metadata);
+    } else if (node.type === 'ExportNamedDeclaration') {
+      const specifiers = node.specifiers as AstNode[] | undefined;
+      const defaultSpec = specifiers?.find((s) => isAstNode(s.exported) && s.exported.name === 'default');
+
+      if (defaultSpec && isAstNode(defaultSpec.local)) {
+        const resolved = resolveIdentifierInitializer(defaultSpec.local.name as string, body);
+
+        if (resolved !== undefined) {
+          extractFromDefaultExport(resolved, body, metadata);
+        }
+      }
+    }
+
     if (metadata.stepId !== undefined || metadata.type !== undefined) break;
   }
 
   return metadata;
 }
 
-function extractFromDefaultExport(declaration: unknown, metadata: StepMetadata): void {
-  const unwrapped = unwrapExpression(declaration);
-  if (!unwrapped || unwrapped.type !== 'CallExpression') return;
+function extractFromDefaultExport(declaration: unknown, body: unknown[], metadata: StepMetadata): void {
+  let unwrapped = unwrapExpression(declaration);
+  if (!unwrapped) return;
+
+  if (unwrapped.type === 'Identifier') {
+    const resolved = resolveIdentifierInitializer(unwrapped.name as string, body);
+    if (resolved === undefined) return;
+    unwrapped = unwrapExpression(resolved);
+    if (!unwrapped) return;
+  }
+
+  if (unwrapped.type !== 'CallExpression') return;
 
   const callee = unwrapped.callee;
   if (!isAstNode(callee) || callee.type !== 'MemberExpression') return;
@@ -168,6 +191,38 @@ function extractFromDefaultExport(declaration: unknown, metadata: StepMetadata):
 
   metadata.stepId = firstArg.value as string;
   metadata.type = METHOD_NAME_TO_TYPE[methodName] ?? methodName;
+}
+
+function resolveIdentifierInitializer(name: string, body: unknown[]): unknown {
+  for (const node of body) {
+    if (!isAstNode(node)) continue;
+
+    if (node.type === 'VariableDeclaration') {
+      const declarations = node.declarations as AstNode[] | undefined;
+      const declarator = declarations?.find((d) => isAstNode(d) && isAstNode(d.id) && (d.id as AstNode).name === name);
+
+      if (declarator !== undefined) return (declarator as AstNode).init;
+    }
+
+    if (node.type === 'FunctionDeclaration' && isAstNode(node.id) && (node.id as AstNode).name === name) {
+      return node;
+    }
+
+    if (node.type === 'ExportNamedDeclaration' && isAstNode(node.declaration)) {
+      const decl = node.declaration as AstNode;
+
+      if (decl.type === 'VariableDeclaration') {
+        const declarations = decl.declarations as AstNode[] | undefined;
+        const declarator = declarations?.find(
+          (d) => isAstNode(d) && isAstNode(d.id) && (d.id as AstNode).name === name
+        );
+
+        if (declarator !== undefined) return (declarator as AstNode).init;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function unwrapExpression(node: unknown): AstNode | null {


### PR DESCRIPTION
## Problem

Step resolver (custom code) steps were not resolving Liquid template variables in control schema fields. Variables like `{{subscriber.email}}` or `{{payload.orderId}}` entered in the dashboard control fields were passed as raw literal strings to `step.resolve()` instead of their actual runtime values.

This affected both preview and live notification execution.

## Root Cause

For regular NOVU_CLOUD steps, the framework's `Client.compileControls()` is called on the API side — it Liquid-renders all control values against `subscriber`, `payload`, `context`, and `steps` before `step.resolve()` is invoked.

For step resolver (custom code) steps, execution bypasses the framework entirely and routes through `ExecuteStepResolverRequest` → Cloudflare dispatch worker. The generated worker code (`worker-wrapper.ts`) only validates controls against the JSON schema and never runs Liquid rendering. So `step.resolve()` received the literal string `"{{subscriber.email}}"`.

## Fix

Added `compileControlValues()` to `ExecuteStepResolverRequest` that Liquid-renders `event.controls` with `subscriber`, `payload`, `context`, and `steps` variables before dispatching — mirroring what `Client.compileControls()` does for framework steps.

Error handling is consistent with the framework: compilation failures call `processError` to log an execution detail (visible in the activity feed) and throw `StepResolverRequestError` with code `STEP_RESOLVER_CONTROL_COMPILATION_FAILED`, matching how the framework throws `StepControlCompilationFailedError`. The HMAC signature is computed over the compiled event body.

## Affected paths

Both paths are fixed since both route through `ExecuteStepResolverRequest` when `stepResolverHash` is set:
- **Preview**: `PreviewStep` → `ExecuteBridgeRequest` → `ExecuteStepResolverRequest`
- **Execution**: `ExecuteBridgeJob` → `ExecuteBridgeRequest` → `ExecuteStepResolverRequest`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Step resolver (custom code) steps were receiving raw Liquid template strings from dashboard control fields (e.g., `{{subscriber.email}}`). The fix adds Liquid template compilation for control values before sending them to the step resolver, mirroring the behavior of regular NOVU_CLOUD steps. Additionally, step discovery was improved to handle indirect default export patterns (e.g., `export { foo as default }`).

## Affected areas

**application-generic** (`libs`): Added `compileControlValues()` to `ExecuteStepResolverRequest` to Liquid-render `event.controls` with subscriber, payload, context, and steps variables. On compilation failure, the code logs an execution detail via `processError` and throws `StepResolverRequestError` with code `STEP_RESOLVER_CONTROL_COMPILATION_FAILED`. HMAC signature is computed over the compiled body.

**novu** (`packages`): Improved `extractStepMetadata` and added `resolveIdentifierInitializer` to step discovery to resolve named exports and identifier bindings before extracting metadata, handling patterns like `export { foo as default }` and `const foo = step.email(...); export default foo;`.

## Key technical decisions

- Compilation errors are treated as step resolver control compilation failures (HTTP 400) with detailed logging, maintaining consistency with other validation failures.
- Both preview and execution paths are fixed through the same `ExecuteStepResolverRequest` flow since both route through it when `stepResolverHash` is set.

## Testing

No tests were added in this PR. The fix extends existing validation paths that are covered by current integration and e2e tests for step resolver execution and preview flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->