### PR TITLE
fix(shared): persist step type when updating bridge workflow steps fixes NV-7323

### DIFF
--- a/apps/api/src/app/events/e2e/bridge-trigger.e2e.ts
+++ b/apps/api/src/app/events/e2e/bridge-trigger.e2e.ts
@@ -157,6 +157,143 @@ contexts.forEach((context: Context) => {
       expect(smsMessage?.content).to.include('sms result test_name');
     });
 
+    it(`should update message template type when replacing a step with the same stepId after re-sync [${context.name}]`, async () => {
+      const workflowId = `step-type-replace-${context.name}`;
+      const middleStepId = 'shared-middle-step';
+
+      const workflowWithCustomMiddle = workflow(
+        workflowId,
+        async ({ step, payload }) => {
+          await step.inApp(
+            'first-in-app',
+            async () => ({
+              body: `first ${payload.name}`,
+            }),
+            {
+              controlSchema: {
+                type: 'object',
+                properties: {},
+              } as const,
+            }
+          );
+
+          await step.custom(
+            middleStepId,
+            async () => ({
+              data: 'custom',
+            }),
+            {
+              controlSchema: {
+                type: 'object',
+                properties: {},
+              } as const,
+            }
+          );
+
+          await step.inApp(
+            'last-in-app',
+            async () => ({
+              body: `last ${payload.name}`,
+            }),
+            {
+              controlSchema: {
+                type: 'object',
+                properties: {},
+              } as const,
+            }
+          );
+        },
+        {
+          payloadSchema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string', default: 'default_name' },
+            },
+            required: [],
+            additionalProperties: false,
+          } as const,
+        }
+      );
+
+      const workflowWithChatMiddle = workflow(
+        workflowId,
+        async ({ step, payload }) => {
+          await step.inApp(
+            'first-in-app',
+            async () => ({
+              body: `first ${payload.name}`,
+            }),
+            {
+              controlSchema: {
+                type: 'object',
+                properties: {},
+              } as const,
+            }
+          );
+
+          await step.chat(middleStepId, async () => ({
+            body: 'chat body',
+          }));
+
+          await step.inApp(
+            'last-in-app',
+            async () => ({
+              body: `last ${payload.name}`,
+            }),
+            {
+              controlSchema: {
+                type: 'object',
+                properties: {},
+              } as const,
+            }
+          );
+        },
+        {
+          payloadSchema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string', default: 'default_name' },
+            },
+            required: [],
+            additionalProperties: false,
+          } as const,
+        }
+      );
+
+      await bridgeServer.start({ workflows: [workflowWithCustomMiddle] });
+
+      if (context.isStateful) {
+        await syncWorkflow(session, workflowsRepository, workflowId, bridgeServer);
+
+        const afterCustom = await workflowsRepository.findByTriggerIdentifier(session.environment._id, workflowId);
+        expect(afterCustom?.steps?.length).to.be.eq(3);
+        const middleAfterCustom = afterCustom?.steps?.find((s) => s.stepId === middleStepId);
+        expect(middleAfterCustom?.template?.type).to.eql(StepTypeEnum.CUSTOM);
+      }
+
+      await bridgeServer.stop();
+
+      /*
+       * The framework Client caches discovery per workflow id. Reusing the same TestBridgeServer
+       * after start/stop would still serve the first discovered definition, so use a fresh server
+       * (fresh Client) for the updated workflow.
+       */
+      const chatBridgePort = await getPort();
+      const bridgeServerChat = new TestBridgeServer(chatBridgePort);
+      await bridgeServerChat.start({ workflows: [workflowWithChatMiddle] });
+
+      if (context.isStateful) {
+        await syncWorkflow(session, workflowsRepository, workflowId, bridgeServerChat);
+
+        const afterChat = await workflowsRepository.findByTriggerIdentifier(session.environment._id, workflowId);
+        expect(afterChat?.steps?.length).to.be.eq(3);
+        const middleAfterChat = afterChat?.steps?.find((s) => s.stepId === middleStepId);
+        expect(middleAfterChat?.template?.type).to.eql(StepTypeEnum.CHAT);
+      }
+
+      await bridgeServerChat.stop();
+    });
+
     it(`should skip by static value [${context.name}]`, async () => {
       const workflowIdSkipByStatic = `skip-by-static-value-workflow-${`${context.name}`}`;
       const newWorkflow = workflow(

--- a/libs/application-generic/src/usecases/message-template/update-message-template/update-message-template.usecase.ts
+++ b/libs/application-generic/src/usecases/message-template/update-message-template/update-message-template.usecase.ts
@@ -36,8 +36,14 @@ export class UpdateMessageTemplate {
       updatePayload.name = command.name;
     }
 
+    const effectiveTemplateType = command.type !== undefined ? command.type : existingTemplate.type;
+
+    if (command.type !== undefined && command.type !== existingTemplate.type) {
+      updatePayload.type = command.type;
+    }
+
     if (command.content !== null || command.content !== undefined) {
-      updatePayload.content = shouldSanitize(existingTemplate.type, command.contentType)
+      updatePayload.content = shouldSanitize(effectiveTemplateType, command.contentType)
         ? sanitizeMessageContentV0(command.content)
         : command.content;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a framework workflow step was replaced with a different channel type but the same `stepId` (e.g. custom → chat), the workflow sync/upsert path updated the message template’s controls and other fields but **never persisted `type` on the message template document**. The DB row kept the previous step type, so execution and the dashboard still behaved like the old step.

## Root cause

`UpdateMessageTemplate` built an update payload from the command but did not map `command.type` into `$set`, unlike create.

## Fix

- When `command.type` is provided and differs from the stored template, set `updatePayload.type`.
- Use the effective type when deciding content sanitization so a type change in the same update uses the new channel rules.

## Testing

- `nx run @novu/application-generic:build` passed locally.
- **E2E:** `bridge-trigger.e2e.ts` — `should update message template type when replacing a step with the same stepId after re-sync [stateful]` syncs a workflow with a custom middle step, then re-syncs after replacing that step with chat (same `stepId`) and asserts the middle step’s message template type is `CHAT`. A **second `TestBridgeServer` instance** is required because `@novu/framework`’s `Client` caches discovery per workflow id; restarting the same server does not refresh discovery.

Linear: NV-7323
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7323](https://linear.app/novu/issue/NV-7323/workflow-keeps-old-custom-step-after-replacement)

<div><a href="https://cursor.com/agents/bc-f9e22e11-570a-4c02-97db-0bc33621bbdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9e22e11-570a-4c02-97db-0bc33621bbdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

When a framework workflow step was replaced with a different channel type (e.g., custom → chat) while retaining the same `stepId`, the update flow modified message template controls but failed to persist the new step type to the database. The fix ensures `UpdateMessageTemplate` now maps `command.type` into the MongoDB update payload and uses the effective (new) type when deciding content sanitization rules.

## Affected areas

**@novu/api-service**: Updated `UpdateMessageTemplate` usecase to persist the `type` field when provided and differs from the stored template, and to apply content sanitization rules based on the new type rather than the stale type.

**@novu/api-service (e2e)**: Added E2E test `bridge-trigger.e2e.ts` that verifies custom→chat step replacement updates the persisted message template type after workflow re-sync, using a second `TestBridgeServer` instance to avoid framework client discovery caching.

## Key technical decisions

- Computed an `effectiveTemplateType` that uses `command.type` when provided, falling back to the existing template type. This ensures content sanitization behavior immediately reflects any type change in the same update operation.
- Required a fresh bridge server and client in the test because `@novu/framework`'s discovery is cached per workflow id.

## Testing

Added an E2E test that syncs a workflow with a custom middle step, then re-syncs after replacing it with a chat step (same `stepId`), verifying the persisted message template type updates to `CHAT`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->