### PR TITLE
feat(dashboard): add note to response body schema and fix step variable syntax fixes NV-7293

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/http-request/http-request-console-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/http-request/http-request-console-preview.tsx
@@ -228,7 +228,7 @@ function ResponsePanel({ result, stepName }: { result: TestHttpEndpointResponse;
           <p className="text-xs leading-4 text-[#525866]">
             <span className="font-medium text-[#0e121b]">Note: </span>
             {'These values can be accessed in the subsequent steps via '}
-            <span className="font-mono font-medium tracking-[-0.24px]">{`{{steps.${stepName}.`}</span>
+            <span className="font-mono font-medium tracking-[-0.24px]">{`{{steps.${stepName}.KEY_NAME}}`}</span>
           </p>
         </div>
       )}

--- a/apps/dashboard/src/components/workflow-editor/steps/http-request/http-request-console-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/http-request/http-request-console-preview.tsx
@@ -227,8 +227,8 @@ function ResponsePanel({ result, stepName }: { result: TestHttpEndpointResponse;
           </div>
           <p className="text-xs leading-4 text-[#525866]">
             <span className="font-medium text-[#0e121b]">Note: </span>
-            {'These values can be accessed in the subsequent steps via '}
-            <span className="font-mono font-medium tracking-[-0.24px]">{`{{steps.${stepName}.KEY_NAME}}`}</span>
+            {'These values can be accessed in subsequent steps via '}
+            <span className="font-mono font-medium tracking-[-0.24px]">{`{{steps.${stepName}.<key>}}`}</span>
           </p>
         </div>
       )}

--- a/apps/dashboard/src/components/workflow-editor/steps/http-request/http-request-console-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/http-request/http-request-console-preview.tsx
@@ -228,7 +228,7 @@ function ResponsePanel({ result, stepName }: { result: TestHttpEndpointResponse;
           <p className="text-xs leading-4 text-[#525866]">
             <span className="font-medium text-[#0e121b]">Note: </span>
             {'These values can be accessed in the subsequent steps via '}
-            <span className="font-mono font-medium tracking-[-0.24px]">{`{{${stepName}.`}</span>
+            <span className="font-mono font-medium tracking-[-0.24px]">{`{{steps.${stepName}.`}</span>
           </p>
         </div>
       )}

