### PR TITLE
feat(dashboard): add Environment Variables to pricing comparison

### DIFF
--- a/apps/dashboard/src/components/billing/features-config.ts
+++ b/apps/dashboard/src/components/billing/features-config.ts
@@ -33,6 +33,7 @@ export const FEATURE_SECTIONS: FeatureSectionConfig[] = [
       FeatureNameEnum.CUSTOM_ENVIRONMENTS_BOOLEAN,
       FeatureNameEnum.AUTO_TRANSLATIONS,
       FeatureNameEnum.WEBHOOKS,
+      FeatureNameEnum.ENVIRONMENT_VARIABLES,
     ],
   },
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Environment Variables** to the pricing page feature matrix under the Platform section.

## Behavior

- **Free**: minus (not included) — driven by existing `FeatureNameEnum.ENVIRONMENT_VARIABLES` tier data in `@novu/shared` (`value: false`).
- **Pro** and **Team** (Business): checkmark — `value: true` for those tiers.

No changes to `packages/shared` were required; tier definitions were already present. The row was missing only from `FEATURE_SECTIONS` in `features-config.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1774775303397179?thread_ts=1774775303.397179&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-c65ddda7-c199-53d1-8b46-f007916836ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c65ddda7-c199-53d1-8b46-f007916836ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The Environment Variables feature was added to the pricing page comparison table in the Platform section. Previously, the feature existed in the tier data (`@novu/shared`) but was not displayed on the pricing page. This change makes the feature visible in the matrix, showing that it's unavailable on the Free plan but available on Pro and Team (Business) plans.

## Affected areas

**@novu/dashboard**: Added `FeatureNameEnum.ENVIRONMENT_VARIABLES` to the Platform section's features array in the pricing configuration, making the feature row appear on the pricing comparison page with the appropriate tier indicators.

## Testing

No tests were added. This is a UI configuration change that displays existing tier data; manual verification of the pricing page rendering is sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->