### PR TITLE
feat(dashboard): Fix URL formatting in support drawer constants

### DIFF
--- a/apps/dashboard/src/components/header-navigation/support-drawer-constants.ts
+++ b/apps/dashboard/src/components/header-navigation/support-drawer-constants.ts
@@ -52,7 +52,7 @@ const DEFAULT_SUGGESTIONS: SuggestionItem[] = [
     icon: RiRouteFill,
     title: 'Understand Novu',
     description: 'Learn what Novu is and how it simplifies notification delivery across channels.',
-    url: docsUrl('platform/what-is-novu'),
+    url: docsUrl('/platform/what-is-novu'),
   },
   {
     icon: RiCodeLine,


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Fixed URL path formatting in the support drawer constants by adding a leading slash to the "Understand Novu" documentation link. The path passed to `docsUrl()` was changed from `platform/what-is-novu` to `/platform/what-is-novu` to ensure consistent formatting with other documentation URLs throughout the constants file.

## Affected areas

**dashboard**: Updated the default suggestion URL in support drawer constants to follow consistent URL path formatting with a leading slash.

## Testing

No tests were added or modified; this is a formatting fix that affects only the support drawer suggestion URL construction and does not require additional test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
