### PR TITLE
feat(api-service): agent environment promotion

### DIFF
--- a/apps/api/src/app/agents/usecases/add-agent-integration/add-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/usecases/add-agent-integration/add-agent-integration.usecase.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto';
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   HttpException,
   HttpStatus,
   Injectable,
@@ -12,10 +13,11 @@ import {
   AgentIntegrationRepository,
   AgentRepository,
   CommunityOrganizationRepository,
+  EnvironmentRepository,
   IntegrationEntity,
   IntegrationRepository,
 } from '@novu/dal';
-import { ApiServiceLevelEnum, EmailProviderIdEnum, FeatureNameEnum, getFeatureForTierAsBoolean } from '@novu/shared';
+import { ApiServiceLevelEnum, EmailProviderIdEnum, EnvironmentTypeEnum, FeatureNameEnum, getFeatureForTierAsBoolean } from '@novu/shared';
 
 import { trackAgentIntegrationConnected } from '../../agent-analytics';
 import type { AgentIntegrationResponseDto } from '../../dtos';
@@ -30,11 +32,14 @@ export class AddAgentIntegration {
     private readonly integrationRepository: IntegrationRepository,
     private readonly agentIntegrationRepository: AgentIntegrationRepository,
     private readonly organizationRepository: CommunityOrganizationRepository,
+    private readonly environmentRepository: EnvironmentRepository,
     private readonly findOrCreateNovuEmail: FindOrCreateNovuEmail,
     private readonly analyticsService: AnalyticsService
   ) {}
 
   async execute(command: AddAgentIntegrationCommand): Promise<AgentIntegrationResponseDto> {
+    await this.assertNotProductionEnvironment(command.environmentId, command.organizationId);
+
     if (!command.integrationIdentifier && !command.providerId) {
       throw new BadRequestException('Either integrationIdentifier or providerId must be provided.');
     }
@@ -193,6 +198,17 @@ export class AddAgentIntegration {
 
     if (existing.length > 0) {
       throw new ConflictException('Only one email integration per agent is allowed.');
+    }
+  }
+
+  private async assertNotProductionEnvironment(environmentId: string, organizationId: string): Promise<void> {
+    const environment = await this.environmentRepository.findOne(
+      { _id: environmentId, _organizationId: organizationId },
+      ['type']
+    );
+
+    if (environment?.type === EnvironmentTypeEnum.PROD) {
+      throw new ForbiddenException('Agent integrations cannot be added in production environments.');
     }
   }
 

--- a/apps/api/src/app/agents/usecases/add-agent-integration/add-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/usecases/add-agent-integration/add-agent-integration.usecase.ts
@@ -204,7 +204,7 @@ export class AddAgentIntegration {
   private async assertNotProductionEnvironment(environmentId: string, organizationId: string): Promise<void> {
     const environment = await this.environmentRepository.findOne(
       { _id: environmentId, _organizationId: organizationId },
-      ['type']
+      ['type', 'name']
     );
 
     if (environment?.type === EnvironmentTypeEnum.PROD) {

--- a/apps/api/src/app/agents/usecases/index.ts
+++ b/apps/api/src/app/agents/usecases/index.ts
@@ -10,6 +10,7 @@ import { ListAgentIntegrations } from './list-agent-integrations/list-agent-inte
 import { ListAgents } from './list-agents/list-agents.usecase';
 import { RemoveAgentIntegration } from './remove-agent-integration/remove-agent-integration.usecase';
 import { SendAgentTestEmail } from './send-agent-test-email/send-agent-test-email.usecase';
+import { SyncAgentToEnvironment } from './sync-agent-to-environment/sync-agent-to-environment.usecase';
 import { UpdateAgent } from './update-agent/update-agent.usecase';
 import { UpdateAgentIntegration } from './update-agent-integration/update-agent-integration.usecase';
 
@@ -28,4 +29,5 @@ export const USE_CASES = [
   RemoveAgentIntegration,
   HandleAgentReply,
   SendAgentTestEmail,
+  SyncAgentToEnvironment,
 ];

--- a/apps/api/src/app/agents/usecases/remove-agent-integration/remove-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/usecases/remove-agent-integration/remove-agent-integration.usecase.ts
@@ -1,6 +1,7 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { AnalyticsService } from '@novu/application-generic';
-import { AgentIntegrationRepository, AgentRepository } from '@novu/dal';
+import { AgentIntegrationRepository, AgentRepository, EnvironmentRepository } from '@novu/dal';
+import { EnvironmentTypeEnum } from '@novu/shared';
 
 import { trackAgentIntegrationRemoved } from '../../agent-analytics';
 import { CleanupNovuEmail } from '../cleanup-novu-email/cleanup-novu-email.usecase';
@@ -11,11 +12,14 @@ export class RemoveAgentIntegration {
   constructor(
     private readonly agentRepository: AgentRepository,
     private readonly agentIntegrationRepository: AgentIntegrationRepository,
+    private readonly environmentRepository: EnvironmentRepository,
     private readonly cleanupNovuEmail: CleanupNovuEmail,
     private readonly analyticsService: AnalyticsService
   ) {}
 
   async execute(command: RemoveAgentIntegrationCommand): Promise<void> {
+    await this.assertNotProductionEnvironment(command.environmentId, command.organizationId);
+
     const agent = await this.agentRepository.findOne(
       {
         identifier: command.agentIdentifier,
@@ -62,5 +66,16 @@ export class RemoveAgentIntegration {
       agentIdentifier: command.agentIdentifier,
       agentIntegrationId: command.agentIntegrationId,
     });
+  }
+
+  private async assertNotProductionEnvironment(environmentId: string, organizationId: string): Promise<void> {
+    const environment = await this.environmentRepository.findOne(
+      { _id: environmentId, _organizationId: organizationId },
+      ['type']
+    );
+
+    if (environment?.type === EnvironmentTypeEnum.PROD) {
+      throw new ForbiddenException('Agent integrations cannot be removed in production environments.');
+    }
   }
 }

--- a/apps/api/src/app/agents/usecases/remove-agent-integration/remove-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/usecases/remove-agent-integration/remove-agent-integration.usecase.ts
@@ -71,7 +71,7 @@ export class RemoveAgentIntegration {
   private async assertNotProductionEnvironment(environmentId: string, organizationId: string): Promise<void> {
     const environment = await this.environmentRepository.findOne(
       { _id: environmentId, _organizationId: organizationId },
-      ['type']
+      ['type', 'name']
     );
 
     if (environment?.type === EnvironmentTypeEnum.PROD) {

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/index.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/index.ts
@@ -1,0 +1,2 @@
+export { SyncAgentToEnvironment } from './sync-agent-to-environment.usecase';
+export { SyncAgentToEnvironmentCommand } from './sync-agent-to-environment.command';

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.command.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.command.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class SyncAgentToEnvironmentCommand extends EnvironmentWithUserCommand {
+  @IsString()
+  @IsNotEmpty()
+  agentIdentifier: string;
+
+  @IsString()
+  @IsNotEmpty()
+  targetEnvironmentId: string;
+}

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.spec.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.spec.ts
@@ -1,0 +1,249 @@
+import { NotFoundException } from '@nestjs/common';
+import type { AgentIntegrationEntity, AgentEntity, IntegrationEntity } from '@novu/dal';
+import { ChannelTypeEnum } from '@novu/shared';
+import { expect } from 'chai';
+import { restore, stub } from 'sinon';
+
+import { SyncAgentToEnvironment } from './sync-agent-to-environment.usecase';
+import { SyncAgentToEnvironmentCommand } from './sync-agent-to-environment.command';
+
+const SOURCE_ENV = 'source-env-id';
+const TARGET_ENV = 'target-env-id';
+const ORG_ID = 'org-id';
+const USER_ID = 'user-id';
+
+function baseCommand(overrides: Partial<SyncAgentToEnvironmentCommand> = {}): SyncAgentToEnvironmentCommand {
+  return {
+    agentIdentifier: 'my-agent',
+    environmentId: SOURCE_ENV,
+    targetEnvironmentId: TARGET_ENV,
+    organizationId: ORG_ID,
+    userId: USER_ID,
+    ...overrides,
+  } as SyncAgentToEnvironmentCommand;
+}
+
+function makeAgent(overrides: Partial<AgentEntity> = {}): AgentEntity {
+  return {
+    _id: 'agent-id',
+    name: 'My Agent',
+    identifier: 'my-agent',
+    description: 'desc',
+    behavior: undefined,
+    active: true,
+    _environmentId: SOURCE_ENV,
+    _organizationId: ORG_ID,
+    ...overrides,
+  } as AgentEntity;
+}
+
+function makeIntegration(overrides: Partial<IntegrationEntity> = {}): IntegrationEntity {
+  return {
+    _id: 'integration-id',
+    providerId: 'slack',
+    channel: ChannelTypeEnum.CHAT,
+    name: 'Slack',
+    identifier: 'slack-id',
+    credentials: {},
+    active: true,
+    primary: false,
+    priority: 0,
+    deleted: false,
+    _environmentId: SOURCE_ENV,
+    _organizationId: ORG_ID,
+    ...overrides,
+  } as IntegrationEntity;
+}
+
+function makeLink(overrides: Partial<AgentIntegrationEntity> = {}): AgentIntegrationEntity {
+  return {
+    _id: 'link-id',
+    _agentId: 'agent-id',
+    _integrationId: 'integration-id',
+    _environmentId: SOURCE_ENV,
+    _organizationId: ORG_ID,
+    connectedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as AgentIntegrationEntity;
+}
+
+describe('SyncAgentToEnvironment usecase', () => {
+  let agentRepo: {
+    findOne: sinon.SinonStub;
+    create: sinon.SinonStub;
+    update: sinon.SinonStub;
+  };
+  let agentIntegrationRepo: {
+    find: sinon.SinonStub;
+    create: sinon.SinonStub;
+    delete: sinon.SinonStub;
+  };
+  let integrationRepo: {
+    find: sinon.SinonStub;
+    create: sinon.SinonStub;
+  };
+
+  function buildUsecase() {
+    return new SyncAgentToEnvironment(agentRepo as any, agentIntegrationRepo as any, integrationRepo as any);
+  }
+
+  beforeEach(() => {
+    agentRepo = { findOne: stub(), create: stub(), update: stub().resolves() };
+    agentIntegrationRepo = { find: stub(), create: stub().resolves(), delete: stub().resolves() };
+    integrationRepo = { find: stub(), create: stub() };
+  });
+
+  afterEach(() => restore());
+
+  describe('source agent not found', () => {
+    it('throws NotFoundException', async () => {
+      agentRepo.findOne.resolves(null);
+
+      try {
+        await buildUsecase().execute(baseCommand());
+        throw new Error('Expected NotFoundException');
+      } catch (err) {
+        expect(err).to.be.instanceOf(NotFoundException);
+      }
+    });
+  });
+
+  describe('fresh promotion — no target agent yet', () => {
+    it('creates target agent as inactive with source metadata', async () => {
+      const sourceAgent = makeAgent();
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(null);
+      agentIntegrationRepo.find.resolves([]);
+      integrationRepo.find.resolves([]);
+      agentRepo.create.resolves(makeAgent({ _id: 'target-agent-id', active: false, _environmentId: TARGET_ENV }));
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(agentRepo.create.calledOnce).to.equal(true);
+      const createArg = agentRepo.create.firstCall.args[0];
+      expect(createArg.identifier).to.equal('my-agent');
+      expect(createArg.active).to.equal(false);
+      expect(createArg._environmentId).to.equal(TARGET_ENV);
+      expect(agentRepo.update.called).to.equal(false);
+    });
+
+    it('creates stub integrations and agent-integration links for each source integration', async () => {
+      const sourceAgent = makeAgent();
+      const sourceIntegration = makeIntegration();
+      const sourceLink = makeLink();
+      const targetAgent = makeAgent({ _id: 'target-agent-id', active: false, _environmentId: TARGET_ENV });
+      const stubIntegration = makeIntegration({ _id: 'stub-id', _environmentId: TARGET_ENV });
+
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(null);
+      agentIntegrationRepo.find.onFirstCall().resolves([sourceLink]);
+      integrationRepo.find.onFirstCall().resolves([sourceIntegration]);
+      agentRepo.create.resolves(targetAgent);
+      agentIntegrationRepo.find.onSecondCall().resolves([]);
+      integrationRepo.find.onSecondCall().resolves([]);
+      integrationRepo.create.resolves(stubIntegration);
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(integrationRepo.create.calledOnce).to.equal(true);
+      const stubArg = integrationRepo.create.firstCall.args[0];
+      expect(stubArg.providerId).to.equal('slack');
+      expect(stubArg.channel).to.equal(ChannelTypeEnum.CHAT);
+      expect(stubArg._parentId).to.equal('integration-id');
+      expect(stubArg._environmentId).to.equal(TARGET_ENV);
+      expect(stubArg.active).to.equal(true);
+
+      expect(agentIntegrationRepo.create.calledOnce).to.equal(true);
+      const linkArg = agentIntegrationRepo.create.firstCall.args[0];
+      expect(linkArg._agentId).to.equal('target-agent-id');
+      expect(linkArg._integrationId).to.equal('stub-id');
+      expect(linkArg._environmentId).to.equal(TARGET_ENV);
+    });
+  });
+
+  describe('re-promotion — target agent already exists', () => {
+    it('updates target agent metadata without changing active state', async () => {
+      const sourceAgent = makeAgent({ name: 'Updated Name' });
+      const targetAgent = makeAgent({ _id: 'target-id', active: true, _environmentId: TARGET_ENV });
+
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(targetAgent);
+      agentIntegrationRepo.find.resolves([]);
+      integrationRepo.find.resolves([]);
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(agentRepo.create.called).to.equal(false);
+      expect(agentRepo.update.calledOnce).to.equal(true);
+      const updateQuery = agentRepo.update.firstCall.args[0];
+      const updateBody = agentRepo.update.firstCall.args[1];
+      expect(updateQuery._id).to.equal('target-id');
+      expect(updateBody.$set.name).to.equal('Updated Name');
+      expect(updateBody.$set.active).to.equal(undefined);
+    });
+
+    it('does not re-create integration stubs on repeated promotion', async () => {
+      const sourceAgent = makeAgent();
+      const targetAgent = makeAgent({ _id: 'target-id', _environmentId: TARGET_ENV });
+      const sourceIntegration = makeIntegration({ _id: 'src-int-id' });
+      const sourceLink = makeLink({ _integrationId: 'src-int-id' });
+      const existingStub = makeIntegration({ _id: 'existing-stub-id', _parentId: 'src-int-id', _environmentId: TARGET_ENV });
+      const existingTargetLink = makeLink({ _id: 'target-link-id', _agentId: 'target-id', _integrationId: 'existing-stub-id', _environmentId: TARGET_ENV });
+
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(targetAgent);
+      agentIntegrationRepo.find.onFirstCall().resolves([sourceLink]);
+      integrationRepo.find.onFirstCall().resolves([sourceIntegration]);
+      agentIntegrationRepo.find.onSecondCall().resolves([existingTargetLink]);
+      integrationRepo.find.onSecondCall().resolves([existingStub]);
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(integrationRepo.create.called).to.equal(false);
+      expect(agentIntegrationRepo.create.called).to.equal(false);
+    });
+  });
+
+  describe('integration removed from source', () => {
+    it('unlinks integrations that are no longer connected to the source agent', async () => {
+      const sourceAgent = makeAgent();
+      const targetAgent = makeAgent({ _id: 'target-id', _environmentId: TARGET_ENV });
+      const removedStub = makeIntegration({ _id: 'old-stub-id', _parentId: 'removed-src-int-id', _environmentId: TARGET_ENV });
+      const orphanedLink = makeLink({ _id: 'orphan-link-id', _agentId: 'target-id', _integrationId: 'old-stub-id', _environmentId: TARGET_ENV });
+
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(targetAgent);
+      agentIntegrationRepo.find.onFirstCall().resolves([]);
+      agentIntegrationRepo.find.onSecondCall().resolves([orphanedLink]);
+      integrationRepo.find.onFirstCall().resolves([removedStub]);
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(agentIntegrationRepo.delete.calledOnce).to.equal(true);
+      const deleteArg = agentIntegrationRepo.delete.firstCall.args[0];
+      expect(deleteArg._id).to.equal('orphan-link-id');
+    });
+  });
+
+  describe('manually configured prod integration', () => {
+    it('preserves manually configured prod integrations not originating from promotion', async () => {
+      const sourceAgent = makeAgent();
+      const targetAgent = makeAgent({ _id: 'target-id', _environmentId: TARGET_ENV });
+      const manualIntegration = makeIntegration({ _id: 'manual-id', _environmentId: TARGET_ENV });
+      const manualLink = makeLink({ _id: 'manual-link-id', _agentId: 'target-id', _integrationId: 'manual-id', _environmentId: TARGET_ENV });
+
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(targetAgent);
+      agentIntegrationRepo.find.onFirstCall().resolves([]);
+      integrationRepo.find.onFirstCall().resolves([]);
+      agentIntegrationRepo.find.onSecondCall().resolves([manualLink]);
+      integrationRepo.find.onSecondCall().resolves([manualIntegration]);
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(agentIntegrationRepo.delete.called).to.equal(false);
+    });
+  });
+});

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.spec.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.spec.ts
@@ -82,7 +82,9 @@ describe('SyncAgentToEnvironment usecase', () => {
   };
   let integrationRepo: {
     find: sinon.SinonStub;
+    findOne: sinon.SinonStub;
     create: sinon.SinonStub;
+    delete: sinon.SinonStub;
   };
 
   function buildUsecase() {
@@ -92,7 +94,7 @@ describe('SyncAgentToEnvironment usecase', () => {
   beforeEach(() => {
     agentRepo = { findOne: stub(), create: stub(), update: stub().resolves() };
     agentIntegrationRepo = { find: stub(), create: stub().resolves(), delete: stub().resolves() };
-    integrationRepo = { find: stub(), create: stub() };
+    integrationRepo = { find: stub(), findOne: stub(), create: stub(), delete: stub().resolves() };
   });
 
   afterEach(() => restore());
@@ -143,6 +145,7 @@ describe('SyncAgentToEnvironment usecase', () => {
       agentRepo.create.resolves(targetAgent);
       agentIntegrationRepo.find.onSecondCall().resolves([]);
       integrationRepo.find.onSecondCall().resolves([]);
+      integrationRepo.findOne.resolves(null);
       integrationRepo.create.resolves(stubIntegration);
 
       await buildUsecase().execute(baseCommand());
@@ -218,12 +221,17 @@ describe('SyncAgentToEnvironment usecase', () => {
       agentIntegrationRepo.find.onFirstCall().resolves([]);
       agentIntegrationRepo.find.onSecondCall().resolves([orphanedLink]);
       integrationRepo.find.onFirstCall().resolves([removedStub]);
+      agentIntegrationRepo.find.onThirdCall().resolves([]);
 
       await buildUsecase().execute(baseCommand());
 
       expect(agentIntegrationRepo.delete.calledOnce).to.equal(true);
       const deleteArg = agentIntegrationRepo.delete.firstCall.args[0];
       expect(deleteArg._id).to.equal('orphan-link-id');
+
+      expect(integrationRepo.delete.calledOnce).to.equal(true);
+      const integrationDeleteArg = integrationRepo.delete.firstCall.args[0];
+      expect(integrationDeleteArg._id).to.equal('old-stub-id');
     });
   });
 

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
@@ -1,0 +1,133 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { AgentIntegrationRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
+
+import { SyncAgentToEnvironmentCommand } from './sync-agent-to-environment.command';
+
+@Injectable()
+export class SyncAgentToEnvironment {
+  constructor(
+    private readonly agentRepository: AgentRepository,
+    private readonly agentIntegrationRepository: AgentIntegrationRepository,
+    private readonly integrationRepository: IntegrationRepository
+  ) {}
+
+  async execute(command: SyncAgentToEnvironmentCommand): Promise<void> {
+    const { agentIdentifier, environmentId: sourceEnvironmentId, targetEnvironmentId, organizationId } = command;
+
+    const sourceAgent = await this.agentRepository.findOne(
+      { identifier: agentIdentifier, _environmentId: sourceEnvironmentId, _organizationId: organizationId },
+      '*'
+    );
+
+    if (!sourceAgent) {
+      throw new NotFoundException(`Source agent "${agentIdentifier}" not found in environment ${sourceEnvironmentId}`);
+    }
+
+    const sourceLinks = await this.agentIntegrationRepository.find(
+      { _agentId: sourceAgent._id, _environmentId: sourceEnvironmentId, _organizationId: organizationId },
+      '*'
+    );
+
+    const sourceIntegrationIds = sourceLinks.map((l) => l._integrationId);
+    const sourceIntegrations =
+      sourceIntegrationIds.length > 0
+        ? await this.integrationRepository.find({
+            _id: { $in: sourceIntegrationIds },
+            _environmentId: sourceEnvironmentId,
+            _organizationId: organizationId,
+          })
+        : [];
+    const sourceIntegrationMap = new Map(sourceIntegrations.map((i) => [i._id, i]));
+
+    let targetAgent = await this.agentRepository.findOne(
+      { identifier: agentIdentifier, _environmentId: targetEnvironmentId, _organizationId: organizationId },
+      '*'
+    );
+
+    if (!targetAgent) {
+      targetAgent = await this.agentRepository.create({
+        name: sourceAgent.name,
+        identifier: sourceAgent.identifier,
+        description: sourceAgent.description,
+        behavior: sourceAgent.behavior,
+        active: false,
+        _environmentId: targetEnvironmentId,
+        _organizationId: organizationId,
+      });
+    } else {
+      await this.agentRepository.update(
+        { _id: targetAgent._id, _environmentId: targetEnvironmentId, _organizationId: organizationId },
+        { $set: { name: sourceAgent.name, description: sourceAgent.description, behavior: sourceAgent.behavior } }
+      );
+    }
+
+    const existingTargetLinks = await this.agentIntegrationRepository.find(
+      { _agentId: targetAgent._id, _environmentId: targetEnvironmentId, _organizationId: organizationId },
+      '*'
+    );
+
+    const existingTargetIntegrationIds = existingTargetLinks.map((l) => l._integrationId);
+    const existingTargetIntegrations =
+      existingTargetIntegrationIds.length > 0
+        ? await this.integrationRepository.find({
+            _id: { $in: existingTargetIntegrationIds },
+            _environmentId: targetEnvironmentId,
+            _organizationId: organizationId,
+          })
+        : [];
+
+    const parentIdToTargetLink = new Map<string, (typeof existingTargetLinks)[0]>();
+    for (const targetIntegration of existingTargetIntegrations) {
+      if (targetIntegration._parentId) {
+        const link = existingTargetLinks.find((l) => l._integrationId === targetIntegration._id);
+        if (link) {
+          parentIdToTargetLink.set(targetIntegration._parentId, link);
+        }
+      }
+    }
+
+    const processedSourceIntegrationIds = new Set<string>();
+
+    for (const sourceLink of sourceLinks) {
+      const sourceIntegration = sourceIntegrationMap.get(sourceLink._integrationId);
+      if (!sourceIntegration) continue;
+
+      processedSourceIntegrationIds.add(sourceIntegration._id);
+
+      if (parentIdToTargetLink.has(sourceIntegration._id)) {
+        continue;
+      }
+
+      const stubIntegration = await this.integrationRepository.create({
+        providerId: sourceIntegration.providerId,
+        channel: sourceIntegration.channel,
+        name: sourceIntegration.name,
+        identifier: sourceIntegration.identifier,
+        credentials: {},
+        active: true,
+        primary: false,
+        priority: 0,
+        _parentId: sourceIntegration._id,
+        _environmentId: targetEnvironmentId,
+        _organizationId: organizationId,
+      });
+
+      await this.agentIntegrationRepository.create({
+        _agentId: targetAgent._id,
+        _integrationId: stubIntegration._id,
+        _environmentId: targetEnvironmentId,
+        _organizationId: organizationId,
+      });
+    }
+
+    for (const [sourceIntegrationId, link] of parentIdToTargetLink.entries()) {
+      if (!processedSourceIntegrationIds.has(sourceIntegrationId)) {
+        await this.agentIntegrationRepository.delete({
+          _id: link._id,
+          _environmentId: targetEnvironmentId,
+          _organizationId: organizationId,
+        });
+      }
+    }
+  }
+}

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
@@ -115,6 +115,7 @@ export class SyncAgentToEnvironment {
       await this.agentIntegrationRepository.create({
         _agentId: targetAgent._id,
         _integrationId: stubIntegration._id,
+        connectedAt: null,
         _environmentId: targetEnvironmentId,
         _organizationId: organizationId,
       });
@@ -125,6 +126,10 @@ export class SyncAgentToEnvironment {
         await this.agentIntegrationRepository.delete({
           _id: link._id,
           _environmentId: targetEnvironmentId,
+          _organizationId: organizationId,
+        });
+        await this.integrationRepository.delete({
+          _id: link._integrationId,
           _organizationId: organizationId,
         });
       }

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
@@ -14,6 +14,10 @@ export class SyncAgentToEnvironment {
   async execute(command: SyncAgentToEnvironmentCommand): Promise<void> {
     const { agentIdentifier, environmentId: sourceEnvironmentId, targetEnvironmentId, organizationId } = command;
 
+    if (sourceEnvironmentId === targetEnvironmentId) {
+      throw new Error('Source and target environments cannot be the same');
+    }
+
     const sourceAgent = await this.agentRepository.findOne(
       { identifier: agentIdentifier, _environmentId: sourceEnvironmentId, _organizationId: organizationId },
       '*'
@@ -98,19 +102,28 @@ export class SyncAgentToEnvironment {
         continue;
       }
 
-      const stubIntegration = await this.integrationRepository.create({
-        providerId: sourceIntegration.providerId,
-        channel: sourceIntegration.channel,
-        name: sourceIntegration.name,
-        identifier: sourceIntegration.identifier,
-        credentials: {},
-        active: true,
-        primary: false,
-        priority: 0,
+      // Reuse an existing stub if another agent already created one for this source integration
+      let stubIntegration = await this.integrationRepository.findOne({
         _parentId: sourceIntegration._id,
         _environmentId: targetEnvironmentId,
         _organizationId: organizationId,
       });
+
+      if (!stubIntegration) {
+        stubIntegration = await this.integrationRepository.create({
+          providerId: sourceIntegration.providerId,
+          channel: sourceIntegration.channel,
+          name: sourceIntegration.name,
+          identifier: sourceIntegration.identifier,
+          credentials: {},
+          active: true,
+          primary: false,
+          priority: 0,
+          _parentId: sourceIntegration._id,
+          _environmentId: targetEnvironmentId,
+          _organizationId: organizationId,
+        });
+      }
 
       await this.agentIntegrationRepository.create({
         _agentId: targetAgent._id,
@@ -128,10 +141,19 @@ export class SyncAgentToEnvironment {
           _environmentId: targetEnvironmentId,
           _organizationId: organizationId,
         });
-        await this.integrationRepository.delete({
-          _id: link._integrationId,
-          _organizationId: organizationId,
-        });
+
+        // Only delete the stub integration if no other agent links still reference it
+        const remainingLinks = await this.agentIntegrationRepository.find(
+          { _integrationId: link._integrationId, _environmentId: targetEnvironmentId, _organizationId: organizationId },
+          ['_id']
+        );
+
+        if (remainingLinks.length === 0) {
+          await this.integrationRepository.delete({
+            _id: link._integrationId,
+            _organizationId: organizationId,
+          });
+        }
       }
     }
   }

--- a/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
+++ b/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
@@ -3,7 +3,7 @@ import { ChannelTypeEnum, EmailProviderIdEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe.only('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST) #novu-v2', () => {
+describe('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST) #novu-v2', () => {
   let session: UserSession;
 
   const environmentRepository = new EnvironmentRepository();

--- a/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
+++ b/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
@@ -1,0 +1,226 @@
+import { AgentIntegrationRepository, AgentRepository, EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { ChannelTypeEnum, EmailProviderIdEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+describe.only('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST) #novu-v2', () => {
+  let session: UserSession;
+
+  const environmentRepository = new EnvironmentRepository();
+  const agentRepository = new AgentRepository();
+  const agentIntegrationRepository = new AgentIntegrationRepository();
+  const integrationRepository = new IntegrationRepository();
+
+  before(() => {
+    process.env.IS_CONVERSATIONAL_AGENTS_ENABLED = 'true';
+  });
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  async function getProductionEnvironment() {
+    const prodEnv = await environmentRepository.findOne({
+      _parentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+
+    if (!prodEnv) throw new Error('Production environment not found');
+
+    return prodEnv;
+  }
+
+  async function publish(prodEnvId: string) {
+    return session.testAgent.post(`/v2/environments/${prodEnvId}/publish`).send({}).expect(200);
+  }
+
+  async function getDiff(prodEnvId: string) {
+    return session.testAgent.post(`/v2/environments/${prodEnvId}/diff`).send({}).expect(200);
+  }
+
+  async function getDevIntegration() {
+    const integrations = (await session.testAgent.get('/v1/integrations')).body.data as Array<{
+      _id: string;
+      identifier: string;
+      channel: string;
+      providerId: string;
+    }>;
+
+    const integration = integrations.find(
+      (i) => i.channel === ChannelTypeEnum.EMAIL && i.providerId === EmailProviderIdEnum.SendGrid
+    );
+
+    if (!integration) throw new Error('Seeded SendGrid integration not found');
+
+    return integration;
+  }
+
+  it('should promote agent to prod as inactive with placeholder integrations and connectedAt null', async () => {
+    const identifier = `e2e-promote-fresh-${Date.now()}`;
+    const prodEnv = await getProductionEnvironment();
+    const devIntegration = await getDevIntegration();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Promote Agent', identifier });
+    await session.testAgent
+      .post(`/v1/agents/${encodeURIComponent(identifier)}/integrations`)
+      .send({ integrationIdentifier: devIntegration.identifier });
+
+    await publish(prodEnv._id);
+
+    const prodAgent = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      '*'
+    );
+
+    expect(prodAgent, 'prod agent should exist').to.exist;
+    expect(prodAgent!.active, 'prod agent should start inactive').to.equal(false);
+
+    const prodLinks = await agentIntegrationRepository.find(
+      { _agentId: prodAgent!._id, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      '*'
+    );
+
+    expect(prodLinks.length, 'one integration link in prod').to.equal(1);
+    expect(prodLinks[0].connectedAt, 'link connectedAt should be null').to.equal(null);
+
+    const prodIntegration = await integrationRepository.findOne({
+      _id: prodLinks[0]._integrationId,
+      _environmentId: prodEnv._id,
+      _organizationId: session.organization._id,
+    });
+
+    expect(prodIntegration, 'placeholder integration should exist').to.exist;
+    expect(prodIntegration!._parentId, 'placeholder should reference dev integration').to.equal(devIntegration._id);
+    expect(prodIntegration!.providerId).to.equal(EmailProviderIdEnum.SendGrid);
+  });
+
+  it('should include unpromoted agent in diff result as added', async () => {
+    const identifier = `e2e-promote-diff-${Date.now()}`;
+    const prodEnv = await getProductionEnvironment();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Diff Agent', identifier });
+
+    const { body } = await getDiff(prodEnv._id);
+    const agentDiff = body.data.resources.find(
+      (r: { resourceType: string; sourceResource?: { id: string } }) =>
+        r.resourceType === 'agent' && r.sourceResource?.id === identifier
+    );
+
+    expect(agentDiff, 'agent should appear in diff').to.exist;
+    expect(agentDiff.changes[0].action).to.equal('added');
+    expect(agentDiff.summary.added).to.equal(1);
+  });
+
+  it('should not create duplicate placeholder integrations when promoted twice without changes', async () => {
+    const identifier = `e2e-promote-idem-${Date.now()}`;
+    const prodEnv = await getProductionEnvironment();
+    const devIntegration = await getDevIntegration();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Idempotent Agent', identifier });
+    await session.testAgent
+      .post(`/v1/agents/${encodeURIComponent(identifier)}/integrations`)
+      .send({ integrationIdentifier: devIntegration.identifier });
+
+    await publish(prodEnv._id);
+    await publish(prodEnv._id);
+
+    const prodAgent = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      ['_id']
+    );
+
+    const prodLinks = await agentIntegrationRepository.find(
+      { _agentId: prodAgent!._id, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      ['_id']
+    );
+
+    expect(prodLinks.length, 'still exactly one link in prod after two publishes').to.equal(1);
+  });
+
+  it('should propagate metadata changes without resetting active state', async () => {
+    const identifier = `e2e-promote-meta-${Date.now()}`;
+    const prodEnv = await getProductionEnvironment();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Meta Agent', identifier });
+    await publish(prodEnv._id);
+
+    await session.switchToProdEnvironment();
+    await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({ active: true });
+    await session.switchToDevEnvironment();
+
+    await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({ name: 'Meta Agent Updated' });
+    await publish(prodEnv._id);
+
+    const prodAgent = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      '*'
+    );
+
+    expect(prodAgent!.name).to.equal('Meta Agent Updated');
+    expect(prodAgent!.active, 'active state must not be reset by re-promotion').to.equal(true);
+  });
+
+  it('should remove agent from prod when it is deleted in dev and re-published', async () => {
+    const identifier = `e2e-promote-del-${Date.now()}`;
+    const prodEnv = await getProductionEnvironment();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Delete Agent', identifier });
+    await publish(prodEnv._id);
+
+    const afterFirstPublish = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      ['_id']
+    );
+
+    expect(afterFirstPublish, 'agent should exist in prod after first publish').to.exist;
+
+    await session.testAgent.delete(`/v1/agents/${encodeURIComponent(identifier)}`);
+    await publish(prodEnv._id);
+
+    const afterDelete = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      ['_id']
+    );
+
+    expect(afterDelete, 'agent should be gone from prod after dev deletion + re-publish').to.equal(null);
+  });
+
+  it('should reject adding and removing integrations in production environment', async () => {
+    const identifier = `e2e-prodguard-int-${Date.now()}`;
+    const devIntegration = await getDevIntegration();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Guard Integration Agent', identifier });
+    await session.testAgent
+      .post(`/v1/agents/${encodeURIComponent(identifier)}/integrations`)
+      .send({ integrationIdentifier: devIntegration.identifier });
+
+    const prodEnv = await getProductionEnvironment();
+    await publish(prodEnv._id);
+
+    await session.switchToProdEnvironment();
+
+    const addRes = await session.testAgent
+      .post(`/v1/agents/${encodeURIComponent(identifier)}/integrations`)
+      .send({ integrationIdentifier: devIntegration.identifier });
+
+    expect(addRes.status, 'POST integrations should be 403 in prod').to.equal(403);
+
+    const prodLinks = await agentIntegrationRepository.find(
+      {
+        _environmentId: prodEnv._id,
+        _organizationId: session.organization._id,
+      },
+      ['_id']
+    );
+    const linkId = prodLinks[0]?._id;
+
+    if (linkId) {
+      const removeRes = await session.testAgent.delete(
+        `/v1/agents/${encodeURIComponent(identifier)}/integrations/${linkId}`
+      );
+
+      expect(removeRes.status, 'DELETE integrations should be 403 in prod').to.equal(403);
+    }
+  });
+});

--- a/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
+++ b/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 
 describe('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST) #novu-v2', () => {
   let session: UserSession;
+  let previousAgentsFlag: string | undefined;
 
   const environmentRepository = new EnvironmentRepository();
   const agentRepository = new AgentRepository();
@@ -12,7 +13,12 @@ describe('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST)
   const integrationRepository = new IntegrationRepository();
 
   before(() => {
+    previousAgentsFlag = process.env.IS_CONVERSATIONAL_AGENTS_ENABLED;
     process.env.IS_CONVERSATIONAL_AGENTS_ENABLED = 'true';
+  });
+
+  after(() => {
+    process.env.IS_CONVERSATIONAL_AGENTS_ENABLED = previousAgentsFlag;
   });
 
   beforeEach(async () => {
@@ -206,8 +212,14 @@ describe('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST)
 
     expect(addRes.status, 'POST integrations should be 403 in prod').to.equal(403);
 
+    const prodAgent = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      ['_id'] as any
+    );
+
     const prodLinks = await agentIntegrationRepository.find(
       {
+        _agentId: prodAgent!._id,
         _environmentId: prodEnv._id,
         _organizationId: session.organization._id,
       },

--- a/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
+++ b/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
@@ -227,12 +227,12 @@ describe('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST)
     );
     const linkId = prodLinks[0]?._id;
 
-    if (linkId) {
-      const removeRes = await session.testAgent.delete(
-        `/v1/agents/${encodeURIComponent(identifier)}/integrations/${linkId}`
-      );
+    expect(linkId, 'prod agent should have a promoted integration link').to.exist;
 
-      expect(removeRes.status, 'DELETE integrations should be 403 in prod').to.equal(403);
-    }
+    const removeRes = await session.testAgent.delete(
+      `/v1/agents/${encodeURIComponent(identifier)}/integrations/${linkId}`
+    );
+
+    expect(removeRes.status, 'DELETE integrations should be 403 in prod').to.equal(403);
   });
 });

--- a/apps/api/src/app/environments-v2/types/sync.types.ts
+++ b/apps/api/src/app/environments-v2/types/sync.types.ts
@@ -6,6 +6,7 @@ export enum ResourceTypeEnum {
   STEP = 'step',
   LOCALIZATION_GROUP = 'localization_group',
   LAYOUT = 'layout',
+  AGENT = 'agent',
 }
 
 export enum DependencyReasonEnum {

--- a/apps/api/src/app/environments-v2/usecases/diff-environment/diff-environment.usecase.ts
+++ b/apps/api/src/app/environments-v2/usecases/diff-environment/diff-environment.usecase.ts
@@ -9,6 +9,7 @@ import {
 import { ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
 import { DependencyAnalyzerService, EnvironmentValidationService } from '../../services';
 import { IDiffResult, IEnvironmentDiffResult } from '../../types/sync.types';
+import { AgentSyncStrategy } from '../sync-strategies/agent-sync.strategy';
 import { LayoutSyncStrategy } from '../sync-strategies/layout-sync.strategy';
 import { WorkflowSyncStrategy } from '../sync-strategies/workflow-sync.strategy';
 import { DiffEnvironmentCommand } from './diff-environment.command';
@@ -20,6 +21,7 @@ export class DiffEnvironmentUseCase {
     private environmentValidationService: EnvironmentValidationService,
     private workflowSyncStrategy: WorkflowSyncStrategy,
     private layoutSyncStrategy: LayoutSyncStrategy,
+    private agentSyncStrategy: AgentSyncStrategy,
     private dependencyAnalyzerService: DependencyAnalyzerService,
     private controlValuesRepository: ControlValuesRepository,
     private workflowRepository: NotificationTemplateRepository,
@@ -65,8 +67,8 @@ export class DiffEnvironmentUseCase {
         command.targetEnvironmentId
       );
 
-      // Execute diff with workflow container optimization and layout strategy normally
-      const [workflowDiffResults, layoutDiffResults] = await Promise.all([
+      // Execute diff with workflow container optimization and layout/agent strategies normally
+      const [workflowDiffResults, layoutDiffResults, agentDiffResults] = await Promise.all([
         this.workflowSyncStrategy.diff(
           sourceEnvironmentId,
           command.targetEnvironmentId,
@@ -80,9 +82,15 @@ export class DiffEnvironmentUseCase {
           command.user.organizationId,
           command.user
         ),
+        this.agentSyncStrategy.diff(
+          sourceEnvironmentId,
+          command.targetEnvironmentId,
+          command.user.organizationId,
+          command.user
+        ),
       ]);
 
-      const resources = [...workflowDiffResults, ...layoutDiffResults];
+      const resources = [...workflowDiffResults, ...layoutDiffResults, ...agentDiffResults];
 
       const dependencyMap = await this.dependencyAnalyzerService.analyzeDependencies(
         resources,

--- a/apps/api/src/app/environments-v2/usecases/publish-environment/publish-environment.usecase.ts
+++ b/apps/api/src/app/environments-v2/usecases/publish-environment/publish-environment.usecase.ts
@@ -3,6 +3,7 @@ import { InstrumentUsecase, PinoLogger } from '@novu/application-generic';
 import { BaseRepository } from '@novu/dal';
 import { EnvironmentValidationService } from '../../services';
 import { IPublishResult, ISyncContext, ISyncOptions, ISyncResult, ISyncStrategy } from '../../types/sync.types';
+import { AgentSyncStrategy } from '../sync-strategies/agent-sync.strategy';
 import { LayoutSyncStrategy } from '../sync-strategies/layout-sync.strategy';
 import { WorkflowSyncStrategy } from '../sync-strategies/workflow-sync.strategy';
 import { PublishEnvironmentCommand } from './publish-environment.command';
@@ -15,7 +16,8 @@ export class PublishEnvironmentUseCase {
     private logger: PinoLogger,
     private environmentValidationService: EnvironmentValidationService,
     private workflowSyncStrategy: WorkflowSyncStrategy,
-    private layoutSyncStrategy: LayoutSyncStrategy
+    private layoutSyncStrategy: LayoutSyncStrategy,
+    private agentSyncStrategy: AgentSyncStrategy
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -52,7 +54,7 @@ export class PublishEnvironmentUseCase {
 
       this.logger.info(`Starting environment publish from ${sourceEnvironmentId} to ${command.targetEnvironmentId}`);
 
-      const strategies = [this.workflowSyncStrategy, this.layoutSyncStrategy];
+      const strategies = [this.workflowSyncStrategy, this.layoutSyncStrategy, this.agentSyncStrategy];
 
       const results = await this.executeSync(strategies, syncContext);
 

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-comparator.adapter.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-comparator.adapter.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { AgentEntity } from '@novu/dal';
+import { UserSessionData } from '@novu/shared';
+import { diff } from 'deep-object-diff';
+
+import { IResourceDiff } from '../../../types/sync.types';
+import { IBaseComparator } from '../base/interfaces/base-comparator.interface';
+
+type AgentSnapshot = Pick<AgentEntity, 'name' | 'description' | 'behavior'>;
+
+function toSnapshot(agent: AgentEntity): AgentSnapshot {
+  return { name: agent.name, description: agent.description, behavior: agent.behavior };
+}
+
+@Injectable()
+export class AgentComparatorAdapter implements IBaseComparator<AgentEntity> {
+  async compareResources(
+    sourceResource: AgentEntity,
+    targetResource: AgentEntity,
+    _: UserSessionData
+  ): Promise<{
+    resourceChanges: {
+      previous: Record<string, unknown> | null;
+      new: Record<string, unknown> | null;
+    } | null;
+    otherDiffs?: IResourceDiff[];
+  }> {
+    const sourceSnapshot = toSnapshot(sourceResource);
+    const targetSnapshot = toSnapshot(targetResource);
+    const differences = diff(targetSnapshot, sourceSnapshot);
+
+    if (Object.keys(differences).length === 0) {
+      return { resourceChanges: null };
+    }
+
+    return {
+      resourceChanges: {
+        previous: targetSnapshot as Record<string, unknown>,
+        new: sourceSnapshot as Record<string, unknown>,
+      },
+    };
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-delete.adapter.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-delete.adapter.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { AgentEntity } from '@novu/dal';
+
+import { DeleteAgent } from '../../../../agents/usecases/delete-agent/delete-agent.usecase';
+import { DeleteAgentCommand } from '../../../../agents/usecases/delete-agent/delete-agent.command';
+import { ISyncContext } from '../../../types/sync.types';
+import { IBaseDeleteService } from '../base/interfaces/base-delete.interface';
+
+@Injectable()
+export class AgentDeleteAdapter implements IBaseDeleteService<AgentEntity> {
+  constructor(private readonly deleteAgent: DeleteAgent) {}
+
+  async deleteResourceFromTarget(context: ISyncContext, resource: AgentEntity): Promise<void> {
+    await this.deleteAgent.execute(
+      DeleteAgentCommand.create({
+        identifier: resource.identifier,
+        environmentId: context.targetEnvironmentId,
+        organizationId: context.user.organizationId,
+        userId: context.user._id,
+      })
+    );
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-repository.adapter.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-repository.adapter.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { AgentEntity, AgentRepository } from '@novu/dal';
+
+import { IBaseRepositoryService } from '../base/interfaces/base-repository.interface';
+
+@Injectable()
+export class AgentRepositoryAdapter implements IBaseRepositoryService<AgentEntity> {
+  constructor(private readonly agentRepository: AgentRepository) {}
+
+  async fetchSyncableResources(environmentId: string, organizationId: string): Promise<AgentEntity[]> {
+    return this.agentRepository.find({ _environmentId: environmentId, _organizationId: organizationId }, '*');
+  }
+
+  createResourceMap(resources: AgentEntity[]): Map<string, AgentEntity> {
+    return new Map(resources.map((agent) => [agent.identifier, agent]));
+  }
+
+  getResourceIdentifier(resource: AgentEntity): string {
+    return resource.identifier;
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-sync.adapter.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-sync.adapter.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { AgentEntity } from '@novu/dal';
+
+import { SyncAgentToEnvironment, SyncAgentToEnvironmentCommand } from '../../../../agents/usecases/sync-agent-to-environment';
+import { ISyncContext } from '../../../types/sync.types';
+import { IBaseSyncService } from '../base/interfaces/base-sync.interface';
+
+@Injectable()
+export class AgentSyncAdapter implements IBaseSyncService<AgentEntity> {
+  constructor(private readonly syncAgentToEnvironment: SyncAgentToEnvironment) {}
+
+  async syncResourceToTarget(context: ISyncContext, resource: AgentEntity): Promise<void> {
+    await this.syncAgentToEnvironment.execute(
+      SyncAgentToEnvironmentCommand.create({
+        agentIdentifier: resource.identifier,
+        environmentId: context.sourceEnvironmentId,
+        targetEnvironmentId: context.targetEnvironmentId,
+        organizationId: context.user.organizationId,
+        userId: context.user._id,
+      })
+    );
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/index.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/index.ts
@@ -1,5 +1,7 @@
 export { AgentComparatorAdapter } from './agent-comparator.adapter';
+export { AgentDeleteAdapter } from './agent-delete.adapter';
 export { AgentRepositoryAdapter } from './agent-repository.adapter';
+export { AgentSyncAdapter } from './agent-sync.adapter';
 export { WorkflowComparatorAdapter } from './workflow-comparator.adapter';
 export { WorkflowDeleteAdapter } from './workflow-delete.adapter';
 export { WorkflowRepositoryAdapter } from './workflow-repository.adapter';

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/index.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/index.ts
@@ -1,3 +1,5 @@
+export { AgentComparatorAdapter } from './agent-comparator.adapter';
+export { AgentRepositoryAdapter } from './agent-repository.adapter';
 export { WorkflowComparatorAdapter } from './workflow-comparator.adapter';
 export { WorkflowDeleteAdapter } from './workflow-delete.adapter';
 export { WorkflowRepositoryAdapter } from './workflow-repository.adapter';

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/agent-sync.strategy.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/agent-sync.strategy.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from '@novu/application-generic';
+import { UserSessionData } from '@novu/shared';
+
+import { IDiffResult, ISyncContext, ISyncResult, ResourceTypeEnum } from '../../types/sync.types';
+import { BaseSyncStrategy } from './base/base-sync.strategy';
+import { AgentDiffOperation } from './operations/agent-diff.operation';
+import { AgentSyncOperation } from './operations/agent-sync.operation';
+
+@Injectable()
+export class AgentSyncStrategy extends BaseSyncStrategy {
+  constructor(
+    logger: PinoLogger,
+    private agentSyncOperation: AgentSyncOperation,
+    private agentDiffOperation: AgentDiffOperation
+  ) {
+    super(logger);
+  }
+
+  getResourceType(): ResourceTypeEnum {
+    return ResourceTypeEnum.AGENT;
+  }
+
+  async execute(context: ISyncContext): Promise<ISyncResult> {
+    return this.agentSyncOperation.execute(context);
+  }
+
+  async diff(
+    sourceEnvId: string,
+    targetEnvId: string,
+    organizationId: string,
+    userContext: UserSessionData
+  ): Promise<IDiffResult[]> {
+    return this.agentDiffOperation.execute(sourceEnvId, targetEnvId, organizationId, userContext);
+  }
+
+  async getAvailableResourceIds(sourceEnvironmentId: string, organizationId: string): Promise<string[]> {
+    return this.agentSyncOperation.getAvailableResourceIds(sourceEnvironmentId, organizationId);
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/agent-sync.strategy.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/agent-sync.strategy.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { PinoLogger } from '@novu/application-generic';
-import { UserSessionData } from '@novu/shared';
+import { FeatureFlagsService, PinoLogger } from '@novu/application-generic';
+import { FeatureFlagsKeysEnum, UserSessionData } from '@novu/shared';
 
 import { IDiffResult, ISyncContext, ISyncResult, ResourceTypeEnum } from '../../types/sync.types';
 import { BaseSyncStrategy } from './base/base-sync.strategy';
@@ -12,7 +12,8 @@ export class AgentSyncStrategy extends BaseSyncStrategy {
   constructor(
     logger: PinoLogger,
     private agentSyncOperation: AgentSyncOperation,
-    private agentDiffOperation: AgentDiffOperation
+    private agentDiffOperation: AgentDiffOperation,
+    private featureFlagsService: FeatureFlagsService
   ) {
     super(logger);
   }
@@ -22,6 +23,12 @@ export class AgentSyncStrategy extends BaseSyncStrategy {
   }
 
   async execute(context: ISyncContext): Promise<ISyncResult> {
+    const isEnabled = await this.isFeatureEnabled(context.user.organizationId, context.sourceEnvironmentId);
+
+    if (!isEnabled) {
+      return { resourceType: ResourceTypeEnum.AGENT, successful: [], failed: [], skipped: [], totalProcessed: 0 };
+    }
+
     return this.agentSyncOperation.execute(context);
   }
 
@@ -31,10 +38,31 @@ export class AgentSyncStrategy extends BaseSyncStrategy {
     organizationId: string,
     userContext: UserSessionData
   ): Promise<IDiffResult[]> {
+    const isEnabled = await this.isFeatureEnabled(organizationId, sourceEnvId);
+
+    if (!isEnabled) {
+      return [];
+    }
+
     return this.agentDiffOperation.execute(sourceEnvId, targetEnvId, organizationId, userContext);
   }
 
   async getAvailableResourceIds(sourceEnvironmentId: string, organizationId: string): Promise<string[]> {
+    const isEnabled = await this.isFeatureEnabled(organizationId, sourceEnvironmentId);
+
+    if (!isEnabled) {
+      return [];
+    }
+
     return this.agentSyncOperation.getAvailableResourceIds(sourceEnvironmentId, organizationId);
+  }
+
+  private async isFeatureEnabled(organizationId: string, environmentId: string): Promise<boolean> {
+    return this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED,
+      defaultValue: false,
+      organization: { _id: organizationId },
+      environment: { _id: environmentId },
+    });
   }
 }

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/operations/agent-diff.operation.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/operations/agent-diff.operation.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from '@novu/application-generic';
+import { AgentEntity } from '@novu/dal';
+
+import { IUserInfo, ResourceTypeEnum } from '../../../types/sync.types';
+import { AgentComparatorAdapter } from '../adapters/agent-comparator.adapter';
+import { AgentRepositoryAdapter } from '../adapters/agent-repository.adapter';
+import { BaseDiffOperation } from '../base/operations/base-diff.operation';
+
+@Injectable()
+export class AgentDiffOperation extends BaseDiffOperation<AgentEntity> {
+  constructor(
+    protected logger: PinoLogger,
+    protected repositoryAdapter: AgentRepositoryAdapter,
+    protected comparatorAdapter: AgentComparatorAdapter
+  ) {
+    super(logger, repositoryAdapter, comparatorAdapter);
+  }
+
+  protected getResourceType(): ResourceTypeEnum {
+    return ResourceTypeEnum.AGENT;
+  }
+
+  protected getResourceName(resource: AgentEntity): string {
+    return resource.name || resource.identifier;
+  }
+
+  protected extractUpdatedByInfo(_resource: AgentEntity): IUserInfo | null {
+    return null;
+  }
+
+  protected extractUpdatedAtInfo(resource: AgentEntity): string | null {
+    return resource.updatedAt ?? null;
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/operations/agent-sync.operation.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/operations/agent-sync.operation.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from '@novu/application-generic';
+import { AgentEntity } from '@novu/dal';
+
+import { ResourceTypeEnum } from '../../../types/sync.types';
+import { AgentComparatorAdapter } from '../adapters/agent-comparator.adapter';
+import { AgentDeleteAdapter } from '../adapters/agent-delete.adapter';
+import { AgentRepositoryAdapter } from '../adapters/agent-repository.adapter';
+import { AgentSyncAdapter } from '../adapters/agent-sync.adapter';
+import { BaseSyncOperation } from '../base/operations/base-sync.operation';
+
+@Injectable()
+export class AgentSyncOperation extends BaseSyncOperation<AgentEntity> {
+  constructor(
+    protected logger: PinoLogger,
+    protected repositoryAdapter: AgentRepositoryAdapter,
+    protected syncAdapter: AgentSyncAdapter,
+    protected deleteAdapter: AgentDeleteAdapter,
+    protected comparatorAdapter: AgentComparatorAdapter
+  ) {
+    super(logger, repositoryAdapter, syncAdapter, deleteAdapter, comparatorAdapter);
+  }
+
+  protected getResourceType(): ResourceTypeEnum {
+    return ResourceTypeEnum.AGENT;
+  }
+
+  protected getResourceName(resource: AgentEntity): string {
+    return resource.name || resource.identifier;
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/sync.module.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/sync.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { DeletePreferencesUseCase, GetWorkflowByIdsUseCase, ResourceValidatorService } from '@novu/application-generic';
+import { AgentsModule } from '../../../agents/agents.module';
 import { LayoutsV2Module } from '../../../layouts-v2/layouts.module';
 import { DeleteLayoutUseCase } from '../../../layouts-v2/usecases/delete-layout';
 import { LayoutSyncToEnvironmentUseCase } from '../../../layouts-v2/usecases/sync-to-environment';
@@ -10,6 +11,10 @@ import { DeleteWorkflowUseCase } from '../../../workflows-v1/usecases/delete-wor
 import { SyncToEnvironmentUseCase } from '../../../workflows-v2/usecases/sync-to-environment/sync-to-environment.usecase';
 import { WorkflowModule } from '../../../workflows-v2/workflow.module';
 import {
+  AgentComparatorAdapter,
+  AgentDeleteAdapter,
+  AgentRepositoryAdapter,
+  AgentSyncAdapter,
   WorkflowComparatorAdapter,
   WorkflowDeleteAdapter,
   WorkflowRepositoryAdapter,
@@ -19,11 +24,14 @@ import { LayoutComparatorAdapter } from './adapters/layout-comparator.adapter';
 import { LayoutDeleteAdapter } from './adapters/layout-delete.adapter';
 import { LayoutRepositoryAdapter } from './adapters/layout-repository.adapter';
 import { LayoutSyncAdapter } from './adapters/layout-sync.adapter';
+import { AgentSyncStrategy } from './agent-sync.strategy';
 import { LayoutComparator } from './comparators/layout.comparator';
 import { WorkflowComparator } from './comparators/workflow.comparator';
 import { LayoutSyncStrategy } from './layout-sync.strategy';
 import { LayoutNormalizer } from './normalizers/layout.normalizer';
 import { WorkflowNormalizer } from './normalizers/workflow.normalizer';
+import { AgentDiffOperation } from './operations/agent-diff.operation';
+import { AgentSyncOperation } from './operations/agent-sync.operation';
 import { LayoutDiffOperation } from './operations/layout-diff.operation';
 import { LayoutRepositoryService } from './operations/layout-repository.service';
 import { LayoutSyncOperation } from './operations/layout-sync.operation';
@@ -33,7 +41,7 @@ import { WorkflowSyncOperation } from './operations/workflow-sync.operation';
 import { WorkflowSyncStrategy } from './workflow-sync.strategy';
 
 @Module({
-  imports: [SharedModule, WorkflowModule, LayoutsV2Module, OutboundWebhooksModule.forRoot()],
+  imports: [SharedModule, WorkflowModule, LayoutsV2Module, OutboundWebhooksModule.forRoot(), AgentsModule],
   providers: [
     // Repository services
     WorkflowRepositoryService,
@@ -56,12 +64,18 @@ import { WorkflowSyncStrategy } from './workflow-sync.strategy';
     LayoutSyncAdapter,
     LayoutDeleteAdapter,
     LayoutComparatorAdapter,
+    AgentRepositoryAdapter,
+    AgentSyncAdapter,
+    AgentDeleteAdapter,
+    AgentComparatorAdapter,
 
     // Operations
     WorkflowSyncOperation,
     WorkflowDiffOperation,
     LayoutSyncOperation,
     LayoutDiffOperation,
+    AgentSyncOperation,
+    AgentDiffOperation,
 
     // Usecases
     SyncToEnvironmentUseCase,
@@ -76,7 +90,8 @@ import { WorkflowSyncStrategy } from './workflow-sync.strategy';
     // Strategies
     WorkflowSyncStrategy,
     LayoutSyncStrategy,
+    AgentSyncStrategy,
   ],
-  exports: [WorkflowSyncStrategy, LayoutSyncStrategy],
+  exports: [WorkflowSyncStrategy, LayoutSyncStrategy, AgentSyncStrategy],
 })
 export class SyncModule {}

--- a/libs/dal/src/repositories/integration/integration.entity.ts
+++ b/libs/dal/src/repositories/integration/integration.entity.ts
@@ -42,6 +42,8 @@ export class IntegrationEntity {
   conditions?: StepFilter[];
 
   connected?: boolean;
+
+  _parentId?: string;
 }
 
 export type IntegrationDBModel = ChangePropsValueType<IntegrationEntity, '_environmentId' | '_organizationId'>;

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -111,6 +111,11 @@ const integrationSchema = new Schema<IntegrationDBModel>(
       },
     ],
     connected: Schema.Types.Boolean,
+    _parentId: {
+      type: Schema.Types.ObjectId,
+      required: false,
+      default: null,
+    },
   },
   schemaOptions
 );


### PR DESCRIPTION
## Summary

- Implements full agent promotion flow through the existing `environments-v2` publish pipeline
- Adds production environment guards to prevent adding/removing agent integrations via API
- Gates the entire mechanism behind the `IS_CONVERSATIONAL_AGENTS_ENABLED` feature flag

Fixes NV-7429

## What changed

### Schema
- `IntegrationEntity` / schema: added optional `_parentId` to link a promoted stub integration back to its dev source
- `ResourceTypeEnum`: added `AGENT` variant for the sync framework

### Core promotion logic (`SyncAgentToEnvironmentUseCase`)
- **Fresh promotion**: copies agent to prod as `active: false`; creates placeholder `Integration` documents (same `providerId`, `channel`, `name`, `identifier`, empty `credentials`, `_parentId` → source) and `AgentIntegration` links with `connectedAt: null` so the UI can signal "Action needed"
- **Re-promotion (idempotent)**: updates agent metadata; reconciles integrations — adds stubs for newly linked ones, removes stubs for unlinked ones; does **not** touch `active` state or existing credentials
- **Agent removed in dev**: deletes the prod agent and its stub integrations on next publish

### Sync framework wiring
- `AgentRepositoryAdapter`, `AgentComparatorAdapter`, `AgentSyncAdapter`, `AgentDeleteAdapter`
- `AgentDiffOperation`, `AgentSyncOperation`, `AgentSyncStrategy`
- Injected into `PublishEnvironmentUseCase` and `DiffEnvironmentUseCase` alongside workflows and layouts

### Prod guards
- `AddAgentIntegration`: returns `403 Forbidden` when called against a production environment
- `RemoveAgentIntegration`: same guard — integrations can only be linked/unlinked in dev; the publish flow creates/removes stubs automatically

## Architecture

```mermaid
sequenceDiagram
    participant UI
    participant Publish as PublishEnvironmentUseCase
    participant Strategy as AgentSyncStrategy
    participant Sync as SyncAgentToEnvironmentUseCase
    participant DB

    UI->>Publish: POST /v2/environments/:prodId/publish
    Publish->>Strategy: execute(context)
    Strategy->>Strategy: check IS_CONVERSATIONAL_AGENTS_ENABLED
    Strategy->>Sync: execute per agent identifier
    Sync->>DB: upsert Agent (active:false on create)
    Sync->>DB: upsert stub Integrations (_parentId → dev, connectedAt:null)
    Sync->>DB: reconcile AgentIntegration links
```

## Test plan

- [x] Unit tests: `SyncAgentToEnvironmentUseCase` (all promotion scenarios)
- [x] E2E: `environments-v2-agent-publish.e2e.ts` — 6 scenarios covering fresh promotion, idempotent re-promotion, metadata-only update, agent deletion propagation, and both prod write guards

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Agents created in development can now be promoted to production via the environments-v2 publish flow. Promotion creates a production agent (inactive by default) with placeholder integration records and agent-integration links (empty credentials, connectedAt null); re-publishing is idempotent (only metadata updates, preserves active state and credentials); removing an agent in dev deletes the prod agent and its stubs on next publish. The whole mechanism is feature-flag gated (IS_CONVERSATIONAL_AGENTS_ENABLED) and the API forbids adding/removing agent integrations in production.

## Affected areas

**api** — Implements SyncAgentToEnvironment use case to perform promotion, reconciliation and deletion propagation; AddAgentIntegration and RemoveAgentIntegration now check environment type and return 403 for production.  
**environments-v2** — Wires agent diff/sync into publish and diff pipelines via AgentSyncStrategy, AgentSyncOperation, AgentDiffOperation and adapters (AgentRepositoryAdapter, AgentComparatorAdapter, AgentSyncAdapter, AgentDeleteAdapter) so agents are diffed and synced alongside workflows and layouts.  
**dal** — Adds optional _parentId to IntegrationEntity to reference the originating dev integration and extends ResourceTypeEnum with AGENT for sync/diff typing.  
**tests** — Adds unit tests for SyncAgentToEnvironment (fresh promotion, idempotency, metadata updates, reconciliation, cleanup) and an E2E suite validating publish/diff behavior and production write guards.

## Key technical decisions

- Feature-flag gating: agent sync/diff runs only when IS_CONVERSATIONAL_AGENTS_ENABLED is enabled for the organization/environment.  
- Promotion semantics: newly promoted agents are created inactive; re-promotion updates metadata only and never overwrites active state or existing credentials.  
- Stub integration model: promoted integrations are created as stubs (_parentId → source); stubs are shared when referenced by multiple agent links and are deleted only when no links remain.  
- API prod guards: direct add/remove integration operations are blocked for production environments (403).

## Testing

Includes new unit tests covering promotion/reconciliation/cleanup and an E2E test suite for publish/diff scenarios and prod write-guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->