### PR TITLE
fix(shared): validate condition webhook URLs against SSRF

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
@@ -15,6 +15,7 @@ import {
   shouldIncludeBody,
   toBodyRecord,
   toHeadersRecord,
+  validateUrlSsrf,
 } from '@novu/application-generic';
 import { ControlValuesRepository, JobRepository, MessageRepository, NotificationTemplateRepository } from '@novu/dal';
 import { createLiquidEngine } from '@novu/framework/internal';
@@ -28,17 +29,10 @@ import {
 } from '@novu/shared';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
-import * as dns from 'dns';
 import { AdditionalOperation, RulesLogic } from 'json-logic-js';
-import { LRUCache } from 'lru-cache';
 
 import { SendMessageChannelCommand } from './send-message-channel.command';
 import { SendMessageResult, SendMessageStatus, SendMessageType } from './send-message-type.usecase';
-
-const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
-  max: 500,
-  ttl: 1000 * 60 * 5, // 5 minutes
-});
 
 const MAX_RAW_SIZE = 10_240;
 
@@ -380,60 +374,4 @@ function truncateRaw(obj: unknown, maxSize: number = MAX_RAW_SIZE): string {
   const suffix = '... [truncated]';
 
   return serialized.slice(0, maxSize - suffix.length) + suffix;
-}
-
-function isPrivateIp(ip: string): boolean {
-  const privateRanges = [
-    /^127\./,
-    /^10\./,
-    /^172\.(1[6-9]|2[0-9]|3[01])\./,
-    /^192\.168\./,
-    /^169\.254\./,
-    /^::1$/,
-    /^fc00:/i,
-    /^fe80:/i,
-  ];
-
-  return privateRanges.some((range) => range.test(ip));
-}
-
-async function validateUrlSsrf(url: string): Promise<string | null> {
-  let parsed: URL;
-
-  try {
-    parsed = new URL(url);
-  } catch {
-    return 'Invalid URL format.';
-  }
-
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    return `URL scheme "${parsed.protocol}" is not allowed. Only http and https are permitted.`;
-  }
-
-  const hostname = parsed.hostname.toLowerCase();
-
-  const blockedHostnames = ['localhost', 'metadata.google.internal'];
-
-  if (blockedHostnames.includes(hostname)) {
-    return `Requests to "${hostname}" are not allowed.`;
-  }
-
-  let addresses = DNS_CACHE.get(hostname);
-
-  if (!addresses) {
-    try {
-      addresses = await dns.promises.lookup(hostname, { all: true });
-      DNS_CACHE.set(hostname, addresses);
-    } catch {
-      return `Unable to resolve hostname "${hostname}".`;
-    }
-  }
-
-  for (const { address } of addresses) {
-    if (isPrivateIp(address)) {
-      return `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`;
-    }
-  }
-
-  return null;
 }

--- a/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
+++ b/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
@@ -30,7 +30,14 @@ import axios from 'axios';
 import { differenceInDays, differenceInHours, differenceInMinutes, parseISO } from 'date-fns';
 import { decryptApiKey } from '../../encryption';
 import { buildSubscriberKey, CachedResponse } from '../../services';
-import { createHash, Filter, FilterProcessingDetails, IFilterVariables, PlatformException } from '../../utils';
+import {
+  createHash,
+  Filter,
+  FilterProcessingDetails,
+  IFilterVariables,
+  PlatformException,
+  validateUrlSsrf,
+} from '../../utils';
 import { CompileTemplate } from '../compile-template';
 import { CreateExecutionDetails, CreateExecutionDetailsCommand, DetailEnum } from '../create-execution-details';
 import { ConditionsFilterCommand } from './conditions-filter.command';
