### PR TITLE
fix(api-service): add PinoLogger setContext in all API constructors

### DIFF
--- a/apps/api/src/app/agents/services/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-config-resolver.service.ts
@@ -72,7 +72,9 @@ export class AgentConfigResolver {
     private readonly channelConnectionRepository: ChannelConnectionRepository,
     private readonly logger: PinoLogger,
     private readonly analyticsService: AnalyticsService
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async resolve(agentId: string, integrationIdentifier: string): Promise<ResolvedAgentConfig> {
     const agent = await this.agentRepository.findByIdForWebhook(agentId);

--- a/apps/api/src/app/agents/services/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.ts
@@ -79,7 +79,9 @@ export class AgentConversationService {
     private readonly conversationRepository: ConversationRepository,
     private readonly activityRepository: ConversationActivityRepository,
     private readonly logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   getPrimaryChannel(conversation: ConversationEntity): ConversationChannel {
     const channel = conversation.channels?.[0];

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -35,7 +35,9 @@ export class AgentInboundHandler {
     private readonly bridgeExecutor: BridgeExecutorService,
     private readonly subscriberRepository: SubscriberRepository,
     private readonly analyticsService: AnalyticsService
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async handle(
     agentId: string,

--- a/apps/api/src/app/agents/services/agent-subscriber-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-subscriber-resolver.service.ts
@@ -17,7 +17,9 @@ export class AgentSubscriberResolver {
   constructor(
     private readonly channelEndpointRepository: ChannelEndpointRepository,
     private readonly logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async resolve(params: ResolveSubscriberParams): Promise<string | null> {
     const { environmentId, organizationId, platform, platformUserId, integrationIdentifier } = params;

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -56,7 +56,9 @@ export class BridgeExecutorService {
   constructor(
     private readonly getDecryptedSecretKey: GetDecryptedSecretKey,
     private readonly logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(params: BridgeExecutorParams): Promise<void> {
     const agentIdentifier = params.config.agentIdentifier;

--- a/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
@@ -11,6 +11,7 @@ describe('ChatSdkService', () => {
         error: sinon.stub(),
         debug: sinon.stub(),
         info: sinon.stub(),
+        setContext: sinon.stub(),
       };
       const integrationRepository = {
         findOne: sinon.stub().resolves({
@@ -71,6 +72,7 @@ describe('ChatSdkService', () => {
         error: sinon.stub(),
         debug: sinon.stub(),
         info: sinon.stub(),
+        setContext: sinon.stub(),
       };
       const integrationRepository = {
         findOne: sinon.stub().resolves({

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -89,6 +89,7 @@ export class ChatSdkService implements OnModuleDestroy {
     private readonly inboundHandler: AgentInboundHandler,
     private readonly integrationRepository: IntegrationRepository
   ) {
+    this.logger.setContext(this.constructor.name);
     this.instances = new LRUCache<string, CachedChat>({
       max: MAX_CACHED_INSTANCES,
       ttl: INSTANCE_TTL_MS,

--- a/apps/api/src/app/agents/usecases/cleanup-novu-email/cleanup-novu-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/cleanup-novu-email/cleanup-novu-email.usecase.ts
@@ -13,7 +13,9 @@ export class CleanupNovuEmail {
     private readonly integrationRepository: IntegrationRepository,
     private readonly domainRouteRepository: DomainRouteRepository,
     private readonly logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   /**
    * Removes all NovuAgent email resources tied to an agent:

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -33,7 +33,9 @@ export class HandleAgentReply {
     private readonly logger: PinoLogger,
     private readonly parseEventRequest: ParseEventRequest,
     private readonly analyticsService: AnalyticsService
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: HandleAgentReplyCommand): Promise<SentMessageInfo | null> {
     if (command.reply && command.edit) {

--- a/apps/api/src/app/agents/usecases/list-agent-integrations/list-agent-integrations.usecase.ts
+++ b/apps/api/src/app/agents/usecases/list-agent-integrations/list-agent-integrations.usecase.ts
@@ -14,7 +14,9 @@ export class ListAgentIntegrations {
     private readonly agentIntegrationRepository: AgentIntegrationRepository,
     private readonly integrationRepository: IntegrationRepository,
     private readonly logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   @InstrumentUsecase()
   async execute(command: ListAgentIntegrationsCommand): Promise<ListAgentIntegrationsResponseDto> {

--- a/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts
@@ -55,7 +55,9 @@ export class ConstructFrameworkWorkflow {
     private throttleOutputRendererUseCase: ThrottleOutputRendererUsecase,
     private featureFlagsService: FeatureFlagsService,
     private inMemoryLRUCacheService: InMemoryLRUCacheService
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   @InstrumentUsecase()
   async execute(command: ConstructFrameworkWorkflowCommand): Promise<Workflow> {

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/comparators/layout.comparator.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/comparators/layout.comparator.ts
@@ -11,7 +11,9 @@ export class LayoutComparator {
     private logger: PinoLogger,
     private getLayoutUseCase: GetLayoutUseCase,
     private layoutNormalizer: LayoutNormalizer
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async compareLayouts(sourceLayout: LayoutEntity, targetLayout: LayoutEntity): Promise<ILayoutComparison> {
     try {

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/comparators/workflow.comparator.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/comparators/workflow.comparator.ts
@@ -23,7 +23,9 @@ export class WorkflowComparator {
     private workflowNormalizer: WorkflowNormalizer,
     private workflowRepositoryService: WorkflowRepositoryService,
     private moduleRef: ModuleRef
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async compareWorkflows(
     sourceWorkflow: NotificationTemplateEntity,

--- a/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/snooze-notification/snooze-notification.usecase.ts
@@ -44,7 +44,9 @@ export class SnoozeNotification {
     private createExecutionDetails: CreateExecutionDetails,
     private markNotificationAs: MarkNotificationAs,
     private analyticsService: AnalyticsService
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   public async execute(command: SnoozeNotificationCommand): Promise<InboxNotificationDto> {
     const snoozeDurationMs = this.calculateDelayInMs(command.snoozeUntil);

--- a/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/unsnooze-notification/unsnooze-notification.usecase.ts
@@ -20,7 +20,9 @@ export class UnsnoozeNotification {
     private jobRepository: JobRepository,
     private markNotificationAs: MarkNotificationAs,
     private createExecutionDetails: CreateExecutionDetails
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: UnsnoozeNotificationCommand): Promise<InboxNotificationDto> {
     const snoozedNotification = await this.messageRepository.findOne({

--- a/apps/api/src/app/layouts-v2/usecases/build-layout-issues/build-layout-issues.usecase.ts
+++ b/apps/api/src/app/layouts-v2/usecases/build-layout-issues/build-layout-issues.usecase.ts
@@ -21,7 +21,9 @@ export class BuildLayoutIssuesUsecase {
   constructor(
     private layoutVariablesSchemaUseCase: LayoutVariablesSchemaUseCase,
     private logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   @InstrumentUsecase()
   async execute(command: BuildLayoutIssuesCommand): Promise<LayoutIssuesDto> {

--- a/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.ts
+++ b/apps/api/src/app/layouts-v2/usecases/delete-layout/delete-layout.use-case.ts
@@ -20,7 +20,9 @@ export class DeleteLayoutUseCase {
     private analyticsService: AnalyticsService,
     private moduleRef: ModuleRef,
     private logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: DeleteLayoutCommand): Promise<void> {
     const { environmentId, organizationId, userId } = command;

--- a/apps/api/src/app/layouts-v2/usecases/duplicate-layout/duplicate-layout.use-case.ts
+++ b/apps/api/src/app/layouts-v2/usecases/duplicate-layout/duplicate-layout.use-case.ts
@@ -21,7 +21,9 @@ export class DuplicateLayoutUseCase {
     private analyticsService: AnalyticsService,
     private moduleRef: ModuleRef,
     private logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: DuplicateLayoutCommand): Promise<LayoutResponseDto> {
     const originalLayout = await this.getLayoutUseCase.execute(

--- a/apps/api/src/app/layouts-v2/usecases/upsert-layout/upsert-layout.usecase.ts
+++ b/apps/api/src/app/layouts-v2/usecases/upsert-layout/upsert-layout.usecase.ts
@@ -48,7 +48,9 @@ export class UpsertLayout {
     private getLayoutUseCase: GetLayoutUseCase,
     private moduleRef: ModuleRef,
     private logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   @InstrumentUsecase()
   async execute(command: UpsertLayoutCommand): Promise<LayoutResponseDto> {

--- a/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
@@ -39,7 +39,9 @@ export class GetActivityFeed {
     private traceLogRepository: TraceLogRepository,
     private featureFlagsService: FeatureFlagsService,
     private logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: GetActivityFeedCommand): Promise<ActivitiesResponseDto> {
     let subscriberIds: string[] | undefined;

--- a/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
@@ -75,7 +75,9 @@ export class GetActivity {
     private workflowRunRepository: WorkflowRunRepository,
     private logger: PinoLogger,
     private featureFlagsService: FeatureFlagsService
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: GetActivityCommand): Promise<ActivityNotificationResponseDto> {
     this.analyticsService.track('Get Activity Feed Item - [Activity Feed]', command.userId, {

--- a/apps/api/src/app/organization/usecases/enrich-organization-brand/brand-retrieval.service.ts
+++ b/apps/api/src/app/organization/usecases/enrich-organization-brand/brand-retrieval.service.ts
@@ -28,7 +28,9 @@ function isLogoMode(value: unknown): value is IBrandLogo['mode'] {
 export class BrandRetrievalService {
   private client: ContextDev | null = null;
 
-  constructor(private readonly logger: PinoLogger) {}
+  constructor(private readonly logger: PinoLogger) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async initialize(): Promise<void> {
     const apiKey = process.env.CONTEXT_DEV_API_KEY;

--- a/apps/api/src/app/organization/usecases/enrich-organization-brand/enrich-organization-brand.usecase.ts
+++ b/apps/api/src/app/organization/usecases/enrich-organization-brand/enrich-organization-brand.usecase.ts
@@ -63,7 +63,9 @@ export class EnrichOrganizationBrand {
     private readonly brandRetrievalService: BrandRetrievalService,
     private readonly moduleRef: ModuleRef,
     private readonly logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: EnrichOrganizationBrandCommand): Promise<void> {
     const isEnabled = await this.featureFlagsService.getFlag({

--- a/apps/api/src/app/workflows-v1/usecases/delete-workflow/delete-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v1/usecases/delete-workflow/delete-workflow.usecase.ts
@@ -32,7 +32,9 @@ export class DeleteWorkflowUseCase {
     private moduleRef: ModuleRef,
     private logger: PinoLogger,
     private sendWebhookMessage: SendWebhookMessage
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   @InstrumentUsecase()
   async execute(command: DeleteWorkflowCommand): Promise<void> {

--- a/apps/api/src/app/workflows-v2/usecases/duplicate-workflow/duplicate-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/duplicate-workflow/duplicate-workflow.usecase.ts
@@ -29,7 +29,9 @@ export class DuplicateWorkflowUseCase {
     private upsertWorkflowUseCase: UpsertWorkflowUseCase,
     private moduleRef: ModuleRef,
     private logger: PinoLogger
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   @InstrumentUsecase()
   async execute(command: DuplicateWorkflowCommand): Promise<WorkflowResponseDto> {

--- a/apps/api/src/app/workflows-v2/usecases/patch-workflow/patch-workflow.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/patch-workflow/patch-workflow.usecase.ts
@@ -27,7 +27,9 @@ export class PatchWorkflowUsecase {
     private moduleRef: ModuleRef,
     private logger: PinoLogger,
     private sendWebhookMessage: SendWebhookMessage
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   @InstrumentUsecase()
   async execute(command: PatchWorkflowCommand): Promise<WorkflowResponseDto> {

--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -21,9 +21,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
   constructor(
     private readonly logger: PinoLogger,
     private readonly requestLogRepository: RequestLogRepository
-  ) {
-    this.logger.setContext(this.constructor.name);
-  }
+  ) {}
   async catch(exception: unknown, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();

--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -21,7 +21,9 @@ export class AllExceptionsFilter implements ExceptionFilter {
   constructor(
     private readonly logger: PinoLogger,
     private readonly requestLogRepository: RequestLogRepository
-  ) {}
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
   async catch(exception: unknown, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Added `this.logger.setContext(this.constructor.name)` to all 25 constructor bodies in `apps/api` that inject `PinoLogger` but were missing the context initialization call.

## Why

Without `setContext`, log entries from these classes lack the class name context, making it harder to trace which component emitted a given log line. Every other PinoLogger injection in the API already followed this pattern — these 25 were the outliers.

## Notes

- **`AllExceptionsFilter`** (`exception-filter.ts`) was intentionally excluded: it is manually instantiated in `bootstrap.ts` with `app.get(Logger)` (a NestJS Logger, not PinoLogger), so calling `setContext` would throw at runtime.
- **`chat-sdk.service.spec.ts`** mock loggers were updated to include `setContext: sinon.stub()` since the spec constructs `ChatSdkService` with plain object mocks rather than `sinon.createStubInstance(PinoLogger)`.

## Files changed

- **agents/services**: `agent-config-resolver`, `agent-conversation`, `agent-inbound-handler`, `agent-subscriber-resolver`, `bridge-executor`, `chat-sdk`
- **agents/usecases**: `cleanup-novu-email`, `handle-agent-reply`, `list-agent-integrations`
- **environments-v1**: `construct-framework-workflow`
- **environments-v2**: `layout.comparator`, `workflow.comparator`
- **inbox**: `snooze-notification`, `unsnooze-notification`
- **layouts-v2**: `build-layout-issues`, `delete-layout`, `duplicate-layout`, `upsert-layout`
- **notifications**: `get-activity`, `get-activity-feed`
- **organization**: `brand-retrieval`, `enrich-organization-brand`
- **workflows-v1**: `delete-workflow`
- **workflows-v2**: `duplicate-workflow`, `patch-workflow`
- **spec fix**: `chat-sdk.service.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D092998U7KR/p1777554790020979?thread_ts=1777554790.020979&cid=D092998U7KR)

<div><a href="https://cursor.com/agents/bc-12dfa0b2-731d-51d3-9fe6-f2ee2affb01d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12dfa0b2-731d-51d3-9fe6-f2ee2affb01d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Added `this.logger.setContext(this.constructor.name)` initialization to PinoLogger-injected constructors across 26 files in apps/api. This ensures log entries are tagged with their source class name for better traceability. The pattern was already in use elsewhere; these files were missing it due to empty constructor bodies.

## Affected areas
- **api**: Added logger context initialization in agent services (6 files), agent use cases (3 files), environment/workflow comparators (2 files), inbox notifications (2 files), layout management use cases (4 files), notification activity use cases (2 files), organization/brand enrichment (2 files), and workflow management use cases (3 files). Also updated test mocks in `chat-sdk.service.spec.ts` to stub the `setContext` method.

## Key technical decisions
None — this is a consistency fix with no architectural changes, new dependencies, or API contract updates.

## Testing
Updated mocks in `chat-sdk.service.spec.ts` to stub `setContext` so tests match the service's constructor expectations. No new tests were added as this change only affects logging infrastructure initialization, not core business logic. An exception was made for AllExceptionsFilter (reverted) since it uses NestJS Logger instead of PinoLogger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->