### PR TITLE
fix(api-service): use Chat SDK parseMarkdown for outbound email formatting fixes NV-7409

### DIFF
--- a/packages/chat-adapter-email/src/adapter.ts
+++ b/packages/chat-adapter-email/src/adapter.ts
@@ -37,7 +37,7 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
   private readonly messageParser = new MessageParser();
   private readonly formatConverter = new EmailFormatConverter();
   private readonly webhookHandler: WebhookHandler;
-  private parseMarkdownFn: ((md: string) => Root) | null = null;
+  private parseMarkdownFn!: (md: string) => Root;
 
   constructor(config: NovuEmailAdapterConfig) {
     this.config = config;
@@ -189,7 +189,7 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
     }
     if ('markdown' in message) {
       const md = (message as { markdown: string }).markdown;
-      const formatted = this.parseMarkdownFn ? this.parseMarkdownFn(md) : this.formatConverter.toAst(md);
+      const formatted = this.parseMarkdownFn(md);
 
       return { formatted, text: md };
     }

--- a/packages/chat-adapter-email/src/adapter.ts
+++ b/packages/chat-adapter-email/src/adapter.ts
@@ -37,6 +37,7 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
   private readonly messageParser = new MessageParser();
   private readonly formatConverter = new EmailFormatConverter();
   private readonly webhookHandler: WebhookHandler;
+  private parseMarkdownFn: ((md: string) => Root) | null = null;
 
   constructor(config: NovuEmailAdapterConfig) {
     this.config = config;
@@ -49,6 +50,7 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
     this.threadResolver.setStateAdapter(chat.getState());
 
     const chatModule = await import('chat');
+    this.parseMarkdownFn = chatModule.parseMarkdown;
     this.messageParser.setChatModule(chatModule.Message as any, chatModule.parseMarkdown);
   }
 
@@ -187,8 +189,9 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
     }
     if ('markdown' in message) {
       const md = (message as { markdown: string }).markdown;
+      const formatted = this.parseMarkdownFn ? this.parseMarkdownFn(md) : this.formatConverter.toAst(md);
 
-      return { formatted: this.formatConverter.toAst(md), text: md };
+      return { formatted, text: md };
     }
     if ('raw' in message) {
       return { text: (message as { raw: string }).raw };


### PR DESCRIPTION
## Summary

- The email adapter's outbound markdown-to-HTML conversion used a naive `toAst()` stub that only split text into paragraphs — markdown syntax like `**bold**`, `# Heading`, or `- list items` rendered literally in emails.
- Reuses the Chat SDK's `parseMarkdown` (remark + remarkGfm) on the outbound path, matching the inbound path which already used it correctly.
- Single-file change in `packages/chat-adapter-email/src/adapter.ts`: store `parseMarkdown` during `initialize()` and call it in `normalizeMessage()` instead of the stub.

## Test plan

- [ ] Send an agent reply with markdown formatting (`**bold**`, `# heading`, `- list`, `` `code` ``) and verify the email renders proper HTML (not raw markdown syntax)
- [ ] Verify plain text replies still render in `<pre>` tags
- [ ] Verify card replies still render via React Email components
- [ ] Verify inbound email parsing is unaffected


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The email chat adapter now uses the Chat SDK's parseMarkdown (remark + remark-gfm) for outbound markdown-to-HTML conversion instead of a naive paragraph-only stub. This fixes outbound emails rendering raw markdown (e.g., **bold**, # headings, lists, `code`) and aligns outbound formatting with inbound parsing, ensuring agent replies with markdown produce proper HTML in emails.

## Affected areas

**chat-adapter-email**: Initialization now imports and stores the Chat SDK's parseMarkdown and uses it in normalizeMessage for markdown messages; the previous fallback stub was removed and plain text, card rendering, and inbound parsing behavior remain unchanged.

## Key technical decisions

- Initialization now requires and stores parseMarkdown from the Chat module and will fail-fast if missing (no silent fallback).  
- The existing remark-based parser from the Chat SDK is reused to avoid duplicating markdown parsing logic and ensure consistency between inbound and outbound paths.

## Testing

Manual verification only: send agent replies containing markdown (**bold**, # heading, - list, `code`) and confirm emails render correct HTML; confirm plain text still renders in <pre> and cards render via React Email components. No unit or e2e tests were added for this targeted formatter change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->