### PR TITLE
fix: update deprecation banner and add deprecation modal

### DIFF
--- a/apps/web/src/components/layout/components/DeprecationBanner.tsx
+++ b/apps/web/src/components/layout/components/DeprecationBanner.tsx
@@ -1,5 +1,5 @@
 import { Group } from '@mantine/core';
-import { colors, Text, Warning } from '@novu/design-system';
+import { colors, Text } from '@novu/design-system';
 import { ApiServiceLevelEnum } from '@novu/shared';
 import { differenceInDays, startOfDay } from 'date-fns';
 import { useSubscription } from '../../../ee/billing/hooks/useSubscription';
@@ -23,12 +23,17 @@ export function DeprecationBanner() {
   const migrationGuideBaseUrl = isFreeOrg ? 'https://dub.sh/eGRzfpk' : 'https://go.novu.co/migration-guide';
   const migrationGuideUrl = new URL(migrationGuideBaseUrl);
 
-  if (currentOrganization?.name) {
-    migrationGuideUrl.searchParams.set('org_name', currentOrganization.name);
-  }
+  // Dub passes any query string to the destination, but the Dub dashboard only breaks out
+  // standard UTM params (and `ref`). Use UTMs so org context shows in Dub analytics.
+  migrationGuideUrl.searchParams.set('utm_source', 'legacy_dashboard');
+  migrationGuideUrl.searchParams.set('utm_medium', 'deprecation_banner');
 
   if (currentOrganization?._id) {
-    migrationGuideUrl.searchParams.set('org_id', currentOrganization?._id);
+    migrationGuideUrl.searchParams.set('utm_campaign', currentOrganization._id);
+  }
+
+  if (currentOrganization?.name) {
+    migrationGuideUrl.searchParams.set('utm_content', currentOrganization.name.slice(0, 200));
   }
 
   const MIGRATION_GUIDE_URL = migrationGuideUrl.toString();
@@ -50,10 +55,12 @@ export function DeprecationBanner() {
       data-test-id="deprecation-banner"
     >
       <Group spacing={8} noWrap style={{ justifyContent: 'center', width: '100%', maxWidth: 1200 }}>
-        <Warning color={colors.white} />
         <Text color={colors.white} style={{ whiteSpace: 'normal', minWidth: 0 }}>
-          This dashboard will be deprecated {timePhrase}. After 31st May, you will loose support SLA for this dashboard.
-          To avoid disruption, please migrate to the new dashboard in advance.{' '}
+          <span aria-hidden={true} style={{ color: colors.white, flexShrink: 0, fontSize: '1.1em', lineHeight: 1.2 }}>
+            {'u26A0\uFE0F'}
+          </span>{' '}
+          This dashboard will be deprecated {timePhrase}. After 31st May ({daysLeft} days), you will loose support SLA
+          for this dashboard. To avoid disruption, please migrate to the new dashboard in advance.{' '}
           <a
             href={MIGRATION_GUIDE_URL}
             target="_blank"

--- a/apps/web/src/components/layout/components/DeprecationBanner.tsx
+++ b/apps/web/src/components/layout/components/DeprecationBanner.tsx
@@ -20,16 +20,13 @@ export function DeprecationBanner() {
   }
 
   const daysLeft = getDaysUntilDashboardDeprecation();
-  const timePhrase =
-    daysLeft === 0
-      ? 'today'
-      : `in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`;
+  const timePhrase = daysLeft === 0 ? 'today' : `in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`;
 
   return (
     <div
       style={{
         width: '100%',
-        padding: 8,
+        padding: '8px 16px',
         background: colors.horizontal,
         textAlign: 'center',
         display: 'flex',
@@ -38,11 +35,11 @@ export function DeprecationBanner() {
       }}
       data-test-id="deprecation-banner"
     >
-      <Group spacing={8}>
+      <Group spacing={8} style={{ flexWrap: 'wrap', justifyContent: 'center' }}>
         <Warning color={colors.white} />
-        <Text color={colors.white}>
-          This dashboard will be deprecated {timePhrase}. After 31st May, you will loose support SLA for this dashboard. To avoid disruption, please migrate to the new dashboard in
-          advance.{' '}
+        <Text color={colors.white} style={{ whiteSpace: 'normal' }}>
+          This dashboard will be deprecated {timePhrase}. After 31st May, you will loose support SLA for this dashboard.
+          To avoid disruption, please migrate to the new dashboard in advance.{' '}
           <a
             href={MIGRATION_GUIDE_URL}
             target="_blank"

--- a/apps/web/src/components/layout/components/DeprecationBanner.tsx
+++ b/apps/web/src/components/layout/components/DeprecationBanner.tsx
@@ -27,10 +27,8 @@ export function DeprecationBanner() {
     migrationGuideUrl.searchParams.set('org_name', currentOrganization.name);
   }
 
-  const organizationId = currentOrganization?.id || currentOrganization?._id;
-
-  if (organizationId) {
-    migrationGuideUrl.searchParams.set('org_id', organizationId);
+  if (currentOrganization?._id) {
+    migrationGuideUrl.searchParams.set('org_id', currentOrganization?._id);
   }
 
   const MIGRATION_GUIDE_URL = migrationGuideUrl.toString();

--- a/apps/web/src/components/layout/components/DeprecationBanner.tsx
+++ b/apps/web/src/components/layout/components/DeprecationBanner.tsx
@@ -3,8 +3,7 @@ import { colors, Text, Warning } from '@novu/design-system';
 import { ApiServiceLevelEnum } from '@novu/shared';
 import { differenceInDays, startOfDay } from 'date-fns';
 import { useSubscription } from '../../../ee/billing/hooks/useSubscription';
-
-const MIGRATION_GUIDE_URL = 'https://go.novu.co/migration-guide';
+import { useAuth } from '../../../hooks/useAuth';
 
 const DASHBOARD_DEPRECATION_DATE = new Date(2026, 4, 31);
 
@@ -14,10 +13,27 @@ function getDaysUntilDashboardDeprecation(): number {
 
 export function DeprecationBanner() {
   const { apiServiceLevel, isLoading } = useSubscription();
+  const { currentOrganization } = useAuth();
 
-  if (isLoading || apiServiceLevel === ApiServiceLevelEnum.FREE) {
+  if (isLoading) {
     return null;
   }
+
+  const isFreeOrg = apiServiceLevel === ApiServiceLevelEnum.FREE;
+  const migrationGuideBaseUrl = isFreeOrg ? 'https://dub.sh/eGRzfpk' : 'https://go.novu.co/migration-guide';
+  const migrationGuideUrl = new URL(migrationGuideBaseUrl);
+
+  if (currentOrganization?.name) {
+    migrationGuideUrl.searchParams.set('org_name', currentOrganization.name);
+  }
+
+  const organizationId = currentOrganization?.id || currentOrganization?._id;
+
+  if (organizationId) {
+    migrationGuideUrl.searchParams.set('org_id', organizationId);
+  }
+
+  const MIGRATION_GUIDE_URL = migrationGuideUrl.toString();
 
   const daysLeft = getDaysUntilDashboardDeprecation();
   const timePhrase = daysLeft === 0 ? 'today' : `in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`;
@@ -35,9 +51,9 @@ export function DeprecationBanner() {
       }}
       data-test-id="deprecation-banner"
     >
-      <Group spacing={8} style={{ flexWrap: 'wrap', justifyContent: 'center' }}>
+      <Group spacing={8} noWrap style={{ justifyContent: 'center', width: '100%', maxWidth: 1200 }}>
         <Warning color={colors.white} />
-        <Text color={colors.white} style={{ whiteSpace: 'normal' }}>
+        <Text color={colors.white} style={{ whiteSpace: 'normal', minWidth: 0 }}>
           This dashboard will be deprecated {timePhrase}. After 31st May, you will loose support SLA for this dashboard.
           To avoid disruption, please migrate to the new dashboard in advance.{' '}
           <a

--- a/apps/web/src/components/layout/components/DeprecationBanner.tsx
+++ b/apps/web/src/components/layout/components/DeprecationBanner.tsx
@@ -56,10 +56,7 @@ export function DeprecationBanner() {
     >
       <Group spacing={8} noWrap style={{ justifyContent: 'center', width: '100%', maxWidth: 1200 }}>
         <Text color={colors.white} style={{ whiteSpace: 'normal', minWidth: 0 }}>
-          <span aria-hidden={true} style={{ color: colors.white, flexShrink: 0, fontSize: '1.1em', lineHeight: 1.2 }}>
-            {'u26A0\uFE0F'}
-          </span>{' '}
-          This dashboard will be deprecated {timePhrase}. After 31st May ({daysLeft} days), you will loose support SLA
+          ⚠️ This dashboard will be deprecated {timePhrase}. After 31st May ({daysLeft} days), you will loose support SLA
           for this dashboard. To avoid disruption, please migrate to the new dashboard in advance.{' '}
           <a
             href={MIGRATION_GUIDE_URL}

--- a/apps/web/src/components/layout/components/DeprecationBanner.tsx
+++ b/apps/web/src/components/layout/components/DeprecationBanner.tsx
@@ -1,9 +1,16 @@
 import { Group } from '@mantine/core';
 import { colors, Text, Warning } from '@novu/design-system';
 import { ApiServiceLevelEnum } from '@novu/shared';
+import { differenceInDays, startOfDay } from 'date-fns';
 import { useSubscription } from '../../../ee/billing/hooks/useSubscription';
 
 const MIGRATION_GUIDE_URL = 'https://go.novu.co/migration-guide';
+
+const DASHBOARD_DEPRECATION_DATE = new Date(2026, 4, 31);
+
+function getDaysUntilDashboardDeprecation(): number {
+  return Math.max(0, differenceInDays(startOfDay(DASHBOARD_DEPRECATION_DATE), startOfDay(new Date())));
+}
 
 export function DeprecationBanner() {
   const { apiServiceLevel, isLoading } = useSubscription();
@@ -11,6 +18,12 @@ export function DeprecationBanner() {
   if (isLoading || apiServiceLevel === ApiServiceLevelEnum.FREE) {
     return null;
   }
+
+  const daysLeft = getDaysUntilDashboardDeprecation();
+  const timePhrase =
+    daysLeft === 0
+      ? 'today'
+      : `in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`;
 
   return (
     <div
@@ -28,7 +41,7 @@ export function DeprecationBanner() {
       <Group spacing={8}>
         <Warning color={colors.white} />
         <Text color={colors.white}>
-          This dashboard will be deprecated after May 31. To avoid disruption, please migrate to the new dashboard in
+          This dashboard will be deprecated {timePhrase}. After 31st May, you will loose support SLA for this dashboard. To avoid disruption, please migrate to the new dashboard in
           advance.{' '}
           <a
             href={MIGRATION_GUIDE_URL}

--- a/apps/web/src/components/layout/components/DeprecationDashboardNoticeContent.tsx
+++ b/apps/web/src/components/layout/components/DeprecationDashboardNoticeContent.tsx
@@ -1,0 +1,41 @@
+import { colors, Text } from '@novu/design-system';
+
+type DeprecationDashboardNoticeContentProps = {
+  migrationGuideUrl: string;
+  daysLeft: number;
+  timePhrase: string;
+  variant: 'banner' | 'modal';
+};
+
+export function DeprecationDashboardNoticeContent({
+  migrationGuideUrl,
+  daysLeft,
+  timePhrase,
+  variant,
+}: DeprecationDashboardNoticeContentProps) {
+  const isBanner = variant === 'banner';
+
+  return (
+    <Text
+      color={isBanner ? colors.white : undefined}
+      style={
+        isBanner ? { whiteSpace: 'normal', minWidth: 0 } : { whiteSpace: 'normal', maxWidth: 640, lineHeight: 1.6 }
+      }
+    >
+      ⚠️ This dashboard will be deprecated {timePhrase}. After 31st May ({daysLeft} days), you will loose support SLA for
+      this dashboard. To avoid disruption, please migrate to the new dashboard in advance.{' '}
+      <a
+        href={migrationGuideUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          color: isBanner ? colors.white : colors.horizontal,
+          fontWeight: 700,
+          textDecoration: 'underline',
+        }}
+      >
+        Migration Guide →
+      </a>
+    </Text>
+  );
+}

--- a/apps/web/src/components/layout/components/DeprecationNoticeModal.tsx
+++ b/apps/web/src/components/layout/components/DeprecationNoticeModal.tsx
@@ -56,36 +56,25 @@ export function DeprecationNoticeModal() {
     <Modal
       opened={opened}
       onClose={handleDismiss}
-      fullScreen
-      transition="fade"
-      transitionDuration={200}
       withCloseButton
       closeOnClickOutside
+      centered
+      size="lg"
+      radius="md"
       title={<Title size={2}>Legacy dashboard deprecation</Title>}
       overlayColor={theme.colorScheme === 'dark' ? colors.BGDark : colors.BGLight}
-      overlayOpacity={0.85}
+      overlayOpacity={0.7}
       sx={{ backdropFilter: 'blur(10px)' }}
       shadow={theme.colorScheme === 'dark' ? shadows.dark : shadows.medium}
-      radius="md"
       styles={{
         root: {
           zIndex: 250,
-        },
-        inner: {
-          padding: 0,
         },
         modal: {
           backgroundColor: theme.colorScheme === 'dark' ? colors.B15 : colors.white,
         },
         body: {
-          padding: '48px 24px',
-          maxWidth: 720,
-          margin: '0 auto',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          minHeight: '100vh',
-          boxSizing: 'border-box',
+          paddingTop: 5,
         },
       }}
     >

--- a/apps/web/src/components/layout/components/DeprecationNoticeModal.tsx
+++ b/apps/web/src/components/layout/components/DeprecationNoticeModal.tsx
@@ -1,0 +1,105 @@
+import { Group, Modal, useMantineTheme } from '@mantine/core';
+import { Button, colors, shadows, Title } from '@novu/design-system';
+import { useEffect, useState } from 'react';
+import { useSubscription } from '../../../ee/billing/hooks/useSubscription';
+import { useAuth } from '../../../hooks/useAuth';
+import { DeprecationDashboardNoticeContent } from './DeprecationDashboardNoticeContent';
+import {
+  buildMigrationGuideUrl,
+  getDaysUntilDashboardDeprecation,
+  LEGACY_DASHBOARD_DEPRECATION_MODAL_DISMISSED_KEY,
+} from './deprecation-dashboard-notice';
+
+function readDismissedFromStorage(): boolean {
+  try {
+    return (
+      typeof window !== 'undefined' && localStorage.getItem(LEGACY_DASHBOARD_DEPRECATION_MODAL_DISMISSED_KEY) === 'true'
+    );
+  } catch {
+    return false;
+  }
+}
+
+function persistDismissed(): void {
+  try {
+    localStorage.setItem(LEGACY_DASHBOARD_DEPRECATION_MODAL_DISMISSED_KEY, 'true');
+  } catch {
+    // private mode / quota
+  }
+}
+
+export function DeprecationNoticeModal() {
+  const theme = useMantineTheme();
+  const { apiServiceLevel, isLoading } = useSubscription();
+  const { currentOrganization } = useAuth();
+  const [opened, setOpened] = useState(false);
+
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+    if (!readDismissedFromStorage()) {
+      setOpened(true);
+    }
+  }, [isLoading]);
+
+  const handleDismiss = () => {
+    persistDismissed();
+    setOpened(false);
+  };
+
+  const migrationGuideUrl = buildMigrationGuideUrl(apiServiceLevel, currentOrganization);
+  const daysLeft = getDaysUntilDashboardDeprecation();
+  const timePhrase = daysLeft === 0 ? 'today' : `in ${daysLeft} day${daysLeft === 1 ? '' : 's'}`;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={handleDismiss}
+      fullScreen
+      transition="fade"
+      transitionDuration={200}
+      withCloseButton
+      closeOnClickOutside
+      title={<Title size={2}>Legacy dashboard deprecation</Title>}
+      overlayColor={theme.colorScheme === 'dark' ? colors.BGDark : colors.BGLight}
+      overlayOpacity={0.85}
+      sx={{ backdropFilter: 'blur(10px)' }}
+      shadow={theme.colorScheme === 'dark' ? shadows.dark : shadows.medium}
+      radius="md"
+      styles={{
+        root: {
+          zIndex: 250,
+        },
+        inner: {
+          padding: 0,
+        },
+        modal: {
+          backgroundColor: theme.colorScheme === 'dark' ? colors.B15 : colors.white,
+        },
+        body: {
+          padding: '48px 24px',
+          maxWidth: 720,
+          margin: '0 auto',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          minHeight: '100vh',
+          boxSizing: 'border-box',
+        },
+      }}
+    >
+      <DeprecationDashboardNoticeContent
+        migrationGuideUrl={migrationGuideUrl}
+        daysLeft={daysLeft}
+        timePhrase={timePhrase}
+        variant="modal"
+      />
+      <Group position="right" mt={32}>
+        <Button size="md" onClick={handleDismiss} data-autofocus>
+          Acknowledge & Close
+        </Button>
+      </Group>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/layout/components/PrivatePageLayout.tsx
+++ b/apps/web/src/components/layout/components/PrivatePageLayout.tsx
@@ -1,28 +1,28 @@
-import { useEffect, useMemo, useState } from 'react';
-import { ErrorBoundary } from '@sentry/react';
-import { Outlet, useLocation } from 'react-router-dom';
 import styled from '@emotion/styled';
-import { IntercomProvider } from 'react-use-intercom';
-
 import { css } from '@novu/novui/css';
 import { EnvironmentEnum } from '@novu/shared';
+import { ErrorBoundary } from '@sentry/react';
+import { useEffect, useMemo, useState } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
+import { IntercomProvider } from 'react-use-intercom';
 
 import {
-  BRIDGE_SYNC_SAMPLE_ENDPOINT,
   BRIDGE_ENDPOINTS_LEGACY_VERSIONS,
+  BRIDGE_SYNC_SAMPLE_ENDPOINT,
   INTERCOM_APP_ID,
   IS_EE_AUTH_ENABLED,
 } from '../../../config';
-import { SpotLight } from '../../utils/Spotlight';
-import { SpotLightProvider } from '../../providers/SpotlightProvider';
 import { useEnvironment, useRedirectURL, useRouteScopes } from '../../../hooks';
+import { useOptInRedirect } from '../../../hooks/useOptInRedirect';
 // TODO: Move sidebar under layout folder as it belongs here
 import { Sidebar } from '../../nav/Sidebar';
-import { HeaderNav } from './v2/HeaderNav';
+import { SpotLightProvider } from '../../providers/SpotlightProvider';
+import { SpotLight } from '../../utils/Spotlight';
 import { DeprecationBanner } from './DeprecationBanner';
+import { DeprecationNoticeModal } from './DeprecationNoticeModal';
 import { FreeTrialBanner } from './FreeTrialBanner';
+import { HeaderNav } from './v2/HeaderNav';
 import { SampleModeBanner } from './v2/SampleWorkflowsBanner';
-import { useOptInRedirect } from '../../../hooks/useOptInRedirect';
 
 const AppShell = styled.div`
   display: flex;
@@ -104,6 +104,7 @@ export function PrivatePageLayout() {
             <AppShell className={css({ '& *': { colorPalette: isLocalEnv ? 'mode.local' : 'mode.cloud' } })}>
               <Sidebar />
               <ContentShell>
+                <DeprecationNoticeModal />
                 <DeprecationBanner />
                 {showSampleModeBanner && <SampleModeBanner />}
                 <FreeTrialBanner />

--- a/apps/web/src/components/layout/components/deprecation-dashboard-notice.ts
+++ b/apps/web/src/components/layout/components/deprecation-dashboard-notice.ts
@@ -1,0 +1,35 @@
+import { ApiServiceLevelEnum } from '@novu/shared';
+import { differenceInDays, startOfDay } from 'date-fns';
+
+export const DASHBOARD_DEPRECATION_DATE = new Date(2026, 4, 31);
+
+/** Bump suffix if the notice should be shown again to everyone who dismissed a previous version. */
+export const LEGACY_DASHBOARD_DEPRECATION_MODAL_DISMISSED_KEY = 'novu_legacy_dashboard_deprecation_modal_dismissed_v1';
+
+export function getDaysUntilDashboardDeprecation(): number {
+  return Math.max(0, differenceInDays(startOfDay(DASHBOARD_DEPRECATION_DATE), startOfDay(new Date())));
+}
+
+type OrganizationLike = { _id?: string; name?: string } | null | undefined;
+
+export function buildMigrationGuideUrl(
+  apiServiceLevel: ApiServiceLevelEnum | undefined,
+  currentOrganization: OrganizationLike
+): string {
+  const isFreeOrg = apiServiceLevel === ApiServiceLevelEnum.FREE;
+  const migrationGuideBaseUrl = isFreeOrg ? 'https://dub.sh/eGRzfpk' : 'https://go.novu.co/migration-guide';
+  const migrationGuideUrl = new URL(migrationGuideBaseUrl);
+
+  migrationGuideUrl.searchParams.set('utm_source', 'legacy_dashboard');
+  migrationGuideUrl.searchParams.set('utm_medium', 'deprecation_modal');
+
+  if (currentOrganization?._id) {
+    migrationGuideUrl.searchParams.set('utm_campaign', currentOrganization._id);
+  }
+
+  if (currentOrganization?.name) {
+    migrationGuideUrl.searchParams.set('utm_content', currentOrganization.name.slice(0, 200));
+  }
+
+  return migrationGuideUrl.toString();
+}


### PR DESCRIPTION
### What changed? Why was the change needed?

@coderabbitai summary

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily user-facing UI/UX changes (banner + new modal) plus URL/UTM generation and `localStorage` persistence; no auth or data-processing logic is affected.
> 
> **Overview**
> Adds a new legacy dashboard deprecation *modal* (`DeprecationNoticeModal`) that auto-opens once per browser (dismiss persisted in `localStorage`) and is mounted in `PrivatePageLayout`.
> 
> Updates `DeprecationBanner` to show a dynamic “days until deprecation” message, adjust layout styling, and build a migration guide link with UTMs plus org context; free orgs now use a Dub short link instead of hiding the banner entirely. Also introduces shared helpers in `deprecation-dashboard-notice.ts` and a reusable `DeprecationDashboardNoticeContent` component for consistent copy/link styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee485472dae4075d37000f54bb5c83d04f6cef3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->