### PR TITLE
feat(api-service): implement ctx.trigger signal execution in HandleAgentReply fixes NV-7361

### DIFF
--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -7,6 +7,7 @@ import {
 } from '@novu/dal';
 
 import { AuthModule } from '../auth/auth.module';
+import { EventsModule } from '../events/events.module';
 import { SharedModule } from '../shared/shared.module';
 import { AgentsController } from './agents.controller';
 import { AgentsWebhookController } from './agents-webhook.controller';
@@ -19,7 +20,7 @@ import { ChatSdkService } from './services/chat-sdk.service';
 import { USE_CASES } from './usecases';
 
 @Module({
-  imports: [SharedModule, AuthModule],
+  imports: [SharedModule, AuthModule, EventsModule],
   controllers: [AgentsController, AgentsWebhookController],
   providers: [
     ...USE_CASES,

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -189,22 +189,6 @@ export class HandleAgentReply {
             requestId: `agent-trigger-${shortId(12)}`,
           })
         );
-
-        await this.activityRepository.createSignalActivity({
-          identifier: `act-${shortId(8)}`,
-          conversationId: conversation._id,
-          platform: channel.platform,
-          integrationId: channel._integrationId,
-          platformThreadId: channel.platformThreadId,
-          agentId: command.agentIdentifier,
-          content: `Triggered workflow: ${signal.workflowId}`,
-          signalData: {
-            type: 'trigger',
-            payload: { workflowId: signal.workflowId, to: subscriberId, status: 'triggered' },
-          },
-          environmentId: command.environmentId,
-          organizationId: command.organizationId,
-        });
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
         this.logger.error(err, `[agent:${command.agentIdentifier}] Trigger signal failed for workflow '${signal.workflowId}'`);
@@ -228,7 +212,27 @@ export class HandleAgentReply {
         }).catch((activityErr) => {
           this.logger.error(activityErr, `[agent:${command.agentIdentifier}] Failed to log trigger error activity`);
         });
+
+        continue;
       }
+
+      await this.activityRepository.createSignalActivity({
+        identifier: `act-${shortId(8)}`,
+        conversationId: conversation._id,
+        platform: channel.platform,
+        integrationId: channel._integrationId,
+        platformThreadId: channel.platformThreadId,
+        agentId: command.agentIdentifier,
+        content: `Triggered workflow: ${signal.workflowId}`,
+        signalData: {
+          type: 'trigger',
+          payload: { workflowId: signal.workflowId, to: subscriberId, status: 'triggered' },
+        },
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+      }).catch((activityErr) => {
+        this.logger.error(activityErr, `[agent:${command.agentIdentifier}] Failed to log trigger success activity`);
+      });
     }
 
     return errors;

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -9,12 +9,20 @@ import {
   ConversationStatusEnum,
   SubscriberRepository,
 } from '@novu/dal';
+import { AddressingTypeEnum, TriggerRequestCategoryEnum } from '@novu/shared';
 import { AgentEventEnum } from '../../dtos/agent-event.enum';
 import { AgentCredentialService } from '../../services/agent-credential.service';
 import { AgentConversationService } from '../../services/agent-conversation.service';
 import { BridgeExecutorService } from '../../services/bridge-executor.service';
 import { ChatSdkService } from '../../services/chat-sdk.service';
+import { ParseEventRequest, ParseEventRequestMulticastCommand } from '../../../events/usecases/parse-event-request';
 import { HandleAgentReplyCommand } from './handle-agent-reply.command';
