### PR TITLE
fix(api-service): use NOVU_INTERNAL_SECRET_KEY for agents early access trigger

### DIFF
--- a/apps/api/src/app/support/support.controller.ts
+++ b/apps/api/src/app/support/support.controller.ts
@@ -37,10 +37,10 @@ export class SupportController {
     const organization = await this.organizationRepository.findById(user.organizationId);
     const organizationName = organization?.name ?? '';
 
-    const secretKey = process.env.NOVU_SECRET_KEY;
+    const secretKey = process.env.NOVU_INTERNAL_SECRET_KEY;
 
     if (!secretKey) {
-      this.logger.warn('NOVU_SECRET_KEY is not set; skipping early-access-request-agents-internal-email trigger');
+      this.logger.warn('NOVU_INTERNAL_SECRET_KEY is not set; skipping early-access-request-agents-internal-email trigger');
 
       return {
         success: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `POST /support/agents-early-access` handler now reads `NOVU_INTERNAL_SECRET_KEY` instead of `NOVU_SECRET_KEY`, matching other server-side Novu triggers in the same controller (e.g. `mobile-setup`) and the internal secret already validated in `env.validators.ts`.

**Breaking change:** Deployments must set `NOVU_INTERNAL_SECRET_KEY` for this workflow to run; relying on `NOVU_SECRET_KEY` alone will no longer trigger the internal email.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1776082916895139?thread_ts=1776082916.895139&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-67b30251-428f-5093-b5f0-50423801c20f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67b30251-428f-5093-b5f0-50423801c20f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

