### PR TITLE
fix(@novu/js): dedupe notifications in cache.unshift by id

### DIFF
--- a/packages/js/src/cache/notifications-cache.test.ts
+++ b/packages/js/src/cache/notifications-cache.test.ts
@@ -1,0 +1,537 @@
+import { InboxService } from '../api';
+import { NovuEventEmitter } from '../event-emitter';
+import { ListNotificationsArgs, ListNotificationsResponse, Notification } from '../notifications';
+import { ChannelType, SeverityLevelEnum } from '../types';
+import { NotificationsCache } from './notifications-cache';
+
+describe('NotificationsCache', () => {
+  let notificationsCache: NotificationsCache;
+  let mockEmitter: NovuEventEmitter;
+  let mockInboxService: InboxService;
+  let notification1: Notification;
+  let notification2: Notification;
+
+  beforeEach(() => {
+    mockEmitter = {
+      on: jest.fn(),
+      emit: jest.fn(),
+    } as unknown as NovuEventEmitter;
+
+    mockInboxService = {
+      fetchNotifications: jest.fn(),
+    } as unknown as InboxService;
+    notificationsCache = new NotificationsCache({
+      emitter: mockEmitter,
+      inboxService: mockInboxService,
+    });
+
+    notification1 = new Notification(
+      {
+        id: '1',
+        transactionId: 'tx-1',
+        body: 'test1',
+        isRead: false,
+        isArchived: false,
+        isSeen: false,
+        isSnoozed: false,
+        to: { id: '1', subscriberId: '1' },
+        createdAt: new Date().toISOString(),
+        channelType: ChannelType.IN_APP,
+        workflow: {
+          id: 'test-workflow-1',
+          critical: true,
+          identifier: 'test-workflow-1',
+          name: 'Test Workflow 1',
+          tags: ['tag1'],
+          severity: SeverityLevelEnum.NONE,
+        },
+        severity: SeverityLevelEnum.NONE,
+      },
+      mockEmitter,
+      mockInboxService
+    );
+    notification2 = new Notification(
+      {
+        id: '2',
+        transactionId: 'tx-2',
+        body: 'test2',
+        isRead: false,
+        isSeen: false,
+        isArchived: false,
+        isSnoozed: false,
+        to: { id: '2', subscriberId: '2' },
+        createdAt: new Date().toISOString(),
+        channelType: ChannelType.IN_APP,
+        workflow: {
+          id: 'test-workflow-2',
+          critical: false,
+          identifier: 'test-workflow-2',
+          name: 'Test Workflow 2',
+          tags: ['tag1'],
+          severity: SeverityLevelEnum.NONE,
+        },
+        severity: SeverityLevelEnum.NONE,
+      },
+      mockEmitter,
+      mockInboxService
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should set and get notifications from the cache', () => {
+    const args = { tags: ['tag1'], limit: 10, offset: 0 };
+    const data = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    };
+
+    notificationsCache.set(args, data);
+    const result = notificationsCache.getAll(args);
+
+    expect(result).toEqual(data);
+  });
+
+  it('should clear specific filter from the cache', () => {
+    const args = { tags: ['tag1'], limit: 10, offset: 0 };
+    const data = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    };
+    notificationsCache.set(args, data);
+
+    const filter = { tags: args.tags };
+    notificationsCache.clear(filter);
+
+    const result = notificationsCache.getAll(args);
+    expect(result).toBeUndefined();
+  });
+
+  it('should clear specific filter from the cache but leave the others', () => {
+    const args1 = { tags: ['tag1'], limit: 10, offset: 0 };
+    const args2 = { tags: ['newsletter'], limit: 10, offset: 0 };
+    const data = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    };
+    notificationsCache.set(args1, data);
+    notificationsCache.set(args2, data);
+
+    const filter = { tags: args1.tags };
+    notificationsCache.clear(filter);
+
+    const result1 = notificationsCache.getAll(args1);
+    expect(result1).toBeUndefined();
+    const result2 = notificationsCache.getAll(args2);
+    expect(result2).toEqual(data);
+  });
+
+  it('should clear all caches', () => {
+    const args1 = { tags: ['tag1'], limit: 10, offset: 0 };
+    const args2 = { tags: ['newsletter'], limit: 10, offset: 0 };
+    const data = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    };
+    notificationsCache.set(args1, data);
+    notificationsCache.set(args2, data);
+
+    notificationsCache.clearAll();
+
+    const result1 = notificationsCache.getAll(args1);
+    expect(result1).toBeUndefined();
+    const result2 = notificationsCache.getAll(args2);
+    expect(result2).toBeUndefined();
+  });
+
+  it('should get unique notifications based on tags', () => {
+    const args1 = { tags: ['tag1'], limit: 10, offset: 0 };
+    const data1: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    };
+
+    const args2 = { tags: ['tag1'], limit: 10, offset: 1 };
+    const data2: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification2],
+    };
+
+    const args3 = { tags: ['tag2'], limit: 10, offset: 1 };
+    const data3: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification2],
+    };
+
+    notificationsCache.set(args1, data1);
+    notificationsCache.set(args2, data2);
+    notificationsCache.set(args3, data3);
+
+    const result = notificationsCache.getUniqueNotifications({ tags: ['tag1'] });
+    expect(result).toEqual([notification1, notification2]);
+  });
+
+  it('should get unique read notifications based on tags', () => {
+    const updated1 = new Notification({ ...notification1, isRead: true }, mockEmitter, mockInboxService);
+    const updated2 = new Notification({ ...notification2, isRead: true }, mockEmitter, mockInboxService);
+    const updated3 = new Notification({ ...notification2, id: '3' }, mockEmitter, mockInboxService);
+
+    const args1 = { tags: ['tag1'], limit: 10, offset: 0 };
+    const data1: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [updated1, updated2],
+    };
+
+    const args2 = { tags: ['tag1'], limit: 10, offset: 1 };
+    const data2: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [updated3],
+    };
+
+    const args3 = { tags: ['tag2'], limit: 10, offset: 0 };
+    const data3: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification2],
+    };
+
+    notificationsCache.set(args1, data1);
+    notificationsCache.set(args2, data2);
+    notificationsCache.set(args3, data3);
+
+    let result = notificationsCache.getUniqueNotifications({ tags: ['tag1'], read: true });
+    expect(result).toEqual([updated1, updated2]);
+
+    result = notificationsCache.getUniqueNotifications({ tags: ['tag2'] });
+    expect(result).toEqual([notification2]);
+  });
+
+  it('should update notification and emit single event', () => {
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const updatedNotification = new Notification(
+      { ...notification1, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+    const data: ListNotificationsResponse = { hasMore: false, filter: {}, notifications: [notification1] };
+
+    notificationsCache.set(args, data);
+    (notificationsCache as any).handleNotificationEvent()({ data: updatedNotification });
+
+    expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: {},
+        notifications: [updatedNotification],
+      },
+    });
+  });
+
+  it('should remove notification and emit single event', () => {
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const updatedNotification = new Notification(
+      { ...notification1, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+    const data: ListNotificationsResponse = { hasMore: false, filter: {}, notifications: [notification1] };
+
+    notificationsCache.set(args, data);
+    (notificationsCache as any).handleNotificationEvent({ remove: true })({ data: updatedNotification });
+
+    expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: {},
+        notifications: [],
+      },
+    });
+  });
+
+  it('should update notification for different filters and emit two events', () => {
+    const filter1 = { tags: ['tag1'], read: false, archived: false };
+    const filter2 = { tags: ['tag2'], read: false, archived: false };
+    const args1: ListNotificationsArgs = { limit: 10, offset: 0, ...filter1 };
+    const args2: ListNotificationsArgs = { limit: 10, offset: 0, ...filter2 };
+    const updatedNotification = new Notification(
+      { ...notification1, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+
+    notificationsCache.set(args1, { hasMore: false, filter: filter1, notifications: [notification1, notification2] });
+    notificationsCache.set(args2, { hasMore: false, filter: filter2, notifications: [notification1, notification2] });
+    (notificationsCache as any).handleNotificationEvent()({ data: updatedNotification });
+
+    expect(mockEmitter.emit).toHaveBeenCalledTimes(2);
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(1, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter1,
+        notifications: [updatedNotification, notification2],
+      },
+    });
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(2, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter2,
+        notifications: [updatedNotification, notification2],
+      },
+    });
+  });
+
+  it('should remove notification for different filters and emit two events', () => {
+    const filter1 = { tags: ['tag1'], read: false, archived: false };
+    const filter2 = { tags: ['tag2'], read: false, archived: false };
+    const args1: ListNotificationsArgs = { limit: 10, offset: 0, ...filter1 };
+    const args2: ListNotificationsArgs = { limit: 10, offset: 0, ...filter2 };
+    const updatedNotification = new Notification(
+      { ...notification1, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+
+    notificationsCache.set(args1, { hasMore: false, filter: filter1, notifications: [notification1, notification2] });
+    notificationsCache.set(args2, { hasMore: false, filter: filter2, notifications: [notification1, notification2] });
+    (notificationsCache as any).handleNotificationEvent({ remove: true })({ data: updatedNotification });
+
+    expect(mockEmitter.emit).toHaveBeenCalledTimes(2);
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(1, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter1,
+        notifications: [notification2],
+      },
+    });
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(2, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter2,
+        notifications: [notification2],
+      },
+    });
+  });
+
+  it('should update multiple notifications and emit single event', () => {
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const updatedNotification1 = new Notification(
+      { ...notification1, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+    const updatedNotification2 = new Notification(
+      { ...notification2, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+    const data: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1, notification2],
+    };
+
+    notificationsCache.set(args, data);
+    (notificationsCache as any).handleNotificationEvent()({
+      data: [updatedNotification1, updatedNotification2],
+    });
+
+    expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: {},
+        notifications: [updatedNotification1, updatedNotification2],
+      },
+    });
+  });
+
+  it('should remove multiple notifications and emit single event', () => {
+    const args: ListNotificationsArgs = { limit: 10, offset: 0, tags: ['tag1'], read: false, archived: false };
+    const updatedNotification1 = new Notification(
+      { ...notification1, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+    const updatedNotification2 = new Notification(
+      { ...notification2, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+    const notification3 = new Notification({ ...notification1, id: '3' }, mockEmitter, mockInboxService);
+    const data: ListNotificationsResponse = {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1, notification2, notification3],
+    };
+
+    notificationsCache.set(args, data);
+    (notificationsCache as any).handleNotificationEvent({ remove: true })({
+      data: [updatedNotification1, updatedNotification2],
+    });
+
+    expect(mockEmitter.emit).toHaveBeenCalledWith('notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: {},
+        notifications: [notification3],
+      },
+    });
+  });
+
+  it('should update multiple notifications for different filters and emit two events', () => {
+    const filter1 = { tags: ['tag1'], read: false, archived: false };
+    const filter2 = { tags: ['tag2'], read: false, archived: false };
+    const args1: ListNotificationsArgs = { limit: 10, offset: 0, ...filter1 };
+    const args2: ListNotificationsArgs = { limit: 10, offset: 0, ...filter2 };
+    const updatedNotification1 = new Notification(
+      { ...notification1, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+    const updatedNotification2 = new Notification(
+      { ...notification2, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+
+    notificationsCache.set(args1, {
+      hasMore: false,
+      filter: filter1,
+      notifications: [notification1],
+    });
+    notificationsCache.set(args2, {
+      hasMore: false,
+      filter: filter2,
+      notifications: [notification2],
+    });
+    (notificationsCache as any).handleNotificationEvent()({
+      data: [updatedNotification1, updatedNotification2],
+    });
+
+    expect(mockEmitter.emit).toHaveBeenCalledTimes(2);
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(1, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter1,
+        notifications: [updatedNotification1],
+      },
+    });
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(2, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter2,
+        notifications: [updatedNotification2],
+      },
+    });
+  });
+
+  it('should remove multiple notifications for different filters and emit two events', () => {
+    const filter1 = { tags: ['tag1'], read: false, archived: false };
+    const filter2 = { tags: ['tag2'], read: false, archived: false };
+    const args1: ListNotificationsArgs = { limit: 10, offset: 0, ...filter1 };
+    const args2: ListNotificationsArgs = { limit: 10, offset: 0, ...filter2 };
+    const updatedNotification1 = new Notification(
+      { ...notification1, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+    const updatedNotification2 = new Notification(
+      { ...notification2, body: 'Updated Notification' },
+      mockEmitter,
+      mockInboxService
+    );
+    const notification3 = new Notification({ ...notification1, id: '3' }, mockEmitter, mockInboxService);
+
+    notificationsCache.set(args1, {
+      hasMore: false,
+      filter: filter1,
+      notifications: [notification1, notification3],
+    });
+    notificationsCache.set(args2, {
+      hasMore: false,
+      filter: filter2,
+      notifications: [notification2, notification3],
+    });
+    (notificationsCache as any).handleNotificationEvent({ remove: true })({
+      data: [updatedNotification1, updatedNotification2],
+    });
+
+    expect(mockEmitter.emit).toHaveBeenCalledTimes(2);
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(1, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter1,
+        notifications: [notification3],
+      },
+    });
+    expect(mockEmitter.emit).toHaveBeenNthCalledWith(2, 'notifications.list.updated', {
+      data: {
+        hasMore: false,
+        filter: filter2,
+        notifications: [notification3],
+      },
+    });
+  });
+
+  it('should not add duplicate notification when unshift is called with the same id', () => {
+    const args = { limit: 10, offset: 0 };
+    notificationsCache.set(args, {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    });
+
+    // Call unshift with a notification that has the same id as notification1
+    notificationsCache.unshift(args, {
+      id: '1',
+      isRead: false,
+      isArchived: false,
+      isSeen: false,
+      isSnoozed: false,
+      createdAt: new Date().toISOString(),
+      channelType: ChannelType.IN_APP,
+      to: { subscriberId: '1' },
+      content: 'different body',
+    } as any);
+
+    const result = notificationsCache.getAll(args);
+    // Should still have only 1 notification with id '1'
+    expect(result?.notifications.filter((n) => n.id === '1')).toHaveLength(1);
+  });
+
+  it('should allow unshift of notification with different id', () => {
+    const args = { limit: 10, offset: 0 };
+    notificationsCache.set(args, {
+      hasMore: false,
+      filter: {},
+      notifications: [notification1],
+    });
+
+    notificationsCache.unshift(args, {
+      id: '2',
+      isRead: false,
+      isArchived: false,
+      isSeen: false,
+      isSnoozed: false,
+      createdAt: new Date().toISOString(),
+      channelType: ChannelType.IN_APP,
+      to: { subscriberId: '2' },
+      content: 'new notification',
+    } as any);
+
+    const result = notificationsCache.getAll(args);
+    expect(result?.notifications).toHaveLength(2);
+    expect(result?.notifications[0].id).toBe('2');
+    expect(result?.notifications[1].id).toBe('1');
+  });
+});

