### PR TITLE
fix(api-service): initialize Chat SDK adapters eagerly on instance creation

### DIFF
--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -268,6 +268,7 @@ export class ChatSdkService implements OnModuleDestroy {
     adapterFingerprint: string
   ): Promise<Chat> {
     const chat = await this.createChatInstance(instanceKey, platform, config);
+    await chat.initialize();
     const cached: CachedChat = { chat, config, adapterFingerprint };
     this.registerEventHandlers(agentId, cached);
     this.instances.set(instanceKey, cached);


### PR DESCRIPTION
## Summary

- Calls `chat.initialize()` immediately after constructing a new Chat instance in `ChatSdkService.createAndCache()`, ensuring all adapters are fully initialized before any operation (webhook or reply).
- Fixes `"ThreadResolver not initialized — call setStateAdapter() first"` errors on the email agent reply path when the reply request hits a different API pod than the one that processed the inbound webhook.

## Why this only affects email

The Chat SDK calls `adapter.initialize()` lazily — only on the first `chat.webhooks[platform]()` call (via `ensureInitialized()`). `chat.getAdapter()`, used by the reply path in `postToConversation()`, does **not** trigger initialization.

For Slack/Teams/WhatsApp this is invisible because their `postMessage` only uses credentials passed at construction time. The email adapter is unique: its `postMessage` reads thread metadata (reply headers, subject, agent address) from Redis via the `StateAdapter`, which is only available after `initialize()`.

## Test plan

- [x] Verify email agent reply succeeds when inbound webhook and reply hit different API pods
- [ ] Verify no regression on Slack/Teams/WhatsApp agent flows (`initialize()` is idempotent in the Chat SDK)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
Chat SDK adapter initialization now happens eagerly when a Chat instance is created, rather than lazily on first webhook. This ensures all adapters—particularly the email adapter's StateAdapter (Redis)—are fully initialized before any operation. Previously, when a webhook was processed on one API pod and a reply request hit a different pod with a freshly constructed Chat instance, the email adapter would not be initialized, causing "ThreadResolver not initialized" errors.

## Affected areas
**api** — ChatSdkService.createAndCache() now calls chat.initialize() immediately after constructing a Chat instance, before the instance is cached and event handlers are registered.

## Key technical decisions
- The initialization is asynchronous and idempotent, ensuring no breaking changes for existing Slack/Teams/WhatsApp flows which initialize credentials at construction time.
- Eager initialization guarantees that the email adapter's StateAdapter (Redis) is available to read thread metadata (reply headers, subject, agent address) on the reply path via postToConversation().

## Testing
Manual verification confirms email agent replies succeed when inbound webhooks and reply requests hit different API pods. Regression testing on Slack/Teams/WhatsApp agent flows is pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->