### PR TITLE
docs(root): remove unused environment variables and ports from docker-compose.yml fixes NV-7417 NV-7418

### DIFF
--- a/docker/community/docker-compose.yml
+++ b/docker/community/docker-compose.yml
@@ -25,14 +25,10 @@ services:
         max-size: "50m"
         max-file: "5"
     environment:
-      - PUID=1000
-      - PGID=1000
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD}
     volumes:
       - mongodb:/data/db
-    ports:
-      - 27017:27017
     healthcheck:
       test:
         [


### PR DESCRIPTION
### What changed? Why was the change needed?
This addresses #10872 and #10873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Removed unused PUID/PGID environment variables and the explicit port 27017 binding from the MongoDB container in the community Docker Compose configuration. These configurations were not needed for the service to function in the community setup and added unnecessary complexity.

## Affected areas
**docker**: Cleaned up the MongoDB service configuration in `docker/community/docker-compose.yml` by removing redundant environment variables (PUID/PGID) and unused port exposure.

## Testing
No tests required. This is a documentation/configuration cleanup that removes unused settings from the Docker Compose file without altering service functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
