### PR TITLE
feat(dashboard): add context and override handling in activity resent fixes NV-7111

### DIFF
--- a/apps/api/src/app/activity/dtos/workflow-run-response.dto.ts
+++ b/apps/api/src/app/activity/dtos/workflow-run-response.dto.ts
@@ -108,4 +108,13 @@ export class GetWorkflowRunResponseDto extends GetWorkflowRunResponseBaseDto {
   @ApiProperty({ description: 'Trigger payload' })
   @IsObject()
   payload: Record<string, unknown>;
+
+  @ApiPropertyOptional({
+    description: 'Trigger overrides passed to the original workflow trigger',
+    type: 'object',
+    additionalProperties: true,
+  })
+  @IsOptional()
+  @IsObject()
+  overrides?: Record<string, unknown>;
 }

--- a/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
@@ -112,8 +112,11 @@ export class GetWorkflowRun {
       }
 
       const workflowRun = workflowRunResult.data;
-      const stepRuns = await this.getStepRunsForWorkflowRun(command, workflowRun);
-      const workflowRunDto = this.mapWorkflowRunToDto(workflowRun, stepRuns);
+      const [stepRuns, overrides] = await Promise.all([
+        this.getStepRunsForWorkflowRun(command, workflowRun),
+        this.getOverridesByTransactionId(workflowRun.transaction_id, command),
+      ]);
+      const workflowRunDto = this.mapWorkflowRunToDto(workflowRun, stepRuns, overrides);
 
       return workflowRunDto;
     } catch (error) {
@@ -167,6 +170,29 @@ export class GetWorkflowRun {
       );
 
       return new Map();
+    }
+  }
+
+  private async getOverridesByTransactionId(
+    transactionId: string,
+    command: GetWorkflowRunCommand
+  ): Promise<Record<string, unknown>> {
+    try {
+      const jobs: Pick<JobEntity, 'overrides'>[] = await this.jobRepository.find(
+        {
+          transactionId,
+          _environmentId: command.environmentId,
+        },
+        'overrides'
+      );
+
+      const firstWithOverrides = jobs.find((job) => job.overrides && Object.keys(job.overrides).length > 0);
+
+      return firstWithOverrides?.overrides ?? {};
+    } catch (error) {
+      this.logger.warn({ error: error.message, transactionId }, 'Failed to get job overrides data');
+
+      return {};
     }
   }
 
