### PR TITLE
fix(dashboard): exclude Novu demo provider from agent outbound email dropdown

### DIFF
--- a/apps/dashboard/src/components/agents/outbound-provider-select.tsx
+++ b/apps/dashboard/src/components/agents/outbound-provider-select.tsx
@@ -30,7 +30,7 @@ type OutboundDropdownItem = {
   integration?: IIntegration;
 };
 
-const EXCLUDED_OUTBOUND_PROVIDERS = new Set([EmailProviderIdEnum.NovuAgent, EmailProviderIdEnum.Novu]);
+const EXCLUDED_OUTBOUND_PROVIDERS = new Set<string>([EmailProviderIdEnum.NovuAgent, EmailProviderIdEnum.Novu]);
 const OUTBOUND_EMAIL_PROVIDERS = emailProviderConfigs.filter((p) => !EXCLUDED_OUTBOUND_PROVIDERS.has(p.id));
 
 function buildOutboundItems(allIntegrations: IIntegration[] | undefined): OutboundDropdownItem[] {

--- a/apps/dashboard/src/components/agents/outbound-provider-select.tsx
+++ b/apps/dashboard/src/components/agents/outbound-provider-select.tsx
@@ -28,24 +28,16 @@ type OutboundDropdownItem = {
   providerId: string;
   displayName: string;
   integration?: IIntegration;
-  isDemo: boolean;
 };
 
-const OUTBOUND_EMAIL_PROVIDERS = emailProviderConfigs.filter((p) => p.id !== EmailProviderIdEnum.NovuAgent);
-
-function DemoBadge() {
-  return (
-    <span className="bg-warning-lighter text-warning-dark rounded px-1 py-px text-[9px] font-semibold uppercase leading-3">
-      Demo
-    </span>
-  );
-}
+const EXCLUDED_OUTBOUND_PROVIDERS = new Set([EmailProviderIdEnum.NovuAgent, EmailProviderIdEnum.Novu]);
+const OUTBOUND_EMAIL_PROVIDERS = emailProviderConfigs.filter((p) => !EXCLUDED_OUTBOUND_PROVIDERS.has(p.id));
 
 function buildOutboundItems(allIntegrations: IIntegration[] | undefined): OutboundDropdownItem[] {
   const integrationsByProvider = new Map<string, IIntegration[]>();
   for (const i of allIntegrations ?? []) {
     if (i.channel !== ChannelTypeEnum.EMAIL) continue;
-    if (i.providerId === EmailProviderIdEnum.NovuAgent) continue;
+    if (EXCLUDED_OUTBOUND_PROVIDERS.has(i.providerId)) continue;
     const list = integrationsByProvider.get(i.providerId) ?? [];
     list.push(i);
     integrationsByProvider.set(i.providerId, list);
@@ -54,20 +46,16 @@ function buildOutboundItems(allIntegrations: IIntegration[] | undefined): Outbou
   const items: OutboundDropdownItem[] = [];
   for (const cfg of OUTBOUND_EMAIL_PROVIDERS) {
     const existing = integrationsByProvider.get(cfg.id);
-    const isDemo = cfg.id === EmailProviderIdEnum.Novu;
     if (existing?.length) {
       for (const integration of existing) {
         items.push({
           providerId: cfg.id,
           displayName: integration.name || cfg.displayName,
           integration,
-          isDemo,
         });
       }
     }
-    if (!isDemo) {
-      items.push({ providerId: cfg.id, displayName: cfg.displayName, isDemo: false });
-    }
+    items.push({ providerId: cfg.id, displayName: cfg.displayName });
   }
 
   return items;
@@ -178,7 +166,6 @@ export function OutboundProviderSelect({
                     className="size-4 shrink-0"
                   />
                   <span className="text-text-strong text-label-xs font-medium leading-4">{selected.displayName}</span>
-                  {selected.isDemo && <DemoBadge />}
                 </div>
               ) : (
                 <span className="text-text-soft text-label-xs font-medium leading-4">Select provider...</span>
@@ -239,7 +226,6 @@ export function OutboundProviderSelect({
                           <span className="text-text-sub text-label-xs flex-1 font-medium leading-4">
                             {item.displayName}
                           </span>
-                          {item.isDemo && <DemoBadge />}
                         </div>
                         {isRowPending && (
                           <RiLoader4Line className="text-text-soft size-3 shrink-0 animate-spin" aria-hidden />
@@ -260,12 +246,6 @@ export function OutboundProviderSelect({
         </Popover>
       </div>
 
-      {selected?.isDemo && (
-        <p className="text-warning-dark text-label-xs max-w-[320px] font-medium leading-4">
-          This is a demo provider for development and testing. Switch to a production provider (e.g. Resend, SendGrid)
-          before going live.
-        </p>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Excludes the Novu demo email provider (`EmailProviderIdEnum.Novu`) from the agent outbound provider dropdown alongside the already-excluded `NovuAgent` provider.
- Removes the `DemoBadge` component, `isDemo` field, and demo warning text that are no longer reachable.

## Why

The Novu demo provider sends from `no-reply@novu.co` via Novu's own SendGrid account. Agent email replies send from the inbound address (e.g. `support@inbound.customer.com`), which isn't authenticated on Novu's account — so outbound sends always fail with 403 Forbidden. Users must configure their own email provider with their own authenticated domain.

## Test plan

- [ ] Open the agent email setup panel — verify the Novu demo provider no longer appears in the "Send emails via" dropdown
- [ ] Verify other providers (Resend, SendGrid, etc.) still appear and are selectable

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The agent outbound email provider selector in the dashboard now excludes the Novu demo provider (EmailProviderIdEnum.Novu) in addition to the existing NovuAgent exclusion. The dropdown-building logic was simplified to use a centralized EXCLUDED_OUTBOUND_PROVIDERS set; demo-related UI and data (DemoBadge, the isDemo field, and demo warning text) were removed because demo providers should not be selectable for agent outbound emails.

## Affected areas
**dashboard**: Updated the agent outbound provider selection UI (outbound-provider-select.tsx) to filter out Novu demo providers via a shared exclusion set, remove demo badges/warnings, and stop including demo provider rows when constructing dropdown items.

## Key technical decisions
- Provider filtering now uses a Set<string> (EXCLUDED_OUTBOUND_PROVIDERS) to cleanly represent excluded provider IDs and avoid a prior ProvidersIdEnum type mismatch.

## Testing
Manual verification only: open the agent email setup panel and confirm Novu (demo) no longer appears in the "Send emails via" dropdown while other providers (Resend, SendGrid, etc.) remain selectable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->