### PR TITLE
feat(api-service,framework): add rich content support and onAction handler for agent cards fixes NV-7363

### DIFF
--- a/apps/api/src/app/agents/dtos/agent-event.enum.ts
+++ b/apps/api/src/app/agents/dtos/agent-event.enum.ts
@@ -1,4 +1,5 @@
 export enum AgentEventEnum {
   ON_MESSAGE = 'onMessage',
+  ON_ACTION = 'onAction',
   ON_RESOLVE = 'onResolve',
 }

--- a/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
@@ -2,24 +2,72 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsArray,
-  IsDefined,
   IsIn,
   IsNotEmpty,
   IsObject,
   IsOptional,
   IsString,
   MaxLength,
+  Validate,
   ValidateNested,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
 } from 'class-validator';
 
 const SIGNAL_TYPES = ['metadata', 'trigger'] as const;
 
-export class TextContentDto {
-  @ApiProperty()
+export interface FileRef {
+  filename: string;
+  mimeType?: string;
+  data?: string;
+  url?: string;
+}
+
+@ValidatorConstraint({ name: 'isValidReplyContent', async: false })
+export class IsValidReplyContent implements ValidatorConstraintInterface {
+  validate(content: ReplyContentDto): boolean {
+    if (!content) return true;
+
+    const fields = [content.text, content.markdown, content.card].filter((v) => v !== undefined);
+    if (fields.length !== 1) return false;
+
+    if (content.files?.length && !content.markdown) return false;
+
+    for (const file of content.files ?? []) {
+      const sources = [file.data, file.url].filter(Boolean);
+      if (sources.length !== 1) return false;
+    }
+
+    return true;
+  }
+
+  defaultMessage(): string {
+    return 'Content must have exactly one of text, markdown, or card. Files only allowed with markdown. Each file needs exactly one of data or url.';
+  }
+}
+
+export class ReplyContentDto {
+  @ApiPropertyOptional()
+  @IsOptional()
   @IsString()
   @IsNotEmpty()
   @MaxLength(40_000)
-  text: string;
+  text?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  markdown?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsObject()
+  card?: Record<string, unknown>;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsArray()
+  files?: FileRef[];
 }
 
 export class ResolveDto {
@@ -71,19 +119,21 @@ export class AgentReplyPayloadDto {
   @IsNotEmpty()
   integrationIdentifier: string;
 
-  @ApiPropertyOptional({ type: TextContentDto })
+  @ApiPropertyOptional({ type: ReplyContentDto })
   @IsOptional()
   @IsObject()
   @ValidateNested()
-  @Type(() => TextContentDto)
-  reply?: TextContentDto;
+  @Validate(IsValidReplyContent)
+  @Type(() => ReplyContentDto)
+  reply?: ReplyContentDto;
 
-  @ApiPropertyOptional({ type: TextContentDto })
+  @ApiPropertyOptional({ type: ReplyContentDto })
   @IsOptional()
   @IsObject()
   @ValidateNested()
-  @Type(() => TextContentDto)
-  update?: TextContentDto;
+  @Validate(IsValidReplyContent)
+  @Type(() => ReplyContentDto)
+  update?: ReplyContentDto;
 
   @ApiPropertyOptional({ type: ResolveDto })
   @IsOptional()

--- a/apps/api/src/app/agents/e2e/mock-agent-handler.ts
+++ b/apps/api/src/app/agents/e2e/mock-agent-handler.ts
@@ -148,6 +148,9 @@ const echoBot = agent('novu-agent', {
           ],
         })
       );
+    } else if (actionId === 'resolve') {
+      ctx.resolve('Incident resolved via action');
+      await ctx.reply(`Incident resolved by *${ctx.subscriber?.firstName ?? 'unknown'}*.`);
     } else if (actionId === 'assign') {
       await ctx.reply(`On-call assignment updated to *${value}*.`);
     } else if (actionId === 'escalate') {

--- a/apps/api/src/app/agents/e2e/mock-agent-handler.ts
+++ b/apps/api/src/app/agents/e2e/mock-agent-handler.ts
@@ -15,7 +15,19 @@
  *   5. @mention the bot in Slack — watch the round-trip in the logs
  */
 
-import { agent, Client, serve } from '@novu/framework/express';
+import {
+  agent,
+  serve,
+  Client,
+  Actions,
+  Button,
+  Card,
+  CardLink,
+  CardText,
+  Divider,
+  Select,
+  SelectOption,
+} from '@novu/framework/express';
 import express from 'express';
 
 const NOVU_SECRET_KEY = process.env.NOVU_SECRET_KEY;
@@ -47,7 +59,104 @@ const echoBot = agent('novu-agent', {
       return;
     }
 
+    if (userText.toLowerCase().includes('card')) {
+      await ctx.reply(
+        Card({
+          title: `Order #${Math.floor(Math.random() * 9000) + 1000}`,
+          children: [
+            CardText('Your order is ready for pickup.'),
+            Actions([
+              Button({ id: 'confirm', label: 'Confirm Pickup', style: 'primary' }),
+              Button({ id: 'cancel', label: 'Cancel Order', style: 'danger' }),
+            ]),
+          ],
+        })
+      );
+
+      return;
+    }
+
+    if (userText.toLowerCase().includes('incident')) {
+      await ctx.reply(
+        Card({
+          title: `Incident #${Math.floor(Math.random() * 9000) + 1000} — DB Latency Spike`,
+          children: [
+            CardText('*P1 — Production database latency spike*'),
+            CardText('Detected at 14:32 UTC. Response times exceeded 2s threshold for 3 minutes.'),
+            Divider(),
+            CardText('*Status:* Investigating  |  *Service:* payments-api  |  *Region:* us-east-1'),
+            Divider(),
+            Select({
+              id: 'assign',
+              label: 'Assign to on-call',
+              options: [
+                SelectOption({ value: 'alice', label: 'Alice Chen' }),
+                SelectOption({ value: 'bob', label: 'Bob Martinez' }),
+                SelectOption({ value: 'carol', label: 'Carol Wu' }),
+              ],
+            }),
+            Actions([
+              Button({ id: 'ack', label: 'Acknowledge', style: 'primary' }),
+              Button({ id: 'escalate', label: 'Escalate', style: 'danger' }),
+            ]),
+            CardLink({ url: 'https://grafana.example.com/d/abc', label: 'View Grafana Dashboard' }),
+          ],
+        })
+      );
+
+      return;
+    }
+
+    if (userText.toLowerCase().includes('markdown')) {
+      await ctx.reply({
+        markdown: [
+          `**Echo:** ${userText}`,
+          '',
+          '| Metric | Value |',
+          '|--------|-------|',
+          '| Latency | 142ms |',
+          '| Throughput | 1.2k rps |',
+          '| Error rate | 0.02% |',
+          '',
+          '> Sent from _Novu Agent Framework_',
+        ].join('\n'),
+      });
+
+      return;
+    }
+
     await ctx.reply(`Echo: ${userText}`);
+  },
+
+  onAction: async (ctx) => {
+    console.log('\n─────────────────────────────────────────');
+    console.log(`[${ctx.event}] action: ${ctx.action?.actionId} = ${ctx.action?.value ?? '(no value)'}`);
+    console.log('─────────────────────────────────────────');
+
+    const actionId = ctx.action?.actionId ?? 'unknown';
+    const value = ctx.action?.value;
+
+    if (actionId === 'ack') {
+      await ctx.reply(
+        Card({
+          title: 'Incident Acknowledged',
+          children: [
+            CardText(
+              `Acknowledged by *${ctx.subscriber?.firstName ?? 'unknown'}* at ${new Date().toLocaleTimeString()}.`
+            ),
+            Actions([Button({ id: 'resolve', label: 'Resolve Incident', style: 'primary' })]),
+          ],
+        })
+      );
+    } else if (actionId === 'assign') {
+      await ctx.reply(`On-call assignment updated to *${value}*.`);
+    } else if (actionId === 'escalate') {
+      await ctx.reply({
+        markdown: `**Escalated** — paging the secondary on-call team.\n\n_Triggered by ${ctx.subscriber?.firstName ?? 'unknown'}_`,
+      });
+    } else {
+      await ctx.reply(`Got action: *${actionId}*${value ? ` = ${value}` : ''}`);
+    }
   },
 
   onResolve: async (ctx) => {
@@ -70,7 +179,12 @@ app.use(
   })
 );
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`\nAgent Handler (using @novu/framework) running on http://localhost:${PORT}/api/novu`);
   console.log('\nWaiting for bridge calls...\n');
 });
