### PR TITLE
fix(api-service): avoid invalid url env validator to avoid error

### DIFF
--- a/apps/api/src/config/env.validators.ts
+++ b/apps/api/src/config/env.validators.ts
@@ -77,7 +77,7 @@ export const envValidators = {
   STEP_RESOLVER_CF_ACCOUNT_ID: str({ default: undefined }),
   STEP_RESOLVER_CF_API_TOKEN: str({ default: undefined }),
   STEP_RESOLVER_CF_DISPATCH_NAMESPACE: str({ default: undefined }),
-  STEP_RESOLVER_DISPATCH_URL: url({ default: '' }),
+  STEP_RESOLVER_DISPATCH_URL: str({ default: undefined }),
   STEP_RESOLVER_HMAC_SECRET: str({ default: '' }),
   // Novu Cloud third party services
   ...(processEnv.IS_SELF_HOSTED !== 'true' &&


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The environment variable validator for `STEP_RESOLVER_DISPATCH_URL` was updated to prevent startup errors. Changed from `url({ default: '' })` to `str({ default: undefined })`, allowing the API to start normally when the environment variable is not provided, aligning with the worker's behavior.

## Affected areas
**api**: Updated the `STEP_RESOLVER_DISPATCH_URL` validator in `apps/api/src/config/env.validators.ts` from a URL validator with empty string default to a string validator with undefined default.

## Key technical decisions
The change intentionally shifts validation semantics—from enforcing URL parsing with an empty string fallback to accepting any string with undefined as the default. This makes the configuration optional rather than failing validation due to an invalid empty URL.

## Testing
No new tests were added. This addresses a startup configuration issue that should be verified through integration testing or manual verification that the API starts without the environment variable provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

This is to avoid error on startup when env var is not provided. This is now the same as in the worker.

Resolve https://github.com/novuhq/novu/issues/10717

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes env var validation behavior for a single optional setting, affecting startup/config parsing but not core runtime logic when the variable is provided.
> 
> **Overview**
> Prevents API startup failures when `STEP_RESOLVER_DISPATCH_URL` is missing by changing its env validator from `url()` with an empty-string default to `str()` with an `undefined` default in `env.validators.ts` (matching the worker’s behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d79d0bcd1fe81fda932177b808af3b455e4ec6f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->