### PR TITLE
fix(api-service): escape regex special characters in contexts search query

### DIFF
--- a/apps/api/src/app/contexts/e2e/list-contexts.e2e.ts
+++ b/apps/api/src/app/contexts/e2e/list-contexts.e2e.ts
@@ -134,9 +134,30 @@ describe('List Contexts - /contexts (GET) #novu-v2', () => {
       data: {},
     });
 
-    const response = await novuClient.contexts.list({ search: 'list-test-4.*acme' });
+    const response = await novuClient.contexts.list({ search: 'acme' });
 
     expect(response.result.data.length).to.equal(2);
+  });
+
+  it('should handle regex special characters in search without throwing', async () => {
+    await contextRepository.create({
+      _organizationId: session.organization._id,
+      _environmentId: session.environment._id,
+      type: 'tenant',
+      id: 'list-test-7-org-[bracket]',
+      key: 'tenant:list-test-7-org-[bracket]',
+      data: {},
+    });
+
+    const response = await novuClient.contexts.list({ search: '[bracket' });
+
+    expect(response.result.data).to.be.an('array');
+    expect(response.result.data.length).to.equal(1);
+
+    const responseExact = await novuClient.contexts.list({ search: '[bracket]' });
+
+    expect(responseExact.result.data).to.be.an('array');
+    expect(responseExact.result.data.length).to.equal(1);
   });
 
   it('should support cursor-based pagination with limit', async () => {

--- a/apps/api/src/app/contexts/usecases/list-contexts/list-contexts.usecase.ts
+++ b/apps/api/src/app/contexts/usecases/list-contexts/list-contexts.usecase.ts
@@ -24,7 +24,8 @@ export class ListContexts {
 
     // Search across the composite key field (format: "type:id")
     if (command.search) {
-      filter.key = { $regex: command.search, $options: 'i' };
+      const escapedSearch = command.search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      filter.key = { $regex: escapedSearch, $options: 'i' };
     }
 
     // Handle cursor-based pagination


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

The `GET /v2/contexts` endpoint passes user-supplied `search` query parameter directly to MongoDB's `$regex` operator without escaping special regex characters. When users include characters like `[`, `]`, `(`, `)`, `*`, `+`, etc. in their search, MongoDB throws:

```
MongoServerError: Regular expression is invalid: missing terminating ] for character class
```

This was a **recurring production error** tracked as Sentry issues API-Q0 and API-Q1, with **469+ events** since February 2024 and a regression on April 9, 2026.

## Fix

Escape all regex metacharacters (`.*+?^${}()|[]\`) in the user's search string before passing it to `$regex`. This treats the search input as a **literal substring match** rather than interpreting it as a regex pattern.

**Before:**
```ts
filter.key = { $regex: command.search, $options: 'i' };
```

**After:**
```ts
const escapedSearch = command.search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
filter.key = { $regex: escapedSearch, $options: 'i' };
```

## Changes

- `apps/api/src/app/contexts/usecases/list-contexts/list-contexts.usecase.ts` — escape regex metacharacters in search input
- `apps/api/src/app/contexts/e2e/list-contexts.e2e.ts` — add E2E test for regex special characters in search; update existing search test to use literal matching

## Testing

- All 8 E2E tests in `list-contexts.e2e.ts` pass, including the new test that verifies `[bracket` and `[bracket]` searches work without throwing MongoServerError.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12bfc67d-3b1c-416f-ae31-1b4c60b3abde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12bfc67d-3b1c-416f-ae31-1b4c60b3abde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The GET `/v2/contexts` endpoint now escapes regex metacharacters in user-supplied search queries before passing them to MongoDB's `$regex` operator. Previously, special characters like `[`, `]`, `*`, and `+` in the search parameter would trigger MongoServerError, causing recurring production incidents. The fix treats search input as a literal substring match, preventing unintended regex interpretation.

## Affected areas

**api**: Updated the contexts list use-case to sanitize the search parameter by escaping all regex metacharacters (`.*+?^${}()|[\]\`) before constructing the MongoDB regex filter. This prevents malformed regex patterns from reaching the database.

## Key technical decisions

- Search input is now treated as a literal substring match within a case-insensitive regex, rather than allowing users to provide arbitrary regex patterns. This is a semantic change but aligns with expected user behavior and security best practices.

## Testing

Added an E2E test that verifies the endpoint handles regex special characters (`[bracket` and `[bracket]`) without throwing errors. All 8 existing and new E2E tests in the list-contexts suite pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->