### PR TITLE
fix(api-service): Fix state hashing issue when dot is contained in the payload data

### DIFF
--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/chat-oauth-callback.usecase.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { ChatProviderIdEnum } from '@novu/shared';
+import { peekOAuthStatePayload } from '../generate-chat-oath-url/chat-oauth-state.util';
 import { ChatOauthCallbackCommand } from './chat-oauth-callback.command';
 import { ChatOauthCallbackResult } from './chat-oauth-callback.response';
 import { MsTeamsOauthCallbackCommand } from './msteams-oauth-callback/msteams-oauth-callback.command';
@@ -51,15 +52,13 @@ export class ChatOauthCallback {
 
   private extractProviderIdFromState(state: string): ChatProviderIdEnum {
     try {
-      const decoded = Buffer.from(state, 'base64url').toString();
-      const [payload] = decoded.split('.');
-      const preliminaryData = JSON.parse(payload);
+      const preliminaryData = peekOAuthStatePayload<{ providerId?: ChatProviderIdEnum }>(state);
 
       if (!preliminaryData.providerId) {
         throw new BadRequestException('Invalid state: missing providerId');
       }
 
-      return preliminaryData.providerId as ChatProviderIdEnum;
+      return preliminaryData.providerId;
     } catch (error) {
       if (error instanceof BadRequestException) {
         throw error;

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
@@ -10,6 +10,7 @@ import {
 import { ChatProviderIdEnum } from '@novu/shared';
 import { CreateChannelConnectionCommand } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.command';
 import { CreateChannelConnection } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
+import { peekOAuthStatePayload } from '../../generate-chat-oath-url/chat-oauth-state.util';
 import {
   GenerateMsTeamsOauthUrl,
   StateData,
@@ -116,9 +117,7 @@ export class MsTeamsOauthCallback {
 
   private async decodeMsTeamsState(state: string): Promise<StateData> {
     try {
-      const decoded = Buffer.from(state, 'base64url').toString();
-      const [payload] = decoded.split('.');
-      const preliminaryData = JSON.parse(payload);
+      const preliminaryData = peekOAuthStatePayload<Partial<StateData>>(state);
 
       if (!preliminaryData.environmentId) {
         throw new BadRequestException('Invalid MS Teams state: missing environmentId');

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
@@ -17,6 +17,7 @@ import { CreateChannelConnectionCommand } from '../../../../channel-connections/
 import { CreateChannelConnection } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
 import { CreateChannelEndpointCommand } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
 import { CreateChannelEndpoint } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
+import { peekOAuthStatePayload } from '../../generate-chat-oath-url/chat-oauth-state.util';
 import {
   GenerateSlackOauthUrl,
   StateData,
@@ -231,9 +232,7 @@ export class SlackOauthCallback {
 
   private async decodeSlackState(state: string): Promise<StateData> {
     try {
-      const decoded = Buffer.from(state, 'base64url').toString();
-      const [payload] = decoded.split('.');
-      const preliminaryData = JSON.parse(payload);
+      const preliminaryData = peekOAuthStatePayload<Partial<StateData>>(state);
 
       if (!preliminaryData.environmentId) {
         throw new BadRequestException('Invalid Slack state: missing environmentId');

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/chat-oauth-state.util.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/chat-oauth-state.util.ts
@@ -1,0 +1,48 @@
+/**
+ * OAuth state for chat integrations is encoded as base64url(`${json}.${signature}`),
+ * where the JSON payload may itself contain dots (e.g. emails inside subscriberIds, or
+ * versioned identifiers like `agent-quickstart.v2`). The signature is a hex HMAC, so it
+ * never contains '.'. We must therefore always split on the LAST dot, never the first.
+ */
+
+export interface OAuthStateParts {
+  payload: string;
+  signature: string;
+}
+
+export function encodeOAuthState(jsonPayload: string, signature: string): string {
+  return Buffer.from(`${jsonPayload}.${signature}`).toString('base64url');
+}
+
+export function decodeOAuthStateString(state: string): string {
+  return Buffer.from(state, 'base64url').toString();
+}
+
+export function splitOAuthState(state: string): OAuthStateParts {
+  const decoded = decodeOAuthStateString(state);
+  const lastDotIndex = decoded.lastIndexOf('.');
+
+  if (lastDotIndex === -1) {
+    throw new Error('Invalid OAuth state: missing signature separator');
+  }
+
+  return {
+    payload: decoded.slice(0, lastDotIndex),
+    signature: decoded.slice(lastDotIndex + 1),
+  };
+}
+
+/**
+ * Parse only the JSON payload of an OAuth state without verifying the signature.
+ * Use this when you need a hint from the payload (e.g. providerId, environmentId)
+ * to look up the verification key. The caller MUST then verify the signature via
+ * `GenerateSlackOauthUrl.validateAndDecodeState` / `GenerateMsTeamsOauthUrl.validateAndDecodeState`
+ * before trusting any other field.
+ */
+export function peekOAuthStatePayload<T = unknown>(state: string): T {
+  const decoded = decodeOAuthStateString(state);
+  const lastDotIndex = decoded.lastIndexOf('.');
+  const payload = lastDotIndex === -1 ? decoded : decoded.slice(0, lastDotIndex);
+
+  return JSON.parse(payload) as T;
+}

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.usecase.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import { createHash } from '@novu/application-generic';
 import { EnvironmentRepository, ICredentialsEntity, IntegrationEntity, SubscriberRepository } from '@novu/dal';
 import { ChatProviderIdEnum, ContextPayload } from '@novu/shared';
+import { encodeOAuthState, splitOAuthState } from '../chat-oauth-state.util';
 import { CHAT_OAUTH_CALLBACK_PATH } from '../chat-oauth.constants';
 import { GenerateMsTeamsOauthUrlCommand } from './generate-msteams-oauth-url.command';
 
@@ -119,13 +120,12 @@ export class GenerateMsTeamsOauthUrl {
       throw new BadRequestException('Failed to create OAuth state signature');
     }
 
-    return Buffer.from(`${payload}.${signature}`).toString('base64url');
+    return encodeOAuthState(payload, signature);
   }
 
   static async validateAndDecodeState(state: string, environmentApiKey: string): Promise<StateData> {
     try {
-      const decoded = Buffer.from(state, 'base64url').toString();
-      const [payload, signature] = decoded.split('.');
+      const { payload, signature } = splitOAuthState(state);
 
       const expectedSignature = createHash(environmentApiKey, payload);
       if (signature !== expectedSignature) {

--- a/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase.ts
@@ -14,6 +14,7 @@ import {
 } from '@novu/dal';
 import { ChatProviderIdEnum, ConnectionMode, ContextPayload, SLACK_AGENT_OAUTH_SCOPES } from '@novu/shared';
 import { validateConnectionMode } from '../../../../channel-connections/usecases/channel-connection.utils';
+import { encodeOAuthState, splitOAuthState } from '../chat-oauth-state.util';
 import { CHAT_OAUTH_CALLBACK_PATH } from '../chat-oauth.constants';
 import { GenerateSlackOauthUrlCommand } from './generate-slack-oauth-url.command';
 
@@ -72,8 +73,7 @@ export class GenerateSlackOauthUrl {
       command.connectionMode
     );
 
-    const resolvedScope =
-      command.mode === 'link_user' ? undefined : await this.resolveBotScopes(command);
+    const resolvedScope = command.mode === 'link_user' ? undefined : await this.resolveBotScopes(command);
 
     return this.getOAuthUrl(clientId!, secureState, resolvedScope, command.userScope, command.mode);
   }
@@ -189,7 +189,7 @@ export class GenerateSlackOauthUrl {
       throw new BadRequestException('Failed to create OAuth state signature');
     }
 
-    const base64EncodedState = Buffer.from(`${payload}.${signature}`).toString('base64url');
+    const base64EncodedState = encodeOAuthState(payload, signature);
 
     this.logger.info({ stateData, base64EncodedState }, 'Slack OAuth secure state generated');
 
@@ -198,8 +198,7 @@ export class GenerateSlackOauthUrl {
 
   static async validateAndDecodeState(state: string, environmentApiKey: string): Promise<StateData> {
     try {
-      const decoded = Buffer.from(state, 'base64url').toString();
-      const [payload, signature] = decoded.split('.');
+      const { payload, signature } = splitOAuthState(state);
 
       const expectedSignature = createHash(environmentApiKey, payload);
       if (signature !== expectedSignature) {


### PR DESCRIPTION
Introduce chat-oauth-state.util.ts with helpers (encodeOAuthState, decodeOAuthStateString, splitOAuthState, peekOAuthStatePayload) to correctly handle base64url encoded `${json}.${signature}` states where the JSON payload may contain dots. Update callback usecases to use peekOAuthStatePayload when only a preliminary payload hint is needed (providerId/environmentId). Refactor Slack and MS Teams URL generators to use encodeOAuthState and splitOAuthState for robust encoding/decoding and signature validation. This ensures the state parsing splits on the last dot and avoids breaking on payloads that include dots; callers must still verify signatures via existing validateAndDecodeState logic.

### What changed? Why was the change needed?

@coderabbitai summary

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
