### PR TITLE
fix(providers): set APNS apns-collapse-id from message id for retry dedupe

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-push.usecase.ts
@@ -600,6 +600,7 @@ export class SendMessagePush extends SendMessageBase {
         title: (bridgeOutputs as PushOutput)?.subject || title,
         content: (bridgeOutputs as PushOutput)?.body || content,
         payload: { ...command.payload, __nvMessageId: message._id },
+        messageId: message._id,
         overrides,
         subscriber,
         step,

--- a/packages/providers/src/lib/push/apns/apns.provider.spec.ts
+++ b/packages/providers/src/lib/push/apns/apns.provider.spec.ts
@@ -63,6 +63,112 @@ test('should trigger apns library correctly', async () => {
   );
 });
 
+test('should set apns-collapse-id from messageId when collapseId is not in overrides', async () => {
+  const mockSend = vi.fn(() => {
+    return {
+      failed: [],
+      sent: [
+        {
+          device: 'device',
+        },
+      ],
+    };
+  });
+
+  vi.spyOn(apn as any, 'Provider').mockImplementation(() => {
+    return {
+      send: mockSend,
+      shutdown: () => {},
+    };
+  });
+
+  const provider = new APNSPushProvider({
+    key: 'key',
+    keyId: 'keyId',
+    teamId: 'teamId',
+    bundleId: 'bundleId',
+    production: true,
+  });
+
+  await provider.sendMessage({
+    target: ['target'],
+    title: 'title',
+    content: 'content',
+    messageId: 'message-id-1',
+    payload: {
+      data: 'data',
+    },
+    step: {
+      digest: false,
+      events: undefined,
+      total_count: undefined,
+    },
+    subscriber: {},
+  });
+
+  expect(mockSend).toHaveBeenCalledWith(
+    expect.objectContaining({
+      collapseId: 'message-id-1',
+      topic: 'bundleId',
+    }),
+    ['target']
+  );
+});
+
+test('should not override collapseId from overrides when messageId is set', async () => {
+  const mockSend = vi.fn(() => {
+    return {
+      failed: [],
+      sent: [
+        {
+          device: 'device',
+        },
+      ],
+    };
+  });
+
+  vi.spyOn(apn as any, 'Provider').mockImplementation(() => {
+    return {
+      send: mockSend,
+      shutdown: () => {},
+    };
+  });
+
+  const provider = new APNSPushProvider({
+    key: 'key',
+    keyId: 'keyId',
+    teamId: 'teamId',
+    bundleId: 'bundleId',
+    production: true,
+  });
+
+  await provider.sendMessage({
+    target: ['target'],
+    title: 'title',
+    content: 'content',
+    messageId: 'message-id-1',
+    payload: {
+      data: 'data',
+    },
+    overrides: {
+      collapseId: 'custom-collapse',
+    },
+    step: {
+      digest: false,
+      events: undefined,
+      total_count: undefined,
+    },
+    subscriber: {},
+  });
+
+  expect(mockSend).toHaveBeenCalledWith(
+    expect.objectContaining({
+      collapseId: 'custom-collapse',
+    }),
+    ['target']
+  );
+});
+
 test('should trigger apns library correctly with _passthrough', async () => {
   const mockSend = vi.fn(() => {
     return {

--- a/packages/providers/src/lib/push/apns/apns.provider.ts
+++ b/packages/providers/src/lib/push/apns/apns.provider.ts
@@ -48,15 +48,23 @@ export class APNSPushProvider extends BaseProvider implements IPushProvider {
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ): Promise<ISendMessageSuccessResponse> {
     delete (options.overrides as any)?.notificationIdentifiers;
-    const notification = new apn.Notification(
-      this.transform(bridgeProviderData, {
-        body: options.content,
-        title: options.title,
-        payload: options.payload,
-        topic: this.config.bundleId,
-        ...options.overrides,
-      }).body
-    );
+    const transformedBody = this.transform(bridgeProviderData, {
+      body: options.content,
+      title: options.title,
+      payload: options.payload,
+      topic: this.config.bundleId,
+      ...options.overrides,
+    }).body as Record<string, unknown>;
+
+    const collapseId =
+      transformedBody.collapseId != null && transformedBody.collapseId !== ''
+        ? transformedBody.collapseId
+        : options.messageId;
+
+    const notification = new apn.Notification({
+      ...transformedBody,
+      ...(collapseId != null && collapseId !== '' ? { collapseId } : {}),
+    });
     const res = await this.provider.send(notification, options.target);
 
     if (res.failed.length > 0) {

--- a/packages/stateless/src/lib/provider/provider.interface.ts
+++ b/packages/stateless/src/lib/provider/provider.interface.ts
@@ -51,6 +51,7 @@ export interface IPushOptions {
   title: string;
   content: string;
   payload: object;
+  messageId?: string;
   overrides?: {
     type?: 'notification' | 'data';
     data?: { [key: string]: string };
@@ -73,6 +74,7 @@ export interface IPushOptions {
     channelId?: string;
     categoryId?: string;
     mutableContent?: boolean;
+    collapseId?: string;
     android?: { [key: string]: { [key: string]: string } | string };
     apns?: {
       headers?: { [key: string]: string };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the same Novu push message is delivered again (for example after an HTTP/2 or network interruption where the first attempt may have reached APNs but the client did not get a clean response), APNs can deliver multiple copies. We now send **`apns-collapse-id`** set to the Novu **message id** so APNs coalesces those attempts for the same logical notification.

## Changes

- **`IPushOptions`**: optional `messageId` (and `collapseId` on `overrides` for typing parity with the APNS HTTP API).
- **`SendMessagePush`**: passes `messageId: message._id` into the push handler.
- **`APNSPushProvider`**: after `transform`, sets `collapseId` to `messageId` when the merged body does not already define `collapseId` (user/bridge overrides still win).

## Tests

- Extended `apns.provider.spec.ts` to assert `collapseId` from `messageId` and that explicit `overrides.collapseId` is preserved.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1775752023559699?thread_ts=1775752023.559699&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-68e22f1c-5eb3-5b4a-93ba-79e675d9222e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68e22f1c-5eb3-5b4a-93ba-79e675d9222e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

APNS push notifications now set the `apns-collapse-id` header to the Novu message ID to prevent duplicate deliveries during retries. When a push message is resent (e.g., after network interruptions where APNs received the notification but the client didn't), APNs uses the collapse ID to coalesce multiple attempts for the same logical message, ensuring users don't receive duplicates.

## Affected areas

- **worker**: `SendMessagePush` now passes `messageId: message._id` to the push handler alongside the existing payload.
- **providers**: `APNSPushProvider` sets `collapseId` to the message ID when constructing APNS notifications, unless explicitly overridden.
- **stateless**: `IPushOptions` interface extended with optional `messageId` field and `overrides.collapseId` field for typing parity with the APNS HTTP API.

## Key technical decisions

- User-provided or bridge-layer overrides for `collapseId` take precedence; the message ID is used as a fallback only when no explicit `collapseId` is set.

## Testing

Added unit tests in `apns.provider.spec.ts` verifying that `collapseId` is correctly set from `messageId` and that explicit overrides are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->