### PR TITLE
feat(dashboard): hybrid agents empty state with FF-gated CTA

### DIFF
--- a/apps/dashboard/src/components/agents/agents-empty-teaser.tsx
+++ b/apps/dashboard/src/components/agents/agents-empty-teaser.tsx
@@ -1,0 +1,116 @@
+import type { ReactNode } from 'react';
+import { RiChat3Line, RiCheckLine, RiGithubFill, RiUser3Line } from 'react-icons/ri';
+import { SiLinear, SiWhatsapp } from 'react-icons/si';
+import { cn } from '@/utils/ui';
+
+const slackIcon = '/images/providers/light/square/slack.svg';
+const msTeamsIcon = '/images/providers/light/square/msteams.svg';
+
+type AgentsPillProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+function AgentsPill({ children, className }: AgentsPillProps) {
+  return (
+    <span
+      className={cn(
+        'border-stroke-soft bg-bg-weak text-text-strong inline-flex items-center gap-1 rounded border px-1 py-0.5 text-label-sm font-medium',
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+type AgentsEmptyTeaserProps = {
+  cta: ReactNode;
+};
+
+export function AgentsEmptyTeaser({ cta }: AgentsEmptyTeaserProps) {
+  return (
+    <div className="flex min-h-[min(720px,calc(100vh-8rem))] flex-col items-center justify-center px-4 py-10 md:px-8">
+      <div className="flex w-full max-w-[1133px] flex-col items-stretch gap-12">
+        <img
+          src="/images/agents-teaser.svg"
+          alt=""
+          className="block h-auto w-full max-w-[456px]"
+          width={456}
+          height={256}
+        />
+
+        <div className="flex w-full max-w-[700px] flex-col items-start gap-3 self-start">
+          <div className="flex flex-col gap-1 text-left">
+            <p className="text-text-strong text-[16px] font-medium leading-6 tracking-[-0.176px]">
+              Unified conversational API for AI agents
+            </p>
+            <p className="text-text-soft text-[14px] font-medium leading-5 tracking-[-0.084px]">
+              You own the agent Brain, and Novu gives it voice. Distribute your agent across multiple channels with a
+              unified API.
+            </p>
+          </div>
+
+          <ul className="flex flex-col gap-1.5 py-3">
+            <li className="text-text-sub flex flex-wrap items-center gap-1 text-[14px] font-medium leading-5 tracking-[-0.084px]">
+              <RiCheckLine className="text-success size-3 shrink-0" aria-hidden />
+              <span>Connect your agent to</span>
+              <AgentsPill className="-rotate-1">
+                <img src={slackIcon} alt="" className="size-3.5" />
+                <span>Slack</span>
+              </AgentsPill>
+              <AgentsPill className="rotate-1">
+                <RiGithubFill className="size-3.5 shrink-0" aria-hidden />
+                <span>GitHub</span>
+              </AgentsPill>
+              <AgentsPill className="-rotate-1">
+                <img src={msTeamsIcon} alt="" className="size-3.5" />
+                <span>MS Teams</span>
+              </AgentsPill>
+              <AgentsPill className="rotate-1">
+                <SiWhatsapp className="size-3.5 shrink-0 text-[#25D366]" aria-hidden />
+                <span>WhatsApp</span>
+              </AgentsPill>
+              <AgentsPill className="-rotate-1">
+                <SiLinear className="text-text-strong size-3.5 shrink-0" aria-hidden />
+                <span>Linear</span>
+              </AgentsPill>
+              <span>and +15 more.</span>
+            </li>
+
+            <li className="text-text-sub flex flex-wrap items-center gap-1 text-[14px] font-medium leading-5 tracking-[-0.084px]">
+              <RiCheckLine className="text-success size-3 shrink-0" aria-hidden />
+              <span>Access conversation history</span>
+              <AgentsPill>
+                <RiChat3Line className="text-text-sub size-3" aria-hidden />
+                <span className="font-mono text-[14px] tracking-[-0.28px]">5</span>
+              </AgentsPill>
+              <span>
+                and state via unified <code className="text-text-strong font-mono text-[14px]">agent()</code> handler.
+              </span>
+            </li>
+
+            <li className="text-text-sub flex flex-wrap items-center gap-1 text-[14px] font-medium leading-5 tracking-[-0.084px]">
+              <RiCheckLine className="text-success size-3 shrink-0" aria-hidden />
+              <span>Provider identities resolved to</span>
+              <AgentsPill>
+                <span className="bg-neutral-alpha-200 flex size-4 items-center justify-center rounded-full">
+                  <RiUser3Line className="text-text-sub size-3" aria-hidden />
+                </span>
+                <span className="text-text-strong">Subscriber</span>
+              </AgentsPill>
+              <span>entity.</span>
+            </li>
+
+            <li className="text-text-sub flex flex-wrap items-center gap-1 text-[14px] font-medium leading-5 tracking-[-0.084px]">
+              <RiCheckLine className="text-success size-3 shrink-0" aria-hidden />
+              <span>Rich provider interactions, like action buttons, attachments, reactions, and more.</span>
+            </li>
+          </ul>
+
+          <div className="flex w-full justify-start">{cta}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -1,7 +1,7 @@
 import { DirectionEnum, PermissionsEnum } from '@novu/shared';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
-import { RiRobot2Line } from 'react-icons/ri';
+import { RiArrowRightSLine, RiRobot2Line } from 'react-icons/ri';
 import {
   AGENTS_LIST_QUERY_KEY,
   type AgentResponse,
@@ -12,6 +12,7 @@ import {
   listAgents,
 } from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
+import { AgentsEmptyTeaser } from '@/components/agents/agents-empty-teaser';
 import { AgentsTable } from '@/components/agents/agents-table';
 import { CreateAgentDialog } from '@/components/agents/create-agent-dialog';
 import { DeleteAgentDialog } from '@/components/agents/delete-agent-dialog';
@@ -183,6 +184,33 @@ export function AgentsList() {
   const showEmptyBlank = !listQuery.isError && !isLoading && !hasFilters && agents.length === 0;
   const showNoResults = !listQuery.isError && !isLoading && hasFilters && agents.length === 0;
 
+  if (showEmptyBlank) {
+    return (
+      <>
+        <AgentsEmptyTeaser
+          cta={
+            <PermissionButton
+              permission={PermissionsEnum.AGENT_WRITE}
+              size="xs"
+              variant="secondary"
+              mode="gradient"
+              trailingIcon={RiArrowRightSLine}
+              onClick={() => setCreateOpen(true)}
+            >
+              Create agent
+            </PermissionButton>
+          }
+        />
+        <CreateAgentDialog
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+          onSubmit={handleCreateSubmit}
+          isSubmitting={createMutation.isPending}
+        />
+      </>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-2 py-2">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -211,26 +239,6 @@ export function AgentsList() {
         <div className="text-error-base text-label-sm">Could not load agents. Try again later.</div>
       ) : null}
 
-      {showEmptyBlank ? (
-        <div className="border-stroke-soft flex flex-col items-center justify-center gap-4 rounded-lg border border-dashed px-6 py-16">
-          <p className="text-text-strong text-label-sm font-medium">No agents yet</p>
-          <p className="text-text-soft max-w-md text-center text-label-sm">
-            Create an agent to connect your brain to channels with a unified API.
-          </p>
-          <PermissionButton
-            permission={PermissionsEnum.AGENT_WRITE}
-            size="xs"
-            variant="primary"
-            mode="gradient"
-            className="gap-1"
-            leadingIcon={RiRobot2Line}
-            onClick={() => setCreateOpen(true)}
-          >
-            Add Agent
-          </PermissionButton>
-        </div>
-      ) : null}
-
       {showNoResults ? (
         <ListNoResults
           title="No agents found"
@@ -239,7 +247,7 @@ export function AgentsList() {
         />
       ) : null}
 
-      {!listQuery.isError && !showEmptyBlank && !showNoResults ? (
+      {!listQuery.isError && !showNoResults ? (
         <AgentsTable
           agents={agents}
           isLoading={isLoading}

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -1,19 +1,9 @@
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { CaretSortIcon } from '@radix-ui/react-icons';
 import { useMutation } from '@tanstack/react-query';
-import type { FormEvent, ReactElement, ReactNode } from 'react';
+import type { FormEvent, ReactElement } from 'react';
 import { useCallback, useId, useMemo, useState } from 'react';
-import {
-  RiArrowRightSLine,
-  RiChat3Line,
-  RiCheckLine,
-  RiCloseLine,
-  RiGithubFill,
-  RiMailLine,
-  RiMessage3Line,
-  RiMoreLine,
-  RiUser3Line,
-} from 'react-icons/ri';
+import { RiArrowRightSLine, RiCheckLine, RiCloseLine, RiMailLine, RiMessage3Line, RiMoreLine } from 'react-icons/ri';
 import {
   SiGithub,
   SiGooglechat,
@@ -25,6 +15,7 @@ import {
   SiZoom,
 } from 'react-icons/si';
 import { NovuApiError, post } from '@/api/api.client';
+import { AgentsEmptyTeaser } from '@/components/agents/agents-empty-teaser';
 import { AgentsList } from '@/components/agents/agents-list';
 import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
@@ -41,7 +32,6 @@ import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { cn } from '@/utils/ui';
 
 const slackIcon = '/images/providers/light/square/slack.svg';
-const msTeamsIcon = '/images/providers/light/square/msteams.svg';
 const discordIcon = '/images/providers/light/square/discord.svg';
 
 const AGENT_RUN_OPTIONS = [
@@ -113,24 +103,6 @@ const PROVIDER_DEFINITIONS: ProviderDefinition[] = [
   },
   { id: 'other', label: 'Other', icon: <RiMoreLine className="size-4 shrink-0 text-text-sub" aria-hidden /> },
 ];
-
-type AgentsPillProps = {
-  children: ReactNode;
-  className?: string;
-};
-
-function AgentsPill({ children, className }: AgentsPillProps) {
-  return (
-    <span
-      className={cn(
-        'border-stroke-soft bg-bg-weak text-text-strong inline-flex items-center gap-1 rounded border px-1 py-0.5 text-label-sm font-medium',
-        className
-      )}
-    >
-      {children}
-    </span>
-  );
-}
 
 type AgentsEarlyAccessDialogProps = {
   open: boolean;
@@ -440,100 +412,20 @@ export function AgentsPage() {
         {isConversationalAgentsEnabled ? (
           <AgentsList />
         ) : (
-          <div className="flex min-h-[min(720px,calc(100vh-8rem))] flex-col items-center justify-center px-4 py-10 md:px-8">
-            <div className="flex w-full max-w-[1133px] flex-col items-stretch gap-12">
-              <img
-                src="/images/agents-teaser.svg"
-                alt=""
-                className="block h-auto w-full max-w-[456px]"
-                width={456}
-                height={256}
-              />
-
-              <div className="flex w-full max-w-[700px] flex-col items-start gap-3 self-start">
-                <div className="flex flex-col gap-1 text-left">
-                  <p className="text-text-strong text-[16px] font-medium leading-6 tracking-[-0.176px]">
-                    Unified conversational API for AI agents
-                  </p>
-                  <p className="text-text-soft text-[14px] font-medium leading-5 tracking-[-0.084px]">
-                    You own the agent Brain, and Novu gives it voice. Distribute your agent across multiple channels
-                    with a unified API.
-                  </p>
-                </div>
-
-                <ul className="flex flex-col gap-1.5 py-3">
-                  <li className="text-text-sub flex flex-wrap items-center gap-1 text-[14px] font-medium leading-5 tracking-[-0.084px]">
-                    <RiCheckLine className="text-success size-3 shrink-0" aria-hidden />
-                    <span>Connect your agent to</span>
-                    <AgentsPill className="-rotate-1">
-                      <img src={slackIcon} alt="" className="size-3.5" />
-                      <span>Slack</span>
-                    </AgentsPill>
-                    <AgentsPill className="rotate-1">
-                      <RiGithubFill className="size-3.5 shrink-0" aria-hidden />
-                      <span>GitHub</span>
-                    </AgentsPill>
-                    <AgentsPill className="-rotate-1">
-                      <img src={msTeamsIcon} alt="" className="size-3.5" />
-                      <span>MS Teams</span>
-                    </AgentsPill>
-                    <AgentsPill className="rotate-1">
-                      <SiWhatsapp className="size-3.5 shrink-0 text-[#25D366]" aria-hidden />
-                      <span>WhatsApp</span>
-                    </AgentsPill>
-                    <AgentsPill className="-rotate-1">
-                      <SiLinear className="text-text-strong size-3.5 shrink-0" aria-hidden />
-                      <span>Linear</span>
-                    </AgentsPill>
-                    <span>and +15 more.</span>
-                  </li>
-
-                  <li className="text-text-sub flex flex-wrap items-center gap-1 text-[14px] font-medium leading-5 tracking-[-0.084px]">
-                    <RiCheckLine className="text-success size-3 shrink-0" aria-hidden />
-                    <span>Access conversation history</span>
-                    <AgentsPill>
-                      <RiChat3Line className="text-text-sub size-3" aria-hidden />
-                      <span className="font-mono text-[14px] tracking-[-0.28px]">5</span>
-                    </AgentsPill>
-                    <span>
-                      and state via unified <code className="text-text-strong font-mono text-[14px]">agent()</code>{' '}
-                      handler.
-                    </span>
-                  </li>
-
-                  <li className="text-text-sub flex flex-wrap items-center gap-1 text-[14px] font-medium leading-5 tracking-[-0.084px]">
-                    <RiCheckLine className="text-success size-3 shrink-0" aria-hidden />
-                    <span>Provider identities resolved to</span>
-                    <AgentsPill>
-                      <span className="bg-neutral-alpha-200 flex size-4 items-center justify-center rounded-full">
-                        <RiUser3Line className="text-text-sub size-3" aria-hidden />
-                      </span>
-                      <span className="text-text-strong">Subscriber</span>
-                    </AgentsPill>
-                    <span>entity.</span>
-                  </li>
-
-                  <li className="text-text-sub flex flex-wrap items-center gap-1 text-[14px] font-medium leading-5 tracking-[-0.084px]">
-                    <RiCheckLine className="text-success size-3 shrink-0" aria-hidden />
-                    <span>Rich provider interactions, like action buttons, attachments, reactions, and more.</span>
-                  </li>
-                </ul>
-
-                <div className="flex w-full justify-start">
-                  <Button
-                    variant="secondary"
-                    mode="gradient"
-                    size="xs"
-                    trailingIcon={RiArrowRightSLine}
-                    type="button"
-                    onClick={() => setEarlyAccessOpen(true)}
-                  >
-                    Request early access
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
+          <AgentsEmptyTeaser
+            cta={
+              <Button
+                variant="secondary"
+                mode="gradient"
+                size="xs"
+                trailingIcon={RiArrowRightSLine}
+                type="button"
+                onClick={() => setEarlyAccessOpen(true)}
+              >
+                Request early access
+              </Button>
+            }
+          />
         )}
       </DashboardLayout>
     </>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Reuses the Agents teaser empty state in a hybrid mode so it renders whether the `IS_CONVERSATIONAL_AGENTS_ENABLED` feature flag is on or off. The CTA swaps based on the flag:

- FF **off** → `Request early access` (opens the existing early access dialog).
- FF **on** and no agents exist → `Create agent` (opens the existing create-agent dialog).

Once the user has at least one agent, the list UI renders as before (search toolbar + `Add Agent` + table).

## Why

Previously the rich teaser/illustration only showed when the flag was off, and the flag-on empty state was a plain dashed-border "No agents yet" box. This gives both audiences the same product pitch and a clear next step.

## Changes

- New `apps/dashboard/src/components/agents/agents-empty-teaser.tsx` holding the illustration, copy, pill list, and a `cta` slot.
- `apps/dashboard/src/pages/agents.tsx` uses the teaser for the FF-off branch with the `Request early access` CTA; inline teaser JSX and now-unused imports are removed.
- `apps/dashboard/src/components/agents/agents-list.tsx` short-circuits to the teaser with a `Create agent` CTA (guarded by `PermissionsEnum.AGENT_WRITE` via `PermissionButton`) whenever the list is empty and no search filter is active. Search + table continue to render for the non-empty and filtered cases.

## Testing

- ✅ `pnpm exec tsc -b --noEmit` (from `apps/dashboard`)
- ✅ `pnpm exec biome check src/components/agents/agents-empty-teaser.tsx src/components/agents/agents-list.tsx src/pages/agents.tsx`
- Manual UI verification skipped per user request.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32ecf9aa-930c-449b-b150-5ae32ad056b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32ecf9aa-930c-449b-b150-5ae32ad056b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR introduces a reusable `AgentsEmptyTeaser` component that adapts its CTA based on a feature flag: when `IS_CONVERSATIONAL_AGENTS_ENABLED` is off, it shows "Request early access"; when enabled but no agents exist, it shows "Create agent". This centralizes the empty state UI, eliminates duplicate teaser markup across files, and provides a consistent user experience whether users are accessing early access or actively creating agents.

## Affected areas

**dashboard**: Created a new `AgentsEmptyTeaser` component (`agents-empty-teaser.tsx`) and integrated it into the agents feature. The agents page now uses it for the FF-disabled state, and the agents list now uses it when empty and the user has write permissions. Removed inline teaser markup, unused imports, and the redundant local `AgentsPill` component from the agents page.

## Key technical decisions

- The empty state CTA is guarded by `PermissionsEnum.AGENT_WRITE` via `PermissionButton` to ensure only authorized users can create agents.
- The component uses a `cta` prop to accept flexible CTA content, enabling reuse across different contexts without duplicating teaser content.

## Testing

- TypeScript compilation: ✅
- Biome code formatting: ✅
- Manual UI verification: Skipped per user request
- No unit tests added (this is a UI component refactoring and consolidation, not new logic).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->