### PR TITLE
feat(api,shared,framework): add WhatsApp support for agent conversations fixes NV-7374

### DIFF
--- a/apps/api/src/app/agents/agents-webhook.controller.ts
+++ b/apps/api/src/app/agents/agents-webhook.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpException,
   HttpStatus,
@@ -56,6 +57,16 @@ export class AgentsWebhookController {
     );
   }
 
+  @Get('/:agentId/webhook/:integrationIdentifier')
+  async handleWebhookVerification(
+    @Param('agentId') agentId: string,
+    @Param('integrationIdentifier') integrationIdentifier: string,
+    @Req() req: Request,
+    @Res() res: Response
+  ) {
+    return this.routeWebhook(agentId, integrationIdentifier, req, res);
+  }
+
   @Post('/:agentId/webhook/:integrationIdentifier')
   @HttpCode(HttpStatus.OK)
   async handleInboundWebhook(
@@ -64,12 +75,13 @@ export class AgentsWebhookController {
     @Req() req: Request,
     @Res() res: Response
   ) {
+    return this.routeWebhook(agentId, integrationIdentifier, req, res);
+  }
+
+  private async routeWebhook(agentId: string, integrationIdentifier: string, req: Request, res: Response) {
     try {
-      console.log('handleInboundWebhook', agentId, integrationIdentifier);
       await this.chatSdkService.handleWebhook(agentId, integrationIdentifier, req, res);
-      console.log('handleInboundWebhook success');
     } catch (err) {
-      console.log(err);
       if (err instanceof HttpException) {
         res.status(err.getStatus()).json(err.getResponse());
       } else {

--- a/apps/api/src/app/agents/dtos/agent-platform.enum.ts
+++ b/apps/api/src/app/agents/dtos/agent-platform.enum.ts
@@ -3,3 +3,7 @@ export enum AgentPlatformEnum {
   WHATSAPP = 'whatsapp',
   TEAMS = 'teams',
 }
+
+export const PLATFORMS_WITHOUT_TYPING_INDICATOR = new Set<AgentPlatformEnum>([
+  AgentPlatformEnum.WHATSAPP,
+]);

--- a/apps/api/src/app/agents/services/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.ts
@@ -32,6 +32,7 @@ export interface PersistInboundMessageParams {
   senderId: string;
   senderName?: string;
   content: string;
+  richContent?: Record<string, unknown>;
   platformMessageId?: string;
   environmentId: string;
   organizationId: string;
@@ -140,6 +141,7 @@ export class AgentConversationService {
         senderId: params.senderId,
         senderName: params.senderName,
         content: params.content,
+        richContent: params.richContent,
         platformMessageId: params.platformMessageId,
         environmentId: params.environmentId,
         organizationId: params.organizationId,

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@novu/dal';
 import type { Message, Thread } from 'chat';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
+import { PLATFORMS_WITHOUT_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
 import { HandleAgentReplyCommand } from '../usecases/handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from '../usecases/handle-agent-reply/handle-agent-reply.usecase';
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
@@ -121,7 +122,7 @@ export class AgentInboundHandler {
         });
     }
 
-    if (config.thinkingIndicatorEnabled) {
+    if (config.thinkingIndicatorEnabled && !PLATFORMS_WITHOUT_TYPING_INDICATOR.has(config.platform)) {
       await thread.startTyping('Thinking...');
     }
 

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -90,6 +90,18 @@ export class AgentInboundHandler {
       ? ConversationActivitySenderTypeEnum.SUBSCRIBER
       : ConversationActivitySenderTypeEnum.PLATFORM_USER;
 
+    const richContent = message.attachments?.length
+      ? {
+          attachments: message.attachments.map((a) => ({
+            type: a.type,
+            url: a.url,
+            name: a.name,
+            mimeType: a.mimeType,
+            size: a.size,
+          })),
+        }
+      : undefined;
+
     await this.conversationService.persistInboundMessage({
       conversationId: conversation._id,
       platform: config.platform,
@@ -99,6 +111,7 @@ export class AgentInboundHandler {
       senderId: participantId,
       senderName: message.author.fullName,
       content: message.text,
+      richContent,
       platformMessageId: message.id,
       environmentId: config.environmentId,
       organizationId: config.organizationId,

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -51,11 +51,20 @@ interface BridgeMessageAuthor {
   isBot: boolean | 'unknown';
 }
 
+interface BridgeAttachment {
+  type: string;
+  url?: string;
+  name?: string;
+  mimeType?: string;
+  size?: number;
+}
+
 interface BridgeMessage {
   text: string;
   platformMessageId: string;
   author: BridgeMessageAuthor;
   timestamp: string;
+  attachments?: BridgeAttachment[];
 }
 
 export interface BridgeAction {
@@ -87,6 +96,7 @@ interface BridgeHistoryEntry {
   role: ConversationActivitySenderTypeEnum;
   type: ConversationActivityTypeEnum;
   content: string;
+  richContent?: Record<string, unknown>;
   senderName?: string;
   signalData?: { type: string; payload?: Record<string, unknown> };
   createdAt: string;
@@ -282,7 +292,7 @@ export class BridgeExecutorService {
   }
 
   private mapMessage(message: Message): BridgeMessage {
-    return {
+    const mapped: BridgeMessage = {
       text: message.text,
       platformMessageId: message.id,
       author: {
@@ -293,6 +303,18 @@ export class BridgeExecutorService {
       },
       timestamp: message.metadata?.dateSent?.toISOString() ?? new Date().toISOString(),
     };
+
+    if (message.attachments?.length) {
+      mapped.attachments = message.attachments.map((a) => ({
+        type: a.type,
+        url: a.url,
+        name: a.name,
+        mimeType: a.mimeType,
+        size: a.size,
+      }));
+    }
+
+    return mapped;
   }
 
   private mapConversation(conversation: ConversationEntity): BridgeConversation {
@@ -337,6 +359,7 @@ export class BridgeExecutorService {
       role: activity.senderType,
       type: activity.type,
       content: activity.content,
+      richContent: activity.richContent || undefined,
       senderName: activity.senderName || undefined,
       signalData: activity.signalData || undefined,
       createdAt: activity.createdAt,

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -224,35 +224,49 @@ export class ChatSdkService implements OnModuleDestroy {
 
     switch (platform) {
       case AgentPlatformEnum.SLACK: {
+        if (!connectionAccessToken || !credentials.signingSecret) {
+          throw new BadRequestException('Slack agent integration requires botToken and signingSecret credentials');
+        }
+
         const { createSlackAdapter } = await esmImport('@chat-adapter/slack');
 
         return {
           slack: createSlackAdapter({
-            botToken: connectionAccessToken!,
-            signingSecret: credentials.signingSecret!,
+            botToken: connectionAccessToken,
+            signingSecret: credentials.signingSecret,
           }),
         };
       }
       case AgentPlatformEnum.TEAMS: {
+        if (!credentials.clientId || !credentials.secretKey || !credentials.tenantId) {
+          throw new BadRequestException('Teams agent integration requires appId, appPassword, and appTenantId credentials');
+        }
+
         const { createTeamsAdapter } = await esmImport('@chat-adapter/teams');
 
         return {
           teams: createTeamsAdapter({
-            appId: credentials.clientId!,
-            appPassword: credentials.secretKey!,
-            appTenantId: credentials.tenantId!,
+            appId: credentials.clientId,
+            appPassword: credentials.secretKey,
+            appTenantId: credentials.tenantId,
           }),
         };
       }
       case AgentPlatformEnum.WHATSAPP: {
+        if (!credentials.apiToken || !credentials.secretKey || !credentials.token || !credentials.phoneNumberIdentification) {
+          throw new BadRequestException(
+            'WhatsApp agent integration requires accessToken, appSecret, verifyToken, and phoneNumberId credentials'
+          );
+        }
+
         const { createWhatsAppAdapter } = await esmImport('@chat-adapter/whatsapp');
 
         return {
           whatsapp: createWhatsAppAdapter({
-            accessToken: credentials.apiToken!,
-            appSecret: credentials.secretKey!,
-            verifyToken: credentials.token!,
-            phoneNumberId: credentials.phoneNumberIdentification!,
+            accessToken: credentials.apiToken,
+            appSecret: credentials.secretKey,
+            verifyToken: credentials.token,
+            phoneNumberId: credentials.phoneNumberIdentification,
           }),
         };
       }

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -20,9 +20,9 @@ import { AgentInboundHandler } from './agent-inbound-handler.service';
  *           credentials.secretKey → appPassword
  *           credentials.tenantId  → appTenantId
  *
- * WhatsApp: credentials.token                    → accessToken
+ * WhatsApp: credentials.apiToken                  → accessToken
  *           credentials.secretKey                → appSecret
- *           credentials.apiToken                 → verifyToken
+ *           credentials.token                    → verifyToken
  *           credentials.phoneNumberIdentification → phoneNumberId
  */
 
@@ -249,9 +249,9 @@ export class ChatSdkService implements OnModuleDestroy {
 
         return {
           whatsapp: createWhatsAppAdapter({
-            accessToken: credentials.token!,
+            accessToken: credentials.apiToken!,
             appSecret: credentials.secretKey!,
-            verifyToken: credentials.apiToken!,
+            verifyToken: credentials.token!,
             phoneNumberId: credentials.phoneNumberIdentification!,
           }),
         };

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
@@ -54,6 +54,7 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
     senderType: ConversationActivitySenderTypeEnum;
     senderId: string;
     content: string;
+    richContent?: Record<string, unknown>;
     platformMessageId?: string;
     senderName?: string;
     environmentId: string;
@@ -69,6 +70,7 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
       senderType: params.senderType,
       senderId: params.senderId,
       content: params.content,
+      richContent: params.richContent,
       platformMessageId: params.platformMessageId,
       senderName: params.senderName,
       _environmentId: params.environmentId,

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -18,11 +18,20 @@ export interface AgentMessageAuthor {
   isBot: boolean | 'unknown';
 }
 
+export interface AgentAttachment {
+  type: string;
+  url?: string;
+  name?: string;
+  mimeType?: string;
+  size?: number;
+}
+
 export interface AgentMessage {
   text: string;
   platformMessageId: string;
   author: AgentMessageAuthor;
   timestamp: string;
+  attachments?: AgentAttachment[];
 }
 
 export interface AgentConversation {
@@ -49,6 +58,7 @@ export interface AgentHistoryEntry {
   role: string;
   type: string;
   content: string;
+  richContent?: Record<string, unknown>;
   senderName?: string;
   signalData?: { type: string; payload?: Record<string, unknown> };
   createdAt: string;

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -16,6 +16,7 @@ export { agent } from './agent.resource';
 export type {
   Agent,
   AgentAction,
+  AgentAttachment,
   AgentBridgeRequest,
   AgentContext,
   AgentConversation,

--- a/packages/shared/src/consts/providers/conversational-providers.ts
+++ b/packages/shared/src/consts/providers/conversational-providers.ts
@@ -9,7 +9,7 @@ export type ConversationalProvider = {
 export const CONVERSATIONAL_PROVIDERS: ConversationalProvider[] = [
   { providerId: ChatProviderIdEnum.Slack, displayName: 'Slack' },
   { providerId: ChatProviderIdEnum.MsTeams, displayName: 'MS Teams', comingSoon: true },
-  { providerId: ChatProviderIdEnum.WhatsAppBusiness, displayName: 'WhatsApp Business', comingSoon: true },
+  { providerId: ChatProviderIdEnum.WhatsAppBusiness, displayName: 'WhatsApp Business' },
   { providerId: 'telegram', displayName: 'Telegram', comingSoon: true },
   { providerId: 'google-chat', displayName: 'Google Chat', comingSoon: true },
   { providerId: 'linear', displayName: 'Linear', comingSoon: true },

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -1290,6 +1290,20 @@ export const whatsAppBusinessConfig: IConfigCredential[] = [
     type: 'string',
     required: true,
   },
+  {
+    key: CredentialsKeyEnum.SecretKey,
+    displayName: 'App Secret',
+    description: 'Found under App Settings > Basic in your Meta app dashboard — used to verify inbound webhook signatures',
+    type: 'string',
+    required: false,
+  },
+  {
+    key: CredentialsKeyEnum.Token,
+    displayName: 'Verify Token',
+    description: 'A secret string you define — must match the Verify Token entered in your Meta webhook configuration',
+    type: 'string',
+    required: false,
+  },
 ];
 
 export const mobishastraConfig: IConfigCredential[] = [


### PR DESCRIPTION
## Summary

Adds full backend support for WhatsApp as an agent conversation platform, enabling bidirectional messaging between WhatsApp users and Novu agent handlers.

**What changed:**

- **Credentials** — Extended `whatsAppBusinessConfig` with `AppSecret` and `VerifyToken` fields; fixed the adapter credential mapping in `ChatSdkService` (`apiToken` → `accessToken`, `token` → `verifyToken`)
- **Webhook verification** — Added `GET` endpoint on the webhook controller for Meta's webhook URL verification handshake (delegates to the same `routeWebhook` as `POST`)
- **Platform capabilities** — Introduced `PLATFORMS_WITHOUT_TYPING_INDICATOR` set to generically suppress typing indicators on platforms that don't support them (WhatsApp); confirmed `ctx.update()` is safe (posts new message, not an edit)
- **Enabled WhatsApp** — Removed `comingSoon: true` from `CONVERSATIONAL_PROVIDERS` so WhatsApp is selectable
- **Inbound media passthrough** — Wired `Message.attachments` through the full pipeline: persisted as `richContent` on `ConversationActivity`, included in bridge payload as `message.attachments`, replayed in `history[].richContent`, exposed as `AgentAttachment` in the framework SDK

**Adapter-level limitations (not in scope):**
- Outbound media sending not supported by `@chat-adapter/whatsapp` (files silently ignored)
- `Select`/list interactive messages not mapped by the adapter (falls back to text)

```mermaid
sequenceDiagram
    participant WA as WhatsApp User
    participant API as Novu API
    participant SDK as Chat SDK Adapter
    participant Bridge as Customer Handler

    WA->>API: POST webhook (message + media)
    API->>SDK: handleWebhook()
    SDK->>API: onMessage(thread, message)
    API->>API: persist activity + richContent
    API->>Bridge: POST bridge payload (text + attachments)
    Bridge->>API: ctx.reply(text / markdown / card)
    API->>SDK: thread.post(content)
    SDK->>WA: Deliver message
```

## Test plan

- [x] Webhook verification — Meta "Verify and Save" succeeds against local tunnel
- [x] Inbound text message — arrives at bridge handler with correct `ctx.message.text`
- [x] Outbound plain text — reply delivered to WhatsApp
- [x] Outbound markdown — formatting converted to WhatsApp syntax
- [x] Outbound buttons — `Card` + `Button` renders as WhatsApp interactive reply buttons
- [x] Button action callback — tapping a button fires `onAction` with correct `actionId`/`value`
- [ ] Inbound image — `ctx.message.attachments` populated with type/url/mimeType
- [ ] History replay — attachments persisted in `richContent` and replayed in `ctx.history`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

WhatsApp Business is added as a supported agent conversation platform: webhook verification (GET) and inbound message POSTs are routed to a unified handler, WhatsApp credentials and validation were updated (App Secret & Verify Token added; apiToken → accessToken, token → verifyToken), inbound media attachments are passed through and persisted as richContent, and WhatsApp was enabled in the conversational provider list. This enables bidirectional messaging between WhatsApp users and Novu agent handlers and preserves history/replay of inbound media.

## Affected areas

api: Added GET webhook verification endpoint and refactored webhook routing into a shared routeWebhook handler; added PLATFORMS_WITHOUT_TYPING_INDICATOR and conditional typing behavior; updated inbound handler to extract attachments and persist richContent; and fixed WhatsApp credential mapping and runtime validation in chat SDK adapter construction.

dal: ConversationActivityRepository.createUserActivity now accepts and persists an optional richContent field for user activities.

shared: Removed comingSoon flag for WhatsApp Business in CONVERSATIONAL_PROVIDERS and extended whatsAppBusinessConfig with optional App Secret and Verify Token credential entries.

framework: Exposed AgentAttachment type and added attachments to AgentMessage and richContent to AgentHistoryEntry so framework consumers can access inbound media and history entries.

providers/worker/dashboard: Existing provider/worker logic and UI entries now include WhatsApp where applicable (configuration and provider lists).

## Key technical decisions

- Inbound media is persisted as richContent on conversation activities and replayed in history rather than attempting outbound media sends (adapter outbound media is unsupported), enabling read/replay without adding media upload/forwarding paths.
- GET webhook verification and POST inbound events share a single routeWebhook handler to centralize verification and processing logic.
- Platforms that don't support typing indicators (currently WhatsApp) are flagged via PLATFORMS_WITHOUT_TYPING_INDICATOR to avoid per-platform special-casing.

## Testing

Manual verification performed: webhook verification via local tunnel, inbound text delivered correctly, outbound plain text/markdown/buttons and callbacks tested; inbound image/history replay noted as pending completion. No new automated tests were added in this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->