### PR TITLE
feat(notifications): add throttling configuration to usage report workflow

### DIFF
--- a/libs/notifications/src/workflows/usage-report/usage-report.workflow.ts
+++ b/libs/notifications/src/workflows/usage-report/usage-report.workflow.ts
@@ -16,6 +16,13 @@ export const usageReportWorkflow = workflow(
       }
     );
 
+    await step.throttle('throttle', async () => ({
+      type: 'fixed',
+      amount: 7,
+      unit: 'days',
+      threshold: 1,
+    }));
+
     await step.email(
       'email',
       async (controls) => {


### PR DESCRIPTION

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added a new monthly usage report workflow with throttling configuration. The workflow executes in sequence: optional delay step, throttle step (fixed 7-day interval with threshold of 1), and email rendering/sending. The throttle step prevents the email from being sent more than once per 7-day period, ensuring usage reports are delivered at controlled intervals rather than on-demand.

## Affected areas

**notifications**: Added new `usageReportWorkflow` implementation in the workflow library that combines optional delays, rate-limiting via throttle, and email distribution of usage reports.

## Testing

No tests were added. Testing should include verifying that the throttle step correctly prevents email delivery within the 7-day window and allows it after the interval expires.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
