### PR TITLE
feat(dashboard): rename workflows list page title to All workflows

### DIFF
--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -200,8 +200,10 @@ export const WorkflowsPage = () => {
 
   return (
     <>
-      <PageMeta title="Workflows" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows</h1>}>
+      <PageMeta title="All workflows" />
+      <DashboardLayout
+        headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">All workflows</h1>}
+      >
         <div className="flex h-full w-full flex-col">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-wrap items-center gap-2 py-2.5">

--- a/apps/dashboard/tests/manage-workflows.e2e.ts
+++ b/apps/dashboard/tests/manage-workflows.e2e.ts
@@ -19,7 +19,7 @@ test('manage workflows', async ({ page }) => {
 
   const workflowsPage = new WorkflowsPage(page);
   await workflowsPage.goTo();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`All workflows | Novu Cloud Dashboard`);
 
   await workflowsPage.createWorkflowBtnClick();
 
@@ -171,7 +171,7 @@ test('manage workflows', async ({ page }) => {
 
   // Navigate back to workflows page
   await workflowEditorPage.clickWorkflowsBreadcrumb();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`All workflows | Novu Cloud Dashboard`);
 
   // Verify workflow exists and status
   const workflowElement = await workflowsPage.getWorkflowElement(workflowNameUpdated);

--- a/apps/dashboard/tests/sync-workflow.e2e.ts
+++ b/apps/dashboard/tests/sync-workflow.e2e.ts
@@ -55,7 +55,7 @@ test('sync workflow', async ({ page }) => {
   // go to the workflows page
   const workflowsPage = new WorkflowsPage(page);
   await workflowsPage.goTo();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`All workflows | Novu Cloud Dashboard`);
 
   // check the workflow
   const workflowElement = await workflowsPage.getWorkflowElement(workflowId);
@@ -133,7 +133,7 @@ test('sync workflow', async ({ page }) => {
 
   // go to the workflows page
   await workflowEditorPage.clickWorkflowsBreadcrumb();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`All workflows | Novu Cloud Dashboard`);
 
   // check the delete workflow button
   await workflowsPage.clickWorkflowActionsMenu(workflowId);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the workflows list page so the in-app header and browser tab title read **All workflows** instead of **Workflows**, keeping `PageMeta` and the `DashboardLayout` header in sync.

## Test plan

- [ ] Open `/env/:environmentSlug/workflows` and confirm the header shows **All workflows** and the document title includes **All workflows**.
- E2E title assertions in `manage-workflows.e2e.ts` and `sync-workflow.e2e.ts` were updated to match.

## Screenshot

Static preview of the new title styling and document title (full dashboard capture was not available in the agent environment without Clerk/Mongo-backed E2E setup):

![Workflows list page title: All workflows](https://cursor.com/artifacts/c/art-379a566b-5455-4a27-8ca0-7ff7deddf034)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1775760159268339?thread_ts=1775760159.268339&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-038c99bb-a879-5602-a0cc-3d6d9c312e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-038c99bb-a879-5602-a0cc-3d6d9c312e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

