### PR TITLE
feat(api-service,dashboard): add MS Teams ARM template deploy-to-Azure flow

### DIFF
--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -67,6 +67,9 @@ import { GenerateConnectOauthUrlCommand } from './usecases/generate-chat-oath-ur
 import { GenerateConnectOauthUrl } from './usecases/generate-chat-oath-url/generate-connect-oauth-url.usecase';
 import { GenerateLinkUserOauthUrlCommand } from './usecases/generate-chat-oath-url/generate-link-user-oauth-url.command';
 import { GenerateLinkUserOauthUrl } from './usecases/generate-chat-oath-url/generate-link-user-oauth-url.usecase';
+import { GenerateMsTeamsArmTemplateCommand } from './usecases/generate-msteams-arm-template/generate-msteams-arm-template.command';
+import { GenerateMsTeamsArmTemplate } from './usecases/generate-msteams-arm-template/generate-msteams-arm-template.usecase';
+import { GetMsTeamsArmTemplate } from './usecases/generate-msteams-arm-template/get-msteams-arm-template.usecase';
 import { GetInAppActivatedCommand } from './usecases/get-in-app-activated/get-in-app-activated.command';
 import { GetInAppActivated } from './usecases/get-in-app-activated/get-in-app-activated.usecase';
 import { GetIntegrationsCommand } from './usecases/get-integrations/get-integrations.command';
@@ -101,7 +104,9 @@ export class IntegrationsController {
     private generateConnectOauthUrlUsecase: GenerateConnectOauthUrl,
     private generateLinkUserOauthUrlUsecase: GenerateLinkUserOauthUrl,
     private chatOauthCallbackUsecase: ChatOauthCallback,
-    private featureFlagsService: FeatureFlagsService
+    private featureFlagsService: FeatureFlagsService,
+    private generateMsTeamsArmTemplateUsecase: GenerateMsTeamsArmTemplate,
+    private getMsTeamsArmTemplateUsecase: GetMsTeamsArmTemplate
   ) {}
 
   @Get('/')
@@ -411,6 +416,56 @@ export class IntegrationsController {
         environmentId: user.environmentId,
       })
     );
