### PR TITLE
fix(dashboard): skip cloud layout limits UI when self-hosted

### DIFF
--- a/apps/dashboard/src/components/layouts/create-layout-btn.tsx
+++ b/apps/dashboard/src/components/layouts/create-layout-btn.tsx
@@ -4,6 +4,7 @@ import { RiAddCircleLine } from 'react-icons/ri';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { PermissionButton } from '@/components/primitives/permission-button';
+import { IS_SELF_HOSTED } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchLayouts } from '@/hooks/use-fetch-layouts';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
@@ -43,7 +44,7 @@ export const CreateLayoutButton = ({
     navigate(`${buildRoute(ROUTES.LAYOUTS_CREATE, { environmentSlug: currentEnvironment?.slug ?? '' })}${search}`);
   };
 
-  if (tier === ApiServiceLevelEnum.FREE && data?.layouts && data?.layouts?.length >= 1) {
+  if (!IS_SELF_HOSTED && tier === ApiServiceLevelEnum.FREE && data?.layouts && data?.layouts?.length >= 1) {
     return (
       <Tooltip>
         <TooltipTrigger className="cursor-not-allowed">

--- a/apps/dashboard/src/components/layouts/layout-list-blank.tsx
+++ b/apps/dashboard/src/components/layouts/layout-list-blank.tsx
@@ -1,6 +1,7 @@
 import { ApiServiceLevelEnum } from '@novu/shared';
 import { RiAddCircleLine, RiInformation2Line } from 'react-icons/ri';
 import { Link } from 'react-router-dom';
+import { IS_SELF_HOSTED } from '@/config';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { ROUTES } from '@/utils/routes';
 import { CreateLayoutButton } from './create-layout-btn';
@@ -35,7 +36,7 @@ export const LayoutListBlank = () => {
 
       <div className="flex flex-col items-center gap-1">
         <CreateLayoutButton text="Create your first layout" icon={RiAddCircleLine} />
-        {tier === ApiServiceLevelEnum.FREE && (
+        {!IS_SELF_HOSTED && tier === ApiServiceLevelEnum.FREE && (
           <p className="text-text-soft text-paragraph-xs mt-2 flex items-center gap-1">
             <RiInformation2Line />
             One layout is included in your plan,{' '}

--- a/apps/dashboard/src/components/layouts/layout-list.tsx
+++ b/apps/dashboard/src/components/layouts/layout-list.tsx
@@ -24,6 +24,7 @@ import {
   TableRow,
 } from '@/components/primitives/table';
 import { TablePaginationFooter } from '@/components/primitives/table-pagination-footer';
+import { IS_SELF_HOSTED } from '@/config';
 import { useFetchLayouts } from '@/hooks/use-fetch-layouts';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { cn } from '@/utils/ui';
@@ -192,7 +193,7 @@ export const LayoutList = (props: LayoutListProps) => {
     );
   }
 
-  if (tier === ApiServiceLevelEnum.FREE && data?.layouts.length === 1) {
+  if (!IS_SELF_HOSTED && tier === ApiServiceLevelEnum.FREE && data?.layouts.length === 1) {
     return <LayoutsListUpgradeCta />;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Community self-hosted builds do not load billing subscription data (`useFetchSubscription` is disabled when `IS_SELF_HOSTED` and not enterprise). The layouts UI was defaulting tier to `FREE`, which incorrectly showed Novu Cloud free-tier limits: the full-page upgrade CTA when one layout exists, a disabled **Create layout** button with an upgrade tooltip, and the empty-state line about “one layout” and upgrading.

The API already treats self-hosted as unlimited for layout count. This change gates those cloud-only affordances behind `!IS_SELF_HOSTED` so self-hosted users see the normal list and can create additional layouts without misleading limit messaging.

## Files

- `layout-list.tsx` — only show `LayoutsListUpgradeCta` for cloud free tier
- `create-layout-btn.tsx` — only disable create for cloud free tier at layout cap
- `layout-list-blank.tsx` — hide “one layout in your plan” copy when self-hosted
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1775146428307949?thread_ts=1775146428.307949&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-d061dcc0-367b-5e6e-a115-3dd50c50a125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d061dcc0-367b-5e6e-a115-3dd50c50a125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
Self-hosted instances were incorrectly showing Novu Cloud's free-tier limits (upgrade CTAs, disabled create button, upgrade messaging) because billing subscription data isn't loaded for self-hosted builds. The fix gates three cloud-only UI affordances behind `!IS_SELF_HOSTED`: the full-page upgrade prompt, the disabled create-layout button warning, and the empty-state upgrade message. Self-hosted users now see normal layout list and create behavior without misleading limit messaging.

## Affected areas
**dashboard**: Updated layout list components (`layout-list.tsx`, `create-layout-btn.tsx`, `layout-list-blank.tsx`) to conditionally render cloud-specific upgrade CTAs and disabled states only when `!IS_SELF_HOSTED`. Added `IS_SELF_HOSTED` config import to gate these affordances.

## Key technical decisions
The solution relies on the existing `IS_SELF_HOSTED` flag rather than adding new subscription-detection logic. This aligns with the API already treating self-hosted as unlimited for layout count and avoids double-checking subscription state where it's already disabled during build.

## Testing
No new tests were added. The changes are configuration-driven guards on existing UI logic, testable through manual verification in self-hosted and cloud deployments. The PR references a Slack thread validating the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->