### PR TITLE
fix(dashboard): hide step drag handle for code-first workflows fixes NV-7328

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/drag-context.tsx
+++ b/apps/dashboard/src/components/workflow-editor/drag-context.tsx
@@ -5,6 +5,8 @@ import { NODE_TYPE_TO_STEP_TYPE } from './node-utils';
 interface CanvasContextType {
   isReadOnly?: boolean;
   showStepPreview?: boolean;
+  /** Code-first (bridge) workflows synced from the framework — canvas reordering is not supported */
+  isCodeFirstWorkflow?: boolean;
   onNodeDragStart: (nodeId: string, position: { x: number; y: number }) => void;
   onNodeDragMove: (position: { x: number; y: number }) => void;
   onNodeDragEnd: () => void;

--- a/apps/dashboard/src/components/workflow-editor/nodes.tsx
+++ b/apps/dashboard/src/components/workflow-editor/nodes.tsx
@@ -116,6 +116,7 @@ const StepNode = (props: StepNodeProps) => {
   const {
     isReadOnly,
     showStepPreview,
+    isCodeFirstWorkflow,
     onNodeDragEnd,
     onNodeDragMove,
     onNodeDragStart,
@@ -131,7 +132,7 @@ const StepNode = (props: StepNodeProps) => {
   const isAnimating = id ? animatingNodeIds.has(id) : false;
   const areActionsVisible = !isAnyNodeDragging && isHovered && !showStepPreview && !!type;
   const hasConditions = conditionsCount > 0;
-  const isDraggable = !isReadOnly && !showStepPreview;
+  const isDraggable = !isReadOnly && !showStepPreview && !isCodeFirstWorkflow;
 
   const handleMouseEnter = () => {
     if (!isAnyNodeDragging) {
@@ -187,7 +188,7 @@ const StepNode = (props: StepNodeProps) => {
           )}
           nodeId={id}
           isDraggable={isDraggable}
-          isDragHandleVisible={areActionsVisible}
+          isDragHandleVisible={areActionsVisible && !isCodeFirstWorkflow}
           onNodeDragStart={onNodeDragStart}
           onNodeDragMove={onNodeDragMove}
           onNodeDragEnd={handleNodeDragEnd}

--- a/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
+++ b/apps/dashboard/src/components/workflow-editor/workflow-canvas.tsx
@@ -79,10 +79,13 @@ const WorkflowCanvasChild = ({
     return () => observer.disconnect();
   }, [reactFlowInstance]);
 
+  const isCodeFirstWorkflow = workflow?.origin === ResourceOriginEnum.EXTERNAL;
+
   const dragContextValue = useMemo(() => {
     return {
       isReadOnly,
       showStepPreview,
+      isCodeFirstWorkflow,
       onNodeDragStart,
       onNodeDragMove,
       onNodeDragEnd,
@@ -100,6 +103,7 @@ const WorkflowCanvasChild = ({
   }, [
     isReadOnly,
     showStepPreview,
+    isCodeFirstWorkflow,
     onNodeDragStart,
     onNodeDragMove,
     onNodeDragEnd,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Code-first (bridge) workflows are identified by `workflow.origin === ResourceOriginEnum.EXTERNAL`, consistent with the rest of the workflow editor (read-only canvas, add-step behavior, etc.).

For those workflows, the hover drag handle next to step nodes is removed and step dragging is disabled so the UI does not suggest reordering that is not supported in the dashboard.

## Changes

- Extended `CanvasContext` with optional `isCodeFirstWorkflow`, set in `workflow-canvas.tsx` from workflow origin.
- In `StepNode`, `isDraggable` and `isDragHandleVisible` are false when `isCodeFirstWorkflow` is true.

## Testing

- `pnpm exec biome check` on the touched files (no new issues from these edits).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7328](https://linear.app/novu/issue/NV-7328/remove-drag-and-drop-component-on-step-hover-for-code-first-workflows)

<div><a href="https://cursor.com/agents/bc-d26405b4-3d87-42ed-b999-567cec4a6ca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d26405b4-3d87-42ed-b999-567cec4a6ca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Code-first (bridge) workflows no longer display a drag handle on step nodes and cannot be reordered in the dashboard canvas. This prevents the UI from suggesting operations not supported in code-first workflows, which are identified by their external origin (`workflow.origin === ResourceOriginEnum.EXTERNAL`).

## Affected areas

**`@novu/dashboard`**  
Added an optional `isCodeFirstWorkflow` flag to `CanvasContext` and computed it from workflow origin in `WorkflowCanvasChild`. Updated `StepNode` to disable both draggability and drag handle visibility when the flag is true, ensuring code-first workflows display read-only step nodes without reordering affordances.

## Testing

Ran `pnpm exec biome check` on touched files with no new linting issues reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->