### PR TITLE
feat(api-service,framework): agent onReaction event fixes NV-7370

### DIFF
--- a/apps/api/src/app/agents/dtos/agent-event.enum.ts
+++ b/apps/api/src/app/agents/dtos/agent-event.enum.ts
@@ -2,4 +2,5 @@ export enum AgentEventEnum {
   ON_MESSAGE = 'onMessage',
   ON_ACTION = 'onAction',
   ON_RESOLVE = 'onResolve',
+  ON_REACTION = 'onReaction',
 }

--- a/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
@@ -7,7 +7,7 @@ import {
 import { testServer } from '@novu/testing';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { AgentInboundHandler } from '../services/agent-inbound-handler.service';
+import { AgentInboundHandler, InboundReactionEvent } from '../services/agent-inbound-handler.service';
 import { BridgeExecutorService, BridgeExecutorParams } from '../services/bridge-executor.service';
 import { AgentConfigResolver } from '../services/agent-config-resolver.service';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
@@ -357,6 +357,121 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
         (p) => p.type === ConversationParticipantTypeEnum.PLATFORM_USER && p.id === 'slack:U_LATER'
       );
       expect(remainingPlatformUsers.length).to.equal(0);
+    });
+  });
+
+  describe('Reaction handling', () => {
+    async function invokeReaction(threadId: string, reaction: InboundReactionEvent) {
+      const config = await configResolver.resolve(ctx.agentId, ctx.integrationIdentifier);
+      await inboundHandler.handleReaction(ctx.agentId, config, reaction);
+    }
+
+    it('should fire ON_REACTION bridge call for an existing conversation', async () => {
+      const threadId = `T_REACT_${Date.now()}`;
+      const msg = mockMessage({ userId: 'U_REACT', text: 'React to this' });
+
+      await invokeInbound(threadId, msg);
+      bridgeCalls = [];
+
+      const reactionEvent: InboundReactionEvent = {
+        emoji: { name: 'thumbs_up' },
+        added: true,
+        messageId: msg.id,
+        message: msg as any,
+        thread: mockThread(threadId) as any,
+      };
+
+      await invokeReaction(threadId, reactionEvent);
+
+      expect(bridgeCalls.length).to.equal(1);
+      const call = bridgeCalls[0];
+      expect(call.event).to.equal(AgentEventEnum.ON_REACTION);
+      expect(call.reaction).to.exist;
+      expect(call.reaction!.emoji).to.equal('thumbs_up');
+      expect(call.reaction!.added).to.equal(true);
+      expect(call.reaction!.messageId).to.equal(msg.id);
+    });
+
+    it('should skip reaction when no conversation exists for the thread', async () => {
+      const reactionEvent: InboundReactionEvent = {
+        emoji: { name: 'wave' },
+        added: true,
+        messageId: 'msg-orphan',
+        thread: mockThread(`T_NOCONV_${Date.now()}`) as any,
+      };
+
+      await invokeReaction('ignored', reactionEvent);
+
+      expect(bridgeCalls.length).to.equal(0);
+    });
+
+    it('should skip reaction when thread context is missing', async () => {
+      const reactionEvent: InboundReactionEvent = {
+        emoji: { name: 'fire' },
+        added: false,
+        messageId: 'msg-no-thread',
+      };
+
+      await invokeReaction('ignored', reactionEvent);
+
+      expect(bridgeCalls.length).to.equal(0);
+    });
+
+    it('should include sourceMessage in reaction bridge call', async () => {
+      const threadId = `T_REACT_MSG_${Date.now()}`;
+      const msg = mockMessage({ userId: 'U_REACT_MSG', text: 'Source message test', fullName: 'Jane Doe' });
+
+      await invokeInbound(threadId, msg);
+      bridgeCalls = [];
+
+      const reactionEvent: InboundReactionEvent = {
+        emoji: { name: 'tada' },
+        added: true,
+        messageId: msg.id,
+        message: msg as any,
+        thread: mockThread(threadId) as any,
+      };
+
+      await invokeReaction(threadId, reactionEvent);
+
+      expect(bridgeCalls.length).to.equal(1);
+      const call = bridgeCalls[0];
+      expect(call.reaction!.sourceMessage).to.exist;
+      expect(call.reaction!.sourceMessage!.text).to.equal('Source message test');
+      expect(call.reaction!.sourceMessage!.author.fullName).to.equal('Jane Doe');
+    });
+
+    it('should not persist conversation activity for reactions', async () => {
+      const threadId = `T_REACT_NOACT_${Date.now()}`;
+      const msg = mockMessage({ userId: 'U_REACT2', text: 'Activity test' });
+
+      await invokeInbound(threadId, msg);
+
+      const conversation = await conversationRepository.findByPlatformThread(
+        ctx.session.environment._id,
+        ctx.session.organization._id,
+        threadId
+      );
+      const activitiesBefore = await activityRepository.findByConversation(
+        ctx.session.environment._id,
+        conversation!._id
+      );
+
+      const reactionEvent: InboundReactionEvent = {
+        emoji: { name: 'heart' },
+        added: true,
+        messageId: msg.id,
+        message: msg as any,
+        thread: mockThread(threadId) as any,
+      };
+
+      await invokeReaction(threadId, reactionEvent);
+
+      const activitiesAfter = await activityRepository.findByConversation(
+        ctx.session.environment._id,
+        conversation!._id
+      );
+      expect(activitiesAfter.length).to.equal(activitiesBefore.length);
     });
   });
 });

