### PR TITLE
refactor(dashboard, api-service): ack flow for conversational

### DIFF
--- a/apps/api/src/app/agents/dtos/agent-behavior.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-behavior.dto.ts
@@ -1,19 +1,19 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsBoolean, IsOptional, ValidateIf, ValidateNested } from 'class-validator';
-import { Type } from 'class-transformer';
+import { IsBoolean, IsOptional, ValidateIf } from 'class-validator';
 import { IsWellKnownEmoji } from '../validators/is-well-known-emoji.validator';
 
-export class AgentReactionSettingsDto {
+export class AgentBehaviorDto {
   @ApiPropertyOptional({
     description:
-      'Cross-platform emoji name for incoming messages (e.g. "eyes", "thumbs_up"). ' +
-      'Set to null to disable. Default: "eyes"',
-    default: 'eyes',
+      'Acknowledge incoming messages. On platforms that support a native typing indicator ' +
+      '(e.g. Microsoft Teams), shows a "Typing…" indicator while the agent processes the message. ' +
+      'On platforms that do not (e.g. Slack, WhatsApp), reacts with an "eyes" emoji to the first ' +
+      'inbound message in a thread. Default: true',
+    default: true,
   })
+  @IsBoolean()
   @IsOptional()
-  @ValidateIf((_, value) => value !== null)
-  @IsWellKnownEmoji()
-  onMessageReceived?: string | null;
+  acknowledgeOnReceived?: boolean;
 
   @ApiPropertyOptional({
     description:
@@ -24,18 +24,5 @@ export class AgentReactionSettingsDto {
   @IsOptional()
   @ValidateIf((_, value) => value !== null)
   @IsWellKnownEmoji()
-  onResolved?: string | null;
-}
-
-export class AgentBehaviorDto {
-  @ApiPropertyOptional({ description: 'Show a "Thinking..." indicator while the agent is processing a message' })
-  @IsBoolean()
-  @IsOptional()
-  thinkingIndicatorEnabled?: boolean;
-
-  @ApiPropertyOptional({ type: AgentReactionSettingsDto, description: 'Automatic emoji reactions on messages' })
-  @ValidateNested()
-  @Type(() => AgentReactionSettingsDto)
-  @IsOptional()
-  reactions?: AgentReactionSettingsDto;
+  reactionOnResolved?: string | null;
 }

--- a/apps/api/src/app/agents/dtos/agent-behavior.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-behavior.dto.ts
@@ -6,8 +6,8 @@ export class AgentBehaviorDto {
   @ApiPropertyOptional({
     description:
       'Acknowledge incoming messages. On platforms that support a native typing indicator ' +
-      '(e.g. Microsoft Teams), shows a "Typing…" indicator while the agent processes the message. ' +
-      'On platforms that do not (e.g. Slack, WhatsApp), reacts with an "eyes" emoji to the first ' +
+      '(e.g. Slack, Microsoft Teams), shows a "Typing…" indicator while the agent processes the message. ' +
+      'On platforms that do not (e.g. WhatsApp), reacts with an "eyes" emoji to the first ' +
       'inbound message in a thread. Default: true',
     default: true,
   })

--- a/apps/api/src/app/agents/dtos/agent-platform.enum.ts
+++ b/apps/api/src/app/agents/dtos/agent-platform.enum.ts
@@ -5,5 +5,6 @@ export enum AgentPlatformEnum {
 }
 
 export const PLATFORMS_WITHOUT_TYPING_INDICATOR = new Set<AgentPlatformEnum>([
+  AgentPlatformEnum.SLACK,
   AgentPlatformEnum.WHATSAPP,
 ]);

--- a/apps/api/src/app/agents/dtos/agent-platform.enum.ts
+++ b/apps/api/src/app/agents/dtos/agent-platform.enum.ts
@@ -4,7 +4,7 @@ export enum AgentPlatformEnum {
   TEAMS = 'teams',
 }
 
-export const PLATFORMS_WITHOUT_TYPING_INDICATOR = new Set<AgentPlatformEnum>([
+export const PLATFORMS_WITH_TYPING_INDICATOR = new Set<AgentPlatformEnum>([
   AgentPlatformEnum.SLACK,
-  AgentPlatformEnum.WHATSAPP,
+  AgentPlatformEnum.TEAMS,
 ]);

--- a/apps/api/src/app/agents/e2e/agents.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agents.e2e.ts
@@ -65,7 +65,7 @@ describe('Agents API - /agents #novu-v2', () => {
     expect(afterDelete.status).to.equal(404);
   });
 
-  it('should update and return agent behavior settings', async () => {
+  it('should update and return acknowledgeOnReceived behavior', async () => {
     const identifier = `e2e-behavior-${Date.now()}`;
 
     const createRes = await session.testAgent.post('/v1/agents').send({
@@ -77,28 +77,28 @@ describe('Agents API - /agents #novu-v2', () => {
     expect(createRes.body.data.behavior).to.equal(undefined);
 
     const patchRes = await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({
-      behavior: { thinkingIndicatorEnabled: false },
+      behavior: { acknowledgeOnReceived: false },
     });
 
     expect(patchRes.status).to.equal(200);
-    expect(patchRes.body.data.behavior).to.deep.equal({ thinkingIndicatorEnabled: false });
+    expect(patchRes.body.data.behavior).to.deep.equal({ acknowledgeOnReceived: false });
 
     const getRes = await session.testAgent.get(`/v1/agents/${encodeURIComponent(identifier)}`);
 
     expect(getRes.status).to.equal(200);
-    expect(getRes.body.data.behavior.thinkingIndicatorEnabled).to.equal(false);
+    expect(getRes.body.data.behavior.acknowledgeOnReceived).to.equal(false);
 
     const reEnableRes = await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({
-      behavior: { thinkingIndicatorEnabled: true },
+      behavior: { acknowledgeOnReceived: true },
     });
 
     expect(reEnableRes.status).to.equal(200);
-    expect(reEnableRes.body.data.behavior.thinkingIndicatorEnabled).to.equal(true);
+    expect(reEnableRes.body.data.behavior.acknowledgeOnReceived).to.equal(true);
 
     await session.testAgent.delete(`/v1/agents/${encodeURIComponent(identifier)}`);
   });
 
-  it('should update and return agent reaction settings with defaults', async () => {
+  it('should update and return reactionOnResolved behavior', async () => {
     const identifier = `e2e-reactions-${Date.now()}`;
 
     const createRes = await session.testAgent.post('/v1/agents').send({
@@ -109,31 +109,24 @@ describe('Agents API - /agents #novu-v2', () => {
     expect(createRes.status).to.equal(201);
     expect(createRes.body.data.behavior).to.equal(undefined);
 
-    const setReactionsRes = await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({
-      behavior: {
-        reactions: { onMessageReceived: 'wave', onResolved: 'thumbs_up' },
-      },
+    const setRes = await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({
+      behavior: { reactionOnResolved: 'thumbs_up' },
     });
 
-    expect(setReactionsRes.status).to.equal(200);
-    expect(setReactionsRes.body.data.behavior.reactions.onMessageReceived).to.equal('wave');
-    expect(setReactionsRes.body.data.behavior.reactions.onResolved).to.equal('thumbs_up');
+    expect(setRes.status).to.equal(200);
+    expect(setRes.body.data.behavior.reactionOnResolved).to.equal('thumbs_up');
 
     const getRes = await session.testAgent.get(`/v1/agents/${encodeURIComponent(identifier)}`);
 
     expect(getRes.status).to.equal(200);
-    expect(getRes.body.data.behavior.reactions.onMessageReceived).to.equal('wave');
-    expect(getRes.body.data.behavior.reactions.onResolved).to.equal('thumbs_up');
+    expect(getRes.body.data.behavior.reactionOnResolved).to.equal('thumbs_up');
 
     const disableRes = await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({
-      behavior: {
-        reactions: { onMessageReceived: null },
-      },
+      behavior: { reactionOnResolved: null },
     });
 
     expect(disableRes.status).to.equal(200);
-    expect(disableRes.body.data.behavior.reactions.onMessageReceived).to.equal(null);
-    expect(disableRes.body.data.behavior.reactions.onResolved).to.equal('thumbs_up');
+    expect(disableRes.body.data.behavior.reactionOnResolved).to.equal(null);
 
     await session.testAgent.delete(`/v1/agents/${encodeURIComponent(identifier)}`);
   });

--- a/apps/api/src/app/agents/services/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-config-resolver.service.ts
@@ -33,20 +33,14 @@ export interface ResolvedAgentConfig {
   agentIdentifier: string;
   integrationIdentifier: string;
   integrationId: string;
-  thinkingIndicatorEnabled: boolean;
-  reactionOnMessageReceived: WellKnownEmoji | null;
+  acknowledgeOnReceived: boolean;
   reactionOnResolved: WellKnownEmoji | null;
   bridgeUrl?: string;
   devBridgeUrl?: string;
   devBridgeActive?: boolean;
 }
 
-const DEFAULT_REACTION_ON_MESSAGE: WellKnownEmoji = 'eyes';
 const DEFAULT_REACTION_ON_RESOLVED: WellKnownEmoji = 'check';
-
-function resolveThinkingIndicator(agent: { behavior?: { thinkingIndicatorEnabled?: boolean } }): boolean {
-  return agent.behavior?.thinkingIndicatorEnabled !== false;
-}
 
 async function resolveReaction(
   value: string | null | undefined,
@@ -156,14 +150,9 @@ export class AgentConfigResolver {
       agentIdentifier: agent.identifier,
       integrationIdentifier,
       integrationId: integration._id,
-      thinkingIndicatorEnabled: resolveThinkingIndicator(agent),
-      reactionOnMessageReceived: await resolveReaction(
-        agent.behavior?.reactions?.onMessageReceived,
-        DEFAULT_REACTION_ON_MESSAGE,
-        this.logger
-      ),
+      acknowledgeOnReceived: agent.behavior?.acknowledgeOnReceived !== false,
       reactionOnResolved: await resolveReaction(
-        agent.behavior?.reactions?.onResolved,
+        agent.behavior?.reactionOnResolved,
         DEFAULT_REACTION_ON_RESOLVED,
         this.logger
       ),

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -8,7 +8,7 @@ import {
 } from '@novu/dal';
 import type { EmojiValue, Message, Thread } from 'chat';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
-import { PLATFORMS_WITHOUT_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
+import { PLATFORMS_WITH_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
 import { HandleAgentReplyCommand } from '../usecases/handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from '../usecases/handle-agent-reply/handle-agent-reply.usecase';
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
@@ -119,7 +119,7 @@ export class AgentInboundHandler {
     const isFirstMessage = !channel?.firstPlatformMessageId;
 
     if (config.acknowledgeOnReceived) {
-      const supportsTyping = !PLATFORMS_WITHOUT_TYPING_INDICATOR.has(config.platform);
+      const supportsTyping = PLATFORMS_WITH_TYPING_INDICATOR.has(config.platform);
 
       if (supportsTyping) {
         await thread.startTyping('Thinking...');

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -17,6 +17,8 @@ import { AgentSubscriberResolver } from './agent-subscriber-resolver.service';
 import type { AgentAction } from '@novu/framework';
 import { BridgeExecutorService, type BridgeReaction, NoBridgeUrlError } from './bridge-executor.service';
 
+const ACKNOWLEDGE_FALLBACK_EMOJI = 'eyes' as const;
+
 const ONBOARDING_NO_BRIDGE_REPLY_MARKDOWN = `*You're connected to Novu*
 
 Your bot is linked successfully. Go back to the *Novu dashboard* to complete onboarding.`;
@@ -116,23 +118,31 @@ export class AgentInboundHandler {
     const channel = conversation.channels?.[0];
     const isFirstMessage = !channel?.firstPlatformMessageId;
 
-    if (isFirstMessage && config.reactionOnMessageReceived && message.id) {
-      thread
-        .createSentMessageFromMessage(message)
-        .addReaction(config.reactionOnMessageReceived)
-        .catch((err) => {
-          this.logger.warn(err, `[agent:${agentId}] Failed to add ack reaction to first message`);
-        });
+    if (config.acknowledgeOnReceived) {
+      const supportsTyping = !PLATFORMS_WITHOUT_TYPING_INDICATOR.has(config.platform);
 
-      this.conversationRepository
-        .setFirstPlatformMessageId(config.environmentId, config.organizationId, conversation._id, thread.id, message.id)
-        .catch((err) => {
-          this.logger.warn(err, `[agent:${agentId}] Failed to store firstPlatformMessageId`);
-        });
-    }
+      if (supportsTyping) {
+        await thread.startTyping('Thinking...');
+      } else if (isFirstMessage && message.id) {
+        thread
+          .createSentMessageFromMessage(message)
+          .addReaction(ACKNOWLEDGE_FALLBACK_EMOJI)
+          .catch((err) => {
+            this.logger.warn(err, `[agent:${agentId}] Failed to add ack reaction to first message`);
+          });
 
-    if (config.thinkingIndicatorEnabled && !PLATFORMS_WITHOUT_TYPING_INDICATOR.has(config.platform)) {
-      await thread.startTyping('Thinking...');
+        this.conversationRepository
+          .setFirstPlatformMessageId(
+            config.environmentId,
+            config.organizationId,
+            conversation._id,
+            thread.id,
+            message.id
+          )
+          .catch((err) => {
+            this.logger.warn(err, `[agent:${agentId}] Failed to store firstPlatformMessageId`);
+          });
+      }
     }
 
     const serializedThread = thread.toJSON() as unknown as Record<string, unknown>;

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -36,7 +36,7 @@ const INSTANCE_TTL_MS = 1000 * 60 * 30;
  * resolved config. Event handlers registered via registerEventHandlers() close
  * over this box instead of the config value, so updates to fields that the
  * bridge executor and inbound handler read at event time (bridgeUrl,
- * devBridgeUrl, devBridgeActive, thinkingIndicatorEnabled, reactions) take
+ * devBridgeUrl, devBridgeActive, acknowledgeOnReceived, reactionOnResolved) take
  * effect on the next inbound event without rebuilding the Chat instance.
  *
  * adapterFingerprint captures fields that are baked into the platform adapter

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -346,7 +346,7 @@ export class HandleAgentReply {
     channel: ConversationChannel
   ): Promise<void> {
     const firstMessageId = channel.firstPlatformMessageId;
-    if (!firstMessageId || !config.reactionOnMessageReceived) return;
+    if (!firstMessageId || !config.acknowledgeOnReceived) return;
 
     await this.chatSdkService.removeReaction(
       conversation._agentId,
@@ -354,7 +354,7 @@ export class HandleAgentReply {
       channel.platform,
       channel.platformThreadId,
       firstMessageId,
-      config.reactionOnMessageReceived
+      'eyes'
     );
   }
 

--- a/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
@@ -14,9 +14,8 @@ export class UpdateAgent {
 
   async execute(command: UpdateAgentCommand): Promise<AgentResponseDto> {
     const hasBehaviorFields =
-      command.behavior?.thinkingIndicatorEnabled !== undefined ||
-      command.behavior?.reactions?.onMessageReceived !== undefined ||
-      command.behavior?.reactions?.onResolved !== undefined;
+      command.behavior?.acknowledgeOnReceived !== undefined ||
+      command.behavior?.reactionOnResolved !== undefined;
 
     const hasGeneralFields =
       command.name !== undefined ||
@@ -64,17 +63,11 @@ export class UpdateAgent {
     }
 
     if (hasBehaviorFields) {
-      if (command.behavior!.thinkingIndicatorEnabled !== undefined) {
-        $set['behavior.thinkingIndicatorEnabled'] = command.behavior!.thinkingIndicatorEnabled;
+      if (command.behavior!.acknowledgeOnReceived !== undefined) {
+        $set['behavior.acknowledgeOnReceived'] = command.behavior!.acknowledgeOnReceived;
       }
-
-      if (command.behavior!.reactions !== undefined) {
-        if (command.behavior!.reactions.onMessageReceived !== undefined) {
-          $set['behavior.reactions.onMessageReceived'] = command.behavior!.reactions.onMessageReceived;
-        }
-        if (command.behavior!.reactions.onResolved !== undefined) {
-          $set['behavior.reactions.onResolved'] = command.behavior!.reactions.onResolved;
-        }
+      if (command.behavior!.reactionOnResolved !== undefined) {
+        $set['behavior.reactionOnResolved'] = command.behavior!.reactionOnResolved;
       }
     }
 

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -36,12 +36,18 @@ export type AgentIntegrationSummary = {
   active: boolean;
 };
 
+export type AgentBehavior = {
+  acknowledgeOnReceived?: boolean;
+  reactionOnResolved?: string | null;
+};
+
 export type AgentResponse = {
   _id: string;
   name: string;
   identifier: string;
   description?: string;
   active: boolean;
+  behavior?: AgentBehavior;
   bridgeUrl?: string;
   devBridgeUrl?: string;
   devBridgeActive?: boolean;
@@ -71,6 +77,7 @@ export type UpdateAgentBody = {
   name?: string;
   description?: string;
   active?: boolean;
+  behavior?: AgentBehavior;
   bridgeUrl?: string;
   devBridgeUrl?: string;
   devBridgeActive?: boolean;

--- a/apps/dashboard/src/components/agents/agent-behavior-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-behavior-section.tsx
@@ -6,7 +6,6 @@ import { HelpTooltipIndicator } from '@/components/primitives/help-tooltip-indic
 import { Switch } from '@/components/primitives/switch';
 import { useEnvironment } from '@/context/environment/hooks';
 
-const DEFAULT_REACTION_ON_MESSAGE = 'eyes';
 const DEFAULT_REACTION_ON_RESOLVED = 'check';
 
 function useAgentEmoji() {
@@ -37,12 +36,12 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
   );
 }
 
-function ToggleRow({ label, children }: { label: string; children: React.ReactNode }) {
+function ToggleRow({ label, tooltip, children }: { label: string; tooltip: string; children: React.ReactNode }) {
   return (
     <div className="flex items-center justify-between gap-2 py-1">
       <div className="flex flex-1 items-center gap-1">
         <span className="text-text-sub text-label-sm font-medium">{label}</span>
-        <HelpTooltipIndicator text={label} size="5" />
+        <HelpTooltipIndicator text={tooltip} size="5" />
       </div>
       {children}
     </div>
@@ -63,55 +62,24 @@ function EmojiPickerButton({ emoji }: { emoji: string }) {
 
 export function AgentBehaviorSection() {
   const { unicodeMap } = useAgentEmoji();
-  const messageEmoji = unicodeMap.get(DEFAULT_REACTION_ON_MESSAGE) ?? '';
   const resolvedEmoji = unicodeMap.get(DEFAULT_REACTION_ON_RESOLVED) ?? '';
 
   return (
     <div className="bg-bg-weak flex flex-col rounded-[10px] p-1">
       <SectionHeader>Agent behavior</SectionHeader>
       <div className="bg-bg-white flex flex-col overflow-hidden rounded-md shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">
-        {/*
-        Interrupt mode and response timeout are not supported yet.
-
-        <div className="border-stroke-weak flex flex-col gap-3 border-b p-3">
-          <SettingRow
-            label="Interrupt mode"
-            description="What happens when a new message arrives while the agent is still responding."
-          >
-            <Select defaultValue="drop_respond">
-              <SelectTrigger
-                className="border-stroke-soft bg-bg-white text-text-strong text-label-sm h-8 w-full rounded-md shadow-xs"
-                rightIcon={<RiExpandUpDownLine className="text-text-soft size-3" />}
-              >
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="drop_respond">Drop and respond new message</SelectItem>
-                <SelectItem value="queue">Queue and respond in order</SelectItem>
-                <SelectItem value="ignore">Ignore new message</SelectItem>
-              </SelectContent>
-            </Select>
-          </SettingRow>
-
-          <SettingRow label="Response timeout">
-            <div className="border-stroke-soft bg-bg-white flex h-8 w-full items-center justify-between overflow-hidden rounded-md border px-2 shadow-xs">
-              <span className="text-text-strong text-label-sm font-medium">30</span>
-              <span className="text-text-soft text-label-sm font-medium">seconds</span>
-            </div>
-          </SettingRow>
-        </div>
-        */}
-
         <div className="flex flex-col gap-2 p-3">
-          <ToggleRow label={'Show "Typing..." indicator when available'}>
+          <ToggleRow
+            label="Acknowledge incoming messages"
+            tooltip='Show a "Typing…" indicator while the agent works. On platforms that don&#39;t support typing (Slack, WhatsApp), react with an "eyes" emoji instead.'
+          >
             <Switch defaultChecked />
           </ToggleRow>
 
-          <ToggleRow label="React to incoming messages so users know the agent received them">
-            <EmojiPickerButton emoji={messageEmoji} />
-          </ToggleRow>
-
-          <ToggleRow label="React to the final message when a conversation is resolved">
+          <ToggleRow
+            label="React to the final message when a conversation is resolved"
+            tooltip="Add an emoji reaction to the first message in the thread when the conversation is resolved."
+          >
             <EmojiPickerButton emoji={resolvedEmoji} />
           </ToggleRow>
         </div>

--- a/apps/dashboard/src/components/agents/agent-behavior-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-behavior-section.tsx
@@ -71,7 +71,7 @@ export function AgentBehaviorSection() {
         <div className="flex flex-col gap-2 p-3">
           <ToggleRow
             label="Acknowledge incoming messages"
-            tooltip='Show a "Typing…" indicator while the agent works. On platforms that don&#39;t support typing (Slack, WhatsApp), react with an "eyes" emoji instead.'
+            tooltip='Show a "Typing…" indicator while the agent works. On platforms that don&#39;t support typing, react with an "eyes" emoji instead.'
           >
             <Switch defaultChecked />
           </ToggleRow>

--- a/apps/dashboard/src/components/agents/agent-behavior-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-behavior-section.tsx
@@ -1,10 +1,19 @@
-import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
-import { RiExpandUpDownLine } from 'react-icons/ri';
-import { type AgentEmojiEntry, getAgentEmojiQueryKey, listAgentEmoji } from '@/api/agents';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import { RiCloseCircleLine, RiExpandUpDownLine } from 'react-icons/ri';
+import {
+  type AgentEmojiEntry,
+  type AgentResponse,
+  getAgentDetailQueryKey,
+  getAgentEmojiQueryKey,
+  listAgentEmoji,
+  updateAgent,
+} from '@/api/agents';
 import { HelpTooltipIndicator } from '@/components/primitives/help-tooltip-indicator';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/primitives/popover';
+import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { Switch } from '@/components/primitives/switch';
-import { useEnvironment } from '@/context/environment/hooks';
+import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 
 const DEFAULT_REACTION_ON_RESOLVED = 'check';
 
@@ -48,21 +57,98 @@ function ToggleRow({ label, tooltip, children }: { label: string; tooltip: strin
   );
 }
 
-function EmojiPickerButton({ emoji }: { emoji: string }) {
+type ResolvedEmojiPickerProps = {
+  currentEmoji: string | null;
+  emojiList: AgentEmojiEntry[];
+  unicodeMap: Map<string, string>;
+  disabled?: boolean;
+  onSelect: (emojiName: string | null) => void;
+};
+
+function ResolvedEmojiPicker({ currentEmoji, emojiList, unicodeMap, disabled, onSelect }: ResolvedEmojiPickerProps) {
+  const [open, setOpen] = useState(false);
+  const displayUnicode = currentEmoji ? (unicodeMap.get(currentEmoji) ?? '') : null;
+
   return (
-    <button
-      type="button"
-      className="border-stroke-soft bg-bg-white flex shrink-0 items-center gap-1 rounded-md border px-1.5 py-[3px] shadow-xs"
-    >
-      <span className="text-label-sm leading-5">{emoji}</span>
-      <RiExpandUpDownLine className="text-text-soft size-3" />
-    </button>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild disabled={disabled}>
+        <button
+          type="button"
+          className="border-stroke-soft bg-bg-white flex shrink-0 items-center gap-1 rounded-md border px-1.5 py-[3px] shadow-xs disabled:opacity-50"
+        >
+          {displayUnicode ? (
+            <span className="text-label-sm leading-5">{displayUnicode}</span>
+          ) : (
+            <span className="text-text-soft text-label-sm leading-5">Off</span>
+          )}
+          <RiExpandUpDownLine className="text-text-soft size-3" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-auto min-w-0 p-1.5" sideOffset={4}>
+        <div className="flex flex-col gap-0.5">
+          <button
+            type="button"
+            onClick={() => {
+              onSelect(null);
+              setOpen(false);
+            }}
+            className="text-text-sub hover:bg-bg-weak flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors"
+          >
+            <RiCloseCircleLine className="text-text-soft size-4" />
+            <span>Disabled</span>
+          </button>
+          {emojiList.map((entry) => (
+            <button
+              key={entry.name}
+              type="button"
+              onClick={() => {
+                onSelect(entry.name);
+                setOpen(false);
+              }}
+              className={`hover:bg-bg-weak flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors ${
+                currentEmoji === entry.name ? 'bg-bg-weak' : ''
+              }`}
+            >
+              <span className="text-base leading-5">{entry.unicode}</span>
+              <span className="text-text-sub">{entry.name}</span>
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 
-export function AgentBehaviorSection() {
-  const { unicodeMap } = useAgentEmoji();
-  const resolvedEmoji = unicodeMap.get(DEFAULT_REACTION_ON_RESOLVED) ?? '';
+type AgentBehaviorSectionProps = {
+  agent: AgentResponse;
+};
+
+export function AgentBehaviorSection({ agent }: AgentBehaviorSectionProps) {
+  const queryClient = useQueryClient();
+  const { currentEnvironment } = useEnvironment();
+  const { emojiList, unicodeMap } = useAgentEmoji();
+
+  const acknowledgeOnReceived = agent.behavior?.acknowledgeOnReceived !== false;
+  const reactionOnResolved = agent.behavior?.reactionOnResolved === undefined
+    ? DEFAULT_REACTION_ON_RESOLVED
+    : agent.behavior.reactionOnResolved;
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (body: { acknowledgeOnReceived?: boolean; reactionOnResolved?: string | null }) =>
+      updateAgent(
+        requireEnvironment(currentEnvironment, 'No environment selected'),
+        agent.identifier,
+        { behavior: body }
+      ),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: getAgentDetailQueryKey(currentEnvironment?._id, agent.identifier),
+      });
+    },
+    onError: (err: Error) => {
+      showErrorToast(err.message, 'Failed to update behavior');
+    },
+  });
 
   return (
     <div className="bg-bg-weak flex flex-col rounded-[10px] p-1">
@@ -73,14 +159,24 @@ export function AgentBehaviorSection() {
             label="Acknowledge incoming messages"
             tooltip='Show a "Typing…" indicator while the agent works. On platforms that don&#39;t support typing, react with an "eyes" emoji instead.'
           >
-            <Switch defaultChecked />
+            <Switch
+              checked={acknowledgeOnReceived}
+              disabled={isPending}
+              onCheckedChange={(checked) => mutate({ acknowledgeOnReceived: checked })}
+            />
           </ToggleRow>
 
           <ToggleRow
             label="React to the final message when a conversation is resolved"
             tooltip="Add an emoji reaction to the first message in the thread when the conversation is resolved."
           >
-            <EmojiPickerButton emoji={resolvedEmoji} />
+            <ResolvedEmojiPicker
+              currentEmoji={reactionOnResolved}
+              emojiList={emojiList}
+              unicodeMap={unicodeMap}
+              disabled={isPending}
+              onSelect={(emojiName) => mutate({ reactionOnResolved: emojiName })}
+            />
           </ToggleRow>
         </div>
       </div>

--- a/apps/dashboard/src/components/agents/agent-behavior-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-behavior-section.tsx
@@ -67,7 +67,7 @@ type ResolvedEmojiPickerProps = {
 
 function ResolvedEmojiPicker({ currentEmoji, emojiList, unicodeMap, disabled, onSelect }: ResolvedEmojiPickerProps) {
   const [open, setOpen] = useState(false);
-  const displayUnicode = currentEmoji ? (unicodeMap.get(currentEmoji) ?? '') : null;
+  const displayUnicode = currentEmoji ? unicodeMap.get(currentEmoji) : undefined;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -76,10 +76,12 @@ function ResolvedEmojiPicker({ currentEmoji, emojiList, unicodeMap, disabled, on
           type="button"
           className="border-stroke-soft bg-bg-white flex shrink-0 items-center gap-1 rounded-md border px-1.5 py-[3px] shadow-xs disabled:opacity-50"
         >
-          {displayUnicode ? (
+          {currentEmoji === null ? (
+            <span className="text-text-soft text-label-sm leading-5">Off</span>
+          ) : displayUnicode ? (
             <span className="text-label-sm leading-5">{displayUnicode}</span>
           ) : (
-            <span className="text-text-soft text-label-sm leading-5">Off</span>
+            <span className="text-text-soft text-label-sm leading-5">{currentEmoji}</span>
           )}
           <RiExpandUpDownLine className="text-text-soft size-3" />
         </button>
@@ -167,8 +169,8 @@ export function AgentBehaviorSection({ agent }: AgentBehaviorSectionProps) {
           </ToggleRow>
 
           <ToggleRow
-            label="React to the thread root message when a conversation is resolved"
-            tooltip="Add an emoji reaction to the first message in the thread when the conversation is resolved."
+            label="React to the first message when a conversation is resolved"
+            tooltip="Add an emoji reaction to the first message in the thread when the agent resolves the conversation."
           >
             <ResolvedEmojiPicker
               currentEmoji={reactionOnResolved}

--- a/apps/dashboard/src/components/agents/agent-behavior-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-behavior-section.tsx
@@ -167,7 +167,7 @@ export function AgentBehaviorSection({ agent }: AgentBehaviorSectionProps) {
           </ToggleRow>
 
           <ToggleRow
-            label="React to the final message when a conversation is resolved"
+            label="React to the thread root message when a conversation is resolved"
             tooltip="Add an emoji reaction to the first message in the thread when the conversation is resolved."
           >
             <ResolvedEmojiPicker

--- a/apps/dashboard/src/components/agents/agent-connected-overview.tsx
+++ b/apps/dashboard/src/components/agents/agent-connected-overview.tsx
@@ -10,7 +10,7 @@ type AgentConnectedOverviewProps = {
 export function AgentConnectedOverview({ agent }: AgentConnectedOverviewProps) {
   return (
     <div className="flex min-w-0 flex-1 flex-col gap-4">
-      <AgentBehaviorSection />
+      <AgentBehaviorSection agent={agent} />
       <ConnectedProvidersSection agent={agent} />
       <RecentConversationsSection agent={agent} />
     </div>

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -1,5 +1,5 @@
 import { ChatProviderIdEnum } from '@novu/shared';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 import { RiExpandUpDownLine } from 'react-icons/ri';
 import { type AgentResponse, getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
@@ -34,9 +34,9 @@ function resolveProviderSetupGuide(providerId: string) {
 export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
   const [isExpanded, setIsExpanded] = useState(true);
   const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(undefined);
-  const [isProviderComplete, setIsProviderComplete] = useState(false);
   const { currentEnvironment } = useEnvironment();
   const { integrations } = useFetchIntegrations();
+  const queryClient = useQueryClient();
 
   const agentIntegrationsQuery = useQuery({
     queryKey: getAgentIntegrationsQueryKey(currentEnvironment?._id, agent.identifier),
@@ -49,14 +49,15 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
     enabled: Boolean(currentEnvironment && agent.identifier),
   });
 
+  // Only reveal "2/2 Connect your code" once an integration link has actually been
+  // marked connected by the backend (connectedAt set). The OAuth success handler
+  // below refetches the list so this updates promptly after the user finishes the flow.
   const hasConnectedIntegration = useMemo(() => {
-    if (isProviderComplete) return true;
-
     const links = agentIntegrationsQuery.data?.data;
     if (!links?.length) return false;
 
     return links.some((link) => Boolean(link.connectedAt));
-  }, [isProviderComplete, agentIntegrationsQuery.data?.data]);
+  }, [agentIntegrationsQuery.data?.data]);
 
   const defaultFromAgent = agent.integrations?.[0];
 
@@ -82,8 +83,10 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
   const ProviderGuide = selectedProviderId ? resolveProviderSetupGuide(selectedProviderId) : null;
 
   const handleProviderStepsCompleted = useCallback(() => {
-    setIsProviderComplete(true);
-  }, []);
+    queryClient.invalidateQueries({
+      queryKey: getAgentIntegrationsQueryKey(currentEnvironment?._id, agent.identifier),
+    });
+  }, [queryClient, currentEnvironment?._id, agent.identifier]);
 
   return (
     <div className="bg-bg-weak flex min-w-0 flex-1 flex-col rounded-[10px] p-1">

--- a/apps/dashboard/src/components/agents/slack-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/slack-setup-guide.tsx
@@ -266,6 +266,7 @@ export function SlackSetupGuide({
                 connectionMode="subscriber"
                 connectLabel={`Install ${agent.name} ↗`}
                 connectedLabel="Connected to Slack"
+                onConnectSuccess={handleSlackWorkspaceConnected}
               />
             </NovuProvider>
           ) : null

--- a/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
@@ -85,14 +85,14 @@ export function WhatsAppSetupGuide({
 
   const firstIncompleteStep = useMemo(() => {
     if (isConnected) {
-      return base + 3;
+      return base + 5;
     }
 
     if (!isCredentialsSaved) {
       return base;
     }
 
-    return base + 2;
+    return base + 3;
   }, [base, isCredentialsSaved, isConnected]);
 
   const stepsColumn = (
@@ -100,44 +100,78 @@ export function WhatsAppSetupGuide({
       <SetupStep
         index={base}
         status={deriveStepStatus(base, firstIncompleteStep)}
-        title="Create a Meta app and get credentials"
+        title="Create a Meta app"
         description={
           <span>
-            {'Go to the '}
+            {'Open the '}
             <a
               href="https://developers.facebook.com/apps/"
               target="_blank"
               rel="noopener noreferrer"
               className="text-text-sub underline"
             >
-              Meta Developer Portal
+              Meta App Dashboard
             </a>
-            {', click '}
+            {' and click '}
             <strong className="text-text-sub">Create App</strong>
-            {' and select the '}
-            <strong className="text-text-sub">Business</strong>
-            {
-              ' type. Add the WhatsApp product to your app, then copy these values from your app dashboard into the credentials form:'
+            {'. Select the '}
+            <strong className="text-text-sub">Connect with customers through WhatsApp</strong>
+            {' use case, then pick or create a business portfolio.'}
+          </span>
+        }
+        rightContent={
+          <SetupButton
+            href="https://developers.facebook.com/apps/"
+            leadingIcon={
+              <ProviderIcon
+                providerId={ChatProviderIdEnum.WhatsAppBusiness}
+                providerDisplayName="WhatsApp Business"
+                className="size-4 shrink-0"
+              />
             }
+          >
+            Meta App Dashboard
+          </SetupButton>
+        }
+      />
+
+      <SetupStep
+        index={base + 1}
+        status={deriveStepStatus(base + 1, firstIncompleteStep)}
+        title="Get your API credentials"
+        description={
+          <span>
+            {'After creating the app you land on the Quickstart page. Go to '}
+            <strong className="text-text-sub">WhatsApp &gt; API Setup</strong>
+            {' and collect these four values:'}
           </span>
         }
         extraContent={
-          <ul className="text-text-soft text-label-xs mt-1.5 list-inside list-disc space-y-0.5 font-medium leading-4">
+          <ol className="text-text-soft text-label-xs mt-1.5 list-inside list-decimal space-y-0.5 font-medium leading-4">
             <li>
-              <strong className="text-text-sub">Access Token</strong> — WhatsApp &gt; API Setup
+              <strong className="text-text-sub">Access Token</strong> — click &quot;Generate access token&quot; on the
+              API Setup page
             </li>
             <li>
-              <strong className="text-text-sub">Phone Number ID</strong> — WhatsApp &gt; API Setup
+              <strong className="text-text-sub">Phone Number ID</strong> — shown under your selected phone number on the
+              API Setup page
             </li>
             <li>
-              <strong className="text-text-sub">App Secret</strong> — App Settings &gt; Basic
+              <strong className="text-text-sub">App Secret</strong> — found under App Settings &gt; Basic
             </li>
             <li>
-              <strong className="text-text-sub">Verify Token</strong> — a secret string of your choice (you'll reuse it
-              in the next step)
+              <strong className="text-text-sub">Verify Token</strong> — choose any secret string (you will reuse it when
+              configuring the webhook)
             </li>
-          </ul>
+          </ol>
         }
+      />
+
+      <SetupStep
+        index={base + 2}
+        status={deriveStepStatus(base + 2, firstIncompleteStep)}
+        title="Save credentials in Novu"
+        description="Open the credentials form and enter the four values from the previous step."
         rightContent={
           <div className="flex flex-col gap-3">
             <SetupButton
@@ -165,40 +199,42 @@ export function WhatsAppSetupGuide({
       />
 
       <SetupStep
-        index={base + 1}
-        status={deriveStepStatus(base + 1, firstIncompleteStep)}
-        title="Configure the webhook in Meta"
+        index={base + 3}
+        status={deriveStepStatus(base + 3, firstIncompleteStep)}
+        title="Configure the webhook"
         description={
           <span>
             {'In your Meta app, go to '}
             <strong className="text-text-sub">WhatsApp &gt; Configuration</strong>
-            {
-              '. Paste the webhook URL below as the Callback URL, and set the Verify Token to the same secret string you entered in the previous step.'
-            }
+            {'. Set the '}
+            <strong className="text-text-sub">Callback URL</strong>
+            {' to the webhook URL below, and enter the same '}
+            <strong className="text-text-sub">Verify Token</strong>
+            {' you chose earlier.'}
           </span>
         }
         extraContent={
           <InlineToast
             className="mt-2 w-full"
             variant="tip"
-            title="Important:"
-            description="Subscribe to the 'messages' webhook field so your agent receives inbound messages."
+            title="Don't forget:"
+            description="Click 'Subscribe' next to the 'messages' webhook field — without it your agent won't receive incoming messages."
           />
         }
         rightContent={<WebhookUrlSection webhookUrl={webhookUrl} />}
       />
 
       <SetupStep
-        index={base + 2}
-        status={deriveStepStatus(base + 2, firstIncompleteStep)}
-        title="Verify by sending a message"
-        description="Send a WhatsApp message to your business phone number to confirm the webhook is connected and the agent responds."
+        index={base + 4}
+        status={deriveStepStatus(base + 4, firstIncompleteStep)}
+        title="Send a test message"
+        description="Open WhatsApp and send a message to your business phone number. If everything is configured correctly, your agent will respond."
         extraContent={
           <InlineToast
             className="mt-2 w-full"
             variant="tip"
-            title="Production tip:"
-            description="The access token from API Setup is temporary. For production, generate a permanent System User Token in your Meta Business Settings."
+            title="Before going live:"
+            description="The token from API Setup expires after 24 hours. For production, create a permanent System User Token in Meta Business Settings > System Users."
           />
         }
       />
@@ -210,8 +246,8 @@ export function WhatsAppSetupGuide({
       agentIdentifier={agent.identifier}
       watchedIntegrationId={integrationId}
       onConnected={handleConnected}
-      connectedMessage="Your WhatsApp Business account is connected. This agent is ready to receive messages."
-      listeningMessage="Send a WhatsApp message to your business number to verify configuration."
+      connectedMessage="WhatsApp is connected — your agent is ready to receive messages."
+      listeningMessage="Waiting for a message on your business number to confirm the webhook is working…"
     />
   );
 

--- a/libs/dal/src/repositories/agent/agent.entity.ts
+++ b/libs/dal/src/repositories/agent/agent.entity.ts
@@ -2,16 +2,9 @@ import type { ChangePropsValueType } from '../../types/helpers';
 import type { EnvironmentId } from '../environment';
 import type { OrganizationId } from '../organization';
 
-export interface AgentReactionSettings {
-  /** Emoji name for acknowledging incoming messages (null = disabled, undefined = default "eyes") */
-  onMessageReceived?: string | null;
-  /** Emoji name for resolved conversations (null = disabled, undefined = default "check") */
-  onResolved?: string | null;
-}
-
 export interface AgentBehavior {
-  thinkingIndicatorEnabled?: boolean;
-  reactions?: AgentReactionSettings;
+  acknowledgeOnReceived?: boolean;
+  reactionOnResolved?: string | null;
 }
 
 export class AgentEntity {

--- a/libs/dal/src/repositories/agent/agent.schema.ts
+++ b/libs/dal/src/repositories/agent/agent.schema.ts
@@ -19,11 +19,8 @@ const agentSchema = new Schema<AgentDBModel>(
       default: true,
     },
     behavior: {
-      thinkingIndicatorEnabled: Schema.Types.Boolean,
-      reactions: {
-        onMessageReceived: Schema.Types.Mixed,
-        onResolved: Schema.Types.Mixed,
-      },
+      acknowledgeOnReceived: Schema.Types.Boolean,
+      reactionOnResolved: Schema.Types.Mixed,
     },
     bridgeUrl: Schema.Types.String,
     devBridgeUrl: Schema.Types.String,

--- a/libs/dal/src/repositories/agent/agent.schema.ts
+++ b/libs/dal/src/repositories/agent/agent.schema.ts
@@ -20,7 +20,7 @@ const agentSchema = new Schema<AgentDBModel>(
     },
     behavior: {
       acknowledgeOnReceived: Schema.Types.Boolean,
-      reactionOnResolved: Schema.Types.Mixed,
+      reactionOnResolved: Schema.Types.String,
     },
     bridgeUrl: Schema.Types.String,
     devBridgeUrl: Schema.Types.String,


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Refactors conversational acknowledgement: replaces the typing/reaction model (thinkingIndicatorEnabled + nested reactions) with two flat behavior fields—acknowledgeOnReceived (boolean) that controls whether the agent shows typing or sends an acknowledgement on first inbound messages, and reactionOnResolved (emoji | null) for a post-resolution reaction. Platform logic was inverted to an explicit whitelist (PLATFORMS_WITH_TYPING_INDICATOR) so Slack/Teams show typing and other platforms fall back to a single 'eyes' emoji acknowledgement. The dashboard exposes controlled UI to toggle acknowledgement and pick/disable the resolved-reaction emoji.

## Affected areas

api: DTOs, config resolver, inbound handler, chat SDK comments, usecases (update-agent, handle-agent-reply) and services now use acknowledgeOnReceived and reactionOnResolved; platform constant renamed/inverted; first-message flow prefers typing where supported, otherwise adds an 'eyes' reaction.

dashboard: Adds AgentBehavior types, wires AgentBehaviorSection to accept agent props, introduces ResolvedEmojiPicker and behavior toggles that call updateAgent mutations with query invalidation and error toasts.

dal: Agent entity and Mongoose schema updated—removed thinkingIndicatorEnabled and nested reactions, added acknowledgeOnReceived (Boolean) and reactionOnResolved (String | null).

tests: Agent e2e tests updated to verify PATCH/GET behavior for acknowledgeOnReceived and reactionOnResolved.

## Key technical decisions

- Flattened behavior shape (removed nested reactions) to simplify storage and updates and make updates atomic.  
- Switched typing-indicator logic from a blacklist to an explicit whitelist to make supported platforms explicit.  
- Enforced reactionOnResolved as a String in the schema (previously Mixed), which may require migration/cleanup of existing non-string records.

## Testing

E2E tests were updated to cover the new behavior fields (enable/disable ack and set/clear resolved emoji); UI changes rely on these tests and should be manually verified for picker behavior and mutation UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
