### PR TITLE
fix(dashboard): dedupe Data textarea resize grip fixes NV-7439

### DIFF
--- a/apps/dashboard/src/pages/domain-detail.tsx
+++ b/apps/dashboard/src/pages/domain-detail.tsx
@@ -478,7 +478,7 @@ export function DomainDetailPage() {
                       disabled={!canWriteDomains || updateDomainMeta.isPending}
                       isPersisting={updateDomainMeta.isPending}
                       spellCheck={false}
-                      textareaClassName="font-code text-code-xs min-h-[120px] resize-y"
+                      textareaClassName="font-code text-code-xs min-h-[120px]"
                     />
                   )}
                 </DetailsSidebarCard>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the Inbound Email domain detail page, the **Data** expandable textarea showed two resize grips in the bottom-right corner.

## Cause

The shared `Textarea` primitive (`apps/dashboard/src/components/primitives/textarea.tsx`) already implements vertical resize with an invisible `resize-y` layer plus a decorative grip. Passing `resize-y` via `textareaClassName` on `ExpandableDetailsTextarea` re-enabled the **native** textarea resize widget on top of that, so both appeared.

## Change

Drop `resize-y` from the domain detail `textareaClassName` so only the component’s single resize affordance is used. Minimum height and typography classes are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7439](https://linear.app/novu/issue/NV-7439/in-inbound-email-domain-detail-page-data-expand-icon-is-duplicated)

<div><a href="https://cursor.com/agents/bc-b5120476-a6b0-4c4a-87bd-1c23f7112bdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5120476-a6b0-4c4a-87bd-1c23f7112bdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Fixed duplicate resize grips appearing in the Data textarea field on the Inbound Email domain detail page. The shared Textarea primitive component already provides resize functionality with a decorative grip, but the domain detail page was additionally passing `resize-y` via `textareaClassName`, which re-enabled the native textarea resize widget. Removed the `resize-y` class to eliminate the duplicate grip affordance while preserving typography and minimum height styles.

## Affected areas

**dashboard**: Adjusted `ExpandableDetailsTextarea` styling in the domain detail page by removing `resize-y` from the textarea classes, now using only font and minimum height styling.

## Testing

Manual verification is sufficient for this visual UI fix—testing would involve confirming that the Data textarea on the domain detail page now displays a single resize grip instead of two.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->