### PR TITLE
fix(dashboard): improve conversation timeline UX

### DIFF
--- a/apps/dashboard/src/components/conversations/conversation-detail.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-detail.tsx
@@ -32,7 +32,7 @@ export function ConversationDetail({ conversationId, onClose }: ConversationDeta
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto">
+      <div className="shrink-0">
         {isConversationLoading ? (
           <OverviewSkeleton />
         ) : conversation ? (
@@ -40,10 +40,16 @@ export function ConversationDetail({ conversationId, onClose }: ConversationDeta
             <ConversationOverview conversation={conversation} />
           </div>
         ) : null}
-
         <Separator />
+      </div>
 
-        <ConversationTimeline activities={activities} isLoading={isActivitiesLoading} totalCount={totalCount} />
+      <div className="flex-1 overflow-y-auto">
+        <ConversationTimeline
+          activities={activities}
+          isLoading={isActivitiesLoading}
+          totalCount={totalCount}
+          conversationStatus={conversation?.status}
+        />
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/conversations/conversation-overview.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-overview.tsx
@@ -1,31 +1,16 @@
-import { RiRobot2Line } from 'react-icons/ri';
+import { RiArrowRightUpLine, RiRobot2Line } from 'react-icons/ri';
+import { Link } from 'react-router-dom';
 import { ConversationDto } from '@/api/conversations';
+import { TimeDisplayHoverCard } from '@/components/time-display-hover-card';
+import { useEnvironment } from '@/context/environment/hooks';
 import { getProviderSquareIconFileName } from '@/utils/provider-square-icon';
+import { buildRoute, ROUTES } from '@/utils/routes';
 import { ConversationStatusBadge } from './conversation-status-badge';
 import { SubscriberFallbackAvatar } from './subscriber-fallback-avatar';
 
 type ConversationOverviewProps = {
   conversation: ConversationDto;
 };
-
-function formatTimestamp(dateStr: string | undefined): string {
-  if (!dateStr?.trim()) {
-    return '—';
-  }
-
-  const d = new Date(dateStr);
-
-  if (Number.isNaN(d.getTime())) {
-    return '—';
-  }
-
-  const month = d.toLocaleDateString('en-US', { month: 'short' });
-  const day = d.getDate();
-  const year = d.getFullYear();
-  const time = d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' });
-
-  return `${month} ${day} ${year} ${time}`;
-}
 
 function MetaRow({ label, children, isLast }: { label: string; children: React.ReactNode; isLast?: boolean }) {
   return (
@@ -39,11 +24,17 @@ function MetaRow({ label, children, isLast }: { label: string; children: React.R
 }
 
 export function ConversationOverview({ conversation }: ConversationOverviewProps) {
+  const { currentEnvironment } = useEnvironment();
   const participants = conversation.participants ?? [];
   const channels = conversation.channels ?? [];
   const subscriber = participants.find((p) => p.type === 'subscriber');
   const agent = participants.find((p) => p.type === 'agent');
   const agentName = agent?.agent?.name ?? agent?.id ?? conversation._agentId ?? 'agent';
+  const agentIdentifier = agent?.agent?.identifier ?? agent?.id;
+  const agentLink =
+    agentIdentifier && currentEnvironment?.slug
+      ? buildRoute(ROUTES.AGENT_DETAILS, { environmentSlug: currentEnvironment.slug, agentIdentifier })
+      : undefined;
   const platforms = [...new Set(channels.map((c) => c.platform))];
 
   const sourceRequestId = (conversation.metadata?.sourceRequestId as string) ?? undefined;
@@ -61,13 +52,29 @@ export function ConversationOverview({ conversation }: ConversationOverviewProps
             <span className="font-normal">{conversation.identifier}</span>
           </MetaRow>
           <MetaRow label="Thread started">
-            <span className="font-normal">{formatTimestamp(conversation.createdAt)}</span>
+            <TimeDisplayHoverCard date={conversation.createdAt} className="font-normal">
+              {conversation.createdAt ? new Date(conversation.createdAt).toLocaleString('en-US', {
+                month: 'short', day: 'numeric', year: 'numeric',
+                hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+              }) : '—'}
+            </TimeDisplayHoverCard>
           </MetaRow>
           <MetaRow label="Agent">
-            <span className="flex items-center gap-1 font-medium">
-              <RiRobot2Line className="size-3.5" />
-              {agentName} ↗
-            </span>
+            {agentLink ? (
+              <Link
+                to={agentLink}
+                className="flex items-center gap-1 font-medium underline decoration-dashed underline-offset-[3px] decoration-[currentColor]/40 transition-colors hover:text-text-strong hover:decoration-[currentColor]/70"
+              >
+                <RiRobot2Line className="size-3.5" />
+                {agentName}
+                <RiArrowRightUpLine className="size-3" />
+              </Link>
+            ) : (
+              <span className="flex items-center gap-1 font-medium">
+                <RiRobot2Line className="size-3.5" />
+                {agentName}
+              </span>
+            )}
           </MetaRow>
           <MetaRow label="Providers">
             <div className="flex items-center gap-1">

--- a/apps/dashboard/src/components/conversations/conversation-timeline.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-timeline.tsx
@@ -1,6 +1,5 @@
 import { Fragment, useId, useState } from 'react';
 import {
-  RiArrowRightUpLine,
   RiCheckboxCircleFill,
   RiExpandUpDownLine,
   RiReplyLine,
@@ -22,6 +21,7 @@ type ConversationTimelineProps = {
   activities: ConversationActivityDto[];
   isLoading: boolean;
   totalCount: number;
+  conversationStatus?: string;
 };
 
 function formatActivityTimestamp(dateStr: string | undefined): string {
@@ -139,7 +139,7 @@ function MessageContent({ content }: { content: string }) {
           aria-expanded={expanded}
           aria-controls={contentId}
           onClick={() => setExpanded(!expanded)}
-          className="text-text-soft flex shrink-0 items-center gap-0.5"
+          className="text-text-soft hover:text-text-sub flex shrink-0 cursor-pointer items-center gap-0.5 transition-colors"
         >
           <RiExpandUpDownLine className="size-3.5" />
           <span className="text-[10px] font-medium leading-[14px]">{expanded ? 'Collapse' : 'Show full message'}</span>
@@ -189,20 +189,20 @@ function InlineLogRow({ activity }: { activity: ConversationActivityDto }) {
   return (
     <div className="flex items-center gap-1 overflow-hidden py-0.5 pl-[11px]">
       {icon}
-      <span className="text-text-sub text-label-xs min-w-0 truncate font-medium">{activity.content}</span>
+      {activityFeedLink ? (
+        <Link
+          to={activityFeedLink}
+          className="text-text-sub text-label-xs min-w-0 truncate font-medium underline decoration-dashed underline-offset-[3px] decoration-[currentColor]/40 transition-colors hover:text-text-strong hover:decoration-[currentColor]/70"
+        >
+          {activity.content}
+        </Link>
+      ) : (
+        <span className="text-text-sub text-label-xs min-w-0 truncate font-medium">{activity.content}</span>
+      )}
       <span className="text-text-soft font-code shrink-0 text-[11px] leading-normal">•</span>
       <span className="text-text-soft shrink-0 text-[10px] font-medium leading-[14px]">
         {formatActivityTimestamp(activity.createdAt)}
       </span>
-      {activityFeedLink && (
-        <Link
-          to={activityFeedLink}
-          className="text-text-soft hover:text-text-sub ml-auto shrink-0 rounded p-0.5 transition-colors"
-          aria-label="View workflow run in activity feed"
-        >
-          <RiArrowRightUpLine className="size-3.5" />
-        </Link>
-      )}
     </div>
   );
 }
@@ -232,7 +232,7 @@ function ResolvedFooter({ totalCount }: { totalCount: number }) {
   );
 }
 
-export function ConversationTimeline({ activities, isLoading, totalCount }: ConversationTimelineProps) {
+export function ConversationTimeline({ activities, isLoading, totalCount, conversationStatus }: ConversationTimelineProps) {
   if (isLoading) {
     return (
       <div className="flex flex-col gap-3 p-3">
@@ -259,7 +259,7 @@ export function ConversationTimeline({ activities, isLoading, totalCount }: Conv
     );
   }
 
-  const hasResolvedSignal = activities.some((a) => a.type === 'signal' && a.signalData?.type === 'resolve');
+  const isResolved = conversationStatus === 'resolved';
 
   return (
     <div className="flex flex-col gap-3 p-3">
@@ -278,7 +278,7 @@ export function ConversationTimeline({ activities, isLoading, totalCount }: Conv
           </Fragment>
         ))}
 
-        {hasResolvedSignal && (
+        {isResolved && (
           <>
             <TimelineDivider />
             <ResolvedFooter totalCount={totalCount} />


### PR DESCRIPTION
## Summary

- **Fix stale resolved footer** — the RESOLVED badge at the bottom of the timeline was shown even when a conversation had been reopened, because the code used `.some()` to check for any resolve signal in the history. It now reads `conversation.status` directly, which is the source of truth
- **Sticky overview header** — the metadata panel (Conversation ID, Thread started, Agent, etc.) no longer scrolls away; only the timeline list scrolls
- **Triggered workflow deeplink** — instead of an easy-to-miss arrow icon pinned to the far right, the log entry text itself becomes a dashed-underline link (consistent with the rest of the app), and the isolated icon is removed
- **"Show full message" button** — adds `cursor-pointer` and a hover colour so it's obviously interactive
- **Agent field deeplink** — the Agent value in the overview now links directly to the agent's detail page (`AGENT_DETAILS` route)
- **Thread started uses `TimeDisplayHoverCard`** — hovering reveals UTC / local / relative time tooltip, consistent with Triggered at and other date fields across the app

## Test plan

- [ ] Open a conversation that was resolved then reopened — confirm RESOLVED footer is gone
- [ ] Open a resolved conversation — confirm RESOLVED footer is shown
- [ ] Scroll the timeline — confirm the overview header stays pinned
- [ ] Find a "Triggered workflow" log entry — confirm the text is a dashed-underline link that navigates to the activity feed filtered by that transaction
- [ ] Long message — confirm "Show full message" shows pointer cursor and hover colour
- [ ] Hover the Thread started date — confirm tooltip shows UTC, local, and relative time
- [ ] Click the Agent value — confirm navigation to the agent detail page

Made with [Cursor](https://cursor.com)