### PR TITLE
feat(api-service): add Segment analytics for conversational agents

### DIFF
--- a/apps/api/src/app/agents/agent-analytics.ts
+++ b/apps/api/src/app/agents/agent-analytics.ts
@@ -1,0 +1,230 @@
+import type { AnalyticsService } from '@novu/application-generic';
+
+const AGENT_SEGMENT_CATEGORY = '[Agents]';
+
+export function trackAgentCreated(
+  analytics: AnalyticsService,
+  params: {
+    userId: string;
+    organizationId: string;
+    environmentId: string;
+    agentId: string;
+    agentIdentifier: string;
+    active: boolean;
+    name: string;
+  }
+): void {
+  analytics.track(`Agent Created - ${AGENT_SEGMENT_CATEGORY}`, params.userId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentId: params.agentId,
+    agentIdentifier: params.agentIdentifier,
+    active: params.active,
+    name: params.name,
+  });
+}
+
+export function trackAgentIntegrationConnected(
+  analytics: AnalyticsService,
+  params: {
+    userId: string;
+    organizationId: string;
+    environmentId: string;
+    agentId: string;
+    agentIdentifier: string;
+    integrationId: string;
+    integrationIdentifier: string;
+    providerId: string;
+    channel: string;
+    connectionSource: 'existing_integration' | 'novu_email_provisioned';
+  }
+): void {
+  analytics.track(`Agent Integration Connected - ${AGENT_SEGMENT_CATEGORY}`, params.userId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentId: params.agentId,
+    agentIdentifier: params.agentIdentifier,
+    integrationId: params.integrationId,
+    integrationIdentifier: params.integrationIdentifier,
+    providerId: params.providerId,
+    channel: params.channel,
+    connectionSource: params.connectionSource,
+  });
+}
+
+export function trackAgentInboundMessage(
+  analytics: AnalyticsService,
+  params: {
+    organizationId: string;
+    environmentId: string;
+    agentId: string;
+    agentIdentifier: string;
+    integrationIdentifier: string;
+    platform: string;
+    conversationId: string;
+    agentEvent: string;
+    isFirstMessageInThread: boolean;
+  }
+): void {
+  analytics.track(`Agent Inbound Message Processed - ${AGENT_SEGMENT_CATEGORY}`, params.organizationId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentId: params.agentId,
+    agentIdentifier: params.agentIdentifier,
+    integrationIdentifier: params.integrationIdentifier,
+    platform: params.platform,
+    conversationId: params.conversationId,
+    agentEvent: params.agentEvent,
+    isFirstMessageInThread: params.isFirstMessageInThread,
+  });
+}
+
+export function trackAgentInboundReaction(
+  analytics: AnalyticsService,
+  params: {
+    organizationId: string;
+    environmentId: string;
+    agentId: string;
+    agentIdentifier: string;
+    integrationIdentifier: string;
+    platform: string;
+    conversationId: string;
+  }
+): void {
+  analytics.track(`Agent Inbound Reaction Processed - ${AGENT_SEGMENT_CATEGORY}`, params.organizationId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentId: params.agentId,
+    agentIdentifier: params.agentIdentifier,
+    integrationIdentifier: params.integrationIdentifier,
+    platform: params.platform,
+    conversationId: params.conversationId,
+  });
+}
+
+export function trackAgentInboundAction(
+  analytics: AnalyticsService,
+  params: {
+    organizationId: string;
+    environmentId: string;
+    agentId: string;
+    agentIdentifier: string;
+    integrationIdentifier: string;
+    platform: string;
+    conversationId: string;
+    actionId: string;
+  }
+): void {
+  analytics.track(`Agent Inbound Action Processed - ${AGENT_SEGMENT_CATEGORY}`, params.organizationId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentId: params.agentId,
+    agentIdentifier: params.agentIdentifier,
+    integrationIdentifier: params.integrationIdentifier,
+    platform: params.platform,
+    conversationId: params.conversationId,
+    actionId: params.actionId,
+  });
+}
+
+export function trackAgentReplyProcessed(
+  analytics: AnalyticsService,
+  params: {
+    userId: string;
+    organizationId: string;
+    environmentId: string;
+    agentIdentifier: string;
+    conversationId: string;
+    integrationIdentifier: string;
+    actions: string[];
+    triggerSignalCount: number;
+    metadataSignalCount: number;
+    reactionCount: number;
+  }
+): void {
+  analytics.track(`Agent Reply Processed - ${AGENT_SEGMENT_CATEGORY}`, params.userId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentIdentifier: params.agentIdentifier,
+    conversationId: params.conversationId,
+    integrationIdentifier: params.integrationIdentifier,
+    actions: params.actions,
+    triggerSignalCount: params.triggerSignalCount,
+    metadataSignalCount: params.metadataSignalCount,
+    reactionCount: params.reactionCount,
+  });
+}
+
+export function trackAgentDeleted(
+  analytics: AnalyticsService,
+  params: {
+    userId: string;
+    organizationId: string;
+    environmentId: string;
+    agentId: string;
+    agentIdentifier: string;
+  }
+): void {
+  analytics.track(`Agent Deleted - ${AGENT_SEGMENT_CATEGORY}`, params.userId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentId: params.agentId,
+    agentIdentifier: params.agentIdentifier,
+  });
+}
+
+export function trackAgentIntegrationRemoved(
+  analytics: AnalyticsService,
+  params: {
+    userId: string;
+    organizationId: string;
+    environmentId: string;
+    agentIdentifier: string;
+    agentIntegrationId: string;
+  }
+): void {
+  analytics.track(`Agent Integration Removed - ${AGENT_SEGMENT_CATEGORY}`, params.userId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentIdentifier: params.agentIdentifier,
+    agentIntegrationId: params.agentIntegrationId,
+  });
+}
+
+export function trackAgentTestEmailSent(
+  analytics: AnalyticsService,
+  params: {
+    userId: string;
+    organizationId: string;
+    environmentId: string;
+    agentIdentifier: string;
+  }
+): void {
+  analytics.track(`Agent Test Email Sent - ${AGENT_SEGMENT_CATEGORY}`, params.userId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentIdentifier: params.agentIdentifier,
+  });
+}
+
+/** Fired once per agent–integration when the first inbound webhook is successfully resolved (sets connectedAt). */
+export function trackAgentIntegrationFirstWebhook(
+  analytics: AnalyticsService,
+  params: {
+    organizationId: string;
+    environmentId: string;
+    agentId: string;
+    agentIdentifier: string;
+    integrationIdentifier: string;
+    platform: string;
+  }
+): void {
+  analytics.track(`Agent Integration First Webhook - ${AGENT_SEGMENT_CATEGORY}`, params.organizationId, {
+    _organization: params.organizationId,
+    environmentId: params.environmentId,
+    agentId: params.agentId,
+    agentIdentifier: params.agentIdentifier,
+    integrationIdentifier: params.integrationIdentifier,
+    platform: params.platform,
+  });
+}

