### PR TITLE
chore(api-service): remove nestjs swagger plugin when running api app locally

### DIFF
--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -30,14 +30,6 @@
         "outDir": "dist"
       }
     ],
-    "plugins": [
-      {
-        "name": "@nestjs/swagger",
-        "options": {
-          "classValidatorShim": true,
-          "introspectComments": true
-        }
-      }
-    ]
+    "plugins": []
   }
 }

--- a/apps/api/scripts/generate-metadata.ts
+++ b/apps/api/scripts/generate-metadata.ts
@@ -4,6 +4,12 @@
  * not natively supporting Typescript, which is required to use the `reflect-metadata`
  * API and in turn, resolve types for the OpenAPI specification.
  *
+ * The script writes the generated content to a temporary file first and only
+ * swaps it onto `src/metadata.ts` when the content has actually changed.
+ * This keeps `pnpm build:metadata` idempotent so re-running it (e.g. while
+ * `pnpm start:dev` is up) does not touch the file's mtime and therefore
+ * does not trigger a spurious watcher restart.
+ *
  * @see https://docs.nestjs.com/recipes/swc#monorepo-and-cli-plugins
  */
 import fs from 'node:fs';
@@ -13,20 +19,38 @@ import { ReadonlyVisitor } from '@nestjs/swagger/dist/plugin';
 
 const tsconfigPath = 'tsconfig.build.json';
 const srcPath = path.join(__dirname, '..', 'src');
-const metadataPath = path.join(srcPath, 'metadata.ts');
+const metadataFilename = 'metadata.ts';
+const metadataPath = path.join(srcPath, metadataFilename);
+const tmpMetadataFilename = 'metadata.tmp.ts';
+const tmpMetadataPath = path.join(srcPath, tmpMetadataFilename);
 
-/*
- * We create an empty metadata file to ensure that files importing `metadata.ts`
- * will compile successfully before the metadata generation occurs.
- */
-const defaultContent = `export default async () => { return {}; };`;
+const defaultContent = `export default async () => { return {}; };\n`;
 
-fs.writeFileSync(metadataPath, defaultContent, 'utf8');
-console.log('metadata.ts file has been generated with default content.');
+if (!fs.existsSync(metadataPath)) {
+  fs.writeFileSync(metadataPath, defaultContent, 'utf8');
+  console.log('metadata.ts created with default content.');
+}
 
 const generator = new PluginMetadataGenerator();
 generator.generate({
   visitors: [new ReadonlyVisitor({ introspectComments: true, pathToSource: srcPath })],
   outputDir: srcPath,
+  filename: tmpMetadataFilename,
   tsconfigPath,
 });
+
+try {
+  const nextContent = fs.readFileSync(tmpMetadataPath, 'utf8');
+  const currentContent = fs.existsSync(metadataPath) ? fs.readFileSync(metadataPath, 'utf8') : '';
+
+  if (nextContent === currentContent) {
+    console.log('metadata.ts is up to date, skipping write.');
+  } else {
+    fs.renameSync(tmpMetadataPath, metadataPath);
+    console.log('metadata.ts updated.');
+  }
+} finally {
+  if (fs.existsSync(tmpMetadataPath)) {
+    fs.unlinkSync(tmpMetadataPath);
+  }
+}


### PR DESCRIPTION
### What changed? Why was the change needed?

Removed the `@nestjs/swagger` CLI plugin. With this change, nest start --watch's forked type‑checker no longer regenerates `src/metadata.ts` on every recompile, so the API now boots once instead of double-booting. `pnpm build, pnpm build:watch` and `pnpm pretest` already run `pnpm build:metadata` separately, so the build pipeline is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Removed the @nestjs/swagger CLI plugin from the Nest configuration for local API development, preventing the type-checker from unnecessarily regenerating metadata on every recompilation. Updated the metadata generation script to write to a temporary file, compare against the existing file, and only update if content differs—avoiding redundant writes and booting the API once instead of twice during development.

## Affected areas

**api**: Removed the @nestjs/swagger Swagger plugin from nest-cli.json and improved the metadata generation script to use a temp file with atomic updates and change detection, skipping writes when metadata hasn't changed.

## Key technical decisions

- The metadata generation script now writes to a temporary file first, compares content, and performs an atomic rename only when changes are detected, ensuring the API doesn't restart unnecessarily.
- Default metadata.ts is only written on first creation, not on every script run, with proper cleanup of temporary artifacts in a finally block.

## Testing

No tests are added since this is a local development optimization. Manual verification of the development boot process would suffice to confirm the API boots once instead of twice. The build pipeline is unaffected as pnpm build, build:watch, and pretest already call pnpm build:metadata separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
