### PR TITLE
fix(api-service): when slack receive an image without text no trigger was fixes NV-7458

### DIFF
--- a/apps/api/src/app/agents/services/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.ts
@@ -13,6 +13,28 @@ import {
 } from '@novu/dal';
 import type { TriggerRecipientsPayload } from '@novu/shared';
 
+export const INBOUND_ATTACHMENT_ONLY_PREVIEW = '[Attachment]';
+
+export function getInboundActivityPreview(
+  content: string | undefined,
+  options: { richContent?: Record<string, unknown>; hasPlatformAttachments?: boolean } = {}
+): string {
+  const trimmed = content?.trim() ?? '';
+
+  if (trimmed.length > 0) {
+    return trimmed;
+  }
+
+  const attachments = options.richContent?.attachments;
+  const hasStoredAttachments = Array.isArray(attachments) && attachments.length > 0;
+
+  if (hasStoredAttachments || options.hasPlatformAttachments) {
+    return INBOUND_ATTACHMENT_ONLY_PREVIEW;
+  }
+
+  return trimmed;
+}
+
 export interface CreateOrGetConversationParams {
   environmentId: string;
   organizationId: string;
@@ -36,6 +58,7 @@ export interface PersistInboundMessageParams {
   senderName?: string;
   content: string;
   richContent?: Record<string, unknown>;
+  hasPlatformAttachments?: boolean;
   platformMessageId?: string;
   environmentId: string;
   organizationId: string;
@@ -180,6 +203,12 @@ export class AgentConversationService {
   }
 
   async persistInboundMessage(params: PersistInboundMessageParams): Promise<ConversationActivityEntity> {
+    const content = params.content ?? '';
+    const preview = getInboundActivityPreview(content, {
+      richContent: params.richContent,
+      hasPlatformAttachments: params.hasPlatformAttachments,
+    });
+
     const [activity] = await Promise.all([
       this.activityRepository.createUserActivity({
         identifier: `act_${shortId(12)}`,
@@ -190,7 +219,7 @@ export class AgentConversationService {
         senderType: params.senderType,
         senderId: params.senderId,
         senderName: params.senderName,
-        content: params.content,
+        content,
         richContent: params.richContent,
         platformMessageId: params.platformMessageId,
         environmentId: params.environmentId,
@@ -200,7 +229,7 @@ export class AgentConversationService {
         params.environmentId,
         params.organizationId,
         params.conversationId,
-        params.content
+        preview
       ),
     ]);
 

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { AgentInboundHandler } from './agent-inbound-handler.service';
+import { NoBridgeUrlError } from './bridge-executor.service';
 
 describe('AgentInboundHandler', () => {
   const config = {
@@ -29,17 +30,23 @@ describe('AgentInboundHandler', () => {
     };
   }
 
-  function makeHandler(overrides: { history?: any[]; storedAttachments?: any[] } = {}) {
+  function makeHandler(overrides: { history?: any[]; storedAttachments?: any[]; bridgeError?: Error } = {}) {
     const logger = makeLogger();
     const subscriberResolver = {
       resolve: sinon.stub().resolves(null),
     };
     const conversationService = {
+      createOrGetConversation: sinon.stub().resolves(conversation),
+      getPrimaryChannel: sinon.stub().callsFake((conv) => conv.channels[0]),
+      persistInboundMessage: sinon.stub().resolves({ _id: 'activity1' }),
+      persistAgentMessage: sinon.stub().resolves({ _id: 'agent-activity1' }),
+      setFirstPlatformMessageId: sinon.stub().resolves(undefined),
+      updateChannelThread: sinon.stub().resolves(undefined),
       findByPlatformThread: sinon.stub().resolves(conversation),
       getHistory: sinon.stub().resolves(overrides.history ?? []),
     };
     const bridgeExecutor = {
-      execute: sinon.stub().resolves(undefined),
+      execute: overrides.bridgeError ? sinon.stub().rejects(overrides.bridgeError) : sinon.stub().resolves(undefined),
     };
     const subscriberRepository = {
       findBySubscriberId: sinon.stub(),
@@ -60,7 +67,46 @@ describe('AgentInboundHandler', () => {
       attachmentStorage as any
     );
 
-    return { handler, attachmentStorage, bridgeExecutor };
+    return { handler, attachmentStorage, bridgeExecutor, conversationService };
+  }
+
+  function makeSlackDmThread() {
+    return {
+      id: 'slack:D123:',
+      channelId: 'slack:D123',
+      isDM: true,
+      toJSON: () => ({
+        id: 'slack:D123:',
+        channelId: 'slack:D123',
+        isDM: true,
+        currentMessage: {
+          id: '1777837477.371619',
+          threadId: 'slack:D123:',
+        },
+      }),
+      startTyping: sinon.stub().resolves(undefined),
+      post: sinon.stub().resolves({ id: '1777837479.427739', threadId: 'slack:D123:1777837477.371619' }),
+    };
+  }
+
+  function makeSlackDmMessage() {
+    return {
+      id: '1777837477.371619',
+      threadId: 'slack:D123:',
+      text: 'hello',
+      author: {
+        userId: 'user1',
+        fullName: 'User One',
+        userName: 'userone',
+        isBot: false,
+      },
+      raw: {
+        type: 'message',
+        channel_type: 'im',
+        ts: '1777837477.371619',
+      },
+      attachments: [],
+    };
   }
 
   function makeReactionEvent() {
@@ -93,6 +139,44 @@ describe('AgentInboundHandler', () => {
       },
     };
   }
+
+  describe('handle', () => {
+    it('should persist Slack DMs with a message-rooted platform thread id when the SDK thread id is empty', async () => {
+      const { handler, bridgeExecutor, conversationService } = makeHandler();
+      const thread = makeSlackDmThread();
+      const message = makeSlackDmMessage();
+      const expectedThreadId = 'slack:D123:1777837477.371619';
+
+      await handler.handle('agent1', config as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
+
+      expect(conversationService.createOrGetConversation.firstCall.args[0].platformThreadId).to.equal(expectedThreadId);
+      expect(conversationService.persistInboundMessage.firstCall.args[0].platformThreadId).to.equal(expectedThreadId);
+      expect(conversationService.setFirstPlatformMessageId.firstCall.args[3]).to.equal(expectedThreadId);
+      expect(conversationService.updateChannelThread.firstCall.args[3]).to.equal(expectedThreadId);
+      expect(conversationService.updateChannelThread.firstCall.args[4].id).to.equal(expectedThreadId);
+      expect(conversationService.updateChannelThread.firstCall.args[4].currentMessage.threadId).to.equal(
+        expectedThreadId
+      );
+      expect(bridgeExecutor.execute.firstCall.args[0].platformContext.threadId).to.equal(expectedThreadId);
+    });
+
+    it('should post no-bridge Slack DM auto-replies with the message-rooted platform thread id', async () => {
+      const { handler } = makeHandler({ bridgeError: new NoBridgeUrlError('support-agent') });
+      const thread = makeSlackDmThread();
+      const message = makeSlackDmMessage();
+      const expectedThreadId = 'slack:D123:1777837477.371619';
+
+      thread.post.callsFake(async () => {
+        expect(thread.id).to.equal(expectedThreadId);
+
+        return { id: '1777837479.427739', threadId: thread.id };
+      });
+
+      await handler.handle('agent1', config as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
+
+      expect(thread.post.calledOnce).to.equal(true);
+    });
+  });
 
   describe('handleReaction', () => {
     it('should reuse stored source message attachments from history', async () => {

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -13,7 +13,7 @@ import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { PLATFORMS_WITH_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
 import { AgentAttachmentStorage, type StoredAttachment } from './agent-attachment-storage.service';
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
-import { AgentConversationService } from './agent-conversation.service';
+import { AgentConversationService, getInboundActivityPreview } from './agent-conversation.service';
 import { AgentSubscriberResolver } from './agent-subscriber-resolver.service';
 import { BridgeExecutorService, type BridgeReaction, NoBridgeUrlError } from './bridge-executor.service';
 
@@ -136,7 +136,9 @@ export class AgentInboundHandler {
       participantId,
       participantType,
       platformUserId: message.author.userId,
-      firstMessageText: message.text,
+      firstMessageText: getInboundActivityPreview(message.text, {
+        hasPlatformAttachments: Boolean(message.attachments?.length),
+      }),
     });
 
     const senderType = subscriberId
@@ -179,6 +181,7 @@ export class AgentInboundHandler {
       senderName: message.author.fullName,
       content: message.text,
       richContent,
+      hasPlatformAttachments: Boolean(message.attachments?.length),
       platformMessageId: message.id,
       environmentId: config.environmentId,
       organizationId: config.organizationId,

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -10,7 +10,7 @@ import type { AgentAction } from '@novu/framework';
 import type { EmojiValue, Message, Thread } from 'chat';
 import { trackAgentInboundAction, trackAgentInboundMessage, trackAgentInboundReaction } from '../agent-analytics';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
-import { PLATFORMS_WITH_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
+import { AgentPlatformEnum, PLATFORMS_WITH_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
 import { AgentAttachmentStorage, type StoredAttachment } from './agent-attachment-storage.service';
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
 import { AgentConversationService, getInboundActivityPreview } from './agent-conversation.service';
@@ -22,6 +22,47 @@ const ACKNOWLEDGE_FALLBACK_EMOJI = 'eyes' as const;
 const ONBOARDING_NO_BRIDGE_REPLY_MARKDOWN = `*You're connected to Novu*
 
 Your bot is linked successfully. Go back to the *Novu dashboard* to complete onboarding.`;
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function getMessageRawEvent(message: Message): Record<string, unknown> | undefined {
+  const raw = asRecord(message.raw);
+
+  return asRecord(raw?.event) ?? raw;
+}
+
+function getInboundPlatformThreadId(platform: AgentPlatformEnum, thread: Thread, message: Message): string {
+  const rawEvent = getMessageRawEvent(message);
+  const rawThreadTs = rawEvent?.thread_ts;
+  const threadRoot = typeof rawThreadTs === 'string' && rawThreadTs.length > 0 ? rawThreadTs : message.id;
+
+  if (platform !== AgentPlatformEnum.SLACK || !thread.isDM || !threadRoot || !thread.id.endsWith(':')) {
+    return thread.id;
+  }
+
+  return `${thread.id}${threadRoot}`;
+}
+
+function applyPlatformThreadIdToSerializedThread(serializedThread: Record<string, unknown>, platformThreadId: string) {
+  serializedThread.id = platformThreadId;
+
+  const currentMessage = asRecord(serializedThread.currentMessage ?? serializedThread.message);
+  if (!currentMessage) {
+    return;
+  }
+
+  currentMessage.threadId = platformThreadId;
+}
+
+function applyPlatformThreadIdToThread(thread: Thread, platformThreadId: string) {
+  (thread as unknown as { id: string }).id = platformThreadId;
+}
 
 function mapStoredAttachmentsFromRichContent(richContent?: Record<string, unknown>): StoredAttachment[] {
   const rawAttachments = richContent?.attachments;
@@ -125,6 +166,7 @@ export class AgentInboundHandler {
     const participantType = subscriberId
       ? ConversationParticipantTypeEnum.SUBSCRIBER
       : ConversationParticipantTypeEnum.PLATFORM_USER;
+    const platformThreadId = getInboundPlatformThreadId(config.platform, thread, message);
 
     const conversation = await this.conversationService.createOrGetConversation({
       environmentId: config.environmentId,
@@ -132,7 +174,7 @@ export class AgentInboundHandler {
       agentId,
       platform: config.platform,
       integrationId: config.integrationId,
-      platformThreadId: thread.id,
+      platformThreadId,
       participantId,
       participantType,
       platformUserId: message.author.userId,
@@ -175,7 +217,7 @@ export class AgentInboundHandler {
       conversationId: conversation._id,
       platform: config.platform,
       integrationId: config.integrationId,
-      platformThreadId: thread.id,
+      platformThreadId,
       senderType,
       senderId: participantId,
       senderName: message.author.fullName,
@@ -201,7 +243,13 @@ export class AgentInboundHandler {
 
     if (isFirstMessage && message.id) {
       this.conversationService
-        .setFirstPlatformMessageId(config.environmentId, config.organizationId, conversation._id, thread.id, message.id)
+        .setFirstPlatformMessageId(
+          config.environmentId,
+          config.organizationId,
+          conversation._id,
+          platformThreadId,
+          message.id
+        )
         .catch((err) => {
           this.logger.warn(err, `[agent:${agentId}] Failed to store firstPlatformMessageId`);
         });
@@ -223,11 +271,12 @@ export class AgentInboundHandler {
     }
 
     const serializedThread = thread.toJSON() as unknown as Record<string, unknown>;
+    applyPlatformThreadIdToSerializedThread(serializedThread, platformThreadId);
     await this.conversationService.updateChannelThread(
       config.environmentId,
       config.organizationId,
       conversation._id,
-      thread.id,
+      platformThreadId,
       serializedThread
     );
 
@@ -247,7 +296,7 @@ export class AgentInboundHandler {
         history,
         message,
         platformContext: {
-          threadId: thread.id,
+          threadId: platformThreadId,
           channelId: thread.channelId,
           isDM: thread.isDM,
         },
@@ -255,6 +304,7 @@ export class AgentInboundHandler {
       });
     } catch (err) {
       if (err instanceof NoBridgeUrlError) {
+        applyPlatformThreadIdToThread(thread, platformThreadId);
         const sent = await thread.post(ONBOARDING_NO_BRIDGE_REPLY_MARKDOWN);
         const channel = this.conversationService.getPrimaryChannel(conversation);
         await this.conversationService.persistAgentMessage({

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -61,6 +61,8 @@ function applyPlatformThreadIdToSerializedThread(serializedThread: Record<string
 }
 
 function applyPlatformThreadIdToThread(thread: Thread, platformThreadId: string) {
+  // Chat SDK currently gives top-level Slack DMs an empty-root thread id (`slack:D...:`).
+  // Patch the in-memory handle before posting fallback replies so Slack receives a real thread root.
   (thread as unknown as { id: string }).id = platformThreadId;
 }
 

--- a/apps/dashboard/src/api/conversations.ts
+++ b/apps/dashboard/src/api/conversations.ts
@@ -131,6 +131,15 @@ export type ConversationActivityDto = {
   senderId: string;
   senderName?: string;
   platformMessageId?: string;
+  richContent?: {
+    attachments?: Array<{
+      type?: string;
+      name?: string;
+      mimeType?: string;
+      size?: number;
+      storageKey?: string;
+    }>;
+  };
   signalData?:
     | { type: 'metadata'; payload?: Record<string, unknown> }
     | { type: 'trigger'; payload?: { workflowId?: string; transactionId?: string; to?: unknown } }

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -426,13 +426,15 @@ export function ProviderDropdown({
                 const isLocked = item.requiresBusinessTier && !isAgentEmailAvailable;
 
                 const rowContent = (
-                  <div className="flex w-full items-center gap-1">
+                  <div className="flex w-full min-w-0 items-center gap-1 break-normal">
                     <ProviderIcon
                       providerId={item.providerId}
                       providerDisplayName={item.displayName}
                       className="size-4 shrink-0"
                     />
-                    <span className="text-text-sub text-label-xs flex-1 font-medium leading-4">{item.displayName}</span>
+                    <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-medium leading-4">
+                      {item.displayName}
+                    </span>
 
                     {isRowPending && (
                       <RiLoader4Line className="text-text-soft size-3 shrink-0 animate-spin" aria-hidden />
@@ -457,7 +459,10 @@ export function ProviderDropdown({
                       !isLocked &&
                       item.integration &&
                       item.providerId !== EmailProviderIdEnum.NovuAgent && (
-                        <span className="font-code text-text-sub shrink-0 text-[10px] leading-[15px] tracking-[-0.2px]">
+                        <span
+                          className="font-code text-text-sub max-w-[min(7.5rem,38%)] min-w-0 shrink truncate text-[10px] leading-[15px] tracking-[-0.2px]"
+                          title={item.integration.identifier}
+                        >
                           {item.integration.identifier}
                         </span>
                       )}
@@ -476,7 +481,7 @@ export function ProviderDropdown({
                       void handleSelect(item, index);
                     }}
                     className={cn(
-                      'flex items-center gap-2 rounded-md p-1',
+                      'flex min-w-0 items-center gap-2 rounded-md p-1',
                       item.integration?._id === selectedIntegrationId && 'bg-bg-muted',
                       isLocked && '!pointer-events-auto opacity-60'
                     )}
@@ -578,7 +583,7 @@ export function ProviderDropdown({
   }
 
   return (
-    <div className="flex w-full flex-col gap-1">
+    <div className="flex w-full flex-col gap-1 min-w-[300px]">
       <div className="flex items-center gap-px">
         <span className="text-text-sub text-label-xs font-medium leading-4">
           What provider would you like to start with

--- a/apps/dashboard/src/components/agents/slack-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/slack-setup-guide.tsx
@@ -238,28 +238,6 @@ export function SlackSetupGuide({
         status={deriveStepStatus(base + 2, firstIncompleteStep)}
         title="Verify by installing the app to your workspace"
         description={`This is what your users need to do to install the slack app to their workspace to start interacting with it.`}
-        extraContent={
-          <InlineToast
-            className="mt-2 w-full"
-            variant="tip"
-            title="Tip:"
-            description={
-              <>
-                Novu provides a{' '}
-                <code className="font-code text-[12px] tracking-[-0.24px]">{'<SlackConnectButton />'}</code>
-                {' component, to let your users easily connect this agent to their Slack workspace. '}
-                <a
-                  href="https://docs.novu.co"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-text-sub underline"
-                >
-                  Read docs
-                </a>
-              </>
-            }
-          />
-        }
         rightContent={
           user?.externalId && currentEnvironment?.identifier ? (
             <NovuProvider

--- a/apps/dashboard/src/components/conversations/conversation-timeline.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-timeline.tsx
@@ -24,6 +24,20 @@ type ConversationTimelineProps = {
   conversationStatus?: string;
 };
 
+const ATTACHMENT_ONLY_PREVIEW = '[Attachment]';
+
+function getActivityContent(activity: ConversationActivityDto): string {
+  if (activity.content.trim().length > 0) {
+    return activity.content;
+  }
+
+  if (activity.richContent?.attachments?.length) {
+    return ATTACHMENT_ONLY_PREVIEW;
+  }
+
+  return '';
+}
+
 function formatActivityTimestamp(dateStr: string | undefined): string {
   if (!dateStr?.trim()) {
     return '—';
@@ -151,6 +165,7 @@ function MessageContent({ content }: { content: string }) {
 
 function MessageCard({ activity }: { activity: ConversationActivityDto }) {
   const isAgent = activity.senderType === 'agent';
+  const content = getActivityContent(activity);
 
   return (
     <div className={cn('border-stroke-soft flex flex-col rounded-md border', isAgent ? 'bg-bg-weak' : 'bg-white')}>
@@ -159,7 +174,7 @@ function MessageCard({ activity }: { activity: ConversationActivityDto }) {
           <SenderHeader activity={activity} />
           <MessageTimestamp activity={activity} />
         </div>
-        {activity.content && <MessageContent content={activity.content} />}
+        {content && <MessageContent content={content} />}
       </div>
     </div>
   );
@@ -232,7 +247,12 @@ function ResolvedFooter({ totalCount }: { totalCount: number }) {
   );
 }
 
-export function ConversationTimeline({ activities, isLoading, totalCount, conversationStatus }: ConversationTimelineProps) {
+export function ConversationTimeline({
+  activities,
+  isLoading,
+  totalCount,
+  conversationStatus,
+}: ConversationTimelineProps) {
   if (isLoading) {
     return (
       <div className="flex flex-col gap-3 p-3">

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.schema.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.schema.ts
@@ -24,7 +24,7 @@ const conversationActivitySchema = new Schema<ConversationActivityDBModel>(
     },
     content: {
       type: Schema.Types.String,
-      required: true,
+      default: '',
     },
     platform: {
       type: Schema.Types.String,


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Slack inbound messages containing only images or attachments without text now display an `[Attachment]` preview instead of appearing empty. The fix includes normalizing Slack DM thread IDs to prevent malformed threading, extending the conversation activity schema to optionally store attachment metadata, and making the `content` field default to an empty string rather than being required.

## Affected areas

**@novu/api-service**: Added `getInboundActivityPreview` helper function to generate attachment-only previews. Updated `AgentInboundHandler` to derive normalized platform thread IDs from Slack context and apply them consistently during conversation creation and message persistence. Extended `PersistInboundMessageParams` with `hasPlatformAttachments` flag.

**@novu/dal**: Modified the `ConversationActivity` Mongoose schema to allow the `content` field to default to an empty string instead of being required, enabling attachment-only activities.

**@novu/dashboard**: Extended `ConversationActivityDto` with optional `richContent.attachments` array containing metadata fields (`type`, `name`, `mimeType`, `size`, `storageKey`). Updated `ConversationTimeline` to render `[Attachment]` placeholder when activities contain attachments but no text content. Minor layout improvements to the provider dropdown and removed extra content from Slack setup guide.

## Key technical decisions

- Schema change: `content` field now defaults to empty string instead of being required, allowing attachment-only conversation activities.
- Extended `ConversationActivityDto` with attachment metadata shape to support richer context on persisted attachments.
- Slack DM thread handling: normalized malformed thread IDs before persisting to ensure consistent threading across inbound and fallback reply operations.

## Testing

Added test cases for `AgentInboundHandler.handle` covering Slack DM thread ID derivation and no-bridge error fallback scenarios with proper thread assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
