### PR TITLE
fix(dashboard): map agent platform names to correct provider icon filenames

### DIFF
--- a/apps/dashboard/src/utils/provider-square-icon.ts
+++ b/apps/dashboard/src/utils/provider-square-icon.ts
@@ -1,6 +1,8 @@
 const PROVIDER_SQUARE_ICON_FILE_ALIASES: Record<string, string> = {
   whatsapp: 'whatsapp-business',
   'novu-email-agent': 'novu-email',
+  email: 'novu-email',
+  teams: 'msteams',
 };
 
 export function getProviderSquareIconFileName(platform: string): string {

--- a/packages/novu/src/commands/dev/dev.ts
+++ b/packages/novu/src/commands/dev/dev.ts
@@ -164,17 +164,21 @@ async function startTunnelProbe(tunnelOrigin: string, endpointRoute: string, loc
   while (true) {
     await wait(TUNNEL_PROBE_INTERVAL_MS);
 
-    const localHealthy = await tunnelHealthCheck(`${localOrigin}${endpointRoute}`);
+    try {
+      const localHealthy = await tunnelHealthCheck(`${localOrigin}${endpointRoute}`);
 
-    if (!localHealthy) {
-      continue;
-    }
+      if (!localHealthy) {
+        continue;
+      }
 
-    const tunnelHealthy = await tunnelHealthCheck(`${tunnelOrigin}${endpointRoute}`);
+      const tunnelHealthy = await tunnelHealthCheck(`${tunnelOrigin}${endpointRoute}`);
 
-    if (!tunnelHealthy && tunnelClient?.socket) {
-      tunnelClient.socket.addEventListener('open', () => console.log(chalk.green('\n  ✓ Tunnel reconnected')), { once: true });
-      tunnelClient.socket.reconnect();
+      if (!tunnelHealthy && tunnelClient?.socket) {
+        tunnelClient.socket.addEventListener('open', () => console.log(chalk.green('\n  ✓ Tunnel reconnected')), { once: true });
+        tunnelClient.socket.reconnect();
+      }
+    } catch {
+      // keep the probe loop alive regardless of unexpected errors
     }
   }
 }

--- a/packages/novu/src/commands/dev/dev.ts
+++ b/packages/novu/src/commands/dev/dev.ts
@@ -19,6 +19,7 @@ let tunnelClient: NtfrTunnel | null = null;
 
 const WATCHDOG_INTERVAL_MS = 10_000;
 const SLEEP_DRIFT_THRESHOLD_MS = WATCHDOG_INTERVAL_MS * 2.5;
+const TUNNEL_PROBE_INTERVAL_MS = 30_000;
 export const TUNNEL_URL = 'https://novu.sh/api/tunnels';
 const { version } = packageJson;
 
@@ -64,6 +65,7 @@ export async function devCommand(options: DevCommandOptions, anonymousId?: strin
 
   if (!parsedOptions.tunnel) {
     startTunnelWatchdog();
+    startTunnelProbe(tunnelOrigin, NOVU_ENDPOINT_PATH, parsedOptions.origin).catch(() => {});
   }
 
   if (NOVU_SECRET_KEY) {
@@ -156,6 +158,25 @@ function createWatchdogTick(getSocket: () => WatchdogSocket | undefined): () => 
 
 function startTunnelWatchdog(): void {
   setInterval(createWatchdogTick(() => tunnelClient?.socket), WATCHDOG_INTERVAL_MS);
+}
+
+async function startTunnelProbe(tunnelOrigin: string, endpointRoute: string, localOrigin: string): Promise<void> {
+  while (true) {
+    await wait(TUNNEL_PROBE_INTERVAL_MS);
+
+    const localHealthy = await tunnelHealthCheck(`${localOrigin}${endpointRoute}`);
+
+    if (!localHealthy) {
+      continue;
+    }
+
+    const tunnelHealthy = await tunnelHealthCheck(`${tunnelOrigin}${endpointRoute}`);
+
+    if (!tunnelHealthy && tunnelClient?.socket) {
+      tunnelClient.socket.addEventListener('open', () => console.log(chalk.green('\n  ✓ Tunnel reconnected')), { once: true });
+      tunnelClient.socket.reconnect();
+    }
+  }
 }
 
 async function createTunnel(localOrigin: string, endpointRoute: string): Promise<string> {

--- a/packages/novu/src/commands/dev/dev.ts
+++ b/packages/novu/src/commands/dev/dev.ts
@@ -16,6 +16,9 @@ process.on('SIGINT', () => {
 });
 
 let tunnelClient: NtfrTunnel | null = null;
+
+const WATCHDOG_INTERVAL_MS = 10_000;
+const SLEEP_DRIFT_THRESHOLD_MS = WATCHDOG_INTERVAL_MS * 2.5;
 export const TUNNEL_URL = 'https://novu.sh/api/tunnels';
 const { version } = packageJson;
 
@@ -58,6 +61,10 @@ export async function devCommand(options: DevCommandOptions, anonymousId?: strin
   }
 
   await monitorEndpointHealth(parsedOptions, NOVU_ENDPOINT_PATH);
+
+  if (!parsedOptions.tunnel) {
+    startTunnelWatchdog();
+  }
 
   if (NOVU_SECRET_KEY) {
     const bridgeUrl = `${tunnelOrigin}${NOVU_ENDPOINT_PATH}`;
@@ -102,10 +109,14 @@ async function monitorEndpointHealth(parsedOptions: DevCommandOptions, endpointR
 }
 
 async function tunnelHealthCheck(configTunnelUrl: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5_000);
+
   try {
     const res = await (
       await fetch(`${configTunnelUrl}?action=health-check`, {
         method: 'GET',
+        signal: controller.signal,
         headers: {
           accept: 'application/json',
           'Content-Type': 'application/json',
@@ -117,7 +128,34 @@ async function tunnelHealthCheck(configTunnelUrl: string): Promise<boolean> {
     return res.status === 'ok';
   } catch (e) {
     return false;
+  } finally {
+    clearTimeout(timeoutId);
   }
+}
+
+type WatchdogSocket = Pick<NonNullable<NtfrTunnel['socket']>, 'reconnect' | 'addEventListener'>;
+
+function createWatchdogTick(getSocket: () => WatchdogSocket | undefined): () => void {
+  let lastTickMs = Date.now();
+
+  return () => {
+    const now = Date.now();
+    const drift = now - lastTickMs;
+    lastTickMs = now;
+
+    if (drift > SLEEP_DRIFT_THRESHOLD_MS) {
+      const socket = getSocket();
+
+      if (socket) {
+        socket.addEventListener('open', () => console.log(chalk.green('\n  ✓ Tunnel reconnected')), { once: true });
+        socket.reconnect();
+      }
+    }
+  };
+}
+
+function startTunnelWatchdog(): void {
+  setInterval(createWatchdogTick(() => tunnelClient?.socket), WATCHDOG_INTERVAL_MS);
 }
 
 async function createTunnel(localOrigin: string, endpointRoute: string): Promise<string> {


### PR DESCRIPTION
## Summary
- Conversation channels store platform as `email` / `teams` (from `AgentPlatformEnum`), but the provider square-icon SVGs are named `novu-email.svg` / `msteams.svg`. The missing aliases caused broken `<img>` tags in the Providers metadata row and timeline chips.
- Adds two entries to `PROVIDER_SQUARE_ICON_FILE_ALIASES` in `provider-square-icon.ts` to resolve the mismatch.

## Test plan
- [ ] Open a conversation that used the email channel — verify the Providers row and "via Email" chip render the Novu Email icon instead of a broken image
- [ ] Open a conversation that used MS Teams — verify the icon renders correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The provider icon filename mapping now recognizes conversation channel platform names (`email` and `teams` from AgentPlatformEnum) by adding aliases to `PROVIDER_SQUARE_ICON_FILE_ALIASES` that map them to their corresponding SVG filenames (`novu-email.svg` and `msteams.svg`). This fixes broken image tags in the Providers metadata row and timeline chips when displaying conversations using email or MS Teams channels.

## Affected areas
- **dashboard**: Added two platform-to-icon filename mappings in the provider square icon utility to resolve platform name mismatches between conversation channel storage and icon asset filenames.

## Testing
No new tests added. The fix requires manual verification: confirm that conversations using the email channel display the Novu Email icon in the Providers row and "via Email" chip, and that MS Teams conversations display the Teams icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->