### PR TITLE
chore(internal-sdk): update version to 3.15.0 and format peerDependenciesMeta

### DIFF
--- a/libs/internal-sdk/package.json
+++ b/libs/internal-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/api",
-  "version": "0.1.21",
+  "version": "3.15.0",
   "author": "Novu",
   "main": "./index.js",
   "sideEffects": false,
@@ -15,9 +15,15 @@
     "react-dom": "^18 || ^19"
   },
   "peerDependenciesMeta": {
-    "@tanstack/react-query": {"optional":true},
-    "react": {"optional":true},
-    "react-dom": {"optional":true}
+    "@tanstack/react-query": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",


### PR DESCRIPTION
### What changed? Why was the change needed?

Vulnerability Scanners are catching internal SDK for `GHSA-4x48-cgf9-q33f`
<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `@novu/api` package (internal SDK) in `libs/internal-sdk/package.json` was updated to address a vulnerability finding. The version was bumped from 0.1.21 to 3.15.0, and the `peerDependenciesMeta` configuration for `@tanstack/react-query`, `react`, and `react-dom` was reformatted from compact single-line JSON objects to expanded multi-line format for consistency and readability. The dependency declarations themselves remain unchanged.

## Affected areas

**internal-sdk**: Version bump to 3.15.0 and reformatted peer dependency metadata to maintain optional dependency declarations across React and React Query.

## Testing

No tests are needed for this change—package metadata updates do not affect runtime behavior or require test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->