### PR TITLE
feat(api-service): add env parameter to framework resources fixes NV-7281

### DIFF
--- a/libs/application-generic/src/usecases/execute-step-resolver/execute-step-resolver-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-step-resolver/execute-step-resolver-request.usecase.ts
@@ -218,6 +218,7 @@ export class ExecuteStepResolverRequest {
         subscriber: (event.subscriber ?? {}) as Record<string, unknown>,
         context: (event.context ?? {}) as Record<string, unknown>,
         steps: stepsMap,
+        env: (event.env ?? {}) as Record<string, string>,
       };
 
       const compiledString = await liquidEngine.render(parsedTemplate, renderVariables);

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -461,7 +461,7 @@ export class Client {
         concludeExecutionPromise,
         workflow.execute({
           payload: executionData,
-          environment: {},
+          env: event.env ?? {},
           controls: {},
           subscriber: event.subscriber,
           context: event.context,

--- a/packages/framework/src/resources/step-resolver/step.ts
+++ b/packages/framework/src/resources/step-resolver/step.ts
@@ -17,6 +17,7 @@ export type StepResolverContext<TPayload extends Record<string, unknown> = Recor
   subscriber: Subscriber;
   context: ContextResolved;
   steps: Record<string, unknown>;
+  env: Record<string, string>;
 };
 
 type ResolveControls<T extends Schema | undefined> = T extends Schema ? FromSchema<T> : Record<string, unknown>;

--- a/packages/framework/src/resources/step-resolver/step.ts
+++ b/packages/framework/src/resources/step-resolver/step.ts
@@ -12,34 +12,45 @@ import type {
 import type { Subscriber } from '../../types/subscriber.types';
 import type { Awaitable } from '../../types/util.types';
 
-export type StepResolverContext<TPayload extends Record<string, unknown> = Record<string, unknown>> = {
+export type StepResolverContext<
+  TPayload extends Record<string, unknown> = Record<string, unknown>,
+  TEnv extends Record<string, unknown> = Record<string, string>,
+> = {
   payload: TPayload;
   subscriber: Subscriber;
   context: ContextResolved;
   steps: Record<string, unknown>;
-  env: Record<string, string>;
+  env: TEnv;
 };
 
 type ResolveControls<T extends Schema | undefined> = T extends Schema ? FromSchema<T> : Record<string, unknown>;
+
+type ResolveEnv<T extends Schema | undefined> = T extends Schema ? FromSchema<T> : Record<string, string>;
 
 type StepResolverProviders<
   T_StepType extends keyof typeof providerSchemas,
   T_Controls,
   T_Output,
   T_Payload extends Record<string, unknown> = Record<string, unknown>,
+  T_Env extends Record<string, unknown> = Record<string, string>,
 > = {
   [K in keyof (typeof providerSchemas)[T_StepType]]?: (
     step: { controls: T_Controls; outputs: T_Output },
-    ctx: StepResolverContext<T_Payload>
+    ctx: StepResolverContext<T_Payload, T_Env>
   ) => Awaitable<WithPassthrough<Record<string, unknown>>>;
 };
 
-type BaseStepResolverOptions<TControlSchema extends Schema | undefined, TPayloadSchema extends Schema | undefined> = {
+type BaseStepResolverOptions<
+  TControlSchema extends Schema | undefined,
+  TPayloadSchema extends Schema | undefined,
+  TEnvSchema extends Schema | undefined = undefined,
+> = {
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
+  envSchema?: TEnvSchema;
   skip?: (
     controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
   ) => Awaitable<boolean>;
 };
 
@@ -48,12 +59,14 @@ type ChannelStepResolverOptions<
   TControlSchema extends Schema | undefined,
   TPayloadSchema extends Schema | undefined,
   T_Output extends Record<string, unknown>,
-> = BaseStepResolverOptions<TControlSchema, TPayloadSchema> & {
+  TEnvSchema extends Schema | undefined = undefined,
+> = BaseStepResolverOptions<TControlSchema, TPayloadSchema, TEnvSchema> & {
   providers?: StepResolverProviders<
     T_StepType,
     ResolveControls<TControlSchema>,
     T_Output,
-    ResolveControls<TPayloadSchema>
+    ResolveControls<TPayloadSchema>,
+    ResolveEnv<TEnvSchema>
   >;
   disableOutputSanitization?: boolean;
 };
@@ -61,21 +74,24 @@ type ChannelStepResolverOptions<
 export type EmailStepResolver<
   TControlSchema extends Schema | undefined = undefined,
   TPayloadSchema extends Schema | undefined = undefined,
+  TEnvSchema extends Schema | undefined = undefined,
 > = {
   type: 'email';
   stepId: string;
   resolve: (
     controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
   ) => Promise<EmailOutputUnvalidated>;
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
-  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
+  envSchema?: TEnvSchema;
+  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema, TEnvSchema>['skip'];
   providers?: StepResolverProviders<
     'email',
     ResolveControls<TControlSchema>,
     EmailOutputUnvalidated,
-    ResolveControls<TPayloadSchema>
+    ResolveControls<TPayloadSchema>,
+    ResolveEnv<TEnvSchema>
   >;
   disableOutputSanitization?: boolean;
 };
@@ -83,21 +99,24 @@ export type EmailStepResolver<
 export type SmsStepResolver<
   TControlSchema extends Schema | undefined = undefined,
   TPayloadSchema extends Schema | undefined = undefined,
+  TEnvSchema extends Schema | undefined = undefined,
 > = {
   type: 'sms';
   stepId: string;
   resolve: (
     controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
   ) => Promise<SmsOutputUnvalidated>;
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
-  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
+  envSchema?: TEnvSchema;
+  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema, TEnvSchema>['skip'];
   providers?: StepResolverProviders<
     'sms',
     ResolveControls<TControlSchema>,
     SmsOutputUnvalidated,
-    ResolveControls<TPayloadSchema>
+    ResolveControls<TPayloadSchema>,
+    ResolveEnv<TEnvSchema>
   >;
   disableOutputSanitization?: boolean;
 };
@@ -105,21 +124,24 @@ export type SmsStepResolver<
 export type ChatStepResolver<
   TControlSchema extends Schema | undefined = undefined,
   TPayloadSchema extends Schema | undefined = undefined,
+  TEnvSchema extends Schema | undefined = undefined,
 > = {
   type: 'chat';
   stepId: string;
   resolve: (
     controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
   ) => Promise<ChatOutputUnvalidated>;
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
-  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
+  envSchema?: TEnvSchema;
+  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema, TEnvSchema>['skip'];
   providers?: StepResolverProviders<
     'chat',
     ResolveControls<TControlSchema>,
     ChatOutputUnvalidated,
-    ResolveControls<TPayloadSchema>
+    ResolveControls<TPayloadSchema>,
+    ResolveEnv<TEnvSchema>
   >;
   disableOutputSanitization?: boolean;
 };
@@ -127,21 +149,24 @@ export type ChatStepResolver<
 export type PushStepResolver<
   TControlSchema extends Schema | undefined = undefined,
   TPayloadSchema extends Schema | undefined = undefined,
+  TEnvSchema extends Schema | undefined = undefined,
 > = {
   type: 'push';
   stepId: string;
   resolve: (
     controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
   ) => Promise<PushOutputUnvalidated>;
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
-  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
+  envSchema?: TEnvSchema;
+  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema, TEnvSchema>['skip'];
   providers?: StepResolverProviders<
     'push',
     ResolveControls<TControlSchema>,
     PushOutputUnvalidated,
-    ResolveControls<TPayloadSchema>
+    ResolveControls<TPayloadSchema>,
+    ResolveEnv<TEnvSchema>
   >;
   disableOutputSanitization?: boolean;
 };
@@ -149,51 +174,56 @@ export type PushStepResolver<
 export type InAppStepResolver<
   TControlSchema extends Schema | undefined = undefined,
   TPayloadSchema extends Schema | undefined = undefined,
+  TEnvSchema extends Schema | undefined = undefined,
 > = {
   type: 'in_app';
   stepId: string;
   resolve: (
     controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
   ) => Promise<InAppOutputUnvalidated>;
   controlSchema?: TControlSchema;
   payloadSchema?: TPayloadSchema;
-  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema>['skip'];
+  envSchema?: TEnvSchema;
+  skip?: BaseStepResolverOptions<TControlSchema, TPayloadSchema, TEnvSchema>['skip'];
   providers?: StepResolverProviders<
     'in_app',
     ResolveControls<TControlSchema>,
     InAppOutputUnvalidated,
-    ResolveControls<TPayloadSchema>
+    ResolveControls<TPayloadSchema>,
+    ResolveEnv<TEnvSchema>
   >;
   disableOutputSanitization?: boolean;
 };
 
 export type AnyStepResolver =
-  | EmailStepResolver<Schema | undefined, Schema | undefined>
-  | SmsStepResolver<Schema | undefined, Schema | undefined>
-  | ChatStepResolver<Schema | undefined, Schema | undefined>
-  | PushStepResolver<Schema | undefined, Schema | undefined>
-  | InAppStepResolver<Schema | undefined, Schema | undefined>;
+  | EmailStepResolver<Schema | undefined, Schema | undefined, Schema | undefined>
+  | SmsStepResolver<Schema | undefined, Schema | undefined, Schema | undefined>
+  | ChatStepResolver<Schema | undefined, Schema | undefined, Schema | undefined>
+  | PushStepResolver<Schema | undefined, Schema | undefined, Schema | undefined>
+  | InAppStepResolver<Schema | undefined, Schema | undefined, Schema | undefined>;
 
 function email<
   TControlSchema extends Schema | undefined = undefined,
   TPayloadSchema extends Schema | undefined = undefined,
+  TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
   resolve: (
     controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
   ) => Promise<EmailOutputUnvalidated>,
-  options?: ChannelStepResolverOptions<'email', TControlSchema, TPayloadSchema, EmailOutputUnvalidated>
-): EmailStepResolver<TControlSchema, TPayloadSchema> {
+  options?: ChannelStepResolverOptions<'email', TControlSchema, TPayloadSchema, EmailOutputUnvalidated, TEnvSchema>
+): EmailStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'email',
     stepId,
-    resolve: resolve as EmailStepResolver<TControlSchema, TPayloadSchema>['resolve'],
+    resolve: resolve as EmailStepResolver<TControlSchema, TPayloadSchema, TEnvSchema>['resolve'],
     controlSchema: options?.controlSchema,
     payloadSchema: options?.payloadSchema,
+    envSchema: options?.envSchema,
     skip: options?.skip,
-    providers: options?.providers as EmailStepResolver<TControlSchema, TPayloadSchema>['providers'],
+    providers: options?.providers as EmailStepResolver<TControlSchema, TPayloadSchema, TEnvSchema>['providers'],
     disableOutputSanitization: options?.disableOutputSanitization,
   };
 }
@@ -201,22 +231,24 @@ function email<
 function sms<
   TControlSchema extends Schema | undefined = undefined,
   TPayloadSchema extends Schema | undefined = undefined,
+  TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
   resolve: (
     controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
   ) => Promise<SmsOutputUnvalidated>,
-  options?: ChannelStepResolverOptions<'sms', TControlSchema, TPayloadSchema, SmsOutputUnvalidated>
-): SmsStepResolver<TControlSchema, TPayloadSchema> {
+  options?: ChannelStepResolverOptions<'sms', TControlSchema, TPayloadSchema, SmsOutputUnvalidated, TEnvSchema>
+): SmsStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'sms',
     stepId,
-    resolve: resolve as SmsStepResolver<TControlSchema, TPayloadSchema>['resolve'],
+    resolve: resolve as SmsStepResolver<TControlSchema, TPayloadSchema, TEnvSchema>['resolve'],
     controlSchema: options?.controlSchema,
     payloadSchema: options?.payloadSchema,
+    envSchema: options?.envSchema,
     skip: options?.skip,
-    providers: options?.providers as SmsStepResolver<TControlSchema, TPayloadSchema>['providers'],
+    providers: options?.providers as SmsStepResolver<TControlSchema, TPayloadSchema, TEnvSchema>['providers'],
     disableOutputSanitization: options?.disableOutputSanitization,
   };
 }
