### PR TITLE
chore(providers): upgrade nodemailer to v8 and send SES email via SESv2 API

### DIFF
--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@aws-sdk/client-ses": "^3.723.0",
+    "@aws-sdk/client-sesv2": "^3.723.0",
     "@aws-sdk/client-sns": "^3.723.0",
     "@azure/communication-sms": "^1.0.0",
     "@bandwidth/messaging": "^4.1.3",
@@ -66,7 +66,7 @@
     "nanoid": "^3.1.20",
     "node-fetch": "^3.2.10",
     "node-mailjet": "^6.0.8",
-    "nodemailer": "^6.9.9",
+    "nodemailer": "^8.0.4",
     "plivo": "^4.70.0",
     "postmark": "^4.0.2",
     "proxy-agent": "^6.5.0",
@@ -83,7 +83,7 @@
     "@babel/preset-env": "^7.23.2",
     "@babel/preset-typescript": "^7.13.0",
     "@types/node-mailjet": "^4.0.0",
-    "@types/nodemailer": "^6.4.4",
+    "@types/nodemailer": "^8.0.0",
     "@types/sparkpost": "^2.1.5",
     "@types/uuid": "^8.3.4",
     "codecov": "^3.5.0",

--- a/packages/providers/src/lib/email/ses/ses.provider.spec.ts
+++ b/packages/providers/src/lib/email/ses/ses.provider.spec.ts
@@ -1,4 +1,4 @@
-import { SESClient } from '@aws-sdk/client-ses';
+import { SESv2Client } from '@aws-sdk/client-sesv2';
 import { EmailEventStatusEnum } from '@novu/stateless';
 import { describe, expect, test, vi } from 'vitest';
 import { SESEmailProvider } from './ses.provider';
