### PR TITLE
feat(api-service): adopt Chat SDK emoji system for cross-platform agent reactions

### DIFF
--- a/apps/api/src/app/agents/agents.controller.ts
+++ b/apps/api/src/app/agents/agents.controller.ts
@@ -49,6 +49,7 @@ import { DeleteAgentCommand } from './usecases/delete-agent/delete-agent.command
 import { DeleteAgent } from './usecases/delete-agent/delete-agent.usecase';
 import { GetAgentCommand } from './usecases/get-agent/get-agent.command';
 import { GetAgent } from './usecases/get-agent/get-agent.usecase';
+import { ListAgentEmoji } from './usecases/list-agent-emoji/list-agent-emoji.usecase';
 import { ListAgentIntegrationsCommand } from './usecases/list-agent-integrations/list-agent-integrations.command';
 import { ListAgentIntegrations } from './usecases/list-agent-integrations/list-agent-integrations.usecase';
 import { ListAgentsCommand } from './usecases/list-agents/list-agents.command';
@@ -77,8 +78,21 @@ export class AgentsController {
     private readonly addAgentIntegrationUsecase: AddAgentIntegration,
     private readonly listAgentIntegrationsUsecase: ListAgentIntegrations,
     private readonly updateAgentIntegrationUsecase: UpdateAgentIntegration,
-    private readonly removeAgentIntegrationUsecase: RemoveAgentIntegration
+    private readonly removeAgentIntegrationUsecase: RemoveAgentIntegration,
+    private readonly listAgentEmojiUsecase: ListAgentEmoji
   ) {}
+
+  @Get('/emoji')
+  @ApiOperation({
+    summary: 'List available emoji',
+    description:
+      'Returns the set of well-known cross-platform emoji names supported for agent reactions. ' +
+      'Each entry includes the normalized name and a unicode representation for display.',
+  })
+  @RequirePermissions(PermissionsEnum.AGENT_READ)
+  listEmoji() {
+    return this.listAgentEmojiUsecase.execute();
+  }
 
   @Post('/')
   @ApiResponse(AgentResponseDto, 201)

--- a/apps/api/src/app/agents/agents.controller.ts
+++ b/apps/api/src/app/agents/agents.controller.ts
@@ -49,7 +49,7 @@ import { DeleteAgentCommand } from './usecases/delete-agent/delete-agent.command
 import { DeleteAgent } from './usecases/delete-agent/delete-agent.usecase';
 import { GetAgentCommand } from './usecases/get-agent/get-agent.command';
 import { GetAgent } from './usecases/get-agent/get-agent.usecase';
-import { ListAgentEmoji } from './usecases/list-agent-emoji/list-agent-emoji.usecase';
+import { type AgentEmojiEntry, ListAgentEmoji } from './usecases/list-agent-emoji/list-agent-emoji.usecase';
 import { ListAgentIntegrationsCommand } from './usecases/list-agent-integrations/list-agent-integrations.command';
 import { ListAgentIntegrations } from './usecases/list-agent-integrations/list-agent-integrations.usecase';
 import { ListAgentsCommand } from './usecases/list-agents/list-agents.command';
@@ -90,7 +90,7 @@ export class AgentsController {
       'Each entry includes the normalized name and a unicode representation for display.',
   })
   @RequirePermissions(PermissionsEnum.AGENT_READ)
