### PR TITLE
refactor(api-service): clean up agent conversation architecture

### DIFF
--- a/apps/api/src/app/agents/services/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.ts
@@ -75,7 +75,7 @@ export class AgentConversationService {
   ) {}
 
   getPrimaryChannel(conversation: ConversationEntity): ConversationChannel {
-    const channel = conversation.channels[0];
+    const channel = conversation.channels?.[0];
     if (!channel) {
       throw new BadRequestException(`Conversation ${conversation._id} has no channel`);
     }

--- a/apps/api/src/app/agents/services/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.ts
@@ -1,9 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PinoLogger, shortId } from '@novu/application-generic';
 import {
   ConversationActivityEntity,
   ConversationActivityRepository,
   ConversationActivitySenderTypeEnum,
+  ConversationActivityTypeEnum,
+  ConversationChannel,
   ConversationEntity,
   ConversationParticipantTypeEnum,
   ConversationRepository,
@@ -38,6 +40,32 @@ export interface PersistInboundMessageParams {
   organizationId: string;
 }
 
+export interface ConversationActivityContext {
+  conversationId: string;
+  channel: ConversationChannel;
+  agentIdentifier: string;
+  environmentId: string;
+  organizationId: string;
+}
+
+export interface PersistAgentActivityParams extends ConversationActivityContext {
+  platformMessageId: string;
+  /** Overrides channel.platformThreadId when delivery returns a different thread ID */
+  platformThreadId?: string;
+  agentName?: string;
+  content: string;
+  richContent?: Record<string, unknown>;
+}
+
+export interface UpdateMetadataParams extends ConversationActivityContext {
+  currentMetadata: Record<string, unknown>;
+  signals: Array<{ key: string; value: unknown }>;
+}
+
+export interface ResolveConversationParams extends ConversationActivityContext {
+  summary?: string;
+}
+
 @Injectable()
 export class AgentConversationService {
   constructor(
@@ -45,6 +73,15 @@ export class AgentConversationService {
     private readonly activityRepository: ConversationActivityRepository,
     private readonly logger: PinoLogger
   ) {}
+
+  getPrimaryChannel(conversation: ConversationEntity): ConversationChannel {
+    const channel = conversation.channels[0];
+    if (!channel) {
+      throw new BadRequestException(`Conversation ${conversation._id} has no channel`);
+    }
+
+    return channel;
+  }
 
   async createOrGetConversation(params: CreateOrGetConversationParams): Promise<ConversationEntity> {
     const { environmentId, organizationId, platformThreadId } = params;
@@ -164,5 +201,138 @@ export class AgentConversationService {
     serializedThread: Record<string, unknown>
   ): Promise<void> {
     await this.conversationRepository.updateChannelThread(environmentId, organizationId, conversationId, platformThreadId, serializedThread);
+  }
+
+  async getConversation(
+    conversationId: string,
+    environmentId: string,
+    organizationId: string
+  ): Promise<ConversationEntity | null> {
+    return this.conversationRepository.findOne(
+      { _id: conversationId, _environmentId: environmentId, _organizationId: organizationId },
+      '*'
+    );
+  }
+
+  async findByPlatformThread(
+    environmentId: string,
+    organizationId: string,
+    platformThreadId: string
+  ): Promise<ConversationEntity | null> {
+    return this.conversationRepository.findByPlatformThread(environmentId, organizationId, platformThreadId);
+  }
+
+  async setFirstPlatformMessageId(
+    environmentId: string,
+    organizationId: string,
+    conversationId: string,
+    platformThreadId: string,
+    messageId: string
+  ): Promise<void> {
+    await this.conversationRepository.setFirstPlatformMessageId(
+      environmentId,
+      organizationId,
+      conversationId,
+      platformThreadId,
+      messageId
+    );
+  }
+
+  async persistAgentMessage(params: PersistAgentActivityParams): Promise<ConversationActivityEntity> {
+    return this.persistAgentActivity(params, ConversationActivityTypeEnum.MESSAGE, 'activity');
+  }
+
+  async persistAgentEdit(params: PersistAgentActivityParams): Promise<ConversationActivityEntity> {
+    return this.persistAgentActivity(params, ConversationActivityTypeEnum.EDIT, 'preview');
+  }
+
+  private async persistAgentActivity(
+    params: PersistAgentActivityParams,
+    type: ConversationActivityTypeEnum,
+    touch: 'activity' | 'preview'
+  ): Promise<ConversationActivityEntity> {
+    const threadId = params.platformThreadId ?? params.channel.platformThreadId;
+
+    const touchFn =
+      touch === 'activity'
+        ? this.conversationRepository.touchActivity.bind(this.conversationRepository)
+        : this.conversationRepository.touchPreview.bind(this.conversationRepository);
+
+    const [activity] = await Promise.all([
+      this.activityRepository.createAgentActivity({
+        identifier: `act_${shortId(12)}`,
+        conversationId: params.conversationId,
+        platform: params.channel.platform,
+        integrationId: params.channel._integrationId,
+        platformThreadId: threadId,
+        platformMessageId: params.platformMessageId,
+        agentId: params.agentIdentifier,
+        senderName: params.agentName,
+        content: params.content,
+        richContent: params.richContent,
+        type,
+        environmentId: params.environmentId,
+        organizationId: params.organizationId,
+      }),
+      touchFn(params.environmentId, params.organizationId, params.conversationId, params.content),
+    ]);
+
+    return activity;
+  }
+
+  async updateMetadata(params: UpdateMetadataParams): Promise<void> {
+    const merged: Record<string, unknown> = { ...(params.currentMetadata ?? {}) };
+    for (const signal of params.signals) {
+      merged[signal.key] = signal.value;
+    }
+
+    const serialized = JSON.stringify(merged);
+    if (Buffer.byteLength(serialized) > 65_536) {
+      throw new BadRequestException('Conversation metadata exceeds 64KB limit');
+    }
+
+    await Promise.all([
+      this.conversationRepository.updateMetadata(
+        params.environmentId,
+        params.organizationId,
+        params.conversationId,
+        merged
+      ),
+      this.activityRepository.createSignalActivity({
+        identifier: `act_${shortId(12)}`,
+        conversationId: params.conversationId,
+        platform: params.channel.platform,
+        integrationId: params.channel._integrationId,
+        platformThreadId: params.channel.platformThreadId,
+        agentId: params.agentIdentifier,
+        content: `Metadata updated: ${params.signals.map((s) => s.key).join(', ')}`,
+        signalData: { type: 'metadata', payload: merged },
+        environmentId: params.environmentId,
+        organizationId: params.organizationId,
+      }),
+    ]);
+  }
+
+  async resolveConversation(params: ResolveConversationParams): Promise<void> {
+    await Promise.all([
+      this.conversationRepository.updateStatus(
+        params.environmentId,
+        params.organizationId,
+        params.conversationId,
+        ConversationStatusEnum.RESOLVED
+      ),
+      this.activityRepository.createSignalActivity({
+        identifier: `act_${shortId(12)}`,
+        conversationId: params.conversationId,
+        platform: params.channel.platform,
+        integrationId: params.channel._integrationId,
+        platformThreadId: params.channel.platformThreadId,
+        agentId: params.agentIdentifier,
+        content: params.summary ?? 'Conversation resolved',
+        signalData: { type: 'resolve', payload: params.summary ? { summary: params.summary } : undefined },
+        environmentId: params.environmentId,
+        organizationId: params.organizationId,
+      }),
+    ]);
   }
 }

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -1,16 +1,13 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import {
   ConversationActivitySenderTypeEnum,
   ConversationParticipantTypeEnum,
-  ConversationRepository,
   SubscriberRepository,
 } from '@novu/dal';
 import type { EmojiValue, Message, Thread } from 'chat';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { PLATFORMS_WITH_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
-import { HandleAgentReplyCommand } from '../usecases/handle-agent-reply/handle-agent-reply.command';
-import { HandleAgentReply } from '../usecases/handle-agent-reply/handle-agent-reply.usecase';
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
 import { AgentConversationService } from './agent-conversation.service';
 import { AgentSubscriberResolver } from './agent-subscriber-resolver.service';
@@ -38,11 +35,8 @@ export class AgentInboundHandler {
     private readonly logger: PinoLogger,
     private readonly subscriberResolver: AgentSubscriberResolver,
     private readonly conversationService: AgentConversationService,
-    private readonly conversationRepository: ConversationRepository,
     private readonly bridgeExecutor: BridgeExecutorService,
-    private readonly subscriberRepository: SubscriberRepository,
-    @Inject(forwardRef(() => HandleAgentReply))
-    private readonly handleAgentReply: HandleAgentReply
+    private readonly subscriberRepository: SubscriberRepository
   ) {}
 
   async handle(
@@ -115,8 +109,8 @@ export class AgentInboundHandler {
       organizationId: config.organizationId,
     });
 
-    const channel = conversation.channels?.[0];
-    const isFirstMessage = !channel?.firstPlatformMessageId;
+    const primaryChannel = this.conversationService.getPrimaryChannel(conversation);
+    const isFirstMessage = !primaryChannel.firstPlatformMessageId;
 
     if (config.acknowledgeOnReceived) {
       const supportsTyping = PLATFORMS_WITH_TYPING_INDICATOR.has(config.platform);
@@ -131,7 +125,7 @@ export class AgentInboundHandler {
             this.logger.warn(err, `[agent:${agentId}] Failed to add ack reaction to first message`);
           });
 
-        this.conversationRepository
+        this.conversationService
           .setFirstPlatformMessageId(
             config.environmentId,
             config.organizationId,
@@ -177,17 +171,17 @@ export class AgentInboundHandler {
       });
     } catch (err) {
       if (err instanceof NoBridgeUrlError) {
-        await this.handleAgentReply.execute(
-          HandleAgentReplyCommand.create({
-            userId: 'system',
-            environmentId: config.environmentId,
-            organizationId: config.organizationId,
-            conversationId: conversation._id,
-            agentIdentifier: config.agentIdentifier,
-            integrationIdentifier: config.integrationIdentifier,
-            reply: { text: ONBOARDING_NO_BRIDGE_REPLY_MARKDOWN },
-          })
-        );
+        const sent = await thread.post(ONBOARDING_NO_BRIDGE_REPLY_MARKDOWN);
+        const channel = this.conversationService.getPrimaryChannel(conversation);
+        await this.conversationService.persistAgentMessage({
+          conversationId: conversation._id,
+          channel,
+          platformMessageId: (sent as { id?: string })?.id ?? '',
+          agentIdentifier: config.agentIdentifier,
+          content: ONBOARDING_NO_BRIDGE_REPLY_MARKDOWN,
+          environmentId: config.environmentId,
+          organizationId: config.organizationId,
+        });
 
         return;
       }
@@ -204,7 +198,7 @@ export class AgentInboundHandler {
       return;
     }
 
-    const conversation = await this.conversationRepository.findByPlatformThread(
+    const conversation = await this.conversationService.findByPlatformThread(
       config.environmentId,
       config.organizationId,
       threadId

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, forwardRef, Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
+import { BadRequestException, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { CacheService, PinoLogger } from '@novu/application-generic';
 import type { SentMessageInfo } from '@novu/framework';
 import type { AdapterPostableMessage, Chat, EmojiValue, Message, ReactionEvent, Thread } from 'chat';
@@ -58,7 +58,6 @@ export class ChatSdkService implements OnModuleDestroy {
     private readonly logger: PinoLogger,
     private readonly cacheService: CacheService,
     private readonly agentConfigResolver: AgentConfigResolver,
-    @Inject(forwardRef(() => AgentInboundHandler))
     private readonly inboundHandler: AgentInboundHandler
   ) {
     this.instances = new LRUCache<string, CachedChat>({

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -49,7 +49,7 @@ export class HandleAgentReply {
       throw new NotFoundException('Conversation not found');
     }
 
-    const channel = this.getPrimaryChannel(conversation);
+    const channel = this.conversationService.getPrimaryChannel(conversation);
     const agentName = await this.resolveValidatedAgentNameForDelivery(command, conversation);
 
     if (command.edit) {
@@ -63,6 +63,8 @@ export class HandleAgentReply {
 
     let replyInfo: SentMessageInfo | undefined;
     if (command.reply) {
+      this.ensureSerializedThread(channel);
+
       replyInfo = await this.deliverMessage(
         command,
         conversation,
@@ -111,13 +113,10 @@ export class HandleAgentReply {
     return agent.name;
   }
 
-  private getPrimaryChannel(conversation: ConversationEntity): ConversationChannel {
-    const channel = this.conversationService.getPrimaryChannel(conversation);
+  private ensureSerializedThread(channel: ConversationChannel): asserts channel is ConversationChannel & { serializedThread: Record<string, unknown> } {
     if (!channel.serializedThread) {
       throw new BadRequestException('Conversation has no serialized thread — unable to deliver reply');
     }
-
-    return channel;
   }
 
   private async deliverMessage(

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -50,10 +50,9 @@ export class HandleAgentReply {
     }
 
     const channel = this.getPrimaryChannel(conversation);
+    const agentName = await this.resolveValidatedAgentNameForDelivery(command, conversation);
 
     if (command.edit) {
-      const agentName = await this.resolveValidatedAgentNameForDelivery(command, conversation);
-
       return this.deliverEdit(command, conversation, channel, command.edit, agentName);
     }
 
@@ -64,8 +63,6 @@ export class HandleAgentReply {
 
     let replyInfo: SentMessageInfo | undefined;
     if (command.reply) {
-      const agentName = await this.resolveValidatedAgentNameForDelivery(command, conversation);
-
       replyInfo = await this.deliverMessage(
         command,
         conversation,

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -1,26 +1,16 @@
-import {
-  BadRequestException,
-  ForbiddenException,
-  forwardRef,
-  Inject,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
-import { PinoLogger, shortId } from '@novu/application-generic';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { PinoLogger } from '@novu/application-generic';
 import {
   AgentRepository,
-  ConversationActivityRepository,
-  ConversationActivityTypeEnum,
   ConversationChannel,
   ConversationEntity,
-  ConversationRepository,
-  ConversationStatusEnum,
+  ConversationParticipantTypeEnum,
   SubscriberRepository,
 } from '@novu/dal';
 import type { SentMessageInfo } from '@novu/framework';
 import { AgentEventEnum } from '../../dtos/agent-event.enum';
-import { isValidMetadataSignalKey } from '../../dtos/agent-reply-payload.dto';
 import type { EditPayloadDto, ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
+import { isValidMetadataSignalKey } from '../../dtos/agent-reply-payload.dto';
 import { AgentConfigResolver, ResolvedAgentConfig } from '../../services/agent-config-resolver.service';
 import { AgentConversationService } from '../../services/agent-conversation.service';
 import { BridgeExecutorService } from '../../services/bridge-executor.service';
@@ -30,11 +20,8 @@ import { HandleAgentReplyCommand } from './handle-agent-reply.command';
 @Injectable()
 export class HandleAgentReply {
   constructor(
-    private readonly conversationRepository: ConversationRepository,
-    private readonly activityRepository: ConversationActivityRepository,
-    private readonly subscriberRepository: SubscriberRepository,
     private readonly agentRepository: AgentRepository,
-    @Inject(forwardRef(() => ChatSdkService))
+    private readonly subscriberRepository: SubscriberRepository,
     private readonly chatSdkService: ChatSdkService,
     private readonly bridgeExecutor: BridgeExecutorService,
     private readonly agentConfigResolver: AgentConfigResolver,
@@ -53,13 +40,10 @@ export class HandleAgentReply {
       throw new BadRequestException('At least one of reply, edit, resolve, or signals must be provided');
     }
 
-    const conversation = await this.conversationRepository.findOne(
-      {
-        _id: command.conversationId,
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-      },
-      '*'
+    const conversation = await this.conversationService.getConversation(
+      command.conversationId,
+      command.environmentId,
+      command.organizationId
     );
     if (!conversation) {
       throw new NotFoundException('Conversation not found');
@@ -87,7 +71,6 @@ export class HandleAgentReply {
         conversation,
         channel,
         command.reply,
-        ConversationActivityTypeEnum.MESSAGE,
         agentName
       );
 
@@ -132,8 +115,8 @@ export class HandleAgentReply {
   }
 
   private getPrimaryChannel(conversation: ConversationEntity): ConversationChannel {
-    const channel = conversation.channels[0];
-    if (!channel?.serializedThread) {
+    const channel = this.conversationService.getPrimaryChannel(conversation);
+    if (!channel.serializedThread) {
       throw new BadRequestException('Conversation has no serialized thread — unable to deliver reply');
     }
 
@@ -145,7 +128,6 @@ export class HandleAgentReply {
     conversation: ConversationEntity,
     channel: ConversationChannel,
     content: ReplyContentDto,
-    type: ConversationActivityTypeEnum,
     agentName?: string
   ): Promise<SentMessageInfo> {
     const textFallback = this.extractTextFallback(content);
@@ -158,29 +140,18 @@ export class HandleAgentReply {
       content
     );
 
-    await Promise.all([
-      this.activityRepository.createAgentActivity({
-        identifier: `act_${shortId(12)}`,
-        conversationId: conversation._id,
-        platform: channel.platform,
-        integrationId: channel._integrationId,
-        platformThreadId: sent.platformThreadId || channel.platformThreadId,
-        platformMessageId: sent.messageId,
-        agentId: command.agentIdentifier,
-        senderName: agentName,
-        content: textFallback,
-        richContent: content.card || content.files?.length ? (content as Record<string, unknown>) : undefined,
-        type,
-        environmentId: command.environmentId,
-        organizationId: command.organizationId,
-      }),
-      this.conversationRepository.touchActivity(
-        command.environmentId,
-        command.organizationId,
-        conversation._id,
-        textFallback
-      ),
-    ]);
+    await this.conversationService.persistAgentMessage({
+      conversationId: conversation._id,
+      channel,
+      platformThreadId: sent.platformThreadId || undefined,
+      platformMessageId: sent.messageId,
+      agentIdentifier: command.agentIdentifier,
+      agentName,
+      content: textFallback,
+      richContent: content.card || content.files?.length ? (content as Record<string, unknown>) : undefined,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+    });
 
     return sent;
   }
@@ -203,32 +174,19 @@ export class HandleAgentReply {
       edit.content
     );
 
-    await Promise.all([
-      this.activityRepository.createAgentActivity({
-        identifier: `act_${shortId(12)}`,
-        conversationId: conversation._id,
-        platform: channel.platform,
-        integrationId: channel._integrationId,
-        platformThreadId: sent.platformThreadId || channel.platformThreadId,
-        platformMessageId: sent.messageId,
-        agentId: command.agentIdentifier,
-        senderName: agentName,
-        content: textFallback,
-        richContent:
-          edit.content.card || edit.content.files?.length ? (edit.content as Record<string, unknown>) : undefined,
-        type: ConversationActivityTypeEnum.EDIT,
-        environmentId: command.environmentId,
-        organizationId: command.organizationId,
-      }),
-      // Refresh the conversation's lastMessagePreview + lastActivityAt without
-      // incrementing messageCount — edits mutate an existing message, they don't add one.
-      this.conversationRepository.touchPreview(
-        command.environmentId,
-        command.organizationId,
-        conversation._id,
-        textFallback
-      ),
-    ]);
+    await this.conversationService.persistAgentEdit({
+      conversationId: conversation._id,
+      channel,
+      platformThreadId: sent.platformThreadId || undefined,
+      platformMessageId: sent.messageId,
+      agentIdentifier: command.agentIdentifier,
+      agentName,
+      content: textFallback,
+      richContent:
+        edit.content.card || edit.content.files?.length ? (edit.content as Record<string, unknown>) : undefined,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+    });
 
     return sent;
   }
@@ -257,7 +215,16 @@ export class HandleAgentReply {
     );
 
     if (metadataSignals.length) {
-      await this.executeMetadataSignals(command, conversation, channel, metadataSignals);
+      await this.validateMetadataSignalKeys(metadataSignals);
+      await this.conversationService.updateMetadata({
+        conversationId: conversation._id,
+        channel,
+        currentMetadata: conversation.metadata ?? {},
+        signals: metadataSignals,
+        agentIdentifier: command.agentIdentifier,
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+      });
     }
 
     const triggerSignals = (signals ?? []).filter((s) => s.type === 'trigger');
@@ -266,18 +233,7 @@ export class HandleAgentReply {
     }
   }
 
-  private async executeMetadataSignals(
-    command: HandleAgentReplyCommand,
-    conversation: ConversationEntity,
-    channel: ConversationChannel,
-    signals: Array<{ type: 'metadata'; key: string; value: unknown }>
-  ): Promise<void> {
-    // Defense in depth: the DTO validator already enforces this for HTTP callers,
-    // but commands can also be constructed internally (e.g. by the inbound handler).
-    // Reject prototype-pollution gadgets, keys that wouldn't survive a clean
-    // round-trip through downstream consumers, and undefined values (which would
-    // be silently dropped by JSON.stringify and never reach storage).
-    const merged: Record<string, unknown> = { ...(conversation.metadata ?? {}) };
+  private validateMetadataSignalKeys(signals: Array<{ key: string; value: unknown }>): void {
     for (const signal of signals) {
       if (!isValidMetadataSignalKey(signal.key)) {
         throw new BadRequestException(`Invalid metadata signal key: "${signal.key}"`);
@@ -285,34 +241,7 @@ export class HandleAgentReply {
       if (signal.value === undefined) {
         throw new BadRequestException(`Metadata signal "${signal.key}" must have a defined value`);
       }
-      merged[signal.key] = signal.value;
     }
-
-    const serialized = JSON.stringify(merged);
-    if (Buffer.byteLength(serialized) > 65_536) {
-      throw new BadRequestException('Conversation metadata exceeds 64KB limit');
-    }
-
-    await Promise.all([
-      this.conversationRepository.updateMetadata(
-        command.environmentId,
-        command.organizationId,
-        conversation._id,
-        merged
-      ),
-      this.activityRepository.createSignalActivity({
-        identifier: `act_${shortId(12)}`,
-        conversationId: conversation._id,
-        platform: channel.platform,
-        integrationId: channel._integrationId,
-        platformThreadId: channel.platformThreadId,
-        agentId: command.agentIdentifier,
-        content: `Metadata updated: ${signals.map((s) => s.key).join(', ')}`,
-        signalData: { type: 'metadata', payload: merged },
-        environmentId: command.environmentId,
-        organizationId: command.organizationId,
-      }),
-    ]);
   }
 
   private async resolveConversation(
@@ -322,32 +251,20 @@ export class HandleAgentReply {
     channel: ConversationChannel,
     options: { summary?: string }
   ): Promise<void> {
-    await Promise.all([
-      this.conversationRepository.updateStatus(
-        command.environmentId,
-        command.organizationId,
-        conversation._id,
-        ConversationStatusEnum.RESOLVED
-      ),
-      this.activityRepository.createSignalActivity({
-        identifier: `act_${shortId(12)}`,
-        conversationId: conversation._id,
-        platform: channel.platform,
-        integrationId: channel._integrationId,
-        platformThreadId: channel.platformThreadId,
-        agentId: command.agentIdentifier,
-        content: options.summary ?? 'Conversation resolved',
-        signalData: { type: 'resolve', payload: options.summary ? { summary: options.summary } : undefined },
-        environmentId: command.environmentId,
-        organizationId: command.organizationId,
-      }),
-    ]);
+    await this.conversationService.resolveConversation({
+      conversationId: conversation._id,
+      channel,
+      agentIdentifier: command.agentIdentifier,
+      summary: options.summary,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+    });
 
     this.reactOnResolve(config, conversation, channel).catch((err) => {
       this.logger.warn(err, `[agent:${command.agentIdentifier}] Failed to add resolve reaction`);
     });
 
-    this.fireOnResolveBridgeCall(command, config, conversation).catch((err) => {
+    this.fireOnResolveBridgeCall(command, config, conversation, channel).catch((err) => {
       this.logger.error(err, `[agent:${command.agentIdentifier}] Failed to fire onResolve bridge call`);
     });
   }
@@ -391,17 +308,18 @@ export class HandleAgentReply {
   private async fireOnResolveBridgeCall(
     command: HandleAgentReplyCommand,
     config: ResolvedAgentConfig,
-    conversation: ConversationEntity
+    conversation: ConversationEntity,
+    channel: ConversationChannel
   ): Promise<void> {
-    const subscriberParticipant = conversation.participants.find((p) => p.type === 'subscriber');
+    const subscriberParticipant = conversation.participants.find(
+      (p) => p.type === ConversationParticipantTypeEnum.SUBSCRIBER
+    );
     const [subscriber, history] = await Promise.all([
       subscriberParticipant
         ? this.subscriberRepository.findBySubscriberId(command.environmentId, subscriberParticipant.id)
         : Promise.resolve(null),
       this.conversationService.getHistory(command.environmentId, conversation._id),
     ]);
-
-    const channel = conversation.channels[0];
 
     await this.bridgeExecutor.execute({
       event: AgentEventEnum.ON_RESOLVE,
@@ -411,7 +329,7 @@ export class HandleAgentReply {
       history,
       message: null,
       platformContext: {
-        threadId: channel?.platformThreadId ?? '',
+        threadId: channel.platformThreadId,
         channelId: '',
         isDM: false,
       },


### PR DESCRIPTION
## Summary

- **Break circular dependency cycle** — Remove all `forwardRef` usage from `ChatSdkService`, `AgentInboundHandler`, and `HandleAgentReply`. The dependency graph is now a clean DAG.
- **Centralize conversation state in `AgentConversationService`** — All conversation state mutations (persist messages, edits, metadata updates, resolve) now go through this single service instead of being scattered across `HandleAgentReply` and `AgentInboundHandler`.
- **Clean up interfaces** — Reuse `ConversationChannel` from DAL instead of redeclaring flat fields (`platform`, `integrationId`, `platformThreadId`). Extract shared `ConversationActivityContext` base interface. Centralize `channels[0]` assumption into `getPrimaryChannel()`.

### Before (circular dependencies)

```mermaid
graph LR
    ChatSdk -- "forwardRef" --> InboundHandler
    InboundHandler -- "forwardRef" --> HandleReply
    HandleReply -- "forwardRef" --> ChatSdk
    HandleReply --> ConversationRepo
    HandleReply --> ActivityRepo
    InboundHandler --> ConversationRepo
    InboundHandler --> ConversationService

    style ChatSdk fill:#f99
    style InboundHandler fill:#f99
    style HandleReply fill:#f99
```

### After (clean DAG)

```mermaid
graph LR
    ChatSdk --> InboundHandler
    InboundHandler --> ConversationService
    HandleReply --> ChatSdk
    HandleReply --> ConversationService
    ConversationService --> ConversationRepo
    ConversationService --> ActivityRepo

    style ConversationService fill:#9f9
```

### Inbound flow (webhook → bridge)

```mermaid
sequenceDiagram
    participant W as Webhook Controller
    participant SDK as ChatSdkService
    participant IH as AgentInboundHandler
    participant CS as AgentConversationService
    participant BE as BridgeExecutor

    W->>SDK: handleWebhook()
    SDK->>IH: handle(thread, message)
    IH->>CS: createOrGetConversation()
    IH->>CS: persistInboundMessage()
    IH->>CS: updateChannelThread()
    IH->>BE: execute(bridge call)
    Note over IH: NoBridgeUrlError? → thread.post() + CS.persistAgentMessage()
```

### Outbound flow (agent reply → platform)

```mermaid
sequenceDiagram
    participant C as API Controller
    participant HR as HandleAgentReply
    participant CS as AgentConversationService
    participant SDK as ChatSdkService

    C->>HR: execute(command)
    HR->>CS: getConversation()
    HR->>CS: getPrimaryChannel()
    HR->>SDK: postToConversation()
    HR->>CS: persistAgentMessage()
    Note over HR: signals? → CS.updateMetadata()
    Note over HR: resolve? → CS.resolveConversation()
```

## Test plan

- [ ] Existing e2e tests pass (`agent-reply.e2e.ts`, `agent-webhook.e2e.ts`, `agents.e2e.ts`) — tests operate at HTTP/DI level with stubbed `ChatSdkService` and `BridgeExecutorService`, so the internal refactoring is transparent
- [ ] Verify NestJS module bootstraps without `forwardRef` errors
- [ ] Verify inbound webhook flow (message → conversation created → bridge called)
- [ ] Verify outbound reply flow (reply → platform delivery → activity persisted)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Refactors agent conversation handling by introducing AgentConversationService as the single place for conversation state mutations (persisting messages/edits, metadata updates, resolve) and removing forwardRef-based circular dependencies between ChatSdkService, AgentInboundHandler, and HandleAgentReply. The dependency graph is converted to a DAG, channel selection is centralized (getPrimaryChannel), and shared interfaces were added to standardize agent activity operations and reduce duplicated persistence logic.

## Affected areas

**api**: Added AgentConversationService (getConversation, findByPlatformThread, setFirstPlatformMessageId, getPrimaryChannel, persistAgentMessage/persistAgentEdit, updateMetadata, resolveConversation) and new interfaces (ConversationActivityContext, PersistAgentActivityParams, UpdateMetadataParams, ResolveConversationParams); refactored AgentInboundHandler and HandleAgentReply to delegate state changes to the new service; removed forwardRef injection from ChatSdkService and consolidated channels[0] usage into getPrimaryChannel().

## Key technical decisions

- Centralized conversation mutation logic into AgentConversationService to remove forwardRef cycles and consolidate repository interactions.
- Converted dependency graph to a directed acyclic graph by removing forwardRef usage and adjusting constructor wiring.
- Standardized activity/context parameter interfaces to unify persist/edit/metadata/resolve operations.
- Enforced a 64KB JSON size limit when merging/updating conversation metadata to prevent oversized payloads.
- Explicitized primary-channel access via getPrimaryChannel() instead of ad-hoc channels[0] assumptions.

## Testing

Run existing e2e tests (agent-reply.e2e.ts, agent-webhook.e2e.ts, agents.e2e.ts) and verify NestJS module bootstraps without forwardRef errors; no new unit tests were added in this diff and behavior relies on existing e2e coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->