--- a/apps/dashboard/src/components/workflow-editor/steps/http-request/response-body-schema.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/http-request/response-body-schema.tsx
@@ -45,20 +45,20 @@ export function ResponseBodySchema() {
         methods={methods}
       />
 
-      <Separator className="mt-1.5 mb-2 bg-neutral-50" />
+      <Separator className="mt-1.5 mb-1.5 bg-neutral-50" />
 
       <div>
         <EnforceSchemaValidation onSchemaGenerated={resetToSchema} />
       </div>
 
-      <div className="flex items-center gap-2 overflow-clip rounded-md border border-neutral-100 bg-white p-2">
+      <div className="mt-1.5 flex items-center gap-2 overflow-clip rounded-md border border-neutral-100 bg-white p-2">
         <div className="flex h-full shrink-0 items-stretch">
           <div className="w-1 rounded-full bg-[#717784]" />
         </div>
         <p className="text-xs leading-4 text-[#525866]">
           <span className="font-medium text-[#0e121b]">Note: </span>
           {'These values can be accessed in the subsequent steps via '}
-          <span className="font-mono font-medium tracking-[-0.24px]">{`{{steps.${step.stepId}.`}</span>
+          <span className="font-mono font-medium tracking-[-0.24px]">{`{{steps.${step.stepId}.KEY_NAME}}`}</span>
         </p>
       </div>
     </div>

--- a/apps/dashboard/src/components/workflow-editor/steps/http-request/response-body-schema.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/http-request/response-body-schema.tsx
@@ -5,12 +5,14 @@ import type { JSONSchema7 } from '@/components/schema-editor';
 import { SchemaEditor } from '@/components/schema-editor';
 import { useSchemaForm } from '@/components/schema-editor/use-schema-form';
 import { useSaveForm } from '@/components/workflow-editor/steps/save-form-context';
+import { useStepEditor } from '../context/step-editor-context';
 import { EnforceSchemaValidation } from './enforce-schema-validation';
 import { SectionHeader } from './section-header';
 
 export function ResponseBodySchema() {
   const { getValues, setValue } = useFormContext();
   const { saveForm } = useSaveForm();
+  const { step } = useStepEditor();
 
   const initialSchema = (getValues('responseBodySchema') as JSONSchema7) ?? { type: 'object', properties: {} };
 
@@ -47,6 +49,17 @@ export function ResponseBodySchema() {
 
       <div>
         <EnforceSchemaValidation onSchemaGenerated={resetToSchema} />
+      </div>
+
+      <div className="flex items-center gap-2 overflow-clip rounded-md border border-neutral-100 bg-white p-2">
+        <div className="flex h-full shrink-0 items-stretch">
+          <div className="w-1 rounded-full bg-[#717784]" />
+        </div>
+        <p className="text-xs leading-4 text-[#525866]">
+          <span className="font-medium text-[#0e121b]">Note: </span>
+          {'These values can be accessed in the subsequent steps via '}
+          <span className="font-mono font-medium tracking-[-0.24px]">{`{{steps.${step.stepId}.`}</span>
+        </p>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/workflow-editor/steps/http-request/response-body-schema.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/http-request/response-body-schema.tsx
@@ -57,8 +57,8 @@ export function ResponseBodySchema() {
         </div>
         <p className="text-xs leading-4 text-[#525866]">
           <span className="font-medium text-[#0e121b]">Note: </span>
-          {'These values can be accessed in the subsequent steps via '}
-          <span className="font-mono font-medium tracking-[-0.24px]">{`{{steps.${step.stepId}.KEY_NAME}}`}</span>
+          {'These values can be accessed in subsequent steps via '}
+          <span className="font-mono font-medium tracking-[-0.24px]">{`{{steps.${step.stepId}.<key>}}`}</span>
         </p>
       </div>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Two small UI improvements to the HTTP Request step editor:

1. **Added a "Note" below the Response Body Schema section** — identical in style to the existing note shown after a successful test response. This tells users how to reference response values in subsequent steps without needing to consult the docs or run a test first.

2. **Fixed the variable syntax** in both the new note and the existing console preview note — changed from `{{stepName}.` to `{{steps.stepName}.` to match the actual template syntax (`steps.` prefix was missing).

### Files changed

- `apps/dashboard/src/components/workflow-editor/steps/http-request/response-body-schema.tsx` — added `useStepEditor` import, added the Note component below `EnforceSchemaValidation`
- `apps/dashboard/src/components/workflow-editor/steps/http-request/http-request-console-preview.tsx` — updated the template string to include `steps.` prefix

### Screenshot

![Response Body Schema Note](https://github.com/user-attachments/assets/placeholder)

The note reads: **"Note:** These values can be accessed in the subsequent steps via `{{steps.http-request-step.`"
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7293](https://linear.app/novu/issue/NV-7293/small-ui-improvement)

<div><a href="https://cursor.com/agents/bc-abe5f7d2-149f-47c5-b34e-d0690a6d17d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abe5f7d2-149f-47c5-b34e-d0690a6d17d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The HTTP Request step editor UI in the dashboard now includes a persistent note below the Response Body Schema section that displays the correct template syntax for accessing response values in subsequent steps. Additionally, the variable reference syntax was standardized across the response panels from `{{stepName.` to `{{steps.stepName.<key>}}` to include the required `steps.` prefix, ensuring users see accurate variable patterns without needing to run a test first.

## Affected areas

**dashboard** — Added a note component to the Response Body Schema section that dynamically displays the step ID in the correct template format (`{{steps.<stepId>.<key>}}`), and updated the Response Panel's post-test note to use consistent variable syntax with the `steps.` prefix. Minor styling adjustment: reduced Separator margin for better spacing.

## Testing

No new tests were added. Changes are UI-only (note display and template string updates) and can be verified through manual inspection of the workflow editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->