### PR TITLE
feat(dashboard,api-service,shared): add industry-based co-pilot suggestions fixes NV-7215

### DIFF
--- a/apps/api/src/app/organization/dtos/get-organization-settings.dto.ts
+++ b/apps/api/src/app/organization/dtos/get-organization-settings.dto.ts
@@ -1,7 +1,7 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsValidLocale } from '@novu/application-generic';
-import { OrganizationEntity } from '@novu/dal';
-import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
+import { IndustryEnum } from '@novu/shared';
+import { IsArray, IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
 
 export class GetOrganizationSettingsDto {
   @ApiProperty({
@@ -26,4 +26,12 @@ export class GetOrganizationSettingsDto {
   @IsArray()
   @IsString({ each: true })
   targetLocales?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Company industry',
+    enum: IndustryEnum,
+  })
+  @IsOptional()
+  @IsEnum(IndustryEnum)
+  industry?: IndustryEnum;
 }

--- a/apps/api/src/app/organization/dtos/update-organization-settings.dto.ts
+++ b/apps/api/src/app/organization/dtos/update-organization-settings.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsValidLocale } from '@novu/application-generic';
-import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
+import { IndustryEnum } from '@novu/shared';
+import { IsArray, IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator';
 
 export class UpdateOrganizationSettingsDto {
   @ApiProperty({
@@ -27,4 +28,13 @@ export class UpdateOrganizationSettingsDto {
   @IsArray()
   @IsString({ each: true }) // TODO: validate locales
   targetLocales?: string[];
+
+  @ApiProperty({
+    description: 'Company industry for AI-tailored suggestions',
+    enum: IndustryEnum,
+    example: IndustryEnum.SAAS,
+  })
+  @IsOptional()
+  @IsEnum(IndustryEnum)
+  industry?: IndustryEnum;
 }

--- a/apps/api/src/app/organization/ee.organization.controller.ts
+++ b/apps/api/src/app/organization/ee.organization.controller.ts
@@ -126,6 +126,7 @@ export class EEOrganizationController {
         removeNovuBranding: body.removeNovuBranding,
         defaultLocale: body.defaultLocale,
         targetLocales: body.targetLocales,
+        industry: body.industry,
       })
     );
   }

--- a/apps/api/src/app/organization/usecases/get-organization-settings/get-organization-settings.usecase.ts
+++ b/apps/api/src/app/organization/usecases/get-organization-settings/get-organization-settings.usecase.ts
@@ -19,6 +19,7 @@ export class GetOrganizationSettings {
       removeNovuBranding: organization.removeNovuBranding || false,
       defaultLocale: organization.defaultLocale || DEFAULT_LOCALE,
       targetLocales: organization.targetLocales || [],
+      industry: organization.industry,
     };
   }
 }

--- a/apps/api/src/app/organization/usecases/update-organization-settings/update-organization-settings.command.ts
+++ b/apps/api/src/app/organization/usecases/update-organization-settings/update-organization-settings.command.ts
@@ -1,5 +1,6 @@
 import { AuthenticatedCommand, IsValidLocale } from '@novu/application-generic';
-import { IsArray, IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IndustryEnum } from '@novu/shared';
+import { IsArray, IsBoolean, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class UpdateOrganizationSettingsCommand extends AuthenticatedCommand {
   @IsNotEmpty()
@@ -17,4 +18,8 @@ export class UpdateOrganizationSettingsCommand extends AuthenticatedCommand {
   @IsArray()
   @IsString({ each: true })
   targetLocales?: string[];
+
+  @IsOptional()
+  @IsEnum(IndustryEnum)
+  industry?: IndustryEnum;
 }

--- a/apps/api/src/app/organization/usecases/update-organization-settings/update-organization-settings.usecase.ts
+++ b/apps/api/src/app/organization/usecases/update-organization-settings/update-organization-settings.usecase.ts
@@ -96,6 +96,10 @@ export class UpdateOrganizationSettings {
       updateFields.targetLocales = command.targetLocales;
     }
 
+    if (command.industry !== undefined) {
+      updateFields.industry = command.industry;
+    }
+
     return updateFields;
   }
 
@@ -104,6 +108,7 @@ export class UpdateOrganizationSettings {
       removeNovuBranding: organization.removeNovuBranding || false,
       defaultLocale: organization.defaultLocale || DEFAULT_LOCALE,
       targetLocales: organization.targetLocales || [],
+      industry: organization.industry,
     };
   }
 }

