### PR TITLE
feat(worker): add support for environment variables compilation

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
@@ -308,6 +308,7 @@ export class ExecuteHttpRequestStep extends SendMessageType {
       context: compileContext.context ?? {},
       step: compileContext.step,
       webhook: compileContext.webhook ?? {},
+      env: compileContext.env ?? {},
     };
   }
 

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -480,7 +480,12 @@ export class SendMessage {
           );
 
           return resolveEnvironmentVariables(rawEnvVars);
-        } catch {
+        } catch (error) {
+          Logger.warn(
+            { err: error, organizationId: command.organizationId, environmentId: command.environmentId },
+            'Failed to fetch environment variables, falling back to empty object'
+          );
+
           return {};
         }
       },

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message.usecase.ts
@@ -11,14 +11,18 @@ import {
   GetSubscriberTemplatePreferenceCommand,
   IConditionsFilterResponse,
   IFilterVariables,
+  InMemoryLRUCacheService,
+  InMemoryLRUCacheStore,
   Instrument,
   InstrumentUsecase,
   NormalizeVariables,
   NormalizeVariablesCommand,
   PlatformException,
+  resolveEnvironmentVariables,
 } from '@novu/application-generic';
 import {
   ContextRepository,
+  EnvironmentVariableRepository,
   JobEntity,
   NotificationTemplateRepository,
   SubscriberRepository,
@@ -76,7 +80,9 @@ export class SendMessage {
     private analyticsService: AnalyticsService,
     private normalizeVariablesUsecase: NormalizeVariables,
     private contextRepository: ContextRepository,
-    private executeBridgeJob: ExecuteBridgeJob
+    private environmentVariableRepository: EnvironmentVariableRepository,
+    private executeBridgeJob: ExecuteBridgeJob,
+    private inMemoryLRUCacheService: InMemoryLRUCacheService
   ) {}
 
   @InstrumentUsecase()
@@ -427,7 +433,7 @@ export class SendMessage {
 
   @Instrument()
   private async buildCompileContext(command: SendMessageCommand): Promise<SendMessageChannelCommand['compileContext']> {
-    const [subscriber, actor, tenant, context] = await Promise.all([
+    const [subscriber, actor, tenant, context, envVars] = await Promise.all([
       this.getSubscriberBySubscriberId({
         subscriberId: command.subscriberId,
         _environmentId: command.environmentId,
@@ -439,6 +445,7 @@ export class SendMessage {
         }),
       this.handleTenantExecution(command.job),
       this.resolveContext(command),
+      this.getEnvironmentVariables(command),
     ]);
 
     if (!subscriber) throw new PlatformException('Subscriber not found');
@@ -454,7 +461,34 @@ export class SendMessage {
       ...(tenant && { tenant }),
       ...(actor && { actor }),
       ...(context && { context }),
+      ...(Object.keys(envVars).length > 0 && { env: envVars }),
     };
+  }
+
+  @Instrument()
+  private async getEnvironmentVariables(command: SendMessageCommand): Promise<Record<string, string>> {
+    const cacheKey = `${command.organizationId}:${command.environmentId}`;
+
+    return this.inMemoryLRUCacheService.get(
+      InMemoryLRUCacheStore.ENVIRONMENT_VARIABLES,
+      cacheKey,
+      async () => {
+        try {
+          const rawEnvVars = await this.environmentVariableRepository.findByEnvironment(
+            command.organizationId,
+            command.environmentId
+          );
+
+          return resolveEnvironmentVariables(rawEnvVars);
+        } catch {
+          return {};
+        }
+      },
+      {
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+      }
+    );
   }
 
   @Instrument()

--- a/libs/application-generic/src/services/in-memory-lru-cache/in-memory-lru-cache.store.ts
+++ b/libs/application-generic/src/services/in-memory-lru-cache/in-memory-lru-cache.store.ts
@@ -1,10 +1,16 @@
 import type { EnvironmentEntity, NotificationTemplateEntity, OrganizationEntity, PreferencesEntity } from '@novu/dal';
 import type { UserSessionData } from '@novu/shared';
 
+const MS_PER_SECOND = 1000;
+const THIRTY_SECONDS_MS = MS_PER_SECOND * 30;
+const ONE_MINUTE_MS = MS_PER_SECOND * 60;
+const ONE_HOUR_MS = ONE_MINUTE_MS * 60;
+
 export enum InMemoryLRUCacheStore {
   WORKFLOW = 'workflow',
   ORGANIZATION = 'organization',
   ENVIRONMENT = 'environment',
+  ENVIRONMENT_VARIABLES = 'environment-variables',
   API_KEY_USER = 'api-key-user',
   VALIDATOR = 'validator',
   ACTIVE_WORKFLOWS = 'active-workflows',
@@ -14,6 +20,7 @@ export enum InMemoryLRUCacheStore {
 export type WorkflowCacheData = NotificationTemplateEntity | null;
 export type OrganizationCacheData = OrganizationEntity | null;
 export type EnvironmentCacheData = Pick<EnvironmentEntity, '_id' | 'echo' | 'apiKeys'> | null;
+export type EnvironmentVariablesCacheData = Record<string, string>;
 export type ApiKeyUserCacheData = UserSessionData | null;
 export type ValidatorCacheData = unknown;
 export type ActiveWorkflowsCacheData = NotificationTemplateEntity[];
@@ -23,6 +30,7 @@ export type CacheStoreDataTypeMap = {
   [InMemoryLRUCacheStore.WORKFLOW]: WorkflowCacheData;
   [InMemoryLRUCacheStore.ORGANIZATION]: OrganizationCacheData;
   [InMemoryLRUCacheStore.ENVIRONMENT]: EnvironmentCacheData;
+  [InMemoryLRUCacheStore.ENVIRONMENT_VARIABLES]: EnvironmentVariablesCacheData;
   [InMemoryLRUCacheStore.API_KEY_USER]: ApiKeyUserCacheData;
   [InMemoryLRUCacheStore.VALIDATOR]: ValidatorCacheData;
   [InMemoryLRUCacheStore.ACTIVE_WORKFLOWS]: ActiveWorkflowsCacheData;
@@ -39,38 +47,43 @@ export type StoreConfig = {
 export const STORE_CONFIGS: Record<InMemoryLRUCacheStore, StoreConfig> = {
   [InMemoryLRUCacheStore.WORKFLOW]: {
     max: 1000,
-    ttl: 1000 * 30,
+    ttl: THIRTY_SECONDS_MS,
     featureFlagComponent: 'workflow',
   },
   [InMemoryLRUCacheStore.ORGANIZATION]: {
     max: 500,
-    ttl: 1000 * 60,
+    ttl: ONE_MINUTE_MS,
     featureFlagComponent: 'organization',
   },
   [InMemoryLRUCacheStore.ENVIRONMENT]: {
     max: 500,
-    ttl: 1000 * 60,
+    ttl: ONE_MINUTE_MS,
+    featureFlagComponent: 'environment',
+  },
+  [InMemoryLRUCacheStore.ENVIRONMENT_VARIABLES]: {
+    max: 500,
+    ttl: ONE_MINUTE_MS,
     featureFlagComponent: 'environment',
   },
   [InMemoryLRUCacheStore.API_KEY_USER]: {
     max: 1000,
-    ttl: 1000 * 60,
+    ttl: ONE_MINUTE_MS,
     featureFlagComponent: 'api-key-user',
   },
   [InMemoryLRUCacheStore.VALIDATOR]: {
     max: 5000,
-    ttl: 1000 * 60 * 60,
+    ttl: ONE_HOUR_MS,
     featureFlagComponent: 'validator',
     skipFeatureFlag: true,
   },
   [InMemoryLRUCacheStore.ACTIVE_WORKFLOWS]: {
     max: 300,
-    ttl: 1000 * 60,
+    ttl: ONE_MINUTE_MS,
     featureFlagComponent: 'active-workflows',
   },
   [InMemoryLRUCacheStore.WORKFLOW_PREFERENCES]: {
     max: 1000,
-    ttl: 1000 * 60,
+    ttl: ONE_MINUTE_MS,
     featureFlagComponent: 'workflow-preferences',
   },
 };

--- a/libs/application-generic/src/types/compile-context.ts
+++ b/libs/application-generic/src/types/compile-context.ts
@@ -9,6 +9,7 @@ export interface ICompileContext {
   webhook?: Record<string, unknown>;
   tenant?: TenantEntity;
   context?: ContextResolved;
+  env?: Record<string, string>;
   step: {
     digest: boolean;
     events: any[] | undefined;


### PR DESCRIPTION


### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The worker now fetches and injects environment variables into the message compilation context so Liquid templates can reference them (e.g., {{ env.API_KEY }}). This enables dynamic, environment-scoped configuration in compiled messages and HTTP request steps while avoiding hardcoded secrets and reducing repeated DB queries via short-lived caching.

## Affected areas

**worker** — Send-message use case now retrieves environment variables, adds them to the compile context as `env`, and passes them into HTTP request step rendering so templates can access environment-scoped values during the send flow.

**shared** — Added `ENVIRONMENT_VARIABLES` to the in-memory LRU cache with a 1-minute TTL and 500-entry limit; introduced an optional `env?: Record<string,string>` on the compile context interface; refactored cache TTLs to named constants for clarity.

## Key technical decisions

- Environment variables are cached in-memory (per organization:environment key) with a 1-minute TTL to balance freshness and DB load.  
- Cache keys scope variables by organization and environment to prevent cross-tenant leakage.  
- Failures while resolving environment variables are logged and gracefully fall back to an empty `env` object to avoid blocking message compilation.  
- Cache TTL constants (MS_PER_SECOND, THIRTY_SECONDS_MS, ONE_MINUTE_MS, ONE_HOUR_MS) were introduced for maintainability.

## Testing

No new tests were added in this change set; manual or integration tests are recommended to verify variable resolution during compilation and expected cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
