### PR TITLE
feat(dashboard): suggest domain based on user's signup email fixes NV-7517

### DIFF
--- a/apps/dashboard/src/components/domains/add-domain-dialog.tsx
+++ b/apps/dashboard/src/components/domains/add-domain-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
@@ -13,6 +13,7 @@ import {
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/primitives/form/form';
 import { Input } from '@/components/primitives/input';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
+import { useAuth } from '@/context/auth/hooks';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useCreateDomain } from '@/hooks/use-domains';
 import { buildRoute, ROUTES } from '@/utils/routes';
@@ -26,11 +27,23 @@ type AddDomainDialogProps = {
   onOpenChange: (open: boolean) => void;
 };
 
+const DEFAULT_PLACEHOLDER = 'inbound.acme.com';
+
 export function AddDomainDialog({ open, onOpenChange }: AddDomainDialogProps) {
+  const { currentUser } = useAuth();
   const { currentEnvironment } = useEnvironment();
   const navigate = useNavigate();
   const createDomain = useCreateDomain();
   const [isPending, setIsPending] = useState(false);
+
+  const domainPlaceholder = useMemo(() => {
+    const emailDomain = currentUser?.email?.split('@')[1];
+    if (!emailDomain) {
+      return DEFAULT_PLACEHOLDER;
+    }
+
+    return `inbound.${emailDomain}`;
+  }, [currentUser?.email]);
 
   const form = useForm<AddDomainFormData>({
     defaultValues: { name: '' },
@@ -84,7 +97,7 @@ export function AddDomainDialog({ open, onOpenChange }: AddDomainDialogProps) {
                 <FormItem>
                   <FormLabel>Domain</FormLabel>
                   <FormControl>
-                    <Input placeholder="inbound.acme.com" {...field} />
+                    <Input placeholder={domainPlaceholder} {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/apps/dashboard/src/components/domains/add-domain-dialog.tsx
+++ b/apps/dashboard/src/components/domains/add-domain-dialog.tsx
@@ -38,11 +38,12 @@ export function AddDomainDialog({ open, onOpenChange }: AddDomainDialogProps) {
 
   const domainPlaceholder = useMemo(() => {
     const emailDomain = currentUser?.email?.split('@')[1];
+
     if (!emailDomain) {
       return DEFAULT_PLACEHOLDER;
     }
 
-    return `inbound.${emailDomain}`;
+    return emailDomain;
   }, [currentUser?.email]);
 
   const form = useForm<AddDomainFormData>({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

When adding a new domain in the domain management screen, the input placeholder now shows a suggestion based on the user's actual email domain instead of a generic `inbound.acme.com`.

For example, a user signed up with `user@novu.co` will see `inbound.novu.co` as the placeholder.

## Why

This mirrors what services like Resend do — suggesting a domain the user actually owns rather than a generic example. It reduces friction and guides the user toward the correct value.

## How

- In `AddDomainDialog`, extract the domain portion from `currentUser.email` (via `useAuth`)
- Use it to build a dynamic placeholder: `inbound.{userDomain}`
- Falls back to `inbound.acme.com` if no email is available

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7517](https://linear.app/novu/issue/NV-7517/ux-improvement-suggest-the-domain-on-basis-on-what-domain-they-signed)

<div><a href="https://cursor.com/agents/bc-5169ab7c-e279-4cff-8f5c-1d9ec93a6c2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5169ab7c-e279-4cff-8f5c-1d9ec93a6c2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The domain input placeholder in the dashboard's AddDomainDialog now suggests a domain based on the current user's signup email (e.g., user@novu.co → inbound.novu.co) instead of the generic inbound.acme.com. This UX tweak guides users toward a domain they likely own, reducing friction when adding inbound domains; when no email is available it falls back to inbound.acme.com.

## Affected areas

**dashboard**: The AddDomainDialog imports useAuth, extracts the domain from currentUser.email, memoizes the computed placeholder, and uses it as the Input placeholder with a fallback to inbound.acme.com.

## Key technical decisions

- The placeholder computation is memoized with useMemo to avoid recomputation on every render.  
- A safe fallback (DEFAULT_PLACEHOLDER = 'inbound.acme.com') ensures a valid hint when no user email is present.

## Testing

No tests were added; this is a small UX change with straightforward logic suitable for manual QA verification (confirm placeholder updates based on signed-in user's email or falls back when absent).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->