### PR TITLE
fix(api-service): support inbound WhatsApp agent attachments fixes NV-7506

### DIFF
--- a/apps/api/src/app/agents/services/agent-attachment-storage.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-attachment-storage.service.spec.ts
@@ -2,6 +2,7 @@ import type { StorageService } from '@novu/application-generic';
 import { expect } from 'chai';
 import type { Attachment } from 'chat';
 import sinon from 'sinon';
+import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
 import { AgentAttachmentStorage, READ_URL_TTL_SECONDS } from './agent-attachment-storage.service';
 
 describe('AgentAttachmentStorage', () => {
@@ -143,14 +144,14 @@ describe('AgentAttachmentStorage', () => {
     expect(logger.warn.calledWithMatch({ size: 20 * mb, aggregateCap: 50 * mb })).to.equal(true);
   });
 
-  it('should upload fetchData attachments without size metadata', async () => {
+  it('should upload whatsapp fetchData attachments without size metadata', async () => {
     const storageService = makeStorageService();
     const logger = makeLogger();
     const service = new AgentAttachmentStorage(storageService, logger as any);
     const fetchData = sinon.stub().resolves(Buffer.from('x'));
     const attachments = [{ type: 'file', name: 'unknown.bin', fetchData }] as Attachment[];
 
-    const result = await service.storeInbound(attachments, ctx);
+    const result = await service.storeInbound(attachments, { ...ctx, platform: AgentPlatformEnum.WHATSAPP });
 
     expect(result).to.have.length(1);
     expect(fetchData.calledOnce).to.equal(true);
@@ -162,6 +163,21 @@ describe('AgentAttachmentStorage', () => {
       url: 'https://signed/read',
     });
     expect(result[0].mimeType).to.equal(undefined);
+  });
+
+  it('should skip non-whatsapp fetchData attachments without size metadata before downloading', async () => {
+    const storageService = makeStorageService();
+    const logger = makeLogger();
+    const service = new AgentAttachmentStorage(storageService, logger as any);
+    const fetchData = sinon.stub().resolves(Buffer.from('x'));
+    const attachments = [{ type: 'file', name: 'unknown.bin', fetchData }] as Attachment[];
+
+    const result = await service.storeInbound(attachments, { ...ctx, platform: AgentPlatformEnum.SLACK });
+
+    expect(result).to.have.length(0);
+    expect(fetchData.called).to.equal(false);
+    expect(storageService.uploadFile.called).to.equal(false);
+    expect(logger.warn.called).to.equal(true);
   });
 
   it('should skip blob attachments when trusted size metadata is missing', async () => {
@@ -260,7 +276,7 @@ describe('AgentAttachmentStorage', () => {
     expect(storageService.uploadFile.called).to.equal(false);
   });
 
-  it('should skip fetchData attachment without size metadata when fetched data exceeds size limit', async () => {
+  it('should skip whatsapp fetchData attachment without size metadata when fetched data exceeds size limit', async () => {
     const storageService = {
       uploadFile: sinon.stub(),
       getReadSignedUrl: sinon.stub(),
@@ -275,7 +291,7 @@ describe('AgentAttachmentStorage', () => {
       fetchData: async () => Buffer.alloc(26 * 1024 * 1024),
     };
 
-    const result = await service.storeInbound([attachment], ctx);
+    const result = await service.storeInbound([attachment], { ...ctx, platform: AgentPlatformEnum.WHATSAPP });
 
     expect(result).to.have.length(0);
     expect(storageService.uploadFile.called).to.equal(false);

--- a/apps/api/src/app/agents/services/agent-attachment-storage.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-attachment-storage.service.spec.ts
@@ -143,7 +143,7 @@ describe('AgentAttachmentStorage', () => {
     expect(logger.warn.calledWithMatch({ size: 20 * mb, aggregateCap: 50 * mb })).to.equal(true);
   });
 
-  it('should skip fetchData attachments without size metadata before downloading', async () => {
+  it('should upload fetchData attachments without size metadata', async () => {
     const storageService = makeStorageService();
     const logger = makeLogger();
     const service = new AgentAttachmentStorage(storageService, logger as any);
@@ -152,10 +152,16 @@ describe('AgentAttachmentStorage', () => {
 
     const result = await service.storeInbound(attachments, ctx);
 
-    expect(result).to.have.length(0);
-    expect(fetchData.called).to.equal(false);
-    expect(storageService.uploadFile.called).to.equal(false);
-    expect(logger.warn.called).to.equal(true);
+    expect(result).to.have.length(1);
+    expect(fetchData.calledOnce).to.equal(true);
+    expect(storageService.uploadFile.calledOnce).to.equal(true);
+    expect(result[0]).to.include({
+      type: 'file',
+      name: 'unknown.bin',
+      size: 1,
+      url: 'https://signed/read',
+    });
+    expect(result[0].mimeType).to.equal(undefined);
   });
 
   it('should skip blob attachments when trusted size metadata is missing', async () => {
@@ -252,6 +258,28 @@ describe('AgentAttachmentStorage', () => {
 
     expect(result).to.have.length(0);
     expect(storageService.uploadFile.called).to.equal(false);
+  });
+
+  it('should skip fetchData attachment without size metadata when fetched data exceeds size limit', async () => {
+    const storageService = {
+      uploadFile: sinon.stub(),
+      getReadSignedUrl: sinon.stub(),
+      fileExists: sinon.stub(),
+    } as unknown as StorageService;
+
+    const logger = makeLogger();
+    const service = new AgentAttachmentStorage(storageService, logger as any);
+
+    const attachment: Attachment = {
+      type: 'file',
+      fetchData: async () => Buffer.alloc(26 * 1024 * 1024),
+    };
+
+    const result = await service.storeInbound([attachment], ctx);
+
+    expect(result).to.have.length(0);
+    expect(storageService.uploadFile.called).to.equal(false);
+    expect(logger.warn.calledOnce).to.equal(true);
   });
 
   it('should signRead when object exists', async () => {

--- a/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
+++ b/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PinoLogger, StorageService } from '@novu/application-generic';
 import type { Attachment } from 'chat';
+import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
 
 export interface StoredAttachment {
   type: string;
@@ -16,6 +17,7 @@ export interface StoreInboundAttachmentContext {
   environmentId: string;
   conversationId: string;
   platformMessageId: string;
+  platform?: AgentPlatformEnum;
 }
 
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
@@ -43,8 +45,12 @@ function buildStorageKey(params: {
   return `${params.organizationId}/${params.environmentId}/${AGENTS_FOLDER}/${params.conversationId}/${safeMessageId}/${params.index}-${params.filename}`;
 }
 
-async function bufferFromAttachment(attachment: Attachment): Promise<Buffer | null> {
+async function bufferFromAttachment(attachment: Attachment, allowUnknownSizeDownload = false): Promise<Buffer | null> {
   if (!attachment.data) {
+    if (attachment.size == null && !allowUnknownSizeDownload) {
+      throw new Error('Inbound attachment size is required before download');
+    }
+
     if (attachment.size != null && attachment.size > MAX_ATTACHMENT_BYTES) {
       throw new Error('Inbound attachment exceeds size limit');
     }
@@ -177,7 +183,8 @@ export class AgentAttachmentStorage {
         return null;
       }
 
-      const buffer = await bufferFromAttachment(attachment);
+      const allowUnknownSizeDownload = ctx.platform === AgentPlatformEnum.WHATSAPP;
+      const buffer = await bufferFromAttachment(attachment, allowUnknownSizeDownload);
 
       if (!buffer) {
         this.logger.warn({ name: attachment.name }, 'Inbound attachment has neither fetchData nor data');

--- a/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
+++ b/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
@@ -45,11 +45,7 @@ function buildStorageKey(params: {
 
 async function bufferFromAttachment(attachment: Attachment): Promise<Buffer | null> {
   if (!attachment.data) {
-    if (attachment.size == null) {
-      throw new Error('Inbound attachment size is required before download');
-    }
-
-    if (attachment.size > MAX_ATTACHMENT_BYTES) {
+    if (attachment.size != null && attachment.size > MAX_ATTACHMENT_BYTES) {
       throw new Error('Inbound attachment exceeds size limit');
     }
 

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
@@ -176,6 +176,66 @@ describe('AgentInboundHandler', () => {
 
       expect(thread.post.calledOnce).to.equal(true);
     });
+
+    it('should store and forward inbound WhatsApp attachments', async () => {
+      const storedAttachments = [
+        {
+          type: 'image',
+          name: 'photo.jpg',
+          mimeType: 'image/jpeg',
+          size: 1234,
+          storageKey: 'org1/env1/agents/conversation1/whatsapp-msg/0-photo.jpg',
+          url: 'https://signed/read',
+        },
+      ];
+      const { handler, attachmentStorage, bridgeExecutor, conversationService } = makeHandler({ storedAttachments });
+      const whatsappConfig = {
+        ...config,
+        platform: 'whatsapp',
+        integrationIdentifier: 'whatsapp-main',
+      };
+      const thread = {
+        id: 'whatsapp:15551234567',
+        channelId: 'whatsapp:15551234567',
+        isDM: true,
+        toJSON: () => ({ id: 'whatsapp:15551234567' }),
+        startTyping: sinon.stub().resolves(undefined),
+      };
+      const message = {
+        id: 'whatsapp-msg',
+        text: 'photo',
+        author: {
+          userId: '15557654321',
+          fullName: 'User One',
+          userName: 'userone',
+          isBot: false,
+        },
+        attachments: [
+          {
+            type: 'image',
+            name: 'photo.jpg',
+            mimeType: 'image/jpeg',
+            size: 1234,
+          },
+        ],
+      };
+
+      await handler.handle('agent1', whatsappConfig as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
+
+      expect(attachmentStorage.storeInbound.calledOnceWith(message.attachments)).to.equal(true);
+      expect(conversationService.persistInboundMessage.firstCall.args[0].richContent).to.deep.equal({
+        attachments: [
+          {
+            type: 'image',
+            name: 'photo.jpg',
+            mimeType: 'image/jpeg',
+            size: 1234,
+            storageKey: 'org1/env1/agents/conversation1/whatsapp-msg/0-photo.jpg',
+          },
+        ],
+      });
+      expect(bridgeExecutor.execute.firstCall.args[0].storedAttachments).to.deep.equal(storedAttachments);
+    });
   });
 
   describe('handleReaction', () => {

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
@@ -223,6 +223,7 @@ describe('AgentInboundHandler', () => {
       await handler.handle('agent1', whatsappConfig as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
 
       expect(attachmentStorage.storeInbound.calledOnceWith(message.attachments)).to.equal(true);
+      expect(attachmentStorage.storeInbound.firstCall.args[1].platform).to.equal('whatsapp');
       expect(conversationService.persistInboundMessage.firstCall.args[0].richContent).to.deep.equal({
         attachments: [
           {

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -197,6 +197,7 @@ export class AgentInboundHandler {
         environmentId: config.environmentId,
         conversationId: String(conversation._id),
         platformMessageId: message.id ?? `unknown-${Date.now()}`,
+        platform: config.platform,
       });
     }
 
@@ -391,6 +392,7 @@ export class AgentInboundHandler {
         environmentId: config.environmentId,
         conversationId: String(conversation._id),
         platformMessageId: event.message.id ?? event.messageId ?? `unknown-${Date.now()}`,
+        platform: config.platform,
       });
     }
 

--- a/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
@@ -368,32 +368,26 @@ describe('ChatSdkService', () => {
       });
     });
 
-    it('should drop files with a warning for whatsapp', async () => {
-      const logger = {
-        warn: sinon.stub(),
-        error: sinon.stub(),
-        debug: sinon.stub(),
-        info: sinon.stub(),
-        setContext: sinon.stub(),
-      };
-      const service = new ChatSdkService(logger as any, {} as any, {} as any, {} as any, {} as any);
-
+    it('should convert whatsapp file data to a Buffer before passing content to the chat SDK', async () => {
+      const service = makeService();
       const result = await (service as any).prepareContentForDelivery(
         {
           markdown: 'Here is the file',
-          files: [{ filename: 'sample.txt', data: Buffer.from('hello').toString('base64') }],
+          files: [
+            {
+              filename: 'sample.txt',
+              mimeType: 'text/plain',
+              data: Buffer.from('hello').toString('base64'),
+            },
+          ],
         },
-        'whatsapp',
-        'agent-id'
+        'whatsapp'
       );
 
-      expect(result.files).to.equal(undefined);
-      expect(logger.warn.calledOnce).to.equal(true);
-      expect(logger.warn.firstCall.args[0]).to.deep.include({
-        agentId: 'agent-id',
-        platform: 'whatsapp',
-        droppedCount: 1,
-      });
+      expect(Buffer.isBuffer(result.files[0].data)).to.equal(true);
+      expect(result.files[0].data.toString()).to.equal('hello');
+      expect(result.files[0].filename).to.equal('sample.txt');
+      expect(result.files[0].mimeType).to.equal('text/plain');
     });
   });
 

--- a/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
@@ -368,26 +368,32 @@ describe('ChatSdkService', () => {
       });
     });
 
-    it('should convert whatsapp file data to a Buffer before passing content to the chat SDK', async () => {
-      const service = makeService();
+    it('should drop files with a warning for whatsapp', async () => {
+      const logger = {
+        warn: sinon.stub(),
+        error: sinon.stub(),
+        debug: sinon.stub(),
+        info: sinon.stub(),
+        setContext: sinon.stub(),
+      };
+      const service = new ChatSdkService(logger as any, {} as any, {} as any, {} as any, {} as any);
+
       const result = await (service as any).prepareContentForDelivery(
         {
           markdown: 'Here is the file',
-          files: [
-            {
-              filename: 'sample.txt',
-              mimeType: 'text/plain',
-              data: Buffer.from('hello').toString('base64'),
-            },
-          ],
+          files: [{ filename: 'sample.txt', data: Buffer.from('hello').toString('base64') }],
         },
-        'whatsapp'
+        'whatsapp',
+        'agent-id'
       );
 
-      expect(Buffer.isBuffer(result.files[0].data)).to.equal(true);
-      expect(result.files[0].data.toString()).to.equal('hello');
-      expect(result.files[0].filename).to.equal('sample.txt');
-      expect(result.files[0].mimeType).to.equal('text/plain');
+      expect(result.files).to.equal(undefined);
+      expect(logger.warn.calledOnce).to.equal(true);
+      expect(logger.warn.firstCall.args[0]).to.deep.include({
+        agentId: 'agent-id',
+        platform: 'whatsapp',
+        droppedCount: 1,
+      });
     });
   });
 

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -24,10 +24,32 @@ import { sendWebResponse, toWebRequest } from '../utils/express-to-web-request';
 import { AgentConfigResolver, ResolvedAgentConfig } from './agent-config-resolver.service';
 import { AgentInboundHandler } from './agent-inbound-handler.service';
 
+function getErrorResponseBody(err: unknown): unknown {
+  if (!err || typeof err !== 'object') {
+    return undefined;
+  }
+
+  return (err as { response?: { body?: unknown } }).response?.body;
+}
+
+function getDeliveryErrorDetail(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') {
+    return undefined;
+  }
+
+  const responseBody = body as { errors?: Array<{ message?: unknown }>; message?: unknown };
+  const firstErrorMessage = responseBody.errors?.[0]?.message;
+  if (typeof firstErrorMessage === 'string') {
+    return firstErrorMessage;
+  }
+
+  return typeof responseBody.message === 'string' ? responseBody.message : undefined;
+}
+
 function toDeliveryError(err: unknown): never {
   const base = err instanceof Error ? err.message : String(err);
-  const body = (err as any)?.response?.body;
-  const detail = Array.isArray(body?.errors) ? body.errors[0]?.message : body?.message;
+  const detail = getDeliveryErrorDetail(getErrorResponseBody(err));
+
   throw new BadGatewayException({
     error: 'delivery_failed',
     message: detail ? `${base}: ${detail}` : base,
@@ -68,8 +90,12 @@ const MAX_AGGREGATE_FILE_BYTES = 50 * 1024 * 1024;
 const MAX_INLINE_FILE_BASE64_CHARS = 7_000_000;
 const FILE_FETCH_TIMEOUT_MS = 10_000;
 const MAX_FILE_FETCH_REDIRECTS = 3;
-const SUPPORTED_FILE_PLATFORMS = new Set<string>([AgentPlatformEnum.SLACK, AgentPlatformEnum.TEAMS]);
-const UNSUPPORTED_FILE_PLATFORMS = new Set<string>([AgentPlatformEnum.EMAIL, AgentPlatformEnum.WHATSAPP]);
+const SUPPORTED_FILE_PLATFORMS = new Set<string>([
+  AgentPlatformEnum.SLACK,
+  AgentPlatformEnum.TEAMS,
+  AgentPlatformEnum.WHATSAPP,
+]);
+const UNSUPPORTED_FILE_PLATFORMS = new Set<string>([AgentPlatformEnum.EMAIL]);
 // EMAIL_ALTERNATIVES_SUPPORTED_PROVIDERS is a deliberate allowlist for providers that preserve custom MIME
 // alternatives used by Gmail reactions; Braze, Brevo, Mailgun, Mailjet, Mailtrap, Mandrill, Plunk, Postmark,
 // Resend, SparkPost, and similar providers are excluded until their SDK paths are verified.

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -90,12 +90,8 @@ const MAX_AGGREGATE_FILE_BYTES = 50 * 1024 * 1024;
 const MAX_INLINE_FILE_BASE64_CHARS = 7_000_000;
 const FILE_FETCH_TIMEOUT_MS = 10_000;
 const MAX_FILE_FETCH_REDIRECTS = 3;
-const SUPPORTED_FILE_PLATFORMS = new Set<string>([
-  AgentPlatformEnum.SLACK,
-  AgentPlatformEnum.TEAMS,
-  AgentPlatformEnum.WHATSAPP,
-]);
-const UNSUPPORTED_FILE_PLATFORMS = new Set<string>([AgentPlatformEnum.EMAIL]);
+const SUPPORTED_FILE_PLATFORMS = new Set<string>([AgentPlatformEnum.SLACK, AgentPlatformEnum.TEAMS]);
+const UNSUPPORTED_FILE_PLATFORMS = new Set<string>([AgentPlatformEnum.EMAIL, AgentPlatformEnum.WHATSAPP]);
 // EMAIL_ALTERNATIVES_SUPPORTED_PROVIDERS is a deliberate allowlist for providers that preserve custom MIME
 // alternatives used by Gmail reactions; Braze, Brevo, Mailgun, Mailjet, Mailtrap, Mandrill, Plunk, Postmark,
 // Resend, SparkPost, and similar providers are excluded until their SDK paths are verified.


### PR DESCRIPTION
## Summary
- Keep WhatsApp excluded from outbound agent file delivery because `@chat-adapter/whatsapp` does not send `files` as WhatsApp media messages yet.
- Store inbound WhatsApp media attachments that expose `fetchData()` without pre-download size metadata while preserving the existing post-fetch per-file and aggregate caps.
- Add focused regression coverage for inbound WhatsApp attachment storage/bridge forwarding and outbound WhatsApp file dropping.

```mermaid
sequenceDiagram
  participant WA as WhatsApp Adapter
  participant API as AgentInboundHandler
  participant Store as AgentAttachmentStorage
  participant Bridge as Bridge Executor
  WA->>API: message.attachments with fetchData()
  API->>Store: storeInbound(attachments)
  Store->>Store: fetch and enforce size caps
  Store-->>API: stored attachment metadata + signed URL
  API->>Bridge: execute(..., storedAttachments)
```

## Test plan
- `pnpm run build:metadata && pnpm exec cross-env TS_NODE_PROJECT=tsconfig.spec.json TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test NOVU_ENTERPRISE=true CLERK_ENABLED=true NODE_OPTIONS=--no-experimental-strip-types mocha --timeout 15000 --require ts-node/register --exit "src/app/agents/services/agent-attachment-storage.service.spec.ts" "src/app/agents/services/chat-sdk.service.spec.ts" "src/app/agents/services/agent-inbound-handler.service.spec.ts"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR enables inbound WhatsApp agent attachments by allowing the service to fetch media that expose fetchData() but lack pre-download size metadata, then enforce existing per-file and aggregate size caps after download. It preserves existing outbound behavior by keeping WhatsApp excluded from agent outbound file delivery (the WhatsApp adapter does not send files as WhatsApp media yet). Also refactors delivery-error handling to extract error body/details more robustly.

## Affected areas

**api**: AgentAttachmentStorage now accepts a platform hint and, for WhatsApp, allows fetching attachments without pre-known sizes then enforces size caps after download; bufferFromAttachment no longer rejects unknown-size attachments when platform permits fetching. AgentInboundHandler passes the platform into storeInbound so WhatsApp attachments are handled correctly. ChatSdkService.toDeliveryError was refactored to extract error response body and message details via helper functions.

## Key technical decisions

- Only WhatsApp attachments are allowed to be fetched when size metadata is missing (scope-limited behavior) to avoid changing validation semantics for other platforms.  
- Size-cap enforcement remains unchanged in intent: checks occur either before upload when size metadata exists, or after download when it does not.  
- A platform field was added to the inbound storage context rather than broadening global attachment semantics.

## Testing

Added focused unit tests: inbound WhatsApp attachment storage and bridge forwarding, outbound WhatsApp file-dropping behavior, and delivery-error formatting. Tests live under the agents service specs referenced in the PR and should be run via the provided mocha command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->