@@ -91,14 +91,14 @@ const mockSESMessage = {
 
 test('should trigger ses library correctly', async () => {
   const mockResponse = { MessageId: 'mock-message-id' };
-  const spy = vi.spyOn(SESClient.prototype, 'send').mockImplementation(async () => {
+  const spy = vi.spyOn(SESv2Client.prototype, 'send').mockImplementation(async () => {
     return mockResponse as any;
   });
 
   const provider = new SESEmailProvider(mockConfig);
   const response = await provider.sendMessage(mockNovuMessage);
 
-  const bufferArray = spy.mock.calls[0][0].input['RawMessage']['Data'];
+  const bufferArray = spy.mock.calls[0][0].input['Content']['Raw']['Data'];
   const buffer = Buffer.from(bufferArray);
   const emailContent = buffer.toString();
 
@@ -109,7 +109,7 @@ test('should trigger ses library correctly', async () => {
 
 test('should trigger ses library correctly with _passthrough', async () => {
   const mockResponse = { MessageId: 'mock-message-id' };
-  const spy = vi.spyOn(SESClient.prototype, 'send').mockImplementation(async () => {
+  const spy = vi.spyOn(SESv2Client.prototype, 'send').mockImplementation(async () => {
     return mockResponse as any;
   });
 
@@ -122,7 +122,7 @@ test('should trigger ses library correctly with _passthrough', async () => {
     },
   });
 
-  const bufferArray = spy.mock.calls[0][0].input['RawMessage']['Data'];
+  const bufferArray = spy.mock.calls[0][0].input['Content']['Raw']['Data'];
   const buffer = Buffer.from(bufferArray);
   const emailContent = buffer.toString();
 

--- a/packages/providers/src/lib/email/ses/ses.provider.ts
+++ b/packages/providers/src/lib/email/ses/ses.provider.ts
@@ -1,4 +1,4 @@
-import { SESClient, SendRawEmailCommand } from '@aws-sdk/client-ses';
+import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
 import { EmailProviderIdEnum } from '@novu/shared';
 import {
   ChannelTypeEnum,
@@ -21,11 +21,11 @@ export class SESEmailProvider extends BaseProvider implements IEmailProvider {
   id = EmailProviderIdEnum.SES;
   protected casing: CasingEnum = CasingEnum.CAMEL_CASE;
   channelType = ChannelTypeEnum.EMAIL as ChannelTypeEnum.EMAIL;
-  private readonly ses: SESClient;
+  private readonly sesClient: SESv2Client;
 
   constructor(private readonly config: SESConfig) {
     super();
-    this.ses = new SESClient({
+    this.sesClient = new SESv2Client({
       region: this.config.region,
       credentials: {
         accessKeyId: this.config.accessKeyId,
@@ -39,7 +39,7 @@ export class SESEmailProvider extends BaseProvider implements IEmailProvider {
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ) {
     const transporter = nodemailer.createTransport({
-      SES: { ses: this.ses, aws: { SendRawEmailCommand } },
+      SES: { sesClient: this.sesClient, SendEmailCommand },
     });
 
     const mailOptions = this.transform(bridgeProviderData, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3679,9 +3679,9 @@ importers:
 
   packages/providers:
     dependencies:
-      '@aws-sdk/client-ses':
+      '@aws-sdk/client-sesv2':
         specifier: ^3.723.0
-        version: 3.1022.0
+        version: 3.1024.0
       '@aws-sdk/client-sns':
         specifier: ^3.723.0
         version: 3.1022.0
@@ -3762,7 +3762,7 @@ importers:
         version: 8.2.1
       mailtrap:
         specifier: ^3.1.1
-        version: 3.2.0(@types/nodemailer@6.4.11)(nodemailer@6.10.1)
+        version: 3.2.0(@types/nodemailer@8.0.0)(nodemailer@8.0.4)
       messagebird:
         specifier: ^4.0.1
         version: 4.0.1
@@ -3776,8 +3776,8 @@ importers:
         specifier: ^6.0.8
         version: 6.0.8
       nodemailer:
-        specifier: ^6.9.9
-        version: 6.10.1
+        specifier: ^8.0.4
+        version: 8.0.4
       plivo:
         specifier: ^4.70.0
         version: 4.70.0
@@ -3822,8 +3822,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       '@types/nodemailer':
-        specifier: ^6.4.4
-        version: 6.4.11
+        specifier: ^8.0.0
+        version: 8.0.0
       '@types/sparkpost':
         specifier: ^2.1.5
         version: 2.1.5
@@ -4491,8 +4491,8 @@ packages:
     resolution: {integrity: sha512-90EfmhOcj7/m4NyKG5B2LM0/elN1zniqHwUGzJMRADXAXl973jnATT6NbKIDyzHtHYZxo8RughyBIl+uKbt2JA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-ses@3.1022.0':
-    resolution: {integrity: sha512-2GycRZI4nHfjK/O5IaC05Qrk3qftNeN/AjBzvnOw0aCbV/EJ1RttQ/y0XMYrp7mqVZNkFi4d/HC22K0pfeP/ng==}
+  '@aws-sdk/client-sesv2@3.1024.0':
+    resolution: {integrity: sha512-WPPKywO6GKXJPH71MyNuLo9eup/7LjrILKwTdLI64Z8J55zprHz6eFe5Y6S+yjj04mdoIgs/3i1CaFY996fq+g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sns@3.1022.0':
@@ -4777,6 +4777,10 @@ packages:
     resolution: {integrity: sha512-knUtPDxuaFDV7/vhKpzuhF1z8rs7ZZoGXPhu6pet/FmRNgi+vsHjO61mhiAH5ygbId7Nk0sM3G1wxUfSVt0QFA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-s3@3.972.27':
+    resolution: {integrity: sha512-gomO6DZwx+1D/9mbCpcqO5tPBqYBK7DtdgjTIjZ4yvfh/S7ETwAPS0XbJgP2JD8Ycr5CwVrEkV1sFtu3ShXeOw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-sdk-sqs@3.972.8':
     resolution: {integrity: sha512-KhwktzM8+EPoOkh+92WO2Fq6Ibk9GXr9eEh0nBOd/ZO83z7i8a7BF+mTNN6k8+eKAhLerbMWRT196u5JhKe0QA==}
     engines: {node: '>=20.0.0'}
@@ -4849,6 +4853,10 @@ packages:
     resolution: {integrity: sha512-CLSrCdBoyIXSthaUcDzKw3fzRNbbyA/BawEMQBxsybYTZhGeC9P9p2DXuqTqVvla+PtEXBgRq0/Sgz2fEOBKyg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.15':
+    resolution: {integrity: sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1021.0':
     resolution: {integrity: sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==}
     engines: {node: '>=20.0.0'}
@@ -4891,6 +4899,10 @@ packages:
 
   '@aws-sdk/util-arn-parser@3.972.2':
     resolution: {integrity: sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.575.0':
@@ -12443,10 +12455,6 @@ packages:
     resolution: {integrity: sha512-+fEXJxGDLCoqRKVSmo0auGxaqbiCo+8oph+4auefYjaNxjOLKSY2MxVQfRzo65PaZv4fr+5lWg+au7vSuJJ/zw==}
     engines: {node: '>=16.0.0'}
 
-  '@smithy/util-waiter@4.2.14':
-    resolution: {integrity: sha512-2zqq5o/oizvMaFUlNiTyZ7dbgYv1a893aGut2uaxtbzTx/VYYnRxWzDHuD/ftgcw94ffenua+ZNLrbqwUYE+Bg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-waiter@4.2.9':
     resolution: {integrity: sha512-/PYREwfBaj3fV5V4PfMksYj/WKwrjQ4gW/yo8KLpZSkAdBEkvXd68hovAubrw+n+Q8Rcr9XRn6uzcoQCEhrNFQ==}
     engines: {node: '>=18.0.0'}
@@ -13770,11 +13778,11 @@ packages:
   '@types/node@22.15.13':
     resolution: {integrity: sha512-mkmz+UBGCF/ssSObTp1McwQEvIjO2hUnVvZzck61l0su7btUill8OSvzA4N62+AtkJgMhiniyD+wEL5kocZaEA==}
 
-  '@types/nodemailer@6.4.11':
-    resolution: {integrity: sha512-Ld2c0frwpGT4VseuoeboCXQ7UJIkK3X7Lx/4YsZEiUHtHsthWAOCYtf6PAiLhMtfwV0cWJRabLBS3+LD8x6Nrw==}
-
   '@types/nodemailer@6.4.7':
     resolution: {integrity: sha512-f5qCBGAn/f0qtRcd4SEn88c8Fp3Swct1731X4ryPKqS61/A3LmmzN8zaEz7hneJvpjFbUUgY7lru/B/7ODTazg==}
+
+  '@types/nodemailer@8.0.0':
+    resolution: {integrity: sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==}
 
   '@types/normalize-package-data@2.4.1':
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -21721,8 +21729,8 @@ packages:
   nodemailer-shared@1.1.0:
     resolution: {integrity: sha512-68xW5LSyPWv8R0GLm6veAvm7E+XFXkVgvE3FW0FGxNMMZqMkPFeGDVALfR1DPdSfcoO36PnW7q5AAOgFImEZGg==}
 
-  nodemailer@6.10.1:
-    resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
+  nodemailer@8.0.4:
+    resolution: {integrity: sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==}
     engines: {node: '>=6.0.0'}
 
   nodemon@3.0.1:
@@ -27567,7 +27575,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-ses@3.1022.0':
+  '@aws-sdk/client-sesv2@3.1024.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
@@ -27578,6 +27586,7 @@ snapshots:
       '@aws-sdk/middleware-recursion-detection': 3.972.9
       '@aws-sdk/middleware-user-agent': 3.972.28
       '@aws-sdk/region-config-resolver': 3.972.10
+      '@aws-sdk/signature-v4-multi-region': 3.996.15
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
@@ -27607,7 +27616,6 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-retry': 4.2.13
       '@smithy/util-utf8': 4.2.2
-      '@smithy/util-waiter': 4.2.14
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -28758,6 +28766,23 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-s3@3.972.27':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.13
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.21
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-sdk-sqs@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -28988,6 +29013,15 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.15':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.27
+      '@aws-sdk/types': 3.973.6
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1021.0':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -29067,6 +29101,10 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/util-arn-parser@3.972.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
     dependencies:
       tslib: 2.8.1
 
@@ -39703,11 +39741,6 @@ snapshots:
       '@smithy/types': 3.3.0
       tslib: 2.8.1
 
-  '@smithy/util-waiter@4.2.14':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/util-waiter@4.2.9':
     dependencies:
       '@smithy/abort-controller': 4.2.9
@@ -41358,11 +41391,11 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/nodemailer@6.4.11':
+  '@types/nodemailer@6.4.7':
     dependencies:
       '@types/node': 22.15.13
 
-  '@types/nodemailer@6.4.7':
+  '@types/nodemailer@8.0.0':
     dependencies:
       '@types/node': 22.15.13
 
@@ -50353,12 +50386,12 @@ snapshots:
       mimelib: 0.3.1
       uue: 3.1.2
 
-  mailtrap@3.2.0(@types/nodemailer@6.4.11)(nodemailer@6.10.1):
+  mailtrap@3.2.0(@types/nodemailer@8.0.0)(nodemailer@8.0.4):
     dependencies:
       axios: 1.13.6
     optionalDependencies:
-      '@types/nodemailer': 6.4.11
-      nodemailer: 6.10.1
+      '@types/nodemailer': 8.0.0
+      nodemailer: 8.0.4
     transitivePeerDependencies:
       - debug
 
@@ -51752,7 +51785,7 @@ snapshots:
     dependencies:
       nodemailer-fetch: 1.6.0
 
-  nodemailer@6.10.1: {}
+  nodemailer@8.0.4: {}
 
   nodemon@3.0.1:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades `@novu/providers` to **nodemailer 8** and `@types/nodemailer` ^8, replaces `@aws-sdk/client-ses` with **`@aws-sdk/client-sesv2`**, and routes the SES email provider through nodemailer’s SES transport using **`SESv2Client`** and **`SendEmailCommand`** (SES API v2).

This is intentionally **not** the integration-store “API version” selector from the earlier PR: there is no `apiVersion` credential, dashboard UI, or shared provider versioning metadata—only the dependency bump and a single SES v2 send path.

## Breaking / behavior notes

SES Still respected the used by nodemailer SendRawEmail IAM Permission

## Testing

- Unit tests in `ses.provider.spec.ts` were updated to assert against `SESv2Client.prototype.send` and the v2 command input shape (`Content.Raw.Data`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-627f7fe0-69d4-4880-9fd1-cfd7ad11e4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-627f7fe0-69d4-4880-9fd1-cfd7ad11e4c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Upgraded the SES email provider from AWS SES API v1 to v2. Nodemailer was bumped to v8, and the provider now uses `@aws-sdk/client-sesv2` with `SendEmailCommand` instead of `SESClient` with `SendRawEmailCommand`. The Nodemailer SES transport is configured with the new v2 client.

## Affected areas

**providers**: Updated package dependencies (`nodemailer` ^6.9.9 → ^8.0.4, `@aws-sdk/client-sesv2` ^3.723.0), changed the SES provider implementation to use SESv2Client and SendEmailCommand, and updated unit tests to assert against the new v2 API shape.

## Key technical decisions

- **Breaking change**: Outbound Amazon SES traffic now uses SESv2 `SendEmail` instead of SES v1 `SendRawEmail`. AWS IAM policies that only allow `ses:SendRawEmail` will need `ses:SendEmail` and related SESv2 permissions.
- **No integration-store selector**: This is a single SES v2 send path only; no API version selector, apiVersion credential, or dashboard UI was added.
- **Transport configuration**: Nodemailer's SES transport is now wired with `SESv2Client` and `SendEmailCommand`, with the email payload shape changing from `RawMessage.Data` to `Content.Raw.Data`.

## Testing

Unit tests in `ses.provider.spec.ts` were updated to mock `SESv2Client.prototype.send` and assert against the v2 command input shape (`Content.Raw.Data`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->