### PR TITLE
feat(dashboard): add environment-scoped demo page

### DIFF
--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -45,6 +45,7 @@ import { ContextsPage } from './pages/contexts';
 import { CreateContextPage } from './pages/create-context';
 import { CreateSubscriberPage } from './pages/create-subscriber';
 import { CreateTopicPage } from './pages/create-topic';
+import { DemoPage } from './pages/demo-page';
 import { DuplicateLayoutPage } from './pages/duplicate-layout-page';
 import { EditContextPage } from './pages/edit-context';
 import { EditLayoutPage } from './pages/edit-layout';
@@ -162,6 +163,10 @@ const router = createBrowserRouter([
               {
                 path: ROUTES.WELCOME,
                 element: <WelcomePage />,
+              },
+              {
+                path: ROUTES.DEMO,
+                element: <DemoPage />,
               },
               {
                 path: ROUTES.WORKFLOWS,

--- a/apps/dashboard/src/pages/demo-page.tsx
+++ b/apps/dashboard/src/pages/demo-page.tsx
@@ -1,0 +1,51 @@
+import { Link } from 'react-router-dom';
+import { DashboardLayout } from '@/components/dashboard-layout';
+import { PageMeta } from '@/components/page-meta';
+import { Button } from '@/components/primitives/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/primitives/card';
+import { useEnvironment } from '@/context/environment/hooks';
+import { buildRoute, ROUTES } from '@/utils/routes';
+
+export function DemoPage() {
+  const { currentEnvironment } = useEnvironment();
+  const environmentSlug = currentEnvironment?.slug ?? '';
+
+  const workflowsHref = environmentSlug
+    ? buildRoute(ROUTES.WORKFLOWS, { environmentSlug })
+    : ROUTES.ROOT;
+
+  return (
+    <>
+      <PageMeta title="Demo" />
+      <DashboardLayout headerStartItems={<h1 className="text-foreground-950">Demo</h1>}>
+        <div className="mx-auto flex max-w-2xl flex-col gap-6 py-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Dashboard demo</CardTitle>
+              <CardDescription>
+                Use this page as a sandbox for UI experiments. It is scoped to the current environment and is not linked
+                from the main navigation.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
+              <p className="text-foreground-600 text-sm">
+                Navigate to workflows to continue exploring the product, or open the welcome page for onboarding
+                resources.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <Button asChild variant="primary">
+                  <Link to={workflowsHref}>Go to workflows</Link>
+                </Button>
+                {environmentSlug ? (
+                  <Button asChild variant="secondary">
+                    <Link to={buildRoute(ROUTES.WELCOME, { environmentSlug })}>Welcome</Link>
+                  </Button>
+                ) : null}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </DashboardLayout>
+    </>
+  );
+}

--- a/apps/dashboard/src/utils/routes.ts
+++ b/apps/dashboard/src/utils/routes.ts
@@ -27,6 +27,7 @@ export const ROUTES = {
   TEST_WORKFLOW: '/env/:environmentSlug/workflows/:workflowSlug/test',
   TRIGGER_WORKFLOW: '/env/:environmentSlug/workflows/:workflowSlug/trigger',
   WELCOME: '/env/:environmentSlug/welcome',
+  DEMO: '/env/:environmentSlug/demo',
   HOME: '/env/:environmentSlug/home',
   EDIT_WORKFLOW_PREFERENCES: 'preferences',
   EDIT_STEP: 'steps/:stepSlug',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new **Demo** route under the environment namespace so there is a dedicated sandbox page in the dashboard shell (standard layout, no nav entry).

## Changes

- `ROUTES.DEMO` → `/env/:environmentSlug/demo`
- New `DemoPage` with short copy and links to Workflows and Welcome for the current environment
- Registered route in `main.tsx` next to Welcome

## How to try it

Sign in and open `/demo` (catch-all redirects to `/env/<slug>/demo`) or navigate directly to `/env/<your-environment-slug>/demo`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1776245014290209?thread_ts=1776245014.290209&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-421af0b6-1922-5341-89ad-5161c5b03940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-421af0b6-1922-5341-89ad-5161c5b03940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

