### PR TITLE
feat(dashboard,novu): pin CLI framework version and use rc tag for pre-release

### DIFF
--- a/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
@@ -15,6 +15,9 @@ import { deriveStepStatus } from './setup-guide-step-utils';
 const CLI_DEFAULT_API_URL = 'https://api.novu.co';
 const BRIDGE_POLL_INTERVAL_MS = 2000;
 
+// TODO: change to 'latest' when agents are GA and IS_CONVERSATIONAL_AGENTS_ENABLED flag is removed
+const CLI_PACKAGE_TAG = 'rc';
+
 function maskSecretKey(key: string): string {
   return `nv-${'•'.repeat(16)}${key.slice(-4)}`;
 }
@@ -31,7 +34,7 @@ function buildInitCommand({
   masked: boolean;
 }): string {
   const key = masked ? maskSecretKey(secretKey) : secretKey;
-  const parts = [`npx novu@latest init -t agent`, `--agent-identifier ${agentIdentifier}`, `-s ${key}`];
+  const parts = [`npx novu@${CLI_PACKAGE_TAG} init -t agent`, `--agent-identifier ${agentIdentifier}`, `-s ${key}`];
 
   if (apiUrl) {
     parts.push(`-a ${apiUrl}`);
@@ -49,7 +52,7 @@ function buildInitCopyCommand({
   secretKey: string;
   apiUrl: string | null;
 }): string {
-  const parts = [`npx novu@latest init -t agent`, `--agent-identifier ${agentIdentifier}`, `-s ${secretKey}`];
+  const parts = [`npx novu@${CLI_PACKAGE_TAG} init -t agent`, `--agent-identifier ${agentIdentifier}`, `-s ${secretKey}`];
 
   if (apiUrl) {
     parts.push(`-a ${apiUrl}`);
@@ -262,8 +265,8 @@ export function AgentCodeSetupSection({ agent, stepOffset, isProviderComplete }:
         }
         rightContent={
           <TerminalBlock
-            displayCommand="npx novu@latest dev -p 4000 --no-studio"
-            copyCommand="npx novu@latest dev -p 4000 --no-studio"
+            displayCommand={`npx novu@${CLI_PACKAGE_TAG} dev -p 4000 --no-studio`}
+            copyCommand={`npx novu@${CLI_PACKAGE_TAG} dev -p 4000 --no-studio`}
           />
         }
       />

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "2.10.0",
+  "version": "2.10.1-alpha.1",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/cjs/index.d.cts",

--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.8.0",
+  "version": "2.8.1-rc.2",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -4,10 +4,20 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { bold, cyan } from 'picocolors';
+import packageJson from '../../../../package.json';
 import { copy } from '../helpers/copy';
 import { install } from '../helpers/install';
 
 import { GetTemplateFileArgs, InstallTemplateArgs, TemplateTypeEnum } from './types';
+
+function resolveFrameworkVersion(): string {
+  const raw = packageJson.dependencies['@novu/framework'];
+  if (raw.startsWith('workspace:')) {
+    return 'latest';
+  }
+
+  return raw;
+}
 /**
  * Get the file path for a given file in a template, e.g. "next.config.js".
  */
@@ -194,7 +204,7 @@ export const installTemplate = async ({
     react: '^19',
     'react-dom': '^19',
     next: version,
-    '@novu/framework': 'latest',
+    '@novu/framework': resolveFrameworkVersion(),
   };
 
   if (!isAgentTemplate) {

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -1,22 +1,27 @@
 import { Sema } from 'async-sema';
 import { async as glob } from 'fast-glob';
+import { readFileSync } from 'fs';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { bold, cyan } from 'picocolors';
-import packageJson from '../../../../package.json';
 import { copy } from '../helpers/copy';
 import { install } from '../helpers/install';
 
 import { GetTemplateFileArgs, InstallTemplateArgs, TemplateTypeEnum } from './types';
 
 function resolveFrameworkVersion(): string {
-  const raw = packageJson.dependencies['@novu/framework'];
-  if (raw.startsWith('workspace:')) {
+  const distIndex = __dirname.lastIndexOf(`${path.sep}dist${path.sep}`);
+  if (distIndex === -1) return 'latest';
+
+  const pkgRoot = __dirname.slice(0, distIndex);
+  try {
+    const pkg = JSON.parse(readFileSync(path.join(pkgRoot, 'package.json'), 'utf8'));
+
+    return pkg.dependencies?.['@novu/framework'] ?? 'latest';
+  } catch {
     return 'latest';
   }
-
-  return raw;
 }
 /**
  * Get the file path for a given file in a template, e.g. "next.config.js".

--- a/packages/novu/src/commands/init/templates/index.ts
+++ b/packages/novu/src/commands/init/templates/index.ts
@@ -17,8 +17,10 @@ function resolveFrameworkVersion(): string {
   const pkgRoot = __dirname.slice(0, distIndex);
   try {
     const pkg = JSON.parse(readFileSync(path.join(pkgRoot, 'package.json'), 'utf8'));
+    const ver = pkg.dependencies?.['@novu/framework'];
+    if (!ver || ver.startsWith('workspace:')) return 'latest';
 
-    return pkg.dependencies?.['@novu/framework'] ?? 'latest';
+    return ver;
   } catch {
     return 'latest';
   }


### PR DESCRIPTION
## Summary
- Read `@novu/framework` version from `novu`'s own `package.json` instead of hardcoding `'latest'` in the init template — RC publishes automatically scaffold with the matching alpha version
- Extract `CLI_PACKAGE_TAG` constant in the dashboard so all agent setup commands use `@rc` during pre-release, with a single-line change to `'latest'` at GA (linked to `IS_CONVERSATIONAL_AGENTS_ENABLED` flag removal)

## Test plan
- [ ] Publish `novu` RC and verify `npx novu@rc init -t agent` scaffolds with the correct `@novu/framework` alpha version
- [ ] Verify dashboard agent setup guide shows `@rc` in both init and dev commands
- [ ] Verify local dev (`workspace:*`) falls back to `'latest'`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Scaffolding and the dashboard agent setup now use the repo's actual @novu/framework version for pre-releases instead of hardcoded "latest". The CLI init template resolves @novu/framework at runtime from the repository root package.json (falling back to latest on error or workspace:*), and the dashboard renders npx commands with a configurable CLI_PACKAGE_TAG (set to "rc") so pre-release UI and scaffolds reference the matching alpha/rc versions.

## Affected areas
- **dashboard**: Replaced hardcoded npx novu@latest commands with npx novu@${CLI_PACKAGE_TAG} for agent init, copy-init, and dev tunnel commands; added CLI_PACKAGE_TAG = 'rc' (with a TODO to flip at GA).
- **js** (packages/novu init templates): Added resolveFrameworkVersion() used when generating projects so @novu/framework in scaffolded package.json is taken from the repo root dependency (with safe fallbacks to 'latest' for workspace:* or errors).
- **packages/framework & packages/novu**: Bumped package versions for the pre-release: @novu/framework → 2.10.1-alpha.1 and novu → 2.8.1-rc.2.

## Key technical decisions
- resolveFrameworkVersion reads the compiled package location to locate the repository root package.json and returns pkg.dependencies['@novu/framework'], but returns 'latest' for missing/dist failures or workspace:* values to avoid leaking workspace references into generated projects.
- Dashboard command tag is driven by a single CLI_PACKAGE_TAG constant to make switching release tags a one-line change and decouple UI copy from release mechanics.

## Testing
Manual verification: publish an RC and confirm `npx novu@rc init -t agent` scaffolds with the matching @novu/framework alpha; verify the dashboard shows `@rc` in init and dev commands; confirm local monorepo development with workspace:* still falls back to 'latest'.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->