### PR TITLE
feat(dashboard, api-service): Filter conversations by agent; add recent UI & CTA

### DIFF
--- a/apps/dashboard/src/api/conversations.ts
+++ b/apps/dashboard/src/api/conversations.ts
@@ -4,6 +4,7 @@ import { get } from './api.client';
 export type ConversationFilters = {
   dateRange?: string;
   subscriberId?: string;
+  agentId?: string;
   provider?: string[];
   conversationId?: string;
   status?: string;
@@ -87,6 +88,10 @@ export function getConversationsList({
 
   if (filters?.subscriberId) {
     searchParams.append('subscriberId', filters.subscriberId);
+  }
+
+  if (filters?.agentId) {
+    searchParams.append('agentId', filters.agentId);
   }
 
   if (filters?.dateRange) {

--- a/apps/dashboard/src/components/agents/agent-connected-overview.tsx
+++ b/apps/dashboard/src/components/agents/agent-connected-overview.tsx
@@ -12,7 +12,7 @@ export function AgentConnectedOverview({ agent }: AgentConnectedOverviewProps) {
     <div className="flex min-w-0 flex-1 flex-col gap-4">
       <AgentBehaviorSection />
       <ConnectedProvidersSection agent={agent} />
-      <RecentConversationsSection />
+      <RecentConversationsSection agent={agent} />
     </div>
   );
 }

--- a/apps/dashboard/src/components/agents/recent-conversations-section.tsx
+++ b/apps/dashboard/src/components/agents/recent-conversations-section.tsx
@@ -1,89 +1,29 @@
-import { RiArrowRightLine, RiRobot2Line } from 'react-icons/ri';
-import { Link, useLocation } from 'react-router-dom';
+import { RiArrowRightLine, RiCheckboxCircleFill, RiRobot2Line } from 'react-icons/ri';
+import { Link } from 'react-router-dom';
 import type { AgentResponse } from '@/api/agents';
+import type { ConversationDto } from '@/api/conversations';
+import { ConversationStatusBadge } from '@/components/conversations/conversation-status-badge';
+import { ConversationsUpgradeCta } from '@/components/conversations/conversations-upgrade-cta';
+import { SubscriberFallbackAvatar } from '@/components/conversations/subscriber-fallback-avatar';
+import { Skeleton } from '@/components/primitives/skeleton';
+import { IS_ENTERPRISE } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useFetchConversations } from '@/hooks/use-fetch-conversations';
 import { buildRoute, ROUTES } from '@/utils/routes';
+import { cn } from '@/utils/ui';
+
+const RECENT_CONVERSATIONS_DISPLAY_LIMIT = 5;
 
 type RecentConversationsSectionProps = {
   agent: AgentResponse;
 };
 
-function SkeletonBar({ className }: { className?: string }) {
-  return (
-    <div
-      className={className}
-      style={{
-        background: 'linear-gradient(90deg, #f1efef 24%, #f9f8f8 43%, rgba(249,248,248,0.75) 115%)',
-      }}
-    />
-  );
-}
-
-function SkeletonMessageCard({ className }: { className?: string }) {
-  return (
-    <div className={`border-stroke-soft rounded border bg-white p-2 ${className ?? ''}`}>
-      <div className="flex flex-col gap-1">
-        <div className="flex items-center gap-1">
-          <div className="bg-bg-weak size-3 rounded-full" />
-          <SkeletonBar className="h-2 w-11 rounded-sm" />
-        </div>
-        <div className="flex flex-wrap gap-x-0.5 gap-y-[3px]">
-          <SkeletonBar className="h-1.5 w-[77px] rounded-full" />
-          <SkeletonBar className="h-1.5 min-w-0 flex-1 rounded-full" />
-          <SkeletonBar className="h-1.5 min-w-[50px] flex-1 rounded-full" />
-          <SkeletonBar className="h-1.5 w-[91px] rounded-full" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function NovuIcon() {
-  return (
-    <svg className="size-3" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8Zm3.53 11.53L8 8.06l-3.53 3.47L3.06 10.12 6.53 6.65 3.06 3.18l1.41-1.41L8 5.24l3.53-3.47 1.41 1.41L9.47 6.65l3.47 3.47-1.41 1.41Z"
-        fill="currentColor"
-        className="text-text-soft"
-      />
-    </svg>
-  );
-}
-
-function EmptyStateIllustration() {
-  return (
-    <div className="flex flex-col items-center gap-12">
-      <div className="flex flex-col items-center">
-        <div className="border-stroke-weak rounded-lg border p-1">
-          <SkeletonMessageCard className="w-[197px]" />
-        </div>
-      </div>
-
-      <div className="flex items-center gap-[50px]">
-        <div className="border-stroke-weak w-[136px] rounded-lg border border-dashed p-0.5">
-          <div className="border-stroke-soft bg-bg-white flex h-[47px] items-center justify-center gap-6 rounded-md border p-3">
-            <RiRobot2Line className="text-text-soft size-4" />
-            <NovuIcon />
-          </div>
-        </div>
-
-        <div className="border-stroke-weak rounded-lg border p-1">
-          <SkeletonMessageCard className="w-[197px]" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export function RecentConversationsSection({ agent }: RecentConversationsSectionProps) {
   const { currentEnvironment } = useEnvironment();
-  const location = useLocation();
 
-  const activityTabPath = `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
-    environmentSlug: currentEnvironment?.slug ?? '',
-    agentIdentifier: encodeURIComponent(agent.identifier),
-    agentTab: 'activity',
-  })}${location.search}`;
+  const conversationsPath = currentEnvironment?.slug
+    ? buildRoute(ROUTES.ACTIVITY_CONVERSATIONS, { environmentSlug: currentEnvironment.slug })
+    : undefined;
 
   return (
     <div className="bg-bg-weak flex flex-col rounded-[10px] p-1">
@@ -91,23 +31,190 @@ export function RecentConversationsSection({ agent }: RecentConversationsSection
         <span className="text-text-soft font-code text-[11px] font-medium uppercase leading-4 tracking-wider">
           Recent conversations
         </span>
-        <Link
-          to={activityTabPath}
-          className="text-text-sub hover:text-text-strong flex items-center gap-0.5 rounded-lg p-1.5 text-label-xs font-medium transition-colors"
-        >
-          View all activity
-          <RiArrowRightLine className="size-4" />
-        </Link>
+        {IS_ENTERPRISE && conversationsPath ? (
+          <Link
+            to={conversationsPath}
+            className="text-text-sub hover:text-text-strong text-label-xs flex items-center gap-0.5 rounded-lg p-1.5 font-medium transition-colors"
+          >
+            View all
+            <RiArrowRightLine className="size-4" />
+          </Link>
+        ) : null}
       </div>
 
-      <div className="bg-bg-white flex h-[300px] flex-col items-center justify-center overflow-hidden rounded-md shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">
-        <div className="flex flex-1 flex-col items-center justify-center gap-6 p-4">
-          <EmptyStateIllustration />
-          <p className="text-text-soft text-label-xs max-w-[400px] text-center font-medium leading-4">
-            No conversations, agent conversations will appear here once the agent starts responding to messages.
-          </p>
-        </div>
+      <div className="bg-bg-white flex h-[300px] flex-col overflow-hidden rounded-md shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">
+        {IS_ENTERPRISE ? (
+          <RecentConversationsContent agent={agent} />
+        ) : (
+          <ConversationsUpgradeCta source="agent-overview" variant="compact" />
+        )}
       </div>
     </div>
   );
+}
+
+function RecentConversationsContent({ agent }: { agent: AgentResponse }) {
+  const { currentEnvironment } = useEnvironment();
+
+  const { conversations, isLoading, isError } = useFetchConversations({
+    limit: RECENT_CONVERSATIONS_DISPLAY_LIMIT,
+    filters: { agentId: agent.identifier },
+  });
+
+  if (isLoading) {
+    return <RecentConversationsSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-1 items-center justify-center px-4 text-center">
+        <p className="text-text-soft text-label-xs max-w-[320px] font-medium leading-4">
+          We couldn't load recent conversations. Please try again in a moment.
+        </p>
+      </div>
+    );
+  }
+
+  if (conversations.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center px-4 text-center">
+        <p className="text-text-soft text-label-xs max-w-[320px] font-medium leading-4">
+          No conversations yet. Once this agent starts replying to messages, they'll show up here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex flex-1 flex-col divide-y divide-stroke-soft overflow-auto">
+      {conversations.map((conversation) => (
+        <li key={conversation._id}>
+          <RecentConversationItem conversation={conversation} environmentSlug={currentEnvironment?.slug} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+type RecentConversationItemProps = {
+  conversation: ConversationDto;
+  environmentSlug: string | undefined;
+};
+
+function RecentConversationItem({ conversation, environmentSlug }: RecentConversationItemProps) {
+  const subscriber = getSubscriberLabel(conversation);
+  const subscriberParticipant = (conversation.participants ?? []).find((p) => p.type === 'subscriber');
+  const subscriberAvatar = subscriberParticipant?.subscriber?.avatar;
+  const isFailed = conversation.status === 'failed';
+
+  const detailPath = environmentSlug
+    ? `${buildRoute(ROUTES.ACTIVITY_CONVERSATIONS, { environmentSlug })}?conversationItemId=${encodeURIComponent(conversation.identifier)}`
+    : '#';
+
+  return (
+    <Link
+      to={detailPath}
+      className="group flex flex-col gap-1.5 px-3 py-2 transition-colors hover:bg-neutral-50 focus-visible:bg-neutral-50 focus-visible:outline-none"
+    >
+      <div className="flex items-center gap-8">
+        <div className="flex min-w-0 flex-1 items-center gap-1">
+          <RiCheckboxCircleFill
+            className={cn('size-4 shrink-0', isFailed ? 'text-destructive-base' : 'text-success-base')}
+          />
+          <span className="text-text-sub text-label-xs min-w-0 truncate font-medium">
+            {conversation.title || 'Untitled conversation'}
+          </span>
+        </div>
+        <span className="text-text-soft font-code shrink-0 text-[11px] leading-normal">
+          {formatTimestamp(conversation.lastActivityAt || conversation.createdAt)}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1">
+          <RiRobot2Line className="text-text-soft size-4 shrink-0" />
+          <span className="text-text-soft font-code truncate text-xs font-medium tracking-tight">
+            {getAgentName(conversation)}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {subscriber && (
+            <>
+              <div className="border-stroke-soft flex max-w-[150px] items-center gap-1 rounded border bg-[#fbfbfb] px-1 py-0.5">
+                {subscriberAvatar ? (
+                  <img src={subscriberAvatar} alt="" className="size-4 shrink-0 rounded-full object-cover" />
+                ) : (
+                  <SubscriberFallbackAvatar className="size-4" />
+                )}
+                <span className="text-text-strong font-code min-w-0 truncate text-xs font-medium">{subscriber}</span>
+              </div>
+              <span className="text-text-soft font-code text-[11px] leading-normal">•</span>
+            </>
+          )}
+          <ConversationStatusBadge status={conversation.status} />
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function RecentConversationsSkeleton() {
+  return (
+    <ul className="flex flex-1 flex-col divide-y divide-stroke-soft">
+      {Array.from({ length: 4 }, (_, index) => (
+        <li key={`skeleton-${index}`} className="flex flex-col gap-1.5 px-3 py-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1">
+              <Skeleton className="size-4 rounded-full" />
+              <Skeleton className="h-3.5 w-40" />
+            </div>
+            <Skeleton className="h-3 w-24" />
+          </div>
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-3.5 w-20" />
+            <div className="flex items-center gap-1">
+              <Skeleton className="h-4 w-24 rounded" />
+              <Skeleton className="h-4 w-12 rounded-md" />
+            </div>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function getSubscriberLabel(conversation: ConversationDto): string | undefined {
+  const participant = (conversation.participants ?? []).find((p) => p.type === 'subscriber');
+  if (!participant) return undefined;
+
+  const sub = participant.subscriber;
+  if (sub?.firstName || sub?.lastName) {
+    return [sub.firstName, sub.lastName].filter(Boolean).join(' ');
+  }
+
+  return sub?.subscriberId ?? participant.id;
+}
+
+function getAgentName(conversation: ConversationDto): string {
+  const agent = (conversation.participants ?? []).find((p) => p.type === 'agent');
+
+  return agent?.agent?.name ?? agent?.id ?? conversation._agentId ?? 'agent';
+}
+
+function formatTimestamp(dateStr: string | undefined): string {
+  if (!dateStr?.trim()) {
+    return '—';
+  }
+
+  const d = new Date(dateStr);
+
+  if (Number.isNaN(d.getTime())) {
+    return '—';
+  }
+
+  const month = d.toLocaleDateString('en-US', { month: 'short' });
+  const day = d.getDate();
+  const time = d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
+
+  return `${month} ${day} ${time}`;
 }

--- a/apps/dashboard/src/components/agents/recent-conversations-section.tsx
+++ b/apps/dashboard/src/components/agents/recent-conversations-section.tsx
@@ -107,15 +107,12 @@ function RecentConversationItem({ conversation, environmentSlug }: RecentConvers
   const subscriberAvatar = subscriberParticipant?.subscriber?.avatar;
   const isFailed = conversation.status === 'failed';
 
-  const detailPath = environmentSlug
-    ? `${buildRoute(ROUTES.ACTIVITY_CONVERSATIONS, { environmentSlug })}?conversationItemId=${encodeURIComponent(conversation.identifier)}`
-    : '#';
+  const baseClassName = 'flex flex-col gap-1.5 px-3 py-2';
+  const interactiveClassName =
+    'group transition-colors hover:bg-neutral-50 focus-visible:bg-neutral-50 focus-visible:outline-none';
 
-  return (
-    <Link
-      to={detailPath}
-      className="group flex flex-col gap-1.5 px-3 py-2 transition-colors hover:bg-neutral-50 focus-visible:bg-neutral-50 focus-visible:outline-none"
-    >
+  const content = (
+    <>
       <div className="flex items-center gap-8">
         <div className="flex min-w-0 flex-1 items-center gap-1">
           <RiCheckboxCircleFill
@@ -154,6 +151,18 @@ function RecentConversationItem({ conversation, environmentSlug }: RecentConvers
           <ConversationStatusBadge status={conversation.status} />
         </div>
       </div>
+    </>
+  );
+
+  if (!environmentSlug) {
+    return <div className={baseClassName}>{content}</div>;
+  }
+
+  const detailPath = `${buildRoute(ROUTES.ACTIVITY_CONVERSATIONS, { environmentSlug })}?conversationItemId=${encodeURIComponent(conversation.identifier)}`;
+
+  return (
+    <Link to={detailPath} className={cn(baseClassName, interactiveClassName)}>
+      {content}
     </Link>
   );
 }
@@ -161,7 +170,7 @@ function RecentConversationItem({ conversation, environmentSlug }: RecentConvers
 function RecentConversationsSkeleton() {
   return (
     <ul className="flex flex-1 flex-col divide-y divide-stroke-soft">
-      {Array.from({ length: 4 }, (_, index) => (
+      {Array.from({ length: RECENT_CONVERSATIONS_DISPLAY_LIMIT }, (_, index) => (
         <li key={`skeleton-${index}`} className="flex flex-col gap-1.5 px-3 py-2">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-1">

--- a/apps/dashboard/src/components/conversations/conversations-content.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-content.tsx
@@ -5,8 +5,10 @@ import { useCallback, useMemo, useState } from 'react';
 import { conversationQueryKeys } from '@/components/conversations/conversation-query-keys';
 import { ConversationFilters } from '@/components/conversations/conversations-filters';
 import { ConversationsTable } from '@/components/conversations/conversations-table';
+import { ConversationsUpgradeCta } from '@/components/conversations/conversations-upgrade-cta';
 import { ResizablePanel, ResizablePanelGroup } from '@/components/primitives/resizable';
 import { UpdatedAgo } from '@/components/updated-ago';
+import { IS_ENTERPRISE } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useConversationUrlState } from '@/hooks/use-conversation-url-state';
 import { cn } from '@/utils/ui';
@@ -20,6 +22,25 @@ type ConversationsContentProps = {
 };
 
 export function ConversationsContent({
+  className,
+  contentHeight = 'h-[calc(100vh-140px)]',
+}: ConversationsContentProps) {
+  if (!IS_ENTERPRISE) {
+    return (
+      <div className={cn('p-2.5', className)}>
+        <div className={cn('flex', contentHeight)}>
+          <div className="border-stroke-soft flex flex-1 items-center justify-center rounded-lg border bg-white">
+            <ConversationsUpgradeCta source="activity-feed-conversations" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return <EnterpriseConversationsContent className={className} contentHeight={contentHeight} />;
+}
+
+function EnterpriseConversationsContent({
   className,
   contentHeight = 'h-[calc(100vh-140px)]',
 }: ConversationsContentProps) {

--- a/apps/dashboard/src/components/conversations/conversations-upgrade-cta.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-upgrade-cta.tsx
@@ -1,0 +1,105 @@
+import { RiBookMarkedLine, RiChat3Line, RiSparkling2Line } from 'react-icons/ri';
+import { Link, useNavigate } from 'react-router-dom';
+import { LinkButton } from '@/components/primitives/button-link';
+import { IS_SELF_HOSTED, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '@/config';
+import { useTelemetry } from '@/hooks/use-telemetry';
+import { ROUTES } from '@/utils/routes';
+import { TelemetryEvent } from '@/utils/telemetry';
+import { openInNewTab } from '@/utils/url';
+import { cn } from '@/utils/ui';
+import { Button } from '../primitives/button';
+
+type ConversationsUpgradeCtaProps = {
+  source: string;
+  variant?: 'default' | 'compact';
+  className?: string;
+};
+
+const COPY = {
+  default: {
+    title: 'Bring your agents to life with Conversations',
+    description:
+      'Unlock real-time chat across Slack, WhatsApp, and more. See every message your agent sends and receives, right here.',
+  },
+  compact: {
+    title: 'Conversations is part of Novu Enterprise',
+    description:
+      'Upgrade to see every message your agent sends and receives across Slack, WhatsApp, and more — live, in one place.',
+  },
+} as const;
+
+export function ConversationsUpgradeCta({ source, variant = 'default', className }: ConversationsUpgradeCtaProps) {
+  const track = useTelemetry();
+  const navigate = useNavigate();
+  const copy = COPY[variant];
+
+  const handleUpgradeClick = () => {
+    track(TelemetryEvent.UPGRADE_TO_TEAM_TIER_CLICK, { source });
+
+    if (IS_SELF_HOSTED) {
+      openInNewTab(`${SELF_HOSTED_UPGRADE_REDIRECT_URL}?utm_campaign=conversations`);
+    } else {
+      navigate(ROUTES.SETTINGS_BILLING);
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        'flex h-full w-full flex-col items-center justify-center gap-6 px-4 text-center',
+        variant === 'compact' && 'gap-4',
+        className
+      )}
+    >
+      <ConversationsUpgradeIllustration variant={variant} />
+
+      <div className="flex flex-col items-center gap-2">
+        <span
+          className={cn(
+            'text-text-sub block font-medium',
+            variant === 'compact' ? 'text-label-sm' : 'text-label-md'
+          )}
+        >
+          {copy.title}
+        </span>
+        <p
+          className={cn(
+            'text-text-soft max-w-[48ch]',
+            variant === 'compact' ? 'text-label-xs leading-4' : 'text-paragraph-sm'
+          )}
+        >
+          {copy.description}
+        </p>
+      </div>
+
+      <div className="flex flex-col items-center gap-1">
+        <Button
+          variant="primary"
+          mode="gradient"
+          size="xs"
+          className={variant === 'compact' ? 'mb-1.5' : 'mb-3.5'}
+          onClick={handleUpgradeClick}
+          leadingIcon={RiSparkling2Line}
+        >
+          {IS_SELF_HOSTED ? 'Contact Sales' : 'Upgrade now'}
+        </Button>
+        <Link to="https://docs.novu.co/agents/overview" target="_blank" rel="noreferrer noopener">
+          <LinkButton size="sm" leadingIcon={RiBookMarkedLine}>
+            How does this help?
+          </LinkButton>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function ConversationsUpgradeIllustration({ variant }: { variant: 'default' | 'compact' }) {
+  const sizeClass = variant === 'compact' ? 'size-10' : 'size-12';
+  const iconClass = variant === 'compact' ? 'size-5' : 'size-6';
+
+  return (
+    <div className={cn('flex items-center justify-center rounded-xl border border-neutral-200 bg-white', sizeClass)}>
+      <RiChat3Line className={cn('text-neutral-400', iconClass)} />
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/conversations/conversations-upgrade-cta.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-upgrade-cta.tsx
@@ -1,5 +1,5 @@
 import { RiBookMarkedLine, RiChat3Line, RiSparkling2Line } from 'react-icons/ri';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { LinkButton } from '@/components/primitives/button-link';
 import { IS_SELF_HOSTED, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '@/config';
 import { useTelemetry } from '@/hooks/use-telemetry';
@@ -83,11 +83,11 @@ export function ConversationsUpgradeCta({ source, variant = 'default', className
         >
           {IS_SELF_HOSTED ? 'Contact Sales' : 'Upgrade now'}
         </Button>
-        <Link to="https://docs.novu.co/agents/overview" target="_blank" rel="noreferrer noopener">
-          <LinkButton size="sm" leadingIcon={RiBookMarkedLine}>
+        <LinkButton asChild size="sm" leadingIcon={RiBookMarkedLine}>
+          <a href="https://docs.novu.co/agents/overview" target="_blank" rel="noreferrer noopener">
             How does this help?
-          </LinkButton>
-        </Link>
+          </a>
+        </LinkButton>
       </div>
     </div>
   );

--- a/libs/dal/src/repositories/conversation/conversation.repository.ts
+++ b/libs/dal/src/repositories/conversation/conversation.repository.ts
@@ -176,6 +176,7 @@ export class ConversationRepository extends BaseRepositoryV2<
     includeCursor = false,
     status,
     subscriberId,
+    agentId,
     identifier,
     provider,
     createdAfter,
@@ -190,6 +191,7 @@ export class ConversationRepository extends BaseRepositoryV2<
     includeCursor?: boolean;
     status?: ConversationStatusEnum;
     subscriberId?: string;
+    agentId?: string;
     identifier?: string;
     provider?: string[];
     createdAfter?: string;
@@ -242,6 +244,10 @@ export class ConversationRepository extends BaseRepositoryV2<
       query.participants = {
         $elemMatch: { id: subscriberId, type: ConversationParticipantTypeEnum.SUBSCRIBER },
       };
+    }
+
+    if (agentId) {
+      query._agentId = agentId;
     }
 
     const trimmedIdentifier = identifier?.trim();

--- a/libs/dal/src/repositories/conversation/conversation.schema.ts
+++ b/libs/dal/src/repositories/conversation/conversation.schema.ts
@@ -101,6 +101,9 @@ const conversationSchema = new Schema<ConversationDBModel>(
 conversationSchema.index({ _environmentId: 1, identifier: 1 }, { unique: true });
 conversationSchema.index({ _environmentId: 1, 'channels.platformThreadId': 1 });
 conversationSchema.index({ _environmentId: 1, 'participants.id': 1, status: 1 });
+conversationSchema.index({ _environmentId: 1, _agentId: 1, _id: 1 });
+conversationSchema.index({ _environmentId: 1, _agentId: 1, createdAt: 1 });
+conversationSchema.index({ _environmentId: 1, _agentId: 1, lastActivityAt: 1 });
 
 export const Conversation =
   (mongoose.models.Conversation as mongoose.Model<ConversationDBModel>) ||


### PR DESCRIPTION
Expose agentId filtering end-to-end and introduce a compact recent conversations UI with upgrade CTA.

- API: add agentId to ConversationFilters and include it in getConversationsList query params.
- DAL: apply agentId (_agentId) filter in ConversationRepository queries.
- UI: refactor RecentConversationsSection to fetch recent conversations for an agent, render skeleton/error/empty states, conversation items, and format timestamps; gate detailed list behind IS_ENTERPRISE and show ConversationsUpgradeCta for non-enterprise users.
- Conversations page: gate main conversations content behind IS_ENTERPRISE and split into EnterpriseConversationsContent.
- Add ConversationsUpgradeCta component (compact/default variants) to prompt upgrade/contact-sales and link docs.
- Update submodule reference (.source).

These changes enable agent-scoped conversation listing and a clear upgrade path for non-enterprise installs.

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Agent-scoped conversation listing was implemented end-to-end: API and DAL accept an optional agentId filter, the dashboard UI fetches and displays recent conversations scoped to an agent, and a compact Recent Conversations panel plus an upgrade CTA were added to handle non-enterprise/self-hosted installs. The change enables agent-specific conversation views and provides a clear upgrade/contact-sales path where full conversation listing is enterprise-only.

## Affected areas

- **api**: ConversationFilters now includes an optional agentId and getConversationsList forwards agentId as a query parameter when provided.
- **dal**: listConversations accepts an optional agentId and applies an _agentId equality filter; conversation schema adds compound indexes on {_environmentId, _agentId, _id}, {_environmentId, _agentId, createdAt}, and {_environmentId, _agentId, lastActivityAt}.
- **dashboard (react)**: RecentConversationsSection now accepts an agent prop, fetches recent conversations filtered by agentId, renders loading/error/empty states and conversation rows with formatted timestamps; ConversationsContent is gated by IS_ENTERPRISE and delegates enterprise UI to EnterpriseConversationsContent; ConversationsUpgradeCta component (compact/default) was added to prompt upgrades and link docs.
- **submodule**: Updated .source submodule pointer to a new commit.

## Key technical decisions

- Enterprise gating: full conversation listing and navigation are only available when IS_ENTERPRISE is true; non-enterprise installs see an upgrade CTA that routes differently for self-hosted vs SaaS.
- Schema/indexing: added agent-scoped compound indexes to support efficient queries by (_environmentId, _agentId) for createdAt, lastActivityAt, and _id.
- API contract: ConversationFilters gained an additive optional agentId (non-breaking).

## Testing

No automated tests were added; manual verification is recommended for agent-scoped listing correctness, UI loading/error/empty states, enterprise gating behavior, CTA navigation for self-hosted vs SaaS, and telemetry firing on CTA clicks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