--- a/apps/api/src/app/agents/e2e/mock-agent-handler.ts
+++ b/apps/api/src/app/agents/e2e/mock-agent-handler.ts
@@ -128,6 +128,18 @@ const echoBot = agent('novu-agent', {
     await ctx.reply(`Echo: ${userText}`);
   },
 
+  onReaction: async (ctx) => {
+    console.log('\n─────────────────────────────────────────');
+    console.log(`[${ctx.event}] reaction: ${ctx.reaction?.emoji.name} (${ctx.reaction?.added ? 'added' : 'removed'})`);
+    console.log(`Reacted message: ${ctx.reaction?.message?.text ?? '(unavailable)'}`);
+    console.log('─────────────────────────────────────────');
+
+    const emoji = ctx.reaction?.emoji.name ?? 'unknown';
+    const added = ctx.reaction?.added ?? false;
+
+    await ctx.reply(`Got ${added ? '' : 'un'}reaction: :${emoji}:`);
+  },
+
   onAction: async (ctx) => {
     console.log('\n─────────────────────────────────────────');
     console.log(`[${ctx.event}] action: ${ctx.action?.actionId} = ${ctx.action?.value ?? '(no value)'}`);

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -8,11 +8,19 @@ import { HandleAgentReply } from '../usecases/handle-agent-reply/handle-agent-re
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
 import { AgentConversationService } from './agent-conversation.service';
 import { AgentSubscriberResolver } from './agent-subscriber-resolver.service';
-import { type BridgeAction, BridgeExecutorService, NoBridgeUrlError } from './bridge-executor.service';
+import { type BridgeAction, type BridgeReaction, BridgeExecutorService, NoBridgeUrlError } from './bridge-executor.service';
 
 const ONBOARDING_NO_BRIDGE_REPLY_MARKDOWN = `*You're connected to Novu*
 
 Your bot is linked successfully. Go back to the *Novu dashboard* to complete onboarding.`;
+
+export interface InboundReactionEvent {
+  emoji: { name: string };
+  added: boolean;
+  messageId: string;
+  message?: Message;
+  thread?: Thread;
+}
 
 @Injectable()
 export class AgentInboundHandler {
@@ -152,6 +160,76 @@ export class AgentInboundHandler {
 
       throw err;
     }
+  }
+
+  async handleReaction(
+    agentId: string,
+    config: ResolvedAgentConfig,
+    event: InboundReactionEvent
+  ): Promise<void> {
+    const threadId = event.thread?.id;
+    if (!threadId) {
+      this.logger.warn(`[agent:${agentId}] Reaction received without thread context, skipping`);
+
+      return;
+    }
+
+    const conversation = await this.conversationRepository.findByPlatformThread(
+      config.environmentId,
+      config.organizationId,
+      threadId
+    );
+
+    if (!conversation) {
+      return;
+    }
+
+    const platformUserId = event.message?.author?.userId;
+
+    const subscriberId = platformUserId
+      ? await this.subscriberResolver
+          .resolve({
+            environmentId: config.environmentId,
+            organizationId: config.organizationId,
+            platform: config.platform,
+            platformUserId,
+            integrationIdentifier: config.integrationIdentifier,
+          })
+          .catch((err) => {
+            this.logger.warn(err, `[agent:${agentId}] Subscriber resolution failed for reaction, continuing without subscriber`);
+
+            return null;
+          })
+      : null;
+
+    const [subscriber, history] = await Promise.all([
+      subscriberId
+        ? this.subscriberRepository.findBySubscriberId(config.environmentId, subscriberId)
+        : Promise.resolve(null),
+      this.conversationService.getHistory(config.environmentId, conversation._id),
+    ]);
+
+    const reaction: BridgeReaction = {
+      emoji: event.emoji.name,
+      added: event.added,
+      messageId: event.messageId,
+      sourceMessage: event.message,
+    };
+
+    await this.bridgeExecutor.execute({
+      event: AgentEventEnum.ON_REACTION,
+      config,
+      conversation,
+      subscriber,
+      history,
+      message: null,
+      platformContext: {
+        threadId,
+        channelId: event.thread?.channelId ?? '',
+        isDM: event.thread?.isDM ?? false,
+      },
+      reaction,
+    });
   }
 
   async handleAction(

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -20,6 +20,7 @@ export interface InboundReactionEvent {
   messageId: string;
   message?: Message;
   thread?: Thread;
+  user?: { userId: string; fullName?: string; userName?: string };
 }
 
 @Injectable()
@@ -184,7 +185,7 @@ export class AgentInboundHandler {
       return;
     }
 
-    const platformUserId = event.message?.author?.userId;
+    const platformUserId = event.user?.userId;
 
     const subscriberId = platformUserId
       ? await this.subscriberResolver

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -26,6 +26,13 @@ export interface BridgePlatformContext {
   isDM: boolean;
 }
 
+export interface BridgeReaction {
+  emoji: string;
+  added: boolean;
+  messageId: string;
+  sourceMessage?: Message;
+}
+
 export interface BridgeExecutorParams {
   event: AgentEventEnum;
   config: ResolvedAgentConfig;
@@ -35,6 +42,7 @@ export interface BridgeExecutorParams {
   message: Message | null;
   platformContext: BridgePlatformContext;
   action?: BridgeAction;
+  reaction?: BridgeReaction;
 }
 
 interface BridgeMessageAuthor {
@@ -85,6 +93,12 @@ interface BridgeHistoryEntry {
   createdAt: string;
 }
 
+interface BridgeReactionPayload {
+  emoji: { name: string };
+  added: boolean;
+  message: BridgeMessage | null;
+}
+
 export interface AgentBridgeRequest {
   version: 1;
   timestamp: string;
@@ -101,6 +115,7 @@ export interface AgentBridgeRequest {
   platform: string;
   platformContext: BridgePlatformContext;
   action: BridgeAction | null;
+  reaction: BridgeReactionPayload | null;
 }
 
 export class NoBridgeUrlError extends Error {
@@ -220,7 +235,7 @@ export class BridgeExecutorService {
   }
 
   private buildPayload(params: BridgeExecutorParams): AgentBridgeRequest {
-    const { event, config, conversation, subscriber, history, message, platformContext, action } = params;
+    const { event, config, conversation, subscriber, history, message, platformContext, action, reaction } = params;
     const agentIdentifier = config.agentIdentifier;
 
     const apiRootUrl = process.env.API_ROOT_URL || 'http://localhost:3000';
@@ -233,11 +248,13 @@ export class BridgeExecutorService {
       deliveryId = `${conversation._id}:${message.id}`;
     } else if (action) {
       deliveryId = `${conversation._id}:${event}:${action.actionId}:${timestamp}`;
+    } else if (reaction) {
+      deliveryId = `${conversation._id}:${event}:${reaction.messageId}:${timestamp}`;
     } else {
       deliveryId = `${conversation._id}:${event}`;
     }
 
-    return {
+    const payload: AgentBridgeRequest = {
       version: 1,
       timestamp,
       deliveryId,
@@ -253,7 +270,10 @@ export class BridgeExecutorService {
       platform: config.platform,
       platformContext,
       action: action ?? null,
+      reaction: reaction ? this.mapReaction(reaction) : null,
     };
+
+    return payload;
   }
 
   private mapMessage(message: Message): BridgeMessage {
@@ -295,6 +315,14 @@ export class BridgeExecutorService {
       avatar: subscriber.avatar || undefined,
       locale: subscriber.locale || undefined,
       data: subscriber.data || undefined,
+    };
+  }
+
+  private mapReaction(reaction: BridgeReaction): BridgeReactionPayload {
+    return {
+      emoji: { name: reaction.emoji },
+      added: reaction.added,
+      message: reaction.sourceMessage ? this.mapMessage(reaction.sourceMessage) : null,
     };
   }
 

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -94,6 +94,7 @@ interface BridgeHistoryEntry {
 }
 
 interface BridgeReactionPayload {
+  messageId: string;
   emoji: { name: string };
   added: boolean;
   message: BridgeMessage | null;
@@ -320,6 +321,7 @@ export class BridgeExecutorService {
 
   private mapReaction(reaction: BridgeReaction): BridgeReactionPayload {
     return {
+      messageId: reaction.messageId,
       emoji: { name: reaction.emoji },
       added: reaction.added,
       message: reaction.sourceMessage ? this.mapMessage(reaction.sourceMessage) : null,

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -295,5 +295,19 @@ export class ChatSdkService implements OnModuleDestroy {
         this.logger.error(err, `[agent:${agentId}] Error handling action ${event.actionId}`);
       }
     });
+
+    chat.onReaction(async (event: any) => {
+      try {
+        await this.inboundHandler.handleReaction(agentId, config, {
+          emoji: event.emoji,
+          added: event.added,
+          messageId: event.messageId,
+          message: event.message,
+          thread: event.thread,
+        });
+      } catch (err) {
+        this.logger.error(err, `[agent:${agentId}] Error handling reaction`);
+      }
+    });
   }
 }

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -304,6 +304,7 @@ export class ChatSdkService implements OnModuleDestroy {
           messageId: event.messageId,
           message: event.message,
           thread: event.thread,
+          user: event.user,
         });
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling reaction`);

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -297,18 +297,20 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
   }
 
   private async runAgentHandler(registeredAgent: Agent, event: string, ctx: AgentContextImpl): Promise<void> {
-    if (event === AgentEventEnum.ON_RESOLVE) {
-      if (registeredAgent.handlers.onResolve) {
-        await registeredAgent.handlers.onResolve(ctx);
-      }
-    } else if (event === AgentEventEnum.ON_ACTION) {
-      if (registeredAgent.handlers.onAction) {
-        await registeredAgent.handlers.onAction(ctx);
-      }
-    } else if (event === AgentEventEnum.ON_MESSAGE) {
-      await registeredAgent.handlers.onMessage(ctx);
-    } else {
+    const handlerMap: Record<string, ((ctx: AgentContextImpl) => Promise<void>) | undefined> = {
+      [AgentEventEnum.ON_MESSAGE]: registeredAgent.handlers.onMessage,
+      [AgentEventEnum.ON_REACTION]: registeredAgent.handlers.onReaction,
+      [AgentEventEnum.ON_ACTION]: registeredAgent.handlers.onAction,
+      [AgentEventEnum.ON_RESOLVE]: registeredAgent.handlers.onResolve,
+    };
+
+    if (!(event in handlerMap)) {
       throw new InvalidActionError(event, AgentEventEnum);
+    }
+
+    const handler = handlerMap[event];
+    if (handler) {
+      await handler(ctx);
     }
 
     await ctx.flush();

--- a/packages/framework/src/handler.ts
+++ b/packages/framework/src/handler.ts
@@ -297,18 +297,18 @@ export class NovuRequestHandler<Input extends any[] = any[], Output = any> {
   }
 
   private async runAgentHandler(registeredAgent: Agent, event: string, ctx: AgentContextImpl): Promise<void> {
-    const handlerMap: Record<string, ((ctx: AgentContextImpl) => Promise<void>) | undefined> = {
+    const handlerMap: Partial<Record<AgentEventEnum, (ctx: AgentContextImpl) => Promise<void>>> = {
       [AgentEventEnum.ON_MESSAGE]: registeredAgent.handlers.onMessage,
       [AgentEventEnum.ON_REACTION]: registeredAgent.handlers.onReaction,
       [AgentEventEnum.ON_ACTION]: registeredAgent.handlers.onAction,
       [AgentEventEnum.ON_RESOLVE]: registeredAgent.handlers.onResolve,
     };
 
-    if (!(event in handlerMap)) {
+    if (!Object.prototype.hasOwnProperty.call(handlerMap, event)) {
       throw new InvalidActionError(event, AgentEventEnum);
     }
 
-    const handler = handlerMap[event];
+    const handler = handlerMap[event as AgentEventEnum];
     if (handler) {
       await handler(ctx);
     }

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -6,6 +6,7 @@ export type {
   Agent,
   AgentContext,
   AgentHandlers,
+  AgentReaction,
   CardElement,
   CardChild,
   FileRef,

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -6,6 +6,7 @@ import type {
   AgentHistoryEntry,
   AgentMessage,
   AgentPlatformContext,
+  AgentReaction,
   AgentReplyPayload,
   AgentSubscriber,
   MessageContent,
@@ -42,6 +43,7 @@ export class AgentContextImpl implements AgentContext {
   readonly event: string;
   readonly action: AgentAction | null;
   readonly message: AgentMessage | null;
+  readonly reaction: AgentReaction | null;
   readonly conversation: AgentConversation;
   readonly subscriber: AgentSubscriber | null;
   readonly history: AgentHistoryEntry[];
@@ -61,6 +63,7 @@ export class AgentContextImpl implements AgentContext {
     this.event = request.event;
     this.action = request.action ?? null;
     this.message = request.message;
+    this.reaction = request.reaction;
     this.conversation = request.conversation;
     this.subscriber = request.subscriber;
     this.history = request.history;

--- a/packages/framework/src/resources/agent/agent.resource.ts
+++ b/packages/framework/src/resources/agent/agent.resource.ts
@@ -15,9 +15,5 @@ export function agent(agentId: string, handlers: AgentHandlers): Agent {
     throw new Error(`agent('${agentId}') requires an onMessage handler`);
   }
 
-  if (!handlers?.onReaction) {
-    throw new Error(`agent('${agentId}') requires an onReaction handler`);
-  }
-
   return { id: agentId, handlers };
 }

--- a/packages/framework/src/resources/agent/agent.resource.ts
+++ b/packages/framework/src/resources/agent/agent.resource.ts
@@ -15,5 +15,9 @@ export function agent(agentId: string, handlers: AgentHandlers): Agent {
     throw new Error(`agent('${agentId}') requires an onMessage handler`);
   }
 
+  if (!handlers?.onReaction) {
+    throw new Error(`agent('${agentId}') requires an onReaction handler`);
+  }
+
   return { id: agentId, handlers };
 }

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -675,6 +675,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
           event: 'onReaction',
           message: null,
           reaction: {
+            messageId: 'msg-123',
             emoji: { name: 'thumbs_up' },
             added: true,
             message: null,
@@ -717,6 +718,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
           event: 'onReaction',
           message: null,
           reaction: {
+            messageId: 'msg-reacted',
             emoji: { name: 'thumbs_up' },
             added: true,
             message: {
@@ -744,6 +746,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
 
     expect(capturedCtx.event).toBe('onReaction');
     expect(capturedCtx.reaction).toBeDefined();
+    expect(capturedCtx.reaction.messageId).toBe('msg-reacted');
     expect(capturedCtx.reaction.emoji.name).toBe('thumbs_up');
     expect(capturedCtx.reaction.added).toBe(true);
     expect(capturedCtx.reaction.message).toBeDefined();
@@ -777,6 +780,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
           event: 'onReaction',
           message: null,
           reaction: {
+            messageId: 'msg-456',
             emoji: { name: 'heart' },
             added: false,
             message: null,

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -47,23 +47,24 @@ function createMockBridgeRequest(overrides?: Partial<AgentBridgeRequest>): Agent
 
 describe('agent()', () => {
   it('should return an agent with id and handlers', () => {
-    const bot = agent('wine-bot', { onMessage: async () => {}, onReaction: async () => {} });
+    const bot = agent('wine-bot', { onMessage: async () => {} });
 
     expect(bot.id).toBe('wine-bot');
     expect(typeof bot.handlers.onMessage).toBe('function');
-    expect(typeof bot.handlers.onReaction).toBe('function');
   });
 
   it('should throw when agentId is empty', () => {
-    expect(() => agent('', { onMessage: async () => {}, onReaction: async () => {} })).toThrow('non-empty agentId');
+    expect(() => agent('', { onMessage: async () => {} })).toThrow('non-empty agentId');
   });
 
   it('should throw when onMessage is missing', () => {
-    expect(() => agent('wine-bot', { onReaction: async () => {} } as any)).toThrow('onMessage handler');
+    expect(() => agent('wine-bot', {} as any)).toThrow('onMessage handler');
   });
 
-  it('should throw when onReaction is missing', () => {
-    expect(() => agent('wine-bot', { onMessage: async () => {} } as any)).toThrow('onReaction handler');
+  it('should accept agent without onReaction handler', () => {
+    const bot = agent('wine-bot', { onMessage: async () => {} });
+
+    expect(bot.handlers.onReaction).toBeUndefined();
   });
 });
 
@@ -91,7 +92,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
       await ctx.reply('Echo: Hello bot!');
     });
 
-    const testBot = agent('test-bot', { onMessage: onMessageSpy, onReaction: async () => {} });
+    const testBot = agent('test-bot', { onMessage: onMessageSpy });
 
     const handler = new NovuRequestHandler({
       frameworkName: 'test',
@@ -166,7 +167,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
         ctx.metadata.set('language', 'en');
         await ctx.reply('Got it');
       },
-      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -209,7 +209,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
         await ctx.update('Thinking...');
         await ctx.reply('Done thinking');
       },
-      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -254,7 +253,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
   it('should flush remaining signals after onResolve', async () => {
     const testBot = agent('test-bot', {
       onMessage: async () => {},
-      onReaction: async () => {},
       onResolve: async (ctx) => {
         ctx.metadata.set('archived', true);
         ctx.trigger('post-resolve-workflow', { payload: { reason: 'done' } });
@@ -306,7 +304,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
         capturedCtx = ctx;
         await ctx.reply('ok');
       },
-      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -344,7 +341,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
       onMessage: async (ctx) => {
         await ctx.reply({ markdown: '**bold** text' });
       },
-      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -386,7 +382,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
           files: [{ filename: 'report.pdf', url: 'https://example.com/report.pdf' }],
         });
       },
-      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -433,7 +428,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
           })
         );
       },
-      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -478,7 +472,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
         await ctx.update(Card({ title: 'Loading...', children: [] }));
         await ctx.reply('Done');
       },
-      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -522,7 +515,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
         ctx.metadata.set('intent', 'order_confirm');
         await ctx.reply(Card({ title: 'Confirm?', children: [Button({ id: 'yes', label: 'Yes', style: 'primary' })] }));
       },
-      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -561,7 +553,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
 
     const testBot = agent('test-bot', {
       onMessage: async () => {},
-      onReaction: async () => {},
       onAction: async (ctx) => {
         capturedCtx = ctx;
         await ctx.reply('Action received');
@@ -612,7 +603,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
         capturedCtx = ctx;
         await ctx.reply('ok');
       },
-      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -642,7 +632,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
   it('should silently skip onAction when no handler registered', async () => {
     const testBot = agent('test-bot', {
       onMessage: async () => {},
-      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -656,6 +645,42 @@ describe('agent dispatch via NovuRequestHandler', () => {
           message: null,
         });
         const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onAction`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    const result = await handler.createHandler()();
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body).status).toBe('ack');
+  });
+
+  it('should silently skip onReaction when no handler registered', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async () => {},
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest({
+          event: 'onReaction',
+          message: null,
+          reaction: {
+            emoji: { name: 'thumbs_up' },
+            added: true,
+            message: null,
+          },
+        });
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onReaction`);
 
         return {
           body: () => body,
@@ -785,7 +810,6 @@ describe('agent dispatch via NovuRequestHandler', () => {
         capturedCtx = ctx;
         await ctx.reply('ok');
       },
-      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -18,6 +18,7 @@ function createMockBridgeRequest(overrides?: Partial<AgentBridgeRequest>): Agent
     conversationId: 'conv-456',
     integrationIdentifier: 'slack-main',
     action: null,
+    reaction: null,
     message: {
       text: 'Hello bot!',
       platformMessageId: 'msg-789',
@@ -46,18 +47,23 @@ function createMockBridgeRequest(overrides?: Partial<AgentBridgeRequest>): Agent
 
 describe('agent()', () => {
   it('should return an agent with id and handlers', () => {
-    const bot = agent('wine-bot', { onMessage: async () => {} });
+    const bot = agent('wine-bot', { onMessage: async () => {}, onReaction: async () => {} });
 
     expect(bot.id).toBe('wine-bot');
     expect(typeof bot.handlers.onMessage).toBe('function');
+    expect(typeof bot.handlers.onReaction).toBe('function');
   });
 
   it('should throw when agentId is empty', () => {
-    expect(() => agent('', { onMessage: async () => {} })).toThrow('non-empty agentId');
+    expect(() => agent('', { onMessage: async () => {}, onReaction: async () => {} })).toThrow('non-empty agentId');
   });
 
   it('should throw when onMessage is missing', () => {
-    expect(() => agent('wine-bot', {} as any)).toThrow('onMessage handler');
+    expect(() => agent('wine-bot', { onReaction: async () => {} } as any)).toThrow('onMessage handler');
+  });
+
+  it('should throw when onReaction is missing', () => {
+    expect(() => agent('wine-bot', { onMessage: async () => {} } as any)).toThrow('onReaction handler');
   });
 });
 
@@ -85,7 +91,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
       await ctx.reply('Echo: Hello bot!');
     });
 
-    const testBot = agent('test-bot', { onMessage: onMessageSpy });
+    const testBot = agent('test-bot', { onMessage: onMessageSpy, onReaction: async () => {} });
 
     const handler = new NovuRequestHandler({
       frameworkName: 'test',
@@ -160,6 +166,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
         ctx.metadata.set('language', 'en');
         await ctx.reply('Got it');
       },
+      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -202,6 +209,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
         await ctx.update('Thinking...');
         await ctx.reply('Done thinking');
       },
+      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -246,6 +254,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
   it('should flush remaining signals after onResolve', async () => {
     const testBot = agent('test-bot', {
       onMessage: async () => {},
+      onReaction: async () => {},
       onResolve: async (ctx) => {
         ctx.metadata.set('archived', true);
         ctx.trigger('post-resolve-workflow', { payload: { reason: 'done' } });
@@ -297,6 +306,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
         capturedCtx = ctx;
         await ctx.reply('ok');
       },
+      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -334,6 +344,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
       onMessage: async (ctx) => {
         await ctx.reply({ markdown: '**bold** text' });
       },
+      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -375,6 +386,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
           files: [{ filename: 'report.pdf', url: 'https://example.com/report.pdf' }],
         });
       },
+      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -421,6 +433,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
           })
         );
       },
+      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -465,6 +478,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
         await ctx.update(Card({ title: 'Loading...', children: [] }));
         await ctx.reply('Done');
       },
+      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -508,6 +522,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
         ctx.metadata.set('intent', 'order_confirm');
         await ctx.reply(Card({ title: 'Confirm?', children: [Button({ id: 'yes', label: 'Yes', style: 'primary' })] }));
       },
+      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -546,6 +561,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
 
     const testBot = agent('test-bot', {
       onMessage: async () => {},
+      onReaction: async () => {},
       onAction: async (ctx) => {
         capturedCtx = ctx;
         await ctx.reply('Action received');
@@ -596,6 +612,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
         capturedCtx = ctx;
         await ctx.reply('ok');
       },
+      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -625,6 +642,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
   it('should silently skip onAction when no handler registered', async () => {
     const testBot = agent('test-bot', {
       onMessage: async () => {},
+      onReaction: async () => {},
     });
 
     const handler = new NovuRequestHandler({
@@ -652,5 +670,145 @@ describe('agent dispatch via NovuRequestHandler', () => {
     const result = await handler.createHandler()();
     expect(result.status).toBe(200);
     expect(JSON.parse(result.body).status).toBe('ack');
+  });
+
+  it('should dispatch onReaction event with reaction data on ctx', async () => {
+    let capturedCtx: any;
+
+    const testBot = agent('test-bot', {
+      onMessage: async () => {},
+      onReaction: async (ctx) => {
+        capturedCtx = ctx;
+        await ctx.reply('Reaction received');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest({
+          event: 'onReaction',
+          message: null,
+          reaction: {
+            emoji: { name: 'thumbs_up' },
+            added: true,
+            message: {
+              text: 'Hello bot!',
+              platformMessageId: 'msg-reacted',
+              author: { userId: 'u1', fullName: 'Alice', userName: 'alice', isBot: false },
+              timestamp: new Date().toISOString(),
+            },
+          },
+        });
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onReaction`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(capturedCtx).toBeDefined());
+
+    expect(capturedCtx.event).toBe('onReaction');
+    expect(capturedCtx.reaction).toBeDefined();
+    expect(capturedCtx.reaction.emoji.name).toBe('thumbs_up');
+    expect(capturedCtx.reaction.added).toBe(true);
+    expect(capturedCtx.reaction.message).toBeDefined();
+    expect(capturedCtx.reaction.message.text).toBe('Hello bot!');
+    expect(capturedCtx.reaction.message.platformMessageId).toBe('msg-reacted');
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+    expect(replyBody.reply.text).toBe('Reaction received');
+  });
+
+  it('should have null reaction.message when messageText is not provided', async () => {
+    let capturedCtx: any;
+
+    const testBot = agent('test-bot', {
+      onMessage: async () => {},
+      onReaction: async (ctx) => {
+        capturedCtx = ctx;
+        await ctx.reply('ok');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest({
+          event: 'onReaction',
+          message: null,
+          reaction: {
+            emoji: { name: 'heart' },
+            added: false,
+            message: null,
+          },
+        });
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onReaction`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(capturedCtx).toBeDefined());
+
+    expect(capturedCtx.reaction.emoji.name).toBe('heart');
+    expect(capturedCtx.reaction.added).toBe(false);
+    expect(capturedCtx.reaction.message).toBeNull();
+  });
+
+  it('should have null reaction on non-reaction events', async () => {
+    let capturedCtx: any;
+
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        capturedCtx = ctx;
+        await ctx.reply('ok');
+      },
+      onReaction: async () => {},
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(capturedCtx).toBeDefined());
+
+    expect(capturedCtx.reaction).toBeNull();
   });
 });

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -131,7 +131,7 @@ export interface AgentContext {
 
 export interface AgentHandlers {
   onMessage: (ctx: AgentContext) => Promise<void>;
-  onReaction: (ctx: AgentContext) => Promise<void>;
+  onReaction?: (ctx: AgentContext) => Promise<void>;
   onAction?: (ctx: AgentContext) => Promise<void>;
   onResolve?: (ctx: AgentContext) => Promise<void>;
 }

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -4,6 +4,7 @@ export enum AgentEventEnum {
   ON_MESSAGE = 'onMessage',
   ON_ACTION = 'onAction',
   ON_RESOLVE = 'onResolve',
+  ON_REACTION = 'onReaction',
 }
 
 // ---------------------------------------------------------------------------
@@ -102,10 +103,17 @@ export interface AgentAction {
 // Context + handlers
 // ---------------------------------------------------------------------------
 
+export interface AgentReaction {
+  emoji: { name: string };
+  added: boolean;
+  message: AgentMessage | null;
+}
+
 export interface AgentContext {
   readonly event: string;
   readonly action: AgentAction | null;
   readonly message: AgentMessage | null;
+  readonly reaction: AgentReaction | null;
   readonly conversation: AgentConversation;
   readonly subscriber: AgentSubscriber | null;
   readonly history: AgentHistoryEntry[];
@@ -123,6 +131,7 @@ export interface AgentContext {
 
 export interface AgentHandlers {
   onMessage: (ctx: AgentContext) => Promise<void>;
+  onReaction: (ctx: AgentContext) => Promise<void>;
   onAction?: (ctx: AgentContext) => Promise<void>;
   onResolve?: (ctx: AgentContext) => Promise<void>;
 }
@@ -147,6 +156,7 @@ export interface AgentBridgeRequest {
   integrationIdentifier: string;
   action: AgentAction | null;
   message: AgentMessage | null;
+  reaction: AgentReaction | null;
   conversation: AgentConversation;
   subscriber: AgentSubscriber | null;
   history: AgentHistoryEntry[];

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -104,6 +104,7 @@ export interface AgentAction {
 // ---------------------------------------------------------------------------
 
 export interface AgentReaction {
+  messageId: string;
   emoji: { name: string };
   added: boolean;
   message: AgentMessage | null;

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -11,6 +11,7 @@ export type {
   AgentMessage,
   AgentMessageAuthor,
   AgentPlatformContext,
+  AgentReaction,
   AgentReplyPayload,
   AgentSubscriber,
   FileRef,


### PR DESCRIPTION
## Summary

- Fire an `ON_REACTION` bridge event when a user adds or removes an emoji reaction on any message in an agent conversation thread
- API: register `chat.onReaction()`, new `handleReaction()` on inbound handler (ephemeral — no activity persistence, no ack reaction, no typing indicator), extend bridge executor with `mapReaction()` reusing `mapMessage()` for real author data
- Framework SDK: required `onReaction` handler on `AgentHandlers`, `AgentContext.reaction: AgentReaction | null`, uniform map-based dispatch in `runAgentHandler()`, validation in `agent()` factory

## How it works

```mermaid
sequenceDiagram
    participant Slack as Slack (reaction_added/removed)
    participant ChatSDK as Chat SDK
    participant Inbound as AgentInboundHandler
    participant Bridge as BridgeExecutorService
    participant Framework as Framework SDK
    participant Handler as onReaction handler

    Slack->>ChatSDK: reaction event
    ChatSDK->>Inbound: handleReaction(event)
    Inbound->>Inbound: lookup conversation by thread
    Inbound->>Inbound: resolve subscriber
    Inbound->>Bridge: execute(ON_REACTION, reaction)
    Bridge->>Bridge: mapReaction() + mapMessage()
    Bridge->>Framework: POST agent-event?event=onReaction
    Framework->>Handler: handlers.onReaction(ctx)
    Handler->>Framework: ctx.reply() / ctx.resolve() / etc.
```

## Test plan

- [x] All 21 framework agent tests pass (18 existing updated + 3 new)
- [ ] Verify Slack reaction_added/removed events dispatch to onReaction handler
- [ ] Verify reaction on non-agent thread is silently ignored
- [ ] Verify ctx.reaction is null on non-reaction events
- [ ] Verify ctx.reaction.message contains real author data when available

Fixes NV-7370

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR adds ON_REACTION event handling to the agent system, enabling agents to respond when users add or remove emoji reactions on messages in conversation threads. When a reaction occurs on a message, the Chat SDK forwards the event through the inbound handler, which resolves the conversation and subscriber, builds a bridge payload with reaction metadata, and triggers the framework SDK to invoke the agent's `onReaction` handler. Reaction handling is ephemeral—no activity is persisted, no acknowledgment reaction is sent, and no typing indicator is shown.

## Affected areas

- **api**: Added `AgentEventEnum.ON_REACTION`, created `AgentInboundHandler.handleReaction()` to resolve conversations and subscribers from reaction events, registered `chat.onReaction()` handler to dispatch reactions, and extended `BridgeExecutorService` to map reaction payloads with optional message context.
- **framework**: Added `AgentContext.reaction` and `AgentBridgeRequest.reaction` fields, introduced `AgentReaction` type to represent reaction metadata, added optional `onReaction` handler to `AgentHandlers`, and refactored `runAgentHandler()` to use a map-based dispatch pattern supporting all agent event types.

## Key technical decisions

- Reaction events use `event.user` (the reactor) rather than `event.message.author` to correctly identify the subscriber performing the action.
- `messageId` is explicitly included in reaction payloads so consumers can identify the reacted message even when the message body is `null`.
- Handler dispatch uses `hasOwnProperty` checks to avoid prototype traversal risks when looking up handlers by event type.
- Handler invocation is conditional on the handler being defined, making `onReaction` optional without requiring explicit null checks in agent implementations.

## Testing

21 framework agent tests total (18 existing updated + 3 new) verify the feature; all framework agent tests pass. E2E tests validate that reactions correctly dispatch bridge events with proper payload mapping, skip processing for non-agent threads, and do not persist conversation activity. Mock agent handler updated to demonstrate `onReaction` implementation with emoji logging and replies. Manual verification checklist covers Slack dispatch behavior, non-agent-thread filtering, null reaction context on non-reaction events, and real author data mapping when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->