### PR TITLE
fix(dashboard): align Domains list page padding with Workflows

### DIFF
--- a/apps/dashboard/src/pages/domains.tsx
+++ b/apps/dashboard/src/pages/domains.tsx
@@ -151,23 +151,25 @@ export function DomainsPage() {
   return (
     <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Domains</h1>}>
       <PageMeta title="Domains" />
-      <div className="flex h-full flex-col">
-        <div className="flex items-center justify-between gap-3 px-6 py-4">
-          <FacetedFormFilter
-            type="text"
-            size="small"
-            title="Search"
-            value={search}
-            onChange={setSearch}
-            placeholder="Search domains..."
-          />
+      <div className="flex h-full w-full flex-col">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap items-center gap-2 py-2.5">
+            <FacetedFormFilter
+              type="text"
+              size="small"
+              title="Search"
+              value={search}
+              onChange={setSearch}
+              placeholder="Search domains..."
+            />
+          </div>
           <Button onClick={() => setIsAddDialogOpen(true)}>
             <RiAddLine className="size-4" />
             Add domain
           </Button>
         </div>
 
-        <div className="flex-1 overflow-auto px-6 pb-6">
+        <div className="flex-1 overflow-auto">
           <Table isLoading={isTableLoading} loadingRowsCount={3}>
             <TableHeader>
               <TableRow>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Domains list page added extra horizontal padding (`px-6`) and a taller filter bar (`py-4`) on top of `DashboardLayout`'s content wrapper (`p-2`), so it did not line up with Workflows and other list pages.

## Changes

- Remove redundant `px-6` / `py-4` / `pb-6` so content uses the same outer inset as Workflows.
- Mirror the Workflows filter row structure: `flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between` with `py-2.5` on the filters side and the primary action aligned on the right at `sm` breakpoints.

## Testing

- Not run (layout-only Tailwind class changes). Please spot-check Domains vs Workflows in the dashboard.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0AQDQ4J6UU/p1777046396253289?thread_ts=1777046396.253289&cid=C0AQDQ4J6UU)

<div><a href="https://cursor.com/agents/bc-9d52c57a-01bb-5cb3-82e5-9b88d2fd7ae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d52c57a-01bb-5cb3-82e5-9b88d2fd7ae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The Domains list page layout was adjusted to match the Workflows page structure. Removed redundant horizontal padding (`px-6`), filter bar height (`py-4`), and bottom padding (`pb-6`) that were causing misalignment with other list pages. Restructured the filter bar container to use a responsive flexbox layout that stacks vertically on mobile and aligns horizontally on larger screens (`sm:flex-row sm:items-center sm:justify-between`), with the filter wrapped in its own flex container (`py-2.5`) and the "Add domain" button aligned on the right.

## Affected areas

**@novu/dashboard**: The Domains page (`pages/domains.tsx`) was updated to remove redundant spacing classes and adopt a responsive filter bar layout matching Workflows, ensuring consistent padding and behavior across list pages.

## Testing

No automated tests were added as this is a layout-only change involving Tailwind CSS class adjustments. Manual verification against the Workflows page in the dashboard is recommended to confirm visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->