### PR TITLE
feat(dashboard): rename Dev override to Local tunnel connection

### DIFF
--- a/apps/dashboard/src/components/agents/agent-details-header.tsx
+++ b/apps/dashboard/src/components/agents/agent-details-header.tsx
@@ -46,7 +46,7 @@ export function AgentDetailsHeader({ agent, isLoading, onRequestDelete }: AgentD
             <h1 className="text-text-strong text-[18px] font-medium leading-6 tracking-tight">{agent.name}</h1>
             {agent.devBridgeActive ? (
               <Badge variant="lighter" color="orange" size="sm">
-                DEV
+                LOCAL
               </Badge>
             ) : null}
           </div>

--- a/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
+++ b/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
@@ -8,6 +8,7 @@ import type { AgentResponse, UpdateAgentBody } from '@/api/agents';
 import { getAgentDetailQueryKey, updateAgent } from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
 import { AnimatedBadgeDot, Badge } from '@/components/primitives/badge';
+import { HelpTooltipIndicator } from '@/components/primitives/help-tooltip-indicator';
 import { Input } from '@/components/primitives/input';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { Switch } from '@/components/primitives/switch';
@@ -36,10 +37,18 @@ function formatLongDate(dateStr: string): string {
   return formatted;
 }
 
-function SidebarRow({ label, children, className }: { label: string; children: React.ReactNode; className?: string }) {
+function SidebarRow({
+  label,
+  children,
+  className,
+}: {
+  label: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}) {
   return (
     <div className={cn('flex h-8 items-center justify-between px-1.5', className)}>
-      <span className="text-text-soft text-label-xs font-medium">{label}</span>
+      <span className="text-text-soft text-label-xs flex items-center gap-1 font-medium">{label}</span>
       <div className="flex items-center gap-1.5">{children}</div>
     </div>
   );
@@ -72,17 +81,17 @@ type BridgeUrlSectionProps = {
 };
 
 function BridgeUrlSection({ agent, canWrite, isUpdatePending, onUpdate }: BridgeUrlSectionProps) {
-  const isDevOverrideActive = Boolean(agent.devBridgeActive && agent.devBridgeUrl);
-  const activeBridgeUrl = isDevOverrideActive ? agent.devBridgeUrl : agent.bridgeUrl;
+  const isLocalTunnelActive = Boolean(agent.devBridgeActive && agent.devBridgeUrl);
+  const activeBridgeUrl = isLocalTunnelActive ? agent.devBridgeUrl : agent.bridgeUrl;
 
   return (
     <>
       <SidebarRow label="Bridge URL">
         {activeBridgeUrl ? (
           <div className="flex items-center gap-1">
-            {isDevOverrideActive ? (
+            {isLocalTunnelActive ? (
               <Badge variant="lighter" color="orange" size="sm">
-                DEV
+                LOCAL
               </Badge>
             ) : null}
             <TruncatedUrl url={activeBridgeUrl} />
@@ -92,7 +101,17 @@ function BridgeUrlSection({ agent, canWrite, isUpdatePending, onUpdate }: Bridge
         )}
       </SidebarRow>
       {agent.devBridgeUrl ? (
-        <SidebarRow label="Dev override">
+        <SidebarRow
+          label={
+            <>
+              Local tunnel connection
+              <HelpTooltipIndicator
+                size="3"
+                text="When enabled, the agent forwards traffic to your local tunnel URL instead of the deployed agent endpoint. Use this to test changes locally without redeploying."
+              />
+            </>
+          }
+        >
           <Switch
             checked={agent.devBridgeActive ?? false}
             disabled={!canWrite || isUpdatePending}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

In the agent overview panel's sidebar widget:

- Renamed the `Dev override` toggle label to **Local tunnel connection** and added a help-tooltip indicator next to it explaining that when enabled the agent forwards traffic to the user's local tunnel URL instead of the deployed agent endpoint.
- Replaced the `DEV` badge with `LOCAL` in both the agent details header and the sidebar widget's Bridge URL row.

## Why

The previous `Dev override` label/badge did not convey what the toggle actually does. The new copy matches the real behavior (local tunneling) and the tooltip clarifies the use case.

## Files touched

- `apps/dashboard/src/components/agents/agent-sidebar-widget.tsx`
- `apps/dashboard/src/components/agents/agent-details-header.tsx`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54d9722c-23fc-4844-8465-d94b4c85f03d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54d9722c-23fc-4844-8465-d94b4c85f03d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR renamed the agent override toggle from "Dev override" to "Local tunnel connection" and added a help tooltip explaining that when enabled, the agent forwards traffic to the user's local tunnel URL. The "DEV" badge was replaced with "LOCAL" across the agent details header and sidebar widget to better reflect the feature's actual behavior.

## Affected areas

**dashboard**: Updated agent override controls in the agent details header and sidebar widget, including a renamed toggle label with explanatory tooltip and revised badge semantics from "DEV" to "LOCAL" for local tunnel connections.

## Testing

No tests were added. This is a labeling and UX enhancement that should be verified manually through the dashboard UI to confirm the tooltip displays correctly and the badge renders in the appropriate locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->