### PR TITLE
feat(api-service): Add JSON Logic match rules for domain routes

### DIFF
--- a/apps/api/src/app/domains/domains.controller.ts
+++ b/apps/api/src/app/domains/domains.controller.ts
@@ -270,6 +270,7 @@ export class DomainsController {
         agentId: body.agentId,
         type: body.type,
         data: body.data,
+        match: body.match,
       })
     );
   }
@@ -329,6 +330,7 @@ export class DomainsController {
         agentId: body.agentId,
         type: body.type,
         data: body.data,
+        match: body.match,
       })
     );
   }

--- a/apps/api/src/app/domains/dtos/domain-route-response.dto.ts
+++ b/apps/api/src/app/domains/dtos/domain-route-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { DomainRouteTypeEnum } from '@novu/shared';
+import { DomainRouteMatch, DomainRouteTypeEnum } from '@novu/shared';
 
 export class DomainRouteResponseDto {
   @ApiProperty()
@@ -37,4 +37,11 @@ export class DomainRouteResponseDto {
     additionalProperties: { type: 'string' },
   })
   data?: Record<string, string>;
+
+  @ApiPropertyOptional({
+    description: 'JSON Logic rule evaluated against inbound mail context. Truthy rules deliver the route.',
+    type: Object,
+    additionalProperties: true,
+  })
+  match?: DomainRouteMatch;
 }

--- a/apps/api/src/app/domains/dtos/domain-route.dto.ts
+++ b/apps/api/src/app/domains/dtos/domain-route.dto.ts
@@ -1,9 +1,10 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { DomainRouteTypeEnum } from '@novu/shared';
+import { DomainRouteMatch, DomainRouteTypeEnum } from '@novu/shared';
 import { Transform } from 'class-transformer';
 import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { IsBoundedRecord } from '../validators/bounded-record.validator';
 import { IsEmailLocalPart } from '../validators/email-local-part.validator';
