### PR TITLE
fix(dashboard): cast ICredentials to Record for useRef type compatibility

### DIFF
--- a/apps/dashboard/src/components/agents/email-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/email-setup-guide.tsx
@@ -440,7 +440,7 @@ export function EmailSetupGuide({
   );
 
   const serverCredentials = emailIntegration?.credentials ?? {};
-  const credentialsRef = useRef<Record<string, unknown>>(serverCredentials);
+  const credentialsRef = useRef<Record<string, unknown>>(serverCredentials as Record<string, unknown>);
   useEffect(() => {
     credentialsRef.current = { ...credentialsRef.current, ...serverCredentials };
   }, [emailIntegration]);


### PR DESCRIPTION
## Summary

- `ICredentials` lacks an index signature, making it incompatible with `Record<string, unknown>` as required by the `useRef` overload in `email-setup-guide.tsx`
- Added an `as Record<string, unknown>` cast on line 443 to satisfy TypeScript without changing runtime behavior

## Root cause

`useRef<Record<string, unknown>>(serverCredentials)` failed because TypeScript's structural typing requires an explicit index signature (`[key: string]: unknown`) on the argument type when the generic is `Record<string, unknown>`, and `ICredentials` only has named properties.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The email setup guide component now uses an explicit type cast to resolve a TypeScript compatibility issue when initializing a `useRef`. The `ICredentials` type lacks an index signature required by `Record<string, unknown>`, causing a type mismatch. Adding a type cast (`as Record<string, unknown>`) satisfies the type checker without altering runtime behavior.

## Affected areas

- **dashboard**: Fixed TypeScript type incompatibility in the email setup guide component by casting `ICredentials` to `Record<string, unknown>` when initializing a `useRef`.

## Testing

No tests were added. This is a compile-time type compatibility fix with no runtime behavior changes; the credential merging and persistence logic remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->