### PR TITLE
fix(dashboard): allow deleting schema properties with empty names fixes NV-7297

### DIFF
--- a/apps/dashboard/src/components/schema-editor/components/property-actions.tsx
+++ b/apps/dashboard/src/components/schema-editor/components/property-actions.tsx
@@ -14,6 +14,7 @@ type PropertyActionsProps = {
   isNullablePath: string;
   onDeleteProperty: () => void;
   isDisabled?: boolean;
+  isDeleteDisabled?: boolean;
   variableUsageInfo?: VariableUsageInfo;
 };
 
@@ -24,6 +25,7 @@ export function PropertyActions({
   isNullablePath,
   onDeleteProperty,
   isDisabled = false,
+  isDeleteDisabled = false,
   variableUsageInfo,
 }: PropertyActionsProps) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -58,10 +60,10 @@ export function PropertyActions({
         mode="ghost"
         size="2xs"
         leadingIcon={RiDeleteBin2Line}
-        onClick={isDisabled ? undefined : onDeleteProperty}
+        onClick={isDeleteDisabled ? undefined : onDeleteProperty}
         aria-label="Delete property"
         className={cn('border ml-0! h-7 w-7 border-neutral-200')}
-        disabled={isDisabled}
+        disabled={isDeleteDisabled}
       />
     </>
   );

--- a/apps/dashboard/src/components/schema-editor/schema-property-row.tsx
+++ b/apps/dashboard/src/components/schema-editor/schema-property-row.tsx
@@ -124,6 +124,7 @@ export const SchemaPropertyRow = memo<SchemaPropertyRowProps>(function SchemaPro
           isNullablePath={paths.isNullable}
           onDeleteProperty={onDeleteProperty}
           isDisabled={isKeyNameEmpty || readOnly}
+          isDeleteDisabled={readOnly}
           variableUsageInfo={variableUsageInfo}
         />
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

The delete (trash) button on schema property rows in the Response Body Schema editor (and Payload Schema editor) was disabled when the property name was empty. This meant users could not remove a row they had just added by clicking "+ Add property" without first typing a name.

## Why

When a user accidentally adds an extra property row—or simply wants to remove a freshly-added row—they expect the delete button to work immediately. Blocking deletion until a name is entered creates a dead-end UX.

## How

Separated the "disabled" concern in `PropertyActions` into two props:
- `isDisabled` — controls the settings (gear) button; remains `true` when the key name is empty (no settings to configure without a name)
- `isDeleteDisabled` — controls the delete (trash) button; only `true` when `readOnly` is set, so users can always delete rows regardless of whether a name has been entered

### Files changed

| File | Change |
|------|--------|
| `apps/dashboard/src/components/schema-editor/components/property-actions.tsx` | Added `isDeleteDisabled` prop; trash button now uses it instead of `isDisabled` |
| `apps/dashboard/src/components/schema-editor/schema-property-row.tsx` | Passes `isDeleteDisabled={readOnly}` to `PropertyActions` |

This fix applies to both the HTTP Request step's Response Body Schema and the workflow Payload Schema, since they share the same `SchemaEditor` → `SchemaPropertyRow` → `PropertyActions` component stack.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7297](https://linear.app/novu/issue/NV-7297/not-able-to-delete-extra-property-from-response-body)

<div><a href="https://cursor.com/agents/bc-6cf606cf-8a06-4fd6-babd-5e349e516c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cf606cf-8a06-4fd6-babd-5e349e516c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The delete button in schema property rows was previously disabled when the property name was empty, preventing users from removing newly-added rows without first entering a name. The fix separates the disabled behavior: the settings button remains disabled until a name is provided, but the delete button can now be used to remove a row immediately after creation. Deletion is only prevented in read-only mode.

## Affected areas

**dashboard**: Schema editor components were updated to decouple the delete button's disabled state from the settings button. The `PropertyActions` component now accepts an `isDeleteDisabled` prop, controlled independently of the settings button's `isDisabled` state. This change applies to both the Response Body Schema editor (HTTP Request step) and the workflow Payload Schema editor, which share the same underlying `SchemaEditor` → `SchemaPropertyRow` → `PropertyActions` component stack.

## Testing

No new tests are mentioned in the PR. Manual verification in the schema editors would confirm the delete button is now clickable on empty-named properties while respecting read-only mode restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->