### PR TITLE
feat(dashboard,api-service): agent email From uses outbound sender fixes NV-7490

### DIFF
--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -803,8 +803,23 @@ export class ChatSdkService implements OnModuleDestroy {
       }
 
       const decrypted = decryptCredentials(integration.credentials);
+
+      // The chat-adapter-email contract guarantees params.from is the agent's inbound address
+      // (see packages/chat-adapter-email/src/adapter.ts postMessage/addReaction). We treat it as
+      // the Reply-To target so subscriber replies still reach the agent's inbox even when the
+      // outbound From is rewritten to the sending provider's configured sender (or a per-agent
+      // override). When neither override nor outbound.from is set, we fall back to the agent
+      // address for From and skip Reply-To — preserving the legacy behavior.
+      const agentInboundAddress = params.from;
+      const overrideFrom = config.credentials.useFromAddressOverride
+        ? config.credentials.fromAddressOverride?.trim() || undefined
+        : undefined;
+      const outboundFrom = (decrypted.from as string | undefined)?.trim() || undefined;
+      const effectiveFrom = overrideFrom || outboundFrom || agentInboundAddress;
+      const replyToHeader = effectiveFrom !== agentInboundAddress ? agentInboundAddress : undefined;
+
       const mailFactory = new MailFactory();
