### PR TITLE
feat(api-service): improve url handling for webhook requests

### DIFF
--- a/apps/worker/src/app/workflow/specs/inbound-email-parse.spec.ts
+++ b/apps/worker/src/app/workflow/specs/inbound-email-parse.spec.ts
@@ -25,7 +25,7 @@ const axiosInstance = axios.create();
 
 const eventTriggerPath = '/v1/events/trigger';
 const USER_MAIL_DOMAIN = 'mail.domain.com';
-const USER_PARSE_WEBHOOK = 'user-parse.com/webhook/{{compiledVariable}}';
+const USER_PARSE_WEBHOOK = 'https://example.com/webhook/{{compiledVariable}}';
 
 describe('Should handle the new arrived mail', () => {
   let inboundEmailParseUsecase: InboundEmailParse;
@@ -171,7 +171,7 @@ const getEntitiesStubObject = {
         active: true,
         replyCallback: {
           active: true,
-          url: 'user-parse.com/webhook/{{compiledVariable}}',
+          url: 'https://example.com/webhook/{{compiledVariable}}',
         },
         shouldStopOnFail: false,
         filters: [],
@@ -238,7 +238,7 @@ const getEntitiesStubObject = {
     step: {
       replyCallback: {
         active: true,
-        url: 'user-parse.com/webhook/{{compiledVariable}}',
+        url: 'https://example.com/webhook/{{compiledVariable}}',
       },
       metadata: {
         timed: {

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
-import { CompileTemplate, createHash } from '@novu/application-generic';
+import { CompileTemplate, createHash, validateUrlSsrf } from '@novu/application-generic';
 import {
   JobEntity,
   JobRepository,
@@ -49,6 +49,12 @@ export class ReplyToStrategy {
       template: currentParseWebhook as string,
       data: job.payload,
     });
+
+    const ssrfError = await validateUrlSsrf(compiledDomain);
+
+    if (ssrfError) {
+      this.throwError(`Reply callback URL blocked (SSRF): ${ssrfError}`);
+    }
 
     const userPayload: IUserWebhookPayload = {
       hmac: createHash(environment?.apiKeys[0]?.key, subscriber.subscriberId) || '',

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
-import { CompileTemplate, createHash, validateUrlSsrf } from '@novu/application-generic';
+import { CompileTemplate, createHash, normalizeOutboundHttpUrl, validateUrlSsrf } from '@novu/application-generic';
 import {
   JobEntity,
   JobRepository,
@@ -50,7 +50,13 @@ export class ReplyToStrategy {
       data: job.payload,
     });
 
-    const ssrfError = await validateUrlSsrf(compiledDomain);
+    const requestUrl = normalizeOutboundHttpUrl(compiledDomain);
+
+    if (!requestUrl) {
+      this.throwError('Reply callback URL blocked (SSRF): Invalid URL format.');
+    }
+
+    const ssrfError = await validateUrlSsrf(requestUrl);
 
     if (ssrfError) {
       this.throwError(`Reply callback URL blocked (SSRF): ${ssrfError}`);
@@ -67,7 +73,7 @@ export class ReplyToStrategy {
       mail: command,
     };
 
-    await axios.post(compiledDomain, userPayload);
+    await axios.post(requestUrl, userPayload);
   }
 
   private splitTo(address: string) {

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -3,6 +3,44 @@ import { LRUCache } from 'lru-cache';
 
 /* Keep in sync with packages/shared/src/utils/ssrf-url-validation.ts */
 
+/**
+ * Resolves a webhook-style URL for outbound HTTP requests.
+ * Host-only or path-first values (no scheme) are treated as https, matching axios behavior.
+ */
+export function normalizeOutboundHttpUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return trimmed;
+    }
+
+    return null;
+  } catch {
+    // Continue: scheme-less host/path (e.g. example.com/hook)
+  }
+
+  const withHttps = `https://${trimmed}`;
+
+  try {
+    const parsed = new URL(withHttps);
+
+    if (!parsed.hostname) {
+      return null;
+    }
+
+    return withHttps;
+  } catch {
+    return null;
+  }
+}
+
 const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
   max: 500,
   ttl: 1000 * 60 * 5, // 5 minutes

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -59,9 +59,13 @@ function isPrivateIp(ip: string): boolean {
     /^::ffff:172\.(1[6-9]|2[0-9]|3[01])\./i,
     /^::ffff:192\.168\./i,
     /^::ffff:169\.254\./i,
-    /^::1$/,
-    /^fc00:/i,
-    /^fe80:/i,
+    /^::1$/i,
+    /* ULA fc00::/7 (fc00–fdff first hextet) */
+    /^f[cd][0-9a-f]{2}:/i,
+    /^::ffff:f[cd][0-9a-f]{2}:/i,
+    /* Link-local fe80::/10 (fe80–febf first hextet) */
+    /^fe[89ab][0-9a-f]{2}:/i,
+    /^::ffff:fe[89ab][0-9a-f]{2}:/i,
   ];
 
   return privateRanges.some((range) => range.test(ip));

--- a/packages/providers/src/lib/chat/chat-webhook/chat-webhook.provider.ts
+++ b/packages/providers/src/lib/chat/chat-webhook/chat-webhook.provider.ts
@@ -1,4 +1,5 @@
 import { ChatProviderIdEnum } from '@novu/shared';
+import { validateUrlSsrf } from '@novu/shared/utils/ssrf-url-validation';
 import {
   ChannelTypeEnum,
   ENDPOINT_TYPES,
@@ -51,7 +52,14 @@ export class ChatWebhookProvider extends BaseProvider implements IChatProvider {
       delete data.body.hmacSecretKey;
     }
 
-    const response = await axios.create().post((data?.body?.webhookUrl as string) || endpoint.url, body, {
+    const targetUrl = (data?.body?.webhookUrl as string) || endpoint.url;
+    const ssrfError = await validateUrlSsrf(targetUrl);
+
+    if (ssrfError) {
+      throw new Error(`Chat webhook URL blocked: ${ssrfError}`);
+    }
+
+    const response = await axios.create().post(targetUrl, body, {
       headers: {
         'content-type': 'application/json',
         'X-Novu-Signature': hmacValue,

--- a/packages/providers/src/lib/chat/chat-webhook/chat-webhook.provider.ts
+++ b/packages/providers/src/lib/chat/chat-webhook/chat-webhook.provider.ts
@@ -1,5 +1,5 @@
 import { ChatProviderIdEnum } from '@novu/shared';
-import { validateUrlSsrf } from '@novu/shared/utils/ssrf-url-validation';
+import { normalizeOutboundHttpUrl, validateUrlSsrf } from '@novu/shared/utils/ssrf-url-validation';
 import {
   ChannelTypeEnum,
   ENDPOINT_TYPES,
@@ -52,7 +52,13 @@ export class ChatWebhookProvider extends BaseProvider implements IChatProvider {
       delete data.body.hmacSecretKey;
     }
 
-    const targetUrl = (data?.body?.webhookUrl as string) || endpoint.url;
+    const targetUrlRaw = (data?.body?.webhookUrl as string) || endpoint.url;
+    const targetUrl = normalizeOutboundHttpUrl(targetUrlRaw);
+
+    if (!targetUrl) {
+      throw new Error('Chat webhook URL blocked: Invalid URL format.');
+    }
+
     const ssrfError = await validateUrlSsrf(targetUrl);
 
     if (ssrfError) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,15 @@
       "require": "./dist/cjs/utils/index.js",
       "import": "./dist/esm/utils/index.js",
       "types": "./dist/esm/utils/index.d.js"
+    },
+    "./utils/ssrf-url-validation": {
+      "require": "./dist/cjs/utils/ssrf-url-validation.js",
+      "import": "./dist/esm/utils/ssrf-url-validation.js",
+      "types": "./dist/esm/utils/ssrf-url-validation.d.ts"
     }
+  },
+  "dependencies": {
+    "lru-cache": "^11.2.4"
   },
   "devDependencies": {
     "madge": "^8.0.0",

--- a/packages/shared/src/utils/ssrf-url-validation.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.ts
@@ -1,8 +1,6 @@
 import * as dns from 'node:dns';
 import { LRUCache } from 'lru-cache';
 
-/* Keep in sync with packages/shared/src/utils/ssrf-url-validation.ts */
-
 const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
   max: 500,
   ttl: 1000 * 60 * 5, // 5 minutes
@@ -32,6 +30,8 @@ function isPrivateIp(ip: string): boolean {
 /**
  * Validates that a URL is safe to fetch server-side (http/https only, no private IPs after DNS resolution).
  * Returns an error message string if blocked, or null if allowed.
+ *
+ * Keep in sync with `libs/application-generic/src/utils/ssrf-url-validation.ts`.
  */
 export async function validateUrlSsrf(url: string): Promise<string | null> {
   let parsed: URL;

--- a/packages/shared/src/utils/ssrf-url-validation.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.ts
@@ -1,6 +1,46 @@
 import * as dns from 'node:dns';
 import { LRUCache } from 'lru-cache';
 
+/* Keep in sync with libs/application-generic/src/utils/ssrf-url-validation.ts (normalizeOutboundHttpUrl + validateUrlSsrf) */
+
+/**
+ * Resolves a webhook-style URL for outbound HTTP requests.
+ * Host-only or path-first values (no scheme) are treated as https, matching axios behavior.
+ */
+export function normalizeOutboundHttpUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return trimmed;
+    }
+
+    return null;
+  } catch {
+    // Continue: scheme-less host/path (e.g. example.com/hook)
+  }
+
+  const withHttps = `https://${trimmed}`;
+
+  try {
+    const parsed = new URL(withHttps);
+
+    if (!parsed.hostname) {
+      return null;
+    }
+
+    return withHttps;
+  } catch {
+    return null;
+  }
+}
+
 const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
   max: 500,
   ttl: 1000 * 60 * 5, // 5 minutes
@@ -30,8 +70,6 @@ function isPrivateIp(ip: string): boolean {
 /**
  * Validates that a URL is safe to fetch server-side (http/https only, no private IPs after DNS resolution).
  * Returns an error message string if blocked, or null if allowed.
- *
- * Keep in sync with `libs/application-generic/src/utils/ssrf-url-validation.ts`.
  */
 export async function validateUrlSsrf(url: string): Promise<string | null> {
   let parsed: URL;

--- a/packages/shared/src/utils/ssrf-url-validation.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.ts
@@ -59,9 +59,13 @@ function isPrivateIp(ip: string): boolean {
     /^::ffff:172\.(1[6-9]|2[0-9]|3[01])\./i,
     /^::ffff:192\.168\./i,
     /^::ffff:169\.254\./i,
-    /^::1$/,
-    /^fc00:/i,
-    /^fe80:/i,
+    /^::1$/i,
+    /* ULA fc00::/7 (fc00–fdff first hextet) */
+    /^f[cd][0-9a-f]{2}:/i,
+    /^::ffff:f[cd][0-9a-f]{2}:/i,
+    /* Link-local fe80::/10 (fe80–febf first hextet) */
+    /^fe[89ab][0-9a-f]{2}:/i,
+    /^::ffff:fe[89ab][0-9a-f]{2}:/i,
   ];
 
   return privateRanges.some((range) => range.test(ip));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4014,6 +4014,10 @@ importers:
         version: 5.6.2
 
   packages/shared:
+    dependencies:
+      lru-cache:
+        specifier: ^11.2.4
+        version: 11.2.4
     devDependencies:
       madge:
         specifier: ^8.0.0
@@ -30819,7 +30823,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       jose: 6.1.3
       kysely: 0.28.14
       nanostores: 1.2.0
@@ -44167,7 +44171,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.6
       jose: 6.1.3
       kysely: 0.28.14
@@ -44185,15 +44189,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
-
-  better-call@1.3.2(zod@4.3.5):
-    dependencies:
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.0
-    optionalDependencies:
-      zod: 4.3.5
 
   better-call@1.3.2(zod@4.3.6):
     dependencies:
@@ -45820,7 +45815,6 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
-    optional: true
 
   debug@4.3.1(supports-color@8.1.1):
     dependencies:
@@ -52145,7 +52139,7 @@ snapshots:
 
   needle@3.2.0:
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       iconv-lite: 0.6.3
       sax: 1.5.0
     transitivePeerDependencies:
@@ -53475,7 +53469,7 @@ snapshots:
   portfinder@1.0.32:
     dependencies:
       async: 2.6.4
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7(supports-color@8.1.1)
       mkdirp: 0.5.6
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

This PR fixes two medium-severity Server-Side Request Forgery (SSRF) vulnerabilities. The change was needed to prevent attackers from using the inbound email reply webhook or the chat webhook provider to make unauthorized requests to internal or restricted network resources. SSRF validation is now applied to all outbound URLs in these flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR fixes two medium-severity Server-Side Request Forgery (SSRF) issues by normalizing and validating outbound webhook URLs before performing HTTP requests. The inbound email reply callback and chat webhook flows now normalize scheme-less URLs and run SSRF checks (including DNS resolution and IP classification) to block requests to localhost, metadata endpoints, or private/reserved IP ranges.

## Affected areas

**worker**: The reply-to strategy now normalizes callback URLs and rejects or blocks requests with invalid formats or SSRF validation errors before calling out.

**providers**: The chat webhook provider now normalizes and validates target webhook URLs and uses the validated URL for outbound POSTs.

**shared**: Added SSRF utilities (`normalizeOutboundHttpUrl`, `validateUrlSsrf`) with DNS resolution caching and IP-range checks, and exported them via a new `@novu/shared/utils/ssrf-url-validation` subpath.

**application-generic**: Duplicated the SSRF utilities here to avoid package dependency/coupling issues that prevent consuming the shared implementation.

**test**: Updated inbound-email-parse fixtures/specs to use fully-qualified HTTPS webhook URLs so DNS resolution succeeds in CI.

## Key technical decisions

- SSRF validation logic is duplicated in `packages/shared` and `libs/application-generic` to avoid dependency/coupling problems.  
- A dedicated `@novu/shared/utils/ssrf-url-validation` export prevents Node.js-specific code (DNS/IP checks) from being pulled into browser bundles.  
- Added an LRU-backed DNS cache dependency to limit repeated lookups and improve performance.  
- Scheme-less webhook inputs are normalized to `https://...` to preserve backward compatibility while enforcing SSRF checks.

## Testing

Updated unit/spec fixtures (inbound-email-parse) to use scheme-qualified HTTPS URLs; no new unit tests were added for the SSRF utilities in this PR. Manual/CI verification relies on the updated specs and existing test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

- The `validateUrlSsrf` utility logic is duplicated in `packages/shared` and `libs/application-generic` due to package dependency constraints.
- The `@novu/shared/utils/ssrf-url-validation` export is a dedicated entry to avoid pulling Node.js-specific code into browser bundles.

</details>

[Slack Thread](https://novu.slack.com/archives/C0ALBUKK3FA/p1777270227592569?thread_ts=1777270227.592569&cid=C0ALBUKK3FA)

<div><a href="https://cursor.com/agents/bc-d0960137-c54a-47e7-8d58-df0046afe882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0960137-c54a-47e7-8d58-df0046afe882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->