### PR TITLE
fix(js): scope default connectionIdentifier to subscriberId to prevent 409 conflicts

### DIFF
--- a/packages/js/src/ui/components/constants.ts
+++ b/packages/js/src/ui/components/constants.ts
@@ -1,2 +1,18 @@
 export const DEFAULT_MSTEAMS_CONNECTION_IDENTIFIER = 'chconn-msteams-default';
 export const DEFAULT_SLACK_CONNECTION_IDENTIFIER = 'chconn-slack-default';
+
+/**
+ * Builds a per-subscriber default connection identifier so that multiple
+ * subscribers in the same environment each get their own unique default,
+ * avoiding 409 Conflict errors when no explicit connectionIdentifier is given.
+ *
+ * Falls back to the bare prefix when subscriberId is unavailable (e.g. shared
+ * mode before a subscriberId is known).
+ */
+export function buildDefaultConnectionIdentifier(prefix: string, subscriberId: string | undefined): string {
+  if (!subscriberId) {
+    return prefix;
+  }
+
+  return `${prefix}-${subscriberId}`;
+}

--- a/packages/js/src/ui/components/msteams-connect-button/MsTeamsConnectButton.tsx
+++ b/packages/js/src/ui/components/msteams-connect-button/MsTeamsConnectButton.tsx
@@ -8,7 +8,7 @@ import { CheckCircleFill } from '../../icons/CheckCircleFill';
 import { Loader } from '../../icons/Loader';
 import { MsTeamsColored } from '../../icons/MsTeamsColored';
 import type { ChannelConnectButtonAppearanceCallback } from '../../types';
-import { DEFAULT_MSTEAMS_CONNECTION_IDENTIFIER } from '../constants';
+import { buildDefaultConnectionIdentifier, DEFAULT_MSTEAMS_CONNECTION_IDENTIFIER } from '../constants';
 import { Button, Motion } from '../primitives';
 import { Tooltip } from '../primitives/Tooltip';
 import { IconRendererWrapper } from '../shared/IconRendererWrapper';
