### PR TITLE
feat(api): rework delayed step behavior

### DIFF
--- a/apps/api/src/app/events/e2e/cancel-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/cancel-event.e2e.ts
@@ -9,7 +9,7 @@ import { pollForJobStatusChange } from './utils/poll-for-job-status-change.util'
 
 const axiosInstance = axios.create();
 
-describe('Cancel event - /v1/events/trigger/:transactionId (DELETE) #novu-v2', () => {
+describe('Cancel event - /v1/events/trigger (DELETE) #novu-v2', () => {
   let session: UserSession;
   let template: NotificationTemplateEntity;
   let subscriber: SubscriberEntity;
@@ -25,6 +25,17 @@ describe('Cancel event - /v1/events/trigger/:transactionId (DELETE) #novu-v2', (
       },
     });
   }
+
+  async function cancelEventByQuery(query: Record<string, string | string[]>) {
+    await axiosInstance.delete(`${session.serverUrl}/v1/events/trigger`, {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+      params: query,
+    });
+  }
+
+
 
   beforeEach(async () => {
     session = new UserSession();
@@ -80,6 +91,289 @@ describe('Cancel event - /v1/events/trigger/:transactionId (DELETE) #novu-v2', (
     });
 
     expect(cancelledDigestJobs?.length).to.eql(1);
+  });
+
+  it('should cancel active digests by query filters without a transactionId', async () => {
+    template = await session.createTemplate({
+      steps: [
+        {
+          type: StepTypeEnum.DIGEST,
+          content: '',
+          metadata: {
+            unit: DigestUnitEnum.SECONDS,
+            amount: 30,
+            digestKey: 'groupId',
+            type: DigestTypeEnum.REGULAR,
+          },
+        },
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Hello world {{step.events.length}}' as string,
+        },
+      ],
+    });
+
+    await novuClient.trigger({
+      workflowId: template.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        groupId: 'group-1',
+        customVar: 'trigger_1_data',
+      },
+    });
+
+    await novuClient.trigger({
+      workflowId: template.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        groupId: 'group-1',
+        customVar: 'trigger_2_data',
+      },
+    });
+
+    await session.waitForWorkflowQueueCompletion();
+    await session.waitForSubscriberQueueCompletion();
+
+    await cancelEventByQuery({
+      subscriberId: subscriber.subscriberId,
+      workflowId: template.triggers[0].identifier,
+      digestKey: 'groupId',
+      digestValue: 'group-1',
+    });
+
+    const cancelledDigestJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        status: JobStatusEnum.CANCELED,
+        type: StepTypeEnum.DIGEST,
+      },
+      findMultiple: true,
+    });
+
+    expect(cancelledDigestJobs?.length).to.eql(2);
+  });
+
+  it('should cancel active delay steps by query filters using stepName and stepType', async () => {
+    const secondSubscriber = await subscriberService.createSubscriber();
+    template = await session.createTemplate({
+      steps: [
+        {
+          name: 'Wait for cancellation',
+          type: StepTypeEnum.DELAY,
+          content: '',
+          metadata: {
+            type: DelayTypeEnum.NONE,
+          },
+        },
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Hello world {{customVar}}' as string,
+        },
+      ],
+    });
+
+    await novuClient.trigger({
+      workflowId: template.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        customVar: 'trigger_1_data',
+      },
+    });
+
+    await novuClient.trigger({
+      workflowId: template.triggers[0].identifier,
+      to: [secondSubscriber.subscriberId],
+      payload: {
+        customVar: 'trigger_2_data',
+      },
+    });
+
+    await session.waitForWorkflowQueueCompletion();
+    await session.waitForSubscriberQueueCompletion();
+
+    await cancelEventByQuery({
+      workflowId: template.triggers[0].identifier,
+      stepName: 'Wait for cancellation',
+      stepType: StepTypeEnum.DELAY,
+    });
+
+    const cancelledDelayJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        status: JobStatusEnum.CANCELED,
+        type: StepTypeEnum.DELAY,
+      },
+      findMultiple: true,
+    });
+
+    expect(cancelledDelayJobs?.length).to.eql(2);
+  });
+
+  it('should cancel multiple delayed digests using an array of transactionIds', async () => {
+    template = await session.createTemplate({
+      steps: [
+        {
+          type: StepTypeEnum.DIGEST,
+          content: '',
+          metadata: {
+            unit: DigestUnitEnum.SECONDS,
+            amount: 30,
+            digestKey: 'groupId',
+            type: DigestTypeEnum.REGULAR,
+          },
+        },
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Hello world {{step.events.length}}' as string,
+        },
+      ],
+    });
+
+    const { result: firstResult } = await novuClient.trigger({
+      workflowId: template.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        groupId: 'bulk-group-1',
+      },
+    });
+
+    const { result: secondResult } = await novuClient.trigger({
+      workflowId: template.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        groupId: 'bulk-group-2',
+      },
+    });
+
+    await session.waitForWorkflowQueueCompletion();
+    await session.waitForSubscriberQueueCompletion();
+
+    await cancelEventByQuery({
+      transactionId: [firstResult.transactionId as string, secondResult.transactionId as string],
+    });
+
+    const cancelledDigestJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        status: JobStatusEnum.CANCELED,
+        type: StepTypeEnum.DIGEST,
+      },
+      findMultiple: true,
+    });
+
+    expect(cancelledDigestJobs?.length).to.eql(2);
+  });
+
+  it('should cancel multiple digest and delay workflows at once when stepType is omitted', async () => {
+    const secondSubscriber = await subscriberService.createSubscriber();
+
+    const digestTemplate = await session.createTemplate({
+      steps: [
+        {
+          name: 'Shared cancel gate',
+          type: StepTypeEnum.DIGEST,
+          content: '',
+          metadata: {
+            digestKey: 'groupId',
+            type: DigestTypeEnum.NONE,
+          },
+        },
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Digest {{step.events.length}}' as string,
+        },
+      ],
+    });
+
+    const delayTemplate = await session.createTemplate({
+      steps: [
+        {
+          name: 'Shared cancel gate',
+          type: StepTypeEnum.DELAY,
+          content: '',
+          metadata: {
+            type: DelayTypeEnum.NONE,
+          },
+        },
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Delay {{customVar}}' as string,
+        },
+      ],
+    });
+
+    await novuClient.trigger({
+      workflowId: digestTemplate.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        groupId: 'digest-a',
+        customVar: 'digest_1',
+      },
+    });
+
+    await novuClient.trigger({
+      workflowId: digestTemplate.triggers[0].identifier,
+      to: [secondSubscriber.subscriberId],
+      payload: {
+        groupId: 'digest-b',
+        customVar: 'digest_2',
+      },
+    });
+
+    await novuClient.trigger({
+      workflowId: delayTemplate.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        customVar: 'delay_1',
+      },
+    });
+
+    await novuClient.trigger({
+      workflowId: delayTemplate.triggers[0].identifier,
+      to: [secondSubscriber.subscriberId],
+      payload: {
+        customVar: 'delay_2',
+      },
+    });
+
+    await session.waitForWorkflowQueueCompletion();
+    await session.waitForSubscriberQueueCompletion();
+
+    await cancelEventByQuery({
+      subscriberId: [subscriber.subscriberId, secondSubscriber.subscriberId],
+      stepName: 'Shared cancel gate',
+    });
+
+    const cancelledDigestJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: digestTemplate._id,
+        status: JobStatusEnum.CANCELED,
+        type: StepTypeEnum.DIGEST,
+      },
+      findMultiple: true,
+    });
+
+    const cancelledDelayJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: delayTemplate._id,
+        status: JobStatusEnum.CANCELED,
+        type: StepTypeEnum.DELAY,
+      },
+      findMultiple: true,
+    });
+
+    expect(cancelledDigestJobs?.length).to.eql(2);
+    expect(cancelledDelayJobs?.length).to.eql(2);
   });
 
   it('should cancel a delay step for all subscribers', async () => {

--- a/apps/api/src/app/events/e2e/complete-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/complete-event.e2e.ts
@@ -1,0 +1,315 @@
+import { Novu } from '@novu/api';
+import { JobRepository, JobStatusEnum, NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
+import { DelayTypeEnum, DigestTypeEnum, StepTypeEnum } from '@novu/shared';
+import { SubscribersService, UserSession } from '@novu/testing';
+import axios from 'axios';
+import { expect } from 'chai';
+import { initNovuClassSdk } from '../../shared/helpers/e2e/sdk/e2e-sdk.helper';
+import { pollForJobStatusChange } from './utils/poll-for-job-status-change.util';
+
+const axiosInstance = axios.create();
+
+describe('Complete event - /v1/events/trigger/complete (POST) #novu-v2', () => {
+  let session: UserSession;
+  let template: NotificationTemplateEntity;
+  let subscriber: SubscriberEntity;
+  let subscriberService: SubscribersService;
+  const jobRepository = new JobRepository();
+  let novuClient: Novu;
+
+  async function completeMatchingSteps(query: Record<string, string | string[]>) {
+    await axiosInstance.post(`${session.serverUrl}/v1/events/trigger/complete`, undefined, {
+      headers: {
+        authorization: `ApiKey ${session.apiKey}`,
+      },
+      params: query,
+    });
+  }
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+    template = await session.createTemplate();
+    subscriberService = new SubscribersService(session.organization._id, session.environment._id);
+    subscriber = await subscriberService.createSubscriber();
+    novuClient = initNovuClassSdk(session);
+  });
+
+  it('should complete a none digest via query filters', async () => {
+    template = await session.createTemplate({
+      steps: [
+        {
+          name: 'Digest approval batch',
+          type: StepTypeEnum.DIGEST,
+          content: '',
+          metadata: {
+            digestKey: 'groupId',
+            type: DigestTypeEnum.NONE,
+          },
+        },
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Hello world {{step.events.length}}' as string,
+        },
+      ],
+    });
+
+    await novuClient.trigger({
+      workflowId: template.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        groupId: 'wait-group-1',
+        customVar: 'trigger_1_data',
+      },
+    });
+
+    await novuClient.trigger({
+      workflowId: template.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        groupId: 'wait-group-1',
+        customVar: 'trigger_2_data',
+      },
+    });
+
+    await session.waitForWorkflowQueueCompletion();
+    await session.waitForSubscriberQueueCompletion();
+
+    const activeDigestJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        type: StepTypeEnum.DIGEST,
+      },
+      findMultiple: true,
+    });
+
+    expect(activeDigestJobs?.filter((job) => job.status === JobStatusEnum.DELAYED).length).to.eql(1);
+    expect(activeDigestJobs?.filter((job) => job.status === JobStatusEnum.MERGED).length).to.eql(1);
+
+    await completeMatchingSteps({
+      subscriberId: subscriber.subscriberId,
+      workflowId: template.triggers[0].identifier,
+      digestKey: 'groupId',
+      stepName: 'Digest approval batch',
+      stepType: StepTypeEnum.DIGEST,
+    });
+
+    const completedDigestJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        status: JobStatusEnum.COMPLETED,
+        type: StepTypeEnum.DIGEST,
+      },
+      findMultiple: true,
+    });
+
+    expect(completedDigestJobs?.length).to.eql(1);
+    expect(completedDigestJobs?.[0]?.digest?.events?.length).to.eql(2);
+  });
+
+  it('should complete none delay steps in bulk using transactionIds', async () => {
+    template = await session.createTemplate({
+      steps: [
+        {
+          name: 'Wait for approval',
+          type: StepTypeEnum.DELAY,
+          content: '',
+          metadata: {
+            type: DelayTypeEnum.NONE,
+          },
+        },
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Hello world {{customVar}}' as string,
+        },
+      ],
+    });
+
+    const { result: firstResult } = await novuClient.trigger({
+      workflowId: template.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        customVar: 'trigger_1_data',
+      },
+    });
+
+    const { result: secondResult } = await novuClient.trigger({
+      workflowId: template.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        customVar: 'trigger_2_data',
+      },
+    });
+
+    await session.waitForWorkflowQueueCompletion();
+    await session.waitForSubscriberQueueCompletion();
+
+    const delayedJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        status: JobStatusEnum.DELAYED,
+        type: StepTypeEnum.DELAY,
+      },
+      findMultiple: true,
+    });
+
+    expect(delayedJobs?.length).to.eql(2);
+
+    await completeMatchingSteps({
+      transactionId: [firstResult.transactionId as string, secondResult.transactionId as string],
+      workflowId: template.triggers[0].identifier,
+      stepName: 'Wait for approval',
+      stepType: StepTypeEnum.DELAY,
+    });
+
+    const completedDelayJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: template._id,
+        status: JobStatusEnum.COMPLETED,
+        type: StepTypeEnum.DELAY,
+      },
+      findMultiple: true,
+    });
+
+    expect(completedDelayJobs?.length).to.eql(2);
+  });
+
+  it('should complete multiple digest and delay workflows at once when stepType is omitted', async () => {
+    const secondSubscriber = await subscriberService.createSubscriber();
+
+    const digestTemplate = await session.createTemplate({
+      steps: [
+        {
+          name: 'Shared approval gate',
+          type: StepTypeEnum.DIGEST,
+          content: '',
+          metadata: {
+            digestKey: 'groupId',
+            type: DigestTypeEnum.NONE,
+          },
+        },
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Digest {{step.events.length}}' as string,
+        },
+      ],
+    });
+
+    const delayTemplate = await session.createTemplate({
+      steps: [
+        {
+          name: 'Shared approval gate',
+          type: StepTypeEnum.DELAY,
+          content: '',
+          metadata: {
+            type: DelayTypeEnum.NONE,
+          },
+        },
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Delay {{customVar}}' as string,
+        },
+      ],
+    });
+
+    await novuClient.trigger({
+      workflowId: digestTemplate.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        groupId: 'digest-a',
+        customVar: 'digest_1',
+      },
+    });
+
+    await novuClient.trigger({
+      workflowId: digestTemplate.triggers[0].identifier,
+      to: [secondSubscriber.subscriberId],
+      payload: {
+        groupId: 'digest-b',
+        customVar: 'digest_2',
+      },
+    });
+
+    await novuClient.trigger({
+      workflowId: delayTemplate.triggers[0].identifier,
+      to: [subscriber.subscriberId],
+      payload: {
+        customVar: 'delay_1',
+      },
+    });
+
+    await novuClient.trigger({
+      workflowId: delayTemplate.triggers[0].identifier,
+      to: [secondSubscriber.subscriberId],
+      payload: {
+        customVar: 'delay_2',
+      },
+    });
+
+    await session.waitForWorkflowQueueCompletion();
+    await session.waitForSubscriberQueueCompletion();
+
+    const activeDigestJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: digestTemplate._id,
+        status: JobStatusEnum.DELAYED,
+        type: StepTypeEnum.DIGEST,
+      },
+      findMultiple: true,
+    });
+
+    const activeDelayJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: delayTemplate._id,
+        status: JobStatusEnum.DELAYED,
+        type: StepTypeEnum.DELAY,
+      },
+      findMultiple: true,
+    });
+
+    expect(activeDigestJobs?.length).to.eql(2);
+    expect(activeDelayJobs?.length).to.eql(2);
+
+    await completeMatchingSteps({
+      subscriberId: [subscriber.subscriberId, secondSubscriber.subscriberId],
+      stepName: 'Shared approval gate',
+    });
+
+    const completedDigestJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: digestTemplate._id,
+        status: JobStatusEnum.COMPLETED,
+        type: StepTypeEnum.DIGEST,
+      },
+      findMultiple: true,
+    });
+
+    const completedDelayJobs = await pollForJobStatusChange({
+      jobRepository,
+      query: {
+        _environmentId: session.environment._id,
+        _templateId: delayTemplate._id,
+        status: JobStatusEnum.COMPLETED,
+        type: StepTypeEnum.DELAY,
+      },
+      findMultiple: true,
+    });
+
+    expect(completedDigestJobs?.length).to.eql(2);
+    expect(completedDelayJobs?.length).to.eql(2);
+  });
+});