+  }
+
+  @Get('/:integrationId/msteams-arm-template/deploy-url')
+  @ApiOkResponse({
+    description: 'Signed Azure Portal "Deploy to Azure" URL for the MS Teams ARM template.',
+  })
+  @ApiOperation({
+    summary: 'Get MS Teams ARM template deploy URL',
+    description:
+      'Returns a short-lived signed URL that opens the Azure Portal with a pre-filled ARM template to create the Azure Bot resource and enable the MS Teams channel.',
+  })
+  @ApiExcludeEndpoint()
+  @RequireAuthentication()
+  @RequirePermissions(PermissionsEnum.INTEGRATION_READ)
+  async getMsTeamsArmTemplateDeployUrl(
+    @UserSession() user: UserSessionData,
+    @Param('integrationId') integrationId: string
+  ): Promise<{ deployUrl: string }> {
+    return this.generateMsTeamsArmTemplateUsecase.execute(
+      GenerateMsTeamsArmTemplateCommand.create({
+        userId: user._id,
+        organizationId: user.organizationId,
+        integrationId,
+      })
+    );
+  }
+
+  /**
+   * Public endpoint fetched by Azure Portal when the user clicks "Deploy to Azure".
+   * Protected by an HMAC-signed, time-expiring `sig` + `exp` query parameter pair —
+   * no session cookie is available because Azure's servers make this request, not the browser.
+   */
+  @Get('/:integrationId/msteams-arm-template')
+  @ApiExcludeEndpoint()
+  @ApiOperation({ summary: 'Serve MS Teams ARM template JSON (signed)' })
+  async getMsTeamsArmTemplateJson(
+    @Res() res: Response,
+    @Param('integrationId') integrationId: string,
+    @Query('sig') sig: string,
+    @Query('exp') exp: string
+  ): Promise<void> {
+    if (!sig || !exp) {
+      throw new BadRequestException('Missing required parameters: sig, exp');
+    }
+
+    const { template } = await this.getMsTeamsArmTemplateUsecase.execute(integrationId, sig, exp);
+
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Cache-Control', 'no-store');
+    res.send(JSON.stringify(template, null, 2));
   }
 
   /**

--- a/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/generate-msteams-arm-template.command.ts
+++ b/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/generate-msteams-arm-template.command.ts
@@ -1,0 +1,8 @@
+import { IsDefined, IsString } from 'class-validator';
+import { OrganizationCommand } from '../../../shared/commands/organization.command';
+
+export class GenerateMsTeamsArmTemplateCommand extends OrganizationCommand {
+  @IsDefined()
+  @IsString()
+  integrationId: string;
+}

--- a/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/generate-msteams-arm-template.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/generate-msteams-arm-template.usecase.ts
@@ -1,0 +1,87 @@
+import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { GetDecryptedIntegrations } from '@novu/application-generic';
+import { EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { ChatProviderIdEnum } from '@novu/shared';
+import { createHmac } from 'crypto';
+import { GenerateMsTeamsArmTemplateCommand } from './generate-msteams-arm-template.command';
+
+const ARM_TEMPLATE_EXPIRY_MS = 15 * 60 * 1000; // 15 minutes
+
+export type MsTeamsArmTemplateResult = {
+  /** Signed URL the dashboard can hand to the Azure Portal "Deploy to Azure" button */
+  deployUrl: string;
+};
+
+@Injectable()
+export class GenerateMsTeamsArmTemplate {
+  constructor(
+    private integrationRepository: IntegrationRepository,
+    private environmentRepository: EnvironmentRepository
+  ) {}
+
+  async execute(command: GenerateMsTeamsArmTemplateCommand): Promise<MsTeamsArmTemplateResult> {
+    const integration = await this.integrationRepository.findOne({
+      _id: command.integrationId,
+      _organizationId: command.organizationId,
+    });
+
+    if (!integration) {
+      throw new NotFoundException(`Integration ${command.integrationId} not found`);
+    }
+
+    if (integration.providerId !== ChatProviderIdEnum.MsTeams) {
+      throw new UnauthorizedException('ARM template is only supported for MS Teams integrations');
+    }
+
+    const decrypted = GetDecryptedIntegrations.getDecryptedCredentials(integration);
+    const { clientId: appId } = decrypted.credentials as Record<string, string>;
+
+    if (!appId) {
+      throw new NotFoundException('MS Teams integration missing App ID (clientId). Configure credentials first.');
+    }
+
+    const apiKeys = await this.environmentRepository.getApiKeys(integration._environmentId);
+
+    if (!apiKeys.length) {
+      throw new NotFoundException(`Environment for integration ${command.integrationId} not found`);
+    }
+
+    const signingKey = apiKeys[0].key;
+    const exp = Date.now() + ARM_TEMPLATE_EXPIRY_MS;
+
+    const payload = `${command.integrationId}:${exp}`;
+    const sig = createHmac('sha256', signingKey).update(payload).digest('hex');
+
+    const templateApiUrl = this.buildTemplateApiUrl(command.integrationId, sig, exp);
+    const deployUrl = `https://portal.azure.com/#create/Microsoft.Template/uri/${encodeURIComponent(templateApiUrl)}`;
+
+    return { deployUrl };
+  }
+
+  /**
+   * Validates a signed ARM template URL request.
+   * Returns the decoded integrationId on success, throws on failure.
+   *
+   * The route that serves the raw ARM JSON must call this before returning template content.
+   */
+  static async verifySignature(integrationId: string, sig: string, exp: string, signingKey: string): Promise<void> {
+    const expMs = Number(exp);
+
+    if (!Number.isFinite(expMs) || Date.now() > expMs) {
+      throw new UnauthorizedException('ARM template link has expired');
+    }
+
+    const payload = `${integrationId}:${expMs}`;
+    const expected = createHmac('sha256', signingKey).update(payload).digest('hex');
+
+    if (sig !== expected) {
+      throw new UnauthorizedException('Invalid ARM template signature');
+    }
+  }
+
+  private buildTemplateApiUrl(integrationId: string, sig: string, exp: number): string {
+    const base = (process.env.API_ROOT_URL ?? '').replace(/\/$/, '');
+
+    return `${base}/v1/integrations/${integrationId}/msteams-arm-template?sig=${sig}&exp=${exp}`;
+  }
+}

