### PR TITLE
feat(api-service): subscribers v2 notifications support TagsFilter like inbox fixes NV-7090

### DIFF
--- a/apps/api/src/app/subscribers-v2/dtos/get-subscriber-notifications-count-query.dto.ts
+++ b/apps/api/src/app/subscribers-v2/dtos/get-subscriber-notifications-count-query.dto.ts
@@ -1,16 +1,16 @@
 import { BadRequestException } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { SeverityLevelEnum } from '@novu/shared';
+import { SeverityLevelEnum, type TagsFilter } from '@novu/shared';
 import { plainToClass, Transform, Type } from 'class-transformer';
 import { ArrayMaxSize, IsArray, IsBoolean, IsDefined, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { NotificationFilter } from '../../inbox/utils/types';
+import { IsTagsFilter } from '../../inbox/validators/is-tags-filter.validator';
 import { IsEnumOrArray } from '../../shared/validators/is-enum-or-array';
 
 export class SubscriberNotificationsFilter implements NotificationFilter {
   @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  tags?: string[];
+  @IsTagsFilter()
+  tags?: TagsFilter;
 
   @IsOptional()
   @IsBoolean()
@@ -59,7 +59,8 @@ export class GetSubscriberNotificationsCountQueryDto {
   @ApiProperty({
     description: 'Array of filter objects (max 30) to count notifications by different criteria',
     type: 'string',
-    example: '[{"read":false,"archived":false},{"tags":["important"]}]',
+    example:
+      '[{"read":false,"archived":false},{"tags":["important"]},{"tags":{"and":[{"or":["a","b"]},{"or":["c"]}]}}]',
   })
   filters: SubscriberNotificationsFilter[];
 }

--- a/apps/api/src/app/subscribers-v2/dtos/get-subscriber-notifications-query.dto.ts
+++ b/apps/api/src/app/subscribers-v2/dtos/get-subscriber-notifications-query.dto.ts
@@ -1,8 +1,10 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { SeverityLevelEnum } from '@novu/shared';
+import { SeverityLevelEnum, type TagsFilter } from '@novu/shared';
 import { Transform } from 'class-transformer';
 import { IsArray, IsBoolean, IsInt, IsOptional, IsString } from 'class-validator';
+import { parseTagsQueryValue } from '../../inbox/utils/parse-tags-query';
 import { NotificationFilter } from '../../inbox/utils/types';
+import { IsTagsFilter } from '../../inbox/validators/is-tags-filter.validator';
 import { CursorPaginationRequestDto } from '../../shared/dtos/cursor-pagination-request';
 import { IsEnumOrArray } from '../../shared/validators/is-enum-or-array';
 
@@ -16,13 +18,13 @@ export class GetSubscriberNotificationsQueryDto
   implements NotificationFilter
 {
   @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
+  @Transform(({ value }) => parseTagsQueryValue(value))
+  @IsTagsFilter()
   @ApiPropertyOptional({
-    description: 'Filter by workflow tags',
-    type: [String],
+    description:
+      'Filter by workflow tags. Plain string[] is OR. Use { and: [{ or: string[] }, ...] } for AND of OR-groups (same as inbox).',
   })
-  tags?: string[];
+  tags?: TagsFilter;
 
   @IsOptional()
   @IsBoolean()

--- a/apps/api/src/app/subscribers-v2/dtos/mark-subscriber-notifications-as-seen.dto.ts
+++ b/apps/api/src/app/subscribers-v2/dtos/mark-subscriber-notifications-as-seen.dto.ts
@@ -1,5 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { type TagsFilter } from '@novu/shared';
 import { IsArray, IsMongoId, IsOptional, IsString } from 'class-validator';
+import { IsTagsFilter } from '../../inbox/validators/is-tags-filter.validator';
 
 export class MarkSubscriberNotificationsAsSeenDto {
   @IsOptional()
@@ -12,13 +14,12 @@ export class MarkSubscriberNotificationsAsSeenDto {
   notificationIds?: string[];
 
   @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
+  @IsTagsFilter()
   @ApiPropertyOptional({
-    description: 'Filter notifications by workflow tags',
-    type: [String],
+    description:
+      'Filter notifications by workflow tags (OR for string[], or { and: [{ or: string[] }, ...] } for AND of OR-groups).',
   })
-  tags?: string[];
+  tags?: TagsFilter;
 
   @IsOptional()
   @IsString()

--- a/apps/api/src/app/subscribers-v2/dtos/update-all-subscriber-notifications.dto.ts
+++ b/apps/api/src/app/subscribers-v2/dtos/update-all-subscriber-notifications.dto.ts
@@ -1,15 +1,16 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { type TagsFilter } from '@novu/shared';
 import { IsArray, IsOptional, IsString } from 'class-validator';
+import { IsTagsFilter } from '../../inbox/validators/is-tags-filter.validator';
 
 export class UpdateAllSubscriberNotificationsDto {
   @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
+  @IsTagsFilter()
   @ApiPropertyOptional({
-    description: 'Filter notifications by workflow tags',
-    type: [String],
+    description:
+      'Filter notifications by workflow tags (OR for string[], or { and: [{ or: string[] }, ...] } for AND of OR-groups).',
   })
-  tags?: string[];
+  tags?: TagsFilter;
 
   @IsOptional()
   @IsString()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Subscribers v2 notification endpoints (`GET .../notifications`, `GET .../notifications/count`, and bulk body filters for read/archive/delete/seen) now accept the same **TagsFilter** shape and validation as the inbox controller: plain `string[]` (OR semantics), or CNF `{ and: [{ or: string[] }, ...] }`.

## Changes

- **List query** (`GetSubscriberNotificationsQueryDto`): `parseTagsQueryValue` + `@IsTagsFilter()` so repeated query params, nested array shapes, and JSON objects parse like inbox.
- **Count** (`SubscriberNotificationsFilter`): `tags` typed as `TagsFilter` with `@IsTagsFilter()` for each entry in the `filters` JSON array.
- **Bulk operations** (`UpdateAllSubscriberNotificationsDto`, `MarkSubscriberNotificationsAsSeenDto`): `tags` use `@IsTagsFilter()` for JSON bodies.

## Verification

- `pnpm exec tsc -p tsconfig.build.json --noEmit` (apps/api)
- Biome check on touched files

No controller changes were required; the same inbox use cases already consume `TagsFilter` once DTOs pass it through.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1773131947191579?thread_ts=1773131947.191579&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-f95d1aa5-770a-515e-8249-5192b119977c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f95d1aa5-770a-515e-8249-5192b119977c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Subscribers v2 notification endpoints (list, count, and bulk operations) now accept the same TagsFilter shape and validation as the inbox controller. TagsFilter supports both plain `string[]` arrays (OR semantics) and structured `{ and: [{ or: string[] }, ...] }` (CNF) objects. This standardizes tag filtering across the notification API surface.

## Affected areas

**@novu/api-service**: Updated four DTO classes (`GetSubscriberNotificationsQueryDto`, `SubscriberNotificationsFilter`, `UpdateAllSubscriberNotificationsDto`, `MarkSubscriberNotificationsAsSeenDto`) to change the `tags` field from `string[]` to `TagsFilter`, validated via the `@IsTagsFilter()` decorator. Added `parseTagsQueryValue` transformation for query parameter handling. Swagger documentation expanded to document supported tag-filter syntax.

## Key technical decisions

- TagsFilter type supports both simple arrays and nested CNF structures, enabling flexible tag filtering logic.
- The `@IsTagsFilter()` validator and `parseTagsQueryValue` transformation reuse the same validation logic as the inbox controller, ensuring consistency.
- No controller changes needed; the inbox already consumes TagsFilter from the DTOs.

## Testing

TypeScript build check and Biome linting performed on updated DTO files. No new unit tests added; existing inbox controller tests already validate TagsFilter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->