+import { IsJsonLogicRule } from '../validators/json-logic-rule.validator';
 
 export class DomainRouteDto {
   @ApiProperty({ description: 'Inbox address local part (e.g. "support", "*")' })
@@ -32,4 +33,13 @@ export class DomainRouteDto {
   @IsOptional()
   @IsBoundedRecord()
   data?: Record<string, string>;
+
+  @ApiPropertyOptional({
+    description: 'Optional JSON Logic rule evaluated against inbound mail context. Truthy rules deliver the route.',
+    type: Object,
+    additionalProperties: true,
+  })
+  @IsOptional()
+  @IsJsonLogicRule()
+  match?: DomainRouteMatch;
 }

--- a/apps/api/src/app/domains/dtos/test-domain-route-response.dto.ts
+++ b/apps/api/src/app/domains/dtos/test-domain-route-response.dto.ts
@@ -25,6 +25,20 @@ export class TestDomainRouteAgentResultDto {
   latencyMs: number;
 }
 
+export class TestDomainRouteMatchEvaluationDto {
+  @ApiProperty()
+  evaluated: boolean;
+
+  @ApiProperty()
+  passed: boolean;
+
+  @ApiProperty()
+  matchedRouteAddress: string;
+
+  @ApiPropertyOptional({ description: 'Route address tried after this route failed its match rule.' })
+  fallthroughTo?: string;
+}
+
 export class TestDomainRouteResponseDto {
   @ApiProperty()
   matched: boolean;
@@ -52,4 +66,7 @@ export class TestDomainRouteResponseDto {
 
   @ApiPropertyOptional({ type: TestDomainRouteAgentResultDto })
   agent?: TestDomainRouteAgentResultDto;
+
+  @ApiPropertyOptional({ type: TestDomainRouteMatchEvaluationDto })
+  matchEvaluation?: TestDomainRouteMatchEvaluationDto;
 }

--- a/apps/api/src/app/domains/dtos/update-domain-route.dto.ts
+++ b/apps/api/src/app/domains/dtos/update-domain-route.dto.ts
@@ -1,7 +1,8 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { DomainRouteTypeEnum } from '@novu/shared';
+import { DomainRouteMatch, DomainRouteTypeEnum } from '@novu/shared';
 import { IsEnum, IsOptional, IsString } from 'class-validator';
 import { IsBoundedRecord } from '../validators/bounded-record.validator';
+import { IsJsonLogicRule } from '../validators/json-logic-rule.validator';
 
 export class UpdateDomainRouteDto {
   @ApiPropertyOptional({
@@ -24,4 +25,13 @@ export class UpdateDomainRouteDto {
   @IsOptional()
   @IsBoundedRecord()
   data?: Record<string, string>;
+
+  @ApiPropertyOptional({
+    description: 'Optional JSON Logic rule evaluated against inbound mail context. Truthy rules deliver the route.',
+    type: Object,
+    additionalProperties: true,
+  })
+  @IsOptional()
+  @IsJsonLogicRule()
+  match?: DomainRouteMatch | null;
 }

--- a/apps/api/src/app/domains/e2e/domain-routes.e2e-ee.ts
+++ b/apps/api/src/app/domains/e2e/domain-routes.e2e-ee.ts
@@ -77,6 +77,38 @@ describe('Domain Routes API - /v1/domains/:domain/routes #novu-v2', () => {
     expect(route.data).to.deep.equal({ source: 'e2e' });
   });
 
+  it('should create and update a route with a match rule', async () => {
+    const domain = await createDomain();
+    const match = { contains: [{ var: 'mail.subject' }, 'urgent'] };
+
+    const createResponse = await session.testAgent.post(`/v1/domains/${domain.name}/routes`).send({
+      address: 'conditions',
+      type: DomainRouteDtoType.Webhook,
+      match,
+    });
+    expect(createResponse.status).to.equal(201);
+    expect(createResponse.body.data.match).to.deep.equal(match);
+
+    const nextMatch = { in: [{ var: 'mail.fromDomain' }, ['acme.com']] };
+    const updateResponse = await session.testAgent.patch(`/v1/domains/${domain.name}/routes/conditions`).send({
+      match: nextMatch,
+    });
+    expect(updateResponse.status).to.equal(200);
+    expect(updateResponse.body.data.match).to.deep.equal(nextMatch);
+  });
+
+  it('should reject match rules that reference unknown fields', async () => {
+    const domain = await createDomain();
+
+    const response = await session.testAgent.post(`/v1/domains/${domain.name}/routes`).send({
+      address: 'bad-conditions',
+      type: DomainRouteDtoType.Webhook,
+      match: { '==': [{ var: 'unknown.field' }, 'value'] },
+    });
+
+    expect(response.status).to.equal(422);
+  });
+
   it('should reject route data with non-string values (client validation)', async () => {
     const domain = await createDomain();
 

--- a/apps/api/src/app/domains/e2e/test-domain-route.e2e-ee.ts
+++ b/apps/api/src/app/domains/e2e/test-domain-route.e2e-ee.ts
@@ -70,6 +70,68 @@ describe('Domain route test API - /v1/domains/:domain/routes/:address/test #novu
     expect(result.payload).to.be.an('object');
   });
 
+  it('should include match evaluation when testing a route with conditions', async () => {
+    const name = uniqueDomainName();
+    const { result: domain } = await novuClient.domains.create({ name });
+
+    const createResponse = await session.testAgent.post(`/v1/domains/${domain.name}/routes`).send({
+      address: 'support',
+      type: DomainRouteDtoType.Webhook,
+      match: { contains: [{ var: 'mail.subject' }, 'Test'] },
+    });
+    expect(createResponse.status).to.equal(201);
+
+    const { result } = await novuClient.domains.routes.test(
+      {
+        from: { address: 'sender@example.com' },
+        subject: 'Test message',
+        text: 'Ping',
+        dryRun: true,
+      },
+      domain.name,
+      'support'
+    );
+
+    const typedResult = result as typeof result & {
+      matchEvaluation?: { evaluated: boolean; passed: boolean };
+    };
+
+    expect(result.matched).to.equal(true);
+    expect(typedResult.matchEvaluation?.evaluated).to.equal(true);
+    expect(typedResult.matchEvaluation?.passed).to.equal(true);
+  });
+
+  it('should return matched false when route conditions fail', async () => {
+    const name = uniqueDomainName();
+    const { result: domain } = await novuClient.domains.create({ name });
+
+    const createResponse = await session.testAgent.post(`/v1/domains/${domain.name}/routes`).send({
+      address: 'support',
+      type: DomainRouteDtoType.Webhook,
+      match: { contains: [{ var: 'mail.subject' }, 'Nope'] },
+    });
+    expect(createResponse.status).to.equal(201);
+
+    const { result } = await novuClient.domains.routes.test(
+      {
+        from: { address: 'sender@example.com' },
+        subject: 'Test message',
+        text: 'Ping',
+        dryRun: true,
+      },
+      domain.name,
+      'support'
+    );
+
+    const typedResult = result as typeof result & {
+      matchEvaluation?: { evaluated: boolean; passed: boolean };
+    };
+
+    expect(result.matched).to.equal(false);
+    expect(typedResult.matchEvaluation?.evaluated).to.equal(true);
+    expect(typedResult.matchEvaluation?.passed).to.equal(false);
+  });
+
   it('should return 404 when testing a route on a missing domain', async () => {
     const { error } = await expectSdkExceptionGeneric(() =>
       novuClient.domains.routes.test(

--- a/apps/api/src/app/domains/mappers/domain-route-response.mapper.ts
+++ b/apps/api/src/app/domains/mappers/domain-route-response.mapper.ts
@@ -9,6 +9,7 @@ export function toDomainRouteResponse(route: DomainRouteEntity): DomainRouteResp
     agentId: route.destination,
     type: route.type,
     data: route.data,
+    match: route.match,
     _environmentId: route._environmentId as unknown as string,
     _organizationId: route._organizationId as unknown as string,
     createdAt: route.createdAt,

--- a/apps/api/src/app/domains/usecases/create-domain-route/create-domain-route.command.ts
+++ b/apps/api/src/app/domains/usecases/create-domain-route/create-domain-route.command.ts
@@ -1,9 +1,10 @@
-import { DomainRouteTypeEnum } from '@novu/shared';
+import { DomainRouteMatch, DomainRouteTypeEnum } from '@novu/shared';
 import { Transform } from 'class-transformer';
 import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { IsBoundedRecord } from '../../validators/bounded-record.validator';
 import { IsEmailLocalPart } from '../../validators/email-local-part.validator';
+import { IsJsonLogicRule } from '../../validators/json-logic-rule.validator';
 
 export class CreateDomainRouteCommand extends EnvironmentWithUserCommand {
   @IsString()
@@ -27,4 +28,8 @@ export class CreateDomainRouteCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @IsBoundedRecord()
   data?: Record<string, string>;
+
+  @IsOptional()
+  @IsJsonLogicRule()
+  match?: DomainRouteMatch;
 }

--- a/apps/api/src/app/domains/usecases/create-domain-route/create-domain-route.usecase.ts
+++ b/apps/api/src/app/domains/usecases/create-domain-route/create-domain-route.usecase.ts
@@ -64,6 +64,7 @@ export class CreateDomainRoute {
         ...(command.type === DomainRouteTypeEnum.AGENT && destination ? { destination } : {}),
         type: command.type,
         ...(command.data !== undefined ? { data: command.data } : {}),
+        ...(command.match !== undefined ? { match: command.match } : {}),
         _environmentId: command.environmentId,
         _organizationId: command.organizationId,
       });

--- a/apps/api/src/app/domains/usecases/domain-routes.usecase.spec.ts
+++ b/apps/api/src/app/domains/usecases/domain-routes.usecase.spec.ts
@@ -1,5 +1,5 @@
 import { ConflictException, NotFoundException } from '@nestjs/common';
-import { DirectionEnum, DomainRouteTypeEnum } from '@novu/shared';
+import { DirectionEnum, DomainRouteMatch, DomainRouteTypeEnum } from '@novu/shared';
 import { expect } from 'chai';
 import { restore, stub } from 'sinon';
 import { CreateDomainRoute } from './create-domain-route/create-domain-route.usecase';
@@ -17,6 +17,7 @@ const ROUTE_ID = 'route-id';
 const ROUTE_ADDRESS = 'support';
 const AGENT_ID = 'agent-id';
 const AGENT_IDENTIFIER = 'agent-identifier';
+const MATCH_RULE: DomainRouteMatch = { contains: [{ var: 'mail.subject' }, 'urgent'] };
 
 const domain = {
   _id: DOMAIN_ID,
@@ -106,6 +107,24 @@ describe('Domain route usecases', () => {
     ).to.equal(true);
   });
 
+  it('creates a domain route with a match rule', async () => {
+    domainRouteRepositoryMock.findOneByAddressAndDomain.resolves(null);
+    const usecase = new CreateDomainRoute(domainRepositoryMock, domainRouteRepositoryMock, agentRepositoryMock);
+
+    await usecase.execute({
+      domain: DOMAIN_NAME,
+      environmentId: ENVIRONMENT_ID,
+      organizationId: ORGANIZATION_ID,
+      userId: USER_ID,
+      address: ROUTE_ADDRESS,
+      agentId: AGENT_IDENTIFIER,
+      type: DomainRouteTypeEnum.AGENT,
+      match: MATCH_RULE,
+    });
+
+    expect(domainRouteRepositoryMock.create.calledWithMatch({ match: MATCH_RULE })).to.equal(true);
+  });
+
   it('throws ConflictException when a route already exists for the address', async () => {
     domainRouteRepositoryMock.findOneByAddressAndDomain.resolves({ _id: 'existing-route-id' });
     const usecase = new CreateDomainRoute(domainRepositoryMock, domainRouteRepositoryMock, agentRepositoryMock);
@@ -179,6 +198,38 @@ describe('Domain route usecases', () => {
 
     expect(result._id).to.equal(ROUTE_ID);
     expect(domainRouteRepositoryMock.findOneAndUpdate.called).to.equal(true);
+  });
+
+  it('updates a route match rule', async () => {
+    const usecase = new UpdateDomainRoute(domainRepositoryMock, domainRouteRepositoryMock, agentRepositoryMock);
+
+    await usecase.execute({
+      domain: DOMAIN_NAME,
+      address: ROUTE_ADDRESS,
+      environmentId: ENVIRONMENT_ID,
+      organizationId: ORGANIZATION_ID,
+      userId: USER_ID,
+      match: MATCH_RULE,
+    });
+
+    expect(domainRouteRepositoryMock.findOneAndUpdate.calledWithMatch({}, { $set: { match: MATCH_RULE } })).to.equal(
+      true
+    );
+  });
+
+  it('clears a route match rule', async () => {
+    const usecase = new UpdateDomainRoute(domainRepositoryMock, domainRouteRepositoryMock, agentRepositoryMock);
+
+    await usecase.execute({
+      domain: DOMAIN_NAME,
+      address: ROUTE_ADDRESS,
+      environmentId: ENVIRONMENT_ID,
+      organizationId: ORGANIZATION_ID,
+      userId: USER_ID,
+      match: null,
+    });
+
+    expect(domainRouteRepositoryMock.findOneAndUpdate.calledWithMatch({}, { $unset: { match: '' } })).to.equal(true);
   });
 
   it('throws NotFoundException when updating a missing route', async () => {

--- a/apps/api/src/app/domains/usecases/test-domain-route/test-domain-route.usecase.ts
+++ b/apps/api/src/app/domains/usecases/test-domain-route/test-domain-route.usecase.ts
@@ -1,7 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import { InboundDomainRouteDelivery, type InboundDomainRouteMailInput } from '@novu/application-generic';
-import { DomainRepository, DomainRouteRepository } from '@novu/dal';
-import { DomainRouteTypeEnum } from '@novu/shared';
+import {
+  buildRouteMatchContext,
+  evaluateRules,
+  InboundDomainRouteDelivery,
+  type InboundDomainRouteMailInput,
+} from '@novu/application-generic';
+import { DomainRepository, type DomainRouteEntity, DomainRouteRepository } from '@novu/dal';
+import { DomainRouteMatch, DomainRouteTypeEnum } from '@novu/shared';
 import { nanoid } from 'nanoid';
 
 import { TestDomainRouteResponseDto } from '../../dtos/test-domain-route-response.dto';
@@ -30,22 +35,29 @@ export class TestDomainRoute {
       organizationId: command.organizationId,
       addresses: [command.address, '*'],
     });
-    const route = routes.find((r) => r.address === command.address) ?? routes.find((r) => r.address === '*');
+    const exactRoute = routes.find((r) => r.address === command.address);
+    const wildcardRoute = routes.find((r) => r.address === '*');
 
     const dryRun = command.dryRun === true;
 
     const base: TestDomainRouteResponseDto = {
-      matched: Boolean(route),
+      matched: Boolean(exactRoute || wildcardRoute),
       dryRun,
       domainStatus: domain.status,
       mxRecordConfigured: domain.mxRecordConfigured,
     };
 
-    if (!route) {
-      return base;
-    }
+    const mail = this.buildMail(command, domain.name);
+    const selected = this.selectRoute({ exactRoute, wildcardRoute, domain, mail });
+    const route = selected.route;
 
-    const mail = this.buildMail(command, domain.name, route.address);
+    if (!route) {
+      return {
+        ...base,
+        matched: false,
+        matchEvaluation: selected.matchEvaluation,
+      };
+    }
 
     if (dryRun) {
       if (route.type === DomainRouteTypeEnum.WEBHOOK) {
@@ -57,6 +69,7 @@ export class TestDomainRoute {
           type: DomainRouteTypeEnum.WEBHOOK,
           wouldDeliverTo: 'configured outbound webhooks for this environment',
           payload: payload as unknown as Record<string, unknown>,
+          matchEvaluation: selected.matchEvaluation,
         };
       }
 
@@ -74,6 +87,7 @@ export class TestDomainRoute {
         type: DomainRouteTypeEnum.AGENT,
         wouldDeliverTo,
         payload: agentPayload as unknown as Record<string, unknown>,
+        matchEvaluation: selected.matchEvaluation,
       };
     }
 
@@ -94,6 +108,7 @@ export class TestDomainRoute {
           skipped: result.skipped,
           latencyMs: result.latencyMs,
         },
+        matchEvaluation: selected.matchEvaluation,
       };
     }
 
@@ -115,15 +130,82 @@ export class TestDomainRoute {
         agentReply: agentResult.body,
         latencyMs: agentResult.latencyMs,
       },
+      matchEvaluation: selected.matchEvaluation,
     };
   }
 
-  private buildMail(
-    command: TestDomainRouteCommand,
-    domainName: string,
-    routeAddress: string
-  ): InboundDomainRouteMailInput {
-    const toAddress = `${routeAddress}@${domainName}`;
+  private selectRoute({
+    exactRoute,
+    wildcardRoute,
+    domain,
+    mail,
+  }: {
+    exactRoute?: DomainRouteEntity;
+    wildcardRoute?: DomainRouteEntity;
+    domain: Parameters<typeof buildRouteMatchContext>[0];
+    mail: InboundDomainRouteMailInput;
+  }): {
+    route?: DomainRouteEntity;
+    matchEvaluation?: TestDomainRouteResponseDto['matchEvaluation'];
+  } {
+    const exactEvaluation = this.evaluateRouteMatch(exactRoute, domain, mail);
+    if (exactEvaluation.passed && exactRoute) {
+      return {
+        route: exactRoute,
+        matchEvaluation: exactEvaluation.matchEvaluation,
+      };
+    }
+
+    const wildcardEvaluation = this.evaluateRouteMatch(wildcardRoute, domain, mail);
+    if (wildcardEvaluation.passed && wildcardRoute) {
+      return {
+        route: wildcardRoute,
+        matchEvaluation: exactEvaluation.matchEvaluation
+          ? { ...exactEvaluation.matchEvaluation, fallthroughTo: wildcardRoute.address }
+          : wildcardEvaluation.matchEvaluation,
+      };
+    }
+
+    return {
+      matchEvaluation: exactEvaluation.matchEvaluation ?? wildcardEvaluation.matchEvaluation,
+    };
+  }
+
+  private evaluateRouteMatch(
+    route: DomainRouteEntity | undefined,
+    domain: Parameters<typeof buildRouteMatchContext>[0],
+    mail: InboundDomainRouteMailInput
+  ): { passed: boolean; matchEvaluation?: TestDomainRouteResponseDto['matchEvaluation'] } {
+    if (!route) {
+      return { passed: false };
+    }
+
+    if (!route.match) {
+      return {
+        passed: true,
+        matchEvaluation: {
+          evaluated: false,
+          passed: true,
+          matchedRouteAddress: route.address,
+        },
+      };
+    }
+
+    const context = buildRouteMatchContext(domain, route, mail);
+    const evaluation = evaluateRules(route.match as DomainRouteMatch, context, true);
+
+    return {
+      passed: evaluation.result,
+      matchEvaluation: {
+        evaluated: true,
+        passed: evaluation.result,
+        matchedRouteAddress: route.address,
+      },
+    };
+  }
+
+  private buildMail(command: TestDomainRouteCommand, domainName: string): InboundDomainRouteMailInput {
+    const toAddress = `${command.address}@${domainName}`;
     const messageId = `novu-test-${nanoid(12)}`;
 
     return {

--- a/apps/api/src/app/domains/usecases/update-domain-route/update-domain-route.command.ts
+++ b/apps/api/src/app/domains/usecases/update-domain-route/update-domain-route.command.ts
@@ -1,7 +1,8 @@
-import { DomainRouteTypeEnum } from '@novu/shared';
+import { DomainRouteMatch, DomainRouteTypeEnum } from '@novu/shared';
 import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { IsBoundedRecord } from '../../validators/bounded-record.validator';
+import { IsJsonLogicRule } from '../../validators/json-logic-rule.validator';
 
 export class UpdateDomainRouteCommand extends EnvironmentWithUserCommand {
   @IsString()
@@ -23,4 +24,8 @@ export class UpdateDomainRouteCommand extends EnvironmentWithUserCommand {
   @IsOptional()
   @IsBoundedRecord()
   data?: Record<string, string>;
+
+  @IsOptional()
+  @IsJsonLogicRule()
+  match?: DomainRouteMatch | null;
 }

--- a/apps/api/src/app/domains/usecases/update-domain-route/update-domain-route.usecase.ts
+++ b/apps/api/src/app/domains/usecases/update-domain-route/update-domain-route.usecase.ts
@@ -54,11 +54,18 @@ export class UpdateDomainRoute {
     });
 
     const hasChanges =
-      command.type !== undefined || command.agentId !== undefined || command.data !== undefined;
+      command.type !== undefined ||
+      command.agentId !== undefined ||
+      command.data !== undefined ||
+      command.match !== undefined;
 
     if (!hasChanges) {
       return toDomainRouteResponse(currentRoute);
     }
+
+    const unset: Record<string, ''> = {};
+    if (nextType === DomainRouteTypeEnum.WEBHOOK) unset.destination = '';
+    if (command.match === null) unset.match = '';
 
     const updated = await this.domainRouteRepository.findOneAndUpdate(
       {
@@ -74,8 +81,9 @@ export class UpdateDomainRoute {
             ? { destination: resolvedDestination }
             : {}),
           ...(command.data !== undefined ? { data: command.data } : {}),
+          ...(command.match !== undefined && command.match !== null ? { match: command.match } : {}),
         },
-        ...(nextType === DomainRouteTypeEnum.WEBHOOK ? { $unset: { destination: '' } } : {}),
+        ...(Object.keys(unset).length > 0 ? { $unset: unset } : {}),
       },
       { new: true }
     );

--- a/apps/api/src/app/domains/validators/json-logic-rule.validator.ts
+++ b/apps/api/src/app/domains/validators/json-logic-rule.validator.ts
@@ -1,0 +1,177 @@
+import { DomainRouteMatch, ROUTE_MATCH_CONTEXT_PATHS } from '@novu/shared';
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import jsonLogic from 'json-logic-js';
+
+const MAX_JSON_LOGIC_RULE_BYTES = 4096;
+const MAX_JSON_LOGIC_RULE_DEPTH = 8;
+const ALLOWED_DYNAMIC_PREFIXES = ['domain.data.', 'route.data.', 'mail.headers.'];
+const SUPPORTED_JSON_LOGIC_OPERATORS = new Set([
+  '!',
+  '!=',
+  '<',
+  '<=',
+  '=',
+  '==',
+  '>',
+  '>=',
+  'and',
+  'between',
+  'contains',
+  'containsAny',
+  'doesNotBeginWith',
+  'doesNotContain',
+  'doesNotContainAny',
+  'doesNotEndWith',
+  'endsWith',
+  'exactlyXAgo',
+  'in',
+  'lessThanXAgo',
+  'moreThanXAgo',
+  'notBetween',
+  'notIn',
+  'notNull',
+  'notWithinLast',
+  'null',
+  'or',
+  'startsWith',
+  'var',
+  'withinLast',
+]);
+
+function getSerializedSize(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), 'utf8');
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function getDepth(value: unknown): number {
+  if (value === null || typeof value !== 'object') {
+    return 0;
+  }
+
+  if (Array.isArray(value)) {
+    return 1 + Math.max(0, ...value.map(getDepth));
+  }
+
+  return 1 + Math.max(0, ...Object.values(value as Record<string, unknown>).map(getDepth));
+}
+
+function isAllowedRouteMatchPath(path: string): boolean {
+  return (
+    (ROUTE_MATCH_CONTEXT_PATHS as readonly string[]).includes(path) ||
+    ALLOWED_DYNAMIC_PREFIXES.some((prefix) => path.startsWith(prefix))
+  );
+}
+
+function extractVariables(rule: unknown, variables = new Set<string>()): Set<string> {
+  if (rule === null || typeof rule !== 'object') {
+    return variables;
+  }
+
+  if (Array.isArray(rule)) {
+    for (const item of rule) {
+      extractVariables(item, variables);
+    }
+
+    return variables;
+  }
+
+  for (const [operator, value] of Object.entries(rule as Record<string, unknown>)) {
+    if (operator === 'var') {
+      if (typeof value === 'string') {
+        variables.add(value);
+      } else if (Array.isArray(value) && typeof value[0] === 'string') {
+        variables.add(value[0]);
+      }
+    }
+
+    extractVariables(value, variables);
+  }
+
+  return variables;
+}
+
+function extractOperators(rule: unknown, operators = new Set<string>()): Set<string> {
+  if (rule === null || typeof rule !== 'object') {
+    return operators;
+  }
+
+  if (Array.isArray(rule)) {
+    for (const item of rule) {
+      extractOperators(item, operators);
+    }
+
+    return operators;
+  }
+
+  if (jsonLogic.is_logic(rule)) {
+    for (const [operator, value] of Object.entries(rule as Record<string, unknown>)) {
+      operators.add(operator);
+      extractOperators(value, operators);
+    }
+
+    return operators;
+  }
+
+  for (const value of Object.values(rule as Record<string, unknown>)) {
+    extractOperators(value, operators);
+  }
+
+  return operators;
+}
+
+export function isJsonLogicRouteMatchRule(value: unknown): value is DomainRouteMatch {
+  if (value === undefined || value === null) {
+    return true;
+  }
+
+  if (!jsonLogic.is_logic(value)) {
+    return false;
+  }
+
+  if (getSerializedSize(value) > MAX_JSON_LOGIC_RULE_BYTES) {
+    return false;
+  }
+
+  if (getDepth(value) > MAX_JSON_LOGIC_RULE_DEPTH) {
+    return false;
+  }
+
+  const variables = extractVariables(value);
+  const operators = extractOperators(value);
+
+  return (
+    Array.from(variables).every(isAllowedRouteMatchPath) &&
+    Array.from(operators).every((operator) => SUPPORTED_JSON_LOGIC_OPERATORS.has(operator))
+  );
+}
+
+@ValidatorConstraint({ name: 'isJsonLogicRule', async: false })
+class IsJsonLogicRuleConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    return isJsonLogicRouteMatchRule(value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `${args.property} must be a JSON Logic rule under ${MAX_JSON_LOGIC_RULE_BYTES} bytes, at most ${MAX_JSON_LOGIC_RULE_DEPTH} levels deep, and may only reference route match context fields.`;
+  }
+}
+
+export function IsJsonLogicRule(validationOptions?: ValidationOptions) {
+  return (object: object, propertyName: string) => {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: IsJsonLogicRuleConstraint,
+    });
+  };
+}

--- a/apps/dashboard/src/api/domains.ts
+++ b/apps/dashboard/src/api/domains.ts
@@ -1,4 +1,4 @@
-import { DirectionEnum, DomainRouteTypeEnum, DomainStatusEnum, IEnvironment } from '@novu/shared';
+import { DirectionEnum, DomainRouteMatch, DomainRouteTypeEnum, DomainStatusEnum, IEnvironment } from '@novu/shared';
 import { del, get, patch, post } from './api.client';
 
 export type DomainRouteResponse = {
@@ -12,6 +12,7 @@ export type DomainRouteResponse = {
   createdAt: string;
   updatedAt: string;
   data?: Record<string, string>;
+  match?: DomainRouteMatch;
 };
 
 export type ExpectedDnsRecord = {
@@ -41,8 +42,9 @@ export type UpdateDomainBody = { data?: Record<string, string> };
 export type CreateDomainRouteBody = Pick<DomainRouteResponse, 'address' | 'type'> & {
   agentId?: string;
   data?: Record<string, string>;
+  match?: DomainRouteMatch;
 };
-export type UpdateDomainRouteBody = Partial<CreateDomainRouteBody>;
+export type UpdateDomainRouteBody = Omit<Partial<CreateDomainRouteBody>, 'match'> & { match?: DomainRouteMatch | null };
 
 export type DomainDiagnosticIssue = {
   code: string;
@@ -75,6 +77,12 @@ export type TestDomainRouteResponse = {
   agent?: { agentId: string; status: number; agentReply?: unknown; latencyMs: number };
   payload?: unknown;
   wouldDeliverTo?: string;
+  matchEvaluation?: {
+    evaluated: boolean;
+    passed: boolean;
+    matchedRouteAddress: string;
+    fallthroughTo?: string;
+  };
 };
 
 export type CursorPaginatedResponse<T> = {

--- a/apps/dashboard/src/components/conditions-editor/conditions-editor.tsx
+++ b/apps/dashboard/src/components/conditions-editor/conditions-editor.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo } from 'react';
-import { type Field, QueryBuilder, RuleGroupType, Translations } from 'react-querybuilder';
+import { ComponentType, useCallback, useMemo } from 'react';
+import { type Field, QueryBuilder, RuleGroupType, Translations, ValueEditorProps } from 'react-querybuilder';
 import 'react-querybuilder/dist/query-builder.css';
 
 import { AddConditionAction } from '@/components/conditions-editor/add-condition-action';
@@ -22,6 +22,8 @@ import {
   IsAllowedVariable,
   LiquidVariable,
 } from '@/utils/parseStepVariables';
+
+export type ConditionsEditorValueEditor = ComponentType<ValueEditorProps>;
 
 export interface EnhancedField extends Field {
   dataType: FieldDataType;
@@ -53,7 +55,7 @@ const translations: Partial<Translations> = {
   },
 };
 
-const controlElements = {
+const baseControlElements = {
   operatorSelector: OperatorSelector,
   combinatorSelector: CombinatorSelector,
   fieldSelector: FieldSelector,
@@ -77,6 +79,7 @@ function InternalConditionsEditor({
   saveForm,
   enhancedVariables,
   disabled,
+  valueEditor,
 }: {
   fields: EnhancedField[];
   variables: LiquidVariable[];
@@ -86,7 +89,12 @@ function InternalConditionsEditor({
   saveForm: () => void;
   enhancedVariables?: EnhancedLiquidVariable[];
   disabled?: boolean;
+  valueEditor?: ConditionsEditorValueEditor;
 }) {
+  const controlElements = useMemo(
+    () => ({ ...baseControlElements, valueEditor: valueEditor ?? baseControlElements.valueEditor }),
+    [valueEditor]
+  );
   const fieldDataMap = useMemo(() => {
     if (!enhancedVariables) return new Map();
 
@@ -244,6 +252,7 @@ export function ConditionsEditor({
   isAllowedVariable,
   enhancedVariables,
   disabled,
+  valueEditor,
 }: {
   query: RuleGroupType;
   onQueryChange: (query: RuleGroupType) => void;
@@ -253,6 +262,7 @@ export function ConditionsEditor({
   isAllowedVariable: IsAllowedVariable;
   enhancedVariables?: EnhancedLiquidVariable[];
   disabled?: boolean;
+  valueEditor?: ConditionsEditorValueEditor;
 }) {
   return (
     <ConditionsEditorProvider query={query} onQueryChange={onQueryChange}>
@@ -265,6 +275,7 @@ export function ConditionsEditor({
         saveForm={saveForm}
         enhancedVariables={enhancedVariables}
         disabled={disabled}
+        valueEditor={valueEditor}
       />
     </ConditionsEditorProvider>
   );

--- a/apps/dashboard/src/components/domains/domain-routing.tsx
+++ b/apps/dashboard/src/components/domains/domain-routing.tsx
@@ -1,4 +1,4 @@
-import { DomainRouteTypeEnum } from '@novu/shared';
+import { DomainRouteTypeEnum, FeatureFlagsKeysEnum } from '@novu/shared';
 import { useQuery } from '@tanstack/react-query';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { Fragment, forwardRef, useEffect, useId, useImperativeHandle, useState } from 'react';
@@ -12,8 +12,8 @@ import {
   RiWebhookLine,
 } from 'react-icons/ri';
 import { Link } from 'react-router-dom';
-import { NovuApiError } from '@/api/api.client';
 import { listAgents } from '@/api/agents';
+import { NovuApiError } from '@/api/api.client';
 import type { DomainResponse, DomainRouteResponse, TestDomainRouteResponse } from '@/api/domains';
 import { Badge } from '@/components/primitives/badge';
 import { Button } from '@/components/primitives/button';
@@ -39,6 +39,7 @@ import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/primitives/table';
 import { Textarea } from '@/components/primitives/textarea';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useConditionsCount } from '@/hooks/use-conditions-count';
 import {
   useCreateDomainRoute,
   useDeleteDomainRoute,
@@ -46,9 +47,11 @@ import {
   useFetchDomainRoutes,
   useUpdateDomainRoute,
 } from '@/hooks/use-domain-routes';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useTestDomainRoute } from '@/hooks/use-test-domain-route';
 import { parseDomainMetadataJson } from '@/utils/domain-metadata';
 import { buildRoute, ROUTES } from '@/utils/routes';
+import { RouteConditionsDrawer } from './route-conditions-drawer';
 import { RoutingEmptyIllustration } from './routing-empty-illustration';
 
 type RouteFormState = {
@@ -106,6 +109,7 @@ type InlineRouteFormProps = {
   onCancel: () => void;
   isSaving: boolean;
   isAddressLocked?: boolean;
+  showConditions?: boolean;
 };
 
 function InlineRouteForm({
@@ -116,6 +120,7 @@ function InlineRouteForm({
   onCancel,
   isSaving,
   isAddressLocked = false,
+  showConditions = false,
 }: InlineRouteFormProps) {
   const [form, setForm] = useState<RouteFormState>(initialValues);
   const shouldReduceMotion = useReducedMotion();
@@ -198,6 +203,8 @@ function InlineRouteForm({
           </div>
         </TableCell>
 
+        {showConditions ? <TableCell className="text-foreground-400 px-3 py-4 text-sm">-</TableCell> : null}
+
         {/* Actions */}
         <TableCell className="px-3 py-4">
           <div className="flex items-center gap-1">
@@ -232,7 +239,7 @@ function InlineRouteForm({
       </TableRow>
 
       <TableRow className="[&>td]:border-0">
-        <TableCell colSpan={4} className="space-y-1 px-3 pb-4 pt-0">
+        <TableCell colSpan={showConditions ? 5 : 4} className="space-y-1 px-3 pb-4 pt-0">
           <p className="text-foreground-500 text-2xs font-medium">Metadata (optional JSON)</p>
           <Textarea
             value={form.dataJson}
@@ -256,9 +263,11 @@ type ExistingRouteRowProps = {
   agentOptions: Array<{ _id: string; name: string; identifier: string }>;
   onDelete: (address: string) => Promise<void>;
   onEdit: (address: string) => void;
+  onEditConditions: (route: DomainRouteResponse) => void;
   onSendTest: (route: DomainRouteResponse) => void;
   isDeleting: boolean;
   canWrite: boolean;
+  showConditions: boolean;
 };
 
 function ExistingRouteRow({
@@ -267,13 +276,16 @@ function ExistingRouteRow({
   agentOptions,
   onDelete,
   onEdit,
+  onEditConditions,
   onSendTest,
   isDeleting,
   canWrite,
+  showConditions,
 }: ExistingRouteRowProps) {
   const isWebhook = route.type === DomainRouteTypeEnum.WEBHOOK;
   const isCatchAll = route.address === '*';
   const agentName = isWebhook ? null : (agentOptions.find((a) => a._id === route.agentId)?.name ?? route.agentId);
+  const conditionsCount = useConditionsCount(route.match as never);
   const shouldReduceMotion = useReducedMotion();
   const catchAllInitial = shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.94 };
   const catchAllAnimate = shouldReduceMotion ? { opacity: 1 } : { opacity: 1, scale: 1 };
@@ -311,6 +323,17 @@ function ExistingRouteRow({
           </span>
         )}
       </TableCell>
+      {showConditions ? (
+        <TableCell className="px-3 py-4">
+          {conditionsCount > 0 ? (
+            <Badge variant="lighter" color="blue" size="sm">
+              {conditionsCount} {conditionsCount === 1 ? 'condition' : 'conditions'}
+            </Badge>
+          ) : (
+            <span className="text-foreground-400 text-sm">-</span>
+          )}
+        </TableCell>
+      ) : null}
       <TableCell className="px-3 py-4">
         <span className="text-success text-sm">Active</span>
       </TableCell>
@@ -323,6 +346,11 @@ function ExistingRouteRow({
             <DropdownMenuItem onSelect={() => onEdit(route.address)} disabled={!canWrite}>
               Edit
             </DropdownMenuItem>
+            {showConditions ? (
+              <DropdownMenuItem onSelect={() => onEditConditions(route)} disabled={!canWrite}>
+                Edit conditions
+              </DropdownMenuItem>
+            ) : null}
             <DropdownMenuItem onSelect={() => onSendTest(route)} disabled={!canWrite}>
               <span className="flex items-center gap-1.5">
                 <RiSendPlaneLine className="size-3.5 shrink-0" />
@@ -357,6 +385,18 @@ const DEFAULT_TEST_FORM = {
   subject: 'Novu route test',
   text: 'Synthetic inbound message from Novu.',
 };
+
+function getMatchEvaluationText(matchEvaluation: NonNullable<TestDomainRouteResponse['matchEvaluation']>): string {
+  if (!matchEvaluation.evaluated) {
+    return 'has no conditions.';
+  }
+
+  if (matchEvaluation.passed) {
+    return 'passed its conditions.';
+  }
+
+  return 'did not pass its conditions.';
+}
 
 function RouteTestDialog({ open, onOpenChange, domainName, route, mutation }: RouteTestDialogProps) {
   const dryRunFieldId = useId();
@@ -422,9 +462,7 @@ function RouteTestDialog({ open, onOpenChange, domainName, route, mutation }: Ro
         </DialogHeader>
 
         <div className="text-foreground-600 space-y-3 text-xs">
-          <p className="font-code text-code-xs text-foreground-900">
-            {route ? `${route.address}@${domainName}` : ''}
-          </p>
+          <p className="font-code text-code-xs text-foreground-900">{route ? `${route.address}@${domainName}` : ''}</p>
 
           <div className="grid gap-2">
             <p className="text-foreground-500 text-2xs font-medium uppercase tracking-wide">From email</p>
@@ -457,6 +495,19 @@ function RouteTestDialog({ open, onOpenChange, domainName, route, mutation }: Ro
             </label>
           </div>
         </div>
+
+        {lastResult?.matchEvaluation ? (
+          <div className="bg-bg-weak rounded-md border p-3 text-2xs">
+            <p className="text-foreground-600 font-medium">Condition evaluation</p>
+            <p className="text-foreground-500 mt-1">
+              Route <span className="font-code">{lastResult.matchEvaluation.matchedRouteAddress}</span>{' '}
+              {getMatchEvaluationText(lastResult.matchEvaluation)}
+              {lastResult.matchEvaluation.fallthroughTo
+                ? ` Falling through to ${lastResult.matchEvaluation.fallthroughTo}.`
+                : ''}
+            </p>
+          </div>
+        ) : null}
 
         {lastResult ? (
           <pre className="bg-bg-weak text-foreground-700 max-h-48 overflow-auto rounded-md border p-3 font-mono text-2xs">
@@ -590,6 +641,7 @@ export const DomainRouting = forwardRef<DomainRoutingHandle, DomainRoutingProps>
   ref
 ) {
   const { currentEnvironment } = useEnvironment();
+  const isRouteMatchEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_DOMAIN_ROUTE_MATCH_ENABLED, false);
   const { data: agents = [] } = useAgents();
   const [cursor, setCursor] = useState<{ after?: string; before?: string }>({});
   const { data: routesResponse, isLoading: areRoutesLoading } = useFetchDomainRoutes(domain.name, {
@@ -606,6 +658,7 @@ export const DomainRouting = forwardRef<DomainRoutingHandle, DomainRoutingProps>
   const [addInitialValues, setAddInitialValues] = useState<RouteFormState | undefined>(undefined);
   const [editingAddress, setEditingAddress] = useState<string | null>(null);
   const [testDialogRoute, setTestDialogRoute] = useState<DomainRouteResponse | null>(null);
+  const [conditionsRoute, setConditionsRoute] = useState<DomainRouteResponse | null>(null);
   const [isAddRouteTypeDialogOpen, setIsAddRouteTypeDialogOpen] = useState(false);
   const routes = routesResponse?.data ?? [];
   const hasCatchAllRoute = Boolean(catchAllRoute) || routes.some((route) => route.address === '*');
@@ -720,6 +773,22 @@ export const DomainRouting = forwardRef<DomainRoutingHandle, DomainRoutingProps>
     }
   };
 
+  const handleSaveConditions = async (match: DomainRouteResponse['match'] | null) => {
+    if (!conditionsRoute) {
+      return;
+    }
+
+    try {
+      await updateDomainRoute.mutateAsync({
+        address: conditionsRoute.address,
+        body: { match },
+      });
+      setConditionsRoute(null);
+    } catch (error) {
+      showErrorToast(getRouteErrorMessage(error, 'Failed to update route conditions.'), 'Route update failed');
+    }
+  };
+
   const agentOptions = agents.map((a) => ({ _id: a._id, name: a.name, identifier: a.identifier }));
   const hasWebhookRoute = routes.some((route) => route.type === DomainRouteTypeEnum.WEBHOOK);
   const isEmpty = routes.length === 0 && !isAdding;
@@ -733,6 +802,7 @@ export const DomainRouting = forwardRef<DomainRoutingHandle, DomainRoutingProps>
               <TableRow>
                 <TableHead className="h-8 px-3 text-label-xs">Address</TableHead>
                 <TableHead className="h-8 px-3 text-label-xs">Destination</TableHead>
+                {isRouteMatchEnabled ? <TableHead className="h-8 px-3 text-label-xs">Conditions</TableHead> : null}
                 <TableHead className="h-8 px-3 text-label-xs">Status</TableHead>
                 <TableHead className="h-8 px-3 text-label-xs w-12" />
               </TableRow>
@@ -755,6 +825,7 @@ export const DomainRouting = forwardRef<DomainRoutingHandle, DomainRoutingProps>
                     onSave={(values) => handleUpdate(route.address, values)}
                     onCancel={() => setEditingAddress(null)}
                     isSaving={isMutating}
+                    showConditions={isRouteMatchEnabled}
                   />
                 </Fragment>
               ) : (
@@ -765,9 +836,11 @@ export const DomainRouting = forwardRef<DomainRoutingHandle, DomainRoutingProps>
                   agentOptions={agentOptions}
                   onDelete={handleDelete}
                   onEdit={setEditingAddress}
+                  onEditConditions={setConditionsRoute}
                   onSendTest={setTestDialogRoute}
                   isDeleting={isMutating}
                   canWrite={canWrite}
+                  showConditions={isRouteMatchEnabled}
                 />
               )
             )}
@@ -782,12 +855,13 @@ export const DomainRouting = forwardRef<DomainRoutingHandle, DomainRoutingProps>
                 onSave={handleCreate}
                 onCancel={cancelAdding}
                 isSaving={isMutating}
+                showConditions={isRouteMatchEnabled}
               />
             )}
 
             {routes.length === 0 && !isAdding && !areRoutesLoading && (
               <TableRow className="[&>td]:border-0">
-                <TableCell colSpan={4} className="px-3 py-16 text-center">
+                <TableCell colSpan={isRouteMatchEnabled ? 5 : 4} className="px-3 py-16 text-center">
                   <div className="flex flex-col items-center gap-6">
                     <RoutingEmptyIllustration />
                     <div className="space-y-1 text-center">
@@ -863,6 +937,21 @@ export const DomainRouting = forwardRef<DomainRoutingHandle, DomainRoutingProps>
         mutation={testDomainRoute}
         onOpenChange={(open) => {
           if (!open) setTestDialogRoute(null);
+        }}
+      />
+
+      <RouteConditionsDrawer
+        open={!!conditionsRoute}
+        domainName={domain.name}
+        route={conditionsRoute}
+        isSaving={updateDomainRoute.isPending}
+        onSave={handleSaveConditions}
+        onSendTest={(route) => {
+          setConditionsRoute(null);
+          setTestDialogRoute(route);
+        }}
+        onOpenChange={(open) => {
+          if (!open) setConditionsRoute(null);
         }}
       />
 

--- a/apps/dashboard/src/components/domains/domain-routing.tsx
+++ b/apps/dashboard/src/components/domains/domain-routing.tsx
@@ -946,10 +946,6 @@ export const DomainRouting = forwardRef<DomainRoutingHandle, DomainRoutingProps>
         route={conditionsRoute}
         isSaving={updateDomainRoute.isPending}
         onSave={handleSaveConditions}
-        onSendTest={(route) => {
-          setConditionsRoute(null);
-          setTestDialogRoute(route);
-        }}
         onOpenChange={(open) => {
           if (!open) setConditionsRoute(null);
         }}

--- a/apps/dashboard/src/components/domains/route-conditions-drawer.tsx
+++ b/apps/dashboard/src/components/domains/route-conditions-drawer.tsx
@@ -1,14 +1,7 @@
 import type { DomainRouteMatch } from '@novu/shared';
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import {
-  RiCheckLine,
-  RiCloseLine,
-  RiFilterLine,
-  RiInformation2Line,
-  RiPriceTag3Line,
-  RiSendPlaneLine,
-} from 'react-icons/ri';
+import { RiCheckLine, RiCloseLine, RiFilterLine, RiInformation2Line, RiPriceTag3Line } from 'react-icons/ri';
 import { formatQuery, generateID, type RuleGroupType } from 'react-querybuilder';
 import { parseJsonLogic } from 'react-querybuilder/parseJsonLogic';
 import type { DomainRouteResponse } from '@/api/domains';
@@ -52,7 +45,6 @@ type RouteConditionsDrawerProps = {
   domainName: string;
   route: DomainRouteResponse | null;
   onSave: (match: DomainRouteMatch | null) => Promise<void>;
-  onSendTest: (route: DomainRouteResponse) => void;
   isSaving: boolean;
 };
 
@@ -249,7 +241,6 @@ export function RouteConditionsDrawer({
   domainName,
   route,
   onSave,
-  onSendTest,
   isSaving,
 }: RouteConditionsDrawerProps) {
   const initialPresetState = useMemo(() => getInitialPresetState(route?.match), [route?.match]);
@@ -340,21 +331,7 @@ export function RouteConditionsDrawer({
           />
         ) : null}
         <SheetMain className="flex flex-col gap-3 p-4">
-          <div className="flex items-center justify-between gap-3">
-            <TabSwitcher value={tab} onValueChange={handleTabChange} />
-            {route ? (
-              <Button
-                type="button"
-                variant="secondary"
-                mode="ghost"
-                size="2xs"
-                onClick={() => onSendTest(route)}
-                leadingIcon={RiSendPlaneLine}
-              >
-                Send test
-              </Button>
-            ) : null}
-          </div>
+          <TabSwitcher value={tab} onValueChange={handleTabChange} />
 
           {tab === 'presets' ? (
             <div className="flex flex-col gap-4">

--- a/apps/dashboard/src/components/domains/route-conditions-drawer.tsx
+++ b/apps/dashboard/src/components/domains/route-conditions-drawer.tsx
@@ -1,0 +1,444 @@
+import type { DomainRouteMatch } from '@novu/shared';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import {
+  RiCheckLine,
+  RiCloseLine,
+  RiFilterLine,
+  RiInformation2Line,
+  RiPriceTag3Line,
+  RiSendPlaneLine,
+} from 'react-icons/ri';
+import { formatQuery, generateID, type RuleGroupType } from 'react-querybuilder';
+import { parseJsonLogic } from 'react-querybuilder/parseJsonLogic';
+import type { DomainRouteResponse } from '@/api/domains';
+import { ConditionsEditor } from '@/components/conditions-editor/conditions-editor';
+import { Button } from '@/components/primitives/button';
+import { CompactButton } from '@/components/primitives/button-compact';
+import { Form } from '@/components/primitives/form/form';
+import { Hint, HintIcon } from '@/components/primitives/hint';
+import { Separator } from '@/components/primitives/separator';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetMain,
+  SheetTitle,
+} from '@/components/primitives/sheet';
+import { TagInput } from '@/components/primitives/tag-input';
+import { VisuallyHidden } from '@/components/primitives/visually-hidden';
+import { parseJsonLogicOptions } from '@/utils/conditions';
+import { cn } from '@/utils/ui';
+import {
+  isAllowedRouteMatchVariable,
+  ROUTE_MATCH_ENHANCED_VARIABLES,
+  ROUTE_MATCH_FIELDS,
+  ROUTE_MATCH_VARIABLES,
+} from './route-match-fields';
+import {
+  findMatchingRoutePreset,
+  getDefaultPresetValues,
+  type PresetInputValues,
+  ROUTE_MATCH_CATEGORIES,
+  ROUTE_MATCH_PRESETS,
+  type RouteMatchPreset,
+} from './route-match-presets';
+import { RouteValueEditor } from './route-value-editor';
+
+type RouteConditionsDrawerProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  domainName: string;
+  route: DomainRouteResponse | null;
+  onSave: (match: DomainRouteMatch | null) => Promise<void>;
+  onSendTest: (route: DomainRouteResponse) => void;
+  isSaving: boolean;
+};
+
+type DrawerTab = 'presets' | 'advanced';
+type ConditionsFormState = { query: RuleGroupType };
+
+const TAB_OPTIONS: Array<{ id: DrawerTab; label: string }> = [
+  { id: 'presets', label: 'Quick presets' },
+  { id: 'advanced', label: 'Advanced' },
+];
+
+function createEmptyQuery(): RuleGroupType {
+  return { id: generateID(), combinator: 'and', rules: [] };
+}
+
+function parseMatchToQuery(match?: DomainRouteMatch | null): RuleGroupType {
+  if (!match) return createEmptyQuery();
+
+  try {
+    return parseJsonLogic(match as never, {
+      generateIDs: true,
+      ...parseJsonLogicOptions,
+    });
+  } catch {
+    return createEmptyQuery();
+  }
+}
+
+function buildMatchFromQuery(query: RuleGroupType): DomainRouteMatch | null {
+  if (query.rules.length === 0) return null;
+
+  return formatQuery(query, { format: 'jsonlogic' }) as DomainRouteMatch;
+}
+
+function getInitialPresetState(match?: DomainRouteMatch | null): {
+  presetId: string;
+  values: PresetInputValues;
+  tab: DrawerTab;
+} {
+  const matchedPreset = findMatchingRoutePreset(match);
+  if (matchedPreset) {
+    return {
+      presetId: matchedPreset.preset.id,
+      values: matchedPreset.values,
+      tab: 'presets',
+    };
+  }
+
+  const firstPreset = ROUTE_MATCH_PRESETS[0];
+
+  return {
+    presetId: firstPreset.id,
+    values: getDefaultPresetValues(firstPreset),
+    tab: match ? 'advanced' : 'presets',
+  };
+}
+
+function hasRequiredPresetInputs(preset: RouteMatchPreset, values: PresetInputValues): boolean {
+  return preset.inputs.every((input) => (values[input.id] ?? []).length > 0);
+}
+
+function PresetIcon({
+  icon: Icon,
+  category,
+}: {
+  icon: RouteMatchPreset['icon'];
+  category: RouteMatchPreset['category'];
+}) {
+  const tone = {
+    allow: 'bg-success/10 text-success',
+    block: 'bg-destructive/10 text-destructive',
+    quality: 'bg-information/10 text-information',
+  }[category];
+
+  return (
+    <div className={cn('flex size-7 shrink-0 items-center justify-center rounded-md', tone)}>
+      <Icon className="size-3.5" />
+    </div>
+  );
+}
+
+function PresetCard({
+  preset,
+  selected,
+  values,
+  onSelect,
+  onValuesChange,
+}: {
+  preset: RouteMatchPreset;
+  selected: boolean;
+  values: PresetInputValues;
+  onSelect: () => void;
+  onValuesChange: (values: PresetInputValues) => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg border bg-bg-white-0 transition-colors',
+        selected ? 'border-stroke-strong shadow-xs' : 'border-stroke-soft hover:border-stroke-sub'
+      )}
+    >
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-pressed={selected}
+        className="flex w-full items-start gap-2.5 rounded-t-lg px-3 py-2.5 text-left outline-hidden focus-visible:ring-2 focus-visible:ring-stroke-strong focus-visible:ring-offset-1"
+      >
+        <PresetIcon icon={preset.icon} category={preset.category} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-text-strong text-label-sm font-medium">{preset.label}</span>
+            {selected ? (
+              <span className="bg-success/10 text-success inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-2xs font-medium">
+                <RiCheckLine className="size-3" />
+                Selected
+              </span>
+            ) : null}
+          </div>
+          <span className="text-text-soft mt-0.5 block text-label-xs">{preset.description}</span>
+        </div>
+      </button>
+      {selected && preset.inputs.length > 0 ? (
+        <>
+          <Separator />
+          <div className="space-y-3 px-3 py-2.5">
+            {preset.inputs.map((input) => (
+              <div key={input.id} className="space-y-1.5">
+                <label
+                  htmlFor={`${preset.id}-${input.id}`}
+                  className="text-foreground-500 text-2xs font-medium uppercase tracking-wide"
+                >
+                  {input.label}
+                </label>
+                <TagInput
+                  id={`${preset.id}-${input.id}`}
+                  value={values[input.id] ?? []}
+                  suggestions={input.defaultValue ?? []}
+                  placeholder={input.placeholder}
+                  size="xs"
+                  onChange={(next) => onValuesChange({ ...values, [input.id]: next })}
+                />
+              </div>
+            ))}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function DrawerHeader({ title, subtitle, onClose }: { title: string; subtitle: string; onClose: () => void }) {
+  return (
+    <header className="flex items-start justify-between gap-3 border-b border-stroke-soft bg-bg-white-0 px-4 py-3">
+      <div className="flex min-w-0 items-start gap-2.5">
+        <div className="bg-feature/10 text-feature flex size-7 shrink-0 items-center justify-center rounded-md">
+          <RiFilterLine className="size-3.5" />
+        </div>
+        <div className="min-w-0">
+          <SheetTitle className="text-text-strong text-label-md font-medium">{title}</SheetTitle>
+          <SheetDescription className="text-text-soft mt-0.5 truncate text-label-xs">{subtitle}</SheetDescription>
+        </div>
+      </div>
+      <CompactButton icon={RiCloseLine} variant="ghost" size="md" onClick={onClose}>
+        <span className="sr-only">Close</span>
+      </CompactButton>
+    </header>
+  );
+}
+
+function TabSwitcher({ value, onValueChange }: { value: DrawerTab; onValueChange: (tab: DrawerTab) => void }) {
+  return (
+    <div className="bg-bg-white-0 inline-flex items-center gap-1 rounded-md border border-stroke-soft p-0.5">
+      {TAB_OPTIONS.map((option) => (
+        <button
+          key={option.id}
+          type="button"
+          onClick={() => onValueChange(option.id)}
+          aria-pressed={value === option.id}
+          className={cn(
+            'rounded px-3 py-1 text-label-xs font-medium outline-hidden transition-colors focus-visible:ring-2 focus-visible:ring-stroke-strong focus-visible:ring-offset-1',
+            value === option.id ? 'bg-bg-weak text-text-strong' : 'text-text-soft hover:text-text-sub'
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function RouteConditionsDrawer({
+  open,
+  onOpenChange,
+  domainName,
+  route,
+  onSave,
+  onSendTest,
+  isSaving,
+}: RouteConditionsDrawerProps) {
+  const initialPresetState = useMemo(() => getInitialPresetState(route?.match), [route?.match]);
+  const [tab, setTab] = useState<DrawerTab>(initialPresetState.tab);
+  const [selectedPresetId, setSelectedPresetId] = useState(initialPresetState.presetId);
+  const [presetValues, setPresetValues] = useState<PresetInputValues>(initialPresetState.values);
+  const [query, setQuery] = useState<RuleGroupType>(() => parseMatchToQuery(route?.match));
+  const routeIdentity = route?._id;
+  const form = useForm<ConditionsFormState>({ defaultValues: { query } });
+  const { reset, setValue } = form;
+
+  useEffect(() => {
+    if (!routeIdentity) return;
+
+    const nextPresetState = getInitialPresetState(route?.match);
+    setTab(nextPresetState.tab);
+    setSelectedPresetId(nextPresetState.presetId);
+    setPresetValues(nextPresetState.values);
+    const nextQuery = parseMatchToQuery(route?.match);
+    setQuery(nextQuery);
+    reset({ query: nextQuery });
+  }, [routeIdentity, route?.match, reset]);
+
+  const selectedPreset = ROUTE_MATCH_PRESETS.find((preset) => preset.id === selectedPresetId) ?? ROUTE_MATCH_PRESETS[0];
+  const canSavePreset = hasRequiredPresetInputs(selectedPreset, presetValues);
+  const hasExistingMatch = Boolean(route?.match);
+
+  const handlePresetSelect = (preset: RouteMatchPreset) => {
+    setSelectedPresetId(preset.id);
+    setPresetValues(getDefaultPresetValues(preset));
+  };
+
+  const handleTabChange = (next: DrawerTab) => {
+    if (next === 'advanced') {
+      const match = selectedPreset.build(presetValues);
+      const nextQuery = parseMatchToQuery(match);
+      setQuery(nextQuery);
+      reset({ query: nextQuery });
+      setTab('advanced');
+
+      return;
+    }
+
+    const match = buildMatchFromQuery(query);
+    const matchedPreset = findMatchingRoutePreset(match);
+    if (matchedPreset) {
+      setSelectedPresetId(matchedPreset.preset.id);
+      setPresetValues(matchedPreset.values);
+    }
+    setTab('presets');
+  };
+
+  const handleSave = async () => {
+    if (!route) return;
+
+    const match = tab === 'presets' ? selectedPreset.build(presetValues) : buildMatchFromQuery(query);
+    await onSave(match);
+  };
+
+  const handleQueryChange = (nextQuery: RuleGroupType) => {
+    setQuery(nextQuery);
+    setValue('query', nextQuery);
+  };
+
+  const handleClear = async () => {
+    if (!route) return;
+
+    await onSave(null);
+  };
+
+  const groupedPresets = ROUTE_MATCH_CATEGORIES.map((category) => ({
+    ...category,
+    presets: ROUTE_MATCH_PRESETS.filter((preset) => preset.category === category.id),
+  }));
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="bg-bg-weak flex flex-col p-0 sm:max-w-[560px]">
+        <VisuallyHidden>
+          <SheetTitle>Route conditions</SheetTitle>
+          <SheetDescription>Configure conditions for this domain route.</SheetDescription>
+        </VisuallyHidden>
+        {route ? (
+          <DrawerHeader
+            title="Conditions"
+            subtitle={`${route.address}@${domainName}`}
+            onClose={() => onOpenChange(false)}
+          />
+        ) : null}
+        <SheetMain className="flex flex-col gap-3 p-4">
+          <div className="flex items-center justify-between gap-3">
+            <TabSwitcher value={tab} onValueChange={handleTabChange} />
+            {route ? (
+              <Button
+                type="button"
+                variant="secondary"
+                mode="ghost"
+                size="2xs"
+                onClick={() => onSendTest(route)}
+                leadingIcon={RiSendPlaneLine}
+              >
+                Send test
+              </Button>
+            ) : null}
+          </div>
+
+          {tab === 'presets' ? (
+            <div className="flex flex-col gap-4">
+              <Hint className="bg-bg-white-0 rounded-md border border-stroke-soft px-2.5 py-1.5">
+                <HintIcon as={RiInformation2Line} />
+                <span>
+                  Pick one preset. Inbound mail is delivered only when its rule matches; otherwise the wildcard route or
+                  no route is used.
+                </span>
+              </Hint>
+              {groupedPresets.map((category) => (
+                <section key={category.id} className="flex flex-col gap-2">
+                  <div className="flex items-center gap-2">
+                    <RiPriceTag3Line className="text-text-soft size-3.5" />
+                    <h3 className="text-text-soft text-2xs font-medium uppercase tracking-wide">{category.label}</h3>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    {category.presets.map((preset) => (
+                      <PresetCard
+                        key={preset.id}
+                        preset={preset}
+                        selected={preset.id === selectedPresetId}
+                        values={presetValues}
+                        onSelect={() => handlePresetSelect(preset)}
+                        onValuesChange={setPresetValues}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          ) : (
+            <div className="bg-bg-white-0 rounded-lg border border-stroke-soft p-3">
+              <Form {...form}>
+                <ConditionsEditor
+                  query={query}
+                  onQueryChange={handleQueryChange}
+                  fields={ROUTE_MATCH_FIELDS}
+                  saveForm={() => undefined}
+                  variables={ROUTE_MATCH_VARIABLES}
+                  isAllowedVariable={isAllowedRouteMatchVariable}
+                  enhancedVariables={ROUTE_MATCH_ENHANCED_VARIABLES}
+                  valueEditor={RouteValueEditor}
+                />
+              </Form>
+            </div>
+          )}
+        </SheetMain>
+        <SheetFooter className="bg-bg-white-0 mt-auto flex flex-row items-center justify-between border-t border-stroke-soft px-4 py-2.5">
+          <Button
+            type="button"
+            variant="secondary"
+            mode="ghost"
+            size="xs"
+            onClick={handleClear}
+            disabled={isSaving || !hasExistingMatch}
+          >
+            Clear conditions
+          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              mode="outline"
+              size="xs"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              mode="gradient"
+              variant="secondary"
+              size="xs"
+              onClick={handleSave}
+              isLoading={isSaving}
+              disabled={tab === 'presets' && !canSavePreset}
+            >
+              Save conditions
+            </Button>
+          </div>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/dashboard/src/components/domains/route-match-fields.ts
+++ b/apps/dashboard/src/components/domains/route-match-fields.ts
@@ -1,0 +1,61 @@
+import { ROUTE_MATCH_CONTEXT_PATHS } from '@novu/shared';
+import type { EnhancedField } from '@/components/conditions-editor/conditions-editor';
+import type { EnhancedLiquidVariable, LiquidVariable } from '@/utils/parseStepVariables';
+
+const FIELD_LABELS: Record<string, string> = {
+  'mail.fromAddress': 'From email',
+  'mail.fromDomain': 'From domain',
+  'mail.fromName': 'From name',
+  'mail.toAddress': 'To email',
+  'mail.toLocalPart': 'To local part',
+  'mail.toDomain': 'To domain',
+  'mail.subject': 'Subject',
+  'mail.text': 'Text body',
+  'mail.html': 'HTML body',
+  'mail.hasAttachments': 'Has attachments',
+  'mail.attachmentCount': 'Attachment count',
+  'mail.attachmentTotalBytes': 'Attachment total bytes',
+  'mail.inReplyTo': 'In reply to',
+  'mail.headers.auto-submitted': 'Auto-submitted header',
+  'mail.headers.authentication-results': 'Authentication-results header',
+  'domain.name': 'Domain name',
+  'route.address': 'Route address',
+  'auth.spf': 'SPF result',
+  'auth.dkim': 'DKIM result',
+  'auth.dmarc': 'DMARC result',
+  'auth.raw': 'Raw auth results',
+};
+
+const NUMBER_FIELDS = new Set(['mail.attachmentCount', 'mail.attachmentTotalBytes']);
+const BOOLEAN_FIELDS = new Set(['mail.hasAttachments']);
+
+function getDataType(path: string): EnhancedField['dataType'] {
+  if (NUMBER_FIELDS.has(path)) return 'number';
+  if (BOOLEAN_FIELDS.has(path)) return 'boolean';
+
+  return 'string';
+}
+
+export const ROUTE_MATCH_FIELDS: EnhancedField[] = ROUTE_MATCH_CONTEXT_PATHS.map((path) => ({
+  name: path,
+  label: FIELD_LABELS[path] ?? path,
+  value: path,
+  dataType: getDataType(path),
+}));
+
+export const ROUTE_MATCH_VARIABLES: LiquidVariable[] = ROUTE_MATCH_FIELDS.map((field) => ({
+  name: field.name,
+  displayLabel: field.label,
+}));
+
+export const ROUTE_MATCH_ENHANCED_VARIABLES: EnhancedLiquidVariable[] = ROUTE_MATCH_FIELDS.map((field) => ({
+  name: field.name,
+  displayLabel: field.label,
+  dataType: field.dataType,
+  inputType: field.inputType,
+  format: field.format,
+}));
+
+export function isAllowedRouteMatchVariable(variable: LiquidVariable): boolean {
+  return ROUTE_MATCH_FIELDS.some((field) => field.name === variable.name);
+}

--- a/apps/dashboard/src/components/domains/route-match-presets.ts
+++ b/apps/dashboard/src/components/domains/route-match-presets.ts
@@ -1,0 +1,274 @@
+import type { DomainRouteMatch } from '@novu/shared';
+import type { IconType } from 'react-icons';
+import {
+  RiCheckboxCircleLine,
+  RiForbid2Line,
+  RiMailForbidLine,
+  RiReplyLine,
+  RiSearchLine,
+  RiShieldCheckLine,
+  RiSpamLine,
+  RiUserForbidLine,
+} from 'react-icons/ri';
+
+export type PresetCategory = 'allow' | 'block' | 'quality';
+
+export type PresetInputType = 'email-list' | 'domain-list' | 'keyword-list';
+
+export type PresetInputDef = {
+  id: string;
+  label: string;
+  placeholder: string;
+  type: PresetInputType;
+  defaultValue?: string[];
+};
+
+export type PresetInputValues = Record<string, string[]>;
+
+export type RouteMatchPreset = {
+  id: string;
+  label: string;
+  description: string;
+  category: PresetCategory;
+  icon: IconType;
+  inputs: PresetInputDef[];
+  build: (values: PresetInputValues) => DomainRouteMatch;
+  matches: (rule: DomainRouteMatch) => PresetInputValues | null;
+};
+
+export const ROUTE_MATCH_CATEGORIES: Array<{ id: PresetCategory; label: string }> = [
+  { id: 'allow', label: 'Allow lists' },
+  { id: 'block', label: 'Block lists' },
+  { id: 'quality', label: 'Quality & routing' },
+];
+
+const FREE_MAIL_PROVIDERS = [
+  'gmail.com',
+  'yahoo.com',
+  'hotmail.com',
+  'outlook.com',
+  'aol.com',
+  'icloud.com',
+  'proton.me',
+  'gmx.com',
+  'mail.ru',
+  'live.com',
+  'msn.com',
+];
+
+function normalizeList(values: string[] = []): string[] {
+  return Array.from(new Set(values.map((value) => value.trim().toLowerCase()).filter(Boolean)));
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function listRule(path: string, values: string[]): DomainRouteMatch {
+  return { in: [{ var: path }, normalizeList(values)] };
+}
+
+function negatedListRule(path: string, values: string[]): DomainRouteMatch {
+  return { '!': listRule(path, values) };
+}
+
+function matchListRule(rule: DomainRouteMatch, path: string): string[] | null {
+  if (!rule || typeof rule !== 'object' || Array.isArray(rule)) return null;
+
+  const inRule = (rule as { in?: unknown }).in;
+  if (!Array.isArray(inRule) || inRule.length !== 2) return null;
+
+  const [variable, values] = inRule;
+  if (!variable || typeof variable !== 'object' || (variable as { var?: unknown }).var !== path) return null;
+  if (!Array.isArray(values) || !values.every((value) => typeof value === 'string')) return null;
+
+  return values;
+}
+
+function matchNegatedListRule(rule: DomainRouteMatch, path: string): string[] | null {
+  if (!rule || typeof rule !== 'object' || Array.isArray(rule)) return null;
+
+  const negated = (rule as { '!': DomainRouteMatch })['!'];
+
+  return matchListRule(negated, path);
+}
+
+function exactRuleMatcher(expected: DomainRouteMatch) {
+  return (rule: DomainRouteMatch): PresetInputValues | null => {
+    if (stableStringify(rule) !== stableStringify(expected)) return null;
+
+    return {};
+  };
+}
+
+const rejectUnsignedMailRule: DomainRouteMatch = {
+  and: [{ '==': [{ var: 'auth.spf' }, 'pass'] }, { '==': [{ var: 'auth.dkim' }, 'pass'] }],
+};
+
+const dropAutoRespondersRule: DomainRouteMatch = {
+  '!': {
+    or: [
+      {
+        and: [
+          { '!=': [{ var: 'mail.headers.auto-submitted' }, null] },
+          { '!=': [{ var: 'mail.headers.auto-submitted' }, 'no'] },
+        ],
+      },
+      { startsWith: [{ var: 'mail.subject' }, 'Auto-reply:'] },
+      { startsWith: [{ var: 'mail.subject' }, 'Out of office'] },
+    ],
+  },
+};
+
+const repliesOnlyRule: DomainRouteMatch = { '!=': [{ var: 'mail.inReplyTo' }, null] };
+
+export const ROUTE_MATCH_PRESETS: RouteMatchPreset[] = [
+  {
+    id: 'allow-senders',
+    label: 'Allow listed senders',
+    description: 'Deliver only when the sender email address is in the list.',
+    category: 'allow',
+    icon: RiCheckboxCircleLine,
+    inputs: [{ id: 'senders', label: 'Sender emails', placeholder: 'jane@acme.com', type: 'email-list' }],
+    build: (values) => listRule('mail.fromAddress', values.senders),
+    matches: (rule) => {
+      const senders = matchListRule(rule, 'mail.fromAddress');
+      if (!senders) return null;
+
+      return { senders };
+    },
+  },
+  {
+    id: 'allow-domains',
+    label: 'Allow sender domains',
+    description: 'Deliver only when the sender domain is in the list.',
+    category: 'allow',
+    icon: RiCheckboxCircleLine,
+    inputs: [{ id: 'domains', label: 'Sender domains', placeholder: 'acme.com', type: 'domain-list' }],
+    build: (values) => listRule('mail.fromDomain', values.domains),
+    matches: (rule) => {
+      const domains = matchListRule(rule, 'mail.fromDomain');
+      if (!domains) return null;
+
+      return { domains };
+    },
+  },
+  {
+    id: 'block-senders',
+    label: 'Block listed senders',
+    description: 'Deliver unless the sender email address is in the list.',
+    category: 'block',
+    icon: RiUserForbidLine,
+    inputs: [
+      {
+        id: 'senders',
+        label: 'Sender emails',
+        placeholder: 'spam@example.com',
+        type: 'email-list',
+      },
+    ],
+    build: (values) => negatedListRule('mail.fromAddress', values.senders),
+    matches: (rule) => {
+      const senders = matchNegatedListRule(rule, 'mail.fromAddress');
+      if (!senders) return null;
+
+      return { senders };
+    },
+  },
+  {
+    id: 'block-domains',
+    label: 'Block sender domains',
+    description: 'Deliver unless the sender domain is in the list.',
+    category: 'block',
+    icon: RiForbid2Line,
+    inputs: [{ id: 'domains', label: 'Sender domains', placeholder: 'spam.io', type: 'domain-list' }],
+    build: (values) => negatedListRule('mail.fromDomain', values.domains),
+    matches: (rule) => {
+      const domains = matchNegatedListRule(rule, 'mail.fromDomain');
+      if (!domains) return null;
+
+      return { domains };
+    },
+  },
+  {
+    id: 'block-free-mail',
+    label: 'Block free-mail providers',
+    description: 'Reject mail from common consumer mailbox providers.',
+    category: 'block',
+    icon: RiMailForbidLine,
+    inputs: [
+      {
+        id: 'domains',
+        label: 'Blocked domains',
+        placeholder: 'gmail.com',
+        type: 'domain-list',
+        defaultValue: FREE_MAIL_PROVIDERS,
+      },
+    ],
+    build: (values) => negatedListRule('mail.fromDomain', values.domains),
+    matches: () => null,
+  },
+  {
+    id: 'reject-unsigned-mail',
+    label: 'Reject unsigned mail',
+    description: 'Deliver only when SPF and DKIM both pass.',
+    category: 'quality',
+    icon: RiShieldCheckLine,
+    inputs: [],
+    build: () => rejectUnsignedMailRule,
+    matches: exactRuleMatcher(rejectUnsignedMailRule),
+  },
+  {
+    id: 'drop-auto-responders',
+    label: 'Drop auto-responders',
+    description: 'Skip common out-of-office and auto-reply messages.',
+    category: 'quality',
+    icon: RiSpamLine,
+    inputs: [],
+    build: () => dropAutoRespondersRule,
+    matches: exactRuleMatcher(dropAutoRespondersRule),
+  },
+  {
+    id: 'replies-only',
+    label: 'Replies only',
+    description: 'Deliver only messages that are replies to an existing thread.',
+    category: 'quality',
+    icon: RiReplyLine,
+    inputs: [],
+    build: () => repliesOnlyRule,
+    matches: exactRuleMatcher(repliesOnlyRule),
+  },
+  {
+    id: 'subject-keywords',
+    label: 'Subject contains keyword',
+    description: 'Deliver only when the subject includes one of these keywords.',
+    category: 'quality',
+    icon: RiSearchLine,
+    inputs: [{ id: 'keywords', label: 'Keywords', placeholder: 'urgent', type: 'keyword-list' }],
+    build: (values) => ({
+      or: normalizeList(values.keywords).map((keyword) => ({ contains: [{ var: 'mail.subject' }, keyword] })),
+    }),
+    matches: () => null,
+  },
+];
+
+export function findMatchingRoutePreset(match?: DomainRouteMatch | null) {
+  if (!match) return null;
+
+  for (const preset of ROUTE_MATCH_PRESETS) {
+    const values = preset.matches(match);
+    if (values) {
+      return { preset, values };
+    }
+  }
+
+  return null;
+}
+
+export function getDefaultPresetValues(preset: RouteMatchPreset): PresetInputValues {
+  return Object.fromEntries(preset.inputs.map((input) => [input.id, input.defaultValue ?? []]));
+}
+
+export function parsePresetInput(value: string): string[] {
+  return normalizeList(value.split(','));
+}

--- a/apps/dashboard/src/components/domains/route-value-editor.tsx
+++ b/apps/dashboard/src/components/domains/route-value-editor.tsx
@@ -1,0 +1,121 @@
+import { useFormContext } from 'react-hook-form';
+import { useValueEditor, type ValueEditorProps } from 'react-querybuilder';
+import { Input } from '@/components/primitives/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/primitives/select';
+
+const BOOLEAN_OPTIONS = [
+  { value: 'true', label: 'true' },
+  { value: 'false', label: 'false' },
+];
+
+function getQueryPath(path: number[]): string {
+  return `query.rules.${path.join('.rules.')}.value`;
+}
+
+function PlainInput({
+  value,
+  onChange,
+  placeholder,
+  hasError,
+  disabled,
+  type = 'text',
+  className = 'w-48',
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+  hasError: boolean;
+  disabled?: boolean;
+  type?: 'text' | 'number';
+  className?: string;
+}) {
+  return (
+    <Input
+      size="2xs"
+      type={type}
+      value={value}
+      placeholder={placeholder}
+      hasError={hasError}
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value)}
+      className={className}
+    />
+  );
+}
+
+export function RouteValueEditor(props: ValueEditorProps) {
+  const form = useFormContext();
+  const queryPath = getQueryPath(props.path);
+  const { error } = form?.getFieldState ? form.getFieldState(queryPath, form.formState) : { error: undefined };
+  const hasError = Boolean(error);
+
+  const { value, handleOnChange, operator, disabled, inputType } = props;
+  const { valueAsArray, multiValueHandler } = useValueEditor(props);
+  const stringValue = typeof value === 'string' ? value : value == null ? '' : String(value);
+  const placeholder =
+    typeof (props as { placeholder?: unknown }).placeholder === 'string'
+      ? ((props as { placeholder?: string }).placeholder ?? 'value')
+      : 'value';
+
+  if (operator === 'null' || operator === 'notNull') {
+    return null;
+  }
+
+  if (operator === 'between' || operator === 'notBetween') {
+    const stringValueAsArray = valueAsArray.map((v) => (typeof v === 'string' ? v : `${v ?? ''}`));
+
+    return (
+      <div className="flex items-center gap-1.5">
+        <PlainInput
+          className="w-24"
+          value={stringValueAsArray[0] ?? ''}
+          placeholder="from"
+          hasError={hasError && !stringValueAsArray[0]}
+          disabled={disabled}
+          type={inputType === 'number' ? 'number' : 'text'}
+          onChange={(next) => multiValueHandler(next, 0)}
+        />
+        <span className="text-text-soft text-paragraph-xs">and</span>
+        <PlainInput
+          className="w-24"
+          value={stringValueAsArray[1] ?? ''}
+          placeholder="to"
+          hasError={hasError && !stringValueAsArray[1]}
+          disabled={disabled}
+          type={inputType === 'number' ? 'number' : 'text'}
+          onChange={(next) => multiValueHandler(next, 1)}
+        />
+      </div>
+    );
+  }
+
+  if (inputType === 'checkbox' || inputType === 'boolean') {
+    const current = stringValue === 'true' || stringValue === 'false' ? stringValue : 'true';
+
+    return (
+      <Select value={current} onValueChange={handleOnChange} disabled={disabled}>
+        <SelectTrigger className="bg-bg-white text-paragraph-xs h-7 w-24 px-2" size="2xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {BOOLEAN_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value} className="text-paragraph-xs">
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  return (
+    <PlainInput
+      value={stringValue}
+      placeholder={placeholder}
+      hasError={hasError}
+      disabled={disabled}
+      type={inputType === 'number' ? 'number' : 'text'}
+      onChange={handleOnChange}
+    />
+  );
+}

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.spec.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.spec.ts
@@ -1,6 +1,6 @@
 import { InboundDomainRouteDelivery } from '@novu/application-generic';
 import { DomainRepository, DomainRouteRepository } from '@novu/dal';
-import { DomainRouteTypeEnum, DomainStatusEnum } from '@novu/shared';
+import { DomainRouteMatch, DomainRouteTypeEnum, DomainStatusEnum } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { InboundEmailParseCommand } from '../inbound-email-parse.command';
@@ -21,7 +21,9 @@ function makeVerifiedDomain() {
   };
 }
 
-function makeRoutes(routes: Array<{ address: string; type: DomainRouteTypeEnum; destination?: string }>) {
+function makeRoutes(
+  routes: Array<{ address: string; type: DomainRouteTypeEnum; destination?: string; match?: DomainRouteMatch }>
+) {
   return routes.map((route, index) => ({
     _id: `route-${index}`,
     _domainId: 'domain-001',
@@ -144,6 +146,96 @@ describe('DomainRouteStrategy', () => {
     sinon.assert.calledOnce(inboundDomainRouteDelivery.deliverToWebhook);
     const call = inboundDomainRouteDelivery.deliverToWebhook.getCall(0);
     expect(call.args[0].route.address).to.equal('support');
+  });
+
+  it('should deliver an exact route when its match rule passes', async () => {
+    const routes = makeRoutes([
+      {
+        address: 'support',
+        type: DomainRouteTypeEnum.WEBHOOK,
+        match: { contains: [{ var: 'mail.subject' }, 'Hello'] },
+      },
+    ]);
+    domainRepository.findByName.resolves(makeVerifiedDomain() as any);
+    domainRouteRepository.findByDomainAndAddresses.resolves(routes as any);
+
+    await strategy.execute(makeCommand('support'));
+
+    sinon.assert.calledOnce(inboundDomainRouteDelivery.deliverToWebhook);
+    expect(inboundDomainRouteDelivery.deliverToWebhook.getCall(0).args[0].route.address).to.equal('support');
+  });
+
+  it('should fall through to wildcard when the exact route match rule fails', async () => {
+    const routes = makeRoutes([
+      {
+        address: 'support',
+        type: DomainRouteTypeEnum.WEBHOOK,
+        match: { contains: [{ var: 'mail.subject' }, 'Nope'] },
+      },
+      { address: '*', type: DomainRouteTypeEnum.WEBHOOK },
+    ]);
+    domainRepository.findByName.resolves(makeVerifiedDomain() as any);
+    domainRouteRepository.findByDomainAndAddresses.resolves(routes as any);
+
+    await strategy.execute(makeCommand('support'));
+
+    sinon.assert.calledOnce(inboundDomainRouteDelivery.deliverToWebhook);
+    expect(inboundDomainRouteDelivery.deliverToWebhook.getCall(0).args[0].route.address).to.equal('*');
+  });
+
+  it('should deliver a wildcard route when its match rule passes', async () => {
+    const routes = makeRoutes([
+      {
+        address: '*',
+        type: DomainRouteTypeEnum.WEBHOOK,
+        match: { contains: [{ var: 'mail.subject' }, 'Hello'] },
+      },
+    ]);
+    domainRepository.findByName.resolves(makeVerifiedDomain() as any);
+    domainRouteRepository.findByDomainAndAddresses.resolves(routes as any);
+
+    await strategy.execute(makeCommand('anything'));
+
+    sinon.assert.calledOnce(inboundDomainRouteDelivery.deliverToWebhook);
+  });
+
+  it('should not deliver when exact and wildcard match rules fail', async () => {
+    const routes = makeRoutes([
+      {
+        address: 'support',
+        type: DomainRouteTypeEnum.WEBHOOK,
+        match: { contains: [{ var: 'mail.subject' }, 'Nope'] },
+      },
+      {
+        address: '*',
+        type: DomainRouteTypeEnum.WEBHOOK,
+        match: { contains: [{ var: 'mail.subject' }, 'Also nope'] },
+      },
+    ]);
+    domainRepository.findByName.resolves(makeVerifiedDomain() as any);
+    domainRouteRepository.findByDomainAndAddresses.resolves(routes as any);
+
+    await strategy.execute(makeCommand('support'));
+
+    sinon.assert.notCalled(inboundDomainRouteDelivery.deliverToWebhook);
+    sinon.assert.notCalled(inboundDomainRouteDelivery.deliverToAgent);
+  });
+
+  it('should fail closed when route match evaluation throws', async () => {
+    const routes = makeRoutes([
+      {
+        address: 'support',
+        type: DomainRouteTypeEnum.WEBHOOK,
+        match: { unknownOperation: [{ var: 'mail.subject' }, 'Hello'] },
+      },
+    ]);
+    domainRepository.findByName.resolves(makeVerifiedDomain() as any);
+    domainRouteRepository.findByDomainAndAddresses.resolves(routes as any);
+
+    await strategy.execute(makeCommand('support'));
+
+    sinon.assert.notCalled(inboundDomainRouteDelivery.deliverToWebhook);
+    sinon.assert.notCalled(inboundDomainRouteDelivery.deliverToAgent);
   });
 
   it('should not fire any handler when no route matches', async () => {

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/domain-route.strategy.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
-import { InboundDomainRouteDelivery } from '@novu/application-generic';
-import { DomainRepository, DomainRouteRepository } from '@novu/dal';
+import { buildRouteMatchContext, evaluateRules, InboundDomainRouteDelivery } from '@novu/application-generic';
+import { DomainRepository, DomainRouteEntity, DomainRouteRepository } from '@novu/dal';
 import { DomainRouteTypeEnum, DomainStatusEnum } from '@novu/shared';
 import { InboundEmailParseCommand } from '../inbound-email-parse.command';
 
@@ -47,15 +47,22 @@ export class DomainRouteStrategy {
       organizationId: domain._organizationId,
       addresses: [localPart, '*'],
     });
-    const route = routes.find((r) => r.address === localPart) ?? routes.find((r) => r.address === '*');
+    const exactRoute = routes.find((r) => r.address === localPart);
+    const wildcardRoute = routes.find((r) => r.address === '*');
+    const mail = this.commandToMail(command);
+    const route = this.selectRoute({
+      exactRoute,
+      wildcardRoute,
+      domain,
+      mail,
+      toAddress,
+    });
 
     if (!route) {
       Logger.log({ toAddress, domain: domain.name }, 'No route matched the inbound email', LOG_CONTEXT);
 
       return;
     }
-
-    const mail = this.commandToMail(command);
 
     if (route.type === DomainRouteTypeEnum.WEBHOOK) {
       await this.inboundDomainRouteDelivery.deliverToWebhook({
@@ -79,6 +86,82 @@ export class DomainRouteStrategy {
         toAddress,
       });
     }
+  }
+
+  private selectRoute({
+    exactRoute,
+    wildcardRoute,
+    domain,
+    mail,
+    toAddress,
+  }: {
+    exactRoute?: DomainRouteEntity;
+    wildcardRoute?: DomainRouteEntity;
+    domain: Parameters<typeof buildRouteMatchContext>[0];
+    mail: ReturnType<DomainRouteStrategy['commandToMail']>;
+    toAddress: string;
+  }): DomainRouteEntity | undefined {
+    if (!exactRoute && !wildcardRoute) {
+      return undefined;
+    }
+
+    if (this.doesRouteMatch({ route: exactRoute, domain, mail, toAddress, candidate: 'exact' })) {
+      return exactRoute;
+    }
+
+    if (this.doesRouteMatch({ route: wildcardRoute, domain, mail, toAddress, candidate: 'wildcard' })) {
+      return wildcardRoute;
+    }
+
+    Logger.log({ toAddress, domain: domain.name }, 'Domain route match rules dropped the inbound email', LOG_CONTEXT);
+
+    return undefined;
+  }
+
+  private doesRouteMatch({
+    route,
+    domain,
+    mail,
+    toAddress,
+    candidate,
+  }: {
+    route?: DomainRouteEntity;
+    domain: Parameters<typeof buildRouteMatchContext>[0];
+    mail: ReturnType<DomainRouteStrategy['commandToMail']>;
+    toAddress: string;
+    candidate: 'exact' | 'wildcard';
+  }): boolean {
+    if (!route) {
+      return false;
+    }
+
+    if (!route.match) {
+      Logger.log(
+        { toAddress, domain: domain.name, candidate, matchPassed: true },
+        'Route has no match rule',
+        LOG_CONTEXT
+      );
+
+      return true;
+    }
+
+    const context = buildRouteMatchContext(domain, route, mail);
+    const evaluation = evaluateRules(route.match as never, context, true);
+    if (evaluation.error) {
+      Logger.warn(
+        { toAddress, domain: domain.name, candidate, err: evaluation.error },
+        'Route match rule evaluation failed',
+        LOG_CONTEXT
+      );
+    }
+
+    Logger.log(
+      { toAddress, domain: domain.name, candidate, matchPassed: evaluation.result },
+      'Evaluated route match rule',
+      LOG_CONTEXT
+    );
+
+    return evaluation.result;
   }
 
   private commandToMail(command: InboundEmailParseCommand) {

--- a/libs/application-generic/src/usecases/inbound-domain-route-delivery/build-route-match-context.spec.ts
+++ b/libs/application-generic/src/usecases/inbound-domain-route-delivery/build-route-match-context.spec.ts
@@ -1,0 +1,95 @@
+import { DomainRouteAuthStatusEnum, DomainRouteTypeEnum, DomainStatusEnum } from '@novu/shared';
+import { expect } from 'chai';
+import { buildRouteMatchContext } from './build-route-match-context';
+import type { InboundDomainRouteMailInput, RoutableDomain } from './inbound-domain-route-delivery.usecase';
+
+const domain: RoutableDomain = {
+  _id: 'domain-001',
+  name: 'example.com',
+  status: DomainStatusEnum.VERIFIED,
+  mxRecordConfigured: true,
+  _environmentId: 'env-001',
+  _organizationId: 'org-001',
+  data: { tenant: 'acme' },
+};
+
+const route = {
+  _id: 'route-001',
+  _domainId: 'domain-001',
+  address: 'support',
+  type: DomainRouteTypeEnum.WEBHOOK,
+  data: { queue: 'tier-1' },
+  _environmentId: 'env-001',
+  _organizationId: 'org-001',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+function makeMail(overrides: Partial<InboundDomainRouteMailInput> = {}): InboundDomainRouteMailInput {
+  return {
+    from: [{ address: 'Sender@Acme.com', name: 'Sender' }],
+    to: [{ address: 'Support@Example.com', name: '' }],
+    subject: 'Hello',
+    html: '<p>Hello</p>',
+    text: 'Hello',
+    headers: {
+      'content-type': 'text/plain',
+      from: 'Sender@Acme.com',
+      to: 'Support@Example.com',
+      subject: 'Hello',
+      'message-id': 'msg-001',
+      date: new Date().toUTCString(),
+      'mime-version': '1.0',
+      'authentication-results': 'mx.example; spf=pass smtp.mailfrom=acme.com; dkim=fail; dmarc=neutral',
+    } as InboundDomainRouteMailInput['headers'],
+    attachments: [{ size: 10 }, { content: 'hello' }],
+    messageId: 'msg-001',
+    inReplyTo: 'reply-001',
+    date: new Date(),
+    cc: [],
+    ...overrides,
+  };
+}
+
+describe('buildRouteMatchContext', () => {
+  it('normalizes addresses, metadata, attachments, and auth results', () => {
+    const context = buildRouteMatchContext(domain, route, makeMail());
+
+    expect(context.mail.fromAddress).to.equal('sender@acme.com');
+    expect(context.mail.fromDomain).to.equal('acme.com');
+    expect(context.mail.toLocalPart).to.equal('support');
+    expect(context.domain.data).to.deep.equal({ tenant: 'acme' });
+    expect(context.route.data).to.deep.equal({ queue: 'tier-1' });
+    expect(context.mail.hasAttachments).to.equal(true);
+    expect(context.mail.attachmentCount).to.equal(2);
+    expect(context.mail.attachmentTotalBytes).to.equal(15);
+    expect(context.auth.spf).to.equal(DomainRouteAuthStatusEnum.PASS);
+    expect(context.auth.dkim).to.equal(DomainRouteAuthStatusEnum.FAIL);
+    expect(context.auth.dmarc).to.equal(DomainRouteAuthStatusEnum.NEUTRAL);
+  });
+
+  it('falls back to none when authentication headers are missing or malformed', () => {
+    const context = buildRouteMatchContext(
+      domain,
+      route,
+      makeMail({
+        headers: {
+          'content-type': 'text/plain',
+          from: 'sender@acme.com',
+          to: 'support@example.com',
+          subject: 'Hello',
+          'message-id': 'msg-001',
+          date: new Date().toUTCString(),
+          'mime-version': '1.0',
+        },
+        attachments: [],
+      })
+    );
+
+    expect(context.auth.spf).to.equal(DomainRouteAuthStatusEnum.NONE);
+    expect(context.auth.dkim).to.equal(DomainRouteAuthStatusEnum.NONE);
+    expect(context.auth.dmarc).to.equal(DomainRouteAuthStatusEnum.NONE);
+    expect(context.mail.hasAttachments).to.equal(false);
+    expect(context.mail.attachmentTotalBytes).to.equal(0);
+  });
+});

--- a/libs/application-generic/src/usecases/inbound-domain-route-delivery/build-route-match-context.ts
+++ b/libs/application-generic/src/usecases/inbound-domain-route-delivery/build-route-match-context.ts
@@ -1,0 +1,90 @@
+import { DomainRouteAuthStatusEnum, RouteMatchContext } from '@novu/shared';
+import type { DomainRouteEntity } from '@novu/dal';
+import type { InboundDomainRouteMailInput, RoutableDomain } from './inbound-domain-route-delivery.usecase';
+
+type AttachmentLike = {
+  size?: unknown;
+  contentLength?: unknown;
+  content?: unknown;
+};
+
+function splitEmailAddress(address: string): { localPart: string; domain: string } {
+  const [localPart = '', domain = ''] = address.toLowerCase().split('@');
+
+  return { localPart, domain };
+}
+
+function normalizeHeaders(headers: InboundDomainRouteMailInput['headers']): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers ?? {}).map(([key, value]) => [key.toLowerCase(), String(value ?? '')])
+  );
+}
+
+function parseAuthStatus(raw: string, key: 'spf' | 'dkim' | 'dmarc'): DomainRouteAuthStatusEnum {
+  const match = raw.toLowerCase().match(new RegExp(`${key}=([a-z]+)`));
+  const value = match?.[1];
+
+  if (value && Object.values(DomainRouteAuthStatusEnum).includes(value as DomainRouteAuthStatusEnum)) {
+    return value as DomainRouteAuthStatusEnum;
+  }
+
+  return DomainRouteAuthStatusEnum.NONE;
+}
+
+function getAttachmentSize(attachment: unknown): number {
+  const value = attachment as AttachmentLike;
+
+  if (typeof value?.size === 'number') return value.size;
+  if (typeof value?.contentLength === 'number') return value.contentLength;
+  if (typeof value?.content === 'string') return Buffer.byteLength(value.content);
+  if (Buffer.isBuffer(value?.content)) return value.content.byteLength;
+
+  return 0;
+}
+
+export function buildRouteMatchContext(
+  domain: RoutableDomain,
+  route: DomainRouteEntity,
+  mail: InboundDomainRouteMailInput
+): RouteMatchContext {
+  const from = mail.from[0] ?? { address: '', name: '' };
+  const to = mail.to[0] ?? { address: `${route.address}@${domain.name}`, name: '' };
+  const headers = normalizeHeaders(mail.headers);
+  const rawAuthHeader = headers['authentication-results'] ?? '';
+  const fromParts = splitEmailAddress(from.address);
+  const toParts = splitEmailAddress(to.address);
+  const attachments = mail.attachments ?? [];
+
+  return {
+    mail: {
+      fromAddress: from.address.toLowerCase(),
+      fromDomain: fromParts.domain,
+      fromName: from.name || undefined,
+      toAddress: to.address.toLowerCase(),
+      toLocalPart: toParts.localPart,
+      toDomain: toParts.domain,
+      subject: mail.subject,
+      text: mail.text,
+      html: mail.html,
+      hasAttachments: attachments.length > 0,
+      attachmentCount: attachments.length,
+      attachmentTotalBytes: attachments.reduce<number>((total, attachment) => total + getAttachmentSize(attachment), 0),
+      inReplyTo: mail.inReplyTo,
+      headers,
+    },
+    domain: {
+      name: domain.name,
+      data: domain.data ?? {},
+    },
+    route: {
+      address: route.address,
+      data: route.data ?? {},
+    },
+    auth: {
+      spf: parseAuthStatus(rawAuthHeader, 'spf'),
+      dkim: parseAuthStatus(rawAuthHeader, 'dkim'),
+      dmarc: parseAuthStatus(rawAuthHeader, 'dmarc'),
+      raw: rawAuthHeader,
+    },
+  };
+}

--- a/libs/application-generic/src/usecases/index.ts
+++ b/libs/application-generic/src/usecases/index.ts
@@ -35,6 +35,7 @@ export * from './get-tenant';
 export * from './get-topic-subscribers';
 export * from './get-workflow';
 export * from './get-workflow-with-preferences';
+export * from './inbound-domain-route-delivery/build-route-match-context';
 export * from './inbound-domain-route-delivery/inbound-domain-route-delivery.usecase';
 export * from './layout-variables-schema';
 export * from './merge-preferences';

--- a/libs/dal/src/repositories/domain-route/domain-route.entity.ts
+++ b/libs/dal/src/repositories/domain-route/domain-route.entity.ts
@@ -1,4 +1,4 @@
-import { DomainRouteTypeEnum } from '@novu/shared';
+import { DomainRouteMatch, DomainRouteTypeEnum } from '@novu/shared';
 import type { ChangePropsValueType } from '../../types/helpers';
 import type { EnvironmentId } from '../environment';
 import type { OrganizationId } from '../organization';
@@ -15,6 +15,8 @@ export class DomainRouteEntity {
   type: DomainRouteTypeEnum;
 
   data?: Record<string, string>;
+
+  match?: DomainRouteMatch;
 
   _environmentId: EnvironmentId;
 

--- a/libs/dal/src/repositories/domain-route/domain-route.schema.ts
+++ b/libs/dal/src/repositories/domain-route/domain-route.schema.ts
@@ -26,6 +26,9 @@ const domainRouteSchema = new Schema<DomainRouteDBModel>(
     data: {
       type: Schema.Types.Mixed,
     },
+    match: {
+      type: Schema.Types.Mixed,
+    },
     _organizationId: {
       type: Schema.Types.ObjectId,
       ref: 'Organization',

--- a/packages/shared/src/types/domain.ts
+++ b/packages/shared/src/types/domain.ts
@@ -8,6 +8,75 @@ export enum DomainRouteTypeEnum {
   WEBHOOK = 'webhook',
 }
 
+export type DomainRouteMatch = Record<string, unknown>;
+
+export enum DomainRouteAuthStatusEnum {
+  PASS = 'pass',
+  FAIL = 'fail',
+  SOFTFAIL = 'softfail',
+  NEUTRAL = 'neutral',
+  NONE = 'none',
+}
+
+export type RouteMatchContext = {
+  mail: {
+    fromAddress: string;
+    fromDomain: string;
+    fromName?: string;
+    toAddress: string;
+    toLocalPart: string;
+    toDomain: string;
+    subject: string;
+    text: string;
+    html: string;
+    hasAttachments: boolean;
+    attachmentCount: number;
+    attachmentTotalBytes: number;
+    inReplyTo?: string;
+    headers: Record<string, string>;
+  };
+  domain: {
+    name: string;
+    data: Record<string, string>;
+  };
+  route: {
+    address: string;
+    data: Record<string, string>;
+  };
+  auth: {
+    spf: DomainRouteAuthStatusEnum;
+    dkim: DomainRouteAuthStatusEnum;
+    dmarc: DomainRouteAuthStatusEnum;
+    raw: string;
+  };
+};
+
+export const ROUTE_MATCH_CONTEXT_PATHS = [
+  'mail.fromAddress',
+  'mail.fromDomain',
+  'mail.fromName',
+  'mail.toAddress',
+  'mail.toLocalPart',
+  'mail.toDomain',
+  'mail.subject',
+  'mail.text',
+  'mail.html',
+  'mail.hasAttachments',
+  'mail.attachmentCount',
+  'mail.attachmentTotalBytes',
+  'mail.inReplyTo',
+  'mail.headers.auto-submitted',
+  'mail.headers.authentication-results',
+  'domain.name',
+  'route.address',
+  'auth.spf',
+  'auth.dkim',
+  'auth.dmarc',
+  'auth.raw',
+] as const;
+
+export type RouteMatchContextPath = (typeof ROUTE_MATCH_CONTEXT_PATHS)[number];
+
 export enum DomainDiagnosticCodeEnum {
   MX_MISSING = 'mx_missing',
   MX_WRONG_TARGET = 'mx_wrong_target',

--- a/packages/shared/src/types/feature-flags.ts
+++ b/packages/shared/src/types/feature-flags.ts
@@ -100,6 +100,8 @@ export enum FeatureFlagsKeysEnum {
   IS_DOMAINS_PAGE_ENABLED = 'IS_DOMAINS_PAGE_ENABLED',
   /** Enable Domain Connect auto-configuration for inbound email domains. */
   IS_DOMAIN_CONNECT_INBOUND_EMAIL_ENABLED = 'IS_DOMAIN_CONNECT_INBOUND_EMAIL_ENABLED',
+  /** Enable match-rule conditions for inbound email domain routes. */
+  IS_DOMAIN_ROUTE_MATCH_ENABLED = 'IS_DOMAIN_ROUTE_MATCH_ENABLED',
 
   // String flags
   CF_SCHEDULER_MODE = 'CF_SCHEDULER_MODE', // Values: "off" | "shadow" | "live" | "complete"


### PR DESCRIPTION
Introduce optional JSON Logic-based "match" rules for domain routes to enable conditional routing. This change adds the match property across API DTOs, commands, usecases, controller mapping, DAL schema/entity, and client types; includes a class-validator constraint (IsJsonLogicRule) that enforces size, depth, allowed variables and supported operators; and persists/clears match on create/update. It implements runtime evaluation and richer test responses (matchEvaluation) in the TestDomainRoute usecase, adds e2e and unit tests, and updates the dashboard with a Conditions drawer, editor integration and UI hooks/flags to control the feature. Utility helpers for parsing/building JSON Logic queries were added to support the UI and evaluation flow.

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Added optional JSON Logic "match" rules to domain routes so inbound email delivery can be conditionally routed based on mail, domain, route, and auth context. Routes without match rules behave unchanged; routes with rules are evaluated at runtime and produce a matchEvaluation result so callers can see whether conditions were evaluated and passed. This enables allow/block/quality filters and more precise routing.

## Affected areas
**api**: DTOs, commands, controllers, mappers, and usecases now accept and persist an optional `match` JSON-Logic rule; `TestDomainRoute` returns richer `matchEvaluation` responses and a new `IsJsonLogicRule` validator enforces size, depth, allowed variables, and operators.  
**dashboard (react)**: New UI (RouteConditionsDrawer, RouteValueEditor, presets, variables, and editor integration) to create/edit conditions, display condition counts and test-evaluation summaries; gated by feature flag `IS_DOMAIN_ROUTE_MATCH_ENABLED`.  
**worker**: Domain route selection now evaluates rules (exact first, wildcard fallback) and enforces fail-closed behavior when matches fail or throw.  
**shared**: New types for `DomainRouteMatch`, `RouteMatchContext`, auth enums, and allowed context paths; new feature flag key.  
**dal**: Domain route entity and Mongo schema now include an optional `match` field.  
**application-generic**: New `buildRouteMatchContext` helper that normalizes mail/domain/route data, parses auth headers, and computes attachment metadata for rule evaluation.  
**enterprise**: E2E EE tests added/updated to cover creation/update validation in the enterprise test suite.

## Key technical decisions
- JSON Logic rules are constrained: max 4096 bytes, max depth 8, restricted variable paths (mail.*, domain.data.*, route.data.*, mail.headers.* prefixes), and a whitelisted operator set to limit abuse and ensure predictable evaluation.  
- Match evaluation is fail-closed: if evaluation fails or no route matches, delivery is suppressed and a log warning is emitted.  
- API contract extended non-breakingly: optional `match` added to create/update/test endpoints and persisted schema; test responses include an explicit `matchEvaluation` object.  
- UI is feature-flagged for staged rollout.

## Testing
Added unit tests for context building, validator logic, and rule evaluation, worker tests for exact/wildcard/fail-closed routing, and E2E tests (including EE tests) for create/update flows and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
