### PR TITLE
fix(shared): email adapter button fallback and markdown rendering fixes NV-7407

### DIFF
--- a/packages/chat-adapter-email/src/adapter.ts
+++ b/packages/chat-adapter-email/src/adapter.ts
@@ -186,7 +186,9 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
       return { text: message };
     }
     if ('markdown' in message) {
-      return { text: (message as { markdown: string }).markdown };
+      const md = (message as { markdown: string }).markdown;
+
+      return { formatted: this.formatConverter.toAst(md), text: md };
     }
     if ('raw' in message) {
       return { text: (message as { raw: string }).raw };

--- a/packages/chat-adapter-email/src/card-renderer.tsx
+++ b/packages/chat-adapter-email/src/card-renderer.tsx
@@ -102,7 +102,11 @@ function renderNode(node: CardNode): React.ReactNode {
         );
       }
 
-      return <Text style={{ display: 'inline-block', padding: '8px 16px', margin: '4px', backgroundColor: '#e0e0e0', borderRadius: '4px', fontSize: '14px' }}>{node.label || ''}</Text>;
+      return (
+        <Button href="#" style={{ padding: '8px 16px', margin: '4px', backgroundColor: '#0066cc', color: '#ffffff', borderRadius: '4px', fontSize: '14px', textDecoration: 'none' }}>
+          {node.label || ''}
+        </Button>
+      );
 
     case 'link':
       return <Link href={safeUrl(node.url) ?? '#'} style={{ color: '#0066cc' }}>{node.label || ''}</Link>;


### PR DESCRIPTION
## Summary
- **Button fallback**: Buttons without an explicit `url` were rendering as `<Text>` (inert styled `<span>`) in outbound agent emails. Changed to `<Button href="#">` (`<a>` tag) so they look and behave like clickable buttons in email clients — matching the Resend Chat SDK reference adapter.
- **Markdown rendering**: `ctx.reply({ markdown: '...' })` was stored as raw text, causing the HTML output to wrap markdown source in `<pre>`. Now parses through `formatConverter.toAst()` so headings, bold, links, and lists render as proper HTML.

## Test plan
- [ ] Send an agent reply with `<Button id="..." />` (no `url`) and verify the email shows a blue clickable-looking button
- [ ] Send an agent reply with `ctx.reply({ markdown: '**bold** and [link](https://example.com)' })` and verify the email shows rendered bold text and a real hyperlink, not raw markdown

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The email adapter now renders buttons without explicit `url` attributes as clickable `<Button>` elements (with `href="#"`) instead of inert text, and properly parses markdown replies through `formatConverter.toAst()` to produce rendered HTML for headings, bold text, links, and lists instead of displaying raw markdown.

## Affected areas

**chat-adapter-email**: The adapter's `normalizeMessage` method now converts markdown input to an AST representation alongside the original text, and the card renderer applies button styling and semantics to buttons that lack a URL, bringing the adapter into alignment with the Resend Chat SDK reference implementation.

## Testing

No automated tests were added. Testing relies on manual verification: sending button replies without a `url` to confirm they appear as styled clickable elements in email clients, and sending markdown replies to confirm proper HTML rendering of formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->