### PR TITLE
release(framework,novu): @novu/framework v2.10.0 and novu v2.8.0

### DIFF
--- a/packages/framework/CHANGELOG.md
+++ b/packages/framework/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 2.10.0 (2026-03-27)
+
+### 🚀 Features
+
+- **framework:** export param types fixes NV-7261 ([#10407](https://github.com/novuhq/novu/pull/10407))
+- **novu,framework:** align step resolver handlers with framework steps fixes NV-7235 ([#10286](https://github.com/novuhq/novu/pull/10286))
+- **api-service,dashboard,framework:** align step resolver scaffolding with framework fixes NV-7116 ([#10136](https://github.com/novuhq/novu/pull/10136))
+
+### 🩹 Fixes
+
+- **framework:** disable AJV strict mode for user schemas and remove noisy console.error ([#10426](https://github.com/novuhq/novu/pull/10426))
+- **framework:** Liquid output escaping for special JSON characters including `"` ([#9730](https://github.com/novuhq/novu/pull/9730))
+- **framework:** repair invalid JSON strings in control data fixes NV-6904 ([#9632](https://github.com/novuhq/novu/pull/9632))
+- **framework:** fix CORS issue preventing flows from showing in local studio fixes NV-6945 ([#9626](https://github.com/novuhq/novu/pull/9626))
+- **framework:** security patch for next.js dependency ([#9753](https://github.com/novuhq/novu/pull/9753))
+- **root:** resolve high liquidjs vulnerability ([#10263](https://github.com/novuhq/novu/pull/10263))
+- **root:** resolve moderate lodash, ajv, and express vulnerabilities ([#10360](https://github.com/novuhq/novu/pull/10360))
+
+### ❤️ Thank You
+
+- Adam Chmara @ChmaraX
+- Dima Grossman @scopsy
+- George Djabarov @djabarovgeorge
+
 ## 2.9.0 (2025-12-02)
 
 ### 🚀 Features

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "2.10.0-alpha.0",
+  "version": "2.10.0",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/cjs/index.d.cts",

--- a/packages/novu/CHANGELOG.md
+++ b/packages/novu/CHANGELOG.md
@@ -1,3 +1,44 @@
+## 2.8.0 (2026-03-27)
+
+### 🚀 Features
+
+- **novu:** email step resolver init & publish commands fixes NV-7094 ([#9989](https://github.com/novuhq/novu/pull/9989))
+- **novu:** step controls passthrough to CF step resolver fixes NV-7124 ([#10075](https://github.com/novuhq/novu/pull/10075))
+- **novu:** option to publish specific steps within workflow fixes NV-7129 ([#10081](https://github.com/novuhq/novu/pull/10081))
+- **novu:** email publish - prevent publishing directly to prod fixes NV-7158 ([#10109](https://github.com/novuhq/novu/pull/10109))
+- **novu,dashboard:** streamline React Email onboarding DX fixes NV-7183 ([#10153](https://github.com/novuhq/novu/pull/10153))
+- **novu,dashboard:** react email publishing & visual improvements fixes NV-7184 ([#10156](https://github.com/novuhq/novu/pull/10156))
+- **novu,dashboard:** interactive react email template selector in CLI fixes NV-7185 ([#10159](https://github.com/novuhq/novu/pull/10159))
+- **novu,dashboard:** step resolver workflowId is implicit from generated folder fixes NV-7190 ([#10164](https://github.com/novuhq/novu/pull/10164))
+- **novu:** email publish - auto-install @novu/framework as devDependency ([#10165](https://github.com/novuhq/novu/pull/10165))
+- **novu:** improve email publish CLI output DX ([#10166](https://github.com/novuhq/novu/pull/10166))
+- **novu,framework:** align step resolver handlers with framework steps fixes NV-7235 ([#10286](https://github.com/novuhq/novu/pull/10286))
+- **api-service,dashboard,novu:** extend step resolver to all steps fixes NV-7187 ([#10271](https://github.com/novuhq/novu/pull/10271))
+- **api-service,dashboard,novu:** add code step plan limits fixes NV-7271 ([#10416](https://github.com/novuhq/novu/pull/10416))
+
+### 🩹 Fixes
+
+- **novu:** update init step id ([#10001](https://github.com/novuhq/novu/pull/10001))
+- **novu,enterprise:** use workflowId/stepId key for global routing uniqueness ([#10094](https://github.com/novuhq/novu/pull/10094))
+- **novu:** pass steps to step resolver fixes NV-7191 ([#10171](https://github.com/novuhq/novu/pull/10171))
+- **novu,dashboard:** step resolver generated defaults; stale preview fixes NV-7236 ([#10319](https://github.com/novuhq/novu/pull/10319))
+- **novu:** use @babel/parser instead of typescript for email template discovery fixes NV-7252 ([#10351](https://github.com/novuhq/novu/pull/10351))
+- **novu:** resolve zod bundling error and adapt step scaffolding to project setup fixes NV-7257 ([#10352](https://github.com/novuhq/novu/pull/10352))
+- **novu:** log reused step file path and add file column to publish summary fixes NV-7256 ([#10353](https://github.com/novuhq/novu/pull/10353))
+- **novu:** replace typescript with @babel/parser in step-discovery ([#10418](https://github.com/novuhq/novu/pull/10418))
+
+### 🧱 Updated Dependencies
+
+- Updated @novu/framework to 2.10.0
+
+### ❤️ Thank You
+
+- Adam Chmara @ChmaraX
+- Dima Grossman @scopsy
+- George Djabarov @djabarovgeorge
+- Pawan Jain
+- Paweł Tymczuk @LetItRock
+
 ## 2.6.6 (2025-02-25)
 
 ### 🚀 Features

--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Graduates `@novu/framework` from `2.10.0-alpha.0` to stable `2.10.0`
- Bumps `novu` CLI from `2.7.0` to `2.8.0`
- Adds CHANGELOG entries for both packages

## @novu/framework 2.10.0

**Features**
- Export param types (NV-7261, [#10407](https://github.com/novuhq/novu/pull/10407))
- Align step resolver handlers with framework steps (NV-7235, [#10286](https://github.com/novuhq/novu/pull/10286))
- Align step resolver scaffolding with framework (NV-7116, [#10136](https://github.com/novuhq/novu/pull/10136))

**Fixes**
- Disable AJV strict mode for user schemas ([#10426](https://github.com/novuhq/novu/pull/10426))
- Liquid output escaping for special JSON characters ([#9730](https://github.com/novuhq/novu/pull/9730))
- Repair invalid JSON strings in control data (NV-6904, [#9632](https://github.com/novuhq/novu/pull/9632))
- Fix CORS issue preventing flows from showing in local studio (NV-6945, [#9626](https://github.com/novuhq/novu/pull/9626))
- Security patches: next.js ([#9753](https://github.com/novuhq/novu/pull/9753)), liquidjs ([#10263](https://github.com/novuhq/novu/pull/10263)), lodash/ajv/express ([#10360](https://github.com/novuhq/novu/pull/10360))

## novu CLI 2.8.0

**Features**
- Full React Email onboarding DX: init, publish, template selector (NV-7183/7184/7185, [#10153](https://github.com/novuhq/novu/pull/10153), [#10156](https://github.com/novuhq/novu/pull/10156), [#10159](https://github.com/novuhq/novu/pull/10159))
- Email step resolver init & publish commands (NV-7094, [#9989](https://github.com/novuhq/novu/pull/9989))
- Step controls passthrough to CF step resolver (NV-7124, [#10075](https://github.com/novuhq/novu/pull/10075))
- Option to publish specific steps within workflow (NV-7129, [#10081](https://github.com/novuhq/novu/pull/10081))
- Extend step resolver to all steps (NV-7187, [#10271](https://github.com/novuhq/novu/pull/10271))
- Align step resolver handlers with framework steps (NV-7235, [#10286](https://github.com/novuhq/novu/pull/10286))
- Code step plan limits (NV-7271, [#10416](https://github.com/novuhq/novu/pull/10416))
- Auto-install `@novu/framework` as devDependency on email publish ([#10165](https://github.com/novuhq/novu/pull/10165))

**Fixes**
- Replace TypeScript with `@babel/parser` in step/email template discovery ([#10351](https://github.com/novuhq/novu/pull/10351), [#10418](https://github.com/novuhq/novu/pull/10418))
- Resolve zod bundling error in step scaffolding (NV-7257, [#10352](https://github.com/novuhq/novu/pull/10352))
- Step resolver generated defaults; stale preview (NV-7236, [#10319](https://github.com/novuhq/novu/pull/10319))
- Pass steps to step resolver (NV-7191, [#10171](https://github.com/novuhq/novu/pull/10171))

## Test plan

- [ ] `pnpm build --filter @novu/framework` passes
- [ ] `pnpm build --filter novu` passes
- [ ] `cd packages/framework && pnpm run check:exports` passes
- [ ] Publish `@novu/framework@2.10.0` with `pnpm publish --access public --no-git-checks`
- [ ] Publish `novu@2.8.0` with `pnpm publish --access public --no-git-checks`
- [ ] Verify `npm view @novu/framework dist-tags` shows `latest: 2.10.0`
- [ ] Verify `npm view novu dist-tags` shows `latest: 2.8.0`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR graduates @novu/framework from 2.10.0-alpha.0 to stable 2.10.0 and updates novu CLI from 2.7.0 to 2.8.0. Package version fields and CHANGELOG files are updated to document the release, including new features, fixes, and dependency updates for both packages.

## Affected areas

**framework**: Version bumped to 2.10.0 with CHANGELOG entries documenting step resolver handler alignment, framework param type exports, AJV strict mode fixes for user schemas, Liquid output escaping improvements, control data JSON repair, CORS fixes for local studio, and security patches.

**novu (CLI)**: Version bumped to 2.8.0 with CHANGELOG entries covering React Email onboarding improvements, step resolver initialization/publishing, step controls passthrough, step-specific publish options, TypeScript-to-Babel parser migration for template discovery, zod bundling resolution, and framework dependency update to 2.10.0.

## Testing

The PR includes a checklist for manual verification: building both packages, running export checks for the framework, and confirming npm dist-tags reflect the latest versions post-publish. No automated tests are added as this is a release finalization PR where feature work and testing were completed in prior commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->