### PR TITLE
feat(dashboard): rename workflows list page title to Workflows list

### DIFF
--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -200,8 +200,8 @@ export const WorkflowsPage = () => {
 
   return (
     <>
-      <PageMeta title="Workflows" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows</h1>}>
+      <PageMeta title="Workflows list" />
+      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows list</h1>}>
         <div className="flex h-full w-full flex-col">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-wrap items-center gap-2 py-2.5">

--- a/apps/dashboard/tests/manage-workflows.e2e.ts
+++ b/apps/dashboard/tests/manage-workflows.e2e.ts
@@ -19,7 +19,7 @@ test('manage workflows', async ({ page }) => {
 
   const workflowsPage = new WorkflowsPage(page);
   await workflowsPage.goTo();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`Workflows list | Novu Cloud Dashboard`);
 
   await workflowsPage.createWorkflowBtnClick();
 
@@ -171,7 +171,7 @@ test('manage workflows', async ({ page }) => {
 
   // Navigate back to workflows page
   await workflowEditorPage.clickWorkflowsBreadcrumb();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`Workflows list | Novu Cloud Dashboard`);
 
   // Verify workflow exists and status
   const workflowElement = await workflowsPage.getWorkflowElement(workflowNameUpdated);

--- a/apps/dashboard/tests/sync-workflow.e2e.ts
+++ b/apps/dashboard/tests/sync-workflow.e2e.ts
@@ -55,7 +55,7 @@ test('sync workflow', async ({ page }) => {
   // go to the workflows page
   const workflowsPage = new WorkflowsPage(page);
   await workflowsPage.goTo();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`Workflows list | Novu Cloud Dashboard`);
 
   // check the workflow
   const workflowElement = await workflowsPage.getWorkflowElement(workflowId);
@@ -133,7 +133,7 @@ test('sync workflow', async ({ page }) => {
 
   // go to the workflows page
   await workflowEditorPage.clickWorkflowsBreadcrumb();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`Workflows list | Novu Cloud Dashboard`);
 
   // check the delete workflow button
   await workflowsPage.clickWorkflowActionsMenu(workflowId);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The workflows list route now uses **Workflows list** for both the document title (`PageMeta`) and the main header `h1`, so the browser tab and in-app title stay consistent.

## Test plan

- [ ] Open `/env/{devSlug}//workflows` and confirm the header reads **Workflows list** and the tab title includes **Workflows list**.

Playwright expectations in `manage-workflows.e2e.ts` and `sync-workflow.e2e.ts` were updated to match the new tab title suffix.

## Screenshot

![Workflows list page header showing Workflows list title](https://cursor.com/artifacts/c/art-71ba139c-367c-4bcc-80dd-e3d2d05aad46)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1775811336095489?thread_ts=1775811336.095489&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-604cfaa8-cc56-5cf1-9abe-b1e354f63590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-604cfaa8-cc56-5cf1-9abe-b1e354f63590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The workflows list page now displays "Workflows list" as both the document title (browser tab) and the in-app header, replacing the previous "Workflows" title. This aligns the browser tab text with the page header for consistent user experience and clearer page identification throughout the dashboard.

## Affected areas

**dashboard**: Updated the workflows page component to set both `PageMeta` title and header `<h1>` to "Workflows list", and modified e2e test assertions to expect the new browser tab title suffix.

## Testing

E2e tests in `manage-workflows.e2e.ts` and `sync-workflow.e2e.ts` were updated to verify the new page title. No new tests were added; existing Playwright assertions were updated to match the renamed tab title expectation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->