### PR TITLE
fix(dashboard): identify ld with both contexts only

### DIFF
--- a/apps/dashboard/src/context/identity-provider.tsx
+++ b/apps/dashboard/src/context/identity-provider.tsx
@@ -12,22 +12,7 @@ export function IdentityProvider({ children }: { children: React.ReactNode }) {
   const customerIo = useCustomerIo();
   const { currentUser, currentOrganization } = useAuth();
   const { selectedRegion } = useRegion();
-  const hasIdentifiedUser = useRef(false);
   const hasIdentifiedOrg = useRef(false);
-
-  useEffect(() => {
-    if (!currentUser || !currentUser._id || !ldClient || hasIdentifiedUser.current) return;
-
-    ldClient.identify({
-      kind: 'user',
-      key: currentUser._id,
-      firstName: currentUser.firstName,
-      lastName: currentUser.lastName,
-      email: currentUser.email,
-    });
-
-    hasIdentifiedUser.current = true;
-  }, [ldClient, currentUser]);
 
   useEffect(() => {
     if (!currentOrganization || !currentUser) return;


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed? Why was the change needed?

The LaunchDarkly user identification flow was refactored to eliminate standalone user context identification. Previously, the component identified users with LaunchDarkly as soon as `currentUser` became available. Now, identification only occurs when both `currentUser` and `currentOrganization` are present, using the multi-context identification payload. This ensures LaunchDarkly always receives complete context (user + organization) together rather than in separate operations.

## Affected areas

**dashboard**: The identity provider component removed a separate effect that performed standalone user identification with LaunchDarkly. The component now consolidates all user tracking into a single effect that waits for both user and organization contexts to be available before calling `ldClient.identify()` with `kind: 'multi'`.

## Testing

No tests were added. This is a refactoring of internal effect logic with no API or behavioral changes to external consumers of the component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
