### PR TITLE
fix(api): normalize agent attachments through storage fixes NV-7456

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -73,10 +73,7 @@ reviews:
     - Keep the entire summary under 300 words.
   auto_review:
     enabled: true
-    drafts: false
-    ignore_title_keywords:
-      - "WIP"
-      - "DO NOT MERGE"
+    drafts: true
     auto_pause_after_reviewed_commits: 5
   path_instructions:
     - path: "apps/api/**"

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -11,6 +11,7 @@ import { EventsModule } from '../events/events.module';
 import { SharedModule } from '../shared/shared.module';
 import { AgentsController } from './agents.controller';
 import { AgentsWebhookController } from './agents-webhook.controller';
+import { AgentAttachmentStorage } from './services/agent-attachment-storage.service';
 import { AgentConfigResolver } from './services/agent-config-resolver.service';
 import { AgentConversationService } from './services/agent-conversation.service';
 import { AgentInboundHandler } from './services/agent-inbound-handler.service';
@@ -28,6 +29,7 @@ import { USE_CASES } from './usecases';
     ChannelEndpointRepository,
     ConversationRepository,
     ConversationActivityRepository,
+    AgentAttachmentStorage,
     AgentConfigResolver,
     AgentSubscriberResolver,
     AgentConversationService,

--- a/apps/api/src/app/agents/services/agent-attachment-storage.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-attachment-storage.service.spec.ts
@@ -143,25 +143,61 @@ describe('AgentAttachmentStorage', () => {
     expect(logger.warn.calledWithMatch({ size: 20 * mb, aggregateCap: 50 * mb })).to.equal(true);
   });
 