+
+export interface SignalError {
+  type: string;
+  workflowId?: string;
+  error: string;
+}
 
 @Injectable()
 export class HandleAgentReply {
@@ -26,10 +34,11 @@ export class HandleAgentReply {
     private readonly bridgeExecutor: BridgeExecutorService,
     private readonly agentCredentialService: AgentCredentialService,
     private readonly conversationService: AgentConversationService,
+    private readonly parseEventRequest: ParseEventRequest,
     private readonly logger: PinoLogger
   ) {}
 
-  async execute(command: HandleAgentReplyCommand): Promise<{ status: string }> {
+  async execute(command: HandleAgentReplyCommand): Promise<{ status: string; signalErrors?: SignalError[] }> {
     if (command.reply && command.update) {
       throw new BadRequestException('Only one of reply or update can be provided');
     }
@@ -61,15 +70,19 @@ export class HandleAgentReply {
       await this.deliverMessage(command, conversation, channel, command.reply.text, ConversationActivityTypeEnum.MESSAGE);
     }
 
+    let signalErrors: SignalError[] = [];
     if (command.signals?.length) {
-      await this.executeSignals(command, conversation, channel, command.signals);
+      signalErrors = await this.executeSignals(command, conversation, channel, command.signals);
     }
 
     if (command.resolve) {
       await this.executeResolveSignal(command, conversation, channel, command.resolve);
     }
 
-    return { status: 'ok' };
+    return {
+      status: 'ok',
+      ...(signalErrors.length ? { signalErrors } : {}),
+    };
   }
 
   private getPrimaryChannel(conversation: ConversationEntity): ConversationChannel {
@@ -122,7 +135,9 @@ export class HandleAgentReply {
     conversation: ConversationEntity,
     channel: ConversationChannel,
     signals: HandleAgentReplyCommand['signals']
-  ): Promise<void> {
+  ): Promise<SignalError[]> {
+    const errors: SignalError[] = [];
+
     const metadataSignals = (signals ?? []).filter(
       (s): s is Extract<NonNullable<HandleAgentReplyCommand['signals']>[number], { type: 'metadata' }> => s.type === 'metadata'
     );
@@ -131,10 +146,92 @@ export class HandleAgentReply {
       await this.executeMetadataSignals(command, conversation, channel, metadataSignals);
     }
 
-    const triggerSignals = (signals ?? []).filter((s) => s.type === 'trigger');
+    const triggerSignals = (signals ?? []).filter(
+      (s): s is Extract<NonNullable<HandleAgentReplyCommand['signals']>[number], { type: 'trigger' }> => s.type === 'trigger'
+    );
+
     if (triggerSignals.length) {
-      // TODO: execute trigger signals — requires wiring TriggerEvent or ParseEventRequest from EventsModule
+      const triggerErrors = await this.executeTriggerSignals(command, conversation, channel, triggerSignals);
+      errors.push(...triggerErrors);
     }
+
+    return errors;
+  }
+
+  private async executeTriggerSignals(
+    command: HandleAgentReplyCommand,
+    conversation: ConversationEntity,
+    channel: ConversationChannel,
+    signals: Array<{ type: 'trigger'; workflowId: string; to?: string; payload?: Record<string, unknown> }>
+  ): Promise<SignalError[]> {
+    const errors: SignalError[] = [];
+    const subscriberParticipant = conversation.participants.find((p) => p.type === 'subscriber');
+
+    for (const signal of signals) {
+      const subscriberId = signal.to ?? subscriberParticipant?.id;
+
+      try {
+        if (!subscriberId) {
+          throw new Error('No subscriber: signal.to is empty and conversation has no subscriber participant');
+        }
+
+        await this.parseEventRequest.execute(
+          ParseEventRequestMulticastCommand.create({
+            userId: command.userId,
+            environmentId: command.environmentId,
+            organizationId: command.organizationId,
+            identifier: signal.workflowId,
+            payload: signal.payload ?? {},
+            overrides: {},
+            to: [{ subscriberId }],
+            addressingType: AddressingTypeEnum.MULTICAST,
+            requestCategory: TriggerRequestCategoryEnum.SINGLE,
+            requestId: `agent-trigger-${shortId(12)}`,
+          })
+        );
+
+        await this.activityRepository.createSignalActivity({
+          identifier: `act-${shortId(8)}`,
+          conversationId: conversation._id,
+          platform: channel.platform,
+          integrationId: channel._integrationId,
+          platformThreadId: channel.platformThreadId,
+          agentId: command.agentIdentifier,
+          content: `Triggered workflow: ${signal.workflowId}`,
+          signalData: {
+            type: 'trigger',
+            payload: { workflowId: signal.workflowId, to: subscriberId, status: 'triggered' },
+          },
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        this.logger.error(err, `[agent:${command.agentIdentifier}] Trigger signal failed for workflow '${signal.workflowId}'`);
+
+        errors.push({ type: 'trigger', workflowId: signal.workflowId, error: errorMessage });
+
+        await this.activityRepository.createSignalActivity({
+          identifier: `act-${shortId(8)}`,
+          conversationId: conversation._id,
+          platform: channel.platform,
+          integrationId: channel._integrationId,
+          platformThreadId: channel.platformThreadId,
+          agentId: command.agentIdentifier,
+          content: `Failed to trigger workflow: ${signal.workflowId}`,
+          signalData: {
+            type: 'trigger',
+            payload: { workflowId: signal.workflowId, to: subscriberId, status: 'failed', error: errorMessage },
+          },
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+        }).catch((activityErr) => {
+          this.logger.error(activityErr, `[agent:${command.agentIdentifier}] Failed to log trigger error activity`);
+        });
+      }
+    }
+
+    return errors;
   }
 
   private async executeMetadataSignals(

--- a/apps/api/src/app/events/events.module.ts
+++ b/apps/api/src/app/events/events.module.ts
@@ -15,6 +15,7 @@ import { SubscribersV1Module } from '../subscribers/subscribersV1.module';
 import { TenantModule } from '../tenant/tenant.module';
 import { WidgetsModule } from '../widgets/widgets.module';
 import { EventsController } from './events.controller';
+import { ParseEventRequest } from './usecases/parse-event-request';
 import { USE_CASES } from './usecases';
 
 const PROVIDERS = [GetNovuProviderCredentials, StorageHelperService, CommunityOrganizationRepository];
@@ -35,5 +36,6 @@ const PROVIDERS = [GetNovuProviderCredentials, StorageHelperService, CommunityOr
   ],
   controllers: [EventsController],
   providers: [...PROVIDERS, ...USE_CASES, CommunityUserRepository],
+  exports: [ParseEventRequest],
 })
 export class EventsModule {}


### PR DESCRIPTION
## Summary

- Wire `ctx.trigger()` signal execution in `HandleAgentReply` so agent handlers can fire Novu workflows (both Framework and Cloud)
- Delegate to `ParseEventRequest` — the canonical trigger entry point — for full validation, billing, subscriber resolution, and queue insertion
- Trigger failures are non-blocking: chat replies always deliver first, errors are collected per-signal and returned in the response as `signalErrors`

## Changes

- **`events.module.ts`** — export `ParseEventRequest` so other modules can use it
- **`agents.module.ts`** — import `EventsModule` for `ParseEventRequest` access
- **`handle-agent-reply.usecase.ts`** — inject `ParseEventRequest`, implement `executeTriggerSignals`, update `executeSignals` to return `SignalError[]`, include errors in response

## Design decisions

- **`to` default**: when `signal.to` is omitted, defaults to the conversation's subscriber participant
- **Signal ordering**: metadata → triggers → resolve (metadata updates before triggers so workflows see fresh state)
- **Error isolation**: each trigger signal is independently try/caught — one failure doesn't stop others
- **Activity logging**: both successful and failed triggers are logged as conversation signal activities

## Test plan

- [ ] Verify existing e2e tests still pass (`agent-reply.e2e.ts`)
- [ ] E2E: send Slack message with "trigger" keyword → verify workflow fires and chat reply delivers
- [ ] Verify trigger with non-existent workflow returns `signalErrors` without breaking the conversation
- [ ] Verify trigger without explicit `to` defaults to conversation subscriber


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds workflow-triggering side effects to the agent reply path and wires cross-module dependencies (`AgentsModule` -> `EventsModule`), which could impact event validation/queueing behavior and error handling at runtime.
> 
> **Overview**
> Enables agent replies to execute `trigger` signals (`ctx.trigger()`), calling `ParseEventRequest` to enqueue Novu workflows for a resolved subscriber (defaults to the conversation’s subscriber when `to` is omitted).
> 
> `HandleAgentReply` now collects non-blocking per-signal failures and returns them as `signalErrors`, while logging both successful and failed trigger attempts as conversation signal activities.
> 
> Wires the dependency by exporting `ParseEventRequest` from `EventsModule` and importing `EventsModule` into `AgentsModule`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c36e9a36ae5c04e4660ca6e9c8c12e7e8342215. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->