### PR TITLE
feat(framework): expose sourceMessageId on action events (ctx.action.sourceMessageId) fixes NV-7500

### DIFF
--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -982,6 +982,7 @@ export class ChatSdkService implements OnModuleDestroy {
           {
             actionId: event.actionId,
             value: event.value,
+            sourceMessageId: event.messageId,
           },
           event.user.userId
         );

--- a/packages/framework/src/resources/agent/agent.test.ts
+++ b/packages/framework/src/resources/agent/agent.test.ts
@@ -863,7 +863,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
       handler: () => {
         const body = createMockBridgeRequest({
           event: 'onAction',
-          action: { actionId: 'confirm', value: 'yes' },
+          action: { actionId: 'confirm', value: 'yes', sourceMessageId: 'msg-card-001' },
           message: null,
         });
         const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onAction`);
@@ -882,7 +882,7 @@ describe('agent dispatch via NovuRequestHandler', () => {
     await vi.waitFor(() => expect(capturedCtx).toBeDefined());
 
     expect(capturedCtx.event).toBe('onAction');
-    expect(capturedCtx.action).toEqual({ actionId: 'confirm', value: 'yes' });
+    expect(capturedCtx.action).toEqual({ actionId: 'confirm', value: 'yes', sourceMessageId: 'msg-card-001' });
     expect(capturedCtx.message).toBeNull();
 
     const replyCall = fetchMock.mock.calls.find(
@@ -890,6 +890,54 @@ describe('agent dispatch via NovuRequestHandler', () => {
     );
     const replyBody = JSON.parse(replyCall![1].body);
     expect(replyBody.reply.markdown).toBe('Action received');
+  });
+
+  it('should expose sourceMessageId on action so handler can react to the card message', async () => {
+    let capturedCtx: any;
+
+    const testBot = agent('test-bot', {
+      onMessage: async () => {},
+      onAction: async (ctx) => {
+        capturedCtx = ctx;
+        if (ctx.action?.sourceMessageId) {
+          ctx.addReaction(ctx.action.sourceMessageId, 'eyes');
+        }
+        await ctx.reply('Acknowledged');
+      },
+    });
+
+    const handler = new NovuRequestHandler({
+      frameworkName: 'test',
+      agents: [testBot],
+      client,
+      handler: () => {
+        const body = createMockBridgeRequest({
+          event: 'onAction',
+          action: { actionId: 'play', sourceMessageId: 'msg-ttt-board' },
+          message: null,
+        });
+        const url = new URL(`http://localhost?action=${PostActionEnum.AGENT_EVENT}&agentId=test-bot&event=onAction`);
+
+        return {
+          body: () => body,
+          headers: () => null,
+          method: () => 'POST',
+          url: () => url,
+          transformResponse: (res: any) => res,
+        };
+      },
+    });
+
+    await handler.createHandler()();
+    await vi.waitFor(() => expect(capturedCtx).toBeDefined());
+
+    expect(capturedCtx.action?.sourceMessageId).toBe('msg-ttt-board');
+
+    const replyCall = fetchMock.mock.calls.find(
+      (call: any[]) => call[0] === 'https://api.novu.co/v1/agents/test-bot/reply'
+    );
+    const replyBody = JSON.parse(replyCall![1].body);
+    expect(replyBody.addReactions).toEqual([{ messageId: 'msg-ttt-board', emojiName: 'eyes' }]);
   });
 
   it('should have null action on onMessage events', async () => {

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -115,6 +115,8 @@ export interface ReplyContent {
 export interface AgentAction {
   actionId: string;
   value?: string;
+  /** Platform-native message ID of the message containing the clicked button/action. */
+  sourceMessageId?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Added `sourceMessageId` to the `AgentAction` interface so that `onAction` handlers can identify (and react to) the platform message that contained the clicked button.

### Problem

`ctx.message` is `null` on `onAction` events, so there was no way to obtain the platform message ID of the card/message containing the clicked button. This meant developers couldn't add reactions to the original interaction message.

### Solution

Three surgical changes:

1. **`packages/framework/src/resources/agent/agent.types.ts`** — Added optional `sourceMessageId` field to `AgentAction`
2. **`apps/api/src/app/agents/services/chat-sdk.service.ts`** — Forward `event.messageId` from the chat SDK's `onAction` callback through to the `AgentAction` payload
3. **`packages/framework/src/resources/agent/agent.test.ts`** — Updated existing action test to include `sourceMessageId`, added new test verifying the end-to-end pattern of using `ctx.action.sourceMessageId` with `ctx.addReaction()`

### Usage

```typescript
onAction: async (ctx) => {
  ctx.addReaction(ctx.action.sourceMessageId, 'eyes');
  await ctx.reply('Processing...');
}
```

### Data flow

```
Chat SDK onAction event (event.messageId)
  → chat-sdk.service.ts (maps to action.sourceMessageId)
    → AgentInboundHandler.handleAction (passes action through)
      → BridgeExecutorService.buildPayload (includes in AgentBridgeRequest.action)
        → Framework AgentContextImpl (ctx.action.sourceMessageId)
```

### Tests

- Updated: `should dispatch onAction event with action data on ctx` — now includes `sourceMessageId`
- New: `should expose sourceMessageId on action so handler can react to the card message` — verifies the full pattern of reading `sourceMessageId` and using it with `addReaction`
- All 50 agent tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7500](https://linear.app/novu/issue/NV-7500/expose-source-message-id-on-action-events-ctxactionsourcemessageid)

<div><a href="https://cursor.com/agents/bc-cb52e2f2-4c53-4d92-836d-57765ff4f1f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb52e2f2-4c53-4d92-836d-57765ff4f1f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Added an optional `sourceMessageId` field to action events, allowing handlers to access the platform message ID that triggered the action. Previously, `ctx.message` was null in `onAction` handlers, preventing them from identifying or reacting to the original interaction. Now handlers can use `ctx.action.sourceMessageId` with `ctx.addReaction()` to respond to the message containing the clicked button.

## Affected areas

- **api**: ChatSdkService now maps `event.messageId` from the chat SDK's onAction callback to `action.sourceMessageId` in the payload sent to handlers.
- **framework**: AgentAction interface extended with an optional `sourceMessageId` field; handlers can now access this field to identify the source message for reactions.

## Key technical decisions

- The `sourceMessageId` field is optional to maintain backward compatibility with existing action handlers.
- The field is populated directly from the chat SDK's `event.messageId`, ensuring the platform-native message ID is available end-to-end.

## Testing

Updated one existing test to assert `sourceMessageId` in action payloads and added a new end-to-end test verifying that handlers can call `ctx.addReaction(ctx.action.sourceMessageId, 'eyes')` to react to the card message. All 50 agent tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->