### PR TITLE
feat(dashboard): hide workflow runs error line when period has no errors fixes NV-7465

### DIFF
--- a/apps/dashboard/src/components/analytics/charts/workflow-runs-trend-chart.tsx
+++ b/apps/dashboard/src/components/analytics/charts/workflow-runs-trend-chart.tsx
@@ -1,6 +1,6 @@
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { ArrowRight } from 'lucide-react';
-import { useCallback, useId, useMemo } from 'react';
+import { useCallback, useId, useMemo, type ComponentProps } from 'react';
 import { Link } from 'react-router-dom';
 import { Area, ComposedChart, XAxis, YAxis } from 'recharts';
 import { type WorkflowRunsTrendDataPoint } from '../../../api/activity';
@@ -13,6 +13,31 @@ import { generateDummyWorkflowRunsData } from './chart-dummy-data';
 import { type WorkflowRunsChartData } from './chart-types';
 import { ChartWrapper } from './chart-wrapper';
 import { FlickeringGrid } from './flickering-grid';
+
+function periodHasWorkflowErrors(points: WorkflowRunsTrendDataPoint[] | undefined): boolean {
+  if (!points?.length) {
+    return false;
+  }
+
+  return points.some((p) => (p.error ?? 0) > 0);
+}
+
+function WorkflowRunsChartTooltip({
+  omitDataKeys,
+  ...props
+}: ComponentProps<typeof NovuTooltip> & { omitDataKeys?: readonly string[] }) {
+  const filteredPayload = useMemo(() => {
+    if (!omitDataKeys?.length || !props.payload) {
+      return props.payload;
+    }
+
+    const omit = new Set(omitDataKeys);
+
+    return props.payload.filter((item) => !omit.has(String(item.dataKey)));
+  }, [omitDataKeys, props.payload]);
+
+  return <NovuTooltip {...props} payload={filteredPayload} />;
+}
 
 type WorkflowRunsChartDataWithTotal = WorkflowRunsChartData & { total: number };
 
@@ -100,9 +125,17 @@ type ChartContentParams = {
   config: ChartConfig;
   seriesKeys: readonly string[];
   baseId: string;
+  omitTooltipDataKeys?: readonly string[];
 };
 
-function renderWorkflowRunsChartContent({ data, includeTooltip, config, seriesKeys, baseId }: ChartContentParams) {
+function renderWorkflowRunsChartContent({
+  data,
+  includeTooltip,
+  config,
+  seriesKeys,
+  baseId,
+  omitTooltipDataKeys,
+}: ChartContentParams) {
   return (
     <div className="relative w-full -mx-1 group/chart h-full flex flex-col">
       <div className={`pointer-events-none absolute left-0 right-0 top-0 z-0`} style={{ height: CHART_HEIGHT }}>
@@ -143,7 +176,18 @@ function renderWorkflowRunsChartContent({ data, includeTooltip, config, seriesKe
             padding={{ left: 8, right: 8 }}
           />
           <YAxis hide domain={[0, 'auto']} />
-          {includeTooltip && <ChartTooltip cursor={false} content={<NovuTooltip showTotal />} />}
+          {includeTooltip && (
+            <ChartTooltip
+              cursor={false}
+              content={
+                omitTooltipDataKeys?.length ? (
+                  <WorkflowRunsChartTooltip showTotal omitDataKeys={omitTooltipDataKeys} />
+                ) : (
+                  <NovuTooltip showTotal />
+                )
+              }
+            />
+          )}
           {seriesKeys.map((key) => {
             const entry = config[key as keyof typeof config];
             if (!entry || !('color' in entry)) return null;
@@ -223,7 +267,30 @@ function WorkflowRunsTrendChartInner({
   error,
 }: WorkflowRunsTrendChartProps & { variant: Variant }) {
   const baseId = useId();
-  const { config, seriesKeys, getTotal } = VARIANT_CONFIG[variant];
+  const { config: fullChartConfig, seriesKeys: allSeriesKeys, getTotal } = VARIANT_CONFIG[variant];
+
+  const showErrorSeries = useMemo(() => periodHasWorkflowErrors(data), [data]);
+
+  const { chartConfig, seriesKeys, omitTooltipDataKeys } = useMemo(() => {
+    if (showErrorSeries) {
+      return {
+        chartConfig: fullChartConfig,
+        seriesKeys: allSeriesKeys,
+        omitTooltipDataKeys: undefined as readonly string[] | undefined,
+      };
+    }
+
+    const seriesKeysFiltered = allSeriesKeys.filter((key) => key !== 'error');
+    const chartConfig = Object.fromEntries(
+      Object.entries(fullChartConfig).filter(([key]) => key !== 'error')
+    ) as ChartConfig;
+
+    return {
+      chartConfig,
+      seriesKeys: seriesKeysFiltered,
+      omitTooltipDataKeys: ['error'] as const,
+    };
+  }, [allSeriesKeys, fullChartConfig, showErrorSeries]);
 
   const chartData = useMemo(
     () => data?.map((p) => VARIANT_CONFIG[variant].mapDataPoint(p)) ?? undefined,
@@ -246,11 +313,12 @@ function WorkflowRunsTrendChartInner({
       renderWorkflowRunsChartContent({
         data: chartDataToRender,
         includeTooltip,
-        config,
+        config: chartConfig,
         seriesKeys,
         baseId,
+        omitTooltipDataKeys,
       }),
-    [baseId, config, seriesKeys]
+    [baseId, chartConfig, omitTooltipDataKeys, seriesKeys]
   );
 
   const renderEmptyState = useCallback(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the Usage page (`analytics.tsx`), the workflow runs trend chart no longer renders the error series when every data point in the selected period has zero errors. The hover tooltip also omits the error row in that case.

## Implementation

- `periodHasWorkflowErrors()` aggregates across the full `data` array (not per bucket).
- When false: filter `error` out of `seriesKeys` and from `ChartConfig` passed to `ChartContainer` (so gradients, areas, and CSS variables exclude error).
- `WorkflowRunsChartTooltip` strips `error` from the Recharts payload before `NovuTooltip` so the hover card cannot show a stray error line if the library still included it.

## Testing

Typecheck/lint were not run in this environment (`pnpm`/`npx` unavailable in PATH). Please run dashboard checks locally if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7465](https://linear.app/novu/issue/NV-7465/hide-error-line-when-errors-are-zero)

<div><a href="https://cursor.com/agents/bc-8774ae17-80d4-4904-926b-28b5be4f12e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8774ae17-80d4-4904-926b-28b5be4f12e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The workflow runs trend chart on the Usage/analytics page now conditionally hides the error series when the selected period contains no workflow errors. The chart no longer renders the error line in the graph or displays an error row in the hover tooltip when all data points have zero errors.

## Affected areas

**dashboard**: Updated the workflow runs trend chart component to conditionally filter the error series from both the chart visualization and tooltip based on whether the data period contains any errors.

## Key technical decisions

- Added `periodHasWorkflowErrors()` helper function to aggregate the full data array and determine if the period contains any errors, rather than checking per bucket.
- Introduced `WorkflowRunsChartTooltip` wrapper component to filter the error key from the Recharts payload before rendering, ensuring the tooltip cannot display an error row even if the charting library includes it.
- When `periodHasWorkflowErrors()` returns false, the error series is excluded from `seriesKeys` and `ChartConfig` to prevent gradients, areas, and CSS variables from being generated for the error line.

## Testing

The PR notes that typecheck and lint were not run in the development environment; dashboard checks should be run locally as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->