### PR TITLE
refactor(api-service): polish inbox channel endpoints

### DIFF
--- a/apps/api/src/app/inbox/dtos/inbox-channel-connection-response.dto.ts
+++ b/apps/api/src/app/inbox/dtos/inbox-channel-connection-response.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class InboxChannelConnectionResponseDto {
+  @ApiProperty({
+    description: 'The unique identifier of the channel connection.',
+    type: String,
+  })
+  identifier: string;
+}
+
+export class InboxListChannelConnectionsResponseDto {
+  @ApiProperty({ type: [InboxChannelConnectionResponseDto] })
+  data: InboxChannelConnectionResponseDto[];
+
+  @ApiProperty({ type: String, nullable: true })
+  next: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  previous: string | null;
+}

--- a/apps/api/src/app/inbox/dtos/inbox-channel-endpoint-response.dto.ts
+++ b/apps/api/src/app/inbox/dtos/inbox-channel-endpoint-response.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ChannelEndpointType, ENDPOINT_TYPES } from '@novu/shared';
+
+export class InboxChannelEndpointResponseDto {
+  @ApiProperty({
+    description: 'The unique identifier of the channel endpoint.',
+    type: String,
+  })
+  identifier: string;
+
+  @ApiProperty({
+    description: 'Type of channel endpoint',
+    enum: Object.values(ENDPOINT_TYPES),
+    example: ENDPOINT_TYPES.SLACK_CHANNEL,
+  })
+  type: ChannelEndpointType;
+}
+
+export class InboxListChannelEndpointsResponseDto {
+  @ApiProperty({ type: [InboxChannelEndpointResponseDto] })
+  data: InboxChannelEndpointResponseDto[];
+
+  @ApiProperty({ type: String, nullable: true })
+  next: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  previous: string | null;
+}

--- a/apps/api/src/app/inbox/dtos/inbox-dto.mapper.ts
+++ b/apps/api/src/app/inbox/dtos/inbox-dto.mapper.ts
@@ -1,0 +1,16 @@
+import { ChannelConnectionEntity, ChannelEndpointEntity } from '@novu/dal';
+import { InboxChannelConnectionResponseDto } from './inbox-channel-connection-response.dto';
+import { InboxChannelEndpointResponseDto } from './inbox-channel-endpoint-response.dto';
+
+export function mapChannelConnectionToInboxDto(entity: ChannelConnectionEntity): InboxChannelConnectionResponseDto {
+  return {
+    identifier: entity.identifier,
+  };
+}
+
+export function mapChannelEndpointToInboxDto(entity: ChannelEndpointEntity): InboxChannelEndpointResponseDto {
+  return {
+    identifier: entity.identifier,
+    type: entity.type,
+  };
+}

--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -26,26 +26,14 @@ import {
   TriggerRequestCategoryEnum,
   UserSessionData,
 } from '@novu/shared';
-import { CreateChannelConnectionRequestDto } from '../channel-connections/dtos/create-channel-connection-request.dto';
-import { mapChannelConnectionEntityToDto } from '../channel-connections/dtos/dto.mapper';
-import { GetChannelConnectionResponseDto } from '../channel-connections/dtos/get-channel-connection-response.dto';
 import { ListChannelConnectionsQueryDto } from '../channel-connections/dtos/list-channel-connections-query.dto';
-import { ListChannelConnectionsResponseDto } from '../channel-connections/dtos/list-channel-connections-response.dto';
-import { CreateChannelConnectionCommand } from '../channel-connections/usecases/create-channel-connection/create-channel-connection.command';
-import { CreateChannelConnection } from '../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
 import { DeleteChannelConnectionCommand } from '../channel-connections/usecases/delete-channel-connection/delete-channel-connection.command';
 import { DeleteChannelConnection } from '../channel-connections/usecases/delete-channel-connection/delete-channel-connection.usecase';
 import { GetChannelConnectionCommand } from '../channel-connections/usecases/get-channel-connection/get-channel-connection.command';
 import { GetChannelConnection } from '../channel-connections/usecases/get-channel-connection/get-channel-connection.usecase';
 import { ListChannelConnectionsCommand } from '../channel-connections/usecases/list-channel-connections/list-channel-connections.command';
 import { ListChannelConnections } from '../channel-connections/usecases/list-channel-connections/list-channel-connections.usecase';
