### PR TITLE
fix(dashboard): Support agent onboarding in integration UI

### DIFF
--- a/apps/api/src/app/domains/utils/domain-connect.spec.ts
+++ b/apps/api/src/app/domains/utils/domain-connect.spec.ts
@@ -127,6 +127,31 @@ describe('Domain Connect utils', () => {
     expectSignature(url);
   });
 
+  it('normalizes private keys loaded through secret managers before signing', () => {
+    const secretManagerValues = [
+      privateKey.replace(/\n/g, ''),
+      privateKey.replace(/\n/g, '\\n'),
+      privateKey.replace(/\n/g, '\\r\\n'),
+      `"${privateKey.replace(/\n/g, '\\n')}"`,
+    ];
+
+    for (const secretManagerValue of secretManagerValues) {
+      process.env.DOMAIN_CONNECT_PRIVATE_KEY = secretManagerValue;
+
+      const result = buildDomainConnectApplyUrl({
+        domain,
+        connectDomainName: 'example.com',
+        discoveredHost: 'domainconnect.vercel.com',
+        settings: {
+          urlSyncUX: 'https://vercel.com/domain-connect',
+          urlAPI: 'https://vercel.com/api/domain-connect',
+        },
+      });
+
+      expectSignature(new URL(result.applyUrl));
+    }
+  });
+
   it('rejects redirect URIs outside the configured dashboard origin', () => {
     expect(() =>
       buildDomainConnectApplyUrl({

--- a/apps/api/src/app/domains/utils/domain-connect.ts
+++ b/apps/api/src/app/domains/utils/domain-connect.ts
@@ -46,7 +46,7 @@ export function getDomainConnectConfig(): DomainConnectConfig {
   return {
     providerId: DOMAIN_CONNECT_PROVIDER_ID,
     serviceId: DOMAIN_CONNECT_SERVICE_ID,
-    privateKey: process.env.DOMAIN_CONNECT_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+    privateKey: normalizeDomainConnectPrivateKey(process.env.DOMAIN_CONNECT_PRIVATE_KEY),
     keyHost: DOMAIN_CONNECT_KEY_HOST,
     redirectBaseUrl: getDomainConnectRedirectBaseUrl(),
   };
@@ -214,6 +214,45 @@ function getRegistrableDomain(domainName: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function normalizeDomainConnectPrivateKey(value?: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  let privateKey = value.trim();
+
+  if (
+    (privateKey.startsWith('"') && privateKey.endsWith('"')) ||
+    (privateKey.startsWith("'") && privateKey.endsWith("'"))
+  ) {
+    privateKey = privateKey.slice(1, -1);
+  }
+
+  privateKey = privateKey
+    .replace(/\\\\r\\\\n/g, '\n')
+    .replace(/\\\\n/g, '\n')
+    .replace(/\\r\\n/g, '\n')
+    .replace(/\\n/g, '\n')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n');
+
+  const compactPemMatch = privateKey.match(/^(-----BEGIN [^-]+-----)([A-Za-z0-9+/=\s]+)(-----END [^-]+-----)$/);
+
+  if (compactPemMatch && !privateKey.includes('\n')) {
+    const [, header, body, footer] = compactPemMatch;
+    const wrappedBody = body
+      .replace(/\s+/g, '')
+      .match(/.{1,64}/g)
+      ?.join('\n');
+
+    if (wrappedBody) {
+      return `${header}\n${wrappedBody}\n${footer}\n`;
+    }
+  }
+
+  return privateKey;
 }
 
 function buildRedirectUri({

--- a/apps/dashboard/src/components/agents/email-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/email-setup-guide.tsx
@@ -83,7 +83,17 @@ export function EmailSetupGuide({
     if (!testConnected) return testStepIndex;
 
     return testStepIndex + 1;
-  }, [base, outboundId, needsCredentialsStep, hasOutboundCredentials, credentialsStepIndex, hasAddresses, inboundStepIndex, testStepIndex, testConnected]);
+  }, [
+    base,
+    outboundId,
+    needsCredentialsStep,
+    hasOutboundCredentials,
+    credentialsStepIndex,
+    hasAddresses,
+    inboundStepIndex,
+    testStepIndex,
+    testConnected,
+  ]);
 
   const stepsColumn = (
     <>
@@ -193,6 +203,7 @@ export function EmailSetupGuide({
         integrationId={outboundId}
         isOpen={isCredentialsSidebarOpen}
         onClose={() => setIsCredentialsSidebarOpen(false)}
+        agentOnboarding
       />
     ) : null;
 

--- a/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
+++ b/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
@@ -5,6 +5,7 @@ import { type ReactNode, useEffect, useRef, useState } from 'react';
 import ReactConfetti from 'react-confetti';
 import { createPortal } from 'react-dom';
 import { RiArrowRightUpLine } from 'react-icons/ri';
+import { useSearchParams } from 'react-router-dom';
 import { getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
 import { IntegrationSettings } from '@/components/integrations/components/integration-settings';
 import { IntegrationSheet } from '@/components/integrations/components/integration-sheet';
@@ -284,18 +285,43 @@ export function IntegrationCredentialsSidebar({
   isOpen,
   onClose,
   onSaveSuccess,
+  agentOnboarding,
 }: {
   integrationId: string;
   isOpen: boolean;
   onClose: () => void;
   onSaveSuccess?: () => void;
+  agentOnboarding?: boolean;
 }) {
   const { integrations } = useFetchIntegrations();
   const { mutateAsync: updateIntegration, isPending: isUpdating } = useUpdateIntegration();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [formState, setFormState] = useState({ isValid: true, errors: {} as Record<string, unknown>, isDirty: false });
 
   const integration = integrations?.find((i) => i._id === integrationId);
   const provider = novuProviders?.find((p) => p.id === integration?.providerId);
+
+  useEffect(() => {
+    if (!agentOnboarding) {
+      return;
+    }
+
+    const hasAgentOnboardingParam = searchParams.get('agent_onboarding') === 'true';
+
+    if ((isOpen && hasAgentOnboardingParam) || (!isOpen && !searchParams.has('agent_onboarding'))) {
+      return;
+    }
+
+    const nextSearchParams = new URLSearchParams(searchParams);
+
+    if (isOpen) {
+      nextSearchParams.set('agent_onboarding', 'true');
+    } else {
+      nextSearchParams.delete('agent_onboarding');
+    }
+
+    setSearchParams(nextSearchParams, { replace: true });
+  }, [agentOnboarding, isOpen, searchParams, setSearchParams]);
 
   async function onSubmit(data: IntegrationFormData) {
     if (!integration) return;
@@ -332,6 +358,7 @@ export function IntegrationCredentialsSidebar({
           integration={integration}
           onSubmit={onSubmit}
           mode="update"
+          agentOnboarding={agentOnboarding}
           onFormStateChange={setFormState}
         />
       </div>

--- a/apps/dashboard/src/components/agents/slack-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/slack-setup-guide.tsx
@@ -57,6 +57,10 @@ function buildSlackManifestYaml(agent: AgentResponse, webhookHandlerUrl: string,
   description: "${displayDescription}"
 
 features:
+  app_home:
+    home_tab_enabled: false
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: "${botName}"
     always_online: true
@@ -326,6 +330,7 @@ export function SlackSetupGuide({
           isOpen={isCredentialsSidebarOpen}
           onClose={() => setIsCredentialsSidebarOpen(false)}
           onSaveSuccess={() => setIsCredentialsSaved(true)}
+          agentOnboarding
         />
       </div>
     );
@@ -340,6 +345,7 @@ export function SlackSetupGuide({
         isOpen={isCredentialsSidebarOpen}
         onClose={() => setIsCredentialsSidebarOpen(false)}
         onSaveSuccess={() => setIsCredentialsSaved(true)}
+        agentOnboarding
       />
     </>
   );

--- a/apps/dashboard/src/components/agents/teams-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/teams-setup-guide.tsx
@@ -485,6 +485,7 @@ export function TeamsSetupGuide({
       isOpen={isCredentialsSidebarOpen}
       onClose={() => setIsCredentialsSidebarOpen(false)}
       onSaveSuccess={() => {}}
+      agentOnboarding
     />
   );
 

--- a/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
@@ -266,6 +266,7 @@ export function WhatsAppSetupGuide({
           isOpen={isCredentialsSidebarOpen}
           onClose={() => setIsCredentialsSidebarOpen(false)}
           onSaveSuccess={() => setIsCredentialsSaved(true)}
+          agentOnboarding
         />
       </div>
     );
@@ -280,6 +281,7 @@ export function WhatsAppSetupGuide({
         isOpen={isCredentialsSidebarOpen}
         onClose={() => setIsCredentialsSidebarOpen(false)}
         onSaveSuccess={() => setIsCredentialsSaved(true)}
+        agentOnboarding
       />
     </>
   );

--- a/apps/dashboard/src/components/integrations/components/integration-settings.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-settings.tsx
@@ -1,6 +1,7 @@
 import {
   ChannelTypeEnum,
   ChatProviderIdEnum,
+  CredentialsKeyEnum,
   FeatureFlagsKeysEnum,
   IIntegration,
   IProviderConfig,
@@ -10,7 +11,7 @@ import {
 import { useEffect, useMemo } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { RiInputField } from 'react-icons/ri';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/primitives/accordion';
 import { Form, FormRoot } from '@/components/primitives/form/form';
 import { Label } from '@/components/primitives/label';
@@ -44,6 +45,7 @@ type IntegrationConfigurationProps = {
   isChannelSupportPrimary?: boolean;
   hasOtherProviders?: boolean;
   isReadOnly?: boolean;
+  agentOnboarding?: boolean;
   onFormStateChange?: (formState: { isValid: boolean; errors: Record<string, unknown>; isDirty: boolean }) => void;
 };
 
@@ -64,9 +66,11 @@ export function IntegrationSettings({
   isChannelSupportPrimary,
   hasOtherProviders,
   isReadOnly,
+  agentOnboarding,
   onFormStateChange,
 }: IntegrationConfigurationProps) {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { currentEnvironment, environments } = useEnvironment();
 
   const form = useForm<IntegrationFormData>({
@@ -117,12 +121,15 @@ export function IntegrationSettings({
 
   const isDemo = integration && isDemoIntegration(integration.providerId);
   const isSlackTeamsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_SLACK_TEAMS_ENABLED, false);
+  const isAgentOnboarding = agentOnboarding || searchParams.get('agent_onboarding') === 'true';
 
   // Filter credentials based on provider and feature flag
   const providerCredentials = useMemo(() => {
+    let credentials = provider.credentials;
+
     // MS Teams: only show OAuth credentials when feature flag is enabled
     if (provider.id === ChatProviderIdEnum.MsTeams) {
-      return isSlackTeamsEnabled ? provider.credentials : [];
+      credentials = isSlackTeamsEnabled ? provider.credentials : [];
     }
 
     // Slack: hide HMAC for new integrations when feature flag is enabled
@@ -130,16 +137,19 @@ export function IntegrationSettings({
     if (provider.id === ChatProviderIdEnum.Slack && isSlackTeamsEnabled) {
       // For existing integrations (update mode), show HMAC if it is true in credentials
       if (mode === 'update' && integration?.credentials?.hmac === true) {
-        return provider.credentials;
+        credentials = provider.credentials;
+      } else {
+        // For new integrations (create mode), use config without HMAC
+        credentials = slackConfig;
       }
-
-      // For new integrations (create mode), use config without HMAC
-      return slackConfig;
     }
 
-    // Default: return all credentials
-    return provider.credentials;
-  }, [provider.id, provider.credentials, isSlackTeamsEnabled, mode, integration?.credentials]);
+    if (isAgentOnboarding) {
+      return credentials.filter((credential) => credential.key !== CredentialsKeyEnum.RedirectUrl);
+    }
+
+    return credentials;
+  }, [provider.id, provider.credentials, isSlackTeamsEnabled, mode, integration?.credentials, isAgentOnboarding]);
 
   return (
     <Form {...form}>
@@ -168,39 +178,41 @@ export function IntegrationSettings({
             />
           </div>
         </div>
-        <Accordion type="single" collapsible defaultValue="layout" className="p-3">
-          <AccordionItem value="layout">
-            <AccordionTrigger>
-              <div className="flex items-center gap-1 text-xs">
-                <RiInputField className="text-feature size-5" />
-                General Settings
-              </div>
-            </AccordionTrigger>
-            <AccordionContent>
-              <GeneralSettings
-                control={control}
-                mode={mode}
-                isReadOnly={isReadOnly}
-                hidePrimarySelector={!isChannelSupportPrimary}
-                disabledPrimary={!hasOtherProviders && integration?.primary}
-                configurations={provider.configurations}
-                integrationId={integration?._id}
-                isDemo={isDemo}
-                provider={provider}
-                formData={form.getValues()}
-                onAutoConfigureSuccess={(updatedIntegration) => {
-                  // Update form with the new integration data
-                  setValue('configurations', updatedIntegration.configurations as Record<string, string>);
-                  setValue('credentials', updatedIntegration.credentials as Record<string, string>);
-                  setValue('name', updatedIntegration.name);
-                  setValue('identifier', updatedIntegration.identifier);
-                  setValue('active', updatedIntegration.active);
-                  setValue('primary', updatedIntegration.primary ?? false);
-                }}
-              />
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+        {!isAgentOnboarding && (
+          <Accordion type="single" collapsible defaultValue="layout" className="p-3">
+            <AccordionItem value="layout">
+              <AccordionTrigger>
+                <div className="flex items-center gap-1 text-xs">
+                  <RiInputField className="text-feature size-5" />
+                  General Settings
+                </div>
+              </AccordionTrigger>
+              <AccordionContent>
+                <GeneralSettings
+                  control={control}
+                  mode={mode}
+                  isReadOnly={isReadOnly}
+                  hidePrimarySelector={!isChannelSupportPrimary}
+                  disabledPrimary={!hasOtherProviders && integration?.primary}
+                  configurations={provider.configurations}
+                  integrationId={integration?._id}
+                  isDemo={isDemo}
+                  provider={provider}
+                  formData={form.getValues()}
+                  onAutoConfigureSuccess={(updatedIntegration) => {
+                    // Update form with the new integration data
+                    setValue('configurations', updatedIntegration.configurations as Record<string, string>);
+                    setValue('credentials', updatedIntegration.credentials as Record<string, string>);
+                    setValue('name', updatedIntegration.name);
+                    setValue('identifier', updatedIntegration.identifier);
+                    setValue('active', updatedIntegration.active);
+                    setValue('primary', updatedIntegration.primary ?? false);
+                  }}
+                />
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        )}
 
         {isDemo && (
           <div className="p-3">
@@ -253,7 +265,10 @@ export function IntegrationSettings({
 
             {/* TODO: This is a temporary solution to show the guide only for in-app channel, 
               we need to replace it with dedicated view per integration channel */}
-            {integration && integration.channel === ChannelTypeEnum.IN_APP && !integration.connected ? (
+            {!isAgentOnboarding &&
+            integration &&
+            integration.channel === ChannelTypeEnum.IN_APP &&
+            !integration.connected ? (
               <InlineToast
                 variant={'tip'}
                 className="mt-3"
@@ -262,6 +277,7 @@ export function IntegrationSettings({
                 onCtaClick={() => navigate(`${ROUTES.INBOX_EMBED}?environmentId=${integration._environmentId}`)}
               />
             ) : (
+              !isAgentOnboarding &&
               provider?.docReference && (
                 <InlineToast
                   variant={'tip'}

--- a/packages/shared/src/consts/providers/credentials/provider-credentials.ts
+++ b/packages/shared/src/consts/providers/credentials/provider-credentials.ts
@@ -496,7 +496,7 @@ export const messagebirdConfig: IConfigCredential[] = [
 export const slackConfigLegacy: IConfigCredential[] = [
   {
     key: CredentialsKeyEnum.ApplicationId,
-    displayName: 'Application Id',
+    displayName: 'App ID',
     type: 'string',
     required: true,
   },
@@ -517,7 +517,7 @@ export const slackConfigLegacy: IConfigCredential[] = [
     displayName: 'Signing Secret',
     description: 'Slack app Signing Secret, used for verifying inbound webhook requests',
     type: 'string',
-    required: false,
+    required: true,
   },
   {
     key: CredentialsKeyEnum.RedirectUrl,
@@ -537,7 +537,7 @@ export const slackConfigLegacy: IConfigCredential[] = [
 export const slackConfig: IConfigCredential[] = [
   {
     key: CredentialsKeyEnum.ApplicationId,
-    displayName: 'Application Id',
+    displayName: 'App ID',
     type: 'string',
     required: true,
   },
@@ -558,7 +558,7 @@ export const slackConfig: IConfigCredential[] = [
     displayName: 'Signing Secret',
     description: 'Slack app Signing Secret, used for verifying inbound webhook requests',
     type: 'string',
-    required: false,
+    required: true,
   },
   {
     key: CredentialsKeyEnum.RedirectUrl,


### PR DESCRIPTION
Add agent onboarding support across integration components.

- Introduce an agentOnboarding prop to IntegrationCredentialsSidebar and IntegrationSettings and thread it from agent setup guides (email, Slack, Teams, WhatsApp).
- Sync the agent_onboarding query param with the credentials sidebar open state using useSearchParams so the onboarding flow is reflected in the URL.
- In IntegrationSettings detect onboarding (prop or query param) and:
  - Filter out RedirectUrl credential during onboarding.
  - Hide the General Settings accordion and some guidance UI when onboarding to simplify the experience.
- Propagate agentOnboarding to the integration form to control form behavior during onboarding.
- Slack changes: add app_home features to the generated manifest, rename credential label "Application Id" -> "App ID" for slackConfig and slackConfigLegacy, and make the Signing Secret credential required.
- Minor formatting cleanups (useEffect deps array) in the email setup guide.

### What changed? Why was the change needed?

@coderabbitai summary

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
