### PR TITLE
feat(dashboard): add activity feed deep links for workflow trigger signals fixes NV-7399

### DIFF
--- a/apps/dashboard/src/api/conversations.ts
+++ b/apps/dashboard/src/api/conversations.ts
@@ -131,7 +131,11 @@ export type ConversationActivityDto = {
   senderId: string;
   senderName?: string;
   platformMessageId?: string;
-  signalData?: { type: string; payload?: Record<string, unknown> };
+  signalData?:
+    | { type: 'metadata'; payload?: Record<string, unknown> }
+    | { type: 'trigger'; payload?: { workflowId?: string; transactionId?: string; to?: unknown } }
+    | { type: 'resolve'; payload?: Record<string, unknown> }
+    | { type: string; payload?: Record<string, unknown> };
   _environmentId: string;
   _organizationId: string;
   createdAt: string;

--- a/apps/dashboard/src/components/conversations/conversation-timeline.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-timeline.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useId, useState } from 'react';
 import {
+  RiArrowRightUpLine,
   RiCheckboxCircleFill,
   RiExpandUpDownLine,
   RiReplyLine,
@@ -7,9 +8,12 @@ import {
   RiRouteFill,
   RiShareForwardLine,
 } from 'react-icons/ri';
+import { Link } from 'react-router-dom';
 import { ConversationActivityDto } from '@/api/conversations';
 import { Skeleton } from '@/components/primitives/skeleton';
+import { useEnvironment } from '@/context/environment/hooks';
 import { getProviderSquareIconFileName } from '@/utils/provider-square-icon';
+import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 import { ConversationStatusBadge } from './conversation-status-badge';
 import { SubscriberFallbackAvatar } from './subscriber-fallback-avatar';
@@ -163,7 +167,17 @@ function MessageCard({ activity }: { activity: ConversationActivityDto }) {
 
 function InlineLogRow({ activity }: { activity: ConversationActivityDto }) {
   const isAgentAction = activity.senderType === 'agent' || activity.senderType === 'system';
-  const signalType = activity.signalData?.type;
+  const signalData = activity.signalData;
+  const signalType = signalData?.type;
+  const { currentEnvironment } = useEnvironment();
+
+  const transactionId =
+    signalType === 'trigger' && signalData?.type === 'trigger' ? signalData.payload?.transactionId : undefined;
+
+  const activityFeedLink =
+    transactionId && currentEnvironment?.slug
+      ? `${buildRoute(ROUTES.ACTIVITY_WORKFLOW_RUNS, { environmentSlug: currentEnvironment.slug })}?transactionId=${transactionId}`
+      : undefined;
 
   const icon =
     signalType === 'trigger' ? (
@@ -180,6 +194,15 @@ function InlineLogRow({ activity }: { activity: ConversationActivityDto }) {
       <span className="text-text-soft shrink-0 text-[10px] font-medium leading-[14px]">
         {formatActivityTimestamp(activity.createdAt)}
       </span>
+      {activityFeedLink && (
+        <Link
+          to={activityFeedLink}
+          className="text-text-soft hover:text-text-sub ml-auto shrink-0 rounded p-0.5 transition-colors"
+          aria-label="View workflow run in activity feed"
+        >
+          <RiArrowRightUpLine className="size-3.5" />
+        </Link>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- When an agent fires a `trigger` signal, the conversation timeline now shows a clickable ↗ icon next to the row
- Clicking navigates to **Activity Feed → Workflow Runs** pre-filtered by `transactionId`, so the user can immediately inspect the triggered run
- `ConversationActivityDto.signalData` is now a discriminated union — the `trigger` variant exposes `transactionId` as a typed field instead of an opaque `Record<string, unknown>`

> The backend wiring (`executeTriggerSignals`, `persistTriggerSignal`, `EventsModule` export) landed in NV-7388 (#10815) — this PR is purely the frontend deep-link layer on top of it.

## Changes

| File | What changed |
|---|---|
| `apps/dashboard/src/api/conversations.ts` | Narrow `signalData` to a discriminated union with a typed `trigger` variant |
| `apps/dashboard/src/components/conversations/conversation-timeline.tsx` | `InlineLogRow` reads `transactionId` from trigger payload and renders a `↗` link to the activity feed |

## Test plan

- [ ] Trigger a workflow via an agent reply signal in a conversation
- [ ] Open the conversation detail panel — the trigger row should have a `↗` icon
- [ ] Click the icon — should navigate to `/env/<slug>/activity/workflow-runs?transactionId=<id>` with the correct run pre-selected
- [ ] Non-trigger signal rows (metadata, resolve) should be unaffected
- [ ] Trigger rows without a `transactionId` in the payload (older data) should render without the link, no crash


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Added a clickable deep-link icon in the conversation timeline for workflow trigger signals, allowing users to navigate directly to the Activity Feed filtered by transaction ID. The `ConversationActivityDto.signalData` type was refined from an untyped object shape to a discriminated union, explicitly exposing `transactionId` as a typed field for trigger signals while maintaining backward compatibility with other signal types.

## Affected areas

**dashboard**: Updated the API type contract (`ConversationActivityDto.signalData`) to a discriminated union with explicit support for `trigger`, `metadata`, and `resolve` signal types. Modified the conversation timeline component to extract `transactionId` from trigger signals and render a navigation link to the Activity Feed pre-filtered by transaction ID. The deep link uses `useEnvironment()` to access the current environment slug and constructs the route dynamically.

## Key technical decisions

- Used a discriminated union pattern for `signalData` to provide type safety and allow consumers to access `transactionId` as a typed field rather than an untyped record.
- Deep-link construction relies on environment context via `useEnvironment()` hook rather than passing it as a prop, keeping the component interface clean.

## Testing

Manual verification steps outlined in the PR: trigger a workflow via agent reply, confirm the ↗ icon appears for trigger rows, click to validate navigation to the filtered Activity Feed, and ensure non-trigger rows and trigger rows without `transactionId` remain unaffected. No new automated tests were added, as this is a frontend-only UI integration feature that depends on existing backend wiring already landed in NV-7388.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->