### PR TITLE
fix(providers): update attachment content id key to content_id for sendgrid provider fixes NV-7330

### DIFF
--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
@@ -103,7 +103,7 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
       };
 
       if (attachment?.cid) {
-        attachmentJson.contentId = attachment?.cid;
+        attachmentJson['content_id'] = attachment?.cid;
       }
 
       if (attachment?.disposition) {


### PR DESCRIPTION


### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The SendGrid email provider now correctly sets the attachment content ID property using the snake_case key `content_id` instead of camelCase. In the `createMailData` method, when an attachment includes a content ID (`cid`), the code now assigns it to the `content_id` field on the attachment object. This fixes failing inline attachments that require proper Content-ID headers for email clients to render embedded images and other inline content correctly.

## Affected areas

**providers**: Updated the SendGrid email provider to use the correct `content_id` property name when building attachment payloads for emails with inline content.

## Testing

No tests were added. The change is a straightforward property name fix aligned with SendGrid's API requirements for inline attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
