### PR TITLE
feat(dashboard): Conversations page

### DIFF
--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, forwardRef, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { PinoLogger, shortId } from '@novu/application-generic';
 import {
+  AgentRepository,
   ConversationActivityRepository,
   ConversationActivityTypeEnum,
   ConversationChannel,
@@ -10,11 +11,11 @@ import {
   SubscriberRepository,
 } from '@novu/dal';
 import { AgentEventEnum } from '../../dtos/agent-event.enum';
+import type { ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
 import { AgentConfigResolver } from '../../services/agent-config-resolver.service';
 import { AgentConversationService } from '../../services/agent-conversation.service';
 import { BridgeExecutorService } from '../../services/bridge-executor.service';
 import { ChatSdkService } from '../../services/chat-sdk.service';
-import type { ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
 import { HandleAgentReplyCommand } from './handle-agent-reply.command';
 
 @Injectable()
@@ -23,6 +24,7 @@ export class HandleAgentReply {
     private readonly conversationRepository: ConversationRepository,
     private readonly activityRepository: ConversationActivityRepository,
     private readonly subscriberRepository: SubscriberRepository,
+    private readonly agentRepository: AgentRepository,
     @Inject(forwardRef(() => ChatSdkService))
     private readonly chatSdkService: ChatSdkService,
     private readonly bridgeExecutor: BridgeExecutorService,
@@ -53,14 +55,38 @@ export class HandleAgentReply {
 
     const channel = this.getPrimaryChannel(conversation);
 
+    const agent = await this.agentRepository.findOne(
+      {
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+        identifier: command.agentIdentifier,
+      },
+      { name: 1, identifier: 1 }
+    );
+    const agentName = agent?.name;
+
     if (command.update) {
-      await this.deliverMessage(command, conversation, channel, command.update, ConversationActivityTypeEnum.UPDATE);
+      await this.deliverMessage(
+        command,
+        conversation,
+        channel,
+        command.update,
+        ConversationActivityTypeEnum.UPDATE,
+        agentName
+      );
 
       return { status: 'update_sent' };
     }
 
     if (command.reply) {
-      await this.deliverMessage(command, conversation, channel, command.reply, ConversationActivityTypeEnum.MESSAGE);
+      await this.deliverMessage(
+        command,
+        conversation,
+        channel,
+        command.reply,
+        ConversationActivityTypeEnum.MESSAGE,
+        agentName
+      );
 
       this.removeAckReaction(command, conversation, channel).catch((err) => {
         this.logger.warn(err, `[agent:${command.agentIdentifier}] Failed to remove ack reaction`);
@@ -92,7 +118,8 @@ export class HandleAgentReply {
     conversation: ConversationEntity,
     channel: ConversationChannel,
     content: ReplyContentDto,
-    type: ConversationActivityTypeEnum
+    type: ConversationActivityTypeEnum,
+    agentName?: string
   ): Promise<void> {
     const textFallback = this.extractTextFallback(content);
 
@@ -111,8 +138,9 @@ export class HandleAgentReply {
         integrationId: channel._integrationId,
         platformThreadId: channel.platformThreadId,
         agentId: command.agentIdentifier,
+        senderName: agentName,
         content: textFallback,
-        richContent: (content.card || content.files?.length) ? (content as Record<string, unknown>) : undefined,
+        richContent: content.card || content.files?.length ? (content as Record<string, unknown>) : undefined,
         type,
         environmentId: command.environmentId,
         organizationId: command.organizationId,
@@ -145,7 +173,8 @@ export class HandleAgentReply {
     signals: HandleAgentReplyCommand['signals']
   ): Promise<void> {
     const metadataSignals = (signals ?? []).filter(
-      (s): s is Extract<NonNullable<HandleAgentReplyCommand['signals']>[number], { type: 'metadata' }> => s.type === 'metadata'
+      (s): s is Extract<NonNullable<HandleAgentReplyCommand['signals']>[number], { type: 'metadata' }> =>
+        s.type === 'metadata'
     );
 
     if (metadataSignals.length) {

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -1,4 +1,11 @@
-import { BadRequestException, forwardRef, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  forwardRef,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { PinoLogger, shortId } from '@novu/application-generic';
 import {
   AgentRepository,
@@ -55,17 +62,9 @@ export class HandleAgentReply {
 
     const channel = this.getPrimaryChannel(conversation);
 
-    const agent = await this.agentRepository.findOne(
-      {
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-        identifier: command.agentIdentifier,
-      },
-      { name: 1, identifier: 1 }
-    );
-    const agentName = agent?.name;
-
     if (command.update) {
+      const agentName = await this.resolveValidatedAgentNameForDelivery(command, conversation);
+
       await this.deliverMessage(
         command,
         conversation,
@@ -84,6 +83,8 @@ export class HandleAgentReply {
       : null;
 
     if (command.reply) {
+      const agentName = await this.resolveValidatedAgentNameForDelivery(command, conversation);
+
       await this.deliverMessage(
         command,
         conversation,
@@ -107,6 +108,30 @@ export class HandleAgentReply {
     }
 
     return { status: 'ok' };
+  }
+
+  private async resolveValidatedAgentNameForDelivery(
+    command: HandleAgentReplyCommand,
+    conversation: ConversationEntity
+  ): Promise<string | undefined> {
+    const agent = await this.agentRepository.findOne(
+      {
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+        identifier: command.agentIdentifier,
+      },
+      { _id: 1, name: 1, identifier: 1 }
+    );
+
+    if (!agent) {
+      throw new NotFoundException('Agent not found');
+    }
+
+    if (String(agent._id) !== conversation._agentId) {
+      throw new ForbiddenException('Agent identifier does not match this conversation');
+    }
+
+    return agent.name;
   }
 
   private getPrimaryChannel(conversation: ConversationEntity): ConversationChannel {

--- a/apps/dashboard/src/api/conversations.ts
+++ b/apps/dashboard/src/api/conversations.ts
@@ -9,9 +9,23 @@ export type ConversationFilters = {
   status?: string;
 };
 
+export type ParticipantSubscriberData = {
+  firstName?: string;
+  lastName?: string;
+  avatar?: string;
+  subscriberId: string;
+};
+
+export type ParticipantAgentData = {
+  name: string;
+  identifier: string;
+};
+
 export type ConversationParticipantDto = {
   type: string;
   id: string;
+  subscriber?: ParticipantSubscriberData | null;
+  agent?: ParticipantAgentData | null;
 };
 
 export type ConversationChannelDto = {

--- a/apps/dashboard/src/api/conversations.ts
+++ b/apps/dashboard/src/api/conversations.ts
@@ -1,0 +1,150 @@
+import { getDateRangeInMs, type IEnvironment } from '@novu/shared';
+import { get } from './api.client';
+
+export type ConversationFilters = {
+  dateRange?: string;
+  subscriberId?: string;
+  provider?: string[];
+  conversationId?: string;
+  status?: string;
+};
+
+export type ConversationParticipantDto = {
+  type: string;
+  id: string;
+};
+
+export type ConversationChannelDto = {
+  platform: string;
+  _integrationId: string;
+  platformThreadId: string;
+};
+
+export type ConversationDto = {
+  _id: string;
+  identifier: string;
+  _agentId: string;
+  participants?: ConversationParticipantDto[];
+  channels?: ConversationChannelDto[];
+  status: string;
+  title: string;
+  metadata: Record<string, unknown>;
+  _environmentId: string;
+  _organizationId: string;
+  createdAt: string;
+  lastActivityAt: string;
+};
+
+export type ConversationsListResponse = {
+  data: ConversationDto[];
+  page: number;
+  totalCount: number;
+  pageSize: number;
+  hasMore: boolean;
+};
+
+export function getConversationsList({
+  environment,
+  page,
+  limit,
+  filters,
+  signal,
+}: {
+  environment: IEnvironment;
+  page: number;
+  limit: number;
+  filters?: ConversationFilters;
+  signal?: AbortSignal;
+}): Promise<ConversationsListResponse> {
+  const searchParams = new URLSearchParams();
+  searchParams.append('page', page.toString());
+  searchParams.append('limit', limit.toString());
+
+  if (filters?.status) {
+    searchParams.append('status', filters.status);
+  }
+
+  if (filters?.subscriberId) {
+    searchParams.append('subscriberId', filters.subscriberId);
+  }
+
+  if (filters?.dateRange) {
+    const after = new Date(Date.now() - getDateRangeInMs(filters.dateRange));
+    searchParams.append('after', after.toISOString());
+  }
+
+  if (filters?.provider?.length) {
+    for (const p of filters.provider) {
+      searchParams.append('provider', p);
+    }
+  }
+
+  if (filters?.conversationId) {
+    searchParams.append('conversationId', filters.conversationId);
+  }
+
+  return get<ConversationsListResponse>(`/conversations?${searchParams.toString()}`, {
+    environment,
+    signal,
+  });
+}
+
+export type ConversationActivityDto = {
+  _id: string;
+  identifier: string;
+  _conversationId: string;
+  type: 'message' | 'update' | 'signal';
+  content: string;
+  platform: string;
+  _integrationId: string;
+  platformThreadId: string;
+  senderType: 'subscriber' | 'platform_user' | 'agent' | 'system';
+  senderId: string;
+  senderName?: string;
+  platformMessageId?: string;
+  signalData?: { type: string; payload?: Record<string, unknown> };
+  _environmentId: string;
+  _organizationId: string;
+  createdAt: string;
+};
+
+export type ConversationActivitiesResponse = {
+  data: ConversationActivityDto[];
+  page: number;
+  totalCount: number;
+  pageSize: number;
+  hasMore: boolean;
+};
+
+/** `conversationIdentifier` is the public `identifier` field — the API resolves by identifier, not Mongo `_id`. */
+export function getConversation(
+  conversationIdentifier: string,
+  environment: IEnvironment
+): Promise<ConversationDto> {
+  return get<ConversationDto>(`/conversations/${encodeURIComponent(conversationIdentifier)}`, {
+    environment,
+  });
+}
+
+export function getConversationActivities({
+  conversationIdentifier,
+  environment,
+  page = 0,
+  limit = 50,
+  signal,
+}: {
+  conversationIdentifier: string;
+  environment: IEnvironment;
+  page?: number;
+  limit?: number;
+  signal?: AbortSignal;
+}): Promise<ConversationActivitiesResponse> {
+  const searchParams = new URLSearchParams();
+  searchParams.append('page', page.toString());
+  searchParams.append('limit', limit.toString());
+
+  return get<ConversationActivitiesResponse>(
+    `/conversations/${encodeURIComponent(conversationIdentifier)}/activities?${searchParams.toString()}`,
+    { environment, signal }
+  );
+}

--- a/apps/dashboard/src/components/conversations/constants.ts
+++ b/apps/dashboard/src/components/conversations/constants.ts
@@ -1,0 +1,14 @@
+import { CONVERSATIONAL_PROVIDERS } from '@novu/shared';
+import { ConversationFiltersData } from '@/types/conversation';
+
+export const PROVIDER_OPTIONS = CONVERSATIONAL_PROVIDERS.filter((p) => !p.comingSoon).map((p) => ({
+  label: p.displayName,
+  value: p.providerId,
+}));
+
+export const defaultConversationFilters: ConversationFiltersData = {
+  dateRange: '24h',
+  subscriberId: '',
+  provider: [],
+  conversationId: '',
+} as const;

--- a/apps/dashboard/src/components/conversations/conversation-detail.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-detail.tsx
@@ -1,0 +1,99 @@
+import { RiArrowDownSLine, RiArrowUpSLine, RiCloseFill } from 'react-icons/ri';
+import { Separator } from '@/components/primitives/separator';
+import { Skeleton } from '@/components/primitives/skeleton';
+import {
+  useFetchConversation,
+  useFetchConversationActivities,
+} from '@/hooks/use-fetch-conversation-activities';
+import { ConversationOverview } from './conversation-overview';
+import { ConversationTimeline } from './conversation-timeline';
+
+type ConversationDetailProps = {
+  conversationId: string;
+  onClose?: () => void;
+  onNavigate?: (direction: 'prev' | 'next') => void;
+};
+
+export function ConversationDetail({ conversationId, onClose, onNavigate }: ConversationDetailProps) {
+  const { conversation, isLoading: isConversationLoading } = useFetchConversation(conversationId);
+  const { activities, totalCount, isLoading: isActivitiesLoading } =
+    useFetchConversationActivities(conversationId);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-8 shrink-0 items-center justify-between px-2">
+        <span className="text-text-strong text-label-sm font-medium">Conversation</span>
+        <div className="flex items-center gap-0.5">
+          {onNavigate && (
+            <>
+              <button
+                onClick={() => onNavigate('prev')}
+                className="text-text-soft hover:text-text-strong rounded p-0.5"
+              >
+                <RiArrowUpSLine className="size-4" />
+              </button>
+              <button
+                onClick={() => onNavigate('next')}
+                className="text-text-soft hover:text-text-strong rounded p-0.5"
+              >
+                <RiArrowDownSLine className="size-4" />
+              </button>
+            </>
+          )}
+          {onNavigate && onClose && <Separator orientation="vertical" className="mx-0.5 h-4" />}
+          {onClose && (
+            <button onClick={onClose} className="text-text-soft hover:text-text-strong rounded p-0.5">
+              <RiCloseFill className="size-4" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {isConversationLoading ? (
+          <OverviewSkeleton />
+        ) : conversation ? (
+          <div className="px-3 pb-2">
+            <ConversationOverview conversation={conversation} />
+          </div>
+        ) : null}
+
+        <Separator />
+
+        <ConversationTimeline
+          activities={activities}
+          isLoading={isActivitiesLoading}
+          totalCount={totalCount}
+        />
+      </div>
+    </div>
+  );
+}
+
+function OverviewSkeleton() {
+  return (
+    <div className="flex flex-col gap-2 px-3 py-2">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-4 w-36" />
+        <Skeleton className="h-4 w-32" />
+      </div>
+      <div className="border-stroke-soft flex flex-col gap-1 rounded-lg border p-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex items-center justify-between py-1">
+            <Skeleton className="h-3.5 w-24" />
+            <Skeleton className="h-3.5 w-32" />
+          </div>
+        ))}
+      </div>
+      <div className="border-stroke-soft rounded-lg border p-2">
+        <div className="flex items-center gap-2">
+          <Skeleton className="size-8 rounded-full" />
+          <div className="flex flex-1 flex-col gap-1">
+            <Skeleton className="h-3.5 w-24" />
+            <Skeleton className="h-3 w-36" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/conversations/conversation-detail.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-detail.tsx
@@ -40,7 +40,7 @@ export function ConversationDetail({ conversationId, onClose, onNavigate }: Conv
               </button>
             </>
           )}
-          {onNavigate && onClose && <Separator orientation="vertical" className="mx-0.5 h-4" />}
+          {onNavigate && onClose && <div className="bg-stroke-soft mx-0.5 h-4 w-px" />}
           {onClose && (
             <button onClick={onClose} className="text-text-soft hover:text-text-strong rounded p-0.5">
               <RiCloseFill className="size-4" />

--- a/apps/dashboard/src/components/conversations/conversation-detail.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-detail.tsx
@@ -27,12 +27,16 @@ export function ConversationDetail({ conversationId, onClose, onNavigate }: Conv
           {onNavigate && (
             <>
               <button
+                type="button"
+                aria-label="Previous conversation"
                 onClick={() => onNavigate('prev')}
                 className="text-text-soft hover:text-text-strong rounded p-0.5"
               >
                 <RiArrowUpSLine className="size-4" />
               </button>
               <button
+                type="button"
+                aria-label="Next conversation"
                 onClick={() => onNavigate('next')}
                 className="text-text-soft hover:text-text-strong rounded p-0.5"
               >
@@ -42,7 +46,12 @@ export function ConversationDetail({ conversationId, onClose, onNavigate }: Conv
           )}
           {onNavigate && onClose && <div className="bg-stroke-soft mx-0.5 h-4 w-px" />}
           {onClose && (
-            <button onClick={onClose} className="text-text-soft hover:text-text-strong rounded p-0.5">
+            <button
+              type="button"
+              aria-label="Close conversation"
+              onClick={onClose}
+              className="text-text-soft hover:text-text-strong rounded p-0.5"
+            >
               <RiCloseFill className="size-4" />
             </button>
           )}

--- a/apps/dashboard/src/components/conversations/conversation-overview.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-overview.tsx
@@ -1,0 +1,112 @@
+import { RiRobot2Line } from 'react-icons/ri';
+import { ConversationDto } from '@/api/conversations';
+import { ConversationStatusBadge } from './conversation-status-badge';
+
+type ConversationOverviewProps = {
+  conversation: ConversationDto;
+};
+
+function formatTimestamp(dateStr: string): string {
+  const d = new Date(dateStr);
+  const month = d.toLocaleDateString('en-US', { month: 'short' });
+  const day = d.getDate();
+  const year = d.getFullYear();
+  const time = d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+
+  return `${month} ${day} ${year} ${time}`;
+}
+
+function MetaRow({ label, children, isLast }: { label: string; children: React.ReactNode; isLast?: boolean }) {
+  return (
+    <div className={`flex flex-col items-start py-1 ${isLast ? '' : 'border-stroke-soft border-b'}`}>
+      <div className="flex h-6 w-full items-center justify-between overflow-hidden px-1.5">
+        <span className="text-text-soft font-code text-xs font-medium tracking-tight">{label}</span>
+        <div className="text-text-sub font-code text-xs tracking-tight">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+export function ConversationOverview({ conversation }: ConversationOverviewProps) {
+  const participants = conversation.participants ?? [];
+  const channels = conversation.channels ?? [];
+  const subscriber = participants.find((p) => p.type === 'subscriber');
+  const agent = participants.find((p) => p.type === 'agent');
+  const agentName = agent?.id ?? conversation._agentId ?? 'agent';
+  const platforms = [...new Set(channels.map((c) => c.platform))];
+
+  const sourceRequestId = (conversation.metadata?.sourceRequestId as string) ?? undefined;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col">
+        <div className="flex items-center justify-between p-1">
+          <div className="flex items-center px-2">
+            <div className="border-stroke-soft size-2.5 rounded-full border" />
+            <div className="py-1 pl-1.5 pr-1">
+              <span className="text-text-sub font-code text-xs font-medium tracking-tight">
+                Conversation initiated
+              </span>
+            </div>
+          </div>
+          <span className="text-text-sub font-code text-xs font-normal tracking-tight">
+            {formatTimestamp(conversation.createdAt)}
+          </span>
+        </div>
+
+        <div className="border-stroke-soft rounded-lg border bg-white p-1">
+          {sourceRequestId && (
+            <MetaRow label="API request (source)">
+              <span className="font-normal">{sourceRequestId} ↗</span>
+            </MetaRow>
+          )}
+          <MetaRow label="Conversation ID">
+            <span className="font-normal">{conversation.identifier}</span>
+          </MetaRow>
+          <MetaRow label="Agent">
+            <span className="flex items-center gap-1 font-medium">
+              <RiRobot2Line className="size-3.5" />
+              {agentName} ↗
+            </span>
+          </MetaRow>
+          <MetaRow label="Providers">
+            <div className="flex items-center gap-1">
+              {platforms.map((platform) => (
+                <div key={platform} className="border-stroke-soft rounded border bg-[#fbfbfb] p-0.5">
+                  <img
+                    src={`/images/providers/light/square/${platform}.svg`}
+                    alt={platform}
+                    className="size-[15px] object-contain"
+                  />
+                </div>
+              ))}
+              {platforms.length === 0 && <span className="text-text-soft text-xs">—</span>}
+            </div>
+          </MetaRow>
+          <MetaRow label="Status" isLast>
+            <ConversationStatusBadge status={conversation.status} />
+          </MetaRow>
+        </div>
+
+        <div className="px-[18px]">
+          <div className="border-stroke-soft h-2 border-l" />
+        </div>
+
+        {subscriber && (
+          <div className="border-stroke-soft rounded-lg border bg-white p-1">
+            <div className="bg-bg-weak flex items-center gap-2 overflow-hidden rounded p-1">
+              <div className="bg-neutral-200 size-8 shrink-0 rounded-full" />
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <div className="text-label-xs flex items-center justify-between font-medium">
+                  <span className="text-text-strong truncate">{subscriber.id}</span>
+                  <span className="text-text-soft shrink-0 truncate">{subscriber.id}</span>
+                </div>
+                <span className="text-text-soft text-label-xs truncate font-medium">{subscriber.id}</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/conversations/conversation-overview.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-overview.tsx
@@ -32,7 +32,7 @@ export function ConversationOverview({ conversation }: ConversationOverviewProps
   const channels = conversation.channels ?? [];
   const subscriber = participants.find((p) => p.type === 'subscriber');
   const agent = participants.find((p) => p.type === 'agent');
-  const agentName = agent?.id ?? conversation._agentId ?? 'agent';
+  const agentName = agent?.agent?.name ?? agent?.id ?? conversation._agentId ?? 'agent';
   const platforms = [...new Set(channels.map((c) => c.platform))];
 
   const sourceRequestId = (conversation.metadata?.sourceRequestId as string) ?? undefined;
@@ -92,20 +92,30 @@ export function ConversationOverview({ conversation }: ConversationOverviewProps
           <div className="border-stroke-soft h-2 border-l" />
         </div>
 
-        {subscriber && (
-          <div className="border-stroke-soft rounded-lg border bg-white p-1">
-            <div className="bg-bg-weak flex items-center gap-2 overflow-hidden rounded p-1">
-              <div className="bg-neutral-200 size-8 shrink-0 rounded-full" />
-              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                <div className="text-label-xs flex items-center justify-between font-medium">
-                  <span className="text-text-strong truncate">{subscriber.id}</span>
-                  <span className="text-text-soft shrink-0 truncate">{subscriber.id}</span>
+        {subscriber && (() => {
+          const sub = subscriber.subscriber;
+          const displayName = [sub?.firstName, sub?.lastName].filter(Boolean).join(' ') || subscriber.id;
+          const subscriberId = sub?.subscriberId ?? subscriber.id;
+
+          return (
+            <div className="border-stroke-soft rounded-lg border bg-white p-1">
+              <div className="bg-bg-weak flex items-center gap-2 overflow-hidden rounded p-1">
+                {sub?.avatar ? (
+                  <img src={sub.avatar} alt="" className="size-8 shrink-0 rounded-full object-cover" />
+                ) : (
+                  <div className="bg-neutral-200 size-8 shrink-0 rounded-full" />
+                )}
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <div className="text-label-xs flex items-center justify-between font-medium">
+                    <span className="text-text-strong truncate">{displayName}</span>
+                    <span className="text-text-soft shrink-0 truncate">{subscriberId}</span>
+                  </div>
+                  <span className="text-text-soft text-label-xs truncate font-medium">{subscriberId}</span>
                 </div>
-                <span className="text-text-soft text-label-xs truncate font-medium">{subscriber.id}</span>
               </div>
             </div>
-          </div>
-        )}
+          );
+        })()}
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/conversations/conversation-query-keys.ts
+++ b/apps/dashboard/src/components/conversations/conversation-query-keys.ts
@@ -1,0 +1,4 @@
+export const conversationQueryKeys = Object.freeze({
+  fetchConversations: 'fetchConversations',
+  fetchConversation: 'fetchConversation',
+});

--- a/apps/dashboard/src/components/conversations/conversation-status-badge.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-status-badge.tsx
@@ -1,0 +1,41 @@
+import { cn } from '@/utils/ui';
+
+const STATUS_CONFIG: Record<string, { label: string; bgClass: string; textClass: string }> = {
+  resolved: {
+    label: 'RESOLVED',
+    bgClass: 'bg-success-lighter',
+    textClass: 'text-success-base',
+  },
+  active: {
+    label: 'OPEN',
+    bgClass: 'bg-warning-lighter',
+    textClass: 'text-warning-base',
+  },
+  failed: {
+    label: 'FAILED',
+    bgClass: 'bg-error-lighter',
+    textClass: 'text-destructive-base',
+  },
+};
+
+type ConversationStatusBadgeProps = {
+  status: string;
+  className?: string;
+};
+
+export function ConversationStatusBadge({ status, className }: ConversationStatusBadgeProps) {
+  const config = STATUS_CONFIG[status] || STATUS_CONFIG.active;
+
+  return (
+    <span
+      className={cn(
+        'font-code inline-flex items-center rounded-md px-1 py-0.5 text-xs font-medium tracking-tight',
+        config.bgClass,
+        config.textClass,
+        className
+      )}
+    >
+      {config.label}
+    </span>
+  );
+}

--- a/apps/dashboard/src/components/conversations/conversation-status-badge.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-status-badge.tsx
@@ -1,6 +1,8 @@
 import { cn } from '@/utils/ui';
 
-const STATUS_CONFIG: Record<string, { label: string; bgClass: string; textClass: string }> = {
+type StatusStyle = { label: string; bgClass: string; textClass: string };
+
+const STATUS_CONFIG: Record<string, StatusStyle> = {
   resolved: {
     label: 'RESOLVED',
     bgClass: 'bg-success-lighter',
@@ -16,6 +18,11 @@ const STATUS_CONFIG: Record<string, { label: string; bgClass: string; textClass:
     bgClass: 'bg-error-lighter',
     textClass: 'text-destructive-base',
   },
+  unknown: {
+    label: 'UNKNOWN',
+    bgClass: 'bg-neutral-100',
+    textClass: 'text-text-soft',
+  },
 };
 
 type ConversationStatusBadgeProps = {
@@ -24,7 +31,7 @@ type ConversationStatusBadgeProps = {
 };
 
 export function ConversationStatusBadge({ status, className }: ConversationStatusBadgeProps) {
-  const config = STATUS_CONFIG[status] || STATUS_CONFIG.active;
+  const config: StatusStyle = STATUS_CONFIG[status] ?? STATUS_CONFIG.unknown;
 
   return (
     <span

--- a/apps/dashboard/src/components/conversations/conversation-table-row.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-table-row.tsx
@@ -10,14 +10,22 @@ type ConversationTableRowProps = {
   onClick?: (conversationId: string) => void;
 };
 
-function getFirstSubscriberId(conversation: ConversationDto): string | undefined {
-  return (conversation.participants ?? []).find((p) => p.type === 'subscriber')?.id;
+function getSubscriberLabel(conversation: ConversationDto): string | undefined {
+  const p = (conversation.participants ?? []).find((p) => p.type === 'subscriber');
+  if (!p) return undefined;
+
+  const sub = p.subscriber;
+  if (sub?.firstName || sub?.lastName) {
+    return [sub.firstName, sub.lastName].filter(Boolean).join(' ');
+  }
+
+  return sub?.subscriberId ?? p.id;
 }
 
 function getAgentName(conversation: ConversationDto): string {
   const agent = (conversation.participants ?? []).find((p) => p.type === 'agent');
 
-  return agent?.id ?? conversation._agentId ?? 'agent';
+  return agent?.agent?.name ?? agent?.id ?? conversation._agentId ?? 'agent';
 }
 
 function formatTimestamp(dateStr: string): string {
@@ -36,7 +44,7 @@ export function ConversationTableRow({ conversation, isSelected, onClick }: Conv
     onClick?.(conversation.identifier);
   };
 
-  const subscriber = getFirstSubscriberId(conversation);
+  const subscriber = getSubscriberLabel(conversation);
   const agentName = getAgentName(conversation);
   const isResolved = conversation.status === 'resolved';
 

--- a/apps/dashboard/src/components/conversations/conversation-table-row.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-table-row.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from 'react';
 import { RiCheckboxCircleFill, RiRobot2Line } from 'react-icons/ri';
 import { ConversationDto } from '@/api/conversations';
 import { TableCell, TableRow } from '@/components/primitives/table';
@@ -44,14 +45,27 @@ export function ConversationTableRow({ conversation, isSelected, onClick }: Conv
     onClick?.(conversation.identifier);
   };
 
+  const handleKeyDown = (event: KeyboardEvent<HTMLTableRowElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      if (event.key === ' ') {
+        event.preventDefault();
+      }
+
+      handleClick();
+    }
+  };
+
   const subscriber = getSubscriberLabel(conversation);
   const agentName = getAgentName(conversation);
   const isResolved = conversation.status === 'resolved';
 
   return (
     <TableRow
+      tabIndex={0}
+      aria-selected={isSelected}
       className={cn('relative cursor-pointer hover:bg-neutral-50', isSelected && 'bg-neutral-50')}
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
     >
       <TableCell colSpan={2} className="px-3 py-1.5">
         <div className="flex flex-col gap-1.5">

--- a/apps/dashboard/src/components/conversations/conversation-table-row.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-table-row.tsx
@@ -1,0 +1,88 @@
+import { RiCheckboxCircleFill, RiRobot2Line } from 'react-icons/ri';
+import { ConversationDto } from '@/api/conversations';
+import { TableCell, TableRow } from '@/components/primitives/table';
+import { cn } from '@/utils/ui';
+import { ConversationStatusBadge } from './conversation-status-badge';
+
+type ConversationTableRowProps = {
+  conversation: ConversationDto;
+  isSelected?: boolean;
+  onClick?: (conversationId: string) => void;
+};
+
+function getFirstSubscriberId(conversation: ConversationDto): string | undefined {
+  return (conversation.participants ?? []).find((p) => p.type === 'subscriber')?.id;
+}
+
+function getAgentName(conversation: ConversationDto): string {
+  const agent = (conversation.participants ?? []).find((p) => p.type === 'agent');
+
+  return agent?.id ?? conversation._agentId ?? 'agent';
+}
+
+function formatTimestamp(dateStr: string): string {
+  const d = new Date(dateStr);
+
+  const month = d.toLocaleDateString('en-US', { month: 'short' });
+  const day = d.getDate();
+  const year = d.getFullYear();
+  const time = d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
+
+  return `${month} ${day} ${year} ${time}`;
+}
+
+export function ConversationTableRow({ conversation, isSelected, onClick }: ConversationTableRowProps) {
+  const handleClick = () => {
+    onClick?.(conversation.identifier);
+  };
+
+  const subscriber = getFirstSubscriberId(conversation);
+  const agentName = getAgentName(conversation);
+  const isResolved = conversation.status === 'resolved';
+
+  return (
+    <TableRow
+      className={cn('relative cursor-pointer hover:bg-neutral-50', isSelected && 'bg-neutral-50')}
+      onClick={handleClick}
+    >
+      <TableCell colSpan={2} className="px-3 py-1.5">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-8">
+            <div className="flex min-w-0 flex-1 items-center gap-1">
+              <RiCheckboxCircleFill
+                className={cn('size-4 shrink-0', isResolved ? 'text-success-base' : 'text-warning-base')}
+              />
+              <span className="text-text-sub text-label-xs min-w-0 truncate font-medium">
+                {conversation.title || 'Untitled conversation'}
+              </span>
+            </div>
+            <span className="text-text-soft font-code shrink-0 text-[11px] leading-normal">
+              {formatTimestamp(conversation.lastActivityAt || conversation.createdAt)}
+            </span>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1">
+              <RiRobot2Line className="text-text-soft size-4 shrink-0" />
+              <span className="text-text-soft font-code text-xs font-medium tracking-tight">{agentName}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              {subscriber && (
+                <>
+                  <div className="flex max-w-[150px] items-center gap-1 rounded border border-stroke-soft bg-[#fbfbfb] px-1 py-0.5">
+                    <div className="bg-neutral-200 size-4 shrink-0 rounded-full" />
+                    <span className="text-text-strong font-code min-w-0 truncate text-xs font-medium">
+                      {subscriber}
+                    </span>
+                  </div>
+                  <span className="text-text-soft font-code text-[11px] leading-normal">•</span>
+                </>
+              )}
+              <ConversationStatusBadge status={conversation.status} />
+            </div>
+          </div>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/apps/dashboard/src/components/conversations/conversation-timeline.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-timeline.tsx
@@ -1,0 +1,260 @@
+import { Fragment, useState } from 'react';
+import {
+  RiCheckboxCircleFill,
+  RiExpandUpDownLine,
+  RiReplyLine,
+  RiRobot2Line,
+  RiRouteFill,
+  RiShareForwardLine,
+} from 'react-icons/ri';
+import { ConversationActivityDto } from '@/api/conversations';
+import { Skeleton } from '@/components/primitives/skeleton';
+import { cn } from '@/utils/ui';
+import { ConversationStatusBadge } from './conversation-status-badge';
+
+type ConversationTimelineProps = {
+  activities: ConversationActivityDto[];
+  isLoading: boolean;
+  totalCount: number;
+};
+
+function formatActivityTimestamp(dateStr: string): string {
+  const d = new Date(dateStr);
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase();
+  const year = String(d.getFullYear()).slice(2);
+  const time = d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
+
+  return `${day} ${month} ${year}, ${time}`;
+}
+
+function TimelineDivider() {
+  return (
+    <div className="px-[18px]">
+      <div className="border-stroke-soft h-2 border-l" />
+    </div>
+  );
+}
+
+function SenderHeader({ activity }: { activity: ConversationActivityDto }) {
+  const isAgent = activity.senderType === 'agent';
+  const name = activity.senderName ?? activity.senderId;
+
+  return (
+    <div className="flex items-center gap-1">
+      <div className="bg-bg-weak flex h-5 items-center rounded p-0.5">
+        <RiCheckboxCircleFill className="text-success-base size-4" />
+      </div>
+      <div
+        className={cn(
+          'flex max-w-[150px] items-center gap-1 rounded border px-1 py-0.5',
+          isAgent ? 'border-stroke-soft bg-white' : 'border-stroke-soft bg-bg-weak'
+        )}
+      >
+        {isAgent ? (
+          <RiRobot2Line className="text-text-sub size-4 shrink-0" />
+        ) : (
+          <div className="bg-neutral-200 size-4 shrink-0 rounded-full" />
+        )}
+        <span className="text-text-sub text-label-xs min-w-0 truncate font-medium">{name}</span>
+      </div>
+      {isAgent && (
+        <div className="border-stroke-soft flex items-center rounded border bg-white px-1 py-0.5">
+          <RiRobot2Line className="text-text-soft size-4" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MessageTimestamp({ activity }: { activity: ConversationActivityDto }) {
+  const isAgent = activity.senderType === 'agent';
+
+  return (
+    <div className="flex shrink-0 items-center gap-2">
+      <div className="flex items-center gap-1">
+        <div className="flex items-center gap-0.5">
+          {isAgent ? (
+            <RiReplyLine className="text-text-soft size-3" />
+          ) : (
+            <RiShareForwardLine className="text-text-soft size-3" />
+          )}
+          <span className="text-text-soft text-[10px] font-medium leading-[14px]">
+            {formatActivityTimestamp(activity.createdAt)}
+            {activity.platform ? ' via' : ''}
+          </span>
+        </div>
+        {activity.platform && (
+          <div className="border-stroke-soft bg-bg-weak flex items-center gap-[3px] rounded border px-1 py-0.5">
+            <img
+              src={`/images/providers/light/square/${activity.platform}.svg`}
+              alt={activity.platform}
+              className="size-3.5 object-contain"
+            />
+            <span className="text-text-sub text-[10px] font-medium leading-[14px] capitalize">
+              {activity.platform}
+            </span>
+          </div>
+        )}
+      </div>
+      <RiExpandUpDownLine className="text-text-soft size-4 shrink-0" />
+    </div>
+  );
+}
+
+function MessageContent({ content }: { content: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const isLong = content.length > 80;
+  const displayContent = expanded ? content : content.slice(0, 80);
+
+  return (
+    <div className="flex items-center gap-2.5 px-2 py-1">
+      <p className="text-label-xs min-w-0 flex-1 truncate font-medium text-[#1a1a1a]">
+        {displayContent}
+        {isLong && !expanded && '...'}
+      </p>
+      {isLong && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="text-text-soft flex shrink-0 items-center gap-0.5"
+        >
+          <RiExpandUpDownLine className="size-3.5" />
+          <span className="text-[10px] font-medium leading-[14px]">
+            {expanded ? 'Collapse' : 'Show full message'}
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function MessageCard({ activity }: { activity: ConversationActivityDto }) {
+  const isAgent = activity.senderType === 'agent';
+
+  return (
+    <div
+      className={cn(
+        'border-stroke-soft flex flex-col rounded-md border',
+        isAgent ? 'bg-bg-weak' : 'bg-white'
+      )}
+    >
+      <div className="flex flex-col py-1">
+        <div className="flex items-center justify-between px-2 py-1">
+          <SenderHeader activity={activity} />
+          <MessageTimestamp activity={activity} />
+        </div>
+        {activity.content && <MessageContent content={activity.content} />}
+      </div>
+    </div>
+  );
+}
+
+function InlineLogRow({ activity }: { activity: ConversationActivityDto }) {
+  const isAgentAction = activity.senderType === 'agent' || activity.senderType === 'system';
+  const signalType = activity.signalData?.type;
+
+  const icon = signalType === 'trigger' ? (
+    <RiRouteFill className="text-text-soft size-3.5 shrink-0" />
+  ) : (
+    <RiRobot2Line className={cn('size-3.5 shrink-0', isAgentAction ? 'text-text-soft' : 'text-text-soft')} />
+  );
+
+  return (
+    <div className="flex items-center gap-1 overflow-hidden py-0.5 pl-[11px]">
+      {icon}
+      <span className="text-text-sub text-label-xs min-w-0 truncate font-medium">{activity.content}</span>
+      <span className="text-text-soft font-code shrink-0 text-[11px] leading-normal">•</span>
+      <span className="text-text-soft shrink-0 text-[10px] font-medium leading-[14px]">
+        {formatActivityTimestamp(activity.createdAt)}
+      </span>
+    </div>
+  );
+}
+
+function ResolvedFooter({ totalCount }: { totalCount: number }) {
+  return (
+    <div className="relative flex items-center overflow-hidden py-2 pl-9">
+      <div className="border-stroke-soft absolute left-[18px] top-0 h-[calc(50%+1px)] w-3.5 rounded-bl-md border-b border-l" />
+      <div className="flex items-center gap-1.5 px-1">
+        <div className="flex items-center gap-1">
+          <ConversationStatusBadge status="resolved" />
+          <span className="text-text-soft font-code text-[11px] leading-normal">•</span>
+          <div className="border-stroke-soft bg-bg-weak flex items-center gap-0.5 rounded border px-1 py-0.5">
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="text-text-sub shrink-0">
+              <path
+                d="M1.5 2.5h9v6h-3.3L5.4 10v-1.5H1.5v-6Z"
+                stroke="currentColor"
+                strokeWidth="1"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <span className="text-text-sub text-label-xs font-medium">{totalCount}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ConversationTimeline({ activities, isLoading, totalCount }: ConversationTimelineProps) {
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-3 p-3">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-4 w-64" />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-2 py-2">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-3.5 w-32" />
+            </div>
+            <Skeleton className="ml-2 h-4 w-3/4" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (activities.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
+        <p className="text-text-soft text-paragraph-sm">No activities yet</p>
+      </div>
+    );
+  }
+
+  const hasResolvedSignal = activities.some(
+    (a) => a.type === 'signal' && a.signalData?.type === 'resolve'
+  );
+
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <div>
+        <h3 className="text-text-sub text-label-sm font-medium">Conversation timeline</h3>
+        <p className="text-text-soft text-label-xs mt-0.5 font-medium">
+          Everything that happened in this conversation, in order
+        </p>
+      </div>
+
+      <div className="flex flex-col">
+        {activities.map((activity, index) => (
+          <Fragment key={activity._id}>
+            {index > 0 && <TimelineDivider />}
+            {activity.type === 'message' ? (
+              <MessageCard activity={activity} />
+            ) : (
+              <InlineLogRow activity={activity} />
+            )}
+          </Fragment>
+        ))}
+
+        {hasResolvedSignal && (
+          <>
+            <TimelineDivider />
+            <ResolvedFooter totalCount={totalCount} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/conversations/conversation-timeline.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-timeline.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState } from 'react';
+import { Fragment, useId, useState } from 'react';
 import {
   RiCheckboxCircleFill,
   RiExpandUpDownLine,
@@ -104,17 +104,28 @@ function MessageTimestamp({ activity }: { activity: ConversationActivityDto }) {
 
 function MessageContent({ content }: { content: string }) {
   const [expanded, setExpanded] = useState(false);
+  const contentId = useId();
   const isLong = content.length > 80;
   const displayContent = expanded ? content : content.slice(0, 80);
 
   return (
     <div className="flex items-center gap-2.5 px-2 py-1">
-      <p className="text-label-xs min-w-0 flex-1 truncate font-medium text-[#1a1a1a]">
+      <p
+        id={contentId}
+        className={cn(
+          'text-label-xs min-w-0 flex-1 font-medium text-[#1a1a1a]',
+          !expanded && 'truncate',
+          expanded && 'wrap-break-word whitespace-pre-wrap'
+        )}
+      >
         {displayContent}
         {isLong && !expanded && '...'}
       </p>
       {isLong && (
         <button
+          type="button"
+          aria-expanded={expanded}
+          aria-controls={contentId}
           onClick={() => setExpanded(!expanded)}
           className="text-text-soft flex shrink-0 items-center gap-0.5"
         >

--- a/apps/dashboard/src/components/conversations/conversations-content.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-content.tsx
@@ -2,13 +2,13 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useMemo, useState } from 'react';
+import { conversationQueryKeys } from '@/components/conversations/conversation-query-keys';
 import { ConversationFilters } from '@/components/conversations/conversations-filters';
 import { ConversationsTable } from '@/components/conversations/conversations-table';
 import { ResizablePanel, ResizablePanelGroup } from '@/components/primitives/resizable';
 import { UpdatedAgo } from '@/components/updated-ago';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useConversationUrlState } from '@/hooks/use-conversation-url-state';
-import { QueryKeys } from '@/utils/query-keys';
 import { cn } from '@/utils/ui';
 import { EmptyTopicsIllustration } from '../topics/empty-topics-illustration';
 import { defaultConversationFilters } from './constants';
@@ -62,7 +62,7 @@ export function ConversationsContent({
   }, [mergedFilterValues]);
 
   const handleRefresh = async () => {
-    await queryClient.invalidateQueries({ queryKey: [QueryKeys.fetchConversations, currentEnvironment?._id] });
+    await queryClient.invalidateQueries({ queryKey: [conversationQueryKeys.fetchConversations, currentEnvironment?._id] });
     setLastUpdated(new Date());
   };
 

--- a/apps/dashboard/src/components/conversations/conversations-content.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-content.tsx
@@ -1,0 +1,138 @@
+/** biome-ignore-all lint/correctness/useUniqueElementIds: expected */
+import { useQueryClient } from '@tanstack/react-query';
+import { AnimatePresence, motion } from 'motion/react';
+import { useCallback, useMemo, useState } from 'react';
+import { ConversationFilters } from '@/components/conversations/conversations-filters';
+import { ConversationsTable } from '@/components/conversations/conversations-table';
+import { ResizablePanel, ResizablePanelGroup } from '@/components/primitives/resizable';
+import { UpdatedAgo } from '@/components/updated-ago';
+import { useEnvironment } from '@/context/environment/hooks';
+import { useConversationUrlState } from '@/hooks/use-conversation-url-state';
+import { QueryKeys } from '@/utils/query-keys';
+import { cn } from '@/utils/ui';
+import { EmptyTopicsIllustration } from '../topics/empty-topics-illustration';
+import { defaultConversationFilters } from './constants';
+import { ConversationDetail } from './conversation-detail';
+
+type ConversationsContentProps = {
+  className?: string;
+  contentHeight?: string;
+};
+
+export function ConversationsContent({
+  className,
+  contentHeight = 'h-[calc(100vh-140px)]',
+}: ConversationsContentProps) {
+  const { conversationItemId, filters, filterValues, handleConversationSelect, handleFiltersChange } =
+    useConversationUrlState();
+  const [showDetailPanel, setShowDetailPanel] = useState(false);
+  const onListStateChange = useCallback((hasConversations: boolean) => setShowDetailPanel(hasConversations), []);
+
+  const queryClient = useQueryClient();
+  const { currentEnvironment } = useEnvironment();
+
+  const [lastUpdated, setLastUpdated] = useState(new Date());
+
+  const mergedFilterValues = useMemo(
+    () => ({
+      ...defaultConversationFilters,
+      ...filterValues,
+    }),
+    [filterValues]
+  );
+
+  const hasActiveFilters = Object.entries(filters).some(([key, value]) => {
+    if (key === 'dateRange') return false;
+    if (Array.isArray(value)) return value.length > 0;
+
+    return !!value;
+  });
+
+  const handleClearFilters = () => {
+    handleFiltersChange({ ...defaultConversationFilters });
+  };
+
+  const hasChanges = useMemo(() => {
+    return (
+      mergedFilterValues.dateRange !== defaultConversationFilters.dateRange ||
+      mergedFilterValues.subscriberId !== '' ||
+      mergedFilterValues.provider.length > 0 ||
+      mergedFilterValues.conversationId !== ''
+    );
+  }, [mergedFilterValues]);
+
+  const handleRefresh = async () => {
+    await queryClient.invalidateQueries({ queryKey: [QueryKeys.fetchConversations, currentEnvironment?._id] });
+    setLastUpdated(new Date());
+  };
+
+  return (
+    <div className={cn('p-2.5', className)}>
+      <div className="flex items-center justify-between gap-2 pb-2.5">
+        <ConversationFilters
+          filters={mergedFilterValues}
+          onFiltersChange={handleFiltersChange}
+          onReset={handleClearFilters}
+          showReset={hasChanges}
+          className="pb-0"
+        />
+        <UpdatedAgo lastUpdated={lastUpdated} onRefresh={handleRefresh} />
+      </div>
+      <div className={`relative flex ${contentHeight}`}>
+        <ResizablePanelGroup orientation="horizontal" className="gap-2" autoSaveId="conversations-panel-group">
+          <ResizablePanel
+            defaultSize="50%"
+            minSize="35%"
+            className="h-full transition-[flex-basis] duration-300 ease-out"
+            id="conversations-table-panel"
+          >
+            <ConversationsTable
+              selectedConversationId={conversationItemId}
+              onConversationSelect={handleConversationSelect}
+              filters={filters}
+              hasActiveFilters={hasActiveFilters}
+              onClearFilters={handleClearFilters}
+              onListStateChange={onListStateChange}
+            />
+          </ResizablePanel>
+
+          {showDetailPanel && (
+            <ResizablePanel
+              defaultSize="50%"
+              minSize="35%"
+              maxSize="50%"
+              className="overflow-hidden"
+              id="conversations-detail-panel"
+            >
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={conversationItemId}
+                  initial={{ opacity: 0, x: 8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.25, ease: [0.25, 0.1, 0.25, 1] }}
+                  className="border-stroke-soft h-full overflow-auto rounded-lg border bg-white"
+                >
+                  {conversationItemId ? (
+                    <ConversationDetail
+                      conversationId={conversationItemId}
+                      onClose={() => handleConversationSelect('')}
+                    />
+                  ) : (
+                    <div className="flex h-full w-full flex-col items-center justify-center gap-6 text-center">
+                      <EmptyTopicsIllustration />
+                      <p className="text-text-soft text-paragraph-sm max-w-[60ch]">
+                        Nothing to show,
+                        <br />
+                        Select a conversation on the left to view details here
+                      </p>
+                    </div>
+                  )}
+                </motion.div>
+              </AnimatePresence>
+            </ResizablePanel>
+          )}
+        </ResizablePanelGroup>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/conversations/conversations-empty-state.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-empty-state.tsx
@@ -1,0 +1,69 @@
+import { AnimatePresence, motion } from 'motion/react';
+import { RiChat3Line, RiCloseCircleLine } from 'react-icons/ri';
+import { Button } from '../primitives/button';
+
+type ConversationsEmptyStateProps = {
+  emptySearchResults?: boolean;
+  onClearFilters?: () => void;
+};
+
+export function ConversationsEmptyState({ emptySearchResults, onClearFilters }: ConversationsEmptyStateProps) {
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key="empty-state"
+        className="flex h-full w-full items-center justify-center border-t border-t-neutral-200"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.15, ease: [0.4, 0, 0.2, 1] }}
+      >
+        <motion.div
+          initial={{ opacity: 0, scale: 0.98, y: 5 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.98, y: 5 }}
+          transition={{ duration: 0.25, delay: 0.1, ease: [0.4, 0, 0.2, 1] }}
+          className="flex flex-col items-center gap-6"
+        >
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.2, delay: 0.2 }}
+            className="flex size-12 items-center justify-center rounded-xl border border-neutral-200 bg-white"
+          >
+            <RiChat3Line className="size-6 text-neutral-400" />
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 5 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.2, delay: 0.25 }}
+            className="flex flex-col items-center gap-2 text-center"
+          >
+            <h2 className="text-text-sub text-md font-medium">
+              {emptySearchResults ? 'No conversations match that filter' : 'No conversations yet'}
+            </h2>
+            <p className="text-text-soft max-w-md text-sm font-normal">
+              {emptySearchResults
+                ? 'Try adjusting your filters to see more results.'
+                : 'Conversations will appear here once your agents start interacting with subscribers.'}
+            </p>
+          </motion.div>
+
+          {emptySearchResults && onClearFilters && (
+            <motion.div
+              initial={{ opacity: 0, y: 5 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.2, delay: 0.3 }}
+            >
+              <Button variant="secondary" mode="outline" className="gap-2" onClick={onClearFilters}>
+                <RiCloseCircleLine className="h-4 w-4" />
+                Clear Filters
+              </Button>
+            </motion.div>
+          )}
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/apps/dashboard/src/components/conversations/conversations-filters.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-filters.tsx
@@ -1,0 +1,150 @@
+import { useOrganization } from '@clerk/clerk-react';
+import { CONVERSATIONAL_PROVIDERS } from '@novu/shared';
+import { CalendarIcon } from 'lucide-react';
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { useDebouncedForm } from '@/hooks/use-debounced-form';
+import { useFetchSubscription } from '@/hooks/use-fetch-subscription';
+import { ConversationFiltersData } from '@/types/conversation';
+import { buildActivityDateFilters } from '@/utils/activityFilters';
+import { cn } from '@/utils/ui';
+import { IS_SELF_HOSTED } from '../../config';
+import { Button } from '../primitives/button';
+import { FacetedFormFilter } from '../primitives/form/faceted-filter/facated-form-filter';
+import { Form, FormField, FormItem, FormRoot } from '../primitives/form/form';
+
+type ConversationFiltersProps = {
+  filters: ConversationFiltersData;
+  showReset?: boolean;
+  onFiltersChange: (filters: ConversationFiltersData) => void;
+  onReset?: () => void;
+  className?: string;
+};
+
+const PROVIDER_OPTIONS = CONVERSATIONAL_PROVIDERS.filter((p) => !p.comingSoon).map((p) => ({
+  label: p.displayName,
+  value: p.providerId,
+}));
+
+export function ConversationFilters({
+  onFiltersChange,
+  filters,
+  onReset,
+  showReset = false,
+  className,
+}: ConversationFiltersProps) {
+  const { organization } = useOrganization();
+  const { subscription } = useFetchSubscription();
+
+  const form = useForm<ConversationFiltersData>({
+    values: filters,
+    defaultValues: filters,
+  });
+  const { watch, setValue } = form;
+
+  useDebouncedForm(watch, onFiltersChange, 400);
+
+  const dateFilterOptions = useMemo(() => {
+    const missingSubscription = !subscription && !IS_SELF_HOSTED;
+
+    if (!organization || missingSubscription) {
+      return [];
+    }
+
+    return buildActivityDateFilters({
+      organization,
+      apiServiceLevel: subscription?.apiServiceLevel,
+    });
+  }, [organization, subscription]);
+
+  const handleReset = () => {
+    if (onReset) {
+      onReset();
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <FormRoot className={cn('flex w-full flex-wrap items-center gap-2 pb-2.5', className)}>
+        <FormField
+          control={form.control}
+          name="dateRange"
+          render={({ field }) => (
+            <FormItem>
+              <FacetedFormFilter
+                size="small"
+                type="single"
+                hideClear
+                hideSearch
+                hideTitle
+                title="Time period"
+                options={dateFilterOptions}
+                selected={[field.value]}
+                onSelect={(values) => setValue('dateRange', values[0])}
+                icon={CalendarIcon}
+              />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="provider"
+          render={({ field }) => (
+            <FormItem>
+              <FacetedFormFilter
+                size="small"
+                type="multi"
+                title="Provider"
+                hideSearch
+                options={PROVIDER_OPTIONS}
+                selected={field.value}
+                onSelect={(values) => setValue('provider', values)}
+              />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="conversationId"
+          render={({ field }) => (
+            <FormItem>
+              <FacetedFormFilter
+                type="text"
+                size="small"
+                title="Conversation ID"
+                value={field.value}
+                onChange={(value) => setValue('conversationId', value)}
+                placeholder="Search by Conversation ID"
+              />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="subscriberId"
+          render={({ field }) => (
+            <FormItem>
+              <FacetedFormFilter
+                type="text"
+                size="small"
+                title="Subscriber ID"
+                value={field.value}
+                onChange={(value) => setValue('subscriberId', value)}
+                placeholder="Search by Subscriber ID"
+              />
+            </FormItem>
+          )}
+        />
+
+        {showReset && (
+          <Button variant="secondary" mode="ghost" size="2xs" onClick={handleReset}>
+            Reset
+          </Button>
+        )}
+      </FormRoot>
+    </Form>
+  );
+}

--- a/apps/dashboard/src/components/conversations/conversations-filters.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-filters.tsx
@@ -1,5 +1,4 @@
 import { useOrganization } from '@clerk/clerk-react';
-import { CONVERSATIONAL_PROVIDERS } from '@novu/shared';
 import { CalendarIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { useForm } from 'react-hook-form';
@@ -9,6 +8,7 @@ import { ConversationFiltersData } from '@/types/conversation';
 import { buildActivityDateFilters } from '@/utils/activityFilters';
 import { cn } from '@/utils/ui';
 import { IS_SELF_HOSTED } from '../../config';
+import { PROVIDER_OPTIONS } from './constants';
 import { Button } from '../primitives/button';
 import { FacetedFormFilter } from '../primitives/form/faceted-filter/facated-form-filter';
 import { Form, FormField, FormItem, FormRoot } from '../primitives/form/form';
@@ -20,11 +20,6 @@ type ConversationFiltersProps = {
   onReset?: () => void;
   className?: string;
 };
-
-const PROVIDER_OPTIONS = CONVERSATIONAL_PROVIDERS.filter((p) => !p.comingSoon).map((p) => ({
-  label: p.displayName,
-  value: p.providerId,
-}));
 
 export function ConversationFilters({
   onFiltersChange,

--- a/apps/dashboard/src/components/conversations/conversations-table.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-table.tsx
@@ -1,0 +1,183 @@
+import { AnimatePresence, motion } from 'motion/react';
+import { useEffect } from 'react';
+import { createSearchParams, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { ConversationFilters } from '@/api/conversations';
+import { Skeleton } from '@/components/primitives/skeleton';
+import { showErrorToast } from '@/components/primitives/sonner-helpers';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/primitives/table';
+import { TablePaginationFooter } from '@/components/primitives/table-pagination-footer';
+import { useFetchConversations } from '@/hooks/use-fetch-conversations';
+import { usePersistedPageSize } from '@/hooks/use-persisted-page-size';
+import { parsePageParam } from '@/utils/parse-page-param';
+import { ConversationTableRow } from './conversation-table-row';
+import { ConversationsEmptyState } from './conversations-empty-state';
+
+const CONVERSATIONS_TABLE_ID = 'conversations-table';
+
+export type ConversationsTableProps = {
+  selectedConversationId: string | null;
+  onConversationSelect: (conversationId: string) => void;
+  filters?: ConversationFilters;
+  hasActiveFilters: boolean;
+  onClearFilters: () => void;
+  onListStateChange?: (hasConversations: boolean) => void;
+};
+
+export function ConversationsTable({
+  selectedConversationId,
+  onConversationSelect,
+  filters,
+  hasActiveFilters,
+  onClearFilters,
+  onListStateChange,
+}: ConversationsTableProps) {
+  const [searchParams] = useSearchParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { pageSize, setPageSize } = usePersistedPageSize({
+    tableId: CONVERSATIONS_TABLE_ID,
+    defaultPageSize: 10,
+  });
+
+  const page = parsePageParam(searchParams.get('page'));
+
+  const { conversations, hasMore, totalCount, isLoading, error } = useFetchConversations(
+    {
+      filters,
+      page,
+      limit: pageSize,
+    },
+    {
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  useEffect(() => {
+    if (error) {
+      showErrorToast(
+        error instanceof Error ? error.message : 'There was an error loading the conversations.',
+        'Failed to fetch conversations'
+      );
+    }
+  }, [error]);
+
+  useEffect(() => {
+    onListStateChange?.(!isLoading && conversations.length > 0);
+  }, [isLoading, conversations.length, onListStateChange]);
+
+  function handlePageChange(newPage: number) {
+    const newParams = createSearchParams({
+      ...Object.fromEntries(searchParams),
+      page: newPage.toString(),
+    });
+    navigate(`${location.pathname}?${newParams}`);
+  }
+
+  function handlePageSizeChange(newPageSize: number) {
+    setPageSize(newPageSize);
+    handlePageChange(0);
+  }
+
+  return (
+    <AnimatePresence mode="wait" initial={false}>
+      {!isLoading && conversations.length === 0 ? (
+        <motion.div
+          key="empty-state"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="flex h-full w-full items-center justify-center"
+        >
+          <ConversationsEmptyState emptySearchResults={hasActiveFilters} onClearFilters={onClearFilters} />
+        </motion.div>
+      ) : (
+        <motion.div
+          key="table-state"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="flex h-full flex-1 flex-col"
+        >
+          <Table
+            isLoading={isLoading}
+            loadingRow={<SkeletonRow />}
+            containerClassname="bg-transparent w-full flex flex-col overflow-y-auto overflow-x-hidden max-h-full rounded-lg border border-neutral-200 bg-white"
+          >
+            <TableHeader>
+              <TableRow className="bg-bg-weak [&>th]:bg-bg-weak [&>th:last-child]:relative [&>th:last-child]:after:absolute [&>th:last-child]:after:left-full [&>th:last-child]:after:top-0 [&>th:last-child]:after:bottom-0 [&>th:last-child]:after:w-screen [&>th:last-child]:after:bg-bg-weak [&>th:last-child]:after:content-[''] [&>th:last-child]:after:-z-10">
+                <TableHead colSpan={2} className="text-text-strong h-8 px-3 py-0">
+                  Activity
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {conversations.map((conversation) => (
+                <ConversationTableRow
+                  key={conversation._id}
+                  conversation={conversation}
+                  isSelected={selectedConversationId === conversation.identifier}
+                  onClick={onConversationSelect}
+                />
+              ))}
+            </TableBody>
+            <TableFooter className="border-t border-t-neutral-200">
+              <TableRow>
+                <TableCell colSpan={7} className="p-0">
+                  <TablePaginationFooter
+                    pageSize={pageSize}
+                    onPreviousPage={() => handlePageChange(Math.max(0, page - 1))}
+                    onNextPage={() => handlePageChange(page + 1)}
+                    onPageSizeChange={handlePageSizeChange}
+                    hasPreviousPage={page > 0}
+                    hasNextPage={hasMore}
+                    className="bg-transparent shadow-none"
+                    totalCount={totalCount}
+                    pageSizeOptions={[10, 20, 50]}
+                  />
+                </TableCell>
+              </TableRow>
+            </TableFooter>
+          </Table>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function SkeletonRow() {
+  return (
+    <TableRow>
+      <TableCell colSpan={2} className="px-3 py-1.5">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1">
+              <Skeleton className="size-4 rounded-full" />
+              <Skeleton className="h-4 w-48" />
+            </div>
+            <Skeleton className="h-3.5 w-32" />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1">
+              <Skeleton className="size-4" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+            <div className="flex items-center gap-1">
+              <Skeleton className="h-5 w-28 rounded" />
+              <Skeleton className="h-5 w-16 rounded-md" />
+            </div>
+          </div>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/apps/dashboard/src/components/conversations/conversations-table.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-table.tsx
@@ -132,7 +132,7 @@ export function ConversationsTable({
             </TableBody>
             <TableFooter className="border-t border-t-neutral-200">
               <TableRow>
-                <TableCell colSpan={7} className="p-0">
+                <TableCell colSpan={2} className="p-0">
                   <TablePaginationFooter
                     pageSize={pageSize}
                     currentPageItemsCount={conversations.length}

--- a/apps/dashboard/src/components/conversations/conversations-table.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-table.tsx
@@ -135,6 +135,7 @@ export function ConversationsTable({
                 <TableCell colSpan={7} className="p-0">
                   <TablePaginationFooter
                     pageSize={pageSize}
+                    currentPageItemsCount={conversations.length}
                     onPreviousPage={() => handlePageChange(Math.max(0, page - 1))}
                     onNextPage={() => handlePageChange(page + 1)}
                     onPageSizeChange={handlePageSizeChange}

--- a/apps/dashboard/src/hooks/use-conversation-url-state.ts
+++ b/apps/dashboard/src/hooks/use-conversation-url-state.ts
@@ -83,13 +83,9 @@ export function useConversationUrlState(): ConversationUrlState & {
         newParams.set('dateRange', data.dateRange);
       }
 
-      if (searchParams.get('page')) {
-        newParams.set('page', searchParams.get('page') || '0');
-      }
-
       setSearchParams(newParams, { replace: true });
     },
-    [conversationItemId, searchParams, setSearchParams]
+    [conversationItemId, setSearchParams]
   );
 
   const filters = useMemo(() => parseFilters(searchParams), [searchParams]);

--- a/apps/dashboard/src/hooks/use-conversation-url-state.ts
+++ b/apps/dashboard/src/hooks/use-conversation-url-state.ts
@@ -1,0 +1,105 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { ConversationFilters } from '@/api/conversations';
+import { DEFAULT_DATE_RANGE } from '@/components/activity/constants';
+import { ConversationFiltersData, ConversationUrlState } from '@/types/conversation';
+
+function parseFilters(searchParams: URLSearchParams): ConversationFilters {
+  const result: ConversationFilters = {};
+
+  const subscriberId = searchParams.get('subscriberId');
+  if (subscriberId) {
+    result.subscriberId = subscriberId;
+  }
+
+  const provider = searchParams.get('provider')?.split(',').filter(Boolean);
+  if (provider?.length) {
+    result.provider = provider;
+  }
+
+  const conversationId = searchParams.get('conversationId');
+  if (conversationId) {
+    result.conversationId = conversationId;
+  }
+
+  const dateRange = searchParams.get('dateRange');
+  result.dateRange = dateRange || DEFAULT_DATE_RANGE;
+
+  return result;
+}
+
+function parseFilterValues(searchParams: URLSearchParams): ConversationFiltersData {
+  return {
+    dateRange: searchParams.get('dateRange') || DEFAULT_DATE_RANGE,
+    subscriberId: searchParams.get('subscriberId') || '',
+    provider: searchParams.get('provider')?.split(',').filter(Boolean) || [],
+    conversationId: searchParams.get('conversationId') || '',
+  };
+}
+
+export function useConversationUrlState(): ConversationUrlState & {
+  handleConversationSelect: (conversationItemId: string) => void;
+  handleFiltersChange: (data: ConversationFiltersData) => void;
+} {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const conversationItemId = searchParams.get('conversationItemId');
+
+  const handleConversationSelect = useCallback(
+    (newConversationItemId: string) => {
+      const newParams = new URLSearchParams(searchParams);
+
+      if (newConversationItemId === conversationItemId) {
+        newParams.delete('conversationItemId');
+      } else {
+        newParams.set('conversationItemId', newConversationItemId);
+      }
+
+      setSearchParams(newParams, { replace: true });
+    },
+    [conversationItemId, searchParams, setSearchParams]
+  );
+
+  const handleFiltersChange = useCallback(
+    (data: ConversationFiltersData) => {
+      const newParams = new URLSearchParams();
+
+      if (conversationItemId) {
+        newParams.set('conversationItemId', conversationItemId);
+      }
+
+      if (data.subscriberId) {
+        newParams.set('subscriberId', data.subscriberId);
+      }
+
+      if (data.provider?.length) {
+        newParams.set('provider', data.provider.join(','));
+      }
+
+      if (data.conversationId) {
+        newParams.set('conversationId', data.conversationId);
+      }
+
+      if (data.dateRange && data.dateRange !== DEFAULT_DATE_RANGE) {
+        newParams.set('dateRange', data.dateRange);
+      }
+
+      if (searchParams.get('page')) {
+        newParams.set('page', searchParams.get('page') || '0');
+      }
+
+      setSearchParams(newParams, { replace: true });
+    },
+    [conversationItemId, searchParams, setSearchParams]
+  );
+
+  const filters = useMemo(() => parseFilters(searchParams), [searchParams]);
+  const filterValues = useMemo(() => parseFilterValues(searchParams), [searchParams]);
+
+  return {
+    conversationItemId,
+    filters,
+    filterValues,
+    handleConversationSelect,
+    handleFiltersChange,
+  };
+}

--- a/apps/dashboard/src/hooks/use-fetch-conversation-activities.ts
+++ b/apps/dashboard/src/hooks/use-fetch-conversation-activities.ts
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  ConversationActivitiesResponse,
+  ConversationDto,
+  getConversation,
+  getConversationActivities,
+} from '@/api/conversations';
+import { QueryKeys } from '@/utils/query-keys';
+import { useEnvironment } from '../context/environment/hooks';
+
+export function useFetchConversation(conversationId: string | null) {
+  const { currentEnvironment } = useEnvironment();
+
+  const { data, ...rest } = useQuery<ConversationDto>({
+    queryKey: [QueryKeys.fetchConversation, currentEnvironment?._id, conversationId],
+    queryFn: async () => {
+      if (!conversationId || !currentEnvironment) {
+        throw new Error('Missing conversation identifier or environment');
+      }
+
+      return getConversation(conversationId, currentEnvironment);
+    },
+    enabled: !!conversationId && !!currentEnvironment,
+    refetchOnWindowFocus: false,
+  });
+
+  return { conversation: data, ...rest };
+}
+
+export function useFetchConversationActivities(conversationId: string | null) {
+  const { currentEnvironment } = useEnvironment();
+
+  const { data, ...rest } = useQuery<ConversationActivitiesResponse>({
+    queryKey: [QueryKeys.fetchConversation, 'activities', currentEnvironment?._id, conversationId],
+    queryFn: async ({ signal }) => {
+      if (!conversationId || !currentEnvironment) {
+        throw new Error('Missing conversation identifier or environment');
+      }
+
+      return getConversationActivities({
+        conversationIdentifier: conversationId,
+        environment: currentEnvironment,
+        signal,
+      });
+    },
+    enabled: !!conversationId && !!currentEnvironment,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    activities: data?.data ?? [],
+    totalCount: data?.totalCount ?? 0,
+    ...rest,
+  };
+}

--- a/apps/dashboard/src/hooks/use-fetch-conversation-activities.ts
+++ b/apps/dashboard/src/hooks/use-fetch-conversation-activities.ts
@@ -5,14 +5,14 @@ import {
   getConversation,
   getConversationActivities,
 } from '@/api/conversations';
-import { QueryKeys } from '@/utils/query-keys';
+import { conversationQueryKeys } from '@/components/conversations/conversation-query-keys';
 import { useEnvironment } from '../context/environment/hooks';
 
 export function useFetchConversation(conversationId: string | null) {
   const { currentEnvironment } = useEnvironment();
 
   const { data, ...rest } = useQuery<ConversationDto>({
-    queryKey: [QueryKeys.fetchConversation, currentEnvironment?._id, conversationId],
+    queryKey: [conversationQueryKeys.fetchConversation, currentEnvironment?._id, conversationId],
     queryFn: async () => {
       if (!conversationId || !currentEnvironment) {
         throw new Error('Missing conversation identifier or environment');
@@ -31,7 +31,7 @@ export function useFetchConversationActivities(conversationId: string | null) {
   const { currentEnvironment } = useEnvironment();
 
   const { data, ...rest } = useQuery<ConversationActivitiesResponse>({
-    queryKey: [QueryKeys.fetchConversation, 'activities', currentEnvironment?._id, conversationId],
+    queryKey: [conversationQueryKeys.fetchConversation, 'activities', currentEnvironment?._id, conversationId],
     queryFn: async ({ signal }) => {
       if (!conversationId || !currentEnvironment) {
         throw new Error('Missing conversation identifier or environment');

--- a/apps/dashboard/src/hooks/use-fetch-conversations.ts
+++ b/apps/dashboard/src/hooks/use-fetch-conversations.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import { ConversationFilters, ConversationsListResponse, getConversationsList } from '@/api/conversations';
+import { QueryKeys } from '@/utils/query-keys';
+import { useEnvironment } from '../context/environment/hooks';
+
+type UseFetchConversationsOptions = {
+  filters?: ConversationFilters;
+  page?: number;
+  limit?: number;
+};
+
+export function useFetchConversations(
+  { filters, page = 0, limit = 10 }: UseFetchConversationsOptions = {},
+  {
+    enabled = true,
+    refetchOnWindowFocus = false,
+  }: {
+    enabled?: boolean;
+    refetchOnWindowFocus?: boolean;
+  } = {}
+) {
+  const { currentEnvironment } = useEnvironment();
+
+  const { data, ...rest } = useQuery<ConversationsListResponse>({
+    queryKey: [QueryKeys.fetchConversations, currentEnvironment?._id, page, limit, filters],
+    queryFn: async ({ signal }) => {
+      // biome-ignore lint/style/noNonNullAssertion: guarded by `enabled` below
+      return getConversationsList({ environment: currentEnvironment!, page, limit, filters, signal });
+    },
+    refetchOnWindowFocus,
+    enabled: enabled && !!currentEnvironment,
+  });
+
+  return {
+    conversations: data?.data || [],
+    hasMore: data?.hasMore || false,
+    totalCount: data?.totalCount || 0,
+    ...rest,
+    page,
+  };
+}

--- a/apps/dashboard/src/hooks/use-fetch-conversations.ts
+++ b/apps/dashboard/src/hooks/use-fetch-conversations.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { ConversationFilters, ConversationsListResponse, getConversationsList } from '@/api/conversations';
-import { QueryKeys } from '@/utils/query-keys';
+import { conversationQueryKeys } from '@/components/conversations/conversation-query-keys';
 import { useEnvironment } from '../context/environment/hooks';
 
 type UseFetchConversationsOptions = {
@@ -22,7 +22,7 @@ export function useFetchConversations(
   const { currentEnvironment } = useEnvironment();
 
   const { data, ...rest } = useQuery<ConversationsListResponse>({
-    queryKey: [QueryKeys.fetchConversations, currentEnvironment?._id, page, limit, filters],
+    queryKey: [conversationQueryKeys.fetchConversations, currentEnvironment?._id, page, limit, filters],
     queryFn: async ({ signal }) => {
       // biome-ignore lint/style/noNonNullAssertion: guarded by `enabled` below
       return getConversationsList({ environment: currentEnvironment!, page, limit, filters, signal });

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -430,6 +430,14 @@ const router = createBrowserRouter([
                 ),
               },
               {
+                path: ROUTES.ACTIVITY_CONVERSATIONS,
+                element: (
+                  <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>
+                    <ActivityFeed />
+                  </ProtectedRoute>
+                ),
+              },
+              {
                 path: ROUTES.ANALYTICS,
                 element: (
                   <ProtectedRoute permission={PermissionsEnum.NOTIFICATION_READ}>

--- a/apps/dashboard/src/pages/activity-feed.tsx
+++ b/apps/dashboard/src/pages/activity-feed.tsx
@@ -23,6 +23,10 @@ export function ActivityFeed() {
 
   const getCurrentTab = () => {
     if (location.pathname.includes('/activity/conversations')) {
+      if (!isConversationalAgentsEnabled) {
+        return 'workflow-runs';
+      }
+
       return 'conversations';
     }
 
@@ -63,6 +67,17 @@ export function ActivityFeed() {
       });
     }
   }, [isHttpLogsPageEnabled, location.pathname, location.search, currentEnvironment?.slug, navigate]);
+
+  useEffect(() => {
+    if (
+      !isConversationalAgentsEnabled &&
+      location.pathname.includes('/activity/conversations') &&
+      currentEnvironment?.slug
+    ) {
+      const fallbackPath = buildRoute(ROUTES.ACTIVITY_WORKFLOW_RUNS, { environmentSlug: currentEnvironment.slug });
+      navigate(`${fallbackPath}${location.search}`, { replace: true });
+    }
+  }, [isConversationalAgentsEnabled, location.pathname, location.search, currentEnvironment?.slug, navigate]);
 
   useEffect(() => {
     if (currentTab === 'requests') {

--- a/apps/dashboard/src/pages/activity-feed.tsx
+++ b/apps/dashboard/src/pages/activity-feed.tsx
@@ -2,6 +2,7 @@ import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ActivityFeedContent } from '@/components/activity/activity-feed-content';
+import { ConversationsContent } from '@/components/conversations/conversations-content';
 import { DashboardLayout } from '@/components/dashboard-layout';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import { useEnvironment } from '@/context/environment/hooks';
@@ -14,13 +15,17 @@ import { PageMeta } from '../components/page-meta';
 
 export function ActivityFeed() {
   const isHttpLogsPageEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_HTTP_LOGS_PAGE_ENABLED, false);
+  const isConversationalAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
   const { currentEnvironment } = useEnvironment();
   const location = useLocation();
   const navigate = useNavigate();
   const track = useTelemetry();
 
-  // Determine current tab based on URL
   const getCurrentTab = () => {
+    if (location.pathname.includes('/activity/conversations')) {
+      return 'conversations';
+    }
+
     if (location.pathname.includes('/activity/requests')) {
       return 'requests';
     }
@@ -29,7 +34,6 @@ export function ActivityFeed() {
       return 'workflow-runs';
     }
 
-    // Default fallback for the original activity-feed route
     if (location.pathname.includes('/activity-feed')) {
       return 'workflow-runs';
     }
@@ -39,18 +43,18 @@ export function ActivityFeed() {
 
   const currentTab = getCurrentTab();
 
-  // Handle tab changes by navigating to the appropriate URL
   const handleTabChange = (value: string) => {
     if (!currentEnvironment?.slug) return;
 
     if (value === 'requests') {
       navigate(buildRoute(ROUTES.ACTIVITY_REQUESTS, { environmentSlug: currentEnvironment.slug }));
+    } else if (value === 'conversations') {
+      navigate(buildRoute(ROUTES.ACTIVITY_CONVERSATIONS, { environmentSlug: currentEnvironment.slug }));
     } else if (value === 'workflow-runs') {
       navigate(buildRoute(ROUTES.ACTIVITY_WORKFLOW_RUNS, { environmentSlug: currentEnvironment.slug }));
     }
   };
 
-  // Redirect legacy activity-feed URLs to the new runs URL when feature flag is enabled
   useEffect(() => {
     if (isHttpLogsPageEnabled && location.pathname.includes('/activity-feed') && currentEnvironment?.slug) {
       const newPath = buildRoute(ROUTES.ACTIVITY_WORKFLOW_RUNS, { environmentSlug: currentEnvironment.slug });
@@ -60,7 +64,6 @@ export function ActivityFeed() {
     }
   }, [isHttpLogsPageEnabled, location.pathname, location.search, currentEnvironment?.slug, navigate]);
 
-  // Track page visit for requests tab
   useEffect(() => {
     if (currentTab === 'requests') {
       track(TelemetryEvent.REQUEST_LOGS_PAGE_VISIT);
@@ -82,6 +85,11 @@ export function ActivityFeed() {
             <TabsTrigger value="workflow-runs" variant="regular" size="lg">
               Workflow Runs
             </TabsTrigger>
+            {isConversationalAgentsEnabled && (
+              <TabsTrigger value="conversations" variant="regular" size="lg">
+                Conversations
+              </TabsTrigger>
+            )}
             {isHttpLogsPageEnabled && (
               <TabsTrigger value="requests" variant="regular" size="lg">
                 Requests
@@ -91,6 +99,11 @@ export function ActivityFeed() {
           <TabsContent value="workflow-runs">
             <ActivityFeedContent contentHeight="h-[calc(100vh-170px)]" />
           </TabsContent>
+          {isConversationalAgentsEnabled && (
+            <TabsContent value="conversations">
+              <ConversationsContent contentHeight="h-[calc(100vh-170px)]" />
+            </TabsContent>
+          )}
           <TabsContent value="requests" className="h-[calc(100vh-140px)]">
             <RequestsTable />
           </TabsContent>

--- a/apps/dashboard/src/types/conversation.ts
+++ b/apps/dashboard/src/types/conversation.ts
@@ -1,0 +1,14 @@
+import { ConversationFilters } from '@/api/conversations';
+
+export type ConversationFiltersData = {
+  dateRange: string;
+  subscriberId: string;
+  provider: string[];
+  conversationId: string;
+};
+
+export type ConversationUrlState = {
+  conversationItemId: string | null;
+  filters: ConversationFilters;
+  filterValues: ConversationFiltersData;
+};

--- a/apps/dashboard/src/utils/query-keys.ts
+++ b/apps/dashboard/src/utils/query-keys.ts
@@ -39,4 +39,6 @@ export const QueryKeys = Object.freeze({
   fetchEnvironmentVariable: 'fetchEnvironmentVariable',
   fetchEnvironmentVariableUsage: 'fetchEnvironmentVariableUsage',
   stepResolversCount: 'stepResolversCount',
+  fetchConversations: 'fetchConversations',
+  fetchConversation: 'fetchConversation',
 });

--- a/apps/dashboard/src/utils/query-keys.ts
+++ b/apps/dashboard/src/utils/query-keys.ts
@@ -39,6 +39,4 @@ export const QueryKeys = Object.freeze({
   fetchEnvironmentVariable: 'fetchEnvironmentVariable',
   fetchEnvironmentVariableUsage: 'fetchEnvironmentVariableUsage',
   stepResolversCount: 'stepResolversCount',
-  fetchConversations: 'fetchConversations',
-  fetchConversation: 'fetchConversation',
 });

--- a/apps/dashboard/src/utils/routes.ts
+++ b/apps/dashboard/src/utils/routes.ts
@@ -42,6 +42,7 @@ export const ROUTES = {
   ACTIVITY_FEED: '/env/:environmentSlug/activity-feed',
   ACTIVITY_WORKFLOW_RUNS: '/env/:environmentSlug/activity/workflow-runs',
   ACTIVITY_REQUESTS: '/env/:environmentSlug/activity/requests',
+  ACTIVITY_CONVERSATIONS: '/env/:environmentSlug/activity/conversations',
   ANALYTICS: '/env/:environmentSlug/analytics',
   LOGS: '/env/:environmentSlug/requests',
   TEMPLATE_STORE: '/env/:environmentSlug/workflows/templates',


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added a new Conversations page to the dashboard that enables users to browse, filter, and view conversation details. This includes backend support for agent name resolution in conversation activities and a complete frontend implementation with filtering, pagination, activity timeline, and detailed conversation viewing capabilities.

## Affected areas

**@novu/api-service**: Updated the `HandleAgentReply` usecase to fetch agent details by identifier before delivering messages. The agent name is now resolved and passed to `deliverMessage()` to ensure conversation activities include the agent's display name via the `senderName` field. Added an agent identity validation guard to prevent mismatched agent identifiers.

**@novu/dashboard**: Introduced a comprehensive conversations feature with new API client methods (`getConversationsList`, `getConversation`, `getConversationActivities`), React hooks for data fetching (`useFetchConversations`, `useFetchConversation`, `useFetchConversationActivities`), and UI components for the conversations page (filters, table with rows, detail panel, timeline, status badges, empty states). Added URL-synchronized filter state management via `useConversationUrlState` hook, supporting filters for date range, subscriber, provider, and conversation ID. Integrated the new conversations tab into the activity feed page with feature-flag support. Updated routes to include the new `/activity/conversations` path.

**Submodule reference (.source)**: Updated to a new commit hash reflecting changes in the referenced subproject.

## Key technical decisions

- Filter state is synchronized with URL query parameters, enabling shareable filtered views and browser back/forward navigation.
- Pagination state (page size) is persisted to localStorage via `usePersistedPageSize` for consistent UX across sessions.
- Conversation selection and detail viewing uses a resizable panel group (right panel) that can be toggled and is only rendered when a conversation is selected.
- Agent name resolution happens at delivery time on the backend, preventing stale or missing names in activity records.

## Testing

No test files were added in this PR. Manual verification of the conversations page UI, filtering behavior, pagination, and timeline rendering would be necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
