### PR TITLE
fix(api-service): prevent transient DNS failures from demoting verified domains

### DIFF
--- a/apps/api/src/app/domains/usecases/verify-domain/verify-domain.usecase.spec.ts
+++ b/apps/api/src/app/domains/usecases/verify-domain/verify-domain.usecase.spec.ts
@@ -1,0 +1,122 @@
+import * as dns from 'node:dns';
+import { NotFoundException } from '@nestjs/common';
+import type { DomainEntity } from '@novu/dal';
+import { DomainStatusEnum } from '@novu/shared';
+import { expect } from 'chai';
+import { restore, stub } from 'sinon';
+
+import { VerifyDomain } from './verify-domain.usecase';
+
+describe('VerifyDomain usecase', () => {
+  const previousEnv = { ...process.env };
+
+  const baseCommand = {
+    domainId: 'domain-id',
+    environmentId: 'env-id',
+    organizationId: 'org-id',
+    userId: 'user-id',
+  };
+
+  let domainRepositoryMock: { findOneByIdAndEnvironment: sinon.SinonStub; update: sinon.SinonStub };
+  let loggerMock: { setContext: sinon.SinonStub; debug: sinon.SinonStub; warn: sinon.SinonStub };
+  let resolveMxStub: sinon.SinonStub;
+
+  function buildDomain(overrides: Partial<DomainEntity> = {}): DomainEntity {
+    return {
+      _id: 'domain-id',
+      name: 'inbound.example.com',
+      status: DomainStatusEnum.PENDING,
+      mxRecordConfigured: false,
+      _environmentId: 'env-id',
+      _organizationId: 'org-id',
+      ...overrides,
+    } as DomainEntity;
+  }
+
+  function buildUsecase() {
+    return new VerifyDomain(domainRepositoryMock as any, loggerMock as any);
+  }
+
+  beforeEach(async () => {
+    process.env.MAIL_SERVER_DOMAIN = 'mail.novu.co';
+
+    domainRepositoryMock = {
+      findOneByIdAndEnvironment: stub(),
+      update: stub().resolves(),
+    };
+
+    loggerMock = {
+      setContext: stub(),
+      debug: stub(),
+      warn: stub(),
+    };
+
+    resolveMxStub = stub(dns.promises, 'resolveMx');
+  });
+
+  afterEach(() => {
+    restore();
+    process.env = { ...previousEnv };
+  });
+
+  it('marks domain as verified when DNS returns matching MX record', async () => {
+    const domain = buildDomain();
+    domainRepositoryMock.findOneByIdAndEnvironment.resolves(domain);
+    resolveMxStub.resolves([{ exchange: 'mail.novu.co', priority: 10 }]);
+
+    const usecase = buildUsecase();
+    const result = await usecase.execute(baseCommand);
+
+    expect(result.mxRecordConfigured).to.equal(true);
+    expect(result.status).to.equal(DomainStatusEnum.VERIFIED);
+    expect(domainRepositoryMock.update.calledOnce).to.equal(true);
+    expect(
+      domainRepositoryMock.update.calledWithMatch(
+        { _id: 'domain-id' },
+        { $set: { mxRecordConfigured: true, status: DomainStatusEnum.VERIFIED } }
+      )
+    ).to.equal(true);
+  });
+
+  it('keeps domain pending when DNS definitively returns no matching MX record (ENOTFOUND)', async () => {
+    const domain = buildDomain();
+    domainRepositoryMock.findOneByIdAndEnvironment.resolves(domain);
+    const notFoundError = Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' });
+    resolveMxStub.rejects(notFoundError);
+
+    const usecase = buildUsecase();
+    const result = await usecase.execute(baseCommand);
+
+    expect(result.mxRecordConfigured).to.equal(false);
+    expect(result.status).to.equal(DomainStatusEnum.PENDING);
+    expect(domainRepositoryMock.update.called).to.equal(false);
+  });
+
+  it('preserves verified state when DNS lookup fails with a transient error (ESERVFAIL)', async () => {
+    const domain = buildDomain({ status: DomainStatusEnum.VERIFIED, mxRecordConfigured: true });
+    domainRepositoryMock.findOneByIdAndEnvironment.resolves(domain);
+    const transientError = Object.assign(new Error('ESERVFAIL'), { code: 'ESERVFAIL' });
+    resolveMxStub.rejects(transientError);
+
+    const usecase = buildUsecase();
+    const result = await usecase.execute(baseCommand);
+
+    expect(result.mxRecordConfigured).to.equal(true);
+    expect(result.status).to.equal(DomainStatusEnum.VERIFIED);
+    expect(domainRepositoryMock.update.called).to.equal(false);
+    expect(loggerMock.warn.calledOnce).to.equal(true);
+  });
+
+  it('throws NotFoundException when domain does not exist', async () => {
+    domainRepositoryMock.findOneByIdAndEnvironment.resolves(null);
+
+    const usecase = buildUsecase();
+
+    try {
+      await usecase.execute(baseCommand);
+      throw new Error('Expected NotFoundException to be thrown.');
+    } catch (error) {
+      expect(error).to.be.instanceOf(NotFoundException);
+    }
+  });
+});

--- a/apps/api/src/app/domains/usecases/verify-domain/verify-domain.usecase.ts
+++ b/apps/api/src/app/domains/usecases/verify-domain/verify-domain.usecase.ts
@@ -34,7 +34,11 @@ export class VerifyDomain {
       throw new BadRequestException('MAIL_SERVER_DOMAIN is not defined as an environment variable');
     }
 
