### PR TITLE
refactor(api-service): redis state via ioredis instance

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -46,7 +46,7 @@
     "@aws-sdk/client-secrets-manager": "^3.971.0",
     "yargs": "^17.7.2",
     "@chat-adapter/slack": "^4.25.0",
-    "@chat-adapter/state-redis": "^4.25.0",
+    "@chat-adapter/state-ioredis": "^4.25.0",
     "@chat-adapter/teams": "^4.25.0",
     "@chat-adapter/whatsapp": "^4.25.0",
     "@godaddy/terminus": "^4.12.1",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,7 +3,7 @@ import { ForwardReference } from '@nestjs/common/interfaces/modules/forward-refe
 import { Type } from '@nestjs/common/interfaces/type.interface';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { ApiExcludeController } from '@nestjs/swagger';
-import { cacheService, TracingModule } from '@novu/application-generic';
+import { cacheInMemoryProviderService, cacheService, TracingModule } from '@novu/application-generic';
 import { Client, NovuModule } from '@novu/framework/nest';
 import { usageLimitsWorkflow, usageReportWorkflow } from '@novu/notifications';
 import { isClerkEnabled } from '@novu/shared';
@@ -184,6 +184,7 @@ const providers: Provider[] = [
     provide: APP_INTERCEPTOR,
     useClass: AnalyticsLogsInterceptor,
   },
