### PR TITLE
fix(dashboard): clean up dangling integration links on provider switch in setup guide fixes NV-7408

### DIFF
--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -2,7 +2,13 @@ import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { RiExpandUpDownLine } from 'react-icons/ri';
-import { type AgentResponse, getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
+import {
+  type AgentResponse,
+  getAgentDetailQueryKey,
+  getAgentIntegrationsQueryKey,
+  listAgentIntegrations,
+  removeAgentIntegration,
+} from '@/api/agents';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { cn } from '@/utils/ui';
@@ -102,6 +108,35 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
     });
   }, [queryClient, currentEnvironment?._id, agent.identifier]);
 
+  const handleProviderSelect = useCallback(
+    (_providerId: string, integration: { _id: string } | undefined) => {
+      if (!integration?._id || !currentEnvironment) return;
+
+      setSelectedIntegrationId(integration._id);
+      sessionStorage.setItem(SESSION_KEY(agent.identifier), integration._id);
+
+      const staleLinks = (agentIntegrationsQuery.data?.data ?? []).filter(
+        (link) => !link.connectedAt && link.integration._id !== integration._id
+      );
+
+      if (!staleLinks.length) return;
+
+      void Promise.all(
+        staleLinks.map((link) =>
+          removeAgentIntegration(currentEnvironment, agent.identifier, link._id).catch(() => {})
+        )
+      ).then(() => {
+        queryClient.invalidateQueries({
+          queryKey: getAgentIntegrationsQueryKey(currentEnvironment._id, agent.identifier),
+        });
+        queryClient.invalidateQueries({
+          queryKey: getAgentDetailQueryKey(currentEnvironment._id, agent.identifier),
+        });
+      });
+    },
+    [agent.identifier, agentIntegrationsQuery.data?.data, currentEnvironment, queryClient]
+  );
+
   return (
     <div className="bg-bg-weak flex min-w-0 flex-1 flex-col rounded-[10px] p-1">
       <button
@@ -134,12 +169,7 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
                   agentIdentifier={agent.identifier}
                   selectedIntegrationId={selectedIntegrationId ?? defaultFromAgent?.integrationId}
                   linkedIntegrationIds={linkedIntegrationIds}
-                  onSelect={(_providerId, integration) => {
-                    if (integration?._id) {
-                      setSelectedIntegrationId(integration._id);
-                      sessionStorage.setItem(SESSION_KEY(agent.identifier), integration._id);
-                    }
-                  }}
+                  onSelect={handleProviderSelect}
                 />
               }
             />


### PR DESCRIPTION
## Summary

- In the agent setup guide, switching between providers in the dropdown accumulated persistent integration links — each click created a new link without removing the previous one, causing stale provider icons to pile up in the agents list view.
- `handleProviderSelect` now removes any uncompleted sibling links (no `connectedAt`) after the new one is created, giving the setup guide dropdown single-select/replace semantics.
- Completed integrations (user finished OAuth/setup) are protected and never removed.

One-file change in `agent-setup-guide.tsx` — zero modifications to the shared `ProviderDropdown` component.

## Test plan

- [ ] Create a new agent, go to the overview tab setup guide
- [ ] Click Slack in the provider dropdown, then switch to WhatsApp, then switch to Teams
- [ ] Verify only the last-selected provider shows as linked (check Integrations tab and agents list view)
- [ ] Complete OAuth setup for one provider, then switch to another — verify the completed one stays linked

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The agent setup guide's provider selection now automatically removes incomplete integration links when switching providers. When a user selects a provider in the `ProviderDropdown`, the system deletes any sibling integrations that haven't been connected yet (missing `connectedAt` timestamp), ensuring only the newly selected provider remains during onboarding. Completed integrations are never removed.

## Affected areas
**dashboard**: Modified the `handleProviderSelect` callback in `agent-setup-guide.tsx` to clean up dangling integration links by deleting uncompleted sibling integrations and invalidating related React Query caches (integrations list and agent details).

## Key technical decisions
- Only uncompleted integrations (missing `connectedAt`) are removed; completed integrations with active OAuth connections are preserved.
- Backend deletions via `removeAgentIntegration` suppress errors per-delete to ensure the flow continues even if individual deletions fail.
- React Query invalidation is triggered for both the integrations list and agent detail queries to ensure UI consistency after backend cleanup.

## Testing
Manual verification is required: create a new agent, use the setup guide, switch between providers (e.g., Slack → WhatsApp → Teams), and confirm only the last-selected provider remains linked. Additionally, complete OAuth for a provider, switch to others, and verify the completed integration persists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->