### PR TITLE
fix(dashboard): rename email step tab label Code editor to HTML

### DIFF
--- a/apps/dashboard/src/components/email-editor-select.tsx
+++ b/apps/dashboard/src/components/email-editor-select.tsx
@@ -58,7 +58,7 @@ export const EmailEditorSelect = ({
                 </TabsTrigger>
                 <TabsTrigger value="html" className="gap-1.5" size="xs" disabled={disabled}>
                   <RiCodeSSlashFill className="size-3.5" />
-                  <span>Code editor</span>
+                  <span>HTML</span>
                 </TabsTrigger>
               </TabsList>
             </Tabs>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the workflow email step editor mode switch so the HTML tab is labeled **HTML** instead of **Code editor**, matching the underlying `html` editor type.

## Changes

- `EmailEditorSelect`: second `TabsTrigger` label text updated from "Code editor" to "HTML".

No API or behavior changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1774597976363659?thread_ts=1774597976.363659&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-75896c7f-aa7c-537b-b435-250527f21915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75896c7f-aa7c-537b-b435-250527f21915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The HTML editor tab label in the email step editor was updated from the generic "Code editor" to the more specific "HTML". This improves clarity by making the tab label consistent with its underlying editor type value, helping users quickly identify which editor mode they're switching to.

## Affected areas

**@novu/dashboard**: Updated the `EmailEditorSelect` component's HTML tab label from "Code editor" to "HTML" for improved clarity and consistency with the editor type name.

## Testing

No tests are needed for this change—it's a simple UI label update with no functional implications or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->