### PR TITLE
feat(dashboard, api-service): enforce agent active toggle fixes NV-7393

### DIFF
--- a/apps/api/src/app/agents/agents-webhook.controller.ts
+++ b/apps/api/src/app/agents/agents-webhook.controller.ts
@@ -18,6 +18,7 @@ import { RequireAuthentication } from '../auth/framework/auth.decorator';
 import { ExternalApiAccessible } from '../auth/framework/external-api.decorator';
 import { UserSession } from '../shared/framework/user.decorator';
 import { AgentReplyPayloadDto } from './dtos/agent-reply-payload.dto';
+import { AgentInactiveException } from './exceptions/agent-inactive.exception';
 import { AgentConversationEnabledGuard } from './guards/agent-conversation-enabled.guard';
 import { ChatSdkService } from './services/chat-sdk.service';
 import { HandleAgentReplyCommand, Signal } from './usecases/handle-agent-reply/handle-agent-reply.command';
@@ -82,6 +83,13 @@ export class AgentsWebhookController {
     try {
       await this.chatSdkService.handleWebhook(agentId, integrationIdentifier, req, res);
     } catch (err) {
+      if (err instanceof AgentInactiveException) {
+        // Return 200 to avoid retries by the delivery provider
+        res.status(HttpStatus.OK).json({});
+
+        return;
+      }
+
       if (err instanceof HttpException) {
         res.status(err.getStatus()).json(err.getResponse());
       } else {

--- a/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
@@ -316,4 +316,34 @@ describe('Agent Reply - /agents/:agentId/reply #novu-v2', () => {
       expect(resolveActivity).to.exist;
     });
   });
+
+  describe('Inactive agent', () => {
+    it('should return 422 when agent is inactive', async () => {
+      const conversationId = await seedConversation(ctx);
+      const patchRes = await ctx.session.testAgent.patch(`/v1/agents/${ctx.agentIdentifier}`).send({ active: false });
+      expect(patchRes.status).to.equal(200);
+
+      const res = await postReply({
+        conversationId,
+        integrationIdentifier: ctx.integrationIdentifier,
+        reply: { text: 'This should fail' },
+      });
+
+      expect(res.status).to.equal(422);
+    });
+
+    it('should return 422 for signal-only requests when agent is inactive', async () => {
+      const conversationId = await seedConversation(ctx);
+      const patchRes = await ctx.session.testAgent.patch(`/v1/agents/${ctx.agentIdentifier}`).send({ active: false });
+      expect(patchRes.status).to.equal(200);
+
+      const res = await postReply({
+        conversationId,
+        integrationIdentifier: ctx.integrationIdentifier,
+        signals: [{ type: 'metadata', key: 'blocked', value: true }],
+      });
+
+      expect(res.status).to.equal(422);
+    });
+  });
 });

--- a/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
@@ -19,7 +19,7 @@ import {
   seedChannelEndpoint,
   setupAgentTestContext,
 } from './helpers/agent-test-setup';