@@ -224,22 +256,24 @@ function sms<
 function chat<
   TControlSchema extends Schema | undefined = undefined,
   TPayloadSchema extends Schema | undefined = undefined,
+  TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
   resolve: (
     controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
   ) => Promise<ChatOutputUnvalidated>,
-  options?: ChannelStepResolverOptions<'chat', TControlSchema, TPayloadSchema, ChatOutputUnvalidated>
-): ChatStepResolver<TControlSchema, TPayloadSchema> {
+  options?: ChannelStepResolverOptions<'chat', TControlSchema, TPayloadSchema, ChatOutputUnvalidated, TEnvSchema>
+): ChatStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'chat',
     stepId,
-    resolve: resolve as ChatStepResolver<TControlSchema, TPayloadSchema>['resolve'],
+    resolve: resolve as ChatStepResolver<TControlSchema, TPayloadSchema, TEnvSchema>['resolve'],
     controlSchema: options?.controlSchema,
     payloadSchema: options?.payloadSchema,
+    envSchema: options?.envSchema,
     skip: options?.skip,
-    providers: options?.providers as ChatStepResolver<TControlSchema, TPayloadSchema>['providers'],
+    providers: options?.providers as ChatStepResolver<TControlSchema, TPayloadSchema, TEnvSchema>['providers'],
     disableOutputSanitization: options?.disableOutputSanitization,
   };
 }
