### PR TITLE
fix(api-service): trigger workflow agent signal DTO fixes NV-7460

### DIFF
--- a/apps/api/src/app/agents/agents-webhook.controller.ts
+++ b/apps/api/src/app/agents/agents-webhook.controller.ts
@@ -12,6 +12,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
+import type { Signal } from '@novu/framework';
 import { UserSessionData } from '@novu/shared';
 import { Request, Response } from 'express';
 import { RequireAuthentication } from '../auth/framework/auth.decorator';
@@ -21,7 +22,7 @@ import { AgentReplyPayloadDto } from './dtos/agent-reply-payload.dto';
 import { AgentInactiveException } from './exceptions/agent-inactive.exception';
 import { AgentConversationEnabledGuard } from './guards/agent-conversation-enabled.guard';
 import { ChatSdkService } from './services/chat-sdk.service';
-import { HandleAgentReplyCommand, Signal } from './usecases/handle-agent-reply/handle-agent-reply.command';
+import { HandleAgentReplyCommand } from './usecases/handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from './usecases/handle-agent-reply/handle-agent-reply.usecase';
 
 @Controller('/agents')

--- a/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
@@ -68,13 +68,17 @@ export class IsValidTriggerRecipient implements ValidatorConstraintInterface {
   }
 
   private isSubscriberObject(obj: unknown): boolean {
-    return (
-      typeof obj === 'object' && obj !== null && 'subscriberId' in obj && typeof (obj as any).subscriberId === 'string'
-    );
+    if (typeof obj !== 'object' || obj === null) return false;
+    const subscriberId = (obj as { subscriberId?: unknown }).subscriberId;
+
+    return typeof subscriberId === 'string' && subscriberId.trim().length > 0;
   }
 
   private isTopicObject(obj: unknown): boolean {
-    return typeof obj === 'object' && obj !== null && 'type' in obj && 'topicKey' in obj;
+    if (typeof obj !== 'object' || obj === null) return false;
+    const { type, topicKey } = obj as { type?: unknown; topicKey?: unknown };
+
+    return typeof type === 'string' && type.length > 0 && typeof topicKey === 'string' && topicKey.length > 0;
   }
 
   defaultMessage(): string {

--- a/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import type { FileRef } from '@novu/framework';
+import type { TriggerRecipientsPayload } from '@novu/shared';
 import { Type } from 'class-transformer';
 import {
   IsArray,
@@ -41,6 +42,44 @@ export function isValidMetadataSignalKey(key: unknown): key is string {
   if (FORBIDDEN_METADATA_SIGNAL_KEYS.has(key)) return false;
 
   return METADATA_SIGNAL_KEY_REGEX.test(key);
+}
+
+@ValidatorConstraint({ name: 'isValidTriggerRecipient', async: false })
+export class IsValidTriggerRecipient implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (value === undefined || value === null) return true;
+
+    if (typeof value === 'string') return value.length > 0;
+
+    if (Array.isArray(value)) {
+      return value.length > 0 && value.every((item) => this.isRecipientItem(item));
+    }
+
+    return this.isSubscriberObject(value);
+  }
+
+  private isRecipientItem(item: unknown): boolean {
+    if (typeof item === 'string') return item.length > 0;
+    if (typeof item === 'object' && item !== null) {
+      return this.isSubscriberObject(item) || this.isTopicObject(item);
+    }
+
+    return false;
+  }
+
+  private isSubscriberObject(obj: unknown): boolean {
+    return (
+      typeof obj === 'object' && obj !== null && 'subscriberId' in obj && typeof (obj as any).subscriberId === 'string'
+    );
+  }
+
+  private isTopicObject(obj: unknown): boolean {
+    return typeof obj === 'object' && obj !== null && 'type' in obj && 'topicKey' in obj;
+  }
+
+  defaultMessage(): string {
+    return 'to must be a subscriberId string, a subscriber object with subscriberId, a topic object, or an array of those.';
+  }
 }
 
 @ValidatorConstraint({ name: 'isValidSignal', async: false })
