### PR TITLE
chore(maily-core): exclude libs/maily-core from knip dead-code scan

### DIFF
--- a/.cursor/scripts/dead-code/knip.config.jsonc
+++ b/.cursor/scripts/dead-code/knip.config.jsonc
@@ -18,7 +18,7 @@
     "**/scripts/**",
     "**/self-hosted/**",
     "libs/internal-sdk/**",
-    "libs/maily-core/**",
+    "libs/maily-core/**", // cspell:ignore maily
     "packages/js/**",
     "packages/framework/**",
     ".github/**",

--- a/.cursor/scripts/dead-code/knip.config.jsonc
+++ b/.cursor/scripts/dead-code/knip.config.jsonc
@@ -18,6 +18,7 @@
     "**/scripts/**",
     "**/self-hosted/**",
     "libs/internal-sdk/**",
+    "libs/maily-core/**",
     "packages/js/**",
     "packages/framework/**",
     ".github/**",

--- a/knip.json
+++ b/knip.json
@@ -1,3 +1,0 @@
-{
-  "ignore": ["libs/maily-core/**"]
-}

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,3 @@
+{
+  "ignore": ["libs/maily-core/**"]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Added `"libs/maily-core/**"` to the `ignore` list in `.cursor/scripts/dead-code/knip.config.jsonc` so that knip does not report unused files from `libs/maily-core/` when running the dead-code scan.

### Screenshots
N/A — configuration-only change.

**Verified:** running `npx knip --config=.cursor/scripts/dead-code/knip.config.jsonc --workspace libs/maily-core --include files` produces zero output (exit 0), confirming the directory is fully excluded.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba82a22e-4088-48ba-9df2-c1bbb4b5a944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba82a22e-4088-48ba-9df2-c1bbb4b5a944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
Added `libs/maily-core/**` to the ignore patterns in `.cursor/scripts/dead-code/knip.config.jsonc`. This prevents the knip dead-code scanner from analyzing files in the `libs/maily-core` directory during code scans. The change was needed to exclude this library from dead-code reporting, likely because it's generated, experimental, or has intentionally unused code patterns that would clutter scan results.

## Affected areas
**Tooling & Configuration**: The knip dead-code analysis configuration now excludes the `libs/maily-core` directory from scans, preventing false positives or unnecessary warnings for that library.

## Testing
Manual verification confirmed the exclusion works—running `npx knip --config=.cursor/scripts/dead-code/knip.config.jsonc --workspace libs/maily-core --include files` produces zero output, confirming the directory is properly ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->