+
+server.on('error', (err) => console.error('Server error:', err));
+server.on('close', () => console.log('Server closed'));
+process.on('uncaughtException', (err) => console.error('Uncaught:', err));
+process.on('unhandledRejection', (err) => console.error('Unhandled rejection:', err));

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -3,10 +3,10 @@ import { PinoLogger } from '@novu/application-generic';
 import { ConversationActivitySenderTypeEnum, ConversationParticipantTypeEnum, SubscriberRepository } from '@novu/dal';
 import type { Message, Thread } from 'chat';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
-import { ResolvedPlatformConfig } from './agent-credential.service';
 import { AgentConversationService } from './agent-conversation.service';
+import { ResolvedPlatformConfig } from './agent-credential.service';
 import { AgentSubscriberResolver } from './agent-subscriber-resolver.service';
-import { BridgeExecutorService } from './bridge-executor.service';
+import { type BridgeAction, BridgeExecutorService } from './bridge-executor.service';
 
 @Injectable()
 export class AgentInboundHandler {
@@ -105,6 +105,80 @@ export class AgentInboundHandler {
         channelId: thread.channelId,
         isDM: thread.isDM,
       },
+    });
+  }
+
+  async handleAction(
+    agentId: string,
+    config: ResolvedPlatformConfig,
+    thread: Thread,
+    action: BridgeAction,
+    userId: string
+  ): Promise<void> {
+    const subscriberId = await this.subscriberResolver
+      .resolve({
+        environmentId: config.environmentId,
+        organizationId: config.organizationId,
+        platform: config.platform,
+        platformUserId: userId,
+        integrationIdentifier: config.integrationIdentifier,
+      })
+      .catch((err) => {
+        this.logger.warn(
+          err,
+          `[agent:${agentId}] Subscriber resolution failed for action, continuing without subscriber`
+        );
+
+        return null;
+      });
+
+    const participantId = subscriberId ?? `${config.platform}:${userId}`;
+    const participantType = subscriberId
+      ? ConversationParticipantTypeEnum.SUBSCRIBER
+      : ConversationParticipantTypeEnum.PLATFORM_USER;
+
+    const conversation = await this.conversationService.createOrGetConversation({
+      environmentId: config.environmentId,
+      organizationId: config.organizationId,
+      agentId,
+      platform: config.platform,
+      integrationId: config.integrationId,
+      platformThreadId: thread.id,
+      participantId,
+      participantType,
+      platformUserId: userId,
+      firstMessageText: `[action:${action.actionId}]`,
+    });
+
+    const serializedThread = thread.toJSON() as unknown as Record<string, unknown>;
+    await this.conversationService.updateChannelThread(
+      config.environmentId,
+      config.organizationId,
+      conversation._id,
+      thread.id,
+      serializedThread
+    );
+
+    const [subscriber, history] = await Promise.all([
+      subscriberId
+        ? this.subscriberRepository.findBySubscriberId(config.environmentId, subscriberId)
+        : Promise.resolve(null),
+      this.conversationService.getHistory(config.environmentId, conversation._id),
+    ]);
+
+    await this.bridgeExecutor.execute({
+      event: AgentEventEnum.ON_ACTION,
+      config,
+      conversation,
+      subscriber,
+      history,
+      message: null,
+      platformContext: {
+        threadId: thread.id,
+        channelId: thread.channelId,
+        isDM: thread.isDM,
+      },
+      action,
     });
   }
 }

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -34,6 +34,7 @@ export interface BridgeExecutorParams {
   history: ConversationActivityEntity[];
   message: Message | null;
   platformContext: BridgePlatformContext;
+  action?: BridgeAction;
 }
 
 interface BridgeMessageAuthor {
@@ -48,6 +49,11 @@ interface BridgeMessage {
   platformMessageId: string;
   author: BridgeMessageAuthor;
   timestamp: string;
+}
+
+export interface BridgeAction {
+  actionId: string;
+  value?: string;
 }
 
 interface BridgeConversation {
@@ -94,6 +100,7 @@ export interface AgentBridgeRequest {
   history: BridgeHistoryEntry[];
   platform: string;
   platformContext: BridgePlatformContext;
+  action: BridgeAction | null;
 }
 
 @Injectable()
@@ -202,7 +209,7 @@ export class BridgeExecutorService {
   }
 
   private buildPayload(params: BridgeExecutorParams): AgentBridgeRequest {
-    const { event, config, conversation, subscriber, history, message, platformContext } = params;
+    const { event, config, conversation, subscriber, history, message, platformContext, action } = params;
     const agentIdentifier = config.agentIdentifier;
 
     const apiRootUrl = process.env.API_ROOT_URL || 'http://localhost:3000';
@@ -227,6 +234,7 @@ export class BridgeExecutorService {
       history: this.mapHistory(history),
       platform: config.platform,
       platformContext,
+      action: action ?? null,
     };
   }
 

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -215,13 +215,20 @@ export class BridgeExecutorService {
     const apiRootUrl = process.env.API_ROOT_URL || 'http://localhost:3000';
     const replyUrl = `${apiRootUrl}/v1/agents/${agentIdentifier}/reply`;
 
-    const deliveryId = message?.id
-      ? `${conversation._id}:${message.id}`
-      : `${conversation._id}:${event}`;
+    const timestamp = new Date().toISOString();
+
+    let deliveryId: string;
+    if (message?.id) {
+      deliveryId = `${conversation._id}:${message.id}`;
+    } else if (action) {
+      deliveryId = `${conversation._id}:${event}:${action.actionId}:${timestamp}`;
+    } else {
+      deliveryId = `${conversation._id}:${event}`;
+    }
 
     return {
       version: 1,
-      timestamp: new Date().toISOString(),
+      timestamp,
       deliveryId,
       event,
       agentId: agentIdentifier,

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -5,7 +5,7 @@ import { Request as ExpressRequest, Response as ExpressResponse } from 'express'
 import { LRUCache } from 'lru-cache';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
-import type { ReplyContentDto } from '../usecases/handle-agent-reply/handle-agent-reply.command';
+import type { ReplyContentDto } from '../dtos/agent-reply-payload.dto';
 import { sendWebResponse, toWebRequest } from '../utils/express-to-web-request';
 import { AgentCredentialService, ResolvedPlatformConfig } from './agent-credential.service';
 import { AgentInboundHandler } from './agent-inbound-handler.service';
@@ -243,6 +243,23 @@ export class ChatSdkService implements OnModuleDestroy {
         await this.inboundHandler.handle(agentId, config, thread, message, AgentEventEnum.ON_MESSAGE);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling subscribed message`);
+      }
+    });
+
+    chat.onAction(async (event) => {
+      try {
+        if (!event.thread) {
+          this.logger.warn(`[agent:${agentId}] Action received without thread context, skipping`);
+
+          return;
+        }
+
+        await this.inboundHandler.handleAction(agentId, config, event.thread as Thread, {
+          actionId: event.actionId,
+          value: event.value,
+        }, event.user.userId);
+      } catch (err) {
+        this.logger.error(err, `[agent:${agentId}] Error handling action ${event.actionId}`);
       }
     });
   }

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -113,8 +113,8 @@ export class ChatSdkService implements OnModuleDestroy {
 
     if (content.card) {
       await thread.post(content.card);
-    } else if (content.markdown) {
-      await thread.post({ markdown: content.markdown });
+    } else if (content.markdown !== undefined) {
+      await thread.post({ markdown: content.markdown, files: content.files });
     } else {
       await thread.post(content.text ?? '');
     }

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -5,6 +5,7 @@ import { Request as ExpressRequest, Response as ExpressResponse } from 'express'
 import { LRUCache } from 'lru-cache';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
+import type { ReplyContentDto } from '../usecases/handle-agent-reply/handle-agent-reply.command';
 import { sendWebResponse, toWebRequest } from '../utils/express-to-web-request';
 import { AgentCredentialService, ResolvedPlatformConfig } from './agent-credential.service';
 import { AgentInboundHandler } from './agent-inbound-handler.service';
@@ -100,7 +101,7 @@ export class ChatSdkService implements OnModuleDestroy {
     integrationIdentifier: string,
     platform: string,
     serializedThread: Record<string, unknown>,
-    message: string
+    content: ReplyContentDto
   ): Promise<void> {
     const config = await this.agentCredentialService.resolve(agentId, integrationIdentifier);
     const instanceKey = `${agentId}:${integrationIdentifier}`;
@@ -109,7 +110,14 @@ export class ChatSdkService implements OnModuleDestroy {
     const { ThreadImpl } = await esmImport('chat');
     const adapter = chat.getAdapter(platform);
     const thread = ThreadImpl.fromJSON(serializedThread, adapter);
-    await thread.post(message);
+
+    if (content.card) {
+      await thread.post(content.card);
+    } else if (content.markdown) {
+      await thread.post({ markdown: content.markdown });
+    } else {
+      await thread.post(content.text ?? '');
+    }
   }
 
   private async getOrCreate(

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
@@ -1,64 +1,7 @@
 import { Type } from 'class-transformer';
-import {
-  IsArray,
-  IsNotEmpty,
-  IsObject,
-  IsOptional,
-  IsString,
-  Validate,
-  ValidateNested,
-  ValidatorConstraint,
-  ValidatorConstraintInterface,
-} from 'class-validator';
+import { IsArray, IsNotEmpty, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
-
-export interface FileRef {
-  filename: string;
-  mimeType?: string;
-  data?: string;
-  url?: string;
-}
-
-@ValidatorConstraint({ name: 'isValidReplyContent', async: false })
-class IsValidReplyContent implements ValidatorConstraintInterface {
-  validate(content: ReplyContentDto): boolean {
-    if (!content) return true;
-
-    const fields = [content.text, content.markdown, content.card].filter((v) => v !== undefined);
-    if (fields.length !== 1) return false;
-
-    if (content.files?.length && !content.markdown) return false;
-
-    for (const file of content.files ?? []) {
-      const sources = [file.data, file.url].filter(Boolean);
-      if (sources.length !== 1) return false;
-    }
-
-    return true;
-  }
-
-  defaultMessage(): string {
-    return 'Content must have exactly one of text, markdown, or card. Files only allowed with markdown. Each file needs exactly one of data or url.';
-  }
-}
-
-export class ReplyContentDto {
-  @IsOptional()
-  @IsString()
-  text?: string;
-
-  @IsOptional()
-  @IsString()
-  markdown?: string;
-
-  @IsOptional()
-  @IsObject()
-  card?: Record<string, unknown>;
-
-  @IsOptional()
-  @IsArray()
-  files?: FileRef[];
-}
+import { ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
 
 export class HandleAgentReplyCommand extends EnvironmentWithUserCommand {
   @IsString()
@@ -76,13 +19,11 @@ export class HandleAgentReplyCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @ValidateNested()
   @Type(() => ReplyContentDto)
-  @Validate(IsValidReplyContent)
   reply?: ReplyContentDto;
 
   @IsOptional()
   @ValidateNested()
   @Type(() => ReplyContentDto)
-  @Validate(IsValidReplyContent)
   update?: ReplyContentDto;
 
   @IsOptional()

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
@@ -1,5 +1,64 @@
-import { IsArray, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Validate,
+  ValidateNested,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export interface FileRef {
+  filename: string;
+  mimeType?: string;
+  data?: string;
+  url?: string;
+}
+
+@ValidatorConstraint({ name: 'isValidReplyContent', async: false })
+class IsValidReplyContent implements ValidatorConstraintInterface {
+  validate(content: ReplyContentDto): boolean {
+    if (!content) return true;
+
+    const fields = [content.text, content.markdown, content.card].filter((v) => v !== undefined);
+    if (fields.length !== 1) return false;
+
+    if (content.files?.length && !content.markdown) return false;
+
+    for (const file of content.files ?? []) {
+      const sources = [file.data, file.url].filter(Boolean);
+      if (sources.length !== 1) return false;
+    }
+
+    return true;
+  }
+
+  defaultMessage(): string {
+    return 'Content must have exactly one of text, markdown, or card. Files only allowed with markdown. Each file needs exactly one of data or url.';
+  }
+}
+
+export class ReplyContentDto {
+  @IsOptional()
+  @IsString()
+  text?: string;
+
+  @IsOptional()
+  @IsString()
+  markdown?: string;
+
+  @IsOptional()
+  @IsObject()
+  card?: Record<string, unknown>;
+
+  @IsOptional()
+  @IsArray()
+  files?: FileRef[];
+}
 
 export class HandleAgentReplyCommand extends EnvironmentWithUserCommand {
   @IsString()
@@ -15,12 +74,16 @@ export class HandleAgentReplyCommand extends EnvironmentWithUserCommand {
   integrationIdentifier: string;
 
   @IsOptional()
-  @IsObject()
-  reply?: { text: string };
+  @ValidateNested()
+  @Type(() => ReplyContentDto)
+  @Validate(IsValidReplyContent)
+  reply?: ReplyContentDto;
 
   @IsOptional()
-  @IsObject()
-  update?: { text: string };
+  @ValidateNested()
+  @Type(() => ReplyContentDto)
+  @Validate(IsValidReplyContent)
+  update?: ReplyContentDto;
 
   @IsOptional()
   @IsObject()

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -14,7 +14,8 @@ import { AgentCredentialService } from '../../services/agent-credential.service'
 import { AgentConversationService } from '../../services/agent-conversation.service';
 import { BridgeExecutorService } from '../../services/bridge-executor.service';
 import { ChatSdkService } from '../../services/chat-sdk.service';
-import { HandleAgentReplyCommand, type ReplyContentDto } from './handle-agent-reply.command';
+import type { ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
+import { HandleAgentReplyCommand } from './handle-agent-reply.command';
 
 @Injectable()
 export class HandleAgentReply {

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -14,7 +14,7 @@ import { AgentCredentialService } from '../../services/agent-credential.service'
 import { AgentConversationService } from '../../services/agent-conversation.service';
 import { BridgeExecutorService } from '../../services/bridge-executor.service';
 import { ChatSdkService } from '../../services/chat-sdk.service';
-import { HandleAgentReplyCommand } from './handle-agent-reply.command';
+import { HandleAgentReplyCommand, type ReplyContentDto } from './handle-agent-reply.command';
 
 @Injectable()
 export class HandleAgentReply {
@@ -52,13 +52,13 @@ export class HandleAgentReply {
     const channel = this.getPrimaryChannel(conversation);
 
     if (command.update) {
-      await this.deliverMessage(command, conversation, channel, command.update.text, ConversationActivityTypeEnum.UPDATE);
+      await this.deliverMessage(command, conversation, channel, command.update, ConversationActivityTypeEnum.UPDATE);
 
       return { status: 'update_sent' };
     }
 
     if (command.reply) {
-      await this.deliverMessage(command, conversation, channel, command.reply.text, ConversationActivityTypeEnum.MESSAGE);
+      await this.deliverMessage(command, conversation, channel, command.reply, ConversationActivityTypeEnum.MESSAGE);
     }
 
     if (command.signals?.length) {
@@ -85,16 +85,18 @@ export class HandleAgentReply {
     command: HandleAgentReplyCommand,
     conversation: ConversationEntity,
     channel: ConversationChannel,
-    text: string,
+    content: ReplyContentDto,
     type: ConversationActivityTypeEnum
   ): Promise<void> {
+    const textFallback = this.extractTextFallback(content);
+
     await Promise.all([
       this.chatSdkService.postToConversation(
         conversation._agentId,
         command.integrationIdentifier,
         channel.platform,
         channel.serializedThread!,
-        text
+        content
       ),
       this.activityRepository.createAgentActivity({
         identifier: `act-${shortId(8)}`,
@@ -103,7 +105,8 @@ export class HandleAgentReply {
         integrationId: channel._integrationId,
         platformThreadId: channel.platformThreadId,
         agentId: command.agentIdentifier,
-        content: text,
+        content: textFallback,
+        richContent: (content.card || content.files?.length) ? (content as Record<string, unknown>) : undefined,
         type,
         environmentId: command.environmentId,
         organizationId: command.organizationId,
@@ -112,9 +115,21 @@ export class HandleAgentReply {
         command.environmentId,
         command.organizationId,
         conversation._id,
-        text
+        textFallback
       ),
     ]);
+  }
+
+  private extractTextFallback(content: ReplyContentDto): string {
+    if (content.text) return content.text;
+    if (content.markdown) return content.markdown;
+    if (content.card) {
+      const title = (content.card as { title?: string }).title;
+
+      return title ?? '[Card]';
+    }
+
+    return '';
   }
 
   private async executeSignals(

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.entity.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.entity.ts
@@ -56,6 +56,9 @@ export class ConversationActivityEntity {
   /** Platform-native message ID (e.g. Slack ts) — used for deduplication */
   platformMessageId?: string;
 
+  /** Structured content for markdown, card, or file messages — absent for plain text */
+  richContent?: Record<string, unknown>;
+
   /** Populated only when type === SIGNAL */
   signalData?: ConversationActivitySignalData;
 

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
@@ -70,6 +70,7 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
     platformThreadId: string;
     agentId: string;
     content: string;
+    richContent?: Record<string, unknown>;
     type?: ConversationActivityTypeEnum;
     senderName?: string;
     environmentId: string;
@@ -85,6 +86,7 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
       senderType: ConversationActivitySenderTypeEnum.AGENT,
       senderId: params.agentId,
       content: params.content,
+      richContent: params.richContent,
       senderName: params.senderName,
       _environmentId: params.environmentId,
       _organizationId: params.organizationId,

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.schema.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.schema.ts
@@ -54,6 +54,9 @@ const conversationActivitySchema = new Schema<ConversationActivityDBModel>(
     senderName: {
       type: Schema.Types.String,
     },
+    richContent: {
+      type: Schema.Types.Mixed,
+    },
     signalData: {
       type: Schema.Types.Mixed,
     },

--- a/packages/framework/jsx-runtime/package.json
+++ b/packages/framework/jsx-runtime/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "../dist/cjs/jsx-runtime.cjs"
+}

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -26,6 +26,7 @@
     "remix",
     "step-resolver",
     "sveltekit",
+    "jsx-runtime",
     "validators",
     "README.md"
   ],
@@ -71,6 +72,16 @@
       "import": {
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
+      }
+    },
+    "./jsx-runtime": {
+      "require": {
+        "types": "./dist/cjs/jsx-runtime.d.cts",
+        "default": "./dist/cjs/jsx-runtime.cjs"
+      },
+      "import": {
+        "types": "./dist/esm/jsx-runtime.d.ts",
+        "default": "./dist/esm/jsx-runtime.js"
       }
     },
     "./express": {
@@ -252,6 +263,7 @@
     "zod-to-json-schema": "^3.23.3"
   },
   "dependencies": {
+    "chat": "^4.25.0",
     "ajv": "^8.18.0",
     "ajv-formats": "^2.1.1",
     "better-ajv-errors": "^1.2.0",

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -301,6 +301,10 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
       if (registeredAgent.handlers.onResolve) {
         await registeredAgent.handlers.onResolve(ctx);
       }
+    } else if (event === AgentEventEnum.ON_ACTION) {
+      if (registeredAgent.handlers.onAction) {
+        await registeredAgent.handlers.onAction(ctx);
+      }
     } else if (event === AgentEventEnum.ON_MESSAGE) {
       await registeredAgent.handlers.onMessage(ctx);
     } else {

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -6,7 +6,12 @@ export type {
   Agent,
   AgentContext,
   AgentHandlers,
+  CardElement,
+  CardChild,
+  FileRef,
+  MessageContent,
 } from './resources';
+export { Card, Button, CardText, TextInput, Select, SelectOption, Divider, CardLink } from './resources';
 export type {
   AnyStepResolver,
   ChatStepResolver,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -11,7 +11,7 @@ export type {
   FileRef,
   MessageContent,
 } from './resources';
-export { Card, Button, CardText, TextInput, Select, SelectOption, Divider, CardLink } from './resources';
+export { Actions, Card, Button, CardText, TextInput, Select, SelectOption, Divider, CardLink } from './resources';
 export type {
   AnyStepResolver,
   ChatStepResolver,

--- a/packages/framework/src/jsx-runtime.ts
+++ b/packages/framework/src/jsx-runtime.ts
@@ -1,0 +1,2 @@
+export type { JSX } from 'chat/jsx-runtime';
+export { Fragment, jsx, jsxDEV, jsxs } from 'chat/jsx-runtime';

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -25,12 +25,16 @@ function toWireContent(content: MessageContent): WireContent {
     return { card: content };
   }
 
-  const wire: WireContent = { markdown: content.markdown };
-  if (content.files?.length) {
-    wire.files = content.files;
+  if ('markdown' in content && typeof content.markdown === 'string') {
+    const wire: WireContent = { markdown: content.markdown };
+    if (content.files?.length) {
+      wire.files = content.files;
+    }
+
+    return wire;
   }
 
-  return wire;
+  throw new Error('Invalid message content — expected string, { markdown }, or CardElement');
 }
 
 export class AgentContextImpl implements AgentContext {

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -8,15 +8,15 @@ import type {
   AgentReplyPayload,
   AgentSubscriber,
   MessageContent,
+  ReplyContent,
   Signal,
-  WireContent,
 } from './agent.types';
 
 function isCardElement(content: object): content is import('chat').CardElement {
   return 'type' in content && (content as { type: string }).type === 'card';
 }
 
-function toWireContent(content: MessageContent): WireContent {
+function serializeContent(content: MessageContent): ReplyContent {
   if (typeof content === 'string') {
     return { text: content };
   }
@@ -26,12 +26,12 @@ function toWireContent(content: MessageContent): WireContent {
   }
 
   if ('markdown' in content && typeof content.markdown === 'string') {
-    const wire: WireContent = { markdown: content.markdown };
+    const result: ReplyContent = { markdown: content.markdown };
     if (content.files?.length) {
-      wire.files = content.files;
+      result.files = content.files;
     }
 
-    return wire;
+    return result;
   }
 
   throw new Error('Invalid message content — expected string, { markdown }, or CardElement');
@@ -80,7 +80,7 @@ export class AgentContextImpl implements AgentContext {
     const body: AgentReplyPayload = {
       conversationId: this._conversationId,
       integrationIdentifier: this._integrationIdentifier,
-      reply: toWireContent(content),
+      reply: serializeContent(content),
     };
 
     if (this._signals.length) {
@@ -100,7 +100,7 @@ export class AgentContextImpl implements AgentContext {
     const body: AgentReplyPayload = {
       conversationId: this._conversationId,
       integrationIdentifier: this._integrationIdentifier,
-      update: toWireContent(content),
+      update: serializeContent(content),
     };
 
     await this._post(body);

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -7,8 +7,31 @@ import type {
   AgentPlatformContext,
   AgentReplyPayload,
   AgentSubscriber,
+  MessageContent,
   Signal,
+  WireContent,
 } from './agent.types';
+
+function isCardElement(content: object): content is import('chat').CardElement {
+  return 'type' in content && (content as { type: string }).type === 'card';
+}
+
+function toWireContent(content: MessageContent): WireContent {
+  if (typeof content === 'string') {
+    return { text: content };
+  }
+
+  if (isCardElement(content)) {
+    return { card: content };
+  }
+
+  const wire: WireContent = { markdown: content.markdown };
+  if (content.files?.length) {
+    wire.files = content.files;
+  }
+
+  return wire;
+}
 
 export class AgentContextImpl implements AgentContext {
   readonly event: string;
@@ -49,11 +72,11 @@ export class AgentContextImpl implements AgentContext {
     };
   }
 
-  async reply(text: string): Promise<void> {
+  async reply(content: MessageContent): Promise<void> {
     const body: AgentReplyPayload = {
       conversationId: this._conversationId,
       integrationIdentifier: this._integrationIdentifier,
-      reply: { text },
+      reply: toWireContent(content),
     };
 
     if (this._signals.length) {
@@ -69,11 +92,11 @@ export class AgentContextImpl implements AgentContext {
     await this._post(body);
   }
 
-  async update(text: string): Promise<void> {
+  async update(content: MessageContent): Promise<void> {
     const body: AgentReplyPayload = {
       conversationId: this._conversationId,
       integrationIdentifier: this._integrationIdentifier,
-      update: { text },
+      update: toWireContent(content),
     };
 
     await this._post(body);

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentAction,
   AgentBridgeRequest,
   AgentContext,
   AgentConversation,
@@ -39,6 +40,7 @@ function serializeContent(content: MessageContent): ReplyContent {
 
 export class AgentContextImpl implements AgentContext {
   readonly event: string;
+  readonly action: AgentAction | null;
   readonly message: AgentMessage | null;
   readonly conversation: AgentConversation;
   readonly subscriber: AgentSubscriber | null;
@@ -57,6 +59,7 @@ export class AgentContextImpl implements AgentContext {
 
   constructor(request: AgentBridgeRequest, secretKey: string) {
     this.event = request.event;
+    this.action = request.action ?? null;
     this.message = request.message;
     this.conversation = request.conversation;
     this.subscriber = request.subscriber;

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -1,9 +1,9 @@
-import { Button, Card, CardText } from 'chat';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Client } from '../../client';
 import { PostActionEnum } from '../../constants';
 import { NovuRequestHandler } from '../../handler';
+import { Card, CardText, Button } from './index';
 import { agent } from './agent.resource';
 import type { AgentBridgeRequest } from './agent.types';
 

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -1,3 +1,4 @@
+import { Button, Card, CardText } from 'chat';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Client } from '../../client';
@@ -66,7 +67,11 @@ describe('agent dispatch via NovuRequestHandler', () => {
 
   beforeEach(() => {
     client = new Client({ secretKey: 'test-secret-key', strictAuthentication: false });
-    fetchMock = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('{}'), json: () => Promise.resolve({ status: 'ok' }) });
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('{}'),
+      json: () => Promise.resolve({ status: 'ok' }),
+    });
     global.fetch = fetchMock as typeof fetch;
   });
 
@@ -127,7 +132,9 @@ describe('agent dispatch via NovuRequestHandler', () => {
       agents: [],
       client,
       handler: () => {
-        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=unknown-bot&event=onMessage`);
+        const url = new URL(
+          `http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=unknown-bot&event=onMessage`
+        );
 
         return {
           body: () => ({}),
@@ -319,5 +326,217 @@ describe('agent dispatch via NovuRequestHandler', () => {
     expect(capturedCtx.platform).toBe('slack');
     expect(capturedCtx.platformContext.threadId).toBe('t1');
     expect(capturedCtx.history).toEqual([]);
+  });
+
+  it('should serialize markdown content on reply', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        await ctx.reply({ markdown: '**bold** text' });
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+
+    expect(replyBody.reply.markdown).toBe('**bold** text');
+    expect(replyBody.reply.text).toBeUndefined();
+    expect(replyBody.reply.card).toBeUndefined();
+  });
+
+  it('should serialize markdown with file attachments', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        await ctx.reply({
+          markdown: 'Here is the report',
+          files: [{ filename: 'report.pdf', url: 'https://example.com/report.pdf' }],
+        });
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+
+    expect(replyBody.reply.markdown).toBe('Here is the report');
+    expect(replyBody.reply.files).toHaveLength(1);
+    expect(replyBody.reply.files[0]).toEqual({ filename: 'report.pdf', url: 'https://example.com/report.pdf' });
+  });
+
+  it('should serialize CardElement on reply', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        await ctx.reply(
+          Card({
+            title: 'Order #123',
+            children: [
+              CardText({ children: ['Your order is ready'] }),
+              Button({ id: 'confirm', label: 'Confirm', style: 'primary' }),
+            ],
+          })
+        );
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+
+    expect(replyBody.reply.card).toBeDefined();
+    expect(replyBody.reply.card.type).toBe('card');
+    expect(replyBody.reply.card.title).toBe('Order #123');
+    expect(replyBody.reply.card.children).toHaveLength(2);
+    expect(replyBody.reply.card.children[1].type).toBe('button');
+    expect(replyBody.reply.card.children[1].id).toBe('confirm');
+    expect(replyBody.reply.text).toBeUndefined();
+    expect(replyBody.reply.markdown).toBeUndefined();
+  });
+
+  it('should serialize CardElement on update', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        await ctx.update(Card({ title: 'Loading...', children: [] }));
+        await ctx.reply('Done');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2));
+
+    const replyCalls = fetchMock.mock.calls.filter(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const parsedBodies = replyCalls.map(([, init]: any[]) => JSON.parse(init.body));
+
+    const updateBody = parsedBodies.find((body: any) => body.update);
+    expect(updateBody.update.card).toBeDefined();
+    expect(updateBody.update.card.type).toBe('card');
+    expect(updateBody.update.card.title).toBe('Loading...');
+
+    const replyBody = parsedBodies.find((body: any) => body.reply);
+    expect(replyBody.reply.text).toBe('Done');
+  });
+
+  it('should batch signals with card reply', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        ctx.metadata.set('intent', 'order_confirm');
+        await ctx.reply(Card({ title: 'Confirm?', children: [Button({ id: 'yes', label: 'Yes', style: 'primary' })] }));
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+
+    expect(replyBody.reply.card.type).toBe('card');
+    expect(replyBody.signals).toHaveLength(1);
+    expect(replyBody.signals[0]).toEqual({ type: 'metadata', key: 'intent', value: 'order_confirm' });
   });
 });

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -415,7 +415,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
           Card({
             title: 'Order #123',
             children: [
-              CardText({ children: ['Your order is ready'] }),
+              CardText('Your order is ready'),
               Button({ id: 'confirm', label: 'Confirm', style: 'primary' }),
             ],
           })

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -17,6 +17,7 @@ function createMockBridgeRequest(overrides?: Partial<AgentBridgeRequest>): Agent
     replyUrl: 'https://api.novu.co/v1/agents/test-bot/reply',
     conversationId: 'conv-456',
     integrationIdentifier: 'slack-main',
