### PR TITLE
feat(dashboard,api-service): add agent code setup guide and fix inbound handler identifier

### DIFF
--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -163,7 +163,7 @@ export class AgentInboundHandler {
             environmentId: config.environmentId,
             organizationId: config.organizationId,
             conversationId: conversation._id,
-            agentIdentifier: agentId,
+            agentIdentifier: config.agentIdentifier,
             integrationIdentifier: config.integrationIdentifier,
             reply: { text: ONBOARDING_NO_BRIDGE_REPLY_MARKDOWN },
           })

--- a/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
@@ -1,0 +1,274 @@
+import { CheckCircle2, Loader } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { RiCheckLine, RiFileCopyLine } from 'react-icons/ri';
+import { useQueryClient } from '@tanstack/react-query';
+import type { AgentResponse } from '@/api/agents';
+import { getAgent, getAgentDetailQueryKey } from '@/api/agents';
+import { ExternalLink } from '@/components/shared/external-link';
+import { Skeleton } from '@/components/primitives/skeleton';
+import { useEnvironment } from '@/context/environment/hooks';
+import { useFetchApiKeys } from '@/hooks/use-fetch-api-keys';
+import { apiHostnameManager } from '@/utils/api-hostname-manager';
+import { SetupStep } from './setup-guide-primitives';
+import { deriveStepStatus } from './setup-guide-step-utils';
+
+const CLI_DEFAULT_API_URL = 'https://api.novu.co';
+const BRIDGE_POLL_INTERVAL_MS = 2000;
+
+function maskSecretKey(key: string): string {
+  return `nv-${'•'.repeat(16)}${key.slice(-4)}`;
+}
+
+function buildInitCommand({
+  agentIdentifier,
+  secretKey,
+  apiUrl,
+  masked,
+}: {
+  agentIdentifier: string;
+  secretKey: string;
+  apiUrl: string | null;
+  masked: boolean;
+}): string {
+  const key = masked ? maskSecretKey(secretKey) : secretKey;
+  const parts = [`npx novu@latest init -t agent`, `--agent-identifier ${agentIdentifier}`, `-s ${key}`];
+
+  if (apiUrl) {
+    parts.push(`-a ${apiUrl}`);
+  }
+
+  return parts.join(' \\\n  ');
+}
+
+function buildInitCopyCommand({
+  agentIdentifier,
+  secretKey,
+  apiUrl,
+}: {
+  agentIdentifier: string;
+  secretKey: string;
+  apiUrl: string | null;
+}): string {
+  const parts = [`npx novu@latest init -t agent`, `--agent-identifier ${agentIdentifier}`, `-s ${secretKey}`];
+
+  if (apiUrl) {
+    parts.push(`-a ${apiUrl}`);
+  }
+
+  return parts.join(' ');
+}
+
+function TerminalBlock({ displayCommand, copyCommand }: { displayCommand: string; copyCommand: string }) {
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(copyCommand);
+      setCopied(true);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard write failed silently
+    }
+  };
+
+  return (
+    <div className="relative w-full overflow-hidden rounded-lg shadow-[inset_0px_0px_0px_1px_#18181b,inset_0px_0px_0px_1.5px_rgba(255,255,255,0.1)]">
+      <div className="flex items-center justify-between bg-[rgba(14,18,27,0.9)] px-4 py-1.5">
+        <span className="text-label-xs text-[#99a0ae]">Terminal</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="flex size-6 items-center justify-center rounded p-1.5 transition-colors hover:bg-white/10"
+        >
+          {copied ? (
+            <RiCheckLine className="size-3.5 text-[#99a0ae]" />
+          ) : (
+            <RiFileCopyLine className="size-3.5 text-[#99a0ae]" />
+          )}
+        </button>
+      </div>
+      <div className="bg-[rgba(14,18,27,0.9)] px-[5px] pb-[5px]">
+        <div className="flex gap-4 rounded-md border border-[rgba(14,18,27,0.9)] bg-[rgba(14,18,27,0.9)] p-3">
+          <span className="shrink-0 font-mono text-xs text-[#525866]">❯</span>
+          <span className="whitespace-pre-wrap break-all font-mono text-xs text-white">{displayCommand}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BridgeConnectionStatus({
+  agent,
+  agentIdentifier,
+}: {
+  agent: AgentResponse;
+  agentIdentifier: string;
+}) {
+  const { currentEnvironment } = useEnvironment();
+  const queryClient = useQueryClient();
+  const isBridgeConnected = Boolean(agent.bridgeUrl || (agent.devBridgeActive && agent.devBridgeUrl));
+  const [connected, setConnected] = useState(isBridgeConnected);
+
+  useEffect(() => {
+    if (isBridgeConnected) {
+      setConnected(true);
+
+      return;
+    }
+
+    if (!currentEnvironment) {
+      return;
+    }
+
+    let cancelled = false;
+    const environment = currentEnvironment;
+
+    const intervalId = setInterval(async () => {
+      if (cancelled) return;
+
+      try {
+        const data = await getAgent(environment, agentIdentifier);
+        if (cancelled) return;
+
+        const isConnected = Boolean(data.bridgeUrl || (data.devBridgeActive && data.devBridgeUrl));
+
+        if (isConnected) {
+          setConnected(true);
+          queryClient.invalidateQueries({
+            queryKey: getAgentDetailQueryKey(environment._id, agentIdentifier),
+          });
+          clearInterval(intervalId);
+        }
+      } catch {
+        // ignore transient errors while polling
+      }
+    }, BRIDGE_POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [agentIdentifier, currentEnvironment, isBridgeConnected, queryClient]);
+
+  if (connected) {
+    return (
+      <div className="flex flex-col gap-2 py-4 pl-8">
+        <div className="flex items-center gap-1">
+          <CheckCircle2 className="text-success-base size-3.5 shrink-0" />
+          <span className="text-text-strong text-label-sm font-medium">Bridge connected</span>
+        </div>
+        <p className="text-text-soft text-label-xs font-medium leading-4">
+          Your agent is receiving events. Edit{' '}
+          <code className="font-code text-[12px] tracking-[-0.24px]">app/novu/agents/</code> to customize the handler.
+        </p>
+        <ExternalLink href="https://docs.novu.co/agents/overview" variant="documentation">
+          Agent documentation
+        </ExternalLink>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 py-4 pl-8">
+      <div className="flex items-center gap-1">
+        <Loader className="size-3.5 text-[#dd2476] animate-[spin_5s_linear_infinite]" />
+        <span className="animate-gradient bg-linear-to-r from-[#dd2476] via-[#ff512f] to-[#dd2476] bg-size-[400%_400%] bg-clip-text text-label-sm font-medium text-transparent">
+          Waiting for bridge connection…
+        </span>
+      </div>
+      <p className="text-text-soft text-label-xs font-medium leading-4">
+        Run the commands above to scaffold your project and start the dev tunnel.
+      </p>
+    </div>
+  );
+}
+
+type AgentCodeSetupSectionProps = {
+  agent: AgentResponse;
+  stepOffset: number;
+  isProviderComplete: boolean;
+};
+
+export function AgentCodeSetupSection({ agent, stepOffset, isProviderComplete }: AgentCodeSetupSectionProps) {
+  const apiKeysQuery = useFetchApiKeys();
+  const secretKey = apiKeysQuery.data?.data?.[0]?.key;
+
+  const currentApiUrl = apiHostnameManager.getHostname();
+  const apiUrl = currentApiUrl !== CLI_DEFAULT_API_URL ? currentApiUrl : null;
+
+  const isBridgeConnected = Boolean(agent.bridgeUrl || (agent.devBridgeActive && agent.devBridgeUrl));
+
+  let firstIncompleteStep: number;
+  if (isBridgeConnected) {
+    firstIncompleteStep = stepOffset + 2;
+  } else if (isProviderComplete) {
+    firstIncompleteStep = stepOffset;
+  } else {
+    firstIncompleteStep = stepOffset + 3;
+  }
+
+  return (
+    <>
+      <SetupStep
+        index={stepOffset}
+        status={deriveStepStatus(stepOffset, firstIncompleteStep)}
+        sectionLabel="2/2 CONNECT YOUR CODE"
+        title="Scaffold your agent project"
+        description={
+          <span>
+            Run this to create a Next.js project with the bridge endpoint pre-configured for your agent. The CLI
+            installs dependencies and writes your secret key to{' '}
+            <code className="font-code text-[12px] tracking-[-0.24px]">.env.local</code> automatically.
+          </span>
+        }
+        rightContent={
+          apiKeysQuery.isLoading || !secretKey ? (
+            <Skeleton className="h-[80px] w-full rounded-lg" />
+          ) : (
+            <TerminalBlock
+              displayCommand={buildInitCommand({
+                agentIdentifier: agent.identifier,
+                secretKey,
+                apiUrl,
+                masked: true,
+              })}
+              copyCommand={buildInitCopyCommand({
+                agentIdentifier: agent.identifier,
+                secretKey,
+                apiUrl,
+              })}
+            />
+          )
+        }
+      />
+
+      <SetupStep
+        index={stepOffset + 1}
+        status={deriveStepStatus(stepOffset + 1, firstIncompleteStep)}
+        title="Start the dev tunnel"
+        description={
+          <span>
+            Start your app with{' '}
+            <code className="font-code text-[12px] tracking-[-0.24px]">npm run dev</code>, then run this in a second
+            terminal from your project directory. It creates a tunnel and registers the bridge URL with Novu.
+          </span>
+        }
+        rightContent={
+          <TerminalBlock
+            displayCommand="npx novu@latest dev -p 4000 --no-studio"
+            copyCommand="npx novu@latest dev -p 4000 --no-studio"
+          />
+        }
+      />
+
+      <BridgeConnectionStatus agent={agent} agentIdentifier={agent.identifier} />
+    </>
+  );
+}

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -1,9 +1,10 @@
 import { ChatProviderIdEnum } from '@novu/shared';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { RiExpandUpDownLine } from 'react-icons/ri';
 import { type AgentResponse } from '@/api/agents';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { cn } from '@/utils/ui';
+import { AgentCodeSetupSection } from './agent-code-setup-section';
 import { ProviderDropdown } from './provider-dropdown';
 import { SetupStep } from './setup-guide-primitives';
 import { deriveStepStatus } from './setup-guide-step-utils';
@@ -25,6 +26,7 @@ function resolveProviderSetupGuide(providerId: string) {
 export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
   const [isExpanded, setIsExpanded] = useState(true);
   const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(undefined);
+  const [isProviderComplete, setIsProviderComplete] = useState(false);
   const { integrations } = useFetchIntegrations();
 
   const slackFromAgent = agent.integrations?.find((i) => i.providerId === ChatProviderIdEnum.Slack);
@@ -49,6 +51,10 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
   const firstIncompleteStepForProviderRow = hasProviderSelected ? 2 : 1;
 
   const ProviderGuide = selectedProviderId ? resolveProviderSetupGuide(selectedProviderId) : null;
+
+  const handleProviderStepsCompleted = useCallback(() => {
+    setIsProviderComplete(true);
+  }, []);
 
   return (
     <div className="bg-bg-weak flex min-w-0 flex-1 flex-col rounded-[10px] p-1">
@@ -92,8 +98,16 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
             />
 
             {ProviderGuide && effectiveIntegrationId ? (
-              <ProviderGuide agent={agent} integrationId={effectiveIntegrationId} stepOffset={2} embedded={false} />
+              <ProviderGuide
+                agent={agent}
+                integrationId={effectiveIntegrationId}
+                stepOffset={2}
+                embedded={false}
+                onStepsCompleted={handleProviderStepsCompleted}
+              />
             ) : null}
+
+            <AgentCodeSetupSection agent={agent} stepOffset={5} isProviderComplete={isProviderComplete} />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Adds a code setup section to the agent setup guide in the dashboard, showing users the `novu init` and `novu dev` commands with their secret key and agent identifier pre-filled
- Passes `--no-studio` flag in the `novu dev` command since Studio is not needed for the agent flow — the CLI only needs to create the tunnel and register the agent bridge
- Fixes agent identifier reference in the inbound handler no-bridge reply (was using `agentId` instead of `config.agentIdentifier`)
- Includes bridge connection polling that detects when the dev tunnel comes online

## Test plan
- [ ] Create an agent in the dashboard and verify the setup guide shows init + dev commands
- [ ] Verify the copied `novu dev` command includes `--no-studio`
- [ ] Run the scaffolded project and confirm bridge connection status updates in the dashboard
- [ ] Verify the inbound handler no-bridge reply uses the correct agent identifier


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR enhances the agent onboarding experience and fixes a bug in the inbound handler. It adds a new code setup section to the agent setup guide displaying pre-configured `novu init` and `novu dev` commands with the agent identifier pre-filled, includes a bridge connection status panel with polling to detect when the dev tunnel comes online, and fixes an incorrect agent identifier reference in the inbound handler's no-bridge reply.

## Affected areas

**API**: Updated the agent inbound handler to use the correct agent identifier (`config.agentIdentifier` instead of `agentId`) when handling `NoBridgeUrlError` exceptions.

**Dashboard**: Added a new `AgentCodeSetupSection` component that renders a three-step setup UI (scaffold project with command display and copy support, start dev tunnel, and bridge connection status) with polling logic to detect bridge connectivity. Updated `AgentSetupGuide` to track provider completion state and render the new setup section with appropriate step offset.

## Key technical decisions

- Polling with fixed intervals implemented in `AgentCodeSetupSection` to periodically check bridge connection status, suppressing transient errors during polling.
- React Query cache invalidation (`getAgentDetailQueryKey()`) triggered when bridge connection is detected to ensure UI reflects the latest state.

## Testing

Manual verification covers: agent creation and setup guide display, command copying functionality including the `--no-studio` flag, bridge connection status updates after running the scaffolded project, and correct agent identifier in error replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->