-import { CreateChannelEndpointRequest } from '../channel-endpoints/dtos/create-channel-endpoint-request.dto';
-import { mapChannelEndpointEntityToDto } from '../channel-endpoints/dtos/dto.mapper';
-import { GetChannelEndpointResponseDto } from '../channel-endpoints/dtos/get-channel-endpoint-response.dto';
 import { ListChannelEndpointsQueryDto } from '../channel-endpoints/dtos/list-channel-endpoints-query.dto';
-import { ListChannelEndpointsResponseDto } from '../channel-endpoints/dtos/list-channel-endpoints-response.dto';
-import { CreateChannelEndpointCommand } from '../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
-import { CreateChannelEndpoint } from '../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
 import { DeleteChannelEndpointCommand } from '../channel-endpoints/usecases/delete-channel-endpoint/delete-channel-endpoint.command';
 import { DeleteChannelEndpoint } from '../channel-endpoints/usecases/delete-channel-endpoint/delete-channel-endpoint.usecase';
 import { GetChannelEndpointCommand } from '../channel-endpoints/usecases/get-channel-endpoint/get-channel-endpoint.command';
@@ -77,6 +65,12 @@ import { GetNotificationsRequestDto } from './dtos/get-notifications-request.dto
 import { GetNotificationsResponseDto } from './dtos/get-notifications-response.dto';
 import { GetPreferencesRequestDto } from './dtos/get-preferences-request.dto';
 import { GetPreferencesResponseDto } from './dtos/get-preferences-response.dto';
+import {
+  InboxChannelConnectionResponseDto,
+  InboxListChannelConnectionsResponseDto,
+} from './dtos/inbox-channel-connection-response.dto';
+import { InboxListChannelEndpointsResponseDto } from './dtos/inbox-channel-endpoint-response.dto';
+import { mapChannelConnectionToInboxDto, mapChannelEndpointToInboxDto } from './dtos/inbox-dto.mapper';
 import { InboxNotificationDto } from './dtos/inbox-notification.dto';
 import { MarkNotificationsAsSeenRequestDto } from './dtos/mark-notifications-as-seen-request.dto';
 import { SnoozeNotificationRequestDto } from './dtos/snooze-notification-request.dto';
