### PR TITLE
feat(dashboard): improve agent setup guide UX and prod environment handling fixes NV-7436

### DIFF
--- a/apps/dashboard/src/components/agents/agent-behavior-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-behavior-section.tsx
@@ -13,9 +13,11 @@ import { HelpTooltipIndicator } from '@/components/primitives/help-tooltip-indic
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/primitives/popover';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { Switch } from '@/components/primitives/switch';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 
 const DEFAULT_REACTION_ON_RESOLVED = 'check';
+const PROD_READ_ONLY_TOOLTIP = 'This setting is read-only in production. Edit in Development and promote to apply changes.';
 
 function useAgentEmoji() {
   const { currentEnvironment } = useEnvironment();
@@ -127,7 +129,7 @@ type AgentBehaviorSectionProps = {
 
 export function AgentBehaviorSection({ agent }: AgentBehaviorSectionProps) {
   const queryClient = useQueryClient();
-  const { currentEnvironment } = useEnvironment();
+  const { currentEnvironment, readOnly } = useEnvironment();
   const { emojiList, unicodeMap } = useAgentEmoji();
 
   const acknowledgeOnReceived = agent.behavior?.acknowledgeOnReceived !== false;
@@ -158,24 +160,52 @@ export function AgentBehaviorSection({ agent }: AgentBehaviorSectionProps) {
             label="Acknowledge incoming messages"
             tooltip='Show a "Typing…" indicator while the agent works. On platforms that don&#39;t support typing, react with an "eyes" emoji instead.'
           >
-            <Switch
-              checked={acknowledgeOnReceived}
-              disabled={isPending}
-              onCheckedChange={(checked) => mutate({ acknowledgeOnReceived: checked })}
-            />
+            {readOnly ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex">
+                    <Switch checked={acknowledgeOnReceived} disabled />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">{PROD_READ_ONLY_TOOLTIP}</TooltipContent>
+              </Tooltip>
+            ) : (
+              <Switch
+                checked={acknowledgeOnReceived}
+                disabled={isPending}
+                onCheckedChange={(checked) => mutate({ acknowledgeOnReceived: checked })}
+              />
+            )}
           </ToggleRow>
 
           <ToggleRow
             label="React to the first message when a conversation is resolved"
             tooltip="Add an emoji reaction to the first message in the thread when the agent resolves the conversation."
           >
-            <ResolvedEmojiPicker
-              currentEmoji={reactionOnResolved}
-              emojiList={emojiList}
-              unicodeMap={unicodeMap}
-              disabled={isPending}
-              onSelect={(emojiName) => mutate({ reactionOnResolved: emojiName })}
-            />
+            {readOnly ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex">
+                    <ResolvedEmojiPicker
+                      currentEmoji={reactionOnResolved}
+                      emojiList={emojiList}
+                      unicodeMap={unicodeMap}
+                      disabled
+                      onSelect={() => {}}
+                    />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">{PROD_READ_ONLY_TOOLTIP}</TooltipContent>
+              </Tooltip>
+            ) : (
+              <ResolvedEmojiPicker
+                currentEmoji={reactionOnResolved}
+                emojiList={emojiList}
+                unicodeMap={unicodeMap}
+                disabled={isPending}
+                onSelect={(emojiName) => mutate({ reactionOnResolved: emojiName })}
+              />
+            )}
           </ToggleRow>
         </div>
       </div>

--- a/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
@@ -1,12 +1,13 @@
 import { ChatProviderIdEnum } from '@novu/shared';
 import { useQueryClient } from '@tanstack/react-query';
-import { CheckCircle2, Loader } from 'lucide-react';
+import { Loader } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { RiCheckLine, RiFileCopyLine } from 'react-icons/ri';
+import { RiArrowRightSLine, RiCheckLine, RiFileCopyLine, RiInformation2Line } from 'react-icons/ri';
 import type { AgentResponse } from '@/api/agents';
 import { getAgent, getAgentDetailQueryKey } from '@/api/agents';
+import { Button } from '@/components/primitives/button';
 import { Skeleton } from '@/components/primitives/skeleton';
-import { ExternalLink } from '@/components/shared/external-link';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchApiKeys } from '@/hooks/use-fetch-api-keys';
 import { apiHostnameManager } from '@/utils/api-hostname-manager';
@@ -112,15 +113,56 @@ function TerminalBlock({ displayCommand, copyCommand }: { displayCommand: string
   );
 }
 
-function getProviderCallToAction(providerId: string | undefined): string {
+function getProviderSlackMessage(agentName: string): string {
+  return `Hey @${agentName}, can you help me?`;
+}
+
+function getProviderSendDescription(providerId: string | undefined, agentName: string): string {
   switch (providerId) {
     case ChatProviderIdEnum.Slack:
-      return 'Head back to Slack and mention your bot again — this time your agent server will handle the message.';
+      return `Open your Slack workspace and send a message to ${agentName}. Make sure to send in a channel or directly to the bot.`;
     case ChatProviderIdEnum.WhatsAppBusiness:
-      return 'Send a message to your WhatsApp number again — this time your agent server will handle it.';
+      return `Send a message to your WhatsApp number to test the connection.`;
     default:
-      return 'Send a message to your bot from the connected provider again — this time your agent server will handle it.';
+      return `Send a message to your bot from the connected provider to test the connection.`;
   }
+}
+
+
+function CopySlackMessageButton({ agentName }: { agentName: string }) {
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(getProviderSlackMessage(agentName));
+      setCopied(true);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard write failed silently
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="text-text-sub hover:text-text-strong flex cursor-pointer items-center gap-1 transition-colors"
+    >
+      {copied ? (
+        <RiCheckLine className="size-4" />
+      ) : (
+        <RiFileCopyLine className="size-4" />
+      )}
+      <span className="text-label-xs font-medium">{copied ? 'Copied!' : 'Copy Slack message'}</span>
+    </button>
+  );
 }
 
 function useBridgeConnectionPolling(agent: AgentResponse, onBridgeConnected?: () => void) {
@@ -179,41 +221,48 @@ function useBridgeConnectionPolling(agent: AgentResponse, onBridgeConnected?: ()
 
 function BridgeConnectionStatus({
   connected,
-  providerId,
+  onAddProvider,
 }: {
   connected: boolean;
-  providerId: string | undefined;
+  onAddProvider?: () => void;
 }) {
 
   if (connected) {
     return (
-      <div className="flex flex-col gap-2 py-4 pl-8">
-        <div className="flex items-center gap-1">
-          <CheckCircle2 className="text-success-base size-3.5 shrink-0" />
-          <span className="text-text-strong text-label-sm font-medium">Bridge connected — try your agent</span>
-        </div>
-        <p className="text-text-soft text-label-xs font-medium leading-4">{getProviderCallToAction(providerId)}</p>
-        <p className="text-text-soft text-label-xs font-medium leading-4">
-          Edit <code className="font-code text-[12px] tracking-[-0.24px]">app/novu/agents/</code> to customize how your
-          agent responds.
-        </p>
-        <ExternalLink href="https://docs.novu.co/agents/overview" variant="documentation">
-          Agent documentation
-        </ExternalLink>
+      <div className="flex items-center gap-2 py-4 pl-6">
+        <RiCheckLine className="size-3.5 shrink-0 text-[#dd2476]" />
+        <span className="animate-gradient bg-linear-to-r from-[#dd2476] via-[#ff512f] to-[#dd2476] bg-size-[400%_400%] bg-clip-text text-label-sm font-medium text-transparent">
+          Setup complete
+        </span>
+        {onAddProvider && (
+          <span className="text-text-soft text-label-xs font-medium">·</span>
+        )}
+        {onAddProvider && (
+          <Button
+            variant="secondary"
+            mode="outline"
+            size="xs"
+            className="text-text-sub gap-0.5 px-2 py-1.5"
+            onClick={onAddProvider}
+          >
+            <span className="text-label-xs font-medium">Add another provider</span>
+            <RiArrowRightSLine className="size-4" />
+          </Button>
+        )}
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col gap-2 py-4 pl-8">
+    <div className="flex flex-col gap-2 py-4 pl-6">
       <div className="flex items-center gap-1">
         <Loader className="size-3.5 text-[#dd2476] animate-[spin_5s_linear_infinite]" />
         <span className="animate-gradient bg-linear-to-r from-[#dd2476] via-[#ff512f] to-[#dd2476] bg-size-[400%_400%] bg-clip-text text-label-sm font-medium text-transparent">
-          Waiting for bridge connection…
+          Waiting for your agent to connect
         </span>
       </div>
       <p className="text-text-soft text-label-xs font-medium leading-4">
-        Run the commands above to scaffold your project and start the dev tunnel.
+        Run the commands above, then come back here; we'll detect the connection automatically.
       </p>
     </div>
   );
@@ -224,9 +273,10 @@ type AgentCodeSetupSectionProps = {
   stepOffset: number;
   providerId?: string;
   onBridgeConnected?: () => void;
+  onAddProvider?: () => void;
 };
 
-export function AgentCodeSetupSection({ agent, stepOffset, providerId, onBridgeConnected }: AgentCodeSetupSectionProps) {
+export function AgentCodeSetupSection({ agent, stepOffset, providerId, onBridgeConnected, onAddProvider }: AgentCodeSetupSectionProps) {
   const apiKeysQuery = useFetchApiKeys();
   const secretKey = apiKeysQuery.data?.data?.[0]?.key;
 
@@ -235,22 +285,31 @@ export function AgentCodeSetupSection({ agent, stepOffset, providerId, onBridgeC
 
   const bridgeConnected = useBridgeConnectionPolling(agent, onBridgeConnected);
 
-  const firstIncompleteStep = bridgeConnected ? stepOffset + 2 : stepOffset;
+  const firstIncompleteStep = bridgeConnected ? stepOffset + 3 : stepOffset;
 
   return (
     <>
       <SetupStep
         index={stepOffset}
         status={deriveStepStatus(stepOffset, firstIncompleteStep)}
-        sectionLabel="2/2 CONNECT YOUR CODE"
-        title="Scaffold your agent project"
-        description={
-          <span>
-            Run this to create a Next.js project with the bridge endpoint pre-configured for your agent. The CLI
-            installs dependencies and writes your secret key to{' '}
-            <code className="font-code text-[12px] tracking-[-0.24px]">.env.local</code> automatically.
+        sectionLabel="2/2 SETUP AGENT HANDLER"
+        title={
+          <span className="inline-flex items-center gap-1">
+            Scaffold your agent project
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="text-text-soft inline-block">
+                  <RiInformation2Line className="size-4" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                Novu routes messages to your agent. This step generates starter scaffolding for its response logic, runs
+                it locally, and connects it to Novu automatically via bridge.
+              </TooltipContent>
+            </Tooltip>
           </span>
         }
+        description="Run this to create a Next.js project with the bridge endpoint pre-configured for your agent. The CLI installs dependencies and writes your secret key to .env.local automatically."
         rightContent={
           apiKeysQuery.isLoading || !secretKey ? (
             <Skeleton className="h-[80px] w-full rounded-lg" />
@@ -278,9 +337,10 @@ export function AgentCodeSetupSection({ agent, stepOffset, providerId, onBridgeC
         title="Start the dev tunnel"
         description={
           <span>
-            Start your app with <code className="font-code text-[12px] tracking-[-0.24px]">npm run dev</code>, then run
-            this in a second terminal from your project directory. It creates a tunnel and registers the bridge URL with
-            Novu.
+            Start your app with npm run dev, then run this in a second terminal from your project directory.
+            <br />
+            <br />
+            It creates a tunnel and registers the bridge URL with Novu.
           </span>
         }
         rightContent={
@@ -291,7 +351,17 @@ export function AgentCodeSetupSection({ agent, stepOffset, providerId, onBridgeC
         }
       />
 
-      <BridgeConnectionStatus connected={bridgeConnected} providerId={providerId} />
+      <SetupStep
+        index={stepOffset + 2}
+        status={deriveStepStatus(stepOffset + 2, firstIncompleteStep)}
+        title="Send a message to the Slack App on Slack"
+        description={getProviderSendDescription(providerId, agent.name)}
+        rightContent={
+          providerId === ChatProviderIdEnum.Slack ? <CopySlackMessageButton agentName={agent.name} /> : undefined
+        }
+      />
+
+      <BridgeConnectionStatus connected={bridgeConnected} onAddProvider={onAddProvider} />
     </>
   );
 }

--- a/apps/dashboard/src/components/agents/agent-integration-guides/resolve-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/resolve-agent-integration-guide.tsx
@@ -60,7 +60,7 @@ function SetupGuideWithHeader({
   );
 
   return (
-    <div className="flex w-full flex-col gap-4">
+    <div className="flex w-full max-w-[1100px] flex-col gap-4">
       <AgentIntegrationGuideHeader
         providerId={providerId}
         providerDisplayName={providerDisplayName}

--- a/apps/dashboard/src/components/agents/agent-overview-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-overview-tab.tsx
@@ -3,12 +3,14 @@ import type { AgentResponse } from '@/api/agents';
 import { AgentConnectedOverview } from '@/components/agents/agent-connected-overview';
 import { AgentSetupGuide } from '@/components/agents/agent-setup-guide';
 import { AgentSidebarWidget } from '@/components/agents/agent-sidebar-widget';
+import { useEnvironment } from '@/context/environment/hooks';
 
 type AgentOverviewTabProps = {
   agent: AgentResponse;
 };
 
 export function AgentOverviewTab({ agent }: AgentOverviewTabProps) {
+  const { readOnly } = useEnvironment();
   const isBridgeConnected = Boolean(agent.bridgeUrl || (agent.devBridgeActive && agent.devBridgeUrl));
 
   // Snapshot connection state on mount so that users who are actively
@@ -17,10 +19,12 @@ export function AgentOverviewTab({ agent }: AgentOverviewTabProps) {
   // arrive with a bridge already connected get the connected overview.
   const [wasBridgeConnectedOnMount] = useState(isBridgeConnected);
 
+  const showConnectedOverview = readOnly || wasBridgeConnectedOnMount;
+
   return (
     <div className="flex items-start gap-6 px-6 pt-4">
       <AgentSidebarWidget agent={agent} />
-      {wasBridgeConnectedOnMount ? <AgentConnectedOverview agent={agent} /> : <AgentSetupGuide agent={agent} />}
+      {showConnectedOverview ? <AgentConnectedOverview agent={agent} /> : <AgentSetupGuide agent={agent} />}
     </div>
   );
 }

--- a/apps/dashboard/src/components/agents/agent-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-guide.tsx
@@ -8,7 +8,7 @@ type AgentSetupGuideProps = {
 
 export function AgentSetupGuide({ agent }: AgentSetupGuideProps) {
   return (
-    <SetupGuideCard label="Setup agent" className="min-w-0 flex-1">
+    <SetupGuideCard label="Setup agent" className="min-w-0 flex-1 max-w-[1100px]">
       <AgentSetupSteps agent={agent} />
     </SetupGuideCard>
   );

--- a/apps/dashboard/src/components/agents/agent-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-steps.tsx
@@ -1,9 +1,13 @@
 import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { motion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { RiExpandUpDownLine } from 'react-icons/ri';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { type AgentResponse, getAgentIntegrationsQueryKey, listAgentIntegrations } from '@/api/agents';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
+import { buildRoute, ROUTES } from '@/utils/routes';
 import { AgentCodeSetupSection } from './agent-code-setup-section';
 import { EmailSetupGuide } from './email-setup-guide';
 import { ProviderDropdown } from './provider-dropdown';
@@ -33,12 +37,47 @@ const SESSION_KEY = (agentIdentifier: string) => `agent-setup-integration:${agen
 type AgentSetupStepsProps = {
   agent: AgentResponse;
   onBridgeConnected?: () => void;
+  hideAddProvider?: boolean;
 };
 
-export function AgentSetupSteps({ agent, onBridgeConnected }: AgentSetupStepsProps) {
+function CollapsedProviderSection({
+  expanded,
+  onToggle,
+  visible,
+}: {
+  expanded: boolean;
+  onToggle: () => void;
+  visible: boolean;
+}) {
+  if (!visible) return null;
+
+  return (
+    <div className="relative flex items-center pl-6">
+      <div className="absolute -left-[20px] flex w-5 justify-center">
+        <div className="flex size-5 shrink-0 items-center justify-center rounded-full border border-success-dark bg-success-base shadow-[0px_0px_0px_1px_hsl(var(--static-white)),0px_0px_0px_2px_hsl(var(--stroke-soft))]">
+          <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
+            <path d="M1 4L3.5 6.5L9 1" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="text-text-sub hover:text-text-strong flex cursor-pointer items-center gap-1 transition-colors"
+      >
+        <span className="text-label-xs font-medium">{expanded ? 'Hide instructions' : 'View all instructions'}</span>
+        <RiExpandUpDownLine className="size-4" />
+      </button>
+    </div>
+  );
+}
+
+export function AgentSetupSteps({ agent, onBridgeConnected, hideAddProvider }: AgentSetupStepsProps) {
   const { currentEnvironment } = useEnvironment();
   const { integrations } = useFetchIntegrations();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(
     () => sessionStorage.getItem(SESSION_KEY(agent.identifier)) ?? undefined
@@ -68,6 +107,15 @@ export function AgentSetupSteps({ agent, onBridgeConnected }: AgentSetupStepsPro
 
     return links.some((link) => Boolean(link.connectedAt));
   }, [agentIntegrationsQuery.data?.data]);
+
+  const [userExpandedProvider, setUserExpandedProvider] = useState(false);
+  const isProviderExpanded = !hasConnectedIntegration || userExpandedProvider;
+
+  useEffect(() => {
+    if (!hasConnectedIntegration) {
+      setUserExpandedProvider(false);
+    }
+  }, [hasConnectedIntegration]);
 
   const defaultFromAgent = agent.integrations?.[0];
   const effectiveIntegrationId = validatedSelectedId ?? defaultFromAgent?.integrationId;
@@ -103,6 +151,18 @@ export function AgentSetupSteps({ agent, onBridgeConnected }: AgentSetupStepsPro
     });
   }, [queryClient, currentEnvironment?._id, agent.identifier]);
 
+  const handleAddProvider = useCallback(() => {
+    if (!currentEnvironment?.slug) return;
+
+    navigate(
+      `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+        environmentSlug: currentEnvironment.slug,
+        agentIdentifier: encodeURIComponent(agent.identifier),
+        agentTab: 'integrations',
+      })}${location.search}`
+    );
+  }, [agent.identifier, currentEnvironment?.slug, location.search, navigate]);
+
   return (
     <div className="relative flex flex-col gap-10 py-6 pb-3 pl-8 pr-6">
       <div
@@ -112,39 +172,55 @@ export function AgentSetupSteps({ agent, onBridgeConnected }: AgentSetupStepsPro
         }}
       />
 
-      <SetupStep
-        index={1}
-        status={deriveStepStatus(1, firstIncompleteStep)}
-        sectionLabel="1/2 SETUP PROVIDER"
-        title="Choose where your agent listens and communicates"
-        description="Start with one provider your agent can receive and respond on and you can always add more providers as you need."
-        rightContent={
-          <ProviderDropdown
-            agentIdentifier={agent.identifier}
-            selectedIntegrationId={validatedSelectedId ?? defaultFromAgent?.integrationId}
-            linkedIntegrationIds={linkedIntegrationIds}
-            onSelect={(_providerId, integration) => {
-              if (integration?._id) {
-                setSelectedIntegrationId(integration._id);
-                sessionStorage.setItem(SESSION_KEY(agent.identifier), integration._id);
-              }
-            }}
-          />
-        }
+      <CollapsedProviderSection
+        expanded={isProviderExpanded}
+        onToggle={() => setUserExpandedProvider((prev) => !prev)}
+        visible={hasConnectedIntegration}
       />
 
-      {ProviderGuide && effectiveIntegrationId ? (
-        <ProviderGuide
-          agent={agent}
-          integrationId={effectiveIntegrationId}
-          stepOffset={2}
-          embedded={false}
-          onStepsCompleted={handleProviderStepsCompleted}
-        />
-      ) : null}
+      <motion.div
+        initial={false}
+        animate={{ height: isProviderExpanded ? 'auto' : 0, opacity: isProviderExpanded ? 1 : 0 }}
+        transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+        style={{ clipPath: 'inset(0 -100% -100% -100%)' }}
+      >
+        <div className="flex flex-col gap-10">
+          <SetupStep
+            index={1}
+            status={deriveStepStatus(1, firstIncompleteStep)}
+            sectionLabel="1/2 SETUP PROVIDER"
+            title="Choose where your agent listens and communicates"
+            description="Start with one provider your agent can receive and respond on and you can always add more providers as you need."
+            rightContent={
+              <ProviderDropdown
+                agentIdentifier={agent.identifier}
+                agentName={agent.name}
+                selectedIntegrationId={validatedSelectedId ?? defaultFromAgent?.integrationId}
+                linkedIntegrationIds={linkedIntegrationIds}
+                onSelect={(_providerId, integration) => {
+                  if (integration?._id) {
+                    setSelectedIntegrationId(integration._id);
+                    sessionStorage.setItem(SESSION_KEY(agent.identifier), integration._id);
+                  }
+                }}
+              />
+            }
+          />
+
+          {ProviderGuide && effectiveIntegrationId ? (
+            <ProviderGuide
+              agent={agent}
+              integrationId={effectiveIntegrationId}
+              stepOffset={2}
+              embedded={false}
+              onStepsCompleted={handleProviderStepsCompleted}
+            />
+          ) : null}
+        </div>
+      </motion.div>
 
       {hasConnectedIntegration && (
-        <AgentCodeSetupSection agent={agent} stepOffset={5} providerId={selectedProviderId} onBridgeConnected={onBridgeConnected} />
+        <AgentCodeSetupSection agent={agent} stepOffset={5} providerId={selectedProviderId} onBridgeConnected={onBridgeConnected} onAddProvider={hideAddProvider ? undefined : handleAddProvider} />
       )}
     </div>
   );

--- a/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
+++ b/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { RiAlertFill } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
 import type { AgentResponse, UpdateAgentBody } from '@/api/agents';
 import { getAgentDetailQueryKey, updateAgent } from '@/api/agents';
@@ -53,18 +54,19 @@ type BridgeUrlSectionProps = {
 
 function BridgeUrlSection({ agent, canWrite, isUpdatePending, onUpdate, readOnly }: BridgeUrlSectionProps) {
   const [isEditing, setIsEditing] = useState(false);
-  const [bridgeUrl, setBridgeUrl] = useState(agent.bridgeUrl ?? '');
-  const urlBeforeEditRef = useRef(agent.bridgeUrl ?? '');
+  const displayUrl = agent.devBridgeActive ? (agent.devBridgeUrl ?? '') : (agent.bridgeUrl ?? '');
+  const [bridgeUrl, setBridgeUrl] = useState(displayUrl);
+  const urlBeforeEditRef = useRef(displayUrl);
 
   useEffect(() => {
     if (!isEditing) {
-      setBridgeUrl(agent.bridgeUrl ?? '');
+      setBridgeUrl(displayUrl);
     }
-  }, [agent.bridgeUrl, isEditing]);
+  }, [displayUrl, isEditing]);
 
   const persistBridgeUrl = useCallback(async () => {
     const trimmed = bridgeUrl.trim();
-    const server = (agent.bridgeUrl ?? '').trim();
+    const server = displayUrl.trim();
 
     if (trimmed === server) {
       setIsEditing(false);
@@ -80,12 +82,15 @@ function BridgeUrlSection({ agent, canWrite, isUpdatePending, onUpdate, readOnly
 
     setIsEditing(false);
     await onUpdate({ bridgeUrl: trimmed });
-  }, [agent.bridgeUrl, bridgeUrl, canWrite, onUpdate]);
+  }, [displayUrl, bridgeUrl, canWrite, onUpdate]);
 
   return (
     <>
       <div className="flex h-8 items-center justify-between gap-2 px-1.5">
-        <span className="text-text-soft text-label-xs font-medium shrink-0">Bridge URL</span>
+        <span className="text-text-soft text-label-xs font-medium shrink-0 flex items-center gap-0.5">
+          Bridge URL
+          {!displayUrl && <RiAlertFill className="size-3.5 text-orange-500" />}
+        </span>
         <div className="relative flex h-8 min-w-0 flex-1 items-center justify-end">
           <AnimatePresence mode="wait">
             {isEditing && canWrite ? (
@@ -143,7 +148,7 @@ function BridgeUrlSection({ agent, canWrite, isUpdatePending, onUpdate, readOnly
                 )}
               >
                 <span className="block w-full min-w-0 truncate text-right">
-                  {agent.bridgeUrl || <span className="text-text-soft italic">Not configured</span>}
+                  {displayUrl || <span className="text-text-disabled">Not configured</span>}
                 </span>
               </motion.button>
             )}
@@ -153,11 +158,9 @@ function BridgeUrlSection({ agent, canWrite, isUpdatePending, onUpdate, readOnly
       {!readOnly && (
         <DetailsSidebarRow label="Bridge">
           <div className="flex items-center gap-1.5">
-            {!agent.devBridgeActive ? (
-              <Badge variant="lighter" color="green" size="sm">
-                DEVELOPMENT
-              </Badge>
-            ) : null}
+            <Badge variant="lighter" color={!agent.devBridgeActive ? 'green' : 'gray'} size="sm">
+              DEVELOPMENT
+            </Badge>
             <Switch
               checked={agent.devBridgeActive ?? false}
               disabled={!canWrite || isUpdatePending}
@@ -165,11 +168,9 @@ function BridgeUrlSection({ agent, canWrite, isUpdatePending, onUpdate, readOnly
                 void onUpdate({ devBridgeActive: checked });
               }}
             />
-            {agent.devBridgeActive ? (
-              <Badge variant="lighter" color="orange" size="sm">
-                LOCAL
-              </Badge>
-            ) : null}
+            <Badge variant="lighter" color={agent.devBridgeActive ? 'orange' : 'gray'} size="sm">
+              LOCAL
+            </Badge>
           </div>
         </DetailsSidebarRow>
       )}

--- a/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
+++ b/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
@@ -52,7 +52,7 @@ export function SetupStep({
   index: number;
   status: StepStatus;
   sectionLabel?: string;
-  title: string;
+  title: ReactNode;
   description: ReactNode;
   rightContent?: ReactNode;
   extraContent?: ReactNode;
@@ -63,7 +63,7 @@ export function SetupStep({
       <div className={cn('absolute -left-[20px] flex w-5 justify-center', sectionLabel ? 'top-5' : 'top-0')}>
         <StepIndicator status={status} index={index} />
       </div>
-      <div className="flex gap-5">
+      <div className="flex gap-20">
         <div className="flex min-w-0 max-w-[400px] flex-1 flex-col">
           <div className="flex flex-col gap-2">
             {sectionLabel && (
@@ -76,7 +76,7 @@ export function SetupStep({
           </div>
           {extraContent}
         </div>
-        {rightContent && <div className="flex min-h-0 min-w-0 shrink-0 flex-col items-start">{rightContent}</div>}
+        {rightContent && <div className="flex min-h-0 min-w-0 flex-1 flex-col items-start">{rightContent}</div>}
       </div>
       {fullWidthContent}
     </div>
@@ -253,7 +253,7 @@ export function ListeningStatus({
           />,
           document.body
         )}
-      <div className="flex flex-col gap-2 py-4 pl-8">
+      <div className="flex flex-col gap-2 py-4 pl-6">
         <div className="flex flex-col gap-3">
           {connectedAt ? (
             <div className="flex items-center gap-1">

--- a/apps/dashboard/src/components/agents/setup-guide-step-utils.ts
+++ b/apps/dashboard/src/components/agents/setup-guide-step-utils.ts
@@ -1,3 +1,5 @@
+import type { ICredentials } from '@novu/shared';
+
 export type StepStatus = 'completed' | 'current' | 'upcoming';
 
 export function deriveStepStatus(stepIndex: number, firstIncompleteStep: number): StepStatus {
@@ -5,4 +7,15 @@ export function deriveStepStatus(stepIndex: number, firstIncompleteStep: number)
   if (stepIndex === firstIncompleteStep) return 'current';
 
   return 'upcoming';
+}
+
+/**
+ * Returns true when at least one string credential field has been filled in.
+ * Boolean fields (secure, requireTls, etc.) are excluded — their default false
+ * value should not count as "credentials saved".
+ */
+export function hasIntegrationCredentials(credentials: ICredentials | undefined): boolean {
+  if (!credentials) return false;
+
+  return Object.values(credentials).some((v) => typeof v === 'string' && v.length > 0);
 }

--- a/apps/dashboard/src/components/agents/slack-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/slack-setup-guide.tsx
@@ -15,7 +15,7 @@ import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { apiHostnameManager } from '@/utils/api-hostname-manager';
 import { cn } from '@/utils/ui';
 import { IntegrationCredentialsSidebar, ListeningStatus, SetupButton, SetupStep } from './setup-guide-primitives';
-import { deriveStepStatus } from './setup-guide-step-utils';
+import { deriveStepStatus, hasIntegrationCredentials } from './setup-guide-step-utils';
 
 export type SlackSetupGuideProps = {
   agent: AgentResponse;
@@ -151,13 +151,14 @@ export function SlackSetupGuide({
   const { user } = useUser();
   const { currentEnvironment } = useEnvironment();
   const [isCredentialsSidebarOpen, setIsCredentialsSidebarOpen] = useState(false);
-  const [isCredentialsSaved, setIsCredentialsSaved] = useState(false);
+  const [credentialsSavedLocally, setCredentialsSavedLocally] = useState(false);
   const [isSlackWorkspaceConnected, setIsSlackWorkspaceConnected] = useState(false);
   const [showManifest, setShowManifest] = useState(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset when the watched Slack integration changes
   useEffect(() => {
     setIsSlackWorkspaceConnected(false);
+    setCredentialsSavedLocally(false);
   }, [integrationId]);
 
   const handleSlackWorkspaceConnected = useCallback(() => {
@@ -167,11 +168,14 @@ export function SlackSetupGuide({
 
   const { integrations } = useFetchIntegrations();
 
-  const selectedIntegrationIdentifier = useMemo(() => {
-    const row = integrations?.find((i) => i._id === integrationId && i.providerId === ChatProviderIdEnum.Slack);
+  const selectedIntegration = useMemo(
+    () => integrations?.find((i) => i._id === integrationId && i.providerId === ChatProviderIdEnum.Slack),
+    [integrations, integrationId]
+  );
 
-    return row?.identifier ?? '';
-  }, [integrations, integrationId]);
+  const selectedIntegrationIdentifier = selectedIntegration?.identifier ?? '';
+  const hasCredentials = hasIntegrationCredentials(selectedIntegration?.credentials);
+  const isCredentialsSaved = hasCredentials || credentialsSavedLocally;
 
   const webhookHandlerUrl = buildAgentSlackWebhookUrl(
     agent._id,
@@ -258,6 +262,10 @@ export function SlackSetupGuide({
                 connectLabel={`Install ${agent.name} ↗`}
                 connectedLabel="Connected to Slack"
                 onConnectSuccess={handleSlackWorkspaceConnected}
+                onConnectError={(error) => {
+                  toast.error('Failed to connect to Slack. Please try again.');
+                  console.error(error);
+                }}
                 appearance={{
                   elements: {
                     channelConnectButton: 'nt-h-8 nt-px-3 nt-rounded-lg',
@@ -293,12 +301,14 @@ export function SlackSetupGuide({
           />
           {stepsColumn}
         </div>
-        {listening}
+        <div className="pl-8">
+          {listening}
+        </div>
         <IntegrationCredentialsSidebar
           integrationId={integrationId}
           isOpen={isCredentialsSidebarOpen}
           onClose={() => setIsCredentialsSidebarOpen(false)}
-          onSaveSuccess={() => setIsCredentialsSaved(true)}
+          onSaveSuccess={() => setCredentialsSavedLocally(true)}
           agentOnboarding
         />
       </div>
@@ -313,7 +323,7 @@ export function SlackSetupGuide({
         integrationId={integrationId}
         isOpen={isCredentialsSidebarOpen}
         onClose={() => setIsCredentialsSidebarOpen(false)}
-        onSaveSuccess={() => setIsCredentialsSaved(true)}
+        onSaveSuccess={() => setCredentialsSavedLocally(true)}
         agentOnboarding
       />
     </>

--- a/apps/dashboard/src/components/agents/slack-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/slack-setup-guide.tsx
@@ -9,6 +9,7 @@ import { ProviderIcon } from '@/components/integrations/components/provider-icon
 import { Button } from '@/components/primitives/button';
 import { CodeBlock } from '@/components/primitives/code-block';
 import { InlineToast } from '@/components/primitives/inline-toast';
+import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { API_HOSTNAME } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
@@ -263,7 +264,7 @@ export function SlackSetupGuide({
                 connectedLabel="Connected to Slack"
                 onConnectSuccess={handleSlackWorkspaceConnected}
                 onConnectError={(error) => {
-                  toast.error('Failed to connect to Slack. Please try again.');
+                  showErrorToast('Failed to connect to Slack. Please try again.');
                   console.error(error);
                 }}
                 appearance={{

--- a/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
@@ -9,7 +9,7 @@ import { API_HOSTNAME } from '@/config';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { cn } from '@/utils/ui';
 import { IntegrationCredentialsSidebar, ListeningStatus, SetupButton, SetupStep } from './setup-guide-primitives';
-import { deriveStepStatus } from './setup-guide-step-utils';
+import { deriveStepStatus, hasIntegrationCredentials } from './setup-guide-step-utils';
 
 export type WhatsAppSetupGuideProps = {
   agent: AgentResponse;
@@ -53,12 +53,13 @@ export function WhatsAppSetupGuide({
   embedded = false,
 }: WhatsAppSetupGuideProps) {
   const [isCredentialsSidebarOpen, setIsCredentialsSidebarOpen] = useState(false);
-  const [isCredentialsSaved, setIsCredentialsSaved] = useState(false);
+  const [credentialsSavedLocally, setCredentialsSavedLocally] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset when the watched integration changes
   useEffect(() => {
     setIsConnected(false);
+    setCredentialsSavedLocally(false);
   }, [integrationId]);
 
   const handleConnected = useCallback(() => {
@@ -68,13 +69,15 @@ export function WhatsAppSetupGuide({
 
   const { integrations } = useFetchIntegrations();
 
-  const selectedIntegrationIdentifier = useMemo(() => {
-    const row = integrations?.find(
-      (i) => i._id === integrationId && i.providerId === ChatProviderIdEnum.WhatsAppBusiness
-    );
+  const selectedIntegration = useMemo(
+    () =>
+      integrations?.find((i) => i._id === integrationId && i.providerId === ChatProviderIdEnum.WhatsAppBusiness),
+    [integrations, integrationId]
+  );
 
-    return row?.identifier ?? '';
-  }, [integrations, integrationId]);
+  const selectedIntegrationIdentifier = selectedIntegration?.identifier ?? '';
+  const hasCredentials = hasIntegrationCredentials(selectedIntegration?.credentials);
+  const isCredentialsSaved = hasCredentials || credentialsSavedLocally;
 
   const webhookUrl = buildAgentWebhookUrl(agent._id, selectedIntegrationIdentifier || 'YOUR_INTEGRATION_IDENTIFIER');
 
@@ -265,7 +268,7 @@ export function WhatsAppSetupGuide({
           integrationId={integrationId}
           isOpen={isCredentialsSidebarOpen}
           onClose={() => setIsCredentialsSidebarOpen(false)}
-          onSaveSuccess={() => setIsCredentialsSaved(true)}
+          onSaveSuccess={() => setCredentialsSavedLocally(true)}
           agentOnboarding
         />
       </div>
@@ -280,7 +283,7 @@ export function WhatsAppSetupGuide({
         integrationId={integrationId}
         isOpen={isCredentialsSidebarOpen}
         onClose={() => setIsCredentialsSidebarOpen(false)}
-        onSaveSuccess={() => setIsCredentialsSaved(true)}
+        onSaveSuccess={() => setCredentialsSavedLocally(true)}
         agentOnboarding
       />
     </>

--- a/apps/dashboard/src/components/onboarding/onboarding-setup-guide.tsx
+++ b/apps/dashboard/src/components/onboarding/onboarding-setup-guide.tsx
@@ -70,5 +70,5 @@ export function OnboardingSetupGuide({ onBridgeConnected }: OnboardingSetupGuide
     return null;
   }
 
-  return <AgentSetupSteps agent={agent} onBridgeConnected={onBridgeConnected} />;
+  return <AgentSetupSteps agent={agent} onBridgeConnected={onBridgeConnected} hideAddProvider />;
 }


### PR DESCRIPTION
## Summary

- **Collapsible provider steps**: When Slack workspace is connected, the 4 provider setup steps collapse into a "View all instructions" toggle with smooth height animation. Clicking toggles between expanded/collapsed states.
- **New "Send a message" step**: Added the missing step with a "Copy Slack message" button matching the Figma design, along with updated copy for all steps ("2/2 SETUP AGENT HANDLER", info tooltip, waiting text).
- **"Setup complete" state**: Bridge connected now shows gradient "Setup complete" text with an "Add another provider" button that navigates to the Integrations tab. Hidden on the onboarding screen.
- **Production environment handling**: Overview tab shows connected overview (not setup guide) on prod. Agent behavior toggles are disabled with a read-only tooltip explaining to edit in Development.
- **Bridge URL fixes**: Shows `devBridgeUrl` when toggle is LOCAL, both DEVELOPMENT/LOCAL badges always visible (active colored, inactive gray), warning icon when not configured.
- **Alignment & consistency**: Fixed ListeningStatus padding alignment in both views, consistent terminal block widths, consistent integration naming via `agentName` prop.

## Test plan

- [ ] Create a new agent on dev, verify the 4 provider steps show normally
- [ ] Complete Slack connection, verify steps collapse with animation and "View all instructions" toggle works
- [ ] Verify "Send a message to the Slack App on Slack" step appears with working copy button
- [ ] Complete bridge connection, verify "Setup complete" with "Add another provider" button
- [ ] Click "Add another provider", verify navigation to Integrations tab
- [ ] On onboarding screen, verify "Add another provider" button is hidden
- [ ] Switch to production environment, verify Overview shows connected overview (not setup guide)
- [ ] On prod, verify behavior toggles are disabled with tooltip on hover
- [ ] Toggle bridge between DEVELOPMENT/LOCAL, verify both badges show and URL updates
- [ ] Verify Bridge URL shows warning icon when not configured
- [ ] Check Integrations tab embedded view, verify Listening status aligns with steps


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR improves the agent setup guide user experience and fixes production environment handling. The setup guide now features collapsible provider steps with smooth height animations when a Slack workspace is connected, a new "Send a message to Slack" step with a copy-to-clipboard button, and a "Setup complete" state with an "Add another provider" button. Production environments now display the connected overview (read-only) instead of the setup guide, with behavior toggles disabled and tooltips instructing users to edit in Development. Bridge badges and URL handling were corrected to show the appropriate environment indicator and display warnings when unconfigured.

## Affected areas

**dashboard**: Updated agent setup and overview components to support collapsible provider steps with animation, added missing setup steps, implemented read-only mode for production environments, fixed bridge URL display logic, improved alignment consistency in setup step layouts, and unified integration naming. Also updated sidebar widget to show warning icon when bridge URL is unconfigured and always render environment badges with environment-aware styling.

## Key technical decisions

- New `hideAddProvider` prop on `AgentSetupSteps` to allow onboarding screen to hide the "Add another provider" button while keeping it visible on the dashboard.
- Added `hasIntegrationCredentials()` helper function to centralize credential validation logic across multiple setup guide components (Slack, WhatsApp).
- Read-only mode in production is determined via `useEnvironment()` hook and applied consistently across behavior toggles and overview views.
- Provider steps are conditionally collapsible with Framer Motion animations, forced open when no integration is connected and toggleable when connected.

## Testing

Manual verification is required to confirm collapsible provider step behavior and animations work correctly, "Send a message" copy button functions properly, "Setup complete" state displays and navigation works, production read-only mode disables toggles with appropriate tooltips, bridge badges and URL display correctly when switching environments, and alignment is consistent across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->