### PR TITLE
feat(novu): print next-steps guide after init scaffolding

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "2.10.1-alpha.1",
+  "version": "2.10.1-alpha.2",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/cjs/index.d.cts",

--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.8.1-rc.2",
+  "version": "2.8.1-rc.3",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/novu/src/commands/init/create-app.ts
+++ b/packages/novu/src/commands/init/create-app.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { cyan, green } from 'picocolors';
+import { bold, cyan, dim, green } from 'picocolors';
 import type { RepoInfo } from './helpers/examples';
 import type { PackageManager } from './helpers/get-pkg-manager';
 import { tryGitInit } from './helpers/git';
@@ -9,7 +9,7 @@ import { getOnline } from './helpers/is-online';
 import { isWriteable } from './helpers/is-writeable';
 
 import type { TemplateMode, TemplateType } from './templates';
-import { installTemplate } from './templates';
+import { installTemplate, TemplateTypeEnum } from './templates';
 
 export class DownloadError extends Error {}
 
@@ -102,4 +102,49 @@ export async function createApp({
   }
 
   console.log(`${green('Success!')} Created ${appName} at ${appPath}`);
+  printNextSteps({ template, cdPath, skipCd: appPath === originalDirectory });
+}
+
+function printNextSteps({
+  template,
+  cdPath,
+  skipCd,
+}: {
+  template: TemplateType;
+  cdPath: string;
+  skipCd: boolean;
+}): void {
+  const isAgent = template === TemplateTypeEnum.APP_AGENT;
+  const devCommand = isAgent ? 'npx novu@latest dev -p 4000 --no-studio' : 'npx novu@latest dev';
+  const devCommandHint = isAgent
+    ? 'Opens a tunnel and registers the bridge URL with Novu'
+    : 'Starts Novu Studio and a dev tunnel';
+
+  console.log();
+  console.log(bold('Next steps:'));
+  console.log();
+
+  let step = 1;
+  if (!skipCd) {
+    console.log(`  ${step}. ${cyan(`cd ${cdPath}`)}`);
+    step += 1;
+  }
+  console.log(`  ${step}. ${cyan('npm run dev')}${dim('                          Start your app on :4000')}`);
+  step += 1;
+  console.log(`  ${step}. In a second terminal, run:`);
+  console.log(`     ${cyan(devCommand)}`);
+  console.log(`     ${dim(devCommandHint)}`);
+  console.log();
+
+  if (isAgent) {
+    console.log(
+      'Then send a message to your bot from the connected chat provider — your local agent will handle the reply.'
+    );
+    console.log(`Edit ${cyan('app/novu/agents/')} to customize how your agent responds.`);
+    console.log(`Docs: ${cyan('https://docs.novu.co/agents/overview')}`);
+  } else {
+    console.log(`Edit ${cyan('app/novu/workflows/')} to customize your notification workflows.`);
+    console.log(`Docs: ${cyan('https://docs.novu.co/framework/introduction')}`);
+  }
+  console.log();
 }


### PR DESCRIPTION
## Summary

Two related changes bundled for the current `novu@rc` / `@novu/framework@alpha` release train:

1. **CLI UX:** After `novu init` finishes, print a short, dashboard-style next-steps guide directly in the terminal so users don't have to dig through the generated `README.md` to know what to run.
2. **Release bumps:** `novu` → `2.8.1-rc.3`, `@novu/framework` → `2.10.1-alpha.2` (both already published to their respective dist-tags; this commits the version bumps back into the repo).

### Next-steps output (agent template)

```
Success! Created my-agent at /Users/you/my-agent

Next steps:

  1. cd my-agent
  2. npm run dev                          Start your app on :4000
  3. In a second terminal, run:
     npx novu@latest dev -p 4000 --no-studio
     Opens a tunnel and registers the bridge URL with Novu

Then send a message to your bot from the connected chat provider — your local agent will handle the reply.
Edit app/novu/agents/ to customize how your agent responds.
Docs: https://docs.novu.co/agents/overview
```

The notifications template gets the same structure with `npx novu@latest dev` (Studio on) and a link to the framework docs. The `cd` step is skipped when the user scaffolds into the current directory (`novu init .`).

This mirrors the existing dashboard onboarding guide in `apps/dashboard/src/components/agents/agent-code-setup-section.tsx` so the terminal and dashboard flows tell users the same thing.

### Why also bump versions here

`packages/novu` pins `@novu/framework` via `workspace:*`, which pnpm rewrites to the framework's exact in-repo version at publish time. Keeping the repo's `package.json` in sync with what was just published to npm ensures the next `pnpm pack` / `pnpm publish` produces the right pin, and that contributors don't accidentally re-publish stale versions.

## Test plan

- [x] `pnpm --filter novu build` succeeds
- [x] `pnpm pack` in `packages/novu` produces a tarball whose `package.json` contains `"@novu/framework": "2.10.1-alpha.1"` (will be `2.10.1-alpha.2` after this lands and CI rebuilds)
- [x] `npm i -g <tarball> && novu init -t agent my-agent --agent-identifier test-agent` prints the new next-steps block
- [x] Scaffolded `my-agent/package.json` pins `@novu/framework` to the published alpha
- [x] `npm run dev` + `npx novu@latest dev -p 4000 --no-studio` in a second terminal connects the bridge end-to-end
- [ ] Same flow with notifications template (`-t notifications`) — recommend reviewers sanity-check the wording


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR introduces a CLI user experience improvement that displays a formatted "next-steps" guide after `novu init` completes scaffolding. The guide shows users how to proceed (e.g., `cd my-agent`, `npm run dev`, and tunnel commands) with content that varies based on whether an agent or notification template was selected. Version bumps were also applied to keep published packages in sync with their dist-tags.

## Affected areas

- **novu**: Enhanced CLI scaffolding UX with a new `printNextSteps` function that displays next-step guidance after init completion, with conditional messaging for agent vs. notification templates. Bumped to version 2.8.1-rc.3.
- **framework**: Version bumped to 2.10.1-alpha.2 to maintain workspace dependency synchronization with published packages.

## Testing

Testing includes build verification, pnpm pack output validation for expected pins, manual verification of next-steps output following global install + `novu init`, and end-to-end dev + tunnel connection verification. No new unit tests were added as this is a CLI UX enhancement with manual verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->