### PR TITLE
fix(dashboard): email editor loses focus on variable list item click fixes NV-7342

### DIFF
--- a/apps/dashboard/src/components/variable/variable-list.tsx
+++ b/apps/dashboard/src/components/variable/variable-list.tsx
@@ -189,6 +189,9 @@ const VariableListItem = ({
             isHovered ? 'bg-neutral-100' : ''
           )}
           value={option.value}
+          onMouseDown={(e) => {
+            e.preventDefault();
+          }}
           onClick={(e) => {
             e.stopPropagation();
             e.preventDefault();

--- a/apps/dashboard/src/components/workflow-editor/steps/email/translations/translation-pill.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/email/translations/translation-pill.tsx
@@ -107,7 +107,7 @@ export const TranslationPill: React.FC<TranslationPillProps> = ({
           contentEditable={false}
           className={cn(
             'bg-bg-white border-stroke-soft font-code',
-            'relative m-0 box-border inline-flex cursor-pointer items-center gap-1 rounded-lg border px-1.5 py-px align-middle font-medium leading-[inherit] text-inherit',
+            'relative m-0 box-border inline-flex cursor-pointer items-center gap-1 rounded-lg border px-1.5! py-px! align-middle font-medium leading-[inherit] text-inherit',
             'text-text-sub h-[max(18px,calc(1em+2px))] text-[max(12px,calc(1em-3px))]',
             { 'hover:bg-error-base/2.5': hasError }
           )}
@@ -116,7 +116,7 @@ export const TranslationPill: React.FC<TranslationPillProps> = ({
           ref={buttonRef}
         >
           <VariableIcon variableName={decoratorKey} hasError={hasError} context="translations" />
-          <span className="text-text-sub max-w-[24ch] truncate leading-[1.2] antialiased" title={displayTranslationKey}>
+          <span className="text-label-xs text-text-sub max-w-[24ch] truncate" title={displayTranslationKey}>
             {displayTranslationKey}
           </span>
         </button>


### PR DESCRIPTION
### What changed? Why was the change needed?

Dashboard: The issue was that the Maily Email Editor was loosing the focus when the variable list item was clicked.
This resulted in editor `blur` triggering the suggestion plugin's `onExit` handler, which destroyed the popup and cleaned up the suggestion state. Later at the time when `click` callback was called the editor already lost the state, which was leaving the variable `{{payload.foo` as a text, instead of inserting a variable node.

Additionally polished the translation variable pill to have a similar styles to the regular variable pill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Fixed an issue in the Maily Email Editor where clicking a variable list item caused the editor to lose focus. The problem occurred because the `mousedown` event triggered the editor's `blur`, which destroyed the suggestion plugin state before the `click` handler could insert the variable. Added an `onMouseDown` handler with `preventDefault()` to suppress default behavior and preserve the editor state. Also updated the translation variable pill styling to use important modifiers on padding and align typography with standard variable pills.

## Affected areas

**dashboard**: Added focus preservation logic to the variable list item click handler by preventing default mousedown behavior. Updated translation pill styling to override competing styles using important modifiers and adjusted text rendering from custom line-height/antialiased classes to the `text-label-xs` utility.

## Testing

No test additions noted. This is a UI interaction fix and styling alignment that benefits from manual verification in the email editor UI when clicking variables and translation keys in the suggestion popup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

https://github.com/user-attachments/assets/c0b70714-63ed-406d-8b00-0cf8161e4f11


https://github.com/user-attachments/assets/8398a3f8-9c18-4009-b1e8-52430c41f47c


https://github.com/user-attachments/assets/d7205b75-ac8b-436e-a566-393b588e2ba3



<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
