### PR TITLE
feat(react): add realtime opt-out to provider and hooks fixes NV-7438

### DIFF
--- a/packages/react/src/hooks/NovuProvider.tsx
+++ b/packages/react/src/hooks/NovuProvider.tsx
@@ -3,13 +3,23 @@ import { buildSubscriber } from '@novu/js/internal';
 import { createContext, ReactNode, useContext, useMemo } from 'react';
 
 export type NovuProviderProps = NovuOptions & {
+  /**
+   * When `false`, disables the WebSocket subscription that auto-injects
+   * newly received notifications into the list and subscription that auto-resync
+   * notification counts. Built-in mutations like
+   * `readAll`, `seenAll`, `archiveAll`, and `archiveAllRead` continue to
+   * update local state. Use this when you want to drive new-notification updates yourself (e.g.
+   * via your own `novu.on('notifications.notification_received', ...)`
+   * handler combined with `refetch()`). Defaults to `true`.
+   */
+  realtime?: boolean;
   children: ReactNode;
 };
 
-const NovuContext = createContext<Novu | undefined>(undefined);
+const NovuContext = createContext<{ novu: Novu; realtime: boolean }>({ novu: undefined as any, realtime: true });
 
 export const NovuProvider = (props: NovuProviderProps) => {
-  const { subscriberId, ...propsWithoutSubscriberId } = props;
+  const { subscriberId, realtime = true, ...propsWithoutSubscriberId } = props;
   const subscriberObj = useMemo(
     () => buildSubscriber({ subscriberId, subscriber: props.subscriber }),
     [subscriberId, props.subscriber]
@@ -22,6 +32,7 @@ export const NovuProvider = (props: NovuProviderProps) => {
     ...propsWithoutSubscriberId,
     applicationIdentifier,
     subscriber: subscriberObj,
+    realtime,
   };
 
   return (
@@ -52,11 +63,12 @@ export const InternalNovuProvider = (props: NovuProviderProps) => {
     useCache,
     defaultSchedule,
     context,
+    realtime = true,
   } = props;
 
-  const novu = useMemo(
-    () =>
-      new Novu({
+  const value = useMemo(
+    () => ({
+      novu: new Novu({
         applicationIdentifier,
         subscriberHash,
         contextHash,
@@ -69,6 +81,8 @@ export const InternalNovuProvider = (props: NovuProviderProps) => {
         defaultSchedule,
         context,
       }),
+      realtime,
+    }),
     [
       applicationIdentifier,
       subscriberHash,
@@ -80,10 +94,11 @@ export const InternalNovuProvider = (props: NovuProviderProps) => {
       socketUrl,
       socketOptions,
       useCache,
+      realtime,
     ]
   );
 
-  return <NovuContext.Provider value={novu}>{children}</NovuContext.Provider>;
+  return <NovuContext.Provider value={value}>{children}</NovuContext.Provider>;
 };
 
 export const useNovu = () => {
@@ -92,11 +107,16 @@ export const useNovu = () => {
     throw new Error('useNovu must be used within a <NovuProvider />');
   }
 
-  return context;
+  return context.novu;
 };
 
 export const useUnsafeNovu = () => {
   const context = useContext(NovuContext);
 
-  return context;
+  return context.novu;
+};
+
+export const useRealtime = () => {
+  const context = useContext(NovuContext);
+  return context.realtime;
 };

--- a/packages/react/src/hooks/NovuProvider.tsx
+++ b/packages/react/src/hooks/NovuProvider.tsx
@@ -103,7 +103,7 @@ export const InternalNovuProvider = (props: NovuProviderProps) => {
 
 export const useNovu = () => {
   const context = useContext(NovuContext);
-  if (!context) {
+  if (!context.novu) {
     throw new Error('useNovu must be used within a <NovuProvider />');
   }
 
@@ -118,5 +118,6 @@ export const useUnsafeNovu = () => {
 
 export const useRealtime = () => {
   const context = useContext(NovuContext);
+
   return context.realtime;
 };

--- a/packages/react/src/hooks/internal/useBrowserTabsChannel.ts
+++ b/packages/react/src/hooks/internal/useBrowserTabsChannel.ts
@@ -3,19 +3,24 @@ import { useEffect, useState } from 'react';
 export const useBrowserTabsChannel = <T = unknown>({
   channelName,
   onMessage,
+  enabled = true,
 }: {
   channelName: string;
   onMessage: (args: T) => void;
+  enabled?: boolean;
 }) => {
   const [tabsChannel] = useState(
     typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel(channelName) : undefined
   );
 
   const postMessage = (data: T) => {
+    if (!enabled) return;
     tabsChannel?.postMessage(data);
   };
 
   useEffect(() => {
+    if (!enabled) return;
+
     const listener = (event: MessageEvent<T>) => {
       onMessage(event.data);
     };
@@ -25,7 +30,7 @@ export const useBrowserTabsChannel = <T = unknown>({
     return () => {
       tabsChannel?.removeEventListener('message', listener);
     };
-  }, []);
+  }, [enabled]);
 
   return { postMessage };
 };

--- a/packages/react/src/hooks/internal/useWebsocketEvent.ts
+++ b/packages/react/src/hooks/internal/useWebsocketEvent.ts
@@ -7,9 +7,11 @@ import { useBrowserTabsChannel } from './useBrowserTabsChannel';
 export const useWebSocketEvent = <E extends SocketEventNames>({
   event: webSocketEvent,
   eventHandler: onMessage,
+  enabled = true,
 }: {
   event: E;
   eventHandler: (args: Events[E]) => void;
+  enabled?: boolean;
 }) => {
   const novu = useNovu();
   const channelName = `nv_ws_connection:a=${novu.applicationIdentifier}:s=${novu.subscriberId}:c=${novu.contextKey}:e=${webSocketEvent}`;
@@ -17,6 +19,7 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
   const { postMessage } = useBrowserTabsChannel({
     channelName,
     onMessage,
+    enabled,
   });
 
   const updateReadCount: EventHandler<Events[E]> = (data) => {
@@ -25,6 +28,8 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
   };
 
   useEffect(() => {
+    if (!enabled) return;
+
     let cleanup: () => void;
     const resolveLock = requestLock(channelName, () => {
       cleanup = novu.on(webSocketEvent, updateReadCount);
@@ -37,5 +42,5 @@ export const useWebSocketEvent = <E extends SocketEventNames>({
 
       resolveLock();
     };
-  }, []);
+  }, [enabled]);
 };

--- a/packages/react/src/hooks/useCounts.ts
+++ b/packages/react/src/hooks/useCounts.ts
@@ -2,7 +2,7 @@ import { areTagsEqual, isSameFilter, Notification, NotificationFilter, NovuError
 import { useEffect, useState } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useWebSocketEvent } from './internal/useWebsocketEvent';
-import { useNovu } from './NovuProvider';
+import { useNovu, useRealtime } from './NovuProvider';
 
 type Count = {
   count: number;
@@ -28,10 +28,28 @@ type Count = {
  * const { counts } = useCounts({
  *   filters: [{ seen: true, read: false }]
  * });
+ *
+ * // Opt out of the built-in realtime count updates and drive them yourself
+ * const { counts, refetch } = useCounts({
+ *   filters: [{ read: false }],
+ *   realtime: false,
+ * });
  * ```
  */
 export type UseCountsProps = {
   filters: NotificationFilter[];
+  /**
+   * When `false`, disables the WebSocket subscriptions that auto-resync
+   * counts on `notifications.notification_received` and
+   * `notifications.unread_count_changed`. The filter-driven fetch and
+   * `refetch()` keep working. Use alongside
+   * `useNotifications({ realtime: false })` when you drive live updates
+   * yourself.
+   *
+   * When set, this prop takes precedence over the `realtime` config on
+   * `<NovuProvider />`. When omitted, the provider value (default `true`) is used.
+   */
+  realtime?: boolean;
   onSuccess?: (data: Count[]) => void;
   onError?: (error: NovuError) => void;
 };
@@ -45,8 +63,10 @@ export type UseCountsResult = {
 };
 
 export const useCounts = (props: UseCountsProps): UseCountsResult => {
-  const { filters, onSuccess, onError } = props;
+  const { filters, realtime: propsRealtime, onSuccess, onError } = props;
   const { notifications } = useNovu();
+  const providerRealtime = useRealtime();
+  const realtime = propsRealtime ?? providerRealtime;
   const filtersRef = useDataRef<NotificationFilter[]>(filters);
   const [error, setError] = useState<NovuError>();
   const [counts, setCounts] = useState<Count[]>();
@@ -110,6 +130,7 @@ export const useCounts = (props: UseCountsProps): UseCountsResult => {
 
   useWebSocketEvent({
     event: 'notifications.notification_received',
+    enabled: realtime,
     eventHandler: (data) => {
       sync(data.result);
     },
@@ -117,6 +138,7 @@ export const useCounts = (props: UseCountsProps): UseCountsResult => {
 
   useWebSocketEvent({
     event: 'notifications.unread_count_changed',
+    enabled: realtime,
     eventHandler: () => {
       sync();
     },

--- a/packages/react/src/hooks/useNotifications.ts
+++ b/packages/react/src/hooks/useNotifications.ts
@@ -2,7 +2,7 @@ import { checkNotificationMatchesFilter, isSameFilter, Notification, Notificatio
 import { useCallback, useEffect, useState } from 'react';
 import { useDataRef } from './internal/useDataRef';
 import { useWebSocketEvent } from './internal/useWebsocketEvent';
-import { useNovu } from './NovuProvider';
+import { useNovu, useRealtime } from './NovuProvider';
 
 /**
  * Props for the useNotifications hook.
@@ -30,6 +30,12 @@ import { useNovu } from './NovuProvider';
  *   createdGte: 1704067200000,
  *   createdLte: 1735689599999
  * });
+ *
+ * // Opt out of the built-in realtime updates and drive them yourself
+ * const { notifications, refetch } = useNotifications({
+ *   read: false,
+ *   realtime: false,
+ * });
  * ```
  */
 export type UseNotificationsProps = {
@@ -43,6 +49,18 @@ export type UseNotificationsProps = {
   createdGte?: NotificationFilter['createdGte'];
   createdLte?: NotificationFilter['createdLte'];
   limit?: number;
+  /**
+   * When `false`, disables the WebSocket subscription that auto-injects
+   * newly received notifications into the list. Built-in mutations like
+   * `readAll`, `seenAll`, `archiveAll`, and `archiveAllRead` continue to
+   * update local state. Use this when you want to drive new-notification updates yourself (e.g.
+   * via your own `novu.on('notifications.notification_received', ...)`
+   * handler combined with `refetch()`).
+   *
+   * When set, this prop takes precedence over the `realtime` config on
+   * `<NovuProvider />`. When omitted, the provider value (default `true`) is used.
+   */
+  realtime?: boolean;
   onSuccess?: (data: Notification[]) => void;
   onError?: (error: NovuError) => void;
 };
@@ -85,6 +103,7 @@ export const useNotifications = (props?: UseNotificationsProps): UseNotification
     createdGte,
     createdLte,
     limit = 10,
+    realtime: propsRealtime,
     onSuccess,
     onError,
   } = props || {};
@@ -101,6 +120,8 @@ export const useNotifications = (props?: UseNotificationsProps): UseNotification
     createdLte,
   });
   const novu = useNovu();
+  const providerRealtime = useRealtime();
+  const realtime = propsRealtime ?? providerRealtime;
   const [data, setData] = useState<Array<Notification>>();
   const [error, setError] = useState<NovuError>();
   const [isLoading, setIsLoading] = useState(true);
@@ -134,6 +155,7 @@ export const useNotifications = (props?: UseNotificationsProps): UseNotification
 
   useWebSocketEvent({
     event: 'notifications.notification_received',
+    enabled: realtime,
     eventHandler: ({ result: notification }) => {
       const currentFilter = filterRef.current;
       const matches = checkNotificationMatchesFilter(notification, currentFilter);


### PR DESCRIPTION
### What changed? Why was the change needed?

Inbox add the realtime opt-out to NovuProvider and `useNotifications` and `useCounts` hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added a realtime opt-out to the React provider and hooks so apps (notably the Inbox) can disable WebSocket-driven live updates. A new provider-level prop `realtime?: boolean` (default true) is exposed via `useRealtime()`, and `useNotifications` / `useCounts` accept an optional `realtime` prop to override the provider. When realtime is disabled, WebSocket listeners are not registered and updates occur only by explicit `refetch()`.

## Affected areas

**react**: NovuProvider gains a `realtime` prop and the context now carries `{ novu, realtime }`; a new `useRealtime()` hook exposes the flag. `useNotifications` and `useCounts` accept `realtime?: boolean` and use it to gate WebSocket-driven updates. Internal hooks `useWebSocketEvent` and `useBrowserTabsChannel` accept an `enabled` flag to avoid registering listeners when realtime is disabled.

## Key technical decisions

- Provider-level setting with hook-level override ensures prop > provider > default precedence for granular control.  
- NovuContext shape changed from `Novu | undefined` to `{ novu, realtime }` to carry the realtime flag while preserving access to the Novu instance via existing hooks.  
- Side-effect registration is gated by the new `enabled` flag and included in effect dependency arrays so listeners are added/removed when toggled.

## Testing

No tests added in this PR; verification requires manual or automated checks that WebSocket subscriptions are skipped when `realtime: false` and that `refetch()` still retrieves updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
