### PR TITLE
fix(api-service): maily repeat block iterable parsing fixes NV-7400

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -943,6 +943,127 @@ describe('EmailOutputRendererUsecase', () => {
       const matches = result.body.match(/Item item/g);
       expect(matches).to.have.length(3);
     });
+
+    it('should render repeat block over steps.<digest>.events whose payload contains apostrophes', async () => {
+      const mockTipTapNode: MailyJSONContent = {
+        type: 'doc',
+        content: [
+          {
+            type: 'repeat',
+            attrs: {
+              each: 'steps.digest-step.events',
+              isUpdatingKey: false,
+              showIfKey: null,
+            },
+            content: [
+              {
+                type: 'paragraph',
+                attrs: {
+                  textAlign: 'left',
+                },
+                content: [
+                  {
+                    type: 'text',
+                    text: 'Order: ',
+                  },
+                  {
+                    type: 'variable',
+                    attrs: {
+                      id: 'steps.digest-step.events.payload.title',
+                      label: null,
+                      fallback: null,
+                      required: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Digest Events Repeat Regression',
+          body: JSON.stringify(mockTipTapNode),
+          disableOutputSanitization: true,
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          steps: {
+            'digest-step': {
+              events: [{ payload: { title: "John's order" } }, { payload: { title: "it's a test" } }],
+            },
+          },
+        },
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include("Order: John's order");
+      expect(result.body).to.include("Order: it's a test");
+
+      const matches = result.body.match(/Order: /g);
+      expect(matches).to.have.length(2);
+    });
+
+    it('should render repeat block over payload.items when string values contain apostrophes', async () => {
+      const mockTipTapNode: MailyJSONContent = {
+        type: 'doc',
+        content: [
+          {
+            type: 'repeat',
+            attrs: {
+              each: 'payload.names',
+              isUpdatingKey: false,
+              showIfKey: null,
+            },
+            content: [
+              {
+                type: 'paragraph',
+                attrs: {
+                  textAlign: 'left',
+                },
+                content: [
+                  {
+                    type: 'variable',
+                    attrs: {
+                      id: 'payload.names',
+                      label: null,
+                      fallback: null,
+                      required: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Apostrophe primitives repeat',
+          body: JSON.stringify(mockTipTapNode),
+          disableOutputSanitization: true,
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: {
+            names: ["O'Brien", 'Jane'],
+          },
+        },
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include("O'Brien");
+      expect(result.body).to.include('Jane');
+    });
   });
 
   describe('node attrs and marks attrs hydration', () => {

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.usecase.ts
@@ -751,19 +751,24 @@ export class EmailOutputRendererUsecase extends BaseTranslationRendererUsecase {
   }
 
   private async getIterableArray(iterablePath: string, variables: FullPayloadForRender): Promise<unknown[]> {
-    const iterableArrayString = await this.liquidEngine.parseAndRender(iterablePath, variables);
+    // evalValue returns the real JS array; avoids a lossy " <-> ' JSON round-trip that
+    // breaks on apostrophes in string values (e.g. digest events with `John's order`).
+    const cleanPath = iterablePath.replace(/\{\{|\}\}/g, '').trim();
 
+    let value: unknown;
     try {
-      const parsedArray = JSON.parse(iterableArrayString.replace(/'/g, '"'));
-
-      if (!Array.isArray(parsedArray)) {
-        throw new Error(`Iterable "${iterablePath}" is not an array`);
-      }
-
-      return parsedArray;
+      value = await this.liquidEngine.evalValue(cleanPath, variables);
     } catch (error) {
-      throw new Error(`Failed to parse iterable value for "${iterablePath}": ${error.message}`);
+      throw new Error(
+        `Failed to resolve iterable value for "${iterablePath}": ${error instanceof Error ? error.message : String(error)}`
+      );
     }
+
+    if (!Array.isArray(value)) {
+      throw new Error(`Iterable "${iterablePath}" is not an array`);
+    }
+
+    return value;
   }
 
   private processForEachNodes(


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixed the issue with Maily repeat block `each` iterable parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Fixed the repeat block iterable parsing in the email renderer for Maily templates. The issue was that iterables containing special characters (like apostrophes) were being incorrectly processed through string conversion and lossy JSON reconstruction. The fix now resolves iterables directly as JavaScript values using the Liquid template engine's `evalValue` method, preserving special characters throughout the rendering process.

## Affected areas

**api**: Updated the `getIterableArray` method in the email output renderer usecase to evaluate iterables directly instead of converting them to strings and reconstructing them with JSON.parse, ensuring special characters are preserved when rendering repeat blocks.

## Testing

Added two new unit tests for `EmailOutputRendererUsecase` covering repeat rendering with apostrophes in variable values. Tests validate both nested repeat paths (e.g., `steps.digest-step.events...payload.title`) and primitive repeat paths (e.g., `payload.names`), ensuring apostrophes and other special characters are correctly preserved in the rendered output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
<img width="1532" height="1009" alt="Screenshot 2026-04-23 at 11 57 40" src="https://github.com/user-attachments/assets/b636259b-425b-4624-b55f-259f9e61b663" />

<img width="1536" height="1002" alt="Screenshot 2026-04-23 at 11 59 19" src="https://github.com/user-attachments/assets/54d05c0a-ac0b-4b82-89d4-58d8af3693c0" />

<img width="1539" height="1005" alt="Screenshot 2026-04-23 at 12 02 52" src="https://github.com/user-attachments/assets/25ea0754-c6ca-4ea0-96b9-a77088ed2434" />


<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