@@ -247,22 +281,24 @@ function chat<
 function push<
   TControlSchema extends Schema | undefined = undefined,
   TPayloadSchema extends Schema | undefined = undefined,
+  TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
   resolve: (
     controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
   ) => Promise<PushOutputUnvalidated>,
-  options?: ChannelStepResolverOptions<'push', TControlSchema, TPayloadSchema, PushOutputUnvalidated>
-): PushStepResolver<TControlSchema, TPayloadSchema> {
+  options?: ChannelStepResolverOptions<'push', TControlSchema, TPayloadSchema, PushOutputUnvalidated, TEnvSchema>
+): PushStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'push',
     stepId,
-    resolve: resolve as PushStepResolver<TControlSchema, TPayloadSchema>['resolve'],
+    resolve: resolve as PushStepResolver<TControlSchema, TPayloadSchema, TEnvSchema>['resolve'],
     controlSchema: options?.controlSchema,
     payloadSchema: options?.payloadSchema,
+    envSchema: options?.envSchema,
     skip: options?.skip,
-    providers: options?.providers as PushStepResolver<TControlSchema, TPayloadSchema>['providers'],
+    providers: options?.providers as PushStepResolver<TControlSchema, TPayloadSchema, TEnvSchema>['providers'],
     disableOutputSanitization: options?.disableOutputSanitization,
   };
 }