-  it('should skip unknown-size attachments that would exceed the aggregate byte cap after fetch', async () => {
+  it('should skip fetchData attachments without size metadata before downloading', async () => {
+    const storageService = makeStorageService();
+    const logger = makeLogger();
+    const service = new AgentAttachmentStorage(storageService, logger as any);
+    const fetchData = sinon.stub().resolves(Buffer.from('x'));
+    const attachments = [{ type: 'file', name: 'unknown.bin', fetchData }] as Attachment[];
+
+    const result = await service.storeInbound(attachments, ctx);
+
+    expect(result).to.have.length(0);
+    expect(fetchData.called).to.equal(false);
+    expect(storageService.uploadFile.called).to.equal(false);
+    expect(logger.warn.called).to.equal(true);
+  });
+
+  it('should skip blob attachments when trusted size metadata is missing', async () => {
+    const storageService = makeStorageService();
+    const logger = makeLogger();
+    const service = new AgentAttachmentStorage(storageService, logger as any);
+    const blob = new Blob([Buffer.from('x')]);
+    const attachment = {
+      type: 'file',
+      name: 'blob.bin',
+      data: blob,
+    } as Attachment;
+
+    const result = await service.storeInbound([attachment], ctx);
+
+    expect(result).to.have.length(0);
+    expect(storageService.uploadFile.called).to.equal(false);
+    expect(logger.warn.called).to.equal(true);
+  });
+
+  it('should skip attachments that exceed aggregate cap after fetch when size metadata is inaccurate', async () => {
     const storageService = makeStorageService();
     const logger = makeLogger();
     const service = new AgentAttachmentStorage(storageService, logger as any);
     const attachments = [
       {
         type: 'file',
-        name: 'unknown-0.bin',
+        name: 'file-0.bin',
+        size: 24 * mb,
+        fetchData: async () => Buffer.alloc(24 * mb),
+      },
+      {
+        type: 'file',
+        name: 'file-1.bin',
+        size: 25 * mb,
         fetchData: async () => Buffer.alloc(25 * mb),
       },
       {
         type: 'file',
-        name: 'unknown-1.bin',
-        fetchData: async () => Buffer.alloc(25 * mb),
-      },
-      {
-        type: 'file',
-        name: 'unknown-2.bin',
-        fetchData: async () => Buffer.from('x'),
+        name: 'file-2.bin',
+        size: 1,
+        fetchData: async () => Buffer.alloc(2 * mb),
       },
     ] as Attachment[];
 
@@ -169,7 +205,7 @@ describe('AgentAttachmentStorage', () => {
 
     expect(result).to.have.length(2);
     expect(storageService.uploadFile.callCount).to.equal(2);
-    expect(logger.warn.calledWithMatch({ byteLength: 1, aggregateCap: 50 * mb })).to.equal(true);
+    expect(logger.warn.calledWithMatch({ byteLength: 2 * mb, aggregateCap: 50 * mb })).to.equal(true);
   });
 
   it('should skip attachment over pre-fetch size limit', async () => {
@@ -195,7 +231,7 @@ describe('AgentAttachmentStorage', () => {
     expect(logger.warn.calledOnce).to.equal(true);
   });
 
-  it('should skip attachment over post-fetch size limit when size metadata absent', async () => {
+  it('should skip attachment over post-fetch size limit when size metadata is inaccurate', async () => {
     const storageService = {
       uploadFile: sinon.stub(),
       getReadSignedUrl: sinon.stub(),
@@ -208,6 +244,7 @@ describe('AgentAttachmentStorage', () => {
     const huge = Buffer.alloc(26 * 1024 * 1024);
     const attachment: Attachment = {
       type: 'file',
+      size: 1,
       fetchData: async () => huge,
     };
 

--- a/apps/api/src/app/agents/services/agent-attachment-storage.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-attachment-storage.service.spec.ts
@@ -1,0 +1,124 @@
+import type { StorageService } from '@novu/application-generic';
+import { expect } from 'chai';
+import type { Attachment } from 'chat';
+import sinon from 'sinon';
+import { AgentAttachmentStorage, READ_URL_TTL_SECONDS } from './agent-attachment-storage.service';
+
+describe('AgentAttachmentStorage', () => {
+  const ctx = {
+    organizationId: 'org1',
+    environmentId: 'env1',
+    conversationId: 'conv1',
+    platformMessageId: 'msg1',
+  };
+
+  function makeLogger() {
+    return {
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      debug: sinon.stub(),
+      info: sinon.stub(),
+      setContext: sinon.stub(),
+    };
+  }
+
+  it('should upload and return signed url for fetchData attachment', async () => {
+    const uploadFile = sinon.stub().resolves({});
+    const getReadSignedUrl = sinon.stub().resolves('https://signed/read');
+    const storageService = {
+      uploadFile,
+      getReadSignedUrl,
+      fileExists: sinon.stub(),
+    } as unknown as StorageService;
+
+    const service = new AgentAttachmentStorage(storageService, makeLogger() as any);
+
+    const attachment: Attachment = {
+      type: 'file',
+      name: 'doc.pdf',
+      mimeType: 'application/pdf',
+      size: 10,
+      fetchData: async () => Buffer.from('hello'),
+    };
+
+    const result = await service.storeInbound([attachment], ctx);
+
+    expect(result).to.have.length(1);
+    expect(result[0].url).to.equal('https://signed/read');
+    expect(result[0].storageKey).to.include('org1/env1/agents/conv1/msg1/0-doc.pdf');
+    expect(uploadFile.calledOnce).to.equal(true);
+    expect(getReadSignedUrl.calledOnce).to.equal(true);
+    expect(getReadSignedUrl.firstCall.args[1]).to.equal(READ_URL_TTL_SECONDS);
+  });
+
+  it('should skip attachment over pre-fetch size limit', async () => {
+    const storageService = {
+      uploadFile: sinon.stub(),
+      getReadSignedUrl: sinon.stub(),
+      fileExists: sinon.stub(),
+    } as unknown as StorageService;
+
+    const logger = makeLogger();
+    const service = new AgentAttachmentStorage(storageService, logger as any);
+
+    const attachment: Attachment = {
+      type: 'file',
+      size: 26 * 1024 * 1024,
+      fetchData: async () => Buffer.from('x'),
+    };
+
+    const result = await service.storeInbound([attachment], ctx);
+
+    expect(result).to.have.length(0);
+    expect(storageService.uploadFile.called).to.equal(false);
+    expect(logger.warn.calledOnce).to.equal(true);
+  });
+
+  it('should skip attachment over post-fetch size limit when size metadata absent', async () => {
+    const storageService = {
+      uploadFile: sinon.stub(),
+      getReadSignedUrl: sinon.stub(),
+      fileExists: sinon.stub(),
+    } as unknown as StorageService;
+
+    const logger = makeLogger();
+    const service = new AgentAttachmentStorage(storageService, logger as any);
+
+    const huge = Buffer.alloc(26 * 1024 * 1024);
+    const attachment: Attachment = {
+      type: 'file',
+      fetchData: async () => huge,
+    };
+
+    const result = await service.storeInbound([attachment], ctx);
+
+    expect(result).to.have.length(0);
+    expect(storageService.uploadFile.called).to.equal(false);
+  });
+
+  it('should signRead when object exists', async () => {
+    const storageService = {
+      fileExists: sinon.stub().resolves(true),
+      getReadSignedUrl: sinon.stub().resolves('https://read'),
+    } as unknown as StorageService;
+
+    const service = new AgentAttachmentStorage(storageService, makeLogger() as any);
+    const url = await service.signRead('org/env/agents/conv/msg/0-f.txt');
+
+    expect(url).to.equal('https://read');
+    expect(storageService.fileExists.calledOnce).to.equal(true);
+  });
+
+  it('should return null from signRead when object missing', async () => {
+    const storageService = {
+      fileExists: sinon.stub().resolves(false),
+      getReadSignedUrl: sinon.stub(),
+    } as unknown as StorageService;
+
+    const service = new AgentAttachmentStorage(storageService, makeLogger() as any);
+    const url = await service.signRead('missing-key');
+
+    expect(url).to.equal(null);
+    expect(storageService.getReadSignedUrl.called).to.equal(false);
+  });
+});

--- a/apps/api/src/app/agents/services/agent-attachment-storage.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-attachment-storage.service.spec.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import { AgentAttachmentStorage, READ_URL_TTL_SECONDS } from './agent-attachment-storage.service';
 
 describe('AgentAttachmentStorage', () => {
+  const mb = 1024 * 1024;
   const ctx = {
     organizationId: 'org1',
     environmentId: 'env1',
@@ -20,6 +21,14 @@ describe('AgentAttachmentStorage', () => {
       info: sinon.stub(),
       setContext: sinon.stub(),
     };
+  }
+
+  function makeStorageService() {
+    return {
+      uploadFile: sinon.stub().resolves({}),
+      getReadSignedUrl: sinon.stub().resolves('https://signed/read'),
+      fileExists: sinon.stub(),
+    } as unknown as StorageService;
   }
 
   it('should upload and return signed url for fetchData attachment', async () => {
@@ -49,6 +58,118 @@ describe('AgentAttachmentStorage', () => {
     expect(uploadFile.calledOnce).to.equal(true);
     expect(getReadSignedUrl.calledOnce).to.equal(true);
     expect(getReadSignedUrl.firstCall.args[1]).to.equal(READ_URL_TTL_SECONDS);
+  });
+
+  it('should keep uploaded attachment metadata when signing fails', async () => {
+    const uploadFile = sinon.stub().resolves({});
+    const getReadSignedUrl = sinon.stub().rejects(new Error('signing unavailable'));
+    const storageService = {
+      uploadFile,
+      getReadSignedUrl,
+      fileExists: sinon.stub(),
+    } as unknown as StorageService;
+    const logger = makeLogger();
+
+    const service = new AgentAttachmentStorage(storageService, logger as any);
+
+    const attachment: Attachment = {
+      type: 'file',
+      name: 'doc.pdf',
+      mimeType: 'application/pdf',
+      size: 10,
+      fetchData: async () => Buffer.from('hello'),
+    };
+
+    const result = await service.storeInbound([attachment], ctx);
+
+    expect(result).to.have.length(1);
+    expect(result[0]).to.include({
+      type: 'file',
+      name: 'doc.pdf',
+      mimeType: 'application/pdf',
+      size: 10,
+    });
+    expect(result[0].storageKey).to.include('org1/env1/agents/conv1/msg1/0-doc.pdf');
+    expect(result[0].url).to.equal(undefined);
+    expect(uploadFile.calledOnce).to.equal(true);
+    expect(getReadSignedUrl.calledOnce).to.equal(true);
+    expect(logger.warn.calledOnce).to.equal(true);
+  });
+
+  it('should process at most 15 inbound attachments and preserve original indexes', async () => {
+    const storageService = makeStorageService();
+    const logger = makeLogger();
+    const service = new AgentAttachmentStorage(storageService, logger as any);
+    const fetchDataStubs = Array.from({ length: 16 }, () => sinon.stub().resolves(Buffer.from('x')));
+    const attachments = fetchDataStubs.map((fetchData, index) => ({
+      type: 'file',
+      name: `file-${index}.txt`,
+      mimeType: 'text/plain',
+      size: 1,
+      fetchData,
+    })) as Attachment[];
+
+    const result = await service.storeInbound(attachments, ctx);
+
+    expect(result).to.have.length(15);
+    expect(storageService.uploadFile.callCount).to.equal(15);
+    expect(fetchDataStubs[15].called).to.equal(false);
+    expect(result[14].storageKey).to.include('org1/env1/agents/conv1/msg1/14-file-14.txt');
+    expect(logger.warn.calledWithMatch({ attachmentCount: 16, cap: 15 })).to.equal(true);
+  });
+
+  it('should skip known-size attachments that would exceed the aggregate byte cap before fetch', async () => {
+    const storageService = makeStorageService();
+    const logger = makeLogger();
+    const service = new AgentAttachmentStorage(storageService, logger as any);
+    const fetchDataStubs = [
+      sinon.stub().resolves(Buffer.from('a')),
+      sinon.stub().resolves(Buffer.from('b')),
+      sinon.stub().resolves(Buffer.from('c')),
+    ];
+    const attachments = fetchDataStubs.map((fetchData, index) => ({
+      type: 'file',
+      name: `known-${index}.txt`,
+      mimeType: 'text/plain',
+      size: 20 * mb,
+      fetchData,
+    })) as Attachment[];
+
+    const result = await service.storeInbound(attachments, ctx);
+
+    expect(result).to.have.length(2);
+    expect(storageService.uploadFile.callCount).to.equal(2);
+    expect(fetchDataStubs[2].called).to.equal(false);
+    expect(logger.warn.calledWithMatch({ size: 20 * mb, aggregateCap: 50 * mb })).to.equal(true);
+  });
+
+  it('should skip unknown-size attachments that would exceed the aggregate byte cap after fetch', async () => {
+    const storageService = makeStorageService();
+    const logger = makeLogger();
+    const service = new AgentAttachmentStorage(storageService, logger as any);
+    const attachments = [
+      {
+        type: 'file',
+        name: 'unknown-0.bin',
+        fetchData: async () => Buffer.alloc(25 * mb),
+      },
+      {
+        type: 'file',
+        name: 'unknown-1.bin',
+        fetchData: async () => Buffer.alloc(25 * mb),
+      },
+      {
+        type: 'file',
+        name: 'unknown-2.bin',
+        fetchData: async () => Buffer.from('x'),
+      },
+    ] as Attachment[];
+
+    const result = await service.storeInbound(attachments, ctx);
+
+    expect(result).to.have.length(2);
+    expect(storageService.uploadFile.callCount).to.equal(2);
+    expect(logger.warn.calledWithMatch({ byteLength: 1, aggregateCap: 50 * mb })).to.equal(true);
   });
 
   it('should skip attachment over pre-fetch size limit', async () => {

--- a/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
+++ b/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
@@ -8,7 +8,7 @@ export interface StoredAttachment {
   mimeType?: string;
   size?: number;
   storageKey: string;
-  url: string;
+  url?: string;
 }
 
 export interface StoreInboundAttachmentContext {
@@ -19,6 +19,8 @@ export interface StoreInboundAttachmentContext {
 }
 
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+const MAX_ATTACHMENTS_PER_MESSAGE = 15;
+const MAX_AGGREGATE_ATTACHMENT_BYTES = 50 * 1024 * 1024;
 export const READ_URL_TTL_SECONDS = 15 * 60;
 const AGENTS_FOLDER = 'agents';
 
@@ -79,23 +81,50 @@ export class AgentAttachmentStorage {
     ctx: StoreInboundAttachmentContext
   ): Promise<StoredAttachment[]> {
     if (!attachments?.length) {
-
       return [];
     }
 
-    const settled = await Promise.allSettled(
-      attachments.map((attachment, index) => this.storeOne(attachment, ctx, index))
-    );
-
     const result: StoredAttachment[] = [];
+    const attachmentsToProcess = attachments.slice(0, MAX_ATTACHMENTS_PER_MESSAGE);
+    let processedBytes = 0;
 
-    for (const entry of settled) {
-      if (entry.status === 'fulfilled' && entry.value) {
-        result.push(entry.value);
-      }
+    if (attachments.length > MAX_ATTACHMENTS_PER_MESSAGE) {
+      this.logger.warn(
+        { attachmentCount: attachments.length, cap: MAX_ATTACHMENTS_PER_MESSAGE },
+        'Skipping inbound attachments over count limit'
+      );
+    }
 
-      if (entry.status === 'rejected') {
-        this.logger.warn(entry.reason, 'Inbound attachment processing failed');
+    for (const [index, attachment] of attachmentsToProcess.entries()) {
+      try {
+        const knownSize = attachment.size;
+
+        if (
+          knownSize != null &&
+          knownSize <= MAX_ATTACHMENT_BYTES &&
+          processedBytes + knownSize > MAX_AGGREGATE_ATTACHMENT_BYTES
+        ) {
+          this.logger.warn(
+            {
+              size: knownSize,
+              processedBytes,
+              aggregateCap: MAX_AGGREGATE_ATTACHMENT_BYTES,
+              name: attachment.name,
+            },
+            'Skipping inbound attachment over aggregate size limit'
+          );
+
+          continue;
+        }
+
+        const stored = await this.storeOne(attachment, ctx, index, processedBytes);
+
+        if (stored) {
+          processedBytes += stored.size ?? 0;
+          result.push(stored);
+        }
+      } catch (err) {
+        this.logger.warn(err, 'Inbound attachment processing failed');
       }
     }
 
@@ -106,7 +135,6 @@ export class AgentAttachmentStorage {
     const exists = await this.storageService.fileExists(storageKey);
 
     if (!exists) {
-
       return null;
     }
 
@@ -116,7 +144,8 @@ export class AgentAttachmentStorage {
   private async storeOne(
     attachment: Attachment,
     ctx: StoreInboundAttachmentContext,
-    index: number
+    index: number,
+    processedBytes: number
   ): Promise<StoredAttachment | null> {
     try {
       if (attachment.size != null && attachment.size > MAX_ATTACHMENT_BYTES) {
@@ -145,6 +174,20 @@ export class AgentAttachmentStorage {
         return null;
       }
 
+      if (processedBytes + buffer.length > MAX_AGGREGATE_ATTACHMENT_BYTES) {
+        this.logger.warn(
+          {
+            byteLength: buffer.length,
+            processedBytes,
+            aggregateCap: MAX_AGGREGATE_ATTACHMENT_BYTES,
+            name: attachment.name,
+          },
+          'Skipping inbound attachment over aggregate size limit after fetch'
+        );
+
+        return null;
+      }
+
       const rawName = attachment.name ?? `file-${index}`;
       const filename = sanitizeFilenameSegment(rawName);
       const mimeType = attachment.mimeType ?? 'application/octet-stream';
@@ -158,9 +201,20 @@ export class AgentAttachmentStorage {
         filename,
       });
 
-      await this.storageService.uploadFile(storageKey, buffer, mimeType);
+      try {
+        await this.storageService.uploadFile(storageKey, buffer, mimeType);
+      } catch (err) {
+        this.logger.warn(err, 'Failed to upload inbound attachment');
 
-      const url = await this.storageService.getReadSignedUrl(storageKey, READ_URL_TTL_SECONDS);
+        return null;
+      }
+
+      let url: string | undefined;
+      try {
+        url = await this.storageService.getReadSignedUrl(storageKey, READ_URL_TTL_SECONDS);
+      } catch (err) {
+        this.logger.warn(err, 'Failed to sign inbound attachment after upload');
+      }
 
       return {
         type: attachment.type,

--- a/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
+++ b/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
@@ -1,0 +1,179 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger, StorageService } from '@novu/application-generic';
+import type { Attachment } from 'chat';
+
+export interface StoredAttachment {
+  type: string;
+  name?: string;
+  mimeType?: string;
+  size?: number;
+  storageKey: string;
+  url: string;
+}
+
+export interface StoreInboundAttachmentContext {
+  organizationId: string;
+  environmentId: string;
+  conversationId: string;
+  platformMessageId: string;
+}
+
+const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+export const READ_URL_TTL_SECONDS = 15 * 60;
+const AGENTS_FOLDER = 'agents';
+
+function sanitizeFilenameSegment(name: string): string {
+  const base = name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 100);
+
+  return base || 'file';
+}
+
+function buildStorageKey(params: {
+  organizationId: string;
+  environmentId: string;
+  conversationId: string;
+  platformMessageId: string;
+  index: number;
+  filename: string;
+}): string {
+  const safeMessageId = String(params.platformMessageId).replace(/\//g, '_');
+
+  return `${params.organizationId}/${params.environmentId}/${AGENTS_FOLDER}/${params.conversationId}/${safeMessageId}/${params.index}-${params.filename}`;
+}
+
+async function bufferFromAttachment(attachment: Attachment): Promise<Buffer | null> {
+  if (typeof attachment.fetchData === 'function') {
+    return await attachment.fetchData();
+  }
+
+  if (!attachment.data) {
+    return null;
+  }
+
+  if (Buffer.isBuffer(attachment.data)) {
+    return attachment.data;
+  }
+
+  const blob = attachment.data as Blob;
+
+  if (typeof blob.arrayBuffer === 'function') {
+    const ab = await blob.arrayBuffer();
+
+    return Buffer.from(ab);
+  }
+
+  return null;
+}
+
+@Injectable()
+export class AgentAttachmentStorage {
+  constructor(
+    private readonly storageService: StorageService,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  async storeInbound(
+    attachments: Attachment[] | undefined,
+    ctx: StoreInboundAttachmentContext
+  ): Promise<StoredAttachment[]> {
+    if (!attachments?.length) {
+
+      return [];
+    }
+
+    const settled = await Promise.allSettled(
+      attachments.map((attachment, index) => this.storeOne(attachment, ctx, index))
+    );
+
+    const result: StoredAttachment[] = [];
+
+    for (const entry of settled) {
+      if (entry.status === 'fulfilled' && entry.value) {
+        result.push(entry.value);
+      }
+
+      if (entry.status === 'rejected') {
+        this.logger.warn(entry.reason, 'Inbound attachment processing failed');
+      }
+    }
+
+    return result;
+  }
+
+  async signRead(storageKey: string): Promise<string | null> {
+    const exists = await this.storageService.fileExists(storageKey);
+
+    if (!exists) {
+
+      return null;
+    }
+
+    return await this.storageService.getReadSignedUrl(storageKey, READ_URL_TTL_SECONDS);
+  }
+
+  private async storeOne(
+    attachment: Attachment,
+    ctx: StoreInboundAttachmentContext,
+    index: number
+  ): Promise<StoredAttachment | null> {
+    try {
+      if (attachment.size != null && attachment.size > MAX_ATTACHMENT_BYTES) {
+        this.logger.warn(
+          { size: attachment.size, name: attachment.name },
+          'Skipping inbound attachment over size limit'
+        );
+
+        return null;
+      }
+
+      const buffer = await bufferFromAttachment(attachment);
+
+      if (!buffer) {
+        this.logger.warn({ name: attachment.name }, 'Inbound attachment has neither fetchData nor data');
+
+        return null;
+      }
+
+      if (buffer.length > MAX_ATTACHMENT_BYTES) {
+        this.logger.warn(
+          { byteLength: buffer.length, name: attachment.name },
+          'Skipping inbound attachment over size limit after fetch'
+        );
+
+        return null;
+      }
+
+      const rawName = attachment.name ?? `file-${index}`;
+      const filename = sanitizeFilenameSegment(rawName);
+      const mimeType = attachment.mimeType ?? 'application/octet-stream';
+
+      const storageKey = buildStorageKey({
+        organizationId: ctx.organizationId,
+        environmentId: ctx.environmentId,
+        conversationId: ctx.conversationId,
+        platformMessageId: ctx.platformMessageId,
+        index,
+        filename,
+      });
+
+      await this.storageService.uploadFile(storageKey, buffer, mimeType);
+
+      const url = await this.storageService.getReadSignedUrl(storageKey, READ_URL_TTL_SECONDS);
+
+      return {
+        type: attachment.type,
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+        size: attachment.size ?? buffer.length,
+        storageKey,
+        url,
+      };
+    } catch (err) {
+      this.logger.warn(err, 'Failed to store inbound attachment');
+
+      return null;
+    }
+  }
+}

--- a/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
+++ b/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
@@ -44,21 +44,45 @@ function buildStorageKey(params: {
 }
 
 async function bufferFromAttachment(attachment: Attachment): Promise<Buffer | null> {
-  if (typeof attachment.fetchData === 'function') {
-    return await attachment.fetchData();
-  }
-
   if (!attachment.data) {
+    if (attachment.size == null) {
+      throw new Error('Inbound attachment size is required before download');
+    }
+
+    if (attachment.size > MAX_ATTACHMENT_BYTES) {
+      throw new Error('Inbound attachment exceeds size limit');
+    }
+
+    if (typeof attachment.fetchData === 'function') {
+      return await attachment.fetchData();
+    }
+
     return null;
   }
 
   if (Buffer.isBuffer(attachment.data)) {
+    if (attachment.data.length > MAX_ATTACHMENT_BYTES) {
+      throw new Error('Inbound attachment buffer exceeds size limit');
+    }
+
     return attachment.data;
   }
 
   const blob = attachment.data as Blob;
 
   if (typeof blob.arrayBuffer === 'function') {
+    if (attachment.size == null) {
+      throw new Error('Inbound attachment size is required before reading blob data');
+    }
+
+    if (attachment.size > MAX_ATTACHMENT_BYTES) {
+      throw new Error('Inbound attachment exceeds size limit');
+    }
+
+    if (blob.size !== attachment.size) {
+      throw new Error('Inbound attachment blob size does not match trusted size metadata');
+    }
+
     const ab = await blob.arrayBuffer();
 
     return Buffer.from(ab);

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
@@ -1,0 +1,156 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { AgentEventEnum } from '../dtos/agent-event.enum';
+import { AgentInboundHandler } from './agent-inbound-handler.service';
+
+describe('AgentInboundHandler', () => {
+  const config = {
+    environmentId: 'env1',
+    organizationId: 'org1',
+    platform: 'slack',
+    integrationIdentifier: 'slack-main',
+    integrationId: 'integration1',
+    agentIdentifier: 'support-agent',
+    acknowledgeOnReceived: false,
+  };
+
+  const conversation = {
+    _id: 'conversation1',
+    channels: [{ platformThreadId: 'thread1', platform: 'slack', _integrationId: 'integration1' }],
+  };
+
+  function makeLogger() {
+    return {
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      debug: sinon.stub(),
+      info: sinon.stub(),
+      setContext: sinon.stub(),
+    };
+  }
+
+  function makeHandler(overrides: { history?: any[]; storedAttachments?: any[] } = {}) {
+    const logger = makeLogger();
+    const subscriberResolver = {
+      resolve: sinon.stub().resolves(null),
+    };
+    const conversationService = {
+      findByPlatformThread: sinon.stub().resolves(conversation),
+      getHistory: sinon.stub().resolves(overrides.history ?? []),
+    };
+    const bridgeExecutor = {
+      execute: sinon.stub().resolves(undefined),
+    };
+    const subscriberRepository = {
+      findBySubscriberId: sinon.stub(),
+    };
+    const analyticsService = {
+      track: sinon.stub(),
+    };
+    const attachmentStorage = {
+      storeInbound: sinon.stub().resolves(overrides.storedAttachments ?? []),
+    };
+    const handler = new AgentInboundHandler(
+      logger as any,
+      subscriberResolver as any,
+      conversationService as any,
+      bridgeExecutor as any,
+      subscriberRepository as any,
+      analyticsService as any,
+      attachmentStorage as any
+    );
+
+    return { handler, attachmentStorage, bridgeExecutor };
+  }
+
+  function makeReactionEvent() {
+    return {
+      emoji: { name: 'thumbs_up', toJSON: () => 'thumbs_up', toString: () => 'thumbs_up' },
+      added: true,
+      messageId: 'source-msg',
+      message: {
+        id: 'source-msg',
+        text: 'Message with attachment',
+        author: {
+          userId: 'user1',
+          fullName: 'User One',
+          userName: 'userone',
+          isBot: false,
+        },
+        attachments: [
+          {
+            type: 'image',
+            name: 'image.png',
+            mimeType: 'image/png',
+            size: 123,
+          },
+        ],
+      },
+      thread: {
+        id: 'thread1',
+        channelId: 'channel1',
+        isDM: false,
+      },
+    };
+  }
+
+  describe('handleReaction', () => {
+    it('should reuse stored source message attachments from history', async () => {
+      const { handler, attachmentStorage, bridgeExecutor } = makeHandler({
+        history: [
+          {
+            platformMessageId: 'source-msg',
+            richContent: {
+              attachments: [
+                {
+                  type: 'image',
+                  name: 'image.png',
+                  mimeType: 'image/png',
+                  size: 123,
+                  storageKey: 'org1/env1/agents/conversation1/source-msg/0-image.png',
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      await handler.handleReaction('agent1', config as any, makeReactionEvent() as any);
+
+      expect(attachmentStorage.storeInbound.called).to.equal(false);
+      const params = bridgeExecutor.execute.firstCall.args[0];
+      expect(params.event).to.equal(AgentEventEnum.ON_REACTION);
+      expect(params.reaction.sourceMessageStoredAttachments).to.deep.equal([
+        {
+          type: 'image',
+          name: 'image.png',
+          mimeType: 'image/png',
+          size: 123,
+          storageKey: 'org1/env1/agents/conversation1/source-msg/0-image.png',
+          url: undefined,
+        },
+      ]);
+    });
+
+    it('should store source message attachments when history has no stored metadata', async () => {
+      const storedAttachments = [
+        {
+          type: 'image',
+          name: 'image.png',
+          mimeType: 'image/png',
+          size: 123,
+          storageKey: 'org1/env1/agents/conversation1/source-msg/0-image.png',
+          url: 'https://signed/read',
+        },
+      ];
+      const { handler, attachmentStorage, bridgeExecutor } = makeHandler({ storedAttachments });
+
+      await handler.handleReaction('agent1', config as any, makeReactionEvent() as any);
+
+      expect(attachmentStorage.storeInbound.calledOnce).to.equal(true);
+      expect(attachmentStorage.storeInbound.firstCall.args[1].platformMessageId).to.equal('source-msg');
+      const params = bridgeExecutor.execute.firstCall.args[0];
+      expect(params.reaction.sourceMessageStoredAttachments).to.deep.equal(storedAttachments);
+    });
+  });
+});

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -6,6 +6,7 @@ import type { EmojiValue, Message, Thread } from 'chat';
 import { trackAgentInboundAction, trackAgentInboundMessage, trackAgentInboundReaction } from '../agent-analytics';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { PLATFORMS_WITH_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
+import { AgentAttachmentStorage, type StoredAttachment } from './agent-attachment-storage.service';
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
 import { AgentConversationService } from './agent-conversation.service';
 import { AgentSubscriberResolver } from './agent-subscriber-resolver.service';
@@ -34,7 +35,8 @@ export class AgentInboundHandler {
     private readonly conversationService: AgentConversationService,
     private readonly bridgeExecutor: BridgeExecutorService,
     private readonly subscriberRepository: SubscriberRepository,
-    private readonly analyticsService: AnalyticsService
+    private readonly analyticsService: AnalyticsService,
+    private readonly attachmentStorage: AgentAttachmentStorage
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -82,14 +84,25 @@ export class AgentInboundHandler {
       ? ConversationActivitySenderTypeEnum.SUBSCRIBER
       : ConversationActivitySenderTypeEnum.PLATFORM_USER;
 
-    const richContent = message.attachments?.length
+    let storedAttachments: StoredAttachment[] | undefined;
+
+    if (message.attachments?.length) {
+      storedAttachments = await this.attachmentStorage.storeInbound(message.attachments, {
+        organizationId: config.organizationId,
+        environmentId: config.environmentId,
+        conversationId: String(conversation._id),
+        platformMessageId: message.id ?? `unknown-${Date.now()}`,
+      });
+    }
+
+    const richContent = storedAttachments?.length
       ? {
-          attachments: message.attachments.map((a) => ({
-            type: a.type,
-            url: a.url,
-            name: a.name,
-            mimeType: a.mimeType,
-            size: a.size,
+          attachments: storedAttachments.map(({ type, name, mimeType, size, storageKey }) => ({
+            type,
+            name,
+            mimeType,
+            size,
+            storageKey,
           })),
         }
       : undefined;
@@ -176,6 +189,7 @@ export class AgentInboundHandler {
           channelId: thread.channelId,
           isDM: thread.isDM,
         },
+        storedAttachments: message.attachments?.length ? storedAttachments : undefined,
       });
     } catch (err) {
       if (err instanceof NoBridgeUrlError) {
@@ -254,11 +268,25 @@ export class AgentInboundHandler {
       this.conversationService.getHistory(config.environmentId, conversation._id),
     ]);
 
-    const reaction: BridgeReaction = {
+    let sourceMessageStoredAttachments: StoredAttachment[] | undefined;
+
+    if (event.message?.attachments?.length) {
+      sourceMessageStoredAttachments = await this.attachmentStorage.storeInbound(event.message.attachments, {
+        organizationId: config.organizationId,
+        environmentId: config.environmentId,
+        conversationId: String(conversation._id),
+        platformMessageId: event.message.id ?? `unknown-${Date.now()}`,
+      });
+    }
+
+    const reactionPayload: BridgeReaction = {
       emoji: event.emoji.name,
       added: event.added,
       messageId: event.messageId,
       sourceMessage: event.message,
+      sourceMessageStoredAttachments: event.message?.attachments?.length
+        ? sourceMessageStoredAttachments
+        : undefined,
     };
 
     await this.bridgeExecutor.execute({
@@ -273,7 +301,7 @@ export class AgentInboundHandler {
         channelId: event.thread?.channelId ?? '',
         isDM: event.thread?.isDM ?? false,
       },
-      reaction,
+      reaction: reactionPayload,
     });
   }
 

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { AnalyticsService, PinoLogger } from '@novu/application-generic';
-import { ConversationActivitySenderTypeEnum, ConversationParticipantTypeEnum, SubscriberRepository } from '@novu/dal';
+import {
+  ConversationActivityEntity,
+  ConversationActivitySenderTypeEnum,
+  ConversationParticipantTypeEnum,
+  SubscriberRepository,
+} from '@novu/dal';
 import type { AgentAction } from '@novu/framework';
 import type { EmojiValue, Message, Thread } from 'chat';
 import { trackAgentInboundAction, trackAgentInboundMessage, trackAgentInboundReaction } from '../agent-analytics';
@@ -17,6 +22,60 @@ const ACKNOWLEDGE_FALLBACK_EMOJI = 'eyes' as const;
 const ONBOARDING_NO_BRIDGE_REPLY_MARKDOWN = `*You're connected to Novu*
 
 Your bot is linked successfully. Go back to the *Novu dashboard* to complete onboarding.`;
+
+function mapStoredAttachmentsFromRichContent(richContent?: Record<string, unknown>): StoredAttachment[] {
+  const rawAttachments = richContent?.attachments;
+
+  if (!Array.isArray(rawAttachments)) {
+    return [];
+  }
+
+  return rawAttachments.flatMap((item) => {
+    if (!item || typeof item !== 'object') {
+      return [];
+    }
+
+    const attachment = item as Record<string, unknown>;
+    const storageKey = attachment.storageKey;
+
+    if (typeof storageKey !== 'string' || storageKey.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        type: typeof attachment.type === 'string' ? attachment.type : 'file',
+        name: typeof attachment.name === 'string' ? attachment.name : undefined,
+        mimeType: typeof attachment.mimeType === 'string' ? attachment.mimeType : undefined,
+        size: typeof attachment.size === 'number' ? attachment.size : undefined,
+        storageKey,
+        url: typeof attachment.url === 'string' ? attachment.url : undefined,
+      },
+    ];
+  });
+}
+
+function findSourceMessageStoredAttachments(
+  history: ConversationActivityEntity[],
+  messageIds: string[]
+): StoredAttachment[] | undefined {
+  const messageIdSet = new Set(messageIds);
+  const sourceActivity = history.find(
+    (activity) => activity.platformMessageId && messageIdSet.has(activity.platformMessageId)
+  );
+
+  if (!sourceActivity) {
+    return undefined;
+  }
+
+  const storedAttachments = mapStoredAttachmentsFromRichContent(sourceActivity.richContent);
+
+  if (!storedAttachments.length) {
+    return undefined;
+  }
+
+  return storedAttachments;
+}
 
 export interface InboundReactionEvent {
   emoji: EmojiValue;
@@ -268,14 +327,15 @@ export class AgentInboundHandler {
       this.conversationService.getHistory(config.environmentId, conversation._id),
     ]);
 
-    let sourceMessageStoredAttachments: StoredAttachment[] | undefined;
+    const sourceMessageIds = [event.messageId, event.message?.id].filter((id): id is string => Boolean(id));
+    let sourceMessageStoredAttachments = findSourceMessageStoredAttachments(history, sourceMessageIds);
 
-    if (event.message?.attachments?.length) {
+    if (!sourceMessageStoredAttachments && event.message?.attachments?.length) {
       sourceMessageStoredAttachments = await this.attachmentStorage.storeInbound(event.message.attachments, {
         organizationId: config.organizationId,
         environmentId: config.environmentId,
         conversationId: String(conversation._id),
-        platformMessageId: event.message.id ?? `unknown-${Date.now()}`,
+        platformMessageId: event.message.id ?? event.messageId ?? `unknown-${Date.now()}`,
       });
     }
 
@@ -284,7 +344,7 @@ export class AgentInboundHandler {
       added: event.added,
       messageId: event.messageId,
       sourceMessage: event.message,
-      sourceMessageStoredAttachments: event.message?.attachments?.length
+      sourceMessageStoredAttachments: sourceMessageStoredAttachments?.length
         ? sourceMessageStoredAttachments
         : undefined,
     };

--- a/apps/api/src/app/agents/services/bridge-executor.service.spec.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.spec.ts
@@ -3,6 +3,16 @@ import sinon from 'sinon';
 import { BridgeExecutorService } from './bridge-executor.service';
 
 describe('BridgeExecutorService', () => {
+  function makeActivity(overrides: Record<string, unknown> = {}) {
+    return {
+      _id: 'activity-id',
+      _organizationId: 'org',
+      _environmentId: 'env',
+      _conversationId: 'conv',
+      ...overrides,
+    };
+  }
+
   describe('mapRichContentForBridge', () => {
     it('should omit an attachment when signing fails without throwing', async () => {
       const logger = {
@@ -29,11 +39,44 @@ describe('BridgeExecutorService', () => {
             },
           ],
         },
-        'activity-id'
+        makeActivity()
       );
 
       expect(result).to.deep.equal({ attachments: [] });
       expect(logger.warn.calledOnce).to.equal(true);
+    });
+
+    it('should omit an attachment when storageKey is outside the activity namespace', async () => {
+      const logger = {
+        warn: sinon.stub(),
+        error: sinon.stub(),
+        debug: sinon.stub(),
+        info: sinon.stub(),
+        setContext: sinon.stub(),
+      };
+      const attachmentStorage = {
+        signRead: sinon.stub().resolves('https://signed/read'),
+      };
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+
+      const result = await (service as any).mapRichContentForBridge(
+        {
+          attachments: [
+            {
+              type: 'image',
+              storageKey: 'other-org/env/agents/conv/message/0-image.png',
+              name: 'image.png',
+              mimeType: 'image/png',
+              size: 123,
+            },
+          ],
+        },
+        makeActivity()
+      );
+
+      expect(result).to.deep.equal({ attachments: [] });
+      expect(attachmentStorage.signRead.called).to.equal(false);
+      expect(logger.warn.calledWithMatch({ expectedPrefix: 'org/env/agents/conv/' })).to.equal(true);
     });
   });
 });

--- a/apps/api/src/app/agents/services/bridge-executor.service.spec.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { BridgeExecutorService } from './bridge-executor.service';
+
+describe('BridgeExecutorService', () => {
+  describe('mapRichContentForBridge', () => {
+    it('should omit an attachment when signing fails without throwing', async () => {
+      const logger = {
+        warn: sinon.stub(),
+        error: sinon.stub(),
+        debug: sinon.stub(),
+        info: sinon.stub(),
+        setContext: sinon.stub(),
+      };
+      const attachmentStorage = {
+        signRead: sinon.stub().rejects(new Error('storage unavailable')),
+      };
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+
+      const result = await (service as any).mapRichContentForBridge(
+        {
+          attachments: [
+            {
+              type: 'image',
+              storageKey: 'org/env/agents/conv/message/0-image.png',
+              name: 'image.png',
+              mimeType: 'image/png',
+              size: 123,
+            },
+          ],
+        },
+        'activity-id'
+      );
+
+      expect(result).to.deep.equal({ attachments: [] });
+      expect(logger.warn.calledOnce).to.equal(true);
+    });
+  });
+});

--- a/apps/api/src/app/agents/services/bridge-executor.service.spec.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.spec.ts
@@ -141,6 +141,47 @@ describe('BridgeExecutorService', () => {
       expect(maxActive).to.be.at.most(4);
       expect(attachmentStorage.signRead.callCount).to.equal(10);
     });
+
+    it('should not multiply attachment signing concurrency across history entries', async () => {
+      let active = 0;
+      let maxActive = 0;
+      const logger = makeLogger();
+      const attachmentStorage = {
+        signRead: sinon.stub().callsFake(async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          active -= 1;
+
+          return 'https://signed/read';
+        }),
+      };
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+
+      await (service as any).mapHistory([
+        makeActivity({
+          _id: 'activity-1',
+          richContent: {
+            attachments: Array.from({ length: 10 }, (_, index) => ({
+              type: 'image',
+              storageKey: `org/env/agents/conv/message-a/${index}-image.png`,
+            })),
+          },
+        }),
+        makeActivity({
+          _id: 'activity-2',
+          richContent: {
+            attachments: Array.from({ length: 10 }, (_, index) => ({
+              type: 'image',
+              storageKey: `org/env/agents/conv/message-b/${index}-image.png`,
+            })),
+          },
+        }),
+      ]);
+
+      expect(maxActive).to.be.at.most(4);
+      expect(attachmentStorage.signRead.callCount).to.equal(20);
+    });
   });
 
   describe('mapMessage', () => {

--- a/apps/api/src/app/agents/services/bridge-executor.service.spec.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.spec.ts
@@ -92,6 +92,55 @@ describe('BridgeExecutorService', () => {
       expect(attachmentStorage.signRead.called).to.equal(false);
       expect(logger.warn.calledWithMatch({ expectedPrefix: 'org/env/agents/conv/' })).to.equal(true);
     });
+
+    it('should omit malformed attachment entries without throwing', async () => {
+      const logger = makeLogger();
+      const attachmentStorage = {
+        signRead: sinon.stub().resolves('https://signed/read'),
+      };
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+
+      const result = await (service as any).mapRichContentForBridge(
+        {
+          attachments: [null, 'bad-entry'],
+        },
+        makeActivity()
+      );
+
+      expect(result).to.deep.equal({ attachments: [] });
+      expect(attachmentStorage.signRead.called).to.equal(false);
+      expect(logger.warn.callCount).to.equal(2);
+    });
+
+    it('should limit concurrent history attachment signing', async () => {
+      let active = 0;
+      let maxActive = 0;
+      const logger = makeLogger();
+      const attachmentStorage = {
+        signRead: sinon.stub().callsFake(async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          active -= 1;
+
+          return 'https://signed/read';
+        }),
+      };
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+
+      await (service as any).mapRichContentForBridge(
+        {
+          attachments: Array.from({ length: 10 }, (_, index) => ({
+            type: 'image',
+            storageKey: `org/env/agents/conv/message/${index}-image.png`,
+          })),
+        },
+        makeActivity()
+      );
+
+      expect(maxActive).to.be.at.most(4);
+      expect(attachmentStorage.signRead.callCount).to.equal(10);
+    });
   });
 
   describe('mapMessage', () => {
@@ -160,6 +209,40 @@ describe('BridgeExecutorService', () => {
 
       expect(result.attachments).to.deep.equal([]);
       expect(logger.warn.calledOnce).to.equal(true);
+    });
+
+    it('should limit concurrent stored attachment signing', async () => {
+      let active = 0;
+      let maxActive = 0;
+      const logger = makeLogger();
+      const attachmentStorage = {
+        signRead: sinon.stub().callsFake(async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          active -= 1;
+
+          return 'https://fresh-signed/read';
+        }),
+      };
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+
+      const result = await (service as any).mapMessage(
+        makeMessage(),
+        Array.from({ length: 10 }, (_, index) => ({
+          type: 'image',
+          storageKey: `org/env/agents/conv/message/${index}-image.png`,
+        })),
+        {
+          organizationId: 'org',
+          environmentId: 'env',
+          conversationId: 'conv',
+        }
+      );
+
+      expect(result.attachments).to.have.length(10);
+      expect(maxActive).to.be.at.most(4);
+      expect(attachmentStorage.signRead.callCount).to.equal(10);
     });
   });
 });

--- a/apps/api/src/app/agents/services/bridge-executor.service.spec.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.spec.ts
@@ -3,6 +3,16 @@ import sinon from 'sinon';
 import { BridgeExecutorService } from './bridge-executor.service';
 
 describe('BridgeExecutorService', () => {
+  function makeLogger() {
+    return {
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      debug: sinon.stub(),
+      info: sinon.stub(),
+      setContext: sinon.stub(),
+    };
+  }
+
   function makeActivity(overrides: Record<string, unknown> = {}) {
     return {
       _id: 'activity-id',
@@ -13,15 +23,25 @@ describe('BridgeExecutorService', () => {
     };
   }
 
+  function makeMessage() {
+    return {
+      id: 'message-id',
+      text: 'hello',
+      author: {
+        userId: 'user-id',
+        fullName: 'User',
+        userName: 'user',
+        isBot: false,
+      },
+      metadata: {
+        dateSent: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    };
+  }
+
   describe('mapRichContentForBridge', () => {
     it('should omit an attachment when signing fails without throwing', async () => {
-      const logger = {
-        warn: sinon.stub(),
-        error: sinon.stub(),
-        debug: sinon.stub(),
-        info: sinon.stub(),
-        setContext: sinon.stub(),
-      };
+      const logger = makeLogger();
       const attachmentStorage = {
         signRead: sinon.stub().rejects(new Error('storage unavailable')),
       };
@@ -47,13 +67,7 @@ describe('BridgeExecutorService', () => {
     });
 
     it('should omit an attachment when storageKey is outside the activity namespace', async () => {
-      const logger = {
-        warn: sinon.stub(),
-        error: sinon.stub(),
-        debug: sinon.stub(),
-        info: sinon.stub(),
-        setContext: sinon.stub(),
-      };
+      const logger = makeLogger();
       const attachmentStorage = {
         signRead: sinon.stub().resolves('https://signed/read'),
       };
@@ -77,6 +91,75 @@ describe('BridgeExecutorService', () => {
       expect(result).to.deep.equal({ attachments: [] });
       expect(attachmentStorage.signRead.called).to.equal(false);
       expect(logger.warn.calledWithMatch({ expectedPrefix: 'org/env/agents/conv/' })).to.equal(true);
+    });
+  });
+
+  describe('mapMessage', () => {
+    it('should re-sign stored attachments instead of reusing stored urls', async () => {
+      const logger = makeLogger();
+      const attachmentStorage = {
+        signRead: sinon.stub().resolves('https://fresh-signed/read'),
+      };
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+
+      const result = await (service as any).mapMessage(
+        makeMessage(),
+        [
+          {
+            type: 'image',
+            storageKey: 'org/env/agents/conv/message/0-image.png',
+            url: 'https://stale-signed/read',
+            name: 'image.png',
+            mimeType: 'image/png',
+            size: 123,
+          },
+        ],
+        {
+          organizationId: 'org',
+          environmentId: 'env',
+          conversationId: 'conv',
+        }
+      );
+
+      expect(result.attachments).to.deep.equal([
+        {
+          type: 'image',
+          url: 'https://fresh-signed/read',
+          name: 'image.png',
+          mimeType: 'image/png',
+          size: 123,
+        },
+      ]);
+      expect(attachmentStorage.signRead.calledOnceWithExactly('org/env/agents/conv/message/0-image.png')).to.equal(
+        true
+      );
+    });
+
+    it('should omit stored attachments that cannot be signed', async () => {
+      const logger = makeLogger();
+      const attachmentStorage = {
+        signRead: sinon.stub().rejects(new Error('sign failed')),
+      };
+      const service = new BridgeExecutorService({} as any, logger as any, attachmentStorage as any);
+
+      const result = await (service as any).mapMessage(
+        makeMessage(),
+        [
+          {
+            type: 'image',
+            storageKey: 'org/env/agents/conv/message/0-image.png',
+            url: 'https://stale-signed/read',
+          },
+        ],
+        {
+          organizationId: 'org',
+          environmentId: 'env',
+          conversationId: 'conv',
+        }
+      );
+
+      expect(result.attachments).to.deep.equal([]);
+      expect(logger.warn.calledOnce).to.equal(true);
     });
   });
 });

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -25,6 +25,7 @@ import { ResolvedAgentConfig } from './agent-config-resolver.service';
 
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY_MS = 500;
+const AGENTS_STORAGE_FOLDER = 'agents';
 
 export interface BridgeReaction {
   emoji: string;
@@ -307,7 +308,7 @@ export class BridgeExecutorService {
         role: activity.senderType,
         type: activity.type,
         content: activity.content,
-        richContent: await this.mapRichContentForBridge(activity.richContent, activity._id?.toString()),
+        richContent: await this.mapRichContentForBridge(activity.richContent, activity),
         senderName: activity.senderName || undefined,
         signalData: activity.signalData || undefined,
         createdAt: activity.createdAt,
@@ -317,7 +318,7 @@ export class BridgeExecutorService {
 
   private async mapRichContentForBridge(
     richContent: Record<string, unknown> | undefined,
-    activityId?: string
+    activity: ConversationActivityEntity
   ): Promise<Record<string, unknown> | undefined> {
     if (!richContent) {
       return undefined;
@@ -335,7 +336,7 @@ export class BridgeExecutorService {
         const storageKey = att.storageKey;
 
         if (typeof storageKey === 'string' && storageKey.length > 0) {
-          const url = await this.signAttachmentForHistory(storageKey, activityId);
+          const url = await this.signAttachmentForHistory(storageKey, activity);
 
           if (!url) {
             return null;
@@ -350,7 +351,7 @@ export class BridgeExecutorService {
           };
         }
 
-        this.logger.warn({ activityId }, 'History attachment missing storageKey; omitting');
+        this.logger.warn({ activityId: activity._id?.toString() }, 'History attachment missing storageKey; omitting');
 
         return null;
       })
@@ -364,7 +365,22 @@ export class BridgeExecutorService {
     };
   }
 
-  private async signAttachmentForHistory(storageKey: string, activityId?: string): Promise<string | null> {
+  private async signAttachmentForHistory(
+    storageKey: string,
+    activity: ConversationActivityEntity
+  ): Promise<string | null> {
+    const activityId = activity._id?.toString();
+    const expectedPrefix = `${activity._organizationId}/${activity._environmentId}/${AGENTS_STORAGE_FOLDER}/${activity._conversationId}/`;
+
+    if (!storageKey.startsWith(expectedPrefix)) {
+      this.logger.warn(
+        { storageKey, activityId, expectedPrefix },
+        'History attachment storageKey outside expected namespace; omitting from bridge payload'
+      );
+
+      return null;
+    }
+
     try {
       const url = await this.attachmentStorage.signRead(storageKey);
 

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -20,6 +20,7 @@ import type {
 import { AgentEventEnum } from '@novu/framework';
 import { HttpHeaderKeysEnum } from '@novu/framework/internal';
 import type { Message } from 'chat';
+import { AgentAttachmentStorage, type StoredAttachment } from './agent-attachment-storage.service';
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
 
 const MAX_RETRIES = 2;
@@ -30,6 +31,7 @@ export interface BridgeReaction {
   added: boolean;
   messageId: string;
   sourceMessage?: Message;
+  sourceMessageStoredAttachments?: StoredAttachment[];
 }
 
 export interface BridgeExecutorParams {
@@ -42,6 +44,7 @@ export interface BridgeExecutorParams {
   platformContext: AgentPlatformContext;
   action?: AgentAction;
   reaction?: BridgeReaction;
+  storedAttachments?: StoredAttachment[];
 }
 
 export class NoBridgeUrlError extends Error {
@@ -55,7 +58,8 @@ export class NoBridgeUrlError extends Error {
 export class BridgeExecutorService {
   constructor(
     private readonly getDecryptedSecretKey: GetDecryptedSecretKey,
-    private readonly logger: PinoLogger
+    private readonly logger: PinoLogger,
+    private readonly attachmentStorage: AgentAttachmentStorage
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -78,7 +82,7 @@ export class BridgeExecutorService {
         })
       );
 
-      const payload = this.buildPayload(params);
+      const payload = await this.buildPayload(params);
       const signatureHeader = buildNovuSignatureHeader(secretKey, payload);
 
       this.fireWithRetries(bridgeUrl, payload, signatureHeader, agentIdentifier).catch((err) => {
@@ -178,7 +182,7 @@ export class BridgeExecutorService {
     return url.toString();
   }
 
-  private buildPayload(params: BridgeExecutorParams): AgentBridgeRequest {
+  private async buildPayload(params: BridgeExecutorParams): Promise<AgentBridgeRequest> {
     const { event, config, conversation, subscriber, history, message, platformContext, action, reaction } = params;
     const agentIdentifier = config.agentIdentifier;
 
@@ -207,18 +211,18 @@ export class BridgeExecutorService {
       replyUrl,
       conversationId: conversation._id,
       integrationIdentifier: config.integrationIdentifier,
-      message: message ? this.mapMessage(message) : null,
+      message: message ? await this.mapMessage(message, params.storedAttachments) : null,
       conversation: this.mapConversation(conversation),
       subscriber: this.mapSubscriber(subscriber),
-      history: this.mapHistory(history),
+      history: await this.mapHistory(history),
       platform: config.platform,
       platformContext,
       action: action ?? null,
-      reaction: reaction ? this.mapReaction(reaction) : null,
+      reaction: reaction ? await this.mapReaction(reaction) : null,
     };
   }
 
-  private mapMessage(message: Message): AgentMessage {
+  private async mapMessage(message: Message, storedAttachments?: StoredAttachment[]): Promise<AgentMessage> {
     const mapped: AgentMessage = {
       text: message.text,
       platformMessageId: message.id,
@@ -230,6 +234,18 @@ export class BridgeExecutorService {
       },
       timestamp: message.metadata?.dateSent?.toISOString() ?? new Date().toISOString(),
     };
+
+    if (storedAttachments !== undefined) {
+      mapped.attachments = storedAttachments.map((s) => ({
+        type: s.type,
+        url: s.url,
+        name: s.name,
+        mimeType: s.mimeType,
+        size: s.size,
+      }));
+
+      return mapped;
+    }
 
     if (message.attachments?.length) {
       mapped.attachments = message.attachments.map((a) => ({
@@ -272,24 +288,95 @@ export class BridgeExecutorService {
     };
   }
 
-  private mapReaction(reaction: BridgeReaction): AgentReaction {
+  private async mapReaction(reaction: BridgeReaction): Promise<AgentReaction> {
     return {
       messageId: reaction.messageId,
       emoji: { name: reaction.emoji },
       added: reaction.added,
-      message: reaction.sourceMessage ? this.mapMessage(reaction.sourceMessage) : null,
+      message: reaction.sourceMessage
+        ? await this.mapMessage(reaction.sourceMessage, reaction.sourceMessageStoredAttachments)
+        : null,
     };
   }
 
-  private mapHistory(activities: ConversationActivityEntity[]): AgentHistoryEntry[] {
-    return [...activities].reverse().map((activity) => ({
-      role: activity.senderType,
-      type: activity.type,
-      content: activity.content,
-      richContent: activity.richContent || undefined,
-      senderName: activity.senderName || undefined,
-      signalData: activity.signalData || undefined,
-      createdAt: activity.createdAt,
-    }));
+  private async mapHistory(activities: ConversationActivityEntity[]): Promise<AgentHistoryEntry[]> {
+    const reversed = [...activities].reverse();
+
+    return await Promise.all(
+      reversed.map(async (activity) => ({
+        role: activity.senderType,
+        type: activity.type,
+        content: activity.content,
+        richContent: await this.mapRichContentForBridge(activity.richContent, activity._id?.toString()),
+        senderName: activity.senderName || undefined,
+        signalData: activity.signalData || undefined,
+        createdAt: activity.createdAt,
+      }))
+    );
+  }
+
+  private async mapRichContentForBridge(
+    richContent: Record<string, unknown> | undefined,
+    activityId?: string
+  ): Promise<Record<string, unknown> | undefined> {
+    if (!richContent) {
+      return undefined;
+    }
+
+    const rawAttachments = richContent.attachments;
+
+    if (!Array.isArray(rawAttachments)) {
+      return richContent;
+    }
+
+    const mapped = await Promise.all(
+      rawAttachments.map(async (item) => {
+        const att = item as Record<string, unknown>;
+        const storageKey = att.storageKey;
+
+        if (typeof storageKey === 'string' && storageKey.length > 0) {
+          const url = await this.signAttachmentForHistory(storageKey, activityId);
+
+          if (!url) {
+            return null;
+          }
+
+          return {
+            type: att.type,
+            url,
+            name: att.name,
+            mimeType: att.mimeType,
+            size: att.size,
+          };
+        }
+
+        this.logger.warn({ activityId }, 'History attachment missing storageKey; omitting');
+
+        return null;
+      })
+    );
+
+    const attachments = mapped.flatMap((entry) => (entry ? [entry] : []));
+
+    return {
+      ...richContent,
+      attachments,
+    };
+  }
+
+  private async signAttachmentForHistory(storageKey: string, activityId?: string): Promise<string | null> {
+    try {
+      const url = await this.attachmentStorage.signRead(storageKey);
+
+      if (!url) {
+        this.logger.warn({ storageKey, activityId }, 'Agent attachment missing from storage; omitting from history');
+      }
+
+      return url;
+    } catch (err) {
+      this.logger.warn(err, 'Failed to sign agent attachment for history; omitting from bridge payload');
+
+      return null;
+    }
   }
 }

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -26,11 +26,33 @@ import { ResolvedAgentConfig } from './agent-config-resolver.service';
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY_MS = 500;
 const AGENTS_STORAGE_FOLDER = 'agents';
+const ATTACHMENT_SIGNING_CONCURRENCY = 4;
 
 interface AttachmentSigningContext {
   organizationId: string;
   environmentId: string;
   conversationId: string;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await mapper(items[currentIndex], currentIndex);
+    }
+  });
+
+  await Promise.all(workers);
+
+  return results;
 }
 
 export interface BridgeReaction {
@@ -323,17 +345,15 @@ export class BridgeExecutorService {
   private async mapHistory(activities: ConversationActivityEntity[]): Promise<AgentHistoryEntry[]> {
     const reversed = [...activities].reverse();
 
-    return await Promise.all(
-      reversed.map(async (activity) => ({
-        role: activity.senderType,
-        type: activity.type,
-        content: activity.content,
-        richContent: await this.mapRichContentForBridge(activity.richContent, activity),
-        senderName: activity.senderName || undefined,
-        signalData: activity.signalData || undefined,
-        createdAt: activity.createdAt,
-      }))
-    );
+    return await mapWithConcurrency(reversed, ATTACHMENT_SIGNING_CONCURRENCY, async (activity) => ({
+      role: activity.senderType,
+      type: activity.type,
+      content: activity.content,
+      richContent: await this.mapRichContentForBridge(activity.richContent, activity),
+      senderName: activity.senderName || undefined,
+      signalData: activity.signalData || undefined,
+      createdAt: activity.createdAt,
+    }));
   }
 
   private async mapRichContentForBridge(
@@ -350,8 +370,16 @@ export class BridgeExecutorService {
       return richContent;
     }
 
-    const mapped = await Promise.all(
-      rawAttachments.map(async (item) => {
+    const mapped = await mapWithConcurrency(
+      rawAttachments,
+      ATTACHMENT_SIGNING_CONCURRENCY,
+      async (item) => {
+        if (!item || typeof item !== 'object') {
+          this.logger.warn({ activityId: activity._id?.toString() }, 'History attachment is malformed; omitting');
+
+          return null;
+        }
+
         const att = item as Record<string, unknown>;
         const storageKey = att.storageKey;
 
@@ -374,7 +402,7 @@ export class BridgeExecutorService {
         this.logger.warn({ activityId: activity._id?.toString() }, 'History attachment missing storageKey; omitting');
 
         return null;
-      })
+      }
     );
 
     const attachments = mapped.flatMap((entry) => (entry ? [entry] : []));
@@ -424,8 +452,10 @@ export class BridgeExecutorService {
     storedAttachments: StoredAttachment[],
     signingContext: AttachmentSigningContext
   ) {
-    const mapped = await Promise.all(
-      storedAttachments.map(async (attachment) => {
+    const mapped = await mapWithConcurrency(
+      storedAttachments,
+      ATTACHMENT_SIGNING_CONCURRENCY,
+      async (attachment) => {
         const url = await this.signStoredAttachmentForBridge(attachment.storageKey, signingContext);
 
         if (!url) {
@@ -439,7 +469,7 @@ export class BridgeExecutorService {
           mimeType: attachment.mimeType,
           size: attachment.size,
         };
-      })
+      }
     );
 
     return mapped.flatMap((entry) => (entry ? [entry] : []));

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -27,6 +27,12 @@ const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY_MS = 500;
 const AGENTS_STORAGE_FOLDER = 'agents';
 
+interface AttachmentSigningContext {
+  organizationId: string;
+  environmentId: string;
+  conversationId: string;
+}
+
 export interface BridgeReaction {
   emoji: string;
   added: boolean;
@@ -212,18 +218,28 @@ export class BridgeExecutorService {
       replyUrl,
       conversationId: conversation._id,
       integrationIdentifier: config.integrationIdentifier,
-      message: message ? await this.mapMessage(message, params.storedAttachments) : null,
+      message: message
+        ? await this.mapMessage(message, params.storedAttachments, {
+            organizationId: config.organizationId,
+            environmentId: config.environmentId,
+            conversationId: conversation._id,
+          })
+        : null,
       conversation: this.mapConversation(conversation),
       subscriber: this.mapSubscriber(subscriber),
       history: await this.mapHistory(history),
       platform: config.platform,
       platformContext,
       action: action ?? null,
-      reaction: reaction ? await this.mapReaction(reaction) : null,
+      reaction: reaction ? await this.mapReaction(reaction, config, conversation) : null,
     };
   }
 
-  private async mapMessage(message: Message, storedAttachments?: StoredAttachment[]): Promise<AgentMessage> {
+  private async mapMessage(
+    message: Message,
+    storedAttachments?: StoredAttachment[],
+    signingContext?: AttachmentSigningContext
+  ): Promise<AgentMessage> {
     const mapped: AgentMessage = {
       text: message.text,
       platformMessageId: message.id,
@@ -237,13 +253,9 @@ export class BridgeExecutorService {
     };
 
     if (storedAttachments !== undefined) {
-      mapped.attachments = storedAttachments.map((s) => ({
-        type: s.type,
-        url: s.url,
-        name: s.name,
-        mimeType: s.mimeType,
-        size: s.size,
-      }));
+      mapped.attachments = signingContext
+        ? await this.mapStoredAttachmentsForBridge(storedAttachments, signingContext)
+        : [];
 
       return mapped;
     }
@@ -289,13 +301,21 @@ export class BridgeExecutorService {
     };
   }
 
-  private async mapReaction(reaction: BridgeReaction): Promise<AgentReaction> {
+  private async mapReaction(
+    reaction: BridgeReaction,
+    config: ResolvedAgentConfig,
+    conversation: ConversationEntity
+  ): Promise<AgentReaction> {
     return {
       messageId: reaction.messageId,
       emoji: { name: reaction.emoji },
       added: reaction.added,
       message: reaction.sourceMessage
-        ? await this.mapMessage(reaction.sourceMessage, reaction.sourceMessageStoredAttachments)
+        ? await this.mapMessage(reaction.sourceMessage, reaction.sourceMessageStoredAttachments, {
+            organizationId: config.organizationId,
+            environmentId: config.environmentId,
+            conversationId: conversation._id,
+          })
         : null,
     };
   }
@@ -370,7 +390,11 @@ export class BridgeExecutorService {
     activity: ConversationActivityEntity
   ): Promise<string | null> {
     const activityId = activity._id?.toString();
-    const expectedPrefix = `${activity._organizationId}/${activity._environmentId}/${AGENTS_STORAGE_FOLDER}/${activity._conversationId}/`;
+    const expectedPrefix = this.getAttachmentStoragePrefix({
+      organizationId: activity._organizationId,
+      environmentId: activity._environmentId,
+      conversationId: activity._conversationId,
+    });
 
     if (!storageKey.startsWith(expectedPrefix)) {
       this.logger.warn(
@@ -394,5 +418,64 @@ export class BridgeExecutorService {
 
       return null;
     }
+  }
+
+  private async mapStoredAttachmentsForBridge(
+    storedAttachments: StoredAttachment[],
+    signingContext: AttachmentSigningContext
+  ) {
+    const mapped = await Promise.all(
+      storedAttachments.map(async (attachment) => {
+        const url = await this.signStoredAttachmentForBridge(attachment.storageKey, signingContext);
+
+        if (!url) {
+          return null;
+        }
+
+        return {
+          type: attachment.type,
+          url,
+          name: attachment.name,
+          mimeType: attachment.mimeType,
+          size: attachment.size,
+        };
+      })
+    );
+
+    return mapped.flatMap((entry) => (entry ? [entry] : []));
+  }
+
+  private async signStoredAttachmentForBridge(
+    storageKey: string,
+    signingContext: AttachmentSigningContext
+  ): Promise<string | null> {
+    const expectedPrefix = this.getAttachmentStoragePrefix(signingContext);
+
+    if (!storageKey.startsWith(expectedPrefix)) {
+      this.logger.warn(
+        { storageKey, expectedPrefix },
+        'Stored attachment storageKey outside expected namespace; omitting from bridge payload'
+      );
+
+      return null;
+    }
+
+    try {
+      const url = await this.attachmentStorage.signRead(storageKey);
+
+      if (!url) {
+        this.logger.warn({ storageKey }, 'Stored attachment missing from storage; omitting from bridge payload');
+      }
+
+      return url;
+    } catch (err) {
+      this.logger.warn(err, 'Failed to sign stored attachment; omitting from bridge payload');
+
+      return null;
+    }
+  }
+
+  private getAttachmentStoragePrefix(context: AttachmentSigningContext): string {
+    return `${context.organizationId}/${context.environmentId}/${AGENTS_STORAGE_FOLDER}/${context.conversationId}/`;
   }
 }

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -344,16 +344,21 @@ export class BridgeExecutorService {
 
   private async mapHistory(activities: ConversationActivityEntity[]): Promise<AgentHistoryEntry[]> {
     const reversed = [...activities].reverse();
+    const mapped: AgentHistoryEntry[] = [];
 
-    return await mapWithConcurrency(reversed, ATTACHMENT_SIGNING_CONCURRENCY, async (activity) => ({
-      role: activity.senderType,
-      type: activity.type,
-      content: activity.content,
-      richContent: await this.mapRichContentForBridge(activity.richContent, activity),
-      senderName: activity.senderName || undefined,
-      signalData: activity.signalData || undefined,
-      createdAt: activity.createdAt,
-    }));
+    for (const activity of reversed) {
+      mapped.push({
+        role: activity.senderType,
+        type: activity.type,
+        content: activity.content,
+        richContent: await this.mapRichContentForBridge(activity.richContent, activity),
+        senderName: activity.senderName || undefined,
+        signalData: activity.signalData || undefined,
+        createdAt: activity.createdAt,
+      });
+    }
+
+    return mapped;
   }
 
   private async mapRichContentForBridge(

--- a/libs/application-generic/src/services/storage/storage.service.ts
+++ b/libs/application-generic/src/services/storage/storage.service.ts
@@ -1,6 +1,7 @@
 import {
   DeleteObjectCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   PutObjectCommand,
   PutObjectCommandOutput,
   S3Client,
@@ -33,6 +34,8 @@ export abstract class StorageService {
     path: string;
     additionalHeaders?: Record<string, string>;
   }>;
+  abstract getReadSignedUrl(key: string, ttlSeconds: number): Promise<string>;
+  abstract fileExists(key: string): Promise<boolean>;
   abstract uploadFile(key: string, file: Buffer, contentType: string): Promise<PutObjectCommandOutput>;
   abstract getFile(key: string): Promise<Buffer>;
   abstract deleteFile(key: string): Promise<void>;
@@ -105,6 +108,39 @@ export class S3StorageService implements StorageService {
 
     return { signedUrl, path };
   }
+
+  async getReadSignedUrl(key: string, ttlSeconds: number): Promise<string> {
+    const command = new GetObjectCommand({
+      Bucket: process.env.S3_BUCKET_NAME,
+      Key: key,
+    });
+
+    return await getSignedUrl(this.s3, command, { expiresIn: ttlSeconds });
+  }
+
+  async fileExists(key: string): Promise<boolean> {
+    try {
+      await this.s3.send(
+        new HeadObjectCommand({
+          Bucket: process.env.S3_BUCKET_NAME,
+          Key: key,
+        })
+      );
+
+      return true;
+    } catch (error: any) {
+      if (
+        error.name === 'NotFound' ||
+        error.Code === 'NotFound' ||
+        error.Code === 'NoSuchKey' ||
+        error.$metadata?.httpStatusCode === 404
+      ) {
+        return false;
+      }
+
+      throw error;
+    }
+  }
 }
 
 export class GCSStorageService implements StorageService {
@@ -118,9 +154,6 @@ export class GCSStorageService implements StorageService {
 
     return (await fileObject.save(file, {
       contentType,
-      metadata: {
-        cacheControl: 'public, max-age=31536000',
-      },
     })) as unknown as PutObjectCommandOutput;
   }
 
@@ -168,6 +201,29 @@ export class GCSStorageService implements StorageService {
       : `${process.env.GCS_DOMAIN}${parsedUrl.pathname}`;
 
     return { signedUrl, path };
+  }
+
+  async getReadSignedUrl(key: string, ttlSeconds: number): Promise<string> {
+    if (!process.env.GCS_BUCKET_NAME) throw new Error('GCS_BUCKET_NAME is not defined as env variable');
+
+    const [signedUrl] = await this.gcs
+      .bucket(process.env.GCS_BUCKET_NAME)
+      .file(key)
+      .getSignedUrl({
+        version: 'v4',
+        action: 'read',
+        expires: Date.now() + ttlSeconds * 1000,
+      });
+
+    return signedUrl;
+  }
+
+  async fileExists(key: string): Promise<boolean> {
+    if (!process.env.GCS_BUCKET_NAME) throw new Error('GCS_BUCKET_NAME is not defined as env variable');
+
+    const [exists] = await this.gcs.bucket(process.env.GCS_BUCKET_NAME).file(key).exists();
+
+    return exists;
   }
 }
 
@@ -247,5 +303,34 @@ export class AzureBlobStorageService implements StorageService {
       path,
       additionalHeaders,
     };
+  }
+
+  async getReadSignedUrl(key: string, ttlSeconds: number): Promise<string> {
+    const containerName = process.env.AZURE_CONTAINER_NAME || 'novu';
+    const blobName = key;
+    const containerClient = this.blobServiceClient.getContainerClient(containerName);
+    const blobClient = containerClient.getBlobClient(blobName);
+    const blobSAS = generateBlobSASQueryParameters(
+      {
+        containerName,
+        blobName,
+        permissions: BlobSASPermissions.parse('r'),
+        startsOn: new Date(),
+        expiresOn: new Date(Date.now() + ttlSeconds * 1000),
+        protocol: SASProtocol.Https,
+      },
+      this.sharedKeyCredential
+    ).toString();
+
+    return `${blobClient.url}?${blobSAS}`;
+  }
+
+  async fileExists(key: string): Promise<boolean> {
+    if (!process.env.AZURE_CONTAINER_NAME) throw new Error('AZURE_CONTAINER_NAME is not defined as env variable');
+
+    const containerClient = this.blobServiceClient.getContainerClient(process.env.AZURE_CONTAINER_NAME);
+    const blockBlobClient = containerClient.getBlockBlobClient(key);
+
+    return await blockBlobClient.exists();
   }
 }

--- a/packages/shared/src/consts/slack-agent-oauth-scopes.ts
+++ b/packages/shared/src/consts/slack-agent-oauth-scopes.ts
@@ -7,6 +7,7 @@ export const SLACK_AGENT_OAUTH_SCOPES = [
   'channels:history',
   'channels:read',
   'chat:write',
+  'files:read',
   'groups:history',
   'groups:read',
   'im:history',


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Inbound agent attachments are now normalized: provider-protected media (e.g., private Slack/WhatsApp files) are fetched via chat adapters, uploaded into Novu storage, and agent bridges receive short‑lived signed read URLs (15‑minute TTL) instead of raw provider URLs. This prevents broken or credentialed links and ensures stable, secure access for agent bridges. The change is API-only and adds safeguards around size/count limits and graceful degradation when signing fails.

## Affected areas
- **api**: Adds AgentAttachmentStorage to fetch, validate, upload and index inbound attachments (per-file 25 MB cap, 15 attachments max, 50 MB aggregate cap) and exposes signRead(storageKey); AgentInboundHandler persists attachments before building richContent; BridgeExecutorService maps/resigns stored attachments for messages, history and reactions and omits invalid/unsigned items while logging warnings.
- **application-generic**: Extends StorageService API with getReadSignedUrl(key, ttlSeconds) and fileExists(key) and implements them for S3 (presigner/HeadObject), GCS (v4 signed URLs/.exists()), and Azure Blob (SAS URLs/.exists()).
- **shared**: Adds Slack OAuth scope "files:read" to enable private Slack file downloads through the chat adapter.
- **tests**: Adds focused unit tests for AgentAttachmentStorage, BridgeExecutorService, and AgentInboundHandler behavior related to upload/signing, size/cap enforcement, and bridge history degradation.

## Key technical decisions
- Use deterministic, namespaced storage keys (org/env/agents/conversation/platformMessageId/...) to enforce context boundaries and idempotency.
- Generate read URLs on demand with caller-specified TTL (default 15 minutes) to avoid exposing long-lived provider URLs and to prevent expiry during history rendering.
- Enforce per-file, aggregate size, and item-count limits and skip/log oversized or invalid items rather than failing message processing.
- Bridge mapping degrades gracefully: attachments outside the expected namespace, missing in storage, or failing to sign are omitted and logged, so bridge execution continues.

## Testing
Added targeted unit tests covering attachment upload/signing limits and failure modes; verified with a focused package build and Mocha specs for agent-attachment-storage and bridge executor mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Normalizes inbound agent attachments by fetching provider-protected media through the chat adapter, storing it in Novu storage, and passing short-lived signed URLs to agent bridges. This fixes Slack and WhatsApp attachment handling where platform URLs are missing or require provider credentials.

Also adds `files:read` to Slack agent OAuth scopes so private Slack file downloads can succeed.

### Screenshots

Not applicable, API-only change.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None.

### Special notes for your reviewer

Focused tests cover attachment upload/signing behavior and bridge history degradation when signing fails. Verified with:

- `pnpm --filter @novu/application-generic build`
- focused API mocha specs for `agent-attachment-storage.service` and `bridge-executor.service`

</details>

