### PR TITLE
fix(api-service): redirect url spaces in preview values fixes NV-7414

### DIFF
--- a/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
@@ -546,6 +546,48 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
     });
   });
 
+  it('should generate URL-safe in-app preview payload values for redirect URL variables', async () => {
+    const payloadSchema = {
+      type: 'object',
+      properties: {
+        reservation: {
+          type: 'string',
+        },
+      },
+    };
+    const workflow = await createWorkflow({}, payloadSchema);
+    await emulateExternalOrigin(workflow.id);
+
+    const stepId = workflow.steps[0].id;
+    const controlValues = {
+      subject: 'Payment pending',
+      body: 'Complete your payment',
+      redirect: {
+        target: RedirectTargetEnum.SELF,
+        url: '/reservations/{{payload.reservation}}/payments',
+      },
+    };
+
+    const { result } = await novuClient.workflows.steps.generatePreview({
+      workflowId: workflow.id,
+      stepId,
+      generatePreviewRequestDto: {
+        controlValues,
+        previewPayload: {
+          payload: {
+            reservation: 'example text',
+          },
+        },
+      },
+    });
+
+    expect(result.result.type).to.equal(ChannelTypeEnum.InApp);
+    if (result.result.type !== ChannelTypeEnum.InApp) throw new Error('should have an in-app preview');
+
+    expect(result.previewPayloadExample.payload?.reservation).to.equal('example-text');
+    expect(result.result.preview.redirect?.url).to.equal('/reservations/example-text/payments');
+  });
+
   it('should return 201 for non-existent workflow', async () => {
     const pay = {
       type: 'object',

--- a/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
@@ -553,6 +553,9 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
         reservation: {
           type: 'string',
         },
+        payment: {
+          type: 'string',
+        },
       },
     };
     const workflow = await createWorkflow({}, payloadSchema);
@@ -562,6 +565,13 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
     const controlValues = {
       subject: 'Payment pending',
       body: 'Complete your payment',
+      primaryAction: {
+        label: 'Pay',
+        redirect: {
+          target: RedirectTargetEnum.SELF,
+          url: '/payments/{{payload.payment}}',
+        },
+      },
       redirect: {
         target: RedirectTargetEnum.SELF,
         url: '/reservations/{{payload.reservation}}/payments',
@@ -576,6 +586,7 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
         previewPayload: {
           payload: {
             reservation: 'example text',
+            payment: 'example {payment}',
           },
         },
       },
@@ -585,6 +596,8 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
     if (result.result.type !== ChannelTypeEnum.InApp) throw new Error('should have an in-app preview');
 
     expect(result.previewPayloadExample.payload?.reservation).to.equal('example-text');
+    expect(result.previewPayloadExample.payload?.payment).to.equal('example-%7Bpayment%7D');
+    expect(result.result.preview.primaryAction?.redirect?.url).to.equal('/payments/example-%7Bpayment%7D');
     expect(result.result.preview.redirect?.url).to.equal('/reservations/example-text/payments');
   });
 

--- a/libs/application-generic/src/usecases/preview/preview.usecase.ts
+++ b/libs/application-generic/src/usecases/preview/preview.usecase.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { EnvironmentRepository, EnvironmentVariableRepository } from '@novu/dal';
 import { ContextResolved } from '@novu/framework/internal';
 import { ChannelTypeEnum, EnvironmentSystemVariables, ResourceOriginEnum, StepTypeEnum } from '@novu/shared';
+import { get, set } from 'es-toolkit/compat';
 import { PinoLogger } from 'nestjs-pino';
 import { GeneratePreviewResponseDto } from '../../dtos/workflow/generate-preview-response.dto';
 import { PreviewPayloadDto } from '../../dtos/workflow/preview-payload.dto';
@@ -10,6 +11,7 @@ import { resolveEnvironmentVariables } from '../../encryption/encrypt-environmen
 import { Instrument, InstrumentUsecase } from '../../instrumentation';
 import { ControlValueSanitizerService } from '../../services/control-value-sanitizer.service';
 import { resolveHttpRequestBody, shouldIncludeBody } from '../../services/http-client/http-request.utils';
+import { buildVariables } from '../../utils/build-variables';
 import { buildNovuSignatureHeader } from '../../utils/hmac';
 import { isStepResolverActive } from '../../utils/step-resolver-control-state';
 import { BuildStepDataUsecase } from '../build-step-data';
