### PR TITLE
fix(worker): add HTTP_REQUEST to shouldSkipScheduleCheck fixes NV-7296

### DIFF
--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -862,12 +862,13 @@ export class RunJob {
 
   private shouldSkipScheduleCheck(job: JobEntity, critical: boolean | undefined): boolean {
     // always deliver in-app messages or critical messages
-    // let trigger,digest and delay finish their execution
+    // let trigger, digest, delay and http-request finish their execution
     if (
       job.type === StepTypeEnum.TRIGGER ||
       job.type === StepTypeEnum.IN_APP ||
       job.type === StepTypeEnum.DELAY ||
       job.type === StepTypeEnum.DIGEST ||
+      job.type === StepTypeEnum.HTTP_REQUEST ||
       critical
     ) {
       return true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Added `StepTypeEnum.HTTP_REQUEST` to the `shouldSkipScheduleCheck` method in `RunJob` use-case, so that HTTP request steps bypass the subscriber schedule check — just like trigger, delay, and digest steps already do.

## Why

HTTP request is an action step (not a notification delivery step). When a subscriber's schedule restricts delivery, action steps like delay, digest, and trigger should still execute. Without this fix, HTTP request steps were being incorrectly skipped when the current time fell outside the subscriber's schedule window, which then caused downstream steps (like In-App) to still execute — since they independently bypass the schedule — resulting in inconsistent behavior.

## Breaking changes

None.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7296](https://linear.app/novu/issue/NV-7296/subscriber-schedule-only-affects-the-http-step-but-not-in-app-after)

<div><a href="https://cursor.com/agents/bc-8c756078-3c76-412a-9ae7-76cf7d37ea76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c756078-3c76-412a-9ae7-76cf7d37ea76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The PR adds `StepTypeEnum.HTTP_REQUEST` to the `shouldSkipScheduleCheck` method in the RunJob use-case, allowing HTTP request steps to bypass subscriber schedule checks. Previously, HTTP request steps were incorrectly skipped during restricted schedule windows, causing downstream steps (like In-App) to execute inconsistently since they have their own schedule bypass logic.

## Affected areas
- **worker**: Updated `shouldSkipScheduleCheck` in the RunJob use-case to include HTTP_REQUEST in the list of step types that bypass subscriber schedule checks, treating it the same as trigger, delay, and digest steps.

## Testing
No test changes mentioned in the PR. The fix is a single conditional logic update that aligns HTTP request behavior with other existing action steps already bypassing schedule checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->