### PR TITLE
fix(inbound-mail): changes to make it work on enterprise hosted env

### DIFF
--- a/.github/workflows/prepare-enterprise-self-hosted-release.yml
+++ b/.github/workflows/prepare-enterprise-self-hosted-release.yml
@@ -8,7 +8,9 @@ run-name: >
   }}${{
     github.event.inputs.build_dashboard == 'true' && 'dashboard, ' || ''
   }}${{
-    github.event.inputs.build_ws == 'true' && 'ws ' || ''
+    github.event.inputs.build_ws == 'true' && 'ws, ' || ''
+  }}${{
+    github.event.inputs.build_inbound_mail == 'true' && 'inbound-mail ' || ''
   }}
 
 env:
@@ -41,6 +43,11 @@ on:
         required: true
         type: boolean
         default: true
+      build_inbound_mail:
+        description: "Build Inbound Mail service"
+        required: true
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -59,7 +66,8 @@ jobs:
           if [ "${{ github.event.inputs.build_api }}" != "true" ] && \
              [ "${{ github.event.inputs.build_worker }}" != "true" ] && \
              [ "${{ github.event.inputs.build_dashboard }}" != "true" ] && \
-             [ "${{ github.event.inputs.build_ws }}" != "true" ]; then
+             [ "${{ github.event.inputs.build_ws }}" != "true" ] && \
+             [ "${{ github.event.inputs.build_inbound_mail }}" != "true" ]; then
             echo "Error: At least one service must be selected for building."
             exit 1
           fi
@@ -81,6 +89,9 @@ jobs:
           fi
           if [ "${{ github.event.inputs.build_ws }}" == "true" ]; then
             services+=("\"ws-ee\"")
+          fi
+          if [ "${{ github.event.inputs.build_inbound_mail }}" == "true" ]; then
+            services+=("\"inbound-mail-ee\"")
           fi
 
           matrix="[$(IFS=','; echo "${services[*]}")]"

--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -55,14 +55,20 @@ export async function bootstrap(
   };
 
   let rawBodyBuffer: undefined | ((...args) => void);
-  let nestOptions: Record<string, boolean> = {};
+  /*
+   * Always disable NestJS's internal body-parser. The manual app.use(bodyParser.*)
+   * registrations below cover every route, so the internal parser is redundant.
+   *
+   * Keeping it on caused a latent double-parse: with @opentelemetry/instrumentation-express
+   * active, each body-parser layer is wrapped in AsyncLocalStorageContextManager.run().
+   * The internal parser would consume the request stream first; the manual parser then
+   * failed inside raw-body with `InternalServerError: stream is not readable`.
+   */
+  const nestOptions: Record<string, boolean> = { bodyParser: false };
 
   if (process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true') {
     rawBodyBuffer = agentRawBodyBuffer;
-    nestOptions = {
-      bodyParser: false,
-      rawBody: true,
-    };
+    nestOptions.rawBody = true;
   }
 
   const app = await NestFactory.create(AppModule, { bufferLogs: true, ...nestOptions });

--- a/apps/inbound-mail/.example.env
+++ b/apps/inbound-mail/.example.env
@@ -1,6 +1,7 @@
 PORT="2525"
 HOST="127.0.0.1"
 
+IS_SELF_HOSTED=false
 
 REDIS_DB_INDEX="2"
 REDIS_HOST="localhost"

--- a/apps/inbound-mail/Dockerfile
+++ b/apps/inbound-mail/Dockerfile
@@ -78,4 +78,7 @@ RUN --mount=type=cache,id=pnpm-store-inbound-mail,target=/root/.pnpm-store\
  --reporter=silent
 
 WORKDIR /usr/src/app/apps/inbound-mail
+
+ENV NEW_RELIC_NO_CONFIG_FILE=true
+
 ENTRYPOINT [ "sh", "-c", "node dist/dotenvcreate.mjs -s=$SECRET_NAME -r=$NOVU_REGION -e=$NOVU_ENTERPRISE -v=$NODE_ENV && pm2-runtime start dist/src/main.js" ]

--- a/apps/inbound-mail/Dockerfile
+++ b/apps/inbound-mail/Dockerfile
@@ -81,4 +81,4 @@ WORKDIR /usr/src/app/apps/inbound-mail
 
 ENV NEW_RELIC_NO_CONFIG_FILE=true
 
-ENTRYPOINT [ "sh", "-c", "node dist/dotenvcreate.mjs -s=$SECRET_NAME -r=$NOVU_REGION -e=$NOVU_ENTERPRISE -v=$NODE_ENV && pm2-runtime start dist/src/main.js" ]
+ENTRYPOINT [ "sh", "-c", "node dist/dotenvcreate.mjs -s=$SECRET_NAME -r=$NOVU_REGION -e=$NOVU_ENTERPRISE -v=$NODE_ENV -h=$IS_SELF_HOSTED && pm2-runtime start dist/src/main.js" ]

--- a/apps/inbound-mail/e2e/setup.ts
+++ b/apps/inbound-mail/e2e/setup.ts
@@ -1,14 +1,10 @@
-import { testServer } from '@novu/testing';
 import sinon from 'sinon';
 
