### PR TITLE
fix(providers): guard nodemailer sendMail against addressparser DoS

### DIFF
--- a/packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts
+++ b/packages/providers/src/lib/email/nodemailer/nodemailer.provider.ts
@@ -12,6 +12,7 @@ import DKIM from 'nodemailer/lib/dkim';
 import SMTPTransport from 'nodemailer/lib/smtp-transport';
 import { ConnectionOptions } from 'tls';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
+import { assertSafeSendMailOptionsForNodemailerDos } from '../../../utils/nodemailer-address-safety';
 import { WithPassthrough } from '../../../utils/types';
 
 interface INodemailerConfig {
@@ -98,7 +99,9 @@ export class NodemailerProvider extends BaseProvider implements IEmailProvider {
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ): Promise<ISendMessageSuccessResponse> {
     const mailData = this.createMailData(options);
-    const info = await this.transports.sendMail(this.transform(bridgeProviderData, mailData).body);
+    const merged = this.transform(bridgeProviderData, mailData);
+    assertSafeSendMailOptionsForNodemailerDos(merged.body as SendMailOptions);
+    const info = await this.transports.sendMail(merged.body);
 
     return {
       id: info?.messageId,
@@ -109,6 +112,7 @@ export class NodemailerProvider extends BaseProvider implements IEmailProvider {
   async checkIntegration(options: IEmailOptions): Promise<ICheckIntegrationResponse> {
     try {
       const mailData = this.createMailData(options);
+      assertSafeSendMailOptionsForNodemailerDos(mailData);
       await this.transports.sendMail(mailData);
 
       return {

--- a/packages/providers/src/lib/email/outlook365/outlook365.provider.ts
+++ b/packages/providers/src/lib/email/outlook365/outlook365.provider.ts
@@ -9,6 +9,7 @@ import {
 } from '@novu/stateless';
 import nodemailer, { SendMailOptions, Transporter } from 'nodemailer';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
+import { assertSafeSendMailOptionsForNodemailerDos } from '../../../utils/nodemailer-address-safety';
 import { WithPassthrough } from '../../../utils/types';
 
 export class Outlook365Provider extends BaseProvider implements IEmailProvider {
@@ -45,7 +46,9 @@ export class Outlook365Provider extends BaseProvider implements IEmailProvider {
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ): Promise<ISendMessageSuccessResponse> {
     const mailData = this.createMailData(options);
-    const info = await this.transports.sendMail(this.transform(bridgeProviderData, mailData).body);
+    const merged = this.transform(bridgeProviderData, mailData);
+    assertSafeSendMailOptionsForNodemailerDos(merged.body as SendMailOptions);
+    const info = await this.transports.sendMail(merged.body);
 
     return {
       id: info?.messageId,
@@ -56,6 +59,7 @@ export class Outlook365Provider extends BaseProvider implements IEmailProvider {
   async checkIntegration(options: IEmailOptions): Promise<ICheckIntegrationResponse> {
     try {
       const mailData = this.createMailData(options);
+      assertSafeSendMailOptionsForNodemailerDos(mailData);
       await this.transports.sendMail(mailData);
 
       return {

--- a/packages/providers/src/lib/email/ses/ses.provider.ts
+++ b/packages/providers/src/lib/email/ses/ses.provider.ts
@@ -11,8 +11,9 @@ import {
   ISendMessageSuccessResponse,
 } from '@novu/stateless';
 import { createVerify } from 'crypto';
-import nodemailer from 'nodemailer';
+import nodemailer, { SendMailOptions } from 'nodemailer';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
+import { assertSafeSendMailOptionsForNodemailerDos } from '../../../utils/nodemailer-address-safety';
 import { WithPassthrough } from '../../../utils/types';
 import { SESConfig } from './ses.config';
 
@@ -41,25 +42,26 @@ export class SESEmailProvider extends BaseProvider implements IEmailProvider {
       SES: { ses: this.ses, aws: { SendRawEmailCommand } },
     });
 
-    return await transporter.sendMail(
-      this.transform(bridgeProviderData, {
-        to,
-        html,
-        text,
-        subject,
-        attachments,
-        from: {
-          address: from,
-          name: senderName,
-        },
-        cc,
-        bcc,
-        replyTo,
-        ...(this.config.configurationSetName && {
-          ses: { ConfigurationSetName: this.config.configurationSetName },
-        }),
-      }).body
-    );
+    const mailOptions = this.transform(bridgeProviderData, {
+      to,
+      html,
+      text,
+      subject,
+      attachments,
+      from: {
+        address: from,
+        name: senderName,
+      },
+      cc,
+      bcc,
+      replyTo,
+      ...(this.config.configurationSetName && {
+        ses: { ConfigurationSetName: this.config.configurationSetName },
+      }),
+    }).body as SendMailOptions;
+    assertSafeSendMailOptionsForNodemailerDos(mailOptions);
+
+    return await transporter.sendMail(mailOptions);
   }
 
   async sendMessage(

--- a/packages/providers/src/lib/sms/cm-telecom/cm-telecom.provider.spec.ts
+++ b/packages/providers/src/lib/sms/cm-telecom/cm-telecom.provider.spec.ts
@@ -34,7 +34,7 @@ describe('CmTelecomSmsProvider', () => {
       });
 
       expect(axios.post).toHaveBeenCalledWith(
-        'https://gw.cmtelecom.com/v1.0/message',
+        'https://gw.messaging.cm.com/v1.0/message',
         {
           messages: {
             msg: [

--- a/packages/providers/src/utils/nodemailer-address-safety.spec.ts
+++ b/packages/providers/src/utils/nodemailer-address-safety.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+import {
+  assertSafeNodemailerAddressHeader,
+  assertSafeSendMailOptionsForNodemailerDos,
+} from './nodemailer-address-safety';
+
+function buildDeepGroup(depth: number): string {
+  const parts: string[] = [];
+  for (let i = 0; i < depth; i++) {
+    parts.push(`g${i}:`);
+  }
+
+  return `${parts.join(' ')} user@example.com;`;
+}
+
+describe('nodemailer-address-safety', () => {
+  test('allows normal addresses', () => {
+    expect(() => assertSafeNodemailerAddressHeader('Team <team@example.com>, other@example.com')).not.toThrow();
+  });
+
+  test('rejects malicious nested group depth (issue #578)', () => {
+    const payload = buildDeepGroup(3000);
+
+    expect(() => assertSafeNodemailerAddressHeader(payload)).toThrow(/exceeds safe complexity/);
+  });
+
+  test('sendMail options: rejects attack in to', () => {
+    expect(() =>
+      assertSafeSendMailOptionsForNodemailerDos({
+        to: buildDeepGroup(3000),
+      })
+    ).toThrow(/exceeds safe complexity/);
+  });
+
+  test('sendMail options: rejects attack in custom To header', () => {
+    expect(() =>
+      assertSafeSendMailOptionsForNodemailerDos({
+        headers: {
+          To: buildDeepGroup(3000),
+        },
+      })
+    ).toThrow(/exceeds safe complexity/);
+  });
+});

--- a/packages/providers/src/utils/nodemailer-address-safety.spec.ts
+++ b/packages/providers/src/utils/nodemailer-address-safety.spec.ts
@@ -41,4 +41,15 @@ describe('nodemailer-address-safety', () => {
       })
     ).toThrow(/exceeds safe complexity/);
   });
+
+  test('sendMail options: rejects attack in envelope.to as string array', () => {
+    expect(() =>
+      assertSafeSendMailOptionsForNodemailerDos({
+        envelope: {
+          from: 'bounce@example.com',
+          to: ['safe@example.com', buildDeepGroup(3000)],
+        },
+      })
+    ).toThrow(/exceeds safe complexity/);
+  });
 });

--- a/packages/providers/src/utils/nodemailer-address-safety.ts
+++ b/packages/providers/src/utils/nodemailer-address-safety.ts
@@ -1,0 +1,169 @@
+import type { SendMailOptions } from 'nodemailer';
+
+/**
+ * Mitigates DoS in vulnerable nodemailer addressparser (recursive parse on nested `:` groups).
+ * @see https://github.com/nodemailer/nodemailer/issues/578
+ */
+const MAX_COLONS_PER_ADDRESS_HEADER = 100;
+
+const HEADER_KEYS_TO_CHECK = new Set(['to', 'cc', 'bcc', 'from', 'reply-to', 'sender', 'delivered-to']);
+
+function countColons(value: string): number {
+  let n = 0;
+
+  for (let i = 0; i < value.length; i++) {
+    if (value.charCodeAt(i) === 58) {
+      n++;
+    }
+  }
+
+  return n;
+}
+
+export function assertSafeNodemailerAddressHeader(value: string): void {
+  if (countColons(value) > MAX_COLONS_PER_ADDRESS_HEADER) {
+    throw new Error(
+      'Email address header rejected: exceeds safe complexity for parsing (nodemailer address-parser mitigation)'
+    );
+  }
+}
+
+export function assertSafeNodemailerAddressHeaders(values: string[] | undefined): void {
+  if (!values?.length) {
+    return;
+  }
+
+  for (const v of values) {
+    assertSafeNodemailerAddressHeader(v);
+  }
+}
+
+type AddressLike = { name?: string; address?: string };
+
+function checkAddressOrStringField(value: string | AddressLike | Array<string | AddressLike> | undefined): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (typeof value === 'string') {
+    assertSafeNodemailerAddressHeader(value);
+
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (typeof item === 'string') {
+        assertSafeNodemailerAddressHeader(item);
+      } else if (item && typeof item === 'object') {
+        if (item.name) {
+          assertSafeNodemailerAddressHeader(item.name);
+        }
+
+        if (item.address) {
+          assertSafeNodemailerAddressHeader(item.address);
+        }
+      }
+    }
+
+    return;
+  }
+
+  if (value.name) {
+    assertSafeNodemailerAddressHeader(value.name);
+  }
+
+  if (value.address) {
+    assertSafeNodemailerAddressHeader(value.address);
+  }
+}
+
+function checkEnvelope(envelope: SendMailOptions['envelope']): void {
+  if (!envelope || typeof envelope !== 'object') {
+    return;
+  }
+
+  const e = envelope as Record<string, unknown>;
+
+  for (const key of ['from', 'to', 'cc', 'bcc']) {
+    const v = e[key];
+    if (typeof v === 'string') {
+      assertSafeNodemailerAddressHeader(v);
+    }
+  }
+}
+
+function checkHeaders(headers: SendMailOptions['headers']): void {
+  if (!headers) {
+    return;
+  }
+
+  if (Array.isArray(headers)) {
+    for (const row of headers) {
+      if (!row || typeof row !== 'object') {
+        continue;
+      }
+
+      const key = (row as { key?: string }).key;
+      const value = (row as { value?: string }).value;
+      if (key && typeof value === 'string' && HEADER_KEYS_TO_CHECK.has(key.toLowerCase())) {
+        assertSafeNodemailerAddressHeader(value);
+      }
+    }
+
+    return;
+  }
+
+  for (const [key, val] of Object.entries(headers)) {
+    if (!HEADER_KEYS_TO_CHECK.has(key.toLowerCase())) {
+      continue;
+    }
+
+    if (typeof val === 'string') {
+      assertSafeNodemailerAddressHeader(val);
+    } else if (Array.isArray(val)) {
+      for (const item of val) {
+        if (typeof item === 'string') {
+          assertSafeNodemailerAddressHeader(item);
+        }
+      }
+    } else if (val && typeof val === 'object' && 'value' in val) {
+      const v = (val as { value: string }).value;
+      if (typeof v === 'string') {
+        assertSafeNodemailerAddressHeader(v);
+      }
+    }
+  }
+}
+
+function checkReferences(refs: SendMailOptions['references']): void {
+  if (!refs) {
+    return;
+  }
+
+  if (typeof refs === 'string') {
+    assertSafeNodemailerAddressHeader(refs);
+
+    return;
+  }
+
+  for (const r of refs) {
+    assertSafeNodemailerAddressHeader(r);
+  }
+}
+
+/**
+ * Validates address-bearing fields before nodemailer parses them (sendMail / MailComposer).
+ */
+export function assertSafeSendMailOptionsForNodemailerDos(mail: SendMailOptions): void {
+  checkAddressOrStringField(mail.from);
+  checkAddressOrStringField(mail.sender);
+  checkAddressOrStringField(mail.to);
+  checkAddressOrStringField(mail.cc);
+  checkAddressOrStringField(mail.bcc);
+  checkAddressOrStringField(mail.replyTo);
+  checkAddressOrStringField(mail.inReplyTo);
+  checkReferences(mail.references);
+  checkEnvelope(mail.envelope);
+  checkHeaders(mail.headers);
+}

--- a/packages/providers/src/utils/nodemailer-address-safety.ts
+++ b/packages/providers/src/utils/nodemailer-address-safety.ts
@@ -38,7 +38,10 @@ export function assertSafeNodemailerAddressHeaders(values: string[] | undefined)
   }
 }
 
-type AddressLike = { name?: string; address?: string };
+interface AddressLike {
+  name?: string;
+  address?: string;
+}
 
 function checkAddressOrStringField(value: string | AddressLike | Array<string | AddressLike> | undefined): void {
   if (value === undefined) {
@@ -89,6 +92,16 @@ function checkEnvelope(envelope: SendMailOptions['envelope']): void {
     const v = e[key];
     if (typeof v === 'string') {
       assertSafeNodemailerAddressHeader(v);
+
+      continue;
+    }
+
+    if (key !== 'from' && Array.isArray(v)) {
+      for (const item of v) {
+        if (typeof item === 'string') {
+          assertSafeNodemailerAddressHeader(item);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a programmatic mitigation for [nodemailer#578](https://github.com/nodemailer/nodemailer/issues/578) (recursive `addressparser` DoS on malicious nested `:` group headers) for environments that cannot bump nodemailer yet.

## What changed

- New helper `assertSafeSendMailOptionsForNodemailerDos` in `packages/providers/src/utils/nodemailer-address-safety.ts` that rejects address-bearing `SendMailOptions` fields when any single header string contains more than **100** colon (`:`) characters (the attack scales with colon count per the advisory).
- Invoked immediately before every `transporter.sendMail` in:
  - `NodemailerProvider` (Custom SMTP) — including merged bridge/transform output
  - `Outlook365Provider`
  - `SESEmailProvider` (nodemailer SES transport)
- Unit tests cover the PoC-style payload and custom `To` headers.

## Notes

- Legitimate addresses rarely approach this colon density; if a false positive appears, the limit can be tuned.
- Upgrading nodemailer to a patched release remains the definitive fix; this layer reduces crash risk at our integration boundary.

## Follow-up

- CM Telecom `cm-telecom.provider.spec.ts` expected URL updated to match `BASE_URL` in the provider (`gw.messaging.cm.com`) so the providers unit test job passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0eebca9d-e930-44e6-bbc2-28111a6cc93f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0eebca9d-e930-44e6-bbc2-28111a6cc93f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added a provider-layer mitigation for a nodemailer address-parser DoS (nodemailer#578) by validating email send options before Nodemailer parses them. A new utility enforces a per-header colon limit (default 100) and rejects address-bearing fields that exceed it, preventing recursive parsing on malicious nested ":" group headers while keeping Nodemailer upgrades as the long-term fix.

## Affected areas

**providers**: Added a new utils module packages/providers/src/utils/nodemailer-address-safety.ts that inspects SendMailOptions (from/sender/to/cc/bcc/replyTo/inReplyTo/references, envelope, and selected headers) and throws when values exceed safe complexity; integrated this check immediately before transporter.sendMail calls in NodemailerProvider, Outlook365Provider, and SESEmailProvider.  
**providers (tests)**: Added unit tests packages/providers/src/utils/nodemailer-address-safety.spec.ts covering normal headers and PoC DoS payloads injected via direct address fields, custom To headers, and envelope.to arrays.  
**providers (sms tests)**: Updated CmTelecom SMS provider spec URL to match the provider's BASE_URL (gw.messaging.cm.com) so tests pass.

## Key technical decisions

- Validate address-bearing fields programmatically at the provider boundary (before Nodemailer parsing) to protect environments that cannot upgrade Nodemailer immediately.  
- Use a simple, tunable limit (MAX_COLONS_PER_ADDRESS_HEADER = 100) to detect abusive nested group syntax; legitimate addresses are unlikely to approach this density.  
- Cover common Nodemailer address shapes (strings, {name,address} objects, arrays, header-object forms, and envelope arrays) to ensure broad protection across input vectors.

## Testing

Unit tests added for the new utility verify that normal headers pass and malicious high-colon payloads are rejected across multiple injection vectors; provider integrations remain unchanged and no API/DB/schema changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->