### PR TITLE
feat(framework): add agent support to @novu/framework SDK fixes NV-7358

### DIFF
--- a/apps/api/src/app/agents/dtos/agent-event.enum.ts
+++ b/apps/api/src/app/agents/dtos/agent-event.enum.ts
@@ -1,6 +1,4 @@
 export enum AgentEventEnum {
-  ON_START = 'onStart',
   ON_MESSAGE = 'onMessage',
-  ON_ACTION = 'onAction',
   ON_RESOLVE = 'onResolve',
 }

--- a/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
@@ -220,7 +220,7 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       expect(bridgeCalls.length).to.equal(1);
       const call = bridgeCalls[0];
 
-      expect(call.event).to.equal(AgentEventEnum.ON_START);
+      expect(call.event).to.equal(AgentEventEnum.ON_MESSAGE);
       expect(call.config.agentIdentifier).to.equal(ctx.agentIdentifier);
       expect(call.config.integrationIdentifier).to.equal(ctx.integrationIdentifier);
       expect(call.config.platform).to.equal('slack');

--- a/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
@@ -67,7 +67,7 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
     });
   });
 
-  async function invokeInbound(threadId: string, message: ReturnType<typeof mockMessage>, event = AgentEventEnum.ON_START) {
+  async function invokeInbound(threadId: string, message: ReturnType<typeof mockMessage>, event = AgentEventEnum.ON_MESSAGE) {
     const config = await credentialService.resolve(ctx.agentId, ctx.integrationIdentifier);
     const thread = mockThread(threadId);
     await inboundHandler.handle(ctx.agentId, config, thread as any, message as any, event);

--- a/apps/api/src/app/agents/e2e/helpers/agent-test-setup.ts
+++ b/apps/api/src/app/agents/e2e/helpers/agent-test-setup.ts
@@ -52,7 +52,7 @@ export async function setupAgentTestContext(): Promise<AgentTestContext> {
     _organizationId: session.organization._id,
     providerId: ChatProviderIdEnum.Slack,
     channel: ChannelTypeEnum.CHAT,
-    credentials: encryptCredentials({ apiKey: SIGNING_SECRET }),
+    credentials: encryptCredentials({ signingSecret: SIGNING_SECRET }),
     active: true,
     name: 'Slack Agent E2E',
     identifier: `slack-agent-e2e-${Date.now()}`,

--- a/apps/api/src/app/agents/e2e/mock-agent-handler.ts
+++ b/apps/api/src/app/agents/e2e/mock-agent-handler.ts
@@ -1,117 +1,77 @@
 /**
- * Mock Agent Handler — E2E test utility
+ * Agent Handler — E2E test utility using @novu/framework
  *
- * Simulates a customer's serve() endpoint that receives bridge calls from Novu
- * and auto-replies back. Run alongside the Novu API to test the full agent round-trip.
+ * This is a real serve() endpoint that uses the agent SDK to handle bridge calls.
+ * Run alongside the Novu API to test the full agent round-trip with Slack.
  *
  * Usage:
- *   NOVU_API_KEY=<your-env-api-key> npx ts-node apps/api/src/app/agents/e2e/mock-agent-handler.ts
+ *   NOVU_SECRET_KEY=<your-env-secret-key> npx ts-node apps/api/src/app/agents/e2e/mock-agent-handler.ts
  *
  * Setup:
  *   1. Start Novu API: pnpm start:api:dev
- *   2. Set environment bridge URL to http://localhost:4111 (dashboard or direct DB update)
+ *   2. Set environment bridge URL to http://localhost:4111/api/novu (dashboard or direct DB update)
  *   3. Create an agent + link a Slack integration via the API
  *   4. Point Slack event subscriptions to your Novu webhook URL (ngrok/tunnel)
  *   5. @mention the bot in Slack — watch the round-trip in the logs
  */
 
+import { agent, Client, serve } from '@novu/framework/express';
 import express from 'express';
 
-const NOVU_API_KEY = process.env.NOVU_API_KEY;
-const NOVU_API_URL = process.env.NOVU_API_URL || 'http://localhost:3000';
+const NOVU_SECRET_KEY = process.env.NOVU_SECRET_KEY;
 const PORT = Number(process.env.MOCK_PORT) || 4111;
 
-if (!NOVU_API_KEY) {
-  console.error('NOVU_API_KEY is required. Set it to your environment API key.');
+if (!NOVU_SECRET_KEY) {
+  console.error('NOVU_SECRET_KEY is required. Set it to your environment secret key.');
   process.exit(1);
 }
+
+const echoBot = agent('novu-agent', {
+  onMessage: async (ctx) => {
+    console.log('\n─────────────────────────────────────────');
+    console.log(`[${ctx.event}] from ${ctx.subscriber?.firstName ?? 'unknown'} on ${ctx.platform}`);
+    console.log(`Message: ${ctx.message?.text ?? '(none)'}`);
+    console.log(`Conversation: ${ctx.conversation.identifier} (${ctx.conversation.status})`);
+    console.log(`History: ${ctx.history.length} entries`);
+    console.log('─────────────────────────────────────────');
+
+    const userText = ctx.message?.text ?? '';
+    const turnCount = (ctx.conversation.metadata?.turnCount as number) ?? 0;
+
+    ctx.metadata.set('turnCount', turnCount + 1);
+
+    if (userText.toLowerCase().includes('done')) {
+      ctx.resolve(`Conversation resolved after ${turnCount + 1} turns`);
+      await ctx.reply('Thanks for chatting! Resolving this conversation.');
+
+      return;
+    }
+
+    await ctx.reply(`Echo: ${userText}`);
+  },
+
+  onResolve: async (ctx) => {
+    console.log(`\n[onResolve] Conversation ${ctx.conversation.identifier} closed.`);
+    ctx.metadata.set('resolvedAt', new Date().toISOString());
+  },
+});
 
 const app = express();
 app.use(express.json());
 
-app.post('/', async (req, res) => {
-  const { action, agentId, event } = req.query as Record<string, string>;
-
-  console.log('\n─────────────────────────────────────────');
-  console.log(`Bridge call received: action=${action} agentId=${agentId} event=${event}`);
-  console.log('─────────────────────────────────────────');
-
-  const payload = req.body;
-
-  console.log('Event:', payload.event);
-  console.log('Agent:', payload.agentId);
-  console.log('Conversation:', payload.conversation?.identifier, `(status: ${payload.conversation?.status})`);
-  console.log('Subscriber:', payload.subscriber?.subscriberId ?? 'null (unlinked platform user)');
-  console.log('Message:', payload.message?.text ?? '(no message)');
-  console.log('History entries:', payload.history?.length ?? 0);
-  console.log('Platform:', payload.platform, payload.platformContext?.isDM ? '(DM)' : '(channel)');
-  console.log('Reply URL:', payload.replyUrl);
-  console.log('Conversation ID:', payload.conversationId);
-  console.log('Integration:', payload.integrationIdentifier);
-
-  res.status(200).json({ status: 'ack' });
-
-  if (payload.event === 'onResolve') {
-    console.log('\nonResolve — no reply needed. Conversation closed.');
-
-    return;
-  }
-
-  const replyBody = buildReply(payload);
-  console.log('\nSending reply:', JSON.stringify(replyBody, null, 2));
-
-  try {
-    const replyUrl = `${NOVU_API_URL}/v1/agents/${payload.agentId}/reply`;
-    console.log('Reply URL:', replyUrl);
-
-    const replyRes = await fetch(replyUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `ApiKey ${NOVU_API_KEY}`,
-      },
-      body: JSON.stringify(replyBody),
-    });
-
-    const responseBody = await replyRes.text();
-    console.log(`Reply response: ${replyRes.status} ${responseBody}`);
-  } catch (err) {
-    console.error('Reply failed:', err);
-  }
-});
-
-function buildReply(payload: Record<string, unknown>) {
-  const event = payload.event as string;
-  const message = payload.message as { text: string } | null;
-  const conversation = payload.conversation as { identifier: string; metadata: Record<string, unknown> } | undefined;
-  const conversationId = payload.conversationId as string;
-  const integrationIdentifier = payload.integrationIdentifier as string;
-
-  const base = { conversationId, integrationIdentifier };
-
-  const userText = message?.text ?? '';
-
-  if (userText.toLowerCase().includes('done')) {
-    return {
-      ...base,
-      reply: { text: 'Thanks for chatting! Resolving this conversation.' },
-      resolve: { summary: `Conversation resolved after ${(conversation?.metadata as Record<string, unknown>)?.turnCount ?? '?'} turns` },
-      signals: [{ type: 'metadata', key: 'turnCount', value: ((conversation?.metadata as Record<string, unknown>)?.turnCount as number ?? 0) + 1 }],
-    };
-  }
-
-  const turnCount = ((conversation?.metadata as Record<string, unknown>)?.turnCount as number) ?? 0;
-
-  return {
-    ...base,
-    reply: { text: `Echo: ${userText}` },
-    signals: [{ type: 'metadata', key: 'turnCount', value: turnCount + 1 }],
-  };
-}
+app.use(
+  '/api/novu',
+  serve({
+    agents: [echoBot],
+    client: new Client({
+      secretKey: NOVU_SECRET_KEY,
+      strictAuthentication: false,
+    }),
+  })
+);
 
 app.listen(PORT, () => {
-  console.log(`\nMock Agent Handler running on http://localhost:${PORT}`);
-  console.log(`Novu API: ${NOVU_API_URL}`);
-  console.log(`API Key: ${NOVU_API_KEY.slice(0, 10)}...`);
+  console.log(`\nAgent Handler (using @novu/framework) running on http://localhost:${PORT}/api/novu`);
+  console.log(`Secret Key: ${NOVU_SECRET_KEY.slice(0, 10)}...`);
   console.log('\nWaiting for bridge calls...\n');
 });

--- a/apps/api/src/app/agents/e2e/mock-agent-handler.ts
+++ b/apps/api/src/app/agents/e2e/mock-agent-handler.ts
@@ -1,0 +1,117 @@
+/**
+ * Mock Agent Handler — E2E test utility
+ *
+ * Simulates a customer's serve() endpoint that receives bridge calls from Novu
+ * and auto-replies back. Run alongside the Novu API to test the full agent round-trip.
+ *
+ * Usage:
+ *   NOVU_API_KEY=<your-env-api-key> npx ts-node apps/api/src/app/agents/e2e/mock-agent-handler.ts
+ *
+ * Setup:
+ *   1. Start Novu API: pnpm start:api:dev
+ *   2. Set environment bridge URL to http://localhost:4111 (dashboard or direct DB update)
+ *   3. Create an agent + link a Slack integration via the API
+ *   4. Point Slack event subscriptions to your Novu webhook URL (ngrok/tunnel)
+ *   5. @mention the bot in Slack — watch the round-trip in the logs
+ */
+
+import express from 'express';
+
+const NOVU_API_KEY = process.env.NOVU_API_KEY;
+const NOVU_API_URL = process.env.NOVU_API_URL || 'http://localhost:3000';
+const PORT = Number(process.env.MOCK_PORT) || 4111;
+
+if (!NOVU_API_KEY) {
+  console.error('NOVU_API_KEY is required. Set it to your environment API key.');
+  process.exit(1);
+}
+
+const app = express();
+app.use(express.json());
+
+app.post('/', async (req, res) => {
+  const { action, agentId, event } = req.query as Record<string, string>;
+
+  console.log('\n─────────────────────────────────────────');
+  console.log(`Bridge call received: action=${action} agentId=${agentId} event=${event}`);
+  console.log('─────────────────────────────────────────');
+
+  const payload = req.body;
+
+  console.log('Event:', payload.event);
+  console.log('Agent:', payload.agentId);
+  console.log('Conversation:', payload.conversation?.identifier, `(status: ${payload.conversation?.status})`);
+  console.log('Subscriber:', payload.subscriber?.subscriberId ?? 'null (unlinked platform user)');
+  console.log('Message:', payload.message?.text ?? '(no message)');
+  console.log('History entries:', payload.history?.length ?? 0);
+  console.log('Platform:', payload.platform, payload.platformContext?.isDM ? '(DM)' : '(channel)');
+  console.log('Reply URL:', payload.replyUrl);
+  console.log('Conversation ID:', payload.conversationId);
+  console.log('Integration:', payload.integrationIdentifier);
+
+  res.status(200).json({ status: 'ack' });
+
+  if (payload.event === 'onResolve') {
+    console.log('\nonResolve — no reply needed. Conversation closed.');
+
+    return;
+  }
+
+  const replyBody = buildReply(payload);
+  console.log('\nSending reply:', JSON.stringify(replyBody, null, 2));
+
+  try {
+    const replyUrl = `${NOVU_API_URL}/v1/agents/${payload.agentId}/reply`;
+    console.log('Reply URL:', replyUrl);
+
+    const replyRes = await fetch(replyUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `ApiKey ${NOVU_API_KEY}`,
+      },
+      body: JSON.stringify(replyBody),
+    });
+
+    const responseBody = await replyRes.text();
+    console.log(`Reply response: ${replyRes.status} ${responseBody}`);
+  } catch (err) {
+    console.error('Reply failed:', err);
+  }
+});
+
+function buildReply(payload: Record<string, unknown>) {
+  const event = payload.event as string;
+  const message = payload.message as { text: string } | null;
+  const conversation = payload.conversation as { identifier: string; metadata: Record<string, unknown> } | undefined;
+  const conversationId = payload.conversationId as string;
+  const integrationIdentifier = payload.integrationIdentifier as string;
+
+  const base = { conversationId, integrationIdentifier };
+
+  const userText = message?.text ?? '';
+
+  if (userText.toLowerCase().includes('done')) {
+    return {
+      ...base,
+      reply: { text: 'Thanks for chatting! Resolving this conversation.' },
+      resolve: { summary: `Conversation resolved after ${(conversation?.metadata as Record<string, unknown>)?.turnCount ?? '?'} turns` },
+      signals: [{ type: 'metadata', key: 'turnCount', value: ((conversation?.metadata as Record<string, unknown>)?.turnCount as number ?? 0) + 1 }],
+    };
+  }
+
+  const turnCount = ((conversation?.metadata as Record<string, unknown>)?.turnCount as number) ?? 0;
+
+  return {
+    ...base,
+    reply: { text: `Echo: ${userText}` },
+    signals: [{ type: 'metadata', key: 'turnCount', value: turnCount + 1 }],
+  };
+}
+
+app.listen(PORT, () => {
+  console.log(`\nMock Agent Handler running on http://localhost:${PORT}`);
+  console.log(`Novu API: ${NOVU_API_URL}`);
+  console.log(`API Key: ${NOVU_API_KEY.slice(0, 10)}...`);
+  console.log('\nWaiting for bridge calls...\n');
+});

