### PR TITLE
fix(root): exclude libs/internal-sdk from lint-staged biome formatting

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  '*.{e2e,e2e-ee,spec}.{js,ts}': ['stop-only --file'],
+  '**/*.{ts,tsx,js,jsx,json}': (files) => {
+    const filtered = files.filter((file) => !file.includes('/internal-sdk/'));
+    if (filtered.length === 0) return [];
+
+    return [`biome check --write --no-errors-on-unmatched --diagnostic-level=error ${filtered.join(' ')}`];
+  },
+};

--- a/package.json
+++ b/package.json
@@ -144,14 +144,6 @@
       "pre-commit": "lint-staged"
     }
   },
-  "lint-staged": {
-    "*.{e2e,e2e-ee,spec}.{js,ts}": [
-      "stop-only --file"
-    ],
-    "**/*.{ts,tsx,js,jsx,json}": [
-      "biome check --write --no-errors-on-unmatched --diagnostic-level=error"
-    ]
-  },
   "engines": {
     "node": ">=22 <23",
     "pnpm": "^10.0.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

When there's a merge conflict involving `libs/internal-sdk` (auto-generated code), the lint-staged pre-commit hook was running biome formatting on those files. This caused unwanted formatting changes to appear in PRs, since biome reformats the auto-generated code (e.g., changing double quotes to single quotes).

While `biome.json` already excludes `libs/internal-sdk` via `files.includes`, this exclusion is bypassed when lint-staged passes explicit file paths as CLI arguments to biome.

## How it's fixed

- Moved the lint-staged configuration from `package.json` to a new `.lintstagedrc.js` file
- Used a function-based pattern that filters out any files matching `/internal-sdk/` before passing them to biome
- When only `internal-sdk` files are staged, no biome command runs at all

## Testing

Verified locally that:
1. Staging an `internal-sdk` file and running `lint-staged` does **not** run biome on it (formatting is preserved)
2. Staging a normal file still runs biome formatting as expected
3. Mixed staging (internal-sdk + normal files) correctly filters out only the internal-sdk files
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06DU7A7BPV/p1775832001136849?thread_ts=1775832001.136849&cid=C06DU7A7BPV)

<div><a href="https://cursor.com/agents/bc-c8aa4f08-6241-507f-92bd-01a5be0c44aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8aa4f08-6241-507f-92bd-01a5be0c44aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Moved lint-staged configuration from `package.json` to a new `.lintstagedrc.js` file with added filtering logic. The configuration now excludes files matching `/internal-sdk/` (auto-generated code) before passing them to biome for formatting. This prevents biome from reformatting auto-generated files that should not be modified.

## Affected areas

**root**: Lint-staged configuration moved to `.lintstagedrc.js` with filtering to skip internal-sdk files during pre-commit formatting checks.

## Key technical decisions

- Migrated from package.json inline config to a dedicated `.lintstagedrc.js` file using a function-based pattern to filter staged files before passing to biome, allowing dynamic exclusion logic that bypasses the limitation of biome.json file exclusions when explicit file paths are provided via CLI.

## Testing

Manual verification confirmed:
1. Staging an internal-sdk file does not run biome formatting on it.
2. Staging normal files still runs biome formatting as expected.
3. Mixed staging of internal-sdk and normal files correctly filters out only internal-sdk files before running biome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->