### PR TITLE
fix(dashboard): update dead docs links for custom code (step resolver) feature fixes NV-7251

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/shared/step-editor-mode-toggle.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/step-editor-mode-toggle.tsx
@@ -194,7 +194,7 @@ export function StepEditorModeToggle() {
                   <span className="text-paragraph-xs text-text-soft">You can switch back anytime</span>
                 </div>
                 <a
-                  href="https://docs.novu.co/framework/overview"
+                  href="https://docs.novu.co/platform/workflow/add-and-configure-steps/code-steps"
                   target="_blank"
                   rel="noreferrer"
                   className="flex items-center gap-0.5 text-label-xs text-text-strong hover:underline"

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/step-editor-mode-toggle.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/step-editor-mode-toggle.tsx
@@ -196,7 +196,7 @@ export function StepEditorModeToggle() {
                 <a
                   href="https://docs.novu.co/platform/workflow/add-and-configure-steps/code-steps"
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="flex items-center gap-0.5 text-label-xs text-text-strong hover:underline"
                 >
                   Learn more

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/step-resolver-not-published.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/step-resolver-not-published.tsx
@@ -365,7 +365,7 @@ export const StepResolverNotPublished = ({ workflowId, stepId }: StepResolverNot
                 <div className="w-fit">
                   <ExternalLink
                     variant="documentation"
-                    href="https://docs.novu.co/platform/concepts/step-resolvers"
+                    href="https://docs.novu.co/platform/workflow/add-and-configure-steps/code-steps"
                     underline={false}
                     className="cursor-pointer"
                   >

--- a/apps/dashboard/src/components/workflow-editor/steps/shared/use-step-resolver-hint.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/shared/use-step-resolver-hint.tsx
@@ -3,7 +3,7 @@ import { ExternalLink } from '@/components/shared/external-link';
 import { useStepEditor } from '@/components/workflow-editor/steps/context/step-editor-context';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 
-const STEP_RESOLVER_DOCS_LINK = 'https://docs.novu.co/framework/content/step-resolvers';
+const STEP_RESOLVER_DOCS_LINK = 'https://docs.novu.co/platform/workflow/add-and-configure-steps/code-steps';
 
 export function useStepResolverHint(): React.ReactNode {
   const { step } = useStepEditor();


### PR DESCRIPTION
## Summary

- Replaced 3 non-existent/dead documentation URLs for the step resolver (Custom Code) feature with the correct docs page
- Updated links in `use-step-resolver-hint.tsx`, `step-resolver-not-published.tsx`, and `step-editor-mode-toggle.tsx`
- All links now point to: https://docs.novu.co/platform/workflow/add-and-configure-steps/code-steps

## Files Changed

- `apps/dashboard/src/components/workflow-editor/steps/shared/use-step-resolver-hint.tsx` — `framework/content/step-resolvers` → correct URL
- `apps/dashboard/src/components/workflow-editor/steps/shared/step-resolver-not-published.tsx` — `platform/concepts/step-resolvers` → correct URL
- `apps/dashboard/src/components/workflow-editor/steps/shared/step-editor-mode-toggle.tsx` — `framework/overview` → correct URL (used in the Custom Code tooltip "Learn more" link)

## Test plan

- [ ] Click "Learn more" in the Custom Code toggle tooltip → should navigate to the correct docs page
- [ ] Trigger the step resolver not published state → "Read the docs" link should navigate to the correct docs page
- [ ] Trigger the step resolver hint banner → "Learn more" link should navigate to the correct docs page

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Fixed three broken documentation links related to the Custom Code (step resolver) feature in the dashboard UI by replacing dead URLs with the correct docs page (https://docs.novu.co/platform/workflow/add-and-configure-steps/code-steps). Also ensured external links open safely in a new tab by adding target="_blank" and rel="noopener noreferrer" where applicable. This prevents navigation to non-existent docs and improves link security/behavior.

## Affected areas
- **dashboard**: Updated documentation URLs and external-link attributes in shared workflow editor components so the Custom Code tooltip, step resolver hint banner, and "not published" state point to the correct docs and open externally with noopener noreferrer.

## Testing
Manual verification: click "Learn more" in the Custom Code toggle tooltip, trigger the step resolver not-published state and the step resolver hint banner — each link should open the correct docs page in a new tab. No automated tests were added since this is a link/attribute fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->