### PR TITLE
fix: add SCIM on billng page

### DIFF
--- a/packages/shared/src/consts/feature-tiers-constants.ts
+++ b/packages/shared/src/consts/feature-tiers-constants.ts
@@ -431,10 +431,10 @@ const novuServiceTiers: Record<FeatureNameEnum, Record<ApiServiceLevelEnum, Feat
     [ApiServiceLevelEnum.UNLIMITED]: 1,
   },
   [FeatureNameEnum.ACCOUNT_CUSTOM_SAML_SSO_OIDC_BOOLEAN]: {
-    [ApiServiceLevelEnum.FREE]: { label: 'SAML and Enterprise SSO providers', value: false },
-    [ApiServiceLevelEnum.PRO]: { label: 'SAML and Enterprise SSO providers', value: false },
-    [ApiServiceLevelEnum.BUSINESS]: { label: 'SAML and Enterprise SSO providers', value: false },
-    [ApiServiceLevelEnum.ENTERPRISE]: { label: 'SAML and Enterprise SSO providers', value: true },
+    [ApiServiceLevelEnum.FREE]: { label: 'SAML, SCIM and Enterprise SSO providers', value: false },
+    [ApiServiceLevelEnum.PRO]: { label: 'SAML, SCIM and Enterprise SSO providers', value: false },
+    [ApiServiceLevelEnum.BUSINESS]: { label: 'SAML, SCIM and Enterprise SSO providers', value: false },
+    [ApiServiceLevelEnum.ENTERPRISE]: { label: 'SAML, SCIM and Enterprise SSO providers', value: true },
     [ApiServiceLevelEnum.UNLIMITED]: 1,
   },
   [FeatureNameEnum.ACCOUNT_MULTI_FACTOR_AUTHENTICATION_BOOLEAN]: {


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The billing page feature tier labels were updated to include SCIM support in the account authentication and security section. The `ACCOUNT_CUSTOM_SAML_SSO_OIDC_BOOLEAN` feature label changed from "SAML and Enterprise SSO providers" to "SAML, SCIM and Enterprise SSO providers" across all service tiers, clarifying that SCIM is now listed as a supported identity and access management protocol.

## Affected areas

**shared**: Added feature tier constants in `feature-tiers-constants.ts` defining the feature availability matrix and labels across all service tiers (FREE, PRO, BUSINESS, ENTERPRISE, UNLIMITED).

**dashboard**: Added billing features configuration in `features-config.ts` that maps features to billing page sections, including the "Account administration and security" section where the updated SSO/SCIM label is displayed.

## Testing

No tests were added. This is a straightforward content change to billing tier labels without logic modifications, so manual verification on the billing page UI is sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only change in shared feature-tier constants; no logic, permission, or data-handling behavior changes.
> 
> **Overview**
> Updates the `ACCOUNT_CUSTOM_SAML_SSO_OIDC_BOOLEAN` feature tier metadata to change the displayed label from "SAML and Enterprise SSO providers" to **"SAML, SCIM and Enterprise SSO providers"** across Free/Pro/Business/Enterprise tiers, without changing the underlying enabled/disabled values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9304fcec2298490c4b3f50b79e8ba0708a4eb50c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->