@@ -44,7 +44,13 @@ export const MsTeamsConnectButton = (props: MsTeamsConnectButtonProps) => {
   const style = useStyle();
   const novuAccessor = useNovu();
   const integrationIdentifier = () => props.integrationIdentifier;
-  const connectionIdentifier = () => props.connectionIdentifier ?? DEFAULT_MSTEAMS_CONNECTION_IDENTIFIER;
+  const connectionMode = () => props.connectionMode ?? 'subscriber';
+  const resolvedContext = () => props.context ?? novuAccessor().context;
+  const resolvedSubscriberId = () =>
+    connectionMode() === 'subscriber' ? (props.subscriberId ?? novuAccessor().subscriberId) : undefined;
+  const connectionIdentifier = () =>
+    props.connectionIdentifier ??
+    buildDefaultConnectionIdentifier(DEFAULT_MSTEAMS_CONNECTION_IDENTIFIER, resolvedSubscriberId());
 
   const { connection, loading, disconnect, mutate, generateConnectOAuthUrl } = useChannelConnection({
     integrationIdentifier: integrationIdentifier(),
@@ -54,8 +60,6 @@ export const MsTeamsConnectButton = (props: MsTeamsConnectButtonProps) => {
 
   const [actionLoading, setActionLoading] = createSignal(false);
 
-  const connectionMode = () => props.connectionMode ?? 'subscriber';
-  const resolvedContext = () => props.context ?? novuAccessor().context;
   const isMisconfigured = createMemo(() => connectionMode() === 'shared' && !resolvedContext());
 
   createEffect(() => {

--- a/packages/js/src/ui/components/msteams-link-user/MsTeamsLinkUser.tsx
+++ b/packages/js/src/ui/components/msteams-link-user/MsTeamsLinkUser.tsx
@@ -8,7 +8,7 @@ import { CheckCircleFill } from '../../icons/CheckCircleFill';
 import { Loader } from '../../icons/Loader';
 import { MsTeamsColored } from '../../icons/MsTeamsColored';
 import type { MsTeamsLinkUserAppearanceCallback } from '../../types';
-import { DEFAULT_MSTEAMS_CONNECTION_IDENTIFIER } from '../constants';
+import { buildDefaultConnectionIdentifier, DEFAULT_MSTEAMS_CONNECTION_IDENTIFIER } from '../constants';
 import { Button, Motion } from '../primitives';
 import { IconRendererWrapper } from '../shared/IconRendererWrapper';
 
@@ -32,7 +32,10 @@ export const MsTeamsLinkUser = (props: MsTeamsLinkUserProps) => {
   const style = useStyle();
   const novuAccessor = useNovu();
   const integrationIdentifier = () => props.integrationIdentifier;
-  const connectionIdentifier = () => props.connectionIdentifier ?? DEFAULT_MSTEAMS_CONNECTION_IDENTIFIER;
+  const resolvedSubscriberId = () => props.subscriberId ?? novuAccessor().subscriberId;
+  const connectionIdentifier = () =>
+    props.connectionIdentifier ??
+    buildDefaultConnectionIdentifier(DEFAULT_MSTEAMS_CONNECTION_IDENTIFIER, resolvedSubscriberId());
 
   const { generateLinkUserOAuthUrl } = useChannelEndpoint({
     integrationIdentifier: integrationIdentifier(),

--- a/packages/js/src/ui/components/slack-connect-button/SlackConnectButton.tsx
+++ b/packages/js/src/ui/components/slack-connect-button/SlackConnectButton.tsx
@@ -8,7 +8,7 @@ import { CheckCircleFill } from '../../icons/CheckCircleFill';
 import { Loader } from '../../icons/Loader';
 import { SlackColored } from '../../icons/SlackColored';
 import type { ChannelConnectButtonAppearanceCallback } from '../../types';
-import { DEFAULT_SLACK_CONNECTION_IDENTIFIER } from '../constants';
+import { buildDefaultConnectionIdentifier, DEFAULT_SLACK_CONNECTION_IDENTIFIER } from '../constants';
 import { Button, Motion } from '../primitives';
 import { Tooltip } from '../primitives/Tooltip';
 import { IconRendererWrapper } from '../shared/IconRendererWrapper';
@@ -44,7 +44,13 @@ export const SlackConnectButton = (props: SlackConnectButtonProps) => {
   const style = useStyle();
   const novuAccessor = useNovu();
   const integrationIdentifier = () => props.integrationIdentifier;
-  const connectionIdentifier = () => props.connectionIdentifier ?? DEFAULT_SLACK_CONNECTION_IDENTIFIER;
+  const connectionMode = () => props.connectionMode ?? 'subscriber';
+  const resolvedContext = () => props.context ?? novuAccessor().context;
+  const resolvedSubscriberId = () =>
+    connectionMode() === 'subscriber' ? (props.subscriberId ?? novuAccessor().subscriberId) : undefined;
+  const connectionIdentifier = () =>
+    props.connectionIdentifier ??
+    buildDefaultConnectionIdentifier(DEFAULT_SLACK_CONNECTION_IDENTIFIER, resolvedSubscriberId());
 
   const { connection, loading, disconnect, mutate, generateConnectOAuthUrl } = useChannelConnection({
     integrationIdentifier: integrationIdentifier(),
@@ -53,9 +59,6 @@ export const SlackConnectButton = (props: SlackConnectButtonProps) => {
   });
 
   const [actionLoading, setActionLoading] = createSignal(false);
-
-  const connectionMode = () => props.connectionMode ?? 'subscriber';
-  const resolvedContext = () => props.context ?? novuAccessor().context;
   const isMisconfigured = createMemo(() => connectionMode() === 'shared' && !resolvedContext());
 
   createEffect(() => {

--- a/packages/js/src/ui/components/slack-link-user/SlackLinkUser.tsx
+++ b/packages/js/src/ui/components/slack-link-user/SlackLinkUser.tsx
@@ -8,7 +8,7 @@ import { CheckCircleFill } from '../../icons/CheckCircleFill';
 import { Loader } from '../../icons/Loader';
 import { SlackColored } from '../../icons/SlackColored';
 import type { SlackLinkUserAppearanceCallback } from '../../types';
-import { DEFAULT_SLACK_CONNECTION_IDENTIFIER } from '../constants';
+import { buildDefaultConnectionIdentifier, DEFAULT_SLACK_CONNECTION_IDENTIFIER } from '../constants';
 import { Button, Motion } from '../primitives';
 import { IconRendererWrapper } from '../shared/IconRendererWrapper';
 
@@ -32,7 +32,10 @@ export const SlackLinkUser = (props: SlackLinkUserProps) => {
   const style = useStyle();
   const novuAccessor = useNovu();
   const integrationIdentifier = () => props.integrationIdentifier;
-  const connectionIdentifier = () => props.connectionIdentifier ?? DEFAULT_SLACK_CONNECTION_IDENTIFIER;
+  const resolvedSubscriberId = () => props.subscriberId ?? novuAccessor().subscriberId;
+  const connectionIdentifier = () =>
+    props.connectionIdentifier ??
+    buildDefaultConnectionIdentifier(DEFAULT_SLACK_CONNECTION_IDENTIFIER, resolvedSubscriberId());
 
   const { generateLinkUserOAuthUrl } = useChannelEndpoint({
     integrationIdentifier: integrationIdentifier(),


### PR DESCRIPTION
## Problem

When `SlackConnectButton`, `MsTeamsConnectButton`, `SlackLinkUser`, or `MsTeamsLinkUser` are rendered **without** an explicit `connectionIdentifier` prop, all subscribers in the same environment shared a single hardcoded default:

- `chconn-slack-default`
- `chconn-msteams-default`

The `channel_connections` collection enforces a unique index on `{ _environmentId, identifier }`. This means the **second** subscriber in an environment to click Connect would receive a `409 Conflict` from the API and be silently unable to connect — even though their connection was for a completely different subscriber.

The root cause is that the API's `CreateChannelConnection` use-case has two separate uniqueness guards:
1. A semantic check: one connection per `(integration + subscriberId + contextKeys)` — which correctly allows a second subscriber through
2. An identifier uniqueness check: `{ _environmentId, identifier }` — which blocks the second subscriber because both default to the same static string

## Solution

Derive the default `connectionIdentifier` as `<prefix>-<subscriberId>` using a new `buildDefaultConnectionIdentifier` helper, so each subscriber gets their own scoped default. Falls back to the bare prefix when `subscriberId` is unavailable (shared mode), preserving existing behaviour for that edge case.

No backend changes, no DB migration, no API breaking change.

### Files changed

- `packages/js/src/ui/components/constants.ts` — added `buildDefaultConnectionIdentifier(prefix, subscriberId)`
- `SlackConnectButton.tsx` — use per-subscriber default
- `MsTeamsConnectButton.tsx` — use per-subscriber default
- `SlackLinkUser.tsx` — use per-subscriber default
- `MsTeamsLinkUser.tsx` — use per-subscriber default

## Behavior after this fix

| Scenario | Before | After |
|---|---|---|
| Subscriber A connects Slack (no explicit identifier) | Creates `chconn-slack-default` | Creates `chconn-slack-default-user-A` |
| Subscriber B connects Slack (no explicit identifier) | **409 Conflict** | Creates `chconn-slack-default-user-B` |
| Developer passes explicit `connectionIdentifier` | Works | Unchanged — explicit value is always used |
| Shared mode (no subscriberId) | Creates `chconn-slack-default` | Same — falls back to bare prefix |

## Test plan

- [ ] Connect two different subscribers via `SlackConnectButton` without providing `connectionIdentifier` — both should connect successfully
- [ ] Verify each subscriber's connection identifier is `chconn-slack-default-<subscriberId>`
- [ ] Verify that passing an explicit `connectionIdentifier` still uses that value unchanged
- [ ] Verify `SlackLinkUser` and `MsTeamsLinkUser` behave the same way