### PR TITLE
fix(shared): increase workflow name field length fixes NV-7336

### DIFF
--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -1085,7 +1085,7 @@ describe('Workflow Controller E2E API Testing #novu-v2', () => {
 
       it('should respond with 400 when name is too long', async () => {
         const createWorkflowDto: CreateWorkflowDto = buildWorkflow({
-          name: Array.from({ length: 129 }).join('X'),
+          name: 'X'.repeat(129),
         });
 
         await createWorkflowAndExpectValidationError(

--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -1085,13 +1085,13 @@ describe('Workflow Controller E2E API Testing #novu-v2', () => {
 
       it('should respond with 400 when name is too long', async () => {
         const createWorkflowDto: CreateWorkflowDto = buildWorkflow({
-          name: Array.from({ length: 80 }).join('X'),
+          name: Array.from({ length: 129 }).join('X'),
         });
 
         await createWorkflowAndExpectValidationError(
           apiClient,
           createWorkflowDto,
-          'name must be shorter than or equal to 64 characters'
+          'name must be shorter than or equal to 128 characters'
         );
       });
 

--- a/packages/shared/src/consts/upsert-validation-constants.ts
+++ b/packages/shared/src/consts/upsert-validation-constants.ts
@@ -1,4 +1,4 @@
 export const MAX_TAG_ELEMENTS = 16;
 export const MAX_TAG_LENGTH = 64;
-export const MAX_NAME_LENGTH = 64;
+export const MAX_NAME_LENGTH = 128;
 export const MAX_DESCRIPTION_LENGTH = 256;


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The shared validation constant MAX_NAME_LENGTH was raised from 64 to 128 characters so consumers (e.g., workflow name validation) allow longer names, resolving ticket NV-7336 and fixing a failing long-name E2E test.

## Affected areas
- **shared**: Updated exported MAX_NAME_LENGTH in upsert-validation-constants.ts from 64 → 128 so all consumers inherit the new limit.
- **api**: Adjusted the Workflow Controller E2E test for name-length validation to use a 129-character input and expect the updated "shorter than or equal to 128 characters" validation message.

## Testing
Updated E2E coverage: the workflow controller E2E test now asserts the 128-character limit; no new unit tests, schema, or dependency changes were required since this is a shared validation constant update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk constant change limited to shared validation limits; main risk is any downstream consumers expecting the previous 64-char limit.
> 
> **Overview**
> Increases the shared `MAX_NAME_LENGTH` validation constant from 64 to 128, allowing longer names (e.g., workflow name upsert validation) across any consumers of `upsert-validation-constants.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8849bb54754335d97b3310b51368f127aee7088e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->