--- a/apps/api/src/app/events/events.controller.ts
+++ b/apps/api/src/app/events/events.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Param, Post, Req, Scope, ServiceUnavailableException } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Post, Query, Req, Scope, ServiceUnavailableException } from '@nestjs/common';
 import { ApiExcludeEndpoint, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { FeatureFlagsService, RequirePermissions, ResourceCategory } from '@novu/application-generic';
 import {
@@ -8,6 +8,7 @@ import {
   FeatureFlagsKeysEnum,
   PermissionsEnum,
   ResourceEnum,
+  StepTypeEnum,
   TriggerRequestCategoryEnum,
   UserSessionData,
 } from '@novu/shared';
@@ -34,6 +35,7 @@ import {
   TriggerEventToAllRequestDto,
 } from './dtos';
 import { CancelDelayed, CancelDelayedCommand } from './usecases/cancel-delayed';
+import { CompleteDelayed, CompleteDelayedCommand } from './usecases/complete-delayed';
 import { ParseEventRequest, ParseEventRequestMulticastCommand } from './usecases/parse-event-request';
 import { ProcessBulkTrigger, ProcessBulkTriggerCommand } from './usecases/process-bulk-trigger';
 import { SendTestEmail, SendTestEmailCommand } from './usecases/send-test-email';
@@ -49,6 +51,14 @@ function RequestAnalytics(strategy: AnalyticsStrategyEnum = AnalyticsStrategyEnu
   };
 }
 
+function toQueryArray(value?: string | string[]): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return Array.isArray(value) ? value : [value];
+}
+
 @ThrottlerCategory(ApiRateLimitCategoryEnum.TRIGGER)
 @ResourceCategory(ResourceEnum.EVENTS)
 @RequireAuthentication()
