### PR TITLE
fix(dashboard): use collision-resistant unique name generation in provider dropdown

### DIFF
--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -331,8 +331,12 @@ export function ProviderDropdown({
         onSelect(item.providerId, item.integration);
         setOpen(false);
       } else {
-        const sameProviderCount = (integrations ?? []).filter((i) => i.providerId === item.providerId).length;
-        const uniqueName = sameProviderCount > 0 ? `${item.displayName} ${sameProviderCount + 1}` : item.displayName;
+        const existingNames = new Set(
+          (integrations ?? []).filter((i) => i.providerId === item.providerId).map((i) => i.name)
+        );
+        let suffix = existingNames.size + 1;
+        while (existingNames.has(`${item.displayName} ${suffix}`)) suffix += 1;
+        const uniqueName = existingNames.size > 0 ? `${item.displayName} ${suffix}` : item.displayName;
 
         const created = await createIntegrationMutation.mutateAsync({
           providerId: item.providerId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Replaced the count-based unique name generation in `provider-dropdown.tsx` with a Set-based collision-resistant approach that matches the pattern already used in `outbound-provider-select.tsx`.

## Why

The previous implementation:
```ts
const sameProviderCount = (integrations ?? []).filter((i) => i.providerId === item.providerId).length;
const uniqueName = sameProviderCount > 0 ? `${item.displayName} ${sameProviderCount + 1}` : item.displayName;
```

Could produce duplicate names when integrations were deleted or renamed (e.g., if "Slack 2" already existed and count was 1, it would try to create another "Slack 2").

## Fix

The new approach collects existing names into a `Set` and increments the suffix until a truly unique name is found:
```ts
const existingNames = new Set(
  (integrations ?? []).filter((i) => i.providerId === item.providerId).map((i) => i.name)
);
let suffix = existingNames.size + 1;
while (existingNames.has(`${item.displayName} ${suffix}`)) suffix += 1;
const uniqueName = existingNames.size > 0 ? `${item.displayName} ${suffix}` : item.displayName;
```

This is the same proven pattern from `outbound-provider-select.tsx` (lines 125-133).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D092998U7KR/p1777810086845629?thread_ts=1777810086.845629&cid=D092998U7KR)

<div><a href="https://cursor.com/agents/bc-1e899a6c-b23a-546f-9930-da5428889da4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e899a6c-b23a-546f-9930-da5428889da4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed?
Fixed provider dropdown integration naming to use a collision-resistant Set-based approach. Previously, when creating new integrations, the component calculated a suffix using the count of existing providers, which could produce duplicate names if integrations were deleted. The new implementation collects existing names into a Set and increments a numeric suffix until finding an unused name.

## Affected areas

**dashboard**: Updated the provider-dropdown component to replace count-based unique name generation with a Set-based collision-resistant approach when creating new integration names for providers without existing entries.

## Testing

No new tests were added; this is a bug fix to naming logic that occurs when linking providers without existing integrations. Manual verification of the naming behavior in different deletion/renaming scenarios would be the appropriate verification method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->