--- a/apps/api/src/app/agents/services/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-config-resolver.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
-import { decryptCredentials, FeatureFlagsService, PinoLogger } from '@novu/application-generic';
+import { AnalyticsService, decryptCredentials, FeatureFlagsService, PinoLogger } from '@novu/application-generic';
 import {
   AgentIntegrationRepository,
   AgentRepository,
@@ -9,6 +9,7 @@ import {
 } from '@novu/dal';
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import type { WellKnownEmoji } from 'chat';
+import { trackAgentIntegrationFirstWebhook } from '../agent-analytics';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
 import { AgentInactiveException } from '../exceptions/agent-inactive.exception';
 import { esmImport } from '../utils/esm-import';
@@ -69,7 +70,8 @@ export class AgentConfigResolver {
     private readonly agentIntegrationRepository: AgentIntegrationRepository,
     private readonly integrationRepository: IntegrationRepository,
     private readonly channelConnectionRepository: ChannelConnectionRepository,
-    private readonly logger: PinoLogger
+    private readonly logger: PinoLogger,
+    private readonly analyticsService: AnalyticsService
   ) {}
 
   async resolve(agentId: string, integrationIdentifier: string): Promise<ResolvedAgentConfig> {
@@ -135,7 +137,9 @@ export class AgentConfigResolver {
       connectionAccessToken = connection.auth.accessToken;
     }
 
-    if (!agentIntegration.connectedAt) {
+    const hadConnectedAt = Boolean(agentIntegration.connectedAt);
+
+    if (!hadConnectedAt) {
       await this.agentIntegrationRepository.updateOne(
         {
           _id: agentIntegration._id,
@@ -144,6 +148,15 @@ export class AgentConfigResolver {
         },
         { $set: { connectedAt: new Date() } }
       );
+
+      trackAgentIntegrationFirstWebhook(this.analyticsService, {
+        organizationId,
+        environmentId,
+        agentId,
+        agentIdentifier: agent.identifier,
+        integrationIdentifier,
+        platform,
+      });
     }
 
     return {

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { PinoLogger } from '@novu/application-generic';
+import { AnalyticsService, PinoLogger } from '@novu/application-generic';
 import { ConversationActivitySenderTypeEnum, ConversationParticipantTypeEnum, SubscriberRepository } from '@novu/dal';
 import type { AgentAction } from '@novu/framework';
 import type { EmojiValue, Message, Thread } from 'chat';
+import { trackAgentInboundAction, trackAgentInboundMessage, trackAgentInboundReaction } from '../agent-analytics';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { PLATFORMS_WITH_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
@@ -32,7 +33,8 @@ export class AgentInboundHandler {
     private readonly subscriberResolver: AgentSubscriberResolver,
     private readonly conversationService: AgentConversationService,
     private readonly bridgeExecutor: BridgeExecutorService,
-    private readonly subscriberRepository: SubscriberRepository
+    private readonly subscriberRepository: SubscriberRepository,
+    private readonly analyticsService: AnalyticsService
   ) {}
 
   async handle(
@@ -90,6 +92,9 @@ export class AgentInboundHandler {
         }
       : undefined;
 
+    const primaryChannel = this.conversationService.getPrimaryChannel(conversation);
+    const isFirstMessage = !primaryChannel.firstPlatformMessageId;
+
     await this.conversationService.persistInboundMessage({
       conversationId: conversation._id,
       platform: config.platform,
@@ -105,8 +110,17 @@ export class AgentInboundHandler {
       organizationId: config.organizationId,
     });
 
-    const primaryChannel = this.conversationService.getPrimaryChannel(conversation);
-    const isFirstMessage = !primaryChannel.firstPlatformMessageId;
+    trackAgentInboundMessage(this.analyticsService, {
+      organizationId: config.organizationId,
+      environmentId: config.environmentId,
+      agentId,
+      agentIdentifier: config.agentIdentifier,
+      integrationIdentifier: config.integrationIdentifier,
+      platform: config.platform,
+      conversationId: conversation._id,
+      agentEvent: event,
+      isFirstMessageInThread: isFirstMessage,
+    });
 
     if (isFirstMessage && message.id) {
       this.conversationService
@@ -199,6 +213,16 @@ export class AgentInboundHandler {
     if (!conversation) {
       return;
     }
+
+    trackAgentInboundReaction(this.analyticsService, {
+      organizationId: config.organizationId,
+      environmentId: config.environmentId,
+      agentId,
+      agentIdentifier: config.agentIdentifier,
+      integrationIdentifier: config.integrationIdentifier,
+      platform: config.platform,
+      conversationId: conversation._id,
+    });
 
     const platformUserId = event.user?.userId;
 
@@ -301,6 +325,17 @@ export class AgentInboundHandler {
       thread.id,
       serializedThread
     );
+
+    trackAgentInboundAction(this.analyticsService, {
+      organizationId: config.organizationId,
+      environmentId: config.environmentId,
+      agentId,
+      agentIdentifier: config.agentIdentifier,
+      integrationIdentifier: config.integrationIdentifier,
+      platform: config.platform,
+      conversationId: conversation._id,
+      actionId: action.actionId,
+    });
 
     const [subscriber, history] = await Promise.all([
       subscriberId

--- a/apps/api/src/app/agents/usecases/add-agent-integration/add-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/usecases/add-agent-integration/add-agent-integration.usecase.ts
@@ -7,7 +7,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { encryptSecret } from '@novu/application-generic';
+import { AnalyticsService, encryptSecret } from '@novu/application-generic';
 import {
   AgentIntegrationRepository,
   AgentRepository,
@@ -15,13 +15,9 @@ import {
   IntegrationEntity,
   IntegrationRepository,
 } from '@novu/dal';
-import {
-  ApiServiceLevelEnum,
-  EmailProviderIdEnum,
-  FeatureNameEnum,
-  getFeatureForTierAsBoolean,
-} from '@novu/shared';
+import { ApiServiceLevelEnum, EmailProviderIdEnum, FeatureNameEnum, getFeatureForTierAsBoolean } from '@novu/shared';
 
+import { trackAgentIntegrationConnected } from '../../agent-analytics';
 import type { AgentIntegrationResponseDto } from '../../dtos';
 import { toAgentIntegrationResponse } from '../../mappers/agent-response.mapper';
 import { FindOrCreateNovuEmail } from '../find-or-create-novu-email/find-or-create-novu-email.usecase';
@@ -34,7 +30,8 @@ export class AddAgentIntegration {
     private readonly integrationRepository: IntegrationRepository,
     private readonly agentIntegrationRepository: AgentIntegrationRepository,
     private readonly organizationRepository: CommunityOrganizationRepository,
-    private readonly findOrCreateNovuEmail: FindOrCreateNovuEmail
+    private readonly findOrCreateNovuEmail: FindOrCreateNovuEmail,
+    private readonly analyticsService: AnalyticsService
   ) {}
 
   async execute(command: AddAgentIntegrationCommand): Promise<AgentIntegrationResponseDto> {
@@ -60,7 +57,28 @@ export class AddAgentIntegration {
     }
 
     if (command.providerId === EmailProviderIdEnum.NovuAgent) {
-      return this.findOrCreateNovuEmail.execute(agent._id, command.environmentId, command.organizationId);
+      const { response, provisionedNewLink } = await this.findOrCreateNovuEmail.execute(
+        agent._id,
+        command.environmentId,
+        command.organizationId
+      );
+
+      if (provisionedNewLink) {
+        trackAgentIntegrationConnected(this.analyticsService, {
+          userId: command.userId,
+          organizationId: command.organizationId,
+          environmentId: command.environmentId,
+          agentId: agent._id,
+          agentIdentifier: command.agentIdentifier,
+          integrationId: response.integration._id,
+          integrationIdentifier: response.integration.identifier,
+          providerId: response.integration.providerId,
+          channel: response.integration.channel,
+          connectionSource: 'novu_email_provisioned',
+        });
+      }
+
+      return response;
     }
 
     if (!command.integrationIdentifier) {
@@ -122,7 +140,22 @@ export class AddAgentIntegration {
       _organizationId: command.organizationId,
     });
 
-    return toAgentIntegrationResponse(link, integration);
+    const response = toAgentIntegrationResponse(link, integration);
+
+    trackAgentIntegrationConnected(this.analyticsService, {
+      userId: command.userId,
+      organizationId: command.organizationId,
+      environmentId: command.environmentId,
+      agentId,
+      agentIdentifier: command.agentIdentifier,
+      integrationId: integration._id,
+      integrationIdentifier: integration.identifier,
+      providerId: integration.providerId,
+      channel: integration.channel,
+      connectionSource: 'existing_integration',
+    });
+
+    return response;
   }
 
   private async enforceEmailTier(organizationId: string): Promise<void> {

--- a/apps/api/src/app/agents/usecases/create-agent/create-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/create-agent/create-agent.usecase.ts
@@ -1,12 +1,17 @@
 import { ConflictException, Injectable } from '@nestjs/common';
+import { AnalyticsService } from '@novu/application-generic';
 import { AgentRepository } from '@novu/dal';
+import { trackAgentCreated } from '../../agent-analytics';
 import type { AgentResponseDto } from '../../dtos';
 import { toAgentResponse } from '../../mappers/agent-response.mapper';
 import { CreateAgentCommand } from './create-agent.command';
 
 @Injectable()
 export class CreateAgent {
-  constructor(private readonly agentRepository: AgentRepository) {}
+  constructor(
+    private readonly agentRepository: AgentRepository,
+    private readonly analyticsService: AnalyticsService
+  ) {}
 
   async execute(command: CreateAgentCommand): Promise<AgentResponseDto> {
     const existing = await this.agentRepository.findOne(
@@ -31,6 +36,16 @@ export class CreateAgent {
       active: command.active ?? true,
       _environmentId: command.environmentId,
       _organizationId: command.organizationId,
+    });
+
+    trackAgentCreated(this.analyticsService, {
+      userId: command.userId,
+      organizationId: command.organizationId,
+      environmentId: command.environmentId,
+      agentId: agent._id,
+      agentIdentifier: agent.identifier,
+      active: agent.active ?? true,
+      name: agent.name,
     });
 
     return toAgentResponse(agent);

--- a/apps/api/src/app/agents/usecases/delete-agent/delete-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/delete-agent/delete-agent.usecase.ts
@@ -1,6 +1,8 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { AnalyticsService } from '@novu/application-generic';
 import { AgentIntegrationRepository, AgentRepository } from '@novu/dal';
 
+import { trackAgentDeleted } from '../../agent-analytics';
 import { CleanupNovuEmail } from '../cleanup-novu-email/cleanup-novu-email.usecase';
 import { DeleteAgentCommand } from './delete-agent.command';
 
@@ -9,7 +11,8 @@ export class DeleteAgent {
   constructor(
     private readonly agentRepository: AgentRepository,
     private readonly agentIntegrationRepository: AgentIntegrationRepository,
-    private readonly cleanupNovuEmail: CleanupNovuEmail
+    private readonly cleanupNovuEmail: CleanupNovuEmail,
+    private readonly analyticsService: AnalyticsService
   ) {}
 
   async execute(command: DeleteAgentCommand): Promise<void> {
@@ -27,12 +30,7 @@ export class DeleteAgent {
     }
 
     await this.agentRepository.withTransaction(async (session) => {
-      await this.cleanupNovuEmail.cleanupForAgent(
-        agent._id,
-        command.environmentId,
-        command.organizationId,
-        session
-      );
+      await this.cleanupNovuEmail.cleanupForAgent(agent._id, command.environmentId, command.organizationId, session);
 
       await this.agentIntegrationRepository.delete(
         {
@@ -51,6 +49,14 @@ export class DeleteAgent {
         },
         { session }
       );
+    });
+
+    trackAgentDeleted(this.analyticsService, {
+      userId: command.userId,
+      organizationId: command.organizationId,
+      environmentId: command.environmentId,
+      agentId: agent._id,
+      agentIdentifier: command.identifier,
     });
   }
 }

--- a/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.usecase.ts
@@ -22,6 +22,11 @@ import shortid from 'shortid';
 import type { AgentIntegrationResponseDto } from '../../dtos';
 import { toAgentIntegrationResponse } from '../../mappers/agent-response.mapper';
 
+export type FindOrCreateNovuEmailResult = {
+  response: AgentIntegrationResponseDto;
+  provisionedNewLink: boolean;
+};
+
 @Injectable()
 export class FindOrCreateNovuEmail {
   constructor(
@@ -34,19 +39,15 @@ export class FindOrCreateNovuEmail {
    * Find the agent's existing NovuAgent integration link, or create a new
    * Integration + link atomically. Idempotent — safe to call concurrently.
    */
-  async execute(
-    agentId: string,
-    environmentId: string,
-    organizationId: string
-  ): Promise<AgentIntegrationResponseDto> {
+  async execute(agentId: string, environmentId: string, organizationId: string): Promise<FindOrCreateNovuEmailResult> {
     await this.enforceEmailTier(organizationId);
 
     const existing = await this.findExistingLink(agentId, environmentId, organizationId);
-    if (existing) return existing;
+    if (existing) return { response: existing, provisionedNewLink: false };
 
     return this.agentIntegrationRepository.withTransaction(async (session) => {
       const recheck = await this.findExistingLink(agentId, environmentId, organizationId);
-      if (recheck) return recheck;
+      if (recheck) return { response: recheck, provisionedNewLink: false };
 
       const displayName = providers.find((p) => p.id === EmailProviderIdEnum.NovuAgent)?.displayName ?? 'Novu Email';
       const identifier = `${slugify(displayName)}-${shortid.generate()}`;
@@ -66,7 +67,9 @@ export class FindOrCreateNovuEmail {
         { session }
       );
 
-      return this.createLink(agentId, integration, environmentId, organizationId, session);
+      const response = await this.createLink(agentId, integration, environmentId, organizationId, session);
+
+      return { response, provisionedNewLink: true };
     });
   }
 
@@ -109,7 +112,12 @@ export class FindOrCreateNovuEmail {
     session: ClientSession | null
   ): Promise<AgentIntegrationResponseDto> {
     const existingLink = await this.agentIntegrationRepository.findOne(
-      { _agentId: agentId, _integrationId: integration._id, _environmentId: environmentId, _organizationId: organizationId },
+      {
+        _agentId: agentId,
+        _integrationId: integration._id,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      },
       ['_id'],
       { session }
     );
@@ -119,7 +127,12 @@ export class FindOrCreateNovuEmail {
     }
 
     const link = await this.agentIntegrationRepository.create(
-      { _agentId: agentId, _integrationId: integration._id, _environmentId: environmentId, _organizationId: organizationId },
+      {
+        _agentId: agentId,
+        _integrationId: integration._id,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      },
       { session }
     );
 

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
-import { PinoLogger } from '@novu/application-generic';
+import { AnalyticsService, PinoLogger } from '@novu/application-generic';
 import {
   AgentRepository,
   ConversationChannel,
@@ -11,6 +11,7 @@ import {
 import type { SentMessageInfo, TriggerSignal } from '@novu/framework';
 import { AddressingTypeEnum, type TriggerRecipientsPayload, TriggerRequestCategoryEnum } from '@novu/shared';
 import { ParseEventRequest, ParseEventRequestMulticastCommand } from '../../../events/usecases/parse-event-request';
+import { trackAgentReplyProcessed } from '../../agent-analytics';
 import { AgentEventEnum } from '../../dtos/agent-event.enum';
 import type { EditPayloadDto, ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
 import { isValidMetadataSignalKey } from '../../dtos/agent-reply-payload.dto';
@@ -30,7 +31,8 @@ export class HandleAgentReply {
     private readonly agentConfigResolver: AgentConfigResolver,
     private readonly conversationService: AgentConversationService,
     private readonly logger: PinoLogger,
-    private readonly parseEventRequest: ParseEventRequest
+    private readonly parseEventRequest: ParseEventRequest,
+    private readonly analyticsService: AnalyticsService
   ) {}
 
   async execute(command: HandleAgentReplyCommand): Promise<SentMessageInfo | null> {
@@ -40,7 +42,13 @@ export class HandleAgentReply {
     if (command.edit && (command.resolve || command.signals?.length || command.addReactions?.length)) {
       throw new BadRequestException('edit cannot be combined with resolve, signals, or addReactions');
     }
-    if (!command.reply && !command.edit && !command.resolve && !command.signals?.length && !command.addReactions?.length) {
+    if (
+      !command.reply &&
+      !command.edit &&
+      !command.resolve &&
+      !command.signals?.length &&
+      !command.addReactions?.length
+    ) {
       throw new BadRequestException('At least one of reply, edit, resolve, signals, or addReactions must be provided');
     }
 
@@ -98,6 +106,31 @@ export class HandleAgentReply {
     if (command.resolve) {
       await this.resolveConversation(command, config!, conversation, channel, command.resolve);
     }
+
+    const triggerSignalCount = (command.signals ?? []).filter((s) => s.type === 'trigger').length;
+    const metadataSignalCount = (command.signals ?? []).filter((s) => s.type === 'metadata').length;
+    const reactionCount = command.addReactions?.length ?? 0;
+    const actions: string[] = [];
+
+    if (command.reply) actions.push('reply');
+    if (command.edit) actions.push('edit');
+    if (command.resolve) actions.push('resolve');
+    if (triggerSignalCount > 0) actions.push('trigger_signals');
+    if (metadataSignalCount > 0) actions.push('metadata_signals');
+    if (reactionCount > 0) actions.push('add_reactions');
+
+    trackAgentReplyProcessed(this.analyticsService, {
+      userId: command.userId,
+      organizationId: command.organizationId,
+      environmentId: command.environmentId,
+      agentIdentifier: command.agentIdentifier,
+      conversationId: command.conversationId,
+      integrationIdentifier: command.integrationIdentifier,
+      actions,
+      triggerSignalCount,
+      metadataSignalCount,
+      reactionCount,
+    });
 
     return replyInfo ?? null;
   }

--- a/apps/api/src/app/agents/usecases/remove-agent-integration/remove-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/usecases/remove-agent-integration/remove-agent-integration.usecase.ts
@@ -1,6 +1,8 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { AnalyticsService } from '@novu/application-generic';
 import { AgentIntegrationRepository, AgentRepository } from '@novu/dal';
 
+import { trackAgentIntegrationRemoved } from '../../agent-analytics';
 import { CleanupNovuEmail } from '../cleanup-novu-email/cleanup-novu-email.usecase';
 import { RemoveAgentIntegrationCommand } from './remove-agent-integration.command';
 
@@ -9,7 +11,8 @@ export class RemoveAgentIntegration {
   constructor(
     private readonly agentRepository: AgentRepository,
     private readonly agentIntegrationRepository: AgentIntegrationRepository,
-    private readonly cleanupNovuEmail: CleanupNovuEmail
+    private readonly cleanupNovuEmail: CleanupNovuEmail,
+    private readonly analyticsService: AnalyticsService
   ) {}
 
   async execute(command: RemoveAgentIntegrationCommand): Promise<void> {
@@ -50,6 +53,14 @@ export class RemoveAgentIntegration {
         command.organizationId,
         session
       );
+    });
+
+    trackAgentIntegrationRemoved(this.analyticsService, {
+      userId: command.userId,
+      organizationId: command.organizationId,
+      environmentId: command.environmentId,
+      agentIdentifier: command.agentIdentifier,
+      agentIntegrationId: command.agentIntegrationId,
     });
   }
 }

--- a/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
@@ -1,8 +1,9 @@
 import { BadGatewayException, BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
-import { decryptCredentials, InstrumentUsecase, MailFactory } from '@novu/application-generic';
+import { AnalyticsService, decryptCredentials, InstrumentUsecase, MailFactory } from '@novu/application-generic';
 import { AgentIntegrationRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
 import { ChannelTypeEnum, EmailProviderIdEnum, IEmailOptions } from '@novu/shared';
 
+import { trackAgentTestEmailSent } from '../../agent-analytics';
 import { SendAgentTestEmailCommand } from './send-agent-test-email.command';
 
 function escapeHtml(text: string): string {
@@ -14,7 +15,8 @@ export class SendAgentTestEmail {
   constructor(
     private readonly agentRepository: AgentRepository,
     private readonly integrationRepository: IntegrationRepository,
-    private readonly agentIntegrationRepository: AgentIntegrationRepository
+    private readonly agentIntegrationRepository: AgentIntegrationRepository,
+    private readonly analyticsService: AnalyticsService
   ) {}
 
   @InstrumentUsecase()
@@ -93,6 +95,13 @@ export class SendAgentTestEmail {
         error: 'delivery_failed',
         message: detail ? `${base}: ${detail}` : base,
       });
+    });
+
+    trackAgentTestEmailSent(this.analyticsService, {
+      userId: command.userId,
+      organizationId: command.organizationId,
+      environmentId: command.environmentId,
+      agentIdentifier: command.agentIdentifier,
     });
 
     return { success: true };

--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -17,7 +17,9 @@ import { Skeleton } from '@/components/primitives/skeleton';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useHasPermission } from '@/hooks/use-has-permission';
+import { useTelemetry } from '@/hooks/use-telemetry';
 import { buildRoute, ROUTES } from '@/utils/routes';
+import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
 import { ResolveAgentIntegrationGuide } from './agent-integration-guides/resolve-agent-integration-guide';
 import { ProviderDropdown } from './provider-dropdown';
@@ -215,6 +217,7 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
   const queryClient = useQueryClient();
   const { currentEnvironment } = useEnvironment();
   const has = useHasPermission();
+  const track = useTelemetry();
 
   const canRemoveAgentIntegration = has({ permission: PermissionsEnum.AGENT_WRITE });
 
@@ -327,6 +330,11 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
       const name = removed?.integration.name ?? 'Integration';
 
       showSuccessToast('Integration removed', `${name} was unlinked from this agent.`);
+      track(TelemetryEvent.AGENT_INTEGRATION_REMOVED_FROM_DASHBOARD, {
+        agentIdentifier: agent.identifier,
+        agentIntegrationId,
+        integrationIdentifier: removed?.integration.identifier,
+      });
       await queryClient.invalidateQueries({
         queryKey: getAgentIntegrationsQueryKey(currentEnvironment?._id, agent.identifier),
       });

--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -23,7 +23,9 @@ import { PermissionButton } from '@/components/primitives/permission-button';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useHasPermission } from '@/hooks/use-has-permission';
+import { useTelemetry } from '@/hooks/use-telemetry';
 import { AGENT_DETAILS_DEFAULT_TAB, buildRoute, ROUTES } from '@/utils/routes';
+import { TelemetryEvent } from '@/utils/telemetry';
 
 const PAGE_SIZE_OPTIONS = [10, 12, 20, 50];
 
@@ -33,6 +35,7 @@ export function AgentsList() {
   const location = useLocation();
   const { currentEnvironment } = useEnvironment();
   const has = useHasPermission();
+  const track = useTelemetry();
   const canReadAgents = has({ permission: PermissionsEnum.AGENT_READ });
 
   const [search, setSearch] = useState('');
@@ -89,6 +92,11 @@ export function AgentsList() {
       showSuccessToast('Agent created', 'Your agent is ready to use.');
       setCreateOpen(false);
 
+      track(TelemetryEvent.AGENT_CREATED_FROM_DASHBOARD, {
+        agentIdentifier: createdAgent.identifier,
+        active: createdAgent.active,
+      });
+
       const environment = requireEnvironment(currentEnvironment, 'No environment selected');
       const agentDetailsPath = `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
         environmentSlug: environment.slug ?? '',
@@ -108,9 +116,11 @@ export function AgentsList() {
   const deleteMutation = useMutation({
     mutationFn: (identifier: string) =>
       deleteAgent(requireEnvironment(currentEnvironment, 'No environment selected'), identifier),
-    onSuccess: async () => {
+    onSuccess: async (_, identifier) => {
       setAgentToDelete(null);
       showSuccessToast('Agent deleted', 'The agent was removed.');
+
+      track(TelemetryEvent.AGENT_DELETED_FROM_DASHBOARD, { agentIdentifier: identifier });
 
       const environment = requireEnvironment(currentEnvironment, 'No environment selected');
       const listKey = getAgentsListQueryKey(environment._id, {

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -36,8 +36,10 @@ import { IS_SELF_HOSTED, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '@/config';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { useIsAgentEmailAvailable } from '@/hooks/use-is-agent-email-available';
+import { useTelemetry } from '@/hooks/use-telemetry';
 import { QueryKeys } from '@/utils/query-keys';
 import { ROUTES } from '@/utils/routes';
+import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
 import { openInNewTab } from '@/utils/url';
 
@@ -160,6 +162,7 @@ export function ProviderDropdown({
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const isAgentEmailAvailable = useIsAgentEmailAvailable();
+  const track = useTelemetry();
 
   const { supported: allSupported, comingSoon } = useMemo(
     () => buildDropdownItems(CONVERSATIONAL_PROVIDERS, integrations),
@@ -297,6 +300,12 @@ export function ProviderDropdown({
       if (item.providerId === EmailProviderIdEnum.NovuAgent) {
         const link = await addAgentIntegrationMutation.mutateAsync({ providerId: item.providerId });
         showSuccessToast('Integration linked', `${link.integration.name ?? 'Novu Email'} was added to this agent.`);
+        track(TelemetryEvent.AGENT_INTEGRATION_LINKED_FROM_DASHBOARD, {
+          agentIdentifier,
+          providerId: item.providerId,
+          integrationIdentifier: link.integration.identifier,
+          mode: 'novu_email',
+        });
         onSelect(item.providerId, link.integration as unknown as IIntegration);
         setOpen(false);
       } else if (item.integration) {
@@ -306,6 +315,12 @@ export function ProviderDropdown({
           try {
             await addAgentIntegrationMutation.mutateAsync({ integrationIdentifier: item.integration.identifier });
             showSuccessToast('Integration linked', `${item.integration.name} was added to this agent.`);
+            track(TelemetryEvent.AGENT_INTEGRATION_LINKED_FROM_DASHBOARD, {
+              agentIdentifier,
+              providerId: item.providerId,
+              integrationIdentifier: item.integration.identifier,
+              mode: 'existing_integration',
+            });
           } catch (linkErr) {
             if (!isAlreadyLinkedToAgentConflict(linkErr)) {
               throw linkErr;
@@ -325,6 +340,12 @@ export function ProviderDropdown({
         });
         await addAgentIntegrationMutation.mutateAsync({ integrationIdentifier: created.identifier });
         showSuccessToast('Integration linked', `${created.name} was added to this agent.`);
+        track(TelemetryEvent.AGENT_INTEGRATION_LINKED_FROM_DASHBOARD, {
+          agentIdentifier,
+          providerId: item.providerId,
+          integrationIdentifier: created.identifier,
+          mode: 'new_integration_then_link',
+        });
         onSelect(item.providerId, created);
         setOpen(false);
       }

--- a/apps/dashboard/src/pages/agent-details.tsx
+++ b/apps/dashboard/src/pages/agent-details.tsx
@@ -1,6 +1,6 @@
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { RiArrowLeftSLine, RiRobot2Line } from 'react-icons/ri';
 import { Link, Navigate, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { AGENTS_LIST_QUERY_KEY, type AgentResponse, deleteAgent, getAgent, getAgentDetailQueryKey } from '@/api/agents';
@@ -26,6 +26,7 @@ import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { useTelemetry } from '@/hooks/use-telemetry';
 import {
   AGENT_DETAILS_DEFAULT_TAB,
   AGENT_DETAILS_TABS,
@@ -34,6 +35,7 @@ import {
   parseAgentDetailsTab,
   ROUTES,
 } from '@/utils/routes';
+import { TelemetryEvent } from '@/utils/telemetry';
 
 function isValidAgentDetailsTab(tab: string): tab is AgentDetailsTab {
   return (AGENT_DETAILS_TABS as readonly string[]).includes(tab);
@@ -80,6 +82,8 @@ export function AgentDetailsPage() {
   const { currentEnvironment } = useEnvironment();
   const isConversationalAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
   const [agentToDelete, setAgentToDelete] = useState<AgentResponse | null>(null);
+  const track = useTelemetry();
+  const lastAgentDetailsTelemetryKey = useRef<string | null>(null);
 
   const agentsListPath = buildRoute(ROUTES.AGENTS, {
     environmentSlug: currentEnvironment?.slug ?? '',
@@ -94,9 +98,10 @@ export function AgentDetailsPage() {
   const deleteMutation = useMutation({
     mutationFn: (identifier: string) =>
       deleteAgent(requireEnvironment(currentEnvironment, 'No environment selected'), identifier),
-    onSuccess: async () => {
+    onSuccess: async (_, identifier) => {
       setAgentToDelete(null);
       showSuccessToast('Agent deleted', 'The agent was removed.');
+      track(TelemetryEvent.AGENT_DELETED_FROM_DASHBOARD, { agentIdentifier: identifier });
       await queryClient.invalidateQueries({ queryKey: [AGENTS_LIST_QUERY_KEY] });
       navigate(agentsListPath);
     },
@@ -109,6 +114,32 @@ export function AgentDetailsPage() {
 
   const integrationIdentifier = integrationIdentifierParam ? decodeURIComponent(integrationIdentifierParam) : undefined;
   const currentTab = integrationIdentifier ? 'integrations' : parseAgentDetailsTab(agentTabParam);
+
+  useEffect(() => {
+    if (!isConversationalAgentsEnabled || !agentIdentifier || !agentQuery.data) {
+      return;
+    }
+
+    const dedupeKey = `${agentQuery.data.identifier}:${currentTab}:${integrationIdentifier ?? ''}`;
+    if (lastAgentDetailsTelemetryKey.current === dedupeKey) {
+      return;
+    }
+
+    lastAgentDetailsTelemetryKey.current = dedupeKey;
+
+    track(TelemetryEvent.AGENT_DETAILS_PAGE_VISITED, {
+      agentIdentifier: agentQuery.data.identifier,
+      tab: currentTab,
+      integrationIdentifier: integrationIdentifier ?? undefined,
+    });
+
+    if (integrationIdentifier) {
+      track(TelemetryEvent.AGENT_INTEGRATION_GUIDE_VIEWED, {
+        agentIdentifier: agentQuery.data.identifier,
+        integrationIdentifier,
+      });
+    }
+  }, [agentIdentifier, agentQuery.data, currentTab, integrationIdentifier, isConversationalAgentsEnabled, track]);
 
   if (!isConversationalAgentsEnabled) {
     return <Navigate to={agentsListPath} replace />;

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -2,7 +2,7 @@ import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { CaretSortIcon } from '@radix-ui/react-icons';
 import { useMutation } from '@tanstack/react-query';
 import type { FormEvent, ReactElement } from 'react';
-import { useCallback, useId, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { RiArrowRightSLine, RiCheckLine, RiCloseLine, RiMailLine, RiMessage3Line, RiMoreLine } from 'react-icons/ri';
 import {
   SiGithub,
@@ -30,6 +30,8 @@ import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner
 import { DismissButton, Icon as TagIcon, Root as TagRoot } from '@/components/primitives/tag';
 import { Textarea } from '@/components/primitives/textarea';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
+import { useTelemetry } from '@/hooks/use-telemetry';
+import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
 
 const slackIcon = '/images/providers/light/square/slack.svg';
@@ -402,6 +404,15 @@ function AgentsEarlyAccessDialog({ open, onOpenChange }: AgentsEarlyAccessDialog
 export function AgentsPage() {
   const [earlyAccessOpen, setEarlyAccessOpen] = useState(false);
   const isConversationalAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
+  const track = useTelemetry();
+
+  useEffect(() => {
+    if (!isConversationalAgentsEnabled) {
+      return;
+    }
+
+    track(TelemetryEvent.AGENTS_PAGE_VISITED);
+  }, [isConversationalAgentsEnabled, track]);
 
   return (
     <>

--- a/apps/dashboard/src/utils/telemetry.ts
+++ b/apps/dashboard/src/utils/telemetry.ts
@@ -111,4 +111,12 @@ export enum TelemetryEvent {
   COPILOT_SUGGESTIONS_REFRESHED = 'Copilot suggestions refreshed - [AI Copilot]',
 
   STEP_RESOLVER_CUSTOM_CODE_CLICKED = 'Custom code clicked - [Workflow Editor]',
+
+  AGENTS_PAGE_VISITED = 'Agents page visited',
+  AGENT_DETAILS_PAGE_VISITED = 'Agent details page visited',
+  AGENT_CREATED_FROM_DASHBOARD = 'Agent created from dashboard',
+  AGENT_DELETED_FROM_DASHBOARD = 'Agent deleted from dashboard',
+  AGENT_INTEGRATION_LINKED_FROM_DASHBOARD = 'Agent integration linked from dashboard',
+  AGENT_INTEGRATION_GUIDE_VIEWED = 'Agent integration setup guide viewed',
+  AGENT_INTEGRATION_REMOVED_FROM_DASHBOARD = 'Agent integration removed from dashboard',
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Segment tracking for conversational agents so product can measure adoption and usage (agents created, integrations linked, first webhook delivery, inbound traffic, bridge replies, lifecycle).

## API (Segment via `AnalyticsService`)

Central helpers live in `apps/api/src/app/agents/agent-analytics.ts`. Events use the `- [Agents]` suffix for consistent naming.

| Event | When | `userId` |
| --- | --- | --- |
| Agent Created | After successful create | acting user |
| Agent Integration Connected | New link (existing integration or newly provisioned Novu email only when a new link is created) | acting user |
| Agent Integration First Webhook | First time `connectedAt` is set on an agent–integration link (inbound webhook path) | organization (no user) |
| Agent Inbound Message Processed | After persisting an inbound message | organization |
| Agent Inbound Reaction Processed | Reaction routed to bridge | organization |
| Agent Inbound Action Processed | Platform action routed to bridge | organization |
| Agent Reply Processed | After each `/agents/:id/reply` handling (actions taken, signal counts) | acting user |
| Agent Deleted / Agent Integration Removed | Successful deletes | acting user |
| Agent Test Email Sent | Successful send | acting user |

Properties include `_organization`, `environmentId`, agent/integration identifiers, `platform`, `conversationId`, and structured fields where useful (e.g. `connectionSource`, `actions`, `isFirstMessageInThread`).

## Dashboard

New `TelemetryEvent` entries and `useTelemetry` calls for: agents list page visit, agent details + integration guide views, create/delete agent, link integration from provider dropdown, remove integration. These flow through the existing dashboard telemetry pipeline (`measure`), not direct browser Segment, to stay consistent with self-hosted behavior.

## Notes

- `FindOrCreateNovuEmail.execute` now returns `{ response, provisionedNewLink }` so we only emit **Agent Integration Connected** when a new Novu email link is actually created (idempotent re-use does not duplicate the event).
- Full `tsc` for the API package fails in this environment on unrelated `libs/internal-sdk` / `zod` resolution; dashboard `tsc --noEmit` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1777327950564149?thread_ts=1777327950.564149&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-11c9b5d5-8e6b-50ca-958a-e036e059d9f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11c9b5d5-8e6b-50ca-958a-e036e059d9f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Adds comprehensive Segment analytics tracking for conversational agents across the API and dashboard. The feature captures agent lifecycle events (creation, deletion), integration management (connection, removal, first webhook), inbound message processing, reply handling with signal metrics, and dashboard UI interactions. This enables product teams to measure agent adoption, feature usage patterns, and user engagement.

## Affected areas

- `api`: New analytics module with tracking helpers for agent lifecycle, integration management, inbound processing, and reply handling; all agent usecases now emit corresponding analytics events.
- `dashboard`: Added telemetry event tracking for agent list operations (creation/deletion), page visits, integration guide views, and integration linking/removal flows.

## Key technical decisions

- `FindOrCreateNovuEmail.execute` now returns `{ response, provisionedNewLink }` to distinguish between new and existing integration links, preventing duplicate analytics events.
- Analytics events use consistent identifiers (userId, organizationId, environmentId, agentIdentifier) and include context-specific properties (platform, conversationId, integrationIdentifier, signal counts).

## Testing

No new tests were added. This is a telemetry/observability change that does not affect core business logic; validation occurs through the Segment dashboard and browser console inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->