### PR TITLE
fix(root): add Origin header to Better Auth requests in seed-agent-data

### DIFF
--- a/scripts/seed-agent-data.mjs
+++ b/scripts/seed-agent-data.mjs
@@ -7,6 +7,8 @@ const ROOT_DIR = resolve(__dirname, '..');
 
 const API_URL = process.env.API_URL || 'http://localhost:3000';
 const BETTER_AUTH_URL = `${API_URL}/v1/better-auth`;
+const BETTER_AUTH_ORIGIN =
+  process.env.SEED_BETTER_AUTH_ORIGIN || process.env.DASHBOARD_URL || 'http://localhost:4201';
 
 const SEED_EMAIL = process.env.SEED_USER_EMAIL || 'agent@novu.co';
 const SEED_PASSWORD = process.env.SEED_USER_PASSWORD || 'Agent123!@#';
@@ -114,7 +116,7 @@ async function signUp() {
 
   const res = await fetch(`${BETTER_AUTH_URL}/sign-up/email`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: betterAuthRequestHeaders(),
     body: JSON.stringify({
       email: SEED_EMAIL,
       password: SEED_PASSWORD,
@@ -144,7 +146,7 @@ async function signUp() {
 async function signIn() {
   const res = await fetch(`${BETTER_AUTH_URL}/sign-in/email`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: betterAuthRequestHeaders(),
     body: JSON.stringify({
       email: SEED_EMAIL,
       password: SEED_PASSWORD,
@@ -162,11 +164,18 @@ async function signIn() {
   return { token, user: body.user };
 }
 
-function authHeaders(token) {
+function betterAuthRequestHeaders(extra = {}) {
   return {
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${token}`,
+    Origin: BETTER_AUTH_ORIGIN,
+    ...extra,
   };
+}
+
+function authHeaders(token) {
+  return betterAuthRequestHeaders({
+    Authorization: `Bearer ${token}`,
+  });
 }
 
 async function listOrganizations(token) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The cloud agent seed script (`scripts/seed-agent-data.mjs`) calls Better Auth sign-up without an `Origin` header, which triggers `MISSING_OR_NULL_ORIGIN` (403) because Better Auth validates the origin against `trustedOrigins`.

## Changes

- Define `BETTER_AUTH_ORIGIN` from `SEED_BETTER_AUTH_ORIGIN`, then `DASHBOARD_URL`, defaulting to `http://localhost:4201` (matches `trustedOrigins` in Better Auth config).
- Add `betterAuthRequestHeaders()` and use it for sign-up, sign-in, and all bearer-authenticated Better Auth requests (organization APIs use the same CSRF checks).

## Testing

- `node --check scripts/seed-agent-data.mjs`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06DU7A7BPV/p1775765120391819?thread_ts=1775765120.391819&cid=C06DU7A7BPV)

<div><a href="https://cursor.com/agents/bc-ec6e7059-7867-53f5-89ed-8975c5999829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec6e7059-7867-53f5-89ed-8975c5999829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The seed-agent-data script now includes the `Origin` header in Better Auth API requests. A new `BETTER_AUTH_ORIGIN` configuration is set from `SEED_BETTER_AUTH_ORIGIN`, `DASHBOARD_URL`, or defaults to `http://localhost:4201`. A `betterAuthRequestHeaders()` helper centralizes header construction, ensuring `Origin` is present for sign-up, sign-in, and authenticated API calls.

## Affected areas

**scripts**: The seed-agent-data script now properly sets the `Origin` header when calling Better Auth endpoints, resolving 403 MISSING_OR_NULL_ORIGIN errors caused by Better Auth's origin validation checks.

## Key technical decisions

- `Origin` header is derived from `SEED_BETTER_AUTH_ORIGIN` environment variable, falling back to `DASHBOARD_URL` or `http://localhost:4201`, matching the configured trustedOrigins in Better Auth.
- A shared `betterAuthRequestHeaders()` helper centralizes header construction to avoid duplicating the `Origin` header logic across multiple API calls.
- Both authenticated and unauthenticated Better Auth requests use the same header construction to ensure consistent origin validation.

## Testing

Syntax validation performed with `node --check scripts/seed-agent-data.mjs`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->