### PR TITLE
fix(dashboard): rename Novu Sidekick to Novu Copilot in chat UI

### DIFF
--- a/apps/dashboard/src/components/ai-sidekick/chat-body.tsx
+++ b/apps/dashboard/src/components/ai-sidekick/chat-body.tsx
@@ -124,7 +124,7 @@ export const ChatBody = ({
               <div className="flex flex-col gap-3">
                 <BroomSparkle className="size-5" />
                 <span className="text-label-md font-normal bg-linear-to-b from-[hsla(0,0%,57%,1)] to-[hsla(0,0%,39%,1)] bg-clip-text text-transparent">
-                  Novu Sidekick
+                  Novu Copilot
                 </span>
               </div>
               <span className="text-label-xs text-text-soft">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The workflow copilot empty state still showed the label **Novu Sidekick** while the panel header already used **Novu Copilot**. This aligns the empty-state title with the rest of the UI.

## Changes

- `apps/dashboard/src/components/ai-sidekick/chat-body.tsx`: empty-state heading text updated from "Novu Sidekick" to "Novu Copilot".

No breaking changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1774772217673319?thread_ts=1774772217.673319&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-99e7dc11-0cdb-55af-8ac4-40c53b622a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99e7dc11-0cdb-55af-8ac4-40c53b622a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The workflow copilot empty state now displays "Novu Copilot" instead of "Novu Sidekick" in its heading, aligning the label with the panel header and other UI elements that already use "Novu Copilot" as the product name.

## Affected areas
**dashboard** — Updated the empty-state heading text in the AI sidekick chat body component to use consistent terminology across the UI.

## Testing
No tests needed for this trivial text label change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->