### PR TITLE
feat(framework): add ctx.addReaction() to the agent SDK fixes NV-7411

### DIFF
--- a/apps/api/src/app/agents/agents-webhook.controller.ts
+++ b/apps/api/src/app/agents/agents-webhook.controller.ts
@@ -54,6 +54,7 @@ export class AgentsWebhookController {
         edit: body.edit,
         resolve: body.resolve,
         signals: body.signals as Signal[],
+        addReactions: body.addReactions,
       })
     );
   }

--- a/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
@@ -128,6 +128,18 @@ export class ResolveDto {
   summary?: string;
 }
 
+export class AddReactionPayloadDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  messageId: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  emojiName: string;
+}
+
 export class SignalDto {
   @ApiProperty({ enum: SIGNAL_TYPES })
   @IsString()
@@ -199,4 +211,11 @@ export class AgentReplyPayloadDto {
   @Validate(IsValidSignal, { each: true })
   @Type(() => SignalDto)
   signals?: SignalDto[];
+
+  @ApiPropertyOptional({ type: [AddReactionPayloadDto] })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AddReactionPayloadDto)
+  addReactions?: AddReactionPayloadDto[];
 }

--- a/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
@@ -323,12 +323,14 @@ describe('Agent Reply - /agents/:agentId/reply #novu-v2', () => {
       expect(secondCall[5]).to.equal('check');
     });
 
