### PR TITLE
fix(api-service): use environment type for Inbox development mode flag fixes NV-7462

### DIFF
--- a/apps/api/src/app/inbox/usecases/session/session.spec.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.spec.ts
@@ -19,7 +19,7 @@ import {
   NotificationTemplateRepository,
   PreferencesRepository,
 } from '@novu/dal';
-import { ApiServiceLevelEnum, ChannelTypeEnum, InAppProviderIdEnum, SeverityLevelEnum } from '@novu/shared';
+import { ApiServiceLevelEnum, ChannelTypeEnum, EnvironmentTypeEnum, InAppProviderIdEnum, SeverityLevelEnum } from '@novu/shared';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { AuthService } from '../../../auth/services/auth.service';
@@ -134,6 +134,85 @@ describe('Session', () => {
     );
 
     messageRepository.getCountBySeverity.resolves(mockSeverityCounts);
+  });
+
+  it('should set isDevelopmentMode to false for live (prod type) environment regardless of display name', async () => {
+    const command: SessionCommand = {
+      requestData: {
+        applicationIdentifier: 'app-id',
+        subscriber: { subscriberId: 'subscriber-id' },
+        subscriberHash: 'hash',
+      },
+    };
+
+    const environment = {
+      _id: 'env-id',
+      _organizationId: 'org-id',
+      name: 'Third environment',
+      type: EnvironmentTypeEnum.PROD,
+      apiKeys: [{ key: 'api-key' }],
+    };
+    const organization = { _id: 'org-id', apiServiceLevel: ApiServiceLevelEnum.FREE };
+    const subscriber = { _id: 'subscriber-id' };
+    const notificationCount = { data: [{ count: 0, filter: {} }] };
+    const token = 'token';
+
+    environmentRepository.findEnvironmentByIdentifier.resolves(environment as any);
+    organizationRepository.findById.resolves(organization as any);
+    selectIntegration.execute.resolves({ ...mockIntegration, credentials: { hmac: false } });
+    createSubscriber.execute.resolves(subscriber as any);
+    notificationsCount.execute.resolves(notificationCount);
+    authService.getSubscriberWidgetToken.resolves(token);
+    getOrganizationSettingsUsecase.execute.resolves({
+      removeNovuBranding: false,
+      defaultLocale: 'en_US',
+    });
+
+    const response: SubscriberSessionResponseDto = await session.execute(command);
+
+    expect(response.isDevelopmentMode).to.equal(false);
+  });
+
+  it('should fall back to legacy name check when environment type is unset', async () => {
+    const command: SessionCommand = {
+      requestData: {
+        applicationIdentifier: 'app-id',
+        subscriber: { subscriberId: 'subscriber-id' },
+        subscriberHash: 'hash',
+      },
+    };
+
+    const organization = { _id: 'org-id', apiServiceLevel: ApiServiceLevelEnum.FREE };
+    const subscriber = { _id: 'subscriber-id' };
+    const notificationCount = { data: [{ count: 0, filter: {} }] };
+    const token = 'token';
+
+    const legacyProdNamed = {
+      _id: 'env-id',
+      _organizationId: 'org-id',
+      name: 'Production',
+      apiKeys: [{ key: 'api-key' }],
+    };
+
+    environmentRepository.findEnvironmentByIdentifier.resolves(legacyProdNamed as any);
+    organizationRepository.findById.resolves(organization as any);
+    selectIntegration.execute.resolves({ ...mockIntegration, credentials: { hmac: false } });
+    createSubscriber.execute.resolves(subscriber as any);
+    notificationsCount.execute.resolves(notificationCount);
+    authService.getSubscriberWidgetToken.resolves(token);
+    getOrganizationSettingsUsecase.execute.resolves({
+      removeNovuBranding: false,
+      defaultLocale: 'en_US',
+    });
+
+    const prodResponse: SubscriberSessionResponseDto = await session.execute(command);
+    expect(prodResponse.isDevelopmentMode).to.equal(false);
+
+    const legacyDevNamed = { ...legacyProdNamed, name: 'Staging' };
+    environmentRepository.findEnvironmentByIdentifier.resolves(legacyDevNamed as any);
+
+    const devResponse: SubscriberSessionResponseDto = await session.execute(command);
+    expect(devResponse.isDevelopmentMode).to.equal(true);
   });
 
   it('should throw an error if the environment is not found', async () => {

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -45,6 +45,7 @@ import {
   FeatureNameEnum,
   getFeatureForTierAsNumber,
   InAppProviderIdEnum,
+  EnvironmentTypeEnum,
   PreferenceLevelEnum,
   PreferencesTypeEnum,
   ResourceOriginEnum,
@@ -283,7 +284,7 @@ export class Session {
       unreadCount,
       removeNovuBranding,
       maxSnoozeDurationHours,
-      isDevelopmentMode: environment.name.toLowerCase() !== 'production',
+      isDevelopmentMode: this.isInboxDevelopmentMode(environment),
       schedule,
       contextKeys,
     };
@@ -327,6 +328,22 @@ export class Session {
     );
 
     return updatedGlobalPreference.schedule;
+  }
+
+  /**
+   * Live (production-type) environments must not show the Inbox "Development mode" footer,
+   * regardless of display name. Legacy orgs may lack `type`; fall back to the old name check.
+   */
+  private isInboxDevelopmentMode(environment: EnvironmentEntity): boolean {
+    if (environment.type === EnvironmentTypeEnum.PROD) {
+      return false;
+    }
+
+    if (environment.type === EnvironmentTypeEnum.DEV) {
+      return true;
+    }
+
+    return environment.name.toLowerCase() !== 'production';
   }
 
   private validateRequestData(requestData: SubscriberSessionRequestDto): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The subscriber session response set `isDevelopmentMode` using only `environment.name !== 'production'`. Extra Team-plan environments keep user-defined names when promoted to live; live environments are modeled as `type: prod` (same as the dashboard’s “live” grouping), not necessarily named `"Production"`.

## Change

- Compute inbox development mode from `EnvironmentTypeEnum`: `prod` → not development mode; `dev` → development mode.
- If `type` is unset (legacy data), fall back to the previous name-based check.

## Testing

- Added unit tests for prod-type with a non-Production display name and for the legacy fallback.

Could not run `pnpm test` in this agent environment (Node/pnpm unavailable); CI should run API unit tests on push.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7462](https://linear.app/novu/issue/NV-7462/inbox-shows-development-mode-in-live-third-environment)

<div><a href="https://cursor.com/agents/bc-0759b0a1-581f-41ea-82cb-284262da5282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0759b0a1-581f-41ea-82cb-284262da5282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The Inbox development mode flag now uses the environment type enum instead of environment name. This fixes an issue where live/production environments with custom display names (e.g., "Staging", "Custom Name") were incorrectly showing the "development mode" footer because the check only looked for "production" in the name. The new implementation checks `EnvironmentTypeEnum.PROD` (hides development mode) and `EnvironmentTypeEnum.DEV` (shows development mode), with a fallback to the legacy name-based check for backwards compatibility with older environments that lack a type field.

## Affected areas
- **api**: Modified the Session usecase to calculate `isDevelopmentMode` via the new `isInboxDevelopmentMode()` helper method, which evaluates environment type instead of name. The helper also includes fallback logic for legacy environments where the type is unset.

## Key technical decisions
- Environment type enum (EnvironmentTypeEnum) is the source of truth for determining whether development mode should be shown, ensuring live/prod-type environments never display the development mode footer regardless of custom display name.
- Fallback logic preserves compatibility with legacy environments that haven't been assigned a type field, using the original name-based check.

## Testing
Added unit tests covering the new behavior with a prod-type environment bearing a non-Production display name (ensuring development mode is hidden) and the legacy fallback case (ensuring name-based logic activates when type is unset).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->