### PR TITLE
fix(dashboard): workflow canvas translation section ui regression

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/translation-toggle-section.tsx
+++ b/apps/dashboard/src/components/workflow-editor/translation-toggle-section.tsx
@@ -103,21 +103,21 @@ export function TranslationToggleSection({
             className="arrow-right-hover-animation size-4 shrink-0 transition-transform duration-200 ease-out text-text-sub hover:text-text-strong group-hover:translate-x-0.5"
           />
         </div>
-        <span className="text-foreground-400 text-xs">
-          Set up your target locales first to enable translations
-        </span>
+        <span className="text-foreground-400 text-xs">Set up your target locales first to enable translations</span>
       </button>
     );
   }
 
   return (
-    <div className="flex flex-col">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <span className="text-label-xs text-text-strong">Enable Translations </span>
+    <div className={cn('flex w-full min-w-0 flex-col gap-1.5', className)}>
+      <div className="flex w-full min-w-0 items-center justify-between gap-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="text-label-xs text-text-strong">Enable Translations</span>
           <Tooltip>
             <TooltipTrigger asChild>
-              <RiInformation2Line className="size-3 text-text-soft cursor-help" />
+              <span className="inline-flex cursor-help shrink-0">
+                <RiInformation2Line className="size-4 text-text-soft" />
+              </span>
             </TooltipTrigger>
             <TooltipPortal>
               <TooltipContent side="left" hideWhenDetached>


### PR DESCRIPTION
### What changed? Why was the change needed?

@coderabbitai summary

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes limited to `TranslationToggleSection` markup/classes with no business logic or data flow changes.
> 
> **Overview**
> Fixes a UI regression in the workflow canvas `TranslationToggleSection` by tightening the flex layout (full-width/min-width handling, consistent gaps) and allowing an optional `className` to apply to the main container.
> 
> Also adjusts the tooltip trigger to wrap the info icon (and standardizes icon sizing) to improve alignment and prevent layout/interaction issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1f2b1c8717326a23c99a8dec63f7f1c7030cc5f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->