### PR TITLE
feat(api-service): add thinking indicator toggle to agent behavior settings fixes NV-7366

### DIFF
--- a/apps/api/src/app/agents/agents.controller.ts
+++ b/apps/api/src/app/agents/agents.controller.ts
@@ -287,6 +287,7 @@ export class AgentsController {
         identifier,
         name: body.name,
         description: body.description,
+        behavior: body.behavior,
       })
     );
   }

--- a/apps/api/src/app/agents/dtos/agent-behavior.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-behavior.dto.ts
@@ -1,0 +1,9 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class AgentBehaviorDto {
+  @ApiPropertyOptional({ description: 'Show a "Thinking..." indicator while the agent is processing a message' })
+  @IsBoolean()
+  @IsOptional()
+  thinkingIndicatorEnabled?: boolean;
+}

--- a/apps/api/src/app/agents/dtos/agent-response.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+import { AgentBehaviorDto } from './agent-behavior.dto';
 import { AgentIntegrationSummaryDto } from './agent-integration-summary.dto';
 
 export class AgentResponseDto {
@@ -14,6 +15,9 @@ export class AgentResponseDto {
 
   @ApiPropertyOptional()
   description?: string;
+
+  @ApiPropertyOptional({ type: AgentBehaviorDto })
+  behavior?: AgentBehaviorDto;
 
   @ApiProperty()
   _environmentId: string;

--- a/apps/api/src/app/agents/dtos/index.ts
+++ b/apps/api/src/app/agents/dtos/index.ts
@@ -1,4 +1,5 @@
 export * from './add-agent-integration-request.dto';
+export * from './agent-behavior.dto';
 export * from './agent-integration-summary.dto';
 export * from './agent-integration-response.dto';
 export * from './agent-response.dto';

--- a/apps/api/src/app/agents/dtos/update-agent-request.dto.ts
+++ b/apps/api/src/app/agents/dtos/update-agent-request.dto.ts
@@ -1,5 +1,8 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+import { AgentBehaviorDto } from './agent-behavior.dto';
 
 export class UpdateAgentRequestDto {
   @ApiPropertyOptional()
@@ -11,4 +14,10 @@ export class UpdateAgentRequestDto {
   @IsString()
   @IsOptional()
   description?: string;
+
+  @ApiPropertyOptional({ type: AgentBehaviorDto })
+  @ValidateNested()
+  @Type(() => AgentBehaviorDto)
+  @IsOptional()
+  behavior?: AgentBehaviorDto;
 }

--- a/apps/api/src/app/agents/e2e/agents.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agents.e2e.ts
@@ -65,6 +65,39 @@ describe('Agents API - /agents #novu-v2', () => {
     expect(afterDelete.status).to.equal(404);
   });
 
+  it('should update and return agent behavior settings', async () => {
+    const identifier = `e2e-behavior-${Date.now()}`;
+
+    const createRes = await session.testAgent.post('/v1/agents').send({
+      name: 'Behavior Agent',
+      identifier,
+    });
+
+    expect(createRes.status).to.equal(201);
+    expect(createRes.body.data.behavior).to.equal(undefined);
+
+    const patchRes = await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({
+      behavior: { thinkingIndicatorEnabled: false },
+    });
+
+    expect(patchRes.status).to.equal(200);
+    expect(patchRes.body.data.behavior).to.deep.equal({ thinkingIndicatorEnabled: false });
+
+    const getRes = await session.testAgent.get(`/v1/agents/${encodeURIComponent(identifier)}`);
+
+    expect(getRes.status).to.equal(200);
+    expect(getRes.body.data.behavior.thinkingIndicatorEnabled).to.equal(false);
+
+    const reEnableRes = await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({
+      behavior: { thinkingIndicatorEnabled: true },
+    });
+
+    expect(reEnableRes.status).to.equal(200);
+    expect(reEnableRes.body.data.behavior.thinkingIndicatorEnabled).to.equal(true);
+
+    await session.testAgent.delete(`/v1/agents/${encodeURIComponent(identifier)}`);
+  });
+
   it('should return 422 when identifier is not a valid slug', async () => {
     const res = await session.testAgent.post('/v1/agents').send({
       name: 'Invalid Slug Agent',

--- a/apps/api/src/app/agents/mappers/agent-response.mapper.ts
+++ b/apps/api/src/app/agents/mappers/agent-response.mapper.ts
@@ -8,6 +8,7 @@ export function toAgentResponse(agent: AgentEntity): AgentResponseDto {
     name: agent.name,
     identifier: agent.identifier,
     description: agent.description,
+    behavior: agent.behavior,
     _environmentId: agent._environmentId,
     _organizationId: agent._organizationId,
     createdAt: agent.createdAt,

--- a/apps/api/src/app/agents/services/agent-credential.service.ts
+++ b/apps/api/src/app/agents/services/agent-credential.service.ts
@@ -20,6 +20,11 @@ export interface ResolvedPlatformConfig {
   agentIdentifier: string;
   integrationIdentifier: string;
   integrationId: string;
+  thinkingIndicatorEnabled: boolean;
+}
+
+function resolveThinkingIndicator(agent: { behavior?: { thinkingIndicatorEnabled?: boolean } }): boolean {
+  return agent.behavior?.thinkingIndicatorEnabled !== false;
 }
 
 @Injectable()
@@ -100,6 +105,7 @@ export class AgentCredentialService {
       agentIdentifier: agent.identifier,
       integrationIdentifier,
       integrationId: integration._id,
+      thinkingIndicatorEnabled: resolveThinkingIndicator(agent),
     };
   }
 }

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -75,7 +75,9 @@ export class AgentInboundHandler {
       organizationId: config.organizationId,
     });
 
-    await thread.startTyping();
+    if (config.thinkingIndicatorEnabled) {
+      await thread.startTyping('Thinking...');
+    }
 
     const serializedThread = thread.toJSON() as unknown as Record<string, unknown>;
     await this.conversationService.updateChannelThread(

--- a/apps/api/src/app/agents/usecases/update-agent/update-agent.command.ts
+++ b/apps/api/src/app/agents/usecases/update-agent/update-agent.command.ts
@@ -1,6 +1,8 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+import { AgentBehaviorDto } from '../../dtos/agent-behavior.dto';
 
 export class UpdateAgentCommand extends EnvironmentWithUserCommand {
   @IsString()
@@ -14,4 +16,9 @@ export class UpdateAgentCommand extends EnvironmentWithUserCommand {
   @IsString()
   @IsOptional()
   description?: string;
+
+  @ValidateNested()
+  @Type(() => AgentBehaviorDto)
+  @IsOptional()
+  behavior?: AgentBehaviorDto;
 }

--- a/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
@@ -10,8 +10,8 @@ export class UpdateAgent {
   constructor(private readonly agentRepository: AgentRepository) {}
 
   async execute(command: UpdateAgentCommand): Promise<AgentResponseDto> {
-    if (command.name === undefined && command.description === undefined) {
-      throw new BadRequestException('At least one of name or description must be provided.');
+    if (command.name === undefined && command.description === undefined && command.behavior === undefined) {
+      throw new BadRequestException('At least one of name, description, or behavior must be provided.');
     }
 
     const existing = await this.agentRepository.findOne(
@@ -27,7 +27,7 @@ export class UpdateAgent {
       throw new NotFoundException(`Agent with identifier "${command.identifier}" was not found.`);
     }
 
-    const $set: Record<string, string> = {};
+    const $set: Record<string, unknown> = {};
 
     if (command.name !== undefined) {
       $set.name = command.name;
@@ -35,6 +35,12 @@ export class UpdateAgent {
 
     if (command.description !== undefined) {
       $set.description = command.description;
+    }
+
+    if (command.behavior !== undefined) {
+      if (command.behavior.thinkingIndicatorEnabled !== undefined) {
+        $set['behavior.thinkingIndicatorEnabled'] = command.behavior.thinkingIndicatorEnabled;
+      }
     }
 
     await this.agentRepository.updateOne(

--- a/libs/dal/src/repositories/agent/agent.entity.ts
+++ b/libs/dal/src/repositories/agent/agent.entity.ts
@@ -2,6 +2,10 @@ import type { ChangePropsValueType } from '../../types/helpers';
 import type { EnvironmentId } from '../environment';
 import type { OrganizationId } from '../organization';
 
+export interface AgentBehavior {
+  thinkingIndicatorEnabled?: boolean;
+}
+
 export class AgentEntity {
   _id: string;
 
@@ -10,6 +14,8 @@ export class AgentEntity {
   identifier: string;
 
   description?: string;
+
+  behavior?: AgentBehavior;
 
   _environmentId: EnvironmentId;
 

--- a/libs/dal/src/repositories/agent/agent.schema.ts
+++ b/libs/dal/src/repositories/agent/agent.schema.ts
@@ -14,6 +14,9 @@ const agentSchema = new Schema<AgentDBModel>(
       required: true,
     },
     description: Schema.Types.String,
+    behavior: {
+      thinkingIndicatorEnabled: Schema.Types.Boolean,
+    },
     _organizationId: {
       type: Schema.Types.ObjectId,
       ref: 'Organization',


### PR DESCRIPTION
## Summary
- Introduces an `AgentBehavior` subdocument on the Agent entity to hold per-agent runtime behavior settings, starting with `thinkingIndicatorEnabled`
- This architecture supports future settings (reactions, interrupt mode, response timeout, etc.) under `behavior` without adding flat fields to the entity
- Defaults to enabled — only an explicit `false` suppresses the indicator. Status text is "Thinking..." (not the generic platform "typing" label)

## How it works

**Data model** — `AgentEntity` gets an optional `behavior?: AgentBehavior` subdocument (interface + inline Mongoose nested paths, following the same pattern as `Organization.branding`, `Environment.widget`, `Integration.configurations`):

```typescript
interface AgentBehavior {
  thinkingIndicatorEnabled?: boolean;
  // future: inboundReaction, resolveReaction, interruptMode, etc.
}
```

**API** — `PATCH /agents/:identifier` accepts a nested `behavior` object. Uses dot-notation `$set` so individual fields can be updated without overwriting the whole subdocument:

```json
{ "behavior": { "thinkingIndicatorEnabled": false } }
```

**Runtime** — `AgentCredentialService.resolve()` reads `agent.behavior?.thinkingIndicatorEnabled` and resolves it to a boolean (defaulting to `true`). `AgentInboundHandler` gates `thread.startTyping('Thinking...')` behind this resolved value.

## Test plan
- [x] E2E test: `PATCH` with behavior persists and round-trips correctly
- [x] E2E test: re-enabling the indicator after disabling it works
- [ ] Manual: agent with `thinkingIndicatorEnabled: false` does not trigger indicator on inbound messages
- [ ] Manual: agent with no `behavior` set shows "Thinking..." indicator as before

## Linear ticket
https://linear.app/novu/issue/NV-7366/add-typing-indicator-toggle-to-agent-behavior-settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Added an optional behavior.typingIndicatorEnabled boolean to per-agent settings and persisted it in the database so agents can opt out of showing typing indicators. The API accepts and returns the nested behavior object on PATCH/GET /agents/:identifier and updates use dot-notation so individual behavior fields can be patched without overwriting the subdocument. At runtime AgentCredentialService resolves the flag (defaulting to enabled) and AgentInboundHandler only calls thread.startTyping() when the setting is not explicitly false.

## Affected areas

- **api**: Request/response DTOs, controller, update use case, response mapper, and AgentCredentialService were updated to accept, validate, persist, and resolve the new behavior.typingIndicatorEnabled flag; AgentInboundHandler now conditionally calls thread.startTyping().
- **dal**: AgentEntity and Mongoose schema gained an optional behavior.typingIndicatorEnabled nested field to store the setting.
- **e2e tests (api)**: Added an end-to-end test that verifies behavior is initially unset, can be patched to false/true, persists, and is returned by GET.

## Key technical decisions

- Backwards-compatible default: undefined (or true) keeps typing indicators enabled; only an explicit false disables them (implementation: treat !== false as enabled).
- Partial updates supported: PATCH uses dot-notation $set to update individual behavior fields without replacing the whole subdocument.
- No new runtime dependencies or enterprise-specific changes introduced.

## Testing

Added an E2E test covering PATCH/GET persistence and behavior toggling; runtime behavior verified by tests that inbound messages respect typingIndicatorEnabled=false and remain unchanged when true/unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->