### PR TITLE
fix(dashboard): apply row hover background to agent list actions cell

### DIFF
--- a/apps/dashboard/src/components/agents/agents-table.tsx
+++ b/apps/dashboard/src/components/agents/agents-table.tsx
@@ -220,11 +220,11 @@ export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProp
                 >
                   <span className="text-label-sm">{formatDateSimple(agent.updatedAt)}</span>
                 </AgentNavTableCell>
-                <TableCell className="p-3 text-right align-middle">
+                <AgentNavTableCell className="w-1 p-3 text-right align-middle">
                   {canWrite ? (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <CompactButton size="md" variant="ghost" icon={RiMore2Fill} className="z-10" disabled={readOnly}>
+                        <CompactButton variant="ghost" icon={RiMore2Fill} className="z-10 h-8 w-8 p-0" disabled={readOnly}>
                           <span className="sr-only">Open menu</span>
                         </CompactButton>
                       </DropdownMenuTrigger>
@@ -240,7 +240,7 @@ export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProp
                       </DropdownMenuContent>
                     </DropdownMenu>
                   ) : null}
-                </TableCell>
+                </AgentNavTableCell>
               </TableRow>
             );
           })}


### PR DESCRIPTION
The actions (3-dots) TableCell was not using AgentNavTableCell, so it lacked group-hover:bg-neutral-alpha-50 and stayed white while the rest of the row tinted on hover. Align with WorkflowRow by switching to AgentNavTableCell and matching the button sizing (h-8 w-8 p-0).

### What changed? Why was the change needed?

@coderabbitai summary

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
