### PR TITLE
fix(dashboard): keep step preview usable in live environments

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/editor/step-editor-factory.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/editor/step-editor-factory.tsx
@@ -1,4 +1,4 @@
-import { FeatureFlagsKeysEnum, ResourceOriginEnum, StepTypeEnum } from '@novu/shared';
+import { EnvironmentTypeEnum, FeatureFlagsKeysEnum, ResourceOriginEnum, StepTypeEnum } from '@novu/shared';
 import { useCallback, useMemo } from 'react';
 import { ChatEditor } from '@/components/workflow-editor/steps/chat/chat-editor';
 import { useStepEditor } from '@/components/workflow-editor/steps/context/step-editor-context';
@@ -12,16 +12,43 @@ import { StepResolverNotPublished } from '@/components/workflow-editor/steps/sha
 import { SmsEditor } from '@/components/workflow-editor/steps/sms/sms-editor';
 import { ThrottleEditor } from '@/components/workflow-editor/steps/throttle/throttle-editor';
 import { useWorkflow } from '@/components/workflow-editor/workflow-provider';
+import { useEnvironment } from '@/context/environment/hooks';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useStepResolverPolling } from '@/hooks/use-step-resolver-polling';
-import { INLINE_CONFIGURABLE_STEP_TYPES, STEP_RESOLVER_SUPPORTED_STEP_TYPES, STEP_TYPE_LABELS } from '@/utils/constants';
+import {
+  INLINE_CONFIGURABLE_STEP_TYPES,
+  STEP_RESOLVER_SUPPORTED_STEP_TYPES,
+  STEP_TYPE_LABELS,
+} from '@/utils/constants';
+
+const PREVIEW_SUPPORTED_STEP_TYPES = new Set<StepTypeEnum>([
+  StepTypeEnum.EMAIL,
+  StepTypeEnum.IN_APP,
+  StepTypeEnum.SMS,
+  StepTypeEnum.PUSH,
+  StepTypeEnum.CHAT,
+  StepTypeEnum.HTTP_REQUEST,
+]);
 
 function NoEditorAvailable({ message }: { message: string }) {
   return <div className="flex h-full items-center justify-center text-sm text-neutral-500">{message}</div>;
 }
 
+function ReadOnlyStepContentPlaceholder() {
+  return (
+    <div className="text-text-sub flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+      <p className="text-label-sm text-text-strong">Content is read-only in this environment</p>
+      <p className="text-paragraph-xs max-w-sm">
+        Step content cannot be edited outside of development. Use the preview on the right to see how this step will
+        look when sent.
+      </p>
+    </div>
+  );
+}
+
 export function StepEditorFactory() {
   const { workflow, step, isStepEditable, isPendingResolverActivation } = useStepEditor();
+  const { currentEnvironment } = useEnvironment();
   const { refetch } = useWorkflow();
   const isStepResolverEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_STEP_RESOLVER_ENABLED);
   const isActionStepResolverEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_ACTION_STEP_RESOLVER_ENABLED);
@@ -46,6 +73,16 @@ export function StepEditorFactory() {
 
   if (isPendingResolverActivation) {
     return <StepResolverNotPublished workflowId={step.workflowId} stepId={step.stepId} />;
+  }
+
+  const isNonDevEnvironment = currentEnvironment?.type !== EnvironmentTypeEnum.DEV;
+  const canShowPreviewWithoutNativeEditor =
+    isNonDevEnvironment &&
+    PREVIEW_SUPPORTED_STEP_TYPES.has(step.type) &&
+    workflow.origin !== ResourceOriginEnum.EXTERNAL;
+
+  if (!isStepEditable && canShowPreviewWithoutNativeEditor) {
+    return <ReadOnlyStepContentPlaceholder />;
   }
 
   if (!isStepEditable) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In **non-development** environments (production / live), the step template editor often has **no `uiSchema` on the step** while **`controlValues` and the preview API still work**. The UI treated that as “no editor” and showed **“No editor available for this step configuration”** for the whole editor panel, which made it feel like **preview was locked** together with editing.

This change shows a **read-only placeholder** in the editor column for preview-capable channel and HTTP steps when the native editor is not available in that environment, so the **Preview panel remains the primary way to view content** (editing stays disabled).

## Screenshots

![Live environment: read-only editor message with preview panel](https://cursor.com/artifacts/c/art-d93a1e8d-bf05-4b57-b15a-b56c54cbe8de)

## Testing

- `pnpm exec biome check --write` on the touched file
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1776141882559419?thread_ts=1776141882.559419&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-1bfe58f1-bf71-5250-88c5-ddbbce54bae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bfe58f1-bf71-5250-88c5-ddbbce54bae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

In non-development (production/live) environments, step editors often lack a uiSchema configuration. Previously, the UI displayed a generic "No editor available" message, which made the preview feel locked. This change introduces a read-only placeholder component that appears in the editor column for preview-capable steps (EMAIL, IN_APP, SMS, PUSH, CHAT, HTTP_REQUEST) when the native editor is unavailable. The placeholder directs users to the preview panel on the right, making it clear that content can still be previewed even if editing is disabled.

## Affected areas

- **dashboard**: Updated `StepEditorFactory` component to detect non-development environments, check if the current step type supports preview, and display a read-only placeholder instead of a generic "no editor available" message. The component now imports `useEnvironment()` and `EnvironmentTypeEnum` to determine the current environment type.

## Key technical decisions

- Preview-capable steps are limited to a specific set (EMAIL, IN_APP, SMS, PUSH, CHAT, HTTP_REQUEST) to ensure the placeholder only appears for steps that have working preview functionality.
- The placeholder is only shown for internal workflows (`workflow.origin !== ResourceOriginEnum.EXTERNAL`), preserving existing behavior for external/custom steps.

## Testing

Manual verification was performed by running `pnpm exec biome check --write` on the modified file to ensure code formatting compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->