### PR TITLE
fix(application-generic): implement bounded retry strategy for SQS message deletion to handle transient errors

### DIFF
--- a/libs/application-generic/src/services/sqs/sqs-consumer.service.ts
+++ b/libs/application-generic/src/services/sqs/sqs-consumer.service.ts
@@ -28,6 +28,43 @@ const LOG_CONTEXT = 'SqsConsumerService';
  */
 const DELETE_MAX_ATTEMPTS = 3;
 const DELETE_BACKOFF_BASE_MS = 200;
+/**
+ * Proportional jitter added on top of the exponential backoff (0..25%).
+ * Prevents synchronized retry storms when many in-flight deletes hit the
+ * same transient failure (e.g. region-wide DNS blip).
+ */
+const DELETE_BACKOFF_JITTER_FACTOR = 0.25;
+
+/**
+ * SQS / AWS service error names that indicate a permanent failure - retrying
+ * cannot succeed, so we should log and stop immediately to avoid burning
+ * the retry budget and flooding logs.
+ *
+ * - ReceiptHandleIsInvalid: receipt handle expired (visibility timeout passed)
+ *   or never valid; the message will be redelivered regardless of what we do.
+ * - InvalidParameterValue / InvalidAddress: malformed request.
+ * - AccessDenied / AccessDeniedException: IAM/policy issue, won't self-heal.
+ */
+const NON_RETRYABLE_DELETE_ERROR_NAMES = new Set([
+  'ReceiptHandleIsInvalid',
+  'InvalidParameterValue',
+  'InvalidAddress',
+  'AccessDenied',
+  'AccessDeniedException',
+]);
+
+function isNonRetryableDeleteError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const errorName = (error as { name?: string }).name;
+  const errorCode = (error as { Code?: string; code?: string }).Code ?? (error as { code?: string }).code;
+
+  return (
+    (typeof errorName === 'string' && NON_RETRYABLE_DELETE_ERROR_NAMES.has(errorName)) ||
+    (typeof errorCode === 'string' && NON_RETRYABLE_DELETE_ERROR_NAMES.has(errorCode))
+  );
+}
 
 export type SqsMessageProcessor<T = unknown> = (data: T, meta: ISqsMessageMeta) => Promise<void>;
 
