### PR TITLE
fix(dashboard): adjust agent Slack overview copy fixes NV-7381

### DIFF
--- a/apps/dashboard/src/components/agents/agent-integration-guides/slack-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/slack-agent-integration-guide.tsx
@@ -40,8 +40,8 @@ export function SlackAgentIntegrationGuide({
       <AgentIntegrationGuideSection title="Overview">
         {isConnected ? (
           <p>
-            This agent is connected to Slack. Tag the bot in any channel it has been invited to, or DM it directly, to
-            send and receive chat messages through your workspace.
+            This agent is connected to Slack. To send and receive chat messages through your workspace, tag the bot in
+            any channel it has been invited to.
           </p>
         ) : (
           <p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Slack integration **Overview** for connected agents told users they could DM the bot. Direct messages are not supported in the default flow, which led to confusion when the integration looked active but DMs did not work.

## Changes

- Updated the connected-state copy in `slack-agent-integration-guide.tsx` to instruct users to **mention the bot in a channel** it has been invited to, and removed the DM wording.

## Testing

- Not run (copy-only change). Lint check on the edited file is clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7381](https://linear.app/novu/issue/NV-7381/adjust-agent-slack-copy-to-avoid-dm-instructions)

<div><a href="https://cursor.com/agents/bc-ee635d95-fd78-470a-b540-ecbdf0495aa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee635d95-fd78-470a-b540-ecbdf0495aa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
Updated the Slack integration "Overview" text displayed when the integration is connected. Removed instructions misleadingly suggesting users could DM the bot directly (a flow not supported in the default configuration) and rephrased the guidance to clarify that users should mention the bot in channels where it has been invited. This resolves confusion around the unsupported DM interaction pattern.

## Affected areas
**dashboard**: Updated the connected-state copy in `slack-agent-integration-guide.tsx` to provide accurate channel-mention guidance instead of direct message instructions.

## Testing
No automated tests added—this is a copy-only change. Lint checks on the modified file passed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->