### PR TITLE
chore(root): add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.worktrees/
 .nyc_output
 build
 node_modules


### PR DESCRIPTION
## Summary

- Adds `.worktrees/` to `.gitignore` so that git worktree checkout directories don't show up as untracked files in `git status` on the main repo.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Added `.worktrees/` to the repository's `.gitignore` file to prevent git worktree checkout directories from appearing as untracked files in `git status` output. This addresses the issue of worktree directories cluttering the working directory status while enabling team members to use git worktrees for parallel branch development.

## Affected areas

**Root configuration**: Updated `.gitignore` to ignore the `.worktrees/` directory, preventing git worktree checkouts from being tracked by git.

## Testing

No tests required for configuration file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->