@@ -171,8 +210,8 @@ export class SignalDto {
 
   @ApiPropertyOptional()
   @IsOptional()
-  @IsString()
-  to?: string;
+  @Validate(IsValidTriggerRecipient)
+  to?: TriggerRecipientsPayload;
 
   @ApiPropertyOptional()
   @IsOptional()

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.command.ts
@@ -4,8 +4,6 @@ import { IsArray, IsNotEmpty, IsObject, IsOptional, IsString, ValidateNested } f
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 import { AddReactionPayloadDto, EditPayloadDto, ReplyContentDto } from '../../dtos/agent-reply-payload.dto';
 
-export type { Signal } from '@novu/framework';
-
 export class HandleAgentReplyCommand extends EnvironmentWithUserCommand {
   @IsString()
   @IsNotEmpty()

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -9,7 +9,7 @@ import {
   SubscriberRepository,
 } from '@novu/dal';
 import type { SentMessageInfo, TriggerSignal } from '@novu/framework';
-import { AddressingTypeEnum, type TriggerRecipientsPayload, TriggerRequestCategoryEnum } from '@novu/shared';
+import { AddressingTypeEnum, TriggerRequestCategoryEnum } from '@novu/shared';
 import { ParseEventRequest, ParseEventRequestMulticastCommand } from '../../../events/usecases/parse-event-request';
 import { trackAgentReplyProcessed } from '../../agent-analytics';
 import { AgentEventEnum } from '../../dtos/agent-event.enum';
@@ -289,7 +289,7 @@ export class HandleAgentReply {
     );
 
     for (const signal of signals) {
-      const to = (signal.to as TriggerRecipientsPayload | undefined) ?? subscriberParticipant?.id;
+      const to = signal.to ?? subscriberParticipant?.id;
 
       if (!to) {
         this.logger.warn(

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -9,7 +9,7 @@ import {
   SubscriberRepository,
 } from '@novu/dal';
 import type { SentMessageInfo, TriggerSignal } from '@novu/framework';
-import { AddressingTypeEnum, TriggerRequestCategoryEnum } from '@novu/shared';
+import { AddressingTypeEnum, type TriggerRecipientsPayload, TriggerRequestCategoryEnum } from '@novu/shared';
 import { ParseEventRequest, ParseEventRequestMulticastCommand } from '../../../events/usecases/parse-event-request';
 import { trackAgentReplyProcessed } from '../../agent-analytics';
 import { AgentEventEnum } from '../../dtos/agent-event.enum';
@@ -289,7 +289,7 @@ export class HandleAgentReply {
     );
 
     for (const signal of signals) {
-      const to = signal.to ?? subscriberParticipant?.id;
+      const to = (signal.to as TriggerRecipientsPayload | undefined) ?? subscriberParticipant?.id;
 
       if (!to) {
         this.logger.warn(


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Fixed the API service trigger workflow agent signal DTO validation and type handling. The `SignalDto.to` field now accepts `TriggerRecipientsPayload` (subscriber IDs, subscriber objects, topic objects, or arrays thereof) instead of strings only, with hardened validation to reject empty subscriberIds and require non-empty `topicKey`/`type` for topic objects. Type imports were cleaned up to use proper type-only imports instead of re-exporting framework types.

## Affected areas

**api**: Updated the agent reply webhook controller to import `Signal` directly from `@novu/framework`. The DTO for agent replies now includes a new `IsValidTriggerRecipient` validator class that enforces stricter rules on trigger recipient payloads, preventing empty subscriberIds (including whitespace-only) and ensuring topic objects have non-empty `type` and `topicKey` fields. The command class for handling agent replies now uses a proper type-only import instead of re-exporting the `Signal` type.

## Key technical decisions

- Restored use of `TriggerRecipientsPayload` from `@novu/shared` to properly type the `to` field, fixing a framework/shared type mismatch.
- Added custom validator class `IsValidTriggerRecipient` to enforce validation rules at the DTO level rather than relying on basic type checking.
- Replaced type re-exports with type-only imports to reduce unnecessary coupling and improve tree-shaking.

## Testing

No new tests were added. The changes are validation-only and rely on existing integration tests for the agent reply endpoint to verify correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
