### PR TITLE
chore(worker, root): Upgrade bullmq to v5.x

### DIFF
--- a/apps/worker/src/app/workflow/services/active-jobs-metric.service.ts
+++ b/apps/worker/src/app/workflow/services/active-jobs-metric.service.ts
@@ -2,9 +2,9 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import {
   ActiveJobsMetricQueueService,
   ActiveJobsMetricWorkerService,
+  BullMqWorkerOptions,
   MetricsService,
   QueueBaseService,
-  WorkerOptions,
 } from '@novu/application-generic';
 import { CronExpressionEnum } from '@novu/shared';
 
@@ -86,7 +86,7 @@ export class ActiveJobsMetricService {
       });
   }
 
-  private getWorkerOptions(): WorkerOptions {
+  private getWorkerOptions(): BullMqWorkerOptions {
     return {
       lockDuration: 900,
       concurrency: 1,

--- a/apps/worker/src/app/workflow/services/standard.worker.ts
+++ b/apps/worker/src/app/workflow/services/standard.worker.ts
@@ -1,6 +1,7 @@
 import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import {
   BullMqService,
+  BullMqWorkerOptions,
   FeatureFlagsService,
   getStandardWorkerOptions,
   IStandardDataDto,
@@ -10,7 +11,6 @@ import {
   StandardWorkerService,
   Store,
   storage,
-  WorkerOptions,
   WorkflowInMemoryProviderService,
 } from '@novu/application-generic';
 import { CommunityOrganizationRepository, JobRepository } from '@novu/dal';
@@ -68,7 +68,7 @@ export class StandardWorker extends StandardWorkerService {
     this.startSqsConsumer();
   }
 
-  private getWorkerOptions(): WorkerOptions {
+  private getWorkerOptions(): BullMqWorkerOptions {
     return {
       ...getStandardWorkerOptions(),
       settings: {

--- a/apps/worker/src/app/workflow/services/subscriber-process.worker.ts
+++ b/apps/worker/src/app/workflow/services/subscriber-process.worker.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import {
   BullMqService,
+  BullMqWorkerOptions,
   FeatureFlagsService,
   getSubscriberProcessWorkerOptions,
   IProcessSubscriberDataDto,
@@ -9,7 +10,6 @@ import {
   Store,
   SubscriberProcessWorkerService,
   storage,
-  WorkerOptions,
   WorkflowInMemoryProviderService,
 } from '@novu/application-generic';
 import { CommunityOrganizationRepository } from '@novu/dal';
@@ -97,7 +97,7 @@ export class SubscriberProcessWorker extends SubscriberProcessWorkerService {
     };
   }
 
-  private getWorkerOpts(): WorkerOptions {
+  private getWorkerOpts(): BullMqWorkerOptions {
     return getSubscriberProcessWorkerOptions();
   }
 

--- a/apps/worker/src/app/workflow/services/workflow.worker.ts
+++ b/apps/worker/src/app/workflow/services/workflow.worker.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import {
   BullMqService,
+  BullMqWorkerOptions,
   FeatureFlagsService,
   getWorkflowWorkerOptions,
   IWorkflowDataDto,
@@ -9,7 +10,6 @@ import {
   Store,
   storage,
   TriggerEvent,
-  WorkerOptions,
   WorkerProcessor,
   WorkflowInMemoryProviderService,
   WorkflowWorkerService,
@@ -35,7 +35,7 @@ export class WorkflowWorker extends WorkflowWorkerService {
     this.initWorker(this.getWorkerProcessor(), this.getWorkerOptions());
   }
 
-  private getWorkerOptions(): WorkerOptions {
+  private getWorkerOptions(): BullMqWorkerOptions {
     return getWorkflowWorkerOptions();
   }
 

--- a/apps/worker/src/app/workflow/workers/inbound-parse.worker.service.ts
+++ b/apps/worker/src/app/workflow/workers/inbound-parse.worker.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import {
   BullMqService,
+  BullMqWorkerOptions,
   getInboundParseMailWorkerOptions,
   IInboundParseDataDto,
   WorkerBaseService,
-  WorkerOptions,
   WorkflowInMemoryProviderService,
 } from '@novu/application-generic';
 import { JobTopicNameEnum } from '@novu/shared';
@@ -28,7 +28,7 @@ export class InboundParseWorker extends WorkerBaseService {
     this.initWorker(this.getWorkerProcessor(), this.getWorkerOptions());
   }
 
-  private getWorkerOptions(): WorkerOptions {
+  private getWorkerOptions(): BullMqWorkerOptions {
     return getInboundParseMailWorkerOptions();
   }
 

--- a/apps/ws/src/socket/services/web-socket.worker.ts
+++ b/apps/ws/src/socket/services/web-socket.worker.ts
@@ -2,12 +2,12 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import {
   BullMqService,
+  BullMqWorkerOptions,
   getWebSocketWorkerOptions,
   IWebSocketDataDto,
   PinoLogger,
   SqsService,
   WebSocketsWorkerService,
-  WorkerOptions,
   WorkflowInMemoryProviderService,
 } from '@novu/application-generic';
 
@@ -75,7 +75,7 @@ export class WebSocketWorker extends WebSocketsWorkerService {
     };
   }
 
-  private getWorkerOpts(): WorkerOptions {
+  private getWorkerOpts(): BullMqWorkerOptions {
     return getWebSocketWorkerOptions();
   }
 }

--- a/libs/application-generic/package.json
+++ b/libs/application-generic/package.json
@@ -79,7 +79,7 @@
     "ajv": "^8.18.0",
     "ajv-formats": "^2.1.1",
     "axios": "^1.9.0",
-    "bullmq": "^4.18.3",
+    "bullmq": "5.70.0",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.1",
     "clickhouse-schema": "^2.0.1",
@@ -120,7 +120,7 @@
   },
   "optionalDependencies": {
     "@novu/ee-shared-services": "workspace:*",
-    "@taskforcesh/bullmq-pro": "^7.43.0"
+    "@taskforcesh/bullmq-pro": "7.40.0"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",

--- a/libs/application-generic/package.json
+++ b/libs/application-generic/package.json
@@ -79,7 +79,7 @@
     "ajv": "^8.18.0",
     "ajv-formats": "^2.1.1",
     "axios": "^1.9.0",
-    "bullmq": "^3.10.2",
+    "bullmq": "^4.18.3",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.1",
     "clickhouse-schema": "^2.0.1",

--- a/libs/application-generic/package.json
+++ b/libs/application-generic/package.json
@@ -120,7 +120,7 @@
   },
   "optionalDependencies": {
     "@novu/ee-shared-services": "workspace:*",
-    "@taskforcesh/bullmq-pro": "6.11.0"
+    "@taskforcesh/bullmq-pro": "7.43.0"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",

--- a/libs/application-generic/package.json
+++ b/libs/application-generic/package.json
@@ -120,7 +120,7 @@
   },
   "optionalDependencies": {
     "@novu/ee-shared-services": "workspace:*",
-    "@taskforcesh/bullmq-pro": "7.43.0"
+    "@taskforcesh/bullmq-pro": "^7.43.0"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",

--- a/libs/application-generic/src/services/bull-mq/bull-mq.service.spec.ts
+++ b/libs/application-generic/src/services/bull-mq/bull-mq.service.spec.ts
@@ -1,6 +1,6 @@
 import { JobTopicNameEnum } from '@novu/shared';
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
-import { BullMqService, QueueBaseOptions, WorkerOptions } from './bull-mq.service';
+import { BullMqQueueOptions, BullMqService } from './bull-mq.service';
 
 let bullMqService: BullMqService;
 
@@ -33,7 +33,7 @@ describe('BullMQ Service', () => {
 
       it('should create a queue properly with the default configuration', async () => {
         const queueName = JobTopicNameEnum.ACTIVE_JOBS_METRIC;
-        const queueOptions: QueueBaseOptions = {};
+        const queueOptions: BullMqQueueOptions = {};
         await bullMqService.createQueue(queueName, queueOptions);
 
         expect(bullMqService.queue.name).toEqual(queueName);

--- a/libs/application-generic/src/services/bull-mq/bull-mq.service.ts
+++ b/libs/application-generic/src/services/bull-mq/bull-mq.service.ts
@@ -24,6 +24,9 @@ interface IQueueMetrics {
 
 type BullMqJobData = undefined | IJobData | IEventJobData;
 
+export type BullMqQueueOptions = Omit<QueueOptions, 'connection'>;
+export type BullMqWorkerOptions = Omit<WorkerOptions, 'connection'>;
+
 const LOG_CONTEXT = 'BullMqService';
 
 export {
@@ -96,7 +99,7 @@ export class BullMqService {
     return undefined;
   }
 
-  public createQueue(topic: JobTopicNameEnum, queueOptions: QueueOptions) {
+  public createQueue(topic: JobTopicNameEnum, queueOptions: BullMqQueueOptions) {
     const config = {
       connection: this.workflowInMemoryProviderService.getClient(),
       ...(queueOptions?.defaultJobOptions && {
@@ -125,11 +128,11 @@ export class BullMqService {
   public createWorker(
     topic: JobTopicNameEnum,
     processor?: string | Processor<any, unknown | void, string>,
-    workerOptions?: WorkerOptions
+    workerOptions?: BullMqWorkerOptions
   ) {
     const WorkerClass = !BullMqService.pro ? Worker : require('@taskforcesh/bullmq-pro').WorkerPro;
 
-    const { concurrency, connection, lockDuration, settings } = workerOptions;
+    const { concurrency, lockDuration, settings } = workerOptions ?? {};
 
     const config = {
       connection: this.workflowInMemoryProviderService.getClient(),

--- a/libs/application-generic/src/services/index.ts
+++ b/libs/application-generic/src/services/index.ts
@@ -13,6 +13,7 @@ export {
   Worker,
   WorkerOptions,
 } from './bull-mq';
+export type { BullMqQueueOptions, BullMqWorkerOptions } from './bull-mq';
 export * from './cache';
 export * from './calculate-delay';
 export * from './cloudflare-scheduler';

--- a/libs/application-generic/src/services/queues/inbound-parse-queue.service.ts
+++ b/libs/application-generic/src/services/queues/inbound-parse-queue.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { JobTopicNameEnum } from '@novu/shared';
 import { IInboundParseBulkJobDto, IInboundParseJobDto } from '../../dtos/inbound-parse-job.dto';
-import { BullMqService, QueueOptions } from '../bull-mq';
+import { BullMqQueueOptions, BullMqService } from '../bull-mq';
 import { WorkflowInMemoryProviderService } from '../in-memory-provider';
 import { QueueBaseService } from './queue-base.service';
 
@@ -25,7 +25,7 @@ export class InboundParseQueueService extends QueueBaseService {
     return await super.addBulk(data);
   }
 
-  private getOverrideOptions(): QueueOptions {
+  private getOverrideOptions(): BullMqQueueOptions {
     return {
       defaultJobOptions: {
         attempts: 5,

--- a/libs/application-generic/src/services/queues/queue-base.service.ts
+++ b/libs/application-generic/src/services/queues/queue-base.service.ts
@@ -3,7 +3,7 @@ import { CommunityOrganizationRepository } from '@novu/dal';
 import { ApiServiceLevelEnum, FeatureFlagsKeysEnum, JobTopicNameEnum, QueueBackendMode } from '@novu/shared';
 import { PinoLogger } from '../../logging';
 
-import { BulkJobOptions, BullMqService, JobsOptions, Queue, QueueOptions } from '../bull-mq';
+import { BulkJobOptions, BullMqQueueOptions, BullMqService, JobsOptions, Queue } from '../bull-mq';
 import { FeatureFlagsService } from '../feature-flags';
 import { SqsService } from '../sqs';
 
@@ -29,7 +29,7 @@ export class QueueBaseService implements OnModuleDestroy {
     }
   }
 
-  public createQueue(overrideOptions?: QueueOptions): void {
+  public createQueue(overrideOptions?: BullMqQueueOptions): void {
     const options = {
       ...this.getQueueOptions(),
       ...(overrideOptions && {
@@ -43,7 +43,7 @@ export class QueueBaseService implements OnModuleDestroy {
     this.queue = this.bullMqService.createQueue(this.topic, options);
   }
 
-  private getQueueOptions(): QueueOptions {
+  private getQueueOptions(): BullMqQueueOptions {
     return {
       defaultJobOptions: {
         removeOnComplete: true,

--- a/libs/application-generic/src/services/workers/index.ts
+++ b/libs/application-generic/src/services/workers/index.ts
@@ -3,6 +3,7 @@ export { StandardWorkerService } from './standard-worker.service';
 export { SubscriberProcessWorkerService } from './subscriber-process-worker.service';
 export { WebSocketsWorkerService } from './web-sockets-worker.service';
 export {
+  BullMqWorkerOptions,
   SqsCompletedHandler,
   SqsFailedHandler,
   WorkerBaseService,

--- a/libs/application-generic/src/services/workers/worker-base.service.ts
+++ b/libs/application-generic/src/services/workers/worker-base.service.ts
@@ -7,7 +7,7 @@ import {
   getSqsDefaultWaitTimeSeconds,
 } from '../../config/workers';
 import { PinoLogger } from '../../logging';
-import { BullMqService, Job, Processor, WorkerOptions } from '../bull-mq';
+import { BullMqService, BullMqWorkerOptions, Job, Processor, WorkerOptions } from '../bull-mq';
 import { INovuWorker } from '../readiness';
 import {
   createSqsJobAdapter,
@@ -28,7 +28,7 @@ export type WorkerProcessor = string | Processor<any, unknown, string> | undefin
 export type SqsCompletedHandler = (job: Job<any, unknown, string>) => Promise<void>;
 export type SqsFailedHandler = (job: Job<any, unknown, string>, error: Error) => Promise<boolean>;
 
-export { WorkerOptions };
+export { BullMqWorkerOptions, WorkerOptions };
 
 export class WorkerBaseService implements INovuWorker, OnModuleDestroy {
   public bullMqService: BullMqService;
@@ -51,7 +51,7 @@ export class WorkerBaseService implements INovuWorker, OnModuleDestroy {
     this.bullMqService = bullMqServiceInstance;
   }
 
-  public initWorker(processor: WorkerProcessor, options?: WorkerOptions, deferSqsStart = false): void {
+  public initWorker(processor: WorkerProcessor, options?: BullMqWorkerOptions, deferSqsStart = false): void {
     if (typeof processor === 'function') {
       this.createWorker(this.wrapForBullMQ(processor), options);
       this.initSqsConsumer(processor, options);
@@ -106,11 +106,11 @@ export class WorkerBaseService implements INovuWorker, OnModuleDestroy {
     };
   }
 
-  public createWorker(processor: WorkerProcessor, options: WorkerOptions): void {
+  public createWorker(processor: WorkerProcessor, options?: BullMqWorkerOptions): void {
     this.bullMqService.createWorker(this.topic, processor, options);
   }
 
-  private initSqsConsumer(processor: Processor<any, unknown, string>, options?: WorkerOptions): void {
+  private initSqsConsumer(processor: Processor<any, unknown, string>, options?: BullMqWorkerOptions): void {
     if (!this.sqsService?.isConfigured(this.topic)) {
       return;
     }

--- a/libs/testing/package.json
+++ b/libs/testing/package.json
@@ -30,7 +30,7 @@
     "async": "^3.2.0",
     "axios": "^1.9.0",
     "bcrypt": "~5.0.0",
-    "bullmq": "^3.10.2",
+    "bullmq": "^4.18.3",
     "class-transformer": "0.5.1",
     "cross-fetch": "^3.0.4",
     "event-stream": "^4.0.1",

--- a/libs/testing/package.json
+++ b/libs/testing/package.json
@@ -30,7 +30,7 @@
     "async": "^3.2.0",
     "axios": "^1.9.0",
     "bcrypt": "~5.0.0",
-    "bullmq": "^4.18.3",
+    "bullmq": "5.70.0",
     "class-transformer": "0.5.1",
     "cross-fetch": "^3.0.4",
     "event-stream": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2681,6 +2681,9 @@ importers:
       '@novu/ee-shared-services':
         specifier: workspace:*
         version: link:../../enterprise/packages/shared-services
+      '@taskforcesh/bullmq-pro':
+        specifier: 7.40.0
+        version: 7.40.0
 
   libs/automation:
     dependencies:
@@ -13609,6 +13612,9 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@taskforcesh/bullmq-pro@7.40.0':
+    resolution: {integrity: sha512-ZK/2Y2h9SPk6kfmE5X/7H4j88SvvlrdSfXnkJ0Id9hdJFxNXdq94YZSz+G/sLS9HOqy6xOWfSygvrOsAy+Kuyw==, tarball: https://npm.taskforce.sh/@taskforcesh/bullmq-pro/-/@taskforcesh/bullmq-pro-7.40.0.tgz}
+
   '@team-plain/typescript-sdk@5.8.0':
     resolution: {integrity: sha512-qgDGX96yDsdTo5+Yh8R+rhtInmAm90w17607B2Ugik8Ij0H1wocjjp8xtMxHruSmms5ani43Y5xRxVFPSxYVeg==}
 
@@ -16230,6 +16236,9 @@ packages:
   bull@4.10.4:
     resolution: {integrity: sha512-o9m/7HjS/Or3vqRd59evBlWCXd9Lp+ALppKseoSKHaykK46SmRjAilX98PgmOz1yeVaurt8D5UtvEt4bUjM3eA==}
     engines: {node: '>=12'}
+
+  bullmq@5.63.0:
+    resolution: {integrity: sha512-HT1iM3Jt4bZeg3Ru/MxrOy2iIItxcl1Pz5Ync1Vrot70jBpVguMxFEiSaDU57BwYwR4iwnObDnzct2lirKkX5A==}
 
   bullmq@5.70.0:
     resolution: {integrity: sha512-HlBSEJqG7MJ97+d/N/8rtGOcpisjGP3WD/zaXZia0hsmckJqAPTVWN6Yfw32FVfVSUVVInZQ2nUgMd2zCRghKg==}
@@ -26018,7 +26027,6 @@ packages:
   superagent@10.1.0:
     resolution: {integrity: sha512-JMmik7PbnXGlq7g528Gi6apHbVbTz2vrE3du6fuG4kIPSb2PnLoSOPvfjKn8aQYuJcBWAKW6ZG90qPPsE5jZxQ==}
     engines: {node: '>=14.18.0'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superagent@8.1.2:
     resolution: {integrity: sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==}
@@ -28580,8 +28588,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.575.0
@@ -28911,11 +28919,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.575.0':
+  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -28954,6 +28962,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)':
@@ -29292,11 +29301,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
+  '@aws-sdk/client-sts@3.575.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -29335,7 +29344,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.637.0':
@@ -29547,7 +29555,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
       '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
@@ -29876,7 +29884,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
@@ -30427,7 +30435,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -30436,7 +30444,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -42306,6 +42314,17 @@ snapshots:
       '@tanstack/query-core': 5.65.0
       react: 19.2.3
 
+  '@taskforcesh/bullmq-pro@7.40.0':
+    dependencies:
+      bullmq: 5.63.0
+      msgpackr: 1.11.9
+      rxjs: 6.6.7
+      tslib: 2.8.1
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@team-plain/typescript-sdk@5.8.0':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
@@ -45515,6 +45534,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bullmq@5.63.0:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.9.2
+      msgpackr: 1.11.9
+      node-abort-controller: 3.1.1
+      semver: 7.7.4
+      tslib: 2.8.1
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   bullmq@5.70.0:
     dependencies:
       cron-parser: 4.9.0
@@ -46928,7 +46960,6 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
-    optional: true
 
   debug@4.3.1(supports-color@8.1.1):
     dependencies:
@@ -53667,7 +53698,7 @@ snapshots:
 
   needle@2.4.0:
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       iconv-lite: 0.4.24
       sax: 1.4.1
     transitivePeerDependencies:
@@ -53675,7 +53706,7 @@ snapshots:
 
   needle@3.2.0:
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       iconv-lite: 0.6.3
       sax: 1.5.0
     transitivePeerDependencies:
@@ -55083,7 +55114,7 @@ snapshots:
   portfinder@1.0.32:
     dependencies:
       async: 2.6.4
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       mkdirp: 0.5.6
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2494,8 +2494,8 @@ importers:
         specifier: ^1.13.5
         version: 1.13.6
       bullmq:
-        specifier: ^4.18.3
-        version: 4.18.3
+        specifier: 5.70.0
+        version: 5.70.0
       class-transformer:
         specifier: 0.5.1
         version: 0.5.1
@@ -7958,6 +7958,9 @@ packages:
 
   '@ioredis/commands@1.2.0':
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
+
+  '@ioredis/commands@1.5.0':
+    resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -16231,6 +16234,9 @@ packages:
   bullmq@4.18.3:
     resolution: {integrity: sha512-H8t9vhfHEbJDaXp7aalSTe+Do+tR1nvr+lsT+jQxLhy+FFfFj/0p4aYJzADTNLdEqltuxneLVxCGVg92GkQx4w==}
 
+  bullmq@5.70.0:
+    resolution: {integrity: sha512-HlBSEJqG7MJ97+d/N/8rtGOcpisjGP3WD/zaXZia0hsmckJqAPTVWN6Yfw32FVfVSUVVInZQ2nUgMd2zCRghKg==}
+
   bundle-require@5.0.0:
     resolution: {integrity: sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -19877,6 +19883,10 @@ packages:
 
   ioredis@5.3.2:
     resolution: {integrity: sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==}
+    engines: {node: '>=12.22.0'}
+
+  ioredis@5.9.2:
+    resolution: {integrity: sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==}
     engines: {node: '>=12.22.0'}
 
   ip-address@10.1.0:
@@ -28573,8 +28583,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.575.0
@@ -28904,11 +28914,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
+  '@aws-sdk/client-sso-oidc@3.575.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -28947,7 +28957,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)':
@@ -29286,11 +29295,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.575.0':
+  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -29329,6 +29338,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.637.0':
@@ -29540,7 +29550,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
       '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
@@ -29869,7 +29879,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
@@ -30420,7 +30430,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -30429,7 +30439,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -33823,6 +33833,8 @@ snapshots:
       '@swc/helpers': 0.5.15
 
   '@ioredis/commands@1.2.0': {}
+
+  '@ioredis/commands@1.5.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -45520,6 +45532,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bullmq@5.70.0:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.9.2
+      msgpackr: 1.11.9
+      node-abort-controller: 3.1.1
+      semver: 7.7.4
+      tslib: 2.8.1
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   bundle-require@5.0.0(esbuild@0.23.1):
     dependencies:
       esbuild: 0.23.1
@@ -50051,6 +50075,20 @@ snapshots:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
       debug: 4.3.4(supports-color@8.1.1)
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ioredis@5.9.2:
+    dependencies:
+      '@ioredis/commands': 1.5.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3(supports-color@8.1.1)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28573,8 +28573,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.575.0
@@ -28904,11 +28904,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.575.0':
+  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -28947,6 +28947,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)':
@@ -29285,11 +29286,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
+  '@aws-sdk/client-sts@3.575.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -29328,7 +29329,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.637.0':
@@ -29540,7 +29540,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
       '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
@@ -29869,7 +29869,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
@@ -30420,7 +30420,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -30429,7 +30429,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2681,9 +2681,6 @@ importers:
       '@novu/ee-shared-services':
         specifier: workspace:*
         version: link:../../enterprise/packages/shared-services
-      '@taskforcesh/bullmq-pro':
-        specifier: 6.11.0
-        version: 6.11.0
 
   libs/automation:
     dependencies:
@@ -13609,9 +13606,6 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@taskforcesh/bullmq-pro@6.11.0':
-    resolution: {integrity: sha512-S00SeOlo6VMc3YGsAFKX7w/jDAt6b7mNn2Ks7bF4Ilmh5xd/RBPv/vd3ouvhQ5slxAuZxoFLKRnysdPCWHKORA==, tarball: https://npm.taskforce.sh/@taskforcesh/bullmq-pro/-/@taskforcesh/bullmq-pro-6.11.0.tgz}
-
   '@team-plain/typescript-sdk@5.8.0':
     resolution: {integrity: sha512-qgDGX96yDsdTo5+Yh8R+rhtInmAm90w17607B2Ugik8Ij0H1wocjjp8xtMxHruSmms5ani43Y5xRxVFPSxYVeg==}
 
@@ -16233,9 +16227,6 @@ packages:
   bull@4.10.4:
     resolution: {integrity: sha512-o9m/7HjS/Or3vqRd59evBlWCXd9Lp+ALppKseoSKHaykK46SmRjAilX98PgmOz1yeVaurt8D5UtvEt4bUjM3eA==}
     engines: {node: '>=12'}
-
-  bullmq@4.17.0:
-    resolution: {integrity: sha512-URnHgB01rlCP8RTpmW3kFnvv3vdd2aI1OcBMYQwnqODxGiJUlz9MibDVXE83mq7ee1eS1IvD9lMQqGszX6E5Pw==}
 
   bullmq@4.18.3:
     resolution: {integrity: sha512-H8t9vhfHEbJDaXp7aalSTe+Do+tR1nvr+lsT+jQxLhy+FFfFj/0p4aYJzADTNLdEqltuxneLVxCGVg92GkQx4w==}
@@ -21474,9 +21465,6 @@ packages:
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -28585,8 +28573,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.575.0
@@ -28916,11 +28904,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.575.0':
+  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -28959,6 +28947,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)':
@@ -29297,11 +29286,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
+  '@aws-sdk/client-sts@3.575.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -29340,7 +29329,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.637.0':
@@ -29552,7 +29540,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
       '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
@@ -29881,7 +29869,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
@@ -30432,7 +30420,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -30441,7 +30429,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -42309,18 +42297,6 @@ snapshots:
       '@tanstack/query-core': 5.65.0
       react: 19.2.3
 
-  '@taskforcesh/bullmq-pro@6.11.0':
-    dependencies:
-      bullmq: 4.17.0
-      lodash: 4.17.21
-      msgpackr: 1.11.9
-      rxjs: 6.6.7
-      tslib: 2.8.1
-      uuid: 8.3.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@team-plain/typescript-sdk@5.8.0':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
@@ -45529,21 +45505,6 @@ snapshots:
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
-
-  bullmq@4.17.0:
-    dependencies:
-      cron-parser: 4.9.0
-      glob: 8.1.0
-      ioredis: 5.3.2
-      lodash: 4.17.21
-      msgpackr: 1.11.9
-      node-abort-controller: 3.1.1
-      semver: 7.7.2
-      tslib: 2.8.1
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   bullmq@4.18.3:
     dependencies:
@@ -52340,9 +52301,6 @@ snapshots:
   lodash.topath@4.5.2: {}
 
   lodash.uniq@4.5.0: {}
-
-  lodash@4.17.21:
-    optional: true
 
   lodash@4.18.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2494,8 +2494,8 @@ importers:
         specifier: ^1.13.5
         version: 1.13.6
       bullmq:
-        specifier: ^3.10.2
-        version: 3.10.4
+        specifier: ^4.18.3
+        version: 4.18.3
       class-transformer:
         specifier: 0.5.1
         version: 0.5.1
@@ -3140,8 +3140,8 @@ importers:
         specifier: ~5.0.0
         version: 5.0.1(encoding@0.1.13)
       bullmq:
-        specifier: ^3.10.2
-        version: 3.10.4
+        specifier: ^4.18.3
+        version: 4.18.3
       class-transformer:
         specifier: 0.5.1
         version: 0.5.1
@@ -16234,11 +16234,11 @@ packages:
     resolution: {integrity: sha512-o9m/7HjS/Or3vqRd59evBlWCXd9Lp+ALppKseoSKHaykK46SmRjAilX98PgmOz1yeVaurt8D5UtvEt4bUjM3eA==}
     engines: {node: '>=12'}
 
-  bullmq@3.10.4:
-    resolution: {integrity: sha512-KHYopaoAJpf9Fe9qMjY2xxbMTqgrEIgfrQr81wU0V/wLf4eijNpjVjGVhfQ/bWuHMmwKY1xgOzSIF3+lmdkiOg==}
-
   bullmq@4.17.0:
     resolution: {integrity: sha512-URnHgB01rlCP8RTpmW3kFnvv3vdd2aI1OcBMYQwnqODxGiJUlz9MibDVXE83mq7ee1eS1IvD9lMQqGszX6E5Pw==}
+
+  bullmq@4.18.3:
+    resolution: {integrity: sha512-H8t9vhfHEbJDaXp7aalSTe+Do+tR1nvr+lsT+jQxLhy+FFfFj/0p4aYJzADTNLdEqltuxneLVxCGVg92GkQx4w==}
 
   bundle-require@5.0.0:
     resolution: {integrity: sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==}
@@ -31881,7 +31881,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.6)
+      better-call: 1.3.2(zod@4.3.5)
       jose: 6.1.3
       kysely: 0.28.14
       nanostores: 1.2.0
@@ -45281,7 +45281,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.6)
+      better-call: 1.3.2(zod@4.3.5)
       defu: 6.1.4
       jose: 6.1.3
       kysely: 0.28.14
@@ -45299,6 +45299,15 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
+
+  better-call@1.3.2(zod@4.3.5):
+    dependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.0
+    optionalDependencies:
+      zod: 4.3.5
 
   better-call@1.3.2(zod@4.3.6):
     dependencies:
@@ -45521,19 +45530,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bullmq@3.10.4:
-    dependencies:
-      cron-parser: 4.9.0
-      glob: 8.1.0
-      ioredis: 5.3.2
-      lodash: 4.18.1
-      msgpackr: 1.11.9
-      semver: 7.5.4
-      tslib: 2.8.1
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   bullmq@4.17.0:
     dependencies:
       cron-parser: 4.9.0
@@ -45548,6 +45544,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  bullmq@4.18.3:
+    dependencies:
+      cron-parser: 4.9.0
+      glob: 8.1.0
+      ioredis: 5.3.2
+      lodash: 4.18.1
+      msgpackr: 1.11.9
+      node-abort-controller: 3.1.1
+      semver: 7.7.4
+      tslib: 2.8.1
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   bundle-require@5.0.0(esbuild@0.23.1):
     dependencies:
@@ -46950,6 +46960,7 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
+    optional: true
 
   debug@4.3.1(supports-color@8.1.1):
     dependencies:
@@ -53677,7 +53688,7 @@ snapshots:
 
   needle@2.4.0:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       iconv-lite: 0.4.24
       sax: 1.4.1
     transitivePeerDependencies:
@@ -53685,7 +53696,7 @@ snapshots:
 
   needle@3.2.0:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       iconv-lite: 0.6.3
       sax: 1.5.0
     transitivePeerDependencies:
@@ -55093,7 +55104,7 @@ snapshots:
   portfinder@1.0.32:
     dependencies:
       async: 2.6.4
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       mkdirp: 0.5.6
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28573,8 +28573,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.575.0
@@ -28904,11 +28904,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
+  '@aws-sdk/client-sso-oidc@3.575.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -28947,7 +28947,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)':
@@ -29286,11 +29285,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.575.0':
+  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -29329,6 +29328,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.637.0':
@@ -29540,7 +29540,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
       '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
@@ -29869,7 +29869,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0
+      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
@@ -30420,7 +30420,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -30429,7 +30429,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3137,8 +3137,8 @@ importers:
         specifier: ~5.0.0
         version: 5.0.1(encoding@0.1.13)
       bullmq:
-        specifier: ^4.18.3
-        version: 4.18.3
+        specifier: 5.70.0
+        version: 5.70.0
       class-transformer:
         specifier: 0.5.1
         version: 0.5.1
@@ -16230,9 +16230,6 @@ packages:
   bull@4.10.4:
     resolution: {integrity: sha512-o9m/7HjS/Or3vqRd59evBlWCXd9Lp+ALppKseoSKHaykK46SmRjAilX98PgmOz1yeVaurt8D5UtvEt4bUjM3eA==}
     engines: {node: '>=12'}
-
-  bullmq@4.18.3:
-    resolution: {integrity: sha512-H8t9vhfHEbJDaXp7aalSTe+Do+tR1nvr+lsT+jQxLhy+FFfFj/0p4aYJzADTNLdEqltuxneLVxCGVg92GkQx4w==}
 
   bullmq@5.70.0:
     resolution: {integrity: sha512-HlBSEJqG7MJ97+d/N/8rtGOcpisjGP3WD/zaXZia0hsmckJqAPTVWN6Yfw32FVfVSUVVInZQ2nUgMd2zCRghKg==}
@@ -45515,20 +45512,6 @@ snapshots:
       msgpackr: 1.11.9
       semver: 7.5.4
       uuid: 8.3.2
-    transitivePeerDependencies:
-      - supports-color
-
-  bullmq@4.18.3:
-    dependencies:
-      cron-parser: 4.9.0
-      glob: 8.1.0
-      ioredis: 5.3.2
-      lodash: 4.18.1
-      msgpackr: 1.11.9
-      node-abort-controller: 3.1.1
-      semver: 7.7.4
-      tslib: 2.8.1
-      uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Bump bullmq from ^3.10.2 to ^4.18.3 in libs/application-generic and libs/testing. Update pnpm-lock.yaml to reflect the new bullmq 4.18.3 resolution and related dependency snapshot changes. Run tests and verify compatibility with bullmq v4 since there may be breaking or behavioral changes.

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
What changed
BullMQ was upgraded and API typings were tightened across the monorepo: libs/application-generic (and libs/testing) now depend on a newer BullMQ release and the optional @taskforcesh/bullmq-pro was bumped to a compatible major. The code was updated to introduce BullMqQueueOptions and BullMqWorkerOptions (Omit<..., 'connection'>) and to use these types across queue and worker services so callers cannot supply a connection object directly. This modernizes the queue library and prevents accidental connection overrides.

Affected areas
- worker / application-generic: Updated BullMQ dependency and introduced/exported BullMqQueueOptions and BullMqWorkerOptions; queue and worker services (QueueBaseService, WorkerBaseService, BullMqService and related queue/worker implementations) were updated to use the new types and adjusted createWorker/createQueue/initWorker signatures.  
- testing: Updated BullMQ dependency in libs/testing and updated unit tests to use the new option types.

Key technical decisions
- New exported types omit the connection field (BullMqQueueOptions, BullMqWorkerOptions) to centralize connection handling and avoid callers passing connection configs.  
- Several worker/queue method signatures were changed to accept the new option types and some worker options became optional to simplify initialization.  
- No database/schema changes; dependency upgrades and type/API surface changes are the primary impact.

Testing
Existing unit tests were updated to the new types and automated tests were run by the author to verify compatibility; no new tests were added. Consumers should run integration/e2e suites to validate runtime queue/worker behavior after the BullMQ major upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