-      const handler = mailFactory.getHandler({ ...integration, credentials: decrypted }, params.from);
+      const handler = mailFactory.getHandler({ ...integration, credentials: decrypted }, effectiveFrom);
 
       const mailOptions: IEmailOptions = {
         to: [params.to],
@@ -812,7 +827,8 @@ export class ChatSdkService implements OnModuleDestroy {
         html: params.html,
         text: params.text,
         alternatives: params.alternatives,
-        from: params.from,
+        from: effectiveFrom,
+        ...(replyToHeader ? { replyTo: replyToHeader } : {}),
         senderName: config.credentials.senderName || undefined,
         headers: {
           ...(params.messageId ? { 'Message-ID': wrapMsgId(params.messageId) } : {}),

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -721,6 +721,8 @@ export class ChatSdkService implements OnModuleDestroy {
       phoneNumberIdentification: c.phoneNumberIdentification ?? null,
       connectionAccessToken: connectionAccessToken ?? null,
       outboundIntegrationId: c.outboundIntegrationId ?? null,
+      useFromAddressOverride: c.useFromAddressOverride ?? null,
+      fromAddressOverride: c.fromAddressOverride ?? null,
     });
   }
 

--- a/apps/dashboard/src/components/agents/agent-integration-guides/email-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/email-agent-integration-guide.tsx
@@ -1,8 +1,8 @@
 import { EmailProviderIdEnum } from '@novu/shared';
 import type { AgentIntegrationLink, AgentResponse } from '@/api/agents';
+import { EmailConfigurationCard } from '@/components/agents/email-configuration-card';
 import { EmailSetupGuide } from '@/components/agents/email-setup-guide';
 import { AgentIntegrationGuideLayout } from './agent-integration-guide-layout';
-import { AgentIntegrationGuideSection } from './agent-integration-guide-section';
 
 type EmailAgentIntegrationGuideProps = {
   onBack: () => void;
@@ -38,22 +38,8 @@ export function EmailAgentIntegrationGuide({
       onRequestRemoveIntegration={onRequestRemoveIntegration}
       isRemovingIntegration={isRemovingIntegration}
     >
-      <AgentIntegrationGuideSection title="Overview">
-        {isConnected ? (
-          <p>
-            This agent is connected to email. Subscribers can send emails to the configured inbound address to start
-            conversations, and the agent will reply through the selected outbound provider.
-          </p>
-        ) : (
-          <p>
-            Connect email so this agent can send and receive messages via email. Configure an outbound email provider and
-            an inbound address below.
-          </p>
-        )}
-      </AgentIntegrationGuideSection>
-      {!isConnected && integrationId && (
-        <EmailSetupGuide agent={agent} integrationId={integrationId} embedded />
-      )}
+      {integrationId && <EmailConfigurationCard agent={agent} integrationId={integrationId} />}
+      {!isConnected && integrationId && <EmailSetupGuide agent={agent} integrationId={integrationId} embedded />}
     </AgentIntegrationGuideLayout>
   );
 }

--- a/apps/dashboard/src/components/agents/email-configuration-card.tsx
+++ b/apps/dashboard/src/components/agents/email-configuration-card.tsx
@@ -1,0 +1,119 @@
+import { EmailProviderIdEnum } from '@novu/shared';
+import { type ReactNode, useMemo } from 'react';
+import { RiArrowRightSLine } from 'react-icons/ri';
+import { Link } from 'react-router-dom';
+import type { AgentResponse } from '@/api/agents';
+import { OutboundProviderSelect } from '@/components/agents/outbound-provider-select';
+import { SenderAddressOverride } from '@/components/agents/sender-address-override';
+import { useEmailSetupCredentials } from '@/components/agents/use-email-setup-credentials';
+import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
+import { ROUTES } from '@/utils/routes';
+
+export type EmailConfigurationCardProps = {
+  agent: AgentResponse;
+  integrationId: string;
+};
+
+export function EmailConfigurationCard({ agent, integrationId }: EmailConfigurationCardProps) {
+  const { integrations } = useFetchIntegrations();
+  const emailIntegration = useMemo(
+    () => integrations?.find((i) => i._id === integrationId && i.providerId === EmailProviderIdEnum.NovuAgent),
+    [integrations, integrationId]
+  );
+
+  const {
+    outboundId,
+    outboundFromAddress,
+    configuredAddresses,
+    serverUseFromAddressOverride,
+    serverFromAddressOverride,
+    onOutboundSelect,
+    saveSenderOverride,
+  } = useEmailSetupCredentials({ emailIntegration, integrations, agent });
+
+  const inboundAddresses = useMemo(
+    () => configuredAddresses.map(({ address, domain }) => (address === '*' ? `*@${domain}` : `${address}@${domain}`)),
+    [configuredAddresses]
+  );
+
+  if (!emailIntegration) return null;
+
+  return (
+    <div className="bg-bg-weak flex flex-col rounded-[10px] p-1">
+      <SectionHeader>EMAIL CONFIGURATION</SectionHeader>
+      <div className="bg-bg-white flex flex-col overflow-hidden rounded-md shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">
+        <CardRow
+          title="Providers to send emails"
+          description="Configure providers to send emails via Novu. Only providers configured in the Integration store will be available here."
+          divider
+        >
+          <OutboundProviderSelect selectedId={outboundId || undefined} onSelect={onOutboundSelect} hideLabel />
+          <ManageLink to={ROUTES.INTEGRATIONS}>Manage email providers</ManageLink>
+        </CardRow>
+
+        <CardRow
+          title="Sender address"
+          description="By default, replies use your sending provider's From address. Override it to send from another address. Reply-To always routes back to the agent so subscriber replies stay in the thread."
+        >
+          <SenderAddressOverride
+            serverEnabled={serverUseFromAddressOverride}
+            serverValue={serverFromAddressOverride}
+            outboundFromAddress={outboundFromAddress}
+            inboundAddresses={inboundAddresses}
+            onSave={saveSenderOverride}
+          />
+        </CardRow>
+      </div>
+    </div>
+  );
+}
+
+function SectionHeader({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center px-2 py-1.5">
+      <span className="text-text-soft font-code text-[11px] font-medium uppercase leading-4 tracking-wider">
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function CardRow({
+  title,
+  description,
+  children,
+  divider,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+  divider?: boolean;
+}) {
+  return (
+    <div
+      className={
+        divider
+          ? 'border-stroke-weak flex items-start justify-between gap-4 border-b p-3'
+          : 'flex items-start justify-between gap-4 p-3'
+      }
+    >
+      <div className="flex max-w-[350px] min-w-0 flex-1 flex-col gap-1">
+        <h4 className="text-text-sub text-label-sm font-medium leading-5">{title}</h4>
+        <p className="text-text-soft text-paragraph-xs leading-4">{description}</p>
+      </div>
+      <div className="flex w-[340px] shrink-0 flex-col gap-1.5">{children}</div>
+    </div>
+  );
+}
+
+function ManageLink({ to, children }: { to: string; children: ReactNode }) {
+  return (
+    <Link
+      to={to}
+      className="text-text-sub hover:text-text-strong inline-flex items-center gap-0.5 self-start py-0.5 text-label-xs font-medium leading-4 transition-colors"
+    >
+      <span>{children}</span>
+      <RiArrowRightSLine className="size-4" aria-hidden />
+    </Link>
+  );
+}

--- a/apps/dashboard/src/components/agents/outbound-provider-select.tsx
+++ b/apps/dashboard/src/components/agents/outbound-provider-select.tsx
@@ -68,9 +68,11 @@ function getItemKey(item: OutboundDropdownItem, index: number): string {
 export function OutboundProviderSelect({
   selectedId,
   onSelect,
+  hideLabel = false,
 }: {
   selectedId: string | undefined;
   onSelect: (integrationId: string) => void;
+  hideLabel?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const [pendingKey, setPendingKey] = useState<string | null>(null);
@@ -144,21 +146,26 @@ export function OutboundProviderSelect({
   }
 
   return (
-    <div className="flex w-full flex-col gap-1 min-w-[300px]">
-      <div className="flex items-center gap-px">
-        <span className="text-text-sub text-label-xs font-medium leading-4">Send emails via</span>
-        <span aria-hidden="true" className="text-text-soft ml-0.5 text-[10px]">
-          &#9432;
-        </span>
-      </div>
+    <div className={cn('flex w-full flex-col gap-1', !hideLabel && 'min-w-[300px]')}>
+      {!hideLabel && (
+        <div className="flex items-center gap-px">
+          <span className="text-text-sub text-label-xs font-medium leading-4">Send emails via</span>
+          <span aria-hidden="true" className="text-text-soft ml-0.5 text-[10px]">
+            &#9432;
+          </span>
+        </div>
+      )}
 
-      <div className="w-full max-w-[320px]">
+      <div className={cn('w-full', !hideLabel && 'max-w-[320px]')}>
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild>
             <button
               type="button"
               disabled={isBusy}
-              className="border-stroke-soft bg-bg-white flex h-7 w-full max-w-[320px] items-center justify-between overflow-hidden rounded-md border px-1.5 py-1 shadow-xs disabled:opacity-60"
+              className={cn(
+                'border-stroke-soft bg-bg-white flex h-7 w-full items-center justify-between overflow-hidden rounded-md border px-1.5 py-1 shadow-xs disabled:opacity-60',
+                !hideLabel && 'max-w-[320px]'
+              )}
             >
               {selected ? (
                 <div className="flex items-center gap-1">
@@ -181,7 +188,10 @@ export function OutboundProviderSelect({
           </PopoverTrigger>
 
           <PopoverContent
-            className="w-(--radix-popover-trigger-width) max-w-[320px] min-w-[220px] overflow-hidden p-0"
+            className={cn(
+              'w-(--radix-popover-trigger-width) min-w-[220px] overflow-hidden p-0',
+              !hideLabel && 'max-w-[320px]'
+            )}
             align="start"
           >
             <Command>

--- a/apps/dashboard/src/components/agents/outbound-provider-select.tsx
+++ b/apps/dashboard/src/components/agents/outbound-provider-select.tsx
@@ -161,6 +161,7 @@ export function OutboundProviderSelect({
           <PopoverTrigger asChild>
             <button
               type="button"
+              aria-label={hideLabel ? 'Send emails via, select email provider' : undefined}
               disabled={isBusy}
               className={cn(
                 'border-stroke-soft bg-bg-white flex h-7 w-full items-center justify-between overflow-hidden rounded-md border px-1.5 py-1 shadow-xs disabled:opacity-60',

--- a/apps/dashboard/src/components/agents/sender-address-override.tsx
+++ b/apps/dashboard/src/components/agents/sender-address-override.tsx
@@ -42,6 +42,7 @@ export function SenderAddressOverride({
   }, [serverEnabled, serverValue, enabled, value]);
 
   const placeholder = outboundFromAddress || 'no-reply@yourdomain.com';
+  const inputErrorId = `${inputId}-error`;
 
   const trimmedValue = value.trim();
   const isDirty = enabled !== serverEnabled || trimmedValue !== serverValue.trim();
@@ -80,17 +81,25 @@ export function SenderAddressOverride({
       </div>
 
       {enabled && (
-        <Input
-          id={inputId}
-          type="email"
-          size="2xs"
-          value={value}
-          placeholder={placeholder}
-          onChange={(e) => setValue(e.target.value)}
-          hasError={hasInvalidValue}
-          aria-invalid={hasInvalidValue || undefined}
-          disabled={isSaving}
-        />
+        <div className="flex w-full flex-col gap-1">
+          <Input
+            id={inputId}
+            type="email"
+            size="2xs"
+            value={value}
+            placeholder={placeholder}
+            onChange={(e) => setValue(e.target.value)}
+            hasError={hasInvalidValue}
+            aria-invalid={hasInvalidValue ? true : undefined}
+            aria-errormessage={hasInvalidValue ? inputErrorId : undefined}
+            disabled={isSaving}
+          />
+          {hasInvalidValue && (
+            <p id={inputErrorId} className="text-destructive text-label-xs leading-4">
+              Enter a valid email address (for example, name@company.com).
+            </p>
+          )}
+        </div>
       )}
 
       <AddressPreview from={resolvedFrom} replyTo={resolvedReplyTo} />

--- a/apps/dashboard/src/components/agents/sender-address-override.tsx
+++ b/apps/dashboard/src/components/agents/sender-address-override.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useId, useRef, useState } from 'react';
+import { Button } from '@/components/primitives/button';
+import { Input } from '@/components/primitives/input';
+import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
+import { Switch } from '@/components/primitives/switch';
+
+export type SenderAddressOverrideProps = {
+  serverEnabled: boolean;
+  serverValue: string;
+  outboundFromAddress: string;
+  inboundAddresses: string[];
+  onSave: (params: { enabled: boolean; value: string }) => Promise<void>;
+};
+
+export function SenderAddressOverride({
+  serverEnabled,
+  serverValue,
+  outboundFromAddress,
+  inboundAddresses,
+  onSave,
+}: SenderAddressOverrideProps) {
+  const switchId = useId();
+  const inputId = useId();
+
+  const [enabled, setEnabled] = useState(serverEnabled);
+  const [value, setValue] = useState(serverValue);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Re-sync local form state with server values when they change AND the user
+  // hasn't started editing. Compare against the previous server snapshot so we
+  // don't clobber unsaved edits during background refetches/invalidations.
+  const prevServerEnabled = useRef(serverEnabled);
+  const prevServerValue = useRef(serverValue);
+  useEffect(() => {
+    const localMatchesPrevServer = enabled === prevServerEnabled.current && value === prevServerValue.current;
+    if (localMatchesPrevServer) {
+      setEnabled(serverEnabled);
+      setValue(serverValue);
+    }
+    prevServerEnabled.current = serverEnabled;
+    prevServerValue.current = serverValue;
+  }, [serverEnabled, serverValue, enabled, value]);
+
+  const placeholder = outboundFromAddress || 'no-reply@yourdomain.com';
+
+  const trimmedValue = value.trim();
+  const isDirty = enabled !== serverEnabled || trimmedValue !== serverValue.trim();
+  const hasInvalidValue = enabled && trimmedValue.length > 0 && !isValidEmail(trimmedValue);
+  const canSave = isDirty && !isSaving && !hasInvalidValue;
+
+  // Mirror the resolution in apps/api/src/app/agents/services/chat-sdk.service.ts
+  // buildSendEmailCallback: override > outbound.from > agent inbound.
+  const previewOverride = enabled ? trimmedValue : '';
+  const fallbackInbound = inboundAddresses[0] ?? '';
+  const resolvedFrom = previewOverride || outboundFromAddress || fallbackInbound;
+  const resolvedReplyTo = resolvedFrom && resolvedFrom !== fallbackInbound ? fallbackInbound : '';
+
+  async function handleSave() {
+    if (!canSave) return;
+    setIsSaving(true);
+    try {
+      await onSave({ enabled, value: trimmedValue });
+      setValue(trimmedValue);
+      showSuccessToast('Sender settings saved.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Could not save sender settings.';
+      showErrorToast(message, 'Save failed');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex w-full items-center justify-between gap-2">
+        <label htmlFor={switchId} className="text-text-sub text-label-xs cursor-pointer font-medium leading-4">
+          Use a custom From address
+        </label>
+        <Switch id={switchId} checked={enabled} onCheckedChange={setEnabled} disabled={isSaving} />
+      </div>
+
+      {enabled && (
+        <Input
+          id={inputId}
+          type="email"
+          size="2xs"
+          value={value}
+          placeholder={placeholder}
+          onChange={(e) => setValue(e.target.value)}
+          hasError={hasInvalidValue}
+          aria-invalid={hasInvalidValue || undefined}
+          disabled={isSaving}
+        />
+      )}
+
+      <AddressPreview from={resolvedFrom} replyTo={resolvedReplyTo} />
+
+      {isDirty && (
+        <div className="flex justify-end">
+          <Button
+            variant="primary"
+            mode="filled"
+            size="2xs"
+            onClick={handleSave}
+            disabled={!canSave}
+            isLoading={isSaving}
+          >
+            Save
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AddressPreview({ from, replyTo }: { from: string; replyTo: string }) {
+  return (
+    <div className="border-stroke-soft bg-bg-weak flex flex-col gap-1 rounded-md border px-2.5 py-2">
+      <PreviewRow label="From" value={from || 'Not configured yet'} muted={!from} />
+      <PreviewRow label="Reply-To" value={replyTo || 'Not set (replies go to From)'} muted={!replyTo} />
+    </div>
+  );
+}
+
+function PreviewRow({ label, value, muted }: { label: string; value: string; muted: boolean }) {
+  return (
+    <div className="flex items-baseline gap-2.5">
+      <span className="text-text-soft text-[10px] w-[52px] shrink-0 font-medium uppercase leading-4 whitespace-nowrap">
+        {label}
+      </span>
+      <span
+        className={
+          muted
+            ? 'text-text-soft text-paragraph-xs min-w-0 flex-1 italic'
+            : 'text-text-strong font-code min-w-0 flex-1 text-[12px] leading-4 break-all'
+        }
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isValidEmail(value: string): boolean {
+  return EMAIL_REGEX.test(value);
+}

--- a/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
+++ b/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
@@ -93,6 +93,10 @@ export function useEmailSetupCredentials({
   const [outboundId, setOutboundId] = useState('');
 
   const serverCredentials = useMemo(() => emailIntegration?.credentials ?? {}, [emailIntegration?.credentials]);
+  const serverUseFromAddressOverride =
+    typeof serverCredentials.useFromAddressOverride === 'boolean' ? serverCredentials.useFromAddressOverride : false;
+  const serverFromAddressOverride =
+    typeof serverCredentials.fromAddressOverride === 'string' ? serverCredentials.fromAddressOverride : '';
   const credentialsRef = useRef<Record<string, unknown>>(serverCredentials as Record<string, unknown>);
   const pendingKeysRef = useRef<Set<string>>(new Set());
   useEffect(() => {
@@ -176,35 +180,43 @@ export function useEmailSetupCredentials({
 
   const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
 
-  function saveCredentials(patch: Record<string, unknown>) {
-    if (!emailIntegration) return;
+  // Returns a promise that resolves on successful persistence and rejects on failure.
+  // Callers are responsible for showing user-facing error feedback. Saves are queued
+  // sequentially so concurrent calls cannot interleave on the integration document.
+  function saveCredentials(patch: Record<string, unknown>): Promise<void> {
+    if (!emailIntegration) return Promise.resolve();
     credentialsRef.current = { ...credentialsRef.current, ...patch };
     for (const key of Object.keys(patch)) pendingKeysRef.current.add(key);
     const snapshot = { ...credentialsRef.current };
     const patchKeys = Object.keys(patch);
-    saveQueueRef.current = saveQueueRef.current
-      .then(() =>
-        updateIntegration({
-          integrationId: emailIntegration._id,
-          data: {
-            name: emailIntegration.name,
-            identifier: emailIntegration.identifier,
-            active: emailIntegration.active,
-            primary: emailIntegration.primary ?? false,
-            credentials: snapshot,
-            configurations: {},
-            check: false,
-          },
-        })
-      )
-      .then(() => {
-        for (const key of patchKeys) pendingKeysRef.current.delete(key);
+    const next = saveQueueRef.current.then(() =>
+      updateIntegration({
+        integrationId: emailIntegration._id,
+        data: {
+          name: emailIntegration.name,
+          identifier: emailIntegration.identifier,
+          active: emailIntegration.active,
+          primary: emailIntegration.primary ?? false,
+          credentials: snapshot,
+          configurations: {},
+          check: false,
+        },
       })
-      .catch((err: unknown) => {
+    );
+
+    // Always clean up pendingKeys regardless of outcome; swallow the rejection on the
+    // queue so a failed save doesn't poison subsequent queued saves. The caller still
+    // observes the rejection through the returned promise below.
+    saveQueueRef.current = next.then(
+      () => {
         for (const key of patchKeys) pendingKeysRef.current.delete(key);
-        const message = err instanceof Error ? err.message : 'Could not save credentials.';
-        showErrorToast(message, 'Settings not saved');
-      });
+      },
+      () => {
+        for (const key of patchKeys) pendingKeysRef.current.delete(key);
+      }
+    );
+
+    return next.then(() => undefined);
   }
 
   const { mutate: mutateDomainRoutes } = useMutation({
@@ -286,8 +298,17 @@ export function useEmailSetupCredentials({
 
   function onOutboundSelect(id: string) {
     setOutboundId(id);
-    saveCredentials({ outboundIntegrationId: id });
+    saveCredentials({ outboundIntegrationId: id }).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : 'Could not save provider selection.';
+      showErrorToast(message, 'Settings not saved');
+    });
   }
+
+  function saveSenderOverride({ enabled, value }: { enabled: boolean; value: string }): Promise<void> {
+    return saveCredentials({ useFromAddressOverride: enabled, fromAddressOverride: value });
+  }
+
+  const outboundFromAddress = (outboundIntegration?.credentials?.from as string | undefined) ?? '';
 
   return {
     outboundId,
@@ -301,5 +322,9 @@ export function useEmailSetupCredentials({
     onOutboundSelect,
     addAddress,
     removeAddress,
+    serverUseFromAddressOverride,
+    serverFromAddressOverride,
+    outboundFromAddress,
+    saveSenderOverride,
   };
 }

--- a/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
+++ b/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
@@ -91,6 +91,7 @@ export function useEmailSetupCredentials({
   const queryClient = useQueryClient();
 
   const [outboundId, setOutboundId] = useState('');
+  const lastConfirmedOutboundIdRef = useRef('');
 
   const serverCredentials = useMemo(() => emailIntegration?.credentials ?? {}, [emailIntegration?.credentials]);
   const serverUseFromAddressOverride =
@@ -107,6 +108,10 @@ export function useEmailSetupCredentials({
       }
     }
     credentialsRef.current = merged;
+    const serverOutbound = serverCredentials.outboundIntegrationId;
+    if (typeof serverOutbound === 'string') {
+      lastConfirmedOutboundIdRef.current = serverOutbound;
+    }
   }, [serverCredentials]);
 
   const hasInitializedFromServer = useRef(false);
@@ -185,10 +190,16 @@ export function useEmailSetupCredentials({
   // sequentially so concurrent calls cannot interleave on the integration document.
   function saveCredentials(patch: Record<string, unknown>): Promise<void> {
     if (!emailIntegration) return Promise.resolve();
-    credentialsRef.current = { ...credentialsRef.current, ...patch };
-    for (const key of Object.keys(patch)) pendingKeysRef.current.add(key);
-    const snapshot = { ...credentialsRef.current };
     const patchKeys = Object.keys(patch);
+    const prePatchByKey: Record<string, unknown> = {};
+    for (const key of patchKeys) {
+      if (Object.prototype.hasOwnProperty.call(credentialsRef.current, key)) {
+        prePatchByKey[key] = credentialsRef.current[key];
+      }
+    }
+    credentialsRef.current = { ...credentialsRef.current, ...patch };
+    for (const key of patchKeys) pendingKeysRef.current.add(key);
+    const snapshot = { ...credentialsRef.current };
     const next = saveQueueRef.current.then(() =>
       updateIntegration({
         integrationId: emailIntegration._id,
@@ -212,7 +223,14 @@ export function useEmailSetupCredentials({
         for (const key of patchKeys) pendingKeysRef.current.delete(key);
       },
       () => {
-        for (const key of patchKeys) pendingKeysRef.current.delete(key);
+        for (const key of patchKeys) {
+          if (Object.prototype.hasOwnProperty.call(prePatchByKey, key)) {
+            credentialsRef.current[key] = prePatchByKey[key];
+          } else {
+            delete credentialsRef.current[key];
+          }
+          pendingKeysRef.current.delete(key);
+        }
       }
     );
 
@@ -299,6 +317,7 @@ export function useEmailSetupCredentials({
   function onOutboundSelect(id: string) {
     setOutboundId(id);
     saveCredentials({ outboundIntegrationId: id }).catch((err: unknown) => {
+      setOutboundId(lastConfirmedOutboundIdRef.current);
       const message = err instanceof Error ? err.message : 'Could not save provider selection.';
       showErrorToast(message, 'Settings not saved');
     });

--- a/libs/application-generic/src/dtos/credentials.dto.ts
+++ b/libs/application-generic/src/dtos/credentials.dto.ts
@@ -1,7 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ICredentials } from '@novu/shared';
 import { Transform } from 'class-transformer';
-import { IsBoolean, IsObject, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsEmail, IsObject, IsOptional, IsString, ValidateIf } from 'class-validator';
 import { TransformToBoolean } from '../decorators/to-boolean';
 
 export class CredentialsDto implements ICredentials {
@@ -269,7 +269,8 @@ export class CredentialsDto implements ICredentials {
   useFromAddressOverride?: boolean;
 
   @ApiPropertyOptional()
-  @IsString()
   @IsOptional()
+  @ValidateIf((_, v) => typeof v === 'string' && v.trim().length > 0)
+  @IsEmail()
   fromAddressOverride?: string;
 }

--- a/libs/application-generic/src/dtos/credentials.dto.ts
+++ b/libs/application-generic/src/dtos/credentials.dto.ts
@@ -261,4 +261,15 @@ export class CredentialsDto implements ICredentials {
   @IsOptional()
   @IsString()
   outboundIntegrationId?: string;
+
+  @ApiPropertyOptional()
+  @TransformToBoolean()
+  @IsBoolean()
+  @IsOptional()
+  useFromAddressOverride?: boolean;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  fromAddressOverride?: string;
 }

--- a/libs/dal/src/repositories/integration/integration.schema.ts
+++ b/libs/dal/src/repositories/integration/integration.schema.ts
@@ -68,6 +68,8 @@ const integrationSchema = new Schema<IntegrationDBModel>(
       tenantId: Schema.Types.String,
       signingSecret: Schema.Types.String,
       outboundIntegrationId: Schema.Types.String,
+      useFromAddressOverride: Schema.Types.Boolean,
+      fromAddressOverride: Schema.Types.String,
       AppIOBaseUrl: Schema.Types.String,
       AppIOSubscriptionId: Schema.Types.String,
       AppIOBearerToken: Schema.Types.String,

--- a/packages/shared/src/entities/integration/credential.interface.ts
+++ b/packages/shared/src/entities/integration/credential.interface.ts
@@ -55,4 +55,6 @@ export interface ICredentials {
   tenantId?: string;
   signingSecret?: string;
   outboundIntegrationId?: string;
+  useFromAddressOverride?: boolean;
+  fromAddressOverride?: string;
 }


### PR DESCRIPTION


- Default outbound From to sending integration credentials.from; Reply-To agent inbound
- Optional per-agent override (useFromAddressOverride, fromAddressOverride) with save + toast
- Email configuration card UI; persist fields in CredentialsDto and integration schema
- OutboundProviderSelect hideLabel for embedded layout

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Agent email sends now use an "effective From" computed at send time: agent-level override (optional) → outbound integration credentials.from → inbound fallback. Reply-To is set to the agent inbound address only when the effective From differs. A dashboard Email Configuration card exposes outbound provider selection and a per-agent sender override (enable + custom From) with validation and save UX improvements. This reduces friction when operators need to control the outbound sender per agent without changing global integrations.

## Affected areas

- **api**: chat-sdk now computes an effective From and passes it to the mail handler; reply-to behavior is conditional; the cached Chat fingerprint was extended to include the new credential fields so adapter rebuilds on change.
- **dashboard (react)**: Added EmailConfigurationCard, SenderAddressOverride component, and updated EmailAgentIntegrationGuide; OutboundProviderSelect gained a hideLabel option; useEmailSetupCredentials was enhanced to surface server override values, derive outboundFromAddress, provide saveSenderOverride, and revert outbound selection on failed saves.
- **dal**: Integration schema credentials subdocument now includes useFromAddressOverride (Boolean) and fromAddressOverride (String).
- **shared / application-generic**: ICredentials and CredentialsDto now include useFromAddressOverride and fromAddressOverride (with validation/coercion on the DTO).

## Key technical decisions

- Store per-agent override flags inside integration credentials rather than agent objects to keep credential-scoped config and enable reuse across flows.
- Compute effective From at send time (override → credentials → fallback) to avoid precomputing and to allow dynamic changes without re-deploying cached adapters.
- Include override fields in the cached fingerprint so changing them invalidates cached email adapters.
- UI save flow records last-confirmed outbound id and reverts on failure to keep client/server state consistent.

## Testing

No new automated tests were added in this PR; changes touch backend send logic, dashboard UI, and schema and should be covered by existing integration tests and manual verification (save/rollback behavior, email header expectations, and UI validation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