@@ -270,22 +306,24 @@ function push<
 function inApp<
   TControlSchema extends Schema | undefined = undefined,
   TPayloadSchema extends Schema | undefined = undefined,
+  TEnvSchema extends Schema | undefined = undefined,
 >(
   stepId: string,
   resolve: (
     controls: ResolveControls<TControlSchema>,
-    ctx: StepResolverContext<ResolveControls<TPayloadSchema>>
+    ctx: StepResolverContext<ResolveControls<TPayloadSchema>, ResolveEnv<TEnvSchema>>
   ) => Promise<InAppOutputUnvalidated>,
-  options?: ChannelStepResolverOptions<'in_app', TControlSchema, TPayloadSchema, InAppOutputUnvalidated>
-): InAppStepResolver<TControlSchema, TPayloadSchema> {
+  options?: ChannelStepResolverOptions<'in_app', TControlSchema, TPayloadSchema, InAppOutputUnvalidated, TEnvSchema>
+): InAppStepResolver<TControlSchema, TPayloadSchema, TEnvSchema> {
   return {
     type: 'in_app',
     stepId,
-    resolve: resolve as InAppStepResolver<TControlSchema, TPayloadSchema>['resolve'],
+    resolve: resolve as InAppStepResolver<TControlSchema, TPayloadSchema, TEnvSchema>['resolve'],
     controlSchema: options?.controlSchema,
     payloadSchema: options?.payloadSchema,
+    envSchema: options?.envSchema,
     skip: options?.skip,
-    providers: options?.providers as InAppStepResolver<TControlSchema, TPayloadSchema>['providers'],
+    providers: options?.providers as InAppStepResolver<TControlSchema, TPayloadSchema, TEnvSchema>['providers'],
     disableOutputSanitization: options?.disableOutputSanitization,
   };
 }

