### PR TITLE
fix(billing): bump enterprise submodule for Stripe customer name

### DIFF
--- a/apps/api/src/app/billing/e2e/create-checkout-session.e2e-ee.ts
+++ b/apps/api/src/app/billing/e2e/create-checkout-session.e2e-ee.ts
@@ -15,7 +15,6 @@ const checkoutSessionCreateParamsMock = {
   },
   billing_address_collection: 'required',
   customer_update: {
-    name: 'auto',
     address: 'auto',
   },
   success_url: `${dashboardOrigin}/manage-account/billing?result=success&session_id={CHECKOUT_SESSION_ID}`,


### PR DESCRIPTION
## Summary
Points the `.source` (packages-enterprise) submodule at the billing fix that drops `customer_update.name: 'auto'` from Checkout, and updates the API e2e expectation.

## Depends on
Merge **packages-enterprise** first: https://github.com/novuhq/packages-enterprise/pull/433

## Why
Keeps Stripe `Customer.name` as the organization name; billing address still syncs via `customer_update.address: 'auto'` for Automatic Tax.