### PR TITLE
fix(api-service): add SSRF validation to HTTP step test endpoint fixes NV-7467

### DIFF
--- a/apps/api/src/app/workflows-v2/e2e/test-http-endpoint.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/test-http-endpoint.e2e.ts
@@ -1,6 +1,9 @@
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
+/** Public HTTPS URL for outbound tests (localhost is blocked by SSRF validation). */
+const HTTP_TEST_POST_URL = 'https://httpbin.org/post';
+
 describe('Test HTTP Request Endpoint - /v2/workflows/steps/test-http-request (POST) #novu-v2', () => {
   let session: UserSession;
 
@@ -9,10 +12,25 @@ describe('Test HTTP Request Endpoint - /v2/workflows/steps/test-http-request (PO
     await session.initialize();
   });
 
-  it('should resolve canonical raw JSON string body controls', async () => {
+  it('should reject localhost URLs blocked by SSRF validation', async () => {
     const response = await session.testAgent.post('/v2/workflows/steps/test-http-request').send({
       controlValues: {
         url: `http://localhost:${process.env.PORT}/v1/health-check`,
+        method: 'GET',
+      },
+    });
+
+    expect(response.status).to.equal(201);
+    expect(response.body.data.statusCode).to.equal(400);
+    expect(response.body.data.body).to.deep.include({
+      error: 'Requests to "localhost" are not allowed.',
+    });
+  });
+
+  it('should resolve canonical raw JSON string body controls', async () => {
+    const response = await session.testAgent.post('/v2/workflows/steps/test-http-request').send({
+      controlValues: {
+        url: HTTP_TEST_POST_URL,
         method: 'POST',
         headers: [{ key: 'content-type', value: 'application/json' }],
         body: JSON.stringify({
@@ -42,7 +60,7 @@ describe('Test HTTP Request Endpoint - /v2/workflows/steps/test-http-request (PO
   it('should resolve legacy key-value array body controls', async () => {
     const response = await session.testAgent.post('/v2/workflows/steps/test-http-request').send({
       controlValues: {
-        url: `http://localhost:${process.env.PORT}/v1/health-check`,
+        url: HTTP_TEST_POST_URL,
         method: 'POST',
         headers: [{ key: 'content-type', value: 'application/json' }],
         body: [

--- a/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
@@ -11,6 +11,7 @@ import {
   KeyValuePair,
   resolveHttpRequestBody,
   shouldIncludeBody,
+  validateUrlSsrf,
 } from '@novu/application-generic';
 import { createLiquidEngine } from '@novu/framework/internal';
 import { Liquid } from 'liquidjs';
@@ -88,6 +89,24 @@ export class TestHttpEndpointUsecase {
     }
 
     const hasBody = shouldIncludeBody(resolvedBody, method);
+
+    const ssrfValidationError = await validateUrlSsrf(resolvedUrl);
+
+    if (ssrfValidationError) {
+      const durationMs = Math.round(performance.now() - startTime);
+
+      return {
+        statusCode: 400,
+        body: { error: ssrfValidationError },
+        headers: {},
+        durationMs,
+        resolvedRequest: {
+          url: resolvedUrl,
+          method,
+          headers: resolvedHeaders,
+        },
+      };
+    }
 
     const secretKey = await this.getDecryptedSecretKey.execute(
       GetDecryptedSecretKeyCommand.create({ environmentId: command.user.environmentId })

--- a/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
@@ -104,6 +104,7 @@ export class TestHttpEndpointUsecase {
           url: resolvedUrl,
           method,
           headers: resolvedHeaders,
+          ...(hasBody ? { body: resolvedBody } : {}),
         },
       };
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The workflow HTTP step **test** endpoint resolved Liquid templates into a URL and called `HttpClientService.request()` without the same SSRF checks as production (`ExecuteHttpRequestStep`).

## Changes

- Import `validateUrlSsrf` from `@novu/application-generic`.
- After resolving URL/body/headers (and before secret key lookup and outbound request), call `validateUrlSsrf(resolvedUrl)`.
- On failure, return HTTP 400 with the validation error message in the response body, without performing the request. `resolvedRequest` includes the resolved body when present (same shape as success paths).
- E2E: use a public HTTPS URL (`https://httpbin.org/post`) for happy-path body tests; add a regression test that `http://localhost:...` returns `statusCode` 400 with the SSRF error.

## Testing

- CI: E2E shard 3 previously failed because tests targeted `localhost`, which SSRF correctly blocks; e2e updated accordingly.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7467](https://linear.app/novu/issue/NV-7467/add-ssrf-validation-to-http-step-test-endpoint)

<div><a href="https://cursor.com/agents/bc-d166f105-40ba-4d5d-a83d-81f8fc8179ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d166f105-40ba-4d5d-a83d-81f8fc8179ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The API's workflow HTTP step test endpoint now runs SSRF validation on the resolved URL (and related resolved body/headers) before decrypting secrets or making outbound requests. This closes a security gap where test requests previously bypassed production SSRF checks; on validation failure the endpoint returns HTTP 400 with the SSRF error and does not perform the outbound call.

## Affected areas

**api**: TestHttpEndpointUsecase imports and calls validateUrlSsrf after Liquid resolution and before secret lookup/signature creation; on failure it returns a 400 response and includes the resolvedRequest payload (url, method, headers, and body when applicable). E2E tests were updated to use a public HTTPS endpoint for happy-path tests and a new regression test asserts localhost is rejected.

## Key technical decisions

- Reuse the existing validateUrlSsrf utility from @novu/application-generic to keep SSRF rules consistent with production ExecuteHttpRequestStep.
- Run validation after template resolution but before secret decryption and the outbound HTTP request to avoid performing blocked network calls.
- Validation failures return HTTP 400 with the validation message and a resolvedRequest shape matching success responses.

## Testing

E2E updates added: happy-path tests now target https://httpbin.org/post and a regression test verifies localhost URLs return 400 with the SSRF error; CI shard failures caused by prior localhost tests were addressed. No new npm dependencies or enterprise changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->