### PR TITLE
fix(api-service): add activityFeedLink to trigger event e2e key validation

### DIFF
--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -1360,8 +1360,8 @@ describe('Trigger event - /v1/events/trigger (POST) #novu-v2', () => {
     it('should correctly set expiration date (TTL) for notification and messages', async () => {
       const templateName = template.triggers[0].identifier;
 
-      const response = await novuClient.trigger({
-        workflowId: templateName,
+      const response = await session.testAgent.post('/v1/events/trigger').send({
+        name: templateName,
         to: [
           {
             subscriberId: subscriber.subscriberId,
@@ -1372,11 +1372,11 @@ describe('Trigger event - /v1/events/trigger (POST) #novu-v2', () => {
           urlVar: '/test/url/path',
         },
       });
-      const body = response.result;
-      expect(body).to.have.all.keys('acknowledged', 'status', 'transactionId', 'activityFeedLink');
-      expect(body.acknowledged).to.equal(true);
-      expect(body.status).to.equal('processed');
-      expect(body.transactionId).to.be.a.string;
+      const { body } = response;
+      expect(body.data).to.have.all.keys('acknowledged', 'status', 'transactionId', 'activityFeedLink');
+      expect(body.data.acknowledged).to.equal(true);
+      expect(body.data.status).to.equal('processed');
+      expect(body.data.transactionId).to.be.a.string;
 
       await session.waitForJobCompletion(template._id);
 

--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -1373,7 +1373,7 @@ describe('Trigger event - /v1/events/trigger (POST) #novu-v2', () => {
         },
       });
       const body = response.result;
-      expect(body).to.have.all.keys('acknowledged', 'status', 'transactionId');
+      expect(body).to.have.all.keys('acknowledged', 'status', 'transactionId', 'activityFeedLink');
       expect(body.acknowledged).to.equal(true);
       expect(body.status).to.equal('processed');
       expect(body.transactionId).to.be.a.string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Added `activityFeedLink` to the key validation assertion in the trigger event E2E test at line 1376 of `trigger-event.e2e.ts`.

### Changes

- Updated `expect(body).to.have.all.keys(...)` to include `'activityFeedLink'` alongside the existing `'acknowledged'`, `'status'`, and `'transactionId'` keys.
- Switched the test from using the `@novu/api` SDK client (`novuClient.trigger()`) to a raw HTTP request via `session.testAgent.post('/v1/events/trigger')`. This is necessary because the auto-generated SDK's Zod schema strips `activityFeedLink` from the response (the field isn't in the SDK types yet), preventing the assertion from passing.

### Testing

- Ran the specific test locally. The key validation assertion passes (test proceeds past it), confirming `activityFeedLink` is present in the raw API response. The test times out later at `waitForJobCompletion` only because the worker service isn't running in the local test environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D092998U7KR/p1774445318438799?thread_ts=1774445318.438799&cid=D092998U7KR)

<div><a href="https://cursor.com/agents/bc-9a0d210f-3381-5c7f-898d-45bcec2068dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a0d210f-3381-5c7f-898d-45bcec2068dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
What changed

The trigger-event E2E test for /v1/events/trigger was updated to call the HTTP endpoint directly and validate an additional response field. The test now asserts the response body contains activityFeedLink alongside acknowledged, status, and transactionId. This change ensures the E2E suite verifies the real API response (including activity feed links) instead of relying on the SDK which previously stripped that field.

Affected areas

api — Updated the trigger event E2E test (apps/api/src/app/events/e2e/trigger-event.e2e.ts) to use a raw HTTP POST via session.testAgent and to assert the presence of activityFeedLink in the response payload.

Key technical decisions

- The test was switched from using the @novu/api SDK to a raw HTTP request because the SDK’s generated Zod types do not include activityFeedLink and therefore remove it from responses; using a direct HTTP call preserves the actual API response for validation.

Testing

This change is an update to the existing E2E test suite (trigger-event.e2e.ts) to strengthen coverage by asserting activityFeedLink is returned; no new tests beyond the modified E2E assertion were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->