### PR TITLE
fix(js, react): localize sub-minute relative time in inbox fixes NV-7345

### DIFF
--- a/packages/js/src/ui/helpers/formatToRelativeTime.ts
+++ b/packages/js/src/ui/helpers/formatToRelativeTime.ts
@@ -24,9 +24,10 @@ export function formatToRelativeTime({
 
   const diffInSeconds = Math.floor(elapsed / 1000);
 
-  // If the difference is less than a minute, return 'Just now'
   if (Math.abs(diffInSeconds) < SECONDS.inMinute) {
-    return 'Just now';
+    const subMinuteFormatter = new Intl.RelativeTimeFormat(locale, { style: 'narrow', numeric: 'auto' });
+
+    return subMinuteFormatter.format(-0, 'second');
   }
   // If the difference is less than an hour, return the difference in minutes. i.e 3 minutes ago
   else if (Math.abs(diffInSeconds) < SECONDS.inHour) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaced the hardcoded English string `Just now` in `formatToRelativeTime` with `Intl.RelativeTimeFormat` using the same `locale` as the rest of the inbox. Sub-minute notifications now show a locale-appropriate equivalent (e.g. German `jetzt`, English `now`).

## Implementation

For elapsed time under one minute, use `numeric: 'auto'` and `format(-0, 'second')` so engines produce a natural "now" style string instead of `0s ago`.

## Testing

- `pnpm exec nx run @novu/js:build`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7345](https://linear.app/novu/issue/NV-7345/bug-report-hardcoded-string-just-now-in-formattorelativetime-helper)

<div><a href="https://cursor.com/agents/bc-7c41b725-a004-447b-a917-b28feb29e182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c41b725-a004-447b-a917-b28feb29e182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `formatToRelativeTime` function in the inbox helper now localizes sub-minute relative timestamps instead of returning a hardcoded English "Just now" string. When elapsed time is under one minute, it uses `Intl.RelativeTimeFormat` with `numeric: 'auto'` to generate locale-specific "now" strings (e.g., "jetzt" in German, "now" in English). This ensures consistent localization across all time ranges in the inbox UI.

## Affected areas

**js**: Updated the relative time formatting helper to use the browser's `Intl.RelativeTimeFormat` API with the `numeric: 'auto'` option for sub-minute durations, ensuring localized output that matches the locale parameter passed to the function.

## Key technical decisions

- Uses `format(-0, 'second')` with `numeric: 'auto'` to produce natural "now" style strings instead of "0 seconds ago," relying on the browser's native internationalization for correct phrasing across languages.
- Creates a separate formatter instance for the sub-minute case to apply the `numeric: 'auto'` option only where needed.

## Testing

No new tests are mentioned. The change is isolated to a single helper function and can be verified by checking the inbox UI displays correct locale-specific "now" strings for recent notifications across different browser language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->