### PR TITLE
ci(root): add Linear release tracking to Cloud, Community, and Enterprise pipelines fixes NV-7463

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -528,3 +528,26 @@ jobs:
             -H "Content-Type: application/json" \
             -H "x-api-key: ${{ secrets.BUG0_SECRET_KEY }}" \
             -d '{"url": "https://eu.dashboard.novu.co", "source": "novuhq-novu", "prod": "true"}'
+
+  linear_release_cloud:
+    name: Linear Release Sync (Cloud)
+    needs: [deploy, prepare-matrix]
+    runs-on: ubuntu-latest
+    if: |
+      always() &&
+      needs.deploy.result == 'success' &&
+      contains(github.event.inputs.environment, 'production')
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Sync release to Linear
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_CLOUD }}
+          name: ${{ github.event.inputs.environment }}
+          version: ${{ github.event.inputs.environment }}-${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -546,7 +546,7 @@ jobs:
           fetch-depth: 0
 
       - name: Sync release to Linear
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_CLOUD }}
           name: ${{ github.event.inputs.environment }}

--- a/.github/workflows/linear-release-community.yml
+++ b/.github/workflows/linear-release-community.yml
@@ -29,6 +29,6 @@ jobs:
           fetch-depth: 0
 
       - name: Sync release to Linear
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_COMMUNITY }}

--- a/.github/workflows/linear-release-community.yml
+++ b/.github/workflows/linear-release-community.yml
@@ -1,0 +1,34 @@
+name: Linear Release - Community Edition
+
+# Scheduled Linear pipeline for the Community / OSS self-hosted release stream.
+# - Push to `next`: incrementally syncs commits/issues to the in-progress release.
+# - Tag push (`v*.*.*`): handled inside `prepare-self-hosted-release.yml`, which
+#   syncs and completes the Linear release using the tag version after Docker
+#   images are built and pushed.
+
+on:
+  push:
+    branches:
+      - next
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linear-release-community-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync to Linear (Community)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Sync release to Linear
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_COMMUNITY }}

--- a/.github/workflows/linear-release-enterprise.yml
+++ b/.github/workflows/linear-release-enterprise.yml
@@ -1,0 +1,34 @@
+name: Linear Release - Enterprise Edition
+
+# Scheduled Linear pipeline for the Enterprise self-hosted release stream.
+# - Push to `next`: incrementally syncs commits/issues to the in-progress release.
+# - Manual enterprise build: handled inside
+#   `prepare-enterprise-self-hosted-release.yml`, which syncs and completes the
+#   Linear release using the dispatched `version` input after images are built.
+
+on:
+  push:
+    branches:
+      - next
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linear-release-enterprise-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync to Linear (Enterprise)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Sync release to Linear
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_ENTERPRISE }}

--- a/.github/workflows/linear-release-enterprise.yml
+++ b/.github/workflows/linear-release-enterprise.yml
@@ -29,6 +29,6 @@ jobs:
           fetch-depth: 0
 
       - name: Sync release to Linear
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_ENTERPRISE }}

--- a/.github/workflows/prepare-enterprise-self-hosted-release.yml
+++ b/.github/workflows/prepare-enterprise-self-hosted-release.yml
@@ -265,16 +265,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Normalize Linear release version
+        env:
+          RAW_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          ver="${RAW_VERSION#v}"
+          echo "LINEAR_RELEASE_VERSION=$ver" >> "$GITHUB_ENV"
+
       - name: Sync release to Linear
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_ENTERPRISE }}
-          name: v${{ github.event.inputs.version }}
-          version: ${{ github.event.inputs.version }}
+          name: v${{ env.LINEAR_RELEASE_VERSION }}
+          version: ${{ env.LINEAR_RELEASE_VERSION }}
 
       - name: Complete release in Linear
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_ENTERPRISE }}
           command: complete
-          version: ${{ github.event.inputs.version }}
+          version: ${{ env.LINEAR_RELEASE_VERSION }}

