### PR TITLE
feat(dashboard): add WhatsApp onboarding for agents fixes NV-7375

### DIFF
--- a/apps/dashboard/src/components/agents/agent-integration-guides/resolve-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/resolve-agent-integration-guide.tsx
@@ -1,8 +1,10 @@
 import { ChatProviderIdEnum } from '@novu/shared';
 import type { AgentIntegrationLink, AgentResponse } from '@/api/agents';
 import { SlackSetupGuide } from '@/components/agents/slack-setup-guide';
+import { WhatsAppSetupGuide } from '@/components/agents/whatsapp-setup-guide';
 import { GenericAgentIntegrationGuide } from './generic-agent-integration-guide';
 import { SlackAgentIntegrationGuide } from './slack-agent-integration-guide';
+import { WhatsAppAgentIntegrationGuide } from './whatsapp-agent-integration-guide';
 
 type ResolveAgentIntegrationGuideProps = {
   integrationLink: AgentIntegrationLink;
@@ -32,6 +34,24 @@ export function ResolveAgentIntegrationGuide({
   if (providerId === ChatProviderIdEnum.Slack) {
     return (
       <SlackAgentIntegrationGuide
+        embedded={embedded}
+        onBack={onBack}
+        agent={agent}
+        integrationLink={integrationLink}
+        canRemoveIntegration={canRemoveIntegration}
+        onRequestRemoveIntegration={onRequestRemoveIntegration}
+        isRemovingIntegration={isRemovingIntegration}
+      />
+    );
+  }
+
+  if (providerId === ChatProviderIdEnum.WhatsAppBusiness && !integrationLink.connectedAt) {
+    return <WhatsAppSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />;
+  }
+
+  if (providerId === ChatProviderIdEnum.WhatsAppBusiness) {
+    return (
+      <WhatsAppAgentIntegrationGuide
         embedded={embedded}
         onBack={onBack}
         agent={agent}

--- a/apps/dashboard/src/components/agents/agent-integration-guides/whatsapp-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/whatsapp-agent-integration-guide.tsx
@@ -1,0 +1,65 @@
+import { ChatProviderIdEnum } from '@novu/shared';
+import type { AgentIntegrationLink, AgentResponse } from '@/api/agents';
+import { AgentIntegrationGuideLayout } from './agent-integration-guide-layout';
+import { AgentIntegrationGuideSection } from './agent-integration-guide-section';
+import { AgentIntegrationGuideStep } from './agent-integration-guide-step';
+
+type WhatsAppAgentIntegrationGuideProps = {
+  onBack: () => void;
+  embedded?: boolean;
+  agent: AgentResponse;
+  integrationLink?: AgentIntegrationLink;
+  canRemoveIntegration: boolean;
+  onRequestRemoveIntegration?: () => void;
+  isRemovingIntegration?: boolean;
+};
+
+export function WhatsAppAgentIntegrationGuide({
+  onBack,
+  embedded = false,
+  agent,
+  integrationLink,
+  canRemoveIntegration,
+  onRequestRemoveIntegration,
+  isRemovingIntegration,
+}: WhatsAppAgentIntegrationGuideProps) {
+
+  return (
+    <AgentIntegrationGuideLayout
+      providerId={ChatProviderIdEnum.WhatsAppBusiness}
+      providerDisplayName="WhatsApp Business"
+      onBack={onBack}
+      embedded={embedded}
+      agent={agent}
+      integrationLink={integrationLink}
+      canRemoveIntegration={canRemoveIntegration}
+      onRequestRemoveIntegration={onRequestRemoveIntegration}
+      isRemovingIntegration={isRemovingIntegration}
+    >
+      <AgentIntegrationGuideSection title="Overview">
+        <p>
+          Connect WhatsApp Business so this agent can send and receive messages through your business phone number.
+          Ensure the integration is configured and active in the integration store for this environment.
+        </p>
+      </AgentIntegrationGuideSection>
+      <div className="flex flex-col gap-3">
+        <p className="text-text-strong text-label-sm font-medium">Steps</p>
+        <AgentIntegrationGuideStep
+          step={1}
+          title="Configure credentials"
+          description="Add the Access Token, Phone Number ID, App Secret, and Verify Token from the Meta Developer portal into the integration store."
+        />
+        <AgentIntegrationGuideStep
+          step={2}
+          title="Set up the webhook"
+          description="Paste the agent's webhook URL into your Meta app's WhatsApp webhook configuration and subscribe to the messages field."
+        />
+        <AgentIntegrationGuideStep
+          step={3}
+          title="Test from the agent"
+          description="Send a WhatsApp message to your business phone number and confirm the agent receives and responds."
+        />
+      </div>
+    </AgentIntegrationGuideLayout>
+  );
+}

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -11,6 +11,7 @@ import { ProviderDropdown } from './provider-dropdown';
 import { SetupStep } from './setup-guide-primitives';
 import { deriveStepStatus } from './setup-guide-step-utils';
 import { SlackSetupGuide } from './slack-setup-guide';
+import { WhatsAppSetupGuide } from './whatsapp-setup-guide';
 
 type AgentSetupGuideProps = {
   agent: AgentResponse;
@@ -20,6 +21,8 @@ function resolveProviderSetupGuide(providerId: string) {
   switch (providerId) {
     case ChatProviderIdEnum.Slack:
       return SlackSetupGuide;
+    case ChatProviderIdEnum.WhatsAppBusiness:
+      return WhatsAppSetupGuide;
     default:
       return null;
   }
@@ -64,17 +67,17 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
     return links.some((link) => Boolean(link.connectedAt));
   }, [isProviderComplete, agentIntegrationsQuery.data?.data]);
 
-  const slackFromAgent = agent.integrations?.find((i) => i.providerId === ChatProviderIdEnum.Slack);
+  const defaultFromAgent = agent.integrations?.[0];
 
-  const effectiveIntegrationId = selectedIntegrationId ?? slackFromAgent?.integrationId;
+  const effectiveIntegrationId = selectedIntegrationId ?? defaultFromAgent?.integrationId;
 
   const selectedProviderId = useMemo(() => {
     if (selectedIntegrationId) {
       return integrations?.find((i) => i._id === selectedIntegrationId)?.providerId;
     }
 
-    return slackFromAgent?.providerId;
-  }, [integrations, selectedIntegrationId, slackFromAgent?.providerId]);
+    return defaultFromAgent?.providerId;
+  }, [integrations, selectedIntegrationId, defaultFromAgent?.providerId]);
 
   const hasProviderSelected = Boolean(effectiveIntegrationId);
 
@@ -126,7 +129,7 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
                 rightContent={
                   <ProviderDropdown
                     agentIdentifier={agent.identifier}
-                    selectedIntegrationId={selectedIntegrationId ?? slackFromAgent?.integrationId}
+                    selectedIntegrationId={selectedIntegrationId ?? defaultFromAgent?.integrationId}
                     linkedIntegrationIds={linkedIntegrationIds}
                     onSelect={(_providerId, integration) => {
                       if (integration?._id) {

--- a/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
@@ -1,0 +1,363 @@
+import { ChatProviderIdEnum } from '@novu/shared';
+import { useQueryClient } from '@tanstack/react-query';
+import { CheckCircle2, Loader } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ReactConfetti from 'react-confetti';
+import { createPortal } from 'react-dom';
+import { RiArrowRightUpLine, RiKey2Line } from 'react-icons/ri';
+import { type AgentResponse, getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
+import { ProviderIcon } from '@/components/integrations/components/provider-icon';
+import { CopyButton } from '@/components/primitives/copy-button';
+import { InlineToast } from '@/components/primitives/inline-toast';
+import { ExternalLink } from '@/components/shared/external-link';
+import { API_HOSTNAME } from '@/config';
+import { useEnvironment } from '@/context/environment/hooks';
+import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
+import { cn } from '@/utils/ui';
+import { IntegrationCredentialsSidebar, SetupButton, SetupStep } from './setup-guide-primitives';
+import { deriveStepStatus } from './setup-guide-step-utils';
+
+export type WhatsAppSetupGuideProps = {
+  agent: AgentResponse;
+  integrationId: string;
+  stepOffset?: number;
+  onStepsCompleted?: () => void;
+  embedded?: boolean;
+};
+
+function ListeningStatus({
+  agentIdentifier,
+  watchedIntegrationId,
+  onConnected,
+}: {
+  agentIdentifier: string;
+  watchedIntegrationId: string | undefined;
+  onConnected?: () => void;
+}) {
+  const { currentEnvironment } = useEnvironment();
+  const queryClient = useQueryClient();
+  const [connectedAt, setConnectedAt] = useState<string | null>(null);
+  const [showConfetti, setShowConfetti] = useState(false);
+  const confettiTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!currentEnvironment || !watchedIntegrationId) {
+      return;
+    }
+
+    const environment = currentEnvironment;
+    let cancelled = false;
+    let confettiFired = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    async function tick() {
+      if (cancelled) {
+        return;
+      }
+
+      try {
+        const res = await listAgentIntegrations({
+          environment,
+          agentIdentifier,
+          limit: 100,
+        });
+
+        if (cancelled) {
+          return;
+        }
+
+        const link = res.data.find((l) => l.integration._id === watchedIntegrationId);
+
+        if (!link) {
+          return;
+        }
+
+        if (!link.connectedAt) {
+          return;
+        }
+
+        setConnectedAt(link.connectedAt);
+
+        if (!confettiFired) {
+          confettiFired = true;
+          setShowConfetti(true);
+
+          if (confettiTimeoutRef.current) {
+            clearTimeout(confettiTimeoutRef.current);
+          }
+
+          confettiTimeoutRef.current = window.setTimeout(() => {
+            confettiTimeoutRef.current = null;
+            setShowConfetti(false);
+          }, 10_000);
+          onConnected?.();
+        }
+
+        queryClient.invalidateQueries({
+          queryKey: getAgentIntegrationsQueryKey(environment._id, agentIdentifier),
+        });
+
+        if (intervalId) {
+          clearInterval(intervalId);
+          intervalId = null;
+        }
+      } catch {
+        // ignore transient errors while polling
+      }
+    }
+
+    void tick();
+    intervalId = setInterval(() => void tick(), 1000);
+
+    return () => {
+      cancelled = true;
+
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+
+      if (confettiTimeoutRef.current) {
+        clearTimeout(confettiTimeoutRef.current);
+        confettiTimeoutRef.current = null;
+      }
+    };
+  }, [agentIdentifier, currentEnvironment, onConnected, queryClient, watchedIntegrationId]);
+
+  return (
+    <>
+      {showConfetti &&
+        createPortal(
+          <ReactConfetti
+            width={window.innerWidth}
+            height={window.innerHeight}
+            recycle={false}
+            numberOfPieces={1000}
+            style={{
+              position: 'fixed',
+              inset: 0,
+              pointerEvents: 'none',
+              zIndex: 10000,
+            }}
+          />,
+          document.body
+        )}
+      <div className="flex flex-col gap-2 py-4 pl-8">
+        <div className="flex flex-col gap-3">
+          {connectedAt ? (
+            <div className="flex items-center gap-1">
+              <CheckCircle2 className="text-success-base size-3.5 shrink-0" />
+              <span className="text-text-strong text-label-sm font-medium">Connected</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1">
+              <Loader className="size-3.5 text-[#dd2476] animate-[spin_5s_linear_infinite]" />
+              <span className="animate-gradient bg-linear-to-r from-[#dd2476] via-[#ff512f] to-[#dd2476] bg-size-[400%_400%] bg-clip-text text-label-sm font-medium text-transparent">
+                Listening...
+              </span>
+            </div>
+          )}
+          <p className="text-text-soft text-label-xs font-medium leading-4">
+            {connectedAt
+              ? 'Your WhatsApp Business account is connected. This agent is ready to receive messages.'
+              : 'Send a WhatsApp message to your business number to verify configuration.'}
+          </p>
+        </div>
+        <ExternalLink href="https://docs.novu.co/agents/overview" variant="documentation">
+          Learn more in docs
+        </ExternalLink>
+      </div>
+    </>
+  );
+}
+
+function getApiBaseUrl(): string {
+  return (API_HOSTNAME ?? 'https://api.novu.co').replace(/\/$/, '');
+}
+
+function buildAgentWebhookUrl(agentId: string, integrationIdentifier: string): string {
+  return `${getApiBaseUrl()}/v1/agents/${agentId}/webhook/${integrationIdentifier}`;
+}
+
+function WebhookUrlSection({ webhookUrl }: { webhookUrl: string }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <p className="text-text-sub text-label-xs font-medium leading-5">Webhook URL</p>
+      <div className="border-stroke-soft bg-bg-white flex h-7 items-center overflow-hidden rounded-md border shadow-xs">
+        <input
+          type="text"
+          readOnly
+          value={webhookUrl}
+          className="text-text-soft min-w-0 flex-1 truncate bg-transparent px-2 font-mono text-[12px] leading-4 outline-none"
+        />
+        <CopyButton valueToCopy={webhookUrl} size="xs" className="shrink-0 border-l border-stroke-soft" />
+      </div>
+    </div>
+  );
+}
+
+export function WhatsAppSetupGuide({
+  agent,
+  integrationId,
+  stepOffset = 1,
+  onStepsCompleted,
+  embedded = false,
+}: WhatsAppSetupGuideProps) {
+  const { currentEnvironment } = useEnvironment();
+  const [isCredentialsSidebarOpen, setIsCredentialsSidebarOpen] = useState(false);
+  const [isCredentialsSaved, setIsCredentialsSaved] = useState(false);
+  const [isConnected, setIsConnected] = useState(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset when the watched integration changes
+  useEffect(() => {
+    setIsConnected(false);
+  }, [integrationId]);
+
+  const handleConnected = useCallback(() => {
+    setIsConnected(true);
+    onStepsCompleted?.();
+  }, [onStepsCompleted]);
+
+  const { integrations } = useFetchIntegrations();
+
+  const selectedIntegrationIdentifier = useMemo(() => {
+    const row = integrations?.find(
+      (i) => i._id === integrationId && i.providerId === ChatProviderIdEnum.WhatsAppBusiness
+    );
+
+    return row?.identifier ?? '';
+  }, [integrations, integrationId]);
+
+  const webhookUrl = buildAgentWebhookUrl(
+    agent._id,
+    selectedIntegrationIdentifier || 'YOUR_INTEGRATION_IDENTIFIER'
+  );
+
+  const base = stepOffset;
+
+  const firstIncompleteStep = useMemo(() => {
+    if (isConnected) {
+      return base + 3;
+    }
+
+    if (!isCredentialsSaved) {
+      return base;
+    }
+
+    return base + 2;
+  }, [base, isCredentialsSaved, isConnected]);
+
+  const stepsColumn = (
+    <>
+      <SetupStep
+        index={base}
+        status={deriveStepStatus(base, firstIncompleteStep)}
+        title="Configure WhatsApp credentials"
+        description={
+          <span>
+            {'Paste the Access Token, Phone Number ID, App Secret and Verify Token from your '}
+            <a
+              href="https://developers.facebook.com/apps/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-text-sub underline"
+            >
+              Meta Developer portal
+            </a>
+            {' into the integration.'}
+          </span>
+        }
+        rightContent={
+          <div className="flex flex-col gap-3">
+            <SetupButton
+              leadingIcon={<RiKey2Line className="size-3.5" />}
+              onClick={() => setIsCredentialsSidebarOpen(true)}
+            >
+              Configure credentials
+            </SetupButton>
+            <a
+              href="https://developers.facebook.com/apps/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-fit items-center gap-1"
+            >
+              <ProviderIcon
+                providerId={ChatProviderIdEnum.WhatsAppBusiness}
+                providerDisplayName="WhatsApp Business"
+                className="size-4 shrink-0"
+              />
+              <span className="text-text-sub text-label-xs font-medium">Meta Developer Portal</span>
+              <RiArrowRightUpLine className="text-text-sub size-3" />
+            </a>
+          </div>
+        }
+      />
+
+      <SetupStep
+        index={base + 1}
+        status={deriveStepStatus(base + 1, firstIncompleteStep)}
+        title="Set the webhook URL in Meta"
+        description="In your Meta app's WhatsApp configuration, paste this webhook URL and set the Verify Token to the same value you entered in the credentials step."
+        extraContent={
+          <InlineToast
+            className="mt-2 w-full"
+            variant="tip"
+            title="Tip:"
+            description="Subscribe to the 'messages' webhook field so your agent receives inbound messages."
+          />
+        }
+        rightContent={<WebhookUrlSection webhookUrl={webhookUrl} />}
+      />
+
+      <SetupStep
+        index={base + 2}
+        status={deriveStepStatus(base + 2, firstIncompleteStep)}
+        title="Verify by sending a message"
+        description="Send a WhatsApp message to your business phone number to confirm the webhook is connected and the agent responds."
+      />
+    </>
+  );
+
+  const listening = (
+    <ListeningStatus
+      agentIdentifier={agent.identifier}
+      watchedIntegrationId={integrationId}
+      onConnected={handleConnected}
+    />
+  );
+
+  if (embedded) {
+    return (
+      <div className="flex flex-col gap-0">
+        <div className={cn('relative flex flex-col gap-10 py-6 pb-3 pl-8 pr-6')}>
+          <div
+            className="absolute bottom-0 left-[22px] top-0 w-px"
+            style={{
+              background: 'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
+            }}
+          />
+          {stepsColumn}
+        </div>
+        {listening}
+        <IntegrationCredentialsSidebar
+          integrationId={integrationId}
+          isOpen={isCredentialsSidebarOpen}
+          onClose={() => setIsCredentialsSidebarOpen(false)}
+          onSaveSuccess={() => setIsCredentialsSaved(true)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {stepsColumn}
+      {listening}
+      <IntegrationCredentialsSidebar
+        integrationId={integrationId}
+        isOpen={isCredentialsSidebarOpen}
+        onClose={() => setIsCredentialsSidebarOpen(false)}
+        onSaveSuccess={() => setIsCredentialsSaved(true)}
+      />
+    </>
+  );
+}

--- a/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
@@ -187,6 +187,7 @@ function WebhookUrlSection({ webhookUrl }: { webhookUrl: string }) {
           type="text"
           readOnly
           value={webhookUrl}
+          aria-label="Webhook URL"
           className="text-text-soft min-w-0 flex-1 truncate bg-transparent px-2 font-mono text-[12px] leading-4 outline-none"
         />
         <CopyButton valueToCopy={webhookUrl} size="xs" className="shrink-0 border-l border-stroke-soft" />
@@ -202,7 +203,6 @@ export function WhatsAppSetupGuide({
   onStepsCompleted,
   embedded = false,
 }: WhatsAppSetupGuideProps) {
-  const { currentEnvironment } = useEnvironment();
   const [isCredentialsSidebarOpen, setIsCredentialsSidebarOpen] = useState(false);
   const [isCredentialsSaved, setIsCredentialsSaved] = useState(false);
   const [isConnected, setIsConnected] = useState(false);


### PR DESCRIPTION
## Summary
- Add WhatsApp Business setup wizard (overview tab) with 3 steps: configure credentials, set webhook URL in Meta, and verify by sending a message — includes polling `ListeningStatus` with confetti on first connection
- Add WhatsApp integration guide (integrations tab) with overview section and numbered steps, using the same `AgentIntegrationGuideLayout` shared by Slack
- Wire both guides into the resolver and setup-guide provider switch, and generalize default integration detection from Slack-only to first linked integration

## Test plan
- [ ] Create an agent, select WhatsApp Business from the provider dropdown on the Overview tab — verify the 3-step setup wizard renders
- [ ] Click "Configure credentials" — verify the credentials sidebar opens with WhatsApp fields (Access Token, Phone Number ID, App Secret, Verify Token)
- [ ] Verify the webhook URL is displayed with a copy button in step 2
- [ ] Navigate to the Integrations tab — verify the WhatsApp integration guide shows overview and steps when connected
- [ ] Verify the existing Slack onboarding flow still works unchanged

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added WhatsApp Business onboarding for agents: a 3-step Overview wizard to configure credentials, show/copy the webhook URL for Meta, and verify the integration by sending a message. The wizard polls integration status and shows confetti on the first successful connection. Added a WhatsApp integration guide on the Integrations tab that reuses the shared AgentIntegrationGuideLayout. Also generalized default integration selection from Slack-only logic to use the first linked integration.

## Affected areas

**dashboard**: New WhatsApp onboarding UI components — WhatsAppSetupGuide (multi-step wizard with credentials sidebar, webhook URL generation, ListeningStatus polling) and WhatsAppAgentIntegrationGuide (overview + numbered steps using AgentIntegrationGuideLayout). ResolveAgentIntegrationGuide now routes WhatsApp to the correct guide based on connection state. Provider setup selection logic in agent-setup-guide was updated to default to the first linked integration instead of Slack-specific detection. Minor accessibility and cleanup fixes (aria-label on webhook input; removed unused destructuring).

## Key technical decisions

- Polling: ListeningStatus polls listAgentIntegrations every second and invalidates the query on connection to detect live status promptly.  
- Default integration: selection now falls back to agent.integrations?.[0] to support providers beyond Slack.  
- UX: Confetti rendered via portal and auto-hides after 10s; webhook URL is read-only with copy-to-clipboard for reliability.

## Testing

Manual verification per PR test plan (create agent, select WhatsApp, walk the 3-step wizard, open credentials sidebar, copy webhook URL, verify Integrations tab guide, confirm Slack flow unchanged). No automated tests were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->