### PR TITLE
fix(api-service): surface provider delivery errors in agents flow fixes NV-7410

### DIFF
--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, OnModuleDestroy } from '@nestjs/common';
+import { BadGatewayException, BadRequestException, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { CacheService, decryptCredentials, MailFactory, PinoLogger } from '@novu/application-generic';
 import { IntegrationRepository } from '@novu/dal';
 import type { SentMessageInfo } from '@novu/framework';
@@ -13,6 +13,13 @@ import { esmImport } from '../utils/esm-import';
 import { sendWebResponse, toWebRequest } from '../utils/express-to-web-request';
 import { AgentConfigResolver, ResolvedAgentConfig } from './agent-config-resolver.service';
 import { AgentInboundHandler } from './agent-inbound-handler.service';
+
+function toDeliveryError(err: unknown): never {
+  throw new BadGatewayException({
+    error: 'delivery_failed',
+    message: err instanceof Error ? err.message : String(err),
+  });
+}
 
 /** Ensure a Message-ID value is wrapped in RFC 5322 angle brackets. */
 function wrapMsgId(id: string): string {
@@ -134,14 +141,16 @@ export class ChatSdkService implements OnModuleDestroy {
     const adapter = chat.getAdapter(platform);
     const thread = ThreadImpl.fromJSON(serializedThread, adapter);
 
-    let sent: { id: string; threadId: string };
+    let postPromise: Promise<{ id: string; threadId: string }>;
     if (content.card) {
-      sent = await thread.post(content.card);
+      postPromise = thread.post(content.card);
     } else if (content.markdown !== undefined) {
-      sent = await thread.post({ markdown: content.markdown, files: content.files });
+      postPromise = thread.post({ markdown: content.markdown, files: content.files });
     } else {
-      sent = await thread.post(content.text ?? '');
+      postPromise = thread.post(content.text ?? '');
     }
+
+    const sent = await postPromise.catch(toDeliveryError);
 
     return { messageId: sent.id, platformThreadId: sent.threadId };
   }
@@ -163,21 +172,23 @@ export class ChatSdkService implements OnModuleDestroy {
       throw new BadRequestException(`Platform ${platform} does not support editing messages`);
     }
 
-    let edited: { id: string; threadId: string };
+    let editPromise: Promise<{ id: string; threadId: string }>;
     if (content.card) {
-      edited = await adapter.editMessage(
+      editPromise = adapter.editMessage(
         platformThreadId,
         platformMessageId,
         content.card as unknown as AdapterPostableMessage
       );
     } else if (content.markdown !== undefined) {
-      edited = await adapter.editMessage(platformThreadId, platformMessageId, {
+      editPromise = adapter.editMessage(platformThreadId, platformMessageId, {
         markdown: content.markdown,
         files: content.files,
       } as unknown as AdapterPostableMessage);
     } else {
-      edited = await adapter.editMessage(platformThreadId, platformMessageId, content.text ?? '');
+      editPromise = adapter.editMessage(platformThreadId, platformMessageId, content.text ?? '');
     }
+
+    const edited = await editPromise.catch(toDeliveryError);
 
     return { messageId: edited.id, platformThreadId: edited.threadId };
   }
@@ -419,7 +430,7 @@ export class ChatSdkService implements OnModuleDestroy {
         },
       };
 
-      const result = await handler.send(mailOptions);
+      const result = await handler.send(mailOptions).catch(toDeliveryError);
 
       return { messageId: result?.id || params.messageId || '' };
     };

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -15,9 +15,12 @@ import { AgentConfigResolver, ResolvedAgentConfig } from './agent-config-resolve
 import { AgentInboundHandler } from './agent-inbound-handler.service';
 
 function toDeliveryError(err: unknown): never {
+  const base = err instanceof Error ? err.message : String(err);
+  const body = (err as any)?.response?.body;
+  const detail = Array.isArray(body?.errors) ? body.errors[0]?.message : body?.message;
   throw new BadGatewayException({
     error: 'delivery_failed',
-    message: err instanceof Error ? err.message : String(err),
+    message: detail ? `${base}: ${detail}` : base,
   });
 }
 

--- a/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
@@ -86,9 +86,12 @@ export class SendAgentTestEmail {
     };
 
     await handler.send(mailOptions).catch((err) => {
+      const base = err instanceof Error ? err.message : String(err);
+      const body = (err as any)?.response?.body;
+      const detail = Array.isArray(body?.errors) ? body.errors[0]?.message : body?.message;
       throw new BadGatewayException({
         error: 'delivery_failed',
-        message: err instanceof Error ? err.message : String(err),
+        message: detail ? `${base}: ${detail}` : base,
       });
     });
 

--- a/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadGatewayException, BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { decryptCredentials, InstrumentUsecase, MailFactory } from '@novu/application-generic';
 import { AgentIntegrationRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
 import { ChannelTypeEnum, EmailProviderIdEnum, IEmailOptions } from '@novu/shared';
@@ -85,7 +85,12 @@ export class SendAgentTestEmail {
       senderName: (senderIntegration.credentials?.senderName as string) || 'Novu',
     };
 
-    await handler.send(mailOptions);
+    await handler.send(mailOptions).catch((err) => {
+      throw new BadGatewayException({
+        error: 'delivery_failed',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    });
 
     return { success: true };
   }

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "2.10.1-alpha.3",
+  "version": "2.10.1-alpha.2",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/cjs/index.d.cts",

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "2.10.1-alpha.2",
+  "version": "2.10.1-alpha.3",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/cjs/index.d.cts",

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -30,6 +30,7 @@ export type {
 } from './resources';
 export {
   Actions,
+  AgentDeliveryError,
   AgentEventEnum,
   agent,
   Button,

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -1,4 +1,5 @@
 import { isJSX, toCardElement } from 'chat/jsx-runtime';
+import { AgentDeliveryError } from './agent.errors';
 import type {
   AgentAction,
   AgentBridgeRequest,
@@ -216,6 +217,18 @@ export class AgentContextImpl implements AgentContext {
 
     if (!response.ok) {
       const text = await response.text().catch(() => '');
+
+      if (response.status === 502) {
+        let message = text;
+        try {
+          const parsed = JSON.parse(text) as { message?: string };
+          if (parsed.message) message = parsed.message;
+        } catch {
+          // use raw text if JSON parsing fails
+        }
+        throw new AgentDeliveryError(502, message);
+      }
+
       throw new Error(`Agent reply failed (${response.status}): ${text}`);
     }
 

--- a/packages/framework/src/resources/agent/agent.errors.ts
+++ b/packages/framework/src/resources/agent/agent.errors.ts
@@ -1,0 +1,32 @@
+/**
+ * Thrown by `ctx.reply()` and `handle.edit()` when the upstream message delivery
+ * fails — e.g. the configured email provider returns 401, Slack rejects the token,
+ * or Teams rejects the request.
+ *
+ * The `message` property contains the original provider error text
+ *
+ * @example
+ * ```ts
+ * import { AgentDeliveryError } from '@novu/framework';
+ *
+ * try {
+ *   await ctx.reply('Hello!');
+ * } catch (err) {
+ *   if (err instanceof AgentDeliveryError) {
+ *     // Delivery failed (misconfigured provider, rate limit, etc.)
+ *     console.error('Delivery failed:', err.message);
+ *     return;
+ *   }
+ *   throw err;
+ * }
+ * ```
+ */
+export class AgentDeliveryError extends Error {
+  readonly statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.name = 'AgentDeliveryError';
+    this.statusCode = statusCode;
+  }
+}

--- a/packages/framework/src/resources/agent/index.ts
+++ b/packages/framework/src/resources/agent/index.ts
@@ -12,6 +12,7 @@ export type {
 } from 'chat';
 export { Actions, Button, Card, CardLink, CardText, Divider, Select, SelectOption, TextInput } from 'chat';
 export { AgentContextImpl } from './agent.context';
+export { AgentDeliveryError } from './agent.errors';
 export { agent } from './agent.resource';
 export type {
   Agent,


### PR DESCRIPTION
## Problem

When an outbound provider (SendGrid, Slack, Teams, WhatsApp, etc.) rejects a message delivery — e.g. 401 Unauthorized, 403 Forbidden — the error was not caught at the delivery boundary. NestJS's default exception filter swallowed it as a generic 500 with an opaque `errorId`, making it completely unactionable for developers:

```
[agent:help-agent] Handler error: Error: Agent reply failed (500): {"statusCode":500,"message":"Internal server error, contact support and provide them with the errorId","errorId":"288c52ac1f1b4ff082ce3ec3d47f19f2"}
```

## Solution

### API (`apps/api`)

Wrap all three provider delivery boundaries in `chat-sdk.service.ts` with `.catch(toDeliveryError)`:

- `thread.post()` in `postToConversation` — Slack, Teams, WhatsApp, Email chat delivery
- `adapter.editMessage()` in `editInConversation` — same platforms, edit path
- `handler.send()` in `buildSendEmailCallback` — direct email provider sends

Any error from these calls is now returned as a `BadGatewayException` (502) with the original provider error message preserved:

```json
{ "error": "delivery_failed", "message": "Email provider returned: 403 Forbidden — sender identity not verified" }
```

Pre-existing 4xx errors from our own validation code are unaffected.

### Framework (`packages/framework`)

Add `AgentDeliveryError` — a simple typed error class exported from `@novu/framework`. `_post()` in `agent.context.ts` now throws it on 502 responses instead of a generic `Error`, so developers can branch on it:

```ts
import { AgentDeliveryError } from '@novu/framework';

try {
  await ctx.reply(<Card title="Hi">How can I help?</Card>);
} catch (err) {
  if (err instanceof AgentDeliveryError) {
    // provider or delivery failure — log, skip, or alert
    return;
  }
  throw err;
}
```

## Backwards compatibility

Merging the API change alone already improves error messages for all framework versions — old SDK users still get a generic `Error` but the message now contains the actual provider error text. The `AgentDeliveryError` class is purely additive.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Provider delivery failures from outbound integrations (e.g., 401/403 from SendGrid, Slack, Teams, WhatsApp) are no longer swallowed as opaque 500s. The API maps provider errors to 502 Bad Gateway with a structured body ({ "error": "delivery_failed", "message": "..." }) and preserves provider detail, and the framework adds AgentDeliveryError so agent handlers can detect and handle delivery failures programmatically.

## Affected areas

**api**: Wrapped provider delivery boundaries in agent chat and email flows so adapter/thread/post/edit/send calls are routed through a centralized toDeliveryError mapper that throws BadGatewayException (502) with an actionable message; same mapping added to the send-agent-test-email use case.

**framework**: Added AgentDeliveryError and exported it from @novu/framework; agent.context._post() now throws AgentDeliveryError for 502 responses and preserves provider text so agent code can instanceof-check and respond to delivery failures.

## Key technical decisions

- Use 502 Bad Gateway (not 500) to explicitly signal downstream/provider delivery failures while leaving existing 4xx validation errors unchanged.  
- Surface provider details by extracting nested error shapes (e.g., errors[0].message, body.message) and including them in the structured response payload error: "delivery_failed".  
- Introduce AgentDeliveryError as an additive, non-breaking error type consumers can check with instanceof.

## Testing
No new automated tests were added; changes are focused on error handling paths and should be validated via manual tests that trigger provider 4xx/5xx responses and by running existing unit/e2e suites to ensure no regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->