### PR TITLE
fix(dashboard): show read-only placeholder for live step preview fixes NV-7354

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/editor/step-editor-factory.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/editor/step-editor-factory.tsx
@@ -14,10 +14,24 @@ import { ThrottleEditor } from '@/components/workflow-editor/steps/throttle/thro
 import { useWorkflow } from '@/components/workflow-editor/workflow-provider';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useStepResolverPolling } from '@/hooks/use-step-resolver-polling';
-import { INLINE_CONFIGURABLE_STEP_TYPES, STEP_RESOLVER_SUPPORTED_STEP_TYPES, STEP_TYPE_LABELS } from '@/utils/constants';
+import {
+  INLINE_CONFIGURABLE_STEP_TYPES,
+  STEP_RESOLVER_SUPPORTED_STEP_TYPES,
+  STEP_TYPE_LABELS,
+  TEMPLATE_CONFIGURABLE_STEP_TYPES,
+} from '@/utils/constants';
 
 function NoEditorAvailable({ message }: { message: string }) {
   return <div className="flex h-full items-center justify-center text-sm text-neutral-500">{message}</div>;
+}
+
+function ReadOnlyLiveStepPlaceholder() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+      <p className="text-sm text-neutral-500">Step content cannot be edited in this environment.</p>
+      <p className="text-sm text-neutral-400">Use the preview panel to see how this step renders.</p>
+    </div>
+  );
 }
 
 export function StepEditorFactory() {
@@ -49,6 +63,13 @@ export function StepEditorFactory() {
   }
 
   if (!isStepEditable) {
+    const isPreviewSupportedTemplateStep =
+      workflow.origin !== ResourceOriginEnum.EXTERNAL && TEMPLATE_CONFIGURABLE_STEP_TYPES.includes(step.type);
+
+    if (isPreviewSupportedTemplateStep) {
+      return <ReadOnlyLiveStepPlaceholder />;
+    }
+
     return <NoEditorAvailable message="No editor available for this step configuration" />;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In non-development environments, Novu Cloud steps sometimes have no `uiSchema` while `controlValues` and the preview API still work. `isStepEditable` was false in that case, and `StepEditorFactory` returned **"No editor available for this step configuration"**, which made the whole step view feel broken or locked even though the preview column could still render.

## Change

When editing is not available and the workflow is not external, for step types that support the template preview (email, in-app, SMS, push, chat, HTTP), show a short **read-only** message in the editor column explaining that content cannot be edited here and to use the **Preview** panel. Other step types keep the previous generic message.

## Testing

- `pnpm exec biome check src/components/workflow-editor/steps/editor/step-editor-factory.tsx`

Manual: open a published workflow in a live/production environment, select a content step that has no editor UI schema; confirm the right-hand preview still loads and the left column shows the placeholder instead of "No editor available…".
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7354](https://linear.app/novu/issue/NV-7354/step-preview-is-locked-in-live-environments)

<div><a href="https://cursor.com/agents/bc-a0d15ff9-c216-4578-ad09-3177354ab5d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0d15ff9-c216-4578-ad09-3177354ab5d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

