### PR TITLE
fix(api-service,dashboard): skip email branding injection for self-hosted installations

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -2408,6 +2408,35 @@ describe('EmailOutputRendererUsecase', () => {
       expect(result.body).to.equal(simpleHtmlBody);
     });
 
+    it('should not add Novu branding when IS_SELF_HOSTED is true', async () => {
+      const originalValue = process.env.IS_SELF_HOSTED;
+      process.env.IS_SELF_HOSTED = 'true';
+
+      try {
+        getOrganizationSettingsMock.execute.resolves({
+          removeNovuBranding: false,
+          defaultLocale: 'en_US',
+        });
+
+        const renderCommand: EmailOutputRendererCommand = {
+          dbWorkflow: mockDbWorkflow,
+          controlValues: {
+            subject: 'Self-Hosted Branding Test',
+            body: simpleHtmlBody,
+          },
+          fullPayloadForRender: mockFullPayload,
+          stepId: 'fake_step_id',
+        };
+
+        const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+        expect(result.body).to.equal(simpleHtmlBody);
+        expect(result.body).to.not.include('data-novu-branding');
+      } finally {
+        process.env.IS_SELF_HOSTED = originalValue;
+      }
+    });
+
     it('should properly insert branding into HTML with body tag', async () => {
       getOrganizationSettingsMock.execute.resolves({
         removeNovuBranding: false,

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -874,6 +874,11 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
     organizationId: string,
     organization?: OrganizationEntity
   ): Promise<string> {
+    const isSelfHosted = process.env.IS_SELF_HOSTED === 'true';
+    if (isSelfHosted) {
+      return html;
+    }
+
     try {
       const { removeNovuBranding } = await this.getOrganizationSettings.execute(
         GetOrganizationSettingsCommand.create({

--- a/apps/api/src/app/organization/usecases/update-organization-settings/update-organization-settings.usecase.ts
+++ b/apps/api/src/app/organization/usecases/update-organization-settings/update-organization-settings.usecase.ts
@@ -43,8 +43,10 @@ export class UpdateOrganizationSettings {
   }
 
   private validateTierRestrictions(command: UpdateOrganizationSettingsCommand, organization: OrganizationEntity): void {
+    const isSelfHosted = process.env.IS_SELF_HOSTED === 'true';
+
     // Only validate branding feature access if user is trying to update it
-    if (command.removeNovuBranding !== undefined) {
+    if (command.removeNovuBranding !== undefined && !isSelfHosted) {
       const canRemoveNovuBranding = getFeatureForTierAsBoolean(
         FeatureNameEnum.PLATFORM_REMOVE_NOVU_BRANDING_BOOLEAN,
         organization.apiServiceLevel || ApiServiceLevelEnum.FREE

--- a/apps/dashboard/src/components/workflow-editor/steps/email/novu-branding.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/novu-branding.tsx
@@ -5,6 +5,7 @@ import { Separator } from '@/components/primitives/separator';
 import { Switch } from '@/components/primitives/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { UpgradeCTATooltip } from '@/components/upgrade-cta-tooltip';
+import { IS_SELF_HOSTED } from '@/config';
 import { useFetchOrganizationSettings } from '@/hooks/use-fetch-organization-settings';
 import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
 import { useUpdateOrganizationSettings } from '@/hooks/use-update-organization-settings';
@@ -31,7 +32,11 @@ export const NovuBranding = ({ className, resourceOrigin, isStepResolver, ...res
   const isUpdating = updateOrganizationSettings.isPending;
 
   const showBranding =
-    resourceOrigin === ResourceOriginEnum.NOVU_CLOUD && !removeNovuBranding && !isLoadingSettings && !isStepResolver;
+    resourceOrigin === ResourceOriginEnum.NOVU_CLOUD &&
+    !removeNovuBranding &&
+    !isLoadingSettings &&
+    !isStepResolver &&
+    !IS_SELF_HOSTED;
 
   if (!showBranding) return null;
 


### PR DESCRIPTION
### What changed? Why was the change needed?

The backend `appendNovuBranding()` in the email output renderer was unconditionally injecting "Powered by Novu" branding into all sent emails, with no `IS_SELF_HOSTED` bypass. This is inconsistent with the rest of the codebase — layouts, workflows, step resolvers, activity retention, and other resource limits all check `process.env.IS_SELF_HOSTED === 'true'` to skip cloud-only restrictions for self-hosted installations.

Additionally, the `removeNovuBranding` organization setting was gated behind a paid-tier check that did not account for self-hosted users, and the dashboard branding toggle was locked for self-hosted users on the free plan.

**Changes:**
- **API (`email-output-renderer.usecase.ts`)**: Added `IS_SELF_HOSTED` check in `appendNovuBranding()` to skip branding injection for self-hosted deployments, matching the established pattern
- **API (`update-organization-settings.usecase.ts`)**: Bypassed the paid-tier restriction for `removeNovuBranding` when `IS_SELF_HOSTED` is true, so self-hosted users can toggle the setting via API
- **Dashboard (`novu-branding.tsx`)**: Added `IS_SELF_HOSTED` to the `showBranding` condition so the email editor preview doesn't show branding for self-hosted deployments, matching the actual rendered output
- **Test (`email-output-renderer.spec.ts`)**: Added unit test verifying branding is skipped when `IS_SELF_HOSTED` is true

### Screenshots

N/A — no visual changes to the UI layout, only behavioral change (branding is no longer injected for self-hosted).

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

The `IS_SELF_HOSTED` pattern is already used consistently in 10+ locations across the API service. This change follows the exact same pattern to close the gap in the email rendering pipeline.

</details>

Fixes #10572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Self-hosted installations can now disable the "Powered by Novu" email branding without being gated by tier restrictions or locked behind the paid plan. Previously, the branding injection was unconditionally applied regardless of the `IS_SELF_HOSTED` setting, and the removal toggle was locked behind a paid-tier check that blocked self-hosted users on free plans.

## Affected areas

**api** — Two changes: (1) The email output renderer now checks `process.env.IS_SELF_HOSTED` and skips branding injection entirely for self-hosted deployments. (2) The organization settings update endpoint bypasses the paid-tier validation for the `removeNovuBranding` setting when the instance is self-hosted, allowing self-hosted users to disable branding via API.

**dashboard** — The email editor's branding preview component now respects the `IS_SELF_HOSTED` flag and will not display branding for self-hosted deployments, even when other conditions would normally show it.

## Testing

Added a new unit test in the email output renderer suite that verifies branding is skipped when `IS_SELF_HOSTED` is true, confirming the branding HTML marker is not injected into the email output. The test properly isolates environment state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->