### PR TITLE
fix(api-service): Use ioredis state adapter

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -46,7 +46,7 @@
     "@aws-sdk/client-secrets-manager": "^3.971.0",
     "yargs": "^17.7.2",
     "@chat-adapter/slack": "^4.25.0",
-    "@chat-adapter/state-redis": "^4.25.0",
+    "@chat-adapter/state-ioredis": "^4.26.0",
     "@chat-adapter/teams": "^4.25.0",
     "@chat-adapter/whatsapp": "^4.25.0",
     "@godaddy/terminus": "^4.12.1",

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -313,7 +313,7 @@ export class ChatSdkService implements OnModuleDestroy {
     const adapters = await this.buildAdapters(platform, config);
     const client = this.cacheService.client;
     if (!client) {
-      throw new Error('Cache in-memory provider client is not available for Chat SDK state adapter');
+      throw new Error('Cache in-memory provider client is not available for Conversational SDK state adapter');
     }
 
     return new Chat({

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, forwardRef, Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
-import { PinoLogger } from '@novu/application-generic';
+import { CacheService, PinoLogger } from '@novu/application-generic';
 import type { SentMessageInfo } from '@novu/framework';
 import type { AdapterPostableMessage, Chat, EmojiValue, Message, ReactionEvent, Thread } from 'chat';
 import { Request as ExpressRequest, Response as ExpressResponse } from 'express';
@@ -56,6 +56,7 @@ export class ChatSdkService implements OnModuleDestroy {
 
   constructor(
     private readonly logger: PinoLogger,
+    private readonly cacheService: CacheService,
     private readonly agentConfigResolver: AgentConfigResolver,
     @Inject(forwardRef(() => AgentInboundHandler))
     private readonly inboundHandler: AgentInboundHandler
@@ -304,27 +305,36 @@ export class ChatSdkService implements OnModuleDestroy {
     platform: AgentPlatformEnum,
     config: ResolvedAgentConfig
   ): Promise<Chat> {
-    const [{ Chat }, { createRedisState }] = await Promise.all([
+    const [{ Chat }, { createIoRedisState }] = await Promise.all([
       esmImport('chat'),
-      esmImport('@chat-adapter/state-redis'),
+      esmImport('@chat-adapter/state-ioredis'),
     ]);
 
     const adapters = await this.buildAdapters(platform, config);
-    const redisHost = process.env.REDIS_HOST || 'localhost';
-    const redisPort = process.env.REDIS_PORT || '6379';
-    const redisScheme = process.env.REDIS_TLS_ENABLED === 'true' ? 'rediss' : 'redis';
-    const redisPassword = process.env.REDIS_PASSWORD;
-    const redisAuth = redisPassword ? `:${encodeURIComponent(redisPassword)}@` : '';
+    const client = this.cacheService.client;
+    if (!client) {
+      throw new Error('Cache in-memory provider client is not available for Chat SDK state adapter');
+    }
 
     return new Chat({
       userName: `novu-agent-${instanceKey}`,
       adapters,
-      state: createRedisState({
-        url: `${redisScheme}://${redisAuth}${redisHost}:${redisPort}`,
+      state: createIoRedisState({
+        client,
         keyPrefix: `novu:agent:${instanceKey}`,
+        logger: this.chatStateLogger(),
       }),
       logger: 'silent',
     });
+  }
+
+  private chatStateLogger() {
+    return {
+      debug: (msg: string, ctx?: Record<string, unknown>) => this.logger.debug(ctx ?? {}, msg),
+      info: (msg: string, ctx?: Record<string, unknown>) => this.logger.info(ctx ?? {}, msg),
+      warn: (msg: string, ctx?: Record<string, unknown>) => this.logger.warn(ctx ?? {}, msg),
+      error: (msg: string, ctx?: Record<string, unknown>) => this.logger.error(ctx ?? {}, msg),
+    };
   }
 
   private async buildAdapters(

--- a/libs/application-generic/package.json
+++ b/libs/application-generic/package.json
@@ -90,7 +90,7 @@
     "got": "^11.8.6",
     "handlebars": "4.7.9",
     "i18next": "^23.7.6",
-    "ioredis": "^5.2.4",
+    "ioredis": "^5.4.1",
     "json-logic-js": "^2.0.5",
     "json-schema-to-ts": "^3.0.0",
     "json-schema-faker": "^0.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,9 +318,9 @@ importers:
       '@chat-adapter/slack':
         specifier: ^4.25.0
         version: 4.25.0
-      '@chat-adapter/state-redis':
-        specifier: ^4.25.0
-        version: 4.25.0
+      '@chat-adapter/state-ioredis':
+        specifier: ^4.26.0
+        version: 4.26.0
       '@chat-adapter/teams':
         specifier: ^4.25.0
         version: 4.25.0
@@ -2565,8 +2565,8 @@ importers:
         specifier: ^23.7.6
         version: 23.7.11
       ioredis:
-        specifier: ^5.2.4
-        version: 5.3.2
+        specifier: ^5.4.1
+        version: 5.10.1
       json-logic-js:
         specifier: ^2.0.5
         version: 2.0.5
@@ -6099,8 +6099,8 @@ packages:
   '@chat-adapter/slack@4.25.0':
     resolution: {integrity: sha512-5jTLMzRUB3iyezaxNSxXAdJIX1xQFvMsVyOResrTWs72Mfa9Ae0K69iS7+X/Z2kbgj65w0wR54Oa5HXDt8HQWQ==}
 
-  '@chat-adapter/state-redis@4.25.0':
-    resolution: {integrity: sha512-XHZ6Kv9vbKP19YaRKXaurnsxzizHpQOkfY0P4JPS8oEGVKSCJ5a9ZEnlsT3guLG8zcO6cFqNR2Br+PmX6fh1Dw==}
+  '@chat-adapter/state-ioredis@4.26.0':
+    resolution: {integrity: sha512-DhTkcZv0qq5tYxyOrQTCDkwAepka5pi+gr1g3rjOfklX1AMdON/9N5x/+8v/wm7vahukcQTjG2hsDYE+Xwo+uA==}
 
   '@chat-adapter/teams@4.25.0':
     resolution: {integrity: sha512-oxRy6VgbGaLHvh7RMoxS5ZxJxZIwxJH57/2VUHiPXkmdJfvhFxfdYDJ3pKP3dVZKYKPr4gXAOR2no0MeQmyftQ==}
@@ -11408,39 +11408,6 @@ packages:
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
-  '@redis/bloom@5.11.0':
-    resolution: {integrity: sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.11.0
-
-  '@redis/client@5.11.0':
-    resolution: {integrity: sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@node-rs/xxhash': ^1.1.0
-    peerDependenciesMeta:
-      '@node-rs/xxhash':
-        optional: true
-
-  '@redis/json@5.11.0':
-    resolution: {integrity: sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.11.0
-
-  '@redis/search@5.11.0':
-    resolution: {integrity: sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.11.0
-
-  '@redis/time-series@5.11.0':
-    resolution: {integrity: sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@redis/client': ^5.11.0
-
   '@reduxjs/toolkit@2.8.2':
     resolution: {integrity: sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==}
     peerDependencies:
@@ -15966,6 +15933,9 @@ packages:
 
   chat@4.25.0:
     resolution: {integrity: sha512-QM8ex4Gpn8zYIPyQXh41Who6R9Wq3WcQeOjAy4EuR1m1ha0tASuzHkLQfjaTAGLgrgrThV0Zh5KKoH0S92iwNA==}
+
+  chat@4.26.0:
+    resolution: {integrity: sha512-QToDnIEGpyb8yQA6YLMHOSRK30YVk4RtsyFyuWFYyB2c4jQlyIrSWtwVK7qyvmvqzQp9uDwCdJRAhS8GtCHAGQ==}
 
   check-disk-space@3.4.0:
     resolution: {integrity: sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==}
@@ -23825,10 +23795,6 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
-  redis@5.11.0:
-    resolution: {integrity: sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==}
-    engines: {node: '>= 18'}
-
   reduce-flatten@2.0.0:
     resolution: {integrity: sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==}
     engines: {node: '>=6'}
@@ -27568,8 +27534,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.575.0
@@ -27865,11 +27831,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.575.0':
+  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -27908,6 +27874,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)':
@@ -28086,11 +28053,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
+  '@aws-sdk/client-sts@3.575.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -28129,7 +28096,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.637.0':
@@ -28334,7 +28300,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
       '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
@@ -28648,7 +28614,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
@@ -29191,7 +29157,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -29200,7 +29166,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -30746,12 +30712,11 @@ snapshots:
       - debug
       - supports-color
 
-  '@chat-adapter/state-redis@4.25.0':
+  '@chat-adapter/state-ioredis@4.26.0':
     dependencies:
-      chat: 4.25.0
-      redis: 5.11.0
+      chat: 4.26.0
+      ioredis: 5.10.1
     transitivePeerDependencies:
-      - '@node-rs/xxhash'
       - supports-color
 
   '@chat-adapter/teams@4.25.0':
@@ -32398,7 +32363,8 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.15
 
-  '@ioredis/commands@1.2.0': {}
+  '@ioredis/commands@1.2.0':
+    optional: true
 
   '@ioredis/commands@1.5.1': {}
 
@@ -38388,26 +38354,6 @@ snapshots:
   '@react-email/text@0.1.5(react@19.2.3)':
     dependencies:
       react: 19.2.3
-
-  '@redis/bloom@5.11.0(@redis/client@5.11.0)':
-    dependencies:
-      '@redis/client': 5.11.0
-
-  '@redis/client@5.11.0':
-    dependencies:
-      cluster-key-slot: 1.1.2
-
-  '@redis/json@5.11.0(@redis/client@5.11.0)':
-    dependencies:
-      '@redis/client': 5.11.0
-
-  '@redis/search@5.11.0(@redis/client@5.11.0)':
-    dependencies:
-      '@redis/client': 5.11.0
-
-  '@redis/time-series@5.11.0(@redis/client@5.11.0)':
-    dependencies:
-      '@redis/client': 5.11.0
 
   '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
     dependencies:
@@ -44423,6 +44369,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  chat@4.26.0:
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      remend: 1.3.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   check-disk-space@3.4.0: {}
 
   check-error@1.0.3:
@@ -48438,6 +48396,7 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   ip-address@10.1.0: {}
 
@@ -54560,16 +54519,6 @@ snapshots:
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
-
-  redis@5.11.0:
-    dependencies:
-      '@redis/bloom': 5.11.0(@redis/client@5.11.0)
-      '@redis/client': 5.11.0
-      '@redis/json': 5.11.0(@redis/client@5.11.0)
-      '@redis/search': 5.11.0(@redis/client@5.11.0)
-      '@redis/time-series': 5.11.0(@redis/client@5.11.0)
-    transitivePeerDependencies:
-      - '@node-rs/xxhash'
 
   reduce-flatten@2.0.0: {}
 


### PR DESCRIPTION
Replace @chat-adapter/state-redis with @chat-adapter/state-ioredis and bump ioredis dependency. ChatSdkService now injects CacheService and passes its ioredis client to createIoRedisState (removing manual REDIS_* env parsing), and adds a chatStateLogger that forwards adapter logs to the existing PinoLogger. Update package files and pnpm lockfile to reflect the adapter and dependency version changes.

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The chat state adapter was replaced: `@chat-adapter/state-redis` → `@chat-adapter/state-ioredis`, and ioredis was bumped. ChatSdkService no longer builds a Redis URL from REDIS_* env vars; it injects the shared CacheService and passes its ioredis client to createIoRedisState. A chatStateLogger forwards adapter logs to the existing PinoLogger. These changes centralize Redis client management, simplify configuration, and improve observability.

## Affected areas

**api**: ChatSdkService now injects CacheService, uses the shared ioredis client with `createIoRedisState`, adds a logger bridge, and validates the cache client; dependency switched to `@chat-adapter/state-ioredis` (^4.26.0).

**shared (application-generic)**: Upgraded `ioredis` from ^5.2.4 to ^5.4.1 to align with the new adapter.

## Key technical decisions

- Use the injected CacheService ioredis client instead of assembling connection info from environment variables to centralize connection handling and improve testability.
- Add a small logger adapter to forward adapter logs into the existing PinoLogger.
- Fail-fast if the CacheService client is unavailable during initialization.

## Testing

No new tests were added; this is a dependency/configuration change and should be covered by existing unit/integration tests and manual verification of chat state persistence and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
