### PR TITLE
fix(root): track cloud deploys with separate Linear pipelines fixes NV-7469

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -530,11 +530,8 @@ jobs:
             -d '{"url": "https://eu.dashboard.novu.co", "source": "novuhq-novu", "prod": "true"}'
 
   linear_release_cloud:
-    # Scheduled Linear pipeline: sync issues for this commit, then either move the
-    # release to the staging stage (staging deploys) or complete it (production).
-    # In Linear: set the Cloud pipeline to "Scheduled", add a stage named exactly
-    # "staging" (or change the `stage` input below to match your Linear stage name).
-    # Pass the same commit SHA as `version` from staging → prod for one release.
+    # Cloud uses two continuous Linear pipelines: staging and production.
+    # Each successful deploy syncs a completed release to the matching pipeline.
     name: Linear Release (Cloud)
     needs: [deploy, prepare-matrix]
     runs-on: ubuntu-latest
@@ -554,27 +551,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Sync release to Linear
-        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
-        with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY_CLOUD }}
-          version: ${{ github.sha }}
-
-      - name: Update Linear stage — staging
+      - name: Sync staging release to Linear
         if: |
           github.event.inputs.environment == 'staging' ||
           github.event.inputs.environment == 'staging-sg'
         uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
         with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY_CLOUD }}
-          command: update
-          stage: staging
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_CLOUD_STAGING }}
           version: ${{ github.sha }}
 
-      - name: Complete Linear release — production
+      - name: Sync production release to Linear
         if: contains(github.event.inputs.environment, 'production')
         uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
         with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY_CLOUD }}
-          command: complete
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_CLOUD_PROD }}
           version: ${{ github.sha }}


### PR DESCRIPTION
## Summary
- Switches the Cloud Linear release job from one scheduled pipeline to separate continuous staging and production pipelines.
- Uses `LINEAR_ACCESS_KEY_CLOUD_STAGING` for staging deploys and `LINEAR_ACCESS_KEY_CLOUD_PROD` for production deploys.
- Removes scheduled-pipeline `update` and `complete` commands from the cloud deploy workflow.

## Test plan
- Reviewed the workflow diff against `next`.
- Checked IDE diagnostics for `.github/workflows/deploy.yml`; the new secret warnings are expected until GitHub Actions secrets are added.
- `actionlint` is not installed locally, so no full GitHub Actions lint was run.

## Rollout notes
- Add GitHub Actions secrets `LINEAR_ACCESS_KEY_CLOUD_STAGING` and `LINEAR_ACCESS_KEY_CLOUD_PROD` before relying on the workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The Linear Release (Cloud) workflow was refactored to track staging and production deployments through separate pipelines instead of a single shared pipeline. Two distinct workflow steps now handle each environment: staging deployments (`staging`, `staging-sg`) use the `LINEAR_ACCESS_KEY_CLOUD_STAGING` secret, while production deployments use `LINEAR_ACCESS_KEY_CLOUD_PROD`. The scheduled-pipeline `update` and `complete` commands were removed, and both steps now provide the deployed version via `${{ github.sha }}`.

## Affected areas

**GitHub Actions** — The `.github/workflows/deploy.yml` workflow was refactored to split Cloud Linear release tracking into separate staging and production pipelines with distinct access keys.

## Key technical decisions

- New GitHub Actions secrets (`LINEAR_ACCESS_KEY_CLOUD_STAGING` and `LINEAR_ACCESS_KEY_CLOUD_PROD`) are required for the workflow to function and must be configured before the workflow is relied upon in production.

## Testing

Manual verification of the workflow diff and IDE diagnostics were performed. Secret warnings are expected until the new GitHub Actions secrets are created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->