### PR TITLE
feat(js): add PartySocket hibernation heartbeat fixes NV-7445

### DIFF
--- a/packages/js/src/ws/party-socket.ts
+++ b/packages/js/src/ws/party-socket.ts
@@ -263,20 +263,27 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
 
     this.#partySocket = new WebSocket(url.toString(), undefined, this.#socketOptions);
 
-    this.#partySocket.addEventListener('open', () => {
+    const socket = this.#partySocket;
+
+    socket.addEventListener('open', () => {
       this.#startHibernationHeartbeat();
       this.#emitter.emit('socket.connect.resolved', { args });
     });
 
-    this.#partySocket.addEventListener('error', (error) => {
+    socket.addEventListener('error', (error) => {
       this.#emitter.emit('socket.connect.resolved', { args, error });
     });
 
-    this.#partySocket.addEventListener('close', () => {
+    socket.addEventListener('close', () => {
+      if (socket !== this.#partySocket) {
+        return;
+      }
+
       this.#clearHibernationHeartbeat();
+      this.#partySocket = undefined;
     });
 
-    this.#partySocket.addEventListener('message', this.#handleMessage);
+    socket.addEventListener('message', this.#handleMessage);
   }
 
   async #handleConnectSocket(): Result<void> {

--- a/packages/js/src/ws/party-socket.ts
+++ b/packages/js/src/ws/party-socket.ts
@@ -24,6 +24,10 @@ import { NovuError } from '../utils/errors';
 import type { BaseSocketInterface } from './base-socket';
 
 export const PRODUCTION_SOCKET_URL = 'wss://socket.novu.co';
+
+const HIBERNATION_HEARTBEAT_MS = 25_000;
+const HIBERNATION_PING_PAYLOAD = 'ping';
+
 const NOTIFICATION_RECEIVED: NotificationReceivedEvent = 'notifications.notification_received';
 const UNSEEN_COUNT_CHANGED: NotificationUnseenEvent = 'notifications.unseen_count_changed';
 const UNREAD_COUNT_CHANGED: NotificationUnreadEvent = 'notifications.unread_count_changed';
@@ -129,6 +133,7 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
   #partySocket: WebSocket | undefined;
   #socketUrl: string;
   #socketOptions?: Record<string, unknown>;
+  #hibernationHeartbeatIntervalId: ReturnType<typeof setInterval> | undefined;
 
   constructor({
     socketUrl,
@@ -195,6 +200,10 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
   };
 
   #handleMessage = (event: MessageEvent) => {
+    if (event.data === HIBERNATION_PING_PAYLOAD || event.data === 'pong') {
+      return;
+    }
+
     try {
       const data = JSON.parse(event.data);
 
@@ -216,6 +225,31 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
     }
   };
 
+  #clearHibernationHeartbeat(): void {
+    if (this.#hibernationHeartbeatIntervalId !== undefined) {
+      clearInterval(this.#hibernationHeartbeatIntervalId);
+      this.#hibernationHeartbeatIntervalId = undefined;
+    }
+  }
+
+  #startHibernationHeartbeat(): void {
+    this.#clearHibernationHeartbeat();
+
+    this.#hibernationHeartbeatIntervalId = setInterval(() => {
+      const socket = this.#partySocket;
+
+      if (!socket || socket.readyState !== WebSocket.OPEN) {
+        return;
+      }
+
+      try {
+        socket.send(HIBERNATION_PING_PAYLOAD);
+      } catch {
+        // Socket may have closed between readyState check and send
+      }
+    }, HIBERNATION_HEARTBEAT_MS);
+  }
+
   async #initializeSocket(): Promise<void> {
     if (this.#partySocket) {
       return;
@@ -230,11 +264,16 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
     this.#partySocket = new WebSocket(url.toString(), undefined, this.#socketOptions);
 
     this.#partySocket.addEventListener('open', () => {
+      this.#startHibernationHeartbeat();
       this.#emitter.emit('socket.connect.resolved', { args });
     });
 
     this.#partySocket.addEventListener('error', (error) => {
       this.#emitter.emit('socket.connect.resolved', { args, error });
+    });
+
+    this.#partySocket.addEventListener('close', () => {
+      this.#clearHibernationHeartbeat();
     });
 
     this.#partySocket.addEventListener('message', this.#handleMessage);
@@ -252,6 +291,7 @@ export class PartySocketClient extends BaseModule implements BaseSocketInterface
 
   async #handleDisconnectSocket(): Result<void> {
     try {
+      this.#clearHibernationHeartbeat();
       this.#partySocket?.close();
       this.#partySocket = undefined;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the client half of NV-7445 for Cloudflare Durable Object hibernation compatibility.

The Cloudflare socket worker already calls `setWebSocketAutoResponse(new WebSocketRequestResponsePair('ping', 'pong'))` in `WebSocketRoom` (`enterprise/workers/socket/src/durable-objects/websocket-room.ts`).

## Changes

- **`PartySocketClient`** (`packages/js/src/ws/party-socket.ts`): send the literal string `ping` every 25 seconds while the WebSocket is open so the edge can auto-reply with `pong` without waking the DO.
- Clear the interval on `close`, on explicit `disconnect()`, and before starting a new interval to avoid leaks.
- Ignore `ping` / `pong` text frames in the message handler so they are not parsed as JSON.

## Testing

Local `pnpm` was unavailable in the agent VM; CI should run package checks on merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7445](https://linear.app/novu/issue/NV-7445/implement-cloudflare-hibernation-compatible-heartbeats)

<div><a href="https://cursor.com/agents/bc-e1c51837-85ce-4fd3-a295-488848107e87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1c51837-85ce-4fd3-a295-488848107e87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

PartySocketClient now sends a literal "ping" text frame every 25 seconds while a WebSocket is open so Cloudflare's edge can auto-reply with "pong" without waking Durable Objects. The client tracks and clears the heartbeat interval on socket close, on explicit disconnect(), and before starting a new interval to avoid leaks. The message handler ignores incoming "ping" and "pong" text frames so they are not parsed as JSON. A guard was also added to the close handler to avoid reconnect/close races.

## Affected areas

**js**: The WebSocket client (PartySocketClient) was updated to add a hibernation heartbeat, ignore ping/pong text frames, and ensure proper interval cleanup and close-reconnect race protection.

## Key technical decisions

- Use a 25-second interval to balance keepalive frequency and overhead for Cloudflare Durable Object hibernation compatibility.  
- Heartbeat interval is cleared on close, explicit disconnect, and before starting a new interval to prevent leaks and duplicate timers.  
- Ping/pong text frames are short-circuited before JSON parsing to avoid interfering with existing message handling.  
- A close-handler guard was added to handle race conditions between reconnect and close.

## Testing

No new unit or integration tests were added in this PR; local pnpm was unavailable in the agent VM, so CI will run package checks and validate the change on merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->