### PR TITLE
fix(shared): remove Get layout analytics from GetLayoutUseCase

### DIFF
--- a/libs/application-generic/src/usecases/get-layout-v2/get-layout.use-case.spec.ts
+++ b/libs/application-generic/src/usecases/get-layout-v2/get-layout.use-case.spec.ts
@@ -2,7 +2,6 @@ import { ControlValuesRepository } from '@novu/dal';
 import { ChannelTypeEnum, ControlValuesLevelEnum, ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { AnalyticsService } from '../../services';
 import { GetLayoutUseCaseV0 } from '../get-layout-v0';
 import { LayoutVariablesSchemaUseCase } from '../layout-variables-schema';
 import { GetLayoutCommand } from './get-layout.command';
@@ -12,7 +11,6 @@ describe('GetLayoutUseCase', () => {
   let getLayoutUseCaseV1Mock: sinon.SinonStubbedInstance<GetLayoutUseCaseV0>;
   let controlValuesRepositoryMock: sinon.SinonStubbedInstance<ControlValuesRepository>;
   let layoutVariablesSchemaUseCaseMock: sinon.SinonStubbedInstance<LayoutVariablesSchemaUseCase>;
-  let analyticsServiceMock: sinon.SinonStubbedInstance<AnalyticsService>;
   let getLayoutUseCase: GetLayoutUseCase;
 
   const mockUser = {
@@ -65,13 +63,11 @@ describe('GetLayoutUseCase', () => {
     getLayoutUseCaseV1Mock = sinon.createStubInstance(GetLayoutUseCaseV0);
     controlValuesRepositoryMock = sinon.createStubInstance(ControlValuesRepository);
     layoutVariablesSchemaUseCaseMock = sinon.createStubInstance(LayoutVariablesSchemaUseCase);
-    analyticsServiceMock = sinon.createStubInstance(AnalyticsService);
 
     getLayoutUseCase = new GetLayoutUseCase(
       getLayoutUseCaseV1Mock as any,
       controlValuesRepositoryMock as any,
-      layoutVariablesSchemaUseCaseMock as any,
-      analyticsServiceMock as any
+      layoutVariablesSchemaUseCaseMock as any
     );
 
     // Default mocks
@@ -157,26 +153,6 @@ describe('GetLayoutUseCase', () => {
       const schemaCommand = layoutVariablesSchemaUseCaseMock.execute.firstCall.args[0];
       expect(schemaCommand.environmentId).to.equal('env_id');
       expect(schemaCommand.organizationId).to.equal('org_id');
-    });
-
-    it('should track analytics event', async () => {
-      const command = GetLayoutCommand.create({
-        layoutIdOrInternalId: 'layout_identifier',
-        environmentId: 'env_id',
-        organizationId: 'org_id',
-        userId: 'user_id',
-      });
-
-      await getLayoutUseCase.execute(command);
-
-      expect(analyticsServiceMock.track.calledOnce).to.be.true;
-      expect(analyticsServiceMock.track.firstCall.args[0]).to.equal('Get layout - [Layouts]');
-      expect(analyticsServiceMock.track.firstCall.args[1]).to.equal('user_id');
-      expect(analyticsServiceMock.track.firstCall.args[2]).to.deep.equal({
-        _organizationId: 'org_id',
-        _environmentId: 'env_id',
-        layoutId: 'layout_id',
-      });
     });
 
     it('should handle empty control values controls', async () => {

--- a/libs/application-generic/src/usecases/get-layout-v2/get-layout.use-case.ts
+++ b/libs/application-generic/src/usecases/get-layout-v2/get-layout.use-case.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { ControlValuesRepository } from '@novu/dal';
 import { ControlValuesLevelEnum, ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
 import { LayoutResponseDto } from '../../dtos/layout/layout-response.dto';
-import { AnalyticsService } from '../../services';
 import { GetLayoutCommandV0, GetLayoutUseCaseV0 } from '../get-layout-v0';
 import { LayoutVariablesSchemaCommand, LayoutVariablesSchemaUseCase } from '../layout-variables-schema';
 import { GetLayoutCommand } from './get-layout.command';
@@ -13,8 +12,7 @@ export class GetLayoutUseCase {
   constructor(
     private getLayoutUseCaseV1: GetLayoutUseCaseV0,
     private controlValuesRepository: ControlValuesRepository,
-    private layoutVariablesSchemaUseCase: LayoutVariablesSchemaUseCase,
-    private analyticsService: AnalyticsService
+    private layoutVariablesSchemaUseCase: LayoutVariablesSchemaUseCase
   ) {}
 
   async execute(command: GetLayoutCommand): Promise<LayoutResponseDto> {
@@ -27,12 +25,6 @@ export class GetLayoutUseCase {
         origin: ResourceOriginEnum.NOVU_CLOUD,
       })
     );
-
-    this.analyticsService.track('Get layout - [Layouts]', command.userId, {
-      _organizationId: command.organizationId,
-      _environmentId: command.environmentId,
-      layoutId: layout._id!,
-    });
 
     if (command.skipAdditionalFields) {
       return mapLayoutToResponseDto({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the Segment/analytics `track` call for `Get layout - [Layouts]` from `GetLayoutUseCase` in `@novu/application-generic`.

## Changes

- Deleted `this.analyticsService.track(...)` and dropped `AnalyticsService` from the use case constructor (Nest DI no longer injects it for this class).
- Removed the unit test that asserted the analytics event.

## Verification

- `nx run @novu/application-generic:build` succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1774430686725689?thread_ts=1774430686.725689&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-e19037e6-7f0b-574e-8e83-08e81625eff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e19037e6-7f0b-574e-8e83-08e81625eff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR removes analytics tracking from `GetLayoutUseCase` in the shared library. The `AnalyticsService` dependency and its call to emit a "Get layout - [Layouts]" event were deleted, along with the associated test assertion. This simplifies the use case by removing the analytics reporting of layout retrieval operations.

## Affected areas

**shared** (`@novu/application-generic`): Removed `AnalyticsService` import, constructor dependency injection, and the `track()` call that emitted analytics events after layout retrieval. Updated tests to remove the `analyticsServiceMock` and the test case verifying event emission. The remaining test coverage continues to validate layout retrieval, control value handling, and error propagation from dependencies.

## Testing

The unit test that asserted the analytics event was called is removed as part of this change. The remaining tests continue to verify layout retrieval functionality, control values handling, layout variables schema invocation, and error propagation from the underlying use cases and repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->