### PR TITLE
fix(dashboard): normalize HTTP step control values for breadcrumb navigation fixes NV-7325

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/configure-step-form.tsx
@@ -4,13 +4,13 @@ import {
   EnvironmentTypeEnum,
   FeatureFlagsKeysEnum,
   FeatureNameEnum,
+  getFeatureForTierAsNumber,
   IEnvironment,
   ResourceOriginEnum,
   StepResponseDto,
   StepUpdateDto,
   UNLIMITED_VALUE,
   WorkflowResponseDto,
-  getFeatureForTierAsNumber,
 } from '@novu/shared';
 import { FileCode2 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
@@ -36,6 +36,7 @@ import { Input } from '@/components/primitives/input';
 import { Separator } from '@/components/primitives/separator';
 import { SidebarContent, SidebarFooter, SidebarHeader } from '@/components/side-navigation/sidebar';
 import TruncatedText from '@/components/truncated-text';
+import { UpgradeCTATooltip } from '@/components/upgrade-cta-tooltip';
 import { stepSchema } from '@/components/workflow-editor/schema';
 import { flattenIssues, getFirstErrorMessage, updateStepInWorkflow } from '@/components/workflow-editor/step-utils';
 import { ConfigureChatStepPreview } from '@/components/workflow-editor/steps/chat/configure-chat-step-preview';
@@ -55,12 +56,11 @@ import { SdkBanner } from '@/components/workflow-editor/steps/sdk-banner';
 import { SkipConditionsButton } from '@/components/workflow-editor/steps/skip-conditions-button';
 import { ConfigureSmsStepPreview } from '@/components/workflow-editor/steps/sms/configure-sms-step-preview';
 import { ThrottleControlValues } from '@/components/workflow-editor/steps/throttle/throttle-control-values';
-import { UpgradeCTATooltip } from '@/components/upgrade-cta-tooltip';
 import { UpdateWorkflowFn } from '@/components/workflow-editor/workflow-provider';
 import { IS_SELF_HOSTED } from '@/config';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
-import { useFormAutosave } from '@/hooks/use-form-autosave';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
+import { useFormAutosave } from '@/hooks/use-form-autosave';
 import { useStepResolversCount } from '@/hooks/use-step-resolvers-count';
 import {
   INLINE_CONFIGURABLE_STEP_TYPES,
@@ -68,7 +68,7 @@ import {
   STEP_TYPE_LABELS,
   TEMPLATE_CONFIGURABLE_STEP_TYPES,
 } from '@/utils/constants';
-import { getControlsDefaultValues } from '@/utils/default-values';
+import { getControlsDefaultValues, normalizeHttpRequestControlValues } from '@/utils/default-values';
 import { StepTypeEnum } from '@/utils/enums';
 import { buildRoute, ROUTES } from '@/utils/routes';
 
@@ -181,11 +181,13 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
       }
 
       if ((step.type as string) === StepTypeEnum.HTTP_REQUEST) {
+        const raw = (step.controls.values ?? {}) as Record<string, unknown>;
+
         return {
-          controlValues: {
-            ...(step.controls.values ?? {}),
-            continueOnFailure: (step.controls.values?.continueOnFailure as boolean) ?? false,
-          },
+          controlValues: normalizeHttpRequestControlValues({
+            ...raw,
+            continueOnFailure: (raw.continueOnFailure as boolean) ?? false,
+          }),
         };
       }
 
@@ -504,7 +506,6 @@ export const ConfigureStepForm = (props: ConfigureStepFormProps) => {
           )}
         </motion.div>
       </AnimatePresence>
-
     </>
   );
 };

--- a/apps/dashboard/src/components/workflow-editor/steps/http-request/curl-utils.ts
+++ b/apps/dashboard/src/components/workflow-editor/steps/http-request/curl-utils.ts
@@ -4,7 +4,11 @@ export const NOVU_SIGNATURE_HEADER_KEY = 'novu-signature';
 
 const METHODS_WITH_BODY = new Set(['POST', 'PUT', 'PATCH']);
 
