### PR TITLE
fix(dashboard): persist agent provider selection across page navigation fixes NOV-7404

### DIFF
--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -1,6 +1,6 @@
 import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { RiExpandUpDownLine } from 'react-icons/ri';
 import { type AgentResponse, getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
@@ -34,9 +34,13 @@ function resolveProviderSetupGuide(providerId: string) {
   }
 }
 
+const SESSION_KEY = (agentIdentifier: string) => `agent-setup-integration:${agentIdentifier}`;
+
 export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
   const [isExpanded, setIsExpanded] = useState(true);
-  const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(undefined);
+  const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(
+    () => sessionStorage.getItem(SESSION_KEY(agent.identifier)) ?? undefined
+  );
   const { currentEnvironment } = useEnvironment();
   const { integrations } = useFetchIntegrations();
   const queryClient = useQueryClient();
@@ -65,6 +69,13 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
   const defaultFromAgent = agent.integrations?.[0];
 
   const effectiveIntegrationId = selectedIntegrationId ?? defaultFromAgent?.integrationId;
+
+  // Once the server has the integration link, sessionStorage is no longer needed.
+  useEffect(() => {
+    if (defaultFromAgent?.integrationId) {
+      sessionStorage.removeItem(SESSION_KEY(agent.identifier));
+    }
+  }, [defaultFromAgent?.integrationId, agent.identifier]);
 
   const selectedProviderId = useMemo(() => {
     if (selectedIntegrationId) {
@@ -126,6 +137,7 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
                   onSelect={(_providerId, integration) => {
                     if (integration?._id) {
                       setSelectedIntegrationId(integration._id);
+                      sessionStorage.setItem(SESSION_KEY(agent.identifier), integration._id);
                     }
                   }}
                 />


### PR DESCRIPTION
## What changed

During agent onboarding, the provider selected in the setup guide was stored only in local `useState`. Navigating away from the agent detail page and returning would reset that selection — the setup guide reverted to blank even if the user had already picked a provider and partially filled in fields.

## How it's fixed

`selectedIntegrationId` in `AgentSetupGuide` is now persisted to `sessionStorage`, keyed per agent (`agent-setup-integration:<identifier>`).

- **On mount** — reads from `sessionStorage` so the previous selection is restored when navigating back
- **On select** — writes to `sessionStorage` when the user picks a provider from the dropdown
- **Auto-cleanup** — removes the entry via `useEffect` once `defaultFromAgent?.integrationId` is populated, meaning the server has confirmed the integration link and the agent data itself becomes the source of truth

`sessionStorage` was chosen over `localStorage` because this is transient in-progress UI state that should not persist beyond the tab session, and over URL params because cross-page navigation changes the URL entirely (making params ineffective for this scenario).

## Flow

```mermaid
sequenceDiagram
    participant U as User
    participant SS as sessionStorage
    participant AG as AgentSetupGuide
    participant SRV as Server

    U->>AG: Pick provider from dropdown
    AG->>SS: setItem(agent-setup-integration:<id>, integrationId)
    U->>U: Navigate to another page
    U->>AG: Navigate back to agent page
    AG->>SS: getItem(agent-setup-integration:<id>)
    SS-->>AG: integrationId restored ✓
    U->>U: Complete provider setup
    SRV-->>AG: agent.integrations[0] populated
    AG->>SS: removeItem(agent-setup-integration:<id>)
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `AgentSetupGuide` component now persists the user's provider selection to `sessionStorage` during agent onboarding. Previously, navigating away from the agent detail page and returning would reset the selected integration and clear any partially filled setup fields. The selected integration ID is now saved per-agent using a session key, restored on page return, and automatically cleaned up once the backend confirms the integration link.

## Affected areas

**dashboard**: Added sessionStorage-based persistence to the agent setup guide. When a user selects a provider integration, it is saved with a per-agent key (`agent-setup-integration:<identifier>`). On component mount, the selection is restored from sessionStorage. Once the backend populates the integration link (`defaultFromAgent?.integrationId`), a cleanup effect removes the sessionStorage entry so server state becomes the source of truth.

## Key technical decisions

- **sessionStorage over localStorage**: Session-scoped persistence is appropriate since this is transient state valid only for the tab session.
- **sessionStorage over URL params**: Avoids polluting the URL and handles cross-page navigation where the URL changes completely.
- **Auto-cleanup via useEffect**: Removes the persisted selection once the server confirms the integration, ensuring server state takes precedence over client-side persistence.

## Testing

No additional tests were added. This change is a storage mechanism for an existing UI flow and can be verified through manual testing of the agent onboarding workflow (navigate away and return to confirm selection persists).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->