-import { buildSlackChallenge, signSlackRequest } from './helpers/providers/slack';
+import { buildSlackAppMention, buildSlackChallenge, signSlackRequest } from './helpers/providers/slack';
 
 function mockEmoji(name: string): EmojiValue {
   return { name, toJSON: () => `{{emoji:${name}}}`, toString: () => `{{emoji:${name}}}` };
@@ -267,6 +267,47 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
         .send(body);
 
       expect(res.status).to.not.equal(200);
+    });
+  });
+
+  describe('Inactive agent', () => {
+    it('should return 200 and not process inbound when agent is inactive', async () => {
+      await ctx.session.testAgent.patch(`/v1/agents/${ctx.agentIdentifier}`).send({ active: false });
+
+      const body = JSON.stringify(
+        buildSlackAppMention({ userId: 'U_INACTIVE', channel: 'C_TEST', threadTs: `T_INACTIVE_${Date.now()}` })
+      );
+      const timestamp = Math.floor(Date.now() / 1000);
+      const headers = signSlackRequest(ctx.signingSecret, timestamp, body);
+
+      const res = await ctx.session.testAgent
+        .post(`/v1/agents/${ctx.agentId}/webhook/${ctx.integrationIdentifier}`)
+        .set(headers)
+        .set('content-type', 'application/json')
+        .send(body);
+
+      expect(res.status).to.equal(200);
+      expect(bridgeCalls.length).to.equal(0);
+    });
+
+    it('should process inbound again after reactivation', async () => {
+      await ctx.session.testAgent.patch(`/v1/agents/${ctx.agentIdentifier}`).send({ active: false });
+      await ctx.session.testAgent.patch(`/v1/agents/${ctx.agentIdentifier}`).send({ active: true });
+
+      const body = JSON.stringify(
+        buildSlackAppMention({ userId: 'U_REACTIVATED', channel: 'C_TEST', threadTs: `T_REACTIVATE_${Date.now()}` })
+      );
+      const timestamp = Math.floor(Date.now() / 1000);
+      const headers = signSlackRequest(ctx.signingSecret, timestamp, body);
+
+      const res = await ctx.session.testAgent
+        .post(`/v1/agents/${ctx.agentId}/webhook/${ctx.integrationIdentifier}`)
+        .set(headers)
+        .set('content-type', 'application/json')
+        .send(body);
+
+      expect(res.status).to.equal(200);
+      expect(bridgeCalls.length).to.equal(1);
     });
   });
 

--- a/apps/api/src/app/agents/exceptions/agent-inactive.exception.ts
+++ b/apps/api/src/app/agents/exceptions/agent-inactive.exception.ts
@@ -1,0 +1,7 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+
+export class AgentInactiveException extends UnprocessableEntityException {
+  constructor(agentId: string) {
+    super(`Agent ${agentId} is inactive`);
+  }
+}

--- a/apps/api/src/app/agents/services/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-config-resolver.service.ts
@@ -9,6 +9,7 @@ import {
 } from '@novu/dal';
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import type { WellKnownEmoji } from 'chat';
+import { AgentInactiveException } from '../exceptions/agent-inactive.exception';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
 import { esmImport } from '../utils/esm-import';
 import { resolveAgentPlatform } from '../utils/provider-to-platform';
@@ -75,6 +76,10 @@ export class AgentConfigResolver {
     const agent = await this.agentRepository.findByIdForWebhook(agentId);
     if (!agent) {
       throw new NotFoundException(`Agent ${agentId} not found`);
+    }
+
+    if (agent.active === false) {
+      throw new AgentInactiveException(agentId);
     }
 
     const { _environmentId: environmentId, _organizationId: organizationId } = agent;

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -56,7 +56,7 @@ export class HandleAgentReply {
       return this.deliverEdit(command, conversation, channel, command.edit, agentName);
     }
 
-    const needsConfig = !!(command.reply || command.resolve);
+    const needsConfig = !!(command.reply || command.resolve || command.signals?.length);
     const config = needsConfig
       ? await this.agentConfigResolver.resolve(conversation._agentId, command.integrationIdentifier)
       : null;

--- a/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
+++ b/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
@@ -15,6 +15,7 @@ import { Switch } from '@/components/primitives/switch';
 import { Textarea } from '@/components/primitives/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { TimeDisplayHoverCard } from '@/components/time-display-hover-card';
+import { ConfirmationModal } from '@/components/confirmation-modal';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { cn } from '@/utils/ui';
@@ -130,6 +131,8 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
   const { currentEnvironment } = useEnvironment();
   const has = useHasPermission();
   const canWrite = has({ permission: PermissionsEnum.AGENT_WRITE });
+
+  const [isDeactivateModalOpen, setIsDeactivateModalOpen] = useState(false);
 
   const [isEditingName, setIsEditingName] = useState(false);
   const [name, setName] = useState(agent.name);
@@ -266,7 +269,11 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
             checked={agent.active}
             disabled={!canWrite || isUpdatePending}
             onCheckedChange={(checked) => {
-              void updateAgentAsync({ active: checked });
+              if (!checked) {
+                setIsDeactivateModalOpen(true);
+              } else {
+                void updateAgentAsync({ active: true });
+              }
             }}
           />
         </SidebarRow>
@@ -418,6 +425,24 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
         <span className="text-text-soft">Last updated </span>
         <span className="text-text-sub">{formatDistanceToNow(new Date(agent.updatedAt), { addSuffix: true })}</span>
       </p>
+
+      <ConfirmationModal
+        open={isDeactivateModalOpen}
+        onOpenChange={setIsDeactivateModalOpen}
+        onConfirm={() => {
+          void updateAgentAsync({ active: false }).finally(() => setIsDeactivateModalOpen(false));
+        }}
+        title="Deactivate agent?"
+        description={
+          <>
+            Deactivating <span className="font-semibold">{agent.name}</span> will immediately stop it from processing
+            new inbound messages. The agent can be reactivated at any time.
+          </>
+        }
+        confirmButtonText="Deactivate"
+        isLoading={isUpdatePending}
+        confirmButtonVariant="error"
+      />
     </div>
   );
 }