@@ -139,11 +133,9 @@ export class InboxController {
     private deleteAllNotificationsUsecase: DeleteAllNotifications,
     private listChannelConnectionsUsecase: ListChannelConnections,
     private getChannelConnectionUsecase: GetChannelConnection,
-    private createChannelConnectionUsecase: CreateChannelConnection,
     private deleteChannelConnectionUsecase: DeleteChannelConnection,
     private listChannelEndpointsUsecase: ListChannelEndpoints,
     private getChannelEndpointUsecase: GetChannelEndpoint,
-    private createChannelEndpointUsecase: CreateChannelEndpoint,
     private deleteChannelEndpointUsecase: DeleteChannelEndpoint,
     private generateChatOauthUrlUsecase: GenerateChatOauthUrl,
     private featureFlagsService: FeatureFlagsService
@@ -674,7 +666,7 @@ export class InboxController {
   async listChannelConnections(
     @SubscriberSession() subscriberSession: SubscriberSession,
     @Query() query: ListChannelConnectionsQueryDto
-  ): Promise<ListChannelConnectionsResponseDto> {
+  ): Promise<InboxListChannelConnectionsResponseDto> {
     await this.checkChannelFeatureEnabled(subscriberSession._organizationId);
 
     const result = await this.listChannelConnectionsUsecase.execute(
@@ -698,11 +690,9 @@ export class InboxController {
     );
 
     return {
-      data: result.data.map(mapChannelConnectionEntityToDto),
-      next: result.next,
-      previous: result.previous,
-      totalCount: result.totalCount!,
-      totalCountCapped: result.totalCountCapped!,
+      data: result.data.map(mapChannelConnectionToInboxDto),
+      next: result.next ?? null,
+      previous: result.previous ?? null,
     };
   }
 
@@ -711,7 +701,7 @@ export class InboxController {
   async getChannelConnection(
     @SubscriberSession() subscriberSession: SubscriberSession,
     @Param('identifier') identifier: string
-  ): Promise<GetChannelConnectionResponseDto> {
+  ): Promise<InboxChannelConnectionResponseDto> {
     await this.checkChannelFeatureEnabled(subscriberSession._organizationId);
 
     const channelConnection = await this.getChannelConnectionUsecase.execute(
@@ -726,31 +716,7 @@ export class InboxController {
       throw new NotFoundException(`Channel connection not found: ${identifier}`);
     }
 
-    return mapChannelConnectionEntityToDto(channelConnection);
-  }
-
-  @UseGuards(AuthGuard('subscriberJwt'))
-  @Post('/channel-connections')
-  async createChannelConnection(
-    @SubscriberSession() subscriberSession: SubscriberSession,
-    @Body() body: CreateChannelConnectionRequestDto
-  ): Promise<GetChannelConnectionResponseDto> {
-    await this.checkChannelFeatureEnabled(subscriberSession._organizationId);
-
-    const channelConnection = await this.createChannelConnectionUsecase.execute(
-      CreateChannelConnectionCommand.create({
-        environmentId: subscriberSession._environmentId,
-        organizationId: subscriberSession._organizationId,
-        identifier: body.identifier,
-        integrationIdentifier: body.integrationIdentifier,
-        subscriberId: subscriberSession.subscriberId,
-        context: body.context,
-        workspace: body.workspace,
-        auth: body.auth,
-      })
-    );
-
-    return mapChannelConnectionEntityToDto(channelConnection);
+    return mapChannelConnectionToInboxDto(channelConnection);
   }
 
   @UseGuards(AuthGuard('subscriberJwt'))
@@ -788,7 +754,7 @@ export class InboxController {
   async listChannelEndpoints(
     @SubscriberSession() subscriberSession: SubscriberSession,
     @Query() query: ListChannelEndpointsQueryDto
-  ): Promise<ListChannelEndpointsResponseDto> {
+  ): Promise<InboxListChannelEndpointsResponseDto> {
     await this.checkChannelFeatureEnabled(subscriberSession._organizationId);
 
     const result = await this.listChannelEndpointsUsecase.execute(
@@ -813,64 +779,10 @@ export class InboxController {
     );
 
     return {
-      data: result.data.map(mapChannelEndpointEntityToDto),
-      next: result.next,
-      previous: result.previous,
-      totalCount: result.totalCount!,
-      totalCountCapped: result.totalCountCapped!,
+      data: result.data.map(mapChannelEndpointToInboxDto),
+      next: result.next ?? null,
+      previous: result.previous ?? null,
     };
-  }
-
-  @UseGuards(AuthGuard('subscriberJwt'))
-  @Get('/channel-endpoints/:identifier')
-  async getChannelEndpoint(
-    @SubscriberSession() subscriberSession: SubscriberSession,
-    @Param('identifier') identifier: string
-  ): Promise<GetChannelEndpointResponseDto> {
-    await this.checkChannelFeatureEnabled(subscriberSession._organizationId);
-
-    const channelEndpoint = await this.getChannelEndpointUsecase.execute(
-      GetChannelEndpointCommand.create({
-        environmentId: subscriberSession._environmentId,
-        organizationId: subscriberSession._organizationId,
-        identifier,
-      })
-    );
-
-    if (channelEndpoint.subscriberId && channelEndpoint.subscriberId !== subscriberSession.subscriberId) {
-      throw new NotFoundException(`Channel endpoint not found: ${identifier}`);
-    }
-
-    return mapChannelEndpointEntityToDto(channelEndpoint);
-  }
-
-  @UseGuards(AuthGuard('subscriberJwt'))
-  @Post('/channel-endpoints')
-  async createChannelEndpoint(
-    @SubscriberSession() subscriberSession: SubscriberSession,
-    @Body() body: CreateChannelEndpointRequest
-  ): Promise<GetChannelEndpointResponseDto> {
-    await this.checkChannelFeatureEnabled(subscriberSession._organizationId);
-
-    // Cast needed because CreateChannelEndpointRequest is a discriminated union; the type/endpoint
-    // fields are correctly validated by class-validator before reaching this handler.
-    const typedBody = body as Extract<CreateChannelEndpointRequest, { type: (typeof body)['type'] }>;
-
-    const channelEndpoint = await this.createChannelEndpointUsecase.execute(
-      CreateChannelEndpointCommand.create({
-        environmentId: subscriberSession._environmentId,
-        organizationId: subscriberSession._organizationId,
-        identifier: typedBody.identifier,
-        integrationIdentifier: typedBody.integrationIdentifier,
-        connectionIdentifier: typedBody.connectionIdentifier,
-        subscriberId: subscriberSession.subscriberId,
-        context: typedBody.context,
-        type: typedBody.type,
-        endpoint: typedBody.endpoint,
-      } as Parameters<typeof CreateChannelEndpointCommand.create>[0])
-    );
-
-    return mapChannelEndpointEntityToDto(channelEndpoint);
   }
 
   @UseGuards(AuthGuard('subscriberJwt'))

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.usecase.ts
@@ -152,8 +152,7 @@ export class GenerateMsTeamsOauthUrl {
     }
 
     const baseUrl = process.env.API_ROOT_URL.replace(/\/$/, ''); // Remove trailing slash
-    return `https://c9f4-79-177-157-205.ngrok-free.app${CHAT_OAUTH_CALLBACK_PATH}`;
-    // return `${baseUrl}${CHAT_OAUTH_CALLBACK_PATH}`;
+    return `${baseUrl}${CHAT_OAUTH_CALLBACK_PATH}`;
   }
 
   private async getIntegrationCredentials(integration: IntegrationEntity): Promise<ICredentialsEntity> {

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.usecase.ts
@@ -152,7 +152,8 @@ export class GenerateMsTeamsOauthUrl {
     }
 
     const baseUrl = process.env.API_ROOT_URL.replace(/\/$/, ''); // Remove trailing slash
-    return `${baseUrl}${CHAT_OAUTH_CALLBACK_PATH}`;
+    return `https://c9f4-79-177-157-205.ngrok-free.app${CHAT_OAUTH_CALLBACK_PATH}`;
+    // return `${baseUrl}${CHAT_OAUTH_CALLBACK_PATH}`;
   }
 
   private async getIntegrationCredentials(integration: IntegrationEntity): Promise<ICredentialsEntity> {

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
@@ -62,10 +62,9 @@ export class GenerateSlackOauthUrl {
     await this.assertResourceExists(command);
 
     const { clientId } = await this.getIntegrationCredentials(command.integration);
-    const subscriberId = command.connectionMode === 'shared' ? undefined : command.subscriberId;
     const secureState = await this.createSecureState(
       command.integration,
-      subscriberId,
+      command.subscriberId,
       command.context,
       command.connectionIdentifier,
       command.mode,

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
@@ -72,8 +72,7 @@ export class GenerateSlackOauthUrl {
       command.connectionMode
     );
 
-    const resolvedScope =
-      command.mode === 'link_user' ? undefined : await this.resolveBotScopes(command);
+    const resolvedScope = command.mode === 'link_user' ? undefined : await this.resolveBotScopes(command);
 
     return this.getOAuthUrl(clientId!, secureState, resolvedScope, command.userScope, command.mode);
   }
@@ -226,7 +225,8 @@ export class GenerateSlackOauthUrl {
     }
 
     const baseUrl = process.env.API_ROOT_URL.replace(/\/$/, ''); // Remove trailing slash
-    return `${baseUrl}${CHAT_OAUTH_CALLBACK_PATH}`;
+    return `https://c9f4-79-177-157-205.ngrok-free.app${CHAT_OAUTH_CALLBACK_PATH}`;
+    // return `${baseUrl}${CHAT_OAUTH_CALLBACK_PATH}`; 22
   }
 
   private async getIntegrationCredentials(integration: IntegrationEntity): Promise<ICredentialsEntity> {

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
@@ -224,8 +224,7 @@ export class GenerateSlackOauthUrl {
     }
 
     const baseUrl = process.env.API_ROOT_URL.replace(/\/$/, ''); // Remove trailing slash
-    return `https://c9f4-79-177-157-205.ngrok-free.app${CHAT_OAUTH_CALLBACK_PATH}`;
-    // return `${baseUrl}${CHAT_OAUTH_CALLBACK_PATH}`; 22
+    return `${baseUrl}${CHAT_OAUTH_CALLBACK_PATH}`;
   }
 
   private async getIntegrationCredentials(integration: IntegrationEntity): Promise<ICredentialsEntity> {

--- a/packages/js/src/channel-connections/types.ts
+++ b/packages/js/src/channel-connections/types.ts
@@ -2,28 +2,11 @@ import type { Context } from '../types';
 
 export type ChannelConnectionResponse = {
   identifier: string;
-  integrationIdentifier: string;
-  providerId: string;
-  channel: string;
-  subscriberId?: string;
-  contextKeys: string[];
-  workspace: { id: string; name?: string };
-  createdAt: string;
-  updatedAt: string;
 };
 
 export type ChannelEndpointResponse = {
   identifier: string;
-  integrationIdentifier: string;
-  connectionIdentifier?: string;
-  providerId: string;
-  channel: string;
-  subscriberId: string;
-  contextKeys: string[];
   type: string;
-  endpoint: Record<string, string>;
-  createdAt: string;
-  updatedAt: string;
 };
 
 export type OAuthMode = 'connect' | 'link_user';


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR refactors the inbox channel endpoints to improve separation of concerns by removing channel connection and endpoint creation from the inbox controller and simplifying response DTOs. Creation of these resources is now handled exclusively through OAuth callback flows in the integrations and subscribers modules, while the inbox controller only handles read operations (list and get).

## Affected areas

**@novu/api-service**: The inbox controller now only exposes list and get endpoints for channel connections and endpoints, removing the `POST /channel-connections` and `POST /channel-endpoints` handlers. New simplified DTOs (`InboxChannelConnectionResponseDto`, `InboxChannelEndpointResponseDto`) were introduced that reduce response payloads to essential fields: `identifier` for connections and `identifier`/`type` for endpoints. Pagination shapes were normalized by dropping `totalCount` and `totalCountCapped`. A minor fix to the Slack OAuth URL generation usecase ensures `subscriberId` is always included in the secure state regardless of connection mode.

**@novu/js**: Response types for channel connections and endpoints were simplified to match the new API shape, removing redundant fields like `integrationIdentifier`, `providerId`, `channel`, timestamps, and other metadata.

## Key technical decisions

- Channel connection and endpoint creation logic is now exclusively handled in OAuth callback usecases (`ChatOauthCallback`, `SlackOauthCallback`) rather than direct inbox endpoints, providing a more appropriate flow for these operations.
- Response DTOs were minimized to expose only `identifier` (and `type` for endpoints), reducing API surface and improving contract stability.
- Pagination cursors (`next`/`previous`) are normalized to nullable strings with no cardinality counters.

## Testing

No tests are mentioned in the PR. Given that this is a refactoring that moves creation logic to existing callback flows (which already handle these operations), existing tests for those callback usecases should provide coverage. The inbox controller changes primarily involve removing endpoints and updating response mappers, which may require updates to existing inbox endpoint tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