--- a/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/get-msteams-arm-template.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/get-msteams-arm-template.usecase.ts
@@ -91,13 +91,18 @@ export class GetMsTeamsArmTemplate {
 
   private sanitizeBotName(name: string): string {
     // Azure Bot resource names: 2-64 chars, alphanumeric and hyphens only
-    return name
+    const sanitized = name
       .toLowerCase()
       .replace(/[^a-z0-9-]/g, '-')
       .replace(/-+/g, '-')
       .replace(/^-|-$/g, '')
-      .slice(0, 64)
-      .padEnd(2, 'bot');
+      .slice(0, 64);
+
+    if (sanitized.length < 2) {
+      return 'bot';
+    }
+
+    return sanitized;
   }
 
   private buildWebhookUrl(agentIdentifier: string | null, integrationIdentifier: string): string {

--- a/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/get-msteams-arm-template.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-msteams-arm-template/get-msteams-arm-template.usecase.ts
@@ -1,0 +1,255 @@
+import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { GetDecryptedIntegrations } from '@novu/application-generic';
+import { AgentIntegrationRepository, AgentRepository, EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { ChatProviderIdEnum } from '@novu/shared';
+import { GenerateMsTeamsArmTemplate } from './generate-msteams-arm-template.usecase';
+
+export type GetMsTeamsArmTemplateResult = {
+  template: Record<string, unknown>;
+};
+
+@Injectable()
+export class GetMsTeamsArmTemplate {
+  constructor(
+    private integrationRepository: IntegrationRepository,
+    private environmentRepository: EnvironmentRepository,
+    private agentIntegrationRepository: AgentIntegrationRepository,
+    private agentRepository: AgentRepository
+  ) {}
+
+  async execute(integrationId: string, sig: string, exp: string): Promise<GetMsTeamsArmTemplateResult> {
+    /**
+     * Internal lookup by _id only — bypasses the EnforceEnvOrOrgIds constraint.
+     * Use only in contexts where the caller has already verified authorization
+     * through another mechanism (e.g. HMAC signature validation).
+     */
+    // @ts-expect-error EnforceEnvOrOrgIds: _id-only query is intentional here (see comment above).
+    const integration = await this.integrationRepository.findOne({ _id: integrationId });
+
+    if (!integration) {
+      throw new NotFoundException(`Integration ${integrationId} not found`);
+    }
+
+    if (integration.providerId !== ChatProviderIdEnum.MsTeams) {
+      throw new UnauthorizedException('ARM template is only supported for MS Teams integrations');
+    }
+
+    const apiKeys = await this.environmentRepository.getApiKeys(integration._environmentId);
+
+    if (!apiKeys.length) {
+      throw new NotFoundException(`Environment for integration ${integrationId} not found`);
+    }
+
+    await GenerateMsTeamsArmTemplate.verifySignature(integrationId, sig, exp, apiKeys[0].key);
+
+    const decrypted = GetDecryptedIntegrations.getDecryptedCredentials(integration);
+    const credentials = decrypted.credentials as Record<string, string>;
+    const appId = credentials.clientId ?? '';
+    const tenantId = credentials.tenantId ?? '';
+
+    const botName = this.sanitizeBotName(integration.name ?? 'NovuBot');
+    const displayName = integration.name ?? 'Novu Bot';
+    const agentIdentifier = await this.resolveAgentIdentifier(
+      integrationId,
+      integration._environmentId,
+      integration._organizationId
+    );
+    const endpoint = this.buildWebhookUrl(agentIdentifier, integration.identifier);
+
+    return { template: buildArmTemplate({ appId, tenantId, botName, displayName, endpoint }) };
+  }
+
+  private async resolveAgentIdentifier(
+    integrationId: string,
+    environmentId: string,
+    organizationId: string
+  ): Promise<string | null> {
+    const link = await this.agentIntegrationRepository.findOne(
+      {
+        _integrationId: integrationId,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      },
+      ['_agentId']
+    );
+
+    if (!link) {
+      return null;
+    }
+
+    const agent = await this.agentRepository.findOne(
+      {
+        _id: link._agentId,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      },
+      ['identifier']
+    );
+
+    return agent?.identifier ?? null;
+  }
+
+  private sanitizeBotName(name: string): string {
+    // Azure Bot resource names: 2-64 chars, alphanumeric and hyphens only
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 64)
+      .padEnd(2, 'bot');
+  }
+
+  private buildWebhookUrl(agentIdentifier: string | null, integrationIdentifier: string): string {
+    const base = (process.env.API_ROOT_URL ?? '').replace(/\/$/, '');
+
+    if (!agentIdentifier) {
+      return `${base}/v1/agents/unknown/webhook/${integrationIdentifier}`;
+    }
+
+    return `${base}/v1/agents/${agentIdentifier}/webhook/${integrationIdentifier}`;
+  }
+}
+
+/**
+ * Builds a subscription-scoped ARM template that:
+ *   1. Creates a dedicated resource group (rg-{botName}) if it does not exist.
+ *   2. Deploys into that resource group:
+ *        - Microsoft.BotService/botServices  (SingleTenant Azure Bot, F0 free tier)
+ *        - Microsoft.BotService/botServices/channels/MsTeamsChannel  (Teams channel enabled)
+ *
+ * Using the subscription schema allows resource-group creation in a single "Deploy to Azure" click.
+ * Parameters with defaultValue are pre-filled so the Azure Portal form needs minimal manual input.
+ * The template contains NO secrets — appId is public, endpoint is a webhook URL.
+ */
+function buildArmTemplate({
+  appId,
+  tenantId,
+  botName,
+  displayName,
+  endpoint,
+}: {
+  appId: string;
+  tenantId: string;
+  botName: string;
+  displayName: string;
+  endpoint: string;
+}): Record<string, unknown> {
+  const resourceGroupName = `rg-${botName}`;
+
+  return {
+    $schema: 'https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#',
+    contentVersion: '1.0.0.0',
+    parameters: {
+      resourceGroupName: {
+        type: 'string',
+        defaultValue: resourceGroupName,
+        metadata: { description: 'Name of the resource group to create or use for the Azure Bot resources.' },
+      },
+      location: {
+        type: 'string',
+        defaultValue: 'eastus',
+        metadata: { description: 'Azure region for the resource group and bot resources.' },
+      },
+      botName: {
+        type: 'string',
+        defaultValue: botName,
+        metadata: { description: 'Resource name for the Azure Bot (2-64 chars, alphanumeric and hyphens).' },
+      },
+      displayName: {
+        type: 'string',
+        defaultValue: displayName,
+        metadata: { description: 'Human-readable display name for the bot.' },
+      },
+      msaAppId: {
+        type: 'string',
+        defaultValue: appId,
+        metadata: { description: 'The App ID (client ID) from your Azure App Registration.' },
+      },
+      msaAppTenantId: {
+        type: 'string',
+        defaultValue: tenantId,
+        metadata: { description: 'The Tenant ID of your Azure AD tenant.' },
+      },
+      botEndpoint: {
+        type: 'string',
+        defaultValue: endpoint,
+        metadata: { description: 'The messaging endpoint URL for your Novu agent webhook.' },
+      },
+    },
+    resources: [
+      {
+        type: 'Microsoft.Resources/resourceGroups',
+        apiVersion: '2022-09-01',
+        name: "[parameters('resourceGroupName')]",
+        location: "[parameters('location')]",
+        properties: {},
+      },
+      {
+        type: 'Microsoft.Resources/deployments',
+        apiVersion: '2022-09-01',
+        name: 'botDeployment',
+        resourceGroup: "[parameters('resourceGroupName')]",
+        dependsOn: ["[resourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroupName'))]"],
+        properties: {
+          mode: 'Incremental',
+          expressionEvaluationOptions: { scope: 'inner' },
+          parameters: {
+            botName: { value: "[parameters('botName')]" },
+            displayName: { value: "[parameters('displayName')]" },
+            msaAppId: { value: "[parameters('msaAppId')]" },
+            msaAppTenantId: { value: "[parameters('msaAppTenantId')]" },
+            botEndpoint: { value: "[parameters('botEndpoint')]" },
+            location: { value: "[parameters('location')]" },
+          },
+          template: {
+            $schema: 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#',
+            contentVersion: '1.0.0.0',
+            parameters: {
+              botName: { type: 'string' },
+              displayName: { type: 'string' },
+              msaAppId: { type: 'string' },
+              msaAppTenantId: { type: 'string' },
+              botEndpoint: { type: 'string' },
+              location: { type: 'string' },
+            },
+            resources: [
+              {
+                type: 'Microsoft.BotService/botServices',
+                apiVersion: '2023-09-15-preview',
+                name: "[parameters('botName')]",
+                location: 'global',
+                kind: 'azurebot',
+                sku: { name: 'F0' },
+                properties: {
+                  displayName: "[parameters('displayName')]",
+                  endpoint: "[parameters('botEndpoint')]",
+                  msaAppId: "[parameters('msaAppId')]",
+                  msaAppTenantId: "[parameters('msaAppTenantId')]",
+                  msaAppType: 'SingleTenant',
+                },
+              },
+              {
+                type: 'Microsoft.BotService/botServices/channels',
+                apiVersion: '2023-09-15-preview',
+                name: "[concat(parameters('botName'), '/MsTeamsChannel')]",
+                location: 'global',
+                kind: 'azurebot',
+                dependsOn: ["[resourceId('Microsoft.BotService/botServices', parameters('botName'))]"],
+                properties: {
+                  channelName: 'MsTeamsChannel',
+                  location: 'global',
+                  properties: {
+                    isEnabled: true,
+                    enableCalling: false,
+                    acceptedTerms: true,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  };
+}

--- a/apps/api/src/app/integrations/usecases/index.ts
+++ b/apps/api/src/app/integrations/usecases/index.ts
@@ -19,6 +19,8 @@ import { GenerateConnectOauthUrl } from './generate-chat-oath-url/generate-conne
 import { GenerateLinkUserOauthUrl } from './generate-chat-oath-url/generate-link-user-oauth-url.usecase';
 import { GenerateMsTeamsOauthUrl } from './generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.usecase';
 import { GenerateSlackOauthUrl } from './generate-chat-oath-url/generate-slack-oath-url/generate-slack-oauth-url.usecase';
+import { GenerateMsTeamsArmTemplate } from './generate-msteams-arm-template/generate-msteams-arm-template.usecase';
+import { GetMsTeamsArmTemplate } from './generate-msteams-arm-template/get-msteams-arm-template.usecase';
 import { GetInAppActivated } from './get-in-app-activated/get-in-app-activated.usecase';
 import { GetIntegrations } from './get-integrations/get-integrations.usecase';
 import { GetWebhookSupportStatus } from './get-webhook-support-status/get-webhook-support-status.usecase';
@@ -49,6 +51,8 @@ export const USE_CASES = [
   GenerateLinkUserOauthUrl,
   GenerateSlackOauthUrl,
   GenerateMsTeamsOauthUrl,
+  GenerateMsTeamsArmTemplate,
+  GetMsTeamsArmTemplate,
   SlackOauthCallback,
   MsTeamsOauthCallback,
   ChatOauthCallback,

--- a/apps/dashboard/src/api/integrations.ts
+++ b/apps/dashboard/src/api/integrations.ts
@@ -80,3 +80,15 @@ export async function updateIntegration(integrationId: string, data: UpdateInteg
     environment: environment,
   });
 }
+
+export async function getMsTeamsArmTemplateDeployUrl(
+  integrationId: string,
+  environment: IEnvironment
+): Promise<{ deployUrl: string }> {
+  const { data } = await get<{ data: { deployUrl: string } }>(
+    `/integrations/${integrationId}/msteams-arm-template/deploy-url`,
+    { environment }
+  );
+
+  return data;
+}

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -155,7 +155,7 @@ export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
             ) : null}
 
             {hasConnectedIntegration && (
-              <AgentCodeSetupSection agent={agent} stepOffset={5} providerId={selectedProviderId} />
+              <AgentCodeSetupSection agent={agent} stepOffset={1} providerId={selectedProviderId} />
             )}
           </div>
         </div>

--- a/apps/dashboard/src/components/agents/teams-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/teams-setup-guide.tsx
@@ -6,6 +6,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { RiArrowDownSLine, RiKey2Line } from 'react-icons/ri';
 import type { AgentResponse } from '@/api/agents';
+import { getMsTeamsArmTemplateDeployUrl } from '@/api/integrations';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { CodeBlock } from '@/components/primitives/code-block';
 import { CopyButton } from '@/components/primitives/copy-button';
@@ -41,10 +42,6 @@ function getApiHostname(): string {
   } catch {
     return 'api.novu.co';
   }
-}
-
-function buildWebhookUrl(agentId: string, integrationIdentifier: string): string {
-  return `${getApiBaseUrl()}/v1/agents/${agentId}/webhook/${integrationIdentifier}`;
 }
 
 function buildOAuthCallbackUrl(): string {
@@ -112,24 +109,6 @@ function RedirectUriSection({ redirectUri }: { redirectUri: string }) {
   );
 }
 
-function WebhookUrlSection({ webhookUrl }: { webhookUrl: string }) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <p className="text-text-sub text-label-xs font-medium leading-5">Messaging endpoint</p>
-      <div className="border-stroke-soft bg-bg-white flex h-7 items-center overflow-hidden rounded-md border shadow-xs">
-        <input
-          type="text"
-          readOnly
-          value={webhookUrl}
-          aria-label="Messaging endpoint URL"
-          className="text-text-soft min-w-0 flex-1 truncate bg-transparent px-2 font-mono text-[12px] leading-4 outline-none"
-        />
-        <CopyButton valueToCopy={webhookUrl} size="xs" className="shrink-0 border-l border-stroke-soft" />
-      </div>
-    </div>
-  );
-}
-
 function ManifestPreview({ manifestJson }: { manifestJson: string }) {
   const [open, setOpen] = useState(false);
 
@@ -177,6 +156,7 @@ export function TeamsSetupGuide({
   const { currentEnvironment } = useEnvironment();
   const [isCredentialsSidebarOpen, setIsCredentialsSidebarOpen] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
+  const [isDeploying, setIsDeploying] = useState(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset when the watched integration changes
   useEffect(() => {
@@ -200,7 +180,6 @@ export function TeamsSetupGuide({
   const appId = credentials?.clientId ?? '';
   const hasCredentials = Boolean(appId && credentials?.secretKey && credentials?.tenantId);
 
-  const webhookUrl = buildWebhookUrl(agent._id, integrationIdentifier || 'YOUR_INTEGRATION_IDENTIFIER');
   const manifestJson = JSON.stringify(buildManifest(appId, agent.name), null, 2);
 
   const canDownload = Boolean(appId);
@@ -213,8 +192,25 @@ export function TeamsSetupGuide({
     void downloadTeamsAppPackage(manifestJson, agent.name);
   }, [canDownload, manifestJson, agent.name]);
 
+  const handleDeployToAzure = useCallback(async () => {
+    if (!currentEnvironment || !hasCredentials || isDeploying) {
+      return;
+    }
+
+    setIsDeploying(true);
+
+    try {
+      const { deployUrl } = await getMsTeamsArmTemplateDeployUrl(integrationId, currentEnvironment);
+      window.open(deployUrl, '_blank', 'noopener,noreferrer');
+    } finally {
+      setIsDeploying(false);
+    }
+  }, [currentEnvironment, hasCredentials, integrationId, isDeploying]);
+
   const base = stepOffset;
 
+  // Steps: App Reg + Redirect URI (base+0), Graph perms (base+1),
+  //        Credentials (base+2), Deploy to Azure (base+3), Download pkg (base+4), Upload+connect (base+5)
   const firstIncomplete = useMemo(() => {
     if (isConnected) {
       return base + 7;
@@ -224,7 +220,7 @@ export function TeamsSetupGuide({
       return base;
     }
 
-    return base + 6;
+    return base + 5;
   }, [base, hasCredentials, isConnected]);
 
   const steps = (
@@ -232,21 +228,32 @@ export function TeamsSetupGuide({
       <SetupStep
         index={base}
         status={deriveStepStatus(base, firstIncomplete)}
-        title="Create an Azure Bot resource"
-        description="In the Azure Portal, create a new Azure Bot (Single Tenant). Choose F0 (free) pricing for testing. Once created, note your App ID from the Bot Configuration page."
+        title="Create an App Registration"
+        description={
+          <span>
+            {'In the Azure Portal, create a new '}
+            <strong>App Registration</strong>
+            {' (Single Tenant). When prompted for a Redirect URI, add the OAuth callback URL shown below as a '}
+            <strong>Web</strong>
+            {' platform URI. Once created, note the App ID from the Overview page.'}
+          </span>
+        }
         rightContent={
-          <SetupButton
-            href="https://portal.azure.com/#create/Microsoft.AzureBot"
-            leadingIcon={
-              <ProviderIcon
-                providerId={ChatProviderIdEnum.MsTeams}
-                providerDisplayName="MS Teams"
-                className="size-4 shrink-0"
-              />
-            }
-          >
-            Open Azure Portal
-          </SetupButton>
+          <div className="flex min-w-0 flex-col gap-3">
+            <SetupButton
+              href="https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/RegisteredApps"
+              leadingIcon={
+                <ProviderIcon
+                  providerId={ChatProviderIdEnum.MsTeams}
+                  providerDisplayName="MS Teams"
+                  className="size-4 shrink-0"
+                />
+              }
+            >
+              Open App Registrations
+            </SetupButton>
+            <RedirectUriSection redirectUri={buildOAuthCallbackUrl()} />
+          </div>
         }
       />
 
@@ -301,28 +308,8 @@ export function TeamsSetupGuide({
       <SetupStep
         index={base + 2}
         status={deriveStepStatus(base + 2, firstIncomplete)}
-        title="Add Novu's redirect URI"
-        description={
-          <span>
-            {'In your App Registration, go to '}
-            <strong>Authentication</strong>
-            {' → '}
-            <strong>Add a platform</strong>
-            {' → '}
-            <strong>Web</strong>
-            {'. Paste the URL below as the Redirect URI, then click '}
-            <strong>Configure</strong>
-            {'. This is where Microsoft sends the user after they grant admin consent.'}
-          </span>
-        }
-        rightContent={<RedirectUriSection redirectUri={buildOAuthCallbackUrl()} />}
-      />
-
-      <SetupStep
-        index={base + 3}
-        status={deriveStepStatus(base + 3, firstIncomplete)}
         title="Configure credentials"
-        description="Copy the App ID, Client Secret, and Tenant ID from your Azure Bot registration into the integration."
+        description="Copy the App ID, Client Secret, and Tenant ID from your App Registration into the integration."
         rightContent={
           <SetupButton
             leadingIcon={<RiKey2Line className="size-3.5" />}
@@ -336,7 +323,44 @@ export function TeamsSetupGuide({
             className="mt-2 w-full"
             variant="tip"
             title="Where to find these:"
-            description="App ID is on the Bot Configuration page. For the secret, click Manage Password → Certificates & secrets → New client secret and copy the Value immediately — it's only shown once. Tenant ID is on the App Registration Overview page."
+            description="App ID is on the Overview page. For the secret, go to Certificates & secrets → New client secret and copy the Value immediately — it's only shown once. Tenant ID is also on the Overview page."
+          />
+        }
+      />
+
+      <SetupStep
+        index={base + 3}
+        status={deriveStepStatus(base + 3, firstIncomplete)}
+        title="Deploy the Azure Bot to your subscription"
+        description="Click the button to open a pre-filled Azure deployment. It creates the Azure Bot resource, sets the messaging endpoint, and enables the Microsoft Teams channel — all in one click."
+        rightContent={
+          <div className="flex min-w-0 flex-col gap-3">
+            <SetupButton
+              leadingIcon={
+                isDeploying ? null : (
+                  <ProviderIcon
+                    providerId={ChatProviderIdEnum.MsTeams}
+                    providerDisplayName="MS Teams"
+                    className="size-4 shrink-0"
+                  />
+                )
+              }
+              onClick={handleDeployToAzure}
+              disabled={!hasCredentials || isDeploying}
+            >
+              {isDeploying ? 'Opening Azure Portal…' : 'Deploy to Azure'}
+            </SetupButton>
+            {!hasCredentials && (
+              <p className="text-text-soft text-label-xs">Configure credentials in step {base + 2} first.</p>
+            )}
+          </div>
+        }
+        extraContent={
+          <InlineToast
+            className="mt-2 w-full"
+            variant="tip"
+            title="What this deploys:"
+            description="An Azure Bot resource (F0 free tier, Single Tenant) with your messaging endpoint pre-filled and the Microsoft Teams channel enabled. Your App ID and Tenant ID are pre-populated from the credentials you saved."
           />
         }
       />
@@ -344,14 +368,6 @@ export function TeamsSetupGuide({
       <SetupStep
         index={base + 4}
         status={deriveStepStatus(base + 4, firstIncomplete)}
-        title="Set the messaging endpoint and enable Teams"
-        description="In your Azure Bot, go to Configuration → paste the endpoint below. Then go to Channels → enable Microsoft Teams."
-        rightContent={<WebhookUrlSection webhookUrl={webhookUrl} />}
-      />
-
-      <SetupStep
-        index={base + 5}
-        status={deriveStepStatus(base + 5, firstIncomplete)}
         title="Download the Teams app package"
         description="We've generated a ready-to-upload app package with your manifest and placeholder icons. Before deploying to production, replace the icons and update the developer fields in manifest.json with your company info."
         rightContent={
@@ -379,8 +395,8 @@ export function TeamsSetupGuide({
       />
 
       <SetupStep
-        index={base + 6}
-        status={deriveStepStatus(base + 6, firstIncomplete)}
+        index={base + 5}
+        status={deriveStepStatus(base + 5, firstIncomplete)}
         title="Upload to Teams and verify"
         description={
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
## What

Adds a one-click **Deploy to Azure** flow for the MS Teams integration setup, replacing the multi-step manual Azure Bot configuration.

## Why

The previous setup required users to navigate multiple Azure Portal screens, manually paste a messaging endpoint, and enable the Teams channel. This collapses that into a single signed URL that pre-fills an ARM template in the Azure Portal.

## Changes

### `apps/api` — new usecases & endpoints

| File | Change |
|---|---|
| `generate-msteams-arm-template.usecase.ts` | Generates a 15-minute HMAC-signed `deployUrl` pointing to the Azure Portal with the ARM template pre-filled |
| `get-msteams-arm-template.usecase.ts` | Serves the ARM template JSON after verifying the `sig`/`exp` query params |
| `generate-msteams-arm-template.command.ts` | Typed command for the generate usecase |
| `integrations.controller.ts` | Two new routes: `GET /:id/msteams-arm-template/deploy-url` (authenticated) and `GET /:id/msteams-arm-template` (public, HMAC-protected) |
| `usecases/index.ts` | Registers both new usecases |
| `cors.config.ts` | Cleaned up leftover commented-out code from exploration; restored valid syntax |

### `apps/dashboard` — setup guide refactor

- `getMsTeamsArmTemplateDeployUrl` API helper added to `integrations.ts`
- `TeamsSetupGuide` step sequence restructured:
  - **Step 0** — Create App Registration (was "Create Azure Bot"); redirect URI section moved here
  - **Step 1** — Add Graph API permissions (unchanged)
  - **Step 2** — Configure credentials (was step 3; help text updated)
  - **Step 3** — **Deploy to Azure** (new) — button fetches signed URL and opens Azure Portal
  - **Step 4** — Download Teams app package (was step 5)
  - **Step 5** — Upload to Teams and verify (was step 6)
- Removed `WebhookUrlSection` and `buildWebhookUrl` (superseded by ARM template deployment)
- `AgentSetupGuide` corrected `stepOffset` from `5` → `1`

## Flow diagram

```mermaid
sequenceDiagram
    participant U as User (browser)
    participant D as Dashboard
    participant API as API Service
    participant AZ as Azure Portal

    U->>D: Click "Deploy to Azure"
    D->>API: GET /integrations/:id/msteams-arm-template/deploy-url
    API-->>D: { deployUrl } (HMAC-signed, 15 min TTL)
    D->>AZ: window.open(deployUrl)
    AZ->>API: GET /integrations/:id/msteams-arm-template?sig=…&exp=…
    API-->>AZ: ARM template JSON (after sig verification)
    AZ-->>U: Pre-filled "Deploy to Azure" form
```

## Testing

- [ ] Create an MS Teams integration, save credentials (App ID, Secret, Tenant ID)
- [ ] Click "Deploy to Azure" in step 3 — Azure Portal should open with the ARM template pre-filled
- [ ] Verify expired/tampered `sig` returns 401
- [ ] Verify missing `sig`/`exp` returns 400
- [ ] Verify non-MS Teams integration returns 401 from the ARM template endpoint

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Replaces the manual multi-step Azure Bot setup for MS Teams with a one-click "Deploy to Azure" flow: the backend generates a 15-minute HMAC-signed deploy URL that opens the Azure Portal with a pre-filled ARM template, and serves the ARM JSON via a public endpoint that verifies signature and expiration. The dashboard fetches the signed URL and adds a "Deploy to Azure" step to the Teams setup guide, removing the manual webhook configuration and reordering steps.

## Affected areas

**api**: Added two use-cases, GenerateMsTeamsArmTemplate and GetMsTeamsArmTemplate, to create HMAC-signed deploy URLs and to serve the ARM template JSON; added two IntegrationsController routes (authenticated deploy-url and public signed template endpoint); registered the new use-cases.

**dashboard**: Added getMsTeamsArmTemplateDeployUrl helper and refactored TeamsSetupGuide to add the Deploy to Azure step, remove webhook URL UI/logic, handle deployment state, and adjust step ordering; fixed AgentSetupGuide step offset.

## Key technical decisions

- Use HMAC-SHA256 signatures with a 15-minute expiry to protect the public ARM-template endpoint while keeping it accessible to Azure Portal; signature verification logic is centralized in the generation use-case.  
- ARM template returned contains no secrets; credentials remain injected via environment/ARM parameters during deployment.  
- Integration lookup for template generation bypasses typical env/org guards to allow Azure to fetch the template by integration ID when validated by sig/exp.

## Testing

No automated tests were added; manual verification is expected for the new flow (valid/expired/missing sig handling, 400/401 responses for bad requests or non-MS Teams integrations, and end-to-end deploy URL → Azure → template retrieval).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->