### PR TITLE
fix(shared): harden setNestedProperty against prototype pollution

### DIFF
--- a/libs/application-generic/src/utils/json-schema-utils.ts
+++ b/libs/application-generic/src/utils/json-schema-utils.ts
@@ -244,19 +244,31 @@ function isPrototypePollutionKey(key: string): boolean {
 function setNestedProperty(obj: Record<string, unknown>, path: string, value: string) {
   const keys = path.split('.');
 
+  if (keys.length === 0) return;
+
   if (keys.some(isPrototypePollutionKey)) return;
+
+  const lastKey = keys[keys.length - 1];
+
+  if (isPrototypePollutionKey(lastKey)) return;
 
   let current = obj;
 
   for (let i = 0; i < keys.length - 1; i += 1) {
     const key = keys[i];
-    if (!(key in current) || typeof current[key] !== 'object' || current[key] === null) {
+
+    if (isPrototypePollutionKey(key)) return;
+
+    const existing = Object.prototype.hasOwnProperty.call(current, key) ? current[key] : undefined;
+
+    if (existing === undefined || existing === null || typeof existing !== 'object') {
       current[key] = {};
     }
+
     current = current[key] as Record<string, unknown>;
   }
 
-  current[keys[keys.length - 1]] = value;
+  current[lastKey] = value;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses CodeQL alert `js/prototype-pollution-utility` on `setNestedProperty` in `libs/application-generic/src/utils/json-schema-utils.ts`.

## Changes

- Reject empty paths and block dangerous **final** segment keys (`__proto__`, `constructor`, `prototype`), not only intermediate segments.
- When traversing, only treat an existing value as a container if it is an **own** property (`Object.prototype.hasOwnProperty.call`), so inherited prototype properties are not followed as traversal targets.
- Assign the leaf value with an explicit `lastKey` after guards.

Existing unit coverage in `json-schema-utils.spec.ts` (`describe('prototype pollution guard')`) already exercises digest payload paths with `__proto__` and `constructor.prototype`.

## Verification

- `pnpm exec tsc -p libs/application-generic/tsconfig.json --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1775491489842659?thread_ts=1775491489.842659&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-d7a1a583-f957-58b3-831e-06a58b356629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7a1a583-f957-58b3-831e-06a58b356629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The `setNestedProperty` utility function in the shared library was hardened against prototype pollution attacks. The function now rejects empty paths, blocks dangerous keys (`__proto__`, `constructor`, `prototype`) at both intermediate and final path segments, validates that intermediate objects are own properties before traversal, and uses explicit key assignment to prevent unintended prototype chain modifications.

## Affected areas
**shared** — Updated `setNestedProperty` in the JSON schema utilities to add prototype-pollution safeguards and improve traversal logic with own-property checks.

## Testing
Existing unit test coverage in `json-schema-utils.spec.ts` already includes a "prototype pollution guard" test suite that exercises digest payload paths with dangerous keys like `__proto__` and `constructor.prototype`, verifying the fix works as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->