### PR TITLE
fix(novu): improve local tunnel reliability after sleep and silent disconnects fixes NV-7428

### DIFF
--- a/packages/novu/src/commands/dev/dev.ts
+++ b/packages/novu/src/commands/dev/dev.ts
@@ -164,17 +164,21 @@ async function startTunnelProbe(tunnelOrigin: string, endpointRoute: string, loc
   while (true) {
     await wait(TUNNEL_PROBE_INTERVAL_MS);
 
-    const localHealthy = await tunnelHealthCheck(`${localOrigin}${endpointRoute}`);
+    try {
+      const localHealthy = await tunnelHealthCheck(`${localOrigin}${endpointRoute}`);
 
-    if (!localHealthy) {
-      continue;
-    }
+      if (!localHealthy) {
+        continue;
+      }
 
-    const tunnelHealthy = await tunnelHealthCheck(`${tunnelOrigin}${endpointRoute}`);
+      const tunnelHealthy = await tunnelHealthCheck(`${tunnelOrigin}${endpointRoute}`);
 
-    if (!tunnelHealthy && tunnelClient?.socket) {
-      tunnelClient.socket.addEventListener('open', () => console.log(chalk.green('\n  ✓ Tunnel reconnected')), { once: true });
-      tunnelClient.socket.reconnect();
+      if (!tunnelHealthy && tunnelClient?.socket) {
+        tunnelClient.socket.addEventListener('open', () => console.log(chalk.green('\n  ✓ Tunnel reconnected')), { once: true });
+        tunnelClient.socket.reconnect();
+      }
+    } catch {
+      // keep the probe loop alive regardless of unexpected errors
     }
   }
 }

--- a/packages/novu/src/commands/dev/dev.ts
+++ b/packages/novu/src/commands/dev/dev.ts
@@ -19,6 +19,7 @@ let tunnelClient: NtfrTunnel | null = null;
 
 const WATCHDOG_INTERVAL_MS = 10_000;
 const SLEEP_DRIFT_THRESHOLD_MS = WATCHDOG_INTERVAL_MS * 2.5;
+const TUNNEL_PROBE_INTERVAL_MS = 30_000;
 export const TUNNEL_URL = 'https://novu.sh/api/tunnels';
 const { version } = packageJson;
 
@@ -64,6 +65,7 @@ export async function devCommand(options: DevCommandOptions, anonymousId?: strin
 
   if (!parsedOptions.tunnel) {
     startTunnelWatchdog();
+    startTunnelProbe(tunnelOrigin, NOVU_ENDPOINT_PATH, parsedOptions.origin).catch(() => {});
   }
 
   if (NOVU_SECRET_KEY) {
@@ -156,6 +158,25 @@ function createWatchdogTick(getSocket: () => WatchdogSocket | undefined): () => 
 
 function startTunnelWatchdog(): void {
   setInterval(createWatchdogTick(() => tunnelClient?.socket), WATCHDOG_INTERVAL_MS);
+}
+
+async function startTunnelProbe(tunnelOrigin: string, endpointRoute: string, localOrigin: string): Promise<void> {
+  while (true) {
+    await wait(TUNNEL_PROBE_INTERVAL_MS);
+
+    const localHealthy = await tunnelHealthCheck(`${localOrigin}${endpointRoute}`);
+
+    if (!localHealthy) {
+      continue;
+    }
+
+    const tunnelHealthy = await tunnelHealthCheck(`${tunnelOrigin}${endpointRoute}`);
+
+    if (!tunnelHealthy && tunnelClient?.socket) {
+      tunnelClient.socket.addEventListener('open', () => console.log(chalk.green('\n  ✓ Tunnel reconnected')), { once: true });
+      tunnelClient.socket.reconnect();
+    }
+  }
 }
 
 async function createTunnel(localOrigin: string, endpointRoute: string): Promise<string> {

--- a/packages/novu/src/commands/dev/dev.ts
+++ b/packages/novu/src/commands/dev/dev.ts
@@ -16,6 +16,9 @@ process.on('SIGINT', () => {
 });
 
 let tunnelClient: NtfrTunnel | null = null;
+
+const WATCHDOG_INTERVAL_MS = 10_000;
+const SLEEP_DRIFT_THRESHOLD_MS = WATCHDOG_INTERVAL_MS * 2.5;
 export const TUNNEL_URL = 'https://novu.sh/api/tunnels';
 const { version } = packageJson;
 
@@ -58,6 +61,10 @@ export async function devCommand(options: DevCommandOptions, anonymousId?: strin
   }
 
   await monitorEndpointHealth(parsedOptions, NOVU_ENDPOINT_PATH);
+
+  if (!parsedOptions.tunnel) {
+    startTunnelWatchdog();
+  }
 
   if (NOVU_SECRET_KEY) {
     const bridgeUrl = `${tunnelOrigin}${NOVU_ENDPOINT_PATH}`;
@@ -102,10 +109,14 @@ async function monitorEndpointHealth(parsedOptions: DevCommandOptions, endpointR
 }
 
 async function tunnelHealthCheck(configTunnelUrl: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5_000);
+
   try {
     const res = await (
       await fetch(`${configTunnelUrl}?action=health-check`, {
         method: 'GET',
+        signal: controller.signal,
         headers: {
           accept: 'application/json',
           'Content-Type': 'application/json',
@@ -117,7 +128,34 @@ async function tunnelHealthCheck(configTunnelUrl: string): Promise<boolean> {
     return res.status === 'ok';
   } catch (e) {
     return false;
+  } finally {
+    clearTimeout(timeoutId);
   }
+}
+
+type WatchdogSocket = Pick<NonNullable<NtfrTunnel['socket']>, 'reconnect' | 'addEventListener'>;
+
+function createWatchdogTick(getSocket: () => WatchdogSocket | undefined): () => void {
+  let lastTickMs = Date.now();
+
+  return () => {
+    const now = Date.now();
+    const drift = now - lastTickMs;
+    lastTickMs = now;
+
+    if (drift > SLEEP_DRIFT_THRESHOLD_MS) {
+      const socket = getSocket();
+
+      if (socket) {
+        socket.addEventListener('open', () => console.log(chalk.green('\n  ✓ Tunnel reconnected')), { once: true });
+        socket.reconnect();
+      }
+    }
+  };
+}
+
+function startTunnelWatchdog(): void {
+  setInterval(createWatchdogTick(() => tunnelClient?.socket), WATCHDOG_INTERVAL_MS);
 }
 
 async function createTunnel(localOrigin: string, endpointRoute: string): Promise<string> {


### PR DESCRIPTION
## What

Fixes `npx novu dev` tunnel silently breaking after laptop sleep/wake and other network disruptions. Two independent mechanisms are added on top of partysocket's existing reconnect logic.

## Why it broke

`partysocket` (ReconnectingWebSocket inside `@novu/ntfr-client`) reconnects on `close`/`error` events. Two failure modes bypass this entirely:

1. **OS sleep/wake** — the process is suspended, the WebSocket TCP connection dies server-side, but no socket event fires on resume. The socket reports `readyState === OPEN` while completely stale.
2. **Silent disconnects** — WiFi switch, NAT expiry, VPN change, server-side session drop without a proper close frame. The OS never generates a `close`/`error` event, so partysocket never reconnects.

## Fix

### 1. Sleep-drift watchdog (catches OS sleep/wake)

A `setInterval` ticking every 10s measures wall-clock drift against the expected interval. If the callback fires after >25s (expected ~10s), the process was suspended. Calls `socket.reconnect()` immediately on wake.

- Zero network cost
- Detects within one tick (~10s) of waking

### 2. HTTP tunnel probe (catches silent disconnects)

An async loop probing the public tunnel URL every 30s. Before reconnecting, it checks the local app first — if local is down, the tunnel isn't at fault and we skip. Only reconnects when local is healthy but tunnel is dead.

- Catches WiFi switches, NAT expiry, VPN changes, server-side drops
- 1 HTTP request per 30s
- Local-first check prevents false positives when the user's app is stopped

```
setInterval fires at t=0  → drift ~10s        → no-op
laptop sleeps at t=30s
laptop wakes at t=8h30s
setInterval fires         → drift ~8h         → socket.reconnect() ✓

every 30s while running   → probe tunnel URL
                          → local healthy?    → yes
                          → tunnel healthy?   → no → socket.reconnect() ✓
```

Both mechanisms call `socket.reconnect()` which partysocket handles safely even if both fire simultaneously. Both are skipped when `--tunnel` (custom tunnel) is passed.

## What it still doesn't cover

If the tunnel server permanently expires the session after a very long sleep, reconnecting the WebSocket succeeds but traffic won't route. The HTTP probe will keep detecting failure. The real fix is re-provisioning a new tunnel URL — but that requires propagating it to `DevServer`, `/.well-known/novu`, and registered agent bridges, which is a larger change best made in `@novu/ntfr-client` itself.

## Testing

```bash
# 1. Build and run
cd packages/novu && pnpm build
node dist/src/index.js dev

# 2. Confirm tunnel works
curl "https://<tunnel-id>.novu.sh/api/novu?action=health-check"
# → {"status":"ok"}

# 3. Simulate sleep (STOP suspends the process like OS sleep)
kill -STOP <pid>
sleep 6 && kill -CONT <pid>

# 4. Within ~10s of resume:
# → ✓ Tunnel reconnected

# 5. For silent disconnect — kill -STOP for 30s+ to also trigger the probe
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What changed**

Fixed `npx novu dev` tunnel reliability by adding automatic reconnection mechanisms to detect and recover from laptop sleep/wake and network disruptions. Two background tasks now maintain tunnel health when no custom tunnel is provided: a sleep-drift watchdog that detects OS suspension by measuring time delays between checks, and a periodic HTTP probe that validates tunnel connectivity and triggers reconnection when needed.

**Affected areas**

- `novu` package: Enhanced the dev command to include a drift watchdog (running every 10 seconds with >25 second threshold to detect sleep) and an HTTP tunnel probe (every 30 seconds). The probe checks local endpoint health first, only reconnecting when the tunnel fails but the local service remains healthy. Improved `tunnelHealthCheck` function with a strict 5-second request timeout using `AbortController` to prevent hanging requests.

**Key technical decisions**

- Both monitoring mechanisms are disabled when the `--tunnel` flag is used (custom tunnel mode).
- The probe loop catches and silently handles all exceptions to prevent crashes, keeping the monitoring running even on transient errors.
- Drift detection uses wall-clock time measurement with zero network cost, typically detecting wake within one interval (~10 seconds).
- Uses `AbortController` for precise timeout control instead of relying on fetch timeout defaults, with proper cleanup in a finally block.

**Testing**

Manual verification provided: build the project, run `node dist/src/index.js dev`, confirm health-check passes, simulate sleep with `kill -STOP/CONT`, and observe automatic reconnection. No new unit tests were added as the monitoring logic is tightly coupled to the tunnel client lifecycle and network conditions, making unit testing impractical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->