### PR TITLE
feat(dashboard): agent production environment UI and publish flow

### DIFF
--- a/apps/api/src/app/agents/usecases/add-agent-integration/add-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/usecases/add-agent-integration/add-agent-integration.usecase.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto';
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   HttpException,
   HttpStatus,
   Injectable,
@@ -12,10 +13,11 @@ import {
   AgentIntegrationRepository,
   AgentRepository,
   CommunityOrganizationRepository,
+  EnvironmentRepository,
   IntegrationEntity,
   IntegrationRepository,
 } from '@novu/dal';
-import { ApiServiceLevelEnum, EmailProviderIdEnum, FeatureNameEnum, getFeatureForTierAsBoolean } from '@novu/shared';
+import { ApiServiceLevelEnum, EmailProviderIdEnum, EnvironmentTypeEnum, FeatureNameEnum, getFeatureForTierAsBoolean } from '@novu/shared';
 
 import { trackAgentIntegrationConnected } from '../../agent-analytics';
 import type { AgentIntegrationResponseDto } from '../../dtos';
@@ -30,11 +32,14 @@ export class AddAgentIntegration {
     private readonly integrationRepository: IntegrationRepository,
     private readonly agentIntegrationRepository: AgentIntegrationRepository,
     private readonly organizationRepository: CommunityOrganizationRepository,
+    private readonly environmentRepository: EnvironmentRepository,
     private readonly findOrCreateNovuEmail: FindOrCreateNovuEmail,
     private readonly analyticsService: AnalyticsService
   ) {}
 
   async execute(command: AddAgentIntegrationCommand): Promise<AgentIntegrationResponseDto> {
+    await this.assertNotProductionEnvironment(command.environmentId, command.organizationId);
+
     if (!command.integrationIdentifier && !command.providerId) {
       throw new BadRequestException('Either integrationIdentifier or providerId must be provided.');
     }
@@ -193,6 +198,17 @@ export class AddAgentIntegration {
 
     if (existing.length > 0) {
       throw new ConflictException('Only one email integration per agent is allowed.');
+    }
+  }
+
+  private async assertNotProductionEnvironment(environmentId: string, organizationId: string): Promise<void> {
+    const environment = await this.environmentRepository.findOne(
+      { _id: environmentId, _organizationId: organizationId },
+      ['type']
+    );
+
+    if (environment?.type === EnvironmentTypeEnum.PROD) {
+      throw new ForbiddenException('Agent integrations cannot be added in production environments.');
     }
   }
 

--- a/apps/api/src/app/agents/usecases/add-agent-integration/add-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/usecases/add-agent-integration/add-agent-integration.usecase.ts
@@ -204,7 +204,7 @@ export class AddAgentIntegration {
   private async assertNotProductionEnvironment(environmentId: string, organizationId: string): Promise<void> {
     const environment = await this.environmentRepository.findOne(
       { _id: environmentId, _organizationId: organizationId },
-      ['type']
+      ['type', 'name']
     );
 
     if (environment?.type === EnvironmentTypeEnum.PROD) {

--- a/apps/api/src/app/agents/usecases/index.ts
+++ b/apps/api/src/app/agents/usecases/index.ts
@@ -10,6 +10,7 @@ import { ListAgentIntegrations } from './list-agent-integrations/list-agent-inte
 import { ListAgents } from './list-agents/list-agents.usecase';
 import { RemoveAgentIntegration } from './remove-agent-integration/remove-agent-integration.usecase';
 import { SendAgentTestEmail } from './send-agent-test-email/send-agent-test-email.usecase';
+import { SyncAgentToEnvironment } from './sync-agent-to-environment/sync-agent-to-environment.usecase';
 import { UpdateAgent } from './update-agent/update-agent.usecase';
 import { UpdateAgentIntegration } from './update-agent-integration/update-agent-integration.usecase';
 
@@ -28,4 +29,5 @@ export const USE_CASES = [
   RemoveAgentIntegration,
   HandleAgentReply,
   SendAgentTestEmail,
+  SyncAgentToEnvironment,
 ];

--- a/apps/api/src/app/agents/usecases/remove-agent-integration/remove-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/usecases/remove-agent-integration/remove-agent-integration.usecase.ts
@@ -1,6 +1,7 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { AnalyticsService } from '@novu/application-generic';
-import { AgentIntegrationRepository, AgentRepository } from '@novu/dal';
+import { AgentIntegrationRepository, AgentRepository, EnvironmentRepository } from '@novu/dal';
+import { EnvironmentTypeEnum } from '@novu/shared';
 
 import { trackAgentIntegrationRemoved } from '../../agent-analytics';
 import { CleanupNovuEmail } from '../cleanup-novu-email/cleanup-novu-email.usecase';
@@ -11,11 +12,14 @@ export class RemoveAgentIntegration {
   constructor(
     private readonly agentRepository: AgentRepository,
     private readonly agentIntegrationRepository: AgentIntegrationRepository,
+    private readonly environmentRepository: EnvironmentRepository,
     private readonly cleanupNovuEmail: CleanupNovuEmail,
     private readonly analyticsService: AnalyticsService
   ) {}
 
   async execute(command: RemoveAgentIntegrationCommand): Promise<void> {
+    await this.assertNotProductionEnvironment(command.environmentId, command.organizationId);
+
     const agent = await this.agentRepository.findOne(
       {
         identifier: command.agentIdentifier,
@@ -62,5 +66,16 @@ export class RemoveAgentIntegration {
       agentIdentifier: command.agentIdentifier,
       agentIntegrationId: command.agentIntegrationId,
     });
+  }
+
+  private async assertNotProductionEnvironment(environmentId: string, organizationId: string): Promise<void> {
+    const environment = await this.environmentRepository.findOne(
+      { _id: environmentId, _organizationId: organizationId },
+      ['type']
+    );
+
+    if (environment?.type === EnvironmentTypeEnum.PROD) {
+      throw new ForbiddenException('Agent integrations cannot be removed in production environments.');
+    }
   }
 }

--- a/apps/api/src/app/agents/usecases/remove-agent-integration/remove-agent-integration.usecase.ts
+++ b/apps/api/src/app/agents/usecases/remove-agent-integration/remove-agent-integration.usecase.ts
@@ -71,7 +71,7 @@ export class RemoveAgentIntegration {
   private async assertNotProductionEnvironment(environmentId: string, organizationId: string): Promise<void> {
     const environment = await this.environmentRepository.findOne(
       { _id: environmentId, _organizationId: organizationId },
-      ['type']
+      ['type', 'name']
     );
 
     if (environment?.type === EnvironmentTypeEnum.PROD) {

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/index.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/index.ts
@@ -1,0 +1,2 @@
+export { SyncAgentToEnvironment } from './sync-agent-to-environment.usecase';
+export { SyncAgentToEnvironmentCommand } from './sync-agent-to-environment.command';

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.command.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.command.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class SyncAgentToEnvironmentCommand extends EnvironmentWithUserCommand {
+  @IsString()
+  @IsNotEmpty()
+  agentIdentifier: string;
+
+  @IsString()
+  @IsNotEmpty()
+  targetEnvironmentId: string;
+}

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.spec.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.spec.ts
@@ -1,0 +1,249 @@
+import { NotFoundException } from '@nestjs/common';
+import type { AgentIntegrationEntity, AgentEntity, IntegrationEntity } from '@novu/dal';
+import { ChannelTypeEnum } from '@novu/shared';
+import { expect } from 'chai';
+import { restore, stub } from 'sinon';
+
+import { SyncAgentToEnvironment } from './sync-agent-to-environment.usecase';
+import { SyncAgentToEnvironmentCommand } from './sync-agent-to-environment.command';
+
+const SOURCE_ENV = 'source-env-id';
+const TARGET_ENV = 'target-env-id';
+const ORG_ID = 'org-id';
+const USER_ID = 'user-id';
+
+function baseCommand(overrides: Partial<SyncAgentToEnvironmentCommand> = {}): SyncAgentToEnvironmentCommand {
+  return {
+    agentIdentifier: 'my-agent',
+    environmentId: SOURCE_ENV,
+    targetEnvironmentId: TARGET_ENV,
+    organizationId: ORG_ID,
+    userId: USER_ID,
+    ...overrides,
+  } as SyncAgentToEnvironmentCommand;
+}
+
+function makeAgent(overrides: Partial<AgentEntity> = {}): AgentEntity {
+  return {
+    _id: 'agent-id',
+    name: 'My Agent',
+    identifier: 'my-agent',
+    description: 'desc',
+    behavior: undefined,
+    active: true,
+    _environmentId: SOURCE_ENV,
+    _organizationId: ORG_ID,
+    ...overrides,
+  } as AgentEntity;
+}
+
+function makeIntegration(overrides: Partial<IntegrationEntity> = {}): IntegrationEntity {
+  return {
+    _id: 'integration-id',
+    providerId: 'slack',
+    channel: ChannelTypeEnum.CHAT,
+    name: 'Slack',
+    identifier: 'slack-id',
+    credentials: {},
+    active: true,
+    primary: false,
+    priority: 0,
+    deleted: false,
+    _environmentId: SOURCE_ENV,
+    _organizationId: ORG_ID,
+    ...overrides,
+  } as IntegrationEntity;
+}
+
+function makeLink(overrides: Partial<AgentIntegrationEntity> = {}): AgentIntegrationEntity {
+  return {
+    _id: 'link-id',
+    _agentId: 'agent-id',
+    _integrationId: 'integration-id',
+    _environmentId: SOURCE_ENV,
+    _organizationId: ORG_ID,
+    connectedAt: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as AgentIntegrationEntity;
+}
+
+describe('SyncAgentToEnvironment usecase', () => {
+  let agentRepo: {
+    findOne: sinon.SinonStub;
+    create: sinon.SinonStub;
+    update: sinon.SinonStub;
+  };
+  let agentIntegrationRepo: {
+    find: sinon.SinonStub;
+    create: sinon.SinonStub;
+    delete: sinon.SinonStub;
+  };
+  let integrationRepo: {
+    find: sinon.SinonStub;
+    create: sinon.SinonStub;
+  };
+
+  function buildUsecase() {
+    return new SyncAgentToEnvironment(agentRepo as any, agentIntegrationRepo as any, integrationRepo as any);
+  }
+
+  beforeEach(() => {
+    agentRepo = { findOne: stub(), create: stub(), update: stub().resolves() };
+    agentIntegrationRepo = { find: stub(), create: stub().resolves(), delete: stub().resolves() };
+    integrationRepo = { find: stub(), create: stub() };
+  });
+
+  afterEach(() => restore());
+
+  describe('source agent not found', () => {
+    it('throws NotFoundException', async () => {
+      agentRepo.findOne.resolves(null);
+
+      try {
+        await buildUsecase().execute(baseCommand());
+        throw new Error('Expected NotFoundException');
+      } catch (err) {
+        expect(err).to.be.instanceOf(NotFoundException);
+      }
+    });
+  });
+
+  describe('fresh promotion — no target agent yet', () => {
+    it('creates target agent as inactive with source metadata', async () => {
+      const sourceAgent = makeAgent();
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(null);
+      agentIntegrationRepo.find.resolves([]);
+      integrationRepo.find.resolves([]);
+      agentRepo.create.resolves(makeAgent({ _id: 'target-agent-id', active: false, _environmentId: TARGET_ENV }));
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(agentRepo.create.calledOnce).to.equal(true);
+      const createArg = agentRepo.create.firstCall.args[0];
+      expect(createArg.identifier).to.equal('my-agent');
+      expect(createArg.active).to.equal(false);
+      expect(createArg._environmentId).to.equal(TARGET_ENV);
+      expect(agentRepo.update.called).to.equal(false);
+    });
+
+    it('creates stub integrations and agent-integration links for each source integration', async () => {
+      const sourceAgent = makeAgent();
+      const sourceIntegration = makeIntegration();
+      const sourceLink = makeLink();
+      const targetAgent = makeAgent({ _id: 'target-agent-id', active: false, _environmentId: TARGET_ENV });
+      const stubIntegration = makeIntegration({ _id: 'stub-id', _environmentId: TARGET_ENV });
+
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(null);
+      agentIntegrationRepo.find.onFirstCall().resolves([sourceLink]);
+      integrationRepo.find.onFirstCall().resolves([sourceIntegration]);
+      agentRepo.create.resolves(targetAgent);
+      agentIntegrationRepo.find.onSecondCall().resolves([]);
+      integrationRepo.find.onSecondCall().resolves([]);
+      integrationRepo.create.resolves(stubIntegration);
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(integrationRepo.create.calledOnce).to.equal(true);
+      const stubArg = integrationRepo.create.firstCall.args[0];
+      expect(stubArg.providerId).to.equal('slack');
+      expect(stubArg.channel).to.equal(ChannelTypeEnum.CHAT);
+      expect(stubArg._parentId).to.equal('integration-id');
+      expect(stubArg._environmentId).to.equal(TARGET_ENV);
+      expect(stubArg.active).to.equal(true);
+
+      expect(agentIntegrationRepo.create.calledOnce).to.equal(true);
+      const linkArg = agentIntegrationRepo.create.firstCall.args[0];
+      expect(linkArg._agentId).to.equal('target-agent-id');
+      expect(linkArg._integrationId).to.equal('stub-id');
+      expect(linkArg._environmentId).to.equal(TARGET_ENV);
+    });
+  });
+
+  describe('re-promotion — target agent already exists', () => {
+    it('updates target agent metadata without changing active state', async () => {
+      const sourceAgent = makeAgent({ name: 'Updated Name' });
+      const targetAgent = makeAgent({ _id: 'target-id', active: true, _environmentId: TARGET_ENV });
+
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(targetAgent);
+      agentIntegrationRepo.find.resolves([]);
+      integrationRepo.find.resolves([]);
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(agentRepo.create.called).to.equal(false);
+      expect(agentRepo.update.calledOnce).to.equal(true);
+      const updateQuery = agentRepo.update.firstCall.args[0];
+      const updateBody = agentRepo.update.firstCall.args[1];
+      expect(updateQuery._id).to.equal('target-id');
+      expect(updateBody.$set.name).to.equal('Updated Name');
+      expect(updateBody.$set.active).to.equal(undefined);
+    });
+
+    it('does not re-create integration stubs on repeated promotion', async () => {
+      const sourceAgent = makeAgent();
+      const targetAgent = makeAgent({ _id: 'target-id', _environmentId: TARGET_ENV });
+      const sourceIntegration = makeIntegration({ _id: 'src-int-id' });
+      const sourceLink = makeLink({ _integrationId: 'src-int-id' });
+      const existingStub = makeIntegration({ _id: 'existing-stub-id', _parentId: 'src-int-id', _environmentId: TARGET_ENV });
+      const existingTargetLink = makeLink({ _id: 'target-link-id', _agentId: 'target-id', _integrationId: 'existing-stub-id', _environmentId: TARGET_ENV });
+
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(targetAgent);
+      agentIntegrationRepo.find.onFirstCall().resolves([sourceLink]);
+      integrationRepo.find.onFirstCall().resolves([sourceIntegration]);
+      agentIntegrationRepo.find.onSecondCall().resolves([existingTargetLink]);
+      integrationRepo.find.onSecondCall().resolves([existingStub]);
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(integrationRepo.create.called).to.equal(false);
+      expect(agentIntegrationRepo.create.called).to.equal(false);
+    });
+  });
+
+  describe('integration removed from source', () => {
+    it('unlinks integrations that are no longer connected to the source agent', async () => {
+      const sourceAgent = makeAgent();
+      const targetAgent = makeAgent({ _id: 'target-id', _environmentId: TARGET_ENV });
+      const removedStub = makeIntegration({ _id: 'old-stub-id', _parentId: 'removed-src-int-id', _environmentId: TARGET_ENV });
+      const orphanedLink = makeLink({ _id: 'orphan-link-id', _agentId: 'target-id', _integrationId: 'old-stub-id', _environmentId: TARGET_ENV });
+
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(targetAgent);
+      agentIntegrationRepo.find.onFirstCall().resolves([]);
+      agentIntegrationRepo.find.onSecondCall().resolves([orphanedLink]);
+      integrationRepo.find.onFirstCall().resolves([removedStub]);
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(agentIntegrationRepo.delete.calledOnce).to.equal(true);
+      const deleteArg = agentIntegrationRepo.delete.firstCall.args[0];
+      expect(deleteArg._id).to.equal('orphan-link-id');
+    });
+  });
+
+  describe('manually configured prod integration', () => {
+    it('preserves manually configured prod integrations not originating from promotion', async () => {
+      const sourceAgent = makeAgent();
+      const targetAgent = makeAgent({ _id: 'target-id', _environmentId: TARGET_ENV });
+      const manualIntegration = makeIntegration({ _id: 'manual-id', _environmentId: TARGET_ENV });
+      const manualLink = makeLink({ _id: 'manual-link-id', _agentId: 'target-id', _integrationId: 'manual-id', _environmentId: TARGET_ENV });
+
+      agentRepo.findOne.onFirstCall().resolves(sourceAgent);
+      agentRepo.findOne.onSecondCall().resolves(targetAgent);
+      agentIntegrationRepo.find.onFirstCall().resolves([]);
+      integrationRepo.find.onFirstCall().resolves([]);
+      agentIntegrationRepo.find.onSecondCall().resolves([manualLink]);
+      integrationRepo.find.onSecondCall().resolves([manualIntegration]);
+
+      await buildUsecase().execute(baseCommand());
+
+      expect(agentIntegrationRepo.delete.called).to.equal(false);
+    });
+  });
+});

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
@@ -1,0 +1,133 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { AgentIntegrationRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
+
+import { SyncAgentToEnvironmentCommand } from './sync-agent-to-environment.command';
+
+@Injectable()
+export class SyncAgentToEnvironment {
+  constructor(
+    private readonly agentRepository: AgentRepository,
+    private readonly agentIntegrationRepository: AgentIntegrationRepository,
+    private readonly integrationRepository: IntegrationRepository
+  ) {}
+
+  async execute(command: SyncAgentToEnvironmentCommand): Promise<void> {
+    const { agentIdentifier, environmentId: sourceEnvironmentId, targetEnvironmentId, organizationId } = command;
+
+    const sourceAgent = await this.agentRepository.findOne(
+      { identifier: agentIdentifier, _environmentId: sourceEnvironmentId, _organizationId: organizationId },
+      '*'
+    );
+
+    if (!sourceAgent) {
+      throw new NotFoundException(`Source agent "${agentIdentifier}" not found in environment ${sourceEnvironmentId}`);
+    }
+
+    const sourceLinks = await this.agentIntegrationRepository.find(
+      { _agentId: sourceAgent._id, _environmentId: sourceEnvironmentId, _organizationId: organizationId },
+      '*'
+    );
+
+    const sourceIntegrationIds = sourceLinks.map((l) => l._integrationId);
+    const sourceIntegrations =
+      sourceIntegrationIds.length > 0
+        ? await this.integrationRepository.find({
+            _id: { $in: sourceIntegrationIds },
+            _environmentId: sourceEnvironmentId,
+            _organizationId: organizationId,
+          })
+        : [];
+    const sourceIntegrationMap = new Map(sourceIntegrations.map((i) => [i._id, i]));
+
+    let targetAgent = await this.agentRepository.findOne(
+      { identifier: agentIdentifier, _environmentId: targetEnvironmentId, _organizationId: organizationId },
+      '*'
+    );
+
+    if (!targetAgent) {
+      targetAgent = await this.agentRepository.create({
+        name: sourceAgent.name,
+        identifier: sourceAgent.identifier,
+        description: sourceAgent.description,
+        behavior: sourceAgent.behavior,
+        active: false,
+        _environmentId: targetEnvironmentId,
+        _organizationId: organizationId,
+      });
+    } else {
+      await this.agentRepository.update(
+        { _id: targetAgent._id, _environmentId: targetEnvironmentId, _organizationId: organizationId },
+        { $set: { name: sourceAgent.name, description: sourceAgent.description, behavior: sourceAgent.behavior } }
+      );
+    }
+
+    const existingTargetLinks = await this.agentIntegrationRepository.find(
+      { _agentId: targetAgent._id, _environmentId: targetEnvironmentId, _organizationId: organizationId },
+      '*'
+    );
+
+    const existingTargetIntegrationIds = existingTargetLinks.map((l) => l._integrationId);
+    const existingTargetIntegrations =
+      existingTargetIntegrationIds.length > 0
+        ? await this.integrationRepository.find({
+            _id: { $in: existingTargetIntegrationIds },
+            _environmentId: targetEnvironmentId,
+            _organizationId: organizationId,
+          })
+        : [];
+
+    const parentIdToTargetLink = new Map<string, (typeof existingTargetLinks)[0]>();
+    for (const targetIntegration of existingTargetIntegrations) {
+      if (targetIntegration._parentId) {
+        const link = existingTargetLinks.find((l) => l._integrationId === targetIntegration._id);
+        if (link) {
+          parentIdToTargetLink.set(targetIntegration._parentId, link);
+        }
+      }
+    }
+
+    const processedSourceIntegrationIds = new Set<string>();
+
+    for (const sourceLink of sourceLinks) {
+      const sourceIntegration = sourceIntegrationMap.get(sourceLink._integrationId);
+      if (!sourceIntegration) continue;
+
+      processedSourceIntegrationIds.add(sourceIntegration._id);
+
+      if (parentIdToTargetLink.has(sourceIntegration._id)) {
+        continue;
+      }
+
+      const stubIntegration = await this.integrationRepository.create({
+        providerId: sourceIntegration.providerId,
+        channel: sourceIntegration.channel,
+        name: sourceIntegration.name,
+        identifier: sourceIntegration.identifier,
+        credentials: {},
+        active: true,
+        primary: false,
+        priority: 0,
+        _parentId: sourceIntegration._id,
+        _environmentId: targetEnvironmentId,
+        _organizationId: organizationId,
+      });
+
+      await this.agentIntegrationRepository.create({
+        _agentId: targetAgent._id,
+        _integrationId: stubIntegration._id,
+        _environmentId: targetEnvironmentId,
+        _organizationId: organizationId,
+      });
+    }
+
+    for (const [sourceIntegrationId, link] of parentIdToTargetLink.entries()) {
+      if (!processedSourceIntegrationIds.has(sourceIntegrationId)) {
+        await this.agentIntegrationRepository.delete({
+          _id: link._id,
+          _environmentId: targetEnvironmentId,
+          _organizationId: organizationId,
+        });
+      }
+    }
+  }
+}

--- a/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
+++ b/apps/api/src/app/agents/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
@@ -115,6 +115,7 @@ export class SyncAgentToEnvironment {
       await this.agentIntegrationRepository.create({
         _agentId: targetAgent._id,
         _integrationId: stubIntegration._id,
+        connectedAt: null,
         _environmentId: targetEnvironmentId,
         _organizationId: organizationId,
       });
@@ -125,6 +126,10 @@ export class SyncAgentToEnvironment {
         await this.agentIntegrationRepository.delete({
           _id: link._id,
           _environmentId: targetEnvironmentId,
+          _organizationId: organizationId,
+        });
+        await this.integrationRepository.delete({
+          _id: link._integrationId,
           _organizationId: organizationId,
         });
       }

--- a/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
@@ -29,8 +29,25 @@ export class UpdateAgent {
       throw new BadRequestException('At least one field must be provided.');
     }
 
+    const hasReadOnlyFields =
+      command.name !== undefined ||
+      command.description !== undefined ||
+      hasBehaviorFields;
+
+    if (hasReadOnlyFields) {
+      await this.assertNotProduction(
+        command.environmentId,
+        command.organizationId,
+        'Only the active status and bridge URL can be modified in production environments.'
+      );
+    }
+
     if (command.devBridgeActive === true || (command.devBridgeUrl !== undefined && command.devBridgeUrl !== null)) {
-      await this.assertNotProductionEnvironment(command.environmentId, command.organizationId);
+      await this.assertNotProduction(
+        command.environmentId,
+        command.organizationId,
+        'Dev bridge cannot be activated on production environments.'
+      );
     }
 
     // The bridge executor `fetch()`s these URLs from inside the API process on every
@@ -113,14 +130,14 @@ export class UpdateAgent {
     return toAgentResponse(updated);
   }
 
-  private async assertNotProductionEnvironment(environmentId: string, organizationId: string): Promise<void> {
+  private async assertNotProduction(environmentId: string, organizationId: string, message: string): Promise<void> {
     const environment = await this.environmentRepository.findOne(
       { _id: environmentId, _organizationId: organizationId },
       ['type', 'name']
     );
 
     if (environment?.type === EnvironmentTypeEnum.PROD) {
-      throw new ForbiddenException('Dev bridge cannot be activated on production environments.');
+      throw new ForbiddenException(message);
     }
   }
 

--- a/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
+++ b/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
@@ -3,7 +3,7 @@ import { ChannelTypeEnum, EmailProviderIdEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
-describe.only('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST) #novu-v2', () => {
+describe('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST) #novu-v2', () => {
   let session: UserSession;
 
   const environmentRepository = new EnvironmentRepository();

--- a/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
+++ b/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
@@ -1,0 +1,226 @@
+import { AgentIntegrationRepository, AgentRepository, EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { ChannelTypeEnum, EmailProviderIdEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+describe.only('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST) #novu-v2', () => {
+  let session: UserSession;
+
+  const environmentRepository = new EnvironmentRepository();
+  const agentRepository = new AgentRepository();
+  const agentIntegrationRepository = new AgentIntegrationRepository();
+  const integrationRepository = new IntegrationRepository();
+
+  before(() => {
+    process.env.IS_CONVERSATIONAL_AGENTS_ENABLED = 'true';
+  });
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  async function getProductionEnvironment() {
+    const prodEnv = await environmentRepository.findOne({
+      _parentId: session.environment._id,
+      _organizationId: session.organization._id,
+    });
+
+    if (!prodEnv) throw new Error('Production environment not found');
+
+    return prodEnv;
+  }
+
+  async function publish(prodEnvId: string) {
+    return session.testAgent.post(`/v2/environments/${prodEnvId}/publish`).send({}).expect(200);
+  }
+
+  async function getDiff(prodEnvId: string) {
+    return session.testAgent.post(`/v2/environments/${prodEnvId}/diff`).send({}).expect(200);
+  }
+
+  async function getDevIntegration() {
+    const integrations = (await session.testAgent.get('/v1/integrations')).body.data as Array<{
+      _id: string;
+      identifier: string;
+      channel: string;
+      providerId: string;
+    }>;
+
+    const integration = integrations.find(
+      (i) => i.channel === ChannelTypeEnum.EMAIL && i.providerId === EmailProviderIdEnum.SendGrid
+    );
+
+    if (!integration) throw new Error('Seeded SendGrid integration not found');
+
+    return integration;
+  }
+
+  it('should promote agent to prod as inactive with placeholder integrations and connectedAt null', async () => {
+    const identifier = `e2e-promote-fresh-${Date.now()}`;
+    const prodEnv = await getProductionEnvironment();
+    const devIntegration = await getDevIntegration();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Promote Agent', identifier });
+    await session.testAgent
+      .post(`/v1/agents/${encodeURIComponent(identifier)}/integrations`)
+      .send({ integrationIdentifier: devIntegration.identifier });
+
+    await publish(prodEnv._id);
+
+    const prodAgent = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      '*'
+    );
+
+    expect(prodAgent, 'prod agent should exist').to.exist;
+    expect(prodAgent!.active, 'prod agent should start inactive').to.equal(false);
+
+    const prodLinks = await agentIntegrationRepository.find(
+      { _agentId: prodAgent!._id, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      '*'
+    );
+
+    expect(prodLinks.length, 'one integration link in prod').to.equal(1);
+    expect(prodLinks[0].connectedAt, 'link connectedAt should be null').to.equal(null);
+
+    const prodIntegration = await integrationRepository.findOne({
+      _id: prodLinks[0]._integrationId,
+      _environmentId: prodEnv._id,
+      _organizationId: session.organization._id,
+    });
+
+    expect(prodIntegration, 'placeholder integration should exist').to.exist;
+    expect(prodIntegration!._parentId, 'placeholder should reference dev integration').to.equal(devIntegration._id);
+    expect(prodIntegration!.providerId).to.equal(EmailProviderIdEnum.SendGrid);
+  });
+
+  it('should include unpromoted agent in diff result as added', async () => {
+    const identifier = `e2e-promote-diff-${Date.now()}`;
+    const prodEnv = await getProductionEnvironment();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Diff Agent', identifier });
+
+    const { body } = await getDiff(prodEnv._id);
+    const agentDiff = body.data.resources.find(
+      (r: { resourceType: string; sourceResource?: { id: string } }) =>
+        r.resourceType === 'agent' && r.sourceResource?.id === identifier
+    );
+
+    expect(agentDiff, 'agent should appear in diff').to.exist;
+    expect(agentDiff.changes[0].action).to.equal('added');
+    expect(agentDiff.summary.added).to.equal(1);
+  });
+
+  it('should not create duplicate placeholder integrations when promoted twice without changes', async () => {
+    const identifier = `e2e-promote-idem-${Date.now()}`;
+    const prodEnv = await getProductionEnvironment();
+    const devIntegration = await getDevIntegration();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Idempotent Agent', identifier });
+    await session.testAgent
+      .post(`/v1/agents/${encodeURIComponent(identifier)}/integrations`)
+      .send({ integrationIdentifier: devIntegration.identifier });
+
+    await publish(prodEnv._id);
+    await publish(prodEnv._id);
+
+    const prodAgent = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      ['_id']
+    );
+
+    const prodLinks = await agentIntegrationRepository.find(
+      { _agentId: prodAgent!._id, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      ['_id']
+    );
+
+    expect(prodLinks.length, 'still exactly one link in prod after two publishes').to.equal(1);
+  });
+
+  it('should propagate metadata changes without resetting active state', async () => {
+    const identifier = `e2e-promote-meta-${Date.now()}`;
+    const prodEnv = await getProductionEnvironment();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Meta Agent', identifier });
+    await publish(prodEnv._id);
+
+    await session.switchToProdEnvironment();
+    await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({ active: true });
+    await session.switchToDevEnvironment();
+
+    await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}`).send({ name: 'Meta Agent Updated' });
+    await publish(prodEnv._id);
+
+    const prodAgent = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      '*'
+    );
+
+    expect(prodAgent!.name).to.equal('Meta Agent Updated');
+    expect(prodAgent!.active, 'active state must not be reset by re-promotion').to.equal(true);
+  });
+
+  it('should remove agent from prod when it is deleted in dev and re-published', async () => {
+    const identifier = `e2e-promote-del-${Date.now()}`;
+    const prodEnv = await getProductionEnvironment();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Delete Agent', identifier });
+    await publish(prodEnv._id);
+
+    const afterFirstPublish = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      ['_id']
+    );
+
+    expect(afterFirstPublish, 'agent should exist in prod after first publish').to.exist;
+
+    await session.testAgent.delete(`/v1/agents/${encodeURIComponent(identifier)}`);
+    await publish(prodEnv._id);
+
+    const afterDelete = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      ['_id']
+    );
+
+    expect(afterDelete, 'agent should be gone from prod after dev deletion + re-publish').to.equal(null);
+  });
+
+  it('should reject adding and removing integrations in production environment', async () => {
+    const identifier = `e2e-prodguard-int-${Date.now()}`;
+    const devIntegration = await getDevIntegration();
+
+    await session.testAgent.post('/v1/agents').send({ name: 'Guard Integration Agent', identifier });
+    await session.testAgent
+      .post(`/v1/agents/${encodeURIComponent(identifier)}/integrations`)
+      .send({ integrationIdentifier: devIntegration.identifier });
+
+    const prodEnv = await getProductionEnvironment();
+    await publish(prodEnv._id);
+
+    await session.switchToProdEnvironment();
+
+    const addRes = await session.testAgent
+      .post(`/v1/agents/${encodeURIComponent(identifier)}/integrations`)
+      .send({ integrationIdentifier: devIntegration.identifier });
+
+    expect(addRes.status, 'POST integrations should be 403 in prod').to.equal(403);
+
+    const prodLinks = await agentIntegrationRepository.find(
+      {
+        _environmentId: prodEnv._id,
+        _organizationId: session.organization._id,
+      },
+      ['_id']
+    );
+    const linkId = prodLinks[0]?._id;
+
+    if (linkId) {
+      const removeRes = await session.testAgent.delete(
+        `/v1/agents/${encodeURIComponent(identifier)}/integrations/${linkId}`
+      );
+
+      expect(removeRes.status, 'DELETE integrations should be 403 in prod').to.equal(403);
+    }
+  });
+});

--- a/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
+++ b/apps/api/src/app/environments-v2/e2e/environments-v2-agent-publish.e2e.ts
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 
 describe('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST) #novu-v2', () => {
   let session: UserSession;
+  let previousAgentsFlag: string | undefined;
 
   const environmentRepository = new EnvironmentRepository();
   const agentRepository = new AgentRepository();
@@ -12,7 +13,12 @@ describe('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST)
   const integrationRepository = new IntegrationRepository();
 
   before(() => {
+    previousAgentsFlag = process.env.IS_CONVERSATIONAL_AGENTS_ENABLED;
     process.env.IS_CONVERSATIONAL_AGENTS_ENABLED = 'true';
+  });
+
+  after(() => {
+    process.env.IS_CONVERSATIONAL_AGENTS_ENABLED = previousAgentsFlag;
   });
 
   beforeEach(async () => {
@@ -206,8 +212,14 @@ describe('Agent Promotion - /v2/environments/:targetEnvironmentId/publish (POST)
 
     expect(addRes.status, 'POST integrations should be 403 in prod').to.equal(403);
 
+    const prodAgent = await agentRepository.findOne(
+      { identifier, _environmentId: prodEnv._id, _organizationId: session.organization._id },
+      ['_id'] as any
+    );
+
     const prodLinks = await agentIntegrationRepository.find(
       {
+        _agentId: prodAgent!._id,
         _environmentId: prodEnv._id,
         _organizationId: session.organization._id,
       },

--- a/apps/api/src/app/environments-v2/types/sync.types.ts
+++ b/apps/api/src/app/environments-v2/types/sync.types.ts
@@ -6,6 +6,7 @@ export enum ResourceTypeEnum {
   STEP = 'step',
   LOCALIZATION_GROUP = 'localization_group',
   LAYOUT = 'layout',
+  AGENT = 'agent',
 }
 
 export enum DependencyReasonEnum {

--- a/apps/api/src/app/environments-v2/usecases/diff-environment/diff-environment.usecase.ts
+++ b/apps/api/src/app/environments-v2/usecases/diff-environment/diff-environment.usecase.ts
@@ -9,6 +9,7 @@ import {
 import { ResourceOriginEnum, ResourceTypeEnum } from '@novu/shared';
 import { DependencyAnalyzerService, EnvironmentValidationService } from '../../services';
 import { IDiffResult, IEnvironmentDiffResult } from '../../types/sync.types';
+import { AgentSyncStrategy } from '../sync-strategies/agent-sync.strategy';
 import { LayoutSyncStrategy } from '../sync-strategies/layout-sync.strategy';
 import { WorkflowSyncStrategy } from '../sync-strategies/workflow-sync.strategy';
 import { DiffEnvironmentCommand } from './diff-environment.command';
@@ -20,6 +21,7 @@ export class DiffEnvironmentUseCase {
     private environmentValidationService: EnvironmentValidationService,
     private workflowSyncStrategy: WorkflowSyncStrategy,
     private layoutSyncStrategy: LayoutSyncStrategy,
+    private agentSyncStrategy: AgentSyncStrategy,
     private dependencyAnalyzerService: DependencyAnalyzerService,
     private controlValuesRepository: ControlValuesRepository,
     private workflowRepository: NotificationTemplateRepository,
@@ -65,8 +67,8 @@ export class DiffEnvironmentUseCase {
         command.targetEnvironmentId
       );
 
-      // Execute diff with workflow container optimization and layout strategy normally
-      const [workflowDiffResults, layoutDiffResults] = await Promise.all([
+      // Execute diff with workflow container optimization and layout/agent strategies normally
+      const [workflowDiffResults, layoutDiffResults, agentDiffResults] = await Promise.all([
         this.workflowSyncStrategy.diff(
           sourceEnvironmentId,
           command.targetEnvironmentId,
@@ -80,9 +82,15 @@ export class DiffEnvironmentUseCase {
           command.user.organizationId,
           command.user
         ),
+        this.agentSyncStrategy.diff(
+          sourceEnvironmentId,
+          command.targetEnvironmentId,
+          command.user.organizationId,
+          command.user
+        ),
       ]);
 
-      const resources = [...workflowDiffResults, ...layoutDiffResults];
+      const resources = [...workflowDiffResults, ...layoutDiffResults, ...agentDiffResults];
 
       const dependencyMap = await this.dependencyAnalyzerService.analyzeDependencies(
         resources,

--- a/apps/api/src/app/environments-v2/usecases/publish-environment/publish-environment.usecase.ts
+++ b/apps/api/src/app/environments-v2/usecases/publish-environment/publish-environment.usecase.ts
@@ -3,6 +3,7 @@ import { InstrumentUsecase, PinoLogger } from '@novu/application-generic';
 import { BaseRepository } from '@novu/dal';
 import { EnvironmentValidationService } from '../../services';
 import { IPublishResult, ISyncContext, ISyncOptions, ISyncResult, ISyncStrategy } from '../../types/sync.types';
+import { AgentSyncStrategy } from '../sync-strategies/agent-sync.strategy';
 import { LayoutSyncStrategy } from '../sync-strategies/layout-sync.strategy';
 import { WorkflowSyncStrategy } from '../sync-strategies/workflow-sync.strategy';
 import { PublishEnvironmentCommand } from './publish-environment.command';
@@ -15,7 +16,8 @@ export class PublishEnvironmentUseCase {
     private logger: PinoLogger,
     private environmentValidationService: EnvironmentValidationService,
     private workflowSyncStrategy: WorkflowSyncStrategy,
-    private layoutSyncStrategy: LayoutSyncStrategy
+    private layoutSyncStrategy: LayoutSyncStrategy,
+    private agentSyncStrategy: AgentSyncStrategy
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -52,7 +54,7 @@ export class PublishEnvironmentUseCase {
 
       this.logger.info(`Starting environment publish from ${sourceEnvironmentId} to ${command.targetEnvironmentId}`);
 
-      const strategies = [this.workflowSyncStrategy, this.layoutSyncStrategy];
+      const strategies = [this.workflowSyncStrategy, this.layoutSyncStrategy, this.agentSyncStrategy];
 
       const results = await this.executeSync(strategies, syncContext);
 

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-comparator.adapter.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-comparator.adapter.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { AgentEntity } from '@novu/dal';
+import { UserSessionData } from '@novu/shared';
+import { diff } from 'deep-object-diff';
+
+import { IResourceDiff } from '../../../types/sync.types';
+import { IBaseComparator } from '../base/interfaces/base-comparator.interface';
+
+type AgentSnapshot = Pick<AgentEntity, 'name' | 'description' | 'behavior'>;
+
+function toSnapshot(agent: AgentEntity): AgentSnapshot {
+  return { name: agent.name, description: agent.description, behavior: agent.behavior };
+}
+
+@Injectable()
+export class AgentComparatorAdapter implements IBaseComparator<AgentEntity> {
+  async compareResources(
+    sourceResource: AgentEntity,
+    targetResource: AgentEntity,
+    _: UserSessionData
+  ): Promise<{
+    resourceChanges: {
+      previous: Record<string, unknown> | null;
+      new: Record<string, unknown> | null;
+    } | null;
+    otherDiffs?: IResourceDiff[];
+  }> {
+    const sourceSnapshot = toSnapshot(sourceResource);
+    const targetSnapshot = toSnapshot(targetResource);
+    const differences = diff(targetSnapshot, sourceSnapshot);
+
+    if (Object.keys(differences).length === 0) {
+      return { resourceChanges: null };
+    }
+
+    return {
+      resourceChanges: {
+        previous: targetSnapshot as Record<string, unknown>,
+        new: sourceSnapshot as Record<string, unknown>,
+      },
+    };
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-delete.adapter.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-delete.adapter.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { AgentEntity } from '@novu/dal';
+
+import { DeleteAgent } from '../../../../agents/usecases/delete-agent/delete-agent.usecase';
+import { DeleteAgentCommand } from '../../../../agents/usecases/delete-agent/delete-agent.command';
+import { ISyncContext } from '../../../types/sync.types';
+import { IBaseDeleteService } from '../base/interfaces/base-delete.interface';
+
+@Injectable()
+export class AgentDeleteAdapter implements IBaseDeleteService<AgentEntity> {
+  constructor(private readonly deleteAgent: DeleteAgent) {}
+
+  async deleteResourceFromTarget(context: ISyncContext, resource: AgentEntity): Promise<void> {
+    await this.deleteAgent.execute(
+      DeleteAgentCommand.create({
+        identifier: resource.identifier,
+        environmentId: context.targetEnvironmentId,
+        organizationId: context.user.organizationId,
+        userId: context.user._id,
+      })
+    );
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-repository.adapter.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-repository.adapter.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { AgentEntity, AgentRepository } from '@novu/dal';
+
+import { IBaseRepositoryService } from '../base/interfaces/base-repository.interface';
+
+@Injectable()
+export class AgentRepositoryAdapter implements IBaseRepositoryService<AgentEntity> {
+  constructor(private readonly agentRepository: AgentRepository) {}
+
+  async fetchSyncableResources(environmentId: string, organizationId: string): Promise<AgentEntity[]> {
+    return this.agentRepository.find({ _environmentId: environmentId, _organizationId: organizationId }, '*');
+  }
+
+  createResourceMap(resources: AgentEntity[]): Map<string, AgentEntity> {
+    return new Map(resources.map((agent) => [agent.identifier, agent]));
+  }
+
+  getResourceIdentifier(resource: AgentEntity): string {
+    return resource.identifier;
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-sync.adapter.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/agent-sync.adapter.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { AgentEntity } from '@novu/dal';
+
+import { SyncAgentToEnvironment, SyncAgentToEnvironmentCommand } from '../../../../agents/usecases/sync-agent-to-environment';
+import { ISyncContext } from '../../../types/sync.types';
+import { IBaseSyncService } from '../base/interfaces/base-sync.interface';
+
+@Injectable()
+export class AgentSyncAdapter implements IBaseSyncService<AgentEntity> {
+  constructor(private readonly syncAgentToEnvironment: SyncAgentToEnvironment) {}
+
+  async syncResourceToTarget(context: ISyncContext, resource: AgentEntity): Promise<void> {
+    await this.syncAgentToEnvironment.execute(
+      SyncAgentToEnvironmentCommand.create({
+        agentIdentifier: resource.identifier,
+        environmentId: context.sourceEnvironmentId,
+        targetEnvironmentId: context.targetEnvironmentId,
+        organizationId: context.user.organizationId,
+        userId: context.user._id,
+      })
+    );
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/index.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/index.ts
@@ -1,5 +1,7 @@
 export { AgentComparatorAdapter } from './agent-comparator.adapter';
+export { AgentDeleteAdapter } from './agent-delete.adapter';
 export { AgentRepositoryAdapter } from './agent-repository.adapter';
+export { AgentSyncAdapter } from './agent-sync.adapter';
 export { WorkflowComparatorAdapter } from './workflow-comparator.adapter';
 export { WorkflowDeleteAdapter } from './workflow-delete.adapter';
 export { WorkflowRepositoryAdapter } from './workflow-repository.adapter';

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/index.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/adapters/index.ts
@@ -1,3 +1,5 @@
+export { AgentComparatorAdapter } from './agent-comparator.adapter';
+export { AgentRepositoryAdapter } from './agent-repository.adapter';
 export { WorkflowComparatorAdapter } from './workflow-comparator.adapter';
 export { WorkflowDeleteAdapter } from './workflow-delete.adapter';
 export { WorkflowRepositoryAdapter } from './workflow-repository.adapter';

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/agent-sync.strategy.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/agent-sync.strategy.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from '@novu/application-generic';
+import { UserSessionData } from '@novu/shared';
+
+import { IDiffResult, ISyncContext, ISyncResult, ResourceTypeEnum } from '../../types/sync.types';
+import { BaseSyncStrategy } from './base/base-sync.strategy';
+import { AgentDiffOperation } from './operations/agent-diff.operation';
+import { AgentSyncOperation } from './operations/agent-sync.operation';
+
+@Injectable()
+export class AgentSyncStrategy extends BaseSyncStrategy {
+  constructor(
+    logger: PinoLogger,
+    private agentSyncOperation: AgentSyncOperation,
+    private agentDiffOperation: AgentDiffOperation
+  ) {
+    super(logger);
+  }
+
+  getResourceType(): ResourceTypeEnum {
+    return ResourceTypeEnum.AGENT;
+  }
+
+  async execute(context: ISyncContext): Promise<ISyncResult> {
+    return this.agentSyncOperation.execute(context);
+  }
+
+  async diff(
+    sourceEnvId: string,
+    targetEnvId: string,
+    organizationId: string,
+    userContext: UserSessionData
+  ): Promise<IDiffResult[]> {
+    return this.agentDiffOperation.execute(sourceEnvId, targetEnvId, organizationId, userContext);
+  }
+
+  async getAvailableResourceIds(sourceEnvironmentId: string, organizationId: string): Promise<string[]> {
+    return this.agentSyncOperation.getAvailableResourceIds(sourceEnvironmentId, organizationId);
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/agent-sync.strategy.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/agent-sync.strategy.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { PinoLogger } from '@novu/application-generic';
-import { UserSessionData } from '@novu/shared';
+import { FeatureFlagsService, PinoLogger } from '@novu/application-generic';
+import { FeatureFlagsKeysEnum, UserSessionData } from '@novu/shared';
 
 import { IDiffResult, ISyncContext, ISyncResult, ResourceTypeEnum } from '../../types/sync.types';
 import { BaseSyncStrategy } from './base/base-sync.strategy';
@@ -12,7 +12,8 @@ export class AgentSyncStrategy extends BaseSyncStrategy {
   constructor(
     logger: PinoLogger,
     private agentSyncOperation: AgentSyncOperation,
-    private agentDiffOperation: AgentDiffOperation
+    private agentDiffOperation: AgentDiffOperation,
+    private featureFlagsService: FeatureFlagsService
   ) {
     super(logger);
   }
@@ -22,6 +23,12 @@ export class AgentSyncStrategy extends BaseSyncStrategy {
   }
 
   async execute(context: ISyncContext): Promise<ISyncResult> {
+    const isEnabled = await this.isFeatureEnabled(context.user.organizationId, context.sourceEnvironmentId);
+
+    if (!isEnabled) {
+      return { resourceType: ResourceTypeEnum.AGENT, successful: [], failed: [], skipped: [], totalProcessed: 0 };
+    }
+
     return this.agentSyncOperation.execute(context);
   }
 
@@ -31,10 +38,31 @@ export class AgentSyncStrategy extends BaseSyncStrategy {
     organizationId: string,
     userContext: UserSessionData
   ): Promise<IDiffResult[]> {
+    const isEnabled = await this.isFeatureEnabled(organizationId, sourceEnvId);
+
+    if (!isEnabled) {
+      return [];
+    }
+
     return this.agentDiffOperation.execute(sourceEnvId, targetEnvId, organizationId, userContext);
   }
 
   async getAvailableResourceIds(sourceEnvironmentId: string, organizationId: string): Promise<string[]> {
+    const isEnabled = await this.isFeatureEnabled(organizationId, sourceEnvironmentId);
+
+    if (!isEnabled) {
+      return [];
+    }
+
     return this.agentSyncOperation.getAvailableResourceIds(sourceEnvironmentId, organizationId);
+  }
+
+  private async isFeatureEnabled(organizationId: string, environmentId: string): Promise<boolean> {
+    return this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED,
+      defaultValue: false,
+      organization: { _id: organizationId },
+      environment: { _id: environmentId },
+    });
   }
 }

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/operations/agent-diff.operation.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/operations/agent-diff.operation.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from '@novu/application-generic';
+import { AgentEntity } from '@novu/dal';
+
+import { IUserInfo, ResourceTypeEnum } from '../../../types/sync.types';
+import { AgentComparatorAdapter } from '../adapters/agent-comparator.adapter';
+import { AgentRepositoryAdapter } from '../adapters/agent-repository.adapter';
+import { BaseDiffOperation } from '../base/operations/base-diff.operation';
+
+@Injectable()
+export class AgentDiffOperation extends BaseDiffOperation<AgentEntity> {
+  constructor(
+    protected logger: PinoLogger,
+    protected repositoryAdapter: AgentRepositoryAdapter,
+    protected comparatorAdapter: AgentComparatorAdapter
+  ) {
+    super(logger, repositoryAdapter, comparatorAdapter);
+  }
+
+  protected getResourceType(): ResourceTypeEnum {
+    return ResourceTypeEnum.AGENT;
+  }
+
+  protected getResourceName(resource: AgentEntity): string {
+    return resource.name || resource.identifier;
+  }
+
+  protected extractUpdatedByInfo(_resource: AgentEntity): IUserInfo | null {
+    return null;
+  }
+
+  protected extractUpdatedAtInfo(resource: AgentEntity): string | null {
+    return resource.updatedAt ?? null;
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/operations/agent-sync.operation.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/operations/agent-sync.operation.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from '@novu/application-generic';
+import { AgentEntity } from '@novu/dal';
+
+import { ResourceTypeEnum } from '../../../types/sync.types';
+import { AgentComparatorAdapter } from '../adapters/agent-comparator.adapter';
+import { AgentDeleteAdapter } from '../adapters/agent-delete.adapter';
+import { AgentRepositoryAdapter } from '../adapters/agent-repository.adapter';
+import { AgentSyncAdapter } from '../adapters/agent-sync.adapter';
+import { BaseSyncOperation } from '../base/operations/base-sync.operation';
+
+@Injectable()
+export class AgentSyncOperation extends BaseSyncOperation<AgentEntity> {
+  constructor(
+    protected logger: PinoLogger,
+    protected repositoryAdapter: AgentRepositoryAdapter,
+    protected syncAdapter: AgentSyncAdapter,
+    protected deleteAdapter: AgentDeleteAdapter,
+    protected comparatorAdapter: AgentComparatorAdapter
+  ) {
+    super(logger, repositoryAdapter, syncAdapter, deleteAdapter, comparatorAdapter);
+  }
+
+  protected getResourceType(): ResourceTypeEnum {
+    return ResourceTypeEnum.AGENT;
+  }
+
+  protected getResourceName(resource: AgentEntity): string {
+    return resource.name || resource.identifier;
+  }
+}

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/sync.module.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/sync.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { DeletePreferencesUseCase, GetWorkflowByIdsUseCase, ResourceValidatorService } from '@novu/application-generic';
+import { AgentsModule } from '../../../agents/agents.module';
 import { LayoutsV2Module } from '../../../layouts-v2/layouts.module';
 import { DeleteLayoutUseCase } from '../../../layouts-v2/usecases/delete-layout';
 import { LayoutSyncToEnvironmentUseCase } from '../../../layouts-v2/usecases/sync-to-environment';
@@ -10,6 +11,10 @@ import { DeleteWorkflowUseCase } from '../../../workflows-v1/usecases/delete-wor
 import { SyncToEnvironmentUseCase } from '../../../workflows-v2/usecases/sync-to-environment/sync-to-environment.usecase';
 import { WorkflowModule } from '../../../workflows-v2/workflow.module';
 import {
+  AgentComparatorAdapter,
+  AgentDeleteAdapter,
+  AgentRepositoryAdapter,
+  AgentSyncAdapter,
   WorkflowComparatorAdapter,
   WorkflowDeleteAdapter,
   WorkflowRepositoryAdapter,
@@ -19,11 +24,14 @@ import { LayoutComparatorAdapter } from './adapters/layout-comparator.adapter';
 import { LayoutDeleteAdapter } from './adapters/layout-delete.adapter';
 import { LayoutRepositoryAdapter } from './adapters/layout-repository.adapter';
 import { LayoutSyncAdapter } from './adapters/layout-sync.adapter';
+import { AgentSyncStrategy } from './agent-sync.strategy';
 import { LayoutComparator } from './comparators/layout.comparator';
 import { WorkflowComparator } from './comparators/workflow.comparator';
 import { LayoutSyncStrategy } from './layout-sync.strategy';
 import { LayoutNormalizer } from './normalizers/layout.normalizer';
 import { WorkflowNormalizer } from './normalizers/workflow.normalizer';
+import { AgentDiffOperation } from './operations/agent-diff.operation';
+import { AgentSyncOperation } from './operations/agent-sync.operation';
 import { LayoutDiffOperation } from './operations/layout-diff.operation';
 import { LayoutRepositoryService } from './operations/layout-repository.service';
 import { LayoutSyncOperation } from './operations/layout-sync.operation';
@@ -33,7 +41,7 @@ import { WorkflowSyncOperation } from './operations/workflow-sync.operation';
 import { WorkflowSyncStrategy } from './workflow-sync.strategy';
 
 @Module({
-  imports: [SharedModule, WorkflowModule, LayoutsV2Module, OutboundWebhooksModule.forRoot()],
+  imports: [SharedModule, WorkflowModule, LayoutsV2Module, OutboundWebhooksModule.forRoot(), AgentsModule],
   providers: [
     // Repository services
     WorkflowRepositoryService,
@@ -56,12 +64,18 @@ import { WorkflowSyncStrategy } from './workflow-sync.strategy';
     LayoutSyncAdapter,
     LayoutDeleteAdapter,
     LayoutComparatorAdapter,
+    AgentRepositoryAdapter,
+    AgentSyncAdapter,
+    AgentDeleteAdapter,
+    AgentComparatorAdapter,
 
     // Operations
     WorkflowSyncOperation,
     WorkflowDiffOperation,
     LayoutSyncOperation,
     LayoutDiffOperation,
+    AgentSyncOperation,
+    AgentDiffOperation,
 
     // Usecases
     SyncToEnvironmentUseCase,
@@ -76,7 +90,8 @@ import { WorkflowSyncStrategy } from './workflow-sync.strategy';
     // Strategies
     WorkflowSyncStrategy,
     LayoutSyncStrategy,
+    AgentSyncStrategy,
   ],
-  exports: [WorkflowSyncStrategy, LayoutSyncStrategy],
+  exports: [WorkflowSyncStrategy, LayoutSyncStrategy, AgentSyncStrategy],
 })
 export class SyncModule {}

--- a/apps/dashboard/src/api/environments.ts
+++ b/apps/dashboard/src/api/environments.ts
@@ -84,7 +84,7 @@ export interface IEnvironmentPublishResponse {
 }
 
 export type ResourceToPublish = {
-  resourceType: 'workflow' | 'layout' | 'localization_group' | 'step';
+  resourceType: 'workflow' | 'layout' | 'localization_group' | 'step' | 'agent';
   resourceId: string;
 };
 

--- a/apps/dashboard/src/components/agents/agent-details-header.tsx
+++ b/apps/dashboard/src/components/agents/agent-details-header.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/primitives/dropdown-menu';
 import { Skeleton } from '@/components/primitives/skeleton';
+import { useEnvironment } from '@/context/environment/hooks';
 import { useHasPermission } from '@/hooks/use-has-permission';
 
 type AgentDetailsHeaderProps = {
@@ -20,6 +21,7 @@ type AgentDetailsHeaderProps = {
 
 export function AgentDetailsHeader({ agent, isLoading, onRequestDelete }: AgentDetailsHeaderProps) {
   const has = useHasPermission();
+  const { readOnly } = useEnvironment();
   const canWrite = has({ permission: PermissionsEnum.AGENT_WRITE });
 
   if (isLoading || !agent) {
@@ -74,6 +76,7 @@ export function AgentDetailsHeader({ agent, isLoading, onRequestDelete }: AgentD
               <DropdownMenuContent align="end">
                 <DropdownMenuItem
                   className="text-destructive cursor-pointer"
+                  disabled={readOnly}
                   onClick={() => {
                     setTimeout(() => onRequestDelete(agent), 0);
                   }}

--- a/apps/dashboard/src/components/agents/agent-integration-guides/agent-integration-guide-layout.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/agent-integration-guide-layout.tsx
@@ -13,6 +13,15 @@ import {
 } from '@/components/primitives/dropdown-menu';
 import { API_HOSTNAME } from '@/config';
 
+export type AgentIntegrationGuideHeaderProps = {
+  providerId: string;
+  providerDisplayName: string;
+  integrationLink: AgentIntegrationLink;
+  canRemoveIntegration: boolean;
+  onRequestRemoveIntegration?: () => void;
+  isRemovingIntegration?: boolean;
+};
+
 type AgentIntegrationGuideLayoutProps = {
   providerDisplayName: string;
   providerId: string;
@@ -38,86 +47,67 @@ function buildWebhookUrl(agentId: string, integrationIdentifier: string): string
   return `${baseUrl}/v1/agents/${agentId}/webhook/${integrationIdentifier}`;
 }
 
-export function AgentIntegrationGuideLayout({
-  providerDisplayName,
+export function AgentIntegrationGuideHeader({
   providerId,
-  onBack,
-  children,
-  embedded = false,
-  agent,
+  providerDisplayName,
   integrationLink,
   canRemoveIntegration,
   onRequestRemoveIntegration,
   isRemovingIntegration = false,
-}: AgentIntegrationGuideLayoutProps) {
-  const webhookUrlId = useId();
-  const isActive = integrationLink?.integration.active ?? false;
-  const integrationIdentifier = integrationLink?.integration.identifier;
-  const createdAt = integrationLink?.createdAt;
-  const webhookUrl = buildWebhookUrl(agent._id, integrationIdentifier ?? 'YOUR_INTEGRATION_IDENTIFIER');
+}: AgentIntegrationGuideHeaderProps) {
+  const isConnected = Boolean(integrationLink.connectedAt);
+  const integrationIdentifier = integrationLink.integration.identifier;
+  const createdAt = integrationLink.createdAt;
 
   return (
-    <div className="flex w-full flex-col gap-6">
-      {!embedded && (
-        <CompactButton
-          type="button"
-          size="lg"
-          variant="ghost"
-          className="w-fit"
-          icon={RiArrowLeftSLine}
-          onClick={onBack}
-        >
-          Back to integrations
-        </CompactButton>
-      )}
-
-      <header className="flex items-start justify-between">
-        <div className="flex min-w-0 flex-col gap-2">
-          <div className="flex items-center gap-2">
-            <div className="flex items-center gap-1.5">
-              <ProviderIcon
-                providerId={providerId}
-                providerDisplayName={providerDisplayName}
-                className="size-4 shrink-0"
-              />
-              <span className="text-text-strong text-label-sm font-medium leading-5">{providerDisplayName}</span>
-            </div>
-            {isActive ? (
-              <span className="bg-success-lighter flex items-center gap-1 rounded-md px-1 py-0.5">
-                <span className="flex size-4 items-center justify-center rounded-full bg-success-lighter">
-                  <span className="bg-success-base size-1.5 rounded-full" />
-                </span>
-                <span className="text-success-base text-label-xs font-medium leading-4">Active</span>
-              </span>
-            ) : (
-              <span className="bg-error-lighter flex items-center gap-1 rounded-md px-1 py-0.5">
-                <span className="bg-error-lighter flex size-4 items-center justify-center rounded-full">
-                  <span className="bg-error-base size-1.5 rounded-full" />
-                </span>
-                <span className="text-error-base text-label-xs font-medium leading-4">Action needed</span>
-              </span>
-            )}
+    <header className="flex items-start justify-between">
+      <div className="flex min-w-0 flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
+            <ProviderIcon
+              providerId={providerId}
+              providerDisplayName={providerDisplayName}
+              className="size-4 shrink-0"
+            />
+            <span className="text-text-strong text-label-sm font-medium leading-5">{providerDisplayName}</span>
           </div>
-
-          {integrationIdentifier ? (
-            <div className="flex items-center gap-1.5">
-              <span className="text-text-sub font-mono text-[12px] leading-4 tracking-tight">
-                {integrationIdentifier}
+          {isConnected ? (
+            <span className="bg-success-lighter flex items-center gap-1 rounded-md px-1 py-0.5">
+              <span className="flex size-4 items-center justify-center rounded-full bg-success-lighter">
+                <span className="bg-success-base size-1.5 rounded-full" />
               </span>
-              {createdAt ? (
-                <>
-                  <span className="bg-text-soft size-0.5 shrink-0 rounded-full" />
-                  <span className="text-[12px] leading-4">
-                    <span className="text-text-soft">Created </span>
-                    <span className="text-text-sub font-medium">{formatCreatedDate(createdAt)}</span>
-                  </span>
-                </>
-              ) : null}
-            </div>
-          ) : null}
+              <span className="text-success-base text-label-xs font-medium leading-4">Connected</span>
+            </span>
+          ) : (
+            <span className="bg-error-lighter flex items-center gap-1 rounded-md px-1 py-0.5">
+              <span className="bg-error-lighter flex size-4 items-center justify-center rounded-full">
+                <span className="bg-error-base size-1.5 rounded-full" />
+              </span>
+              <span className="text-error-base text-label-xs font-medium leading-4">Action needed</span>
+            </span>
+          )}
         </div>
 
-        {integrationLink && canRemoveIntegration && onRequestRemoveIntegration ? (
+        {integrationIdentifier ? (
+          <div className="flex items-center gap-1.5">
+            <span className="text-text-sub font-mono text-[12px] leading-4 tracking-tight">
+              {integrationIdentifier}
+            </span>
+            {createdAt ? (
+              <>
+                <span className="bg-text-soft size-0.5 shrink-0 rounded-full" />
+                <span className="text-[12px] leading-4">
+                  <span className="text-text-soft">Created </span>
+                  <span className="text-text-sub font-medium">{formatCreatedDate(createdAt)}</span>
+                </span>
+              </>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="flex items-center gap-2">
+        {onRequestRemoveIntegration ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -135,7 +125,7 @@ export function AgentIntegrationGuideLayout({
             <DropdownMenuContent align="end">
               <DropdownMenuItem
                 className="text-destructive cursor-pointer"
-                disabled={isRemovingIntegration}
+                disabled={!canRemoveIntegration || isRemovingIntegration}
                 onClick={onRequestRemoveIntegration}
               >
                 Remove integration
@@ -143,7 +133,53 @@ export function AgentIntegrationGuideLayout({
             </DropdownMenuContent>
           </DropdownMenu>
         ) : null}
-      </header>
+      </div>
+    </header>
+  );
+}
+
+export function AgentIntegrationGuideLayout({
+  providerDisplayName,
+  providerId,
+  onBack,
+  children,
+  embedded = false,
+  agent,
+  integrationLink,
+  canRemoveIntegration,
+  onRequestRemoveIntegration,
+  isRemovingIntegration = false,
+}: AgentIntegrationGuideLayoutProps) {
+  const webhookUrlId = useId();
+  const integrationIdentifier = integrationLink?.integration.identifier;
+  const webhookUrl = buildWebhookUrl(agent._id, integrationIdentifier ?? 'YOUR_INTEGRATION_IDENTIFIER');
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      {!embedded && (
+        <CompactButton
+          type="button"
+          size="lg"
+          variant="ghost"
+          className="w-fit"
+          icon={RiArrowLeftSLine}
+          onClick={onBack}
+        >
+          Back to integrations
+        </CompactButton>
+      )}
+
+      {integrationLink ? (
+        <AgentIntegrationGuideHeader
+          providerId={providerId}
+          providerDisplayName={providerDisplayName}
+          integrationLink={integrationLink}
+          canRemoveIntegration={canRemoveIntegration}
+          onRequestRemoveIntegration={onRequestRemoveIntegration}
+          isRemovingIntegration={isRemovingIntegration}
+
+        />
+      ) : null}
 
       <section className="flex flex-col gap-4">
         <h3 className="text-text-sub text-[11px] font-medium uppercase leading-4 tracking-wider">Agent metadata</h3>

--- a/apps/dashboard/src/components/agents/agent-integration-guides/resolve-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/resolve-agent-integration-guide.tsx
@@ -1,9 +1,11 @@
 import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
 import type { AgentIntegrationLink, AgentResponse } from '@/api/agents';
 import { EmailSetupGuide } from '@/components/agents/email-setup-guide';
+import { SetupGuideCard } from '@/components/agents/setup-guide-card';
 import { SlackSetupGuide } from '@/components/agents/slack-setup-guide';
 import { TeamsSetupGuide } from '@/components/agents/teams-setup-guide';
 import { WhatsAppSetupGuide } from '@/components/agents/whatsapp-setup-guide';
+import { AgentIntegrationGuideHeader } from './agent-integration-guide-layout';
 import { EmailAgentIntegrationGuide } from './email-agent-integration-guide';
 import { GenericAgentIntegrationGuide } from './generic-agent-integration-guide';
 import { SlackAgentIntegrationGuide } from './slack-agent-integration-guide';
@@ -20,6 +22,60 @@ type ResolveAgentIntegrationGuideProps = {
   isRemovingIntegration?: boolean;
 };
 
+type SetupGuideWrapperProps = {
+  providerId: string;
+  providerDisplayName: string;
+  integrationLink: AgentIntegrationLink;
+  canRemoveIntegration: boolean;
+  onRequestRemoveIntegration?: () => void;
+  isRemovingIntegration?: boolean;
+  children: React.ReactNode;
+};
+
+function SetupGuideWithHeader({
+  providerId,
+  providerDisplayName,
+  integrationLink,
+  canRemoveIntegration,
+  onRequestRemoveIntegration,
+  isRemovingIntegration,
+  children,
+}: SetupGuideWrapperProps) {
+  const isConnected = Boolean(integrationLink.connectedAt);
+
+  const statusBadge = isConnected ? (
+    <span className="bg-success-lighter flex items-center gap-1 rounded-md px-1 py-0.5">
+      <span className="flex size-4 items-center justify-center rounded-full bg-success-lighter">
+        <span className="bg-success-base size-1.5 rounded-full" />
+      </span>
+      <span className="text-success-base text-label-xs font-medium leading-4">Connected</span>
+    </span>
+  ) : (
+    <span className="bg-error-lighter flex items-center gap-1 rounded-md px-1 py-0.5">
+      <span className="bg-error-lighter flex size-4 items-center justify-center rounded-full">
+        <span className="bg-error-base size-1.5 rounded-full" />
+      </span>
+      <span className="text-error-base text-label-xs font-medium leading-4">Action needed</span>
+    </span>
+  );
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <AgentIntegrationGuideHeader
+        providerId={providerId}
+        providerDisplayName={providerDisplayName}
+        integrationLink={integrationLink}
+        canRemoveIntegration={canRemoveIntegration}
+        onRequestRemoveIntegration={onRequestRemoveIntegration}
+        isRemovingIntegration={isRemovingIntegration}
+      />
+      <SetupGuideCard label={`Setup ${providerDisplayName} integration`} rightContent={statusBadge}>
+        {children}
+      </SetupGuideCard>
+    </div>
+  );
+}
+
 export function ResolveAgentIntegrationGuide({
   integrationLink,
   onBack,
@@ -32,7 +88,18 @@ export function ResolveAgentIntegrationGuide({
   const providerId = integrationLink.integration.providerId;
 
   if (providerId === ChatProviderIdEnum.Slack && !integrationLink.connectedAt) {
-    return <SlackSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />;
+    return (
+      <SetupGuideWithHeader
+        providerId={providerId}
+        providerDisplayName="Slack"
+        integrationLink={integrationLink}
+        canRemoveIntegration={canRemoveIntegration}
+        onRequestRemoveIntegration={onRequestRemoveIntegration}
+        isRemovingIntegration={isRemovingIntegration}
+      >
+        <SlackSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />
+      </SetupGuideWithHeader>
+    );
   }
 
   if (providerId === ChatProviderIdEnum.Slack) {
@@ -50,7 +117,18 @@ export function ResolveAgentIntegrationGuide({
   }
 
   if (providerId === ChatProviderIdEnum.MsTeams && !integrationLink.connectedAt) {
-    return <TeamsSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />;
+    return (
+      <SetupGuideWithHeader
+        providerId={providerId}
+        providerDisplayName="MS Teams"
+        integrationLink={integrationLink}
+        canRemoveIntegration={canRemoveIntegration}
+        onRequestRemoveIntegration={onRequestRemoveIntegration}
+        isRemovingIntegration={isRemovingIntegration}
+      >
+        <TeamsSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />
+      </SetupGuideWithHeader>
+    );
   }
 
   if (providerId === ChatProviderIdEnum.MsTeams) {
@@ -68,7 +146,18 @@ export function ResolveAgentIntegrationGuide({
   }
 
   if (providerId === ChatProviderIdEnum.WhatsAppBusiness && !integrationLink.connectedAt) {
-    return <WhatsAppSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />;
+    return (
+      <SetupGuideWithHeader
+        providerId={providerId}
+        providerDisplayName="WhatsApp Business"
+        integrationLink={integrationLink}
+        canRemoveIntegration={canRemoveIntegration}
+        onRequestRemoveIntegration={onRequestRemoveIntegration}
+        isRemovingIntegration={isRemovingIntegration}
+      >
+        <WhatsAppSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />
+      </SetupGuideWithHeader>
+    );
   }
 
   if (providerId === ChatProviderIdEnum.WhatsAppBusiness) {
@@ -86,7 +175,18 @@ export function ResolveAgentIntegrationGuide({
   }
 
   if (providerId === EmailProviderIdEnum.NovuAgent && !integrationLink.connectedAt) {
-    return <EmailSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />;
+    return (
+      <SetupGuideWithHeader
+        providerId={providerId}
+        providerDisplayName="Novu Email"
+        integrationLink={integrationLink}
+        canRemoveIntegration={canRemoveIntegration}
+        onRequestRemoveIntegration={onRequestRemoveIntegration}
+        isRemovingIntegration={isRemovingIntegration}
+      >
+        <EmailSetupGuide agent={agent} integrationId={integrationLink.integration._id} embedded />
+      </SetupGuideWithHeader>
+    );
   }
 
   if (providerId === EmailProviderIdEnum.NovuAgent) {

--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -15,6 +15,7 @@ import { NovuApiError } from '@/api/api.client';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { Skeleton } from '@/components/primitives/skeleton';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
+import { InlineToast } from '@/components/primitives/inline-toast';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { useTelemetry } from '@/hooks/use-telemetry';
@@ -215,11 +216,11 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
-  const { currentEnvironment } = useEnvironment();
+  const { currentEnvironment, readOnly, oppositeEnvironment } = useEnvironment();
   const has = useHasPermission();
   const track = useTelemetry();
 
-  const canRemoveAgentIntegration = has({ permission: PermissionsEnum.AGENT_WRITE });
+  const canRemoveAgentIntegration = !readOnly && has({ permission: PermissionsEnum.AGENT_WRITE });
 
   const integrationsHubPath = `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
     environmentSlug: currentEnvironment?.slug ?? '',
@@ -400,8 +401,25 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
   return (
     <div className="flex min-w-0 w-full gap-6 px-6 pt-4">
       <aside className="w-[300px] shrink-0">
-        <div className="flex flex-col gap-4">
-          <div className="bg-bg-weak flex flex-col gap-2 rounded-[10px] p-1">
+        <div className="flex flex-col gap-2.5">
+          {readOnly && (
+            <InlineToast
+              variant="soft-warning"
+              description="Viewing in production"
+              ctaLabel="Switch to dev"
+              onCtaClick={() => {
+                if (!oppositeEnvironment?.slug) return;
+                navigate(
+                  buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+                    environmentSlug: oppositeEnvironment.slug,
+                    agentIdentifier: encodeURIComponent(agent.identifier),
+                    agentTab: 'integrations',
+                  })
+                );
+              }}
+            />
+          )}
+          <div className="bg-bg-weak flex flex-col gap-2 rounded p-1 py-1.5">
             <p className="text-text-sub px-1 pt-1 text-label-xs font-medium leading-4">Connected providers</p>
             {isLoading ? (
               <>
@@ -468,26 +486,28 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
 
                 {links.length > 0 ? <div className="bg-stroke-weak h-px" role="presentation" /> : null}
 
-                <ProviderDropdown
-                  agentIdentifier={agent.identifier}
-                  selectedIntegrationId={selectedIntegration?.integration._id}
-                  linkedIntegrationIds={linkedIntegrationIdSet}
-                  excludeLinked
-                  onSelect={handleProviderDropdownSelect}
-                  renderTrigger={({ isBusy }) => (
-                    <button
-                      type="button"
-                      disabled={isBusy}
-                      className="bg-bg-white border-stroke-weak hover:border-stroke-soft text-text-sub flex h-auto w-full items-center justify-between gap-1.5 rounded-md border px-2 py-1.5 text-left font-medium transition-colors disabled:opacity-60"
-                    >
-                      <span className="flex items-center gap-1.5">
-                        <RiAddLine className="size-4 shrink-0" aria-hidden />
-                        <span className="text-label-sm leading-5">Add provider</span>
-                      </span>
-                      <RiArrowRightSLine className="text-text-soft size-4 shrink-0" aria-hidden />
-                    </button>
-                  )}
-                />
+                {!readOnly && (
+                  <ProviderDropdown
+                    agentIdentifier={agent.identifier}
+                    selectedIntegrationId={selectedIntegration?.integration._id}
+                    linkedIntegrationIds={linkedIntegrationIdSet}
+                    excludeLinked
+                    onSelect={handleProviderDropdownSelect}
+                    renderTrigger={({ isBusy }) => (
+                      <button
+                        type="button"
+                        disabled={isBusy}
+                        className="bg-bg-white border-stroke-weak hover:border-stroke-soft text-text-sub flex h-auto w-full items-center justify-between gap-1.5 rounded-md border px-2 py-1.5 text-left font-medium transition-colors disabled:opacity-60"
+                      >
+                        <span className="flex items-center gap-1.5">
+                          <RiAddLine className="size-4 shrink-0" aria-hidden />
+                          <span className="text-label-sm leading-5">Add provider</span>
+                        </span>
+                        <RiArrowRightSLine className="text-text-soft size-4 shrink-0" aria-hidden />
+                      </button>
+                    )}
+                  />
+                )}
               </>
             )}
           </div>

--- a/apps/dashboard/src/components/agents/agent-overview-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-overview-tab.tsx
@@ -18,7 +18,7 @@ export function AgentOverviewTab({ agent }: AgentOverviewTabProps) {
   const [wasBridgeConnectedOnMount] = useState(isBridgeConnected);
 
   return (
-    <div className="flex gap-6 px-6 pt-4">
+    <div className="flex items-start gap-6 px-6 pt-4">
       <AgentSidebarWidget agent={agent} />
       {wasBridgeConnectedOnMount ? <AgentConnectedOverview agent={agent} /> : <AgentSetupGuide agent={agent} />}
     </div>

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -1,32 +1,15 @@
-import { useState } from 'react';
-import { RiExpandUpDownLine } from 'react-icons/ri';
 import type { AgentResponse } from '@/api/agents';
-import { cn } from '@/utils/ui';
 import { AgentSetupSteps } from './agent-setup-steps';
+import { SetupGuideCard } from './setup-guide-card';
 
 type AgentSetupGuideProps = {
   agent: AgentResponse;
 };
 
 export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
-  const [isExpanded, setIsExpanded] = useState(true);
-
   return (
-    <div className="bg-bg-weak flex min-w-0 flex-1 flex-col rounded-[10px] p-1">
-      <button
-        type="button"
-        className="flex w-full items-center justify-between px-2 py-1.5"
-        onClick={() => setIsExpanded(!isExpanded)}
-      >
-        <span className="text-text-soft text-[11px] font-medium uppercase leading-4 tracking-wider">Setup agent</span>
-        <RiExpandUpDownLine className={cn('text-text-soft size-3 transition-transform', isExpanded && 'rotate-180')} />
-      </button>
-
-      {isExpanded && (
-        <div className="bg-bg-white flex flex-col gap-0 overflow-hidden rounded-md p-3 shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">
-          <AgentSetupSteps agent={agent} />
-        </div>
-      )}
-    </div>
+    <SetupGuideCard label="Setup agent" className="min-w-0 flex-1">
+      <AgentSetupSteps agent={agent} />
+    </SetupGuideCard>
   );
 }

--- a/apps/dashboard/src/components/agents/agent-setup-modal.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-modal.tsx
@@ -1,0 +1,122 @@
+import {
+  RiAlertFill,
+  RiBookMarkedLine,
+  RiCheckboxCircleFill,
+  RiCheckLine,
+  RiCloseLine,
+  RiCornerDownLeftLine,
+  RiInformation2Fill,
+} from 'react-icons/ri';
+import { Button } from '../primitives/button';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../primitives/dialog';
+import { VisuallyHidden } from '../primitives/visually-hidden';
+
+type AgentSetupModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSetupClick: () => void;
+};
+
+const PUBLISHED_ITEMS = ['Agent metadata (name, AgentID, tags, description)', 'Agent behavior configurations'];
+
+const MISSING_ITEMS = [
+  'Agent handler production URL (Bridge endpoint URL)',
+  'Integrations (eg: Slack, Resend, MSTeams)',
+  'Inbound Email domain setup',
+];
+
+export function AgentSetupModal({ isOpen, onClose, onSetupClick }: AgentSetupModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent hideCloseButton className="min-w-[600px] max-w-[600px] gap-0 overflow-hidden rounded-xl p-0">
+        <VisuallyHidden>
+          <DialogTitle>Agent published to production</DialogTitle>
+          <DialogDescription>Complete the setup to start sending and receiving messages.</DialogDescription>
+        </VisuallyHidden>
+
+        {/* Header — grey background */}
+        <div className="border-stroke-weak flex flex-col gap-2 border-b bg-[#fbfbfb] p-3">
+          <div className="flex items-start justify-between">
+            <div className="bg-warning-lighter rounded-lg p-2">
+              <RiInformation2Fill className="text-warning-base size-6" />
+            </div>
+            <button
+              onClick={onClose}
+              className="text-text-soft hover:text-text-strong transition-colors"
+              aria-label="Close"
+            >
+              <RiCloseLine className="size-4" />
+            </button>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <h2 className="text-label-sm font-medium text-text-strong">Agent published to production</h2>
+            <p className="text-label-xs font-medium text-text-soft">
+              Your agent is live in production, but not active yet. Complete the setup by configuring integrations and
+              adding an inbound domain to start sending and receiving messages.
+            </p>
+          </div>
+        </div>
+
+        {/* Content — white background */}
+        <div className="flex flex-col gap-4 p-4">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <div className="flex size-5 items-center justify-center rounded-[6px] bg-[#e0faec]">
+                <div className="flex size-3 items-center justify-center rounded-full bg-white shadow-xs">
+                  <RiCheckboxCircleFill className="size-[9px] text-success-base" />
+                </div>
+              </div>
+              <span className="text-label-xs font-medium text-success-base">What was published</span>
+            </div>
+            <div className="flex flex-col gap-2 pl-8">
+              {PUBLISHED_ITEMS.map((item) => (
+                <div key={item} className="flex items-center gap-2">
+                  <RiCheckLine className="text-text-sub size-3 shrink-0" />
+                  <span className="text-label-xs font-medium text-text-sub">{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <div className="bg-warning-lighter flex size-5 items-center justify-center rounded-[6px]">
+                <div className="flex size-3 items-center justify-center rounded-full shadow-xs">
+                  <RiAlertFill className="text-warning-base size-[9px]" />
+                </div>
+              </div>
+              <span className="text-label-xs font-medium text-warning-base">What is missing</span>
+            </div>
+            <div className="flex flex-col gap-2 pl-8">
+              {MISSING_ITEMS.map((item) => (
+                <div key={item} className="flex items-center gap-2">
+                  <RiCloseLine className="text-text-sub size-3 shrink-0" />
+                  <span className="text-label-xs font-medium text-text-sub">{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer — grey background with top border */}
+        <div className="border-stroke-weak flex items-center gap-3 border-t bg-[#fbfbfb] p-3">
+          <a
+            href="https://docs.novu.co/agents/overview"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-label-xs text-text-sub hover:text-text-strong inline-flex items-center gap-1 font-medium underline transition-colors"
+          >
+            <RiBookMarkedLine className="size-5" />
+            View docs
+          </a>
+          <div className="flex flex-1 items-center justify-end">
+            <Button variant="primary" mode="gradient" size="xs" trailingIcon={RiCornerDownLeftLine} onClick={onSetupClick}>
+              Setup agent
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
+++ b/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import type { AgentResponse, UpdateAgentBody } from '@/api/agents';
 import { getAgentDetailQueryKey, updateAgent } from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
@@ -14,14 +15,14 @@ import {
   ExpandableDetailsTextarea,
 } from '@/components/details-sidebar';
 import { AnimatedBadgeDot, Badge } from '@/components/primitives/badge';
-import { HelpTooltipIndicator } from '@/components/primitives/help-tooltip-indicator';
 import { Input } from '@/components/primitives/input';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { Switch } from '@/components/primitives/switch';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { TimeDisplayHoverCard } from '@/components/time-display-hover-card';
+import { InlineToast } from '@/components/primitives/inline-toast';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useHasPermission } from '@/hooks/use-has-permission';
+import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 
 type AgentSidebarWidgetProps = {
@@ -42,81 +43,149 @@ function formatLongDate(dateStr: string): string {
   return formatted;
 }
 
-function TruncatedUrl({ url }: { url: string }) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          className="text-text-sub font-code text-label-xs block max-w-[160px] truncate tracking-tight bg-transparent p-0 text-left"
-        >
-          {url}
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" className="max-w-xs break-all">
-        {url}
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
 type BridgeUrlSectionProps = {
   agent: AgentResponse;
   canWrite: boolean;
   isUpdatePending: boolean;
   onUpdate: (body: UpdateAgentBody) => Promise<AgentResponse>;
+  readOnly: boolean;
 };
 
-function BridgeUrlSection({ agent, canWrite, isUpdatePending, onUpdate }: BridgeUrlSectionProps) {
-  const isLocalTunnelActive = Boolean(agent.devBridgeActive && agent.devBridgeUrl);
-  const activeBridgeUrl = isLocalTunnelActive ? agent.devBridgeUrl : agent.bridgeUrl;
+function BridgeUrlSection({ agent, canWrite, isUpdatePending, onUpdate, readOnly }: BridgeUrlSectionProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [bridgeUrl, setBridgeUrl] = useState(agent.bridgeUrl ?? '');
+  const urlBeforeEditRef = useRef(agent.bridgeUrl ?? '');
+
+  useEffect(() => {
+    if (!isEditing) {
+      setBridgeUrl(agent.bridgeUrl ?? '');
+    }
+  }, [agent.bridgeUrl, isEditing]);
+
+  const persistBridgeUrl = useCallback(async () => {
+    const trimmed = bridgeUrl.trim();
+    const server = (agent.bridgeUrl ?? '').trim();
+
+    if (trimmed === server) {
+      setIsEditing(false);
+
+      return;
+    }
+
+    if (!canWrite) {
+      setIsEditing(false);
+
+      return;
+    }
+
+    setIsEditing(false);
+    await onUpdate({ bridgeUrl: trimmed || null });
+  }, [agent.bridgeUrl, bridgeUrl, canWrite, onUpdate]);
+
+  const isLocalTunnelActive = !readOnly && Boolean(agent.devBridgeActive && agent.devBridgeUrl);
 
   return (
     <>
-      <DetailsSidebarRow label="Bridge URL">
-        {activeBridgeUrl ? (
-          <div className="flex items-center gap-1">
-            {isLocalTunnelActive ? (
+      <div className="flex h-8 items-center justify-between gap-2 px-1.5">
+        <span className="text-text-soft text-label-xs font-medium shrink-0">Bridge URL</span>
+        <div className="relative flex h-8 min-w-0 flex-1 items-center justify-end">
+          <AnimatePresence mode="wait">
+            {isEditing && canWrite ? (
+              <motion.div
+                key="bridge-input"
+                initial={{ opacity: 0, scale: 0.98 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.98 }}
+                transition={{ duration: 0.15, ease: 'easeOut' }}
+                className="absolute inset-0 flex items-center"
+              >
+                <Input
+                  placeholder="api.example.com/v1/api/novu"
+                  value={bridgeUrl}
+                  onChange={(e) => setBridgeUrl(e.target.value)}
+                  className="w-full text-right whitespace-nowrap overflow-x-hidden mask-none"
+                  size="xs"
+                  autoFocus
+                  disabled={isUpdatePending}
+                  onBlur={() => {
+                    void persistBridgeUrl();
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.currentTarget.blur();
+                    }
+
+                    if (e.key === 'Escape') {
+                      setBridgeUrl(urlBeforeEditRef.current);
+                      setIsEditing(false);
+                    }
+                  }}
+                />
+              </motion.div>
+            ) : (
+              <motion.button
+                key="bridge-display"
+                type="button"
+                onClick={() => {
+                  if (!canWrite) return;
+                  urlBeforeEditRef.current = bridgeUrl;
+                  setIsEditing(true);
+                }}
+                disabled={!canWrite}
+                initial={{ opacity: 0, scale: 0.98 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.98 }}
+                transition={{ duration: 0.15, ease: 'easeOut' }}
+                whileHover={canWrite ? { x: 2 } : {}}
+                whileTap={canWrite ? { scale: 0.98 } : {}}
+                className={cn(
+                  'text-text-sub flex h-8 min-w-0 w-full items-center justify-end text-right text-label-xs font-medium transition-colors',
+                  canWrite && 'hover:text-text-strong cursor-pointer',
+                  !canWrite && 'cursor-default'
+                )}
+              >
+                <span className="block w-full min-w-0 truncate text-right">
+                  {agent.bridgeUrl || <span className="text-text-soft italic">Not configured</span>}
+                </span>
+              </motion.button>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+      {!readOnly && (
+        <DetailsSidebarRow label="Bridge">
+          <div className="flex items-center gap-1.5">
+            {!agent.devBridgeActive ? (
+              <Badge variant="lighter" color="green" size="sm">
+                DEVELOPMENT
+              </Badge>
+            ) : null}
+            <Switch
+              checked={agent.devBridgeActive ?? false}
+              disabled={!canWrite || isUpdatePending}
+              onCheckedChange={(checked) => {
+                void onUpdate({ devBridgeActive: checked });
+              }}
+            />
+            {agent.devBridgeActive ? (
               <Badge variant="lighter" color="orange" size="sm">
                 LOCAL
               </Badge>
             ) : null}
-            <TruncatedUrl url={activeBridgeUrl} />
           </div>
-        ) : (
-          <span className="text-text-soft text-label-xs italic">Not configured</span>
-        )}
-      </DetailsSidebarRow>
-      {agent.devBridgeUrl ? (
-        <DetailsSidebarRow
-          label={
-            <>
-              Local tunnel connection
-              <HelpTooltipIndicator
-                size="3"
-                text="When enabled, the agent forwards traffic to your local tunnel URL instead of the deployed agent endpoint. Use this to test changes locally without redeploying."
-              />
-            </>
-          }
-        >
-          <Switch
-            checked={agent.devBridgeActive ?? false}
-            disabled={!canWrite || isUpdatePending}
-            onCheckedChange={(checked) => {
-              void onUpdate({ devBridgeActive: checked });
-            }}
-          />
         </DetailsSidebarRow>
-      ) : null}
+      )}
     </>
   );
 }
 
 export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
   const queryClient = useQueryClient();
-  const { currentEnvironment } = useEnvironment();
+  const navigate = useNavigate();
+  const { currentEnvironment, readOnly, oppositeEnvironment } = useEnvironment();
   const has = useHasPermission();
   const canWrite = has({ permission: PermissionsEnum.AGENT_WRITE });
+  const canEditFields = canWrite && !readOnly;
 
   const [isDeactivateModalOpen, setIsDeactivateModalOpen] = useState(false);
 
@@ -160,12 +229,12 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
       return;
     }
 
-    if (!canWrite) {
+    if (!canEditFields) {
       return;
     }
 
     await updateAgentAsync({ description: trimmed });
-  }, [agent.description, canWrite, description, updateAgentAsync]);
+  }, [agent.description, canEditFields, description, updateAgentAsync]);
 
   const persistName = useCallback(async () => {
     const trimmed = name.trim();
@@ -175,12 +244,12 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
       return;
     }
 
-    if (!canWrite) {
+    if (!canEditFields) {
       return;
     }
 
     await updateAgentAsync({ name: trimmed });
-  }, [agent.name, canWrite, name, updateAgentAsync]);
+  }, [agent.name, canEditFields, name, updateAgentAsync]);
 
   useEffect(() => {
     if (isDescriptionExpanded) {
@@ -200,6 +269,22 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
 
   return (
     <DetailsSidebar>
+      {readOnly && (
+        <InlineToast
+          variant="soft-warning"
+          description="Viewing in production"
+          ctaLabel="Switch to dev"
+          onCtaClick={() => {
+            if (!oppositeEnvironment?.slug) return;
+            navigate(
+              buildRoute(ROUTES.AGENT_DETAILS, {
+                environmentSlug: oppositeEnvironment.slug,
+                agentIdentifier: agent.identifier,
+              })
+            );
+          }}
+        />
+      )}
       <DetailsSidebarCard>
         <DetailsSidebarRow label="Status">
           {agent.active ? (
@@ -230,7 +315,7 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
           <span className="text-text-soft text-label-xs font-medium shrink-0">Name</span>
           <div className="relative flex h-8 min-w-0 flex-1 items-center justify-end">
             <AnimatePresence mode="wait">
-              {isEditingName && canWrite ? (
+              {isEditingName && canEditFields ? (
                 <motion.div
                   key="name-input"
                   initial={{ opacity: 0, scale: 0.98 }}
@@ -281,7 +366,7 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
                   key="name-display"
                   type="button"
                   onClick={() => {
-                    if (!canWrite) {
+                    if (!canEditFields) {
                       return;
                     }
 
@@ -290,17 +375,17 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
                     nameBeforeEditRef.current = current ? name : agent.name;
                     setIsEditingName(true);
                   }}
-                  disabled={!canWrite}
+                  disabled={!canEditFields}
                   initial={{ opacity: 0, scale: 0.98 }}
                   animate={{ opacity: 1, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.98 }}
                   transition={{ duration: 0.15, ease: 'easeOut' }}
-                  whileHover={canWrite ? { x: 2 } : {}}
-                  whileTap={canWrite ? { scale: 0.98 } : {}}
+                  whileHover={canEditFields ? { x: 2 } : {}}
+                  whileTap={canEditFields ? { scale: 0.98 } : {}}
                   className={cn(
                     'text-text-sub flex h-8 min-w-0 w-full items-center justify-end text-right text-label-xs font-medium transition-colors',
-                    canWrite && 'hover:text-text-strong cursor-pointer',
-                    !canWrite && 'cursor-default'
+                    canEditFields && 'hover:text-text-strong cursor-pointer',
+                    !canEditFields && 'cursor-default'
                   )}
                 >
                   <span className="block w-full min-w-0 truncate text-right">{name || 'Untitled agent'}</span>
@@ -322,13 +407,6 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
           </TimeDisplayHoverCard>
         </DetailsSidebarRow>
 
-        <BridgeUrlSection
-          agent={agent}
-          canWrite={canWrite}
-          isUpdatePending={isUpdatePending}
-          onUpdate={updateAgentAsync}
-        />
-
         <ExpandableDetailsTextarea
           label="Description"
           value={description}
@@ -339,8 +417,18 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
           placeholder="Describe what this agent does"
           maxLength={MAX_DESCRIPTION_LENGTH}
           showCounter
-          disabled={!canWrite || isUpdatePending}
+          disabled={!canEditFields || isUpdatePending}
           isPersisting={isUpdatePending}
+        />
+      </DetailsSidebarCard>
+
+      <DetailsSidebarCard>
+        <BridgeUrlSection
+          agent={agent}
+          canWrite={canWrite}
+          isUpdatePending={isUpdatePending}
+          onUpdate={updateAgentAsync}
+          readOnly={readOnly}
         />
       </DetailsSidebarCard>
 

--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -1,4 +1,4 @@
-import { DirectionEnum, PermissionsEnum } from '@novu/shared';
+import { DirectionEnum, EnvironmentTypeEnum, PermissionsEnum } from '@novu/shared';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
 import { RiArrowRightSLine, RiRobot2Line } from 'react-icons/ri';
@@ -14,13 +14,16 @@ import {
 } from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
 import { AgentsEmptyTeaser } from '@/components/agents/agents-empty-teaser';
+import { AgentsProductionEmptyState } from '@/components/agents/agents-production-empty-state';
 import { AgentsTable } from '@/components/agents/agents-table';
 import { CreateAgentDialog } from '@/components/agents/create-agent-dialog';
 import { DeleteAgentDialog } from '@/components/agents/delete-agent-dialog';
 import { ListNoResults } from '@/components/list-no-results';
+import { Button } from '@/components/primitives/button';
 import { FacetedFormFilter } from '@/components/primitives/form/faceted-filter/facated-form-filter';
 import { PermissionButton } from '@/components/primitives/permission-button';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { useTelemetry } from '@/hooks/use-telemetry';
@@ -33,7 +36,7 @@ export function AgentsList() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
-  const { currentEnvironment } = useEnvironment();
+  const { currentEnvironment, readOnly } = useEnvironment();
   const has = useHasPermission();
   const track = useTelemetry();
   const canReadAgents = has({ permission: PermissionsEnum.AGENT_READ });
@@ -208,7 +211,13 @@ export function AgentsList() {
   const showEmptyBlank = !listQuery.isError && !isLoading && !hasFilters && agents.length === 0;
   const showNoResults = !listQuery.isError && !isLoading && hasFilters && agents.length === 0;
 
+  const isProductionEnv = readOnly || currentEnvironment?.type !== EnvironmentTypeEnum.DEV;
+
   if (showEmptyBlank) {
+    if (isProductionEnv) {
+      return <AgentsProductionEmptyState />;
+    }
+
     return (
       <>
         <AgentsEmptyTeaser
@@ -246,17 +255,38 @@ export function AgentsList() {
           onChange={setSearch}
           placeholder="Search by identifier..."
         />
-        <PermissionButton
-          permission={PermissionsEnum.AGENT_WRITE}
-          size="xs"
-          variant="primary"
-          mode="gradient"
-          className="gap-1.5"
-          leadingIcon={RiRobot2Line}
-          onClick={() => setCreateOpen(true)}
-        >
-          Add Agent
-        </PermissionButton>
+        {isProductionEnv ? (
+          <Tooltip>
+            <TooltipTrigger className="cursor-not-allowed">
+              <Button size="xs" variant="primary" className="gap-1.5" leadingIcon={RiRobot2Line} disabled>
+                Add Agent
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-60">
+              {'Add agents in your development environment. '}
+              <a
+                href="https://docs.novu.co/platform/agents"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="underline"
+              >
+                Learn More ↗
+              </a>
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <PermissionButton
+            permission={PermissionsEnum.AGENT_WRITE}
+            size="xs"
+            variant="primary"
+            mode="gradient"
+            className="gap-1.5"
+            leadingIcon={RiRobot2Line}
+            onClick={() => setCreateOpen(true)}
+          >
+            Add Agent
+          </PermissionButton>
+        )}
       </div>
 
       {listQuery.isError ? (

--- a/apps/dashboard/src/components/agents/agents-production-empty-state.tsx
+++ b/apps/dashboard/src/components/agents/agents-production-empty-state.tsx
@@ -1,0 +1,84 @@
+import { RiArrowRightSLine, RiBookMarkedLine } from 'react-icons/ri';
+import { useNavigate } from 'react-router-dom';
+import { useEnvironment } from '@/context/environment/hooks';
+import { buildRoute, ROUTES } from '@/utils/routes';
+import { Button } from '../primitives/button';
+import { cn } from '@/utils/ui';
+
+function ProductionIllustration() {
+  return (
+    <svg width="136" height="125" viewBox="0 0 136 125" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0.5" y="79.5" width="135" height="45" rx="7.5" stroke="#7D52F4" strokeOpacity="0.1" />
+      <rect x="2.5" y="81.5" width="131" height="41" rx="5.5" fill="white" />
+      <rect x="2.5" y="81.5" width="131" height="41" rx="5.5" stroke="#7D52F4" />
+      <path
+        d="M67.3996 102L63.157 106.243L62.3086 105.394L65.7028 102L62.3086 98.6059L63.157 97.7581L67.3996 102ZM67.3996 106.2H73.3996V107.4H67.3996V106.2Z"
+        fill="#7D52F4"
+      />
+      <rect x="0.5" y="0.5" width="135" height="45" rx="7.5" stroke="#E1E4EA" strokeDasharray="5 3" />
+      <rect x="2.5" y="2.5" width="131" height="41" rx="5.5" fill="white" />
+      <rect x="2.5" y="2.5" width="131" height="41" rx="5.5" stroke="#CACFD8" />
+      <path
+        d="M69.4528 23.375C69.3693 23.6968 69.1814 23.9818 68.9185 24.1853C68.6555 24.3888 68.3325 24.4992 68 24.4992C67.6675 24.4992 67.3445 24.3888 67.0815 24.1853C66.8186 23.9818 66.6307 23.6968 66.5473 23.375H64.625V22.625H66.5473C66.6307 22.3031 66.8186 22.0181 67.0815 21.8146C67.3445 21.6111 67.6675 21.5007 68 21.5007C68.3325 21.5007 68.6555 21.6111 68.9185 21.8146C69.1814 22.0181 69.3693 22.3031 69.4528 22.625H71.375V23.375H69.4528Z"
+        fill="#99A0AE"
+      />
+      <path
+        d="M68.665 46V45.335H67.335V46H68H68.665ZM67.335 69.185L64.604 75.0671C64.4203 75.3852 64.68 75.835 65.0473 75.835H70.9527C71.32 75.835 71.5797 75.3852 71.396 75.0671L68.665 69.185H67.335ZM68 46H67.335V69.85H68H68.665V46H68Z"
+        fill="#E1E4EA"
+      />
+    </svg>
+  );
+}
+
+export function AgentsProductionEmptyState() {
+  const navigate = useNavigate();
+  const { oppositeEnvironment } = useEnvironment();
+
+  const handleSwitchToDevelopment = () => {
+    if (!oppositeEnvironment?.slug) return;
+    navigate(buildRoute(ROUTES.AGENTS, { environmentSlug: oppositeEnvironment.slug }));
+  };
+
+  return (
+    <div className="flex min-h-[min(720px,calc(100vh-8rem))] flex-col items-center justify-center px-4 py-10">
+      <div className="flex flex-col items-center gap-12">
+        <ProductionIllustration />
+
+        <div className="flex flex-col items-center gap-6">
+          <div className="flex flex-col items-center gap-2 text-center">
+            <p className="text-label-md font-medium text-text-strong">No agents in production</p>
+            <p className="text-paragraph-sm max-w-[500px] text-text-soft">
+              To promote agents to production: switch to Development, click &apos;Publish changes&apos;, then follow the
+              setup instructions.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-4">
+            <a
+              href="https://docs.novu.co/agents"
+              target="_blank"
+              rel="noreferrer"
+              className={cn(
+                'text-label-sm flex items-center gap-1 rounded-lg p-1.5 text-text-sub underline',
+                'transition-colors hover:text-text-strong'
+              )}
+            >
+              <RiBookMarkedLine className="size-4 shrink-0" aria-hidden />
+              View docs
+            </a>
+
+            <Button
+              variant="secondary"
+              mode="gradient"
+              size="xs"
+              trailingIcon={RiArrowRightSLine}
+              onClick={handleSwitchToDevelopment}
+            >
+              Switch to development
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/agents/agents-table.tsx
+++ b/apps/dashboard/src/components/agents/agents-table.tsx
@@ -156,7 +156,7 @@ function AgentsTableSkeletonRow() {
 export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProps }: AgentsTableProps) {
   const has = useHasPermission();
   const canWrite = has({ permission: PermissionsEnum.AGENT_WRITE });
-  const { currentEnvironment } = useEnvironment();
+  const { currentEnvironment, readOnly } = useEnvironment();
   const location = useLocation();
 
   return (
@@ -224,7 +224,7 @@ export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProp
                   {canWrite ? (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <CompactButton size="md" variant="ghost" icon={RiMore2Fill} className="z-10">
+                        <CompactButton size="md" variant="ghost" icon={RiMore2Fill} className="z-10" disabled={readOnly}>
                           <span className="sr-only">Open menu</span>
                         </CompactButton>
                       </DropdownMenuTrigger>

--- a/apps/dashboard/src/components/agents/setup-guide-card.tsx
+++ b/apps/dashboard/src/components/agents/setup-guide-card.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { RiExpandUpDownLine } from 'react-icons/ri';
+import { cn } from '@/utils/ui';
+
+type SetupGuideCardProps = {
+  label: string;
+  rightContent?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+};
+
+export function SetupGuideCard({ label, rightContent, children, className }: SetupGuideCardProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  return (
+    <div className={cn('bg-bg-weak flex flex-col rounded-[10px] p-1', className)}>
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-2 py-1.5"
+        onClick={() => setIsExpanded((prev) => !prev)}
+      >
+        <span className="font-code text-text-sub text-[12px] uppercase leading-4 tracking-[-0.24px]">{label}</span>
+        <div className="flex items-center gap-2">
+          {rightContent}
+          <RiExpandUpDownLine className={cn('text-text-soft size-3 transition-transform', isExpanded && 'rotate-180')} />
+        </div>
+      </button>
+      {isExpanded && (
+        <div className="bg-bg-white flex flex-col overflow-hidden rounded-md p-3 pr-6 shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/header-navigation/publish-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-modal.tsx
@@ -1,4 +1,4 @@
-import type { IEnvironment } from '@novu/shared';
+import { FeatureFlagsKeysEnum, type IEnvironment } from '@novu/shared';
 import { useEffect, useState } from 'react';
 import {
   RiAddBoxLine,
@@ -14,6 +14,7 @@ import {
 } from 'react-icons/ri';
 import type { IResourceDependency, IResourceDiffResult, ResourceToPublish } from '@/api/environments';
 import { useDiffEnvironments } from '@/hooks/use-environments';
+import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useResourceDependencies } from '@/hooks/use-resource-dependencies';
 import { formatDateSimple } from '@/utils/format-date';
 import { Badge, BadgeIcon } from '../primitives/badge';
@@ -21,6 +22,7 @@ import { Button } from '../primitives/button';
 import { Checkbox } from '../primitives/checkbox';
 import { Collapsible, CollapsibleContent } from '../primitives/collapsible';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../primitives/dialog';
+import { InlineToast } from '../primitives/inline-toast';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../primitives/tooltip';
 import { LayoutUsageIndicator } from './layout-usage-indicator';
 import { WorkflowHoverCard } from './workflow-hover-card';
@@ -60,6 +62,8 @@ export function PublishModal({
     targetEnvironmentId: environment?._id,
     enabled: isOpen,
   });
+
+  const isAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
 
   const { workflows, layouts, agents, dependencyMap, calculateDependencyState } = useResourceDependencies(diffData);
 
@@ -132,6 +136,11 @@ export function PublishModal({
   const getTotalSelectedCount = () => {
     return Object.values(resourceSelection).filter((state) => state.selected).length;
   };
+
+  const newSelectedAgentCount = agents.filter((a) => {
+    const id = a.sourceResource?.id || a.targetResource?.id;
+    return id && resourceSelection[id]?.selected && a.summary.added > 0;
+  }).length;
 
   const handleConfirm = () => {
     const selectedResources: ResourceToPublish[] = Object.entries(resourceSelection)
@@ -210,7 +219,7 @@ export function PublishModal({
             </ResourceGroupCompact>
           )}
 
-          {agents.length > 0 && (
+          {isAgentsEnabled && agents.length > 0 && (
             <ResourceGroupCompact
               title="Agents"
               count={agents.length}
@@ -237,6 +246,8 @@ export function PublishModal({
             </ResourceGroupCompact>
           )}
         </div>
+
+        {isAgentsEnabled && newSelectedAgentCount > 0 && <AgentInactiveWarning count={newSelectedAgentCount} />}
 
         <PublishModalActions
           environment={environment}
@@ -403,6 +414,16 @@ function CompactResourceRow({
                   </TooltipContent>
                 </Tooltip>
               )}
+              {resource.resourceType === 'agent' && resource.summary.added > 0 && (
+                <Tooltip>
+                  <TooltipTrigger>
+                    <RiAlertFill className="h-3 w-3 shrink-0 text-orange-500" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="rounded bg-gray-900 px-2 py-1 text-xs text-white">
+                    This agent will publish as inactive until configured in production.
+                  </TooltipContent>
+                </Tooltip>
+              )}
             </div>
             <div className="truncate font-mono text-xs tracking-tight text-gray-400">{slug}</div>
           </>
@@ -487,6 +508,28 @@ function PublishModalContent({ environment }: { environment: IEnvironment }) {
         <p className="text-xs text-gray-500">{description}</p>
       </div>
     </>
+  );
+}
+
+function AgentInactiveWarning({ count }: { count: number }) {
+  return (
+    <InlineToast
+      variant="soft-warning"
+      description={
+        <div className="space-y-1.5">
+          <p className="text-label-xs font-medium text-text-strong">
+            {count} agent{count !== 1 ? 's' : ''} will publish as{' '}
+            <Badge variant="lighter" color="orange" size="sm" className="rounded">
+              Inactive.
+            </Badge>
+          </p>
+          <p className="text-xs text-text-sub">
+            Affected agents will publish in{' '}
+            <span className="font-medium text-text-strong">Inactive</span> state until configured in production.
+          </p>
+        </div>
+      }
+    />
   );
 }
 

--- a/apps/dashboard/src/components/header-navigation/publish-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-modal.tsx
@@ -9,6 +9,7 @@ import {
   RiExpandUpDownLine,
   RiGitCommitFill,
   RiLinkUnlinkM,
+  RiRobot2Line,
   RiRouteFill,
 } from 'react-icons/ri';
 import type { IResourceDependency, IResourceDiffResult, ResourceToPublish } from '@/api/environments';
@@ -52,6 +53,7 @@ export function PublishModal({
   const [resourceSelection, setResourceSelection] = useState<ResourceSelection>({});
   const [workflowsExpanded, setWorkflowsExpanded] = useState(true);
   const [layoutsExpanded, setLayoutsExpanded] = useState(true);
+  const [agentsExpanded, setAgentsExpanded] = useState(true);
 
   const { data: diffData } = useDiffEnvironments({
     sourceEnvironmentId: currentEnvironmentId,
@@ -59,7 +61,7 @@ export function PublishModal({
     enabled: isOpen,
   });
 
-  const { workflows, layouts, dependencyMap, calculateDependencyState } = useResourceDependencies(diffData);
+  const { workflows, layouts, agents, dependencyMap, calculateDependencyState } = useResourceDependencies(diffData);
 
   // Initialize selection state
   useEffect(() => {
@@ -97,8 +99,8 @@ export function PublishModal({
     });
   };
 
-  const handleGroupToggle = (resourceType: 'workflow' | 'layout') => {
-    const resources = resourceType === 'workflow' ? workflows : layouts;
+  const handleGroupToggle = (resourceType: 'workflow' | 'layout' | 'agent') => {
+    const resources = resourceType === 'workflow' ? workflows : resourceType === 'layout' ? layouts : agents;
     const allSelected = resources.every((r) => {
       const id = r.sourceResource?.id || r.targetResource?.id;
       return id && resourceSelection[id]?.selected;
@@ -119,8 +121,8 @@ export function PublishModal({
     });
   };
 
-  const getSelectedCount = (resourceType: 'workflow' | 'layout') => {
-    const resources = resourceType === 'workflow' ? workflows : layouts;
+  const getSelectedCount = (resourceType: 'workflow' | 'layout' | 'agent') => {
+    const resources = resourceType === 'workflow' ? workflows : resourceType === 'layout' ? layouts : agents;
     return resources.filter((r) => {
       const id = r.sourceResource?.id || r.targetResource?.id;
       return id && resourceSelection[id]?.selected;
@@ -202,6 +204,33 @@ export function PublishModal({
                     dependencies={layout.dependencies}
                     allWorkflows={workflows}
                     dependencyMap={dependencyMap}
+                  />
+                );
+              })}
+            </ResourceGroupCompact>
+          )}
+
+          {agents.length > 0 && (
+            <ResourceGroupCompact
+              title="Agents"
+              count={agents.length}
+              selectedCount={getSelectedCount('agent')}
+              isExpanded={agentsExpanded}
+              onToggle={() => setAgentsExpanded(!agentsExpanded)}
+              onGroupToggle={() => handleGroupToggle('agent')}
+              icon={RiRobot2Line}
+            >
+              {agents.map((agent) => {
+                const id = agent.sourceResource?.id || agent.targetResource?.id;
+                if (!id) return null;
+
+                return (
+                  <CompactResourceRow
+                    key={id}
+                    resource={agent}
+                    selected={resourceSelection[id]?.selected || false}
+                    disabled={resourceSelection[id]?.disabled || false}
+                    onToggle={() => handleResourceToggle(id)}
                   />
                 );
               })}

--- a/apps/dashboard/src/components/header-navigation/publish-success-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-success-modal.tsx
@@ -27,6 +27,7 @@ export function PublishSuccessModal({
   const layoutCount = publishResult?.results?.find((r) => r.resourceType === 'layout')?.successful?.length || 0;
   const translationCount =
     publishResult?.results?.find((r) => r.resourceType === 'translation')?.successful?.length || 0;
+  const agentCount = publishResult?.results?.find((r) => r.resourceType === 'agent')?.successful?.length || 0;
 
   const buildSummaryText = () => {
     const parts: string[] = [];
@@ -41,6 +42,10 @@ export function PublishSuccessModal({
 
     if (translationCount > 0) {
       parts.push(`${translationCount} shared component${translationCount !== 1 ? 's' : ''}`);
+    }
+
+    if (agentCount > 0) {
+      parts.push(`${agentCount} agent${agentCount !== 1 ? 's' : ''}`);
     }
 
     if (parts.length === 0) return 'No items';

--- a/apps/dashboard/src/components/header-navigation/publish-success-modal.tsx
+++ b/apps/dashboard/src/components/header-navigation/publish-success-modal.tsx
@@ -1,9 +1,24 @@
 import type { IEnvironment } from '@novu/shared';
-import { RiArrowRightSLine, RiCheckboxCircleFill } from 'react-icons/ri';
+import { useState } from 'react';
+import {
+  RiArrowRightSLine,
+  RiCheckboxCircleFill,
+  RiContractUpDownLine,
+  RiErrorWarningLine,
+  RiExpandUpDownLine,
+  RiListCheck3,
+  RiRobot2Line,
+} from 'react-icons/ri';
+import { Link } from 'react-router-dom';
 import type { IEnvironmentPublishResponse } from '@/api/environments';
 import { useEnvironment } from '@/context/environment/hooks';
+import { buildRoute, ROUTES } from '@/utils/routes';
+import { Badge, BadgeIcon } from '../primitives/badge';
 import { Button } from '../primitives/button';
+import { Collapsible, CollapsibleContent } from '../primitives/collapsible';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../primitives/dialog';
+import { EnvironmentBranchIcon } from '../primitives/environment-branch-icon';
+import { InlineToast } from '../primitives/inline-toast';
 import { VisuallyHidden } from '../primitives/visually-hidden';
 
 type PublishSuccessModalProps = {
@@ -22,69 +37,131 @@ export function PublishSuccessModal({
   onSwitchEnvironment,
 }: PublishSuccessModalProps) {
   const { currentEnvironment } = useEnvironment();
+  const [needsSetupExpanded, setNeedsSetupExpanded] = useState(true);
 
-  const workflowCount = publishResult?.results?.find((r) => r.resourceType === 'workflow')?.successful?.length || 0;
-  const layoutCount = publishResult?.results?.find((r) => r.resourceType === 'layout')?.successful?.length || 0;
-  const translationCount =
-    publishResult?.results?.find((r) => r.resourceType === 'translation')?.successful?.length || 0;
-  const agentCount = publishResult?.results?.find((r) => r.resourceType === 'agent')?.successful?.length || 0;
+  const workflowCount = publishResult?.results?.find((r) => r.resourceType === 'workflow')?.successful?.length ?? 0;
+  const layoutCount = publishResult?.results?.find((r) => r.resourceType === 'layout')?.successful?.length ?? 0;
+  const translationCount = publishResult?.results?.find((r) => r.resourceType === 'translation')?.successful?.length ?? 0;
+  const publishedAgents = publishResult?.results?.find((r) => r.resourceType === 'agent')?.successful ?? [];
+  // First-time promotions publish as inactive and require production setup
+  const newAgents = publishedAgents.filter((a) => a.action === 'created');
 
-  const buildSummaryText = () => {
+  const summaryText = (() => {
     const parts: string[] = [];
-
-    if (workflowCount > 0) {
-      parts.push(`${workflowCount} workflow${workflowCount !== 1 ? 's' : ''}`);
-    }
-
-    if (layoutCount > 0) {
-      parts.push(`${layoutCount} layout${layoutCount !== 1 ? 's' : ''}`);
-    }
-
-    if (translationCount > 0) {
-      parts.push(`${translationCount} shared component${translationCount !== 1 ? 's' : ''}`);
-    }
-
-    if (agentCount > 0) {
-      parts.push(`${agentCount} agent${agentCount !== 1 ? 's' : ''}`);
-    }
-
+    if (workflowCount > 0) parts.push(`${workflowCount} workflow${workflowCount !== 1 ? 's' : ''}`);
+    if (layoutCount > 0) parts.push(`${layoutCount} layout${layoutCount !== 1 ? 's' : ''}`);
+    if (translationCount > 0) parts.push(`${translationCount} shared component${translationCount !== 1 ? 's' : ''}`);
+    if (publishedAgents.length > 0) parts.push(`${publishedAgents.length} agent${publishedAgents.length !== 1 ? 's' : ''}`);
     if (parts.length === 0) return 'No items';
     if (parts.length === 1) return parts[0];
     if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
-
     return `${parts.slice(0, -1).join(', ')}, and ${parts[parts.length - 1]}`;
-  };
+  })();
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-sm gap-4 p-4">
+      <DialogContent className="min-w-[400px] max-w-[600px] gap-4 p-3">
         <VisuallyHidden>
-          <DialogTitle>Environment Published to {environment?.name}</DialogTitle>
+          <DialogTitle>Changes published to {environment?.name}</DialogTitle>
           <DialogDescription>
-            {buildSummaryText()} have been published to {environment?.name}.
+            {summaryText} have been published to {environment?.name}.
           </DialogDescription>
         </VisuallyHidden>
-        <div className="bg-success-lighter w-fit rounded-full p-2">
+
+        <div className="bg-success-lighter w-fit rounded-[10px] p-2">
           <RiCheckboxCircleFill className="text-success-base size-6" />
         </div>
 
-        <div className="space-y-2">
-          <h2 className="text-label-sm text-text-strong font-medium">Environment Published to {environment?.name}</h2>
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1">
+            <h2 className="text-label-sm font-medium text-text-strong">
+              Changes published to {environment?.name}
+            </h2>
+            {environment && (
+              <span className="inline-flex max-w-[150px] shrink-0 items-center gap-1 rounded border border-feature-lighter bg-feature-lighter pl-0.5 pr-1 py-px">
+                <EnvironmentBranchIcon environment={environment} size="xs" />
+                <span className="text-label-sm truncate font-medium text-feature-base">{environment.name}</span>
+              </span>
+            )}
+          </div>
           <p className="text-paragraph-xs text-text-soft">
-            <span className="text-text-sub font-medium">{buildSummaryText()}</span> in{' '}
+            <span className="text-text-sub font-medium">{summaryText}</span> in{' '}
             <span className="text-text-sub font-medium">{currentEnvironment?.name?.toLowerCase()}</span> have been
             Published to {environment?.name}.
           </p>
         </div>
 
+        {newAgents.length > 0 && (
+          <div className="space-y-3">
+            <div className="overflow-hidden rounded-lg border border-stroke-soft">
+              {/* Header */}
+              <div className="flex h-7 items-center gap-1 border-b border-stroke-soft bg-bg-weak px-1.5 pt-1 pb-[5px]">
+                <RiListCheck3 className="h-4 w-4 shrink-0 text-text-sub" />
+                <span className="text-label-xs flex-1 font-medium text-text-sub">Needs setup in production</span>
+                <Badge variant="lighter" color="orange" size="sm" square>
+                  {newAgents.length}
+                </Badge>
+                <button
+                  onClick={() => setNeedsSetupExpanded(!needsSetupExpanded)}
+                  className="flex h-4 w-4 items-center justify-center rounded-lg p-0.5"
+                >
+                  {needsSetupExpanded ? (
+                    <RiContractUpDownLine className="h-3 w-3 text-text-sub" />
+                  ) : (
+                    <RiExpandUpDownLine className="h-3 w-3 text-text-sub" />
+                  )}
+                </button>
+              </div>
+
+              {/* Rows */}
+              <Collapsible open={needsSetupExpanded}>
+                <CollapsibleContent>
+                  {newAgents.map((agent) => (
+                    <Link
+                      key={agent.resourceId}
+                      to={buildRoute(ROUTES.AGENT_DETAILS, {
+                        environmentSlug: environment?.slug ?? '',
+                        agentIdentifier: agent.resourceId,
+                      })}
+                      onClick={onClose}
+                      className="flex items-center gap-1.5 border-b border-stroke-soft px-2.5 pt-2 pb-[9px] last:border-b-0 hover:bg-bg-weak transition-colors"
+                    >
+                      <RiRobot2Line className="h-4 w-4 shrink-0 text-text-sub" />
+                      <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                        <span className="text-label-xs truncate font-medium text-text-strong">
+                          {agent.resourceName}
+                        </span>
+                        <span className="truncate font-mono text-[10px] tracking-[-0.2px] text-text-soft">
+                          {agent.resourceId}
+                        </span>
+                      </div>
+                      <Badge variant="lighter" color="red" size="sm">
+                        <BadgeIcon as={RiErrorWarningLine} />
+                        Action needed
+                      </Badge>
+                      <RiArrowRightSLine className="h-4 w-4 shrink-0 text-text-sub" />
+                    </Link>
+                  ))}
+                </CollapsibleContent>
+              </Collapsible>
+            </div>
+
+            <InlineToast
+              variant="soft-warning"
+              description={
+                <span>
+                  <span className="font-medium text-text-strong">Warning: </span>
+                  {newAgents.length} agent{newAgents.length !== 1 ? 's' : ''} have been published in{' '}
+                  <span className="font-medium">Inactive</span> state. Setup required instructions by checking the
+                  agent.
+                </span>
+              }
+            />
+          </div>
+        )}
+
         <div className="flex justify-end">
-          <Button
-            variant="secondary"
-            mode="filled"
-            size="2xs"
-            onClick={onSwitchEnvironment}
-            trailingIcon={RiArrowRightSLine}
-          >
+          <Button variant="secondary" mode="filled" size="2xs" onClick={onSwitchEnvironment} trailingIcon={RiArrowRightSLine}>
             Switch to {environment?.name}
           </Button>
         </div>

--- a/apps/dashboard/src/components/primitives/inline-toast.tsx
+++ b/apps/dashboard/src/components/primitives/inline-toast.tsx
@@ -8,6 +8,7 @@ const inlineToastVariants = cva('flex items-center justify-between gap-3 rounded
     variant: {
       tip: 'border-neutral-100 bg-neutral-50',
       warning: 'border-warning/20 bg-warning/10',
+      'soft-warning': 'border-neutral-100 bg-neutral-50',
       success: 'border-success/20 bg-success/10',
       error: 'border-destructive/20 bg-destructive/10',
       info: 'border-information/20 bg-information/10',
@@ -21,6 +22,7 @@ const inlineToastVariants = cva('flex items-center justify-between gap-3 rounded
 const VARIANT_COLORS = {
   tip: 'bg-[#717784]',
   warning: 'bg-warning',
+  'soft-warning': 'bg-warning',
   success: 'bg-success',
   error: 'bg-destructive',
   info: 'bg-information',
@@ -29,6 +31,7 @@ const VARIANT_COLORS = {
 const BUTTON_COLORS = {
   tip: 'text-[#DD2450]',
   warning: 'text-warning',
+  'soft-warning': 'text-warning',
   success: 'text-success',
   error: 'text-destructive',
   info: 'text-information',

--- a/apps/dashboard/src/hooks/use-resource-dependencies.ts
+++ b/apps/dashboard/src/hooks/use-resource-dependencies.ts
@@ -12,18 +12,20 @@ type ResourceSelection = {
 type UseResourceDependenciesResult = {
   workflows: IResourceDiffResult[];
   layouts: IResourceDiffResult[];
+  agents: IResourceDiffResult[];
   dependencyMap: Map<string, IResourceDependency[]>;
   calculateDependencyState: (selection: ResourceSelection) => ResourceSelection;
 };
 
 export function useResourceDependencies(diffData: IEnvironmentDiffResponse | undefined): UseResourceDependenciesResult {
-  const { workflows, layouts, dependencyMap } = useMemo(() => {
+  const { workflows, layouts, agents, dependencyMap } = useMemo(() => {
     if (!diffData?.resources) {
-      return { workflows: [], layouts: [], dependencyMap: new Map() };
+      return { workflows: [], layouts: [], agents: [], dependencyMap: new Map() };
     }
 
     const workflowResources = diffData.resources.filter((r: IResourceDiffResult) => r.resourceType === 'workflow');
     const layoutResources = diffData.resources.filter((r: IResourceDiffResult) => r.resourceType === 'layout');
+    const agentResources = diffData.resources.filter((r: IResourceDiffResult) => r.resourceType === 'agent');
 
     // Build dependency map for quick lookup (include both workflows and layouts)
     const depMap = new Map<string, IResourceDependency[]>();
@@ -53,6 +55,7 @@ export function useResourceDependencies(diffData: IEnvironmentDiffResponse | und
     return {
       workflows: workflowResources,
       layouts: layoutResources,
+      agents: agentResources,
       dependencyMap: depMap,
     };
   }, [diffData]);
@@ -129,6 +132,7 @@ export function useResourceDependencies(diffData: IEnvironmentDiffResponse | und
   return {
     workflows,
     layouts,
+    agents,
     dependencyMap,
     calculateDependencyState,
   };

--- a/apps/dashboard/src/pages/agent-details.tsx
+++ b/apps/dashboard/src/pages/agent-details.tsx
@@ -1,12 +1,21 @@
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { RiArrowLeftSLine, RiRobot2Line } from 'react-icons/ri';
 import { Link, Navigate, useLocation, useNavigate, useParams } from 'react-router-dom';
-import { AGENTS_LIST_QUERY_KEY, type AgentResponse, deleteAgent, getAgent, getAgentDetailQueryKey } from '@/api/agents';
+import {
+  AGENTS_LIST_QUERY_KEY,
+  type AgentResponse,
+  deleteAgent,
+  getAgent,
+  getAgentDetailQueryKey,
+  getAgentIntegrationsQueryKey,
+  listAgentIntegrations,
+} from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
 import { AgentDetailsHeader } from '@/components/agents/agent-details-header';
 import { AgentIntegrationsTab } from '@/components/agents/agent-integrations-tab';
+import { AgentSetupModal } from '@/components/agents/agent-setup-modal';
 import { AgentOverviewTab } from '@/components/agents/agent-overview-tab';
 import { DeleteAgentDialog } from '@/components/agents/delete-agent-dialog';
 import { DashboardLayout } from '@/components/dashboard-layout';
@@ -79,9 +88,10 @@ export function AgentDetailsPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
-  const { currentEnvironment } = useEnvironment();
+  const { currentEnvironment, readOnly } = useEnvironment();
   const isConversationalAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
   const [agentToDelete, setAgentToDelete] = useState<AgentResponse | null>(null);
+  const [setupModalDismissed, setSetupModalDismissed] = useState(false);
   const track = useTelemetry();
   const lastAgentDetailsTelemetryKey = useRef<string | null>(null);
 
@@ -111,6 +121,29 @@ export function AgentDetailsPage() {
       showErrorToast(message, 'Delete failed');
     },
   });
+
+  const agentIntegrationsQuery = useQuery({
+    queryKey: getAgentIntegrationsQueryKey(currentEnvironment?._id, agentIdentifier),
+    queryFn: () =>
+      listAgentIntegrations({
+        environment: requireEnvironment(currentEnvironment, 'No environment selected'),
+        agentIdentifier,
+        limit: 100,
+      }),
+    enabled: Boolean(currentEnvironment && agentIdentifier && isConversationalAgentsEnabled),
+  });
+
+  const hasConnectedIntegration = useMemo(() => {
+    const links = agentIntegrationsQuery.data?.data;
+    if (!links?.length) return false;
+
+    return links.some((link) => Boolean(link.connectedAt));
+  }, [agentIntegrationsQuery.data?.data]);
+
+  const isProductionEnv = readOnly;
+  const agent = agentQuery.data;
+  const showSetupModal =
+    isProductionEnv && agent != null && !agent.active && !hasConnectedIntegration && !setupModalDismissed;
 
   const integrationIdentifier = integrationIdentifierParam ? decodeURIComponent(integrationIdentifierParam) : undefined;
   const currentTab = integrationIdentifier ? 'integrations' : parseAgentDetailsTab(agentTabParam);
@@ -163,7 +196,6 @@ export function AgentDetailsPage() {
   }
 
   const isLoading = agentQuery.isLoading;
-  const agent = agentQuery.data;
   const error = agentQuery.error;
   const isNotFound = error instanceof NovuApiError && error.status === 404;
 
@@ -300,6 +332,15 @@ export function AgentDetailsPage() {
               agentName={agentToDelete?.name ?? ''}
               agentIdentifier={agentToDelete?.identifier ?? ''}
               isDeleting={deleteMutation.isPending}
+            />
+
+            <AgentSetupModal
+              isOpen={showSetupModal}
+              onClose={() => setSetupModalDismissed(true)}
+              onSetupClick={() => {
+                setSetupModalDismissed(true);
+                handleTabChange('integrations');
+              }}
             />
           </>
         ) : null}

--- a/libs/dal/src/repositories/integration/integration.entity.ts
+++ b/libs/dal/src/repositories/integration/integration.entity.ts
@@ -42,6 +42,8 @@ export class IntegrationEntity {
   conditions?: StepFilter[];
 
   connected?: boolean;
+
+  _parentId?: string;
 }
 
 export type IntegrationDBModel = ChangePropsValueType<IntegrationEntity, '_environmentId' | '_organizationId'>;

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -111,6 +111,11 @@ const integrationSchema = new Schema<IntegrationDBModel>(
       },
     ],
     connected: Schema.Types.Boolean,
+    _parentId: {
+      type: Schema.Types.ObjectId,
+      required: false,
+      default: null,
+    },
   },
   schemaOptions
 );


### PR DESCRIPTION
## Summary

- Hooks agents into the existing publish-to-production modal with warning icons for first-time (inactive) agents and an InlineToast summary
- Rewrites the publish success modal to a new Figma design with a conditional "Needs setup in production" section linking to agent detail pages
- Adds a production empty state for the agents list page with illustration
- Disables "Add Agent" button and table action menus in production environments
- Adds a first-time agent setup modal shown when opening a newly promoted agent
- Makes agent info fields (name, description, behavior) read-only in production on both frontend (`canEditFields` gate) and backend (`assertNotProduction` guard that returns 403)
- Moves Bridge URL into its own card with click-to-edit; remains editable in production. Dev environments additionally show a DEVELOPMENT/LOCAL toggle
- Adds "Viewing in production" InlineToast (`soft-warning` variant) above the sidebar and integrations tab with a "Switch to dev" CTA
- Disables Delete menu item and hides "Add provider" button in production
- Improves setup guide layout spacing to match Figma proportions

## Test plan

- [ ] Verify agents appear in the publish modal with warning icons when publishing for the first time
- [ ] Verify the new publish success modal renders correctly, with "Needs setup in production" section for new agents
- [ ] Verify agents list shows the production empty state (illustration + text) when no agents exist in prod
- [ ] Verify "Add Agent" button is disabled with tooltip in production
- [ ] Verify agent table action menus are disabled in production
- [ ] Verify the agent setup modal appears on first open of a promoted agent in production
- [ ] Verify name/description fields are not editable in production, but the status toggle and bridge URL are
- [ ] Verify backend rejects PATCH requests modifying name/description/behavior in production (403)
- [ ] Verify bridge URL can be edited in production via click-to-edit
- [ ] Verify "Viewing in production" toast appears on Overview and Integrations tabs with working "Switch to dev" link
- [ ] Verify Delete option is disabled in the agent header menu in production
- [ ] Verify "Add provider" is hidden on the integrations tab in production


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR adds agents to the production-environment promotion flow and implements production-specific guards and UI states. Backend: a new `SyncAgentToEnvironment` use case copies agents and integration stubs between environments (idempotent, with cleanup). The `PublishEnvironment` and `DiffEnvironment` use cases now include `AgentSyncStrategy` to synchronize agents during publish. Production environment checks (via `EnvironmentRepository`) block modification of agent name/description/behavior fields and prevent add/remove-integration operations. Frontend: agents are added to the publish-to-production modal (with inactive-agent warnings) and the redesigned publish-success modal shows "Needs setup in production" for newly promoted agents. The agents dashboard gains a production empty state; "Add Agent" button and action menus are disabled in production. A setup modal appears after opening a newly promoted agent. Agent info fields become read-only in production; the bridge URL moves to an editable click-to-edit card. An "Viewing in production" inline toast with "Switch to dev" CTA appears in overview/integrations tabs. Delete and provider-add actions are hidden/disabled in production.

## Affected areas

**api**: Backend adds production environment guards in `add-agent-integration`, `remove-agent-integration`, and `update-agent` use cases. New `SyncAgentToEnvironment` use case handles agent promotion with idempotent stub-integration creation and cleanup. `AgentSyncStrategy` integrated into `PublishEnvironment` and `DiffEnvironment` pipelines. New adapters (`AgentRepositoryAdapter`, `AgentSyncAdapter`, `AgentDeleteAdapter`, `AgentComparatorAdapter`) and operations (`AgentSyncOperation`, `AgentDiffOperation`) implement the sync framework. Feature flag `IS_CONVERSATIONAL_AGENTS_ENABLED` gates agent sync. Comprehensive e2e tests validate agent promotion, duplicate prevention, and production write guards.

**dashboard**: Frontend adds agents to the `ResourceToPublish` type and publish/success modals. New components: `AgentSetupModal` (post-promotion checklist), `AgentsProductionEmptyState` (prod empty state), `SetupGuideCard` (collapsible guide wrapper). Agent component updates: `agent-sidebar-widget` refactored for read-only mode with inline bridge URL editing; `agent-integrations-tab` and `agent-details-header` read `readOnly` flag; `agents-list` and `agents-table` disable production actions. Integration guides show "Connected" status based on `connectedAt` instead of active flag.

**dal**: `IntegrationEntity` gains optional `_parentId` field to track parent-integration relationships for stub creation. Mongoose schema updated accordingly.

## Key technical decisions

- **Feature flag control**: Agent sync is disabled by default (`IS_CONVERSATIONAL_AGENTS_ENABLED` flag) to allow staged rollout.
- **Idempotent promotion**: `SyncAgentToEnvironment` is idempotent; repeated promotions update metadata without recreating stubs or resetting `active` flag.
- **Stub integrations**: Promoted agents receive placeholder integrations per source agent's integrations, linked via `_parentId` to identify promotion origin for cleanup on deletion.
- **Production read-only gates**: Frontend gates via `readOnly` context flag; backend rejects via 403 on PATCH for name/description/behavior in production.
- **Connection status tracking**: Agent-integration connection state now determined by `connectedAt` nullable field instead of integration `active` flag.

## Testing

New e2e test suite (`environments-v2-agent-publish.e2e.ts`) covers six scenarios: promotion creates inactive agent with stub integrations, diff reporting, duplicate-prevention on re-publish, metadata updates, agent deletion sync, and 403 rejection of production integration modifications. Unit tests for `SyncAgentToEnvironment` validate stub creation, link preservation, and cleanup logic. Manual verification expected for new UI states (read-only fields, production empty state, setup modal, inline toast).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->