### PR TITLE
fix(dashboard): persist edited layout identifier when duplicating fixes NV-7359

### DIFF
--- a/apps/api/src/app/layouts-v2/dtos/duplicate-layout.dto.ts
+++ b/apps/api/src/app/layouts-v2/dtos/duplicate-layout.dto.ts
@@ -7,6 +7,13 @@ export class DuplicateLayoutDto {
   name: string;
 
   @ApiPropertyOptional({
+    description: 'Identifier for the duplicated layout. When omitted, it is derived from the name.',
+  })
+  @IsOptional()
+  @IsString()
+  layoutId?: string;
+
+  @ApiPropertyOptional({
     description: 'Enable or disable translations for this layout',
     required: false,
     default: false,

--- a/apps/api/src/app/layouts-v2/usecases/duplicate-layout/duplicate-layout.use-case.spec.ts
+++ b/apps/api/src/app/layouts-v2/usecases/duplicate-layout/duplicate-layout.use-case.spec.ts
@@ -136,6 +136,7 @@ describe('DuplicateLayoutUseCase', () => {
       expect(upsertLayoutUseCaseMock.execute.calledOnce).to.be.true;
       const upsertCommand = upsertLayoutUseCaseMock.execute.firstCall.args[0];
       expect(upsertCommand.layoutDto.name).to.equal('Duplicated Layout');
+      expect(upsertCommand.layoutDto.layoutId).to.be.undefined;
       expect(upsertCommand.layoutDto.controlValues).to.deep.equal(mockOriginalControlValues.controls);
       expect(upsertCommand.userId).to.deep.equal(mockUser._id);
       expect(upsertCommand.environmentId).to.deep.equal(mockUser.environmentId);
@@ -231,6 +232,27 @@ describe('DuplicateLayoutUseCase', () => {
       expect(upsertLayoutUseCaseMock.execute.calledOnce).to.be.true;
       const upsertCommand = upsertLayoutUseCaseMock.execute.firstCall.args[0];
       expect(upsertCommand.layoutDto.name).to.equal('Custom Duplicated Name');
+    });
+
+    it('should pass custom layoutId override to upsert', async () => {
+      const customOverrides = {
+        name: 'My Layout (Copy)',
+        layoutId: 'my-custom-layout-id',
+      };
+
+      const command = DuplicateLayoutCommand.create({
+        layoutIdOrInternalId: 'original_layout_identifier',
+        overrides: customOverrides,
+        userId: mockUser._id,
+        environmentId: mockUser.environmentId,
+        organizationId: mockUser.organizationId,
+      });
+
+      await duplicateLayoutUseCase.execute(command);
+
+      expect(upsertLayoutUseCaseMock.execute.calledOnce).to.be.true;
+      const upsertCommand = upsertLayoutUseCaseMock.execute.firstCall.args[0];
+      expect(upsertCommand.layoutDto.layoutId).to.equal('my-custom-layout-id');
     });
 
     it('should propagate error from v1 use case', async () => {

--- a/apps/api/src/app/layouts-v2/usecases/duplicate-layout/duplicate-layout.use-case.ts
+++ b/apps/api/src/app/layouts-v2/usecases/duplicate-layout/duplicate-layout.use-case.ts
@@ -45,6 +45,7 @@ export class DuplicateLayoutUseCase {
       UpsertLayoutCommand.create({
         layoutDto: {
           name: command.overrides.name,
+          layoutId: command.overrides.layoutId,
           isTranslationEnabled: command.overrides.isTranslationEnabled,
           controlValues: originalControlValues?.controls ?? null,
         },

--- a/apps/dashboard/src/api/layouts.ts
+++ b/apps/dashboard/src/api/layouts.ts
@@ -1,5 +1,6 @@
 import {
   CreateLayoutDto,
+  DuplicateLayoutDto,
   GeneratePreviewResponseDto,
   IEnvironment,
   LayoutResponseDto,
@@ -88,7 +89,7 @@ export const duplicateLayout = async ({
 }: {
   environment: IEnvironment;
   layoutSlug: string;
-  data: { name: string; isTranslationEnabled: boolean };
+  data: DuplicateLayoutDto;
 }) => {
   const { data: result } = await postV2<{ data: LayoutResponseDto }>(`/layouts/${layoutSlug}/duplicate`, {
     environment,

--- a/apps/dashboard/src/components/layouts/create-layout-form.tsx
+++ b/apps/dashboard/src/components/layouts/create-layout-form.tsx
@@ -23,9 +23,11 @@ interface CreateLayoutFormProps {
     name: string;
     isTranslationEnabled?: boolean;
   };
+  /** When true, changing the name does not overwrite the identifier (duplicate flow). */
+  disableIdentifierSlugSync?: boolean;
 }
 
-export function CreateLayoutForm({ onSubmit, template }: CreateLayoutFormProps) {
+export function CreateLayoutForm({ onSubmit, template, disableIdentifierSlugSync }: CreateLayoutFormProps) {
   const form = useForm({
     resolver: standardSchemaResolver(layoutSchema),
     defaultValues: {
@@ -56,7 +58,10 @@ export function CreateLayoutForm({ onSubmit, template }: CreateLayoutFormProps) 
                   autoFocus
                   onChange={(e) => {
                     field.onChange(e);
-                    form.setValue('layoutId', slugify(e.target.value));
+
+                    if (!disableIdentifierSlugSync) {
+                      form.setValue('layoutId', slugify(e.target.value));
+                    }
                   }}
                 />
               </FormControl>

--- a/apps/dashboard/src/pages/new-layout-drawer.tsx
+++ b/apps/dashboard/src/pages/new-layout-drawer.tsx
@@ -144,6 +144,7 @@ export const NewLayoutDrawer = (props: NewLayoutDrawerProps) => {
             <CreateLayoutFormSkeleton />
           ) : (
             <CreateLayoutForm
+              disableIdentifierSlugSync={mode === 'duplicate'}
               onSubmit={(formData) => {
                 if (mode === 'create') {
                   createLayout({
@@ -156,12 +157,17 @@ export const NewLayoutDrawer = (props: NewLayoutDrawerProps) => {
                   return;
                 }
 
+                if (!layoutId) {
+                  return;
+                }
+
                 duplicateLayout({
                   data: {
                     name: formData.name,
+                    layoutId: formData.layoutId,
                     isTranslationEnabled: formData.isTranslationEnabled,
                   },
-                  layoutSlug: layoutId!,
+                  layoutSlug: layoutId,
                 }).catch(() => {});
               }}
               template={template}

--- a/packages/shared/src/dto/layout/layout.dto.ts
+++ b/packages/shared/src/dto/layout/layout.dto.ts
@@ -49,6 +49,8 @@ export type UpdateLayoutDto = {
 
 export type DuplicateLayoutDto = {
   name: string;
+  /** When set, used as the new layout identifier instead of slugifying the name. */
+  layoutId?: string;
   isTranslationEnabled?: boolean;
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Duplicating a layout showed an auto-generated identifier in the form, but the duplicate API only received `name` and `isTranslationEnabled`. The server always created the new layout with `slugify(name)`, so any manual identifier edit was ignored.

## Changes

- **API**: Optional `layoutId` on duplicate request body; `DuplicateLayoutUseCase` passes it into `UpsertLayout` as `layoutDto.layoutId` (same path as create).
- **Shared**: `DuplicateLayoutDto` includes optional `layoutId`.
- **Dashboard**: Submit `formData.layoutId` when duplicating; in duplicate mode, stop syncing identifier from the name field so editing the identifier is not overwritten when the name still contains `(Copy)`.

## Testing

- `pnpm nx run @novu/shared:build`
- `pnpm nx run @novu/application-generic:build`
- Mocha: `duplicate-layout.use-case.spec.ts` (including new case for custom `layoutId`).

Note: Default `pnpm test` in this repo uses Node flags that are incompatible with Node 20 in this environment; the spec file was run with a minimal mocha config and deps built as above.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7359](https://linear.app/novu/issue/NV-7359/duplicated-dashboard-layouts-ignore-custom-layout-id)

<div><a href="https://cursor.com/agents/bc-8a64b994-db19-424c-92b5-21a67d135057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a64b994-db19-424c-92b5-21a67d135057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Duplicating a layout previously failed to preserve user-edited identifiers because the duplicate API only accepted `name` and `isTranslationEnabled`, causing the server to always generate the identifier from the name via `slugify()`. This fix adds optional `layoutId` support to the duplicate flow: the API now accepts it, the dashboard submits it, and the form disables automatic name-to-identifier synchronization in duplicate mode so manual edits persist.

## Affected areas

**api**: Added optional `layoutId` field to `DuplicateLayoutDto` and updated `DuplicateLayoutUseCase` to forward it to the upsert operation.

**shared**: Updated `DuplicateLayoutDto` to include optional `layoutId?: string` field.

**dashboard**: Modified the `duplicateLayout` API call to use `DuplicateLayoutDto`, updated `CreateLayoutForm` to accept `disableIdentifierSlugSync` prop, and `NewLayoutDrawer` now disables identifier sync when in duplicate mode and submits the custom `layoutId`.

## Key technical decisions

- Added optional `layoutId` field to `DuplicateLayoutDto` to extend the API contract while maintaining backward compatibility.
- Introduced conditional form behavior (`disableIdentifierSlugSync` prop) to prevent automatic slug generation from overwriting user edits in duplicate mode.

## Testing

Unit tests were added to `duplicate-layout.use-case.spec.ts` to verify that custom `layoutId` values are properly forwarded through the duplicate and upsert flow. Existing test case was updated to assert undefined `layoutId` when no override is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->