### PR TITLE
fix(worker): pulse cron issue with resume on restart 

### DIFF
--- a/libs/application-generic/src/modules/cron.module.ts
+++ b/libs/application-generic/src/modules/cron.module.ts
@@ -34,6 +34,7 @@ export const cronService = {
        * @see https://github.com/pulsecron/pulse#name
        */
       name: `${os.hostname}-${process.pid}`,
+      resumeOnRestart: false,
     });
     const service = new PulseCronService(metricsService, activeCronJobs, pulse);
 


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added `resumeOnRestart: false` to the Pulse cron configuration in the CronModule factory. This disables automatic resumption of pending cron jobs after process restarts, preventing unintended job re-execution when the worker restarts.

## Affected areas

**application-generic**: The Pulse cron scheduler configuration was updated to explicitly disable resume-on-restart behavior, fixing issues where cron jobs would incorrectly resume after worker restarts.

## Testing

No tests were added. This is a configuration fix that disables automatic behavior in the Pulse library; verification likely occurred through integration testing or manual verification in the worker environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
