### PR TITLE
fix(dashboard): add ProtectedAuthRoute for organization signup and invitation acceptance

### DIFF
--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -65,7 +65,7 @@ import { TopicsPage } from './pages/topics';
 import { UpsertVariablePage } from './pages/upsert-variable';
 import { VariablesPage } from './pages/variables';
 import { VercelIntegrationPage } from './pages/vercel-integration-page';
-import { AuthRoute, CatchAllRoute, DashboardRoute, RootRoute } from './routes';
+import { AuthRoute, CatchAllRoute, DashboardRoute, ProtectedAuthRoute, RootRoute } from './routes';
 import { OnboardingParentRoute } from './routes/onboarding';
 import { ProtectedRoute } from './routes/protected-route';
 import { ROUTES } from './utils/routes';
@@ -96,14 +96,6 @@ const router = createBrowserRouter([
             element: <SignUpPage />,
           },
           {
-            path: ROUTES.SIGNUP_ORGANIZATION_LIST,
-            element: <OrganizationListPage />,
-          },
-          {
-            path: ROUTES.INVITATION_ACCEPT,
-            element: <InvitationAcceptPage />,
-          },
-          {
             path: ROUTES.FORGOT_PASSWORD,
             element: <ForgotPasswordPage />,
           },
@@ -118,6 +110,19 @@ const router = createBrowserRouter([
           {
             path: ROUTES.VERIFY_EMAIL,
             element: <VerifyEmailPage />,
+          },
+        ],
+      },
+      {
+        element: <ProtectedAuthRoute />,
+        children: [
+          {
+            path: ROUTES.SIGNUP_ORGANIZATION_LIST,
+            element: <OrganizationListPage />,
+          },
+          {
+            path: ROUTES.INVITATION_ACCEPT,
+            element: <InvitationAcceptPage />,
           },
         ],
       },

--- a/apps/dashboard/src/routes/auth.tsx
+++ b/apps/dashboard/src/routes/auth.tsx
@@ -1,3 +1,4 @@
+import { RedirectToSignIn, SignedIn, SignedOut } from '@clerk/clerk-react';
 import { Outlet } from 'react-router-dom';
 import { AuthLayout } from '@/components/auth-layout';
 
@@ -6,5 +7,20 @@ export const AuthRoute = () => {
     <AuthLayout>
       <Outlet />
     </AuthLayout>
+  );
+};
+
+export const ProtectedAuthRoute = () => {
+  return (
+    <>
+      <SignedIn>
+        <AuthLayout>
+          <Outlet />
+        </AuthLayout>
+      </SignedIn>
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+    </>
   );
 };


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added a new `ProtectedAuthRoute` component that enforces Clerk authentication checks for organization signup and invitation acceptance flows. These routes were previously under the generic `AuthRoute` wrapper, which did not verify user authentication state. The two routes (`/auth/organization-list` and `/auth/invitation/accept`) have been moved into their own route segment with the new `ProtectedAuthRoute`, ensuring users must be signed in to access them.

## Affected areas

**dashboard**: Created a new `ProtectedAuthRoute` export in `routes/auth.tsx` that wraps routes in Clerk's `SignedIn`/`SignedOut` components, redirecting unauthenticated users to sign-in. Updated the router configuration in `main.tsx` to use this new route wrapper for the organization list and invitation acceptance paths instead of the basic `AuthRoute`.

## Key technical decisions

- **Authentication enforcement**: `ProtectedAuthRoute` uses Clerk's declarative `SignedIn`/`SignedOut` components rather than imperative guards, ensuring consistent authentication behavior across the auth UI layer.
- **Route isolation**: The two protected routes are now in a separate top-level route segment, clearly distinguishing them from unauthenticated auth flows (sign-in, sign-up, password reset, etc.).

## Testing

No new tests are mentioned. Testing for this change would involve verifying that unauthenticated users are redirected to the sign-in flow when attempting to access the organization list or invitation acceptance URLs, and that authenticated users can access these routes normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