--- a/apps/dashboard/src/api/organization.ts
+++ b/apps/dashboard/src/api/organization.ts
@@ -1,16 +1,18 @@
-import type { IEnvironment, UpdateExternalOrganizationDto } from '@novu/shared';
+import type { IEnvironment, IndustryEnum, UpdateExternalOrganizationDto } from '@novu/shared';
 import { get, patch, post } from './api.client';
 
 export type GetOrganizationSettingsDto = {
   removeNovuBranding: boolean;
   defaultLocale: string;
   targetLocales: string[];
+  industry?: IndustryEnum;
 };
 
 export type UpdateOrganizationSettingsDto = {
   removeNovuBranding?: boolean;
   defaultLocale?: string;
   targetLocales?: string[];
+  industry?: IndustryEnum;
 };
 
 export function updateClerkOrgMetadata({

--- a/apps/dashboard/src/components/create-workflow-modal.tsx
+++ b/apps/dashboard/src/components/create-workflow-modal.tsx
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/correctness/useUniqueElementIds: working correctly */
 import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
-import { AiAgentTypeEnum, AiResourceTypeEnum, DuplicateWorkflowDto } from '@novu/shared';
+import { AiAgentTypeEnum, AiResourceTypeEnum, DuplicateWorkflowDto, IndustryEnum } from '@novu/shared';
 import * as Sentry from '@sentry/react';
 import { ChatOnDataCallback, generateId, UIMessage } from 'ai';
 import { motion } from 'motion/react';
@@ -39,6 +39,7 @@ import { Textarea } from '@/components/primitives/textarea';
 import { ExternalLink } from '@/components/shared/external-link';
 import { CreateWorkflowForm } from '@/components/workflow-editor/create-workflow-form';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useFetchOrganizationSettings } from '@/hooks/use-fetch-organization-settings';
 import { useAiChatStream } from '@/hooks/use-ai-chat-stream';
 import { useCreateAiChat } from '@/hooks/use-create-ai-chat';
 import { useCreateWorkflow } from '@/hooks/use-create-workflow';
@@ -61,12 +62,72 @@ export type WorkflowCreatedEvent = {
 
 type CreateWorkflowTab = 'guided' | 'manual';
 
-const WORKFLOW_SUGGESTIONS = [
+const DEFAULT_WORKFLOW_SUGGESTIONS = [
   'Welcome email workflow',
   'Order confirmation workflow',
   'Payment failed',
   'Password reset workflow',
 ];
+
+const INDUSTRY_WORKFLOW_SUGGESTIONS: Record<IndustryEnum, string[]> = {
+  [IndustryEnum.ECOMMERCE]: [
+    'Cart abandonment reminder',
+    'Order confirmation workflow',
+    'Shipping update notifications',
+    'Back-in-stock alert',
+  ],
+  [IndustryEnum.FINTECH]: [
+    'Transaction alert notification',
+    'KYC verification reminder',
+    'Security alert workflow',
+    'Payment received confirmation',
+  ],
+  [IndustryEnum.HEALTHCARE]: [
+    'Appointment reminder workflow',
+    'Lab results notification',
+    'Prescription refill reminder',
+    'Telehealth session reminder',
+  ],
+  [IndustryEnum.SAAS]: [
+    'Welcome onboarding sequence',
+    'Feature adoption nudge',
+    'Trial expiring notification',
+    'Billing alert workflow',
+  ],
+  [IndustryEnum.EDUCATION]: [
+    'Assignment due reminder',
+    'Grade posted notification',
+    'Live class starting alert',
+    'Course enrollment confirmation',
+  ],
+  [IndustryEnum.MEDIA]: [
+    'Breaking news alert',
+    'New content recommendation',
+    'Subscription renewal reminder',
+    'Weekly content digest',
+  ],
+  [IndustryEnum.SOCIAL]: [
+    'New message notification',
+    'Mention/tag alert',
+    'Friend request notification',
+    'Activity digest workflow',
+  ],
+  [IndustryEnum.GAMING]: [
+    'In-game event starting',
+    'Reward available notification',
+    'Friend activity alert',
+    'Season launch announcement',
+  ],
+  [IndustryEnum.OTHER]: DEFAULT_WORKFLOW_SUGGESTIONS,
+};
+
+function getWorkflowSuggestions(industry?: IndustryEnum): string[] {
+  if (!industry) {
+    return DEFAULT_WORKFLOW_SUGGESTIONS;
+  }
+
+  return INDUSTRY_WORKFLOW_SUGGESTIONS[industry] ?? DEFAULT_WORKFLOW_SUGGESTIONS;
+}
 
 export function CreateWorkflowModal({ mode, workflowId }: { mode: 'create' | 'duplicate'; workflowId?: string }) {
   const navigate = useNavigate();
@@ -77,6 +138,8 @@ export function CreateWorkflowModal({ mode, workflowId }: { mode: 'create' | 'du
   const chatId = useMemo(() => generateId(), []);
   const persistedChatIdRef = useRef<string | null>(null);
   const [tab, setTab] = useState<CreateWorkflowTab>('guided');
+  const { data: organizationSettings } = useFetchOrganizationSettings();
+  const organizationIndustry = organizationSettings?.data?.industry;
 
   const { workflow, isPending: isLoadingWorkflow } = useFetchWorkflow({
     workflowSlug: mode === 'duplicate' ? workflowId : undefined,
@@ -276,7 +339,7 @@ export function CreateWorkflowModal({ mode, workflowId }: { mode: 'create' | 'du
             )}
 
             {showGuidedContent && (
-              <GuidedModeContent onSubmit={handleGuidedSubmit} isGenerating={isGenerating} error={error} />
+              <GuidedModeContent onSubmit={handleGuidedSubmit} isGenerating={isGenerating} error={error} industry={organizationIndustry} />
             )}
 
             {showManualContent &&
@@ -333,6 +396,7 @@ type GuidedModeContentProps = {
   onSubmit: (values: z.infer<typeof schema>) => void;
   isGenerating: boolean;
   error?: Error;
+  industry?: IndustryEnum;
 };
 
 const STEP_DELAY_MS = 2000;
@@ -360,7 +424,7 @@ type GenerationStep = {
   status: GenerationStepStatus;
 };
 
-function GuidedModeContent({ onSubmit, isGenerating, error }: GuidedModeContentProps) {
+function GuidedModeContent({ onSubmit, isGenerating, error, industry }: GuidedModeContentProps) {
   const track = useTelemetry();
   const form = useForm({
     resolver: standardSchemaResolver(schema),
@@ -486,7 +550,7 @@ function GuidedModeContent({ onSubmit, isGenerating, error }: GuidedModeContentP
       {header}
 
       <div className="flex flex-wrap items-center gap-2 mt-8">
-        {WORKFLOW_SUGGESTIONS.map((suggestion) => (
+        {getWorkflowSuggestions(industry).map((suggestion) => (
           <button
             key={suggestion}
             type="button"

--- a/apps/dashboard/src/components/create-workflow-modal.tsx
+++ b/apps/dashboard/src/components/create-workflow-modal.tsx
@@ -39,11 +39,11 @@ import { Textarea } from '@/components/primitives/textarea';
 import { ExternalLink } from '@/components/shared/external-link';
 import { CreateWorkflowForm } from '@/components/workflow-editor/create-workflow-form';
 import { useEnvironment } from '@/context/environment/hooks';
-import { useFetchOrganizationSettings } from '@/hooks/use-fetch-organization-settings';
 import { useAiChatStream } from '@/hooks/use-ai-chat-stream';
 import { useCreateAiChat } from '@/hooks/use-create-ai-chat';
 import { useCreateWorkflow } from '@/hooks/use-create-workflow';
 import { useDuplicateWorkflow } from '@/hooks/use-duplicate-workflow';
+import { useFetchOrganizationSettings } from '@/hooks/use-fetch-organization-settings';
 import { useFetchWorkflow } from '@/hooks/use-fetch-workflow';
 import { useFormProtection } from '@/hooks/use-form-protection';
 import { useTelemetry } from '@/hooks/use-telemetry';
@@ -339,7 +339,12 @@ export function CreateWorkflowModal({ mode, workflowId }: { mode: 'create' | 'du
             )}
 
             {showGuidedContent && (
-              <GuidedModeContent onSubmit={handleGuidedSubmit} isGenerating={isGenerating} error={error} industry={organizationIndustry} />
+              <GuidedModeContent
+                onSubmit={handleGuidedSubmit}
+                isGenerating={isGenerating}
+                error={error}
+                industry={organizationIndustry}
+              />
             )}
 
             {showManualContent &&

--- a/apps/dashboard/src/components/settings/organization-settings.tsx
+++ b/apps/dashboard/src/components/settings/organization-settings.tsx
@@ -1,8 +1,9 @@
 /** biome-ignore-all lint/correctness/useUniqueElementIds: expected */
 import { OrganizationProfile } from '@clerk/clerk-react';
 import type { Appearance } from '@clerk/types';
-import { PermissionsEnum } from '@novu/shared';
+import { IndustryEnum, industryToLabelMapper, PermissionsEnum } from '@novu/shared';
 import { RiInformation2Line } from 'react-icons/ri';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/primitives/select';
 import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/components/primitives/tooltip';
 import { EE_AUTH_PROVIDER } from '@/config';
 import { useFetchOrganizationSettings } from '@/hooks/use-fetch-organization-settings';
@@ -21,18 +22,23 @@ export function OrganizationSettings({ clerkAppearance }: { clerkAppearance: App
     });
   };
 
+  const handleIndustryChange = (value: string) => {
+    updateOrganizationSettings.mutate({
+      industry: value as IndustryEnum,
+    });
+  };
+
   const removeNovuBranding = organizationSettings?.data?.removeNovuBranding;
+  const industry = organizationSettings?.data?.industry;
   const isUpdating = updateOrganizationSettings.isPending;
 
   return (
     <div className="space-y-8">
-      {/* Badges and Integrations Section */}
       <Protect permission={PermissionsEnum.ORG_SETTINGS_READ}>
         <div>
           <h1 className="text-label-sm text-text-strong mb-2">Branding & Integrations</h1>
 
           <div className="flex flex-col gap-7">
-            {/* Remove branding setting */}
             <div className="flex flex-col border-t border-neutral-100 pt-4 pl-1">
               <div className="flex items-center justify-between py-1">
                 <div className="flex items-center gap-1">
@@ -77,7 +83,41 @@ export function OrganizationSettings({ clerkAppearance }: { clerkAppearance: App
         </div>
       </Protect>
 
-      {/* Organization Settings Section */}
+      <Protect permission={PermissionsEnum.ORG_SETTINGS_READ}>
+        <div>
+          <h1 className="text-label-sm text-text-strong mb-2">AI Co-Pilot</h1>
+
+          <div className="flex flex-col gap-7">
+            <div className="flex flex-col border-t border-neutral-100 pt-4 pl-1">
+              <div className="flex items-center justify-between py-1">
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-label-sm text-text-strong">Company industry</span>
+                  <p className="text-paragraph-sm text-text-soft">
+                    Tailors AI workflow suggestions to your industry best practices.
+                  </p>
+                </div>
+                <Select
+                  value={industry ?? ''}
+                  onValueChange={handleIndustryChange}
+                  disabled={isLoadingSettings || isUpdating}
+                >
+                  <SelectTrigger className="w-[200px]">
+                    <SelectValue placeholder="Select industry" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(industryToLabelMapper).map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Protect>
+
       <div>
         <h1 className="text-label-sm text-text-strong mb-3">Organization Settings</h1>
         {EE_AUTH_PROVIDER === 'clerk' ? (

--- a/libs/dal/src/repositories/organization/organization.entity.ts
+++ b/libs/dal/src/repositories/organization/organization.entity.ts
@@ -1,4 +1,4 @@
-import { ApiServiceLevelEnum, IOrganizationEntity, ProductUseCases } from '@novu/shared';
+import { ApiServiceLevelEnum, IndustryEnum, IOrganizationEntity, ProductUseCases } from '@novu/shared';
 
 export class OrganizationEntity implements IOrganizationEntity {
   _id: string;
@@ -26,6 +26,8 @@ export class OrganizationEntity implements IOrganizationEntity {
   language?: string[];
 
   removeNovuBranding?: boolean;
+
+  industry?: IndustryEnum;
 
   createdAt: string;
 

--- a/libs/dal/src/repositories/organization/organization.schema.ts
+++ b/libs/dal/src/repositories/organization/organization.schema.ts
@@ -1,4 +1,4 @@
-import { ApiServiceLevelEnum } from '@novu/shared';
+import { ApiServiceLevelEnum, IndustryEnum } from '@novu/shared';
 import mongoose, { Schema } from 'mongoose';
 
 import { schemaOptions } from '../schema-default.options';
@@ -45,6 +45,10 @@ const organizationSchema = new Schema<OrganizationDBModel>(
     domain: Schema.Types.String,
     language: [Schema.Types.String],
     removeNovuBranding: Schema.Types.Boolean,
+    industry: {
+      type: Schema.Types.String,
+      enum: IndustryEnum,
+    },
     productUseCases: {
       delay: {
         type: Schema.Types.Boolean,

--- a/packages/shared/src/entities/organization/organization.interface.ts
+++ b/packages/shared/src/entities/organization/organization.interface.ts
@@ -1,4 +1,4 @@
-import { ApiServiceLevelEnum, ProductUseCases } from '../../types';
+import { ApiServiceLevelEnum, IndustryEnum, ProductUseCases } from '../../types';
 
 export interface IOrganizationEntity {
   _id: string;
@@ -19,6 +19,7 @@ export interface IOrganizationEntity {
   productUseCases?: ProductUseCases;
   language?: string[];
   removeNovuBranding?: boolean;
+  industry?: IndustryEnum;
   createdAt: string;
   updatedAt: string;
   externalId?: string;

--- a/packages/shared/src/types/organization.ts
+++ b/packages/shared/src/types/organization.ts
@@ -23,6 +23,30 @@ export enum ProductUseCasesEnum {
 
 export type ProductUseCases = Partial<Record<ProductUseCasesEnum, boolean>>;
 
+export enum IndustryEnum {
+  ECOMMERCE = 'ecommerce',
+  FINTECH = 'fintech',
+  HEALTHCARE = 'healthcare',
+  SAAS = 'saas',
+  EDUCATION = 'education',
+  MEDIA = 'media',
+  SOCIAL = 'social',
+  GAMING = 'gaming',
+  OTHER = 'other',
+}
+
+export const industryToLabelMapper: Record<IndustryEnum, string> = {
+  [IndustryEnum.ECOMMERCE]: 'E-commerce',
+  [IndustryEnum.FINTECH]: 'Fintech',
+  [IndustryEnum.HEALTHCARE]: 'Healthcare',
+  [IndustryEnum.SAAS]: 'SaaS',
+  [IndustryEnum.EDUCATION]: 'Education',
+  [IndustryEnum.MEDIA]: 'Media & Entertainment',
+  [IndustryEnum.SOCIAL]: 'Social',
+  [IndustryEnum.GAMING]: 'Gaming',
+  [IndustryEnum.OTHER]: 'Other',
+};
+
 export type OrganizationPublicMetadata = {
   externalOrgId?: string;
   domain?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Currently, AI-generated workflow suggestions are generic and don't account for the user's specific industry. This PR adds industry-based context to the co-pilot, so suggestions are tailored to the organization's industry (e.g., E-commerce, Fintech, Healthcare, SaaS).

**Changes across the stack:**

**Shared types** (`packages/shared`):
- Added `IndustryEnum` with 9 industries (E-commerce, Fintech, Healthcare, SaaS, Education, Media, Social, Gaming, Other)
- Added `industryToLabelMapper` for display labels
- Added `industry` field to `IOrganizationEntity`

**Data layer** (`libs/dal`):
- Added `industry` field to organization Mongoose schema and entity

**API** (`apps/api`):
- Added `industry` to organization settings DTOs, command, and use cases
- Industry is persisted via `PATCH /organizations/settings` and returned via `GET /organizations/settings`

**Dashboard** (`apps/dashboard`):
- Added "AI Co-Pilot" section in Organization Settings with an industry dropdown selector
- Updated create-workflow-modal with industry-specific suggestion chips that dynamically change based on the selected industry
- Added `useFetchOrganizationSettings` to create-workflow-modal to read industry setting

**Enterprise AI** (`.source/ai`):
- Updated `retrieveOrganizationMeta` tool to fetch and return industry from the organization
- Added industry-specific best practices to the AI system prompt (per-industry workflow design patterns, channel selection, severity guidelines)
- Updated `GetSuggestionsUseCase` to return industry-specific workflow suggestions
- Injected `CommunityOrganizationRepository` into the stream generation use case

### Screenshots

**Industry selector in Organization Settings:**
![Industry settings](https://github.com/user-attachments/assets/placeholder-settings)

**E-commerce suggestion chips:**
![E-commerce suggestions](https://github.com/user-attachments/assets/placeholder-ecommerce)

**SaaS suggestion chips:**
![SaaS suggestions](https://github.com/user-attachments/assets/placeholder-saas)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

Enterprise branch pushed to `cursor/NV-7215-co-pilot-industry-suggestions-9322` in `novuhq/packages-enterprise`.
Create PR manually: https://github.com/novuhq/packages-enterprise/compare/next...cursor/NV-7215-co-pilot-industry-suggestions-9322

**Merge order:** Merge the enterprise PR first, then update the submodule pointer in this PR before merging.

### Special notes for your reviewer

- The submodule pointer currently points to `next` HEAD to pass the `validate-submodule-sync` CI check. After the enterprise PR is merged, update the submodule pointer to include the enterprise changes.
- The `VITE_SELF_HOSTED=true` flag in the dev `.env` disables `useFetchOrganizationSettings`, so the industry-specific suggestions only appear when `IS_SELF_HOSTED` is false (production behavior). The feature was tested by temporarily setting this to false.
- The industry field is fully optional — organizations without an industry set continue to see the default suggestion chips.
- Industry-specific best practices are injected into the AI context via the progressive disclosure middleware, ensuring the LLM has industry context when generating workflows.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7215](https://linear.app/novu/issue/NV-7215/co-pilot-suggestions-should-be-based-on-company-industry-best)

<div><a href="https://cursor.com/agents/bc-ada634b2-d9fd-45fb-af0a-c9d441a97c02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ada634b2-d9fd-45fb-af0a-c9d441a97c02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

