### PR TITLE
fix(dashboard): keep quick-start visible on bridge connect and drop p…

### DIFF
--- a/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
@@ -1,3 +1,4 @@
+import { ChatProviderIdEnum } from '@novu/shared';
 import { CheckCircle2, Loader } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { RiCheckLine, RiFileCopyLine } from 'react-icons/ri';
@@ -107,12 +108,25 @@ function TerminalBlock({ displayCommand, copyCommand }: { displayCommand: string
   );
 }
 
+function getProviderCallToAction(providerId: string | undefined): string {
+  switch (providerId) {
+    case ChatProviderIdEnum.Slack:
+      return 'Head back to Slack and mention your bot again — this time your agent server will handle the message.';
+    case ChatProviderIdEnum.WhatsAppBusiness:
+      return 'Send a message to your WhatsApp number again — this time your agent server will handle it.';
+    default:
+      return 'Send a message to your bot from the connected provider again — this time your agent server will handle it.';
+  }
+}
+
 function BridgeConnectionStatus({
   agent,
   agentIdentifier,
+  providerId,
 }: {
   agent: AgentResponse;
   agentIdentifier: string;
+  providerId: string | undefined;
 }) {
   const { currentEnvironment } = useEnvironment();
   const queryClient = useQueryClient();
@@ -165,11 +179,12 @@ function BridgeConnectionStatus({
       <div className="flex flex-col gap-2 py-4 pl-8">
         <div className="flex items-center gap-1">
           <CheckCircle2 className="text-success-base size-3.5 shrink-0" />
-          <span className="text-text-strong text-label-sm font-medium">Bridge connected</span>
+          <span className="text-text-strong text-label-sm font-medium">Bridge connected — try your agent</span>
         </div>
+        <p className="text-text-soft text-label-xs font-medium leading-4">{getProviderCallToAction(providerId)}</p>
         <p className="text-text-soft text-label-xs font-medium leading-4">
-          Your agent is receiving events. Edit{' '}
-          <code className="font-code text-[12px] tracking-[-0.24px]">app/novu/agents/</code> to customize the handler.
+          Edit <code className="font-code text-[12px] tracking-[-0.24px]">app/novu/agents/</code> to customize how your
+          agent responds.
         </p>
         <ExternalLink href="https://docs.novu.co/agents/overview" variant="documentation">
           Agent documentation
@@ -197,9 +212,15 @@ type AgentCodeSetupSectionProps = {
   agent: AgentResponse;
   stepOffset: number;
   isProviderComplete: boolean;
+  providerId?: string;
 };
 
-export function AgentCodeSetupSection({ agent, stepOffset, isProviderComplete }: AgentCodeSetupSectionProps) {
+export function AgentCodeSetupSection({
+  agent,
+  stepOffset,
+  isProviderComplete,
+  providerId,
+}: AgentCodeSetupSectionProps) {
   const apiKeysQuery = useFetchApiKeys();
   const secretKey = apiKeysQuery.data?.data?.[0]?.key;
 
@@ -271,7 +292,7 @@ export function AgentCodeSetupSection({ agent, stepOffset, isProviderComplete }:
         }
       />
 
-      <BridgeConnectionStatus agent={agent} agentIdentifier={agent.identifier} />
+      <BridgeConnectionStatus agent={agent} agentIdentifier={agent.identifier} providerId={providerId} />
     </>
   );
 }

--- a/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
@@ -211,16 +211,10 @@ function BridgeConnectionStatus({
 type AgentCodeSetupSectionProps = {
   agent: AgentResponse;
   stepOffset: number;
-  isProviderComplete: boolean;
   providerId?: string;
 };
 
-export function AgentCodeSetupSection({
-  agent,
-  stepOffset,
-  isProviderComplete,
-  providerId,
-}: AgentCodeSetupSectionProps) {
+export function AgentCodeSetupSection({ agent, stepOffset, providerId }: AgentCodeSetupSectionProps) {
   const apiKeysQuery = useFetchApiKeys();
   const secretKey = apiKeysQuery.data?.data?.[0]?.key;
 
@@ -229,14 +223,9 @@ export function AgentCodeSetupSection({
 
   const isBridgeConnected = Boolean(agent.bridgeUrl || (agent.devBridgeActive && agent.devBridgeUrl));
 
-  let firstIncompleteStep: number;
-  if (isBridgeConnected) {
-    firstIncompleteStep = stepOffset + 2;
-  } else if (isProviderComplete) {
-    firstIncompleteStep = stepOffset;
-  } else {
-    firstIncompleteStep = stepOffset + 3;
-  }
+  // The caller only renders this section once a provider integration is
+  // connected, so the "2/2 Connect your code" steps start out active.
+  const firstIncompleteStep = isBridgeConnected ? stepOffset + 2 : stepOffset;
 
   return (
     <>

--- a/apps/dashboard/src/components/agents/agent-connected-overview.tsx
+++ b/apps/dashboard/src/components/agents/agent-connected-overview.tsx
@@ -12,7 +12,7 @@ export function AgentConnectedOverview({ agent }: AgentConnectedOverviewProps) {
     <div className="flex min-w-0 flex-1 flex-col gap-4">
       <AgentBehaviorSection />
       <ConnectedProvidersSection agent={agent} />
-      <RecentConversationsSection agent={agent} />
+      <RecentConversationsSection />
     </div>
   );
 }

--- a/apps/dashboard/src/components/agents/agent-integration-guides/slack-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/slack-agent-integration-guide.tsx
@@ -23,6 +23,7 @@ export function SlackAgentIntegrationGuide({
   onRequestRemoveIntegration,
   isRemovingIntegration,
 }: SlackAgentIntegrationGuideProps) {
+  const isConnected = Boolean(integrationLink?.connectedAt);
 
   return (
     <AgentIntegrationGuideLayout
@@ -37,29 +38,38 @@ export function SlackAgentIntegrationGuide({
       isRemovingIntegration={isRemovingIntegration}
     >
       <AgentIntegrationGuideSection title="Overview">
-        <p>
-          Connect Slack so this agent can send and receive chat messages through your workspace. Ensure the integration
-          is configured and active in the integration store for this environment.
-        </p>
+        {isConnected ? (
+          <p>
+            This agent is connected to Slack. Tag the bot in any channel it has been invited to, or DM it directly, to
+            send and receive chat messages through your workspace.
+          </p>
+        ) : (
+          <p>
+            Connect Slack so this agent can send and receive chat messages through your workspace. Ensure the
+            integration is configured and active in the integration store for this environment.
+          </p>
+        )}
       </AgentIntegrationGuideSection>
-      <div className="flex flex-col gap-3">
-        <p className="text-text-strong text-label-sm font-medium">Steps</p>
-        <AgentIntegrationGuideStep
-          step={1}
-          title="Install the Slack app"
-          description="Complete OAuth in the integration store and grant the channels your agent should use."
-        />
-        <AgentIntegrationGuideStep
-          step={2}
-          title="Verify credentials"
-          description="Confirm the integration shows as active for this environment before testing the agent."
-        />
-        <AgentIntegrationGuideStep
-          step={3}
-          title="Test from the agent"
-          description="Send a test message from your application and confirm delivery in Slack."
-        />
-      </div>
+      {!isConnected && (
+        <div className="flex flex-col gap-3">
+          <p className="text-text-strong text-label-sm font-medium">Steps</p>
+          <AgentIntegrationGuideStep
+            step={1}
+            title="Install the Slack app"
+            description="Complete OAuth in the integration store and grant the channels your agent should use."
+          />
+          <AgentIntegrationGuideStep
+            step={2}
+            title="Verify credentials"
+            description="Confirm the integration shows as active for this environment before testing the agent."
+          />
+          <AgentIntegrationGuideStep
+            step={3}
+            title="Test from the agent"
+            description="Send a test message from your application and confirm delivery in Slack."
+          />
+        </div>
+      )}
     </AgentIntegrationGuideLayout>
   );
 }

--- a/apps/dashboard/src/components/agents/agent-integration-guides/whatsapp-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/whatsapp-agent-integration-guide.tsx
@@ -23,6 +23,7 @@ export function WhatsAppAgentIntegrationGuide({
   onRequestRemoveIntegration,
   isRemovingIntegration,
 }: WhatsAppAgentIntegrationGuideProps) {
+  const isConnected = Boolean(integrationLink?.connectedAt);
 
   return (
     <AgentIntegrationGuideLayout
@@ -37,29 +38,38 @@ export function WhatsAppAgentIntegrationGuide({
       isRemovingIntegration={isRemovingIntegration}
     >
       <AgentIntegrationGuideSection title="Overview">
-        <p>
-          This agent sends and receives messages through your WhatsApp Business phone number. If you need to update
-          credentials or reconfigure the webhook, follow the steps below.
-        </p>
+        {isConnected ? (
+          <p>
+            This agent is connected to WhatsApp Business. Send a message to your business phone number to start a
+            conversation — replies are routed through your agent server.
+          </p>
+        ) : (
+          <p>
+            Connect WhatsApp Business so this agent can send and receive messages through your business phone number.
+            Follow the steps below to create a Meta app, configure the webhook, and verify the connection.
+          </p>
+        )}
       </AgentIntegrationGuideSection>
-      <div className="flex flex-col gap-3">
-        <p className="text-text-strong text-label-sm font-medium">Steps</p>
-        <AgentIntegrationGuideStep
-          step={1}
-          title="Create a Meta app and get credentials"
-          description="Go to developers.facebook.com/apps, create a Business-type app, and add the WhatsApp product. Copy the Access Token and Phone Number ID from WhatsApp > API Setup, and the App Secret from App Settings > Basic. For production, generate a permanent System User Token instead of the temporary access token."
-        />
-        <AgentIntegrationGuideStep
-          step={2}
-          title="Configure the webhook"
-          description="In your Meta app go to WhatsApp > Configuration. Set the Callback URL to the webhook URL shown above and the Verify Token to the same secret you entered in the credentials. Subscribe to the 'messages' webhook field so the agent receives inbound messages."
-        />
-        <AgentIntegrationGuideStep
-          step={3}
-          title="Verify the connection"
-          description="Send a WhatsApp message to your business phone number and confirm the agent receives and responds."
-        />
-      </div>
+      {!isConnected && (
+        <div className="flex flex-col gap-3">
+          <p className="text-text-strong text-label-sm font-medium">Steps</p>
+          <AgentIntegrationGuideStep
+            step={1}
+            title="Create a Meta app and get credentials"
+            description="Go to developers.facebook.com/apps, create a Business-type app, and add the WhatsApp product. Copy the Access Token and Phone Number ID from WhatsApp > API Setup, and the App Secret from App Settings > Basic. For production, generate a permanent System User Token instead of the temporary access token."
+          />
+          <AgentIntegrationGuideStep
+            step={2}
+            title="Configure the webhook"
+            description="In your Meta app go to WhatsApp > Configuration. Set the Callback URL to the webhook URL shown above and the Verify Token to the same secret you entered in the credentials. Subscribe to the 'messages' webhook field so the agent receives inbound messages."
+          />
+          <AgentIntegrationGuideStep
+            step={3}
+            title="Verify the connection"
+            description="Send a WhatsApp message to your business phone number and confirm the agent receives and responds."
+          />
+        </div>
+      )}
     </AgentIntegrationGuideLayout>
   );
 }

--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -231,12 +231,6 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
 
   const integrationsStorePath = ROUTES.INTEGRATIONS;
 
-  const activityTabPath = `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
-    environmentSlug: currentEnvironment?.slug ?? '',
-    agentIdentifier: encodeURIComponent(agent.identifier),
-    agentTab: 'activity',
-  })}${location.search}`;
-
   const navigateToGuide = (nextIntegrationIdentifier: string) => {
     if (!currentEnvironment?.slug) {
       return;
@@ -507,12 +501,6 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
           <div className="border-stroke-soft border-t pt-3">
             <p className="text-text-soft text-label-xs font-medium leading-4">Quick actions</p>
             <div className="mt-3 flex flex-wrap gap-2">
-              <Link
-                to={activityTabPath}
-                className="border-stroke-soft text-text-strong hover:bg-bg-weak text-label-xs inline-flex h-7 items-center rounded-md border bg-transparent px-3 font-medium transition-colors"
-              >
-                View activity
-              </Link>
               <Link
                 to={integrationsStorePath}
                 className="border-stroke-soft text-text-strong hover:bg-bg-weak text-label-xs inline-flex h-7 items-center rounded-md border bg-transparent px-3 font-medium transition-colors"

--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -424,7 +424,7 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
                       const int = link.integration;
                       const providerMeta = novuProviders.find((p) => p.id === int.providerId);
                       const isSelected = integrationIdentifier === int.identifier;
-                      const showActionNeeded = !int.active;
+                      const showActionNeeded = !link.connectedAt;
 
                       return (
                         <button
@@ -449,7 +449,7 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
                           <span className="flex shrink-0 items-center gap-1">
                             {showActionNeeded ? (
                               <RiErrorWarningFill
-                                className="text-error-base size-3 shrink-0"
+                                className="text-warning-base size-3 shrink-0"
                                 aria-label="Action needed"
                               />
                             ) : (

--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -426,11 +426,14 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
                       const isSelected = integrationIdentifier === int.identifier;
                       const showActionNeeded = !link.connectedAt;
 
+                      const statusLabel = showActionNeeded ? 'Action needed' : 'Active';
+
                       return (
                         <button
                           key={link._id}
                           type="button"
                           onClick={() => handleLinkedRowClick(link)}
+                          aria-label={`${int.name} — ${statusLabel}`}
                           className={cn(
                             'bg-bg-white border-stroke-weak hover:border-stroke-soft flex w-full items-center justify-between gap-1.5 rounded-md border px-2 py-1.5 text-left transition-colors',
                             isSelected && 'border-stroke-soft'
@@ -446,20 +449,13 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
                               {int.name}
                             </span>
                           </span>
-                          <span className="flex shrink-0 items-center gap-1">
+                          <span className="flex shrink-0 items-center gap-1" aria-hidden>
                             {showActionNeeded ? (
-                              <RiErrorWarningFill
-                                className="text-warning-base size-3 shrink-0"
-                                aria-label="Action needed"
-                              />
+                              <RiErrorWarningFill className="text-warning-base size-3 shrink-0" />
                             ) : (
-                              <div
-                                className="bg-success-base size-1.5 shrink-0 rounded-full"
-                                role="img"
-                                aria-label="Active"
-                              />
+                              <div className="bg-success-base size-1.5 shrink-0 rounded-full" />
                             )}
-                            <RiArrowRightSLine className="text-text-soft size-4 shrink-0" aria-hidden />
+                            <RiArrowRightSLine className="text-text-soft size-4 shrink-0" />
                           </span>
                         </button>
                       );

--- a/apps/dashboard/src/components/agents/agent-overview-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-overview-tab.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { AgentResponse } from '@/api/agents';
 import { AgentConnectedOverview } from '@/components/agents/agent-connected-overview';
 import { AgentSetupGuide } from '@/components/agents/agent-setup-guide';
@@ -10,10 +11,16 @@ type AgentOverviewTabProps = {
 export function AgentOverviewTab({ agent }: AgentOverviewTabProps) {
   const isBridgeConnected = Boolean(agent.bridgeUrl || (agent.devBridgeActive && agent.devBridgeUrl));
 
+  // Snapshot connection state on mount so that users who are actively
+  // completing the quick-start stay on the setup guide (and see the
+  // completion step) even after the bridge connects mid-session. Users who
+  // arrive with a bridge already connected get the connected overview.
+  const [wasBridgeConnectedOnMount] = useState(isBridgeConnected);
+
   return (
     <div className="flex gap-6 px-6 pt-4">
       <AgentSidebarWidget agent={agent} />
-      {isBridgeConnected ? <AgentConnectedOverview agent={agent} /> : <AgentSetupGuide agent={agent} />}
+      {wasBridgeConnectedOnMount ? <AgentConnectedOverview agent={agent} /> : <AgentSetupGuide agent={agent} />}
     </div>
   );
 }

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -28,18 +28,6 @@ function resolveProviderSetupGuide(providerId: string) {
   }
 }
 
-function AgentSetupGuideComingSoon() {
-
-  return (
-    <div className="border-stroke-soft bg-bg-weak/30 flex flex-col items-center justify-center rounded-md border border-dashed px-6 py-12 text-center">
-      <p className="text-text-strong text-label-sm font-medium">Coming soon</p>
-      <p className="text-text-soft text-label-xs mt-2 max-w-sm leading-5">
-        In-dashboard setup steps will return here as we expand agent tooling.
-      </p>
-    </div>
-  );
-}
-
 export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
   const [isExpanded, setIsExpanded] = useState(true);
   const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(undefined);
@@ -94,8 +82,6 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
     setIsProviderComplete(true);
   }, []);
 
-  const isBridgeConnected = Boolean(agent.bridgeUrl || (agent.devBridgeActive && agent.devBridgeUrl));
-
   return (
     <div className="bg-bg-weak flex min-w-0 flex-1 flex-col rounded-[10px] p-1">
       <button
@@ -109,52 +95,53 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
 
       {isExpanded && (
         <div className="bg-bg-white flex flex-col gap-0 overflow-hidden rounded-md p-3 shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">
-          {isBridgeConnected ? (
-            <AgentSetupGuideComingSoon />
-          ) : (
-            <div className="relative flex flex-col gap-10 py-6 pb-3 pl-8 pr-6">
-              <div
-                className="absolute bottom-0 left-[22px] top-0 w-px"
-                style={{
-                  background: 'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
-                }}
-              />
+          <div className="relative flex flex-col gap-10 py-6 pb-3 pl-8 pr-6">
+            <div
+              className="absolute bottom-0 left-[22px] top-0 w-px"
+              style={{
+                background: 'linear-gradient(to bottom, transparent 0%, #E1E4EA 10%, #E1E4EA 90%, transparent 100%)',
+              }}
+            />
 
-              <SetupStep
-                index={1}
-                status={deriveStepStatus(1, firstIncompleteStepForProviderRow)}
-                sectionLabel="1/2 SETUP PROVIDER"
-                title="Choose where your agent listens and communicates"
-                description="Start with one provider your agent can receive and respond on and you can always add more providers as you need."
-                rightContent={
-                  <ProviderDropdown
-                    agentIdentifier={agent.identifier}
-                    selectedIntegrationId={selectedIntegrationId ?? defaultFromAgent?.integrationId}
-                    linkedIntegrationIds={linkedIntegrationIds}
-                    onSelect={(_providerId, integration) => {
-                      if (integration?._id) {
-                        setSelectedIntegrationId(integration._id);
-                      }
-                    }}
-                  />
-                }
-              />
-
-              {ProviderGuide && effectiveIntegrationId ? (
-                <ProviderGuide
-                  agent={agent}
-                  integrationId={effectiveIntegrationId}
-                  stepOffset={2}
-                  embedded={false}
-                  onStepsCompleted={handleProviderStepsCompleted}
+            <SetupStep
+              index={1}
+              status={deriveStepStatus(1, firstIncompleteStepForProviderRow)}
+              sectionLabel="1/2 SETUP PROVIDER"
+              title="Choose where your agent listens and communicates"
+              description="Start with one provider your agent can receive and respond on and you can always add more providers as you need."
+              rightContent={
+                <ProviderDropdown
+                  agentIdentifier={agent.identifier}
+                  selectedIntegrationId={selectedIntegrationId ?? defaultFromAgent?.integrationId}
+                  linkedIntegrationIds={linkedIntegrationIds}
+                  onSelect={(_providerId, integration) => {
+                    if (integration?._id) {
+                      setSelectedIntegrationId(integration._id);
+                    }
+                  }}
                 />
-              ) : null}
+              }
+            />
 
-              {hasConnectedIntegration && (
-                <AgentCodeSetupSection agent={agent} stepOffset={5} isProviderComplete={hasConnectedIntegration} />
-              )}
-            </div>
-          )}
+            {ProviderGuide && effectiveIntegrationId ? (
+              <ProviderGuide
+                agent={agent}
+                integrationId={effectiveIntegrationId}
+                stepOffset={2}
+                embedded={false}
+                onStepsCompleted={handleProviderStepsCompleted}
+              />
+            ) : null}
+
+            {hasConnectedIntegration && (
+              <AgentCodeSetupSection
+                agent={agent}
+                stepOffset={5}
+                isProviderComplete={hasConnectedIntegration}
+                providerId={selectedProviderId}
+              />
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -134,12 +134,7 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
             ) : null}
 
             {hasConnectedIntegration && (
-              <AgentCodeSetupSection
-                agent={agent}
-                stepOffset={5}
-                isProviderComplete={hasConnectedIntegration}
-                providerId={selectedProviderId}
-              />
+              <AgentCodeSetupSection agent={agent} stepOffset={5} providerId={selectedProviderId} />
             )}
           </div>
         </div>

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -1,4 +1,4 @@
-import { SLUG_IDENTIFIER_REGEX, slugIdentifierFormatMessage } from '@novu/shared';
+import { SLUG_IDENTIFIER_REGEX, slugIdentifierFormatMessage, slugify } from '@novu/shared';
 import type { FormEvent, ReactNode } from 'react';
 import { useId, useState } from 'react';
 import { RiArrowRightSLine, RiCloseLine, RiExternalLinkLine, RiInformationFill } from 'react-icons/ri';
@@ -45,12 +45,15 @@ export function CreateAgentDialog({ open, onOpenChange, onSubmit, isSubmitting }
   const [identifier, setIdentifier] = useState('');
   const [description, setDescription] = useState('');
   const [errors, setErrors] = useState<FormErrors>({});
+  // Once the user edits the identifier manually, stop auto-syncing it from the name.
+  const [isIdentifierTouched, setIsIdentifierTouched] = useState(false);
 
   const reset = () => {
     setName('');
     setIdentifier('');
     setDescription('');
     setErrors({});
+    setIsIdentifierTouched(false);
   };
 
   const handleOpenChange = (next: boolean) => {
@@ -144,8 +147,14 @@ export function CreateAgentDialog({ open, onOpenChange, onSubmit, isSubmitting }
                   size="2xs"
                   value={name}
                   onChange={(e) => {
-                    setName(e.target.value);
+                    const nextName = e.target.value;
+                    setName(nextName);
                     setErrors((prev) => ({ ...prev, name: undefined }));
+
+                    if (!isIdentifierTouched) {
+                      setIdentifier(slugify(nextName));
+                      setErrors((prev) => ({ ...prev, identifier: undefined }));
+                    }
                   }}
                   placeholder="e.g. Wine Sommelier Agent"
                   hasError={Boolean(errors.name)}
@@ -168,6 +177,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSubmit, isSubmitting }
                   value={identifier}
                   onChange={(e) => {
                     setIdentifier(e.target.value);
+                    setIsIdentifierTouched(true);
                     setErrors((prev) => ({ ...prev, identifier: undefined }));
                   }}
                   placeholder="e.g. wine-sommelier-agent"

--- a/apps/dashboard/src/components/agents/recent-conversations-section.tsx
+++ b/apps/dashboard/src/components/agents/recent-conversations-section.tsx
@@ -1,12 +1,4 @@
-import { RiArrowRightLine, RiRobot2Line } from 'react-icons/ri';
-import { Link, useLocation } from 'react-router-dom';
-import type { AgentResponse } from '@/api/agents';
-import { useEnvironment } from '@/context/environment/hooks';
-import { buildRoute, ROUTES } from '@/utils/routes';
-
-type RecentConversationsSectionProps = {
-  agent: AgentResponse;
-};
+import { RiRobot2Line } from 'react-icons/ri';
 
 function SkeletonBar({ className }: { className?: string }) {
   return (
@@ -75,29 +67,13 @@ function EmptyStateIllustration() {
   );
 }
 
-export function RecentConversationsSection({ agent }: RecentConversationsSectionProps) {
-  const { currentEnvironment } = useEnvironment();
-  const location = useLocation();
-
-  const activityTabPath = `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
-    environmentSlug: currentEnvironment?.slug ?? '',
-    agentIdentifier: encodeURIComponent(agent.identifier),
-    agentTab: 'activity',
-  })}${location.search}`;
-
+export function RecentConversationsSection() {
   return (
     <div className="bg-bg-weak flex flex-col rounded-[10px] p-1">
       <div className="flex items-center justify-between px-2 py-1.5">
         <span className="text-text-soft font-code text-[11px] font-medium uppercase leading-4 tracking-wider">
           Recent conversations
         </span>
-        <Link
-          to={activityTabPath}
-          className="text-text-sub hover:text-text-strong flex items-center gap-0.5 rounded-lg p-1.5 text-label-xs font-medium transition-colors"
-        >
-          View all activity
-          <RiArrowRightLine className="size-4" />
-        </Link>
       </div>
 
       <div className="bg-bg-white flex h-[300px] flex-col items-center justify-center overflow-hidden rounded-md shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">

--- a/apps/dashboard/src/pages/agent-details.tsx
+++ b/apps/dashboard/src/pages/agent-details.tsx
@@ -235,9 +235,6 @@ export function AgentDetailsPage() {
                 <TabsTrigger variant="regular" value="integrations" size="xl">
                   Integrations
                 </TabsTrigger>
-                <TabsTrigger variant="regular" value="activity" size="xl">
-                  Activity
-                </TabsTrigger>
               </TabsList>
 
               <TabsContent value="overview" className="outline-none">
@@ -247,11 +244,6 @@ export function AgentDetailsPage() {
                 {currentTab === 'integrations' ? (
                   <AgentIntegrationsTab agent={agent} integrationIdentifier={integrationIdentifier} />
                 ) : null}
-              </TabsContent>
-              <TabsContent value="activity" className="outline-none">
-                <div className="mx-auto mt-4 max-w-3xl px-3 py-2 md:px-6">
-                  <p className="text-text-soft text-label-sm">Test content — Activity tab (placeholder).</p>
-                </div>
               </TabsContent>
             </Tabs>
 

--- a/apps/dashboard/src/utils/routes.ts
+++ b/apps/dashboard/src/utils/routes.ts
@@ -82,7 +82,7 @@ export const ROUTES = {
 
 export const AGENT_DETAILS_DEFAULT_TAB = 'overview';
 
-export const AGENT_DETAILS_TABS = ['overview', 'integrations', 'activity'] as const;
+export const AGENT_DETAILS_TABS = ['overview', 'integrations'] as const;
 
 export type AgentDetailsTab = (typeof AGENT_DETAILS_TABS)[number];
 


### PR DESCRIPTION
## Placeholder Activity tab

Users completing the agent quick-start lost all context the moment the bridge connected because the overview swapped to the connected view and the setup guide replaced itself with a "Coming soon" placeholder — leaving no prompt to go back and tag the bot with the new agent server.

- Snapshot bridge-connected state on mount in the overview tab so in-flight setups stay on the guide while return visits skip the quick-start.
- Drop the "Coming soon" placeholder in the setup guide and always render the flow so the final step remains visible.
- Replace the terminal "Bridge connected" copy with a provider-aware prompt (Slack / WhatsApp / generic) telling users to message the bot again.
- Remove the unfinished Activity tab and its references across the agent details page, integrations quick actions, and recent conversations section.

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
This PR improves agent setup UX by freezing the quick-start flow when a bridge connection occurs mid-setup, always rendering the full setup guide (removing the "Coming soon" placeholder), replacing the generic "Bridge connected" text with provider-aware prompts (Slack / WhatsApp / generic) instructing users to message the bot again, and removing the unfinished Activity tab and its related links. The intent is to prevent mid-setup UI jumps, give actionable post-connection guidance, and simplify the agent details UI by removing incomplete features.

## Affected areas
**dashboard**: Snapshot bridge-connected state on mount in the overview tab so in-flight quick-starts remain visible; render the full Agent Setup Guide unconditionally; make bridge-connected copy provider-aware and thread providerId into connection UI; remove the Activity tab from tabs, routing constants, and UI links; simplify RecentConversationsSection to a presentation-only component (removed agent prop and routing/env coupling); adjust integrations/quick-actions to drop activity navigation and update provider status labeling and accessibility.  

## Key technical decisions
- Freeze UI for quick-start by initializing local state from the live bridge connection at mount rather than reacting to subsequent connection events.  
- Remove the Activity tab from AGENT_DETAILS_TABS and related routing to simplify types and behavior (breaking acceptance of the former "activity" tab value).  
- Decouple RecentConversationsSection from routing/environment data and the agent prop to reduce coupling and make it render-only.

## Testing
No new automated tests were added; changes are behavioral/UI-focused. Manual verification is recommended: ensure quick-start remains visible when bridge connects mid-setup, provider-specific post-connection copy appears for Slack/WhatsApp/generic, and the Activity tab and its links are removed across agent pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
