### PR TITLE
fix(dashboard): redirect to agent details after creation

### DIFF
--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -91,7 +91,7 @@ export function AgentsList() {
 
       const environment = requireEnvironment(currentEnvironment, 'No environment selected');
       const agentDetailsPath = `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
-        environmentSlug: environment.slug,
+        environmentSlug: environment.slug ?? '',
         agentIdentifier: encodeURIComponent(createdAgent.identifier),
         agentTab: AGENT_DETAILS_DEFAULT_TAB,
       })}${location.search}`;

--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -2,6 +2,7 @@ import { DirectionEnum, PermissionsEnum } from '@novu/shared';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
 import { RiArrowRightSLine, RiRobot2Line } from 'react-icons/ri';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   AGENTS_LIST_QUERY_KEY,
   type AgentResponse,
@@ -22,11 +23,14 @@ import { PermissionButton } from '@/components/primitives/permission-button';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useHasPermission } from '@/hooks/use-has-permission';
+import { AGENT_DETAILS_DEFAULT_TAB, buildRoute, ROUTES } from '@/utils/routes';
 
 const PAGE_SIZE_OPTIONS = [10, 12, 20, 50];
 
 export function AgentsList() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const location = useLocation();
   const { currentEnvironment } = useEnvironment();
   const has = useHasPermission();
   const canReadAgents = has({ permission: PermissionsEnum.AGENT_READ });
@@ -80,9 +84,19 @@ export function AgentsList() {
   const createMutation = useMutation({
     mutationFn: (body: CreateAgentBody) =>
       createAgent(requireEnvironment(currentEnvironment, 'No environment selected'), body),
-    onSuccess: async () => {
+    onSuccess: async (createdAgent) => {
       await queryClient.invalidateQueries({ queryKey: [AGENTS_LIST_QUERY_KEY] });
       showSuccessToast('Agent created', 'Your agent is ready to use.');
+      setCreateOpen(false);
+
+      const environment = requireEnvironment(currentEnvironment, 'No environment selected');
+      const agentDetailsPath = `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+        environmentSlug: environment.slug,
+        agentIdentifier: encodeURIComponent(createdAgent.identifier),
+        agentTab: AGENT_DETAILS_DEFAULT_TAB,
+      })}${location.search}`;
+
+      navigate(agentDetailsPath);
     },
     onError: (err: Error) => {
       const message = err instanceof NovuApiError ? err.message : 'Could not create agent.';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After successfully creating an agent from the Create agent modal, the app now navigates to that agent’s detail page (overview tab) instead of staying on the agents list. The modal closes on success, and the current query string is preserved on navigation (same behavior as row links in the agents table).

`environment.slug` is optional on the environment type; the redirect uses `environment.slug ?? ''` so the dashboard build matches other agent routes (e.g. agents table).

## Testing

- `pnpm --filter @novu/dashboard exec tsc -b`
- `pnpm exec vite build` in `apps/dashboard`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1776609551110229?thread_ts=1776609551.110229&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-87189db1-a017-5dfb-8e5a-01316bab4c3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87189db1-a017-5dfb-8e5a-01316bab4c3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

After successfully creating an agent from the modal, users are now redirected to that agent's detail page instead of remaining on the agents list. The modal closes, and the current query string is preserved during navigation. The navigation URL is constructed to match other agent routes, with environment slug handled as optional.

## Affected areas

**dashboard**: Modified the AgentsList component's agent creation success callback to close the modal and navigate to the newly created agent's detail page using its identifier, while preserving query parameters.

## Key technical decisions

- Environment slug is marked as optional (`slug ?? ''`) in the URL construction to ensure type consistency with other agent routes in the dashboard.
- Query parameters are preserved during navigation to maintain consistent user context.

## Testing

Local TypeScript build and Vite build verification were performed to validate the changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->