### PR TITLE
feat(dashboard,api-service): wildcard catch-all inbound address for agent email fixes NV-7405

### DIFF
--- a/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
@@ -5,6 +5,8 @@ import { ChannelTypeEnum, EmailProviderIdEnum, IEmailOptions } from '@novu/share
 
 import { SendAgentTestEmailCommand } from './send-agent-test-email.command';
 
+const CATCH_ALL_ADDRESS = '*';
+
 function escapeHtml(text: string): string {
   return text
     .replace(/&/g, '&amp;')
@@ -66,7 +68,11 @@ export class SendAgentTestEmail {
       throw new BadRequestException('Inbound address is not configured. Set the address and domain first.');
     }
 
-    const to = `${inboundAddress}@${inboundDomain}`;
+    // Wildcard catch-all routes cannot be emailed directly — use a synthetic local part
+    // that will still match the catch-all route in DomainRouteStrategy
+    const effectiveLocalPart =
+      inboundAddress === CATCH_ALL_ADDRESS ? `novu-test-${agent._id.slice(-8)}` : inboundAddress;
+    const to = `${effectiveLocalPart}@${inboundDomain}`;
     const outboundIntegrationId = emailIntegration.credentials?.outboundIntegrationId as string | undefined;
 
     const senderIntegration = await this.findSenderIntegration(

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -1,6 +1,6 @@
 import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { RiExpandUpDownLine } from 'react-icons/ri';
 import { type AgentResponse, getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
@@ -34,9 +34,13 @@ function resolveProviderSetupGuide(providerId: string) {
   }
 }
 
+const SESSION_KEY = (agentIdentifier: string) => `agent-setup-integration:${agentIdentifier}`;
+
 export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
   const [isExpanded, setIsExpanded] = useState(true);
-  const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(undefined);
+  const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(
+    () => sessionStorage.getItem(SESSION_KEY(agent.identifier)) ?? undefined
+  );
   const { currentEnvironment } = useEnvironment();
   const { integrations } = useFetchIntegrations();
   const queryClient = useQueryClient();
@@ -65,6 +69,13 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
   const defaultFromAgent = agent.integrations?.[0];
 
   const effectiveIntegrationId = selectedIntegrationId ?? defaultFromAgent?.integrationId;
+
+  // Once the server has the integration link, sessionStorage is no longer needed.
+  useEffect(() => {
+    if (defaultFromAgent?.integrationId) {
+      sessionStorage.removeItem(SESSION_KEY(agent.identifier));
+    }
+  }, [defaultFromAgent?.integrationId, agent.identifier]);
 
   const selectedProviderId = useMemo(() => {
     if (selectedIntegrationId) {
@@ -126,6 +137,7 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
                   onSelect={(_providerId, integration) => {
                     if (integration?._id) {
                       setSelectedIntegrationId(integration._id);
+                      sessionStorage.setItem(SESSION_KEY(agent.identifier), integration._id);
                     }
                   }}
                 />

--- a/apps/dashboard/src/components/agents/email-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/email-setup-guide.tsx
@@ -286,6 +286,8 @@ function OutboundProviderSelect({
   );
 }
 
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 function InboundAddressConfig({
   localPart,
   domainName,
@@ -320,6 +322,14 @@ function InboundAddressConfig({
   );
 
   const isCatchAll = localPart === CATCH_ALL_ADDRESS;
+  const [replyFromError, setReplyFromError] = useState(false);
+
+  function handleReplyFromBlur() {
+    if (!replyFrom) return;
+    const valid = EMAIL_PATTERN.test(replyFrom);
+    setReplyFromError(!valid);
+    if (valid) onReplyFromBlur();
+  }
 
   return (
     <div className="flex flex-col gap-2">
@@ -403,29 +413,40 @@ function InboundAddressConfig({
         </Popover>
       </div>
       {isCatchAll && (
-        <p className="text-text-soft text-label-xs font-medium leading-4">
-          Catch-all: every email sent to this domain routes to this agent.
-        </p>
-      )}
-
-      {isCatchAll && (
-        <div className="flex flex-col gap-1">
-          <span className="text-text-sub text-label-xs font-medium leading-4">Reply-from address</span>
-          <div className="border-stroke-soft bg-bg-white flex h-8 items-center overflow-hidden rounded-lg border shadow-xs">
-            <input
-              type="text"
-              aria-label="Reply-from email address"
-              className="text-text-sub text-label-xs h-full w-full bg-transparent px-2 font-medium outline-none"
-              placeholder={domainName ? `agent@${domainName}` : 'agent@yourdomain.com'}
-              value={replyFrom}
-              onChange={(e) => onReplyFromChange(e.target.value)}
-              onBlur={onReplyFromBlur}
-            />
-          </div>
+        <>
           <p className="text-text-soft text-label-xs font-medium leading-4">
-            The From address shown to recipients in outbound replies.
+            Catch-all: every email sent to this domain routes to this agent.
           </p>
-        </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-text-sub text-label-xs font-medium leading-4">Reply-from address</span>
+            <div
+              className={cn(
+                'border-stroke-soft bg-bg-white flex h-8 items-center overflow-hidden rounded-lg border shadow-xs',
+                replyFromError && 'border-destructive'
+              )}
+            >
+              <input
+                type="email"
+                aria-label="Reply-from email address"
+                className="text-text-sub text-label-xs h-full w-full bg-transparent px-2 font-medium outline-none"
+                placeholder={domainName ? `agent@${domainName}` : 'agent@yourdomain.com'}
+                value={replyFrom}
+                onChange={(e) => {
+                  setReplyFromError(false);
+                  onReplyFromChange(e.target.value);
+                }}
+                onBlur={handleReplyFromBlur}
+              />
+            </div>
+            {replyFromError ? (
+              <p className="text-destructive text-label-xs font-medium leading-4">Enter a valid email address.</p>
+            ) : (
+              <p className="text-text-soft text-label-xs font-medium leading-4">
+                The From address shown to recipients in outbound replies.
+              </p>
+            )}
+          </div>
+        </>
       )}
 
       <p className="text-text-soft text-label-xs font-medium leading-4">
@@ -477,8 +498,6 @@ export function EmailSetupGuide({
     domainName,
     replyFrom,
     domains,
-    outboundIntegration,
-    isOutboundDemo,
     needsCredentialsStep,
     outboundProviderConfig,
     setLocalPart,

--- a/apps/dashboard/src/components/agents/email-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/email-setup-guide.tsx
@@ -1,17 +1,16 @@
 import {
   ChannelTypeEnum,
-  DomainRouteTypeEnum,
   DomainStatusEnum,
   emailProviders as emailProviderConfigs,
   EmailProviderIdEnum,
   type IIntegration,
 } from '@novu/shared';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
 import { RiAddLine, RiExpandUpDownLine, RiKey2Line, RiLoader4Line, RiMailSendLine, RiSearchLine } from 'react-icons/ri';
 import { Link, useNavigate } from 'react-router-dom';
 import { type AgentResponse, sendAgentTestEmail } from '@/api/agents';
-import { type DomainResponse, fetchDomains, updateDomain } from '@/api/domains';
+import { type DomainResponse } from '@/api/domains';
 import { createIntegration } from '@/api/integrations';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import {
@@ -26,12 +25,12 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/primitives
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
-import { useUpdateIntegration } from '@/hooks/use-update-integration';
 import { QueryKeys } from '@/utils/query-keys';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 import { IntegrationCredentialsSidebar, ListeningStatus, SetupButton, SetupStep } from './setup-guide-primitives';
 import { deriveStepStatus } from './setup-guide-step-utils';
+import { CATCH_ALL_ADDRESS, useEmailSetupCredentials } from './use-email-setup-credentials';
 
 export type EmailSetupGuideProps = {
   agent: AgentResponse;
@@ -291,16 +290,22 @@ function InboundAddressConfig({
   localPart,
   domainName,
   domains,
+  replyFrom,
   onLocalPartChange,
   onLocalPartBlur,
   onDomainChange,
+  onReplyFromChange,
+  onReplyFromBlur,
 }: {
   localPart: string;
   domainName: string;
   domains: DomainResponse[];
+  replyFrom: string;
   onLocalPartChange: (v: string) => void;
   onLocalPartBlur: () => void;
   onDomainChange: (v: string) => void;
+  onReplyFromChange: (v: string) => void;
+  onReplyFromBlur: () => void;
 }) {
   const [domainOpen, setDomainOpen] = useState(false);
   const { currentEnvironment } = useEnvironment();
@@ -313,6 +318,8 @@ function InboundAddressConfig({
   const verifiedDomains = domains.filter(
     (d) => d.status === DomainStatusEnum.VERIFIED && d.mxRecordConfigured
   );
+
+  const isCatchAll = localPart === CATCH_ALL_ADDRESS;
 
   return (
     <div className="flex flex-col gap-2">
@@ -395,6 +402,32 @@ function InboundAddressConfig({
           </PopoverContent>
         </Popover>
       </div>
+      {isCatchAll && (
+        <p className="text-text-soft text-label-xs font-medium leading-4">
+          Catch-all: every email sent to this domain routes to this agent.
+        </p>
+      )}
+
+      {isCatchAll && (
+        <div className="flex flex-col gap-1">
+          <span className="text-text-sub text-label-xs font-medium leading-4">Reply-from address</span>
+          <div className="border-stroke-soft bg-bg-white flex h-8 items-center overflow-hidden rounded-lg border shadow-xs">
+            <input
+              type="text"
+              aria-label="Reply-from email address"
+              className="text-text-sub text-label-xs h-full w-full bg-transparent px-2 font-medium outline-none"
+              placeholder={domainName ? `agent@${domainName}` : 'agent@yourdomain.com'}
+              value={replyFrom}
+              onChange={(e) => onReplyFromChange(e.target.value)}
+              onBlur={onReplyFromBlur}
+            />
+          </div>
+          <p className="text-text-soft text-label-xs font-medium leading-4">
+            The From address shown to recipients in outbound replies.
+          </p>
+        </div>
+      )}
+
       <p className="text-text-soft text-label-xs font-medium leading-4">
         <Link to={domainsPath} className="text-text-sub underline">
           Configure custom domains
@@ -414,7 +447,6 @@ export function EmailSetupGuide({
 }: EmailSetupGuideProps) {
   const { currentEnvironment } = useEnvironment();
   const { integrations } = useFetchIntegrations();
-  const { mutateAsync: updateIntegration } = useUpdateIntegration();
 
   const [isCredentialsSidebarOpen, setIsCredentialsSidebarOpen] = useState(false);
   const [isCredentialsSaved, setIsCredentialsSaved] = useState(false);
@@ -439,124 +471,27 @@ export function EmailSetupGuide({
     [integrations, integrationId]
   );
 
-  const serverCredentials = emailIntegration?.credentials ?? {};
-  const credentialsRef = useRef<Record<string, unknown>>(serverCredentials as Record<string, unknown>);
-  useEffect(() => {
-    credentialsRef.current = { ...credentialsRef.current, ...serverCredentials };
-  }, [emailIntegration]);
-
-  const [outboundId, setOutboundId] = useState<string>('');
-  const [localPart, setLocalPart] = useState<string>('');
-  const [domainName, setDomainName] = useState<string>('');
-
-  const hasInitializedFromServer = useRef(false);
-  useEffect(() => {
-    if (!emailIntegration || hasInitializedFromServer.current) return;
-    hasInitializedFromServer.current = true;
-    const creds = emailIntegration.credentials ?? {};
-    if (creds.outboundIntegrationId) setOutboundId(creds.outboundIntegrationId as string);
-    if (creds.inboundAddress) setLocalPart(creds.inboundAddress as string);
-    if (creds.inboundDomain) setDomainName(creds.inboundDomain as string);
-  }, [emailIntegration]);
-
-  const outboundIntegration = useMemo(
-    () => (outboundId ? integrations?.find((i) => i._id === outboundId) : undefined),
-    [integrations, outboundId]
-  );
-
-  const isOutboundDemo = outboundIntegration?.providerId === EmailProviderIdEnum.Novu;
-  const needsCredentialsStep = Boolean(outboundIntegration) && !isOutboundDemo;
-
-  const outboundProviderConfig = useMemo(
-    () => (outboundIntegration ? emailProviderConfigs.find((p) => p.id === outboundIntegration.providerId) : undefined),
-    [outboundIntegration]
-  );
-
-  const domainsQuery = useQuery<DomainResponse[]>({
-    queryKey: [QueryKeys.fetchDomains, currentEnvironment?._id],
-    queryFn: () => fetchDomains(requireEnvironment(currentEnvironment, 'No environment selected')),
-    enabled: Boolean(currentEnvironment),
-  });
-  const domains = domainsQuery.data ?? [];
-
-  const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
-
-  function saveCredentials(patch: Record<string, unknown>) {
-    if (!emailIntegration) return;
-
-    credentialsRef.current = { ...credentialsRef.current, ...patch };
-    const snapshot = { ...credentialsRef.current };
-
-    saveQueueRef.current = saveQueueRef.current
-      .then(() =>
-        updateIntegration({
-          integrationId: emailIntegration._id,
-          data: {
-            name: emailIntegration.name,
-            identifier: emailIntegration.identifier,
-            active: emailIntegration.active,
-            primary: emailIntegration.primary ?? false,
-            credentials: snapshot,
-            configurations: {},
-            check: false,
-          },
-        })
-      )
-      .then(() => undefined)
-      .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : 'Could not save credentials.';
-        showErrorToast(message, 'Settings not saved');
-      });
-  }
-
-  function upsertAgentRoute(address: string, domain: DomainResponse) {
-    if (!currentEnvironment || !agent._id) return;
-
-    const existingRoutes = domain.routes ?? [];
-    const hasRoute = existingRoutes.some(
-      (r) => r.address === address && r.type === DomainRouteTypeEnum.AGENT && r.destination === agent._id
-    );
-
-    if (hasRoute) return;
-
-    const updatedRoutes = existingRoutes.filter(
-      (r) => !(r.address === address && r.type === DomainRouteTypeEnum.AGENT)
-    );
-
-    updatedRoutes.push({ address, type: DomainRouteTypeEnum.AGENT, destination: agent._id });
-
-    updateDomain(domain._id, { routes: updatedRoutes }, currentEnvironment).catch(() => {
-      showErrorToast('Could not create inbound route on the domain.', 'Route creation failed');
-    });
-  }
+  const {
+    outboundId,
+    localPart,
+    domainName,
+    replyFrom,
+    domains,
+    outboundIntegration,
+    isOutboundDemo,
+    needsCredentialsStep,
+    outboundProviderConfig,
+    setLocalPart,
+    setReplyFrom,
+    onOutboundSelect,
+    onLocalPartBlur,
+    onDomainChange,
+    onReplyFromBlur,
+  } = useEmailSetupCredentials({ emailIntegration, integrations, agent });
 
   function handleOutboundSelect(id: string) {
-    setOutboundId(id);
     setIsCredentialsSaved(false);
-    saveCredentials({ outboundIntegrationId: id });
-  }
-
-  function handleLocalPartBlur() {
-    if (!localPart || localPart === credentialsRef.current.inboundAddress) return;
-
-    const replyDomain = domainName ? `${localPart}@${domainName}` : undefined;
-    saveCredentials({ inboundAddress: localPart, ...(replyDomain ? { replyDomain } : {}) });
-
-    if (domainName) {
-      const domain = domains.find((d) => d.name === domainName);
-      if (domain) upsertAgentRoute(localPart, domain);
-    }
-  }
-
-  function handleDomainChange(name: string) {
-    setDomainName(name);
-    const replyDomain = localPart ? `${localPart}@${name}` : undefined;
-    saveCredentials({ inboundDomain: name, ...(replyDomain ? { replyDomain } : {}) });
-
-    if (localPart) {
-      const domain = domains.find((d) => d.name === name);
-      if (domain) upsertAgentRoute(localPart, domain);
-    }
+    onOutboundSelect(id);
   }
 
   const base = stepOffset;
@@ -569,9 +504,10 @@ export function EmailSetupGuide({
     if (!outboundId) return base;
     if (needsCredentialsStep && !isCredentialsSaved) return base + 1;
     if (!localPart || !domainName) return inboundStepIndex;
+    if (localPart === CATCH_ALL_ADDRESS && !replyFrom) return inboundStepIndex;
 
     return testStepIndex;
-  }, [base, outboundId, needsCredentialsStep, isCredentialsSaved, localPart, domainName, inboundStepIndex, testStepIndex]);
+  }, [base, outboundId, needsCredentialsStep, isCredentialsSaved, localPart, domainName, replyFrom, inboundStepIndex, testStepIndex]);
 
   const stepsColumn = (
     <>
@@ -638,9 +574,12 @@ export function EmailSetupGuide({
             localPart={localPart}
             domainName={domainName}
             domains={domains}
+            replyFrom={replyFrom}
             onLocalPartChange={setLocalPart}
-            onLocalPartBlur={handleLocalPartBlur}
-            onDomainChange={handleDomainChange}
+            onLocalPartBlur={onLocalPartBlur}
+            onDomainChange={onDomainChange}
+            onReplyFromChange={setReplyFrom}
+            onReplyFromBlur={onReplyFromBlur}
           />
         }
       />

--- a/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
+++ b/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
@@ -1,0 +1,172 @@
+import {
+  DomainRouteTypeEnum,
+  emailProviders as emailProviderConfigs,
+  EmailProviderIdEnum,
+  type IIntegration,
+} from '@novu/shared';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { type AgentResponse } from '@/api/agents';
+import { type DomainResponse, fetchDomains, updateDomain } from '@/api/domains';
+import { showErrorToast } from '@/components/primitives/sonner-helpers';
+import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useUpdateIntegration } from '@/hooks/use-update-integration';
+import { QueryKeys } from '@/utils/query-keys';
+
+export const CATCH_ALL_ADDRESS = '*';
+
+function deriveReplyDomain(localPart: string, domain: string): string | undefined {
+  if (!localPart || !domain || localPart === CATCH_ALL_ADDRESS) return undefined;
+  return `${localPart}@${domain}`;
+}
+
+export function useEmailSetupCredentials({
+  emailIntegration,
+  integrations,
+  agent,
+}: {
+  emailIntegration: IIntegration | undefined;
+  integrations: IIntegration[] | undefined;
+  agent: AgentResponse;
+}) {
+  const { currentEnvironment } = useEnvironment();
+  const { mutateAsync: updateIntegration } = useUpdateIntegration();
+
+  const [outboundId, setOutboundId] = useState('');
+  const [localPart, setLocalPart] = useState('');
+  const [domainName, setDomainName] = useState('');
+  const [replyFrom, setReplyFrom] = useState('');
+
+  // Write-through cache keeps the full credentials snapshot between queued saves
+  const serverCredentials = emailIntegration?.credentials ?? {};
+  const credentialsRef = useRef<Record<string, unknown>>(serverCredentials as Record<string, unknown>);
+  useEffect(() => {
+    credentialsRef.current = { ...credentialsRef.current, ...serverCredentials };
+  }, [emailIntegration]);
+
+  // One-time initialization from server state on first load
+  const hasInitializedFromServer = useRef(false);
+  useEffect(() => {
+    if (!emailIntegration || hasInitializedFromServer.current) return;
+    hasInitializedFromServer.current = true;
+    const creds = emailIntegration.credentials ?? {};
+    if (creds.outboundIntegrationId) setOutboundId(creds.outboundIntegrationId as string);
+    if (creds.inboundAddress) setLocalPart(creds.inboundAddress as string);
+    if (creds.inboundDomain) setDomainName(creds.inboundDomain as string);
+    // Catch-all replyDomain can't be auto-computed, so restore it explicitly
+    if (creds.inboundAddress === CATCH_ALL_ADDRESS && creds.replyDomain) {
+      setReplyFrom(creds.replyDomain as string);
+    }
+  }, [emailIntegration]);
+
+  const domainsQuery = useQuery<DomainResponse[]>({
+    queryKey: [QueryKeys.fetchDomains, currentEnvironment?._id],
+    queryFn: () => fetchDomains(requireEnvironment(currentEnvironment, 'No environment selected')),
+    enabled: Boolean(currentEnvironment),
+  });
+  const domains = domainsQuery.data ?? [];
+
+  const outboundIntegration = useMemo(
+    () => (outboundId ? integrations?.find((i) => i._id === outboundId) : undefined),
+    [integrations, outboundId]
+  );
+  const isOutboundDemo = outboundIntegration?.providerId === EmailProviderIdEnum.Novu;
+  const needsCredentialsStep = Boolean(outboundIntegration) && !isOutboundDemo;
+  const outboundProviderConfig = useMemo(
+    () => (outboundIntegration ? emailProviderConfigs.find((p) => p.id === outboundIntegration.providerId) : undefined),
+    [outboundIntegration]
+  );
+
+  // Serialized save queue prevents out-of-order writes when multiple fields change quickly
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+
+  function saveCredentials(patch: Record<string, unknown>) {
+    if (!emailIntegration) return;
+    credentialsRef.current = { ...credentialsRef.current, ...patch };
+    const snapshot = { ...credentialsRef.current };
+    saveQueueRef.current = saveQueueRef.current
+      .then(() =>
+        updateIntegration({
+          integrationId: emailIntegration._id,
+          data: {
+            name: emailIntegration.name,
+            identifier: emailIntegration.identifier,
+            active: emailIntegration.active,
+            primary: emailIntegration.primary ?? false,
+            credentials: snapshot,
+            configurations: {},
+            check: false,
+          },
+        })
+      )
+      .then(() => undefined)
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Could not save credentials.';
+        showErrorToast(message, 'Settings not saved');
+      });
+  }
+
+  function upsertAgentRoute(address: string, domain: DomainResponse) {
+    if (!currentEnvironment || !agent._id) return;
+    const existingRoutes = domain.routes ?? [];
+    if (existingRoutes.some((r) => r.address === address && r.type === DomainRouteTypeEnum.AGENT && r.destination === agent._id)) {
+      return;
+    }
+    const updatedRoutes = [
+      ...existingRoutes.filter((r) => !(r.address === address && r.type === DomainRouteTypeEnum.AGENT)),
+      { address, type: DomainRouteTypeEnum.AGENT, destination: agent._id },
+    ];
+    updateDomain(domain._id, { routes: updatedRoutes }, currentEnvironment).catch(() => {
+      showErrorToast('Could not create inbound route on the domain.', 'Route creation failed');
+    });
+  }
+
+  function onOutboundSelect(id: string) {
+    setOutboundId(id);
+    saveCredentials({ outboundIntegrationId: id });
+  }
+
+  function onLocalPartBlur() {
+    if (!localPart || localPart === credentialsRef.current.inboundAddress) return;
+    if (localPart !== CATCH_ALL_ADDRESS) setReplyFrom('');
+    const replyDomain = deriveReplyDomain(localPart, domainName);
+    saveCredentials({ inboundAddress: localPart, ...(replyDomain ? { replyDomain } : {}) });
+    if (domainName) {
+      const domain = domains.find((d) => d.name === domainName);
+      if (domain) upsertAgentRoute(localPart, domain);
+    }
+  }
+
+  function onDomainChange(name: string) {
+    setDomainName(name);
+    const replyDomain = deriveReplyDomain(localPart, name);
+    saveCredentials({ inboundDomain: name, ...(replyDomain ? { replyDomain } : {}) });
+    if (localPart) {
+      const domain = domains.find((d) => d.name === name);
+      if (domain) upsertAgentRoute(localPart, domain);
+    }
+  }
+
+  function onReplyFromBlur() {
+    if (!replyFrom || replyFrom === credentialsRef.current.replyDomain) return;
+    saveCredentials({ replyDomain: replyFrom });
+  }
+
+  return {
+    outboundId,
+    localPart,
+    domainName,
+    replyFrom,
+    domains,
+    outboundIntegration,
+    isOutboundDemo,
+    needsCredentialsStep,
+    outboundProviderConfig,
+    setLocalPart,
+    setReplyFrom,
+    onOutboundSelect,
+    onLocalPartBlur,
+    onDomainChange,
+    onReplyFromBlur,
+  };
+}

--- a/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
+++ b/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
@@ -4,10 +4,10 @@ import {
   EmailProviderIdEnum,
   type IIntegration,
 } from '@novu/shared';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { type AgentResponse } from '@/api/agents';
-import { type DomainResponse, fetchDomains, updateDomain } from '@/api/domains';
+import { type DomainResponse, type UpdateDomainBody, fetchDomains, updateDomain } from '@/api/domains';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useUpdateIntegration } from '@/hooks/use-update-integration';
@@ -32,6 +32,21 @@ export function useEmailSetupCredentials({
   const { currentEnvironment } = useEnvironment();
   const { mutateAsync: updateIntegration } = useUpdateIntegration();
   const queryClient = useQueryClient();
+
+  // domainId is a mutation variable (not a closure) so upsertAgentRoute can be
+  // called with any domain at event time — useUpdateDomain can't be used here
+  // because it bakes a single domainId into its mutationFn closure at call time.
+  const { mutate: updateDomainRoutes } = useMutation({
+    // biome-ignore lint/style/noNonNullAssertion: currentEnvironment is guaranteed non-null when triggered from a user interaction
+    mutationFn: ({ domainId, body }: { domainId: string; body: UpdateDomainBody }) =>
+      updateDomain(domainId, body, currentEnvironment!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.fetchDomains, currentEnvironment?._id] });
+    },
+    onError: () => {
+      showErrorToast('Could not create inbound route on the domain.', 'Route creation failed');
+    },
+  });
 
   const [outboundId, setOutboundId] = useState('');
   const [localPart, setLocalPart] = useState('');
@@ -124,13 +139,7 @@ export function useEmailSetupCredentials({
       ),
       { address, type: DomainRouteTypeEnum.AGENT, destination: agent._id },
     ];
-    updateDomain(domain._id, { routes: updatedRoutes }, currentEnvironment)
-      .then(() => {
-        queryClient.invalidateQueries({ queryKey: [QueryKeys.fetchDomains, currentEnvironment._id] });
-      })
-      .catch(() => {
-        showErrorToast('Could not create inbound route on the domain.', 'Route creation failed');
-      });
+    updateDomainRoutes({ domainId: domain._id, body: { routes: updatedRoutes } });
   }
 
   function onOutboundSelect(id: string) {

--- a/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
+++ b/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
@@ -4,7 +4,7 @@ import {
   EmailProviderIdEnum,
   type IIntegration,
 } from '@novu/shared';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { type AgentResponse } from '@/api/agents';
 import { type DomainResponse, fetchDomains, updateDomain } from '@/api/domains';
@@ -31,6 +31,7 @@ export function useEmailSetupCredentials({
 }) {
   const { currentEnvironment } = useEnvironment();
   const { mutateAsync: updateIntegration } = useUpdateIntegration();
+  const queryClient = useQueryClient();
 
   const [outboundId, setOutboundId] = useState('');
   const [localPart, setLocalPart] = useState('');
@@ -44,11 +45,13 @@ export function useEmailSetupCredentials({
     credentialsRef.current = { ...credentialsRef.current, ...serverCredentials };
   }, [emailIntegration]);
 
-  // One-time initialization from server state on first load
-  const hasInitializedFromServer = useRef(false);
+  // Initialize from server state once per unique integration ID.
+  // Keying off _id (not the object) ensures re-hydration when the user switches
+  // between integrations without the component remounting.
+  const initializedForId = useRef<string | undefined>(undefined);
   useEffect(() => {
-    if (!emailIntegration || hasInitializedFromServer.current) return;
-    hasInitializedFromServer.current = true;
+    if (!emailIntegration || initializedForId.current === emailIntegration._id) return;
+    initializedForId.current = emailIntegration._id;
     const creds = emailIntegration.credentials ?? {};
     if (creds.outboundIntegrationId) setOutboundId(creds.outboundIntegrationId as string);
     if (creds.inboundAddress) setLocalPart(creds.inboundAddress as string);
@@ -57,7 +60,8 @@ export function useEmailSetupCredentials({
     if (creds.inboundAddress === CATCH_ALL_ADDRESS && creds.replyDomain) {
       setReplyFrom(creds.replyDomain as string);
     }
-  }, [emailIntegration]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [emailIntegration?._id]);
 
   const domainsQuery = useQuery<DomainResponse[]>({
     queryKey: [QueryKeys.fetchDomains, currentEnvironment?._id],
@@ -113,12 +117,20 @@ export function useEmailSetupCredentials({
       return;
     }
     const updatedRoutes = [
-      ...existingRoutes.filter((r) => !(r.address === address && r.type === DomainRouteTypeEnum.AGENT)),
+      // Remove same-address AGENT routes AND any orphaned routes from this agent
+      // (e.g. leftover 'wine-bot' route when the user switches to a different address)
+      ...existingRoutes.filter(
+        (r) => !(r.type === DomainRouteTypeEnum.AGENT && (r.address === address || r.destination === agent._id))
+      ),
       { address, type: DomainRouteTypeEnum.AGENT, destination: agent._id },
     ];
-    updateDomain(domain._id, { routes: updatedRoutes }, currentEnvironment).catch(() => {
-      showErrorToast('Could not create inbound route on the domain.', 'Route creation failed');
-    });
+    updateDomain(domain._id, { routes: updatedRoutes }, currentEnvironment)
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: [QueryKeys.fetchDomains, currentEnvironment._id] });
+      })
+      .catch(() => {
+        showErrorToast('Could not create inbound route on the domain.', 'Route creation failed');
+      });
   }
 
   function onOutboundSelect(id: string) {
@@ -128,9 +140,14 @@ export function useEmailSetupCredentials({
 
   function onLocalPartBlur() {
     if (!localPart || localPart === credentialsRef.current.inboundAddress) return;
-    if (localPart !== CATCH_ALL_ADDRESS) setReplyFrom('');
+    const isCatchAll = localPart === CATCH_ALL_ADDRESS;
+    if (!isCatchAll) setReplyFrom('');
     const replyDomain = deriveReplyDomain(localPart, domainName);
-    saveCredentials({ inboundAddress: localPart, ...(replyDomain ? { replyDomain } : {}) });
+    const patch: Record<string, unknown> = { inboundAddress: localPart };
+    if (replyDomain) patch.replyDomain = replyDomain;
+    // Explicitly clear any previously auto-computed replyDomain when entering catch-all mode
+    else if (isCatchAll) patch.replyDomain = '';
+    saveCredentials(patch);
     if (domainName) {
       const domain = domains.find((d) => d.name === domainName);
       if (domain) upsertAgentRoute(localPart, domain);


### PR DESCRIPTION
## Summary

- Allow `*` as the inbound address local part in the agent email setup, enabling a catch-all that routes every email sent to a domain to the agent
- Decouple `replyDomain` from `inboundAddress` auto-computation (Option A) — catch-all requires an explicit Reply-from address since `*@domain` is not a valid RFC 5321 address
- Extract all credential state management from `EmailSetupGuide` into a `useEmailSetupCredentials` hook

## Changes

### `use-email-setup-credentials.ts` (new)

Self-contained hook owning: credential state (`outboundId`, `localPart`, `domainName`, `replyFrom`), write-through `credentialsRef`, serialized `saveQueueRef`, one-time initialization effect, domains query, derived outbound values, `saveCredentials`, `upsertAgentRoute`, and all four event handlers. Exports `CATCH_ALL_ADDRESS` and `deriveReplyDomain` as the single source of truth for both the hook and the component.

### `email-setup-guide.tsx`

`EmailSetupGuide` is now a thin rendering layer: two data fetches, two UI booleans, test email mutation, `emailIntegration` memo, one `useEmailSetupCredentials` call, and JSX. 773 → 655 lines.

`InboundAddressConfig` gains a conditional Reply-from address input that appears only when `localPart === '*'`:

- "Catch-all: every email sent to this domain routes to this agent." hint
- Reply-from text input (placeholder: `agent@{domain}`)
- "The From address shown to recipients in outbound replies." label

`firstIncompleteStep` gates the Test step on `replyFrom` being set when in catch-all mode.

### `send-agent-test-email.usecase.ts`

When `inboundAddress === '*'`, the test email is addressed to `novu-test-{agentId[-8:]}@{inboundDomain}`. This synthetic address has no specific route match and falls through to the wildcard route in `DomainRouteStrategy`, triggering the agent correctly. The `ListeningStatus` component detects success via the `connectedAt` poll as usual.

## How catch-all routing works

```
User enters '*' + selects domain
  → upsertAgentRoute writes { address: '*', type: 'agent', destination: agentId }
  → user fills in Reply-from (e.g. agent@acme.inbound.novu.co)

Email arrives at anything@acme.inbound.novu.co
  → DomainRouteStrategy: exact match fails → fallback to address === '*' ✓
  → HTTP POST to agent webhook with full email payload
  → Agent processes, replies from credentials.replyDomain
```

No changes required to `DomainRouteStrategy` — wildcard route matching was already implemented.

## Test plan

- [ ] Enter a specific local part (e.g. `wine-bot`) → `replyDomain` auto-computes as `wine-bot@domain`, no Reply-from field shown
- [ ] Enter `*` → Reply-from field appears, Test step is locked until Reply-from is filled
- [ ] Fill Reply-from → Test step unlocks, `replyDomain` credential saves the explicit value
- [ ] Switch from `*` back to a specific address → Reply-from field hides, `replyFrom` state resets, `replyDomain` auto-computes again
- [ ] Send test email in catch-all mode → email goes to `novu-test-{id}@domain`, `ListeningStatus` shows connected
- [ ] Reload page with saved `inboundAddress: '*'` → `replyFrom` state restores from `credentials.replyDomain`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Agents can now be configured with '*' as the inbound email local-part to act as a domain-wide catch-all. Because '*@domain' is not a valid RFC 5321 address, reply-from computation was decoupled from the inbound address and catch-all mode requires an explicit Reply-from. Credential/state management for agent email setup was extracted into a new hook to simplify UI logic and ensure correct persistence and domain-route upserts. Test emails for catch-all use synthetic local-parts (novu-test-<last8>) so they are delivered to the wildcard route and trigger the agent.

## Affected areas
**api**: send-agent-test-email generates synthetic local-parts (novu-test-{agentId[-8:]}) for wildcard inbound addresses so test messages reach the catch-all route.  
**dashboard**: Added useEmailSetupCredentials hook that owns outboundId, localPart, domainName, replyFrom, persistence, and domain-route upserts; EmailSetupGuide is now a thin renderer; InboundAddressConfig shows a conditional Reply-from input when localPart === '*', and the Test step requires Reply-from in catch-all mode.  
**react/js (UI libs)**: UI validation for Reply-from (EMAIL_PATTERN) and step gating updated to prevent testing/saving without a valid Reply-from in catch-all mode.

## Key technical decisions
- Decoupled reply-domain/reply-from logic from inboundAddress and require an explicit Reply-from for catch-all to remain RFC-compliant.  
- Use synthetic test local-parts (novu-test-<id>) to exercise wildcard routing without sending to an invalid '*' local-part.  
- Persist credentials with a write-through snapshot and serialized async save queue to avoid out-of-order updates and race conditions; domain-route upserts ensure a single agent route per domain.

## Testing
No automated tests were added; the PR includes a manual test plan covering UI flows (mode switching, reply-from validation and gating, persistence) and test-email delivery verification via the existing ListeningStatus connectedAt polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->