### PR TITLE
fix(api-service): Attach expectedDnsRecords to domain responses

### DIFF
--- a/apps/api/src/app/domains/dtos/test-domain-route-response.dto.ts
+++ b/apps/api/src/app/domains/dtos/test-domain-route-response.dto.ts
@@ -44,7 +44,11 @@ export class TestDomainRouteResponseDto {
   @ApiPropertyOptional({ description: 'Human-readable delivery target summary in dry-run mode.' })
   wouldDeliverTo?: string;
 
-  @ApiPropertyOptional({ type: Object, description: 'The outbound payload (dry-run only).' })
+  @ApiPropertyOptional({
+    type: Object,
+    description: 'The outbound payload (dry-run only).',
+    additionalProperties: true,
+  })
   payload?: Record<string, unknown>;
 
   @ApiPropertyOptional({ type: TestDomainRouteWebhookResultDto })

--- a/apps/api/src/app/domains/e2e/domains.e2e-ee.ts
+++ b/apps/api/src/app/domains/e2e/domains.e2e-ee.ts
@@ -38,6 +38,15 @@ describe('Domains API - /v1/domains #novu-v2', () => {
     expect(domain.mxRecordConfigured).to.equal(false);
     expect(domain.environmentId).to.equal(session.environment._id);
     expect(domain.organizationId).to.equal(session.organization._id);
+    expect(domain.expectedDnsRecords).to.deep.equal([
+      {
+        type: 'MX',
+        name,
+        content: process.env.MAIL_SERVER_DOMAIN,
+        ttl: 'Auto',
+        priority: 10,
+      },
+    ]);
   });
 
   it('should return 409 when creating a duplicate domain name in the same environment', async () => {
@@ -90,6 +99,7 @@ describe('Domains API - /v1/domains #novu-v2', () => {
 
     expect(fetched.id).to.equal(created.id);
     expect(fetched.name).to.equal(name);
+    expect(fetched.expectedDnsRecords).to.deep.equal(created.expectedDnsRecords);
   });
 
   it('should return 404 when retrieving a non-existent domain', async () => {

--- a/apps/api/src/app/domains/usecases/create-domain/create-domain.usecase.ts
+++ b/apps/api/src/app/domains/usecases/create-domain/create-domain.usecase.ts
@@ -6,6 +6,7 @@ import { DomainStatusEnum } from '@novu/shared';
 import { DomainResponseDto } from '../../dtos/domain-response.dto';
 import { toDomainResponse } from '../../mappers/domain-response.mapper';
 import { detectDnsProvider } from '../../utils/dns-provider';
+import { buildExpectedDnsRecords } from '../../utils/dns-records';
 import { CreateDomainCommand } from './create-domain.command';
 
 function isDuplicateKeyError(err: unknown): boolean {
@@ -51,6 +52,9 @@ export class CreateDomain {
       throw err;
     }
 
-    return toDomainResponse(domain);
+    return {
+      ...toDomainResponse(domain),
+      expectedDnsRecords: buildExpectedDnsRecords(domain.name),
+    };
   }
 }

--- a/libs/internal-sdk/src/funcs/domainsDiagnose.ts
+++ b/libs/internal-sdk/src/funcs/domainsDiagnose.ts
@@ -30,7 +30,7 @@ import { Result } from "../types/fp.js";
  * Diagnose inbound DNS for a domain
  *
  * @remarks
- * Runs live DNS checks (MX correctness, apex CNAME collision, NS delegation, and common DNS blocklists for the Novu mail host). Returns structured issues with plain-language fixes.
+ * Runs live DNS checks for inbound email readiness (MX correctness, apex CNAME collision, and common DNS blocklists for the Novu mail host). Returns structured issues with plain-language fixes.
  *
  * This operation requires either {@link Security.bearerAuth} or {@link Security.secretKey} to be set on the `security` parameter when initializing the SDK.
  */

--- a/libs/internal-sdk/src/models/components/domaindiagnosticcheckdto.ts
+++ b/libs/internal-sdk/src/models/components/domaindiagnosticcheckdto.ts
@@ -13,7 +13,6 @@ export const Code = {
   MxWrongTarget: "mx_wrong_target",
   MxLowPriority: "mx_low_priority",
   ApexCnameCollision: "apex_cname_collision",
-  NsUnresolvable: "ns_unresolvable",
   DnsblListed: "dnsbl_listed",
 } as const;
 export type Code = ClosedEnum<typeof Code>;

--- a/libs/internal-sdk/src/models/components/domaindiagnosticissuedto.ts
+++ b/libs/internal-sdk/src/models/components/domaindiagnosticissuedto.ts
@@ -13,7 +13,6 @@ export const DomainDiagnosticIssueDtoCode = {
   MxWrongTarget: "mx_wrong_target",
   MxLowPriority: "mx_low_priority",
   ApexCnameCollision: "apex_cname_collision",
-  NsUnresolvable: "ns_unresolvable",
   DnsblListed: "dnsbl_listed",
 } as const;
 export type DomainDiagnosticIssueDtoCode = ClosedEnum<

--- a/libs/internal-sdk/src/models/components/testdomainrouteresponsedto.ts
+++ b/libs/internal-sdk/src/models/components/testdomainrouteresponsedto.ts
@@ -30,11 +30,6 @@ export type TestDomainRouteResponseDtoType = ClosedEnum<
   typeof TestDomainRouteResponseDtoType
 >;
 
-/**
- * The outbound payload (dry-run only).
- */
-export type TestDomainRouteResponseDtoPayload = {};
-
 export type TestDomainRouteResponseDto = {
   matched: boolean;
   dryRun: boolean;
@@ -48,7 +43,7 @@ export type TestDomainRouteResponseDto = {
   /**
    * The outbound payload (dry-run only).
    */
-  payload?: TestDomainRouteResponseDtoPayload | undefined;
+  payload?: { [k: string]: any } | undefined;
   webhook?: TestDomainRouteWebhookResultDto | undefined;
   agent?: TestDomainRouteAgentResultDto | undefined;
 };
@@ -63,23 +58,6 @@ export const TestDomainRouteResponseDtoType$inboundSchema: z.ZodNativeEnum<
 > = z.nativeEnum(TestDomainRouteResponseDtoType);
 
 /** @internal */
-export const TestDomainRouteResponseDtoPayload$inboundSchema: z.ZodType<
-  TestDomainRouteResponseDtoPayload,
-  z.ZodTypeDef,
-  unknown
-> = z.object({});
-
-export function testDomainRouteResponseDtoPayloadFromJSON(
-  jsonString: string,
-): SafeParseResult<TestDomainRouteResponseDtoPayload, SDKValidationError> {
-  return safeParse(
-    jsonString,
-    (x) => TestDomainRouteResponseDtoPayload$inboundSchema.parse(JSON.parse(x)),
-    `Failed to parse 'TestDomainRouteResponseDtoPayload' from JSON`,
-  );
-}
-
-/** @internal */
 export const TestDomainRouteResponseDto$inboundSchema: z.ZodType<
   TestDomainRouteResponseDto,
   z.ZodTypeDef,
@@ -91,8 +69,7 @@ export const TestDomainRouteResponseDto$inboundSchema: z.ZodType<
   mxRecordConfigured: z.boolean().optional(),
   type: TestDomainRouteResponseDtoType$inboundSchema.optional(),
   wouldDeliverTo: z.string().optional(),
-  payload: z.lazy(() => TestDomainRouteResponseDtoPayload$inboundSchema)
-    .optional(),
+  payload: z.record(z.any()).optional(),
   webhook: TestDomainRouteWebhookResultDto$inboundSchema.optional(),
   agent: TestDomainRouteAgentResultDto$inboundSchema.optional(),
 });

--- a/libs/internal-sdk/src/react-query/domainsDiagnose.ts
+++ b/libs/internal-sdk/src/react-query/domainsDiagnose.ts
@@ -52,7 +52,7 @@ export type DomainsDiagnoseMutationError =
  * Diagnose inbound DNS for a domain
  *
  * @remarks
- * Runs live DNS checks (MX correctness, apex CNAME collision, NS delegation, and common DNS blocklists for the Novu mail host). Returns structured issues with plain-language fixes.
+ * Runs live DNS checks for inbound email readiness (MX correctness, apex CNAME collision, and common DNS blocklists for the Novu mail host). Returns structured issues with plain-language fixes.
  */
 export function useDomainsDiagnoseMutation(
   options?: MutationHookOptions<

--- a/libs/internal-sdk/src/sdk/domains.ts
+++ b/libs/internal-sdk/src/sdk/domains.ts
@@ -126,7 +126,7 @@ export class Domains extends ClientSDK {
    * Diagnose inbound DNS for a domain
    *
    * @remarks
-   * Runs live DNS checks (MX correctness, apex CNAME collision, NS delegation, and common DNS blocklists for the Novu mail host). Returns structured issues with plain-language fixes.
+   * Runs live DNS checks for inbound email readiness (MX correctness, apex CNAME collision, and common DNS blocklists for the Novu mail host). Returns structured issues with plain-language fixes.
    */
   async diagnose(
     domain: string,


### PR DESCRIPTION
Return expected DNS records when creating a domain by importing buildExpectedDnsRecords and merging its output into the domain response. Update E2E tests to assert expectedDnsRecords (adds an MX record using MAIL_SERVER_DOMAIN, ttl 'Auto', priority 10) and to compare fetched.created expectedDnsRecords. This ensures clients receive the DNS instructions needed after domain creation.

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
API domain responses now include an expectedDnsRecords field containing DNS instructions clients must apply (an MX record derived from the domain name and MAIL_SERVER_DOMAIN). The create-domain flow was updated to merge buildExpectedDnsRecords into responses so clients receive DNS guidance immediately after domain operations. Additionally, some domain diagnostic enums and dry-run payload typing were simplified to allow flexible payloads.

## Affected areas
**api**: Domain creation (and related domain response paths) now return expectedDnsRecords in responses so clients get MX configuration details immediately after create/get operations.  
**libs/internal-sdk**: SDK models and generated types were adjusted — TestDomainRouteResponseDto.payload is now a generic record and domain diagnostic DTO enums removed the ns_unresolvable code; corresponding Zod inbound schemas were updated.  
**apps/api (EE)**: Enterprise e2e tests were updated to assert expectedDnsRecords is present and matches the MX record derived from MAIL_SERVER_DOMAIN.

## Key technical decisions
- API contract: domain response objects now include a new expectedDnsRecords property (non-breaking for callers that ignore extra properties, but SDK typings were updated).  
- Model cleanup: removed the ns_unresolvable diagnostic enum value and replaced a strict empty payload schema with a flexible record for test route payloads.

## Testing
E2E tests (including EE tests) were updated to assert expectedDnsRecords contains a single MX record with the domain name, MAIL_SERVER_DOMAIN as content, ttl 'Auto', and priority 10; fetching a domain by name is asserted to return the same expectedDnsRecords as creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