@@ -255,6 +262,17 @@ export class ConditionsFilter extends Filter {
 
     if (hmac) {
       config.headers['nv-hmac-256'] = hmac;
+    }
+
+    const ssrfError = await validateUrlSsrf(child.webhookUrl);
+
+    if (ssrfError) {
+      throw new Error(
+        JSON.stringify({
+          message: ssrfError,
+          data: 'Webhook URL blocked by SSRF protection.',
+        })
+      );
     }
 
     try {

--- a/libs/application-generic/src/utils/index.ts
+++ b/libs/application-generic/src/utils/index.ts
@@ -28,6 +28,7 @@ export * from './object';
 export * from './parse-payload-schema';
 export * from './parse-step-variables';
 export * from './sanitize-control-values';
+export * from './ssrf-url-validation';
 export * from './step-resolver-control-state';
 export * from './step-type-to-control.mapper';
 export * from './subscriber';

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -1,0 +1,67 @@
+import * as dns from 'node:dns';
+import { LRUCache } from 'lru-cache';
+
+const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
+  max: 500,
+  ttl: 1000 * 60 * 5, // 5 minutes
+});
+
+function isPrivateIp(ip: string): boolean {
+  const privateRanges = [
+    /^127\./,
+    /^10\./,
+    /^172\.(1[6-9]|2[0-9]|3[01])\./,
+    /^192\.168\./,
+    /^169\.254\./,
+    /^::1$/,
+    /^fc00:/i,
+    /^fe80:/i,
+  ];
+
+  return privateRanges.some((range) => range.test(ip));
+}
+
+/**
+ * Validates that a URL is safe to fetch server-side (http/https only, no private IPs after DNS resolution).
+ * Returns an error message string if blocked, or null if allowed.
+ */
+export async function validateUrlSsrf(url: string): Promise<string | null> {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(url);
+  } catch {
+    return 'Invalid URL format.';
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return `URL scheme "${parsed.protocol}" is not allowed. Only http and https are permitted.`;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  const blockedHostnames = ['localhost', 'metadata.google.internal'];
+
+  if (blockedHostnames.includes(hostname)) {
+    return `Requests to "${hostname}" are not allowed.`;
+  }
+
+  let addresses = DNS_CACHE.get(hostname);
+
+  if (!addresses) {
+    try {
+      addresses = await dns.promises.lookup(hostname, { all: true });
+      DNS_CACHE.set(hostname, addresses);
+    } catch {
+      return `Unable to resolve hostname "${hostname}".`;
+    }
+  }
+
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) {
+      return `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`;
+    }
+  }
+
+  return null;
+}

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -8,11 +8,17 @@ const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
 
 function isPrivateIp(ip: string): boolean {
   const privateRanges = [
+    /^0\.0\.0\.0$/i,
     /^127\./,
     /^10\./,
     /^172\.(1[6-9]|2[0-9]|3[01])\./,
     /^192\.168\./,
     /^169\.254\./,
+    /^::ffff:127\./i,
+    /^::ffff:10\./i,
+    /^::ffff:172\.(1[6-9]|2[0-9]|3[01])\./i,
+    /^::ffff:192\.168\./i,
+    /^::ffff:169\.254\./i,
     /^::1$/,
     /^fc00:/i,
     /^fe80:/i,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The workflow **conditions filter** webhook path called `axios.post` to user-configured URLs without SSRF checks. This aligns that path with the HTTP Request step by validating URLs before any outbound request.

## Changes

- Added `validateUrlSsrf()` in `libs/application-generic` (`ssrf-url-validation.ts`): same behavior as before in the worker (http/https only, blocked hostnames, DNS lookup with private/reserved IP rejection, 5-minute LRU cache).
- `ConditionsFilter.getWebhookResponse` now runs `validateUrlSsrf(child.webhookUrl)` before `axios.post`. Blocked URLs throw with a JSON error payload including the validation message and `Webhook URL blocked by SSRF protection.`
- `ExecuteHttpRequestStep` imports the shared helper and removes the duplicated implementation.

## Testing

- `pnpm --filter @novu/application-generic build`
- `pnpm exec tsc -p tsconfig.json --noEmit` in `apps/worker`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1774429713011369?thread_ts=1774429713.011369&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-7b6b537b-dcfd-5ff0-8c38-70cca0807831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b6b537b-dcfd-5ff0-8c38-70cca0807831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

SSRF URL validation was centralized into a shared utility and applied to all outbound webhook/http-request paths. A new validateUrlSsrf() enforces only http/https, blocks denylisted hostnames, resolves DNS and rejects private/reserved IPs (including IPv4-mapped IPv6 and 0.0.0.0), and caches results with a 5-minute LRU to avoid repeated lookups; webhook and HTTP request codepaths now call this validator before making outbound requests to prevent SSRF.

## Affected areas

**shared (@novu/application-generic)**: Added exportable validateUrlSsrf() in utils (ssrf-url-validation.ts) that performs parsing, protocol checks, denylist checks, DNS lookup, private/reserved IP detection, and an LRU cache.

**worker (@novu/worker)**: Replaced the in-file SSRF check in the HTTP request step with the shared validateUrlSsrf() to remove duplication and ensure consistent validation.

**application-generic usecases**: The conditions filter webhook path now validates webhook URLs with validateUrlSsrf() and returns a serialized JSON error when blocked, preventing execution of axios.post for disallowed targets.

## Key technical decisions

- Centralized SSRF logic into a shared utility to ensure consistent behavior across services and reduce duplication.  
- DNS resolution results are cached (LRU, 5-minute TTL) to balance performance and freshness.  
- The validator explicitly blocks IPv4-mapped IPv6 addresses and 0.0.0.0 in addition to standard private/reserved ranges.

## Testing

Build and type-check steps were run (pnpm build for @novu/application-generic; pnpm exec tsc --noEmit in apps/worker); no new unit or e2e tests were added — manual/coverage verification of existing SSRF paths is recommended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->