### PR TITLE
fix(dashboard): skip Sanity changelog on staging and suppress toast fixes NV-7440

### DIFF
--- a/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
+++ b/apps/dashboard/src/components/side-navigation/changelog-cards.tsx
@@ -2,8 +2,11 @@ import { useUser } from '@clerk/clerk-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { motion } from 'motion/react';
 import { RiCloseLine } from 'react-icons/ri';
+import { API_HOSTNAME } from '@/config';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { TelemetryEvent } from '@/utils/telemetry';
+
+const IS_NOVU_STAGING_API = API_HOSTNAME === 'https://api.novu-staging.co';
 
 type SanityAsset = {
   _ref: string;
@@ -113,6 +116,10 @@ export function ChangelogStack() {
   };
 
   const fetchChangelogs = async (): Promise<Changelog[]> => {
+    if (IS_NOVU_STAGING_API) {
+      return [];
+    }
+
     // Build Sanity query to get published changelog posts with covers, sorted by publishedAt
     const query = encodeURIComponent(`
       *[_type == "changelogPost" && defined(cover.asset)] | order(publishedAt desc, _createdAt desc) [0...10] {
@@ -150,6 +157,7 @@ export function ChangelogStack() {
   const { data: changelogs = [] } = useQuery({
     queryKey: CONSTANTS.QUERY_KEY,
     queryFn: fetchChangelogs,
+    meta: { showError: false },
     // Refetch every hour to ensure users see new changelogs
     staleTime: 60 * 60 * 1000,
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The sidebar changelog stack was calling Sanity's public API (`api.sanity.io`) from the browser. On staging (`api.novu-staging.co`) that request fails (403 / CORS), which surfaced as a global TanStack Query error toast with the generic message **"Failed to fetch"** from the `QueryCache` handler in `root.tsx`.

## Changes

- **Skip the Sanity fetch** when `VITE_API_HOSTNAME` resolves to `https://api.novu-staging.co`, so staging does not hit Sanity at all.
- Set **`meta: { showError: false }`** on the changelog query so any remaining Sanity failures (optional UI) do not trigger the global error toast.

## Testing

Not run in this environment (pnpm unavailable in shell). Change is localized to `changelog-cards.tsx`; lint diagnostics clean for the edited file.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7440](https://linear.app/novu/issue/NV-7440/fix-or-remove-the-query-to-apisanityio-in-staging)

<div><a href="https://cursor.com/agents/bc-bf2c9db4-283a-4dd1-ba24-f77a7a5e358e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf2c9db4-283a-4dd1-ba24-f77a7a5e358e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The sidebar changelog was fetching data from Sanity's public API (`api.sanity.io`), which fails on the staging environment with a 403 CORS error, causing a global error toast to appear. The fix skips the Sanity fetch entirely when the API hostname is the staging instance, and adds error suppression to prevent toast notifications for any remaining Sanity failures.

## Affected areas

**dashboard**: Changelog cards component now conditionally disables Sanity retrieval when running against the staging API and suppresses error display for the changelog query, returning an empty changelog on staging instead.

## Testing

No tests were added. The change is localized to a single file (`changelog-cards.tsx`) with lint diagnostics clean. Manual verification on staging would confirm the fix resolves the error toast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->