### PR TITLE
fix(dashboard): map WhatsApp platform to whatsapp-business square icon

### DIFF
--- a/apps/dashboard/src/components/conversations/conversation-overview.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-overview.tsx
@@ -1,5 +1,6 @@
 import { RiRobot2Line } from 'react-icons/ri';
 import { ConversationDto } from '@/api/conversations';
+import { getProviderSquareIconFileName } from '@/utils/provider-square-icon';
 import { ConversationStatusBadge } from './conversation-status-badge';
 import { SubscriberFallbackAvatar } from './subscriber-fallback-avatar';
 
@@ -73,7 +74,7 @@ export function ConversationOverview({ conversation }: ConversationOverviewProps
               {platforms.map((platform) => (
                 <div key={platform} className="border-stroke-soft rounded border bg-[#fbfbfb] p-0.5">
                   <img
-                    src={`/images/providers/light/square/${platform}.svg`}
+                    src={`/images/providers/light/square/${getProviderSquareIconFileName(platform)}.svg`}
                     alt={platform}
                     className="size-[15px] object-contain"
                   />

--- a/apps/dashboard/src/components/conversations/conversation-timeline.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-timeline.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-icons/ri';
 import { ConversationActivityDto } from '@/api/conversations';
 import { Skeleton } from '@/components/primitives/skeleton';
+import { getProviderSquareIconFileName } from '@/utils/provider-square-icon';
 import { cn } from '@/utils/ui';
 import { ConversationStatusBadge } from './conversation-status-badge';
 import { SubscriberFallbackAvatar } from './subscriber-fallback-avatar';
@@ -97,7 +98,7 @@ function MessageTimestamp({ activity }: { activity: ConversationActivityDto }) {
         {activity.platform && (
           <div className="border-stroke-soft bg-bg-weak flex items-center gap-[3px] rounded border px-1 py-0.5">
             <img
-              src={`/images/providers/light/square/${activity.platform}.svg`}
+              src={`/images/providers/light/square/${getProviderSquareIconFileName(activity.platform)}.svg`}
               alt={activity.platform}
               className="size-3.5 object-contain"
             />

--- a/apps/dashboard/src/components/integrations/components/provider-icon.tsx
+++ b/apps/dashboard/src/components/integrations/components/provider-icon.tsx
@@ -1,3 +1,4 @@
+import { getProviderSquareIconFileName } from '@/utils/provider-square-icon';
 import { cn } from '../../../utils/ui';
 
 interface ProviderIconProps {
@@ -9,7 +10,7 @@ interface ProviderIconProps {
 export function ProviderIcon({ providerId, providerDisplayName, className }: ProviderIconProps) {
   return (
     <img
-      src={`/images/providers/light/square/${providerId}.svg`}
+      src={`/images/providers/light/square/${getProviderSquareIconFileName(providerId)}.svg`}
       alt={providerDisplayName}
       className={cn('h-6 w-6 object-contain', className)}
     />

--- a/apps/dashboard/src/utils/provider-square-icon.ts
+++ b/apps/dashboard/src/utils/provider-square-icon.ts
@@ -1,0 +1,7 @@
+const PROVIDER_SQUARE_ICON_FILE_ALIASES: Record<string, string> = {
+  whatsapp: 'whatsapp-business',
+};
+
+export function getProviderSquareIconFileName(platform: string): string {
+  return PROVIDER_SQUARE_ICON_FILE_ALIASES[platform] ?? platform;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Conversation details and timeline load provider logos from `/images/providers/light/square/${platform}.svg`. The API returns `whatsapp` for WhatsApp Business, but the asset on disk is `whatsapp-business.svg`, so the image failed to load.

## Changes

- Added `getProviderSquareIconFileName()` in `apps/dashboard/src/utils/provider-square-icon.ts` with a `whatsapp` → `whatsapp-business` mapping.
- Wired it into conversation overview, conversation timeline, and `ProviderIcon` so all square provider icons resolve consistently.

## Testing

- Not run (small static path fix; verify in UI that WhatsApp conversations show the logo in Providers and in message “via” rows).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1776584257605329?thread_ts=1776584257.605329&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-04db947b-ac92-54a1-abf5-54e2a8f029ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04db947b-ac92-54a1-abf5-54e2a8f029ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

A utility function `getProviderSquareIconFileName()` was added to map provider platform identifiers to their correct square icon filenames. This resolves broken WhatsApp provider logos in conversation interfaces, where the API returns `whatsapp` but the icon asset is named `whatsapp-business.svg`. The function is wired into three components that display provider icons: conversation overview, conversation timeline, and the provider icon component.

## Affected areas

**dashboard**: Added a new utility module for provider icon filename mapping and integrated it into conversation overview, conversation timeline, and provider icon components to resolve mismatches between platform identifiers and icon asset filenames.

## Testing

No automated tests were added. This is a small static path mapping fix. Manual verification in the UI is suggested to confirm WhatsApp conversations display provider logos correctly in the conversation list and message timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->