### PR TITLE
refactor(api-service): optimize the charts render

### DIFF
--- a/apps/api/src/app/activity/usecases/build-workflow-runs-count-chart/build-workflow-runs-count-chart.usecase.ts
+++ b/apps/api/src/app/activity/usecases/build-workflow-runs-count-chart/build-workflow-runs-count-chart.usecase.ts
@@ -1,20 +1,25 @@
 import { Injectable } from '@nestjs/common';
 import {
+  FeatureFlagsService,
   InstrumentUsecase,
   PinoLogger,
   QueryBuilder,
   WorkflowRun,
+  WorkflowRunCountRepository,
   WorkflowRunRepository,
   WorkflowRunStatusEnum,
 } from '@novu/application-generic';
+import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { WorkflowRunsCountDataPointDto } from '../../dtos/get-charts.response.dto';
-import { BuildWorkflowRunsCountChartCommand } from './build-workflow-runs-count-chart.command';
 import { WorkflowRunStatusDtoEnum } from '../../dtos/shared.dto';
- 
+import { BuildWorkflowRunsCountChartCommand } from './build-workflow-runs-count-chart.command';
+
 @Injectable()
 export class BuildWorkflowRunsCountChart {
   constructor(
     private workflowRunRepository: WorkflowRunRepository,
+    private workflowRunCountRepository: WorkflowRunCountRepository,
+    private featureFlagsService: FeatureFlagsService,
     private logger: PinoLogger
   ) {
     this.logger.setContext(BuildWorkflowRunsCountChart.name);
@@ -22,6 +27,41 @@ export class BuildWorkflowRunsCountChart {
 
   @InstrumentUsecase()
   async execute(command: BuildWorkflowRunsCountChartCommand): Promise<WorkflowRunsCountDataPointDto> {
+    const { environmentId, organizationId, startDate, endDate } = command;
+
+    const isWorkflowRunCountEnabled = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_WORKFLOW_RUN_COUNT_ENABLED,
+      defaultValue: false,
+      organization: { _id: organizationId },
+      environment: { _id: environmentId },
+    });
+
+    if (isWorkflowRunCountEnabled) {
+      return this.buildCountFromWorkflowRunCount(startDate, endDate, environmentId, organizationId);
+    }
+
+    return this.buildCountFromWorkflowRuns(command);
+  }
+
+  private async buildCountFromWorkflowRunCount(
+    startDate: Date,
+    endDate: Date,
+    environmentId: string,
+    organizationId: string
+  ): Promise<WorkflowRunsCountDataPointDto> {
+    const count = await this.workflowRunCountRepository.getTotalRunsCount(
+      environmentId,
+      organizationId,
+      startDate,
+      endDate
+    );
+
+    return { count };
+  }
+
+  private async buildCountFromWorkflowRuns(
+    command: BuildWorkflowRunsCountChartCommand
+  ): Promise<WorkflowRunsCountDataPointDto> {
     const {
       environmentId,
       startDate,
@@ -34,21 +74,14 @@ export class BuildWorkflowRunsCountChart {
       topicKey,
     } = command;
 
-    this.logger.debug({
-      organizationId: command.organizationId,
-      environmentId: command.environmentId,
-    }, 'Getting workflow runs count for chart');
-
     try {
       const queryBuilder = new QueryBuilder<WorkflowRun>({
         environmentId,
       });
 
-      // Add date range filters
       queryBuilder.whereGreaterThanOrEqual('created_at', startDate);
       queryBuilder.whereLessThanOrEqual('created_at', endDate);
 
-      // Add optional filters
       if (workflowIds?.length) {
         queryBuilder.whereIn('workflow_id', workflowIds);
       }
@@ -62,7 +95,8 @@ export class BuildWorkflowRunsCountChart {
       }
 
       if (statuses?.length) {
-        const mappedStatuses = statuses.map((status) => { //backward compatibility: if new statuses are used, append old status until renewed in the database, nv-6562
+        const mappedStatuses = statuses.map((status) => {
+          //backward compatibility: if new statuses are used, append old status until renewed in the database, nv-6562
           if (status === WorkflowRunStatusDtoEnum.PROCESSING) {
             return [WorkflowRunStatusEnum.PENDING, WorkflowRunStatusEnum.PROCESSING];
           }
@@ -99,15 +133,16 @@ export class BuildWorkflowRunsCountChart {
         useFinal: true,
       });
 
-      return {
-        count: result,
-      };
+      return { count: result };
     } catch (error) {
-      this.logger.error({
-        error: error.message,
-        organizationId: command.organizationId,
-        environmentId: command.environmentId,
-      }, 'Failed to get workflow runs count for chart');
+      this.logger.error(
+        {
+          error: error.message,
+          organizationId: command.organizationId,
+          environmentId: command.environmentId,
+        },
+        'Failed to get workflow runs count for chart'
+      );
       throw error;
     }
   }

--- a/apps/api/src/app/activity/usecases/get-charts/get-charts.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-charts/get-charts.usecase.ts
@@ -116,6 +116,7 @@ export class GetCharts {
         | MessagesDeliveredDataPointDto
         | ActiveSubscribersDataPointDto
         | AvgMessagesPerSubscriberDataPointDto
+        | WorkflowRunsCountDataPointDto
         | WorkflowRunsMetricDataPointDto
         | TotalInteractionsDataPointDto
         | WorkflowRunsTrendDataPointDto[]
@@ -244,20 +245,23 @@ export class GetCharts {
     }
 
     if (reportType.includes(ReportTypeEnum.WORKFLOW_RUNS_COUNT)) {
-      data[ReportTypeEnum.WORKFLOW_RUNS_COUNT] = await this.buildWorkflowRunsCountChart.execute(
-        Object.assign(new BuildWorkflowRunsCountChartCommand(), {
-          environmentId,
-          organizationId,
-          startDate,
-          endDate,
-          workflowIds,
-          subscriberIds,
-          transactionIds,
-          statuses,
-          channels,
-          topicKey,
-        })
-      );
+      chartPromises.push({
+        type: ReportTypeEnum.WORKFLOW_RUNS_COUNT,
+        promise: this.buildWorkflowRunsCountChart.execute(
+          Object.assign(new BuildWorkflowRunsCountChartCommand(), {
+            environmentId,
+            organizationId,
+            startDate,
+            endDate,
+            workflowIds,
+            subscriberIds,
+            transactionIds,
+            statuses,
+            channels,
+            topicKey,
+          })
+        ),
+      });
     }
 
     if (reportType.includes(ReportTypeEnum.TOTAL_INTERACTIONS)) {

--- a/apps/dashboard/src/pages/analytics.tsx
+++ b/apps/dashboard/src/pages/analytics.tsx
@@ -1,14 +1,13 @@
 import { useOrganization } from '@clerk/clerk-react';
 import { EnvironmentTypeEnum, FeatureFlagsKeysEnum } from '@novu/shared';
 import { CalendarIcon } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useState } from 'react';
+import { motion } from 'motion/react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   type ActiveSubscribersTrendDataPoint,
   type ProviderVolumeDataPoint,
   ReportTypeEnum,
-  type WorkflowRunsCountDataPoint,
   type WorkflowRunsTrendDataPoint,
 } from '../api/activity';
 import {
@@ -17,11 +16,9 @@ import {
   AnalyticsUpgradeCtaIcon,
   CHART_CONFIG,
   ChartsSection,
-  SKELETON_TO_CONTENT_TRANSITION,
   useAnalyticsDateFilter,
   useMetricData,
 } from '../components/analytics';
-import { AnalyticsPageSkeleton } from '../components/analytics/components/analytics-page-skeleton';
 import { ActiveSubscribersTrendChart } from '../components/analytics/charts/active-subscribers-trend-chart';
 import { ProvidersByVolume } from '../components/analytics/charts/providers-by-volume';
 import { WorkflowRunsTrendChart } from '../components/analytics/charts/workflow-runs-trend-chart';
@@ -35,7 +32,6 @@ import { useFeatureFlag } from '../hooks/use-feature-flag';
 import { useFetchCharts } from '../hooks/use-fetch-charts';
 import { useFetchSubscription } from '../hooks/use-fetch-subscription';
 import { useFetchWorkflows } from '../hooks/use-fetch-workflows';
-import { useDelayedLoading } from '../hooks/use-delayed-loading';
 import { useTelemetry } from '../hooks/use-telemetry';
 import { TelemetryEvent } from '../utils/telemetry';
 
@@ -77,11 +73,7 @@ export function AnalyticsPage() {
   ];
 
   // Request 3: Workflow charts
-  const workflowReportTypes = [
-    ReportTypeEnum.WORKFLOW_BY_VOLUME,
-    ReportTypeEnum.WORKFLOW_RUNS_TREND,
-    ReportTypeEnum.WORKFLOW_RUNS_COUNT,
-  ];
+  const workflowReportTypes = [ReportTypeEnum.WORKFLOW_BY_VOLUME, ReportTypeEnum.WORKFLOW_RUNS_TREND];
 
   const { charts: metricsCharts, isLoading: isMetricsLoading } = useFetchCharts({
     reportType: metricsReportTypes,
@@ -126,8 +118,12 @@ export function AnalyticsPage() {
   const { messagesDeliveredData, activeSubscribersData, avgMessagesPerSubscriberData, totalInteractionsData } =
     useMetricData(metricsCharts);
 
-  const isPageLoading = isMetricsLoading || isTrendsLoading || isWorkflowLoading;
-  const showSkeleton = useDelayedLoading(isPageLoading, 400);
+  const workflowRunsCount = useMemo(() => {
+    const trend = chartsData?.[ReportTypeEnum.WORKFLOW_RUNS_TREND] as WorkflowRunsTrendDataPoint[] | undefined;
+    if (!trend) return undefined;
+
+    return trend.reduce((sum, day) => sum + day.completed + day.error, 0);
+  }, [chartsData]);
 
   useEffect(() => {
     telemetry(TelemetryEvent.ANALYTICS_PAGE_VISIT);
@@ -148,7 +144,12 @@ export function AnalyticsPage() {
           </h1>
         }
       >
-        <motion.div className="flex flex-col gap-1.5" variants={ANIMATION_VARIANTS.page} initial="hidden" animate="show">
+        <motion.div
+          className="flex flex-col gap-1.5"
+          variants={ANIMATION_VARIANTS.page}
+          initial="hidden"
+          animate="show"
+        >
           <motion.div variants={ANIMATION_VARIANTS.section} className="flex justify-start gap-2">
             <FacetedFormFilter
               size="small"
@@ -179,77 +180,57 @@ export function AnalyticsPage() {
             )}
           </motion.div>
 
-          <AnimatePresence mode="wait" initial={false}>
-            {showSkeleton ? (
-              <motion.div
-                key="skeleton"
-                className="flex flex-col gap-1.5"
-                initial={false}
-                exit={SKELETON_TO_CONTENT_TRANSITION.skeletonExit}
-              >
-                <AnalyticsPageSkeleton />
-              </motion.div>
-            ) : (
-              <motion.div
-                key="content"
-                className="flex flex-col gap-1.5"
-                initial="hidden"
-                animate="show"
-                variants={SKELETON_TO_CONTENT_TRANSITION.contentEnter}
-              >
-                <motion.div variants={SKELETON_TO_CONTENT_TRANSITION.contentSection}>
-                  <AnalyticsSection
-                    messagesDeliveredData={messagesDeliveredData}
-                    activeSubscribersData={activeSubscribersData}
-                    avgMessagesPerSubscriberData={avgMessagesPerSubscriberData}
-                    totalInteractionsData={totalInteractionsData}
-                    isLoading={isMetricsLoading}
-                  />
-                </motion.div>
+          <motion.div variants={ANIMATION_VARIANTS.section}>
+            <AnalyticsSection
+              messagesDeliveredData={messagesDeliveredData}
+              activeSubscribersData={activeSubscribersData}
+              avgMessagesPerSubscriberData={avgMessagesPerSubscriberData}
+              totalInteractionsData={totalInteractionsData}
+              isLoading={isMetricsLoading}
+            />
+          </motion.div>
 
-                <motion.div variants={SKELETON_TO_CONTENT_TRANSITION.contentSection}>
-                  <ChartsSection
-                    charts={chartsData}
-                    isTrendsLoading={isTrendsLoading}
-                    isWorkflowLoading={isWorkflowLoading}
-                    trendsError={trendsError}
-                    workflowError={workflowError}
-                  />
-                </motion.div>
+          <motion.div variants={ANIMATION_VARIANTS.section}>
+            <ChartsSection
+              charts={chartsData}
+              isTrendsLoading={isTrendsLoading}
+              isWorkflowLoading={isWorkflowLoading}
+              trendsError={trendsError}
+              workflowError={workflowError}
+            />
+          </motion.div>
 
-                <motion.div variants={SKELETON_TO_CONTENT_TRANSITION.contentSection}>
-                  <WorkflowRunsTrendChart
-                    data={chartsData?.[ReportTypeEnum.WORKFLOW_RUNS_TREND] as WorkflowRunsTrendDataPoint[]}
-                    count={(chartsData?.[ReportTypeEnum.WORKFLOW_RUNS_COUNT] as WorkflowRunsCountDataPoint | undefined)?.count}
-                    periodLabel={selectedPeriodLabel}
-                    isLoading={isWorkflowLoading}
-                    error={workflowError}
-                  />
-                </motion.div>
+          <motion.div variants={ANIMATION_VARIANTS.section}>
+            <WorkflowRunsTrendChart
+              data={chartsData?.[ReportTypeEnum.WORKFLOW_RUNS_TREND] as WorkflowRunsTrendDataPoint[]}
+              count={workflowRunsCount}
+              periodLabel={selectedPeriodLabel}
+              isLoading={isWorkflowLoading}
+              error={workflowError}
+            />
+          </motion.div>
 
-                <motion.div
-                  variants={SKELETON_TO_CONTENT_TRANSITION.contentSection}
-                  className="grid grid-cols-1 lg:grid-cols-12 gap-1.5 items-stretch lg:h-[200px]"
-                >
-                  <div className="lg:col-span-8 h-full min-h-0">
-                    <ActiveSubscribersTrendChart
-                      data={chartsData?.[ReportTypeEnum.ACTIVE_SUBSCRIBERS_TREND] as ActiveSubscribersTrendDataPoint[]}
-                      isLoading={isTrendsLoading}
-                      error={trendsError}
-                    />
-                  </div>
-                  <div className="lg:col-span-4 h-full min-h-0">
-                    <ProvidersByVolume
-                      data={chartsData?.[ReportTypeEnum.PROVIDER_BY_VOLUME] as ProviderVolumeDataPoint[]}
-                      isLoading={isTrendsLoading}
-                      error={trendsError}
-                    />
-                  </div>
-                </motion.div>
-              </motion.div>
-            )}
-          </AnimatePresence>
-          {currentEnvironment?.type === EnvironmentTypeEnum.DEV && !showSkeleton && (
+          <motion.div
+            variants={ANIMATION_VARIANTS.section}
+            className="grid grid-cols-1 lg:grid-cols-12 gap-1.5 items-stretch lg:h-[200px]"
+          >
+            <div className="lg:col-span-8 h-full min-h-0">
+              <ActiveSubscribersTrendChart
+                data={chartsData?.[ReportTypeEnum.ACTIVE_SUBSCRIBERS_TREND] as ActiveSubscribersTrendDataPoint[]}
+                isLoading={isTrendsLoading}
+                error={trendsError}
+              />
+            </div>
+            <div className="lg:col-span-4 h-full min-h-0">
+              <ProvidersByVolume
+                data={chartsData?.[ReportTypeEnum.PROVIDER_BY_VOLUME] as ProviderVolumeDataPoint[]}
+                isLoading={isTrendsLoading}
+                error={trendsError}
+              />
+            </div>
+          </motion.div>
+
+          {currentEnvironment?.type === EnvironmentTypeEnum.DEV && (
             <InlineToast
               title="You're viewing usage for the Development environment"
               variant="tip"

--- a/apps/dashboard/src/pages/analytics.tsx
+++ b/apps/dashboard/src/pages/analytics.tsx
@@ -113,17 +113,17 @@ export function AnalyticsPage() {
     useMockData: isDevMockMode,
   });
 
-  const chartsData = { ...trendsCharts, ...workflowCharts };
+  const chartsData = useMemo(() => ({ ...trendsCharts, ...workflowCharts }), [trendsCharts, workflowCharts]);
 
   const { messagesDeliveredData, activeSubscribersData, avgMessagesPerSubscriberData, totalInteractionsData } =
     useMetricData(metricsCharts);
 
   const workflowRunsCount = useMemo(() => {
-    const trend = chartsData?.[ReportTypeEnum.WORKFLOW_RUNS_TREND] as WorkflowRunsTrendDataPoint[] | undefined;
+    const trend = workflowCharts?.[ReportTypeEnum.WORKFLOW_RUNS_TREND] as WorkflowRunsTrendDataPoint[] | undefined;
     if (!trend) return undefined;
 
     return trend.reduce((sum, day) => sum + day.completed + day.error, 0);
-  }, [chartsData]);
+  }, [workflowCharts]);
 
   useEffect(() => {
     telemetry(TelemetryEvent.ANALYTICS_PAGE_VISIT);

--- a/apps/dashboard/src/utils/analytics-mock-data.ts
+++ b/apps/dashboard/src/utils/analytics-mock-data.ts
@@ -9,7 +9,6 @@ import {
   type ProviderVolumeDataPoint,
   ReportTypeEnum,
   type TotalInteractionsDataPoint,
-  type WorkflowRunsCountDataPoint,
   type WorkflowRunsMetricDataPoint,
   type WorkflowRunsTrendDataPoint,
   type WorkflowVolumeDataPoint,
@@ -112,10 +111,6 @@ export function generateMockAnalyticsData(): GetChartsResponse {
     previousPeriod: randomBetween(400, 1200),
   };
 
-  const workflowRunsCountData: WorkflowRunsCountDataPoint = {
-    count: randomBetween(800, 2000),
-  };
-
   return {
     data: {
       [ReportTypeEnum.DELIVERY_TREND]: deliveryTrendData,
@@ -129,7 +124,6 @@ export function generateMockAnalyticsData(): GetChartsResponse {
       [ReportTypeEnum.AVG_MESSAGES_PER_SUBSCRIBER]: avgMessagesPerSubscriberData,
       [ReportTypeEnum.TOTAL_INTERACTIONS]: totalInteractionsData,
       [ReportTypeEnum.WORKFLOW_RUNS_METRIC]: workflowRunsMetricData,
-      [ReportTypeEnum.WORKFLOW_RUNS_COUNT]: workflowRunsCountData,
     },
   };
 }

--- a/apps/dashboard/src/utils/analytics-mock-data.ts
+++ b/apps/dashboard/src/utils/analytics-mock-data.ts
@@ -9,6 +9,7 @@ import {
   type ProviderVolumeDataPoint,
   ReportTypeEnum,
   type TotalInteractionsDataPoint,
+  type WorkflowRunsCountDataPoint,
   type WorkflowRunsMetricDataPoint,
   type WorkflowRunsTrendDataPoint,
   type WorkflowVolumeDataPoint,
@@ -111,6 +112,10 @@ export function generateMockAnalyticsData(): GetChartsResponse {
     previousPeriod: randomBetween(400, 1200),
   };
 
+  const workflowRunsCountData: WorkflowRunsCountDataPoint = {
+    count: randomBetween(500, 1500),
+  };
+
   return {
     data: {
       [ReportTypeEnum.DELIVERY_TREND]: deliveryTrendData,
@@ -124,6 +129,7 @@ export function generateMockAnalyticsData(): GetChartsResponse {
       [ReportTypeEnum.AVG_MESSAGES_PER_SUBSCRIBER]: avgMessagesPerSubscriberData,
       [ReportTypeEnum.TOTAL_INTERACTIONS]: totalInteractionsData,
       [ReportTypeEnum.WORKFLOW_RUNS_METRIC]: workflowRunsMetricData,
+      [ReportTypeEnum.WORKFLOW_RUNS_COUNT]: workflowRunsCountData,
     },
   };
 }

--- a/libs/application-generic/src/services/analytic-logs/workflow-run-count/workflow-run-count.repository.ts
+++ b/libs/application-generic/src/services/analytic-logs/workflow-run-count/workflow-run-count.repository.ts
@@ -253,6 +253,38 @@ export class WorkflowRunCountRepository extends LogRepository<typeof workflowRun
     return result.data;
   }
 
+  async getTotalRunsCount(
+    environmentId: string,
+    organizationId: string,
+    startDate: Date,
+    endDate: Date
+  ): Promise<number> {
+    const query = `
+      SELECT sum(count) as total
+      FROM ${WORKFLOW_RUN_COUNT_TABLE_NAME}
+      WHERE 
+        environment_id = {environmentId:String}
+        AND organization_id = {organizationId:String}
+        AND date >= {startDate:Date}
+        AND date <= {endDate:Date}
+        AND event_type = 'workflow_run_status_processing'
+    `;
+
+    const params: Record<string, unknown> = {
+      environmentId,
+      organizationId,
+      startDate: startDate.toISOString().split('T')[0],
+      endDate: endDate.toISOString().split('T')[0],
+    };
+
+    const result = await this.clickhouseService.query<{ total: string }>({
+      query,
+      params,
+    });
+
+    return parseInt(result.data[0]?.total || '0', 10);
+  }
+
   async getWorkflowRunsTrendData(
     environmentId: string,
     organizationId: string,


### PR DESCRIPTION


- Added `WorkflowRunCountRepository` to fetch total workflow runs count from the database.
- Enhanced `BuildWorkflowRunsCountChart` use case to conditionally build counts based on feature flag.
- Updated `GetCharts` use case to include workflow runs count in chart data.
- Modified analytics page to calculate and display workflow runs count.
- Removed mock data for workflow runs count as it is now fetched from the repository.### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR replaces mock workflow-runs-count data with a repository-backed count sourced from ClickHouse, adds a feature flag to control using that repository, and optimizes chart rendering by running all chart builders in parallel. The analytics page no longer requests a separate runs-count chart; it derives and memoizes workflow runs count from the trend chart to reduce API calls and improve render performance.

## Affected areas

**api**: The BuildWorkflowRunsCountChart use case now checks the IS_WORKFLOW_RUN_COUNT_ENABLED feature flag (scoped by organization and environment) and, when enabled, uses the new repository method to fetch total workflow run counts; GetCharts now includes the runs-count builder in the shared Promise.all flow instead of resolving it sequentially.

**dashboard**: Analytics page removed skeleton-driven loading transitions, simplified chart request types, computes workflow runs count from WORKFLOW_RUNS_TREND via useMemo, and memoizes combined chart data to avoid unnecessary recalculations and re-renders.

**shared (application-generic)**: Added WorkflowRunCountRepository.getTotalRunsCount(...) which queries ClickHouse to sum counts from the workflow run count table filtered by environment, organization, date range, and event type.

**dashboard utilities**: Mock analytics data adjusted—mock workflow runs count was modified/removed (range adjusted in analytics-mock-data), since real counts are now sourced from the repository when the feature is enabled.

## Key technical decisions

- Feature-flag gating enables gradual rollout and safe fallback to legacy query logic.  
- Moving runs-count derivation to trend data reduces extra API responses and payloads.  
- Unifying chart builders into a Promise.all flow parallelizes work and simplifies control flow.

## Testing

No unit or e2e tests were added; verify both feature-flag states (enabled/disabled), confirm ClickHouse-backed counts match expectations, and validate UI renders (including memoized derivation) and chart performance improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