-    it('should return 400 when payload has no recognised operation', async () => {
+    it('should return 400 when edit and addReactions are combined', async () => {
       const conversationId = await seedConversation(ctx);
 
       const res = await postReply({
         conversationId,
         integrationIdentifier: ctx.integrationIdentifier,
+        edit: { messageId: 'msg-edit', content: { markdown: 'updated' } },
+        addReactions: [{ messageId: 'msg-abc', emojiName: 'thumbs_up' }],
       });
 
       expect(res.status).to.equal(400);

--- a/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
@@ -297,6 +297,44 @@ describe('Agent Reply - /agents/:agentId/reply #novu-v2', () => {
     });
   });
 
+  describe('addReactions', () => {
+    it('should call reactToMessage for each addReaction entry', async () => {
+      const conversationId = await seedConversation(ctx);
+      const chatSdkService = testServer.getService(ChatSdkService);
+
+      const res = await postReply({
+        conversationId,
+        integrationIdentifier: ctx.integrationIdentifier,
+        addReactions: [
+          { messageId: 'msg-abc', emojiName: 'thumbs_up' },
+          { messageId: 'msg-def', emojiName: 'check' },
+        ],
+      });
+
+      expect(res.status).to.equal(200);
+      expect((chatSdkService.reactToMessage as sinon.SinonStub).callCount).to.equal(2);
+
+      const firstCall = (chatSdkService.reactToMessage as sinon.SinonStub).getCall(0).args;
+      expect(firstCall[4]).to.equal('msg-abc');
+      expect(firstCall[5]).to.equal('thumbs_up');
+
+      const secondCall = (chatSdkService.reactToMessage as sinon.SinonStub).getCall(1).args;
+      expect(secondCall[4]).to.equal('msg-def');
+      expect(secondCall[5]).to.equal('check');
+    });
+
+    it('should return 400 when payload has no recognised operation', async () => {
+      const conversationId = await seedConversation(ctx);
+
+      const res = await postReply({
+        conversationId,
+        integrationIdentifier: ctx.integrationIdentifier,
+      });
+
+      expect(res.status).to.equal(400);
+    });
+  });
+
   describe('Inactive agent', () => {
     it('should return 422 when agent is inactive', async () => {
       const conversationId = await seedConversation(ctx);

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
@@ -36,4 +36,8 @@ export class HandleAgentReplyCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @IsArray()
   signals?: Signal[];
+
+  @IsOptional()
+  @IsArray()
+  addReactions?: { messageId: string; emojiName: string }[];
 }

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
@@ -2,7 +2,7 @@ import type { Signal } from '@novu/framework';
 import { Type } from 'class-transformer';
 import { IsArray, IsNotEmpty, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
-import { EditPayloadDto, ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
+import { AddReactionPayloadDto, EditPayloadDto, ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
 
 export type { Signal } from '@novu/framework';
 
@@ -39,5 +39,7 @@ export class HandleAgentReplyCommand extends EnvironmentWithUserCommand {
 
   @IsOptional()
   @IsArray()
-  addReactions?: { messageId: string; emojiName: string }[];
+  @ValidateNested({ each: true })
+  @Type(() => AddReactionPayloadDto)
+  addReactions?: AddReactionPayloadDto[];
 }

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -40,8 +40,8 @@ export class HandleAgentReply {
     if (command.edit && (command.resolve || command.signals?.length)) {
       throw new BadRequestException('edit cannot be combined with resolve or signals');
     }
-    if (!command.reply && !command.edit && !command.resolve && !command.signals?.length) {
-      throw new BadRequestException('At least one of reply, edit, resolve, or signals must be provided');
+    if (!command.reply && !command.edit && !command.resolve && !command.signals?.length && !command.addReactions?.length) {
+      throw new BadRequestException('At least one of reply, edit, resolve, signals, or addReactions must be provided');
     }
 
     const conversation = await this.conversationService.getConversation(
@@ -78,6 +78,21 @@ export class HandleAgentReply {
 
     if (command.signals?.length) {
       await this.executeSignals(command, conversation, channel, command.signals);
+    }
+
+    if (command.addReactions?.length) {
+      await Promise.all(
+        command.addReactions.map((r) =>
+          this.chatSdkService.reactToMessage(
+            conversation._agentId,
+            command.integrationIdentifier,
+            channel.platform,
+            channel.platformThreadId,
+            r.messageId,
+            r.emojiName
+          )
+        )
+      );
     }
 
     if (command.resolve) {

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -81,7 +81,7 @@ export class HandleAgentReply {
     }
 
     if (command.addReactions?.length) {
-      const results = await Promise.allSettled(
+      await Promise.allSettled(
         command.addReactions.map((r) =>
           this.chatSdkService.reactToMessage(
             conversation._agentId,
@@ -93,15 +93,6 @@ export class HandleAgentReply {
           )
         )
       );
-
-      results.forEach((result, i) => {
-        if (result.status === 'rejected') {
-          this.logger.warn(
-            { err: result.reason, reaction: command.addReactions![i], agentIdentifier: command.agentIdentifier },
-            `[agent:${command.agentIdentifier}] Failed to add reaction`
-          );
-        }
-      });
     }
 
     if (command.resolve) {

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -37,8 +37,8 @@ export class HandleAgentReply {
     if (command.reply && command.edit) {
       throw new BadRequestException('Only one of reply or edit can be provided');
     }
-    if (command.edit && (command.resolve || command.signals?.length)) {
-      throw new BadRequestException('edit cannot be combined with resolve or signals');
+    if (command.edit && (command.resolve || command.signals?.length || command.addReactions?.length)) {
+      throw new BadRequestException('edit cannot be combined with resolve, signals, or addReactions');
     }
     if (!command.reply && !command.edit && !command.resolve && !command.signals?.length && !command.addReactions?.length) {
       throw new BadRequestException('At least one of reply, edit, resolve, signals, or addReactions must be provided');
@@ -81,7 +81,7 @@ export class HandleAgentReply {
     }
 
     if (command.addReactions?.length) {
-      await Promise.all(
+      const results = await Promise.allSettled(
         command.addReactions.map((r) =>
           this.chatSdkService.reactToMessage(
             conversation._agentId,
@@ -93,6 +93,16 @@ export class HandleAgentReply {
           )
         )
       );
+
+      for (let i = 0; i < results.length; i++) {
+        const result = results[i];
+        if (result.status === 'rejected') {
+          this.logger.warn(
+            { err: result.reason, reaction: command.addReactions[i], agentIdentifier: command.agentIdentifier },
+            `[agent:${command.agentIdentifier}] Failed to add reaction`
+          );
+        }
+      }
     }
 
     if (command.resolve) {

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -94,15 +94,14 @@ export class HandleAgentReply {
         )
       );
 
-      for (let i = 0; i < results.length; i++) {
-        const result = results[i];
+      results.forEach((result, i) => {
         if (result.status === 'rejected') {
           this.logger.warn(
-            { err: result.reason, reaction: command.addReactions[i], agentIdentifier: command.agentIdentifier },
+            { err: result.reason, reaction: command.addReactions![i], agentIdentifier: command.agentIdentifier },
             `[agent:${command.agentIdentifier}] Failed to add reaction`
           );
         }
-      }
+      });
     }
 
     if (command.resolve) {

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -1,6 +1,8 @@
 import { isJSX, toCardElement } from 'chat/jsx-runtime';
 import { AgentDeliveryError } from './agent.errors';
+import type { Emoji } from 'chat';
 import type {
+  AddReactionPayload,
   AgentAction,
   AgentBridgeRequest,
   AgentContext,
@@ -108,6 +110,7 @@ export class AgentContextImpl implements AgentContext {
   readonly metadata: { set: (key: string, value: unknown) => void };
 
   private _signals: Signal[] = [];
+  private _pendingReactions: AddReactionPayload[] = [];
   private _resolveSignal: { summary?: string } | null = null;
   private readonly _replyUrl: string;
   private readonly _conversationId: string;
@@ -151,6 +154,11 @@ export class AgentContextImpl implements AgentContext {
       this._signals = [];
     }
 
+    if (this._pendingReactions.length) {
+      body.addReactions = this._pendingReactions;
+      this._pendingReactions = [];
+    }
+
     if (this._resolveSignal) {
       body.resolve = this._resolveSignal;
       this._resolveSignal = null;
@@ -178,12 +186,16 @@ export class AgentContextImpl implements AgentContext {
     this._signals.push({ ...opts, type: 'trigger', workflowId });
   }
 
+  addReaction(messageId: string, emojiName: Emoji): void {
+    this._pendingReactions.push({ messageId, emojiName });
+  }
+
   /**
    * Flush any remaining signals that weren't sent with reply().
    * Called internally after onResolve returns.
    */
   async flush(): Promise<void> {
-    if (!this._signals.length && !this._resolveSignal) {
+    if (!this._signals.length && !this._resolveSignal && !this._pendingReactions.length) {
       return;
     }
 
@@ -195,6 +207,11 @@ export class AgentContextImpl implements AgentContext {
     if (this._signals.length) {
       body.signals = this._signals;
       this._signals = [];
+    }
+
+    if (this._pendingReactions.length) {
+      body.addReactions = this._pendingReactions;
+      this._pendingReactions = [];
     }
 
     if (this._resolveSignal) {

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -921,6 +921,45 @@ describe('agent dispatch via NovuRequestHandler', () => {
     expect(capturedCtx.reaction.message).toBeNull();
   });
 
+  it('should batch addReaction with reply', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        ctx.addReaction('msg-reacted', 'thumbs_up');
+        await ctx.reply('Got it');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+
+    expect(replyBody.reply.markdown).toBe('Got it');
+    expect(replyBody.addReactions).toHaveLength(1);
+    expect(replyBody.addReactions[0]).toEqual({ messageId: 'msg-reacted', emojiName: 'thumbs_up' });
+  });
+
   it('should have null reaction on non-reaction events', async () => {
     let capturedCtx: any;
 

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -921,6 +921,44 @@ describe('agent dispatch via NovuRequestHandler', () => {
     expect(capturedCtx.reaction.message).toBeNull();
   });
 
+  it('should flush addReaction without a reply', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async (ctx) => {
+        ctx.addReaction('msg-123', 'eyes');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest();
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const flushBody = JSON.parse(replyCall![1].body);
+
+    expect(flushBody.reply).toBeUndefined();
+    expect(flushBody.addReactions).toHaveLength(1);
+    expect(flushBody.addReactions[0]).toEqual({ messageId: 'msg-123', emojiName: 'eyes' });
+  });
+
   it('should batch addReaction with reply', async () => {
     const testBot = agent('test-bot', {
       onMessage: async (ctx) => {

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -1,4 +1,4 @@
-import type { CardElement, ChatElement } from 'chat';
+import type { CardElement, ChatElement, Emoji } from 'chat';
 import type { TriggerRecipientsPayload } from '../../shared';
 export type { TriggerRecipientsPayload };
 
@@ -178,6 +178,19 @@ export interface AgentContext {
    *   ctx.trigger('team-alert', { to: { type: 'Topic', topicKey: 'support-team' } });
    */
   trigger(workflowId: string, opts?: { to?: TriggerRecipientsPayload; payload?: Record<string, unknown> }): void;
+  /**
+   * Add an emoji reaction to any platform message.
+   * Reactions are queued and sent with the next `ctx.reply()`, or flushed automatically
+   * when the handler completes (same batching contract as `ctx.trigger()`).
+   *
+   * @param messageId - Platform-native message ID to react to (e.g. Slack `ts`).
+   * @param emojiName - Emoji short-name (e.g. `'thumbs_up'`, `'check_mark'`).
+   *
+   * @example
+   *   ctx.addReaction(ctx.reaction!.messageId, 'check_mark');
+   *   await ctx.reply('Done!');
+   */
+  addReaction(messageId: string, emojiName: Emoji): void;
 }
 
 export interface AgentHandlers {
@@ -241,6 +254,12 @@ export interface EditPayload {
   content: ReplyContent;
 }
 
+/** An emoji reaction to be added to a platform message. */
+export interface AddReactionPayload {
+  messageId: string;
+  emojiName: Emoji;
+}
+
 export interface AgentReplyPayload {
   conversationId: string;
   integrationIdentifier: string;
@@ -248,6 +267,7 @@ export interface AgentReplyPayload {
   edit?: EditPayload;
   resolve?: { summary?: string };
   signals?: Signal[];
+  addReactions?: AddReactionPayload[];
 }
 
 /** Shape returned by /agents/:id/reply when a reply or edit was delivered. */


### PR DESCRIPTION
## What

Adds `ctx.addReaction(messageId, emojiName)` to `AgentContext` so agent handler code can programmatically react to any platform message. Previously the SDK could only *read* incoming reactions (`ctx.reaction`) — there was no way to *send* one.

## Why

Agent handlers often need to acknowledge actions or signal state with emoji reactions (e.g. `eyes` while thinking, `check` when done). The backend capability (`ChatSdkService.reactToMessage`) already existed; this wires it up through the public SDK.

## How

Reactions follow the same batching contract as `ctx.trigger()` — they are queued synchronously and flushed with the next `ctx.reply()`, or automatically when the handler completes.

```mermaid
sequenceDiagram
    participant Handler as Agent handler
    participant Ctx as AgentContextImpl
    participant API as Novu API /reply
    participant Chat as ChatSdkService

    Handler->>Ctx: ctx.addReaction('msg-id', 'thumbs_up')
    Note over Ctx: queued in _pendingReactions[]
    Handler->>Ctx: await ctx.reply('Done!')
    Ctx->>API: POST {reply, addReactions: [{messageId, emojiName}]}
    API->>Chat: reactToMessage(..., 'msg-id', 'thumbs_up')
```

If no `reply()` is called, reactions are flushed automatically when the handler returns (same path as `ctx.trigger()`-only handlers).

## Changes

| Layer | File | Change |
|-------|------|--------|
| Framework SDK | `agent.types.ts` | `AddReactionPayload` interface, `addReactions` on `AgentReplyPayload`, `addReaction()` on `AgentContext` — `emojiName` typed as `Emoji` from `chat` for IDE autocomplete |
| Framework SDK | `agent.context.ts` | `_pendingReactions` queue, `addReaction()` impl, drain in `reply()` and `flush()` |
| API DTO | `agent-reply-payload.dto.ts` | `AddReactionPayloadDto` + `addReactions` field on `AgentReplyPayloadDto` |
| API use-case | `handle-agent-reply.usecase.ts` | `Promise.all` dispatch to `reactToMessage`, guard updated |
| API controller | `agents-webhook.controller.ts` | `addReactions` wired through to command |
| Tests | `agent.test.ts` | batch-with-reply + flush-only coverage |
| Tests | `agent-reply.e2e.ts` | multi-reaction routing + empty-payload 400 |

## Test plan

- [x] `packages/framework`: 28/28 unit tests passing (`npx vitest run src/resources/agent/agent.test.ts`)
- [x] `apps/api`: 14/14 e2e tests passing (`agent-reply.e2e.ts`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The agent SDK now exposes ctx.addReaction(messageId, emojiName) so agent handlers can enqueue emoji reactions for platform messages; reactions are buffered and are sent with the next ctx.reply() or automatically flushed when the handler completes. The API was extended to accept addReactions on agent replies and to dispatch each reaction to ChatSdkService.reactToMessage, surfacing existing backend reaction support to public agent handlers.

## Affected areas

**framework**: Added AgentContext.addReaction, an AddReactionPayload type, and a _pendingReactions buffer in AgentContextImpl; reply() and flush() include queued addReactions in outgoing AgentReplyPayloads and clear the buffer.

**api**: Added AddReactionPayloadDto and addReactions to AgentReplyPayloadDto and HandleAgentReplyCommand; the agents webhook controller forwards body.addReactions; the handle-agent-reply use case validates addReactions, rejects conflicting edit+resolve/signals/addReactions payloads, and dispatches each reaction to ChatSdkService.reactToMessage.

## Key technical decisions

- Reactions use the same batching contract as ctx.reply(): queued synchronously and flushed with the next reply or on handler completion.  
- The API dispatches reactions with Promise.allSettled so individual reactToMessage failures are reported but do not block the overall reply flow.  
- Validation explicitly rejects requests that combine edit with resolve, signals, or addReactions to prevent conflicting operations.

## Testing

Added framework unit tests for flush-only reactions and reactions batched with reply; added API e2e tests for multi-reaction routing and rejection of edit+addReactions; reported runs: framework 28/28 passing, API e2e 14/14 passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->