--- a/.github/workflows/prepare-enterprise-self-hosted-release.yml
+++ b/.github/workflows/prepare-enterprise-self-hosted-release.yml
@@ -252,3 +252,29 @@ jobs:
           echo "  - $REGISTRY/novu/$REPO_NAME:$IMAGE_TAG"
           echo "Platform: linux/amd64 (x86)"
           echo "Type: Enterprise Self-hosted"
+
+  linear_release_complete:
+    name: Complete Linear Release (Enterprise)
+    needs: build_docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Sync release to Linear
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_ENTERPRISE }}
+          name: v${{ github.event.inputs.version }}
+          version: ${{ github.event.inputs.version }}
+
+      - name: Complete release in Linear
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_ENTERPRISE }}
+          command: complete
+          version: ${{ github.event.inputs.version }}

--- a/.github/workflows/prepare-self-hosted-release.yml
+++ b/.github/workflows/prepare-self-hosted-release.yml
@@ -238,3 +238,33 @@ jobs:
             docker tag novu-$SERVICE_COMMON_NAME ghcr.io/$REGISTRY_OWNER/${{ matrix.name }}:latest
             docker push ghcr.io/$REGISTRY_OWNER/${{ matrix.name }}:latest
           fi
+
+  linear_release_complete:
+    name: Complete Linear Release (Community)
+    needs: build_docker
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set release version
+        run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Sync release to Linear
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_COMMUNITY }}
+          name: v${{ env.RELEASE_VERSION }}
+          version: ${{ env.RELEASE_VERSION }}
+
+      - name: Complete release in Linear
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_COMMUNITY }}
+          command: complete
+          version: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/prepare-self-hosted-release.yml
+++ b/.github/workflows/prepare-self-hosted-release.yml
@@ -256,14 +256,14 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
       - name: Sync release to Linear
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_COMMUNITY }}
           name: v${{ env.RELEASE_VERSION }}
           version: ${{ env.RELEASE_VERSION }}
 
       - name: Complete release in Linear
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_COMMUNITY }}
           command: complete


### PR DESCRIPTION
## Summary