@@ -70,6 +72,13 @@ export class PreviewUsecase {
         payloadExample: previewTemplateData.payloadExample,
         userPayloadExample: command.generatePreviewRequestDto.previewPayload,
         user: command.user,
+      });
+
+      payloadExample = this.applyUrlSafePreviewValues({
+        payloadExample,
+        controlValues: sanitizedControls,
+        variableSchema: context.variableSchema,
+        stepType: context.stepData.type,
       });
 
       payloadExample = this.payloadProcessor.enhanceEventCountValue(payloadExample);
@@ -137,6 +146,65 @@ export class PreviewUsecase {
       // Return default response for non-existent workflows/steps or other critical errors
       return this.errorHandler.createErrorResponse();
     }
+  }
+
+  private applyUrlSafePreviewValues({
+    payloadExample,
+    controlValues,
+    variableSchema,
+    stepType,
+  }: {
+    payloadExample: Record<string, unknown>;
+    controlValues: Record<string, unknown>;
+    variableSchema: StepResponseDto['variables'];
+    stepType: StepResponseDto['type'];
+  }): Record<string, unknown> {
+    if (stepType !== StepTypeEnum.IN_APP) {
+      return payloadExample;
+    }
+
+    const redirectVariablePaths = this.getInAppRedirectVariablePaths(controlValues, variableSchema);
+    if (redirectVariablePaths.length === 0) {
+      return payloadExample;
+    }
+
+    for (const variablePath of redirectVariablePaths) {
+      const currentValue = get(payloadExample, variablePath);
+      const urlSafeValue = this.toUrlSafePreviewValue(currentValue, variablePath);
+
+      set(payloadExample, variablePath, urlSafeValue);
+    }
+
+    return payloadExample;
+  }
+
+  private getInAppRedirectVariablePaths(
+    controlValues: Record<string, unknown>,
+    variableSchema: StepResponseDto['variables']
+  ): string[] {
+    const redirectUrlControlPaths = ['redirect.url', 'primaryAction.redirect.url', 'secondaryAction.redirect.url'];
+    const variablePaths = redirectUrlControlPaths.flatMap((controlPath) => {
+      const redirectUrl = get(controlValues, controlPath);
+      if (typeof redirectUrl !== 'string') {
+        return [];
+      }
+
+      return buildVariables({
+        variableSchema,
+        controlValue: redirectUrl,
+        logger: this.logger,
+      }).validVariables.map((variable) => variable.name);
+    });
+
+    return [...new Set(variablePaths)].filter((variablePath) => variablePath.startsWith('payload.'));
+  }
+
+  private toUrlSafePreviewValue(value: unknown, variablePath: string): string {
+    if (typeof value !== 'string') {
+      return variablePath.split('.').pop() ?? 'example';
+    }
+
+    return value.trim().replace(/\s+/g, '-');
   }
 
   private async initializePreviewContext(command: PreviewCommand) {

--- a/libs/application-generic/src/usecases/preview/preview.usecase.ts
+++ b/libs/application-generic/src/usecases/preview/preview.usecase.ts
@@ -204,7 +204,7 @@ export class PreviewUsecase {
       return variablePath.split('.').pop() ?? 'example';
     }
 
-    return value.trim().replace(/\s+/g, '-');
+    return encodeURI(value.trim().replace(/\s+/g, '-'));
   }
 
   private async initializePreviewContext(command: PreviewCommand) {


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The PR ensures that redirect URLs in in-app message previews handle spaces and special characters correctly. When generating preview payloads for IN_APP steps, variables referenced in redirect controls (such as `redirect.url`, `primaryAction.redirect.url`, and `secondaryAction.redirect.url`) are now transformed to be URL-safe by trimming whitespace, replacing spaces with hyphens, and URI-encoding the values. This prevents broken redirect URLs when preview payload values contain spaces or special characters like `{` and `}`.

## Affected areas
- **api**: Added E2E test to verify that redirect URLs with special characters in payload values are correctly encoded and appear in the generated in-app preview response.
- **application-generic**: Modified the `PreviewUsecase` to post-process payload example values for redirect URL variables, applying URL-safe transformations before the preview payload is finalized.

## Testing
Added a new E2E test (`generate-preview.e2e.ts`) that verifies redirect URLs with special characters in payload values are correctly encoded (e.g., `{` → `%7B`, `}` → `%7D`) and that the preview response includes the encoded values in both the payload and redirect URL segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
