### PR TITLE
fix(api-service): store firstPlatformMessageId unconditionally for resolved emoji reactions

### DIFF
--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -108,6 +108,20 @@ export class AgentInboundHandler {
     const primaryChannel = this.conversationService.getPrimaryChannel(conversation);
     const isFirstMessage = !primaryChannel.firstPlatformMessageId;
 
+    if (isFirstMessage && message.id) {
+      this.conversationService
+        .setFirstPlatformMessageId(
+          config.environmentId,
+          config.organizationId,
+          conversation._id,
+          thread.id,
+          message.id
+        )
+        .catch((err) => {
+          this.logger.warn(err, `[agent:${agentId}] Failed to store firstPlatformMessageId`);
+        });
+    }
+
     if (config.acknowledgeOnReceived) {
       const supportsTyping = PLATFORMS_WITH_TYPING_INDICATOR.has(config.platform);
 
@@ -119,18 +133,6 @@ export class AgentInboundHandler {
           .addReaction(ACKNOWLEDGE_FALLBACK_EMOJI)
           .catch((err) => {
             this.logger.warn(err, `[agent:${agentId}] Failed to add ack reaction to first message`);
-          });
-
-        this.conversationService
-          .setFirstPlatformMessageId(
-            config.environmentId,
-            config.organizationId,
-            conversation._id,
-            thread.id,
-            message.id
-          )
-          .catch((err) => {
-            this.logger.warn(err, `[agent:${agentId}] Failed to store firstPlatformMessageId`);
           });
       }
     }


### PR DESCRIPTION
## Summary

- `firstPlatformMessageId` was only stored when `acknowledgeOnReceived` was enabled **and** the platform lacked a typing indicator (WhatsApp only). Slack and Teams never had this field written.
- Because `reactOnResolve` gates on `channel.firstPlatformMessageId`, the configured resolved-emoji reaction was silently dropped for every Slack and Teams conversation.
- Also broken when `acknowledgeOnReceived` was turned off on any platform.
- Fix: move `setFirstPlatformMessageId` outside the `acknowledgeOnReceived` block so it is always recorded on the first inbound message. The `eyes` ack reaction for non-typing platforms is unchanged.

## Root cause flow

```
inbound message arrives
  └─ if (config.acknowledgeOnReceived)            ← gate that should NOT apply here
       └─ if (!supportsTyping && isFirstMessage)   ← excludes Slack + Teams entirely
            └─ setFirstPlatformMessageId(...)       ← only reached on WhatsApp

conversation resolved
  └─ reactOnResolve(config, conversation, channel)
       └─ if (!channel.firstPlatformMessageId) return  ← always exits for Slack/Teams
```

## After fix

```
inbound message arrives
  └─ if (isFirstMessage && message.id)
       └─ setFirstPlatformMessageId(...)            ← always runs regardless of platform/ack config

  └─ if (config.acknowledgeOnReceived)
       └─ if (supportsTyping)  → startTyping()
          else if (isFirstMessage && message.id) → addReaction('eyes')

conversation resolved
  └─ reactOnResolve → firstPlatformMessageId now present → emoji reaction added ✓
```

## Test plan

- [ ] Configure a Slack agent with a resolved emoji (e.g. `check`) and verify the reaction appears on the first message when the conversation is resolved
- [ ] Verify the same with `acknowledgeOnReceived` disabled
- [ ] Verify WhatsApp ack (eyes emoji) still works as before

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `firstPlatformMessageId` field is now stored unconditionally on every first inbound message, regardless of platform or the `acknowledgeOnReceived` configuration setting. Previously, this field was only persisted when `acknowledgeOnReceived` was enabled and typing indicators were unsupported, causing resolved-emoji reactions to be skipped on Slack, Teams, and when acknowledgements were disabled. The fix moves the `setFirstPlatformMessageId` call outside the acknowledge/typing-control conditional block.

## Affected areas

**api**: The agent inbound message handler now stores `firstPlatformMessageId` immediately after identifying the first message, ensuring the field is always available for downstream resolved-emoji reaction logic.

## Key technical decisions

The `acknowledgeOnReceived` conditional logic is preserved unchanged — only the timing of `firstPlatformMessageId` persistence is moved earlier in the flow, decoupling it from acknowledge behavior while maintaining backward compatibility for existing ack and typing-indicator features.

## Testing

Manual verification is required to confirm: (1) resolved emoji reactions appear for Slack when configured, (2) behavior remains correct when `acknowledgeOnReceived` is disabled, and (3) WhatsApp acknowledgement (eyes emoji) reactions continue as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->