### PR TITLE
chore(ee-billing,ee-translation): align shortid to ^2.2.17 (latest)

### DIFF
--- a/enterprise/packages/billing/package.json
+++ b/enterprise/packages/billing/package.json
@@ -26,7 +26,7 @@
     "date-fns-tz": "^3.2.0",
     "mongoose": "^8.9.5",
     "rxjs": "7.8.1",
-    "shortid": "^2.2.16",
+    "shortid": "^2.2.17",
     "stripe": "^11.18.0",
     "stripe-event-types": "^3.1.0"
   },

--- a/enterprise/packages/translation/package.json
+++ b/enterprise/packages/translation/package.json
@@ -25,7 +25,7 @@
     "i18next": "^23.7.11",
     "lodash": "^4.18.0",
     "multer": "^2.1.1",
-    "shortid": "^2.2.16"
+    "shortid": "^2.2.17"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2175,8 +2175,8 @@ importers:
         specifier: 7.8.1
         version: 7.8.1
       shortid:
-        specifier: ^2.2.16
-        version: 2.2.16
+        specifier: ^2.2.17
+        version: 2.2.17
       stripe:
         specifier: ^11.18.0
         version: 11.18.0
@@ -2297,8 +2297,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       shortid:
-        specifier: ^2.2.16
-        version: 2.2.16
+        specifier: ^2.2.17
+        version: 2.2.17
     devDependencies:
       '@types/chai':
         specifier: ^4.2.11
@@ -21453,9 +21453,6 @@ packages:
   nanoclone@0.2.1:
     resolution: {integrity: sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==}
 
-  nanoid@2.1.11:
-    resolution: {integrity: sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==}
-
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -24270,10 +24267,6 @@ packages:
 
   shimmer@1.2.1:
     resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
-
-  shortid@2.2.16:
-    resolution: {integrity: sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   shortid@2.2.17:
     resolution: {integrity: sha512-GpbM3gLF1UUXZvQw6MCyulHkWbRseNO4cyBEZresZRorwl1+SLu1ZdqgVtuwqz8mB6RpwPkm541mYSqrKyJSaA==}
@@ -45121,6 +45114,7 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
+    optional: true
 
   debug@4.3.1(supports-color@8.1.1):
     dependencies:
@@ -51415,8 +51409,6 @@ snapshots:
 
   nanoclone@0.2.1: {}
 
-  nanoid@2.1.11: {}
-
   nanoid@3.3.8: {}
 
   nanoid@5.1.6: {}
@@ -51443,7 +51435,7 @@ snapshots:
 
   needle@3.2.0:
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       iconv-lite: 0.6.3
       sax: 1.5.0
     transitivePeerDependencies:
@@ -52736,7 +52728,7 @@ snapshots:
   portfinder@1.0.32:
     dependencies:
       async: 2.6.4
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       mkdirp: 0.5.6
     transitivePeerDependencies:
       - supports-color
@@ -54796,10 +54788,6 @@ snapshots:
       '@types/hast': 3.0.4
 
   shimmer@1.2.1: {}
-
-  shortid@2.2.16:
-    dependencies:
-      nanoid: 2.1.11
 
   shortid@2.2.17:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The npm registry lists **shortid@2.2.17** as the latest release. Most workspace packages already depended on `^2.2.17`; **enterprise** `billing` and `translation` were still on `^2.2.16`.

## Changes

- Bump `shortid` from `^2.2.16` to `^2.2.17` in `enterprise/packages/billing` and `enterprise/packages/translation`.
- Refresh `pnpm-lock.yaml` after the version alignment.

No application code changes; the public API (`shortid.generate()`, default import) is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a0e5e68-3049-4de1-a8d9-97701e097673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a0e5e68-3049-4de1-a8d9-97701e097673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Aligned the `shortid` dependency from `^2.2.16` to `^2.2.17` (the latest release) in two enterprise packages: billing and translation. Most workspace packages already used this version; this change brings these two packages into alignment. No application code was modified—only dependency version updates in package.json files and the pnpm lock file.

## Affected areas

**ee-billing**: Updated shortid dependency to ^2.2.17.

**ee-translation**: Updated shortid dependency to ^2.2.17.

## Testing

No new tests are required. This is a minor patch version bump with no public API changes—the `shortid.generate()` function and default export behavior remain unchanged. Existing tests will validate compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->