### PR TITLE
fix(api,worker,ws): introduction of pnpm deploy in build phase 

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -45,7 +45,12 @@ RUN pnpm --filter @novu/api-service deploy --legacy --prod /usr/src/deploy
 
 RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && \
     if [ -n "${BULL_MQ_PRO_NPM_TOKEN}" ]; then \
-      cd /usr/src/deploy && npm install --no-save @taskforcesh/bullmq-pro@6.11.0 --registry=https://npm.taskforce.sh/; \
+      cd $(mktemp -d) && \
+      echo "@taskforcesh:registry=https://npm.taskforce.sh/" > .npmrc && \
+      echo "//npm.taskforce.sh/:_authToken=${BULL_MQ_PRO_NPM_TOKEN}" >> .npmrc && \
+      npm init -y > /dev/null 2>&1 && \
+      npm install @taskforcesh/bullmq-pro@6.11.0 && \
+      cp -r node_modules/@taskforcesh /usr/src/deploy/node_modules/@taskforcesh; \
     fi
 
 # ------- PRODUCTION BUILD ----------

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -41,16 +41,17 @@ WORKDIR /usr/src/app
 FROM dev AS deploy
 
 WORKDIR /usr/src/app
-RUN pnpm --filter @novu/api-service deploy --legacy --prod /usr/src/deploy
-
 RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && \
+    pnpm --filter @novu/api-service deploy --legacy --prod /usr/src/deploy && \
     if [ -n "${BULL_MQ_PRO_NPM_TOKEN}" ]; then \
       cd $(mktemp -d) && \
       echo "@taskforcesh:registry=https://npm.taskforce.sh/" > .npmrc && \
       echo "//npm.taskforce.sh/:_authToken=${BULL_MQ_PRO_NPM_TOKEN}" >> .npmrc && \
       npm init -y > /dev/null 2>&1 && \
-      npm install @taskforcesh/bullmq-pro@6.11.0 && \
-      cp -r node_modules/@taskforcesh /usr/src/deploy/node_modules/@taskforcesh; \
+      npm install @taskforcesh/bullmq-pro@6.11.0 2>/dev/null && \
+      cp -r node_modules/@taskforcesh /usr/src/deploy/node_modules/@taskforcesh && \
+      rm -rf node_modules/@taskforcesh && \
+      mv node_modules /usr/src/deploy/node_modules/@taskforcesh/bullmq-pro/node_modules; \
     fi
 
 # ------- PRODUCTION BUILD ----------

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -63,6 +63,18 @@ COPY --chown=1000:1000 --from=deploy /usr/src/deploy .
 # Built output (not included by pnpm deploy because dist is gitignored)
 COPY --chown=1000:1000 --from=dev /usr/src/app/apps/api/dist ./dist
 
+# The NestJS swagger plugin generates dist/metadata.js with hardcoded
+# monorepo-relative paths (e.g. ../../../packages/shared/dist/...).
+# These break in the flat pnpm-deploy layout. Rewrite them so they
+# resolve against node_modules instead.
+RUN if [ -f dist/metadata.js ]; then \
+      sed -i \
+        -e 's|../../../packages/shared/dist|../node_modules/@novu/shared/dist|g' \
+        -e 's|../../../libs/application-generic/build|../node_modules/@novu/application-generic/build|g' \
+        -e 's|../../../libs/dal/dist|../node_modules/@novu/dal/dist|g' \
+        dist/metadata.js; \
+    fi
+
 ENV NEW_RELIC_NO_CONFIG_FILE=true
 
 ENTRYPOINT [ "sh", "-c", "node dist/dotenvcreate.mjs -s=$SECRET_NAME -r=$NOVU_REGION -e=$NOVU_ENTERPRISE -v=$NODE_ENV -h=$IS_SELF_HOSTED && pm2-runtime start dist/main.js -i max" ]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -37,41 +37,32 @@ RUN cp src/.env.production dist/.env.production
 
 WORKDIR /usr/src/app
 
