### PR TITLE
ci(workflow): add step to close existing cloud release PRs before creating a new one

### DIFF
--- a/.github/workflows/prepare-cloud-release.yaml
+++ b/.github/workflows/prepare-cloud-release.yaml
@@ -29,6 +29,23 @@ jobs:
           echo "date_humanized=$(date +'%Y-%m-%d %H:%M')" >> "$GITHUB_OUTPUT"
           echo "branch_name=release_$(date +'%Y_%m_%d_%H_%M')" >> "$GITHUB_OUTPUT"
 
+      - name: Close existing cloud release PRs
+        id: close-existing-prs
+        run: |
+          EXISTING_PRS=$(gh pr list --base prod --search "chore(root): Release" --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("release_"))')
+          if [ -n "$EXISTING_PRS" ]; then
+            echo "$EXISTING_PRS" | jq -r '.number' | while read PR_NUMBER; do
+              BRANCH_NAME=$(echo "$EXISTING_PRS" | jq -r "select(.number == $PR_NUMBER) | .headRefName")
+              echo "Closing existing cloud release PR #$PR_NUMBER (branch: $BRANCH_NAME)"
+              gh pr close "$PR_NUMBER" --comment "Superseded by a newer cloud release PR."
+              git push origin --delete "$BRANCH_NAME" || true
+            done
+          else
+            echo "No existing cloud release PRs found."
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Novu Cloud release branch
         run: git checkout -b ${{ steps.output-variables.outputs.branch_name }}
 

--- a/.github/workflows/prepare-cloud-release.yaml
+++ b/.github/workflows/prepare-cloud-release.yaml
@@ -32,17 +32,13 @@ jobs:
       - name: Close existing cloud release PRs
         id: close-existing-prs
         run: |
-          EXISTING_PRS=$(gh pr list --base prod --search "chore(root): Release" --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("release_"))')
-          if [ -n "$EXISTING_PRS" ]; then
-            echo "$EXISTING_PRS" | jq -r '.number' | while read PR_NUMBER; do
-              BRANCH_NAME=$(echo "$EXISTING_PRS" | jq -r "select(.number == $PR_NUMBER) | .headRefName")
-              echo "Closing existing cloud release PR #$PR_NUMBER (branch: $BRANCH_NAME)"
-              gh pr close "$PR_NUMBER" --comment "Superseded by a newer cloud release PR."
-              git push origin --delete "$BRANCH_NAME" || true
-            done
-          else
-            echo "No existing cloud release PRs found."
-          fi
+          gh pr list --base prod --search "chore(root): Release" --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("release_")) | [.number, .headRefName] | @tsv' | \
+          while IFS=$'\t' read -r PR_NUMBER BRANCH_NAME; do
+            echo "Closing existing cloud release PR #$PR_NUMBER (branch: $BRANCH_NAME)"
+            gh pr close "$PR_NUMBER" --comment "Superseded by a newer cloud release PR."
+            git push origin --delete "$BRANCH_NAME" || true
+          done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION

### What changed? Why was the change needed?

Small DX improvement, It closes exiting release PR. Lets say on holidays it becomes multiple PRs and also if just run this action again it close existing unmerged PRs. 

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Streamlined the workflow step that closes existing open cloud release PRs before creating a new one. The implementation now uses a more efficient jq query with tab-separated value output and pipes directly to a while loop, eliminating redundant jq calls and simplifying the logic. The functionality remains the same: PRs matching specific criteria are closed with a supersession comment and their head branches are deleted.

## Affected areas

**CI/CD workflows**: The cloud release preparation workflow (`prepare-cloud-release.yaml`) now uses a more efficient command pattern for closing superseded release PRs.

## Testing

This is a workflow configuration change. Testing occurs by triggering the workflow and verifying that existing release PRs are correctly identified and closed before the new release PR is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->