### PR TITLE
fix(dashboard): remove duplicate dialog overlay blocking clicks after confirm

### DIFF
--- a/apps/dashboard/src/components/confirmation-modal.tsx
+++ b/apps/dashboard/src/components/confirmation-modal.tsx
@@ -9,8 +9,6 @@ import {
   DialogContent,
   DialogDescription,
   DialogFooter,
-  DialogOverlay,
-  DialogPortal,
   DialogTitle,
 } from '@/components/primitives/dialog';
 
@@ -41,60 +39,56 @@ export const ConfirmationModal = ({
 }: ConfirmationModalProps) => {
   return (
     <Dialog modal open={open} onOpenChange={onOpenChange}>
-      <DialogPortal>
-        <DialogOverlay />
-        <DialogContent className="max-w-[440px] gap-4 rounded-xl! p-4 overflow-hidden" hideCloseButton>
-          <div className="flex items-start justify-between">
-            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-warning/10">
-              <RiAlertFill className="size-6 text-warning" />
-            </div>
-            <DialogClose>
-              <Cross2Icon className="size-4" />
-              <span className="sr-only">Close</span>
-            </DialogClose>
+      <DialogContent className="max-w-[440px] gap-4 rounded-xl! p-4 overflow-hidden" hideCloseButton>
+        <div className="flex items-start justify-between">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-warning/10">
+            <RiAlertFill className="size-6 text-warning" />
           </div>
+          <DialogClose>
+            <Cross2Icon className="size-4" />
+            <span className="sr-only">Close</span>
+          </DialogClose>
+        </div>
 
-          <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
-            <DialogTitle className="text-md font-medium tracking-normal">{title}</DialogTitle>
-            <DialogDescription className="text-foreground-600 min-w-0 overflow-hidden">{description}</DialogDescription>
-          </div>
+        <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
+          <DialogTitle className="text-md font-medium tracking-normal">{title}</DialogTitle>
+          <DialogDescription className="text-foreground-600 min-w-0 overflow-hidden">{description}</DialogDescription>
+        </div>
 
-          {/* <div className="flex justify-end gap-3"> */}
-          <DialogFooter>
-            <DialogClose asChild aria-label="Close">
-              <Button
-                type="button"
-                size="sm"
-                mode="outline"
-                variant="secondary"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onOpenChange(false);
-                }}
-              >
-                Cancel
-              </Button>
-            </DialogClose>
-
+        <DialogFooter>
+          <DialogClose asChild aria-label="Close">
             <Button
               type="button"
               size="sm"
-              variant={confirmButtonVariant}
+              mode="outline"
+              variant="secondary"
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                onConfirm();
+                onOpenChange(false);
               }}
-              trailingIcon={confirmTrailingIcon}
-              isLoading={isLoading}
-              disabled={isConfirmDisabled}
             >
-              {confirmButtonText}
+              Cancel
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </DialogPortal>
+          </DialogClose>
+
+          <Button
+            type="button"
+            size="sm"
+            variant={confirmButtonVariant}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onConfirm();
+            }}
+            trailingIcon={confirmTrailingIcon}
+            isLoading={isLoading}
+            disabled={isConfirmDisabled}
+          >
+            {confirmButtonText}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
     </Dialog>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After confirming delete in the agent delete modal (agents list and agent details), the page could become non-interactive until a full refresh.

## Root cause

`ConfirmationModal` wrapped `DialogContent` in an extra `DialogPortal` and rendered a standalone `DialogOverlay` before the content. Our `DialogContent` primitive already portals and renders its own overlay, so the modal had **two** full-screen overlays. The outer overlay was not tied to the same Radix content subtree in a way that always cleaned up on close, leaving an invisible layer that captured pointer events.

## Fix

Use `DialogContent` directly under `Dialog` so there is a single portal and a single overlay, matching the standard shadcn/Radix pattern.

## Testing

- `pnpm exec biome check src/components/confirmation-modal.tsx` (dashboard)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1776686033965339?thread_ts=1776686033.965339&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-c3eaf655-afe0-555a-b7db-58778e57ea37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3eaf655-afe0-555a-b7db-58778e57ea37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