-# ------- ASSETS BUILD ----------
-FROM dev AS assets
+# ------- DEPLOY ----------
+FROM dev AS deploy
 
 WORKDIR /usr/src/app
-
-# Remove source files but KEEP node_modules (already compiled)
-RUN pnpm recursive exec -- rm -rf ./src
+RUN pnpm --filter @novu/api-service deploy --legacy --prod /usr/src/deploy
 
 # ------- PRODUCTION BUILD ----------
 FROM node:22.22-alpine3.23 AS prod
 
-ARG PACKAGE_PATH
-
 ENV CI=true
-ENV NX_DAEMON=false
 
 RUN apk upgrade --no-cache && \
-    # Manually upgrade packages from edge/main to patch CVEs
-    # until fixes are backported to the alpine3.23 stable repo
     apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --upgrade libcrypto3 libssl3 musl musl-utils && \
-    npm --no-update-notifier --no-fund --global install pm2 pnpm@10.33.0 && \
-    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
-           /usr/local/lib/node_modules/pnpm /usr/local/bin/pnpm /usr/local/bin/pnpx
+    npm --no-update-notifier --no-fund --global install pm2 && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 # Set non-root user
 USER 1000
 WORKDIR /usr/src/app
 
-COPY --chown=1000:1000 ./meta .
+# Flat node_modules from pnpm deploy (no symlinks, no hoisting issues)
+COPY --chown=1000:1000 --from=deploy /usr/src/deploy .
 
-# Copy build artifacts AND pre-compiled node_modules from assets
-COPY --chown=1000:1000 --from=assets /usr/src/app .
-
+# Built output (not included by pnpm deploy because dist is gitignored)
+COPY --chown=1000:1000 --from=dev /usr/src/app/apps/api/dist ./dist
 
 ENV NEW_RELIC_NO_CONFIG_FILE=true
 
-WORKDIR /usr/src/app/apps/api
 ENTRYPOINT [ "sh", "-c", "node dist/dotenvcreate.mjs -s=$SECRET_NAME -r=$NOVU_REGION -e=$NOVU_ENTERPRISE -v=$NODE_ENV -h=$IS_SELF_HOSTED && pm2-runtime start dist/main.js -i max" ]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -43,6 +43,11 @@ FROM dev AS deploy
 WORKDIR /usr/src/app
 RUN pnpm --filter @novu/api-service deploy --legacy --prod /usr/src/deploy
 
+RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && \
+    if [ -n "${BULL_MQ_PRO_NPM_TOKEN}" ]; then \
+      cd /usr/src/deploy && npm install --no-save @taskforcesh/bullmq-pro@6.11.0 --registry=https://npm.taskforce.sh/; \
+    fi
+
 # ------- PRODUCTION BUILD ----------
 FROM node:22.22-alpine3.23 AS prod
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.971.0",
+    "yargs": "^17.7.2",
     "@chat-adapter/slack": "^4.25.0",
     "@chat-adapter/state-redis": "^4.25.0",
     "@chat-adapter/teams": "^4.25.0",
@@ -97,6 +98,7 @@
     "dotenv": "^16.5.0",
     "entities": "^7.0.0",
     "envalid": "^8.1.1",
+    "express": "^5.0.1",
     "es-toolkit": "^1.39.10",
     "handlebars": "4.7.9",
     "helmet": "^6.0.1",
@@ -154,7 +156,6 @@
     "async": "^3.2.0",
     "chai": "^4.2.0",
     "chai-subset": "^1.6.0",
-    "express": "^5.0.1",
     "get-port": "^5.1.1",
     "mocha": "^10.2.0",
     "pirates": "^4.0.7",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -172,7 +172,8 @@
     "@novu/ee-auth": "workspace:*",
     "@novu/ee-billing": "workspace:*",
     "@novu/ee-shared-services": "workspace:*",
