### PR TITLE
fix(providers): support SendGrid blocked webhook in activity tracking

### DIFF
--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.spec.ts
@@ -1,5 +1,6 @@
 import { Client } from '@sendgrid/client';
 import { MailService } from '@sendgrid/mail';
+import { EmailEventStatusEnum } from '@novu/stateless';
 import { expect, test, vi } from 'vitest';
 import { SendgridEmailProvider } from './sendgrid.provider';
 
@@ -200,4 +201,28 @@ test('should not set data residency when region is not provided', async () => {
   new SendgridEmailProvider(mockConfig);
 
   expect(setDataResidencySpy).not.toHaveBeenCalled();
+});
+
+test('parseEventBody maps SendGrid blocked event to BLOCKED status', () => {
+  const provider = new SendgridEmailProvider(mockConfig);
+  const externalId = 'sg-msg-blocked-1';
+
+  const result = provider.parseEventBody(
+    {
+      id: externalId,
+      event: 'blocked',
+      attempt: '1',
+      response: 'blocked by suppression',
+    },
+    externalId
+  );
+
+  expect(result).toEqual({
+    status: EmailEventStatusEnum.BLOCKED,
+    date: expect.any(String),
+    externalId,
+    attempts: 1,
+    response: 'blocked by suppression',
+    row: expect.any(String),
+  });
 });

--- a/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
+++ b/packages/providers/src/lib/email/sendgrid/sendgrid.provider.ts
@@ -229,6 +229,7 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
           open: true,
           click: true,
           bounce: true,
+          blocked: true,
           dropped: true,
           delivered: true,
         },
@@ -326,6 +327,8 @@ export class SendgridEmailProvider extends BaseProvider implements IEmailProvide
         return EmailEventStatusEnum.OPENED;
       case 'bounce':
         return EmailEventStatusEnum.BOUNCED;
+      case 'blocked':
+        return EmailEventStatusEnum.BLOCKED;
       case 'click':
         return EmailEventStatusEnum.CLICKED;
       case 'dropped':


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SendGrid emits a `blocked` event when a message is blocked (for example, suppression list). We previously ignored it in `getStatus`, so inbound webhook processing returned `undefined` and the event was not tracked.

## Changes

- Map SendGrid `blocked` to `EmailEventStatusEnum.BLOCKED` (already used elsewhere for `message_blocked`).
- When auto-configuring the SendGrid Event Webhook via API, set `blocked: true` so new webhooks receive these events alongside open, click, bounce, dropped, and delivered.

## Testing

- `pnpm exec vitest run src/lib/email/sendgrid/sendgrid.provider.spec.ts` in `packages/providers`
- `pnpm exec nx run @novu/providers:build`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1775742757372229?thread_ts=1775742757.372229&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-8e0b0860-4938-5fbd-a966-f172b722367b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e0b0860-4938-5fbd-a966-f172b722367b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