+  cacheInMemoryProviderService,
   cacheService,
 ];
 

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { cacheInMemoryProviderService } from '@novu/application-generic';
 import {
   ChannelConnectionRepository,
   ChannelEndpointRepository,
@@ -32,6 +33,7 @@ import { USE_CASES } from './usecases';
     AgentConversationService,
     AgentInboundHandler,
     BridgeExecutorService,
+    cacheInMemoryProviderService,
     ChatSdkService,
   ],
   exports: [...USE_CASES, ChatSdkService],

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-import { cacheInMemoryProviderService } from '@novu/application-generic';
 import {
   ChannelConnectionRepository,
   ChannelEndpointRepository,
@@ -33,7 +32,6 @@ import { USE_CASES } from './usecases';
     AgentConversationService,
     AgentInboundHandler,
     BridgeExecutorService,
-    cacheInMemoryProviderService,
     ChatSdkService,
   ],
   exports: [...USE_CASES, ChatSdkService],

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -1,5 +1,5 @@
-import { BadRequestException, forwardRef, Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
-import { PinoLogger } from '@novu/application-generic';
+import { BadRequestException, forwardRef, Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { CacheInMemoryProviderService, PinoLogger } from '@novu/application-generic';
 import type { SentMessageInfo } from '@novu/framework';
 import type { AdapterPostableMessage, Chat, EmojiValue, Message, ReactionEvent, Thread } from 'chat';
 import { Request as ExpressRequest, Response as ExpressResponse } from 'express';
@@ -50,13 +50,14 @@ interface CachedChat {
 }
 
 @Injectable()
-export class ChatSdkService implements OnModuleDestroy {
+export class ChatSdkService implements OnModuleInit, OnModuleDestroy {
   private readonly instances: LRUCache<string, CachedChat>;
   private readonly pendingCreations = new Map<string, Promise<Chat>>();
 
   constructor(
     private readonly logger: PinoLogger,
     private readonly agentConfigResolver: AgentConfigResolver,
+    private readonly cacheInMemoryProviderService: CacheInMemoryProviderService,
     @Inject(forwardRef(() => AgentInboundHandler))
     private readonly inboundHandler: AgentInboundHandler
   ) {
@@ -69,6 +70,10 @@ export class ChatSdkService implements OnModuleDestroy {
         });
       },
     });
+  }
+
+  async onModuleInit() {
+    await this.cacheInMemoryProviderService.initialize();
   }
 
   async handleWebhook(agentId: string, integrationIdentifier: string, req: ExpressRequest, res: ExpressResponse) {
@@ -304,23 +309,22 @@ export class ChatSdkService implements OnModuleDestroy {
     platform: AgentPlatformEnum,
     config: ResolvedAgentConfig
   ): Promise<Chat> {
-    const [{ Chat }, { createRedisState }] = await Promise.all([
+    const [{ Chat }, { createIORedisState }] = await Promise.all([
       esmImport('chat'),
-      esmImport('@chat-adapter/state-redis'),
+      esmImport('@chat-adapter/state-ioredis'),
     ]);
 
     const adapters = await this.buildAdapters(platform, config);
-    const redisHost = process.env.REDIS_HOST || 'localhost';
-    const redisPort = process.env.REDIS_PORT || '6379';
-    const redisScheme = process.env.REDIS_TLS_ENABLED === 'true' ? 'rediss' : 'redis';
-    const redisPassword = process.env.REDIS_PASSWORD;
-    const redisAuth = redisPassword ? `:${encodeURIComponent(redisPassword)}@` : '';
+    const client = this.cacheInMemoryProviderService.getClient();
+    if (!client) {
+      throw new Error('In-memory provider client is not available for the chat SDK state adapter');
+    }
 
     return new Chat({
       userName: `novu-agent-${instanceKey}`,
       adapters,
-      state: createRedisState({
-        url: `${redisScheme}://${redisAuth}${redisHost}:${redisPort}`,
+      state: createIORedisState({
+        client,
         keyPrefix: `novu:agent:${instanceKey}`,
       }),
       logger: 'silent',
@@ -350,7 +354,9 @@ export class ChatSdkService implements OnModuleDestroy {
       }
       case AgentPlatformEnum.TEAMS: {
         if (!credentials.clientId || !credentials.secretKey || !credentials.tenantId) {
-          throw new BadRequestException('Teams agent integration requires appId, appPassword, and appTenantId credentials');
+          throw new BadRequestException(
+            'Teams agent integration requires appId, appPassword, and appTenantId credentials'
+          );
         }
 
         const { createTeamsAdapter } = await esmImport('@chat-adapter/teams');
@@ -364,7 +370,12 @@ export class ChatSdkService implements OnModuleDestroy {
         };
       }
       case AgentPlatformEnum.WHATSAPP: {
-        if (!credentials.apiToken || !credentials.secretKey || !credentials.token || !credentials.phoneNumberIdentification) {
+        if (
+          !credentials.apiToken ||
+          !credentials.secretKey ||
+          !credentials.token ||
+          !credentials.phoneNumberIdentification
+        ) {
           throw new BadRequestException(
             'WhatsApp agent integration requires accessToken, appSecret, verifyToken, and phoneNumberId credentials'
           );

--- a/apps/api/src/app/auth/ee.auth.module.config.ts
+++ b/apps/api/src/app/auth/ee.auth.module.config.ts
@@ -1,5 +1,6 @@
 import { MiddlewareConsumer, ModuleMetadata } from '@nestjs/common';
 import {
+  cacheInMemoryProviderService,
   cacheService,
   featureFlagsService,
   InMemoryLRUCacheService,
@@ -27,6 +28,7 @@ export function getEEModuleConfig(): ModuleMetadata {
       ApiKeyStrategy,
       JwtSubscriberStrategy,
       AuthService,
+      cacheInMemoryProviderService,
       cacheService,
       featureFlagsService,
       InMemoryLRUCacheService,

--- a/apps/api/src/app/rate-limiting/usecases/evaluate-token-bucket-rate-limit/evaluate-token-bucket-rate-limit.spec.ts
+++ b/apps/api/src/app/rate-limiting/usecases/evaluate-token-bucket-rate-limit/evaluate-token-bucket-rate-limit.spec.ts
@@ -1,5 +1,9 @@
 import { Test } from '@nestjs/testing';
-import { CacheService, cacheInMemoryProviderService, cacheService } from '@novu/application-generic';
+import {
+  CacheService,
+  cacheInMemoryProviderService,
+  cacheService as cacheServiceFactory,
+} from '@novu/application-generic';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { v4 as uuid } from 'uuid';
@@ -357,7 +361,7 @@ describe('EvaluateTokenBucketRateLimit', () => {
 
                 before(async () => {
                   const inMemoryProvider = await cacheInMemoryProviderService.useFactory();
-                  const cacheServiceInitialized = await cacheService.useFactory(inMemoryProvider);
+                  const cacheServiceInitialized = await cacheServiceFactory.useFactory(inMemoryProvider);
                   testContext = {
                     redis: EvaluateTokenBucketRateLimit.getCacheClient(cacheServiceInitialized),
                   };

--- a/apps/api/src/app/rate-limiting/usecases/evaluate-token-bucket-rate-limit/evaluate-token-bucket-rate-limit.spec.ts
+++ b/apps/api/src/app/rate-limiting/usecases/evaluate-token-bucket-rate-limit/evaluate-token-bucket-rate-limit.spec.ts
@@ -1,5 +1,5 @@
 import { Test } from '@nestjs/testing';
-import { CacheService, cacheService as inMemoryCacheService } from '@novu/application-generic';
+import { CacheService, cacheInMemoryProviderService, cacheService } from '@novu/application-generic';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { v4 as uuid } from 'uuid';
@@ -356,7 +356,8 @@ describe('EvaluateTokenBucketRateLimit', () => {
                 const refillPerWindow = (maxTokens * mockProportionRefill) / mockWindowDuration;
 
                 before(async () => {
-                  const cacheServiceInitialized = await inMemoryCacheService.useFactory();
+                  const inMemoryProvider = await cacheInMemoryProviderService.useFactory();
+                  const cacheServiceInitialized = await cacheService.useFactory(inMemoryProvider);
                   testContext = {
                     redis: EvaluateTokenBucketRateLimit.getCacheClient(cacheServiceInitialized),
                   };

--- a/apps/api/src/app/shared/shared.module.ts
+++ b/apps/api/src/app/shared/shared.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import {
   analyticsService,
+  cacheInMemoryProviderService,
   CacheServiceHealthIndicator,
   CloudflareSchedulerService,
   ComputeJobWaitDurationService,
@@ -143,6 +144,7 @@ const ANALYTICS_PROVIDERS = [
 
 const PROVIDERS = [
   analyticsService,
+  cacheInMemoryProviderService,
   cacheService,
   CacheServiceHealthIndicator,
   CloudflareSchedulerService,

--- a/apps/api/src/app/subscribers-v2/subscribers.module.ts
+++ b/apps/api/src/app/subscribers-v2/subscribers.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
 import {
   analyticsService,
-  CacheInMemoryProviderService,
   CreateOrUpdateSubscriberUseCase,
+  cacheInMemoryProviderService,
   cacheService,
   featureFlagsService,
   GetPreferences,
@@ -49,7 +49,6 @@ const USE_CASES = [
   IntegrationRepository,
   CreateOrUpdateSubscriberUseCase,
   UpdateSubscriber,
-  CacheInMemoryProviderService,
   GetSubscriber,
   PatchSubscriber,
   RemoveSubscriber,
@@ -82,6 +81,7 @@ const DAL_MODELS = [
   providers: [
     ...USE_CASES,
     ...DAL_MODELS,
+    cacheInMemoryProviderService,
     cacheService,
     InvalidateCacheService,
     analyticsService,

--- a/apps/worker/src/app/shared/shared.module.ts
+++ b/apps/worker/src/app/shared/shared.module.ts
@@ -8,6 +8,7 @@ import {
   CreateNotificationJobs,
   CreateOrUpdateSubscriberUseCase,
   CreateTenant,
+  cacheInMemoryProviderService,
   cacheService,
   clickHouseBatchService,
   clickHouseService,
@@ -109,6 +110,7 @@ const ANALYTICS_PROVIDERS = [
 const PROVIDERS = [
   analyticsService,
   BulkCreateExecutionDetails,
+  cacheInMemoryProviderService,
   cacheService,
   CloudflareSchedulerService,
   ComputeJobWaitDurationService,

--- a/libs/application-generic/src/custom-providers/index.ts
+++ b/libs/application-generic/src/custom-providers/index.ts
@@ -27,6 +27,10 @@ export const cacheInMemoryProviderService = {
   },
 };
 
+// Nest injects the same CacheInMemoryProviderService instance registered as cacheInMemoryProviderService.
+// Previously this factory called cacheInMemoryProviderService.useFactory() internally, which created a
+// second in-memory provider (and Redis connection) unrelated to the one ChatSdkService and other
+// injectors receive via DI.
 export const cacheService = {
   provide: CacheService,
   useFactory: async (inMemoryProvider: CacheInMemoryProviderService): Promise<CacheService> => {

--- a/libs/application-generic/src/custom-providers/index.ts
+++ b/libs/application-generic/src/custom-providers/index.ts
@@ -29,15 +29,14 @@ export const cacheInMemoryProviderService = {
 
 export const cacheService = {
   provide: CacheService,
-  useFactory: async (): Promise<CacheService> => {
-    const factoryCacheInMemoryProviderService = cacheInMemoryProviderService.useFactory();
-
-    const service = new CacheService(factoryCacheInMemoryProviderService);
+  useFactory: async (inMemoryProvider: CacheInMemoryProviderService): Promise<CacheService> => {
+    const service = new CacheService(inMemoryProvider);
 
     await service.initialize();
 
     return service;
   },
+  inject: [CacheInMemoryProviderService],
 };
 
 export const dalService = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,9 +318,9 @@ importers:
       '@chat-adapter/slack':
         specifier: ^4.25.0
         version: 4.25.0
-      '@chat-adapter/state-redis':
+      '@chat-adapter/state-ioredis':
         specifier: ^4.25.0
-        version: 4.25.0
+        version: 4.26.0
       '@chat-adapter/teams':
         specifier: ^4.25.0
         version: 4.25.0
@@ -6099,8 +6099,8 @@ packages:
   '@chat-adapter/slack@4.25.0':
     resolution: {integrity: sha512-5jTLMzRUB3iyezaxNSxXAdJIX1xQFvMsVyOResrTWs72Mfa9Ae0K69iS7+X/Z2kbgj65w0wR54Oa5HXDt8HQWQ==}
 
-  '@chat-adapter/state-redis@4.25.0':
-    resolution: {integrity: sha512-XHZ6Kv9vbKP19YaRKXaurnsxzizHpQOkfY0P4JPS8oEGVKSCJ5a9ZEnlsT3guLG8zcO6cFqNR2Br+PmX6fh1Dw==}
+  '@chat-adapter/state-ioredis@4.26.0':
+    resolution: {integrity: sha512-DhTkcZv0qq5tYxyOrQTCDkwAepka5pi+gr1g3rjOfklX1AMdON/9N5x/+8v/wm7vahukcQTjG2hsDYE+Xwo+uA==}
 
   '@chat-adapter/teams@4.25.0':
     resolution: {integrity: sha512-oxRy6VgbGaLHvh7RMoxS5ZxJxZIwxJH57/2VUHiPXkmdJfvhFxfdYDJ3pKP3dVZKYKPr4gXAOR2no0MeQmyftQ==}
@@ -11408,39 +11408,6 @@ packages:
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
-  '@redis/bloom@5.11.0':
-    resolution: {integrity: sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.11.0
-
-  '@redis/client@5.11.0':
-    resolution: {integrity: sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@node-rs/xxhash': ^1.1.0
-    peerDependenciesMeta:
-      '@node-rs/xxhash':
-        optional: true
-
-  '@redis/json@5.11.0':
-    resolution: {integrity: sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.11.0
-
-  '@redis/search@5.11.0':
-    resolution: {integrity: sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.11.0
-
-  '@redis/time-series@5.11.0':
-    resolution: {integrity: sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.11.0
-
   '@reduxjs/toolkit@2.8.2':
     resolution: {integrity: sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==}
     peerDependencies:
@@ -15966,6 +15933,9 @@ packages:
 
   chat@4.25.0:
     resolution: {integrity: sha512-QM8ex4Gpn8zYIPyQXh41Who6R9Wq3WcQeOjAy4EuR1m1ha0tASuzHkLQfjaTAGLgrgrThV0Zh5KKoH0S92iwNA==}
+
+  chat@4.26.0:
+    resolution: {integrity: sha512-QToDnIEGpyb8yQA6YLMHOSRK30YVk4RtsyFyuWFYyB2c4jQlyIrSWtwVK7qyvmvqzQp9uDwCdJRAhS8GtCHAGQ==}
 
   check-disk-space@3.4.0:
     resolution: {integrity: sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==}
@@ -23825,10 +23795,6 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
-  redis@5.11.0:
-    resolution: {integrity: sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==}
-    engines: {node: '>= 18'}
-
   reduce-flatten@2.0.0:
     resolution: {integrity: sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==}
     engines: {node: '>=6'}
@@ -30746,12 +30712,11 @@ snapshots:
       - debug
       - supports-color
 
-  '@chat-adapter/state-redis@4.25.0':
+  '@chat-adapter/state-ioredis@4.26.0':
     dependencies:
-      chat: 4.25.0
-      redis: 5.11.0
+      chat: 4.26.0
+      ioredis: 5.10.1
     transitivePeerDependencies:
-      - '@node-rs/xxhash'
       - supports-color
 
   '@chat-adapter/teams@4.25.0':
@@ -38389,26 +38354,6 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  '@redis/bloom@5.11.0(@redis/client@5.11.0)':
-    dependencies:
-      '@redis/client': 5.11.0
-
-  '@redis/client@5.11.0':
-    dependencies:
-      cluster-key-slot: 1.1.2
-
-  '@redis/json@5.11.0(@redis/client@5.11.0)':
-    dependencies:
-      '@redis/client': 5.11.0
-
-  '@redis/search@5.11.0(@redis/client@5.11.0)':
-    dependencies:
-      '@redis/client': 5.11.0
-
-  '@redis/time-series@5.11.0(@redis/client@5.11.0)':
-    dependencies:
-      '@redis/client': 5.11.0
-
   '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -44423,6 +44368,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  chat@4.26.0:
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      remend: 1.3.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   check-disk-space@3.4.0: {}
 
   check-error@1.0.3:
@@ -45573,7 +45530,6 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
-    optional: true
 
   debug@4.3.1(supports-color@8.1.1):
     dependencies:
@@ -51896,7 +51852,7 @@ snapshots:
 
   needle@3.2.0:
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       iconv-lite: 0.6.3
       sax: 1.5.0
     transitivePeerDependencies:
@@ -53226,7 +53182,7 @@ snapshots:
   portfinder@1.0.32:
     dependencies:
       async: 2.6.4
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       mkdirp: 0.5.6
     transitivePeerDependencies:
       - supports-color
@@ -54560,16 +54516,6 @@ snapshots:
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
-
-  redis@5.11.0:
-    dependencies:
-      '@redis/bloom': 5.11.0(@redis/client@5.11.0)
-      '@redis/client': 5.11.0
-      '@redis/json': 5.11.0(@redis/client@5.11.0)
-      '@redis/search': 5.11.0(@redis/client@5.11.0)
-      '@redis/time-series': 5.11.0(@redis/client@5.11.0)
-    transitivePeerDependencies:
-      - '@node-rs/xxhash'
 
   reduce-flatten@2.0.0: {}
 


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Refactors Redis state handling so the API and related services use a shared ioredis client provided by CacheInMemoryProviderService instead of constructing Redis connections from environment variables. The chat state adapter was swapped from @chat-adapter/state-redis to @chat-adapter/state-ioredis and DI/lifecycle initialization was added to ensure the shared client is initialized and reused to avoid duplicate connections and type/build errors.

## Affected areas

- api: ChatSdkService now injects CacheInMemoryProviderService, implements OnModuleInit to initialize it, and builds chat state via createIORedisState using the injected client; app.module and shared.module register the provider.
- worker: Shared module registers and exports cacheInMemoryProviderService so worker processes reuse the same ioredis client.
- libs/application-generic: cacheService provider factory now receives CacheInMemoryProviderService via inject instead of instantiating its own provider, centralizing client management.
- subscribers (subscribers-v2): provider registration changed to register cacheInMemoryProviderService in the module providers so it’s available via DI rather than used as a local use-case import.
- enterprise (EE): EE auth module configuration updated to include cacheInMemoryProviderService so EE modules receive the shared provider.
- package deps: apps/api package.json replaces @chat-adapter/state-redis with @chat-adapter/state-ioredis (^4.25.0).

## Key technical decisions

- Use @chat-adapter/state-ioredis to accept an ioredis client instance instead of creating raw Redis connections from env vars.
- Centralize Redis/ioredis client lifecycle in CacheInMemoryProviderService and inject it into cacheService and ChatSdkService to prevent duplicate connections and DI/runtime type issues.
- Add OnModuleInit initialization in ChatSdkService to ensure the provider is ready before use.

## Testing

Existing unit tests were updated to initialize the cache through the new provider chain (example: token-bucket rate-limit spec); no new e2e tests were added — verify CI and EE-enabled environments for provider registration and DI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