-    "@novu/ee-translation": "workspace:*"
+    "@novu/ee-translation": "workspace:*",
+    "@taskforcesh/bullmq-pro": "6.11.0"
   },
   "nx": {
     "tags": [

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -172,8 +172,7 @@
     "@novu/ee-auth": "workspace:*",
     "@novu/ee-billing": "workspace:*",
     "@novu/ee-shared-services": "workspace:*",
-    "@novu/ee-translation": "workspace:*",
-    "@taskforcesh/bullmq-pro": "6.11.0"
+    "@novu/ee-translation": "workspace:*"
   },
   "nx": {
     "tags": [

--- a/apps/webhook/Dockerfile
+++ b/apps/webhook/Dockerfile
@@ -33,35 +33,29 @@ RUN cp src/.env.production dist/.env.production
 # Set the working directory to the root of the app
 WORKDIR /usr/src/app
 
-# ------- ASSETS BUILD ----------
-# Create a new stage for building assets
-FROM dev AS assets
+# ------- DEPLOY ----------
+FROM dev AS deploy
 
-# Remove source files but KEEP node_modules (already compiled)
-RUN pnpm recursive exec -- rm -rf ./src
+WORKDIR /usr/src/app
+RUN pnpm --filter @novu/webhook deploy --legacy --prod /usr/src/deploy
 
 # ------- PRODUCTION BUILD ----------
 # Use clean base for production (NO Python)
 FROM node:22.22.1-alpine3.22 AS prod
-ARG PACKAGE_PATH
 
-# Set environment variables for production
 ENV CI=true
-ENV NX_DAEMON=false
 
 # Install only runtime dependencies
-RUN npm --no-update-notifier --no-fund --global install pm2 pnpm@10.33.0
+RUN npm --no-update-notifier --no-fund --global install pm2 && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 USER 1000
-
-# Set the working directory to the root of the app
 WORKDIR /usr/src/app
 
-# Copy necessary directories from the build stage
-COPY --chown=1000:1000 ./meta ./
-# Copy build artifacts AND pre-compiled node_modules from assets
-COPY --chown=1000:1000 --from=assets /usr/src/app .
+# Flat node_modules from pnpm deploy (no symlinks, no hoisting issues)
+COPY --chown=1000:1000 --from=deploy /usr/src/deploy .
 
-# Set the working directory to the webhook app and start the application using pm2-runtime
-WORKDIR /usr/src/app/apps/webhook
+# Built output (not included by pnpm deploy because dist is gitignored)
+COPY --chown=1000:1000 --from=dev /usr/src/app/apps/webhook/dist ./dist
+
 ENTRYPOINT [ "sh", "-c", "node dist/dotenvcreate.mjs -s=novu/webhook -r=$NOVU_REGION -e=$NOVU_ENTERPRISE -v=$NODE_ENV && pm2-runtime start dist/main.js -i max" ]

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -46,6 +46,11 @@ FROM dev AS deploy
 WORKDIR /usr/src/app
 RUN pnpm --filter @novu/worker deploy --legacy --prod /usr/src/deploy
 
+RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && \
+    if [ -n "${BULL_MQ_PRO_NPM_TOKEN}" ]; then \
+      cd /usr/src/deploy && npm install --no-save @taskforcesh/bullmq-pro@6.11.0 --registry=https://npm.taskforce.sh/; \
+    fi
+
 # ------- PRODUCTION BUILD ----------
 FROM node:22.22-alpine3.23 AS prod
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -40,39 +40,32 @@ RUN cp src/.env.production dist/.env.production
 
 WORKDIR /usr/src/app
 
-# ------- ASSETS BUILD ----------
-FROM dev AS assets
+# ------- DEPLOY ----------
+FROM dev AS deploy
 
 WORKDIR /usr/src/app
-
-# Remove source files but KEEP node_modules (already compiled)
-RUN pnpm recursive exec -- rm -rf ./src
+RUN pnpm --filter @novu/worker deploy --legacy --prod /usr/src/deploy
 
 # ------- PRODUCTION BUILD ----------
 FROM node:22.22-alpine3.23 AS prod
-ARG PACKAGE_PATH
 
 ENV CI=true
-ENV NX_DAEMON=false
 
 RUN apk upgrade --no-cache && \
-    # Manually upgrade packages from edge/main to patch CVEs
-    # until fixes are backported to the alpine3.23 stable repo
     apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --upgrade libcrypto3 libssl3 musl musl-utils && \
     apk --no-cache add curl && \
-    npm i pm2 -g && npm --no-update-notifier --no-fund --global install pnpm@10.33.0 && \
-    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
-           /usr/local/lib/node_modules/pnpm /usr/local/bin/pnpm /usr/local/bin/pnpx
+    npm i pm2 -g && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 USER 1000
 WORKDIR /usr/src/app
 
-COPY --chown=1000:1000 ./meta .
+# Flat node_modules from pnpm deploy (no symlinks, no hoisting issues)
+COPY --chown=1000:1000 --from=deploy /usr/src/deploy .
 
-# Copy build artifacts AND pre-compiled node_modules from assets
-COPY --chown=1000:1000 --from=assets /usr/src/app .
+# Built output (not included by pnpm deploy because dist is gitignored)
+COPY --chown=1000:1000 --from=dev /usr/src/app/apps/worker/dist ./dist
 
 ENV NEW_RELIC_NO_CONFIG_FILE=true
 
-WORKDIR /usr/src/app/apps/worker
 ENTRYPOINT [ "sh", "-c", "node dist/dotenvcreate.mjs -s=$SECRET_NAME -r=$NOVU_REGION -e=$NOVU_ENTERPRISE -v=$NODE_ENV -h=$IS_SELF_HOSTED && pm2-runtime start dist/main.js -i max" ]

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -48,7 +48,12 @@ RUN pnpm --filter @novu/worker deploy --legacy --prod /usr/src/deploy
 
 RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && \
     if [ -n "${BULL_MQ_PRO_NPM_TOKEN}" ]; then \
-      cd /usr/src/deploy && npm install --no-save @taskforcesh/bullmq-pro@6.11.0 --registry=https://npm.taskforce.sh/; \
+      cd $(mktemp -d) && \
+      echo "@taskforcesh:registry=https://npm.taskforce.sh/" > .npmrc && \
+      echo "//npm.taskforce.sh/:_authToken=${BULL_MQ_PRO_NPM_TOKEN}" >> .npmrc && \
+      npm init -y > /dev/null 2>&1 && \
+      npm install @taskforcesh/bullmq-pro@6.11.0 && \
+      cp -r node_modules/@taskforcesh /usr/src/deploy/node_modules/@taskforcesh; \
     fi
 
 # ------- PRODUCTION BUILD ----------

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -44,16 +44,17 @@ WORKDIR /usr/src/app
 FROM dev AS deploy
 
 WORKDIR /usr/src/app
-RUN pnpm --filter @novu/worker deploy --legacy --prod /usr/src/deploy
-
 RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && \
+    pnpm --filter @novu/worker deploy --legacy --prod /usr/src/deploy && \
     if [ -n "${BULL_MQ_PRO_NPM_TOKEN}" ]; then \
       cd $(mktemp -d) && \
       echo "@taskforcesh:registry=https://npm.taskforce.sh/" > .npmrc && \
       echo "//npm.taskforce.sh/:_authToken=${BULL_MQ_PRO_NPM_TOKEN}" >> .npmrc && \
       npm init -y > /dev/null 2>&1 && \
-      npm install @taskforcesh/bullmq-pro@6.11.0 && \
-      cp -r node_modules/@taskforcesh /usr/src/deploy/node_modules/@taskforcesh; \
+      npm install @taskforcesh/bullmq-pro@6.11.0 2>/dev/null && \
+      cp -r node_modules/@taskforcesh /usr/src/deploy/node_modules/@taskforcesh && \
+      rm -rf node_modules/@taskforcesh && \
+      mv node_modules /usr/src/deploy/node_modules/@taskforcesh/bullmq-pro/node_modules; \
     fi
 
 # ------- PRODUCTION BUILD ----------

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.971.0",
+    "yargs": "^17.7.2",
     "@nestjs/axios": "3.0.3",
     "@nestjs/common": "10.4.18",
     "@nestjs/core": "10.4.18",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -99,7 +99,8 @@
   "optionalDependencies": {
     "@novu/ee-billing": "workspace:*",
     "@novu/ee-shared-services": "workspace:*",
-    "@novu/ee-translation": "workspace:*"
+    "@novu/ee-translation": "workspace:*",
+    "@taskforcesh/bullmq-pro": "6.11.0"
   },
   "nx": {
     "tags": [

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -99,8 +99,7 @@
   "optionalDependencies": {
     "@novu/ee-billing": "workspace:*",
     "@novu/ee-shared-services": "workspace:*",
-    "@novu/ee-translation": "workspace:*",
-    "@taskforcesh/bullmq-pro": "6.11.0"
+    "@novu/ee-translation": "workspace:*"
   },
   "nx": {
     "tags": [

--- a/apps/ws/Dockerfile
+++ b/apps/ws/Dockerfile
@@ -38,38 +38,30 @@ RUN cp src/.env.production dist/.env.production
 
 WORKDIR /usr/src/app
 
-# ------- ASSETS BUILD ----------
-FROM dev AS assets
+# ------- DEPLOY ----------
+FROM dev AS deploy
 
 WORKDIR /usr/src/app
-
-# Remove source files but KEEP node_modules (already compiled)
-RUN pnpm recursive exec -- rm -rf ./src
+RUN pnpm --filter @novu/ws deploy --legacy --prod /usr/src/deploy
 
 # ------- PRODUCTION BUILD ----------
 FROM node:22.22-alpine3.23 AS prod
 
-ARG PACKAGE_PATH
-
 ENV CI=true
-ENV NX_DAEMON=false
 
 RUN apk upgrade --no-cache && \
-    # Manually upgrade packages from edge/main to patch CVEs
-    # until fixes are backported to the alpine3.23 stable repo
     apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --upgrade libcrypto3 libssl3 musl musl-utils && \
-    npm --no-update-notifier --no-fund --global install pm2 pnpm@10.33.0 && \
-    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
-           /usr/local/lib/node_modules/pnpm /usr/local/bin/pnpm /usr/local/bin/pnpx
+    npm --no-update-notifier --no-fund --global install pm2 && \
+    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 # Set non-root user
 USER 1000
 WORKDIR /usr/src/app
 
-COPY --chown=1000:1000 ./meta .
+# Flat node_modules from pnpm deploy (no symlinks, no hoisting issues)
+COPY --chown=1000:1000 --from=deploy /usr/src/deploy .
 
-# Copy build artifacts AND pre-compiled node_modules from assets
-COPY --chown=1000:1000 --from=assets /usr/src/app .
+# Built output (not included by pnpm deploy because dist is gitignored)
+COPY --chown=1000:1000 --from=dev /usr/src/app/apps/ws/dist ./dist
 
-WORKDIR /usr/src/app/apps/ws
 ENTRYPOINT [ "sh", "-c", "node dist/dotenvcreate.mjs -s=$SECRET_NAME -r=$NOVU_REGION -e=$NOVU_ENTERPRISE -v=$NODE_ENV -h=$IS_SELF_HOSTED && pm2-runtime start dist/main.js -i max" ]

--- a/apps/ws/Dockerfile
+++ b/apps/ws/Dockerfile
@@ -42,16 +42,17 @@ WORKDIR /usr/src/app
 FROM dev AS deploy
 
 WORKDIR /usr/src/app
-RUN pnpm --filter @novu/ws deploy --legacy --prod /usr/src/deploy
-
 RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && \
+    pnpm --filter @novu/ws deploy --legacy --prod /usr/src/deploy && \
     if [ -n "${BULL_MQ_PRO_NPM_TOKEN}" ]; then \
       cd $(mktemp -d) && \
       echo "@taskforcesh:registry=https://npm.taskforce.sh/" > .npmrc && \
       echo "//npm.taskforce.sh/:_authToken=${BULL_MQ_PRO_NPM_TOKEN}" >> .npmrc && \
       npm init -y > /dev/null 2>&1 && \
-      npm install @taskforcesh/bullmq-pro@6.11.0 && \
-      cp -r node_modules/@taskforcesh /usr/src/deploy/node_modules/@taskforcesh; \
+      npm install @taskforcesh/bullmq-pro@6.11.0 2>/dev/null && \
+      cp -r node_modules/@taskforcesh /usr/src/deploy/node_modules/@taskforcesh && \
+      rm -rf node_modules/@taskforcesh && \
+      mv node_modules /usr/src/deploy/node_modules/@taskforcesh/bullmq-pro/node_modules; \
     fi
 
 # ------- PRODUCTION BUILD ----------

--- a/apps/ws/Dockerfile
+++ b/apps/ws/Dockerfile
@@ -46,7 +46,12 @@ RUN pnpm --filter @novu/ws deploy --legacy --prod /usr/src/deploy
 
 RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && \
     if [ -n "${BULL_MQ_PRO_NPM_TOKEN}" ]; then \
-      cd /usr/src/deploy && npm install --no-save @taskforcesh/bullmq-pro@6.11.0 --registry=https://npm.taskforce.sh/; \
+      cd $(mktemp -d) && \
+      echo "@taskforcesh:registry=https://npm.taskforce.sh/" > .npmrc && \
+      echo "//npm.taskforce.sh/:_authToken=${BULL_MQ_PRO_NPM_TOKEN}" >> .npmrc && \
+      npm init -y > /dev/null 2>&1 && \
+      npm install @taskforcesh/bullmq-pro@6.11.0 && \
+      cp -r node_modules/@taskforcesh /usr/src/deploy/node_modules/@taskforcesh; \
     fi
 
 # ------- PRODUCTION BUILD ----------

--- a/apps/ws/Dockerfile
+++ b/apps/ws/Dockerfile
@@ -44,6 +44,11 @@ FROM dev AS deploy
 WORKDIR /usr/src/app
 RUN pnpm --filter @novu/ws deploy --legacy --prod /usr/src/deploy
 
+RUN --mount=type=secret,id=BULL_MQ_PRO_NPM_TOKEN,uid=1000 export BULL_MQ_PRO_NPM_TOKEN=$(cat /run/secrets/BULL_MQ_PRO_NPM_TOKEN) && \
+    if [ -n "${BULL_MQ_PRO_NPM_TOKEN}" ]; then \
+      cd /usr/src/deploy && npm install --no-save @taskforcesh/bullmq-pro@6.11.0 --registry=https://npm.taskforce.sh/; \
+    fi
+
 # ------- PRODUCTION BUILD ----------
 FROM node:22.22-alpine3.23 AS prod
 

--- a/apps/ws/package.json
+++ b/apps/ws/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.971.0",
+    "yargs": "^17.7.2",
     "@godaddy/terminus": "^4.3.1",
     "@nestjs/common": "10.4.18",
     "@nestjs/core": "10.4.18",

--- a/apps/ws/package.json
+++ b/apps/ws/package.json
@@ -80,9 +80,6 @@
     "tsconfig-paths": "~4.1.0",
     "typescript": "5.6.2"
   },
-  "optionalDependencies": {
-    "@taskforcesh/bullmq-pro": "6.11.0"
-  },
   "workspaces": {
     "nohoist": [
       "@nestjs/platform-socket.io",

--- a/apps/ws/package.json
+++ b/apps/ws/package.json
@@ -80,6 +80,9 @@
     "tsconfig-paths": "~4.1.0",
     "typescript": "5.6.2"
   },
+  "optionalDependencies": {
+    "@taskforcesh/bullmq-pro": "6.11.0"
+  },
   "workspaces": {
     "nohoist": [
       "@nestjs/platform-socket.io",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,9 @@ importers:
       es-toolkit:
         specifier: ^1.39.10
         version: 1.39.10
+      express:
+        specifier: ^5.0.1
+        version: 5.0.1
       handlebars:
         specifier: 4.7.9
         version: 4.7.9
@@ -566,6 +569,9 @@ importers:
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
       zod:
         specifier: ^3.23.8
         version: 3.25.20
@@ -636,9 +642,6 @@ importers:
       chai-subset:
         specifier: ^1.6.0
         version: 1.6.0
-      express:
-        specifier: ^5.0.1
-        version: 5.0.1
       get-port:
         specifier: ^5.1.1
         version: 5.1.1
@@ -1594,6 +1597,9 @@ importers:
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
     devDependencies:
       '@faker-js/faker':
         specifier: ^6.0.0
@@ -1788,6 +1794,9 @@ importers:
       socket.io:
         specifier: ^4.7.2
         version: 4.8.1
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
     devDependencies:
       '@nestjs/cli':
         specifier: 10.4.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27581,8 +27581,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.575.0
@@ -27878,11 +27878,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.575.0':
+  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -27921,6 +27921,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)':
@@ -28099,11 +28100,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
+  '@aws-sdk/client-sts@3.575.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -28142,7 +28143,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.637.0':
@@ -28347,7 +28347,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
       '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
@@ -28661,7 +28661,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
@@ -29204,7 +29204,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -29213,7 +29213,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4


### PR DESCRIPTION
### What changed? Why was the change needed?

This approach removes need of symlinks. This uses a flat structure. pnpm deploy only keeps prod dependencies around. Its also save 25% in docker size. Now images are more slimmer 

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Docker build stages for api, worker, webhook, and ws services now use `pnpm deploy --prod` to produce a flattened, production-only node_modules structure instead of the previous symlink-based approach. This eliminates the need for intermediate asset-build stages and reduces Docker image size by approximately 25%. The deploy stage outputs directly to `/usr/src/deploy`, which is then copied into the production image, simplifying the build artifact handling.

## Affected areas

- **api**: Dockerfile restructured with a new deploy stage; `pnpm deploy` replaces the assets stage. Added runtime dependencies: `yargs@^17.7.2` and `express@^5.0.1`. Updated metadata.js path references via sed for the flattened layout.
- **worker**: Dockerfile updated with deploy stage; added conditional `@taskforcesh/bullmq-pro@6.11.0` installation when `BULL_MQ_PRO_NPM_TOKEN` is available. Added `yargs@^17.7.2` dependency.
- **webhook**: Dockerfile simplified with deploy stage replacing the assets build; removed npm binaries cleanup from production.
- **ws**: Dockerfile refactored with deploy stage; conditional bullmq-pro installation supported. Added `yargs@^17.7.2` dependency.

## Key technical decisions

- Uses `pnpm deploy --legacy --prod` to create a flat, production-only node_modules in `/usr/src/deploy`.
- Conditional installation of `@taskforcesh/bullmq-pro@6.11.0` via secret-based npm token (`BULL_MQ_PRO_NPM_TOKEN`) in api, worker, and ws services.
- Removed explicit `WORKDIR` steps in production stages; paths now rely directly on `dist/` references.
- Added new dependencies (`yargs`, `express`) to support the new build structure.

## Testing

No tests were added; this is a build/deployment infrastructure change that requires manual verification of Docker image builds and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->