### PR TITLE
feat(shared): add ctx.metadata.delete(), clear(), get(), and current fixes NV-7501

### DIFF
--- a/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
@@ -18,6 +18,7 @@ import {
 export type { FileRef } from '@novu/framework';
 
 const SIGNAL_TYPES = ['metadata', 'trigger'] as const;
+const METADATA_ACTIONS = ['set', 'delete', 'clear'] as const;
 const MAX_INLINE_FILE_BASE64_CHARS = 7_000_000;
 const MAX_FILES_PER_MESSAGE = 15;
 
@@ -92,7 +93,12 @@ export class IsValidSignal implements ValidatorConstraintInterface {
     if (!signal?.type) return false;
 
     if (signal.type === 'metadata') {
-      return isValidMetadataSignalKey(signal.key) && signal.value !== undefined;
+      const action = signal.action ?? 'set';
+      if (action === 'set') return isValidMetadataSignalKey(signal.key) && signal.value !== undefined;
+      if (action === 'delete') return isValidMetadataSignalKey(signal.key);
+      if (action === 'clear') return true;
+
+      return false;
     }
 
     if (signal.type === 'trigger') {
@@ -104,8 +110,9 @@ export class IsValidSignal implements ValidatorConstraintInterface {
 
   defaultMessage(): string {
     return (
-      'metadata signals require a key 1-128 chars of letters, digits and "-", "_", ":" separators ' +
-      '(no leading, trailing or consecutive separators) plus a defined value; ' +
+      'metadata signals require action (set|delete|clear): ' +
+      'set requires a key 1-128 chars of letters, digits and "-", "_", ":" separators plus a defined value; ' +
+      'delete requires a valid key; clear requires no additional fields; ' +
       'trigger signals require workflowId.'
     );
   }
@@ -197,6 +204,12 @@ export class SignalDto {
   @IsString()
   @IsIn(SIGNAL_TYPES)
   type: (typeof SIGNAL_TYPES)[number];
+
+  @ApiPropertyOptional({ enum: METADATA_ACTIONS })
+  @IsOptional()
+  @IsString()
+  @IsIn(METADATA_ACTIONS)
+  action?: (typeof METADATA_ACTIONS)[number];
 
   @ApiPropertyOptional()
   @IsOptional()

--- a/apps/api/src/app/agents/services/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.ts
@@ -81,9 +81,14 @@ export interface PersistAgentActivityParams extends ConversationActivityContext 
   richContent?: Record<string, unknown>;
 }
 
+export type MetadataOp =
+  | { action: 'set'; key: string; value: unknown }
+  | { action: 'delete'; key: string }
+  | { action: 'clear' };
+
 export interface UpdateMetadataParams extends ConversationActivityContext {
   currentMetadata: Record<string, unknown>;
-  signals: Array<{ key: string; value: unknown }>;
+  ops: MetadataOp[];
 }
 
 export interface ResolveConversationParams extends ConversationActivityContext {
@@ -334,9 +339,24 @@ export class AgentConversationService {
   }
 
   async updateMetadata(params: UpdateMetadataParams): Promise<void> {
-    const merged: Record<string, unknown> = { ...(params.currentMetadata ?? {}) };
-    for (const signal of params.signals) {
-      merged[signal.key] = signal.value;
+    let merged: Record<string, unknown> = { ...(params.currentMetadata ?? {}) };
+    const descriptions: string[] = [];
+
+    for (const op of params.ops) {
+      switch (op.action) {
+        case 'set':
+          merged[op.key] = op.value;
+          descriptions.push(op.key);
+          break;
+        case 'delete':
+          delete merged[op.key];
+          descriptions.push(`-${op.key}`);
+          break;
+        case 'clear':
+          merged = {};
+          descriptions.push('(cleared)');
+          break;
+      }
     }
 
     const serialized = JSON.stringify(merged);
@@ -358,7 +378,7 @@ export class AgentConversationService {
         integrationId: params.channel._integrationId,
         platformThreadId: params.channel.platformThreadId,
         agentId: params.agentIdentifier,
-        content: `Metadata updated: ${params.signals.map((s) => s.key).join(', ')}`,
+        content: `Metadata updated: ${descriptions.join(', ')}`,
         signalData: { type: 'metadata', payload: merged },
         environmentId: params.environmentId,
         organizationId: params.organizationId,

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -16,6 +16,7 @@ import { AgentEventEnum } from '../../dtos/agent-event.enum';
 import type { EditPayloadDto, ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
 import { isValidMetadataSignalKey } from '../../dtos/agent-reply-payload.dto';
 import { AgentConfigResolver, ResolvedAgentConfig } from '../../services/agent-config-resolver.service';
+import type { MetadataOp } from '../../services/agent-conversation.service';
 import { AgentConversationService } from '../../services/agent-conversation.service';
 import { BridgeExecutorService } from '../../services/bridge-executor.service';
 import { ChatSdkService } from '../../services/chat-sdk.service';
@@ -254,18 +255,20 @@ export class HandleAgentReply {
     channel: ConversationChannel,
     signals: HandleAgentReplyCommand['signals']
   ): Promise<void> {
-    const metadataSignals = (signals ?? []).filter(
-      (s): s is Extract<NonNullable<HandleAgentReplyCommand['signals']>[number], { type: 'metadata' }> =>
-        s.type === 'metadata'
-    );
+    const rawMetadata = (signals ?? []).filter((s) => s.type === 'metadata') as Array<{
+      type: 'metadata';
+      action?: string;
+      key?: string;
+      value?: unknown;
+    }>;
 
-    if (metadataSignals.length) {
-      await this.validateMetadataSignalKeys(metadataSignals);
+    if (rawMetadata.length) {
+      const ops = this.normalizeMetadataOps(rawMetadata);
       await this.conversationService.updateMetadata({
         conversationId: conversation._id,
         channel,
         currentMetadata: conversation.metadata ?? {},
-        signals: metadataSignals,
+        ops,
         agentIdentifier: command.agentIdentifier,
         environmentId: command.environmentId,
         organizationId: command.organizationId,
@@ -344,15 +347,38 @@ export class HandleAgentReply {
     }
   }
 
-  private validateMetadataSignalKeys(signals: Array<{ key: string; value: unknown }>): void {
+  private normalizeMetadataOps(
+    signals: Array<{ type: 'metadata'; action?: string; key?: string; value?: unknown }>
+  ): MetadataOp[] {
+    const ops: MetadataOp[] = [];
+
     for (const signal of signals) {
-      if (!isValidMetadataSignalKey(signal.key)) {
-        throw new BadRequestException(`Invalid metadata signal key: "${signal.key}"`);
-      }
-      if (signal.value === undefined) {
-        throw new BadRequestException(`Metadata signal "${signal.key}" must have a defined value`);
+      const action = signal.action ?? 'set';
+
+      switch (action) {
+        case 'clear':
+          ops.push({ action: 'clear' });
+          break;
+        case 'delete':
+          if (!signal.key || !isValidMetadataSignalKey(signal.key)) {
+            throw new BadRequestException(`Invalid metadata signal key: "${signal.key}"`);
+          }
+          ops.push({ action: 'delete', key: signal.key });
+          break;
+        case 'set':
+        default:
+          if (!signal.key || !isValidMetadataSignalKey(signal.key)) {
+            throw new BadRequestException(`Invalid metadata signal key: "${signal.key}"`);
+          }
+          if (signal.value === undefined) {
+            throw new BadRequestException(`Metadata signal "${signal.key}" must have a defined value`);
+          }
+          ops.push({ action: 'set', key: signal.key, value: signal.value });
+          break;
       }
     }
+
+    return ops;
   }
 
   private async resolveConversation(

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -366,7 +366,6 @@ export class HandleAgentReply {
           ops.push({ action: 'delete', key: signal.key });
           break;
         case 'set':
-        default:
           if (!signal.key || !isValidMetadataSignalKey(signal.key)) {
             throw new BadRequestException(`Invalid metadata signal key: "${signal.key}"`);
           }
@@ -375,6 +374,8 @@ export class HandleAgentReply {
           }
           ops.push({ action: 'set', key: signal.key, value: signal.value });
           break;
+        default:
+          throw new BadRequestException(`Unsupported metadata signal action: "${action}"`);
       }
     }
 

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -257,11 +257,18 @@ export class AgentContextImpl {
   readonly platform: string;
   readonly platformContext: AgentPlatformContext;
 
-  readonly metadata: { set: (key: string, value: unknown) => void };
+  readonly metadata: {
+    get(key: string): unknown;
+    set(key: string, value: unknown): void;
+    delete(key: string): void;
+    clear(): void;
+    readonly current: Readonly<Record<string, unknown>>;
+  };
 
   private _signals: Signal[] = [];
   private _pendingReactions: AddReactionPayload[] = [];
   private _resolveSignal: { summary?: string } | null = null;
+  private _metadataState: Record<string, unknown>;
   private readonly _replyUrl: string;
   private readonly _conversationId: string;
   private readonly _integrationIdentifier: string;
@@ -285,9 +292,27 @@ export class AgentContextImpl {
     this._secretKey = secretKey;
     this._poster = { post: (body) => this._post(body) };
 
+    this._metadataState = { ...(request.conversation.metadata ?? {}) };
+
+    const self = this;
     this.metadata = {
-      set: (key: string, value: unknown) => {
-        this._signals.push({ type: 'metadata', key, value });
+      get(key: string) {
+        return self._metadataState[key];
+      },
+      set(key: string, value: unknown) {
+        self._metadataState[key] = value;
+        self._signals.push({ type: 'metadata', action: 'set', key, value });
+      },
+      delete(key: string) {
+        delete self._metadataState[key];
+        self._signals.push({ type: 'metadata', action: 'delete', key });
+      },
+      clear() {
+        self._metadataState = {};
+        self._signals.push({ type: 'metadata', action: 'clear' });
+      },
+      get current() {
+        return { ...self._metadataState } as Readonly<Record<string, unknown>>;
       },
     };
   }

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -229,8 +229,8 @@ describe('agent dispatch via NovuRequestHandler', () => {
 
     expect(replyBody.reply.markdown).toBe('Got it');
     expect(replyBody.signals).toHaveLength(2);
-    expect(replyBody.signals[0]).toEqual({ type: 'metadata', key: 'turnCount', value: 1 });
-    expect(replyBody.signals[1]).toEqual({ type: 'metadata', key: 'language', value: 'en' });
+    expect(replyBody.signals[0]).toEqual({ type: 'metadata', action: 'set', key: 'turnCount', value: 1 });
+    expect(replyBody.signals[1]).toEqual({ type: 'metadata', action: 'set', key: 'language', value: 'en' });
   });
 
   it('should edit a previously sent reply via the returned handle', async () => {
@@ -361,7 +361,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
 
     expect(flushBody.reply).toBeUndefined();
     expect(flushBody.signals).toHaveLength(2);
-    expect(flushBody.signals[0]).toEqual({ type: 'metadata', key: 'archived', value: true });
+    expect(flushBody.signals[0]).toEqual({ type: 'metadata', action: 'set', key: 'archived', value: true });
     expect(flushBody.signals[1]).toEqual({
       type: 'trigger',
       workflowId: 'post-resolve-workflow',
@@ -842,7 +842,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
 
     expect(replyBody.reply.card.type).toBe('card');
     expect(replyBody.signals).toHaveLength(1);
-    expect(replyBody.signals[0]).toEqual({ type: 'metadata', key: 'intent', value: 'order_confirm' });
+    expect(replyBody.signals[0]).toEqual({ type: 'metadata', action: 'set', key: 'intent', value: 'order_confirm' });
   });
 
   it('should dispatch onAction event with action data on ctx', async () => {

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -845,6 +845,156 @@ describe('agent dispatch via NovuRequestHandler', () => {
     expect(replyBody.signals[0]).toEqual({ type: 'metadata', action: 'set', key: 'intent', value: 'order_confirm' });
   });
 
+  it('should emit delete signal for ctx.metadata.delete()', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async ({ ctx }) => {
+        ctx.metadata.delete('board');
+        await ctx.reply('Deleted');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => ({
+        body: () =>
+          createMockBridgeRequest({
+            conversation: {
+              identifier: 'conv-456',
+              status: 'active',
+              metadata: { board: 'chess' },
+              messageCount: 2,
+              createdAt: new Date().toISOString(),
+              lastActivityAt: new Date().toISOString(),
+            },
+          }),
+        headers: () => null,
+        method: () => 'POST',
+        url: () => new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`),
+        transformResponse: (res: any) => res,
+      }),
+    });
+
+    const result = await handler.createHandler()();
+    expect(result.status).toBe(200);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+
+    expect(replyBody.signals).toHaveLength(1);
+    expect(replyBody.signals[0]).toEqual({ type: 'metadata', action: 'delete', key: 'board' });
+  });
+
+  it('should emit clear signal for ctx.metadata.clear()', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async ({ ctx }) => {
+        ctx.metadata.clear();
+        await ctx.reply('Cleared');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => ({
+        body: () => createMockBridgeRequest(),
+        headers: () => null,
+        method: () => 'POST',
+        url: () => new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`),
+        transformResponse: (res: any) => res,
+      }),
+    });
+
+    const result = await handler.createHandler()();
+    expect(result.status).toBe(200);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+
+    expect(replyBody.signals).toHaveLength(1);
+    expect(replyBody.signals[0]).toEqual({ type: 'metadata', action: 'clear' });
+  });
+
+  it('should preserve signal ordering for mixed clear, set, and delete', async () => {
+    const testBot = agent('test-bot', {
+      onMessage: async ({ ctx }) => {
+        ctx.metadata.clear();
+        ctx.metadata.set('newGame', true);
+        ctx.metadata.delete('oldKey');
+        await ctx.reply('Mixed');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => ({
+        body: () => createMockBridgeRequest(),
+        headers: () => null,
+        method: () => 'POST',
+        url: () => new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`),
+        transformResponse: (res: any) => res,
+      }),
+    });
+
+    const result = await handler.createHandler()();
+    expect(result.status).toBe(200);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+
+    expect(replyBody.signals).toHaveLength(3);
+    expect(replyBody.signals[0]).toEqual({ type: 'metadata', action: 'clear' });
+    expect(replyBody.signals[1]).toEqual({ type: 'metadata', action: 'set', key: 'newGame', value: true });
+    expect(replyBody.signals[2]).toEqual({ type: 'metadata', action: 'delete', key: 'oldKey' });
+  });
+
+  it('should track local state across get, set, delete, and current', async () => {
+    let getResult: unknown;
+    let currentSnapshot: Record<string, unknown>;
+
+    const testBot = agent('test-bot', {
+      onMessage: async ({ ctx }) => {
+        ctx.metadata.set('score', 42);
+        getResult = ctx.metadata.get('score');
+        ctx.metadata.delete('score');
+        currentSnapshot = { ...ctx.metadata.current };
+        await ctx.reply('Done');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => ({
+        body: () => createMockBridgeRequest(),
+        headers: () => null,
+        method: () => 'POST',
+        url: () => new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onMessage`),
+        transformResponse: (res: any) => res,
+      }),
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    expect(getResult).toBe(42);
+    expect(currentSnapshot!).toEqual({});
+  });
+
   it('should dispatch onAction event with action data on ctx', async () => {
     let capturedCtx: any;
 

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -219,12 +219,20 @@ interface AgentContextBase {
    */
   resolve(summary?: string): void;
   /**
-   * Write key/value pairs to the conversation's persistent metadata store.
-   * Values are flushed to Novu with the next `ctx.reply()` call, or automatically
-   * when the handler completes. Read stored values via `ctx.conversation.metadata`.
+   * Persistent key/value store for this conversation.
+   *
+   * - `get(key)` — read a value from the current metadata state
+   * - `set(key, value)` — write a value (flushed with the next reply or on handler completion)
+   * - `delete(key)` — remove a key
+   * - `clear()` — reset metadata to `{}`
+   * - `current` — readonly snapshot of the current state
    */
   metadata: {
+    get(key: string): unknown;
     set(key: string, value: unknown): void;
+    delete(key: string): void;
+    clear(): void;
+    readonly current: Readonly<Record<string, unknown>>;
   };
   /**
    * Trigger a Novu workflow from within this agent handler.
@@ -352,7 +360,10 @@ export interface AgentBridgeRequest {
   platformContext: AgentPlatformContext;
 }
 
-export type MetadataSignal = { type: 'metadata'; key: string; value: unknown };
+export type MetadataSignal =
+  | { type: 'metadata'; action: 'set'; key: string; value: unknown }
+  | { type: 'metadata'; action: 'delete'; key: string }
+  | { type: 'metadata'; action: 'clear' };
 
 /**
  * Queued by `ctx.trigger()` — instructs Novu to fire a workflow from inside an agent handler.

--- a/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/support-agent.tsx
+++ b/packages/novu/src/commands/init/templates/app-agent/ts/app/novu/agents/support-agent.tsx
@@ -43,7 +43,7 @@ export const supportAgent = agent('support-agent', {
       `**Got it.** You said: "${message.text}"\n\n` +
       `_This is a demo agent. Replace this handler with your LLM call._\n\n` +
       `**Conversation so far:** ${ctx.history.length} messages | ` +
-      `**Topic:** ${ctx.conversation.metadata?.topic ?? 'unknown'}`
+      `**Topic:** ${ctx.metadata.get('topic') ?? 'unknown'}`
     );
   },
 


### PR DESCRIPTION
## Summary

Complete the metadata CRUD API on the agent context:

- `ctx.metadata.get(key)` — read a value from local state (reflects `set()`/`delete()` within the same handler)
- `ctx.metadata.delete(key)` — remove a key and emit a delete signal
- `ctx.metadata.clear()` — reset metadata to `{}` and emit a clear signal
- `ctx.metadata.current` — readonly snapshot of the current metadata state
- `ctx.metadata.set(key, value)` — existing, now emits an explicit `action: 'set'` in the signal

### API-side refactoring

- DTO: validate `action` field (`set`/`delete`/`clear`) on metadata signals at the wire boundary
- Service: `MetadataOp` discriminated union replaces raw signal arrays, `updateMetadata` handles all 3 actions via switch
- UseCase: `normalizeMetadataOps` replaces `validateMetadataSignalKeys`, converting optional wire `action` to required `MetadataOp`

### Template

- `support-agent.tsx` uses `ctx.metadata.get('topic')` instead of `ctx.conversation.metadata?.topic`

## Test plan

- [x] Framework tests pass (313 tests, 0 type errors)
- [ ] Verify metadata signals are correctly persisted for set, delete, and clear actions
- [ ] Verify `get()` reflects `set()`/`delete()` within the same handler invocation
- [ ] Verify backwards compat: agents not using delete/clear continue to work (action defaults to `'set'`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Agent metadata handling was completed with full CRUD on the runtime context: ctx.metadata.get(key), delete(key), clear(), set(key, value) (now emits explicit 'set' action), and a readonly ctx.metadata.current snapshot. These operations enqueue metadata signals with explicit actions (set/delete/clear) so they are batched and persisted via the existing reply/flush pipeline; validation and server-side handling were updated to apply ops in order and keep backward compatibility for clients that omit action.

## Affected areas

**shared / framework**: AgentContext.metadata now exposes get, set, delete, clear, and readonly current; internal state is updated locally and emits metadata signals containing an action to be flushed with replies; tests updated to assert new behaviors and signal ordering.

**api**: Signal DTOs and validation were extended to accept an action (set|delete|clear); normalizeMetadataOps converts optional wire actions into required MetadataOp entries and updateMetadata applies set/delete/clear ops in order, including clear resetting metadata to {}.

**templates (novu CLI)**: Example support agent reads topic from ctx.metadata instead of ctx.conversation.metadata.

## Key technical decisions

- Use a discriminated union for metadata signals (action: 'set' | 'delete' | 'clear') and normalize omitted actions to 'set' to preserve backward compatibility.  
- Route metadata operations as ordered ops through the existing reply/flush signal mechanism (no new API path), so batching and persistence semantics remain unchanged.  
- Server-side validation enforces known actions and validates values only for actions that require them (e.g., skip value check for delete).

## Testing

Added and updated unit tests in the framework to cover ctx.metadata.get(), delete(), clear(), current, mixed signal ordering, and flush behavior; API validation updated accordingly. Framework tests reported passing in the branch (313 tests, 0 type errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->