--- a/packages/js/src/cache/notifications-cache.ts
+++ b/packages/js/src/cache/notifications-cache.ts
@@ -1,0 +1,383 @@
+import { InboxService } from '../api';
+import { NotificationEvents, NovuEventEmitter } from '../event-emitter';
+import type {
+  ArchivedArgs,
+  CompleteArgs,
+  DeletedArgs,
+  ListNotificationsArgs,
+  ListNotificationsResponse,
+  Notification,
+  ReadArgs,
+  RevertArgs,
+  SeenArgs,
+  SnoozeArgs,
+  UnarchivedArgs,
+  UnreadArgs,
+  UnsnoozeArgs,
+} from '../notifications';
+import type { InboxNotification, NotificationFilter, TagsFilter } from '../types';
+import { createNotification } from '../ui/internal/createNotification';
+import { areDataEqual, areTagsEqual, isSameFilter } from '../utils/notification-utils';
+import { InMemoryCache } from './in-memory-cache';
+import type { Cache } from './types';
+
+const excludeEmpty = ({
+  tags,
+  data,
+  read,
+  archived,
+  snoozed,
+  seen,
+  severity,
+  limit,
+  offset,
+  after,
+  createdGte,
+  createdLte,
+}: ListNotificationsArgs) =>
+  Object.entries({ tags, data, read, archived, snoozed, seen, severity, limit, offset, after, createdGte, createdLte })
+    .filter(([_, value]) => value !== null && value !== undefined && !(Array.isArray(value) && value.length === 0))
+    .reduce((acc, [key, value]) => {
+      // @ts-expect-error
+      acc[key] = value;
+
+      return acc;
+    }, {});
+
+const getCacheKey = ({
+  tags,
+  data,
+  read,
+  archived,
+  snoozed,
+  seen,
+  severity,
+  limit,
+  offset,
+  after,
+  createdGte,
+  createdLte,
+}: ListNotificationsArgs): string => {
+  return JSON.stringify(
+    excludeEmpty({ tags, data, read, archived, snoozed, seen, severity, limit, offset, after, createdGte, createdLte })
+  );
+};
+
+const getFilterKey = ({
+  tags,
+  data,
+  read,
+  archived,
+  snoozed,
+  seen,
+  severity,
+  createdGte,
+  createdLte,
+}: Pick<
+  ListNotificationsArgs,
+  'tags' | 'data' | 'read' | 'archived' | 'snoozed' | 'seen' | 'severity' | 'createdGte' | 'createdLte'
+>): string => {
+  return JSON.stringify(excludeEmpty({ tags, data, read, archived, snoozed, seen, severity, createdGte, createdLte }));
+};
+
+const getFilter = (key: string): NotificationFilter => {
+  return JSON.parse(key);
+};
+
+// these events should update the notification in the cache
+const updateEvents: NotificationEvents[] = [
+  'notification.read.pending',
+  'notification.read.resolved',
+  'notification.unread.pending',
+  'notification.unread.resolved',
+  'notification.complete_action.pending',
+  'notification.complete_action.resolved',
+  'notification.revert_action.pending',
+  'notification.revert_action.resolved',
+  'notifications.read_all.pending',
+  'notifications.read_all.resolved',
+];
+
+// these events should remove the notification from the cache
+const removeEvents: NotificationEvents[] = [
+  'notification.archive.pending',
+  'notification.unarchive.pending',
+  'notification.snooze.pending',
+  'notification.unsnooze.pending',
+  'notification.delete.pending',
+  'notifications.archive_all.pending',
+  'notifications.archive_all_read.pending',
+  'notifications.delete_all.pending',
+];
+
+// Union type for all possible args in notification events
+type NotificationEventArgs =
+  | ReadArgs
+  | UnreadArgs
+  | ArchivedArgs
+  | UnarchivedArgs
+  | DeletedArgs
+  | SeenArgs
+  | SnoozeArgs
+  | UnsnoozeArgs
+  | CompleteArgs
+  | RevertArgs
+  | { tags?: TagsFilter; data?: Record<string, unknown> } // for bulk operations
+  | { notificationIds: string[] } // for seen_all operations
+  | Record<string, never>; // for empty args
+
+export class NotificationsCache {
+  #emitter: NovuEventEmitter;
+  #inboxService: InboxService;
+  /**
+   * The key is the stringified notifications filter, the values are the paginated notifications.
+   */
+  #cache: Cache<ListNotificationsResponse>;
+
+  constructor({ emitter, inboxService }: { emitter: NovuEventEmitter; inboxService: InboxService }) {
+    this.#emitter = emitter;
+    this.#inboxService = inboxService;
+    updateEvents.forEach((event) => {
+      this.#emitter.on(event, this.handleNotificationEvent());
+    });
+    removeEvents.forEach((event) => {
+      this.#emitter.on(event, this.handleNotificationEvent({ remove: true }));
+    });
+    this.#cache = new InMemoryCache();
+  }
+
+  private updateNotification = (key: string, data: Notification): boolean => {
+    const notificationsResponse = this.#cache.get(key);
+    if (!notificationsResponse) {
+      return false;
+    }
+
+    const index = notificationsResponse.notifications.findIndex((el) => el.id === data.id);
+    if (index === -1) {
+      return false;
+    }
+
+    const updatedNotifications = [...notificationsResponse.notifications];
+    updatedNotifications[index] = data;
+
+    this.#cache.set(key, { ...notificationsResponse, notifications: updatedNotifications });
+
+    return true;
+  };
+
+  private removeNotification = (key: string, data: Notification): boolean => {
+    const notificationsResponse = this.#cache.get(key);
+    if (!notificationsResponse) {
+      return false;
+    }
+
+    const index = notificationsResponse.notifications.findIndex((el) => el.id === data.id);
+    if (index === -1) {
+      return false;
+    }
+
+    const newNotifications = [...notificationsResponse.notifications];
+    newNotifications.splice(index, 1);
+
+    this.#cache.set(key, {
+      ...notificationsResponse,
+      notifications: newNotifications,
+    });
+
+    return true;
+  };
+
+  private handleNotificationEvent =
+    ({ remove }: { remove: boolean } = { remove: false }) =>
+    (event: { data?: unknown; args?: NotificationEventArgs }): void => {
+      const { data, args } = event;
+
+      let notifications: Notification[] = [];
+
+      if (data !== undefined && data !== null) {
+        if (
+          Array.isArray(data) &&
+          data.every((item): item is Notification => typeof item === 'object' && 'id' in item)
+        ) {
+          notifications = data;
+        } else if (typeof data === 'object' && 'id' in data) {
+          notifications = [data as Notification];
+        }
+      } else if (remove && args) {
+        if ('notification' in args && args.notification) {
+          notifications = [args.notification];
+        } else if ('notificationId' in args && args.notificationId) {
+          const foundNotifications: Notification[] = [];
+          this.#cache.keys().forEach((key) => {
+            const cachedResponse = this.#cache.get(key);
+            if (cachedResponse) {
+              const found = cachedResponse.notifications.find((n) => n.id === args.notificationId);
+              if (found) {
+                foundNotifications.push(found);
+              }
+            }
+          });
+          notifications = foundNotifications;
+        }
+      }
+
+      if (notifications.length === 0) {
+        return;
+      }
+
+      const uniqueFilterKeys = new Set<string>();
+      this.#cache.keys().forEach((key) => {
+        notifications.forEach((notification) => {
+          let isNotificationFound = false;
+          if (remove) {
+            isNotificationFound = this.removeNotification(key, notification);
+          } else {
+            isNotificationFound = this.updateNotification(key, notification);
+          }
+
+          if (isNotificationFound) {
+            uniqueFilterKeys.add(getFilterKey(getFilter(key)));
+          }
+        });
+      });
+
+      uniqueFilterKeys.forEach((key) => {
+        const notificationsResponse = this.getAggregated(getFilter(key));
+
+        this.#emitter.emit('notifications.list.updated', {
+          data: notificationsResponse,
+        });
+      });
+    };
+
+  private getAggregated(filter: NotificationFilter): ListNotificationsResponse {
+    const cacheKeys = this.#cache.keys().filter((key) => {
+      const parsedFilter = getFilter(key);
+
+      return isSameFilter(parsedFilter, filter);
+    });
+
+    return cacheKeys
+      .map((key) => this.#cache.get(key))
+      .reduce<ListNotificationsResponse>(
+        (acc, el) => {
+          if (!el) {
+            return acc;
+          }
+
+          return {
+            hasMore: el.hasMore,
+            filter: el.filter,
+            notifications: [...acc.notifications, ...el.notifications],
+          };
+        },
+        { hasMore: false, filter: {}, notifications: [] }
+      );
+  }
+
+  get(args: ListNotificationsArgs): ListNotificationsResponse | undefined {
+    return this.#cache.get(getCacheKey(args));
+  }
+
+  has(args: ListNotificationsArgs): boolean {
+    return this.#cache.get(getCacheKey(args)) !== undefined;
+  }
+
+  set(args: ListNotificationsArgs, data: ListNotificationsResponse): void {
+    this.#cache.set(getCacheKey(args), data);
+  }
+
+  unshift(args: ListNotificationsArgs, notification: InboxNotification): void {
+    const cacheKey = getCacheKey(args);
+    const cachedData = this.#cache.get(cacheKey) || {
+      hasMore: false,
+      filter: getFilter(cacheKey),
+      notifications: [],
+    };
+
+    // Skip if a notification with the same id already exists to avoid duplicates
+    if (cachedData.notifications.some((n) => n.id === notification.id)) {
+      return;
+    }
+
+    const notificationInstance = createNotification({
+      notification: { ...notification },
+      emitter: this.#emitter,
+      inboxService: this.#inboxService,
+    });
+
+    this.update(args, {
+      ...cachedData,
+      notifications: [notificationInstance, ...cachedData.notifications],
+    });
+  }
+
+  update(args: ListNotificationsArgs, data: ListNotificationsResponse): void {
+    this.set(args, data);
+    const notificationsResponse = this.getAggregated(getFilter(getCacheKey(args)));
+    this.#emitter.emit('notifications.list.updated', {
+      data: notificationsResponse,
+    });
+  }
+
+  getAll(args: ListNotificationsArgs): ListNotificationsResponse | undefined {
+    if (this.has(args)) {
+      return this.getAggregated({
+        tags: args.tags,
+        data: args.data,
+        read: args.read,
+        snoozed: args.snoozed,
+        archived: args.archived,
+        seen: args.seen,
+        severity: args.severity,
+        createdGte: args.createdGte,
+        createdLte: args.createdLte,
+      });
+    }
+  }
+
+  /**
+   * Get unique notifications based on specified filter fields.
+   * The same tags and data can be applied to multiple filters which means that the same notification can be duplicated.
+   */
+  getUniqueNotifications({
+    tags,
+    read,
+    data,
+  }: Pick<ListNotificationsArgs, 'tags' | 'read' | 'data'>): Array<Notification> {
+    const keys = this.#cache.keys();
+    const uniqueNotifications = new Map<string, Notification>();
+
+    keys.forEach((key) => {
+      const filter = getFilter(key);
+
+      if (areTagsEqual(tags, filter.tags) && areDataEqual(data, filter.data)) {
+        const value = this.#cache.get(key);
+        if (!value) {
+          return;
+        }
+
+        value.notifications
+          .filter((el) => typeof read === 'undefined' || read === el.isRead)
+          .forEach((notification) => {
+            uniqueNotifications.set(notification.id, notification);
+          });
+      }
+    });
+
+    return Array.from(uniqueNotifications.values());
+  }
+
+  clear(filter: NotificationFilter): void {
+    const keys = this.#cache.keys();
+    keys.forEach((key) => {
+      if (isSameFilter(getFilter(key), filter)) {
+        this.#cache.remove(key);
+      }
+    });
+  }
+
+  clearAll(): void {
+    this.#cache.clear();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes \#10762.

When `notifications.cache.unshift()` is called with a notification that has the same `id` as an existing notification in the cache, it now skips the insert to avoid duplicates. This prevents the same notification from appearing multiple times in `useNotifications()` when multiple Novu client instances (e.g., multiple browser tabs) receive the same socket event.

## Root Cause

The `unshift` method in `packages/js/src/cache/notifications-cache.ts` was unconditionally prepending the notification to the cache without checking if a notification with the same `id` already exists. When multiple Novu clients receive the same WebSocket notification event, each one calls `unshift` with the same notification data, resulting in N duplicates for N active clients.

## Fix

Added a guard in `unshift()` that checks if a notification with the same `id` already exists in the cache before prepending:

```typescript
// Skip if a notification with the same id already exists to avoid duplicates
if (cachedData.notifications.some((n) => n.id === notification.id)) {
  return;
}
```

## Testing

Added two new test cases:
1. `should not add duplicate notification when unshift is called with the same id` - verifies deduplication
2. `should allow unshift of notification with different id` - verifies normal behavior still works

## Reproduction (from issue)

```javascript
const novu = new Novu({ applicationIdentifier: 'app', subscriber: 'sub', useCache: true });
const args = { archived: false, limit: 10 };
const notification = { id: 'n1', /* ... */ };

novu.notifications.cache.unshift(args, notification);
novu.notifications.cache.unshift(args, notification);

console.log(novu.notifications.cache.getAll(args).notifications.map(n => n.id));
// Before: ['n1', 'n1']
// After: ['n1']
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavioral guard in `NotificationsCache.unshift` plus new unit tests; main impact is suppressing inserts when an `id` already exists, which could affect callers expecting duplicates (unlikely).
> 
> **Overview**
> Fixes duplicate in-app notifications by adding an `id`-based dedupe guard to `NotificationsCache.unshift()`, skipping the prepend when the cache already contains that notification.
> 
> Adds a comprehensive `notifications-cache.test.ts` suite, including new cases asserting the dedupe behavior and validating cache clearing, aggregation, unique retrieval, and event-driven update/remove emissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89bad2ef9f8220a9fb134afbf9be45e9f0725a0f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->