### PR TITLE
fix(dashboard,api-service): remember agent provider during onboarding fixes NV-7416

### DIFF
--- a/apps/api/src/app/agents/e2e/agents.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agents.e2e.ts
@@ -216,6 +216,16 @@ describe('Agents API - /agents #novu-v2', () => {
     expect(addRes.body.data.integration.identifier).to.equal(emailIntegrationIdentifier);
     const linkId = addRes.body.data._id as string;
 
+    const getAgentAfterLink = await session.testAgent.get(`/v1/agents/${encodeURIComponent(identifier)}`);
+
+    expect(getAgentAfterLink.status).to.equal(200);
+    expect(getAgentAfterLink.body.data.integrations).to.be.an('array');
+    expect(
+      getAgentAfterLink.body.data.integrations.some(
+        (i: { integrationId: string }) => i.integrationId === emailIntegration._id
+      )
+    ).to.be.true;
+
     const listRes = await session.testAgent.get(`/v1/agents/${encodeURIComponent(identifier)}/integrations`);
 
     expect(listRes.status).to.equal(200);

--- a/apps/api/src/app/agents/helpers/load-agent-integration-summaries.helper.ts
+++ b/apps/api/src/app/agents/helpers/load-agent-integration-summaries.helper.ts
@@ -1,0 +1,86 @@
+import type { AgentIntegrationRepository, IntegrationRepository } from '@novu/dal';
+
+import type { AgentIntegrationSummaryDto } from '../dtos/agent-integration-summary.dto';
+import { toAgentIntegrationSummary } from '../mappers/agent-response.mapper';
+
+export async function loadAgentIntegrationSummariesForAgents(
+  agentIntegrationRepository: AgentIntegrationRepository,
+  integrationRepository: IntegrationRepository,
+  environmentId: string,
+  organizationId: string,
+  agents: { _id: string }[]
+): Promise<Map<string, AgentIntegrationSummaryDto[]>> {
+  const result = new Map<string, AgentIntegrationSummaryDto[]>();
+
+  if (agents.length === 0) {
+    return result;
+  }
+
+  const agentIds = agents.map((a) => a._id);
+  const links = await agentIntegrationRepository.findLinksForAgents({
+    environmentId,
+    organizationId,
+    agentIds,
+  });
+
+  const integrationIds = [...new Set(links.map((l) => l._integrationId))];
+
+  if (integrationIds.length === 0) {
+    for (const id of agentIds) {
+      result.set(id, []);
+    }
+
+    return result;
+  }
+
+  const integrations = await integrationRepository.find(
+    {
+      _id: { $in: integrationIds },
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+    },
+    '_id identifier name providerId channel active'
+  );
+
+  const summaryByIntegrationId = new Map(integrations.map((i) => [i._id, toAgentIntegrationSummary(i)] as const));
+
+  const seen = new Map<string, Set<string>>();
+
+  for (const link of links) {
+    const summary = summaryByIntegrationId.get(link._integrationId);
+
+    if (!summary) {
+      continue;
+    }
+
+    let dedupe = seen.get(link._agentId);
+
+    if (!dedupe) {
+      dedupe = new Set<string>();
+      seen.set(link._agentId, dedupe);
+    }
+
+    if (dedupe.has(summary.integrationId)) {
+      continue;
+    }
+
+    dedupe.add(summary.integrationId);
+    const list = result.get(link._agentId) ?? [];
+    list.push(summary);
+
+    result.set(link._agentId, list);
+  }
+
+  for (const id of agentIds) {
+    if (!result.has(id)) {
+      result.set(id, []);
+    } else {
+      const list = result.get(id) ?? [];
+      const sorted = [...list].sort((a, b) => a.name.localeCompare(b.name));
+
+      result.set(id, sorted);
+    }
+  }
+
+  return result;
+}

--- a/apps/api/src/app/agents/usecases/get-agent/get-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/get-agent/get-agent.usecase.ts
@@ -1,12 +1,17 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { AgentRepository } from '@novu/dal';
+import { AgentIntegrationRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
 import type { AgentResponseDto } from '../../dtos';
+import { loadAgentIntegrationSummariesForAgents } from '../../helpers/load-agent-integration-summaries.helper';
 import { toAgentResponse } from '../../mappers/agent-response.mapper';
 import { GetAgentCommand } from './get-agent.command';
 
 @Injectable()
 export class GetAgent {
-  constructor(private readonly agentRepository: AgentRepository) {}
+  constructor(
+    private readonly agentRepository: AgentRepository,
+    private readonly agentIntegrationRepository: AgentIntegrationRepository,
+    private readonly integrationRepository: IntegrationRepository
+  ) {}
 
   async execute(command: GetAgentCommand): Promise<AgentResponseDto> {
     const agent = await this.agentRepository.findOne(
@@ -22,6 +27,17 @@ export class GetAgent {
       throw new NotFoundException(`Agent with identifier "${command.identifier}" was not found.`);
     }
 
-    return toAgentResponse(agent);
+    const integrationsByAgentId = await loadAgentIntegrationSummariesForAgents(
+      this.agentIntegrationRepository,
+      this.integrationRepository,
+      command.environmentId,
+      command.organizationId,
+      [agent]
+    );
+
+    return {
+      ...toAgentResponse(agent),
+      integrations: integrationsByAgentId.get(agent._id) ?? [],
+    };
   }
 }

--- a/apps/api/src/app/agents/usecases/list-agents/list-agents.usecase.ts
+++ b/apps/api/src/app/agents/usecases/list-agents/list-agents.usecase.ts
@@ -2,9 +2,9 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { InstrumentUsecase } from '@novu/application-generic';
 import { AgentIntegrationRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
 import { DirectionEnum } from '@novu/shared';
-import type { AgentIntegrationSummaryDto } from '../../dtos/agent-integration-summary.dto';
 import { ListAgentsResponseDto } from '../../dtos/list-agents-response.dto';
-import { toAgentIntegrationSummary, toAgentResponse } from '../../mappers/agent-response.mapper';
+import { loadAgentIntegrationSummariesForAgents } from '../../helpers/load-agent-integration-summaries.helper';
+import { toAgentResponse } from '../../mappers/agent-response.mapper';
 import { ListAgentsCommand } from './list-agents.command';
 
 @Injectable()
@@ -33,7 +33,9 @@ export class ListAgents {
       identifier: command.identifier,
     });
 
-    const integrationsByAgentId = await this.loadIntegrationsForAgents(
+    const integrationsByAgentId = await loadAgentIntegrationSummariesForAgents(
+      this.agentIntegrationRepository,
+      this.integrationRepository,
       command.environmentId,
       command.organizationId,
       pagination.agents
@@ -49,85 +51,5 @@ export class ListAgents {
       totalCount: pagination.totalCount,
       totalCountCapped: pagination.totalCountCapped,
     };
-  }
-
-  private async loadIntegrationsForAgents(
-    environmentId: string,
-    organizationId: string,
-    agents: { _id: string }[]
-  ): Promise<Map<string, AgentIntegrationSummaryDto[]>> {
-    const result = new Map<string, AgentIntegrationSummaryDto[]>();
-
-    if (agents.length === 0) {
-      return result;
-    }
-
-    const agentIds = agents.map((a) => a._id);
-    const links = await this.agentIntegrationRepository.findLinksForAgents({
-      environmentId,
-      organizationId,
-      agentIds,
-    });
-
-    const integrationIds = [...new Set(links.map((l) => l._integrationId))];
-
-    if (integrationIds.length === 0) {
-      for (const id of agentIds) {
-        result.set(id, []);
-      }
-
-      return result;
-    }
-
-    const integrations = await this.integrationRepository.find(
-      {
-        _id: { $in: integrationIds },
-        _environmentId: environmentId,
-        _organizationId: organizationId,
-      },
-      '_id identifier name providerId channel active'
-    );
-
-    const summaryByIntegrationId = new Map(integrations.map((i) => [i._id, toAgentIntegrationSummary(i)] as const));
-
-    const seen = new Map<string, Set<string>>();
-
-    for (const link of links) {
-      const summary = summaryByIntegrationId.get(link._integrationId);
-
-      if (!summary) {
-        continue;
-      }
-
-      let dedupe = seen.get(link._agentId);
-
-      if (!dedupe) {
-        dedupe = new Set<string>();
-        seen.set(link._agentId, dedupe);
-      }
-
-      if (dedupe.has(summary.integrationId)) {
-        continue;
-      }
-
-      dedupe.add(summary.integrationId);
-      const list = result.get(link._agentId) ?? [];
-      list.push(summary);
-
-      result.set(link._agentId, list);
-    }
-
-    for (const id of agentIds) {
-      if (!result.has(id)) {
-        result.set(id, []);
-      } else {
-        const list = result.get(id) ?? [];
-        const sorted = [...list].sort((a, b) => a.name.localeCompare(b.name));
-
-        result.set(id, sorted);
-      }
-    }
-
-    return result;
   }
 }

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -70,12 +70,20 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
 
   const effectiveIntegrationId = selectedIntegrationId ?? defaultFromAgent?.integrationId;
 
-  // Once the server has the integration link, sessionStorage is no longer needed.
+  // Once the server reflects the same integration as in sessionStorage, drop the session copy.
   useEffect(() => {
-    if (defaultFromAgent?.integrationId) {
+    const stored = sessionStorage.getItem(SESSION_KEY(agent.identifier));
+
+    if (!stored) {
+      return;
+    }
+
+    const serverHasStoredLink = agent.integrations?.some((i) => i.integrationId === stored) ?? false;
+
+    if (serverHasStoredLink) {
       sessionStorage.removeItem(SESSION_KEY(agent.identifier));
     }
-  }, [defaultFromAgent?.integrationId, agent.identifier]);
+  }, [agent.integrations, agent.identifier]);
 
   const selectedProviderId = useMemo(() => {
     if (selectedIntegrationId) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Agent detail (`GET /v1/agents/:identifier`) did not include linked integrations, while the agents list did. The setup guide treated missing `agent.integrations` as "no provider chosen", cleared `sessionStorage` on load, and lost the user's selection after refresh or deep link to the agent page.

## Changes

- **api-service**: Extract shared `loadAgentIntegrationSummariesForAgents` helper (same logic as list agents) and attach `integrations` to the get-agent response.
- **dashboard**: Clear setup `sessionStorage` only when the stored integration id appears in `agent.integrations`, so we do not wipe the user's pick when another integration is listed first.
- **e2e**: Assert get-agent returns `integrations` after linking an integration.

## Testing

- `pnpm exec nest build` in `apps/api` (passes).
- Full agents e2e could not be run in this environment (mocha/node bootstrap issues unrelated to this diff).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7416](https://linear.app/novu/issue/NV-7416/remember-selected-provider-during-agent-onboarding)

<div><a href="https://cursor.com/agents/bc-81d431b9-037a-4d61-b80a-1974f91ce446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81d431b9-037a-4d61-b80a-1974f91ce446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