-  listEmoji() {
+  listAgentEmoji(): Promise<AgentEmojiEntry[]> {
     return this.listAgentEmojiUsecase.execute();
   }
 

--- a/apps/api/src/app/agents/dtos/agent-behavior.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-behavior.dto.ts
@@ -1,24 +1,29 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsBoolean, IsOptional, IsString, ValidateIf, ValidateNested } from 'class-validator';
+import { IsBoolean, IsOptional, ValidateIf, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
+import { IsWellKnownEmoji } from '../validators/is-well-known-emoji.validator';
 
 export class AgentReactionSettingsDto {
   @ApiPropertyOptional({
-    description: 'Emoji reaction for incoming messages. Emoji name string to customize, null to disable. Default: "eyes" (👀)',
+    description:
+      'Cross-platform emoji name for incoming messages (e.g. "eyes", "thumbs_up"). ' +
+      'Set to null to disable. Default: "eyes"',
     default: 'eyes',
   })
   @IsOptional()
   @ValidateIf((_, value) => value !== null)
-  @IsString()
+  @IsWellKnownEmoji()
   onMessageReceived?: string | null;
 
   @ApiPropertyOptional({
-    description: 'Emoji reaction when a conversation is resolved. Emoji name string to customize, null to disable. Default: "check" (✅)',
+    description:
+      'Cross-platform emoji name for resolved conversations (e.g. "check", "star"). ' +
+      'Set to null to disable. Default: "check"',
     default: 'check',
   })
   @IsOptional()
   @ValidateIf((_, value) => value !== null)
-  @IsString()
+  @IsWellKnownEmoji()
   onResolved?: string | null;
 }
 

--- a/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
@@ -7,6 +7,7 @@ import {
 import { testServer } from '@novu/testing';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import type { EmojiValue } from 'chat';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { AgentConfigResolver } from '../services/agent-config-resolver.service';
 import { AgentInboundHandler, InboundReactionEvent } from '../services/agent-inbound-handler.service';
@@ -19,6 +20,10 @@ import {
   setupAgentTestContext,
 } from './helpers/agent-test-setup';
 import { buildSlackChallenge, signSlackRequest } from './helpers/providers/slack';
+
+function mockEmoji(name: string): EmojiValue {
+  return { name, toJSON: () => `{{emoji:${name}}}`, toString: () => `{{emoji:${name}}}` };
+}
 
 function mockSentMessage() {
   return {
@@ -359,7 +364,7 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       bridgeCalls = [];
 
       const reactionEvent: InboundReactionEvent = {
-        emoji: { name: 'thumbs_up' },
+        emoji: mockEmoji('thumbs_up'),
         added: true,
         messageId: msg.id,
         message: msg as any,
@@ -379,7 +384,7 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
 
     it('should skip reaction when no conversation exists for the thread', async () => {
       const reactionEvent: InboundReactionEvent = {
-        emoji: { name: 'wave' },
+        emoji: mockEmoji('wave'),
         added: true,
         messageId: 'msg-orphan',
         thread: mockThread(`T_NOCONV_${Date.now()}`) as any,
@@ -392,7 +397,7 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
 
     it('should skip reaction when thread context is missing', async () => {
       const reactionEvent: InboundReactionEvent = {
-        emoji: { name: 'fire' },
+        emoji: mockEmoji('fire'),
         added: false,
         messageId: 'msg-no-thread',
       };
@@ -410,7 +415,7 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       bridgeCalls = [];
 
       const reactionEvent: InboundReactionEvent = {
-        emoji: { name: 'tada' },
+        emoji: mockEmoji('tada'),
         added: true,
         messageId: msg.id,
         message: msg as any,
@@ -443,7 +448,7 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       );
 
       const reactionEvent: InboundReactionEvent = {
-        emoji: { name: 'heart' },
+        emoji: mockEmoji('heart'),
         added: true,
         messageId: msg.id,
         message: msg as any,

--- a/apps/api/src/app/agents/services/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-config-resolver.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { decryptCredentials, FeatureFlagsService, PinoLogger } from '@novu/application-generic';
 import {
   AgentIntegrationRepository,
@@ -12,8 +12,6 @@ import type { WellKnownEmoji } from 'chat';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
 import { esmImport } from '../utils/esm-import';
 import { resolveAgentPlatform } from '../utils/provider-to-platform';
-
-const logger = new Logger('AgentConfigResolver');
 
 let cachedEmojiNames: Set<string> | null = null;
 
@@ -52,14 +50,15 @@ function resolveThinkingIndicator(agent: { behavior?: { thinkingIndicatorEnabled
 
 async function resolveReaction(
   value: string | null | undefined,
-  defaultEmoji: WellKnownEmoji
+  defaultEmoji: WellKnownEmoji,
+  log: PinoLogger
 ): Promise<WellKnownEmoji | null> {
   if (value === null) return null;
   if (value === undefined) return defaultEmoji;
 
   const known = await loadEmojiNames();
   if (!known.has(value)) {
-    logger.warn(`Unknown emoji "${value}" in agent config, falling back to default "${defaultEmoji}"`);
+    log.warn(`Unknown emoji "${value}" in agent config, falling back to default "${defaultEmoji}"`);
 
     return defaultEmoji;
   }
@@ -160,9 +159,14 @@ export class AgentConfigResolver {
       thinkingIndicatorEnabled: resolveThinkingIndicator(agent),
       reactionOnMessageReceived: await resolveReaction(
         agent.behavior?.reactions?.onMessageReceived,
-        DEFAULT_REACTION_ON_MESSAGE
+        DEFAULT_REACTION_ON_MESSAGE,
+        this.logger
       ),
-      reactionOnResolved: await resolveReaction(agent.behavior?.reactions?.onResolved, DEFAULT_REACTION_ON_RESOLVED),
+      reactionOnResolved: await resolveReaction(
+        agent.behavior?.reactions?.onResolved,
+        DEFAULT_REACTION_ON_RESOLVED,
+        this.logger
+      ),
       bridgeUrl: agent.bridgeUrl,
       devBridgeUrl: agent.devBridgeUrl,
       devBridgeActive: agent.devBridgeActive,

--- a/apps/api/src/app/agents/services/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-config-resolver.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { decryptCredentials, FeatureFlagsService, PinoLogger } from '@novu/application-generic';
 import {
   AgentIntegrationRepository,
@@ -10,7 +10,21 @@ import {
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import type { WellKnownEmoji } from 'chat';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
+import { esmImport } from '../utils/esm-import';
 import { resolveAgentPlatform } from '../utils/provider-to-platform';
+
+const logger = new Logger('AgentConfigResolver');
+
+let cachedEmojiNames: Set<string> | null = null;
+
+async function loadEmojiNames(): Promise<Set<string>> {
+  if (cachedEmojiNames) return cachedEmojiNames;
+
+  const { DEFAULT_EMOJI_MAP } = await esmImport('chat');
+  cachedEmojiNames = new Set<string>(Object.keys(DEFAULT_EMOJI_MAP));
+
+  return cachedEmojiNames;
+}
 
 export interface ResolvedAgentConfig {
   platform: AgentPlatformEnum;
@@ -36,9 +50,19 @@ function resolveThinkingIndicator(agent: { behavior?: { thinkingIndicatorEnabled
   return agent.behavior?.thinkingIndicatorEnabled !== false;
 }
 
-function resolveReaction(value: string | null | undefined, defaultEmoji: WellKnownEmoji): WellKnownEmoji | null {
+async function resolveReaction(
+  value: string | null | undefined,
+  defaultEmoji: WellKnownEmoji
+): Promise<WellKnownEmoji | null> {
   if (value === null) return null;
   if (value === undefined) return defaultEmoji;
+
+  const known = await loadEmojiNames();
+  if (!known.has(value)) {
+    logger.warn(`Unknown emoji "${value}" in agent config, falling back to default "${defaultEmoji}"`);
+
+    return defaultEmoji;
+  }
 
   return value as WellKnownEmoji;
 }
@@ -134,11 +158,11 @@ export class AgentConfigResolver {
       integrationIdentifier,
       integrationId: integration._id,
       thinkingIndicatorEnabled: resolveThinkingIndicator(agent),
-      reactionOnMessageReceived: resolveReaction(
+      reactionOnMessageReceived: await resolveReaction(
         agent.behavior?.reactions?.onMessageReceived,
         DEFAULT_REACTION_ON_MESSAGE
       ),
-      reactionOnResolved: resolveReaction(agent.behavior?.reactions?.onResolved, DEFAULT_REACTION_ON_RESOLVED),
+      reactionOnResolved: await resolveReaction(agent.behavior?.reactions?.onResolved, DEFAULT_REACTION_ON_RESOLVED),
       bridgeUrl: agent.bridgeUrl,
       devBridgeUrl: agent.devBridgeUrl,
       devBridgeActive: agent.devBridgeActive,

--- a/apps/api/src/app/agents/services/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-config-resolver.service.ts
@@ -8,6 +8,7 @@ import {
   IntegrationRepository,
 } from '@novu/dal';
 import { FeatureFlagsKeysEnum } from '@novu/shared';
+import type { WellKnownEmoji } from 'chat';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
 import { resolveAgentPlatform } from '../utils/provider-to-platform';
 
@@ -21,25 +22,25 @@ export interface ResolvedAgentConfig {
   integrationIdentifier: string;
   integrationId: string;
   thinkingIndicatorEnabled: boolean;
-  reactionOnMessageReceived: string | null;
-  reactionOnResolved: string | null;
+  reactionOnMessageReceived: WellKnownEmoji | null;
+  reactionOnResolved: WellKnownEmoji | null;
   bridgeUrl?: string;
   devBridgeUrl?: string;
   devBridgeActive?: boolean;
 }
 
-const DEFAULT_REACTION_ON_MESSAGE = 'eyes';
-const DEFAULT_REACTION_ON_RESOLVED = 'check';
+const DEFAULT_REACTION_ON_MESSAGE: WellKnownEmoji = 'eyes';
+const DEFAULT_REACTION_ON_RESOLVED: WellKnownEmoji = 'check';
 
 function resolveThinkingIndicator(agent: { behavior?: { thinkingIndicatorEnabled?: boolean } }): boolean {
   return agent.behavior?.thinkingIndicatorEnabled !== false;
 }
 
-function resolveReaction(value: string | null | undefined, defaultEmoji: string): string | null {
+function resolveReaction(value: string | null | undefined, defaultEmoji: WellKnownEmoji): WellKnownEmoji | null {
   if (value === null) return null;
   if (value === undefined) return defaultEmoji;
 
-  return value;
+  return value as WellKnownEmoji;
 }
 
 @Injectable()

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -6,7 +6,7 @@ import {
   ConversationRepository,
   SubscriberRepository,
 } from '@novu/dal';
-import type { Message, Thread } from 'chat';
+import type { EmojiValue, Message, Thread } from 'chat';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { PLATFORMS_WITHOUT_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
 import { HandleAgentReplyCommand } from '../usecases/handle-agent-reply/handle-agent-reply.command';
@@ -22,7 +22,7 @@ const ONBOARDING_NO_BRIDGE_REPLY_MARKDOWN = `*You're connected to Novu*
 Your bot is linked successfully. Go back to the *Novu dashboard* to complete onboarding.`;
 
 export interface InboundReactionEvent {
-  emoji: { name: string };
+  emoji: EmojiValue;
   added: boolean;
   messageId: string;
   message?: Message;

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -1,11 +1,12 @@
 import { BadRequestException, forwardRef, Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
-import type { Chat, Message, Thread } from 'chat';
+import type { Chat, EmojiValue, Message, ReactionEvent, Thread } from 'chat';
 import { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import { LRUCache } from 'lru-cache';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
 import type { ReplyContentDto } from '../dtos/agent-reply-payload.dto';
+import { esmImport } from '../utils/esm-import';
 import { sendWebResponse, toWebRequest } from '../utils/express-to-web-request';
 import { AgentConfigResolver, ResolvedAgentConfig } from './agent-config-resolver.service';
 import { AgentInboundHandler } from './agent-inbound-handler.service';
@@ -25,11 +26,6 @@ import { AgentInboundHandler } from './agent-inbound-handler.service';
  *           credentials.token                    → verifyToken
  *           credentials.phoneNumberIdentification → phoneNumberId
  */
-
-// Chat SDK packages are ESM-only; SWC rewrites import() → require() for CJS output.
-// Wrapping in new Function prevents SWC from seeing the import() keyword.
-// eslint-disable-next-line @typescript-eslint/no-implied-eval
-const esmImport = new Function('specifier', 'return import(specifier)') as (s: string) => Promise<any>;
 
 const MAX_CACHED_INSTANCES = 200;
 const INSTANCE_TTL_MS = 1000 * 60 * 30;
@@ -133,14 +129,15 @@ export class ChatSdkService implements OnModuleDestroy {
     platform: string,
     platformThreadId: string,
     platformMessageId: string,
-    emoji: string
+    emojiName: string
   ): Promise<void> {
     const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
     const instanceKey = `${agentId}:${integrationIdentifier}`;
     const chat = await this.getOrCreate(instanceKey, agentId, config.platform, config);
 
     const adapter = chat.getAdapter(platform);
-    await adapter.removeReaction(platformThreadId, platformMessageId, emoji);
+    const resolved = await this.resolveEmoji(emojiName);
+    await adapter.removeReaction(platformThreadId, platformMessageId, resolved);
   }
 
   async reactToMessage(
@@ -149,14 +146,21 @@ export class ChatSdkService implements OnModuleDestroy {
     platform: string,
     platformThreadId: string,
     platformMessageId: string,
-    emoji: string
+    emojiName: string
   ): Promise<void> {
     const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
     const instanceKey = `${agentId}:${integrationIdentifier}`;
     const chat = await this.getOrCreate(instanceKey, agentId, config.platform, config);
 
     const adapter = chat.getAdapter(platform);
-    await adapter.addReaction(platformThreadId, platformMessageId, emoji);
+    const resolved = await this.resolveEmoji(emojiName);
+    await adapter.addReaction(platformThreadId, platformMessageId, resolved);
+  }
+
+  private async resolveEmoji(name: string): Promise<EmojiValue> {
+    const { getEmoji } = await esmImport('chat');
+
+    return getEmoji(name);
   }
 
   private async getOrCreate(
@@ -379,14 +383,14 @@ export class ChatSdkService implements OnModuleDestroy {
       }
     });
 
-    cached.chat.onReaction(async (event: any) => {
+    cached.chat.onReaction(async (event: ReactionEvent) => {
       try {
         await this.inboundHandler.handleReaction(agentId, cached.config, {
           emoji: event.emoji,
           added: event.added,
           messageId: event.messageId,
           message: event.message,
-          thread: event.thread,
+          thread: event.thread as Thread | undefined,
           user: event.user,
         });
       } catch (err) {

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -159,8 +159,12 @@ export class ChatSdkService implements OnModuleDestroy {
 
   private async resolveEmoji(name: string): Promise<EmojiValue> {
     const { getEmoji } = await esmImport('chat');
+    const resolved = getEmoji(name);
+    if (!resolved) {
+      throw new Error(`Unknown emoji name: "${name}". Use GET /agents/emoji to list supported options.`);
+    }
 
-    return getEmoji(name);
+    return resolved;
   }
 
   private async getOrCreate(

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
@@ -1,6 +1,6 @@
+import type { Signal } from '@novu/framework';
 import { Type } from 'class-transformer';
 import { IsArray, IsNotEmpty, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
-import type { Signal } from '@novu/framework';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
 

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -104,7 +104,7 @@ export class HandleAgentReply {
     }
 
     if (command.resolve) {
-      await this.executeResolveSignal(command, config!, conversation, channel, command.resolve);
+      await this.resolveConversation(command, config!, conversation, channel, command.resolve);
     }
 
     return { status: 'ok' };
@@ -255,12 +255,12 @@ export class HandleAgentReply {
     ]);
   }
 
-  private async executeResolveSignal(
+  private async resolveConversation(
     command: HandleAgentReplyCommand,
     config: ResolvedAgentConfig,
     conversation: ConversationEntity,
     channel: ConversationChannel,
-    signal: { summary?: string }
+    options: { summary?: string }
   ): Promise<void> {
     await Promise.all([
       this.conversationRepository.updateStatus(
@@ -276,8 +276,8 @@ export class HandleAgentReply {
         integrationId: channel._integrationId,
         platformThreadId: channel.platformThreadId,
         agentId: command.agentIdentifier,
-        content: signal.summary ?? 'Conversation resolved',
-        signalData: { type: 'resolve', payload: signal.summary ? { summary: signal.summary } : undefined },
+        content: options.summary ?? 'Conversation resolved',
+        signalData: { type: 'resolve', payload: options.summary ? { summary: options.summary } : undefined },
         environmentId: command.environmentId,
         organizationId: command.organizationId,
       }),

--- a/apps/api/src/app/agents/usecases/index.ts
+++ b/apps/api/src/app/agents/usecases/index.ts
@@ -3,6 +3,7 @@ import { CreateAgent } from './create-agent/create-agent.usecase';
 import { DeleteAgent } from './delete-agent/delete-agent.usecase';
 import { GetAgent } from './get-agent/get-agent.usecase';
 import { HandleAgentReply } from './handle-agent-reply/handle-agent-reply.usecase';
+import { ListAgentEmoji } from './list-agent-emoji/list-agent-emoji.usecase';
 import { ListAgentIntegrations } from './list-agent-integrations/list-agent-integrations.usecase';
 import { ListAgents } from './list-agents/list-agents.usecase';
 import { RemoveAgentIntegration } from './remove-agent-integration/remove-agent-integration.usecase';
@@ -16,6 +17,7 @@ export const USE_CASES = [
   UpdateAgent,
   DeleteAgent,
   AddAgentIntegration,
+  ListAgentEmoji,
   ListAgentIntegrations,
   UpdateAgentIntegration,
   RemoveAgentIntegration,

--- a/apps/api/src/app/agents/usecases/list-agent-emoji/list-agent-emoji.usecase.ts
+++ b/apps/api/src/app/agents/usecases/list-agent-emoji/list-agent-emoji.usecase.ts
@@ -19,7 +19,7 @@ export class ListAgentEmoji {
 
     this.cached = Object.entries(map)
       .map(([name, formats]) => {
-        const raw = formats.gchat ?? formats.slack ?? formats.teams ?? formats.whatsapp;
+        const raw = formats.gchat ?? formats.slack;
         const unicode = Array.isArray(raw) ? raw[0] : raw;
 
         return unicode ? { name, unicode } : null;

--- a/apps/api/src/app/agents/usecases/list-agent-emoji/list-agent-emoji.usecase.ts
+++ b/apps/api/src/app/agents/usecases/list-agent-emoji/list-agent-emoji.usecase.ts
@@ -17,10 +17,14 @@ export class ListAgentEmoji {
     const { DEFAULT_EMOJI_MAP } = await esmImport('chat');
     const map = DEFAULT_EMOJI_MAP as Record<string, EmojiFormats>;
 
-    this.cached = Object.entries(map).map(([name, formats]) => ({
-      name,
-      unicode: Array.isArray(formats.gchat) ? formats.gchat[0] : formats.gchat,
-    }));
+    this.cached = Object.entries(map)
+      .map(([name, formats]) => {
+        const raw = formats.gchat ?? formats.slack ?? formats.teams ?? formats.whatsapp;
+        const unicode = Array.isArray(raw) ? raw[0] : raw;
+
+        return unicode ? { name, unicode } : null;
+      })
+      .filter((e): e is AgentEmojiEntry => e !== null);
 
     return this.cached;
   }

--- a/apps/api/src/app/agents/usecases/list-agent-emoji/list-agent-emoji.usecase.ts
+++ b/apps/api/src/app/agents/usecases/list-agent-emoji/list-agent-emoji.usecase.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import type { EmojiFormats } from 'chat';
+import { esmImport } from '../../utils/esm-import';
+
+export interface AgentEmojiEntry {
+  name: string;
+  unicode: string;
+}
+
+@Injectable()
+export class ListAgentEmoji {
+  private cached: AgentEmojiEntry[] | null = null;
+
+  async execute(): Promise<AgentEmojiEntry[]> {
+    if (this.cached) return this.cached;
+
+    const { DEFAULT_EMOJI_MAP } = await esmImport('chat');
+    const map = DEFAULT_EMOJI_MAP as Record<string, EmojiFormats>;
+
+    this.cached = Object.entries(map).map(([name, formats]) => ({
+      name,
+      unicode: Array.isArray(formats.gchat) ? formats.gchat[0] : formats.gchat,
+    }));
+
+    return this.cached;
+  }
+}

--- a/apps/api/src/app/agents/utils/esm-import.ts
+++ b/apps/api/src/app/agents/utils/esm-import.ts
@@ -1,0 +1,4 @@
+// Chat SDK packages are ESM-only; SWC rewrites import() → require() for CJS output.
+// Wrapping in new Function prevents SWC from seeing the import() keyword.
+// eslint-disable-next-line @typescript-eslint/no-implied-eval
+export const esmImport = new Function('specifier', 'return import(specifier)') as (s: string) => Promise<any>;

--- a/apps/api/src/app/agents/validators/is-well-known-emoji.validator.ts
+++ b/apps/api/src/app/agents/validators/is-well-known-emoji.validator.ts
@@ -1,0 +1,46 @@
+import {
+  registerDecorator,
+  type ValidationArguments,
+  type ValidationOptions,
+  ValidatorConstraint,
+  type ValidatorConstraintInterface,
+} from 'class-validator';
+import { esmImport } from '../utils/esm-import';
+
+let cachedNames: Set<string> | null = null;
+
+async function loadEmojiNames(): Promise<Set<string>> {
+  if (cachedNames) return cachedNames;
+
+  const { DEFAULT_EMOJI_MAP } = await esmImport('chat');
+  cachedNames = new Set<string>(Object.keys(DEFAULT_EMOJI_MAP));
+
+  return cachedNames;
+}
+
+@ValidatorConstraint({ async: true, name: 'isWellKnownEmoji' })
+export class IsWellKnownEmojiConstraint implements ValidatorConstraintInterface {
+  async validate(value: unknown): Promise<boolean> {
+    if (typeof value !== 'string') return false;
+
+    const names = await loadEmojiNames();
+
+    return names.has(value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `"${args.value}" is not a supported emoji name. Use GET /agents/emoji to list available options.`;
+  }
+}
+
+export function IsWellKnownEmoji(validationOptions?: ValidationOptions) {
+  return (object: object, propertyName: string) => {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsWellKnownEmojiConstraint,
+    });
+  };
+}

--- a/apps/api/src/app/agents/validators/is-well-known-emoji.validator.ts
+++ b/apps/api/src/app/agents/validators/is-well-known-emoji.validator.ts
@@ -29,7 +29,7 @@ export class IsWellKnownEmojiConstraint implements ValidatorConstraintInterface 
   }
 
   defaultMessage(args: ValidationArguments): string {
-    return `"${args.value}" is not a supported emoji name. Use GET /agents/emoji to list available options.`;
+    return `${JSON.stringify(args.value)} is not a supported emoji name. Use GET /agents/emoji to list available options.`;
   }
 }
 

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -8,6 +8,8 @@ const AGENT_DETAIL_QUERY_KEY = 'fetchAgent' as const;
 
 const AGENT_INTEGRATIONS_QUERY_KEY = 'fetchAgentIntegrations' as const;
 
+const AGENT_EMOJI_QUERY_KEY = 'fetchAgentEmoji' as const;
+
 export function getAgentDetailQueryKey(environmentId: string | undefined, identifier: string | undefined) {
 
   return [AGENT_DETAIL_QUERY_KEY, environmentId, identifier] as const;
@@ -250,4 +252,17 @@ export function removeAgentIntegration(
     `/agents/${encodeURIComponent(agentIdentifier)}/integrations/${encodeURIComponent(agentIntegrationId)}`,
     { environment }
   );
+}
+
+export type AgentEmojiEntry = {
+  name: string;
+  unicode: string;
+};
+
+export function getAgentEmojiQueryKey() {
+  return [AGENT_EMOJI_QUERY_KEY] as const;
+}
+
+export function listAgentEmoji(environment: IEnvironment, signal?: AbortSignal): Promise<AgentEmojiEntry[]> {
+  return get<AgentEmojiEntry[]>('/agents/emoji', { environment, signal });
 }

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -263,6 +263,8 @@ export function getAgentEmojiQueryKey() {
   return [AGENT_EMOJI_QUERY_KEY] as const;
 }
 
-export function listAgentEmoji(environment: IEnvironment, signal?: AbortSignal): Promise<AgentEmojiEntry[]> {
-  return get<AgentEmojiEntry[]>('/agents/emoji', { environment, signal });
+export async function listAgentEmoji(environment: IEnvironment, signal?: AbortSignal): Promise<AgentEmojiEntry[]> {
+  const response = await get<{ data: AgentEmojiEntry[] }>('/agents/emoji', { environment, signal });
+
+  return response.data;
 }

--- a/apps/dashboard/src/components/agents/agent-behavior-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-behavior-section.tsx
@@ -1,6 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { RiExpandUpDownLine } from 'react-icons/ri';
+import { type AgentEmojiEntry, getAgentEmojiQueryKey, listAgentEmoji } from '@/api/agents';
 import { HelpTooltipIndicator } from '@/components/primitives/help-tooltip-indicator';
 import { Switch } from '@/components/primitives/switch';
+import { useEnvironment } from '@/context/environment/hooks';
+
+const DEFAULT_REACTION_ON_MESSAGE = 'eyes';
+const DEFAULT_REACTION_ON_RESOLVED = 'check';
+
+function useAgentEmoji() {
+  const { currentEnvironment } = useEnvironment();
+
+  const { data: emojiList = [] } = useQuery({
+    queryKey: getAgentEmojiQueryKey(),
+    queryFn: ({ signal }) => listAgentEmoji(currentEnvironment!, signal),
+    enabled: !!currentEnvironment,
+    staleTime: Infinity,
+  });
+
+  const unicodeMap = useMemo(
+    () => new Map<string, string>(emojiList.map((e: AgentEmojiEntry) => [e.name, e.unicode])),
+    [emojiList]
+  );
+
+  return { emojiList, unicodeMap };
+}
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
   return (
@@ -37,6 +62,10 @@ function EmojiPickerButton({ emoji }: { emoji: string }) {
 }
 
 export function AgentBehaviorSection() {
+  const { unicodeMap } = useAgentEmoji();
+  const messageEmoji = unicodeMap.get(DEFAULT_REACTION_ON_MESSAGE) ?? '';
+  const resolvedEmoji = unicodeMap.get(DEFAULT_REACTION_ON_RESOLVED) ?? '';
+
   return (
     <div className="bg-bg-weak flex flex-col rounded-[10px] p-1">
       <SectionHeader>Agent behavior</SectionHeader>
@@ -79,11 +108,11 @@ export function AgentBehaviorSection() {
           </ToggleRow>
 
           <ToggleRow label="React to incoming messages so users know the agent received them">
-            <EmojiPickerButton emoji="👀" />
+            <EmojiPickerButton emoji={messageEmoji} />
           </ToggleRow>
 
           <ToggleRow label="React to the final message when a conversation is resolved">
-            <EmojiPickerButton emoji="✅" />
+            <EmojiPickerButton emoji={resolvedEmoji} />
           </ToggleRow>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Replace hardcoded emoji strings with the Chat SDK's type-safe emoji system (`WellKnownEmoji`, `EmojiValue`, `getEmoji()`, `DEFAULT_EMOJI_MAP`) — the SDK is now the single source of truth for cross-platform emoji
- Add `@IsWellKnownEmoji()` DTO validator that lazily loads the SDK's emoji map to reject invalid emoji names at the API boundary
- Add `GET /agents/emoji` endpoint returning the full list of supported emoji with unicode representations, so the dashboard doesn't hardcode emoji characters
- Type `onReaction` handler as `ReactionEvent` (removes `any` cast), type config reaction fields as `WellKnownEmoji | null`
- Extract shared `esmImport` helper to `utils/esm-import.ts`
- Rename `executeResolveSignal` → `resolveConversation` (resolve is a first-class action, not a signal)

## Architecture

```mermaid
graph LR
    SDK["chat SDK<br/>WellKnownEmoji · EmojiValue · DEFAULT_EMOJI_MAP"]

    subgraph API
        CFG["AgentConfigResolver<br/>import type WellKnownEmoji"]
        DTO["AgentBehaviorDto<br/>@IsWellKnownEmoji()"]
        CS["ChatSdkService<br/>getEmoji() → EmojiValue"]
        IH["AgentInboundHandler<br/>EmojiValue on ReactionEvent"]
        EP["GET /agents/emoji<br/>returns DEFAULT_EMOJI_MAP"]
        VAL["IsWellKnownEmojiConstraint<br/>loads DEFAULT_EMOJI_MAP once"]
    end

    subgraph Dashboard
        BEH["AgentBehaviorSection<br/>fetches /agents/emoji"]
    end

    SDK -->|"type-only"| CFG
    SDK -->|"type-only"| IH
    SDK -->|"runtime via esmImport"| CS
    SDK -->|"runtime via esmImport"| EP
    SDK -->|"runtime via esmImport"| VAL
    EP -->|"HTTP"| BEH
    DTO --> VAL
```

### What uses `EmojiValue` at runtime vs. string
| Layer | Type | Why |
|---|---|---|
| `ChatSdkService.reactToMessage/removeReaction` | `EmojiValue` via `getEmoji()` | Ensures per-platform emoji resolution |
| `ReactionEvent` handler | `EmojiValue` (from SDK) | Proper typing, `.name` extracted at boundary |
| `ResolvedAgentConfig` | `WellKnownEmoji` (string literal) | Compile-time safety, stored as string |
| DB / bridge wire protocol | `string` | No change needed |

## Test plan
- [ ] Existing agent webhook e2e tests pass (updated to use `mockEmoji()` helper for `EmojiValue` fixtures)
- [ ] `PATCH /agents/:id` with `behavior.reactions.onMessageReceived: "not_real"` returns 400
- [ ] `PATCH /agents/:id` with `behavior.reactions.onMessageReceived: "fire"` succeeds
- [ ] `GET /agents/emoji` returns list with `name` and `unicode` fields
- [ ] Dashboard behavior section renders emoji from API instead of hardcoded unicode


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Agent reactions now use the Chat SDK's type-safe emoji system instead of hardcoded emoji characters: configs reference WellKnownEmoji names, runtime code resolves to EmojiValue objects, and the API exposes supported emoji with unicode. This centralizes emoji as the single source of truth for cross-platform rendering, prevents invalid emoji config values, and lets the dashboard render platform-correct glyphs.

## Affected areas
**api**: Added a new GET /agents/emoji endpoint and ListAgentEmoji use case; introduced @IsWellKnownEmoji() validator that lazily loads the Chat SDK map; agent config resolution and ChatSdkService now resolve names to EmojiValue at runtime and type-restrict reaction fields as WellKnownEmoji | null.  
**dashboard**: Replaced hardcoded unicode in the agent behavior UI with a React Query hook that fetches emoji entries from /agents/emoji and maps names → unicode for rendering.  
**shared (agents utils)**: Added esmImport helper to dynamically import the Chat SDK at runtime and avoid circular/static import issues.

## Key technical decisions
- Lazy-load Chat SDK runtime map via esmImport and cache results to avoid heavy imports and circular dependencies.  
- Preserve string-typed WellKnownEmoji in configs/DB while using EmojiValue only at runtime, separating compile-time typing from runtime representations.  
- Validate emoji at the API boundary with an async class-validator to reject invalid names early and point clients to GET /agents/emoji.

## Testing
E2E tests updated to use mockEmoji() fixtures; validation behavior should be covered by tests for PATCH /agents/:id (reject invalid, accept valid); GET /agents/emoji returns name/unicode list for the dashboard. Manual verification: dashboard emoji picker and agent reaction flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->