### PR TITLE
fix(api-service): propagate agent config changes through Chat SDK cache fixes NV-7379

### DIFF
--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import { BadRequestException, forwardRef, Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import type { Chat, Message, Thread } from 'chat';
@@ -225,10 +224,12 @@ export class ChatSdkService implements OnModuleDestroy {
    * these values live inside already-constructed platform adapters and cannot
    * be mutated after the fact.
    *
-   * Uses SHA-256 over a JSON-stringified fixed-shape object so the encoding is
-   * injective (no delimiter collisions across free-form secret values) and so
-   * plaintext credentials don't linger as cache-key-adjacent strings for the
-   * lifetime of the LRU entry.
+   * JSON.stringify over a fixed-shape object is injective (JSON escapes rule
+   * out delimiter collisions across free-form secret values), which is all we
+   * need for an equality-based cache-coherence check. We deliberately do NOT
+   * hash: this is not credential verification or password storage, so fast
+   * hashing would be architecturally wrong and the plaintext is already
+   * retained in cached.config for the entry's lifetime anyway.
    *
    * IMPORTANT: keep in sync with buildAdapters() whenever a new adapter input
    * is added. Missing a field here will cause the cache to silently serve
@@ -237,7 +238,7 @@ export class ChatSdkService implements OnModuleDestroy {
   private adapterFingerprint(config: ResolvedAgentConfig): string {
     const { platform, credentials: c, connectionAccessToken } = config;
 
-    const serialized = JSON.stringify({
+    return JSON.stringify({
       platform,
       signingSecret: c.signingSecret ?? null,
       clientId: c.clientId ?? null,
@@ -248,8 +249,6 @@ export class ChatSdkService implements OnModuleDestroy {
       phoneNumberIdentification: c.phoneNumberIdentification ?? null,
       connectionAccessToken: connectionAccessToken ?? null,
     });
-
-    return createHash('sha256').update(serialized).digest('hex');
   }
 
   private async createChatInstance(

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -34,9 +34,27 @@ const esmImport = new Function('specifier', 'return import(specifier)') as (s: s
 const MAX_CACHED_INSTANCES = 200;
 const INSTANCE_TTL_MS = 1000 * 60 * 30;
 
+/**
+ * Holds a cached Chat instance alongside a mutable pointer to the current
+ * resolved config. Event handlers registered via registerEventHandlers() close
+ * over this box instead of the config value, so updates to fields that the
+ * bridge executor and inbound handler read at event time (bridgeUrl,
+ * devBridgeUrl, devBridgeActive, thinkingIndicatorEnabled, reactions) take
+ * effect on the next inbound event without rebuilding the Chat instance.
+ *
+ * adapterFingerprint captures fields that are baked into the platform adapter
+ * at construction (credentials + connectionAccessToken); when these change,
+ * the cached instance is dropped and rebuilt — see getOrCreate().
+ */
+interface CachedChat {
+  chat: Chat;
+  config: ResolvedAgentConfig;
+  adapterFingerprint: string;
+}
+
 @Injectable()
 export class ChatSdkService implements OnModuleDestroy {
-  private readonly instances: LRUCache<string, Chat>;
+  private readonly instances: LRUCache<string, CachedChat>;
   private readonly pendingCreations = new Map<string, Promise<Chat>>();
 
   constructor(
@@ -45,11 +63,11 @@ export class ChatSdkService implements OnModuleDestroy {
     @Inject(forwardRef(() => AgentInboundHandler))
     private readonly inboundHandler: AgentInboundHandler
   ) {
-    this.instances = new LRUCache<string, Chat>({
+    this.instances = new LRUCache<string, CachedChat>({
       max: MAX_CACHED_INSTANCES,
       ttl: INSTANCE_TTL_MS,
-      dispose: (chat, key) => {
-        chat.shutdown().catch((err) => {
+      dispose: (cached, key) => {
+        cached.chat.shutdown().catch((err) => {
           this.logger.error(err, `Failed to shut down evicted Chat instance ${key}`);
         });
       },
@@ -72,22 +90,10 @@ export class ChatSdkService implements OnModuleDestroy {
     await sendWebResponse(webResponse, res);
   }
 
-  evict(agentId: string, integrationIdentifier?: string) {
-    if (integrationIdentifier) {
-      this.instances.delete(`${agentId}:${integrationIdentifier}`);
-    } else {
-      for (const key of this.instances.keys()) {
-        if (key.startsWith(`${agentId}:`)) {
-          this.instances.delete(key);
-        }
-      }
-    }
-  }
-
   async onModuleDestroy() {
-    const shutdowns = [...this.instances.entries()].map(async ([key, chat]) => {
+    const shutdowns = [...this.instances.entries()].map(async ([key, cached]) => {
       try {
-        await chat.shutdown();
+        await cached.chat.shutdown();
       } catch (err) {
         this.logger.error(err, `Failed to shut down Chat instance ${key}`);
       }
@@ -159,13 +165,26 @@ export class ChatSdkService implements OnModuleDestroy {
     platform: AgentPlatformEnum,
     config: ResolvedAgentConfig
   ): Promise<Chat> {
+    const freshFingerprint = this.adapterFingerprint(config);
     const existing = this.instances.get(instanceKey);
-    if (existing) return existing;
+
+    if (existing) {
+      if (existing.adapterFingerprint === freshFingerprint) {
+        existing.config = config;
+
+        return existing.chat;
+      }
+
+      // Credentials / connection token changed since this instance was built —
+      // the platform adapter is frozen with the old values, so we must rebuild.
+      // Delete triggers the LRU dispose hook which calls chat.shutdown().
+      this.instances.delete(instanceKey);
+    }
 
     const pending = this.pendingCreations.get(instanceKey);
     if (pending) return pending;
 
-    const creation = this.createAndCache(instanceKey, agentId, platform, config);
+    const creation = this.createAndCache(instanceKey, agentId, platform, config, freshFingerprint);
     this.pendingCreations.set(instanceKey, creation);
 
     try {
@@ -179,13 +198,44 @@ export class ChatSdkService implements OnModuleDestroy {
     instanceKey: string,
     agentId: string,
     platform: AgentPlatformEnum,
-    config: ResolvedAgentConfig
+    config: ResolvedAgentConfig,
+    adapterFingerprint: string
   ): Promise<Chat> {
     const chat = await this.createChatInstance(instanceKey, platform, config);
-    this.registerEventHandlers(agentId, chat, config);
-    this.instances.set(instanceKey, chat);
+    const cached: CachedChat = { chat, config, adapterFingerprint };
+    this.registerEventHandlers(agentId, cached);
+    this.instances.set(instanceKey, cached);
 
     return chat;
+  }
+
+  /**
+   * Fingerprint of every field baked into the Chat instance at construction
+   * time — i.e. everything read by buildAdapters() and createChatInstance().
+   * When the fingerprint changes, the cached instance must be rebuilt because
+   * these values live inside already-constructed platform adapters and cannot
+   * be mutated after the fact.
+   *
+   * IMPORTANT: keep in sync with buildAdapters() whenever a new adapter input
+   * is added. Missing a field here will cause the cache to silently serve
+   * stale credentials until the LRU TTL expires.
+   */
+  private adapterFingerprint(config: ResolvedAgentConfig): string {
+    const { platform, credentials: c, connectionAccessToken } = config;
+
+    return [
+      platform,
+      c.signingSecret,
+      c.clientId,
+      c.secretKey,
+      c.tenantId,
+      c.apiToken,
+      c.token,
+      c.phoneNumberIdentification,
+      connectionAccessToken,
+    ]
+      .map((v) => v ?? '')
+      .join('|');
   }
 
   private async createChatInstance(
@@ -275,25 +325,25 @@ export class ChatSdkService implements OnModuleDestroy {
     }
   }
 
-  private registerEventHandlers(agentId: string, chat: Chat, config: ResolvedAgentConfig) {
-    chat.onNewMention(async (thread: Thread, message: Message) => {
+  private registerEventHandlers(agentId: string, cached: CachedChat) {
+    cached.chat.onNewMention(async (thread: Thread, message: Message) => {
       try {
         await thread.subscribe();
-        await this.inboundHandler.handle(agentId, config, thread, message, AgentEventEnum.ON_MESSAGE);
+        await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling new mention`);
       }
     });
 
-    chat.onSubscribedMessage(async (thread: Thread, message: Message) => {
+    cached.chat.onSubscribedMessage(async (thread: Thread, message: Message) => {
       try {
-        await this.inboundHandler.handle(agentId, config, thread, message, AgentEventEnum.ON_MESSAGE);
+        await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling subscribed message`);
       }
     });
 
-    chat.onAction(async (event) => {
+    cached.chat.onAction(async (event) => {
       try {
         if (!event.thread) {
           this.logger.warn(`[agent:${agentId}] Action received without thread context, skipping`);
@@ -303,7 +353,7 @@ export class ChatSdkService implements OnModuleDestroy {
 
         await this.inboundHandler.handleAction(
           agentId,
-          config,
+          cached.config,
           event.thread as Thread,
           {
             actionId: event.actionId,
@@ -316,9 +366,9 @@ export class ChatSdkService implements OnModuleDestroy {
       }
     });
 
-    chat.onReaction(async (event: any) => {
+    cached.chat.onReaction(async (event: any) => {
       try {
-        await this.inboundHandler.handleReaction(agentId, config, {
+        await this.inboundHandler.handleReaction(agentId, cached.config, {
           emoji: event.emoji,
           added: event.added,
           messageId: event.messageId,

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { BadRequestException, forwardRef, Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import type { Chat, Message, Thread } from 'chat';
@@ -181,16 +182,24 @@ export class ChatSdkService implements OnModuleDestroy {
       this.instances.delete(instanceKey);
     }
 
-    const pending = this.pendingCreations.get(instanceKey);
+    // Key pending builds by (instanceKey + fingerprint) so that a build kicked
+    // off with stale credentials can't be observed by a later caller that has
+    // already-rotated credentials — that caller would otherwise await the
+    // in-flight promise and receive a Chat whose adapter is baked with the old
+    // secrets. With this keying, concurrent callers with divergent configs
+    // each get their own build; the later instances.set() wins and the LRU
+    // dispose hook shuts down the superseded Chat.
+    const pendingKey = `${instanceKey}:${freshFingerprint}`;
+    const pending = this.pendingCreations.get(pendingKey);
     if (pending) return pending;
 
     const creation = this.createAndCache(instanceKey, agentId, platform, config, freshFingerprint);
-    this.pendingCreations.set(instanceKey, creation);
+    this.pendingCreations.set(pendingKey, creation);
 
     try {
       return await creation;
     } finally {
-      this.pendingCreations.delete(instanceKey);
+      this.pendingCreations.delete(pendingKey);
     }
   }
 
@@ -216,6 +225,11 @@ export class ChatSdkService implements OnModuleDestroy {
    * these values live inside already-constructed platform adapters and cannot
    * be mutated after the fact.
    *
+   * Uses SHA-256 over a JSON-stringified fixed-shape object so the encoding is
+   * injective (no delimiter collisions across free-form secret values) and so
+   * plaintext credentials don't linger as cache-key-adjacent strings for the
+   * lifetime of the LRU entry.
+   *
    * IMPORTANT: keep in sync with buildAdapters() whenever a new adapter input
    * is added. Missing a field here will cause the cache to silently serve
    * stale credentials until the LRU TTL expires.
@@ -223,19 +237,19 @@ export class ChatSdkService implements OnModuleDestroy {
   private adapterFingerprint(config: ResolvedAgentConfig): string {
     const { platform, credentials: c, connectionAccessToken } = config;
 
-    return [
+    const serialized = JSON.stringify({
       platform,
-      c.signingSecret,
-      c.clientId,
-      c.secretKey,
-      c.tenantId,
-      c.apiToken,
-      c.token,
-      c.phoneNumberIdentification,
-      connectionAccessToken,
-    ]
-      .map((v) => v ?? '')
-      .join('|');
+      signingSecret: c.signingSecret ?? null,
+      clientId: c.clientId ?? null,
+      secretKey: c.secretKey ?? null,
+      tenantId: c.tenantId ?? null,
+      apiToken: c.apiToken ?? null,
+      token: c.token ?? null,
+      phoneNumberIdentification: c.phoneNumberIdentification ?? null,
+      connectionAccessToken: connectionAccessToken ?? null,
+    });
+
+    return createHash('sha256').update(serialized).digest('hex');
   }
 
   private async createChatInstance(


### PR DESCRIPTION
## Summary

`ChatSdkService` caches a `Chat` instance per `agentId:integrationIdentifier` for 30 minutes, but the cache silently served stale config:

- **Per-event fields** (`bridgeUrl`, `devBridgeUrl`, `devBridgeActive`, `thinkingIndicatorEnabled`, `reactionOnMessageReceived`, `reactionOnResolved`) — event handlers closed over the `ResolvedAgentConfig` captured at cache-fill time, so `BridgeExecutorService.resolveBridgeUrl()` and `AgentInboundHandler` kept using old values even though `AgentConfigResolver.resolve()` returned fresh ones on every request.
- **Adapter-baked fields** (`Integration.credentials.*`, `ChannelConnection.auth.accessToken`) — injected into Slack/Teams/WhatsApp adapters at construction. On credential rotation, the cached adapter kept validating webhooks against the old signing secret and calling outbound APIs with a revoked token.

`evict()` existed but was never called from anywhere.

## Fix

Self-validating cache entry, entirely inside `ChatSdkService`. No new infra, no cross-module coupling, self-healing across multi-node API.

- `CachedChat { chat, config, adapterFingerprint }` replaces the raw `Chat` in the LRU.
- Event handlers close over the `CachedChat`, reading `cached.config` at event time. Every `getOrCreate` overwrites `cached.config` with the freshly resolved value, so per-event fields propagate on the next inbound webhook without rebuilding the `Chat`.
- `adapterFingerprint` is a deterministic string of the fields `buildAdapters()` and `createChatInstance()` consume. On every `getOrCreate`, compute it from the fresh config and compare: mismatch drops the entry (LRU `dispose` hook calls `chat.shutdown()`) and rebuilds; match reuses the cached Redis connection.
- Remove the unused public `evict()` method — the new design makes it unnecessary.

The DB (already queried per event by `AgentConfigResolver`) becomes the single source of truth; each API node validates independently, so cross-node coordination is not needed.

```mermaid
flowchart TD
    A[Inbound webhook] --> B[AgentConfigResolver.resolve\nfreshly from DB]
    B --> C{Cache hit?}
    C -- No --> D[Build Chat + adapters\nstore CachedChat + fingerprint]
    C -- Yes --> E{Fingerprint match?}
    E -- Yes --> F[cached.config = fresh\nreturn cached.chat]
    E -- No --> G[cache.delete → chat.shutdown\nrebuild]
    D --> H[Event handlers\nread cached.config]
    F --> H
    G --> H
    H --> I[AgentInboundHandler / BridgeExecutor\nsee current bridgeUrl etc.]
```

## Test plan

- [ ] Verify `bridgeUrl` / `devBridgeUrl` / `devBridgeActive` update from the dashboard takes effect on the very next inbound Slack/Teams/WhatsApp message.
- [ ] Verify updating `thinkingIndicatorEnabled` / reaction emojis on the agent propagates to the next inbound message.
- [ ] Verify rotating `Integration.credentials` (e.g. Slack `signingSecret`) rebuilds the instance on the next webhook — the adapter validates against the new secret.
- [ ] Verify rotating `ChannelConnection.auth.accessToken` (Slack reinstall) causes outbound posts to use the new token on the next `postToConversation` call.
- [ ] Confirm no regressions on `postToConversation` / `reactToMessage` / `removeReaction` when no config changed (same `Chat` reused, no Redis reconnection).

## Linear

Fixes [NV-7379](https://linear.app/novu/issue/NV-7379/chat-sdk-cache-propagate-bridgeurl-credential-changes-without-30m)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

ChatSdkService caching now propagates agent/integration configuration changes immediately instead of waiting for the previous 30‑minute LRU TTL. The LRU stores a CachedChat object ({chat, mutable config, adapterFingerprint}) rather than a raw Chat; event handlers read cached.config at event time so per-event fields (bridge URLs, thinking/reaction flags, credentials/access tokens) take effect on the next webhook. Adapter-relevant differences are detected via a deterministic adapterFingerprint so stale Chat instances are evicted and rebuilt; pending creation keys include the fingerprint to avoid races. The unused public evict() API was removed.

## Affected areas

**api** — ChatSdkService: cache entries now hold CachedChat (chat, resolved config, adapterFingerprint); event handlers consult cached.config at runtime; adapterFingerprint (deterministic JSON serialization of adapter inputs) is used to detect and evict stale instances; pending creation keys are fingerprint-aware; removed public evict(agentId, integrationIdentifier?) method.

## Key technical decisions

- Use DB (AgentConfigResolver) as the single source of truth and read resolved config at event time to avoid cross-node coordination.  
- Use a deterministic JSON stringify of adapter-construction fields (removed SHA‑256 hashing) for fingerprint equality checks to avoid crypto dependency and scanner false positives.  
- Scope pending creation keys to instanceKey + fingerprint so in-flight builds for different configs don’t cause callers to await mismatched instances.

## Testing

Manual and regression verification covering propagation of bridge URLs, thinking/reaction settings, credential and access-token rotations, and unchanged-config no-regressions; no new automated tests were added in this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->