### PR TITLE
fix(dashboard): refine Teams onboarding integration setup fixes NV-7492

### DIFF
--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -489,7 +489,6 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
                 {!readOnly && (
                   <ProviderDropdown
                     agentIdentifier={agent.identifier}
-                    agentName={agent.name}
                     selectedIntegrationId={selectedIntegration?.integration._id}
                     linkedIntegrationIds={linkedIntegrationIdSet}
                     excludeLinked

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -59,8 +59,6 @@ type ProviderDropdownProps = {
   fallbackProviderId?: string;
   onSelect: (providerId: string, integration?: IIntegration) => void;
   agentIdentifier: string;
-  /** Agent display name — used to derive the integration name for chat providers (e.g. "My Agent Bot"). */
-  agentName?: string;
   /** Integration IDs already linked to the agent — selecting one of these skips the link API call. */
   linkedIntegrationIds?: Set<string>;
   /** When true, hide integrations whose _id is in `linkedIntegrationIds` from the list. */
@@ -154,7 +152,6 @@ export function ProviderDropdown({
   fallbackProviderId,
   onSelect,
   agentIdentifier,
-  agentName,
   linkedIntegrationIds,
   excludeLinked = false,
   renderTrigger,
@@ -336,7 +333,7 @@ export function ProviderDropdown({
         setOpen(false);
       } else {
         const channel = PROVIDER_ID_TO_CHANNEL_MAP[item.providerId];
-        const uniqueName = channel === ChannelTypeEnum.CHAT && agentName ? `${agentName} - Bot` : item.displayName;
+        const uniqueName = channel === ChannelTypeEnum.CHAT ? `${agentIdentifier} - Bot` : item.displayName;
 
         const created = await createIntegrationMutation.mutateAsync({
           providerId: item.providerId,

--- a/apps/dashboard/src/components/agents/teams-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/teams-setup-guide.tsx
@@ -364,9 +364,10 @@ type HealthCheckViewProps = {
   /** True while the Azure setup popup is still open — polling is suspended until credentials are saved */
   waitingForSetup: boolean;
   onReady: () => void;
+  compact?: boolean;
 };
 
-function HealthCheckView({ integrationId, waitingForSetup, onReady }: HealthCheckViewProps) {
+function HealthCheckView({ integrationId, waitingForSetup, onReady, compact = false }: HealthCheckViewProps) {
   const { currentEnvironment } = useEnvironment();
   const [status, setStatus] = useState<MsTeamsHealthCheckResult | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -415,12 +416,14 @@ function HealthCheckView({ integrationId, waitingForSetup, onReady }: HealthChec
   const hasFailed = status?.appRegistration === 'failed' || status?.azureBotCreated === 'failed';
 
   return (
-    <div className="flex flex-col gap-4">
-      <p className="text-text-sub text-paragraph-sm">
-        {waitingForSetup
-          ? 'Complete authorization in the popup window. Teams readiness will be verified once setup finishes.'
-          : 'Verifying that the Teams app, bot credentials, and permissions are ready. This usually takes 1–3 minutes; permissions can take up to 60 minutes to propagate.'}
-      </p>
+    <div className={cn('flex flex-col', compact ? 'w-[260px] gap-2.5' : 'gap-4')}>
+      {!compact && (
+        <p className="text-text-sub text-paragraph-sm">
+          {waitingForSetup
+            ? 'Complete authorization in the popup window. Teams readiness will be verified once setup finishes.'
+            : 'Verifying that the Teams app, bot credentials, and permissions are ready. This usually takes 1–3 minutes; permissions can take up to 60 minutes to propagate.'}
+        </p>
+      )}
 
       <div className="flex flex-col gap-2.5 rounded-lg border border-stroke-soft bg-bg-weak p-4">
         {checkpoints.map(({ key, label, status: s }) => (
@@ -1009,6 +1012,7 @@ export function TeamsSetupGuide({
                 setShowHealthCheck(false);
                 queryClient.invalidateQueries({ queryKey: [QueryKeys.fetchIntegrations] });
               }}
+              compact
             />
           ) : undefined
         }


### PR DESCRIPTION
## Summary
- Use the stable agent identifier when generating chat integration bot names from the provider dropdown.
- Add a compact Teams health check presentation for the inline setup flow so the readiness card fits the guided UI.

## Test plan
- `lint-staged` via pre-commit hook (`biome check --write --no-errors-on-unmatched --diagnostic-level=error`)

## Screenshots
Not captured; this is a small inline layout and naming behavior change.

## Breaking changes
None.

Related Linear issues: NV-7492, NV-7387

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The integration setup flow for Teams onboarding now uses the stable agent identifier (instead of agent name) when generating bot names for chat integrations from the provider dropdown. Additionally, the Teams health check view has been made compact to fit the inline guided UI layout by reducing container width, spacing, and hiding descriptive text.

## Affected areas

**dashboard**: Updated the `ProviderDropdown` component to accept `agentIdentifier` instead of `agentName` and use it for generating unique integration names. The `HealthCheckView` component now supports a `compact` mode that adjusts layout and visibility based on context, with `TeamsSetupGuide` enabling this for its inline health-check step.

## Key technical decisions

- Switched from using `agentName` (mutable) to `agentIdentifier` (stable) for generating bot names, ensuring consistency across provider integrations.
- Added optional `compact` prop to `HealthCheckView` to support different presentation modes without duplicating the component.

## Testing

No new tests were added. Changes involve UI property updates and conditional styling, verified via lint-staged pre-commit checks (biome linting).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->