-import mailin from '../src/main';
-
-before(async () => {
-  await testServer.create(mailin);
-});
+import '../src/main';
+import mailinServer from '../src/server/index';
 
 after(async () => {
-  await testServer.teardown();
+  await new Promise<void>((resolve) => mailinServer.stop(resolve));
 });
 
 afterEach(() => {

--- a/apps/inbound-mail/nodemon.json
+++ b/apps/inbound-mail/nodemon.json
@@ -1,8 +1,0 @@
-{
-  "watch": ["src", "../core/dist"],
-  "ext": "ts",
-  "delay": 2,
-  "ignoreRoot": [".git"],
-  "ignore": ["src/**/*.spec.ts"],
-  "exec": "ts-node -r tsconfig-paths/register src/main.ts"
-}

--- a/apps/inbound-mail/package.json
+++ b/apps/inbound-mail/package.json
@@ -9,13 +9,13 @@
     "prebuild": "rimraf dist",
     "build": "tsc -p tsconfig.json",
     "docker:build": "pnpm --silent --workspace-root pnpm-context -- apps/inbound-mail/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/inbound-mail --load -t novu-inbound-mail - $DOCKER_BUILD_ARGUMENTS",
-    "start": "nodemon",
-    "start:dev": "nodemon",
-    "start:test": "cross-env NODE_ENV=test nodemon",
+    "start": "tsx watch src/main.ts",
+    "start:dev": "tsx watch src/main.ts",
+    "start:test": "cross-env NODE_ENV=test tsx watch src/main.ts",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "biome check --write .",
-    "test": "cross-env TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\": false}' NODE_ENV=test NODE_OPTIONS=--no-experimental-strip-types mocha --trace-warnings --timeout 10000 --require ts-node/register --exit --file e2e/setup.ts src/**/**/*.spec.ts"
+    "test": "cross-env NODE_ENV=test mocha --require tsx/cjs --trace-warnings --timeout 10000 --exit --file e2e/setup.ts src/**/**/*.spec.ts"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.971.0",
@@ -36,12 +36,12 @@
     "lodash": "^4.17.23",
     "mailparser": "^0.6.0",
     "newrelic": "^13.12.0",
+    "pino": "^8.17.2",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.5",
     "smtp-server": "^1.4.0",
     "spamc": "0.0.5",
     "uuid": "^9.0.0",
-    "winston": "^3.9.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
@@ -55,12 +55,8 @@
     "@types/smtp-server": "^3.5.7",
     "cross-env": "^7.0.3",
     "mocha": "^10.2.0",
-    "nodemon": "^3.0.1",
     "sinon": "^9.2.4",
-    "ts-jest": "^27.0.7",
-    "ts-loader": "~9.4.0",
-    "ts-node": "~10.9.1",
-    "tsconfig-paths": "~4.1.0",
+    "tsx": "^4.21.0",
     "typescript": "5.6.2"
   },
   "nx": {

--- a/apps/inbound-mail/src/config/env.validators.ts
+++ b/apps/inbound-mail/src/config/env.validators.ts
@@ -1,11 +1,12 @@
 import { StringifyEnv } from '@novu/shared';
-import { CleanedEnv, cleanEnv, json, num, port, str, ValidatorSpec } from 'envalid';
+import { bool, CleanedEnv, cleanEnv, json, num, port, str, ValidatorSpec } from 'envalid';
 
 export function validateEnv() {
   return cleanEnv(process.env, envValidators);
 }
 
 export type ValidatedEnv = StringifyEnv<CleanedEnv<typeof envValidators>>;
+const processEnv = process.env as Record<string, string>;
 
 export const envValidators = {
   TZ: str({ default: 'UTC' }),
@@ -16,4 +17,13 @@ export const envValidators = {
   WORKER_DEFAULT_CONCURRENCY: num({ default: undefined }),
   WORKER_DEFAULT_LOCK_DURATION: num({ default: undefined }),
   INBOUND_PARSE_MAIL_WORKER_CONCURRENCY: num({ default: undefined }),
+  ENABLE_OTEL: bool({ default: false }),
+  ENABLE_OTEL_LOGS: bool({ default: false }),
+  OTEL_PROMETHEUS_PORT: num({ default: 9464 }),
+  // New Relic credentials are only required for Novu Cloud / Enterprise builds.
+  ...(processEnv.IS_SELF_HOSTED !== 'true' &&
+    processEnv.NOVU_ENTERPRISE === 'true' && {
+      NEW_RELIC_APP_NAME: str({ default: '' }),
+      NEW_RELIC_LICENSE_KEY: str({ default: '' }),
+    }),
 } satisfies Record<string, ValidatorSpec<unknown>>;

--- a/apps/inbound-mail/src/instrument.ts
+++ b/apps/inbound-mail/src/instrument.ts
@@ -1,5 +1,21 @@
-import { init } from '@sentry/nestjs';
-import { version } from '../package.json';
+import './config/env.config';
+
+// Import from the tracing subpath, NOT the main barrel. The barrel loads
+// @novu/application-generic which transitively pulls in pino/mongoose/ioredis.
+// TypeScript hoists all imports — if pino loads before startOtel() registers
+// instrumentations, PinoInstrumentation cannot patch the already-bound references.
+// Importing only otel-init keeps those modules out of require.cache until after
+// the SDK's require()-hooks are in place.
+import { startOtel } from '@novu/application-generic/build/main/tracing/otel-init';
+import { name, version } from '../package.json';
+
+startOtel(name, version);
+
+// biome-ignore lint: must execute after startOtel() so New Relic layers on top
+require('newrelic');
+
+// biome-ignore lint: lazy require so @sentry/nestjs loads after OTEL instrumentations are installed
+const { init } = require('@sentry/nestjs');
 
 if (process.env.SENTRY_DSN) {
   init({

--- a/apps/inbound-mail/src/main.ts
+++ b/apps/inbound-mail/src/main.ts
@@ -23,12 +23,14 @@ export default mailin.start(
     smtpOptions: env.smtpOptions,
   },
   (err) => {
-    logger.error(err);
+    if (err) {
+      logger.error({ err, context: LOG_CONTEXT }, 'Failed to start mailin');
+      process.exit(1);
+    }
 
-    if (err) process.exit(1);
-
-    if (mailin.configuration.disableDkim) logger.info('Dkim checking is disabled');
-    if (mailin.configuration.disableSpf) logger.info('Spf checking is disabled');
-    if (mailin.configuration.disableSpamScore) logger.info('Spam score computation is disabled');
+    if (mailin.configuration.disableDkim) logger.info({ context: LOG_CONTEXT }, 'Dkim checking is disabled');
+    if (mailin.configuration.disableSpf) logger.info({ context: LOG_CONTEXT }, 'Spf checking is disabled');
+    if (mailin.configuration.disableSpamScore)
+      logger.info({ context: LOG_CONTEXT }, 'Spam score computation is disabled');
   }
 );

--- a/apps/inbound-mail/src/newrelic.ts
+++ b/apps/inbound-mail/src/newrelic.ts
@@ -1,0 +1,74 @@
+/**
+ * New Relic agent configuration.
+ *
+ * See lib/config/default.js in the agent distribution for a more complete
+ * description of configuration variables and their potential values.
+ */
+
+exports.config = {
+  /**
+   * Array of application names.
+   */
+  app_name: [process.env.NEW_RELIC_APP_NAME],
+  /**
+   * Your New Relic license key.
+   */
+  license_key: process.env.NEW_RELIC_LICENSE_KEY,
+  /**
+   * This setting controls distributed tracing.
+   * Distributed tracing lets you see the path that a request takes through your
+   * distributed system. Enabling distributed tracing changes the behavior of some
+   * New Relic features, so carefully consult the transition guide before you enable
+   * this feature: https://docs.newrelic.com/docs/transition-guide-distributed-tracing
+   * Default is true.
+   */
+  distributed_tracing: {
+    /**
+     * Enables/disables distributed tracing.
+     *
+     * @env NEW_RELIC_DISTRIBUTED_TRACING_ENABLED
+     */
+    enabled: true,
+  },
+  application_logging: {
+    forwarding: {
+      enabled: true,
+    },
+  },
+  logging: {
+    /**
+     * Level at which to log. 'trace' is most useful to New Relic when diagnosing
+     * issues with the agent, 'info' and higher will impose the least overhead on
+     * production applications.
+     */
+    level: 'info',
+  },
+  /**
+   * When true, all request headers except for those listed in attributes.exclude
+   * will be captured for all traces, unless otherwise specified in a destination's
+   * attributes include/exclude lists.
+   */
+  allow_all_headers: true,
+  attributes: {
+    /**
+     * Prefix of attributes to exclude from all destinations. Allows * as wildcard
+     * at end.
+     *
+     * NOTE: If excluding headers, they must be in camelCase form to be filtered.
+     *
+     * @env NEW_RELIC_ATTRIBUTES_EXCLUDE
+     */
+    exclude: [
+      'request.headers.cookie',
+      'request.headers.authorization',
+      'request.headers.proxyAuthorization',
+      'request.headers.setCookie*',
+      'request.headers.x*',
+      'response.headers.cookie',
+      'response.headers.authorization',
+      'response.headers.proxyAuthorization',
+      'response.headers.setCookie*',
+      'response.headers.x*',
+    ],
+  },
+};

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -81,16 +81,16 @@ class Mailin extends events.EventEmitter {
 
     /* Basic memory profiling. */
     if (configuration.profile) {
-      logger.info('Enable memory profiling', LOG_CONTEXT);
+      logger.info({ context: LOG_CONTEXT }, 'Enable memory profiling');
       setInterval(() => {
         const memoryUsage = process.memoryUsage();
         const ram = memoryUsage.rss + memoryUsage.heapUsed;
         const million = 1000000;
         logger.info(
+          { context: LOG_CONTEXT },
           `Ram Usage: ${ram / million}mb | rss: ${memoryUsage.rss / million}mb | heapTotal: ${
             memoryUsage.heapTotal / million
-          }mb | heapUsed: ${memoryUsage.heapUsed / million}`,
-          LOG_CONTEXT
+          }mb | heapUsed: ${memoryUsage.heapUsed / million}`
         );
       }, 500);
     }
@@ -154,7 +154,7 @@ class Mailin extends events.EventEmitter {
                 validateViaLocal();
               });
             } catch (e) {
-              logger.error(e, 'Exception occurred while validating DNS', LOG_CONTEXT);
+              logger.error({ err: e, context: LOG_CONTEXT }, 'Exception occurred while validating DNS');
               return reject(new Error(e));
             }
           };
@@ -165,14 +165,17 @@ class Mailin extends events.EventEmitter {
             validateViaDNS();
           }
         } catch (e) {
-          logger.error(e, 'Exception occurred while validating address', LOG_CONTEXT);
+          logger.error({ err: e, context: LOG_CONTEXT }, 'Exception occurred while validating address');
           reject(e);
         }
       });
     }
 
     function dataReady(connection) {
-      logger.info(`${connection.id} Processing message from ${connection.envelope.mailFrom.address}`, LOG_CONTEXT);
+      logger.info(
+        { context: LOG_CONTEXT, connectionId: connection.id },
+        `${connection.id} Processing message from ${connection.envelope.mailFrom.address}`
+      );
 
       return retrieveRawEmail(connection)
         .then((rawEmail) =>
@@ -203,8 +206,10 @@ class Mailin extends events.EventEmitter {
         .then(postQueue.bind(null, connection))
         .then(unlinkFile.bind(null, connection))
         .catch((error) => {
-          logger.error(`${connection.id} Unable to finish processing message!!`, LOG_CONTEXT);
-          logger.error(error);
+          logger.error(
+            { err: error, context: LOG_CONTEXT, connectionId: connection.id },
+            `${connection.id} Unable to finish processing message!!`
+          );
           throw error;
         });
     }
@@ -218,11 +223,13 @@ class Mailin extends events.EventEmitter {
         return Promise.resolve(false);
       }
 
-      logger.verbose(`${connection.id} Validating dkim.`, LOG_CONTEXT);
+      logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Validating dkim.`);
 
       return mailUtilities.validateDkimAsync(rawEmail).catch((err) => {
-        logger.error(`${connection.id} Unable to validate dkim. Consider dkim as failed.`, LOG_CONTEXT);
-        logger.error(err);
+        logger.error(
+          { err, context: LOG_CONTEXT, connectionId: connection.id },
+          `${connection.id} Unable to validate dkim. Consider dkim as failed.`
+        );
 
         return false;
       });
@@ -233,14 +240,16 @@ class Mailin extends events.EventEmitter {
         return Promise.resolve(false);
       }
 
-      logger.verbose(`${connection.id} Validating spf.`, LOG_CONTEXT);
+      logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Validating spf.`);
 
       /* Get ip and host. */
       return mailUtilities
         .validateSpfAsync(connection.remoteAddress, connection.from, connection.clientHostname)
         .catch((err) => {
-          logger.error(`${connection.id} Unable to validate spf. Consider spf as failed.`, LOG_CONTEXT);
-          logger.error(err);
+          logger.error(
+            { err, context: LOG_CONTEXT, connectionId: connection.id },
+            `${connection.id} Unable to validate spf. Consider spf as failed.`
+          );
 
           return false;
         });
@@ -252,8 +261,10 @@ class Mailin extends events.EventEmitter {
       }
 
       return mailUtilities.computeSpamScoreAsync(rawEmail).catch((err) => {
-        logger.error(`${connection.id} Unable to compute spam score. Set spam score to 0.`, LOG_CONTEXT);
-        logger.error(err);
+        logger.error(
+          { err, context: LOG_CONTEXT, connectionId: connection.id },
+          `${connection.id} Unable to compute spam score. Set spam score to 0.`
+        );
 
         return 0.0;
       });
@@ -261,7 +272,7 @@ class Mailin extends events.EventEmitter {
 
     function parseEmail(connection) {
       return new Promise((resolve) => {
-        logger.verbose(`${connection.id} Parsing email.`, LOG_CONTEXT);
+        logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Parsing email.`);
 
         /* Prepare the mail parser. */
         const mailParser = new MailParser();
@@ -295,7 +306,7 @@ class Mailin extends events.EventEmitter {
     }
 
     function detectLanguage(connection, text) {
-      logger.verbose(`${connection.id} Detecting language.`, LOG_CONTEXT);
+      logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Detecting language.`);
 
       let language = '';
 
@@ -303,10 +314,10 @@ class Mailin extends events.EventEmitter {
       const potentialLanguages = languageDetector.detect(text, 2);
       if (potentialLanguages.length !== 0) {
         logger.verbose(
+          { context: LOG_CONTEXT, connectionId: connection.id },
           `Potential languages: ${util.inspect(potentialLanguages, {
             depth: 5,
-          })}`,
-          LOG_CONTEXT
+          })}`
         );
 
         /*
@@ -315,7 +326,10 @@ class Mailin extends events.EventEmitter {
          */
         language = potentialLanguages[0][0];
       } else {
-        logger.info(`${connection.id} Unable to detect language for the current message.`, LOG_CONTEXT);
+        logger.info(
+          { context: LOG_CONTEXT, connectionId: connection.id },
+          `${connection.id} Unable to detect language for the current message.`
+        );
       }
 
       return language;
@@ -368,9 +382,12 @@ class Mailin extends events.EventEmitter {
 
     function postQueue(connection, finalizedMessage) {
       return new Promise((resolve) => {
-        logger.debug(`${connection.id} finalized message is: ${finalizedMessage}`, LOG_CONTEXT);
+        logger.debug(
+          { context: LOG_CONTEXT, connectionId: connection.id },
+          `${connection.id} finalized message is: ${finalizedMessage}`
+        );
 
-        logger.info(`${connection.id} Adding mail to queue `, LOG_CONTEXT);
+        logger.info({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Adding mail to queue `);
 
         const toAddress = getAddressTo(finalizedMessage);
         const parts: string[] = toAddress.split('@');
@@ -397,7 +414,10 @@ class Mailin extends events.EventEmitter {
     function unlinkFile(connection) {
       /* Don't forget to unlink the tmp file. */
       return fs.promises.unlink(connection.mailPath).then(() => {
-        logger.info(`${connection.id} End processing message, deleted ${connection.mailPath}`, LOG_CONTEXT);
+        logger.info(
+          { context: LOG_CONTEXT, connectionId: connection.id },
+          `${connection.id} End processing message, deleted ${connection.mailPath}`
+        );
       });
     }
 
@@ -412,8 +432,11 @@ class Mailin extends events.EventEmitter {
         connection.mailPath = mailPath;
 
         _this.emit('startData', connection);
-        logger.verbose(`Connection id ${connection.id}`, LOG_CONTEXT);
-        logger.info(`${connection.id} Receiving message from ${connection.envelope.mailFrom.address}`, LOG_CONTEXT);
+        logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `Connection id ${connection.id}`);
+        logger.info(
+          { context: LOG_CONTEXT, connectionId: connection.id },
+          `${connection.id} Receiving message from ${connection.envelope.mailFrom.address}`
+        );
 
         _this.emit('startMessage', connection);
 
@@ -436,7 +459,7 @@ class Mailin extends events.EventEmitter {
           _this.emit('error', connection, error);
         });
       } catch (error) {
-        logger.error(error, 'Exception occurred while performing onData callback', LOG_CONTEXT);
+        logger.error({ err: error, context: LOG_CONTEXT }, 'Exception occurred while performing onData callback');
       }
     }
 
@@ -476,22 +499,21 @@ class Mailin extends events.EventEmitter {
     this._smtp = server;
 
     server.listen(configuration.port, configuration.host, () => {
-      logger.info(`Mailin Smtp server listening on port ${configuration.port}`, LOG_CONTEXT);
+      logger.info({ context: LOG_CONTEXT }, `Mailin Smtp server listening on port ${configuration.port}`);
     });
 
     server.on('close', () => {
-      logger.info('Closing smtp server', LOG_CONTEXT);
+      logger.info({ context: LOG_CONTEXT }, 'Closing smtp server');
       _this.emit('close', _session);
     });
 
     server.on('error', (error) => {
       callback(error);
       if (configuration.port < 1000) {
-        logger.error('Ports under 1000 require root privileges.', LOG_CONTEXT);
+        logger.error({ context: LOG_CONTEXT }, 'Ports under 1000 require root privileges.');
       }
 
-      logger.error('Server errored', LOG_CONTEXT);
-      logger.error(error);
+      logger.error({ err: error, context: LOG_CONTEXT }, 'Server errored');
       _this.emit('error', _session, error);
     });
 
@@ -500,7 +522,13 @@ class Mailin extends events.EventEmitter {
 
   public stop(callback: () => void) {
     callback = callback || (() => {});
-    logger.info('Stopping mailin.', LOG_CONTEXT);
+    logger.info({ context: LOG_CONTEXT }, 'Stopping mailin.');
+
+    if (!this._smtp) {
+      callback();
+
+      return;
+    }
 
     /*
      * FIXME A bug in the RAI module prevents the callback to be called, so

--- a/apps/inbound-mail/src/server/logger.ts
+++ b/apps/inbound-mail/src/server/logger.ts
@@ -1,9 +1,9 @@
-import { createLogger, format, transports } from 'winston';
+import pino from 'pino';
 
-const logger = createLogger({
-  exitOnError: false,
-  level: 'debug',
-  transports: [new transports.Console({ format: format.combine(format.prettyPrint()), handleExceptions: true })],
+const logger = pino<'verbose'>({
+  level: process.env.LOG_LEVEL ?? 'info',
+  customLevels: { verbose: 25 },
+  base: { service: '@novu/inbound-mail' },
 });
 
 export default logger;

--- a/apps/inbound-mail/src/server/mailUtilities.ts
+++ b/apps/inbound-mail/src/server/mailUtilities.ts
@@ -4,18 +4,23 @@ import shell from 'shelljs';
 import Spamc from 'spamc';
 import logger from './logger';
 
+const LOG_CONTEXT = 'MailUtilities';
+
 const spamc = new Spamc();
 
 /* Verify Python availability. */
 const isPythonAvailable = shell.which('python');
 if (!isPythonAvailable) {
-  logger.warn('Python is not available. Dkim and spf checking is disabled.');
+  logger.warn({ context: LOG_CONTEXT }, 'Python is not available. Dkim and spf checking is disabled.');
 }
 
 /* Verify spamc/spamassassin availability. */
 let isSpamcAvailable = true;
 if (!shell.which('spamassassin') || !shell.which('spamc')) {
-  logger.warn('Either spamassassin or spamc are not available. Spam score computation is disabled.');
+  logger.warn(
+    { context: LOG_CONTEXT },
+    'Either spamassassin or spamc are not available. Spam score computation is disabled.'
+  );
   isSpamcAvailable = false;
 }
 
@@ -34,11 +39,11 @@ module.exports = {
     const verifyDkim = child_process.spawn('python', [verifyDkimPath]);
 
     verifyDkim.stdout.on('data', (data) => {
-      logger.verbose(data.toString());
+      logger.verbose({ context: LOG_CONTEXT }, data.toString());
     });
 
     verifyDkim.on('close', (code) => {
-      logger.verbose(`closed with return code ${code}`);
+      logger.verbose({ context: LOG_CONTEXT }, `closed with return code ${code}`);
 
       /* Convert return code to appropriate boolean. */
       return callback(null, !code);
@@ -58,13 +63,13 @@ module.exports = {
     const args = [verifySpfPath, ip, address, host];
 
     child_process.execFile(cmd, args, (err, stdout) => {
-      logger.verbose(stdout);
+      logger.verbose({ context: LOG_CONTEXT }, stdout);
       let code = 0;
       if (err) {
         code = err.code;
       }
 
-      logger.verbose(`closed with return code ${code}`);
+      logger.verbose({ context: LOG_CONTEXT }, `closed with return code ${code}`);
 
       /* Convert return code to appropriate boolean. */
       return callback(null, !code);
@@ -78,9 +83,12 @@ module.exports = {
     }
 
     spamc.report(rawEmail, (err, result) => {
-      logger.verbose(result);
-      if (err) logger.error(err);
-      if (err) return callback(new Error('Unable to compute spam score.'));
+      logger.verbose({ context: LOG_CONTEXT, result }, 'spamc report');
+      if (err) {
+        logger.error({ err, context: LOG_CONTEXT }, 'spamc reported an error');
+
+        return callback(new Error('Unable to compute spam score.'));
+      }
       callback(null, result.spamScore);
     });
   },

--- a/libs/application-generic/src/tracing/otel-init.ts
+++ b/libs/application-generic/src/tracing/otel-init.ts
@@ -226,6 +226,30 @@ export function startOtel(serviceName: string, version: string): NodeSDK | undef
         },
 
         /*
+         * Express:
+         * Skip wrapping middleware-type layers (body-parser, helmet, passport,
+         * cors, compression, etc.). The default behaviour wraps each middleware
+         * call in AsyncLocalStorageContextManager.run(), which on body-parsing
+         * middlewares (raw-body / body-parser) can leave the request stream in
+         * a half-consumed state and surface as `InternalServerError: stream is
+         * not readable` on routes with parsed bodies. Route-handler and router
+         * spans still produce useful tracing data; middleware-level spans are
+         * mostly noise in APM views.
+         *
+         * Upstream tracking:
+         *  - https://github.com/open-telemetry/opentelemetry-js-contrib (instrumentation-express)
+         *  - https://github.com/getsentry/sentry-javascript/issues/17131
+         *
+         * The string literal matches ExpressLayerType.MIDDLEWARE at runtime; we cast
+         * rather than importing the enum to avoid declaring `@opentelemetry/instrumentation-express`
+         * as a direct dependency (it's already transitively pulled in by auto-instrumentations-node).
+         */
+        '@opentelemetry/instrumentation-express': {
+          // biome-ignore lint/suspicious/noExplicitAny: see comment above
+          ignoreLayersType: ['middleware' as any],
+        },
+
+        /*
          * Pino (via nestjs-pino):
          * The instrumentation is already included in getNodeAutoInstrumentations —
          * do NOT add a separate new PinoInstrumentation() or the pino module gets

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,7 +714,7 @@ importers:
         version: 3.0.51(react@19.2.3)(zod@4.3.5)
       '@better-auth/sso':
         specifier: ^1.3.0
-        version: 1.4.7(better-auth@1.5.6(d4572e35df2e437d3e0ddbd1fb0a799d))
+        version: 1.4.7(better-auth@1.5.6(58da4474fdc0134baa964fd9efb50afd))
       '@calcom/embed-react':
         specifier: 1.5.2
         version: 1.5.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -921,7 +921,7 @@ importers:
         version: 6.2.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       better-auth:
         specifier: ^1.4.9
-        version: 1.5.6(d4572e35df2e437d3e0ddbd1fb0a799d)
+        version: 1.5.6(58da4474fdc0134baa964fd9efb50afd)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -1144,7 +1144,7 @@ importers:
         version: 8.3.4
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))
+        version: 4.7.0(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))
       cross-fetch:
         specifier: ^4.0.0
         version: 4.0.0(encoding@0.1.13)
@@ -1177,13 +1177,13 @@ importers:
         version: 5.6.2
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+        version: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-ejs:
         specifier: ^1.7.0
-        version: 1.7.0(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))
+        version: 1.7.0(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))
       vite-plugin-static-copy:
         specifier: ^2.3.2
-        version: 2.3.2(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))
+        version: 2.3.2(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/inbound-mail:
     dependencies:
@@ -1241,6 +1241,9 @@ importers:
       newrelic:
         specifier: ^13.12.0
         version: 13.12.0
+      pino:
+        specifier: ^8.17.2
+        version: 8.17.2
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1256,9 +1259,6 @@ importers:
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
-      winston:
-        specifier: ^3.9.0
-        version: 3.10.0
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -1293,24 +1293,12 @@ importers:
       mocha:
         specifier: ^10.2.0
         version: 10.2.0
-      nodemon:
-        specifier: ^3.0.1
-        version: 3.0.1
       sinon:
         specifier: ^9.2.4
         version: 9.2.4
-      ts-jest:
-        specifier: ^27.0.7
-        version: 27.1.5(@babel/core@7.28.0)(@types/jest@30.0.0)(babel-jest@27.5.1(@babel/core@7.28.0))(esbuild@0.27.3)(jest@30.0.5(@types/node@22.15.13)(babel-plugin-macros@3.1.0)(esbuild-register@3.5.0(esbuild@0.27.3))(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@types/node@22.15.13)(typescript@5.6.2)))(typescript@5.6.2)
-      ts-loader:
-        specifier: ~9.4.0
-        version: 9.4.4(typescript@5.6.2)(webpack@5.105.4(@swc/core@1.7.26(@swc/helpers@0.5.15))(esbuild@0.27.3))
-      ts-node:
-        specifier: ~10.9.1
-        version: 10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@types/node@22.15.13)(typescript@5.6.2)
-      tsconfig-paths:
-        specifier: ~4.1.0
-        version: 4.1.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -2072,7 +2060,7 @@ importers:
     dependencies:
       '@better-auth/sso':
         specifier: ^1.4.9
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(d4572e35df2e437d3e0ddbd1fb0a799d))(better-call@1.3.2(zod@4.3.6))
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(58da4474fdc0134baa964fd9efb50afd))(better-call@1.3.2(zod@4.3.6))
       '@clerk/backend':
         specifier: ^1.25.2
         version: 1.25.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2111,7 +2099,7 @@ importers:
         version: link:../../../packages/stateless
       better-auth:
         specifier: ^1.4.9
-        version: 1.5.6(d4572e35df2e437d3e0ddbd1fb0a799d)
+        version: 1.5.6(58da4474fdc0134baa964fd9efb50afd)
       better-call:
         specifier: ^1.3.2
         version: 1.3.2(zod@4.3.6)
@@ -2734,7 +2722,7 @@ importers:
         version: 5.6.2
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       '@novu/ee-shared-services':
         specifier: workspace:*
@@ -3039,16 +3027,16 @@ importers:
         version: 2.0.1(postcss@8.5.10)
       tsup:
         specifier: ^8.1.0
-        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3)
+        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3)
       typescript:
         specifier: 5.6.2
         version: 5.6.2
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+        version: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^2.1.3
-        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
 
   libs/maily-render:
     dependencies:
@@ -3091,16 +3079,16 @@ importers:
         version: 20.8.9
       tsup:
         specifier: ^8.1.0
-        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3)
+        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3)
       typescript:
         specifier: 5.6.2
         version: 5.6.2
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+        version: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^2.1.3
-        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
 
   libs/maily-tailwind-config:
     devDependencies:
@@ -3297,7 +3285,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/agent-toolkit:
     dependencies:
@@ -3325,7 +3313,7 @@ importers:
         version: 4.78.1(encoding@0.1.13)(zod@4.3.5)
       tsup:
         specifier: ^8.0.2
-        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@20.19.10))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3)
+        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@20.19.10))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3)
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -3556,7 +3544,7 @@ importers:
         version: 8.5.10
       postcss-load-config:
         specifier: ^6.0.1
-        version: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(yaml@2.8.3)
+        version: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
       postcss-prefix-selector:
         specifier: ^1.16.1
         version: 1.16.1(postcss@8.5.10)
@@ -3586,10 +3574,10 @@ importers:
         version: 9.4.4(typescript@5.6.2)(webpack@5.105.4)
       tsup:
         specifier: ^8.1.0
-        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3)
+        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3)
       tsup-preset-solid:
         specifier: ^2.2.0
-        version: 2.2.0(esbuild@0.27.3)(solid-js@1.9.6)(tsup@8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3))
+        version: 2.2.0(esbuild@0.27.3)(solid-js@1.9.6)(tsup@8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3))
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -3635,7 +3623,7 @@ importers:
         version: 2.1.4
       tsup:
         specifier: ^8.2.1
-        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3)
+        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3)
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -3768,7 +3756,7 @@ importers:
         version: 5.6.2
       vitest:
         specifier: ^1.2.1
-        version: 1.6.1(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+        version: 1.6.1(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/providers:
     dependencies:
@@ -3949,7 +3937,7 @@ importers:
         version: 5.6.2
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/react:
     dependencies:
@@ -3980,7 +3968,7 @@ importers:
         version: 2.1.4
       tsup:
         specifier: ^8.2.1
-        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3)
+        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3)
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -4008,7 +3996,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       tsup:
         specifier: ^8.2.1
-        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3)
+        version: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3)
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -4026,7 +4014,7 @@ importers:
         version: 5.6.2
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/stateless:
     dependencies:
@@ -4151,7 +4139,7 @@ importers:
         version: 1.5.1(@swc/core@1.7.26(@swc/helpers@0.5.15))(rollup@4.59.0)(webpack-sources@3.3.4)
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+        version: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
 
   playground/nextjs:
     dependencies:
@@ -6658,9 +6646,6 @@ packages:
 
   '@cypress/xvfb@1.2.4':
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
-
-  '@dabh/diagnostics@2.0.3':
-    resolution: {integrity: sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==}
 
   '@datadog/pprof@5.14.1':
     resolution: {integrity: sha512-MlODCE9Gltmx7WChOg1BkIm7W2iE4CDW7K72BMwgzCvxFkG9rFWVsuA7/NEZL1nDvJ0qDe2du7DZZdZHTjcVPw==}
@@ -16419,15 +16404,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
   color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
-
-  color@3.2.1:
-    resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
 
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
@@ -16441,9 +16420,6 @@ packages:
   colors@1.4.0:
     resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
     engines: {node: '>=0.1.90'}
-
-  colorspace@1.1.4:
-    resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
 
   columnify@1.6.0:
     resolution: {integrity: sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==}
@@ -17647,9 +17623,6 @@ packages:
   emojilib@2.4.0:
     resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
 
-  enabled@2.0.0:
-    resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
-
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
@@ -18329,9 +18302,6 @@ packages:
 
   flush-write-stream@2.0.0:
     resolution: {integrity: sha512-uXClqPxT4xW0lcdSBheb2ObVU+kuqUk3Jk64EwieirEXZx9XUrVwp/JuBfKAWaM4T5Td/VL7QLDWPXp/MvGm/g==}
-
-  fn.name@1.1.0:
-    resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -19413,9 +19383,6 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
-  is-arrayish@0.3.2:
-    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
-
   is-bigint@1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
 
@@ -20492,9 +20459,6 @@ packages:
     peerDependencies:
       '@types/node': '>=18'
       typescript: '>=5.0.4'
-
-  kuler@2.0.0:
-    resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
   kysely@0.28.14:
     resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
@@ -22377,9 +22341,6 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
-  one-time@1.0.0:
-    resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
 
   onetime@2.0.1:
     resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
@@ -24683,9 +24644,6 @@ packages:
   simple-statistics@7.8.3:
     resolution: {integrity: sha512-JFvMY00t6SBGtwMuJ+nqgsx9ylkMiJ5JlK9bkj8AdvniIe5615wWQYkKHXe84XtSuc40G/tlrPu0A5/NlJvv8A==}
 
-  simple-swizzle@0.2.2:
-    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
-
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
@@ -24960,9 +24918,6 @@ packages:
     resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
-
-  stack-trace@0.0.10:
-    resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -25520,9 +25475,6 @@ packages:
   text-decoder@1.1.1:
     resolution: {integrity: sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==}
 
-  text-hex@1.0.0:
-    resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
-
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -25936,8 +25888,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  tsx@4.19.0:
-    resolution: {integrity: sha512-bV30kM7bsLZKZIOCHeMNVMJ32/LuJzLVajkQI/qf92J2Qr08ueLQvW00PUZGiuLPP760UINwupgUj8qrSCPUKg==}
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -26903,10 +26855,6 @@ packages:
     resolution: {integrity: sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==}
     engines: {node: '>= 6.4.0'}
 
-  winston@3.10.0:
-    resolution: {integrity: sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==}
-    engines: {node: '>= 12.0.0'}
-
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
@@ -27779,8 +27727,8 @@ snapshots:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-bucket-endpoint': 3.575.0
@@ -28076,11 +28024,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.575.0':
+  '@aws-sdk/client-sso-oidc@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -28119,6 +28067,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)':
@@ -28297,11 +28246,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
+  '@aws-sdk/client-sts@3.575.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/core': 3.575.0
       '@aws-sdk/credential-provider-node': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/middleware-host-header': 3.575.0
@@ -28340,7 +28289,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.637.0':
@@ -28545,7 +28493,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/credential-provider-env': 3.575.0
       '@aws-sdk/credential-provider-process': 3.575.0
       '@aws-sdk/credential-provider-sso': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
@@ -28859,7 +28807,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.575.0(@aws-sdk/client-sts@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.575.0(@aws-sdk/client-sso-oidc@3.575.0)
+      '@aws-sdk/client-sts': 3.575.0
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/types': 3.3.0
@@ -29402,7 +29350,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.575.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.575.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -29411,7 +29359,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.575.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.575.0
+      '@aws-sdk/client-sso-oidc': 3.575.0(@aws-sdk/client-sts@3.575.0)
       '@aws-sdk/types': 3.609.0
       '@smithy/property-provider': 3.1.3
       '@smithy/shared-ini-file-loader': 3.1.4
@@ -30854,21 +30802,21 @@ snapshots:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/sso@1.4.7(better-auth@1.5.6(d4572e35df2e437d3e0ddbd1fb0a799d))':
+  '@better-auth/sso@1.4.7(better-auth@1.5.6(58da4474fdc0134baa964fd9efb50afd))':
     dependencies:
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.5.6(d4572e35df2e437d3e0ddbd1fb0a799d)
+      better-auth: 1.5.6(58da4474fdc0134baa964fd9efb50afd)
       fast-xml-parser: 5.7.0
       jose: 6.1.3
       samlify: 2.10.2
       zod: 4.3.5
 
-  '@better-auth/sso@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(d4572e35df2e437d3e0ddbd1fb0a799d))(better-call@1.3.2(zod@4.3.6))':
+  '@better-auth/sso@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(58da4474fdc0134baa964fd9efb50afd))(better-call@1.3.2(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.5.6(d4572e35df2e437d3e0ddbd1fb0a799d)
+      better-auth: 1.5.6(58da4474fdc0134baa964fd9efb50afd)
       better-call: 1.3.2(zod@4.3.6)
       fast-xml-parser: 5.7.0
       jose: 6.1.3
@@ -31665,12 +31613,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
-
-  '@dabh/diagnostics@2.0.3':
-    dependencies:
-      colorspace: 1.1.4
-      enabled: 2.0.0
-      kuler: 2.0.0
 
   '@datadog/pprof@5.14.1':
     dependencies:
@@ -40929,11 +40871,11 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       typescript: 5.6.2
 
-  '@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)))(svelte@5.53.5)(typescript@5.6.2)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))':
+  '@sveltejs/kit@2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.53.5)(typescript@5.6.2)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))
+      '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.7.2
@@ -40945,7 +40887,7 @@ snapshots:
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
       svelte: 5.53.5
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       typescript: 5.6.2
@@ -40960,12 +40902,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)))(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))':
+  '@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))
+      '@sveltejs/vite-plugin-svelte': 2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))
       debug: 4.4.3(supports-color@8.1.1)
       svelte: 5.53.5
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -40984,17 +40926,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))':
+  '@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)))(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))
       debug: 4.4.3(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.53.5
       svelte-hmr: 0.15.3(svelte@5.53.5)
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
-      vitefu: 0.2.5(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 0.2.5(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -42801,7 +42743,7 @@ snapshots:
       minimatch: 7.4.9
       semver: 7.6.0
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
@@ -42809,7 +42751,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -42826,13 +42768,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))':
+  '@vitest/mocker@2.1.9(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -44154,7 +44096,7 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  better-auth@1.5.6(d4572e35df2e437d3e0ddbd1fb0a799d):
+  better-auth@1.5.6(58da4474fdc0134baa964fd9efb50afd):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
@@ -44174,14 +44116,14 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
-      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)))(svelte@5.53.5)(typescript@5.6.2)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))
+      '@sveltejs/kit': 2.57.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@2.5.3(svelte@5.53.5)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.53.5)(typescript@5.6.2)(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))
       mongodb: 6.21.0(@aws-sdk/credential-providers@3.637.0(@aws-sdk/client-sso-oidc@3.637.0(@aws-sdk/client-sts@3.637.0)))(gcp-metadata@5.3.0(encoding@0.1.13))(socks@2.8.7)
       next: 16.2.3(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.8)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       solid-js: 1.9.6
       svelte: 5.53.5
-      vitest: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vitest: 2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -44979,17 +44921,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.2
-
   color-support@1.1.3: {}
-
-  color@3.2.1:
-    dependencies:
-      color-convert: 1.9.3
-      color-string: 1.9.1
 
   colord@2.9.3: {}
 
@@ -44998,11 +44930,6 @@ snapshots:
   colorjs.io@0.5.2: {}
 
   colors@1.4.0: {}
-
-  colorspace@1.1.4:
-    dependencies:
-      color: 3.2.1
-      text-hex: 1.0.0
 
   columnify@1.6.0:
     dependencies:
@@ -46288,8 +46215,6 @@ snapshots:
 
   emojilib@2.4.0: {}
 
-  enabled@2.0.0: {}
-
   encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
@@ -47261,8 +47186,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  fn.name@1.1.0: {}
-
   follow-redirects@1.16.0(debug@4.4.0):
     optionalDependencies:
       debug: 4.4.0
@@ -47629,7 +47552,6 @@ snapshots:
   get-tsconfig@4.8.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-    optional: true
 
   get-uri@6.0.5:
     dependencies:
@@ -48714,8 +48636,6 @@ snapshots:
       get-intrinsic: 1.3.0
 
   is-arrayish@0.2.1: {}
-
-  is-arrayish@0.3.2: {}
 
   is-bigint@1.0.4:
     dependencies:
@@ -50458,8 +50378,6 @@ snapshots:
       typescript: 5.6.2
       zod: 3.25.76
       zod-validation-error: 3.3.0(zod@3.25.76)
-
-  kuler@2.0.0: {}
 
   kysely@0.28.14: {}
 
@@ -52812,10 +52730,6 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  one-time@1.0.0:
-    dependencies:
-      fn.name: 1.1.0
-
   onetime@2.0.1:
     dependencies:
       mimic-fn: 1.2.0
@@ -53657,13 +53571,13 @@ snapshots:
       tsx: 4.16.2
       yaml: 2.8.3
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
       postcss: 8.5.10
-      tsx: 4.19.0
+      tsx: 4.21.0
       yaml: 2.8.3
 
   postcss-logical@7.0.1(postcss@8.5.10):
@@ -55571,10 +55485,6 @@ snapshots:
 
   simple-statistics@7.8.3: {}
 
-  simple-swizzle@0.2.2:
-    dependencies:
-      is-arrayish: 0.3.2
-
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.4
@@ -55885,8 +55795,6 @@ snapshots:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
-
-  stack-trace@0.0.10: {}
 
   stack-utils@2.0.6:
     dependencies:
@@ -56667,8 +56575,6 @@ snapshots:
       b4a: 1.6.6
     optional: true
 
-  text-hex@1.0.0: {}
-
   text-table@0.2.0: {}
 
   thenify-all@1.6.0:
@@ -56920,24 +56826,6 @@ snapshots:
       babel-jest: 27.5.1(@babel/core@7.28.0)
       esbuild: 0.27.3
 
-  ts-jest@27.1.5(@babel/core@7.28.0)(@types/jest@30.0.0)(babel-jest@27.5.1(@babel/core@7.28.0))(esbuild@0.27.3)(jest@30.0.5(@types/node@22.15.13)(babel-plugin-macros@3.1.0)(esbuild-register@3.5.0(esbuild@0.27.3))(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@types/node@22.15.13)(typescript@5.6.2)))(typescript@5.6.2):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 30.0.5(@types/node@22.15.13)(babel-plugin-macros@3.1.0)(esbuild-register@3.5.0(esbuild@0.27.3))(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@types/node@22.15.13)(typescript@5.6.2))
-      jest-util: 27.5.1
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.3
-      typescript: 5.6.2
-      yargs-parser: 20.2.9
-    optionalDependencies:
-      '@babel/core': 7.28.0
-      '@types/jest': 30.0.0
-      babel-jest: 27.5.1(@babel/core@7.28.0)
-      esbuild: 0.27.3
-
   ts-jest@29.4.1(@babel/core@7.28.0)(@jest/transform@30.0.5)(@jest/types@30.0.5)(babel-jest@30.0.5(@babel/core@7.28.0))(esbuild@0.27.3)(jest-util@30.0.5)(jest@29.7.0(@types/node@22.15.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.7.26(@swc/helpers@0.5.15))(@types/node@22.15.13)(typescript@5.6.2)))(typescript@5.6.2):
     dependencies:
       bs-logger: 0.2.6
@@ -57132,16 +57020,16 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup-preset-solid@2.2.0(esbuild@0.27.3)(solid-js@1.9.6)(tsup@8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3)):
+  tsup-preset-solid@2.2.0(esbuild@0.27.3)(solid-js@1.9.6)(tsup@8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3)):
     dependencies:
       esbuild-plugin-solid: 0.5.0(esbuild@0.27.3)(solid-js@1.9.6)
-      tsup: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3)
+      tsup: 8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - solid-js
       - supports-color
 
-  tsup@8.2.1(@microsoft/api-extractor@7.47.7(@types/node@20.19.10))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3):
+  tsup@8.2.1(@microsoft/api-extractor@7.47.7(@types/node@20.19.10))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.25.12)
       cac: 6.7.14
@@ -57154,7 +57042,7 @@ snapshots:
       joycon: 3.1.1
       picocolors: 1.1.1
       picomatch: 4.0.4
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.8.0-beta.0
@@ -57201,7 +57089,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(typescript@5.6.2)(yaml@2.8.3):
+  tsup@8.2.1(@microsoft/api-extractor@7.47.7(@types/node@22.15.13))(@swc/core@1.7.26(@swc/helpers@0.5.15))(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.6.2)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.25.12)
       cac: 6.7.14
@@ -57214,7 +57102,7 @@ snapshots:
       joycon: 3.1.1
       picocolors: 1.1.1
       picomatch: 4.0.4
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.19.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.8.0-beta.0
@@ -57238,13 +57126,12 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  tsx@4.19.0:
+  tsx@4.21.0:
     dependencies:
-      esbuild: 0.25.12
+      esbuild: 0.27.3
       get-tsconfig: 4.8.0
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -57935,13 +57822,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@1.6.1(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3):
+  vite-node@1.6.1(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -57956,13 +57843,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@2.1.9(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3):
+  vite-node@2.1.9(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -57977,19 +57864,19 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-ejs@1.7.0(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)):
+  vite-plugin-ejs@1.7.0(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       ejs: 3.1.10
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
 
-  vite-plugin-static-copy@2.3.2(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)):
+  vite-plugin-static-copy@2.3.2(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       chokidar: 3.6.0
       fast-glob: 3.3.1
       fs-extra: 11.2.0
       p-map: 7.0.4
       picocolors: 1.1.1
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
 
   vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.16.2)(yaml@2.8.3):
     dependencies:
@@ -58011,7 +57898,7 @@ snapshots:
       tsx: 4.16.2
       yaml: 2.8.3
 
-  vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3):
+  vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.4.5(picomatch@4.0.4)
@@ -58028,16 +57915,16 @@ snapshots:
       sass: 1.77.8
       sugarss: 4.0.1(postcss@8.5.10)
       terser: 5.31.6
-      tsx: 4.19.0
+      tsx: 4.21.0
       yaml: 2.8.3
 
   vitefu@0.2.5(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.16.2)(yaml@2.8.3)):
     optionalDependencies:
       vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.16.2)(yaml@2.8.3)
 
-  vitefu@0.2.5(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)):
+  vitefu@0.2.5(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
     optional: true
 
   vitest@1.6.1(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.16.2)(yaml@2.8.3):
@@ -58080,7 +57967,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@1.6.1(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3):
+  vitest@1.6.1(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -58099,8 +57986,8 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
-      vite-node: 1.6.1(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 1.6.1(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 4.0.2
@@ -58120,10 +58007,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3):
+  vitest@2.1.9(@edge-runtime/vm@4.0.2)(@types/node@22.15.13)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@25.0.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3))
+      '@vitest/mocker': 2.1.9(vite@6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -58139,8 +58026,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
-      vite-node: 2.1.9(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.19.0)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 2.1.9(@types/node@22.15.13)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.10))(terser@5.31.6)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 4.0.2
@@ -58498,20 +58385,6 @@ snapshots:
       logform: 2.5.1
       readable-stream: 3.6.2
       triple-beam: 1.3.0
-
-  winston@3.10.0:
-    dependencies:
-      '@colors/colors': 1.5.0
-      '@dabh/diagnostics': 2.0.3
-      async: 3.2.6
-      is-stream: 2.0.1
-      logform: 2.5.1
-      one-time: 1.0.0
-      readable-stream: 3.6.2
-      safe-stable-stringify: 2.4.3
-      stack-trace: 0.0.10
-      triple-beam: 1.3.0
-      winston-transport: 4.5.0
 
   wordwrap@1.0.0: {}
 


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The inbound-mail service has been refactored to function in enterprise and self-hosted environments. Changes include switching from Winston to Pino for structured logging, replacing nodemon/ts-node with tsx in development tooling, fixing NestJS double body-parser configuration, adding observability controls (OpenTelemetry and conditional New Relic integration), and updating the CI workflow to support building the inbound-mail service in enterprise deployments.

## Affected areas

**inbound-mail**: Migrated logging from Winston to Pino, replaced development tooling (nodemon → tsx), added environment-aware New Relic configuration, integrated OpenTelemetry with conditional log forwarding, updated test setup to remove testServer dependency, and added structured logging across mail utilities and server modules.

**api**: Disabled NestJS internal body-parser to prevent double-parsing issues in enterprise mode while preserving conditional `rawBody` behavior.

**shared (application-generic)**: Updated OpenTelemetry instrumentation to ignore Express middleware layers, preventing unnecessary middleware span traces.

**CI/workflows**: Added `build_inbound_mail` input to the enterprise self-hosted release workflow to include inbound-mail service in the build matrix.

## Key technical decisions

- Switched from Winston to Pino logging library for improved structured logging and performance.
- Replaced nodemon/ts-node development tooling with tsx for faster transpilation and development iteration.
- Introduced conditional New Relic agent configuration based on `IS_SELF_HOSTED` and `NOVU_ENTERPRISE` flags to prevent credential requirements in self-hosted environments.
- Added OpenTelemetry integration with configurable log forwarding (`ENABLE_OTEL`, `ENABLE_OTEL_LOGS`).
- Disabled NestJS internal body-parser globally to avoid conflicts with explicit request body handling.

## Testing

E2e test setup was modified to remove testServer dependency and use direct module imports. No new unit tests were added; existing e2e and integration tests verify the changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
