### PR TITLE
feat(api-service): add permission requirements for domain management endpoints

### DIFF
--- a/apps/api/src/app/domains/domains.controller.ts
+++ b/apps/api/src/app/domains/domains.controller.ts
@@ -12,8 +12,8 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiExcludeController, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { ApiRateLimitCategoryEnum, UserSessionData } from '@novu/shared';
-
+import { RequirePermissions } from '@novu/application-generic';
+import { ApiRateLimitCategoryEnum, PermissionsEnum, UserSessionData } from '@novu/shared';
 import { RequireAuthentication } from '../auth/framework/auth.decorator';
 import { ThrottlerCategory } from '../rate-limiting/guards';
 import { ApiCommonResponses, ApiNoContentResponse, ApiResponse } from '../shared/framework/response.decorator';
@@ -49,6 +49,7 @@ export class DomainsController {
   ) {}
 
   @Get('/')
+  @RequirePermissions(PermissionsEnum.ORG_SETTINGS_READ)
   @ApiOperation({ summary: 'List domains for an environment' })
   @ApiResponse(DomainResponseDto, 200, true)
   async listDomains(@UserSession() user: UserSessionData): Promise<DomainResponseDto[]> {
@@ -62,6 +63,7 @@ export class DomainsController {
   }
 
   @Post('/')
+  @RequirePermissions(PermissionsEnum.ORG_SETTINGS_WRITE)
   @ApiOperation({ summary: 'Create a new domain' })
   @ApiResponse(DomainResponseDto, 201)
   async createDomain(@Body() body: CreateDomainDto, @UserSession() user: UserSessionData): Promise<DomainResponseDto> {
@@ -76,6 +78,7 @@ export class DomainsController {
   }
 
   @Get('/:domainId')
+  @RequirePermissions(PermissionsEnum.ORG_SETTINGS_READ)
   @ApiOperation({ summary: 'Get a domain by ID' })
   @ApiResponse(DomainResponseDto, 200)
   async getDomain(
@@ -93,6 +96,7 @@ export class DomainsController {
   }
 
   @Patch('/:domainId')
+  @RequirePermissions(PermissionsEnum.ORG_SETTINGS_WRITE)
   @ApiOperation({ summary: 'Update a domain' })
   @ApiResponse(DomainResponseDto, 200)
   async updateDomain(
@@ -112,6 +116,7 @@ export class DomainsController {
   }
 
   @Delete('/:domainId')
+  @RequirePermissions(PermissionsEnum.ORG_SETTINGS_WRITE)
   @ApiOperation({ summary: 'Delete a domain' })
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiNoContentResponse()


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The DomainsController now enforces role-based access control on all domain management endpoints. Read operations (`listDomains`, `getDomain`) require the `ORG_SETTINGS_READ` permission, while write operations (`createDomain`, `updateDomain`, `deleteDomain`) require the `ORG_SETTINGS_WRITE` permission. This ensures that only users with appropriate organizational settings permissions can manage domains.

## Affected areas

**api**: Updated `DomainsController` to add `@RequirePermissions` decorators on all five domain management routes, along with imports for the `RequirePermissions` decorator and `PermissionsEnum` from `@novu/shared`.

## Key technical decisions

- Read operations require `ORG_SETTINGS_READ` permission, while write operations require `ORG_SETTINGS_WRITE` permission, establishing a clear separation between read and write access levels.
- Uses the existing `@RequirePermissions` decorator pattern from the application's auth framework, maintaining consistency with other protected endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