Wires up [`linear/linear-release-action@v0`](https://github.com/linear/linear-release-action) to three release streams, each backed by its own Linear pipeline and access key. Linear automatically links commits/PRs to releases for issue tracking.

| Pipeline | Type | Sync trigger | Completion trigger |
| --- | --- | --- | --- |
| **Cloud** | Continuous | End of `deploy.yml` when a `production-*` deploy succeeds (one release per workflow run, version = `<env>-<sha>`) | n/a — continuous releases auto-complete |
| **Community Edition** | Scheduled | Push to `next` (incremental sync to in-progress release) | `v*.*.*` tag push, after `prepare-self-hosted-release` builds succeed |
| **Enterprise Edition** | Scheduled | Push to `next` (incremental sync to in-progress release) | After `prepare-enterprise-self-hosted-release` builds succeed, using the dispatched `version` input |

All jobs use the official action with `actions/checkout@v5` + `fetch-depth: 0` (required for commit history scanning) and `permissions: contents: read`.

## Files changed

- `.github/workflows/deploy.yml` — appended `linear_release_cloud` job (gated on `needs.deploy.result == 'success'` and `production-*` env, dedupes to one release per workflow run)
- `.github/workflows/prepare-self-hosted-release.yml` — appended `linear_release_complete` job (tag-push only, derives version from `${GITHUB_REF_NAME#v}`)
- `.github/workflows/prepare-enterprise-self-hosted-release.yml` — appended `linear_release_complete` job (uses dispatched `inputs.version`)
- `.github/workflows/linear-release-community.yml` — new workflow, syncs Community pipeline on every push to `next`
- `.github/workflows/linear-release-enterprise.yml` — new workflow, syncs Enterprise pipeline on every push to `next`

## Required setup before merge

1. Create three release pipelines in Linear (Settings → Releases): Cloud (continuous), Community Edition (scheduled), Enterprise Edition (scheduled). No intermediate stages on either scheduled pipeline.
2. Add three repository secrets in `novuhq/novu` (Settings → Secrets and variables → Actions):
   - `LINEAR_ACCESS_KEY_CLOUD`
   - `LINEAR_ACCESS_KEY_COMMUNITY`
   - `LINEAR_ACCESS_KEY_ENTERPRISE`
3. Optional: configure monorepo path filters per pipeline directly in Linear settings (intentionally not hardcoded in CI so we can tune without code changes).

## Design notes

- **Cloud version scheme** `version: <environment>-<sha>` so the same SHA deployed to multiple regions yields one Linear release per region; redeploys to the same env are idempotent.
- **Community completion uses the git tag**, not `apps/api/package.json`. They should match in practice, but the tag is the source of truth for the Linear release identifier.
- **Nightly community builds are intentionally skipped** for completion — gated by `github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')`. The push-to-\`next\` sync still tracks ongoing commits.
- **Enterprise completion runs on every successful enterprise build dispatch**. Idempotent against Linear if rebuilding the same version. To suppress for partial rebuilds, gate on a new boolean input.

## Test plan

- [ ] All three Linear pipelines created and access keys added as GitHub secrets
- [ ] Push a no-op commit to \`next\` → confirm Community + Enterprise sync workflows succeed and link any issue identifiers in commits to the in-progress releases
- [ ] Manually dispatch \`Deploy to Novu Cloud\` for \`production-us\` → confirm \`linear_release_cloud\` runs after \`deploy\` and creates a Linear release on the Cloud pipeline
- [ ] Cut a \`v*.*.*\` tag → confirm \`prepare-self-hosted-release\` finishes with \`linear_release_complete\` syncing and completing the Community release
- [ ] Manually dispatch \`prepare-enterprise-self-hosted-release\` with a version → confirm \`linear_release_complete\` syncs and completes the Enterprise release

Linear: [NV-7463](https://linear.app/novu/issue/NV-7463/ci-add-linear-release-tracking-to-cloud-community-and-enterprise)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Integrated Linear release action into CI/CD pipelines for three release streams (Cloud, Community Edition, Enterprise Edition) to automatically link commits and PRs to releases in Linear. Cloud releases trigger on successful production deployments with environment-based versioning. Community Edition releases sync on pushes to `next` and complete when version tags are pushed. Enterprise releases sync on `next` pushes and complete after self-hosted build success using dispatched version input.

## Affected areas

**CI/CD** (`.github/workflows/`) — Added `linear_release_cloud` job to `deploy.yml` for production environments, `linear_release_complete` jobs to `prepare-self-hosted-release.yml` and `prepare-enterprise-self-hosted-release.yml`, and created new workflows `linear-release-community.yml` and `linear-release-enterprise.yml` for incremental syncing to Linear on `next` branch pushes.

**Enterprise Edition** — Added version normalization and Linear sync/completion for enterprise self-hosted release workflow, stripping leading "v" from version input before syncing to maintain naming consistency.

## Key technical decisions

- Pinned `linear/linear-release-action` to commit `0353b5fa8c00326913966f00557d68f8f30b8b6b` across all workflows to satisfy supply-chain security requirements.
- Community Edition derives version from git tag name (`${GITHUB_REF_NAME#v}`); Enterprise Edition uses dispatch input.
- Used concurrency groups with `cancel-in-progress: false` for community and enterprise workflows to serialize releases.

## Testing

No code tests required; changes are CI/CD configuration. Workflows should be verified manually after Linear pipelines are created and repository secrets (`LINEAR_ACCESS_KEY_CLOUD`, `LINEAR_ACCESS_KEY_COMMUNITY`, `LINEAR_ACCESS_KEY_ENTERPRISE`) are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->