### PR TITLE
feat(dashboard): polish domain page

### DIFF
--- a/apps/dashboard/src/components/domains/domain-routing.tsx
+++ b/apps/dashboard/src/components/domains/domain-routing.tsx
@@ -299,8 +299,6 @@ function WebhookForwardingBanner({ environmentSlug, webhooksEnabled }: WebhookFo
   );
 }
 
-const WILDCARD_HINT_DISPLAY_PROBABILITY = 0.35;
-
 type WildcardRouteHintProps = {
   domainName: string;
   onConfigureClick: () => void;
@@ -350,7 +348,6 @@ export const DomainRouting = forwardRef<DomainRoutingHandle, DomainRoutingProps>
   const [addInitialValues, setAddInitialValues] = useState<RouteFormState | undefined>(undefined);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [isWildcardHintDismissed, setIsWildcardHintDismissed] = useState(false);
-  const [isWildcardHintRolledIn] = useState(() => Math.random() < WILDCARD_HINT_DISPLAY_PROBABILITY);
 
   const startAdding = (initialValues?: RouteFormState) => {
     setAddInitialValues(initialValues);
@@ -408,8 +405,7 @@ export const DomainRouting = forwardRef<DomainRoutingHandle, DomainRoutingProps>
   const hasWildcardWebhookRoute = domain.routes.some(
     (route) => route.address === '*' && route.type === DomainRouteTypeEnum.WEBHOOK
   );
-  const shouldShowWildcardHint =
-    isWildcardHintRolledIn && !isWildcardHintDismissed && hasWebhookRoute && !hasWildcardWebhookRoute && !isAdding;
+  const shouldShowWildcardHint = !isWildcardHintDismissed && hasWebhookRoute && !hasWildcardWebhookRoute && !isAdding;
   const isEmpty = domain.routes.length === 0 && !isAdding;
 
   return (

--- a/apps/dashboard/src/components/domains/domains-paywall-banner.tsx
+++ b/apps/dashboard/src/components/domains/domains-paywall-banner.tsx
@@ -23,7 +23,7 @@ export function DomainsPaywallBanner() {
             </div>
             <h2 className="text-foreground-900 text-label-md">Domains</h2>
             <p className="text-text-soft text-label-xs mb-3 max-w-[300px]">
-              Send email from a domain you own - better deliverability, stronger brand.
+              Receive emails on your domain and route them to agents or webhooks.
             </p>
           </div>
         </div>

--- a/apps/dashboard/src/pages/domain-detail.tsx
+++ b/apps/dashboard/src/pages/domain-detail.tsx
@@ -107,11 +107,10 @@ export function DomainDetailPage() {
     }
   };
 
-  const handleRequestDelete = (e: Event) => {
-    e.stopPropagation();
+  const handleRequestDelete = () => {
     if (!domain) return;
 
-    setTimeout(() => setIsDeleteModalOpen(true), 0);
+    setIsDeleteModalOpen(true);
   };
 
   const handleConfirmDelete = async () => {
@@ -202,10 +201,9 @@ export function DomainDetailPage() {
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
                   <DropdownMenuItem
-                    className="text-destructive focus:text-destructive"
-                    onSelect={(e) => {
-                      e.preventDefault();
-                      handleRequestDelete(e);
+                    className="text-destructive cursor-pointer"
+                    onClick={() => {
+                      setTimeout(() => handleRequestDelete(), 0);
                     }}
                     disabled={deleteDomain.isPending || !domain}
                   >

--- a/apps/dashboard/src/pages/domains.tsx
+++ b/apps/dashboard/src/pages/domains.tsx
@@ -42,83 +42,58 @@ function DomainStatusBadge({ status }: { status: DomainStatusEnum }) {
   );
 }
 
-function DomainRow({ domain, environmentSlug }: { domain: DomainResponse; environmentSlug: string }) {
+function DomainRow({
+  domain,
+  environmentSlug,
+  onRequestDelete,
+  isDeleting,
+}: {
+  domain: DomainResponse;
+  environmentSlug: string;
+  onRequestDelete: (domain: DomainResponse) => void;
+  isDeleting: boolean;
+}) {
   const navigate = useNavigate();
-  const deleteDomain = useDeleteDomain();
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-
-  const handleDelete = (e: Event) => {
-    e.stopPropagation();
-    setTimeout(() => setIsDeleteModalOpen(true), 0);
-  };
-
-  const handleConfirmDelete = async () => {
-    try {
-      await deleteDomain.mutateAsync(domain._id);
-      setIsDeleteModalOpen(false);
-      showSuccessToast(`Domain "${domain.name}" deleted.`);
-    } catch {
-      showErrorToast('Failed to delete domain.');
-    }
-  };
 
   const handleRowClick = () => {
     navigate(buildRoute(ROUTES.DOMAIN_DETAIL, { environmentSlug, domainId: domain._id }));
   };
 
   return (
-    <>
-      <TableRow className="hover:bg-neutral-alpha-50 cursor-pointer" onClick={handleRowClick}>
-        <TableCell>
-          <div className="flex items-center gap-2">
-            <span className="font-code text-sm font-medium">{domain.name}</span>
-          </div>
-        </TableCell>
-        <TableCell>
-          <DomainStatusBadge status={domain.status} />
-        </TableCell>
-        <TableCell className="text-foreground-500 text-sm">
-          {formatDistanceToNow(new Date(domain.createdAt), { addSuffix: true })}
-        </TableCell>
-        <TableCell className="text-foreground-500 text-sm">
-          {formatDistanceToNow(new Date(domain.updatedAt), { addSuffix: true })}
-        </TableCell>
-        <TableCell className="w-12 text-right">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-              <CompactButton icon={RiMore2Fill} variant="ghost" className="z-10 h-8 w-8 p-0" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
-              <DropdownMenuItem
-                className="text-destructive focus:text-destructive"
-                onSelect={(e) => {
-                  e.preventDefault();
-                  handleDelete(e);
-                }}
-                disabled={deleteDomain.isPending}
-              >
-                Delete domain
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </TableCell>
-      </TableRow>
-      <ConfirmationModal
-        open={isDeleteModalOpen}
-        onOpenChange={setIsDeleteModalOpen}
-        onConfirm={handleConfirmDelete}
-        title="Delete domain"
-        description={
-          <span>
-            Are you sure you want to delete <span className="font-bold">{domain.name}</span>? This action cannot be
-            undone.
-          </span>
-        }
-        confirmButtonText="Delete domain"
-        confirmButtonVariant="error"
-        isLoading={deleteDomain.isPending}
-      />
-    </>
+    <TableRow className="hover:bg-neutral-alpha-50 cursor-pointer" onClick={handleRowClick}>
+      <TableCell>
+        <div className="flex items-center gap-2">
+          <span className="font-code text-sm font-medium">{domain.name}</span>
+        </div>
+      </TableCell>
+      <TableCell>
+        <DomainStatusBadge status={domain.status} />
+      </TableCell>
+      <TableCell className="text-foreground-500 text-sm">
+        {formatDistanceToNow(new Date(domain.createdAt), { addSuffix: true })}
+      </TableCell>
+      <TableCell className="text-foreground-500 text-sm">
+        {formatDistanceToNow(new Date(domain.updatedAt), { addSuffix: true })}
+      </TableCell>
+      <TableCell className="w-12 text-right">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+            <CompactButton icon={RiMore2Fill} variant="ghost" className="z-10 h-8 w-8 p-0" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+            <DropdownMenuItem
+              className="text-destructive cursor-pointer"
+              onClick={() => {
+                setTimeout(() => onRequestDelete(domain), 0);
+              }}
+              disabled={isDeleting}
+            >
+              Delete domain
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+    </TableRow>
   );
 }
 
@@ -126,8 +101,10 @@ export function DomainsPage() {
   const { currentEnvironment } = useEnvironment();
   const { data: domains, isLoading } = useFetchDomains();
   const { subscription } = useFetchSubscription();
+  const deleteDomain = useDeleteDomain();
   const [search, setSearch] = useState('');
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [domainToDelete, setDomainToDelete] = useState<DomainResponse | null>(null);
 
   const environmentSlug = currentEnvironment?.slug;
   const isTableLoading = isLoading || !environmentSlug;
@@ -136,8 +113,25 @@ export function DomainsPage() {
     FeatureNameEnum.DOMAINS_BOOLEAN,
     subscription?.apiServiceLevel || ApiServiceLevelEnum.FREE
   );
-
   const filtered = (domains ?? []).filter((d) => d.name.toLowerCase().includes(search.toLowerCase()));
+
+  const handleRequestDelete = (domain: DomainResponse) => {
+    setDomainToDelete(domain);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!domainToDelete) {
+      return;
+    }
+
+    try {
+      await deleteDomain.mutateAsync(domainToDelete._id);
+      setDomainToDelete(null);
+      showSuccessToast(`Domain "${domainToDelete.name}" deleted.`);
+    } catch {
+      showErrorToast('Failed to delete domain.');
+    }
+  };
 
   if (!domainsEnabled) {
     return (
@@ -190,7 +184,13 @@ export function DomainsPage() {
                   </TableRow>
                 ) : (
                   filtered.map((domain) => (
-                    <DomainRow key={domain._id} domain={domain} environmentSlug={environmentSlug} />
+                    <DomainRow
+                      key={domain._id}
+                      domain={domain}
+                      environmentSlug={environmentSlug}
+                      onRequestDelete={handleRequestDelete}
+                      isDeleting={deleteDomain.isPending}
+                    />
                   ))
                 )}
               </TableBody>
@@ -200,6 +200,25 @@ export function DomainsPage() {
       </div>
 
       <AddDomainDialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen} />
+      <ConfirmationModal
+        open={!!domainToDelete}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDomainToDelete(null);
+          }
+        }}
+        onConfirm={handleConfirmDelete}
+        title="Delete domain"
+        description={
+          <span>
+            Are you sure you want to delete <span className="font-bold">{domainToDelete?.name ?? ''}</span>? This action
+            cannot be undone.
+          </span>
+        }
+        confirmButtonText="Delete domain"
+        confirmButtonVariant="error"
+        isLoading={deleteDomain.isPending}
+      />
     </DashboardLayout>
   );
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed?

Polish of the domain management UI: removed unused probabilistic logic from the wildcard route hint, clarified paywall banner copy to emphasize receiving and routing emails (agents/webhooks), and consolidated domain deletion into a single page-level confirmation flow instead of per-row modals to simplify UX and state handling.

## Affected areas

**dashboard**: Removed the randomized wildcard hint gating and simplified its visibility logic; updated the Domains paywall banner copy to focus on receiving and routing emails; refactored domain deletion so the parent DomainsPage owns selection and deletion mutation and renders a single confirmation modal, while DomainRow receives callbacks and disabled state.

## Key technical decisions

- Ownership of deletion state and mutation moved from per-row DomainRow components to the parent DomainsPage to centralize control and avoid duplicated modal/mutation logic.

## Testing

No tests were added in the PR. Changes are refactors and copy updates; recommend manual verification of the deletion flow, dropdown behavior, and wildcard hint visibility. Existing component tests should cover most logic paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