--- a/apps/dashboard/src/components/agents/agents-table.tsx
+++ b/apps/dashboard/src/components/agents/agents-table.tsx
@@ -1,10 +1,11 @@
 import { providers as novuProviders, PermissionsEnum } from '@novu/shared';
 import { ComponentProps } from 'react';
-import { RiMore2Fill, RiRobot2Line } from 'react-icons/ri';
+import { RiCheckboxCircleFill, RiForbidFill, RiMore2Fill, RiRobot2Line } from 'react-icons/ri';
 import { Link, useLocation } from 'react-router-dom';
 import type { AgentResponse } from '@/api/agents';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { CompactButton } from '@/components/primitives/button-compact';
+import { StatusBadge, StatusBadgeIcon } from '@/components/primitives/status-badge';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -132,6 +133,9 @@ function AgentsTableSkeletonRow() {
         </div>
       </TableCell>
       <TableCell className="p-3">
+        <Skeleton className="h-6 w-[9ch] rounded-md" />
+      </TableCell>
+      <TableCell className="p-3">
         <div className="flex min-h-[41px] items-center">
           <div className="flex items-center">
             <Skeleton className="border-static-white bg-bg-white size-6 shrink-0 rounded-full border border-solid shadow-xs" />
@@ -161,6 +165,7 @@ export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProp
       <TableHeader>
         <TableRow>
           <TableHead className="h-11 px-3 py-2.5">Agent</TableHead>
+          <TableHead className="h-11 px-3 py-2.5">Status</TableHead>
           <TableHead className="h-11 px-3 py-2.5">Integrations</TableHead>
           <TableHead className="h-11 px-3 py-2.5">Last updated</TableHead>
           <TableHead className="h-11 w-[52px] px-3 py-2.5">
@@ -193,6 +198,19 @@ export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProp
                       </span>
                     </div>
                   </div>
+                </AgentNavTableCell>
+                <AgentNavTableCell to={agentDetailsPath} className="p-3 align-middle">
+                  {agent.active ? (
+                    <StatusBadge variant="light" status="completed">
+                      <StatusBadgeIcon as={RiCheckboxCircleFill} />
+                      Active
+                    </StatusBadge>
+                  ) : (
+                    <StatusBadge variant="light" status="disabled">
+                      <StatusBadgeIcon as={RiForbidFill} />
+                      Inactive
+                    </StatusBadge>
+                  )}
                 </AgentNavTableCell>
                 <AgentNavTableCell to={agentDetailsPath} className="p-3 align-middle">
                   <AgentIntegrationsCell agent={agent} />
@@ -230,7 +248,7 @@ export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProp
       {!isLoading && agents.length > 0 ? (
         <TableFooter>
           <TableRow>
-            <TableCell colSpan={4} className="p-0">
+            <TableCell colSpan={5} className="p-0">
               <TablePaginationFooter
                 pageSize={paginationProps.pageSize}
                 currentPageItemsCount={paginationProps.currentItemsCount}


### PR DESCRIPTION
## Summary

- **Backend**: `AgentConfigResolver` now throws `AgentInactiveException` when `agent.active` is false — inbound webhook returns `200 OK` (prevents platform retry loops); reply endpoint returns `422`
- **Dashboard**: deactivation confirmation modal when toggling active → inactive (same pattern as pause-workflow); dedicated **Status** column in the agents list consistent with the workflow list
- **Tests**: two new e2e cases — inactive webhook returns 200 with zero bridge calls; inactive reply returns 422

## How it works

```
Inbound webhook (Slack/Discord/etc.)
  └─► AgentConfigResolver.resolve()
        └─► agent.active === false → AgentInactiveException
              └─► AgentsWebhookController.routeWebhook()
                    └─► catches AgentInactiveException → res 200 {} (no retry)

Bridge reply (POST /agents/:id/reply)
  └─► HandleAgentReply → AgentConfigResolver.resolve()
        └─► agent.active === false → AgentInactiveException → 422 to bridge
```

## UI changes

**Agent list** — Status column (matches workflow list):

| Agent | Status | Integrations | Last updated |
|---|---|---|---|
| my-agent | ✅ Active | ... | ... |
| old-agent | ⛔ Inactive | ... | ... |

**Agent detail** — deactivation modal on toggle:

> "Deactivating **my-agent** will immediately stop it from processing new inbound messages. The agent can be reactivated at any time."

## Test plan

- [ ] Toggle active → inactive on an agent → confirmation modal appears
- [ ] Confirm deactivation → badge in sidebar turns red "Inactive", Status column in list shows "Inactive"
- [ ] Send a message to the webhook endpoint of an inactive agent → response is 200 OK, no bridge call fired
- [ ] Reactivate agent → messages process normally
- [ ] Run `agent-webhook.e2e.ts` and `agent-reply.e2e.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR enforces the agent "active" toggle across inbound and reply flows so deactivated agents no longer process messages. The backend now prevents processing by throwing an AgentInactiveException when agent.active is false; inbound webhooks return 200 OK (to avoid platform retry loops) and bridge replies return 422. The dashboard adds a deactivation confirmation modal and a Status column/badge so users see and confirm inactive agents.

## Affected areas

**api**
- AgentConfigResolver now checks agent.active and throws AgentInactiveException to gate processing.
- AgentsWebhookController catches AgentInactiveException and returns HTTP 200 with an empty body to avoid retry loops.
- Reply handling (POST /v1/agents/:id/reply) returns 422 when the agent is inactive.
- New AgentInactiveException class (extends UnprocessableEntityException) communicates the inactive state.

**dashboard**
- Agent sidebar adds a confirmation modal when toggling Active → Inactive (matches pause-workflow UX).
- Agents table gains a Status column and badges indicating Active/Inactive consistent with workflow listing.

## Key technical decisions

- AgentInactiveException (422) is used internally but is converted to HTTP 200 for inbound webhooks to prevent external retry loops while still blocking processing.
- Bridge reply flows return 422 so bridges receive explicit error responses for inactive agents.
- UI uses an explicit confirmation modal to reduce accidental deactivations and surface state changes immediately in lists and details.

## Testing

Added e2e tests: inactive webhook returns 200 with zero bridge calls, and inactive reply returns 422; tests include reactivation to confirm normal processing resumes. Manual UI checks for modal, status badge, and list updates are included in the PR test plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->