--- a/apps/api/src/app/agents/e2e/mock-agent-handler.ts
+++ b/apps/api/src/app/agents/e2e/mock-agent-handler.ts
@@ -72,6 +72,5 @@ app.use(
 
 app.listen(PORT, () => {
   console.log(`\nAgent Handler (using @novu/framework) running on http://localhost:${PORT}/api/novu`);
-  console.log(`Secret Key: ${NOVU_SECRET_KEY.slice(0, 10)}...`);
   console.log('\nWaiting for bridge calls...\n');
 });

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -224,7 +224,7 @@ export class ChatSdkService implements OnModuleDestroy {
     chat.onNewMention(async (thread: Thread, message: Message) => {
       try {
         await thread.subscribe();
-        await this.inboundHandler.handle(agentId, config, thread, message, AgentEventEnum.ON_START);
+        await this.inboundHandler.handle(agentId, config, thread, message, AgentEventEnum.ON_MESSAGE);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling new mention`);
       }

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -66,6 +66,7 @@ const integrationSchema = new Schema<IntegrationDBModel>(
       senderId: Schema.Types.String,
       servicePlanId: Schema.Types.String,
       tenantId: Schema.Types.String,
+      signingSecret: Schema.Types.String,
       AppIOBaseUrl: Schema.Types.String,
       AppIOSubscriptionId: Schema.Types.String,
       AppIOBearerToken: Schema.Types.String,

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -414,12 +414,12 @@ export class Client {
   }
 
   public async executeWorkflow(event: Event): Promise<ExecuteOutput> {
-    const actionMessages = {
+    const actionMessages: Record<string, string> = {
       [PostActionEnum.EXECUTE]: 'Executing',
       [PostActionEnum.PREVIEW]: 'Previewing',
-    } as const;
+    };
 
-    const actionMessage = actionMessages[event.action];
+    const actionMessage = actionMessages[event.action] || event.action;
 
     const actionMessageFormatted = `${actionMessage} workflowId:`;
     this.log(`\n${log.bold(log.underline(actionMessageFormatted))} '${event.workflowId}'`);
@@ -507,11 +507,11 @@ export class Client {
     const elapsedTimeInMilliseconds = elapsedSeconds * 1_000 + elapsedNanoseconds / 1_000_000;
 
     const emoji = executionError ? EMOJI.ERROR : EMOJI.SUCCESS;
-    const resultMessages = {
+    const resultMessages: Record<string, string> = {
       [PostActionEnum.EXECUTE]: 'Executed',
       [PostActionEnum.PREVIEW]: 'Previewed',
-    } as const;
-    const resultMessage = resultMessages[event.action];
+    };
+    const resultMessage = resultMessages[event.action] || event.action;
 
     this.log(`${emoji} ${resultMessage} workflowId: \`${event.workflowId}\``);
 
@@ -559,11 +559,11 @@ export class Client {
     if (!this.verbose) return;
 
     const successPrefix = error ? EMOJI.ERROR : EMOJI.SUCCESS;
-    const actionMessages = {
+    const actionMessages: Record<string, string> = {
       [PostActionEnum.EXECUTE]: 'Executed',
       [PostActionEnum.PREVIEW]: 'Previewed',
-    } as const;
-    const actionMessage = actionMessages[event.action];
+    };
+    const actionMessage = actionMessages[event.action] || event.action;
     const message = error ? 'Failed to execute' : actionMessage;
     const executionLog = error ? log.error : log.success;
     const logMessage = `${successPrefix} ${message} workflowId: '${event.workflowId}`;

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -18,6 +18,7 @@ import {
   StepNotFoundError,
   WorkflowNotFoundError,
 } from './errors';
+import type { Agent } from './resources/agent';
 import { mockSchema } from './jsonSchemaFaker';
 import { prettyPrintDiscovery } from './resources/workflow/pretty-print-discovery';
 import type {
@@ -52,6 +53,7 @@ function isRuntimeInDevelopment() {
 export class Client {
   private discoveredWorkflows = new Map<string, DiscoverWorkflowOutput>();
   private discoverWorkflowPromises = new Map<string, Promise<void>>();
+  private registeredAgents = new Map<string, Agent>();
 
   private templateEngine: Liquid;
 
@@ -126,6 +128,16 @@ export class Client {
 
       await workflowPromise;
     }
+  }
+
+  public addAgents(agents: Array<Agent>): void {
+    for (const a of agents) {
+      this.registeredAgents.set(a.id, a);
+    }
+  }
+
+  public getAgent(agentId: string): Agent | undefined {
+    return this.registeredAgents.get(agentId);
   }
 
   private async addWorkflow(workflow: Workflow): Promise<void> {

--- a/packages/framework/src/constants/action.constants.ts
+++ b/packages/framework/src/constants/action.constants.ts
@@ -2,6 +2,7 @@ export enum PostActionEnum {
   TRIGGER = 'trigger',
   EXECUTE = 'execute',
   PREVIEW = 'preview',
+  AGENT_EVENT = 'agent-event',
 }
 
 export enum GetActionEnum {

--- a/packages/framework/src/constants/http-query.constants.ts
+++ b/packages/framework/src/constants/http-query.constants.ts
@@ -3,4 +3,6 @@ export enum HttpQueryKeysEnum {
   STEP_ID = 'stepId',
   ACTION = 'action',
   SOURCE = 'source',
+  AGENT_ID = 'agentId',
+  EVENT = 'event',
 }

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -21,18 +21,21 @@ import {
   SigningKeyNotFoundError,
 } from './errors';
 import { isPlatformError } from './errors/guard.errors';
+import type { Agent } from './resources/agent';
 import type { Awaitable, EventTriggerParams, Workflow } from './types';
 import { createHmacSubtle, initApiClient } from './utils';
 
 export type ServeHandlerOptions = {
   client?: Client;
-  workflows: Array<Workflow>;
+  workflows?: Array<Workflow>;
+  agents?: Array<Agent>;
 };
 
 export type INovuRequestHandlerOptions<Input extends any[] = any[], Output = any> = ServeHandlerOptions & {
   frameworkName: string;
   client?: Client;
-  workflows: Array<Workflow>;
+  workflows?: Array<Workflow>;
+  agents?: Array<Agent>;
   handler: Handler<Input, Output>;
 };
 
@@ -62,14 +65,17 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
   private readonly hmacEnabled: boolean;
   private readonly http;
   private readonly workflows: Array<Workflow>;
+  private readonly agents: Array<Agent>;
 
   constructor(options: INovuRequestHandlerOptions<Input, Output>) {
     this.handler = options.handler;
     this.client = options.client ? options.client : new Client();
-    this.workflows = options.workflows;
+    this.workflows = options.workflows || [];
+    this.agents = options.agents || [];
     this.http = initApiClient(this.client.secretKey, this.client.apiUrl);
     this.frameworkName = options.frameworkName;
     this.hmacEnabled = this.client.strictAuthentication;
+    this.client.addAgents(this.agents);
   }
 
   public createHandler(): (...args: Input) => Promise<Output> {

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -295,8 +295,10 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
       if (registeredAgent.handlers.onResolve) {
         await registeredAgent.handlers.onResolve(ctx);
       }
-    } else {
+    } else if (event === AgentEventEnum.ON_MESSAGE) {
       await registeredAgent.handlers.onMessage(ctx);
+    } else {
+      throw new InvalidActionError(event, AgentEventEnum);
     }
 
     await ctx.flush();

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -21,7 +21,8 @@ import {
   SigningKeyNotFoundError,
 } from './errors';
 import { isPlatformError } from './errors/guard.errors';
-import type { Agent } from './resources/agent';
+import { AgentContextImpl, AgentEventEnum } from './resources/agent';
+import type { Agent, AgentBridgeRequest } from './resources/agent';
 import type { Awaitable, EventTriggerParams, Workflow } from './types';
 import { createHmacSubtle, initApiClient } from './utils';
 
@@ -135,6 +136,8 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
     const action = url.searchParams.get(HttpQueryKeysEnum.ACTION) || GetActionEnum.HEALTH_CHECK;
     const workflowId = url.searchParams.get(HttpQueryKeysEnum.WORKFLOW_ID) || '';
     const stepId = url.searchParams.get(HttpQueryKeysEnum.STEP_ID) || '';
+    const agentId = url.searchParams.get(HttpQueryKeysEnum.AGENT_ID) || '';
+    const agentEvent = url.searchParams.get(HttpQueryKeysEnum.EVENT) || '';
     const signatureHeader = (await actions.headers(HttpHeaderKeysEnum.NOVU_SIGNATURE)) || '';
 
     let body: Record<string, unknown> = {};
@@ -151,7 +154,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
         await this.validateHmac(body, signatureHeader);
       }
 
-      const postActionMap = this.getPostActionMap(body, workflowId, stepId, action);
+      const postActionMap = this.getPostActionMap(body, workflowId, stepId, action, agentId, agentEvent);
       const getActionMap = this.getGetActionMap(workflowId, stepId);
 
       if (method === HttpMethodEnum.POST) {
@@ -177,7 +180,9 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
     body: any,
     workflowId: string,
     stepId: string,
-    action: string
+    action: string,
+    agentId: string,
+    agentEvent: string
   ): Record<PostActionEnum, () => Promise<IActionResponse>> {
     return {
       [PostActionEnum.TRIGGER]: this.triggerAction({ workflowId, ...body }),
@@ -200,6 +205,21 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
         });
 
         return this.createResponse(HttpStatusEnum.OK, result);
+      },
+      [PostActionEnum.AGENT_EVENT]: async () => {
+        const registeredAgent = this.client.getAgent(agentId);
+
+        if (!registeredAgent) {
+          return this.createResponse(HttpStatusEnum.NOT_FOUND, { error: `Agent '${agentId}' not registered` });
+        }
+
+        const ctx = new AgentContextImpl(body as AgentBridgeRequest, this.client.secretKey);
+
+        this.runAgentHandler(registeredAgent, agentEvent, ctx).catch((err) => {
+          console.error(`[agent:${agentId}] Handler error:`, err);
+        });
+
+        return this.createResponse(HttpStatusEnum.OK, { status: 'ack' });
       },
     };
   }
@@ -268,6 +288,18 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
     } else {
       throw new InvalidActionError(action, GetActionEnum);
     }
+  }
+
+  private async runAgentHandler(registeredAgent: Agent, event: string, ctx: AgentContextImpl): Promise<void> {
+    if (event === AgentEventEnum.ON_RESOLVE) {
+      if (registeredAgent.handlers.onResolve) {
+        await registeredAgent.handlers.onResolve(ctx);
+      }
+    } else {
+      await registeredAgent.handlers.onMessage(ctx);
+    }
+
+    await ctx.flush();
   }
 
   private handleError(error: unknown): IActionResponse {

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -26,11 +26,11 @@ import type { Agent, AgentBridgeRequest } from './resources/agent';
 import type { Awaitable, EventTriggerParams, Workflow } from './types';
 import { createHmacSubtle, initApiClient } from './utils';
 
-export type ServeHandlerOptions = {
+export interface ServeHandlerOptions {
   client?: Client;
   workflows?: Array<Workflow>;
   agents?: Array<Agent>;
-};
+}
 
 export type INovuRequestHandlerOptions<Input extends any[] = any[], Output = any> = ServeHandlerOptions & {
   frameworkName: string;

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -49,6 +49,7 @@ type HandlerResponse<Output = any> = {
   queryString?: (key: string, url: URL) => Awaitable<string | null | undefined>;
   url: () => Awaitable<URL>;
   transformResponse: (res: IActionResponse<string>) => Output;
+  waitUntil?: (promise: Promise<unknown>) => void;
 };
 
 export type IActionResponse<TBody extends string = string> = {
@@ -154,7 +155,7 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
         await this.validateHmac(body, signatureHeader);
       }
 
-      const postActionMap = this.getPostActionMap(body, workflowId, stepId, action, agentId, agentEvent);
+      const postActionMap = this.getPostActionMap(body, workflowId, stepId, action, agentId, agentEvent, actions.waitUntil);
       const getActionMap = this.getGetActionMap(workflowId, stepId);
 
       if (method === HttpMethodEnum.POST) {
@@ -182,7 +183,8 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
     stepId: string,
     action: string,
     agentId: string,
-    agentEvent: string
+    agentEvent: string,
+    waitUntil?: (promise: Promise<unknown>) => void
   ): Record<PostActionEnum, () => Promise<IActionResponse>> {
     return {
       [PostActionEnum.TRIGGER]: this.triggerAction({ workflowId, ...body }),
@@ -215,9 +217,13 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
 
         const ctx = new AgentContextImpl(body as AgentBridgeRequest, this.client.secretKey);
 
-        this.runAgentHandler(registeredAgent, agentEvent, ctx).catch((err) => {
+        const handlerPromise = this.runAgentHandler(registeredAgent, agentEvent, ctx).catch((err) => {
           console.error(`[agent:${agentId}] Handler error:`, err);
         });
+
+        if (waitUntil) {
+          waitUntil(handlerPromise);
+        }
 
         return this.createResponse(HttpStatusEnum.OK, { status: 'ack' });
       },

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -1,7 +1,12 @@
 export { Client } from './client';
 export { CronExpression } from './constants';
 export { NovuRequestHandler, type ServeHandlerOptions } from './handler';
-export { workflow } from './resources';
+export { agent, workflow } from './resources';
+export type {
+  Agent,
+  AgentContext,
+  AgentHandlers,
+} from './resources';
 export type {
   AnyStepResolver,
   ChatStepResolver,

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -1,0 +1,132 @@
+import type {
+  AgentBridgeRequest,
+  AgentContext,
+  AgentConversation,
+  AgentHistoryEntry,
+  AgentMessage,
+  AgentPlatformContext,
+  AgentReplyPayload,
+  AgentSubscriber,
+  Signal,
+} from './agent.types';
+
+export class AgentContextImpl implements AgentContext {
+  readonly event: string;
+  readonly message: AgentMessage | null;
+  readonly conversation: AgentConversation;
+  readonly subscriber: AgentSubscriber | null;
+  readonly history: AgentHistoryEntry[];
+  readonly platform: string;
+  readonly platformContext: AgentPlatformContext;
+
+  readonly metadata: { set: (key: string, value: unknown) => void };
+
+  private _signals: Signal[] = [];
+  private _resolveSignal: { summary?: string } | null = null;
+  private readonly _replyUrl: string;
+  private readonly _conversationId: string;
+  private readonly _integrationIdentifier: string;
+  private readonly _secretKey: string;
+
+  constructor(request: AgentBridgeRequest, secretKey: string) {
+    this.event = request.event;
+    this.message = request.message;
+    this.conversation = request.conversation;
+    this.subscriber = request.subscriber;
+    this.history = request.history;
+    this.platform = request.platform;
+    this.platformContext = request.platformContext;
+
+    this._replyUrl = request.replyUrl;
+    this._conversationId = request.conversationId;
+    this._integrationIdentifier = request.integrationIdentifier;
+    this._secretKey = secretKey;
+
+    this.metadata = {
+      set: (key: string, value: unknown) => {
+        this._signals.push({ type: 'metadata', key, value });
+      },
+    };
+  }
+
+  async reply(text: string): Promise<void> {
+    const body: AgentReplyPayload = {
+      conversationId: this._conversationId,
+      integrationIdentifier: this._integrationIdentifier,
+      reply: { text },
+    };
+
+    if (this._signals.length) {
+      body.signals = this._signals;
+      this._signals = [];
+    }
+
+    if (this._resolveSignal) {
+      body.resolve = this._resolveSignal;
+      this._resolveSignal = null;
+    }
+
+    await this._post(body);
+  }
+
+  async update(text: string): Promise<void> {
+    const body: AgentReplyPayload = {
+      conversationId: this._conversationId,
+      integrationIdentifier: this._integrationIdentifier,
+      update: { text },
+    };
+
+    await this._post(body);
+  }
+
+  resolve(summary?: string): void {
+    this._resolveSignal = { summary };
+  }
+
+  trigger(workflowId: string, opts?: { to?: string; payload?: Record<string, unknown> }): void {
+    this._signals.push({ type: 'trigger', workflowId, ...opts });
+  }
+
+  /**
+   * Flush any remaining signals that weren't sent with reply().
+   * Called internally after onResolve returns.
+   */
+  async flush(): Promise<void> {
+    if (!this._signals.length && !this._resolveSignal) {
+      return;
+    }
+
+    const body: AgentReplyPayload = {
+      conversationId: this._conversationId,
+      integrationIdentifier: this._integrationIdentifier,
+    };
+
+    if (this._signals.length) {
+      body.signals = this._signals;
+      this._signals = [];
+    }
+
+    if (this._resolveSignal) {
+      body.resolve = this._resolveSignal;
+      this._resolveSignal = null;
+    }
+
+    await this._post(body);
+  }
+
+  private async _post(body: AgentReplyPayload): Promise<void> {
+    const response = await fetch(this._replyUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `ApiKey ${this._secretKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Agent reply failed (${response.status}): ${text}`);
+    }
+  }
+}

--- a/packages/framework/src/resources/agent/agent.resource.ts
+++ b/packages/framework/src/resources/agent/agent.resource.ts
@@ -1,0 +1,19 @@
+import type { Agent, AgentHandlers } from './agent.types';
+
+/**
+ * Define a new conversational agent.
+ *
+ * @param agentId - Unique identifier matching the agent entity created in Novu (e.g. 'wine-bot')
+ * @param handlers - Handler functions for agent events
+ */
+export function agent(agentId: string, handlers: AgentHandlers): Agent {
+  if (!agentId) {
+    throw new Error('agent() requires a non-empty agentId');
+  }
+
+  if (!handlers?.onMessage) {
+    throw new Error(`agent('${agentId}') requires an onMessage handler`);
+  }
+
+  return { id: agentId, handlers };
+}

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Client } from '../../client';
 import { PostActionEnum } from '../../constants';
@@ -62,11 +62,16 @@ describe('agent()', () => {
 describe('agent dispatch via NovuRequestHandler', () => {
   let client: Client;
   let fetchMock: ReturnType<typeof vi.fn>;
+  const originalFetch = global.fetch;
 
   beforeEach(() => {
     client = new Client({ secretKey: 'test-secret-key', strictAuthentication: false });
-    fetchMock = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('{}') });
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('{}'), json: () => Promise.resolve({ status: 'ok' }) });
     global.fetch = fetchMock as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
   it('should ACK immediately and run onMessage handler in background', async () => {
@@ -217,11 +222,15 @@ describe('agent dispatch via NovuRequestHandler', () => {
       (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
     );
 
-    const updateBody = JSON.parse(replyCalls[0][1].body);
+    const parsedBodies = replyCalls.map(([, init]: any[]) => JSON.parse(init.body));
+    const updateBody = parsedBodies.find((body: any) => body.update);
+    const replyBody = parsedBodies.find((body: any) => body.reply);
+
+    expect(updateBody).toBeDefined();
     expect(updateBody.update.text).toBe('Thinking...');
     expect(updateBody.signals).toBeUndefined();
 
-    const replyBody = JSON.parse(replyCalls[1][1].body);
+    expect(replyBody).toBeDefined();
     expect(replyBody.reply.text).toBe('Done thinking');
     expect(replyBody.signals).toHaveLength(1);
   });

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -1,0 +1,314 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Client } from '../../client';
+import { PostActionEnum } from '../../constants';
+import { NovuRequestHandler } from '../../handler';
+import { agent } from './agent.resource';
+import type { AgentBridgeRequest } from './agent.types';
+
+function createMockBridgeRequest(overrides?: Partial<AgentBridgeRequest>): AgentBridgeRequest {
+  return {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    deliveryId: 'del-123',
+    event: 'onMessage',
+    agentId: 'test-bot',
+    replyUrl: 'https://api.novu.co/v1/agents/test-bot/reply',
+    conversationId: 'conv-456',
+    integrationIdentifier: 'slack-main',
+    message: {
+      text: 'Hello bot!',
+      platformMessageId: 'msg-789',
+      author: { userId: 'u1', fullName: 'Alice', userName: 'alice', isBot: false },
+      timestamp: new Date().toISOString(),
+    },
+    conversation: {
+      identifier: 'conv-456',
+      status: 'active',
+      metadata: {},
+      messageCount: 1,
+      createdAt: new Date().toISOString(),
+      lastActivityAt: new Date().toISOString(),
+    },
+    subscriber: {
+      subscriberId: 'sub-001',
+      firstName: 'Alice',
+      email: 'alice@example.com',
+    },
+    history: [],
+    platform: 'slack',
+    platformContext: { threadId: 't1', channelId: 'c1', isDM: false },
+    ...overrides,
+  };
+}
+
+describe('agent()', () => {
+  it('should return an agent with id and handlers', () => {
+    const bot = agent('wine-bot', { onMessage: async () => {} });
+
+    expect(bot.id).toBe('wine-bot');
+    expect(typeof bot.handlers.onMessage).toBe('function');
+  });
+
+  it('should throw when agentId is empty', () => {
+    expect(() => agent('', { onMessage: async () => {} })).toThrow('non-empty agentId');
+  });
+
+  it('should throw when onMessage is missing', () => {
+    expect(() => agent('wine-bot', {} as any)).toThrow('onMessage handler');
+  });
+});
+
+describe('agent dispatch via NovuRequestHandler', () => {
+  let client: Client;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    client = new Client({ secretKey: 'test-secret-key', strictAuthentication: false });
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('{}') });
+    global.fetch = fetchMock;
+  });
+
+  it('should ACK immediately and run onMessage handler in background', async () => {
+    const onMessageSpy = vi.fn(async (ctx) => {
+      await ctx.reply('Echo: Hello bot!');
+    });
+
+    const testBot = agent('test-bot', { onMessage: onMessageSpy });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    const result = await handler.createHandler()();
+    const parsed = JSON.parse(result.body);
+
+    expect(result.status).toBe(200);
+    expect(parsed.status).toBe('ack');
+
+    await vi.waitFor(() => expect(onMessageSpy).toHaveBeenCalledTimes(1));
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    expect(replyCall).toBeDefined();
+
+    const replyBody = JSON.parse(replyCall![1].body);
+    expect(replyBody.reply.text).toBe('Echo: Hello bot!');
+    expect(replyBody.conversationId).toBe('conv-456');
+    expect(replyBody.integrationIdentifier).toBe('slack-main');
+
+    const replyHeaders = replyCall![1].headers;
+    expect(replyHeaders.Authorization).toBe('ApiKey test-secret-key');
+  });
+
+  it('should return 404 for unknown agent', async () => {
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [],
+      client,
+      handler: () => {
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=unknown-bot&event=onMessage`);
+
+        return {
+          body: () => ({}),
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    const result = await handler.createHandler()();
+
+    expect(result.status).toBe(404);
+    expect(JSON.parse(result.body).error).toContain('unknown-bot');
+  });
+
+  it('should batch metadata signals with reply', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        ctx.metadata.set('turnCount', 1);
+        ctx.metadata.set('language', 'en');
+        await ctx.reply('Got it');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+
+    expect(replyBody.reply.text).toBe('Got it');
+    expect(replyBody.signals).toHaveLength(2);
+    expect(replyBody.signals[0]).toEqual({ type: 'metadata', key: 'turnCount', value: 1 });
+    expect(replyBody.signals[1]).toEqual({ type: 'metadata', key: 'language', value: 'en' });
+  });
+
+  it('should send update independently without signals', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        ctx.metadata.set('step', 'thinking');
+        await ctx.update('Thinking...');
+        await ctx.reply('Done thinking');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+
+    await vi.waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2));
+
+    const replyCalls = fetchMock.mock.calls.filter(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+
+    const updateBody = JSON.parse(replyCalls[0][1].body);
+    expect(updateBody.update.text).toBe('Thinking...');
+    expect(updateBody.signals).toBeUndefined();
+
+    const replyBody = JSON.parse(replyCalls[1][1].body);
+    expect(replyBody.reply.text).toBe('Done thinking');
+    expect(replyBody.signals).toHaveLength(1);
+  });
+
+  it('should flush remaining signals after onResolve', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async () => {},
+      onResolve: async (ctx) => {
+        ctx.metadata.set('archived', true);
+        ctx.trigger('post-resolve-workflow', { payload: { reason: 'done' } });
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest({ event: 'onResolve', message: null });
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onResolve`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const flushBody = JSON.parse(replyCall![1].body);
+
+    expect(flushBody.reply).toBeUndefined();
+    expect(flushBody.signals).toHaveLength(2);
+    expect(flushBody.signals[0]).toEqual({ type: 'metadata', key: 'archived', value: true });
+    expect(flushBody.signals[1]).toEqual({
+      type: 'trigger',
+      workflowId: 'post-resolve-workflow',
+      payload: { reason: 'done' },
+    });
+  });
+
+  it('should provide read-only context properties from bridge payload', async () => {
+    let capturedCtx: any;
+
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        capturedCtx = ctx;
+        await ctx.reply('ok');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(capturedCtx).toBeDefined());
+
+    expect(capturedCtx.event).toBe('onMessage');
+    expect(capturedCtx.message?.text).toBe('Hello bot!');
+    expect(capturedCtx.conversation.identifier).toBe('conv-456');
+    expect(capturedCtx.subscriber?.subscriberId).toBe('sub-001');
+    expect(capturedCtx.platform).toBe('slack');
+    expect(capturedCtx.platformContext.threadId).toBe('t1');
+    expect(capturedCtx.history).toEqual([]);
+  });
+});

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -66,7 +66,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
   beforeEach(() => {
     client = new Client({ secretKey: 'test-secret-key', strictAuthentication: false });
     fetchMock = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('{}') });
-    global.fetch = fetchMock;
+    global.fetch = fetchMock as typeof fetch;
   });
 
   it('should ACK immediately and run onMessage handler in background', async () => {

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------
+// User-facing types (visible on ctx properties)
+// ---------------------------------------------------------------------------
+
+export interface AgentMessageAuthor {
+  userId: string;
+  fullName: string;
+  userName: string;
+  isBot: boolean | 'unknown';
+}
+
+export interface AgentMessage {
+  text: string;
+  platformMessageId: string;
+  author: AgentMessageAuthor;
+  timestamp: string;
+}
+
+export interface AgentConversation {
+  identifier: string;
+  status: string;
+  metadata: Record<string, unknown>;
+  messageCount: number;
+  createdAt: string;
+  lastActivityAt: string;
+}
+
+export interface AgentSubscriber {
+  subscriberId: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  avatar?: string;
+  locale?: string;
+  data?: Record<string, unknown>;
+}
+
+export interface AgentHistoryEntry {
+  role: string;
+  type: string;
+  content: string;
+  senderName?: string;
+  signalData?: { type: string; payload?: Record<string, unknown> };
+  createdAt: string;
+}
+
+export interface AgentPlatformContext {
+  threadId: string;
+  channelId: string;
+  isDM: boolean;
+}
+
+export interface AgentContext {
+  readonly event: string;
+  readonly message: AgentMessage | null;
+  readonly conversation: AgentConversation;
+  readonly subscriber: AgentSubscriber | null;
+  readonly history: AgentHistoryEntry[];
+  readonly platform: string;
+  readonly platformContext: AgentPlatformContext;
+
+  reply(text: string): Promise<void>;
+  update(text: string): Promise<void>;
+  resolve(summary?: string): void;
+  metadata: {
+    set(key: string, value: unknown): void;
+  };
+  trigger(workflowId: string, opts?: { to?: string; payload?: Record<string, unknown> }): void;
+}
+
+export interface AgentHandlers {
+  onMessage: (ctx: AgentContext) => Promise<void>;
+  onResolve?: (ctx: AgentContext) => Promise<void>;
+}
+
+export interface Agent {
+  id: string;
+  handlers: AgentHandlers;
+}
+
+// ---------------------------------------------------------------------------
+// Internal types (bridge protocol — not exposed to SDK consumers)
+// ---------------------------------------------------------------------------
+
+export interface AgentBridgeRequest {
+  version: number;
+  timestamp: string;
+  deliveryId: string;
+  event: string;
+  agentId: string;
+  replyUrl: string;
+  conversationId: string;
+  integrationIdentifier: string;
+  message: AgentMessage | null;
+  conversation: AgentConversation;
+  subscriber: AgentSubscriber | null;
+  history: AgentHistoryEntry[];
+  platform: string;
+  platformContext: AgentPlatformContext;
+}
+
+export type MetadataSignal = { type: 'metadata'; key: string; value: unknown };
+export type TriggerSignal = { type: 'trigger'; workflowId: string; to?: string; payload?: Record<string, unknown> };
+export type Signal = MetadataSignal | TriggerSignal;
+
+export interface AgentReplyPayload {
+  conversationId: string;
+  integrationIdentifier: string;
+  reply?: { text: string };
+  update?: { text: string };
+  resolve?: { summary?: string };
+  signals?: Signal[];
+}

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -1,3 +1,8 @@
+export enum AgentEventEnum {
+  ON_MESSAGE = 'onMessage',
+  ON_RESOLVE = 'onResolve',
+}
+
 // ---------------------------------------------------------------------------
 // User-facing types (visible on ctx properties)
 // ---------------------------------------------------------------------------

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -1,6 +1,8 @@
+export { AgentContextImpl } from './agent.context';
 export { agent } from './agent.resource';
 export type {
   Agent,
+  AgentBridgeRequest,
   AgentContext,
   AgentConversation,
   AgentHandlers,
@@ -8,5 +10,6 @@ export type {
   AgentMessage,
   AgentMessageAuthor,
   AgentPlatformContext,
+  AgentReplyPayload,
   AgentSubscriber,
 } from './agent.types';

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -1,0 +1,12 @@
+export { agent } from './agent.resource';
+export type {
+  Agent,
+  AgentContext,
+  AgentConversation,
+  AgentHandlers,
+  AgentHistoryEntry,
+  AgentMessage,
+  AgentMessageAuthor,
+  AgentPlatformContext,
+  AgentSubscriber,
+} from './agent.types';

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -13,3 +13,4 @@ export type {
   AgentReplyPayload,
   AgentSubscriber,
 } from './agent.types';
+export { AgentEventEnum } from './agent.types';

--- a/packages/framework/src/resources/index.ts
+++ b/packages/framework/src/resources/index.ts
@@ -1,1 +1,2 @@
+export * from './agent';
 export * from './workflow/workflow.resource';


### PR DESCRIPTION
## Summary

Adds conversational agent support to `@novu/framework`, enabling developers to define agents with `agent()` and serve them alongside workflows via `serve()`. The SDK handles the full bridge protocol: receiving events from the Novu API, providing a typed `ctx` object to handlers, and POSTing replies back.

- **`agent()` primitive** — factory function returning `{ id, handlers }` with `onMessage` (required) and `onResolve` (optional) handlers
- **`AgentContextImpl`** — the `ctx` object with read-only properties from the bridge payload, `ctx.reply()` (batches signals), `ctx.update()` (sends immediately), `ctx.metadata.set()`, `ctx.trigger()`, `ctx.resolve()`, and auto-`flush()` after handlers complete
- **Handler dispatch** — `NovuRequestHandler` routes `POST ?action=agent-event` to the registered agent, ACKs immediately, runs handler in background
- **API cleanup** — removed unused `ON_START`/`ON_ACTION` from `AgentEventEnum`
- **E2E verified** — full Slack round-trip tested: user message → Novu API → bridge call → SDK handler → `ctx.reply()` → API → Slack delivery, including resolve flow

### Architecture

```mermaid
sequenceDiagram
    participant Slack
    participant API as Novu API
    participant SDK as serve() endpoint

    Slack->>API: @mention bot
    API->>API: Resolve subscriber, create conversation
    API->>SDK: POST ?action=agent-event&agentId=X&event=onMessage
    SDK-->>API: 200 { status: "ack" }
    Note over SDK: Run onMessage(ctx) in background
    SDK->>API: POST /agents/:id/reply (ApiKey auth)
    API->>Slack: Deliver reply message
```

### Files changed

| Area | Files | What |
|------|-------|------|
| Framework types | `resources/agent/agent.types.ts` | `AgentMessage`, `AgentContext`, `AgentHandlers`, `Agent`, bridge protocol types, `AgentEventEnum` |
| Framework factory | `resources/agent/agent.resource.ts` | `agent()` function with validation |
| Framework context | `resources/agent/agent.context.ts` | `AgentContextImpl` — signal batching, reply/update POST, flush |
| Framework routing | `handler.ts`, `client.ts`, `constants/` | `AGENT_EVENT` action, agent storage/lookup, dispatch + background execution |
| Framework exports | `index.ts`, `resources/index.ts` | Public API: `agent`, `Agent`, `AgentContext`, `AgentHandlers` |
| Framework tests | `resources/agent/agent.test.ts` | 9 tests: factory, ACK dispatch, signal batching, update, onResolve flush, ctx properties |
| API cleanup | `agent-event.enum.ts`, `chat-sdk.service.ts` | Remove unused enum values, align event dispatching |
| E2E handler | `e2e/mock-agent-handler.ts` | Rewritten to use `agent()` + `serve()` from the SDK |

## Test plan

- [x] Framework builds with no errors, no circular deps, all export checks green
- [x] 9 unit/integration tests pass (`vitest run src/resources/agent/agent.test.ts`)
- [x] E2E verified with real Slack workspace: message → echo reply → "done" → resolve → onResolve callback


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new request action (`agent-event`) that executes user-provided agent handlers and performs outbound `fetch` calls to reply/flush signals; mistakes could impact reliability and security (auth headers/HMAC expectations). Also changes API-side event mapping for new mentions, which could alter conversation flows.
> 
> **Overview**
> Adds **conversational agent support** to `@novu/framework`: a new `agent()` factory plus typed agent context (`AgentContextImpl`) that can `reply`, `update`, `resolve`, set metadata, and enqueue trigger signals.
> 
> Extends `serve()`/`NovuRequestHandler` with a new `POST ?action=agent-event&agentId=...&event=...` route that looks up registered agents from `Client`, ACKs immediately, runs handlers in the background, and then `flush()`es any remaining signals back to the API.
> 
> Cleans up API-side agent events by removing unused `ON_START`/`ON_ACTION` and dispatching `onNewMention` as `ON_MESSAGE`, and adds an E2E `mock-agent-handler.ts` that uses the new SDK agent API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c29d9227a46b52d57953f7cb45ee42a7aef9045. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added conversational agent support to @novu/framework: a new agent() factory, typed AgentContextImpl (reply/update/resolve/trigger/metadata), client-side agent registry, and handler routing to accept POST?action=agent-event (agentId + event). The request handler ACKs immediately, runs user agent handlers in the background, and flushes batched signals back to the Novu API. API enums were simplified (removed unused events) and integration credential persistence was extended to store signingSecret.

## Affected areas

- **api**: Removed unused AgentEventEnum members, added an E2E mock agent server for integration testing, updated the Slack/chat inbound mapping to emit ON_MESSAGE for mentions, and persisted integration.credentials.signingSecret in the Integration schema.  
- **framework (packages/framework)**: Added agent resource, types, AgentContextImpl, an agent() factory and exports, client registry methods (addAgents/getAgent), new AGENT_EVENT post action and query keys, handler routing to dispatch agent events asynchronously, and tests covering agent behavior and request routing.  
- **libs/dal**: Extended the Integration Mongoose schema with credentials.signingSecret so signing secrets are stored.  
- **tests / e2e**: New unit/integration tests for the agent factory, request routing, metadata batching, update/reply/resolve behavior, plus a mock-agent-handler used for a manual Slack round-trip E2E verification.

## Key technical decisions

- Immediate ACK with background execution to keep bridge responsiveness while executing user handlers asynchronously.  
- Buffered signal model: metadata and trigger signals are batched and emitted with reply/update/resolve to reduce calls and preserve ordering.  
- Minimal, read-only ctx surface exposing immutable payloads and controlled side effects via ctx methods.  
- Replies use ApiKey Authorization when POSTing back to the Novu API.  
- Handler execution performs outbound network calls (medium risk)—auth/HMAC and reliability/timeout implications were noted.

## Testing

Added Vitest unit/integration tests covering agent factory, routing, metadata batching, update/reply/resolve flows (tests pass), and manual E2E Slack round-trip validation using the mock-agent-handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->