-export function canMethodHaveBody(method: string): boolean {
+export function canMethodHaveBody(method: string | undefined): boolean {
+  if (method == null || typeof method !== 'string') {
+    return false;
+  }
+
   return METHODS_WITH_BODY.has(method.toUpperCase());
 }
 

--- a/apps/dashboard/src/utils/default-values.ts
+++ b/apps/dashboard/src/utils/default-values.ts
@@ -1,5 +1,70 @@
 import { Controls } from '@novu/shared';
+import {
+  DEFAULT_CONTROL_HTTP_REQUEST_BODY,
+  DEFAULT_CONTROL_HTTP_REQUEST_HEADERS,
+  DEFAULT_CONTROL_HTTP_REQUEST_METHOD,
+} from '@/utils/constants';
 import { buildDefaultValues, buildDefaultValuesOfDataSchema } from '@/utils/schema';
+
+function stringifyHttpControlField(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
+}
+
+function normalizeHttpRequestKeyValueArray(raw: unknown): Array<{ key: string; value: string }> {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw.map((entry) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      return { key: '', value: '' };
+    }
+
+    const row = entry as Record<string, unknown>;
+
+    return {
+      key: stringifyHttpControlField(row.key),
+      value: stringifyHttpControlField(row.value),
+    };
+  });
+}
+
+/**
+ * Ensures HTTP request step control values match what CodeMirror-based inputs expect (string values).
+ * API or persisted data may store structured JSON in header/body values, which would otherwise crash @uiw/react-codemirror.
+ */
+export function normalizeHttpRequestControlValues(values: Record<string, unknown>): Record<string, unknown> {
+  const next = { ...values };
+
+  if (typeof next.url !== 'string') {
+    next.url = stringifyHttpControlField(next.url);
+  }
+
+  if (typeof next.method !== 'string' || next.method === '') {
+    next.method = DEFAULT_CONTROL_HTTP_REQUEST_METHOD;
+  }
+
+  next.headers = normalizeHttpRequestKeyValueArray(next.headers ?? DEFAULT_CONTROL_HTTP_REQUEST_HEADERS);
+  next.body = normalizeHttpRequestKeyValueArray(next.body ?? DEFAULT_CONTROL_HTTP_REQUEST_BODY);
+
+  return next;
+}
 
 // Strips out null/undefined/empty-string entries so that unset saved values
 // don't shadow schema-defined defaults during form initialization.

--- a/apps/dashboard/src/utils/default-values.ts
+++ b/apps/dashboard/src/utils/default-values.ts
@@ -1,4 +1,4 @@
-import { Controls } from '@novu/shared';
+import { Controls, UiSchemaGroupEnum } from '@novu/shared';
 import {
   DEFAULT_CONTROL_HTTP_REQUEST_BODY,
   DEFAULT_CONTROL_HTTP_REQUEST_HEADERS,
@@ -111,10 +111,22 @@ export const getControlsDefaultValues = (resource: { controls: Controls }): Reco
   if (Object.keys(resource.controls.uiSchema ?? {}).length !== 0) {
     const defaults = deepMergeDefaults(uiSchemaDefaultValues, dataSchemaDefaultValues);
 
-    return deepMergeDefaults(defaults, strippedControlValues);
+    const merged = deepMergeDefaults(defaults, strippedControlValues);
+
+    if (resource.controls.uiSchema?.group === UiSchemaGroupEnum.HTTP_REQUEST) {
+      return normalizeHttpRequestControlValues(merged as Record<string, unknown>);
+    }
+
+    return merged;
   }
 
-  return deepMergeDefaults(dataSchemaDefaultValues, strippedControlValues);
+  const merged = deepMergeDefaults(dataSchemaDefaultValues, strippedControlValues);
+
+  if (resource.controls.uiSchema?.group === UiSchemaGroupEnum.HTTP_REQUEST) {
+    return normalizeHttpRequestControlValues(merged as Record<string, unknown>);
+  }
+
+  return merged;
 };
 
 // When uiSchema is non-empty, merges both schemas with uiSchema taking precedence over dataSchema for


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switching to the HTTP Request step could crash in two ways:

1. **`value must be typeof string but got object`** — from `@uiw/react-codemirror` when header/body/url values were objects.
2. **`Cannot read properties of undefined (reading 'toUpperCase')`** — the **template editor** route (`edit-step-template-v2.tsx`) calls `form.reset(getControlsDefaultValues(step))` with **flat** control fields at the form root. The first fix only normalized HTTP values in **ConfigureStepForm** (nested under `controlValues`), so the `/editor` route still loaded raw API data and `watch('method')` could be **undefined** → `canMethodHaveBody(method)` called `undefined.toUpperCase()`.

## Changes

- **`getControlsDefaultValues`**: When `uiSchema.group === HTTP_REQUEST`, return `normalizeHttpRequestControlValues(merged)` so both the configure sidebar and the **step editor** page get consistent, CodeMirror-safe defaults.
- **`canMethodHaveBody`**: Treat missing or non-string `method` as “no body” instead of throwing.

Configure-step HTTP defaults still use explicit `normalizeHttpRequestControlValues` + `continueOnFailure` under `controlValues.*` (unchanged).

## Testing

- `pnpm exec tsc -b --noEmit` in `apps/dashboard`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7325](https://linear.app/novu/issue/NV-7325/switching-to-http-step-via-breadcrumb-crashes)

<div><a href="https://cursor.com/agents/bc-acd5ae33-7bc0-4109-9237-adefea85066e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acd5ae33-7bc0-4109-9237-adefea85066e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

