### PR TITLE
fix(shared): handle missing merged preferences when context is set on patch preferences fixes NV-7382

### DIFF
--- a/apps/api/src/app/subscribers-v2/e2e/patch-subscriber-preferences.e2e.ts
+++ b/apps/api/src/app/subscribers-v2/e2e/patch-subscriber-preferences.e2e.ts
@@ -281,6 +281,52 @@ describe('Patch Subscriber Preferences - /subscribers/:subscriberId/preferences 
     expect(response.result.workflows[0].channels).to.deep.equal({ inApp: true, email: false });
   });
 
+  it('should patch workflow preferences with organization context as string id (dashboard shape)', async () => {
+    const organizationContextId = `org_ctx_${randomBytes(6).toString('hex')}`;
+
+    const patchRes = await session.testAgent
+      .patch(`/v2/subscribers/${subscriber.subscriberId}/preferences`)
+      .set('Authorization', `ApiKey ${session.apiKey}`)
+      .send({
+        workflowId: workflow._id,
+        channels: { email: false, inApp: true },
+        context: { organization: organizationContextId },
+      });
+
+    expect(patchRes.status).to.equal(200);
+
+    const listResponse = await novuClient.subscribers.preferences.list({
+      subscriberId: subscriber.subscriberId,
+      contextKeys: [`organization:${organizationContextId}`],
+    });
+
+    expect(listResponse.result.workflows[0].channels.email).to.equal(false);
+    expect(listResponse.result.workflows[0].channels.inApp).to.equal(true);
+  });
+
+  it('should patch workflow preferences with organization context as { id, data } object', async () => {
+    const organizationContextId = `org_ctx_${randomBytes(6).toString('hex')}`;
+
+    const patchRes = await session.testAgent
+      .patch(`/v2/subscribers/${subscriber.subscriberId}/preferences`)
+      .set('Authorization', `ApiKey ${session.apiKey}`)
+      .send({
+        workflowId: workflow._id,
+        channels: { email: true, inApp: false },
+        context: { organization: { id: organizationContextId, data: { tier: 'pro' } } },
+      });
+
+    expect(patchRes.status).to.equal(200);
+
+    const listResponse = await novuClient.subscribers.preferences.list({
+      subscriberId: subscriber.subscriberId,
+      contextKeys: [`organization:${organizationContextId}`],
+    });
+
+    expect(listResponse.result.workflows[0].channels.email).to.equal(true);
+    expect(listResponse.result.workflows[0].channels.inApp).to.equal(false);
+  });
+
   it('should create separate preferences for different contexts', async () => {
     // Create preference for context A
     await novuClient.subscribers.preferences.update(

--- a/apps/api/src/app/subscribers-v2/e2e/patch-subscriber-preferences.e2e.ts
+++ b/apps/api/src/app/subscribers-v2/e2e/patch-subscriber-preferences.e2e.ts
@@ -289,7 +289,7 @@ describe('Patch Subscriber Preferences - /subscribers/:subscriberId/preferences 
       .set('Authorization', `ApiKey ${session.apiKey}`)
       .send({
         workflowId: workflow._id,
-        channels: { email: false, inApp: true },
+        channels: { email: false, in_app: true },
         context: { organization: organizationContextId },
       });
 
@@ -300,8 +300,9 @@ describe('Patch Subscriber Preferences - /subscribers/:subscriberId/preferences 
       contextKeys: [`organization:${organizationContextId}`],
     });
 
-    expect(listResponse.result.workflows[0].channels.email).to.equal(false);
-    expect(listResponse.result.workflows[0].channels.inApp).to.equal(true);
+    expect(listResponse.result.workflows).to.have.lengthOf(1);
+    expect(listResponse.result.workflows[0].workflow.identifier).to.equal(workflow.triggers[0].identifier);
+    expect(listResponse.result.workflows[0].channels).to.deep.include({ email: false, inApp: true });
   });
 
   it('should patch workflow preferences with organization context as { id, data } object', async () => {
@@ -312,7 +313,7 @@ describe('Patch Subscriber Preferences - /subscribers/:subscriberId/preferences 
       .set('Authorization', `ApiKey ${session.apiKey}`)
       .send({
         workflowId: workflow._id,
-        channels: { email: true, inApp: false },
+        channels: { email: true, in_app: false },
         context: { organization: { id: organizationContextId, data: { tier: 'pro' } } },
       });
 
@@ -323,8 +324,9 @@ describe('Patch Subscriber Preferences - /subscribers/:subscriberId/preferences 
       contextKeys: [`organization:${organizationContextId}`],
     });
 
-    expect(listResponse.result.workflows[0].channels.email).to.equal(true);
-    expect(listResponse.result.workflows[0].channels.inApp).to.equal(false);
+    expect(listResponse.result.workflows).to.have.lengthOf(1);
+    expect(listResponse.result.workflows[0].workflow.identifier).to.equal(workflow.triggers[0].identifier);
+    expect(listResponse.result.workflows[0].channels).to.deep.include({ email: true, inApp: false });
   });
 
   it('should create separate preferences for different contexts', async () => {

--- a/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
+++ b/libs/application-generic/src/usecases/get-subscriber-template-preference/get-subscriber-template-preference.usecase.ts
@@ -96,6 +96,17 @@ export class GetSubscriberTemplatePreference {
       contextKeys: command.contextKeys,
     });
 
+    if (!subscriberWorkflowPreference) {
+      const emptyWorkflowChannels = GetPreferences.mapWorkflowPreferencesToChannelPreferences(undefined);
+
+      return {
+        channels: emptyWorkflowChannels,
+        critical: undefined,
+        type: PreferencesTypeEnum.SUBSCRIBER_WORKFLOW,
+        enabled: true,
+      };
+    }
+
     const subscriberWorkflowChannels = GetPreferences.mapWorkflowPreferencesToChannelPreferences(
       subscriberWorkflowPreference.preferences
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`PATCH /v2/subscribers/{id}/preferences` with a non-empty `context` could return HTTP 500 after the preference upsert succeeded. The failure happened when rebuilding the response: `GetSubscriberTemplatePreference` called `GetPreferences.safeExecute()`, which returns `undefined` when `MergePreferences` finds no merged `preferences` (e.g. first write for a context-scoped workflow before subscriber-specific rows exist). The code then dereferenced `subscriberWorkflowPreference.preferences` and threw.

## Changes

- In `GetSubscriberTemplatePreference.getSubscriberWorkflowPreference`, treat `undefined` from `safeExecute` like “no subscriber workflow preference yet”: return default channel map from `buildWorkflowPreferences` via `mapWorkflowPreferencesToChannelPreferences(undefined)` and `PreferencesTypeEnum.SUBSCRIBER_WORKFLOW`, matching the empty-subscriber path.
- **E2E:** Two tests PATCH via raw HTTP with `context.organization` (string and `{ id, data }`), then list with `contextKeys`. Raw JSON must use `in_app` (snake_case) to match `PatchPreferenceChannelsDto`—`inApp` is not mapped and was ignored, which broke the second test’s `inApp: false` expectation. Added `workflows` length and workflow `identifier` assertions for clearer failures.

## Testing

- `pnpm --filter @novu/application-generic build` (passes).
- Run `pnpm --filter @novu/api-service test:e2e:novu-v2` (or the shard containing `patch-subscriber-preferences.e2e.ts`) on Node 22+ per repo engines.

Fixes NV-7382.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7382](https://linear.app/novu/issue/NV-7382/bug-report-patch-v2subscribersidpreferences-returns-500-whenever-a)

<div><a href="https://cursor.com/agents/bc-945ebda5-bb53-4714-bb41-2e73d2288b5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-945ebda5-bb53-4714-bb41-2e73d2288b5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
PATCH /v2/subscribers/{id}/preferences could return HTTP 500 after a successful upsert when the request included a non-empty context (e.g., organization-scoped workflows). The fix treats an undefined result from merged-preferences lookup as “no subscriber workflow preference yet” and returns a default workflow preference shape instead of dereferencing undefined, preventing the 500 and preserving expected response behavior.

## Affected areas
**application-generic** — GetSubscriberTemplatePreference now treats undefined from GetPreferences.safeExecute() as “no preference yet” and returns a default channel map (via mapWorkflowPreferencesToChannelPreferences) with type SUBSCRIBER_WORKFLOW and enabled true, aligning with the empty-subscriber code path.  
**api** — Added two end-to-end tests that PATCH subscriber preferences with context.organization provided as a string and as an { id, data } object, then list preferences with contextKeys to assert the scoped workflow channels.

## Key technical decisions
- Treating undefined from safeExecute as a valid “not yet created” state and returning a consistent default preference structure avoids runtime dereference errors and preserves existing API semantics.

## Testing
Added E2E tests (apps/api) covering organization-scoped context shapes (string id and { id, data }) that validate PATCH then list behavior; application-generic builds pass. Run API e2e on Node 22+ per repo engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->