### PR TITLE
chore(framework,novu): bump package versions

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "2.10.1-alpha.2",
+  "version": "2.10.1-alpha.4",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/cjs/index.d.cts",

--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.8.1-rc.3",
+  "version": "2.8.1-rc.5",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {


### PR DESCRIPTION
## Summary

- `@novu/framework`: `2.10.1-alpha.2` → `2.10.1-alpha.4`
- `novu`: `2.8.1-rc.3` → `2.8.1-rc.5`

Made with [Cursor](https://cursor.com)