### PR TITLE
revert(dashboard): revert "clean up dangling integration links on provider switch" fixes NV-7408

### DIFF
--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -2,13 +2,7 @@ import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { RiExpandUpDownLine } from 'react-icons/ri';
-import {
-  type AgentResponse,
-  getAgentDetailQueryKey,
-  getAgentIntegrationsQueryKey,
-  listAgentIntegrations,
-  removeAgentIntegration,
-} from '@/api/agents';
+import { type AgentResponse, getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { cn } from '@/utils/ui';
@@ -108,35 +102,6 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
     });
   }, [queryClient, currentEnvironment?._id, agent.identifier]);
 
-  const handleProviderSelect = useCallback(
-    (_providerId: string, integration: { _id: string } | undefined) => {
-      if (!integration?._id || !currentEnvironment) return;
-
-      setSelectedIntegrationId(integration._id);
-      sessionStorage.setItem(SESSION_KEY(agent.identifier), integration._id);
-
-      const staleLinks = (agentIntegrationsQuery.data?.data ?? []).filter(
-        (link) => !link.connectedAt && link.integration._id !== integration._id
-      );
-
-      if (!staleLinks.length) return;
-
-      void Promise.all(
-        staleLinks.map((link) =>
-          removeAgentIntegration(currentEnvironment, agent.identifier, link._id).catch(() => {})
-        )
-      ).then(() => {
-        queryClient.invalidateQueries({
-          queryKey: getAgentIntegrationsQueryKey(currentEnvironment._id, agent.identifier),
-        });
-        queryClient.invalidateQueries({
-          queryKey: getAgentDetailQueryKey(currentEnvironment._id, agent.identifier),
-        });
-      });
-    },
-    [agent.identifier, agentIntegrationsQuery.data?.data, currentEnvironment, queryClient]
-  );
-
   return (
     <div className="bg-bg-weak flex min-w-0 flex-1 flex-col rounded-[10px] p-1">
       <button
@@ -169,7 +134,12 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
                   agentIdentifier={agent.identifier}
                   selectedIntegrationId={selectedIntegrationId ?? defaultFromAgent?.integrationId}
                   linkedIntegrationIds={linkedIntegrationIds}
-                  onSelect={handleProviderSelect}
+                  onSelect={(_providerId, integration) => {
+                    if (integration?._id) {
+                      setSelectedIntegrationId(integration._id);
+                      sessionStorage.setItem(SESSION_KEY(agent.identifier), integration._id);
+                    }
+                  }}
                 />
               }
             />


### PR DESCRIPTION
## Summary

- Reverts #10857 — the accumulated integration links from the setup guide dropdown are not actually dangling; they're visible and manageable in the Integrations tab's "Connected providers" sidebar with proper "Action needed" status indicators.
- Silently removing links on provider switch was a worse UX than keeping them: users exploring the dropdown to compare providers would lose links without confirmation.

## Test plan

- [ ] Verify `agent-setup-guide.tsx` matches the state before #10857

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
This PR reverts a previous change that removed integration links when switching providers in the agent setup guide. The reverted change had been attempting to clean up "dangling" integration links by deleting unconnected links during provider selection. However, these links are not actually dangling—they remain visible and manageable in the Integrations tab's "Connected providers" sidebar with proper "Action needed" status indicators. The silent deletion of these links during dropdown exploration was determined to be a worse user experience than preserving them.

## Affected areas
**dashboard**: The `agent-setup-guide.tsx` component no longer removes integration links during provider selection. The `ProviderDropdown` `onSelect` handler now only persists the chosen integration ID to component state and `sessionStorage` when an integration exists, eliminating calls to `removeAgentIntegration` and unnecessary query invalidations.

## Testing
Manual verification required: verify that `agent-setup-guide.tsx` matches its state before the reverted PR #10857.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->