### PR TITLE
feat(root): add agent template to `novu init` CLI scaffolding fixes NV-7371

### DIFF
--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -93,7 +93,7 @@ export class AgentInboundHandler {
       organizationId: config.organizationId,
     });
 
-    const channel = conversation.channels[0];
+    const channel = conversation.channels?.[0];
     const isFirstMessage = !channel?.firstPlatformMessageId;
 
     if (isFirstMessage && config.reactionOnMessageReceived && message.id) {

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -10,7 +10,7 @@ import {
   SubscriberRepository,
 } from '@novu/dal';
 import { AgentEventEnum } from '../../dtos/agent-event.enum';
-import { AgentConfigResolver } from '../../services/agent-config-resolver.service';
+import { AgentConfigResolver, ResolvedAgentConfig } from '../../services/agent-config-resolver.service';
 import { AgentConversationService } from '../../services/agent-conversation.service';
 import { BridgeExecutorService } from '../../services/bridge-executor.service';
 import { ChatSdkService } from '../../services/chat-sdk.service';
@@ -59,10 +59,15 @@ export class HandleAgentReply {
       return { status: 'update_sent' };
     }
 
+    const needsConfig = !!(command.reply || command.resolve);
+    const config = needsConfig
+      ? await this.agentConfigResolver.resolve(conversation._agentId, command.integrationIdentifier)
+      : null;
+
     if (command.reply) {
       await this.deliverMessage(command, conversation, channel, command.reply, ConversationActivityTypeEnum.MESSAGE);
 
-      this.removeAckReaction(command, conversation, channel).catch((err) => {
+      this.removeAckReaction(config!, conversation, channel).catch((err) => {
         this.logger.warn(err, `[agent:${command.agentIdentifier}] Failed to remove ack reaction`);
       });
     }
@@ -72,7 +77,7 @@ export class HandleAgentReply {
     }
 
     if (command.resolve) {
-      await this.executeResolveSignal(command, conversation, channel, command.resolve);
+      await this.executeResolveSignal(command, config!, conversation, channel, command.resolve);
     }
 
     return { status: 'ok' };
@@ -198,6 +203,7 @@ export class HandleAgentReply {
 
   private async executeResolveSignal(
     command: HandleAgentReplyCommand,
+    config: ResolvedAgentConfig,
     conversation: ConversationEntity,
     channel: ConversationChannel,
     signal: { summary?: string }
@@ -223,29 +229,26 @@ export class HandleAgentReply {
       }),
     ]);
 
-    this.reactOnResolve(command, conversation, channel).catch((err) => {
+    this.reactOnResolve(config, conversation, channel).catch((err) => {
       this.logger.warn(err, `[agent:${command.agentIdentifier}] Failed to add resolve reaction`);
     });
 
-    this.fireOnResolveBridgeCall(command, conversation).catch((err) => {
+    this.fireOnResolveBridgeCall(command, config, conversation).catch((err) => {
       this.logger.error(err, `[agent:${command.agentIdentifier}] Failed to fire onResolve bridge call`);
     });
   }
 
   private async removeAckReaction(
-    command: HandleAgentReplyCommand,
+    config: ResolvedAgentConfig,
     conversation: ConversationEntity,
     channel: ConversationChannel
   ): Promise<void> {
     const firstMessageId = channel.firstPlatformMessageId;
-    if (!firstMessageId) return;
-
-    const config = await this.agentConfigResolver.resolve(conversation._agentId, command.integrationIdentifier);
-    if (!config.reactionOnMessageReceived) return;
+    if (!firstMessageId || !config.reactionOnMessageReceived) return;
 
     await this.chatSdkService.removeReaction(
       conversation._agentId,
-      command.integrationIdentifier,
+      config.integrationIdentifier,
       channel.platform,
       channel.platformThreadId,
       firstMessageId,
@@ -254,19 +257,16 @@ export class HandleAgentReply {
   }
 
   private async reactOnResolve(
-    command: HandleAgentReplyCommand,
+    config: ResolvedAgentConfig,
     conversation: ConversationEntity,
     channel: ConversationChannel
   ): Promise<void> {
     const firstMessageId = channel.firstPlatformMessageId;
-    if (!firstMessageId) return;
-
-    const config = await this.agentConfigResolver.resolve(conversation._agentId, command.integrationIdentifier);
-    if (!config.reactionOnResolved) return;
+    if (!firstMessageId || !config.reactionOnResolved) return;
 
     await this.chatSdkService.reactToMessage(
       conversation._agentId,
-      command.integrationIdentifier,
+      config.integrationIdentifier,
       channel.platform,
       channel.platformThreadId,
       firstMessageId,
@@ -276,10 +276,9 @@ export class HandleAgentReply {
 
   private async fireOnResolveBridgeCall(
     command: HandleAgentReplyCommand,
+    config: ResolvedAgentConfig,
     conversation: ConversationEntity
   ): Promise<void> {
-    const config = await this.agentConfigResolver.resolve(conversation._agentId, command.integrationIdentifier);
-
     const subscriberParticipant = conversation.participants.find((p) => p.type === 'subscriber');
     const [subscriber, history] = await Promise.all([
       subscriberParticipant

--- a/libs/dal/src/repositories/conversation/conversation.repository.ts
+++ b/libs/dal/src/repositories/conversation/conversation.repository.ts
@@ -121,7 +121,12 @@ export class ConversationRepository extends BaseRepositoryV2<
         _id: id,
         _environmentId: environmentId,
         _organizationId: organizationId,
-        'channels.platformThreadId': platformThreadId,
+        channels: {
+          $elemMatch: {
+            platformThreadId,
+            firstPlatformMessageId: { $exists: false },
+          },
+        },
       },
       { $set: { 'channels.$.firstPlatformMessageId': firstPlatformMessageId } }
     );

--- a/packages/novu/src/commands/init/create-app.ts
+++ b/packages/novu/src/commands/init/create-app.ts
@@ -16,6 +16,7 @@ export class DownloadError extends Error {}
 export async function createApp({
   appPath,
   packageManager,
+  templateChoice,
   typescript,
   eslint,
   srcDir,
@@ -26,6 +27,7 @@ export async function createApp({
 }: {
   appPath: string;
   packageManager: PackageManager;
+  templateChoice: string;
   typescript: boolean;
   eslint: boolean;
   srcDir: boolean;
@@ -36,7 +38,7 @@ export async function createApp({
 }): Promise<void> {
   let repoInfo: RepoInfo | undefined;
   const mode: TemplateMode = typescript ? 'ts' : 'js';
-  const template: TemplateType = 'app-react-email';
+  const template: TemplateType = templateChoice === 'agent' ? 'app-agent' : 'app-react-email';
 
   const root = path.resolve(appPath);
 

--- a/packages/novu/src/commands/init/index.ts
+++ b/packages/novu/src/commands/init/index.ts
@@ -149,7 +149,13 @@ export async function init(program: IInitCommandOptions, anonymousId?: string): 
     process.exit(1);
   }
 
+  const supportedTemplates = ['notifications', 'agent'] as const;
   let templateChoice = program.template;
+
+  if (templateChoice && !supportedTemplates.includes(templateChoice as (typeof supportedTemplates)[number])) {
+    console.error(`Invalid template "${program.template}". Supported templates: ${supportedTemplates.join(', ')}`);
+    process.exit(1);
+  }
 
   if (!templateChoice) {
     const res = await prompts({

--- a/packages/novu/src/commands/init/index.ts
+++ b/packages/novu/src/commands/init/index.ts
@@ -28,6 +28,7 @@ export interface IInitCommandOptions {
   secretKey?: string;
   projectPath?: string;
   apiUrl: string;
+  template?: string;
 }
 
 export async function init(program: IInitCommandOptions, anonymousId?: string): Promise<void> {
@@ -148,11 +149,30 @@ export async function init(program: IInitCommandOptions, anonymousId?: string): 
     process.exit(1);
   }
 
+  let templateChoice = program.template;
+
+  if (!templateChoice) {
+    const res = await prompts({
+      onState: onPromptState,
+      type: 'select',
+      name: 'template',
+      message: 'What type of Novu app do you want to create?',
+      choices: [
+        { title: 'Notifications', value: 'notifications', description: 'Workflows, email templates, and in-app inbox' },
+        { title: 'Agent', value: 'agent', description: 'Conversational AI agent with chat platform support' },
+      ],
+      initial: 0,
+    });
+
+    templateChoice = res.template;
+  }
+
+  if (!templateChoice) {
+    console.error('No template selected.');
+    process.exit(1);
+  }
+
   const preferences = {} as Record<string, boolean | string>;
-  /**
-   * If the user does not provide the necessary flags, prompt them for whether
-   * to use TS or JS.
-   */
   const defaults: typeof preferences = {
     typescript: true,
     eslint: true,
@@ -175,6 +195,7 @@ export async function init(program: IInitCommandOptions, anonymousId?: string): 
   await createApp({
     appPath: resolvedProjectPath,
     packageManager: 'npm',
+    templateChoice,
     typescript: defaults.typescript as boolean,
     eslint: defaults.eslint as boolean,
     srcDir: defaults.srcDir as boolean,

--- a/packages/novu/src/commands/init/templates/app-agent/ts/README-template.md
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/README-template.md
@@ -12,7 +12,7 @@ npm run dev
 
 2. Connect a chat platform in the [Novu Dashboard](https://dashboard.novu.co).
 
-3. Replace the demo handler in `app/novu/agents/support-agent.ts` with your LLM call.
+3. Replace the demo handler in `app/novu/agents/support-agent.tsx` with your LLM call.
 
 Your agent is served at `/api/novu` and handles incoming messages via the Novu Bridge protocol.
 
@@ -23,7 +23,7 @@ app/
   api/novu/route.ts        → Bridge endpoint serving your agent
   novu/agents/
     index.ts               → Agent exports
-    support-agent.ts       → Your agent handler (edit this!)
+    support-agent.tsx      → Your agent handler (edit this!)
   page.tsx                 → Landing page
 ```
 

--- a/packages/novu/src/commands/init/templates/app-agent/ts/README-template.md
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/README-template.md
@@ -10,13 +10,13 @@ A conversational AI agent powered by [Novu](https://novu.co) and [Next.js](https
 npm run dev
 ```
 
-2. Open Novu Studio:
+2. Create an agent and connect a chat platform (Slack, Teams, WhatsApp) in the [Novu Dashboard](https://dashboard.novu.co).
+
+3. Deploy your bridge endpoint and sync:
 
 ```bash
-npx novu dev
+npx novu sync -b <your-bridge-url>/api/novu -s <your-secret-key>
 ```
-
-3. Connect a chat platform (Slack, Teams, WhatsApp) in the [Novu Dashboard](https://dashboard.novu.co).
 
 Your agent is served at `/api/novu` and handles incoming messages via the Novu Bridge protocol.
 

--- a/packages/novu/src/commands/init/templates/app-agent/ts/README-template.md
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/README-template.md
@@ -1,0 +1,73 @@
+# Novu Agent
+
+A conversational AI agent powered by [Novu](https://novu.co) and [Next.js](https://nextjs.org).
+
+## Getting Started
+
+1. Start the development server:
+
+```bash
+npm run dev
+```
+
+2. Open Novu Studio:
+
+```bash
+npx novu dev
+```
+
+3. Connect a chat platform (Slack, Teams, WhatsApp) in the [Novu Dashboard](https://dashboard.novu.co).
+
+Your agent is served at `/api/novu` and handles incoming messages via the Novu Bridge protocol.
+
+## Project Structure
+
+```
+app/
+  api/novu/route.ts        → Bridge endpoint serving your agent
+  novu/agents/
+    index.ts               → Agent exports
+    support-agent.ts       → Your agent handler (edit this!)
+  page.tsx                 → Landing page
+```
+
+## Agent API
+
+Your agent handler receives a context object with:
+
+| Method / Property | Description |
+|---|---|
+| `ctx.message` | The inbound message (text, author, timestamp) |
+| `ctx.conversation` | Current conversation state and metadata |
+| `ctx.history` | Recent conversation history |
+| `ctx.subscriber` | Resolved subscriber info |
+| `ctx.platform` | Source platform (slack, teams, whatsapp) |
+| `ctx.reply(content)` | Send a reply (text, markdown, or Card) |
+| `ctx.metadata.set(k, v)` | Set conversation metadata |
+| `ctx.resolve(summary?)` | Mark conversation as resolved |
+| `ctx.trigger(workflowId)` | Trigger a Novu workflow |
+
+## Wiring Up Your LLM
+
+Replace the demo handler in `app/novu/agents/support-agent.ts` with your LLM call:
+
+```typescript
+onMessage: async (ctx) => {
+  const response = await openai.chat.completions.create({
+    model: 'gpt-4',
+    messages: [
+      { role: 'system', content: 'You are a helpful support agent.' },
+      ...ctx.history.map((h) => ({ role: h.role, content: h.content })),
+      { role: 'user', content: ctx.message?.text ?? '' },
+    ],
+  });
+
+  await ctx.reply(response.choices[0].message.content ?? '');
+},
+```
+
+## Learn More
+
+- [Novu Agent Docs](https://docs.novu.co/agents)
+- [Novu Framework SDK](https://docs.novu.co/framework)
+- [Next.js Documentation](https://nextjs.org/docs)

--- a/packages/novu/src/commands/init/templates/app-agent/ts/README-template.md
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/README-template.md
@@ -6,9 +6,9 @@ A conversational AI agent powered by [Novu](https://novu.co) and [Next.js](https
 
 1. Start the development server:
 
-```bash
-npm run dev
-```
+   ```bash
+   npm run dev
+   ```
 
 2. Connect a chat platform in the [Novu Dashboard](https://dashboard.novu.co).
 
@@ -18,7 +18,7 @@ Your agent is served at `/api/novu` and handles incoming messages via the Novu B
 
 ## Project Structure
 
-```
+```text
 app/
   api/novu/route.ts        → Bridge endpoint serving your agent
   novu/agents/
@@ -38,14 +38,14 @@ Your agent handler receives a context object with:
 | `ctx.history` | Recent conversation history |
 | `ctx.subscriber` | Resolved subscriber info |
 | `ctx.platform` | Source platform (slack, teams, whatsapp) |
-| `ctx.reply(content)` | Send a reply (text, markdown, or Card) |
+| `ctx.reply(content)` | Send a reply (text, Markdown, or Card) |
 | `ctx.metadata.set(k, v)` | Set conversation metadata |
 | `ctx.resolve(summary?)` | Mark conversation as resolved |
 | `ctx.trigger(workflowId)` | Trigger a Novu workflow |
 
 ## Wiring Up Your LLM
 
-Replace the demo handler in `app/novu/agents/support-agent.ts` with your LLM call:
+Replace the demo handler in `app/novu/agents/support-agent.tsx` with your LLM call:
 
 ```typescript
 onMessage: async (ctx) => {

--- a/packages/novu/src/commands/init/templates/app-agent/ts/README-template.md
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/README-template.md
@@ -10,13 +10,9 @@ A conversational AI agent powered by [Novu](https://novu.co) and [Next.js](https
 npm run dev
 ```
 
-2. Create an agent and connect a chat platform (Slack, Teams, WhatsApp) in the [Novu Dashboard](https://dashboard.novu.co).
+2. Connect a chat platform in the [Novu Dashboard](https://dashboard.novu.co).
 
-3. Deploy your bridge endpoint and sync:
-
-```bash
-npx novu sync -b <your-bridge-url>/api/novu -s <your-secret-key>
-```
+3. Replace the demo handler in `app/novu/agents/support-agent.ts` with your LLM call.
 
 Your agent is served at `/api/novu` and handles incoming messages via the Novu Bridge protocol.
 

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/api/novu/route.ts
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/api/novu/route.ts
@@ -1,0 +1,6 @@
+import { serve } from '@novu/framework/next';
+import { supportAgent } from '../../novu/agents';
+
+export const { GET, POST, OPTIONS } = serve({
+  agents: [supportAgent],
+});

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/globals.css
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/globals.css
@@ -1,0 +1,19 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: #fafafa;
+  color: #171717;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #0a0a0a;
+    color: #fafafa;
+  }
+}

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/layout.tsx
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Novu Agent',
+  description: 'Conversational AI agent powered by Novu',
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/layout.tsx
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/layout.tsx
@@ -11,6 +11,7 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+
   return (
     <html lang="en">
       <body>{children}</body>

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/index.ts
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/index.ts
@@ -1,0 +1,1 @@
+export { supportAgent } from './support-agent';

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/support-agent.ts
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/support-agent.ts
@@ -1,0 +1,60 @@
+import { agent, Card, CardText, Actions, Button } from '@novu/framework';
+
+export const supportAgent = agent('support-agent', {
+  onMessage: async (ctx) => {
+    const text = (ctx.message?.text ?? '').toLowerCase();
+    const isFirstMessage = ctx.conversation.messageCount <= 1;
+
+    if (isFirstMessage) {
+      ctx.metadata.set('topic', 'unknown');
+      await ctx.reply(
+        Card({
+          title: "Hi, I'm Support Agent",
+          children: [
+            CardText('How can I help you today?'),
+            Actions([
+              Button({ label: 'Billing question', actionId: 'topic', value: 'billing' }),
+              Button({ label: 'Technical issue', actionId: 'topic', value: 'technical' }),
+              Button({ label: 'Something else', actionId: 'topic', value: 'other' }),
+            ]),
+          ],
+        })
+      );
+
+      return;
+    }
+
+    if (text.includes('resolve') || text.includes('thanks')) {
+      ctx.resolve(`Resolved by user: ${text}`);
+      await ctx.reply('Glad I could help! Marking this resolved.');
+
+      return;
+    }
+
+    // Replace this block with your LLM call (OpenAI, Anthropic, etc.)
+    ctx.metadata.set('lastMessage', text);
+    await ctx.reply({
+      markdown:
+        `**Got it.** You said: "${ctx.message?.text}"\n\n` +
+        `_This is a demo agent. Replace this handler with your LLM call._\n\n` +
+        `**Conversation so far:** ${ctx.history.length} messages | ` +
+        `**Topic:** ${ctx.conversation.metadata?.topic ?? 'unknown'}`,
+    });
+  },
+
+  onAction: async (ctx) => {
+    const { actionId, value } = ctx.action!;
+    if (actionId === 'topic') {
+      ctx.metadata.set('topic', value!);
+      await ctx.reply({
+        markdown: `Topic set to **${value}**. Describe your issue and I'll help.`,
+      });
+    }
+  },
+
+  onResolve: async (ctx) => {
+    ctx.metadata.set('resolvedAt', new Date().toISOString());
+    // Trigger a follow-up workflow when a conversation is resolved:
+    // ctx.trigger('follow-up-survey', { to: ctx.subscriber?.subscriberId });
+  },
+});

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/support-agent.ts
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/support-agent.ts
@@ -13,9 +13,9 @@ export const supportAgent = agent('support-agent', {
           children: [
             CardText('How can I help you today?'),
             Actions([
-              Button({ label: 'Billing question', actionId: 'topic', value: 'billing' }),
-              Button({ label: 'Technical issue', actionId: 'topic', value: 'technical' }),
-              Button({ label: 'Something else', actionId: 'topic', value: 'other' }),
+              Button({ id: 'topic-billing', label: 'Billing question', value: 'billing' }),
+              Button({ id: 'topic-technical', label: 'Technical issue', value: 'technical' }),
+              Button({ id: 'topic-other', label: 'Something else', value: 'other' }),
             ]),
           ],
         })
@@ -44,8 +44,8 @@ export const supportAgent = agent('support-agent', {
 
   onAction: async (ctx) => {
     const { actionId, value } = ctx.action!;
-    if (actionId === 'topic') {
-      ctx.metadata.set('topic', value!);
+    if (actionId.startsWith('topic-') && value) {
+      ctx.metadata.set('topic', value);
       await ctx.reply({
         markdown: `Topic set to **${value}**. Describe your issue and I'll help.`,
       });

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/support-agent.tsx
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/support-agent.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @novu/framework */
 import { agent, Card, CardText, Actions, Button } from '@novu/framework';
 
 export const supportAgent = agent('support-agent', {
@@ -8,17 +9,14 @@ export const supportAgent = agent('support-agent', {
     if (isFirstMessage) {
       ctx.metadata.set('topic', 'unknown');
       await ctx.reply(
-        Card({
-          title: "Hi, I'm Support Agent",
-          children: [
-            CardText('How can I help you today?'),
-            Actions([
-              Button({ id: 'topic-billing', label: 'Billing question', value: 'billing' }),
-              Button({ id: 'topic-technical', label: 'Technical issue', value: 'technical' }),
-              Button({ id: 'topic-other', label: 'Something else', value: 'other' }),
-            ]),
-          ],
-        })
+        <Card title="Hi, I'm Support Agent">
+          <CardText>How can I help you today?</CardText>
+          <Actions>
+            <Button id="topic-billing" label="Billing question" value="billing" />
+            <Button id="topic-technical" label="Technical issue" value="technical" />
+            <Button id="topic-other" label="Something else" value="other" />
+          </Actions>
+        </Card>
       );
 
       return;

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/page.module.css
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/page.module.css
@@ -1,0 +1,118 @@
+.main {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 2rem;
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+}
+
+.container {
+  max-width: 640px;
+  width: 100%;
+}
+
+.title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  color: #171717;
+}
+
+.description {
+  font-size: 1.1rem;
+  color: #525252;
+  margin-bottom: 2rem;
+}
+
+.code {
+  background: #f5f5f5;
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
+  font-family: monospace;
+}
+
+.steps,
+.features {
+  margin-bottom: 2rem;
+}
+
+.steps h2,
+.features h2 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: #171717;
+}
+
+.steps ol {
+  padding-left: 1.5rem;
+  line-height: 1.8;
+  color: #525252;
+}
+
+.features ul {
+  padding-left: 1.5rem;
+  line-height: 1.8;
+  color: #525252;
+}
+
+.steps a {
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.steps a:hover {
+  text-decoration: underline;
+}
+
+.links {
+  display: flex;
+  gap: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e5e5;
+}
+
+.links a {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.links a:hover {
+  text-decoration: underline;
+}
+
+@media (prefers-color-scheme: dark) {
+  .title {
+    color: #fafafa;
+  }
+
+  .description {
+    color: #a3a3a3;
+  }
+
+  .code {
+    background: #262626;
+  }
+
+  .steps h2,
+  .features h2 {
+    color: #fafafa;
+  }
+
+  .steps ol,
+  .features ul {
+    color: #a3a3a3;
+  }
+
+  .links {
+    border-top-color: #404040;
+  }
+}

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/page.tsx
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/page.tsx
@@ -1,0 +1,59 @@
+import styles from './page.module.css';
+
+export default function Home() {
+  return (
+    <main className={styles.main}>
+      <div className={styles.container}>
+        <h1 className={styles.title}>Novu Agent</h1>
+        <p className={styles.description}>
+          Your conversational agent is running at <code className={styles.code}>/api/novu</code>
+        </p>
+
+        <div className={styles.steps}>
+          <h2>Get started</h2>
+          <ol>
+            <li>
+              Open <code className={styles.code}>app/novu/agents/support-agent.ts</code> to edit your agent
+            </li>
+            <li>
+              Connect a chat platform (Slack, Teams, WhatsApp) in the{' '}
+              <a href="https://dashboard.novu.co" target="_blank" rel="noopener noreferrer">
+                Novu Dashboard
+              </a>
+            </li>
+            <li>
+              Replace the demo handler with your LLM call (OpenAI, Anthropic, etc.)
+            </li>
+            <li>
+              Run <code className={styles.code}>npx novu dev</code> to open Novu Studio
+            </li>
+          </ol>
+        </div>
+
+        <div className={styles.features}>
+          <h2>What the demo agent shows</h2>
+          <ul>
+            <li><strong>Interactive Cards</strong> — buttons and actions rendered natively per platform</li>
+            <li><strong>onAction handler</strong> — respond to button clicks and selections</li>
+            <li><strong>Conversation metadata</strong> — track state across messages</li>
+            <li><strong>Resolve lifecycle</strong> — close conversations and trigger follow-ups</li>
+            <li><strong>Markdown replies</strong> — rich formatted responses</li>
+            <li><strong>Conversation history</strong> — multi-turn awareness</li>
+          </ul>
+        </div>
+
+        <div className={styles.links}>
+          <a href="https://docs.novu.co/agents" target="_blank" rel="noopener noreferrer">
+            Docs
+          </a>
+          <a href="https://discord.novu.co" target="_blank" rel="noopener noreferrer">
+            Discord
+          </a>
+          <a href="https://github.com/novuhq/novu" target="_blank" rel="noopener noreferrer">
+            GitHub
+          </a>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/page.tsx
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
           <h2>Get started</h2>
           <ol>
             <li>
-              Edit your agent in <code className={styles.code}>app/novu/agents/support-agent.ts</code>
+              Edit your agent in <code className={styles.code}>app/novu/agents/support-agent.tsx</code>
             </li>
             <li>
               Connect a chat platform in the{' '}

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/page.tsx
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/page.tsx
@@ -16,7 +16,7 @@ export default function Home() {
               Open <code className={styles.code}>app/novu/agents/support-agent.ts</code> to edit your agent
             </li>
             <li>
-              Connect a chat platform (Slack, Teams, WhatsApp) in the{' '}
+              Create an agent and connect a chat platform (Slack, Teams, WhatsApp) in the{' '}
               <a href="https://dashboard.novu.co" target="_blank" rel="noopener noreferrer">
                 Novu Dashboard
               </a>
@@ -25,7 +25,8 @@ export default function Home() {
               Replace the demo handler with your LLM call (OpenAI, Anthropic, etc.)
             </li>
             <li>
-              Run <code className={styles.code}>npx novu dev</code> to open Novu Studio
+              Deploy your bridge endpoint and sync with{' '}
+              <code className={styles.code}>npx novu sync</code>
             </li>
           </ol>
         </div>

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/page.tsx
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/page.tsx
@@ -13,20 +13,16 @@ export default function Home() {
           <h2>Get started</h2>
           <ol>
             <li>
-              Open <code className={styles.code}>app/novu/agents/support-agent.ts</code> to edit your agent
+              Edit your agent in <code className={styles.code}>app/novu/agents/support-agent.ts</code>
             </li>
             <li>
-              Create an agent and connect a chat platform (Slack, Teams, WhatsApp) in the{' '}
+              Connect a chat platform in the{' '}
               <a href="https://dashboard.novu.co" target="_blank" rel="noopener noreferrer">
                 Novu Dashboard
               </a>
             </li>
             <li>
-              Replace the demo handler with your LLM call (OpenAI, Anthropic, etc.)
-            </li>
-            <li>
-              Deploy your bridge endpoint and sync with{' '}
-              <code className={styles.code}>npx novu sync</code>
+              Replace the demo handler with your LLM call
             </li>
           </ol>
         </div>

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/page.tsx
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/page.tsx
@@ -1,6 +1,7 @@
 import styles from './page.module.css';
 
 export default function Home() {
+
   return (
     <main className={styles.main}>
       <div className={styles.container}>

--- a/packages/novu/src/commands/init/templates/app-agent/ts/eslintrc.json
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/packages/novu/src/commands/init/templates/app-agent/ts/gitignore
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/gitignore
@@ -1,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/packages/novu/src/commands/init/templates/app-agent/ts/next-env.d.ts
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/novu/src/commands/init/templates/app-agent/ts/next.config.mjs
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/packages/novu/src/commands/init/templates/app-agent/ts/tsconfig.json
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {

--- a/packages/novu/src/commands/init/templates/app-agent/ts/tsconfig.json
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -244,7 +244,7 @@ export const installTemplate = async ({
   if (eslint) {
     packageJson.devDependencies = {
       ...packageJson.devDependencies,
-      eslint: '^8',
+      eslint: '^9',
       'eslint-config-next': version,
     };
   }

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -148,26 +148,46 @@ export const installTemplate = async ({
   }
 
   /* write .env file */
-  const val = Object.entries({
-    NOVU_SECRET_KEY: secretKey,
-    NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER: applicationId,
-    NEXT_PUBLIC_NOVU_SUBSCRIBER_ID: userId,
-  }).reduce((acc, [key, value]) => {
+  const envVars =
+    template === TemplateTypeEnum.APP_AGENT
+      ? { NOVU_SECRET_KEY: secretKey }
+      : {
+          NOVU_SECRET_KEY: secretKey,
+          NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER: applicationId,
+          NEXT_PUBLIC_NOVU_SUBSCRIBER_ID: userId,
+        };
+
+  const val = Object.entries(envVars).reduce((acc, [key, value]) => {
     return `${acc}${key}=${value}${os.EOL}`;
   }, '');
 
   await fs.writeFile(path.join(root, '.env.local'), val);
 
-  /* write github action */
-  await copy(copySource, `${root}/.github`, {
-    parents: true,
-    cwd: path.join(__dirname, `./github`),
-  });
+  /* write github action (skip for agent template) */
+  if (template !== TemplateTypeEnum.APP_AGENT) {
+    await copy(copySource, `${root}/.github`, {
+      parents: true,
+      cwd: path.join(__dirname, `./github`),
+    });
+  }
 
   /** Copy the version from package.json or override for tests. */
   const version = '16.2.1';
 
   /** Create a package.json for the new project and write it to disk. */
+  const isAgentTemplate = template === TemplateTypeEnum.APP_AGENT;
+
+  const baseDependencies: Record<string, string> = {
+    react: '^19',
+    'react-dom': '^19',
+    next: version,
+    '@novu/framework': 'latest',
+  };
+
+  if (!isAgentTemplate) {
+    baseDependencies['@novu/nextjs'] = '^2.5.0';
+  }
+
   const packageJson: any = {
     name: appName,
     version: '0.1.0',
@@ -178,22 +198,10 @@ export const installTemplate = async ({
       start: 'next start',
       lint: 'next lint',
     },
-    /**
-     * Default dependencies.
-     */
-    dependencies: {
-      react: '^19',
-      'react-dom': '^19',
-      next: version,
-      '@novu/framework': 'latest',
-      '@novu/nextjs': '^2.5.0',
-    },
+    dependencies: baseDependencies,
     devDependencies: {},
   };
 
-  /**
-   * TypeScript projects will have type definitions and other devDependencies.
-   */
   if (mode === 'ts') {
     packageJson.devDependencies = {
       ...packageJson.devDependencies,
@@ -204,7 +212,6 @@ export const installTemplate = async ({
     };
   }
 
-  /* Add Tailwind CSS dependencies. */
   if (template === TemplateTypeEnum.APP_REACT_EMAIL) {
     packageJson.devDependencies = {
       ...packageJson.devDependencies,
@@ -218,7 +225,14 @@ export const installTemplate = async ({
       '@react-email/tailwind': '0.0.18',
     };
 
-    /* Zod dependencies used in react email example */
+    packageJson.dependencies = {
+      ...packageJson.dependencies,
+      zod: '^3.23.8',
+      'zod-to-json-schema': '^3.23.1',
+    };
+  }
+
+  if (isAgentTemplate) {
     packageJson.dependencies = {
       ...packageJson.dependencies,
       zod: '^3.23.8',

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -224,15 +224,9 @@ export const installTemplate = async ({
       '@react-email/components': '0.0.18',
       '@react-email/tailwind': '0.0.18',
     };
-
-    packageJson.dependencies = {
-      ...packageJson.dependencies,
-      zod: '^3.23.8',
-      'zod-to-json-schema': '^3.23.1',
-    };
   }
 
-  if (isAgentTemplate) {
+  if (template === TemplateTypeEnum.APP_REACT_EMAIL || isAgentTemplate) {
     packageJson.dependencies = {
       ...packageJson.dependencies,
       zod: '^3.23.8',

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -244,7 +244,7 @@ export const installTemplate = async ({
   if (eslint) {
     packageJson.devDependencies = {
       ...packageJson.devDependencies,
-      eslint: '^9',
+      eslint: '^8',
       'eslint-config-next': version,
     };
   }

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -153,8 +153,8 @@ export const installTemplate = async ({
       ? { NOVU_SECRET_KEY: secretKey }
       : {
           NOVU_SECRET_KEY: secretKey,
-          NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER: applicationId,
-          NEXT_PUBLIC_NOVU_SUBSCRIBER_ID: userId,
+          NEXT_PUBLIC_NOVU_APPLICATION_IDENTIFIER: applicationId ?? '',
+          NEXT_PUBLIC_NOVU_SUBSCRIBER_ID: userId ?? '',
         };
 
   const val = Object.entries(envVars).reduce((acc, [key, value]) => {

--- a/packages/novu/src/commands/init/templates/types.ts
+++ b/packages/novu/src/commands/init/templates/types.ts
@@ -5,6 +5,7 @@ export enum TemplateTypeEnum {
   APP = 'app',
   DEFAULT_REACT_EMAIL = 'default-react-email',
   APP_REACT_EMAIL = 'app-react-email',
+  APP_AGENT = 'app-agent',
 }
 
 export type TemplateType = `${TemplateTypeEnum}`;

--- a/packages/novu/src/index.ts
+++ b/packages/novu/src/index.ts
@@ -97,6 +97,7 @@ program
     `The Novu development environment Secret Key. Note that your Novu app won't work outside of local mode without it.`
   )
   .option('-a, --api-url <url>', 'The Novu Cloud API URL', 'https://api.novu.co')
+  .option('-t, --template <name>', 'The template to use (notifications or agent)')
   .action(async (options: IInitCommandOptions) => {
     return await init(options, anonymousId);
   });


### PR DESCRIPTION
## Summary

Extends `npx novu init` with an agent template option so users can scaffold a conversational AI agent app alongside the existing notifications template.

- Adds interactive template prompt ("Notifications" / "Agent") and `--template` CLI flag
- New `app-agent` template scaffolds a Next.js app with a bridge endpoint serving an agent via `@novu/framework`
- Demo agent showcases the full SDK surface: interactive Cards with Buttons, `onAction` handler, `ctx.metadata.set()`, `ctx.resolve()`, markdown replies, and conversation history — all working without an LLM API key
- Agent template generates a leaner `package.json` (no Tailwind, React Email, or `@novu/nextjs`) and a simplified `.env.local` (just `NOVU_SECRET_KEY`)

### CLI flow

```mermaid
flowchart TD
    Start["npx novu init"] --> Name["Prompt: project name"]
    Name --> Flag{"--template flag?"}
    Flag -->|yes| Skip[Use flag value]
    Flag -->|no| Prompt["Prompt: Notifications / Agent"]
    Skip --> Create[createApp]
    Prompt --> Create
    Create -->|notifications| Existing[app-react-email]
    Create -->|agent| New[app-agent]
    Existing --> Install["npm install + git init"]
    New --> Install
```

### Files changed

| File | Change |
|------|--------|
| `packages/novu/src/index.ts` | Added `--template` option |
| `packages/novu/src/commands/init/index.ts` | Template prompt + pass-through |
| `packages/novu/src/commands/init/create-app.ts` | Accept template choice |
| `packages/novu/src/commands/init/templates/types.ts` | `APP_AGENT` enum value |
| `packages/novu/src/commands/init/templates/index.ts` | Agent branch for deps, env, skip GitHub Action |
| `packages/novu/src/commands/init/templates/app-agent/ts/*` | 13 new template files |

## Test plan

- [ ] Run `npx novu init` — verify template prompt appears, selecting "Notifications" produces the same output as before
- [ ] Run `npx novu init --template agent` — verify agent template scaffolds correctly with the right `package.json` deps and `.env.local`
- [ ] Run `npx novu init --template notifications` — verify it skips the prompt and uses the existing template
- [ ] Verify `npm run dev` works in the scaffolded agent project
- [ ] Verify the build script (`pnpm build` in `packages/novu`) copies `app-agent` into `dist`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The `npx novu init` CLI now supports scaffolding conversational AI agent applications alongside the existing notifications template. Users can interactively choose between "Notifications" or "Agent," or use the new `--template` flag to skip the prompt. A new `app-agent` template provides a pre-configured Next.js app with a Novu Bridge endpoint serving a demo agent that showcases SDK features: interactive Cards with action handlers, conversation metadata management, message history, and conversation resolution—all functional without an LLM API key.

## Affected areas

**novu** — Added `--template` CLI flag and interactive template selection in the `init` command. The `createApp` function now accepts `templateChoice` and routes to either the existing `app-react-email` template or the new `app-agent` template based on selection.

**novu** (templates) — Introduced `APP_AGENT` enum value to `TemplateTypeEnum`. Template-specific configuration now varies: the agent template outputs a minimal `.env.local` (only `NOVU_SECRET_KEY`), skips `.github` directory copying, and includes a leaner `package.json` without Tailwind, React Email, or `@novu/nextjs`.

**novu** (new template files) — Added 13 new files under `packages/novu/src/commands/init/templates/app-agent/ts/` including Next.js layout/page components, API route handler, agent definition with `onMessage`/`onAction`/`onResolve` handlers, TypeScript/ESLint/Next.js configuration, and documentation.

## Key technical decisions

- Agent template uses JSX syntax with per-file `@jsxImportSource` pragma and `tsconfig.json` configured with `jsx: react-jsx`.
- Zod dependencies are now included for both `APP_REACT_EMAIL` and `APP_AGENT` templates.
- ESLint version updated from `^8` to `^9` in generated `package.json`.
- Agent template intentionally omits `@novu/nextjs` dependency to keep the scaffold lightweight.

## Testing

No new unit or integration tests were added. The PR includes a manual test plan to verify interactive prompt behavior, `--template` flag functionality, correct file scaffolding, successful `npm run dev` execution in the generated agent project, and build copying of the `app-agent` template to `dist`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->