+    action: null,
     message: {
       text: 'Hello bot!',
       platformMessageId: 'msg-789',
@@ -538,5 +539,118 @@ describe('agent dispatch via NovuRequestHandler', () => {
     expect(replyBody.reply.card.type).toBe('card');
     expect(replyBody.signals).toHaveLength(1);
     expect(replyBody.signals[0]).toEqual({ type: 'metadata', key: 'intent', value: 'order_confirm' });
+  });
+
+  it('should dispatch onAction event with action data on ctx', async () => {
+    let capturedCtx: any;
+
+    const testBot = agent('test-bot', {
+      onMessage: async () => {},
+      onAction: async (ctx) => {
+        capturedCtx = ctx;
+        await ctx.reply('Action received');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest({
+          event: 'onAction',
+          action: { actionId: 'confirm', value: 'yes' },
+          message: null,
+        });
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onAction`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(capturedCtx).toBeDefined());
+
+    expect(capturedCtx.event).toBe('onAction');
+    expect(capturedCtx.action).toEqual({ actionId: 'confirm', value: 'yes' });
+    expect(capturedCtx.message).toBeNull();
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+    expect(replyBody.reply.text).toBe('Action received');
+  });
+
+  it('should have null action on onMessage events', async () => {
+    let capturedCtx: any;
+
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        capturedCtx = ctx;
+        await ctx.reply('ok');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(capturedCtx).toBeDefined());
+
+    expect(capturedCtx.action).toBeNull();
+  });
+
+  it('should silently skip onAction when no handler registered', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async () => {},
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest({
+          event: 'onAction',
+          action: { actionId: 'btn-1' },
+          message: null,
+        });
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onAction`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    const result = await handler.createHandler()();
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body).status).toBe('ack');
   });
 });

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -2,6 +2,7 @@ import type { CardElement } from 'chat';
 
 export enum AgentEventEnum {
   ON_MESSAGE = 'onMessage',
+  ON_ACTION = 'onAction',
   ON_RESOLVE = 'onResolve',
 }
 
