### PR TITLE
fix(root): remove enterprise/ and packages/providers/ from cursorignore

### DIFF
--- a/.copilotignore
+++ b/.copilotignore
@@ -24,9 +24,5 @@ pnpm-lock.yaml
 **/dist/
 **/*.min.js
 
-# Ask-first zones — read only when explicitly working on them
-enterprise/
-packages/providers/
-
 # Generator templates — not production code
 libs/automation/

--- a/.cursorignore
+++ b/.cursorignore
@@ -25,9 +25,5 @@ pnpm-lock.yaml
 **/dist/
 **/*.min.js
 
-# Ask-first zones — read only when explicitly working on them
-enterprise/
-packages/providers/
-
 # Generator templates — not production code
 libs/automation/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Removed the "Ask-first zones" block from both `.cursorignore` and `.copilotignore`. This block was preventing `enterprise/` and `packages/providers/` from being indexed, which meant developers could not tag or reference those files in their IDE context (e.g. Cmd+I).

## Why

After the updated `agent.md` and cursor rules were merged in #10369, developers reported they could no longer add enterprise files to their agent context. The `.cursorignore` entries were blocking indexing of `enterprise/` and `packages/providers/`, making it impossible to work fully with all packages.

## Files changed

- `.cursorignore` — removed `enterprise/` and `packages/providers/` entries
- `.copilotignore` — removed matching entries to stay in sync
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06DU7A7BPV/p1774358342953439?thread_ts=1774358342.953439&cid=C06DU7A7BPV)

<div><a href="https://cursor.com/agents/bc-14fc5e89-dcc5-5e69-a2a5-4ec46582be69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14fc5e89-dcc5-5e69-a2a5-4ec46582be69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Removed `enterprise/` and `packages/providers/` directory exclusions from `.cursorignore` and `.copilotignore`. These directories are now indexable in IDE agent context, allowing developers to reference and include enterprise and provider code when using IDE features like Cursor's Cmd+I context menu.

## Why

After updates to agent rules in #10369, developers reported being unable to add enterprise files to their Cursor agent context. The ignore entries were preventing IDE indexing of these directories, blocking manual context inclusion during development.

## Affected areas

**Configuration:** `.cursorignore` and `.copilotignore` updated to re-enable IDE context indexing for `enterprise/` and `packages/providers/` directories, bringing them back into the developer's available context for agent-assisted development.

## Testing

No tests required—this is a configuration change that restores IDE agent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->