### PR TITLE
refactor(worker): enhance provider-specific overrides handling for email messages fixes NV-7377

### DIFF
--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -169,10 +169,7 @@ export class SendMessageEmail extends SendMessageBase {
       step.template = template;
     }
 
-    const overrides: Record<string, any> = {
-      ...(command.overrides?.email || {}),
-      ...(command.overrides?.[integration?.providerId] || {}),
-    };
+    const overrides = this.buildEmailProviderOverrides(command, integration?.providerId, command.step?.stepId);
 
     let html;
     let subject = (bridgeOutputs as EmailOutput)?.subject || step?.template?.subject || '';
@@ -653,6 +650,39 @@ export class SendMessageEmail extends SendMessageBase {
         })
       );
     }
+  }
+
+  /**
+   * Builds the merged provider overrides object for email sending.
+   *
+   * Provider-specific fields (cc/bcc/from/replyTo/etc.) can arrive in three shapes:
+   *   1. Deprecated channel bucket:     `overrides.email`
+   *   2. Deprecated flat provider key:  `overrides.<providerId>`
+   *   3. Modern nested providers shape: `overrides.providers.<providerId>`
+   *                                     `overrides.steps.<stepId>.providers.<providerId>`
+   *
+   * All three are merged (step-level wins) so values like `cc` reach `createMailData`
+   * and downstream providers (e.g. SendGrid `personalizations[0].cc`).
+   */
+  private buildEmailProviderOverrides(
+    command: SendMessageChannelCommand,
+    providerId: string | undefined,
+    stepId: string | undefined
+  ): Record<string, unknown> {
+    const deprecatedFlatEmailOverride = command.overrides?.email || {};
+    const deprecatedFlatProviderOverride = providerId
+      ? (command.overrides as Record<string, Record<string, unknown>>)?.[providerId] || {}
+      : {};
+    const providerOverride = providerId ? command.overrides?.providers?.[providerId] || {} : {};
+    const stepProviderOverride =
+      providerId && stepId ? command.overrides?.steps?.[stepId]?.providers?.[providerId] || {} : {};
+
+    return {
+      ...deprecatedFlatEmailOverride,
+      ...deprecatedFlatProviderOverride,
+      ...providerOverride,
+      ...stepProviderOverride,
+    };
   }
 
   public buildFactoryIntegration(integration: IntegrationEntity) {


### PR DESCRIPTION


### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Refactored email provider overrides handling in the `SendMessageEmail` use case by extracting the merge logic into a dedicated `buildEmailProviderOverrides` method. This method consolidates provider-specific overrides from three possible shapes—deprecated channel bucket (`overrides.email`), deprecated flat provider key (`overrides.<providerId>`), and modern nested shape (`overrides.providers.<providerId>` and `overrides.steps.<stepId>.providers.<providerId>`)—with step-level values taking precedence. The merged result is passed to `createMailData` to configure email fields like cc, bcc, and from.

## Affected areas

**worker**: Enhanced provider-specific overrides handling in the email sending use case by extracting override merge logic into a dedicated private method that supports backward compatibility with deprecated override shapes while prioritizing step-level provider values.

## Key technical decisions

- Implemented a four-layer merge strategy with step-level provider overrides as the highest priority, enabling granular control over email parameters per provider and workflow step.
- Maintained backward compatibility with existing override shapes to avoid breaking changes for users relying on deprecated override formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