@@ -244,18 +281,28 @@ export class SqsConsumerService {
         );
 
         this.logger?.debug(
-          { messageId, topic: this.topic, attempts: attempt },
+          { messageId, topic: this.topic, attempt, maxAttempts: DELETE_MAX_ATTEMPTS },
           'SQS message processed and deleted'
         );
 
         return;
       } catch (deleteError) {
-        const isFinalAttempt = attempt === DELETE_MAX_ATTEMPTS;
         const errorMessage = deleteError instanceof Error ? deleteError.message : String(deleteError);
+        const errorName = deleteError instanceof Error ? deleteError.name : undefined;
+        const isFinalAttempt = attempt === DELETE_MAX_ATTEMPTS;
+        const isNonRetryable = isNonRetryableDeleteError(deleteError);
 
-        if (isFinalAttempt) {
+        if (isNonRetryable || isFinalAttempt) {
           Logger.error(
-            { error: errorMessage, messageId, topic: this.topic, attempts: attempt },
+            {
+              error: errorMessage,
+              errorName,
+              messageId,
+              topic: this.topic,
+              attempt,
+              maxAttempts: DELETE_MAX_ATTEMPTS,
+              nonRetryable: isNonRetryable,
+            },
             'Failed to delete SQS message after successful processing',
             LOG_CONTEXT
           );
@@ -264,12 +311,21 @@ export class SqsConsumerService {
         }
 
         Logger.warn(
-          { error: errorMessage, messageId, topic: this.topic, attempt, maxAttempts: DELETE_MAX_ATTEMPTS },
+          {
+            error: errorMessage,
+            errorName,
+            messageId,
+            topic: this.topic,
+            attempt,
+            maxAttempts: DELETE_MAX_ATTEMPTS,
+          },
           'Transient error deleting SQS message, retrying',
           LOG_CONTEXT
         );
 
-        const backoffMs = DELETE_BACKOFF_BASE_MS * 2 ** (attempt - 1);
+        const baseBackoffMs = DELETE_BACKOFF_BASE_MS * 2 ** (attempt - 1);
+        const jitterMs = Math.floor(Math.random() * baseBackoffMs * DELETE_BACKOFF_JITTER_FACTOR);
+        const backoffMs = baseBackoffMs + jitterMs;
         await new Promise<void>((resolve) => {
           setTimeout(resolve, backoffMs);
         });

--- a/libs/application-generic/src/services/sqs/sqs-consumer.service.ts
+++ b/libs/application-generic/src/services/sqs/sqs-consumer.service.ts
@@ -16,6 +16,19 @@ import {
 
 const LOG_CONTEXT = 'SqsConsumerService';
 
+/**
+ * Bounded retry config for SQS DeleteMessage calls.
+ *
+ * AWS SDK v3's default retry strategy does NOT classify Node DNS errors
+ * (EAI_AGAIN, ENOTFOUND, etc.) as transient, so a single resolver hiccup
+ * causes the delete to fail on the first attempt. When that happens after
+ * a successful processor run, SQS will redeliver the message after the
+ * visibility timeout, leading to duplicate processing. This bounded retry
+ * with exponential backoff prevents that for typical sub-second blips.
+ */
+const DELETE_MAX_ATTEMPTS = 3;
+const DELETE_BACKOFF_BASE_MS = 200;
+
 export type SqsMessageProcessor<T = unknown> = (data: T, meta: ISqsMessageMeta) => Promise<void>;
 
 /**
@@ -195,26 +208,7 @@ export class SqsConsumerService {
 
     this.processMessage(message)
       .then(async () => {
-        try {
-          await this.sqsService.getClient().send(
-            new DeleteMessageCommand({
-              QueueUrl: this.queueUrl,
-              ReceiptHandle: message.ReceiptHandle,
-            })
-          );
-
-          this.logger?.debug({ messageId, topic: this.topic }, 'SQS message processed and deleted');
-        } catch (deleteError) {
-          Logger.error(
-            {
-              error: deleteError instanceof Error ? deleteError.message : String(deleteError),
-              messageId,
-              topic: this.topic,
-            },
-            'Failed to delete SQS message after successful processing',
-            LOG_CONTEXT
-          );
-        }
+        await this.deleteMessageWithRetry(message, messageId);
       })
       .catch((error) => {
         Logger.error(
@@ -230,6 +224,57 @@ export class SqsConsumerService {
       .finally(() => {
         this.pool.release();
       });
+  }
+
+  /**
+   * Delete an SQS message with bounded exponential backoff retry.
+   *
+   * The processor has already succeeded by this point - failing to delete
+   * means SQS will redeliver and we'll do duplicate work. We retry a few
+   * times to absorb short-lived DNS/network blips before giving up.
+   */
+  private async deleteMessageWithRetry(message: Message, messageId: string): Promise<void> {
+    for (let attempt = 1; attempt <= DELETE_MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.sqsService.getClient().send(
+          new DeleteMessageCommand({
+            QueueUrl: this.queueUrl,
+            ReceiptHandle: message.ReceiptHandle,
+          })
+        );
+
+        this.logger?.debug(
+          { messageId, topic: this.topic, attempts: attempt },
+          'SQS message processed and deleted'
+        );
+
+        return;
+      } catch (deleteError) {
+        const isFinalAttempt = attempt === DELETE_MAX_ATTEMPTS;
+        const errorMessage = deleteError instanceof Error ? deleteError.message : String(deleteError);
+
+        if (isFinalAttempt) {
+          Logger.error(
+            { error: errorMessage, messageId, topic: this.topic, attempts: attempt },
+            'Failed to delete SQS message after successful processing',
+            LOG_CONTEXT
+          );
+
+          return;
+        }
+
+        Logger.warn(
+          { error: errorMessage, messageId, topic: this.topic, attempt, maxAttempts: DELETE_MAX_ATTEMPTS },
+          'Transient error deleting SQS message, retrying',
+          LOG_CONTEXT
+        );
+
+        const backoffMs = DELETE_BACKOFF_BASE_MS * 2 ** (attempt - 1);
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, backoffMs);
+        });
+      }
+    }
   }
 
   private async processMessage(message: Message): Promise<void> {


### PR DESCRIPTION

### What changed? Why was the change needed?
We have seen 3-4 instances of `getaddrinfo EAI_AGAIN` while deleting sqs message in past 3 weeks. Added a retry mechanism while deleting to solve transient DNS Issue. As they are few we should be good with retry. We can introduce a Idempotency guard if we see this again. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The SQS consumer now retries failed DeleteMessage calls with a bounded exponential-backoff (up to 3 attempts with jitter) after a message has been successfully processed. This prevents transient Node.js DNS/network hiccups (e.g., getaddrinfo EAI_AGAIN) from causing immediate delete failures that lead to SQS redeliveries and duplicate processing.

## Affected areas

**application-generic**: The SQS consumer (libs/application-generic) now uses an application-level deleteMessageWithRetry flow that retries deletes up to 3 times with exponential backoff and proportional jitter, logs warnings for intermediate retries and errors for non-retryable or final failures, and includes attempt counts in success logs.

## Key technical decisions

- Bounded retry limit: 3 attempts to avoid prolonged retries since failures have been infrequent.
- Exponential backoff starting at 200ms with proportional jitter (0–25%) to reduce retry storms.
- Application-level retry implemented because AWS SDK v3 does not treat Node DNS errors as transient; certain AWS error names (e.g., ReceiptHandleIsInvalid, AccessDenied) are treated as non-retryable and short-circuit retries.

## Testing

No new automated tests were added; the change addresses intermittent production DNS errors that are hard to reproduce in unit tests. The logic is simple and intended to be validated via manual/observational verification in staging/production after deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