--- a/packages/framework/src/resources/workflow/workflow.resource.ts
+++ b/packages/framework/src/resources/workflow/workflow.resource.ts
@@ -32,13 +32,15 @@ import { mapPreferences } from './map-preferences';
 export function workflow<
   T_PayloadSchema extends Schema,
   T_ControlSchema extends Schema,
+  T_EnvSchema extends Schema,
   T_PayloadValidated extends Record<string, unknown> = FromSchema<T_PayloadSchema>,
   T_PayloadUnvalidated extends Record<string, unknown> = FromSchemaUnvalidated<T_PayloadSchema>,
   T_Controls extends Record<string, unknown> = FromSchema<T_ControlSchema>,
+  T_Env extends Record<string, unknown> = FromSchema<T_EnvSchema>,
 >(
   workflowId: string,
-  execute: Execute<T_PayloadValidated, T_Controls>,
-  workflowOptions?: WorkflowOptions<T_PayloadSchema, T_ControlSchema>
+  execute: Execute<T_PayloadValidated, T_Controls, T_Env>,
+  workflowOptions?: WorkflowOptions<T_PayloadSchema, T_ControlSchema, T_EnvSchema>
 ): Workflow<T_PayloadUnvalidated> {
   const options = workflowOptions || {};
 
@@ -98,6 +100,10 @@ export function workflow<
         schema: await transformSchema(options.controlSchema || emptySchema),
         unknownSchema: options.controlSchema || emptySchema,
       },
+      env: {
+        schema: await transformSchema(options.envSchema || emptySchema),
+        unknownSchema: options.envSchema || emptySchema,
+      },
       tags: options.tags || [],
       preferences: mapPreferences(options.preferences),
       name: options.name,
