### PR TITLE
refactor(framework): remove { markdown } object input form fixes NV-7392

### DIFF
--- a/apps/api/src/app/agents/e2e/mock-agent-handler.ts
+++ b/apps/api/src/app/agents/e2e/mock-agent-handler.ts
@@ -108,8 +108,8 @@ const echoBot = agent('novu-agent', {
     }
 
     if (userText.toLowerCase().includes('markdown')) {
-      await ctx.reply({
-        markdown: [
+      await ctx.reply(
+        [
           `**Echo:** ${userText}`,
           '',
           '| Metric | Value |',
@@ -119,8 +119,8 @@ const echoBot = agent('novu-agent', {
           '| Error rate | 0.02% |',
           '',
           '> Sent from _Novu Agent Framework_',
-        ].join('\n'),
-      });
+        ].join('\n')
+      );
 
       return;
     }
@@ -154,9 +154,9 @@ const echoBot = agent('novu-agent', {
     } else if (actionId === 'assign') {
       await ctx.reply(`On-call assignment updated to *${value}*.`);
     } else if (actionId === 'escalate') {
-      await ctx.reply({
-        markdown: `**Escalated** — paging the secondary on-call team.\n\n_Triggered by ${ctx.subscriber?.firstName ?? 'unknown'}_`,
-      });
+      await ctx.reply(
+        `**Escalated** — paging the secondary on-call team.\n\n_Triggered by ${ctx.subscriber?.firstName ?? 'unknown'}_`
+      );
     } else {
       await ctx.reply(`Got action: *${actionId}*${value ? ` = ${value}` : ''}`);
     }

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -13,6 +13,7 @@ import type {
   AgentReaction,
   AgentReplyPayload,
   AgentSubscriber,
+  FileRef,
   MessageContent,
   ReplyContent,
   ReplyHandle,
@@ -25,9 +26,9 @@ function isCardElement(content: object): content is import('chat').CardElement {
   return 'type' in content && (content as { type: string }).type === 'card';
 }
 
-function serializeContent(content: MessageContent): ReplyContent {
+function serializeContent(content: MessageContent, files?: FileRef[]): ReplyContent {
   if (typeof content === 'string') {
-    return { markdown: content };
+    return files?.length ? { markdown: content, files } : { markdown: content };
   }
 
   if (isJSX(content)) {
@@ -41,16 +42,7 @@ function serializeContent(content: MessageContent): ReplyContent {
     return { card: content };
   }
 
-  if ('markdown' in content && typeof content.markdown === 'string') {
-    const result: ReplyContent = { markdown: content.markdown };
-    if (content.files?.length) {
-      result.files = content.files;
-    }
-
-    return result;
-  }
-
-  throw new Error('Invalid message content — expected string, { markdown }, or CardElement');
+  throw new Error('Invalid message content — expected string or CardElement');
 }
 
 interface ReplyPoster {
@@ -72,13 +64,13 @@ class ReplyHandleImpl implements ReplyHandle {
     this.platformThreadId = platformThreadId;
   }
 
-  async edit(content: MessageContent): Promise<ReplyHandle> {
+  async edit(content: MessageContent, options?: { files?: FileRef[] }): Promise<ReplyHandle> {
     const info = await this.poster.post({
       conversationId: this.conversationId,
       integrationIdentifier: this.integrationIdentifier,
       edit: {
         messageId: this.messageId,
-        content: serializeContent(content),
+        content: serializeContent(content, options?.files),
       },
     });
 
@@ -142,11 +134,11 @@ export class AgentContextImpl implements AgentContext {
     };
   }
 
-  async reply(content: MessageContent): Promise<ReplyHandle> {
+  async reply(content: MessageContent, options?: { files?: FileRef[] }): Promise<ReplyHandle> {
     const body: AgentReplyPayload = {
       conversationId: this._conversationId,
       integrationIdentifier: this._integrationIdentifier,
-      reply: serializeContent(content),
+      reply: serializeContent(content, options?.files),
     };
 
     if (this._signals.length) {

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -411,7 +411,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
   it('should serialize markdown content on reply', async () => {
     const testBot = agent('test-bot', {
       onMessage: async (ctx) => {
-        await ctx.reply({ markdown: '**bold** text' });
+        await ctx.reply('**bold** text');
       },
     });
 
@@ -448,8 +448,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
   it('should serialize markdown with file attachments', async () => {
     const testBot = agent('test-bot', {
       onMessage: async (ctx) => {
-        await ctx.reply({
-          markdown: 'Here is the report',
+        await ctx.reply('Here is the report', {
           files: [{ filename: 'report.pdf', url: 'https://example.com/report.pdf' }],
         });
       },

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -90,11 +90,11 @@ export interface FileRef {
  * Content accepted by ctx.reply() and handle.edit().
  *
  * - `string` — plain text or markdown; converted to platform format by the chat SDK
- * - `{ markdown, files? }` — markdown with optional file attachments
  * - `ChatElement` — interactive card built with Card(), Button(), etc.
- *   (must be a CardElement at runtime; validated by serializeContent)
+ *
+ * For file attachments, pass a `files` array as the second argument to reply()/edit().
  */
-export type MessageContent = string | { markdown: string; files?: FileRef[] } | ChatElement;
+export type MessageContent = string | ChatElement;
 
 /** Normalized content shape sent over HTTP to the reply endpoint. */
 export interface ReplyContent {
@@ -130,7 +130,7 @@ export interface ReplyHandle {
   /** Platform-native thread id this message lives in. */
   readonly platformThreadId: string;
   /** Edit this message in place with new content. Returns the same handle for chaining. */
-  edit(content: MessageContent): Promise<ReplyHandle>;
+  edit(content: MessageContent, options?: { files?: FileRef[] }): Promise<ReplyHandle>;
 }
 
 export interface AgentContext {
@@ -150,10 +150,14 @@ export interface AgentContext {
    *
    * @example
    *   const msg = await ctx.reply('Thinking…');
-   *   // ... do work ...
    *   await msg.edit('Here is the answer');
+   *
+   * @example with file attachment
+   *   await ctx.reply('Here is your report', {
+   *     files: [{ filename: 'report.pdf', url: 'https://...' }],
+   *   });
    */
-  reply(content: MessageContent): Promise<ReplyHandle>;
+  reply(content: MessageContent, options?: { files?: FileRef[] }): Promise<ReplyHandle>;
   resolve(summary?: string): void;
   metadata: {
     set(key: string, value: unknown): void;

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/support-agent.tsx
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/support-agent.tsx
@@ -30,13 +30,12 @@ export const supportAgent = agent('support-agent', {
     // Replace this block with your LLM call (OpenAI, Anthropic, etc.)
     ctx.metadata.set('lastMessage', text);
 
-    return {
-      markdown:
-        `**Got it.** You said: "${ctx.message?.text}"\n\n` +
-        `_This is a demo agent. Replace this handler with your LLM call._\n\n` +
-        `**Conversation so far:** ${ctx.history.length} messages | ` +
-        `**Topic:** ${ctx.conversation.metadata?.topic ?? 'unknown'}`,
-    };
+    return (
+      `**Got it.** You said: "${ctx.message?.text}"\n\n` +
+      `_This is a demo agent. Replace this handler with your LLM call._\n\n` +
+      `**Conversation so far:** ${ctx.history.length} messages | ` +
+      `**Topic:** ${ctx.conversation.metadata?.topic ?? 'unknown'}`
+    );
   },
 
   onAction: async (ctx) => {
@@ -44,7 +43,7 @@ export const supportAgent = agent('support-agent', {
     if (actionId.startsWith('topic-') && value) {
       ctx.metadata.set('topic', value);
 
-      return { markdown: `Topic set to **${value}**. Describe your issue and I'll help.` };
+      return `Topic set to **${value}**. Describe your issue and I'll help.`;
     }
   },
 


### PR DESCRIPTION
## Summary

- Simplifies `MessageContent` from `string | { markdown: string; files?: FileRef[] } | ChatElement` to `string | ChatElement`
- File attachments move to a second argument: `ctx.reply('text', { files: [...] })` instead of `ctx.reply({ markdown: 'text', files: [...] })`
- Updates `ctx.reply()` and `handle.edit()` signatures on both the interface and implementation

## Why

The `{ markdown }` wrapper was pure boilerplate — after NV-7392 made strings go through `{ markdown }` on the wire anyway, the explicit object form added no value. This collapses the API to the simpler and more intuitive string-first form.

## What is unchanged

- Wire format to the API (`{ markdown, files?, card }`) — the API receives exactly the same payload
- `FileRef` type — still exported and used for the `files` option
- `ReplyContent` interface — unchanged
- API DTOs — unchanged

## Breaking change

`ctx.reply({ markdown: '...' })` is no longer valid TypeScript. Users must migrate to `ctx.reply('...')`. For file attachments: `ctx.reply('...', { files: [...] })`.

This is a pre-release breaking change on `@novu/framework` (not yet in a stable release).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Removed the redundant { markdown } object form from MessageContent and simplified reply/edit APIs so message text is passed as a plain string and file attachments are provided via an optional second-argument options object (e.g., ctx.reply('text', { files: [...] })). This reduces API surface and avoids unnecessary object-wrapping while preserving the same wire payload shape sent to the API.

## Affected areas

**framework**: Tightened MessageContent to `string | ChatElement`, updated `AgentContext.reply()` and `ReplyHandle.edit()` signatures to accept `options?: { files?: FileRef[] }`, and refactored serialization to take files from the new options. Tests under framework were updated to the new call form.

**novu (templates)**: Agent template scaffolding updated to return plain markdown strings from handlers instead of `{ markdown: ... }` objects.

**api**: Mock agent handler used in e2e tests updated to call ctx.reply with the new string-first form and pass attachments via the options argument.

## Key technical decisions

- Breaking change: `ctx.reply({ markdown: '...' })` is no longer valid TypeScript; callers must migrate to `ctx.reply('...')` and use the second-argument for files — this is a pre-release breaking change on @novu/framework.  
- Wire contract unchanged: payloads sent to the API remain `{ markdown, files?, card }`.  
- Types like FileRef, ReplyContent, and API DTOs are unchanged.

## Testing

Unit/test updates applied in framework and the mock-agent used by e2e tests were updated to the new calling convention; no new dependencies or schema changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->