### PR TITLE
fix(dashboard): remove MS Teams connect tip from agent setup fixes NV-7496

### DIFF
--- a/apps/dashboard/src/components/agents/agent-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-steps.tsx
@@ -194,7 +194,6 @@ export function AgentSetupSteps({ agent, onBridgeConnected, hideAddProvider }: A
             rightContent={
               <ProviderDropdown
                 agentIdentifier={agent.identifier}
-                agentName={agent.name}
                 selectedIntegrationId={validatedSelectedId ?? defaultFromAgent?.integrationId}
                 linkedIntegrationIds={linkedIntegrationIds}
                 onSelect={(_providerId, integration) => {

--- a/apps/dashboard/src/components/agents/teams-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/teams-setup-guide.tsx
@@ -1132,34 +1132,6 @@ export function TeamsSetupGuide({
             )}
           </div>
         }
-        extraContent={
-          <InlineToast
-            className="mt-2 w-full"
-            variant="tip"
-            title="How your users connect:"
-            description={
-              <>
-                {'A '}
-                <strong>Teams admin</strong>
-                {' must connect once using '}
-                <code className="font-code text-[12px] tracking-[-0.24px]">{'<MsTeamsConnectButton />'}</code>
-                {' to grant tenant-wide consent. Each '}
-                <strong>end user</strong>
-                {' then links their personal Teams identity using '}
-                <code className="font-code text-[12px] tracking-[-0.24px]">{'<MsTeamsLinkUser />'}</code>
-                {' so Novu can deliver notifications directly to them. '}
-                <a
-                  href="https://docs.novu.co"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-text-sub underline"
-                >
-                  Read docs
-                </a>
-              </>
-            }
-          />
-        }
       />
     </>
   );
@@ -1570,34 +1542,6 @@ export function TeamsSetupGuide({
               </>
             )}
           </div>
-        }
-        extraContent={
-          <InlineToast
-            className="mt-2 w-full"
-            variant="tip"
-            title="How your users connect:"
-            description={
-              <>
-                {'A '}
-                <strong>Teams admin</strong>
-                {' must connect once using '}
-                <code className="font-code text-[12px] tracking-[-0.24px]">{'<MsTeamsConnectButton />'}</code>
-                {' to grant tenant-wide consent. Each '}
-                <strong>end user</strong>
-                {' then links their personal Teams identity using '}
-                <code className="font-code text-[12px] tracking-[-0.24px]">{'<MsTeamsLinkUser />'}</code>
-                {' so Novu can deliver notifications directly to them. '}
-                <a
-                  href="https://docs.novu.co"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-text-sub underline"
-                >
-                  Read docs
-                </a>
-              </>
-            }
-          />
         }
       />
     </>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the inline tip under **Connect Novu to MS Teams** in the MS Teams agent setup guide (`teams-setup-guide.tsx`). That tip explained `<MsTeamsConnectButton />` / `<MsTeamsLinkUser />` and linked to docs; it was noisy early in onboarding (including the embedded quickstart flow where subscriber IDs use the `agent-quickstart` suffix).

Also fixes a dashboard build failure: `agent-setup-steps.tsx` passed `agentName` to `ProviderDropdown`, but that prop is not part of `ProviderDropdownProps` (TypeScript error TS2322 in CI / Netlify).

## Changes

- Dropped the `InlineToast` with title **How your users connect:** from both Quick Setup and Manual paths for the connect step in `teams-setup-guide.tsx`.
- Removed the stray `agentName={agent.name}` prop from `ProviderDropdown` in `agent-setup-steps.tsx`.

Users still complete connection via the existing **Connect** controls and step copy; advanced SDK details remain in the documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7496](https://linear.app/novu/issue/NV-7496/remove-the-tip-of-msteams-connect-from-quickstart)

<div><a href="https://cursor.com/agents/bc-d921a8ec-e33e-48c4-9f02-1b769116f517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d921a8ec-e33e-48c4-9f02-1b769116f517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Removed the noisy inline guidance from the MS Teams agent setup UI and fixed a TypeScript build error. The InlineToast titled "How your users connect:" (which described <MsTeamsConnectButton /> / <MsTeamsLinkUser /> and linked to docs) was removed from both Quick Setup and Manual Setup flows to reduce onboarding noise. Separately, an invalid prop (agentName) passed to ProviderDropdown was removed to resolve a TypeScript TS2322 build failure.

## Affected areas
**dashboard**: UI change in the MS Teams setup guide (teams-setup-guide.tsx) — the InlineToast was dropped from the Connect step in both Quick and Manual flows; agent-setup-steps.tsx was updated to remove the stray agentName={agent.name} prop from ProviderDropdown to fix a TypeScript build error.

## Testing
No new tests were added. Validate by running the dashboard TypeScript build and manually verifying the MS Teams Connect step still shows the existing Connect controls and copy (but without the InlineToast); this also confirms the build error is resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->