@@ -108,7 +114,7 @@ export function workflow<
     await execute({
       payload: {} as T_PayloadValidated,
       subscriber: {},
-      env: {},
+      env: {} as T_Env,
       controls: {} as T_Controls,
       context: {},
       step: {

--- a/packages/framework/src/resources/workflow/workflow.resource.ts
+++ b/packages/framework/src/resources/workflow/workflow.resource.ts
@@ -108,7 +108,7 @@ export function workflow<
     await execute({
       payload: {} as T_PayloadValidated,
       subscriber: {},
-      environment: {},
+      env: {},
       controls: {} as T_Controls,
       context: {},
       step: {

--- a/packages/framework/src/types/discover.types.ts
+++ b/packages/framework/src/types/discover.types.ts
@@ -59,6 +59,10 @@ export type DiscoverWorkflowOutput = {
     schema: JsonSchema;
     unknownSchema: Schema;
   };
+  env: {
+    schema: JsonSchema;
+    unknownSchema: Schema;
+  };
   preferences: WorkflowPreferencesPartial;
   tags: string[];
   name?: string;

--- a/packages/framework/src/types/workflow.types.ts
+++ b/packages/framework/src/types/workflow.types.ts
@@ -25,8 +25,8 @@ export type ExecuteInput<T_Payload extends Record<string, unknown>, T_Controls e
   payload: T_Payload;
   /** The subscriber for the event, provided during trigger. */
   subscriber: Prettify<Subscriber>;
-  /** The environment the workflow is running in. */
-  environment: Record<string, unknown>;
+  /** The environment variables, defined in the Novu Dashboard. */
+  env: Record<string, unknown>;
   /** The controls for the event. Provided via the Dashboard. */
   controls: T_Controls;
   /** The resolved context for the event. */

--- a/packages/framework/src/types/workflow.types.ts
+++ b/packages/framework/src/types/workflow.types.ts
@@ -18,7 +18,11 @@ export enum SeverityLevelEnum {
 /**
  * The parameters for the workflow function.
  */
-export type ExecuteInput<T_Payload extends Record<string, unknown>, T_Controls extends Record<string, unknown>> = {
+export type ExecuteInput<
+  T_Payload extends Record<string, unknown>,
+  T_Controls extends Record<string, unknown>,
+  T_Env extends Record<string, unknown> = Record<string, unknown>,
+> = {
   /** Define a step in your workflow. */
   step: Step;
   /** The payload for the event, provided during trigger. */
@@ -26,7 +30,7 @@ export type ExecuteInput<T_Payload extends Record<string, unknown>, T_Controls e
   /** The subscriber for the event, provided during trigger. */
   subscriber: Prettify<Subscriber>;
   /** The environment variables, defined in the Novu Dashboard. */
-  env: Record<string, unknown>;
+  env: T_Env;
   /** The controls for the event. Provided via the Dashboard. */
   controls: T_Controls;
   /** The resolved context for the event. */
@@ -36,9 +40,11 @@ export type ExecuteInput<T_Payload extends Record<string, unknown>, T_Controls e
 /**
  * The function to execute the workflow.
  */
-export type Execute<T_Payload extends Record<string, unknown>, T_Controls extends Record<string, unknown>> = (
-  event: ExecuteInput<T_Payload, T_Controls>
-) => Promise<void>;
+export type Execute<
+  T_Payload extends Record<string, unknown>,
+  T_Controls extends Record<string, unknown>,
+  T_Env extends Record<string, unknown> = Record<string, unknown>,
+> = (event: ExecuteInput<T_Payload, T_Controls, T_Env>) => Promise<void>;
 
 /**
  * A preference for a notification delivery workflow.
@@ -99,11 +105,17 @@ export type WorkflowPreferences = DeepPartial<{
 /**
  * The options for the workflow.
  */
-export type WorkflowOptions<T_PayloadSchema extends Schema, T_ControlSchema extends Schema> = {
+export type WorkflowOptions<
+  T_PayloadSchema extends Schema,
+  T_ControlSchema extends Schema,
+  T_EnvSchema extends Schema = Schema,
+> = {
   /** The schema for the payload. */
   payloadSchema?: T_PayloadSchema;
   /** The schema for the controls. */
   controlSchema?: T_ControlSchema;
+  /** The schema for the environment variables. */
+  envSchema?: T_EnvSchema;
   /**
    * The preferences for the notification workflow.
    *

--- a/packages/novu/src/commands/step/templates/__snapshots__/worker-wrapper.spec.ts.snap
+++ b/packages/novu/src/commands/step/templates/__snapshots__/worker-wrapper.spec.ts.snap
@@ -89,6 +89,7 @@ export default {
       const payload = body.payload ?? {};
       const subscriber = body.subscriber ?? {};
       const context = body.context ?? {};
+      const env = isObject(body.env) ? body.env : {};
       const stateArray = Array.isArray(body.state) ? body.state : [];
       const stepOutputs = stateArray.reduce((acc, s) => { if (s && typeof s.stepId === 'string') acc[s.stepId] = s.outputs ?? {}; return acc; }, {});
       const controls = body.controls ?? {};
@@ -114,7 +115,7 @@ export default {
       }
 
       if (!isPreview && step.skip) {
-        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs, env });
         if (shouldSkip) {
           return jsonResponse(
             {
@@ -134,7 +135,7 @@ export default {
         }
       }
 
-      const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+      const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs, env });
 
       const outputSchema = channelStepSchemas[step.type]?.output;
       let validatedResult = result;
@@ -151,7 +152,7 @@ export default {
 
       const providers = {};
       if (step.providers) {
-        const ctx = { payload, subscriber, context, steps: stepOutputs };
+        const ctx = { payload, subscriber, context, steps: stepOutputs, env };
         for (const [providerKey, providerResolve] of Object.entries(step.providers)) {
           const providerResult = await providerResolve({ controls: validatedControls, outputs: validatedResult }, ctx);
           const providerOutputSchema = providerSchemas[step.type]?.[providerKey]?.output;
@@ -288,6 +289,7 @@ export default {
       const payload = body.payload ?? {};
       const subscriber = body.subscriber ?? {};
       const context = body.context ?? {};
+      const env = isObject(body.env) ? body.env : {};
       const stateArray = Array.isArray(body.state) ? body.state : [];
       const stepOutputs = stateArray.reduce((acc, s) => { if (s && typeof s.stepId === 'string') acc[s.stepId] = s.outputs ?? {}; return acc; }, {});
       const controls = body.controls ?? {};
@@ -313,7 +315,7 @@ export default {
       }
 
       if (!isPreview && step.skip) {
-        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs, env });
         if (shouldSkip) {
           return jsonResponse(
             {
@@ -333,7 +335,7 @@ export default {
         }
       }
 
-      const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+      const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs, env });
 
       const outputSchema = channelStepSchemas[step.type]?.output;
       let validatedResult = result;
@@ -350,7 +352,7 @@ export default {
 
       const providers = {};
       if (step.providers) {
-        const ctx = { payload, subscriber, context, steps: stepOutputs };
+        const ctx = { payload, subscriber, context, steps: stepOutputs, env };
         for (const [providerKey, providerResolve] of Object.entries(step.providers)) {
           const providerResult = await providerResolve({ controls: validatedControls, outputs: validatedResult }, ctx);
           const providerOutputSchema = providerSchemas[step.type]?.[providerKey]?.output;
@@ -489,6 +491,7 @@ export default {
       const payload = body.payload ?? {};
       const subscriber = body.subscriber ?? {};
       const context = body.context ?? {};
+      const env = isObject(body.env) ? body.env : {};
       const stateArray = Array.isArray(body.state) ? body.state : [];
       const stepOutputs = stateArray.reduce((acc, s) => { if (s && typeof s.stepId === 'string') acc[s.stepId] = s.outputs ?? {}; return acc; }, {});
       const controls = body.controls ?? {};
@@ -514,7 +517,7 @@ export default {
       }
 
       if (!isPreview && step.skip) {
-        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs, env });
         if (shouldSkip) {
           return jsonResponse(
             {
@@ -534,7 +537,7 @@ export default {
         }
       }
 
-      const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+      const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs, env });
 
       const outputSchema = channelStepSchemas[step.type]?.output;
       let validatedResult = result;
@@ -551,7 +554,7 @@ export default {
 
       const providers = {};
       if (step.providers) {
-        const ctx = { payload, subscriber, context, steps: stepOutputs };
+        const ctx = { payload, subscriber, context, steps: stepOutputs, env };
         for (const [providerKey, providerResolve] of Object.entries(step.providers)) {
           const providerResult = await providerResolve({ controls: validatedControls, outputs: validatedResult }, ctx);
           const providerOutputSchema = providerSchemas[step.type]?.[providerKey]?.output;

--- a/packages/novu/src/commands/step/templates/worker-wrapper.ts
+++ b/packages/novu/src/commands/step/templates/worker-wrapper.ts
@@ -115,7 +115,7 @@ function generateRequestHandler(): string {
 
       ${generateSkipCheck()}
 
-      const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+      const result = await step.resolve(validatedControls, { payload, subscriber, context, steps: stepOutputs, env });
 
       ${generateOutputValidation()}
 
@@ -158,6 +158,7 @@ function generateBodyValidation(): string {
       const payload = body.payload ?? {};
       const subscriber = body.subscriber ?? {};
       const context = body.context ?? {};
+      const env = isObject(body.env) ? body.env : {};
       const stateArray = Array.isArray(body.state) ? body.state : [];
       const stepOutputs = stateArray.reduce((acc, s) => { if (s && typeof s.stepId === 'string') acc[s.stepId] = s.outputs ?? {}; return acc; }, {});
       const controls = body.controls ?? {};
@@ -187,7 +188,7 @@ function generateSchemaValidation(): string {
 
 function generateSkipCheck(): string {
   return `if (!isPreview && step.skip) {
-        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs });
+        const shouldSkip = await step.skip(validatedControls, { payload, subscriber, context, steps: stepOutputs, env });
         if (shouldSkip) {
           return jsonResponse(
             {
@@ -226,7 +227,7 @@ function generateOutputValidation(): string {
 function generateProviderExecution(): string {
   return `const providers = {};
       if (step.providers) {
-        const ctx = { payload, subscriber, context, steps: stepOutputs };
+        const ctx = { payload, subscriber, context, steps: stepOutputs, env };
         for (const [providerKey, providerResolve] of Object.entries(step.providers)) {
           const providerResult = await providerResolve({ controls: validatedControls, outputs: validatedResult }, ctx);
           const providerOutputSchema = providerSchemas[step.type]?.[providerKey]?.output;


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR adds environment variable support to the framework's step resolution system. Steps can now receive and use environment data during execution, with full type safety through optional schema definitions. The `env` parameter replaces the generic `environment` field across the workflow execution pipeline, and is now available in step resolvers, provider overrides, and control compilation contexts.

## Affected areas

- **application-generic**: Updated `execute-step-resolver-request.usecase.ts` to include `env` in Liquid template rendering for control compilation, allowing templates to access environment variables.

- **framework**: Extended type system across multiple modules:
  - `workflow.resource.ts`: Added `envSchema` option and `env` metadata discovery to workflows
  - `resources/step-resolver/step.ts`: Introduced `TEnv` and `TEnvSchema` generics to `StepResolverContext`, `EmailStepResolver`, `SmsStepResolver`, `ChatStepResolver`, `PushStepResolver`, and `InAppStepResolver` types
  - `types/workflow.types.ts`: Updated `ExecuteInput`, `Execute`, and `WorkflowOptions` to accept `env` and `envSchema`
  - `types/discover.types.ts`: Added `env` schema metadata to `DiscoverWorkflowOutput`
  - `client.ts`: Changed workflow execution to pass `env` from event data instead of empty `environment` object

- **novu**: Updated `worker-wrapper.ts` to thread `env` from request body through step resolution, skip checks, and provider execution contexts.

## Key technical decisions

- Environment data is optional and defaults to an empty object when not provided, maintaining backward compatibility
- `TEnvSchema` follows the same pattern as `TPayloadSchema` and `TControlSchema`, allowing type-safe environment variable definitions via JSON schemas
- `env` is passed through all step resolution pathways (resolve, skip, providers) via the context object for consistent access
- Environment variable schema inference uses `FromSchema<T_EnvSchema>` to derive typed `TEnv` at runtime

## Testing

No new test files were added in this PR. Existing type tests in `workflow.test.ts` and snapshot tests in `worker-wrapper.spec.ts` validate the generated code structure, but explicit test coverage for the new `env` parameter functionality is not included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