@@ -298,7 +324,8 @@ export class GetWorkflowRun {
 
   private mapWorkflowRunToDto(
     workflowRun: WorkflowRunFetchResult,
-    stepRuns: IStepRunWithDetails[]
+    stepRuns: IStepRunWithDetails[],
+    overrides: Record<string, unknown>
   ): GetWorkflowRunResponseDto {
     return {
       id: workflowRun.workflow_run_id,
@@ -320,6 +347,7 @@ export class GetWorkflowRun {
       critical: workflowRun.critical,
       contextKeys: workflowRun.context_keys,
       topics: workflowRun.topics ? JSON.parse(workflowRun.topics) : [],
+      overrides,
     };
   }
 }

--- a/apps/dashboard/src/api/activity.ts
+++ b/apps/dashboard/src/api/activity.ts
@@ -58,6 +58,7 @@ export interface GetWorkflowRunsDto {
 
 export type GetWorkflowRunResponse = GetWorkflowRunsDto & {
   payload: Record<string, unknown>;
+  overrides?: Record<string, unknown>;
 };
 
 export interface GetWorkflowRunsResponseDto {
@@ -67,6 +68,8 @@ export interface GetWorkflowRunsResponseDto {
 }
 
 function mapWorkflowRunToActivity(workflowRun: GetWorkflowRunResponse | GetWorkflowRunsDto): IActivity {
+  const resolvedOverrides = 'overrides' in workflowRun ? (workflowRun.overrides ?? {}) : {};
+
   return {
     _id: workflowRun.id,
     severity: workflowRun.severity,
@@ -151,7 +154,7 @@ function mapWorkflowRunToActivity(workflowRun: GetWorkflowRunResponse | GetWorkf
       _templateId: workflowRun.workflowId,
       payload: 'payload' in workflowRun ? workflowRun.payload : {},
       providerId: step.providerId,
-      overrides: {},
+      overrides: resolvedOverrides,
       transactionId: workflowRun.transactionId,
       createdAt: workflowRun.createdAt,
       updatedAt: workflowRun.updatedAt,

--- a/apps/dashboard/src/api/activity.ts
+++ b/apps/dashboard/src/api/activity.ts
@@ -68,7 +68,10 @@ export interface GetWorkflowRunsResponseDto {
 }
 
 function mapWorkflowRunToActivity(workflowRun: GetWorkflowRunResponse | GetWorkflowRunsDto): IActivity {
-  const resolvedOverrides = 'overrides' in workflowRun ? (workflowRun.overrides ?? {}) : {};
+  const resolvedOverrides = ('overrides' in workflowRun ? (workflowRun.overrides ?? {}) : {}) as Record<
+    string,
+    Record<string, unknown>
+  >;
 
   return {
     _id: workflowRun.id,

--- a/apps/dashboard/src/api/workflows.ts
+++ b/apps/dashboard/src/api/workflows.ts
@@ -100,12 +100,14 @@ export async function triggerWorkflow({
   payload,
   to,
   context,
+  overrides,
 }: {
   environment: IEnvironment;
   name: string;
   payload: unknown;
   to: unknown;
   context?: unknown;
+  overrides?: Record<string, unknown>;
 }) {
   return post<{ data: { transactionId?: string } }>(`/events/trigger`, {
     environment,
@@ -114,6 +116,7 @@ export async function triggerWorkflow({
       to,
       payload: { ...(payload ?? {}), __source: (payload as any)?.__source ?? 'dashboard' },
       context: context ?? undefined,
+      ...(overrides && Object.keys(overrides).length > 0 ? { overrides } : {}),
     },
   });
 }

--- a/apps/dashboard/src/components/activity/activity-header.tsx
+++ b/apps/dashboard/src/components/activity/activity-header.tsx
@@ -1,4 +1,4 @@
-import { IActivity, IEnvironment } from '@novu/shared';
+import { type ContextPayload, IActivity } from '@novu/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { motion } from 'motion/react';
 import { RiCloseLine, RiRouteFill } from 'react-icons/ri';
@@ -11,6 +11,27 @@ import { QueryKeys } from '@/utils/query-keys';
 import { cn } from '@/utils/ui';
 import { triggerWorkflow } from '../../api/workflows';
 import { RepeatPlay } from '../icons/repeat-play';
+
+function contextKeysToContextPayload(contextKeys: string[] | undefined): ContextPayload | undefined {
+  if (!contextKeys?.length) {
+    return undefined;
+  }
+
+  const payload: ContextPayload = {};
+
+  for (const key of contextKeys) {
+    const [type, ...idParts] = key.split(':');
+    const id = idParts.join(':');
+
+    if (!type || !id) {
+      continue;
+    }
+
+    payload[type] = id;
+  }
+
+  return Object.keys(payload).length > 0 ? payload : undefined;
+}
 
 type ActivityHeaderProps = {
   className?: string;
@@ -37,13 +58,18 @@ export const ActivityHeader = ({ className, activity, onTransactionIdChange, onC
     mutationFn: async () => {
       if (!activity) throw new Error('No activity data available');
 
+      if (!currentEnvironment) {
+        throw new Error('No environment selected');
+      }
+
       const {
         data: { transactionId: newTransactionId },
       } = await triggerWorkflow({
         name: activity.template?.triggers[0].identifier ?? '',
         to: activity.subscriber?.subscriberId,
         payload: resentPayload,
-        environment: currentEnvironment!,
+        environment: currentEnvironment,
+        context: contextKeysToContextPayload(activity.contextKeys),
       });
 
       if (!newTransactionId) {

--- a/apps/dashboard/src/components/activity/activity-header.tsx
+++ b/apps/dashboard/src/components/activity/activity-header.tsx
@@ -52,6 +52,7 @@ export const ActivityHeader = ({ className, activity, onTransactionIdChange, onC
     : {};
 
   const resentPayload = activity?.payload ? { ...activity.payload, ...resentMetadata } : resentMetadata;
+  const resentOverrides = activity?.jobs?.[0]?.overrides as Record<string, unknown> | undefined;
   const workflowExists = !!activity?.template;
 
   const { mutate: handleResend, isPending } = useMutation({
@@ -70,6 +71,7 @@ export const ActivityHeader = ({ className, activity, onTransactionIdChange, onC
         payload: resentPayload,
         environment: currentEnvironment,
         context: contextKeysToContextPayload(activity.contextKeys),
+        overrides: resentOverrides,
       });
 
       if (!newTransactionId) {


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The PR adds handling for context payload and workflow run overrides to the activity "resend" flow. When resending an activity, the system now preserves and forwards the original context and any trigger overrides from the previous workflow run so resends use the same runtime parameters and avoid losing customized behavior.

## Affected areas

- **api**: Added an optional `overrides?: Record<string, unknown>` to `GetWorkflowRunResponseDto`, fetches job-level trigger overrides by transaction ID, and includes overrides in the workflow run mapping returned to callers.
- **dashboard**: Activity mapping and types now surface `overrides` from workflow run responses; `triggerWorkflow` accepts an optional `overrides` argument and includes it conditionally in /events/trigger requests; the activity header component parses `contextKeys` into a `ContextPayload` and supplies both context and overrides when triggering a resend.

## Key technical decisions

- Overrides are retrieved from job records filtered by transaction ID and environment, and the first non-empty overrides object is used with a fallback to {} to preserve backward compatibility.
- Context keys are lazily parsed from `type:id` pairs into a ContextPayload only when resending to avoid extra processing on the main path.
- All new fields are optional and validated (object/optional), avoiding breaking changes to existing clients.

## Testing

No tests were added in this change; behavior requires manual or integration verification of resend flows to ensure context and overrides are preserved during resends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
