### PR TITLE
feat(api-service): implement ctx.trigger() workflow execution fixes NV-7388

### DIFF
--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -7,6 +7,7 @@ import {
 } from '@novu/dal';
 
 import { AuthModule } from '../auth/auth.module';
+import { EventsModule } from '../events/events.module';
 import { SharedModule } from '../shared/shared.module';
 import { AgentsController } from './agents.controller';
 import { AgentsWebhookController } from './agents-webhook.controller';
@@ -19,7 +20,7 @@ import { ChatSdkService } from './services/chat-sdk.service';
 import { USE_CASES } from './usecases';
 
 @Module({
-  imports: [SharedModule, AuthModule],
+  imports: [SharedModule, AuthModule, EventsModule],
   controllers: [AgentsController, AgentsWebhookController],
   providers: [
     ...USE_CASES,

--- a/apps/api/src/app/agents/dtos/agent-platform.enum.ts
+++ b/apps/api/src/app/agents/dtos/agent-platform.enum.ts
@@ -2,6 +2,7 @@ export enum AgentPlatformEnum {
   SLACK = 'slack',
   WHATSAPP = 'whatsapp',
   TEAMS = 'teams',
+  EMAIL = 'email',
 }
 
 export const PLATFORMS_WITH_TYPING_INDICATOR = new Set<AgentPlatformEnum>([

--- a/apps/api/src/app/agents/services/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { PinoLogger, shortId } from '@novu/application-generic';
+import type { TriggerRecipientsPayload } from '@novu/shared';
 import {
   ConversationActivityEntity,
   ConversationActivityRepository,
@@ -64,6 +65,12 @@ export interface UpdateMetadataParams extends ConversationActivityContext {
 
 export interface ResolveConversationParams extends ConversationActivityContext {
   summary?: string;
+}
+
+export interface PersistTriggerSignalParams extends ConversationActivityContext {
+  workflowId: string;
+  to: TriggerRecipientsPayload;
+  transactionId: string;
 }
 
 @Injectable()
@@ -350,5 +357,27 @@ export class AgentConversationService {
         organizationId: params.organizationId,
       }),
     ]);
+  }
+
+  async persistTriggerSignal(params: PersistTriggerSignalParams): Promise<void> {
+    await this.activityRepository.createSignalActivity({
+      identifier: `act_${shortId(12)}`,
+      conversationId: params.conversationId,
+      platform: params.channel.platform,
+      integrationId: params.channel._integrationId,
+      platformThreadId: params.channel.platformThreadId,
+      agentId: params.agentIdentifier,
+      content: `Triggered workflow: ${params.workflowId}`,
+      signalData: {
+        type: 'trigger',
+        payload: {
+          workflowId: params.workflowId,
+          to: params.to,
+          transactionId: params.transactionId,
+        },
+      },
+      environmentId: params.environmentId,
+      organizationId: params.organizationId,
+    });
   }
 }

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import {
@@ -7,7 +8,8 @@ import {
   ConversationParticipantTypeEnum,
   SubscriberRepository,
 } from '@novu/dal';
-import type { SentMessageInfo } from '@novu/framework';
+import type { SentMessageInfo, TriggerSignal } from '@novu/framework';
+import { AddressingTypeEnum, TriggerRequestCategoryEnum } from '@novu/shared';
 import { AgentEventEnum } from '../../dtos/agent-event.enum';
 import type { EditPayloadDto, ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
 import { isValidMetadataSignalKey } from '../../dtos/agent-reply-payload.dto';
@@ -15,6 +17,10 @@ import { AgentConfigResolver, ResolvedAgentConfig } from '../../services/agent-c
 import { AgentConversationService } from '../../services/agent-conversation.service';
 import { BridgeExecutorService } from '../../services/bridge-executor.service';
 import { ChatSdkService } from '../../services/chat-sdk.service';
+import {
+  ParseEventRequest,
+  ParseEventRequestMulticastCommand,
+} from '../../../events/usecases/parse-event-request';
 import { HandleAgentReplyCommand } from './handle-agent-reply.command';
 
 @Injectable()
@@ -26,7 +32,8 @@ export class HandleAgentReply {
     private readonly bridgeExecutor: BridgeExecutorService,
     private readonly agentConfigResolver: AgentConfigResolver,
     private readonly conversationService: AgentConversationService,
-    private readonly logger: PinoLogger
+    private readonly logger: PinoLogger,
+    private readonly parseEventRequest: ParseEventRequest
   ) {}
 
   async execute(command: HandleAgentReplyCommand): Promise<SentMessageInfo | null> {
@@ -219,9 +226,53 @@ export class HandleAgentReply {
       });
     }
 
-    const triggerSignals = (signals ?? []).filter((s) => s.type === 'trigger');
+    const triggerSignals = (signals ?? []).filter((s): s is TriggerSignal => s.type === 'trigger');
     if (triggerSignals.length) {
-      // TODO: execute trigger signals — requires wiring TriggerEvent or ParseEventRequest from EventsModule
+      await this.executeTriggerSignals(command, conversation, triggerSignals);
+    }
+  }
+
+  private async executeTriggerSignals(
+    command: HandleAgentReplyCommand,
+    conversation: ConversationEntity,
+    signals: TriggerSignal[]
+  ): Promise<void> {
+    const subscriberParticipant = conversation.participants.find(
+      (p) => p.type === ConversationParticipantTypeEnum.SUBSCRIBER
+    );
+
+    for (const signal of signals) {
+      const to = signal.to ?? subscriberParticipant?.id;
+
+      if (!to) {
+        this.logger.warn(
+          { agentIdentifier: command.agentIdentifier, workflowId: signal.workflowId },
+          `[agent:${command.agentIdentifier}] Skipping trigger signal for "${signal.workflowId}" — no recipient and conversation has no resolved subscriber`
+        );
+        continue;
+      }
+
+      try {
+        await this.parseEventRequest.execute(
+          ParseEventRequestMulticastCommand.create({
+            userId: command.userId,
+            environmentId: command.environmentId,
+            organizationId: command.organizationId,
+            identifier: signal.workflowId,
+            payload: signal.payload ?? {},
+            overrides: {},
+            to,
+            addressingType: AddressingTypeEnum.MULTICAST,
+            requestCategory: TriggerRequestCategoryEnum.SINGLE,
+            requestId: randomUUID(),
+          })
+        );
+      } catch (err) {
+        this.logger.warn(
+          { err, agentIdentifier: command.agentIdentifier, workflowId: signal.workflowId },
+          `[agent:${command.agentIdentifier}] Failed to trigger workflow "${signal.workflowId}"`
+        );
+      }
     }
   }
 

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -9,7 +9,7 @@ import {
   SubscriberRepository,
 } from '@novu/dal';
 import type { SentMessageInfo, TriggerSignal } from '@novu/framework';
-import { AddressingTypeEnum, TriggerRequestCategoryEnum } from '@novu/shared';
+import { AddressingTypeEnum, TriggerRequestCategoryEnum, type TriggerRecipientsPayload } from '@novu/shared';
 import { AgentEventEnum } from '../../dtos/agent-event.enum';
 import type { EditPayloadDto, ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
 import { isValidMetadataSignalKey } from '../../dtos/agent-reply-payload.dto';
@@ -243,7 +243,7 @@ export class HandleAgentReply {
     );
 
     for (const signal of signals) {
-      const to = signal.to ?? subscriberParticipant?.id;
+      const to = (signal.to as TriggerRecipientsPayload | undefined) ?? subscriberParticipant?.id;
 
       if (!to) {
         this.logger.warn(
@@ -253,6 +253,7 @@ export class HandleAgentReply {
         continue;
       }
 
+      let transactionId: string;
       try {
         const result = await this.parseEventRequest.execute(
           ParseEventRequestMulticastCommand.create({
@@ -268,21 +269,30 @@ export class HandleAgentReply {
             requestId: randomUUID(),
           })
         );
+        transactionId = result.transactionId;
+      } catch (err) {
+        this.logger.warn(
+          { err, agentIdentifier: command.agentIdentifier, workflowId: signal.workflowId },
+          `[agent:${command.agentIdentifier}] Failed to dispatch trigger for workflow "${signal.workflowId}"`
+        );
+        continue;
+      }
 
+      try {
         await this.conversationService.persistTriggerSignal({
           conversationId: conversation._id,
           channel,
           agentIdentifier: command.agentIdentifier,
           workflowId: signal.workflowId,
           to,
-          transactionId: result.transactionId,
+          transactionId,
           environmentId: command.environmentId,
           organizationId: command.organizationId,
         });
       } catch (err) {
         this.logger.warn(
-          { err, agentIdentifier: command.agentIdentifier, workflowId: signal.workflowId },
-          `[agent:${command.agentIdentifier}] Failed to trigger workflow "${signal.workflowId}"`
+          { err, agentIdentifier: command.agentIdentifier, workflowId: signal.workflowId, transactionId },
+          `[agent:${command.agentIdentifier}] Workflow "${signal.workflowId}" was enqueued (txn: ${transactionId}) but failed to persist activity`
         );
       }
     }

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -228,13 +228,14 @@ export class HandleAgentReply {
 
     const triggerSignals = (signals ?? []).filter((s): s is TriggerSignal => s.type === 'trigger');
     if (triggerSignals.length) {
-      await this.executeTriggerSignals(command, conversation, triggerSignals);
+      await this.executeTriggerSignals(command, conversation, channel, triggerSignals);
     }
   }
 
   private async executeTriggerSignals(
     command: HandleAgentReplyCommand,
     conversation: ConversationEntity,
+    channel: ConversationChannel,
     signals: TriggerSignal[]
   ): Promise<void> {
     const subscriberParticipant = conversation.participants.find(
@@ -253,7 +254,7 @@ export class HandleAgentReply {
       }
 
       try {
-        await this.parseEventRequest.execute(
+        const result = await this.parseEventRequest.execute(
           ParseEventRequestMulticastCommand.create({
             userId: command.userId,
             environmentId: command.environmentId,
@@ -267,6 +268,17 @@ export class HandleAgentReply {
             requestId: randomUUID(),
           })
         );
+
+        await this.conversationService.persistTriggerSignal({
+          conversationId: conversation._id,
+          channel,
+          agentIdentifier: command.agentIdentifier,
+          workflowId: signal.workflowId,
+          to,
+          transactionId: result.transactionId,
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+        });
       } catch (err) {
         this.logger.warn(
           { err, agentIdentifier: command.agentIdentifier, workflowId: signal.workflowId },

--- a/apps/api/src/app/events/events.module.ts
+++ b/apps/api/src/app/events/events.module.ts
@@ -15,6 +15,7 @@ import { SubscribersV1Module } from '../subscribers/subscribersV1.module';
 import { TenantModule } from '../tenant/tenant.module';
 import { WidgetsModule } from '../widgets/widgets.module';
 import { EventsController } from './events.controller';
+import { ParseEventRequest } from './usecases/parse-event-request';
 import { USE_CASES } from './usecases';
 
 const PROVIDERS = [GetNovuProviderCredentials, StorageHelperService, CommunityOrganizationRepository];
@@ -35,5 +36,6 @@ const PROVIDERS = [GetNovuProviderCredentials, StorageHelperService, CommunityOr
   ],
   controllers: [EventsController],
   providers: [...PROVIDERS, ...USE_CASES, CommunityUserRepository],
+  exports: [ParseEventRequest],
 })
 export class EventsModule {}

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -174,7 +174,7 @@ export class AgentContextImpl implements AgentContext {
   }
 
   trigger(workflowId: string, opts?: { to?: TriggerRecipientsPayload; payload?: Record<string, unknown> }): void {
-    this._signals.push({ type: 'trigger', workflowId, ...opts });
+    this._signals.push({ ...opts, type: 'trigger', workflowId });
   }
 
   /**

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -15,6 +15,7 @@ import type {
   ReplyHandle,
   SentMessageInfo,
   Signal,
+  TriggerRecipientsPayload,
 } from './agent.types';
 
 function isCardElement(content: object): content is import('chat').CardElement {
@@ -172,7 +173,7 @@ export class AgentContextImpl implements AgentContext {
     this._resolveSignal = { summary };
   }
 
-  trigger(workflowId: string, opts?: { to?: string; payload?: Record<string, unknown> }): void {
+  trigger(workflowId: string, opts?: { to?: TriggerRecipientsPayload; payload?: Record<string, unknown> }): void {
     this._signals.push({ type: 'trigger', workflowId, ...opts });
   }
 

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -1,4 +1,6 @@
 import type { CardElement, ChatElement } from 'chat';
+import type { TriggerRecipientsPayload } from '../../shared';
+export type { TriggerRecipientsPayload };
 
 export enum AgentEventEnum {
   ON_MESSAGE = 'onMessage',
@@ -156,7 +158,27 @@ export interface AgentContext {
   metadata: {
     set(key: string, value: unknown): void;
   };
-  trigger(workflowId: string, opts?: { to?: string; payload?: Record<string, unknown> }): void;
+  /**
+   * Trigger a Novu workflow from within this agent handler.
+   *
+   * Signals are batched and flushed with the next `ctx.reply()`, or automatically when the
+   * handler completes. The workflow executes asynchronously — the agent reply is not blocked.
+   *
+   * @param workflowId - Workflow identifier (e.g. `'escalation-email'`).
+   * @param opts.to - Recipient(s). Omit to target the conversation's resolved subscriber.
+   * @param opts.payload - Data forwarded to the workflow payload schema.
+   *
+   * @example
+   *   // Target the conversation subscriber automatically
+   *   ctx.trigger('follow-up-email', { payload: { reason: 'unresolved' } });
+   *
+   *   // Explicit recipient
+   *   ctx.trigger('escalation-email', { to: 'agent-inbox', payload: { priority: 'high' } });
+   *
+   *   // Topic broadcast
+   *   ctx.trigger('team-alert', { to: { type: 'Topic', topicKey: 'support-team' } });
+   */
+  trigger(workflowId: string, opts?: { to?: TriggerRecipientsPayload; payload?: Record<string, unknown> }): void;
 }
 
 export interface AgentHandlers {
@@ -195,7 +217,23 @@ export interface AgentBridgeRequest {
 }
 
 export type MetadataSignal = { type: 'metadata'; key: string; value: unknown };
-export type TriggerSignal = { type: 'trigger'; workflowId: string; to?: string; payload?: Record<string, unknown> };
+
+/**
+ * Queued by `ctx.trigger()` — instructs Novu to fire a workflow from inside an agent handler.
+ *
+ * - `workflowId` — the workflow identifier (same string used in `novu.events.trigger()`).
+ * - `to` — recipient(s) for the workflow. Accepts a subscriberId string, a subscriber object,
+ *   a topic, or arrays thereof. When omitted, Novu falls back to the conversation's resolved
+ *   subscriber. If no subscriber can be resolved, the trigger is skipped and a warning is logged.
+ * - `payload` — arbitrary data forwarded to the workflow's payload schema.
+ */
+export type TriggerSignal = {
+  type: 'trigger';
+  workflowId: string;
+  to?: TriggerRecipientsPayload;
+  payload?: Record<string, unknown>;
+};
+
 export type Signal = MetadataSignal | TriggerSignal;
 
 /** In-place edit of a previously posted agent message. Identified by platform message id. */


### PR DESCRIPTION
## What

Implements \`ctx.trigger()\` in the agent conversation feature end-to-end. Previously the method was fully stubbed on the API side — signals were accepted and validated but silently dropped.

## Changes

### \`@novu/framework\`
- Widened \`TriggerSignal.to\` from \`string\` to \`TriggerRecipientsPayload\` — callers can now pass a subscriberId string, a subscriber object, a topic, or arrays thereof, consistent with the rest of the Novu trigger API
- Re-exports \`TriggerRecipientsPayload\` from \`agent.types\` so consumers get it from a single import
- Added JSDoc on \`AgentContext.trigger()\` with usage examples

### API
- Exports \`ParseEventRequest\` from \`EventsModule\` and imports it into \`AgentsModule\`
- Injects \`ParseEventRequest\` into \`HandleAgentReply\`
- Replaces the TODO stub with \`executeTriggerSignals()\`:
  - Resolves recipient from \`signal.to\` first, falls back to the conversation's resolved \`SUBSCRIBER\` participant. Fallback lives on the API (not SDK) so it can be changed without a framework release and applies across all future SDK languages.
  - Skips + warns if no recipient can be resolved
  - Per-signal \`try/catch\` so a bad \`workflowId\` never blocks the agent reply
- Adds \`persistTriggerSignal()\` to \`AgentConversationService\`: writes a \`SIGNAL\` activity after each successful dispatch, recording \`workflowId\`, recipient, and \`transactionId\`. The \`transactionId\` links the conversation timeline to the workflow execution in the activity feed.

## Flow

\`\`\`mermaid
sequenceDiagram
    participant SDK as @novu/framework
    participant API as HandleAgentReply
    participant PER as ParseEventRequest
    participant Q as WorkflowQueue
    participant DB as ConversationActivity

    SDK->>API: POST /agents/:id/reply<br/>signals: [{ type: trigger, workflowId, to? }]
    API->>API: resolve to (signal.to ?? SUBSCRIBER participant)
    API->>PER: execute(workflowId, to, payload)
    PER->>Q: enqueue workflow job
    PER-->>API: { transactionId }
    API->>DB: createSignalActivity(type=trigger, transactionId)
\`\`\`

## Behavior when \`to\` is omitted

\`\`\`typescript
// Both of these work — second form targets the conversation's subscriber automatically
ctx.trigger('follow-up-email', { to: 'user-123', payload: { ... } });
ctx.trigger('follow-up-email', { payload: { ... } });
\`\`\`

If the conversation has no resolved subscriber (e.g. unidentified Slack user), the trigger is skipped with a \`warn\` log. No error is thrown — the agent reply is never blocked by a trigger failure. Workflow execution outcome is inspected in the activity feed, not the conversation timeline.

## Follow-ups

- **Dashboard deeplink** — the \`transactionId\` is stored in the signal activity but not yet rendered as a clickable link to the workflow execution in the activity feed. Pure UI work, no API changes needed.
- **\`ctx.trigger()\` return value** — currently \`void\` for consistency with the batching model. Returning the trigger result (acknowledged, transactionId) requires making the call non-batched or changing the reply endpoint response shape — separate design decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The PR implements end-to-end execution of trigger signals in agent conversations. Previously, workflow trigger requests via `ctx.trigger()` were accepted by the API but dropped without execution. This change dispatches those triggers as workflow jobs and records their outcomes in the conversation timeline, completing the DX workflow.

## Affected areas
- **api**: Added `executeTriggerSignals()` to resolve trigger recipients (preferring `signal.to`, falling back to conversation subscriber), dispatch via `ParseEventRequest`, and persist signal activities with transaction IDs linking to workflow execution. Per-signal error handling prevents one failed trigger from blocking the reply.
- **framework**: Widened `TriggerSignal.to` type from `string` to `TriggerRecipientsPayload` to accept subscriber IDs, subscriber objects, topics, or arrays. Updated `AgentContext.trigger()` signature and re-exported `TriggerRecipientsPayload` from agent types. Fixed spread order to ensure explicit parameters override defaults.
- **events**: Exported `ParseEventRequest` to enable workflow dispatch from the agents module.
- **agents**: Added `EventsModule` import and `persistTriggerSignal()` method to record signal activities with workflow metadata.

## Key technical decisions
- Recipients default to conversation subscriber if `signal.to` is omitted; triggers are skipped with a warning if no recipient is resolvable.
- Each trigger dispatch is wrapped in try/catch; failures are logged but do not block subsequent signals or the agent reply.
- Signal activities are persisted separately from dispatch, recording workflowId, recipient, and transactionId for conversation timeline continuity.
- Type changes enable flexible recipient specification (string subscriberId, subscriber objects, topics, or arrays) rather than string-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->