@@ -91,12 +92,19 @@ export interface ReplyContent {
   files?: FileRef[];
 }
 
+export interface AgentAction {
+  actionId: string;
+  value?: string;
+  metadata?: Record<string, unknown>;
+}
+
 // ---------------------------------------------------------------------------
 // Context + handlers
 // ---------------------------------------------------------------------------
 
 export interface AgentContext {
   readonly event: string;
+  readonly action: AgentAction | null;
   readonly message: AgentMessage | null;
   readonly conversation: AgentConversation;
   readonly subscriber: AgentSubscriber | null;
@@ -115,6 +123,7 @@ export interface AgentContext {
 
 export interface AgentHandlers {
   onMessage: (ctx: AgentContext) => Promise<void>;
+  onAction?: (ctx: AgentContext) => Promise<void>;
   onResolve?: (ctx: AgentContext) => Promise<void>;
 }
 
@@ -136,6 +145,7 @@ export interface AgentBridgeRequest {
   replyUrl: string;
   conversationId: string;
   integrationIdentifier: string;
+  action: AgentAction | null;
   message: AgentMessage | null;
   conversation: AgentConversation;
   subscriber: AgentSubscriber | null;

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -1,4 +1,4 @@
-import type { CardElement } from 'chat';
+import type { CardElement, ChatElement } from 'chat';
 
 export enum AgentEventEnum {
   ON_MESSAGE = 'onMessage',
@@ -77,12 +77,13 @@ export interface FileRef {
  *
  * - `string` — plain text
  * - `{ markdown, files? }` — markdown-formatted text, optionally with file attachments
- * - `CardElement` — interactive card built with Card(), Button(), etc.
+ * - `ChatElement` — interactive card built with Card(), Button(), etc.
+ *   (must be a CardElement at runtime; validated by serializeContent)
  */
 export type MessageContent =
   | string
   | { markdown: string; files?: FileRef[] }
-  | CardElement;
+  | ChatElement;
 
 /** Normalized content shape sent over HTTP to the reply endpoint. */
 export interface ReplyContent {
@@ -95,7 +96,6 @@ export interface ReplyContent {
 export interface AgentAction {
   actionId: string;
   value?: string;
-  metadata?: Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -83,8 +83,8 @@ export type MessageContent =
   | { markdown: string; files?: FileRef[] }
   | CardElement;
 
-/** Serialized content shape that travels over HTTP to the reply endpoint. */
-export interface WireContent {
+/** Normalized content shape sent over HTTP to the reply endpoint. */
+export interface ReplyContent {
   text?: string;
   markdown?: string;
   card?: CardElement;
@@ -151,8 +151,8 @@ export type Signal = MetadataSignal | TriggerSignal;
 export interface AgentReplyPayload {
   conversationId: string;
   integrationIdentifier: string;
-  reply?: WireContent;
-  update?: WireContent;
+  reply?: ReplyContent;
+  update?: ReplyContent;
   resolve?: { summary?: string };
   signals?: Signal[];
 }

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -1,3 +1,5 @@
+import type { CardElement } from 'chat';
+
 export enum AgentEventEnum {
   ON_MESSAGE = 'onMessage',
   ON_RESOLVE = 'onResolve',
@@ -56,6 +58,43 @@ export interface AgentPlatformContext {
   isDM: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Rich content types
+// ---------------------------------------------------------------------------
+
+export interface FileRef {
+  filename: string;
+  mimeType?: string;
+  /** Base64-encoded file data (< 1 MB decoded) */
+  data?: string;
+  /** Publicly-accessible HTTPS URL */
+  url?: string;
+}
+
+/**
+ * Content accepted by ctx.reply() and ctx.update().
+ *
+ * - `string` — plain text
+ * - `{ markdown, files? }` — markdown-formatted text, optionally with file attachments
+ * - `CardElement` — interactive card built with Card(), Button(), etc.
+ */
+export type MessageContent =
+  | string
+  | { markdown: string; files?: FileRef[] }
+  | CardElement;
+
+/** Serialized content shape that travels over HTTP to the reply endpoint. */
+export interface WireContent {
+  text?: string;
+  markdown?: string;
+  card?: CardElement;
+  files?: FileRef[];
+}
+
+// ---------------------------------------------------------------------------
+// Context + handlers
+// ---------------------------------------------------------------------------
+
 export interface AgentContext {
   readonly event: string;
   readonly message: AgentMessage | null;
@@ -65,8 +104,8 @@ export interface AgentContext {
   readonly platform: string;
   readonly platformContext: AgentPlatformContext;
 
-  reply(text: string): Promise<void>;
-  update(text: string): Promise<void>;
+  reply(content: MessageContent): Promise<void>;
+  update(content: MessageContent): Promise<void>;
   resolve(summary?: string): void;
   metadata: {
     set(key: string, value: unknown): void;
@@ -112,8 +151,8 @@ export type Signal = MetadataSignal | TriggerSignal;
 export interface AgentReplyPayload {
   conversationId: string;
   integrationIdentifier: string;
-  reply?: { text: string };
-  update?: { text: string };
+  reply?: WireContent;
+  update?: WireContent;
   resolve?: { summary?: string };
   signals?: Signal[];
 }

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -2,6 +2,7 @@ export { AgentContextImpl } from './agent.context';
 export { agent } from './agent.resource';
 export type {
   Agent,
+  AgentAction,
   AgentBridgeRequest,
   AgentContext,
   AgentConversation,

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -14,7 +14,7 @@ export type {
   AgentSubscriber,
   FileRef,
   MessageContent,
-  WireContent,
+  ReplyContent,
 } from './agent.types';
 export { AgentEventEnum } from './agent.types';
 

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -19,8 +19,9 @@ export type {
 } from './agent.types';
 export { AgentEventEnum } from './agent.types';
 
-export { Card, Button, CardText, TextInput, Select, SelectOption, Divider, CardLink } from 'chat';
+export { Actions, Card, Button, CardText, TextInput, Select, SelectOption, Divider, CardLink } from 'chat';
 export type {
+  ActionsElement,
   CardElement,
   CardChild,
   TextElement,

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -12,5 +12,21 @@ export type {
   AgentPlatformContext,
   AgentReplyPayload,
   AgentSubscriber,
+  FileRef,
+  MessageContent,
+  WireContent,
 } from './agent.types';
 export { AgentEventEnum } from './agent.types';
+
+export { Card, Button, CardText, TextInput, Select, SelectOption, Divider, CardLink } from 'chat';
+export type {
+  CardElement,
+  CardChild,
+  TextElement,
+  ButtonElement,
+  TextInputElement,
+  SelectElement,
+  SelectOptionElement,
+  DividerElement,
+  LinkElement,
+} from 'chat';

--- a/packages/framework/tsup.config.ts
+++ b/packages/framework/tsup.config.ts
@@ -7,6 +7,7 @@ const frameworks: SupportedFrameworkName[] = ['h3', 'express', 'next', 'nuxt', '
 const baseConfig: Options = {
   entry: [
     'src/index.ts',
+    'src/jsx-runtime.ts',
     'src/internal/index.ts',
     'src/step-resolver.ts',
     'src/validators.ts',

--- a/packages/framework/tsup.config.ts
+++ b/packages/framework/tsup.config.ts
@@ -20,6 +20,7 @@ const baseConfig: Options = {
   minifyWhitespace: true,
   minifyIdentifiers: true,
   minifySyntax: true,
+  noExternal: ['chat'],
   define: {
     SDK_VERSION: `"${version}"`,
     FRAMEWORK_VERSION: `"2024-06-26"`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3311,6 +3311,9 @@ importers:
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
+      chat:
+        specifier: ^4.25.0
+        version: 4.25.0
       cross-fetch:
         specifier: ^4.0.0
         version: 4.0.0(encoding@0.1.13)


### PR DESCRIPTION
## Summary

- **Rich content replies**: Agents can now reply with interactive cards (`Card`, `Button`, `Actions`, `Select`, `Divider`, `CardLink`), markdown with tables/formatting, and plain text via `ctx.reply()`
- **onAction handler**: Slack button clicks and select changes are routed through `chat.onAction()` → API inbound handler → bridge executor → framework `onAction` handler, with `ctx.action.actionId` and `ctx.action.value` populated
- **CJS compatibility**: Bundle `chat` SDK into the framework CJS output (`noExternal: ['chat']` in tsup) to fix ESM-only `ERR_PACKAGE_PATH_NOT_EXPORTED` error at runtime
- **Validation consolidation**: `ReplyContentDto` with `IsValidReplyContent` custom validator now lives in the DTO layer, enforcing one-of text/markdown/card constraint and file source validation at the HTTP boundary

### Data flow

```mermaid
sequenceDiagram
    participant Slack
    participant API as Novu API
    participant Bridge as Agent Handler
    
    Note over Slack,Bridge: Card Reply Flow
    Slack->>API: @mention "incident"
    API->>Bridge: bridge call (onMessage)
    Bridge->>API: POST /reply { card: CardElement }
    API->>Slack: Block Kit card with buttons
    
    Note over Slack,Bridge: onAction Flow
    Slack->>API: button click (interactivity)
    API->>API: chat.onAction → inbound handler
    API->>Bridge: bridge call (onAction, actionId, value)
    Bridge->>API: POST /reply (response card/text)
    API->>Slack: response message
```

### Changed files

| Area | Files | What |
|------|-------|------|
| Framework SDK | `tsup.config.ts` | `noExternal: ['chat']` bundles chat into CJS |
| Framework SDK | `agent.types.ts` | Remove unused `metadata` from `AgentAction` |
| Framework SDK | `index.ts`, `agent/index.ts` | Re-export `Actions` + `ActionsElement` from chat |
| Framework SDK | `agent.test.ts` | Fix `CardText` call signature (string, not array) |
| API | `agent-event.enum.ts` | Add `ON_ACTION = 'onAction'` |
| API | `agent-reply-payload.dto.ts` | Replace `TextContentDto` with `ReplyContentDto` supporting text/markdown/card/files |
| API | `handle-agent-reply.command.ts` | Import `ReplyContentDto` from DTO, remove re-export |
| API | `handle-agent-reply.usecase.ts` | Import `ReplyContentDto` directly from DTO |
| API | `bridge-executor.service.ts` | Add `BridgeAction` type and `action` field to bridge request |
| API | `agent-inbound-handler.service.ts` | Add `handleAction()` for routing action events |
| API | `chat-sdk.service.ts` | Register `chat.onAction()`, import DTO directly |
| API | `mock-agent-handler.ts` | Full showcase: incident card, onAction responses, markdown tables |

## Test plan

- [x] Send "card" in Slack → simple order card with buttons renders
- [x] Send "incident" in Slack → full incident card with text, dividers, select, buttons, link renders
- [x] Send "markdown" in Slack → markdown with table and blockquote renders
- [x] Click "Acknowledge" button → onAction fires, response card posted
- [x] Click "Escalate" button → onAction fires, markdown response posted
- [x] Use select dropdown → onAction fires with selected value
- [x] Plain text echo still works
- [x] Framework build passes (`check:exports` all green, no circular deps)
- [ ] API E2E tests pass


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the agent bridge contract and reply payload validation, adds a new action event path, and extends persisted conversation activity schema with `richContent`, which could affect integrations and stored data shape.
> 
> **Overview**
> **Agents can now send rich replies and handle interactive actions.** The agent reply/update payload is expanded from plain `text` to `ReplyContentDto` supporting exactly-one-of `text`/`markdown`/`card` plus optional markdown file refs (validated at the API boundary), and message delivery now posts cards/markdown appropriately.
> 
> **Interactive card actions are now first-class.** A new `onAction` event is added end-to-end: chat `onAction` events are routed through a new inbound handler (`handleAction`), included in bridge payloads (`action: { actionId, value }`), exposed on `ctx.action`, and dispatched by the framework handler when an agent registers `onAction`.
> 
> **Conversation history storage is extended for rich messages and SDK packaging is adjusted.** Conversation activities gain optional `richContent` to persist structured payloads alongside a text fallback, the framework re-exports card helpers and adds a `./jsx-runtime` export, and the CJS build bundles `chat` (`noExternal: ['chat']`) to avoid runtime export/ESM issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 956705ebf7e06db58d7617665ff1495b1395f22a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR adds rich content reply support and action handlers for agent cards. Agents can now respond to Slack interactions with interactive cards (Card, Button, Actions, Select, Divider, CardLink), markdown with tables and formatting, and plain text. A new `onAction` flow routes Slack button clicks and select changes through the API to the framework's `onAction` handler, with action context fields (`actionId`, `value`) available via `ctx.action`.

## Affected areas

**api**: Added `ReplyContentDto` with `IsValidReplyContent` validator to enforce one-of constraints (text/markdown/card) and file validation at the HTTP boundary. Implemented `handleAction` method in `AgentInboundHandler` to route actions to the bridge executor. Extended `BridgeAction` type to carry action metadata and updated `ChatSdkService` to dispatch `chat.onAction` events. Added `ON_ACTION` to `AgentEventEnum` and persisted `richContent` in conversation activities.

**framework**: Extended `AgentContext` to expose `action: AgentAction | null` and changed `reply`/`update` methods to accept `MessageContent` (string, markdown, or card). Added `onAction` handler to `AgentHandlers` interface and event routing in `NovuRequestHandler`. Re-exported chat SDK card components (`Card`, `Button`, `Actions`, `Select`, `Divider`, `CardLink`) and element types. Added `jsx-runtime` as a subpath export.

**dal**: Added optional `richContent: Record<string, unknown>` field to `ConversationActivityEntity` and schema to store structured content (cards, markdown, files).

**package.json**: Added `chat` dependency (`^4.25.0`) and `jsx-runtime` export subpath. Updated tsup config to bundle chat SDK into framework CJS output (`noExternal: ['chat']`).

## Key technical decisions

- Validation consolidated in DTO layer (`ReplyContentDto` with `IsValidReplyContent`) to enforce constraints at the HTTP boundary rather than in the executor.
- Chat SDK bundled into framework CJS output to address ESM-only runtime export errors in certain environments.
- `MessageContent` type unions `string` (plain text), objects with `markdown` and optional `files`, and `CardElement` types to support multiple reply formats through a single interface.
- Bridge protocol extended with `BridgeAction` type to propagate `actionId` and optional `value` from Slack interactions to framework handlers.

## Testing

Unit tests added for serialization behavior in framework and re-exports validation. Mock agent handler extended with card, markdown, and `onAction` examples demonstrating action routing. Manual/interactive tests verify card replies, incident cards, markdown tables, and select values. Framework build checks pass; API E2E tests pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->