### PR TITLE
feat(dashboard): add MS Teams agent integration onboarding guide fixes NV-7376

### DIFF
--- a/apps/dashboard/src/components/agents/agent-integration-guides/resolve-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/resolve-agent-integration-guide.tsx
@@ -1,9 +1,11 @@
 import { ChatProviderIdEnum } from '@novu/shared';
 import type { AgentIntegrationLink, AgentResponse } from '@/api/agents';
 import { SlackSetupGuide } from '@/components/agents/slack-setup-guide';
+import { TeamsSetupGuide } from '@/components/agents/teams-setup-guide';
 import { WhatsAppSetupGuide } from '@/components/agents/whatsapp-setup-guide';
 import { GenericAgentIntegrationGuide } from './generic-agent-integration-guide';
 import { SlackAgentIntegrationGuide } from './slack-agent-integration-guide';
+import { TeamsAgentIntegrationGuide } from './teams-agent-integration-guide';
 import { WhatsAppAgentIntegrationGuide } from './whatsapp-agent-integration-guide';
 
 type ResolveAgentIntegrationGuideProps = {
@@ -34,6 +36,24 @@ export function ResolveAgentIntegrationGuide({
   if (providerId === ChatProviderIdEnum.Slack) {
     return (
       <SlackAgentIntegrationGuide
+        embedded={embedded}
+        onBack={onBack}
+        agent={agent}
+        integrationLink={integrationLink}
+        canRemoveIntegration={canRemoveIntegration}
+        onRequestRemoveIntegration={onRequestRemoveIntegration}
+        isRemovingIntegration={isRemovingIntegration}
+      />
+    );
+  }
+
+  if (providerId === ChatProviderIdEnum.MsTeams && !integrationLink.connectedAt) {
+    return <TeamsSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />;
+  }
+
+  if (providerId === ChatProviderIdEnum.MsTeams) {
+    return (
+      <TeamsAgentIntegrationGuide
         embedded={embedded}
         onBack={onBack}
         agent={agent}

--- a/apps/dashboard/src/components/agents/agent-integration-guides/teams-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/teams-agent-integration-guide.tsx
@@ -1,0 +1,65 @@
+import { ChatProviderIdEnum } from '@novu/shared';
+import type { AgentIntegrationLink, AgentResponse } from '@/api/agents';
+import { AgentIntegrationGuideLayout } from './agent-integration-guide-layout';
+import { AgentIntegrationGuideSection } from './agent-integration-guide-section';
+import { AgentIntegrationGuideStep } from './agent-integration-guide-step';
+
+type TeamsAgentIntegrationGuideProps = {
+  onBack: () => void;
+  embedded?: boolean;
+  agent: AgentResponse;
+  integrationLink?: AgentIntegrationLink;
+  canRemoveIntegration: boolean;
+  onRequestRemoveIntegration?: () => void;
+  isRemovingIntegration?: boolean;
+};
+
+export function TeamsAgentIntegrationGuide({
+  onBack,
+  embedded = false,
+  agent,
+  integrationLink,
+  canRemoveIntegration,
+  onRequestRemoveIntegration,
+  isRemovingIntegration,
+}: TeamsAgentIntegrationGuideProps) {
+
+  return (
+    <AgentIntegrationGuideLayout
+      providerId={ChatProviderIdEnum.MsTeams}
+      providerDisplayName="MS Teams"
+      onBack={onBack}
+      embedded={embedded}
+      agent={agent}
+      integrationLink={integrationLink}
+      canRemoveIntegration={canRemoveIntegration}
+      onRequestRemoveIntegration={onRequestRemoveIntegration}
+      isRemovingIntegration={isRemovingIntegration}
+    >
+      <AgentIntegrationGuideSection title="Overview">
+        <p>
+          This agent is connected to Microsoft Teams via an Azure Bot. Messages sent to the bot in channels, group
+          chats, or DMs are forwarded to the agent and replies are posted back into the same thread.
+        </p>
+      </AgentIntegrationGuideSection>
+      <div className="flex flex-col gap-3">
+        <p className="text-text-strong text-label-sm font-medium">Setup checklist</p>
+        <AgentIntegrationGuideStep
+          step={1}
+          title="Azure Bot registered"
+          description="The messaging endpoint should point to the webhook URL above with the Teams channel enabled."
+        />
+        <AgentIntegrationGuideStep
+          step={2}
+          title="Teams app installed"
+          description="A Teams app manifest with the bot ID has been packaged and uploaded to the target workspace."
+        />
+        <AgentIntegrationGuideStep
+          step={3}
+          title="Verified"
+          description="@mention the bot in a channel or send it a direct message and confirm the agent responds."
+        />
+      </div>
+    </AgentIntegrationGuideLayout>
+  );
+}

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -11,6 +11,7 @@ import { ProviderDropdown } from './provider-dropdown';
 import { SetupStep } from './setup-guide-primitives';
 import { deriveStepStatus } from './setup-guide-step-utils';
 import { SlackSetupGuide } from './slack-setup-guide';
+import { TeamsSetupGuide } from './teams-setup-guide';
 import { WhatsAppSetupGuide } from './whatsapp-setup-guide';
 
 type AgentSetupGuideProps = {
@@ -21,6 +22,8 @@ function resolveProviderSetupGuide(providerId: string) {
   switch (providerId) {
     case ChatProviderIdEnum.Slack:
       return SlackSetupGuide;
+    case ChatProviderIdEnum.MsTeams:
+      return TeamsSetupGuide;
     case ChatProviderIdEnum.WhatsAppBusiness:
       return WhatsAppSetupGuide;
     default:

--- a/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
+++ b/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
@@ -1,6 +1,11 @@
 import { providers as novuProviders } from '@novu/shared';
-import { type ReactNode, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { CheckCircle2, Loader } from 'lucide-react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
+import ReactConfetti from 'react-confetti';
+import { createPortal } from 'react-dom';
 import { RiArrowRightUpLine } from 'react-icons/ri';
+import { getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
 import { IntegrationSettings } from '@/components/integrations/components/integration-settings';
 import { IntegrationSheet } from '@/components/integrations/components/integration-sheet';
 import { handleIntegrationError } from '@/components/integrations/components/utils/handle-integration-error';
@@ -8,6 +13,8 @@ import { cleanCredentials } from '@/components/integrations/components/utils/hel
 import type { IntegrationFormData } from '@/components/integrations/types';
 import { Button, buttonVariants } from '@/components/primitives/button';
 import { showSuccessToast } from '@/components/primitives/sonner-helpers';
+import { ExternalLink } from '@/components/shared/external-link';
+import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { useUpdateIntegration } from '@/hooks/use-update-integration';
 import { cn } from '@/utils/ui';
@@ -121,6 +128,149 @@ export function SetupButton({
       {leadingIcon}
       <span className="text-label-xs inline-flex min-w-0 items-center font-medium">{children}</span>
     </Button>
+  );
+}
+
+export function ListeningStatus({
+  agentIdentifier,
+  watchedIntegrationId,
+  onConnected,
+  connectedMessage,
+  listeningMessage,
+}: {
+  agentIdentifier: string;
+  watchedIntegrationId: string | undefined;
+  onConnected?: () => void;
+  connectedMessage: string;
+  listeningMessage: string;
+}) {
+  const { currentEnvironment } = useEnvironment();
+  const queryClient = useQueryClient();
+  const [connectedAt, setConnectedAt] = useState<string | null>(null);
+  const [showConfetti, setShowConfetti] = useState(false);
+  const confettiTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!currentEnvironment || !watchedIntegrationId) {
+      return;
+    }
+
+    const environment = currentEnvironment;
+    let cancelled = false;
+    let confettiFired = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    async function tick() {
+      if (cancelled) {
+        return;
+      }
+
+      try {
+        const res = await listAgentIntegrations({
+          environment,
+          agentIdentifier,
+          limit: 100,
+        });
+
+        if (cancelled) {
+          return;
+        }
+
+        const link = res.data.find((l) => l.integration._id === watchedIntegrationId);
+
+        if (!link?.connectedAt) {
+          return;
+        }
+
+        setConnectedAt(link.connectedAt);
+
+        if (!confettiFired) {
+          confettiFired = true;
+          setShowConfetti(true);
+
+          if (confettiTimeoutRef.current) {
+            clearTimeout(confettiTimeoutRef.current);
+          }
+
+          confettiTimeoutRef.current = window.setTimeout(() => {
+            confettiTimeoutRef.current = null;
+            setShowConfetti(false);
+          }, 10_000);
+          onConnected?.();
+        }
+
+        queryClient.invalidateQueries({
+          queryKey: getAgentIntegrationsQueryKey(environment._id, agentIdentifier),
+        });
+
+        if (intervalId) {
+          clearInterval(intervalId);
+          intervalId = null;
+        }
+      } catch {
+        // ignore transient errors while polling
+      }
+    }
+
+    void tick();
+    intervalId = setInterval(() => void tick(), 1000);
+
+    return () => {
+      cancelled = true;
+
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+
+      if (confettiTimeoutRef.current) {
+        clearTimeout(confettiTimeoutRef.current);
+        confettiTimeoutRef.current = null;
+      }
+    };
+  }, [agentIdentifier, currentEnvironment, onConnected, queryClient, watchedIntegrationId]);
+
+  return (
+    <>
+      {showConfetti &&
+        createPortal(
+          <ReactConfetti
+            width={window.innerWidth}
+            height={window.innerHeight}
+            recycle={false}
+            numberOfPieces={1000}
+            style={{
+              position: 'fixed',
+              inset: 0,
+              pointerEvents: 'none',
+              zIndex: 10000,
+            }}
+          />,
+          document.body
+        )}
+      <div className="flex flex-col gap-2 py-4 pl-8">
+        <div className="flex flex-col gap-3">
+          {connectedAt ? (
+            <div className="flex items-center gap-1">
+              <CheckCircle2 className="text-success-base size-3.5 shrink-0" />
+              <span className="text-text-strong text-label-sm font-medium">Connected</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1">
+              <Loader className="size-3.5 text-[#dd2476] animate-[spin_5s_linear_infinite]" />
+              <span className="animate-gradient bg-linear-to-r from-[#dd2476] via-[#ff512f] to-[#dd2476] bg-size-[400%_400%] bg-clip-text text-label-sm font-medium text-transparent">
+                Listening...
+              </span>
+            </div>
+          )}
+          <p className="text-text-soft text-label-xs font-medium leading-4">
+            {connectedAt ? connectedMessage : listeningMessage}
+          </p>
+        </div>
+        <ExternalLink href="https://docs.novu.co/agents/overview" variant="documentation">
+          Learn more in docs
+        </ExternalLink>
+      </div>
+    </>
   );
 }
 

--- a/apps/dashboard/src/components/agents/slack-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/slack-setup-guide.tsx
@@ -1,25 +1,20 @@
 import { useUser } from '@clerk/clerk-react';
 import { NovuProvider, SlackConnectButton } from '@novu/react';
 import { ChatProviderIdEnum, SLACK_AGENT_OAUTH_SCOPES } from '@novu/shared';
-import { useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, Loader } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import ReactConfetti from 'react-confetti';
-import { createPortal } from 'react-dom';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { RiArrowDownSLine, RiArrowRightUpLine, RiKey2Line } from 'react-icons/ri';
-import { type AgentResponse, getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
+import type { AgentResponse } from '@/api/agents';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { Button } from '@/components/primitives/button';
 import { CodeBlock } from '@/components/primitives/code-block';
 import { InlineToast } from '@/components/primitives/inline-toast';
-import { ExternalLink } from '@/components/shared/external-link';
 import { API_HOSTNAME } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { apiHostnameManager } from '@/utils/api-hostname-manager';
 import { cn } from '@/utils/ui';
-import { IntegrationCredentialsSidebar, SetupButton, SetupStep } from './setup-guide-primitives';
+import { IntegrationCredentialsSidebar, ListeningStatus, SetupButton, SetupStep } from './setup-guide-primitives';
 import { deriveStepStatus } from './setup-guide-step-utils';
 
 export type SlackSetupGuideProps = {
@@ -32,151 +27,6 @@ export type SlackSetupGuideProps = {
   /** Integrations tab: same content without Overview chrome */
   embedded?: boolean;
 };
-
-function ListeningStatus({
-  agentIdentifier,
-  watchedIntegrationId,
-  onSlackWorkspaceConnected,
-}: {
-  agentIdentifier: string;
-  watchedIntegrationId: string | undefined;
-  onSlackWorkspaceConnected?: () => void;
-}) {
-  const { currentEnvironment } = useEnvironment();
-  const queryClient = useQueryClient();
-  const [connectedAt, setConnectedAt] = useState<string | null>(null);
-  const [showConfetti, setShowConfetti] = useState(false);
-  const confettiTimeoutRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (!currentEnvironment || !watchedIntegrationId) {
-      return;
-    }
-
-    const environment = currentEnvironment;
-    let cancelled = false;
-    let confettiFired = false;
-    let intervalId: ReturnType<typeof setInterval> | null = null;
-
-    async function tick() {
-      if (cancelled) {
-        return;
-      }
-
-      try {
-        const res = await listAgentIntegrations({
-          environment,
-          agentIdentifier,
-          limit: 100,
-        });
-
-        if (cancelled) {
-          return;
-        }
-
-        const link = res.data.find((l) => l.integration._id === watchedIntegrationId);
-
-        if (!link) {
-          return;
-        }
-
-        if (!link.connectedAt) {
-          return;
-        }
-
-        setConnectedAt(link.connectedAt);
-
-        if (!confettiFired) {
-          confettiFired = true;
-          setShowConfetti(true);
-
-          if (confettiTimeoutRef.current) {
-            clearTimeout(confettiTimeoutRef.current);
-          }
-
-          confettiTimeoutRef.current = window.setTimeout(() => {
-            confettiTimeoutRef.current = null;
-            setShowConfetti(false);
-          }, 10_000);
-          onSlackWorkspaceConnected?.();
-        }
-
-        queryClient.invalidateQueries({
-          queryKey: getAgentIntegrationsQueryKey(environment._id, agentIdentifier),
-        });
-
-        if (intervalId) {
-          clearInterval(intervalId);
-          intervalId = null;
-        }
-      } catch {
-        // ignore transient errors while polling
-      }
-    }
-
-    void tick();
-    intervalId = setInterval(() => void tick(), 1000);
-
-    return () => {
-      cancelled = true;
-
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
-
-      if (confettiTimeoutRef.current) {
-        clearTimeout(confettiTimeoutRef.current);
-        confettiTimeoutRef.current = null;
-      }
-    };
-  }, [agentIdentifier, currentEnvironment, onSlackWorkspaceConnected, queryClient, watchedIntegrationId]);
-
-  return (
-    <>
-      {showConfetti &&
-        createPortal(
-          <ReactConfetti
-            width={window.innerWidth}
-            height={window.innerHeight}
-            recycle={false}
-            numberOfPieces={1000}
-            style={{
-              position: 'fixed',
-              inset: 0,
-              pointerEvents: 'none',
-              zIndex: 10000,
-            }}
-          />,
-          document.body
-        )}
-      <div className="flex flex-col gap-2 pl-8 py-4">
-        <div className="flex flex-col gap-3">
-          {connectedAt ? (
-            <div className="flex items-center gap-1">
-              <CheckCircle2 className="text-success-base size-3.5 shrink-0" />
-              <span className="text-text-strong text-label-sm font-medium">Connected</span>
-            </div>
-          ) : (
-            <div className="flex items-center gap-1">
-              <Loader className="size-3.5 text-[#dd2476] animate-[spin_5s_linear_infinite]" />
-              <span className="animate-gradient bg-linear-to-r from-[#dd2476] via-[#ff512f] to-[#dd2476] bg-size-[400%_400%] bg-clip-text text-label-sm font-medium text-transparent">
-                Listening...
-              </span>
-            </div>
-          )}
-          <p className="text-text-soft text-label-xs font-medium leading-4">
-            {connectedAt
-              ? 'Your Slack workspace is connected. This agent is ready to receive messages.'
-              : 'Tag the Slack bot in your installed workspace and send a message to verify configuration.'}
-          </p>
-        </div>
-        <ExternalLink href="https://docs.novu.co/agents/overview" variant="documentation">
-          Learn more in docs
-        </ExternalLink>
-      </div>
-    </>
-  );
-}
 
 function escapeYamlDoubleQuoted(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
@@ -428,7 +278,9 @@ export function SlackSetupGuide({
     <ListeningStatus
       agentIdentifier={agent.identifier}
       watchedIntegrationId={integrationId}
-      onSlackWorkspaceConnected={handleSlackWorkspaceConnected}
+      onConnected={handleSlackWorkspaceConnected}
+      connectedMessage="Your Slack workspace is connected. This agent is ready to receive messages."
+      listeningMessage="Tag the Slack bot in your installed workspace and send a message to verify configuration."
     />
   );
 

--- a/apps/dashboard/src/components/agents/teams-app-package.ts
+++ b/apps/dashboard/src/components/agents/teams-app-package.ts
@@ -1,0 +1,137 @@
+/**
+ * Generates a Teams app package (.zip) in the browser — no server or dependencies needed.
+ *
+ * Contains: manifest.json (pre-filled), color.png (192x192), outline.png (32x32).
+ * Uses store-only zip (no compression) since PNGs are already compressed and the JSON is tiny.
+ */
+
+function generateIconBlob(size: number, letter: string, style: 'color' | 'outline'): Promise<Blob> {
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d')!;
+
+  const font = `-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
+
+  if (style === 'color') {
+    const gradient = ctx.createLinearGradient(0, 0, size, size);
+    gradient.addColorStop(0, '#6366f1');
+    gradient.addColorStop(1, '#8b5cf6');
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.roundRect(0, 0, size, size, size * 0.18);
+    ctx.fill();
+
+    ctx.fillStyle = '#ffffff';
+    ctx.font = `bold ${size * 0.48}px ${font}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(letter, size / 2, size / 2 + size * 0.02);
+  } else {
+    ctx.clearRect(0, 0, size, size);
+    ctx.fillStyle = '#6366f1';
+    ctx.font = `bold ${size * 0.55}px ${font}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(letter, size / 2, size / 2 + size * 0.02);
+  }
+
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => resolve(blob!), 'image/png');
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Minimal ZIP builder (store-only, no compression)
+// ---------------------------------------------------------------------------
+
+function crc32(data: Uint8Array): number {
+  let crc = 0xffffffff;
+
+  for (let i = 0; i < data.length; i++) {
+    crc ^= data[i];
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+    }
+  }
+
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function buildZip(files: { name: string; data: Uint8Array }[]): Blob {
+  const parts: Uint8Array[] = [];
+  const centralEntries: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const file of files) {
+    const nameBytes = new TextEncoder().encode(file.name);
+    const crc = crc32(file.data);
+
+    const local = new ArrayBuffer(30 + nameBytes.length);
+    const lv = new DataView(local);
+    lv.setUint32(0, 0x04034b50, true);
+    lv.setUint16(4, 20, true);
+    lv.setUint16(8, 0, true);
+    lv.setUint32(14, crc, true);
+    lv.setUint32(18, file.data.length, true);
+    lv.setUint32(22, file.data.length, true);
+    lv.setUint16(26, nameBytes.length, true);
+    new Uint8Array(local).set(nameBytes, 30);
+
+    parts.push(new Uint8Array(local), file.data);
+
+    const central = new ArrayBuffer(46 + nameBytes.length);
+    const cv = new DataView(central);
+    cv.setUint32(0, 0x02014b50, true);
+    cv.setUint16(4, 20, true);
+    cv.setUint16(6, 20, true);
+    cv.setUint32(16, crc, true);
+    cv.setUint32(20, file.data.length, true);
+    cv.setUint32(24, file.data.length, true);
+    cv.setUint16(28, nameBytes.length, true);
+    cv.setUint32(42, offset, true);
+    new Uint8Array(central).set(nameBytes, 46);
+
+    centralEntries.push(new Uint8Array(central));
+    offset += 30 + nameBytes.length + file.data.length;
+  }
+
+  const centralSize = centralEntries.reduce((s, e) => s + e.length, 0);
+  const eocd = new ArrayBuffer(22);
+  const ev = new DataView(eocd);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, files.length, true);
+  ev.setUint16(10, files.length, true);
+  ev.setUint32(12, centralSize, true);
+  ev.setUint32(16, offset, true);
+
+  return new Blob([...parts, ...centralEntries, new Uint8Array(eocd)], { type: 'application/zip' });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function downloadTeamsAppPackage(manifestJson: string, agentName: string) {
+  const letter = (agentName || 'N').charAt(0).toUpperCase();
+
+  const [colorBlob, outlineBlob] = await Promise.all([
+    generateIconBlob(192, letter, 'color'),
+    generateIconBlob(32, letter, 'outline'),
+  ]);
+
+  const zip = buildZip([
+    { name: 'manifest.json', data: new TextEncoder().encode(manifestJson) },
+    { name: 'color.png', data: new Uint8Array(await colorBlob.arrayBuffer()) },
+    { name: 'outline.png', data: new Uint8Array(await outlineBlob.arrayBuffer()) },
+  ]);
+
+  const url = URL.createObjectURL(zip);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${(agentName || 'novu-agent').toLowerCase().replace(/\s+/g, '-')}-teams-app.zip`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/apps/dashboard/src/components/agents/teams-app-package.ts
+++ b/apps/dashboard/src/components/agents/teams-app-package.ts
@@ -129,7 +129,8 @@ export async function downloadTeamsAppPackage(manifestJson: string, agentName: s
   const url = URL.createObjectURL(zip);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `${(agentName || 'novu-agent').toLowerCase().replace(/\s+/g, '-')}-teams-app.zip`;
+  const safeName = (agentName || '').toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '') || 'novu-agent';
+  a.download = `${safeName}-teams-app.zip`;
   document.body.appendChild(a);
   a.click();
   a.remove();

--- a/apps/dashboard/src/components/agents/teams-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/teams-setup-guide.tsx
@@ -1,0 +1,366 @@
+import { ChatProviderIdEnum } from '@novu/shared';
+import { Download } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { RiArrowDownSLine, RiKey2Line } from 'react-icons/ri';
+import type { AgentResponse } from '@/api/agents';
+import { ProviderIcon } from '@/components/integrations/components/provider-icon';
+import { CodeBlock } from '@/components/primitives/code-block';
+import { CopyButton } from '@/components/primitives/copy-button';
+import { InlineToast } from '@/components/primitives/inline-toast';
+import { API_HOSTNAME } from '@/config';
+import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
+import { cn } from '@/utils/ui';
+import { downloadTeamsAppPackage } from './teams-app-package';
+import { IntegrationCredentialsSidebar, ListeningStatus, SetupButton, SetupStep } from './setup-guide-primitives';
+import { deriveStepStatus } from './setup-guide-step-utils';
+
+export type TeamsSetupGuideProps = {
+  agent: AgentResponse;
+  integrationId: string;
+  stepOffset?: number;
+  onStepsCompleted?: () => void;
+  embedded?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getApiBaseUrl(): string {
+  return (API_HOSTNAME ?? 'https://api.novu.co').replace(/\/$/, '');
+}
+
+function getApiHostname(): string {
+  try {
+    return new URL(getApiBaseUrl()).hostname;
+  } catch {
+    return 'api.novu.co';
+  }
+}
+
+function buildWebhookUrl(agentId: string, integrationIdentifier: string): string {
+  return `${getApiBaseUrl()}/v1/agents/${agentId}/webhook/${integrationIdentifier}`;
+}
+
+function buildManifest(appId: string, agentName: string): Record<string, unknown> {
+  const id = appId || 'YOUR_APP_ID';
+  const name = agentName || 'Novu Agent';
+  const hostname = getApiHostname();
+
+  return {
+    $schema: 'https://developer.microsoft.com/json-schemas/teams/v1.16/MicrosoftTeams.schema.json',
+    manifestVersion: '1.16',
+    version: '1.0.0',
+    id,
+    developer: {
+      name: 'Your Company',
+      websiteUrl: 'https://your-domain.com',
+      privacyUrl: 'https://your-domain.com/privacy',
+      termsOfUseUrl: 'https://your-domain.com/terms',
+    },
+    name: { short: name, full: `${name} — powered by Novu` },
+    description: { short: `${name} bot`, full: 'A conversational agent powered by Novu.' },
+    icons: { outline: 'outline.png', color: 'color.png' },
+    accentColor: '#FFFFFF',
+    bots: [
+      {
+        botId: id,
+        scopes: ['personal', 'team', 'groupchat'],
+        supportsFiles: false,
+        isNotificationOnly: false,
+      },
+    ],
+    permissions: ['identity', 'messageTeamMembers'],
+    validDomains: [hostname],
+    webApplicationInfo: { id, resource: `api://${hostname}/${id}` },
+    authorization: {
+      permissions: {
+        resourceSpecific: [{ name: 'ChannelMessage.Read.Group', type: 'Application' }],
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Small presentational pieces
+// ---------------------------------------------------------------------------
+
+function WebhookUrlSection({ webhookUrl }: { webhookUrl: string }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <p className="text-text-sub text-label-xs font-medium leading-5">Messaging endpoint</p>
+      <div className="border-stroke-soft bg-bg-white flex h-7 items-center overflow-hidden rounded-md border shadow-xs">
+        <input
+          type="text"
+          readOnly
+          value={webhookUrl}
+          aria-label="Messaging endpoint URL"
+          className="text-text-soft min-w-0 flex-1 truncate bg-transparent px-2 font-mono text-[12px] leading-4 outline-none"
+        />
+        <CopyButton valueToCopy={webhookUrl} size="xs" className="shrink-0 border-l border-stroke-soft" />
+      </div>
+    </div>
+  );
+}
+
+function ManifestPreview({ manifestJson }: { manifestJson: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      <button
+        type="button"
+        className="text-text-sub hover:text-text-strong flex items-center gap-1 self-start transition-colors"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <RiArrowDownSLine className={cn('size-3.5 transition-transform duration-200', open && 'rotate-180')} />
+        <span className="text-label-xs font-medium">{open ? 'Hide manifest' : 'Preview manifest.json'}</span>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            className="min-w-0 overflow-hidden"
+          >
+            <CodeBlock code={manifestJson} language="json" title="manifest.json" className="max-h-64" />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function TeamsSetupGuide({
+  agent,
+  integrationId,
+  stepOffset = 1,
+  onStepsCompleted,
+  embedded = false,
+}: TeamsSetupGuideProps) {
+  const [isCredentialsSidebarOpen, setIsCredentialsSidebarOpen] = useState(false);
+  const [isCredentialsSaved, setIsCredentialsSaved] = useState(false);
+  const [isConnected, setIsConnected] = useState(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset when the watched integration changes
+  useEffect(() => {
+    setIsConnected(false);
+  }, [integrationId]);
+
+  const handleConnected = useCallback(() => {
+    setIsConnected(true);
+    onStepsCompleted?.();
+  }, [onStepsCompleted]);
+
+  const { integrations } = useFetchIntegrations();
+
+  const selectedIntegration = useMemo(
+    () => integrations?.find((i) => i._id === integrationId && i.providerId === ChatProviderIdEnum.MsTeams),
+    [integrations, integrationId]
+  );
+
+  const integrationIdentifier = selectedIntegration?.identifier ?? '';
+  const appId = (selectedIntegration?.credentials as Record<string, string> | undefined)?.clientId ?? '';
+
+  const webhookUrl = buildWebhookUrl(agent._id, integrationIdentifier || 'YOUR_INTEGRATION_IDENTIFIER');
+  const manifestJson = JSON.stringify(buildManifest(appId, agent.name), null, 2);
+
+  const handleDownload = useCallback(() => {
+    void downloadTeamsAppPackage(manifestJson, agent.name);
+  }, [manifestJson, agent.name]);
+
+  const base = stepOffset;
+
+  const firstIncomplete = useMemo(() => {
+    if (isConnected) {
+      return base + 5;
+    }
+
+    if (!isCredentialsSaved) {
+      return base;
+    }
+
+    return base + 4;
+  }, [base, isCredentialsSaved, isConnected]);
+
+  const steps = (
+    <>
+      <SetupStep
+        index={base}
+        status={deriveStepStatus(base, firstIncomplete)}
+        title="Create an Azure Bot resource"
+        description="In the Azure Portal, create a new Azure Bot (Single Tenant). Choose F0 (free) pricing for testing. Once created, note your App ID from the Bot Configuration page."
+        rightContent={
+          <SetupButton
+            href="https://portal.azure.com/#create/Microsoft.AzureBot"
+            leadingIcon={
+              <ProviderIcon
+                providerId={ChatProviderIdEnum.MsTeams}
+                providerDisplayName="MS Teams"
+                className="size-4 shrink-0"
+              />
+            }
+          >
+            Open Azure Portal
+          </SetupButton>
+        }
+      />
+
+      <SetupStep
+        index={base + 1}
+        status={deriveStepStatus(base + 1, firstIncomplete)}
+        title="Configure credentials"
+        description="Copy the App ID, Client Secret, and Tenant ID from your Azure Bot registration into the integration."
+        rightContent={
+          <SetupButton
+            leadingIcon={<RiKey2Line className="size-3.5" />}
+            onClick={() => setIsCredentialsSidebarOpen(true)}
+          >
+            Configure credentials
+          </SetupButton>
+        }
+        extraContent={
+          <InlineToast
+            className="mt-2 w-full"
+            variant="tip"
+            title="Where to find these:"
+            description="App ID is on the Bot Configuration page. For the secret, click Manage Password → Certificates & secrets → New client secret and copy the Value immediately — it's only shown once. Tenant ID is on the App Registration Overview page."
+          />
+        }
+      />
+
+      <SetupStep
+        index={base + 2}
+        status={deriveStepStatus(base + 2, firstIncomplete)}
+        title="Set the messaging endpoint and enable Teams"
+        description="In your Azure Bot, go to Configuration → paste the endpoint below. Then go to Channels → enable Microsoft Teams."
+        rightContent={<WebhookUrlSection webhookUrl={webhookUrl} />}
+      />
+
+      <SetupStep
+        index={base + 3}
+        status={deriveStepStatus(base + 3, firstIncomplete)}
+        title="Download the Teams app package"
+        description="We've generated a ready-to-upload app package with your manifest and placeholder icons. Replace the icons with your own branding before deploying to production."
+        rightContent={
+          <div className="flex min-w-0 flex-col gap-3 self-stretch">
+            <div className="self-start">
+              <SetupButton leadingIcon={<Download className="size-3.5" />} onClick={handleDownload}>
+                Download app package
+              </SetupButton>
+            </div>
+            <ManifestPreview manifestJson={manifestJson} />
+          </div>
+        }
+        extraContent={
+          <InlineToast
+            className="mt-2 w-full"
+            variant="tip"
+            title="Receiving all messages:"
+            description="By default, Teams bots only receive @mentions. The manifest includes RSC permissions so the bot receives every message in channels it's added to."
+          />
+        }
+      />
+
+      <SetupStep
+        index={base + 4}
+        status={deriveStepStatus(base + 4, firstIncomplete)}
+        title="Upload to Teams and verify"
+        description={
+          <div className="flex flex-col gap-2">
+            <p>
+              {'In Teams, click '}
+              <strong>Apps</strong>
+              {' in the sidebar → '}
+              <strong>Manage your apps</strong>
+              {' → '}
+              <strong>Upload an app</strong>
+              {' → '}
+              <strong>Upload a custom app</strong>
+              {' and select the downloaded '}
+              <code className="font-code text-[11px]">.zip</code>
+              {' file.'}
+            </p>
+            <p>
+              {'Once installed, @mention the bot in a channel or send it a direct message to confirm it responds.'}
+            </p>
+          </div>
+        }
+        extraContent={
+          <InlineToast
+            className="mt-2 w-full"
+            variant="tip"
+            title="Organization-wide:"
+            description={
+              <span>
+                {'For org deployment, use the '}
+                <a
+                  href="https://admin.teams.microsoft.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline underline-offset-2"
+                >
+                  Teams Admin Center
+                </a>
+                {' → Teams apps → Manage apps → Upload new app.'}
+              </span>
+            }
+          />
+        }
+      />
+    </>
+  );
+
+  const listening = (
+    <ListeningStatus
+      agentIdentifier={agent.identifier}
+      watchedIntegrationId={integrationId}
+      onConnected={handleConnected}
+      connectedMessage="Your Teams workspace is connected. This agent is ready to receive messages."
+      listeningMessage="@mention the bot in a Teams channel or send it a direct message to verify configuration."
+    />
+  );
+
+  const credentialsSidebar = (
+    <IntegrationCredentialsSidebar
+      integrationId={integrationId}
+      isOpen={isCredentialsSidebarOpen}
+      onClose={() => setIsCredentialsSidebarOpen(false)}
+      onSaveSuccess={() => setIsCredentialsSaved(true)}
+    />
+  );
+
+  if (embedded) {
+    return (
+      <div className="flex flex-col gap-0">
+        <div className={cn('relative flex flex-col gap-10 py-6 pb-3 pl-8 pr-6')}>
+          <div
+            className="absolute bottom-0 left-[22px] top-0 w-px"
+            style={{
+              background: 'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
+            }}
+          />
+          {steps}
+        </div>
+        {listening}
+        {credentialsSidebar}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {steps}
+      {listening}
+      {credentialsSidebar}
+    </>
+  );
+}

--- a/apps/dashboard/src/components/agents/teams-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/teams-setup-guide.tsx
@@ -111,6 +111,7 @@ function ManifestPreview({ manifestJson }: { manifestJson: string }) {
     <div className="flex min-w-0 flex-col gap-2">
       <button
         type="button"
+        aria-expanded={open}
         className="text-text-sub hover:text-text-strong flex items-center gap-1 self-start transition-colors"
         onClick={() => setOpen((v) => !v)}
       >
@@ -147,7 +148,6 @@ export function TeamsSetupGuide({
   embedded = false,
 }: TeamsSetupGuideProps) {
   const [isCredentialsSidebarOpen, setIsCredentialsSidebarOpen] = useState(false);
-  const [isCredentialsSaved, setIsCredentialsSaved] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset when the watched integration changes
@@ -168,14 +168,22 @@ export function TeamsSetupGuide({
   );
 
   const integrationIdentifier = selectedIntegration?.identifier ?? '';
-  const appId = (selectedIntegration?.credentials as Record<string, string> | undefined)?.clientId ?? '';
+  const credentials = selectedIntegration?.credentials as Record<string, string> | undefined;
+  const appId = credentials?.clientId ?? '';
+  const hasCredentials = Boolean(appId && credentials?.secretKey && credentials?.tenantId);
 
   const webhookUrl = buildWebhookUrl(agent._id, integrationIdentifier || 'YOUR_INTEGRATION_IDENTIFIER');
   const manifestJson = JSON.stringify(buildManifest(appId, agent.name), null, 2);
 
+  const canDownload = Boolean(appId);
+
   const handleDownload = useCallback(() => {
+    if (!canDownload) {
+      return;
+    }
+
     void downloadTeamsAppPackage(manifestJson, agent.name);
-  }, [manifestJson, agent.name]);
+  }, [canDownload, manifestJson, agent.name]);
 
   const base = stepOffset;
 
@@ -184,12 +192,12 @@ export function TeamsSetupGuide({
       return base + 5;
     }
 
-    if (!isCredentialsSaved) {
+    if (!hasCredentials) {
       return base;
     }
 
     return base + 4;
-  }, [base, isCredentialsSaved, isConnected]);
+  }, [base, hasCredentials, isConnected]);
 
   const steps = (
     <>
@@ -249,11 +257,15 @@ export function TeamsSetupGuide({
         index={base + 3}
         status={deriveStepStatus(base + 3, firstIncomplete)}
         title="Download the Teams app package"
-        description="We've generated a ready-to-upload app package with your manifest and placeholder icons. Replace the icons with your own branding before deploying to production."
+        description="We've generated a ready-to-upload app package with your manifest and placeholder icons. Before deploying to production, replace the icons and update the developer fields in manifest.json with your company info."
         rightContent={
           <div className="flex min-w-0 flex-col gap-3 self-stretch">
             <div className="self-start">
-              <SetupButton leadingIcon={<Download className="size-3.5" />} onClick={handleDownload}>
+              <SetupButton
+                leadingIcon={<Download className="size-3.5" />}
+                onClick={handleDownload}
+                disabled={!canDownload}
+              >
                 Download app package
               </SetupButton>
             </div>
@@ -334,7 +346,7 @@ export function TeamsSetupGuide({
       integrationId={integrationId}
       isOpen={isCredentialsSidebarOpen}
       onClose={() => setIsCredentialsSidebarOpen(false)}
-      onSaveSuccess={() => setIsCredentialsSaved(true)}
+      onSaveSuccess={() => {}}
     />
   );
 

--- a/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
@@ -1,20 +1,14 @@
 import { ChatProviderIdEnum } from '@novu/shared';
-import { useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, Loader } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import ReactConfetti from 'react-confetti';
-import { createPortal } from 'react-dom';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { RiArrowRightUpLine, RiKey2Line } from 'react-icons/ri';
-import { type AgentResponse, getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
+import type { AgentResponse } from '@/api/agents';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { CopyButton } from '@/components/primitives/copy-button';
 import { InlineToast } from '@/components/primitives/inline-toast';
-import { ExternalLink } from '@/components/shared/external-link';
 import { API_HOSTNAME } from '@/config';
-import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { cn } from '@/utils/ui';
-import { IntegrationCredentialsSidebar, SetupButton, SetupStep } from './setup-guide-primitives';
+import { IntegrationCredentialsSidebar, ListeningStatus, SetupButton, SetupStep } from './setup-guide-primitives';
 import { deriveStepStatus } from './setup-guide-step-utils';
 
 export type WhatsAppSetupGuideProps = {
@@ -24,151 +18,6 @@ export type WhatsAppSetupGuideProps = {
   onStepsCompleted?: () => void;
   embedded?: boolean;
 };
-
-function ListeningStatus({
-  agentIdentifier,
-  watchedIntegrationId,
-  onConnected,
-}: {
-  agentIdentifier: string;
-  watchedIntegrationId: string | undefined;
-  onConnected?: () => void;
-}) {
-  const { currentEnvironment } = useEnvironment();
-  const queryClient = useQueryClient();
-  const [connectedAt, setConnectedAt] = useState<string | null>(null);
-  const [showConfetti, setShowConfetti] = useState(false);
-  const confettiTimeoutRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (!currentEnvironment || !watchedIntegrationId) {
-      return;
-    }
-
-    const environment = currentEnvironment;
-    let cancelled = false;
-    let confettiFired = false;
-    let intervalId: ReturnType<typeof setInterval> | null = null;
-
-    async function tick() {
-      if (cancelled) {
-        return;
-      }
-
-      try {
-        const res = await listAgentIntegrations({
-          environment,
-          agentIdentifier,
-          limit: 100,
-        });
-
-        if (cancelled) {
-          return;
-        }
-
-        const link = res.data.find((l) => l.integration._id === watchedIntegrationId);
-
-        if (!link) {
-          return;
-        }
-
-        if (!link.connectedAt) {
-          return;
-        }
-
-        setConnectedAt(link.connectedAt);
-
-        if (!confettiFired) {
-          confettiFired = true;
-          setShowConfetti(true);
-
-          if (confettiTimeoutRef.current) {
-            clearTimeout(confettiTimeoutRef.current);
-          }
-
-          confettiTimeoutRef.current = window.setTimeout(() => {
-            confettiTimeoutRef.current = null;
-            setShowConfetti(false);
-          }, 10_000);
-          onConnected?.();
-        }
-
-        queryClient.invalidateQueries({
-          queryKey: getAgentIntegrationsQueryKey(environment._id, agentIdentifier),
-        });
-
-        if (intervalId) {
-          clearInterval(intervalId);
-          intervalId = null;
-        }
-      } catch {
-        // ignore transient errors while polling
-      }
-    }
-
-    void tick();
-    intervalId = setInterval(() => void tick(), 1000);
-
-    return () => {
-      cancelled = true;
-
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
-
-      if (confettiTimeoutRef.current) {
-        clearTimeout(confettiTimeoutRef.current);
-        confettiTimeoutRef.current = null;
-      }
-    };
-  }, [agentIdentifier, currentEnvironment, onConnected, queryClient, watchedIntegrationId]);
-
-  return (
-    <>
-      {showConfetti &&
-        createPortal(
-          <ReactConfetti
-            width={window.innerWidth}
-            height={window.innerHeight}
-            recycle={false}
-            numberOfPieces={1000}
-            style={{
-              position: 'fixed',
-              inset: 0,
-              pointerEvents: 'none',
-              zIndex: 10000,
-            }}
-          />,
-          document.body
-        )}
-      <div className="flex flex-col gap-2 py-4 pl-8">
-        <div className="flex flex-col gap-3">
-          {connectedAt ? (
-            <div className="flex items-center gap-1">
-              <CheckCircle2 className="text-success-base size-3.5 shrink-0" />
-              <span className="text-text-strong text-label-sm font-medium">Connected</span>
-            </div>
-          ) : (
-            <div className="flex items-center gap-1">
-              <Loader className="size-3.5 text-[#dd2476] animate-[spin_5s_linear_infinite]" />
-              <span className="animate-gradient bg-linear-to-r from-[#dd2476] via-[#ff512f] to-[#dd2476] bg-size-[400%_400%] bg-clip-text text-label-sm font-medium text-transparent">
-                Listening...
-              </span>
-            </div>
-          )}
-          <p className="text-text-soft text-label-xs font-medium leading-4">
-            {connectedAt
-              ? 'Your WhatsApp Business account is connected. This agent is ready to receive messages.'
-              : 'Send a WhatsApp message to your business number to verify configuration.'}
-          </p>
-        </div>
-        <ExternalLink href="https://docs.novu.co/agents/overview" variant="documentation">
-          Learn more in docs
-        </ExternalLink>
-      </div>
-    </>
-  );
-}
 
 function getApiBaseUrl(): string {
   return (API_HOSTNAME ?? 'https://api.novu.co').replace(/\/$/, '');
@@ -361,6 +210,8 @@ export function WhatsAppSetupGuide({
       agentIdentifier={agent.identifier}
       watchedIntegrationId={integrationId}
       onConnected={handleConnected}
+      connectedMessage="Your WhatsApp Business account is connected. This agent is ready to receive messages."
+      listeningMessage="Send a WhatsApp message to your business number to verify configuration."
     />
   );
 

--- a/packages/shared/src/consts/providers/conversational-providers.ts
+++ b/packages/shared/src/consts/providers/conversational-providers.ts
@@ -8,7 +8,7 @@ export type ConversationalProvider = {
 
 export const CONVERSATIONAL_PROVIDERS: ConversationalProvider[] = [
   { providerId: ChatProviderIdEnum.Slack, displayName: 'Slack' },
-  { providerId: ChatProviderIdEnum.MsTeams, displayName: 'MS Teams', comingSoon: true },
+  { providerId: ChatProviderIdEnum.MsTeams, displayName: 'MS Teams' },
   { providerId: ChatProviderIdEnum.WhatsAppBusiness, displayName: 'WhatsApp Business' },
   { providerId: 'telegram', displayName: 'Telegram', comingSoon: true },
   { providerId: 'google-chat', displayName: 'Google Chat', comingSoon: true },

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -572,22 +572,22 @@ export const slackConfig: IConfigCredential[] = [
 export const msTeamsConfig: IConfigCredential[] = [
   {
     key: CredentialsKeyEnum.ClientId,
-    displayName: 'Client ID',
-    description: 'Azure Bot Application (client) ID',
+    displayName: 'Microsoft App ID',
+    description: 'From Azure Bot resource → Configuration, or App Registration → Overview (Application client ID)',
     type: 'string',
     required: false,
   },
   {
     key: CredentialsKeyEnum.SecretKey,
     displayName: 'Client Secret',
-    description: 'Azure Bot Client Secret value',
+    description: 'Secret value from App Registration → Certificates & secrets → New client secret',
     type: 'string',
     required: false,
   },
   {
     key: CredentialsKeyEnum.TenantId,
-    displayName: 'Tenant ID',
-    description: 'Azure Bot Tenant ID',
+    displayName: 'Directory (tenant) ID',
+    description: 'From App Registration → Overview (Directory tenant ID)',
     type: 'string',
     required: false,
   },


### PR DESCRIPTION
## Summary

Enable MS Teams as a selectable agent integration provider and add a complete onboarding experience in the dashboard.

- **Provider unblock**: remove `comingSoon` from MS Teams in `conversational-providers.ts`, refine credential descriptions to match Azure Portal terminology
- **5-step onboarding wizard** (`teams-setup-guide.tsx`): Azure Bot creation → credential config → messaging endpoint → one-click app package download → sideloading/upload
- **Client-side zip generation** (`teams-app-package.ts`): manifest.json + Canvas-generated placeholder icons, no external dependencies
- **Post-connection guide** (`teams-agent-integration-guide.tsx`): overview with setup checklist
- **Refactor**: extract shared `ListeningStatus` into `setup-guide-primitives.tsx` (was duplicated across Slack, WhatsApp, Teams — ~140 lines removed)

## Test plan

- [ ] Select MS Teams from the provider dropdown on agent overview — verify it's no longer grayed out
- [ ] Walk through all 5 setup steps — verify credential sidebar opens, webhook URL is copyable, app package downloads as valid .zip
- [ ] Unzip downloaded package — verify manifest.json has correct App ID, icons are valid PNGs
- [ ] Upload the package to Teams via sideloading — verify manifest passes Teams validation
- [ ] Send a message to the bot — verify ListeningStatus transitions to "Connected" with confetti
- [ ] Verify Slack and WhatsApp onboarding flows still work (shared ListeningStatus refactor)

Fixes [NV-7376](https://linear.app/novu/issue/NV-7376)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Enabled Microsoft Teams as an active agent integration and added end-to-end onboarding: a 5-step Teams setup wizard (Azure Bot registration, credentials, messaging endpoint, app package download, sideload/upload) plus a post-connection guide. Implemented client-side Teams app package generation (manifest + icons) and extracted a shared ListeningStatus UI to remove duplicated polling/connection logic across Slack, WhatsApp, and Teams. Small UX/accessibility and filename/security improvements were added (aria-expanded, sanitized filenames, download gating until a real App ID).

## Affected areas

**dashboard**: New Teams onboarding and guide components (TeamsSetupGuide, TeamsAgentIntegrationGuide), client-side app package generator (teams-app-package.ts), routing into Teams flows, and `ListeningStatus` moved to setup-guide-primitives.tsx with Slack/WhatsApp updated to reuse it.

**shared**: Activated MS Teams in the provider list by removing `comingSoon` and revised MS Teams credential metadata to match Azure Portal terminology (Microsoft App ID, Secret Key guidance, Directory (tenant) ID).

## Key technical decisions
- Client-side ZIP writer implemented (CRC32 + central directory) to produce a valid .zip without extra dependencies.  
- Icons are generated in-browser via HTML5 Canvas to avoid external image assets/libraries.  
- Listening and connection polling centralized in a shared component to ensure consistent behavior and avoid duplication.

## Testing
Manual verification is required: confirm Teams is selectable, walk the 5-step flow (credential sidebar, copyable webhook), download and unzip the .zip to validate manifest.json and PNGs, sideload/upload to Teams to verify manifest, and validate connection detection (ListeningStatus) and confetti; perform regression checks for Slack and WhatsApp onboarding. No new automated tests were added in this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->