### PR TITLE
fix(api-service): allow agent replies with files only fixes NV-7458

### DIFF
--- a/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
@@ -73,6 +73,28 @@ export class IsValidReplyContent implements ValidatorConstraintInterface {
   validate(content: ReplyContentDto): boolean {
     if (!content) return true;
 
+    const hasMarkdown = content.markdown !== undefined;
+    const hasCard = content.card !== undefined;
+    const hasFiles = (content.files?.length ?? 0) > 0;
+
+    if (hasMarkdown && hasCard) return false;
+
+    if (hasCard && hasFiles) return false;
+
+    if (hasFiles && !hasMarkdown && !hasCard) {
+      if ((content.files?.length ?? 0) > MAX_FILES_PER_MESSAGE) return false;
+
+      for (const file of content.files ?? []) {
+        const sources = [file.data, file.url].filter(Boolean);
+        if (sources.length !== 1) return false;
+        if (typeof file.data === 'string' && file.data.replace(/\s/g, '').length > MAX_INLINE_FILE_BASE64_CHARS) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
     const fields = [content.markdown, content.card].filter((v) => v !== undefined);
     if (fields.length !== 1) return false;
 
@@ -92,7 +114,8 @@ export class IsValidReplyContent implements ValidatorConstraintInterface {
 
   defaultMessage(): string {
     return (
-      'Content must have exactly one of markdown or card. Files only allowed with markdown. ' +
+      'Content must have exactly one of markdown or card, or files only (no markdown/card). ' +
+      'Files with markdown are allowed; files are not allowed with card. ' +
       `At most ${MAX_FILES_PER_MESSAGE} files are allowed. Each file needs exactly one of data or url. ` +
       'Inline data must be 5 MB or smaller.'
     );

--- a/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
@@ -92,6 +92,29 @@ describe('Agent Reply - /agents/:agentId/reply #novu-v2', () => {
       expect(res.body.data.platformThreadId).to.equal('platform-thread-1');
     });
 
+    it('should accept reply with files only (empty markdown) for attachment-only agent messages', async () => {
+      const conversationId = await seedConversation(ctx);
+
+      const res = await postReply({
+        conversationId,
+        integrationIdentifier: ctx.integrationIdentifier,
+        reply: {
+          files: [{ filename: 'photo.png', url: 'https://example.com/photo.png' }],
+        },
+      });
+
+      expect(res.status).to.equal(200);
+      expect(res.body.data?.messageId).to.equal('platform-msg-1');
+
+      const activities = await activityRepository.findByConversation(ctx.session.environment._id, conversationId);
+      const agentActivity = activities.find(
+        (a) =>
+          a.senderType === ConversationActivitySenderTypeEnum.AGENT && a.type === ConversationActivityTypeEnum.MESSAGE
+      );
+      expect(agentActivity).to.exist;
+      expect(agentActivity!.content).to.equal('[Attachment: photo.png]');
+    });
+
     it('should edit a previously sent message and persist an edit activity', async () => {
       const conversationId = await seedConversation(ctx);
 

--- a/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-reply.e2e.ts
@@ -92,8 +92,14 @@ describe('Agent Reply - /agents/:agentId/reply #novu-v2', () => {
       expect(res.body.data.platformThreadId).to.equal('platform-thread-1');
     });
 
-    it('should accept reply with files only (empty markdown) for attachment-only agent messages', async () => {
+    it('should accept reply with files only (no markdown) for attachment-only agent messages', async () => {
       const conversationId = await seedConversation(ctx);
+
+      const convBefore = await conversationRepository.findOne(
+        { _id: conversationId, _environmentId: ctx.session.environment._id },
+        '*'
+      );
+      const countBefore = convBefore!.messageCount;
 
       const res = await postReply({
         conversationId,
@@ -113,6 +119,13 @@ describe('Agent Reply - /agents/:agentId/reply #novu-v2', () => {
       );
       expect(agentActivity).to.exist;
       expect(agentActivity!.content).to.equal('[Attachment: photo.png]');
+
+      const convAfter = await conversationRepository.findOne(
+        { _id: conversationId, _environmentId: ctx.session.environment._id },
+        '*'
+      );
+      expect(convAfter!.lastMessagePreview).to.equal('[Attachment: photo.png]');
+      expect(convAfter!.messageCount).to.equal(countBefore + 1);
     });
 
     it('should edit a previously sent message and persist an edit activity', async () => {

--- a/apps/api/src/app/agents/services/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.ts
@@ -133,7 +133,7 @@ export class AgentConversationService {
         },
       ],
       status: ConversationStatusEnum.ACTIVE,
-      title: params.firstMessageText.slice(0, 200),
+      title: (params.firstMessageText ?? '').slice(0, 200) || 'New conversation',
       metadata: {},
       _environmentId: environmentId,
       _organizationId: organizationId,

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
@@ -60,7 +60,57 @@ describe('AgentInboundHandler', () => {
       attachmentStorage as any
     );
 
-    return { handler, attachmentStorage, bridgeExecutor };
+    return { handler, attachmentStorage, bridgeExecutor, conversationService };
+  }
+
+  function makeHandleDeps() {
+    const logger = makeLogger();
+    const subscriberResolver = { resolve: sinon.stub().resolves(null) };
+    const createOrGetConversation = sinon.stub().resolves(conversation);
+    const persistInboundMessage = sinon.stub().resolves({});
+    const updateChannelThread = sinon.stub().resolves(undefined);
+    const setFirstPlatformMessageId = sinon.stub().resolves(undefined);
+    const getPrimaryChannel = sinon.stub().returns({ firstPlatformMessageId: undefined });
+    const getHistory = sinon.stub().resolves([]);
+    const conversationService = {
+      createOrGetConversation,
+      persistInboundMessage,
+      updateChannelThread,
+      setFirstPlatformMessageId,
+      getPrimaryChannel,
+      getHistory,
+    };
+    const bridgeExecutor = { execute: sinon.stub().resolves(undefined) };
+    const subscriberRepository = { findBySubscriberId: sinon.stub().resolves(null) };
+    const analyticsService = { track: sinon.stub() };
+    const attachmentStorage = {
+      storeInbound: sinon.stub().resolves([
+        {
+          type: 'image',
+          name: 'photo.png',
+          mimeType: 'image/png',
+          size: 10,
+          storageKey: 'k',
+        },
+      ]),
+    };
+    const handler = new AgentInboundHandler(
+      logger as any,
+      subscriberResolver as any,
+      conversationService as any,
+      bridgeExecutor as any,
+      subscriberRepository as any,
+      analyticsService as any,
+      attachmentStorage as any
+    );
+
+    return {
+      handler,
+      createOrGetConversation,
+      persistInboundMessage,
+      bridgeExecutor,
+      attachmentStorage,
+    };
   }
 
   function makeReactionEvent() {
@@ -151,6 +201,35 @@ describe('AgentInboundHandler', () => {
       expect(attachmentStorage.storeInbound.firstCall.args[1].platformMessageId).to.equal('source-msg');
       const params = bridgeExecutor.execute.firstCall.args[0];
       expect(params.reaction.sourceMessageStoredAttachments).to.deep.equal(storedAttachments);
+    });
+  });
+
+  describe('handle', () => {
+    it('should tolerate attachment-only messages with undefined text', async () => {
+      const { handler, createOrGetConversation, persistInboundMessage, bridgeExecutor } = makeHandleDeps();
+      const thread = {
+        id: 'thread1',
+        channelId: 'C1',
+        isDM: false,
+        toJSON: () => ({ id: 'thread1' }),
+      };
+      const message = {
+        id: 'm1',
+        text: undefined,
+        author: { userId: 'U1', fullName: 'User', userName: 'u', isBot: false },
+        metadata: { dateSent: new Date() },
+        attachments: [{ type: 'image', name: 'photo.png', size: 10 }],
+      };
+
+      await handler.handle('agent1', config as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
+
+      expect(createOrGetConversation.calledOnce).to.equal(true);
+      expect(createOrGetConversation.firstCall.args[0].firstMessageText).to.equal('[Attachment: photo.png]');
+      expect(persistInboundMessage.calledOnce).to.equal(true);
+      expect(persistInboundMessage.firstCall.args[0].content).to.equal('');
+
+      const bridgeParams = bridgeExecutor.execute.firstCall.args[0];
+      expect(bridgeParams.message.text).to.equal('');
     });
   });
 });

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -77,6 +77,40 @@ function findSourceMessageStoredAttachments(
   return storedAttachments;
 }
 
+/** Slack and other providers omit `text` when the message is attachment-only. */
+function inboundMessageBodyText(message: Message): string {
+  const raw = message.text;
+
+  if (typeof raw === 'string') {
+    return raw;
+  }
+
+  return '';
+}
+
+/**
+ * Conversation title / firstMessageText: use body when present; otherwise a short
+ * placeholder when only attachments exist (avoids empty required `title`).
+ */
+function firstMessageTextForConversation(message: Message, bodyText: string): string {
+  if (bodyText.length > 0) {
+    return bodyText;
+  }
+
+  const first = message.attachments?.[0];
+  const name = first && typeof first.name === 'string' ? first.name : undefined;
+
+  if (name && name.length > 0) {
+    return `[Attachment: ${name}]`;
+  }
+
+  if (message.attachments?.length) {
+    return '[Attachment]';
+  }
+
+  return '';
+}
+
 export interface InboundReactionEvent {
   emoji: EmojiValue;
   added: boolean;
@@ -126,6 +160,9 @@ export class AgentInboundHandler {
       ? ConversationParticipantTypeEnum.SUBSCRIBER
       : ConversationParticipantTypeEnum.PLATFORM_USER;
 
+    const inboundBodyText = inboundMessageBodyText(message);
+    const firstMessageText = firstMessageTextForConversation(message, inboundBodyText);
+
     const conversation = await this.conversationService.createOrGetConversation({
       environmentId: config.environmentId,
       organizationId: config.organizationId,
@@ -136,7 +173,7 @@ export class AgentInboundHandler {
       participantId,
       participantType,
       platformUserId: message.author.userId,
-      firstMessageText: message.text,
+      firstMessageText,
     });
 
     const senderType = subscriberId
@@ -177,7 +214,7 @@ export class AgentInboundHandler {
       senderType,
       senderId: participantId,
       senderName: message.author.fullName,
-      content: message.text,
+      content: inboundBodyText,
       richContent,
       platformMessageId: message.id,
       environmentId: config.environmentId,

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -82,6 +82,7 @@ function inboundMessageBodyText(message: Message): string {
   const raw = message.text;
 
   if (typeof raw === 'string') {
+
     return raw;
   }
 
@@ -94,6 +95,7 @@ function inboundMessageBodyText(message: Message): string {
  */
 function firstMessageTextForConversation(message: Message, bodyText: string): string {
   if (bodyText.length > 0) {
+
     return bodyText;
   }
 
@@ -101,10 +103,12 @@ function firstMessageTextForConversation(message: Message, bodyText: string): st
   const name = first && typeof first.name === 'string' ? first.name : undefined;
 
   if (name && name.length > 0) {
+
     return `[Attachment: ${name}]`;
   }
 
   if (message.attachments?.length) {
+
     return '[Attachment]';
   }
 
@@ -161,6 +165,10 @@ export class AgentInboundHandler {
       : ConversationParticipantTypeEnum.PLATFORM_USER;
 
     const inboundBodyText = inboundMessageBodyText(message);
+    if (message.text !== inboundBodyText) {
+      (message as { text?: string }).text = inboundBodyText;
+    }
+
     const firstMessageText = firstMessageTextForConversation(message, inboundBodyText);
 
     const conversation = await this.conversationService.createOrGetConversation({

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -263,7 +263,7 @@ export class BridgeExecutorService {
     signingContext?: AttachmentSigningContext
   ): Promise<AgentMessage> {
     const mapped: AgentMessage = {
-      text: message.text,
+      text: message.text ?? '',
       platformMessageId: message.id,
       author: {
         userId: message.author.userId,

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -245,6 +245,12 @@ export class HandleAgentReply {
       return title ?? '[Card]';
     }
 
+    if (content.files?.length) {
+      const firstName = content.files[0]?.filename;
+
+      return firstName ? `[Attachment: ${firstName}]` : '[Attachment]';
+    }
+
     return '';
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**NV-7458 — Slack attachment-only inbound**

- **Root cause:** `message.text` could be `undefined`; `firstMessageText.slice` threw before the bridge. **Follow-up:** bridge still received `undefined` text until we assign normalized text back onto `message` before `bridgeExecutor.execute` (CI unit test + consistency with persisted content).

- **Inbound:** `inboundMessageBodyText`, `firstMessageTextForConversation`, safe conversation `title`, normalize `message.text` before bridge.

- **Outbound (optional):** Files-only agent reply DTO + `extractTextFallback` placeholder.

## CI

Fixed failing test `expected undefined to equal ''` by syncing `message.text` with `inboundBodyText` before bridge execution.

Resolves **NV-7458**.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7458](https://linear.app/novu/issue/NV-7458/when-slack-receive-an-image-without-text-no-trigger-was-handeled)

<div><a href="https://cursor.com/agents/bc-dc7fe29e-b350-44bf-99eb-e2afe86048d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc7fe29e-b350-44bf-99eb-e2afe86048d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Fixed handling of attachment-only messages across agent inbound and reply paths so files-only interactions no longer error or get rejected. Inbound webhook processing now coerces missing Slack text to a string and derives conversation titles from attachment names when body text is empty; bridge payloads are normalized to always send a string text. Reply validation was relaxed to permit replies containing only files (no markdown/card) while still enforcing mutually exclusive content rules and per-file source limits. This resolves NV-7458 (Slack image-only messages).

## Affected areas

**api** (agents): Validation for agent replies now accepts files-only replies and enforces that files cannot be combined with card/markdown; extractTextFallback produces `[Attachment: <filename>]` previews; AgentInboundHandler normalizes inbound message.text and derives firstMessageText from attachments; AgentConversationService guards conversation title creation; BridgeExecutorService maps missing text to '' for bridge payloads. Added unit and e2e tests covering files-only inbound and reply flows.

## Key technical decisions

- Validation: replies may be files-only but card+files and markdown+card remain disallowed; per-file validation (data XOR url and inline size limits) retained.  
- Conversation title/fallback: derive preview/title from first attachment filename (`[Attachment: name]`) and fall back to a fixed `'New conversation'` when empty.  
- Payload normalization: always coerce agent/inbound message.text to a string to avoid runtime slicing/validation errors.

## Testing

Added unit tests for AgentInboundHandler handling of `text: undefined` with attachments and an e2e test for files-only agent replies verifying 200 response, persisted activity content (`[Attachment: ...]`), and updated conversation preview/message count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->