@@ -61,6 +71,7 @@ function RequestAnalytics(strategy: AnalyticsStrategyEnum = AnalyticsStrategyEnu
 export class EventsController {
   constructor(
     private cancelDelayedUsecase: CancelDelayed,
+    private completeDelayedUsecase: CompleteDelayed,
     private triggerEventToAll: TriggerEventToAll,
     private sendTestEmail: SendTestEmail,
     private parseEventRequest: ParseEventRequest,
@@ -241,6 +252,113 @@ export class EventsController {
   }
 
   @ExternalApiAccessible()
+  @Delete('/trigger')
+  @ApiOkResponse({
+    type: Boolean,
+  })
+  @ApiOperation({
+    summary: 'Cancel active digests or delayed events',
+    description: `
+    Cancel active workflows using query filters like transactionId, subscriberId, workflowId, stepName, digestKey, or stepType.
+    Bulk operations are supported for transactionId and subscriberId.
+    `,
+  })
+  @SdkMethodName('cancelBulk')
+  @SdkUsageExample('Cancel Triggered Events in Bulk')
+  @SdkGroupName('')
+  @RequirePermissions(PermissionsEnum.EVENT_WRITE)
+  async cancelByQuery(
+    @UserSession() user: UserSessionData,
+    @Query('transactionId') transactionId?: string | string[],
+    @Query('subscriberId') subscriberId?: string | string[],
+    @Query('workflowId') workflowId?: string,
+    @Query('stepName') stepName?: string,
+    @Query('stepType') stepType?: StepTypeEnum,
+    @Query('digestKey') digestKey?: string
+  ): Promise<boolean> {
+    return await this.cancelDelayedUsecase.execute(
+      CancelDelayedCommand.create({
+        userId: user._id,
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        transactionId: toQueryArray(transactionId),
+        subscriberId: toQueryArray(subscriberId),
+        workflowId,
+        stepName,
+        stepType,
+        digestKey,
+      })
+    );
+  }
+
+  @ExternalApiAccessible()
+  @Post('/trigger/complete')
+  @ApiOkResponse({
+    type: Boolean,
+  })
+  @ApiOperation({
+    summary: 'Complete Delayed Triggered Events in Bulk (Delay or Digest)',
+    description: `
+    Force-complete active delay or digest steps using query filters like transactionId, subscriberId, workflowId, stepName, digestKey, or stepType.
+    Bulk operations are supported for transactionId and subscriberId.
+    `,
+  })
+  @SdkMethodName('completeBulk')
+  @SdkUsageExample('Complete Delayed Triggered Events in Bulk (Delay or Digest)')
+  @SdkGroupName('')
+  @RequirePermissions(PermissionsEnum.EVENT_WRITE)
+  async completeByQuery(
+    @UserSession() user: UserSessionData,
+    @Query('transactionId') transactionId?: string | string[],
+    @Query('subscriberId') subscriberId?: string | string[],
+    @Query('workflowId') workflowId?: string,
+    @Query('stepName') stepName?: string,
+    @Query('digestKey') digestKey?: string,
+    @Query('stepType') stepType?: StepTypeEnum
+  ): Promise<boolean> {
+    return await this.completeDelayedUsecase.execute(
+      CompleteDelayedCommand.create({
+        userId: user._id,
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        transactionId: toQueryArray(transactionId),
+        subscriberId: toQueryArray(subscriberId),
+        workflowId,
+        stepName,
+        digestKey,
+        stepType,
+      })
+    );
+  }
+
+  @ExternalApiAccessible()
+  @Post('/trigger/complete/:transactionId')
+  @ApiOkResponse({
+    type: Boolean,
+  })
+  @ApiOperation({
+    summary: 'Complete Delayed Triggered Event (Delay or Digest)',
+    description: `
+    Using a previously generated transactionId during the event trigger,
+     will complete any active or pending workflows. This is useful to complete active digests, delays etc...
+    `,
+  })
+  @SdkMethodName('complete')
+  @SdkUsageExample('Complete Delayed Triggered Event (Delay or Digest)')
+  @SdkGroupName('')
+  @RequirePermissions(PermissionsEnum.EVENT_WRITE)
+  async complete(@UserSession() user: UserSessionData, @Param('transactionId') transactionId: string): Promise<boolean> {
+    return await this.completeDelayedUsecase.execute(
+      CompleteDelayedCommand.create({
+        userId: user._id,
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        transactionId: [transactionId],
+      })
+    );
+  }
+
+  @ExternalApiAccessible()
   @Delete('/trigger/:transactionId')
   @ApiOkResponse({
     type: Boolean,
@@ -262,7 +380,7 @@ export class EventsController {
         userId: user._id,
         environmentId: user.environmentId,
         organizationId: user.organizationId,
-        transactionId,
+        transactionId: [transactionId],
       })
     );
   }

--- a/apps/api/src/app/events/usecases/cancel-delayed/cancel-delayed.usecase.ts
+++ b/apps/api/src/app/events/usecases/cancel-delayed/cancel-delayed.usecase.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import {
   isActionStepType,
   isMainDigest,
@@ -28,7 +28,7 @@ export class CancelDelayed {
   public async execute(command: CancelDelayedCommand): Promise<boolean> {
     let jobs: JobEntity[] = await this.jobRepository.find({
       _environmentId: command.environmentId,
-      transactionId: command.transactionId,
+      ...this.buildCancelQuery(command),
       status: [JobStatusEnum.DELAYED, JobStatusEnum.MERGED],
     });
 
@@ -36,14 +36,18 @@ export class CancelDelayed {
       return false;
     }
 
-    if (jobs.find((job) => job.type && isActionStepType(job.type))) {
+    const transactionIds = Array.from(new Set(jobs.map((job) => job.transactionId).filter(Boolean)));
+
+    if (jobs.find((job) => job.type && isActionStepType(job.type)) && transactionIds.length) {
       const possiblePendingJobs: JobEntity[] = await this.jobRepository.find({
         _environmentId: command.environmentId,
-        transactionId: command.transactionId,
+        transactionId: {
+          $in: transactionIds,
+        },
         status: [JobStatusEnum.PENDING],
       });
 
-      jobs = [...jobs, ...possiblePendingJobs];
+      jobs = this.getUniqueJobs([...jobs, ...possiblePendingJobs]);
     }
 
     await this.jobRepository.update(
@@ -70,13 +74,73 @@ export class CancelDelayed {
       status: JobStatusEnum.CANCELED,
     });
 
-    const mainDigestJob = jobs.find((job) => isMainDigest(job.type, job.status));
+    const mainDigestJobs = this.getUniqueJobs(jobs.filter((job) => isMainDigest(job.type, job.status)));
 
-    if (!mainDigestJob) {
+    if (!mainDigestJobs.length) {
       return true;
     }
 
-    return await this.assignNextDigestJob(mainDigestJob);
+    const reassignmentResults = await Promise.all(mainDigestJobs.map((job) => this.assignNextDigestJob(job)));
+
+    return reassignmentResults.every(Boolean);
+  }
+
+  private buildCancelQuery(command: CancelDelayedCommand): Record<string, unknown> {
+    if (
+      !command.transactionId?.length &&
+      !command.subscriberId?.length &&
+      !command.workflowId &&
+      !command.stepType &&
+      !command.stepName &&
+      !command.digestKey
+    ) {
+      throw new BadRequestException('At least one transaction or delayed-step filter is required');
+    }
+
+    const query: Record<string, unknown> = { };
+
+    this.addArrayFilter(query, 'transactionId', command.transactionId);
+    this.addArrayFilter(query, 'subscriberId', command.subscriberId);
+
+    if (command.workflowId) {
+      query.identifier = command.workflowId;
+    }
+
+    if (command.stepType) {
+      query.type = command.stepType;
+    }
+
+    if (command.stepName) {
+      query['step.name'] = command.stepName;
+    }
+
+    if (command.digestKey) {
+      query['digest.digestKey'] = command.digestKey;
+    }
+
+    return query;
+  }
+
+  private addArrayFilter(query: Record<string, unknown>, field: string, values?: string[]): void {
+    const normalizedValues = this.getUniqueStrings(values);
+
+    if (!normalizedValues.length) {
+      return;
+    }
+
+    query[field] = normalizedValues.length === 1 ? normalizedValues[0] : { $in: normalizedValues };
+  }
+
+  private getUniqueStrings(values?: string[]): string[] {
+    if (!values?.length) {
+      return [];
+    }
+
+    return Array.from(new Set(values.filter(Boolean)));
+  }
+
+  private getUniqueJobs(jobs: JobEntity[]): JobEntity[] {
+    return Array.from(new Map(jobs.map((job) => [job._id, job])).values());
   }
 
   private async assignNextDigestJob(job: JobEntity) {

--- a/apps/api/src/app/events/usecases/complete-delayed/complete-delayed.command.ts
+++ b/apps/api/src/app/events/usecases/complete-delayed/complete-delayed.command.ts
@@ -3,7 +3,7 @@ import { IsIn, IsOptional, IsString } from 'class-validator';
 import { StepTypeEnum } from '@novu/shared';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
-export class CancelDelayedCommand extends EnvironmentWithUserCommand {
+export class CompleteDelayedCommand extends EnvironmentWithUserCommand {
   @Transform(({ value }) => (value === undefined ? undefined : Array.isArray(value) ? value : [value]))
   @IsString({ each: true })
   @IsOptional()

--- a/apps/api/src/app/events/usecases/complete-delayed/complete-delayed.usecase.ts
+++ b/apps/api/src/app/events/usecases/complete-delayed/complete-delayed.usecase.ts
@@ -1,0 +1,144 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { PinoLogger, StandardQueueService, StepRunRepository } from '@novu/application-generic';
+import { JobRepository, JobStatusEnum } from '@novu/dal';
+import { StepTypeEnum } from '@novu/shared';
+
+import { CompleteDelayedCommand } from './complete-delayed.command';
+
+@Injectable()
+export class CompleteDelayed {
+  constructor(
+    private jobRepository: JobRepository,
+    private stepRunRepository: StepRunRepository,
+    private standardQueueService: StandardQueueService,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  public async execute(command: CompleteDelayedCommand): Promise<boolean> {
+    const stepTypeFilter = this.getStepTypeFilter(command.stepType);
+    const jobsToComplete = await this.jobRepository.find({
+      _environmentId: command.environmentId,
+      ...this.buildCompleteQuery(command),
+      status: [JobStatusEnum.DELAYED, JobStatusEnum.MERGED],
+      type: stepTypeFilter,
+    });
+
+    if (!jobsToComplete.length) {
+      return false;
+    }
+
+    const activeJobIds = Array.from(
+      new Set(
+        jobsToComplete
+          .map((job) => (job.status === JobStatusEnum.MERGED ? job._mergedDigestId : job._id))
+          .filter((jobId): jobId is string => Boolean(jobId))
+      )
+    );
+
+    if (!activeJobIds.length) {
+      return false;
+    }
+
+    const activeJobs = await this.jobRepository.find({
+      _environmentId: command.environmentId,
+      _id: {
+        $in: activeJobIds,
+      },
+      status: JobStatusEnum.DELAYED,
+      type: stepTypeFilter,
+    });
+
+    if (!activeJobs.length) {
+      return false;
+    }
+
+    await Promise.all(
+      activeJobs.map(async (job) => {
+        await this.jobRepository.updateStatus(job._environmentId, job._id, JobStatusEnum.QUEUED);
+        await this.stepRunRepository.create(job, {
+          status: JobStatusEnum.QUEUED,
+        });
+
+        await this.standardQueueService.add({
+          name: job._id,
+          data: {
+            _environmentId: job._environmentId,
+            _id: job._id,
+            _organizationId: job._organizationId,
+            _userId: job._userId,
+          },
+          groupId: job._organizationId,
+          options: {
+            delay: 0,
+          },
+        });
+      })
+    );
+
+    return true;
+  }
+
+  private buildCompleteQuery(command: CompleteDelayedCommand): Record<string, unknown> {
+    if (
+      !command.transactionId?.length &&
+      !command.subscriberId?.length &&
+      !command.workflowId &&
+      !command.stepType &&
+      !command.stepName &&
+      !command.digestKey
+    ) {
+      throw new BadRequestException('At least one transaction or step filter is required');
+    }
+
+    const query: Record<string, unknown> = { };
+
+    this.addArrayFilter(query, 'transactionId', command.transactionId);
+    this.addArrayFilter(query, 'subscriberId', command.subscriberId);
+
+    if (command.workflowId) {
+      query.identifier = command.workflowId;
+    }
+
+    if (command.stepType) {
+      query.type = command.stepType;
+    }
+
+    if (command.stepName) {
+      query['step.name'] = command.stepName;
+    }
+
+    if (command.digestKey) {
+      query['digest.digestKey'] = command.digestKey;
+    }
+
+    return query;
+  }
+
+  private getStepTypeFilter(stepType?: StepTypeEnum): StepTypeEnum | StepTypeEnum[] {
+    if (!stepType) {
+      return [StepTypeEnum.DIGEST, StepTypeEnum.DELAY];
+    }
+
+    return stepType;
+  }
+
+  private addArrayFilter(query: Record<string, unknown>, field: string, values?: string[]): void {
+    const normalizedValues = this.getUniqueStrings(values);
+
+    if (!normalizedValues.length) {
+      return;
+    }
+
+    query[field] = normalizedValues.length === 1 ? normalizedValues[0] : { $in: normalizedValues };
+  }
+
+  private getUniqueStrings(values?: string[]): string[] {
+    if (!values?.length) {
+      return [];
+    }
+
+    return Array.from(new Set(values.filter(Boolean)));
+  }
+}

--- a/apps/api/src/app/events/usecases/complete-delayed/index.ts
+++ b/apps/api/src/app/events/usecases/complete-delayed/index.ts
@@ -1,0 +1,2 @@
+export { CompleteDelayedCommand } from './complete-delayed.command';
+export { CompleteDelayed } from './complete-delayed.usecase';

--- a/apps/api/src/app/events/usecases/index.ts
+++ b/apps/api/src/app/events/usecases/index.ts
@@ -1,7 +1,15 @@
 import { CancelDelayed } from './cancel-delayed';
+import { CompleteDelayed } from './complete-delayed';
 import { ParseEventRequest } from './parse-event-request';
 import { ProcessBulkTrigger } from './process-bulk-trigger';
 import { SendTestEmail } from './send-test-email';
 import { TriggerEventToAll } from './trigger-event-to-all';
 
-export const USE_CASES = [CancelDelayed, TriggerEventToAll, ParseEventRequest, ProcessBulkTrigger, SendTestEmail];
+export const USE_CASES = [
+  CancelDelayed,
+  CompleteDelayed,
+  TriggerEventToAll,
+  ParseEventRequest,
+  ProcessBulkTrigger,
+  SendTestEmail,
+];

--- a/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
+++ b/apps/api/src/app/workflows-v2/workflow.controller.e2e.ts
@@ -2,6 +2,7 @@ import { Novu } from '@novu/api';
 import {
   ContentIssueEnum,
   CreateWorkflowDto,
+  DelayStepUpsertDto,
   DigestStepUpsertDto,
   EmailStepResponseDto,
   EmailStepUpsertDto,
@@ -62,6 +63,18 @@ function buildDigestStep(overrides: Partial<DigestStepUpsertDto> = {}): DigestSt
     },
     ...overrides,
   } as DigestStepUpsertDto;
+}
+
+function buildDelayStep(overrides: Partial<DelayStepUpsertDto> = {}): DelayStepUpsertDto {
+  return {
+    name: 'Delay Test Step',
+    type: 'delay',
+    controlValues: {
+      amount: 1,
+      unit: 'hours',
+    },
+    ...overrides,
+  } as DelayStepUpsertDto;
 }
 
 function buildEmailStep(overrides: Partial<EmailStepUpsertDto> = {}): EmailStepUpsertDto {
@@ -1232,6 +1245,28 @@ describe('Workflow Controller E2E API Testing #novu-v2', () => {
 
           expect(step.issues?.controls?.amount[0].issueType).to.deep.equal(ContentIssueEnum.TierLimitExceeded);
           expect(step.issues?.controls?.unit[0].issueType).to.deep.equal(ContentIssueEnum.TierLimitExceeded);
+        });
+
+        it('should allow digest control values with the none type for manual-completion', async () => {
+          const steps = [{ ...buildDigestStep({ controlValues: { type: 'none', digestKey: 'groupId' } }) }];
+          const workflowCreated = await createWorkflow(apiClient, buildWorkflow({ steps } as CreateWorkflowDto));
+          const step = workflowCreated.steps[0];
+
+          expect(step.controls?.values).to.containSubset({ type: 'none', digestKey: 'groupId' });
+          expect(step.issues?.controls?.amount).to.be.undefined;
+          expect(step.issues?.controls?.unit).to.be.undefined;
+          expect(step.issues?.controls?.cron).to.be.undefined;
+        });
+
+        it('should allow delay control values with the none type for manual-completion', async () => {
+          const steps = [{ ...buildDelayStep({ controlValues: { type: 'none' } }) }];
+          const workflowCreated = await createWorkflow(apiClient, buildWorkflow({ steps } as CreateWorkflowDto));
+          const step = workflowCreated.steps[0];
+
+          expect(step.controls?.values).to.containSubset({ type: 'none' });
+          expect(step.issues?.controls?.amount).to.be.undefined;
+          expect(step.issues?.controls?.unit).to.be.undefined;
+          expect(step.issues?.controls?.cron).to.be.undefined;
         });
 
         it('should always show issues for illegal variables in control values', async () => {

--- a/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/add-job.usecase.ts
@@ -13,6 +13,7 @@ import {
   InstrumentUsecase,
   isDynamicOutput,
   isLookBackDigestOutput,
+  isNoneOutput,
   isRegularOutput,
   isTimedOutput,
   JobsOptions,
@@ -47,9 +48,11 @@ import {
   ExecutionDetailsSourceEnum,
   ExecutionDetailsStatusEnum,
   IDelayDynamicMetadata,
+  IDelayNoneMetadata,
   IDelayRegularMetadata,
   IDelayTimedMetadata,
   IDigestBaseMetadata,
+  IDigestNoneMetadata,
   IDigestRegularMetadata,
   IDigestTimedMetadata,
   IWorkflowStepMetadata,
@@ -233,9 +236,14 @@ export class AddJob {
     }
 
     let digestResult: {
-      digestAmount: number;
+      digestAmount: number | undefined;
       digestCreationResult: DigestCreationResultEnum;
       cronExpression?: string;
+      shouldQueue: boolean;
+    } | null = null;
+    let delayResult: {
+      delayAmount: number | undefined;
+      shouldQueue: boolean;
     } | null = null;
 
     const subscriber = await this.subscriberRepository.findOne(
@@ -278,6 +286,28 @@ export class AddJob {
       }
 
       digestAmount = digestResult.digestAmount;
+
+      if (!digestResult.shouldQueue) {
+        const updatedJob = await this.jobRepository.findOne({
+          _id: job._id,
+          _environmentId: job._environmentId,
+        });
+
+        if (!updatedJob) {
+          throw new Error(`Job with id ${job._id} not found`);
+        }
+
+        if (digestResult.digestCreationResult === DigestCreationResultEnum.CREATED) {
+          await this.stepRunRepository.create(updatedJob, {
+            status: JobStatusEnum.DELAYED,
+          });
+        }
+
+        return {
+          workflowStatus: null,
+          deliveryLifecycleStatus: null,
+        };
+      }
     }
 
     if (job.type === StepTypeEnum.THROTTLE) {
@@ -309,7 +339,7 @@ export class AddJob {
 
     if (job.type === StepTypeEnum.DELAY) {
       try {
-        delayAmount = await this.handleDelay({
+        delayResult = await this.handleDelay({
           command,
           job,
           bridgeResponse,
@@ -318,8 +348,30 @@ export class AddJob {
           timezone: subscriber?.timezone,
         });
 
+        delayAmount = delayResult.delayAmount;
+
         if (delayAmount === undefined) {
           this.logger.warn(`Delay Amount does not exist on a delay job ${job._id}`);
+
+          return {
+            workflowStatus: null,
+            deliveryLifecycleStatus: null,
+          };
+        }
+
+        if (!delayResult.shouldQueue) {
+          const updatedJob = await this.jobRepository.findOne({
+            _id: job._id,
+            _environmentId: job._environmentId,
+          });
+
+          if (!updatedJob) {
+            throw new Error(`Job with id ${job._id} not found`);
+          }
+
+          await this.stepRunRepository.create(updatedJob, {
+            status: JobStatusEnum.DELAYED,
+          });
 
           return {
             workflowStatus: null,
@@ -439,7 +491,7 @@ export class AddJob {
     bridgeDelayAmountDate: Date | null;
     bridgeDelayAmount: number | undefined;
     timezone: string | undefined;
-  }) {
+  }): Promise<{ delayAmount: number | undefined; shouldQueue: boolean }> {
     let metadata: IWorkflowStepMetadata;
     if (bridgeResponse) {
       // Assign V2 metadata from Bridge response
@@ -463,11 +515,16 @@ export class AddJob {
       await this.validateDynamicDuration(command, job, delayAmount, StepTypeEnum.DELAY);
     }
 
+    const manualCompletionRequired = 'type' in metadata && metadata.type === DelayTypeEnum.NONE;
+
     await this.jobRepository.updateStatus(command.environmentId, job._id, JobStatusEnum.DELAYED);
 
     this.logger.debug(`Delay step Amount is: ${delayAmount}`);
 
-    return delayAmount;
+    return {
+      delayAmount,
+      shouldQueue: !manualCompletionRequired,
+    };
   }
 
   private async validateDynamicDuration(
@@ -608,7 +665,26 @@ export class AddJob {
     const outputDigestValue = outputs?.digestKey;
     const digestType = getDigestType(outputs);
 
-    if (isTimedOutput(outputs)) {
+    if (isNoneOutput(outputs)) {
+      metadata = {
+        type: DigestTypeEnum.NONE,
+        digestValue: outputDigestValue || 'No-Value-Provided',
+        digestKey: digest.digestKey || 'No-Key-Provided',
+      } as IDigestNoneMetadata;
+      await this.jobRepository.updateOne(
+        {
+          _id: command.job._id,
+          _environmentId: command.environmentId,
+        },
+        {
+          $set: {
+            'digest.type': metadata.type,
+            'digest.digestValue': metadata.digestValue,
+            'digest.digestKey': metadata.digestKey,
+          },
+        }
+      );
+    } else if (isTimedOutput(outputs)) {
       metadata = {
         type: DigestTypeEnum.TIMED,
         digestValue: outputDigestValue || 'No-Value-Provided',
@@ -632,9 +708,7 @@ export class AddJob {
           },
         }
       );
-    }
-
-    if (isLookBackDigestOutput(outputs)) {
+    } else if (isLookBackDigestOutput(outputs)) {
       metadata = {
         type: digestType,
         amount: outputs?.amount,
@@ -664,14 +738,7 @@ export class AddJob {
           },
         }
       );
-    }
-
-    if (isRegularOutput(outputs)) {
-      if (!outputs.amount && !outputs.unit) {
-        outputs.amount = 0;
-        outputs.unit = 'seconds';
-      }
-
+    } else if (isRegularOutput(outputs)) {
       metadata = {
         type: digestType,
         amount: outputs?.amount,
@@ -696,7 +763,6 @@ export class AddJob {
         }
       );
     }
-
     return metadata;
   }
 
@@ -704,7 +770,23 @@ export class AddJob {
     const outputs = response.outputs as DelayOutput;
     let metadata = {} as IWorkflowStepMetadata;
 
-    if (isDynamicOutput(outputs)) {
+    if (isNoneOutput(outputs)) {
+      metadata = {
+        type: DelayTypeEnum.NONE,
+      } as IDelayNoneMetadata;
+
+      await this.jobRepository.updateOne(
+        {
+          _id: command.job._id,
+          _environmentId: command.environmentId,
+        },
+        {
+          $set: {
+            'step.metadata.type': metadata.type,
+          },
+        }
+      );
+    } else if (isDynamicOutput(outputs)) {
       metadata = {
         type: DelayTypeEnum.DYNAMIC,
         dynamicKey: (outputs as unknown as { dynamicKey: string }).dynamicKey,
@@ -938,14 +1020,16 @@ export class AddJob {
 
     validateDigest(job);
 
-    const digestAmount =
-      bridgeDelayAmount ??
-      this.computeJobWaitDurationService.calculateDelay({
-        stepMetadata: metadata,
-        payload: job.payload,
-        overrides: job.overrides,
-        timezone,
-      });
+    const manualCompletionRequired = 'type' in metadata && metadata.type === DigestTypeEnum.NONE;
+    const digestAmount = manualCompletionRequired
+      ? undefined
+      : (bridgeDelayAmount ??
+        this.computeJobWaitDurationService.calculateDelay({
+          stepMetadata: metadata,
+          payload: job.payload,
+          overrides: job.overrides,
+          timezone,
+        }));
 
     this.logger.debug(`Digest step amount is: ${digestAmount}`);
 
@@ -963,7 +1047,12 @@ export class AddJob {
       await this.handleDigestSkip(command, job);
     }
 
-    return { digestAmount, digestCreationResult, cronExpression: bridgeResponse?.outputs?.cron as string | undefined };
+    return {
+      digestAmount,
+      digestCreationResult,
+      cronExpression: bridgeResponse?.outputs?.cron as string | undefined,
+      shouldQueue: digestCreationResult === DigestCreationResultEnum.CREATED && !manualCompletionRequired,
+    };
   }
 
   private getBridgeNextCronDate(bridgeResponse: ExecuteOutput | null, timezone?: string): Date | null {

--- a/apps/worker/src/app/workflow/usecases/add-job/merge-or-create-digest.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/merge-or-create-digest.usecase.ts
@@ -66,6 +66,10 @@ export class MergeOrCreateDigest {
     digestMeta: IDigestBaseMetadata | undefined,
     job: JobEntity
   ): Promise<DigestCreationResultEnum> {
+    if ((digestMeta as IDigestBaseMetadata | IDigestTimedMetadata | undefined)?.type === DigestTypeEnum.NONE) {
+      return DigestCreationResultEnum.CREATED;
+    }
+
     if ((digestMeta as unknown as IDigestTimedMetadata)?.timed?.cronExpression) {
       return DigestCreationResultEnum.CREATED;
     }

--- a/apps/worker/src/app/workflow/usecases/add-job/validation.ts
+++ b/apps/worker/src/app/workflow/usecases/add-job/validation.ts
@@ -92,6 +92,10 @@ export const validateDigest = (job: JobEntity): void => {
 
   const digestWithType = job.digest as IDigestRegularMetadata | IDigestTimedMetadata;
 
+  if (digestWithType.type === DigestTypeEnum.NONE) {
+    return;
+  }
+
   if (
     digestWithType.type &&
     (digestWithType.type === DigestTypeEnum.REGULAR || digestWithType.type === DigestTypeEnum.BACKOFF) &&

--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -93,6 +93,18 @@ export class RunJob {
       throw new PlatformException(`Job with id ${command.jobId} not found`);
     }
 
+    if (
+      job.status === JobStatusEnum.CANCELED ||
+      job.status === JobStatusEnum.COMPLETED ||
+      job.status === JobStatusEnum.FAILED ||
+      job.status === JobStatusEnum.MERGED ||
+      job.status === JobStatusEnum.SKIPPED
+    ) {
+      this.logger.debug({ jobId: job._id, status: job.status }, 'Skipping job execution for terminal-state job');
+
+      return job;
+    }
+
     await this.stepRunRepository.create(job, {
       status: JobStatusEnum.RUNNING,
     });

--- a/libs/application-generic/src/dtos/workflow/controls/delay-control.dto.ts
+++ b/libs/application-generic/src/dtos/workflow/controls/delay-control.dto.ts
@@ -5,13 +5,13 @@ import { SkipControlDto } from '../skip.dto';
 
 export class DelayControlDto extends SkipControlDto {
   @ApiProperty({
-    description: "Type of the delay. Currently only 'regular' is supported by the schema.",
-    enum: [DelayTypeEnum.REGULAR, DelayTypeEnum.TIMED],
+    description: "Type of the delay. Currently only 'regular' and 'none' are supported by the schema.",
+    enum: [DelayTypeEnum.REGULAR, DelayTypeEnum.TIMED, DelayTypeEnum.NONE],
     default: DelayTypeEnum.REGULAR,
   })
-  @IsEnum([DelayTypeEnum.REGULAR, DelayTypeEnum.TIMED])
+  @IsEnum([DelayTypeEnum.REGULAR, DelayTypeEnum.TIMED, DelayTypeEnum.NONE])
   @IsOptional()
-  type?: DelayTypeEnum.REGULAR | DelayTypeEnum.TIMED;
+  type?: DelayTypeEnum.REGULAR | DelayTypeEnum.TIMED | DelayTypeEnum.NONE;
 
   @ApiPropertyOptional({
     description: 'Amount of time to delay.',

--- a/libs/application-generic/src/dtos/workflow/controls/digest-control.dto.ts
+++ b/libs/application-generic/src/dtos/workflow/controls/digest-control.dto.ts
@@ -8,11 +8,11 @@ import { LookBackWindowDto } from './look-back-window.dto';
 export class DigestControlDto extends SkipControlDto {
   @ApiPropertyOptional({
     description: 'The type of digest strategy. Determines which fields are applicable.',
-    enum: [DigestTypeEnum.REGULAR, DigestTypeEnum.TIMED],
+    enum: [DigestTypeEnum.REGULAR, DigestTypeEnum.TIMED, DigestTypeEnum.NONE],
   })
-  @IsEnum([DigestTypeEnum.REGULAR, DigestTypeEnum.TIMED])
+  @IsEnum([DigestTypeEnum.REGULAR, DigestTypeEnum.TIMED, DigestTypeEnum.NONE])
   @IsOptional()
-  type?: DigestTypeEnum.REGULAR | DigestTypeEnum.TIMED;
+  type?: DigestTypeEnum.REGULAR | DigestTypeEnum.TIMED | DigestTypeEnum.NONE;
 
   @ApiPropertyOptional({
     description: 'The amount of time for the digest interval (for REGULAR type). Min 1.',

--- a/libs/application-generic/src/schemas/control/delay-control.schema.ts
+++ b/libs/application-generic/src/schemas/control/delay-control.schema.ts
@@ -39,15 +39,25 @@ const delayDynamicControlZodSchema = z
   })
   .strict();
 
+const delayNoneControlZodSchema = z
+  .object({
+    skip: skipZodSchema,
+    type: z.literal(DelayTypeEnum.NONE),
+    extendToSchedule: z.boolean().optional(),
+  })
+  .strict();
+
 export const delayControlZodSchema = z.discriminatedUnion('type', [
   delayRegularControlZodSchema,
   delayTimedControlZodSchema,
   delayDynamicControlZodSchema,
+  delayNoneControlZodSchema,
 ]);
 
 export type DelayRegularControlType = z.infer<typeof delayRegularControlZodSchema>;
 export type DelayTimedControlType = z.infer<typeof delayTimedControlZodSchema>;
 export type DelayDynamicControlType = z.infer<typeof delayDynamicControlZodSchema>;
+export type DelayNoneControlType = z.infer<typeof delayNoneControlZodSchema>;
 export type DelayControlType = z.infer<typeof delayControlZodSchema>;
 
 export const delayControlSchema = zodToJsonSchema(delayControlZodSchema, defaultOptions) as JSONSchemaEntity;

--- a/libs/application-generic/src/schemas/control/digest-control.schema.ts
+++ b/libs/application-generic/src/schemas/control/digest-control.schema.ts
@@ -41,12 +41,26 @@ const digestTimedControlZodSchema = z
   })
   .strict();
 
+const digestNoneControlZodSchema = z
+  .object({
+    skip: skipZodSchema,
+    type: z.literal(DigestTypeEnum.NONE),
+    digestKey: z.string().optional(),
+    extendToSchedule: z.boolean().optional(),
+  })
+  .strict();
+
 export type LookBackWindowType = z.infer<typeof lookBackWindowZodSchema>;
 export type DigestRegularControlType = z.infer<typeof digestRegularControlZodSchema>;
 export type DigestTimedControlType = z.infer<typeof digestTimedControlZodSchema>;
+export type DigestNoneControlType = z.infer<typeof digestNoneControlZodSchema>;
 export type DigestControlSchemaType = z.infer<typeof digestControlZodSchema>;
 
-export const digestControlZodSchema = z.union([digestRegularControlZodSchema, digestTimedControlZodSchema]);
+export const digestControlZodSchema = z.discriminatedUnion('type', [
+  digestRegularControlZodSchema,
+  digestTimedControlZodSchema,
+  digestNoneControlZodSchema,
+]);
 export const digestControlSchema = zodToJsonSchema(digestControlZodSchema, defaultOptions) as JSONSchemaEntity;
 
 export function isDigestRegularControl(data: unknown): data is DigestRegularControlType {

--- a/libs/application-generic/src/services/calculate-delay/compute-job-wait-duration.service.spec.ts
+++ b/libs/application-generic/src/services/calculate-delay/compute-job-wait-duration.service.spec.ts
@@ -1,4 +1,4 @@
-import { DelayTypeEnum, DigestUnitEnum } from '@novu/shared';
+import { DelayTypeEnum, DigestTypeEnum, DigestUnitEnum } from '@novu/shared';
 import { addSeconds } from 'date-fns';
 import { ComputeJobWaitDurationService } from './compute-job-wait-duration.service';
 
@@ -24,6 +24,35 @@ describe('Compute Job Wait Duration Service', () => {
     it('should convert days to milliseconds', () => {
       const result = (computeJobWaitDurationService as any).toMilliseconds(1, DigestUnitEnum.DAYS);
       expect(result).toEqual(86400000);
+    });
+  });
+
+  describe('calculateDelay - None Digest/Delay', () => {
+    it('should return 0 for a digest with the none type', () => {
+      const delay = computeJobWaitDurationService.calculateDelay({
+        stepMetadata: {
+          type: DigestTypeEnum.NONE,
+          digestKey: 'groupId',
+        },
+        payload: {
+          groupId: 'group-1',
+        },
+        overrides: {},
+      });
+
+      expect(delay).toEqual(0);
+    });
+
+    it('should return 0 for a delay with the none type', () => {
+      const delay = computeJobWaitDurationService.calculateDelay({
+        stepMetadata: {
+          type: DelayTypeEnum.NONE,
+        },
+        payload: {},
+        overrides: {},
+      });
+
+      expect(delay).toEqual(0);
     });
   });
 

--- a/libs/application-generic/src/services/calculate-delay/compute-job-wait-duration.service.ts
+++ b/libs/application-generic/src/services/calculate-delay/compute-job-wait-duration.service.ts
@@ -34,7 +34,9 @@ export class ComputeJobWaitDurationService {
 
     const digestType = 'type' in stepMetadata ? stepMetadata.type : null;
 
-    if (digestType === DelayTypeEnum.SCHEDULED) {
+    if (digestType === DigestTypeEnum.NONE || digestType === DelayTypeEnum.NONE) {
+      return 0;
+    } else if (digestType === DelayTypeEnum.SCHEDULED) {
       const { delayPath } = stepMetadata as IDelayScheduledMetadata;
       if (!delayPath) throw new BadRequestException(`Delay path not found`);
 

--- a/libs/application-generic/src/utils/bridge.ts
+++ b/libs/application-generic/src/utils/bridge.ts
@@ -9,7 +9,9 @@ import {
 import { DigestTypeEnum } from '@novu/shared';
 
 export function getDigestType(outputs: DigestOutput): DigestTypeEnum {
-  if (isTimedOutput(outputs)) {
+  if (isNoneOutput(outputs)) {
+    return DigestTypeEnum.NONE;
+  } else if (isTimedOutput(outputs)) {
     return DigestTypeEnum.TIMED;
   } else if (isLookBackDigestOutput(outputs)) {
     return DigestTypeEnum.BACKOFF;
@@ -17,6 +19,10 @@ export function getDigestType(outputs: DigestOutput): DigestTypeEnum {
 
   return DigestTypeEnum.REGULAR;
 }
+
+export const isNoneOutput = (outputs: DigestOutput | DelayOutput | undefined): boolean => {
+  return (outputs as { type?: string })?.type === 'none';
+};
 
 export const isTimedOutput = (
   outputs: DigestOutput | DelayOutput | undefined
@@ -38,7 +44,7 @@ export const isDynamicOutput = (outputs: DelayOutput | undefined): boolean => {
 export const isRegularOutput = (
   outputs: DigestOutput | DelayOutput
 ): outputs is DigestRegularOutput | DelayRegularOutput => {
-  return !isTimedOutput(outputs) && !isLookBackDigestOutput(outputs) && !isDynamicOutput(outputs);
+  return !isNoneOutput(outputs) && !isTimedOutput(outputs) && !isLookBackDigestOutput(outputs) && !isDynamicOutput(outputs);
 };
 
 export const BRIDGE_EXECUTION_ERROR = {

--- a/libs/application-generic/src/utils/digest.ts
+++ b/libs/application-generic/src/utils/digest.ts
@@ -2,8 +2,15 @@ import { JobEntity } from '@novu/dal';
 import {
   DelayTypeEnum,
   DigestTypeEnum,
+  IDelayDynamicMetadata,
+  IDelayNoneMetadata,
+  IDelayRegularMetadata,
+  IDelayScheduledMetadata,
+  IDelayTimedMetadata,
   IDigestBaseMetadata,
+  IDigestNoneMetadata,
   IDigestRegularMetadata,
+  IDigestTimedMetadata,
   JobStatusEnum,
   StepTypeEnum,
 } from '@novu/shared';
@@ -17,9 +24,36 @@ export const isRegularDelay = (type: DelayTypeEnum) => {
   return type === DelayTypeEnum.REGULAR;
 };
 
+type DelayMetadata =
+  | IDelayRegularMetadata
+  | IDelayTimedMetadata
+  | IDelayScheduledMetadata
+  | IDelayDynamicMetadata
+  | IDelayNoneMetadata
+  | null
+  | undefined;
+
+export function hasDelayScheduleConfig(delayMeta: DelayMetadata): boolean {
+  return Boolean(delayMeta && delayMeta.type !== DelayTypeEnum.NONE);
+}
+
+export function isNoneDelay(delayMeta: DelayMetadata): boolean {
+  return delayMeta?.type === DelayTypeEnum.NONE;
+}
+
 export const isMainDigest = (type: StepTypeEnum | undefined, status: JobStatusEnum) => {
   return type === StepTypeEnum.DIGEST && status === JobStatusEnum.DELAYED;
 };
+
+type DigestMetadata = IDigestBaseMetadata | IDigestTimedMetadata | IDigestNoneMetadata | null | undefined;
+
+export function hasDigestScheduleConfig(digestMeta: DigestMetadata): boolean {
+  return Boolean(digestMeta && digestMeta.type !== DigestTypeEnum.NONE);
+}
+
+export function isNoneDigest(digestMeta: DigestMetadata): boolean {
+  return digestMeta?.type === DigestTypeEnum.NONE;
+}
 
 export function isActionStepType(type: StepTypeEnum) {
   const channels = [StepTypeEnum.DELAY, StepTypeEnum.DIGEST, StepTypeEnum.THROTTLE];

--- a/packages/framework/src/schemas/steps/actions/delay.schema.test.ts
+++ b/packages/framework/src/schemas/steps/actions/delay.schema.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { validateData } from '../../../validators';
-import { digestActionSchemas } from './digest.schema';
+import { delayActionSchemas } from './delay.schema';
 
-describe('digest schema', () => {
+describe('delay schema', () => {
   describe('output schema', () => {
-    it('should validate regular digest', async () => {
-      const schema = digestActionSchemas.output;
+    it('should validate regular delay', async () => {
+      const schema = delayActionSchemas.output;
 
       const data = {
         amount: 1,
@@ -21,8 +21,8 @@ describe('digest schema', () => {
       });
     });
 
-    it('should validate timed digest', async () => {
-      const schema = digestActionSchemas.output;
+    it('should validate timed delay', async () => {
+      const schema = delayActionSchemas.output;
 
       const data = {
         cron: '0 0-23/1 * * *',
@@ -36,12 +36,28 @@ describe('digest schema', () => {
       });
     });
 
-    it('should validate none digest', async () => {
-      const schema = digestActionSchemas.output;
+    it('should validate dynamic delay', async () => {
+      const schema = delayActionSchemas.output;
+
+      const data = {
+        type: 'dynamic',
+        dynamicKey: 'payload.sendAt',
+      };
+
+      const result = await validateData(schema, data);
+
+      expect(result.success).toBe(true);
+      expect(result.success && result.data).toEqual({
+        type: 'dynamic',
+        dynamicKey: 'payload.sendAt',
+      });
+    });
+
+    it('should validate none delay', async () => {
+      const schema = delayActionSchemas.output;
 
       const data = {
         type: 'none',
-        digestKey: 'groupId',
       };
 
       const result = await validateData(schema, data);
@@ -49,7 +65,6 @@ describe('digest schema', () => {
       expect(result.success).toBe(true);
       expect(result.success && result.data).toEqual({
         type: 'none',
-        digestKey: 'groupId',
       });
     });
   });

--- a/packages/framework/src/schemas/steps/actions/delay.schema.ts
+++ b/packages/framework/src/schemas/steps/actions/delay.schema.ts
@@ -43,8 +43,20 @@ export const delayDynamicOutputSchema = {
   additionalProperties: false,
 } as const satisfies JsonSchema;
 
+export const delayNoneOutputSchema = {
+  type: 'object',
+  properties: {
+    type: {
+      enum: ['none'],
+    },
+    extendToSchedule: { type: 'boolean' },
+  },
+  required: ['type'],
+  additionalProperties: false,
+} as const satisfies JsonSchema;
+
 export const delayOutputSchema = {
-  oneOf: [delayRegularOutputSchema, delayTimedOutputSchema, delayDynamicOutputSchema],
+  oneOf: [delayRegularOutputSchema, delayTimedOutputSchema, delayDynamicOutputSchema, delayNoneOutputSchema],
 } as const satisfies JsonSchema;
 
 export const delayResultSchema = {

--- a/packages/framework/src/schemas/steps/actions/digest.schema.ts
+++ b/packages/framework/src/schemas/steps/actions/digest.schema.ts
@@ -48,8 +48,23 @@ export const digestTimedOutputSchema = {
   additionalProperties: false,
 } as const satisfies JsonSchema;
 
+export const digestNoneOutputSchema = {
+  type: 'object',
+  properties: {
+    type: {
+      enum: ['none'],
+    },
+    digestKey: {
+      type: 'string',
+    },
+    extendToSchedule: { type: 'boolean' },
+  },
+  required: ['type'],
+  additionalProperties: false,
+} as const satisfies JsonSchema;
+
 export const digestOutputSchema = {
-  oneOf: [digestRegularOutputSchema, digestTimedOutputSchema],
+  oneOf: [digestRegularOutputSchema, digestTimedOutputSchema, digestNoneOutputSchema],
 } as const satisfies JsonSchema;
 
 export const digestResultSchema = {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -68,7 +68,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "start:server": "http-server ./dist -p 4010",
-    "prebuild": "cp ./src/ui/index.css ./src/ui/index.directcss",
+    "prebuild": "node -e \"require('node:fs').copyFileSync('./src/ui/index.css','./src/ui/index.directcss')\"",
     "build": "pnpm run clean && NODE_ENV=production tsup",
     "postbuild": "rm ./src/ui/index.directcss && ./scripts/copy-package-json.sh && node scripts/size-limit.mjs && pnpm run check-exports",
     "build:umd": "webpack --config webpack.config.cjs",

--- a/packages/shared/src/entities/step/index.ts
+++ b/packages/shared/src/entities/step/index.ts
@@ -42,6 +42,7 @@ export enum DigestTypeEnum {
   REGULAR = 'regular',
   BACKOFF = 'backoff',
   TIMED = 'timed',
+  NONE = 'none',
 }
 
 export enum DelayTypeEnum {
@@ -50,6 +51,7 @@ export enum DelayTypeEnum {
   SCHEDULED = 'scheduled',
   TIMED = 'timed',
   DYNAMIC = 'dynamic',
+  NONE = 'none',
 }
 
 export enum MonthlyTypeEnum {
@@ -118,6 +120,10 @@ export interface IDigestTimedMetadata extends IDigestBaseMetadata {
   timed?: ITimedConfig;
 }
 
+export interface IDigestNoneMetadata extends IDigestBaseMetadata {
+  type: DigestTypeEnum.NONE;
+}
+
 export interface IDelayRegularMetadata extends IAmountAndUnit {
   type: DelayTypeEnum.REGULAR;
 }
@@ -138,6 +144,10 @@ export interface IDelayDynamicMetadata {
   dynamicKey: string;
 }
 
+export interface IDelayNoneMetadata {
+  type: DelayTypeEnum.NONE;
+}
+
 export interface IThrottleMetadata {
   type?: 'fixed' | 'dynamic';
   // Fixed throttle fields
@@ -153,8 +163,10 @@ export interface IThrottleMetadata {
 export type IWorkflowStepMetadata =
   | IDigestRegularMetadata
   | IDigestTimedMetadata
+  | IDigestNoneMetadata
   | IDelayRegularMetadata
   | IDelayScheduledMetadata
   | IDelayTimedMetadata
   | IDelayDynamicMetadata
+  | IDelayNoneMetadata
   | IThrottleMetadata;


### PR DESCRIPTION
### What changed? Why was the change needed?

This PR reworks digest and delay handling to support manual placeholder-style behavior and bulk control of active workflow runs without introducing a new workflow step.

closes #6915, #5818

#### Main changes
- added support for `none` type of digest and delay steps, requiring no delay condition
- enabled query-based **cancel** and **complete** operations for active digest/delay jobs
- added bulk filtering support using:
  - `transactionId[]`
  - `subscriberId[]`
  - `workflowId`
  - `stepName`
  - `digestKey`
  - `stepType`
- unified completion behavior through the shared complete flow
- added/updated e2e and schema coverage for the new behavior

#### Why this was needed
The goal was to support workflows where digest and delay steps can act as manual placeholders and be resumed or canceled later through the API.

We explicitly chose to add a new **Digest/Delay type** instead of introducing a new step because this behavior already fits the existing nature of both steps:

- a **digest** step already decides whether events are **grouped or not**
- a **delay** step already decides whether execution is **held or not**

So the `none` type simply leverages that existing behavior rather than creating a brand-new workflow concept.

This keeps the workflow model simpler, reuses the current execution pipeline, and avoids unnecessary abstraction.

@coderabbitai summary

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

- No database migration is required for the new digest/delay type values.
- The implementation intentionally reuses existing digest/delay behavior instead of adding a new workflow step.
- The query-based cancel/complete flow now supports bulk matching across multiple workflows/runs.

</details>