-    const mxRecordConfigured = await this.checkMxRecord(domain.name, INBOUND_DOMAIN);
+    const result = await this.checkMxRecord(domain.name, INBOUND_DOMAIN);
+
+    // For transient DNS failures (non-definitive), preserve the existing state to
+    // prevent a verified domain from being incorrectly demoted back to pending.
+    const mxRecordConfigured = result.definitive ? result.configured : domain.mxRecordConfigured;
 
     if (
       mxRecordConfigured !== domain.mxRecordConfigured ||
@@ -61,19 +65,23 @@ export class VerifyDomain {
     };
   }
 
-  private async checkMxRecord(lookupDomain: string, expectedExchange: string): Promise<boolean> {
+  private async checkMxRecord(
+    lookupDomain: string,
+    expectedExchange: string
+  ): Promise<{ configured: boolean; definitive: boolean }> {
     try {
       const records: MxRecord[] = await dnsPromises.resolveMx(lookupDomain);
+      const configured = records.some((record) => record.exchange.toLowerCase() === expectedExchange.toLowerCase());
 
-      return records.some((record) => record.exchange.toLowerCase() === expectedExchange.toLowerCase());
+      return { configured, definitive: true };
     } catch (error) {
       if (isExpectedDnsLookupMiss(error)) {
         this.logger.debug(
-          { lookupDomain, expectedExchange, code: error.code },
+          { lookupDomain, expectedExchange, code: (error as NodeJS.ErrnoException).code },
           'MX record is not configured for domain verification yet'
         );
 
-        return false;
+        return { configured: false, definitive: true };
       }
 
       this.logger.warn(
@@ -81,7 +89,7 @@ export class VerifyDomain {
         'Failed to resolve MX records for domain verification'
       );
 
-      return false;
+      return { configured: false, definitive: false };
     }
   }
 }


### PR DESCRIPTION
## What changed and why

When verifying a domain's MX record, any DNS error — including transient failures like `ESERVFAIL`, `ETIMEOUT`, or socket hangs — was treated identically to a definitive \"no records\" response. This caused `VerifyDomain` to write `mxRecordConfigured: false` back to MongoDB, demoting an already-verified domain to `pending`. The next successful lookup would re-promote it, creating the observed flaky `true` ↔ `false` oscillation on each \"Retry verification\" click.

The fix distinguishes between:
- **Definitive** DNS answers — the resolver successfully returned records (matched or not), or returned `ENOTFOUND`/`ENODATA` confirming no records exist.
- **Non-definitive** failures — transient errors where we simply don't know the current DNS state.

Only a definitive answer can change the stored `mxRecordConfigured` value. A transient failure on an already-verified domain preserves the existing state and skips the DB write.

## Flow diagram

```mermaid
flowchart TD
    A[GET /domains/:id] --> B[VerifyDomain.execute]
    B --> C[dns.promises.resolveMx]
    C -->|"Records returned"| D["{ configured: true/false, definitive: true }"]
    C -->|"ENOTFOUND / ENODATA"| E["{ configured: false, definitive: true }"]
    C -->|"ESERVFAIL / ETIMEOUT / other"| F["{ configured: false, definitive: false }"]
    D --> G{definitive?}
    E --> G
    F --> G
    G -->|"yes — use result.configured"| H{Changed?}
    G -->|"no — keep domain.mxRecordConfigured"| I[Skip DB write, return current state]
    H -->|"yes"| J[Update MongoDB + return new state]
    H -->|"no"| K[Return unchanged state]
```

## Files changed

- `apps/api/src/app/domains/usecases/verify-domain/verify-domain.usecase.ts` — `checkMxRecord` returns `{ configured, definitive }`; `execute` uses `definitive` to guard against demotions on transient errors.
- `apps/api/src/app/domains/usecases/verify-domain/verify-domain.usecase.spec.ts` _(new)_ — unit tests covering: DNS match → verified, ENOTFOUND → stays pending, ESERVFAIL on verified domain → stays verified.

## Breaking changes

None.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR fixes domain MX verification to distinguish between definitive DNS failures (ENOTFOUND, ENODATA) and transient failures (ESERVFAIL, ETIMEOUT, etc.). Previously, any DNS error would set `mxRecordConfigured: false`, which could demote an already-verified domain back to pending status on retry. Now `checkMxRecord` returns `{ configured, definitive }`, and the use case only updates the stored state for definitive results, preserving verified domains during transient failures.

## Affected areas

**api** — Updated domain verification logic to distinguish definitive DNS failures from transient ones. The `checkMxRecord` method now returns a structured object with `configured` and `definitive` flags, and `execute` preserves existing domain state when encountering transient DNS errors.

## Key technical decisions

- `checkMxRecord` signature changed from returning `boolean` to `Promise<{ configured: boolean; definitive: boolean }>` to communicate whether a DNS result is authoritative or transient.
- Added `isExpectedDnsLookupMiss` helper to identify definitive DNS errors (ENOTFOUND/ENODATA) versus unexpected failures.
- Type cast errors as `NodeJS.ErrnoException` to safely access error codes before checking them.

## Testing

Added comprehensive unit test suite covering DNS match (domain marked VERIFIED), definitive misses (ENOTFOUND, domain remains PENDING), transient errors (ESERVFAIL, verified domain preserved), and error handling (NotFoundException for missing domain). Tests verify update calls and logger behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->