### PR TITLE
fix(dashboard): defer agent delete dialog from menu and add BETA badges

### DIFF
--- a/apps/dashboard/src/components/agents/agent-details-header.tsx
+++ b/apps/dashboard/src/components/agents/agent-details-header.tsx
@@ -72,7 +72,12 @@ export function AgentDetailsHeader({ agent, isLoading, onRequestDelete }: AgentD
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem className="text-destructive cursor-pointer" onClick={() => onRequestDelete(agent)}>
+                <DropdownMenuItem
+                  className="text-destructive cursor-pointer"
+                  onClick={() => {
+                    setTimeout(() => onRequestDelete(agent), 0);
+                  }}
+                >
                   Delete
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/apps/dashboard/src/components/agents/agents-table.tsx
+++ b/apps/dashboard/src/components/agents/agents-table.tsx
@@ -231,7 +231,9 @@ export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProp
                       <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
                         <DropdownMenuItem
                           className="text-destructive cursor-pointer"
-                          onClick={() => onRequestDelete(agent)}
+                          onClick={() => {
+                            setTimeout(() => onRequestDelete(agent), 0);
+                          }}
                         >
                           Delete
                         </DropdownMenuItem>

--- a/apps/dashboard/src/pages/agent-details.tsx
+++ b/apps/dashboard/src/pages/agent-details.tsx
@@ -19,6 +19,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/primitives/breadcrumb';
+import { Badge } from '@/components/primitives/badge';
 import { CompactButton } from '@/components/primitives/button-compact';
 import { Skeleton } from '@/components/primitives/skeleton';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
@@ -182,11 +183,19 @@ export function AgentDetailsPage() {
           <BreadcrumbSeparator />
           <BreadcrumbItem className="min-w-0">
             {isLoading ? (
-              <Skeleton className="inline-block h-5 w-[min(100%,16ch)]" />
+              <div className="flex min-w-0 items-center gap-1.5">
+                <Skeleton className="inline-block h-5 w-[min(100%,16ch)]" />
+                <Badge color="gray" size="sm" variant="lighter" className="shrink-0">
+                  BETA
+                </Badge>
+              </div>
             ) : (
               <BreadcrumbPage className="flex min-w-0 items-center gap-1.5">
                 <RiRobot2Line className="text-text-sub size-4 shrink-0" aria-hidden />
                 <span className="truncate">{breadcrumbCurrentLabel}</span>
+                <Badge color="gray" size="sm" variant="lighter" className="shrink-0">
+                  BETA
+                </Badge>
               </BreadcrumbPage>
             )}
           </BreadcrumbItem>

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -19,6 +19,7 @@ import { AgentsEmptyTeaser } from '@/components/agents/agents-empty-teaser';
 import { AgentsList } from '@/components/agents/agents-list';
 import { DashboardLayout } from '@/components/dashboard-layout';
 import { PageMeta } from '@/components/page-meta';
+import { Badge } from '@/components/primitives/badge';
 import { Button } from '@/components/primitives/button';
 import { CompactButton } from '@/components/primitives/button-compact';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from '@/components/primitives/dialog';
@@ -408,7 +409,16 @@ export function AgentsPage() {
       {!isConversationalAgentsEnabled ? (
         <AgentsEarlyAccessDialog open={earlyAccessOpen} onOpenChange={setEarlyAccessOpen} />
       ) : null}
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950">Agents</h1>}>
+      <DashboardLayout
+        headerStartItems={
+          <h1 className="text-foreground-950 flex items-center gap-1">
+            Agents{' '}
+            <Badge color="gray" size="sm" variant="lighter">
+              BETA
+            </Badge>
+          </h1>
+        }
+      >
         {isConversationalAgentsEnabled ? (
           <AgentsList />
         ) : (


### PR DESCRIPTION
- Open delete confirmation on the next tick after dropdown item click so Radix menu and dialog dismissable layers do not leave pointer-events:none on the document body (same pattern as workflow-row).
- Show BETA badge on Agents list header and agent details breadcrumb.

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The PR defers the agent delete confirmation dialog to the next event loop tick using `setTimeout(..., 0)` to prevent Radix menu and dialog dismissable layers from interfering with document pointer events. BETA badges are added to the Agents list header and the agent details page breadcrumb to indicate the feature's status.

## Affected areas

**dashboard**: Updated agent delete actions in the agent details header and agents table to defer dialog invocation via `setTimeout`. Added BETA badges to the Agents page header and agent details breadcrumb to mark the feature as beta.

## Key technical decisions

- Uses `setTimeout(..., 0)` to defer delete dialog invocation, following the same pattern established in the workflow-row component to avoid Radix layer dismissal issues.

## Testing

No tests were added or modified in this change; testing would require manual verification of the dialog behavior when deleting agents and visual verification of the BETA badge placement and styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
