### PR TITLE
fix(api, worker, ws, inbound-mail): APM traces broke because of new pm2 version which includes open telemetry 

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,7 +3,7 @@ RUN apk add --no-cache g++ make py3-pip
 ENV NX_DAEMON=false
 
 # Install global dependencies
-RUN npm --no-update-notifier --no-fund --global install pm2 pnpm@10.33.0&& \
+RUN npm --no-update-notifier --no-fund --global install pm2@6.0.14 pnpm@10.33.0&& \
     pnpm --version
 
 # Set non-root user
@@ -62,7 +62,7 @@ ENV CI=true
 
 RUN apk upgrade --no-cache && \
     apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --upgrade libcrypto3 libssl3 musl musl-utils && \
-    npm --no-update-notifier --no-fund --global install pm2 && \
+    npm --no-update-notifier --no-fund --global install pm2@6.0.14 && \
     rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 # Set non-root user

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -88,5 +88,7 @@ RUN if [ -f dist/metadata.js ]; then \
     fi
 
 ENV NEW_RELIC_NO_CONFIG_FILE=true
+ENV NEW_RELIC_LOG=stdout
+ENV NEW_RELIC_LOG_LEVEL=trace
 
 ENTRYPOINT [ "sh", "-c", "node dist/dotenvcreate.mjs -s=$SECRET_NAME -r=$NOVU_REGION -e=$NOVU_ENTERPRISE -v=$NODE_ENV -h=$IS_SELF_HOSTED && pm2-runtime start dist/main.js -i max" ]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -88,7 +88,5 @@ RUN if [ -f dist/metadata.js ]; then \
     fi
 
 ENV NEW_RELIC_NO_CONFIG_FILE=true
-ENV NEW_RELIC_LOG=stdout
-ENV NEW_RELIC_LOG_LEVEL=trace
 
 ENTRYPOINT [ "sh", "-c", "node dist/dotenvcreate.mjs -s=$SECRET_NAME -r=$NOVU_REGION -e=$NOVU_ENTERPRISE -v=$NODE_ENV -h=$IS_SELF_HOSTED && pm2-runtime start dist/main.js -i max" ]

--- a/apps/api/src/newrelic.ts
+++ b/apps/api/src/newrelic.ts
@@ -41,7 +41,7 @@ exports.config = {
      * issues with the agent, 'info' and higher will impose the least overhead on
      * production applications.
      */
-    level: 'info',
+    level: 'trace',
   },
   /**
    * When true, all request headers except for those listed in attributes.exclude

--- a/apps/api/src/newrelic.ts
+++ b/apps/api/src/newrelic.ts
@@ -41,7 +41,7 @@ exports.config = {
      * issues with the agent, 'info' and higher will impose the least overhead on
      * production applications.
      */
-    level: 'trace',
+    level: 'info',
   },
   /**
    * When true, all request headers except for those listed in attributes.exclude

--- a/apps/inbound-mail/Dockerfile
+++ b/apps/inbound-mail/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add g++ make py3-pip
 
 ENV NX_DAEMON=false
 
-RUN npm i pm2 -g
+RUN npm i pm2@6.0.14 -g
 RUN npm --no-update-notifier --no-fund --global install pnpm@10.33.0
 RUN pnpm --version
 

--- a/apps/webhook/Dockerfile
+++ b/apps/webhook/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache g++ make py3-pip
 ENV NX_DAEMON=false
 
 # Install global dependencies
-RUN npm --no-update-notifier --no-fund --global install pm2 pnpm@10.33.0&& \
+RUN npm --no-update-notifier --no-fund --global install pm2@6.0.14 pnpm@10.33.0&& \
     pnpm --version
 
 # Set non-root user
@@ -46,7 +46,7 @@ FROM node:22.22.1-alpine3.22 AS prod
 ENV CI=true
 
 # Install only runtime dependencies
-RUN npm --no-update-notifier --no-fund --global install pm2 && \
+RUN npm --no-update-notifier --no-fund --global install pm2@6.0.14 && \
     rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 USER 1000

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -3,7 +3,7 @@ RUN apk --update --no-cache add curl g++ make py3-pip
 ENV NX_DAEMON=false
 
 
-RUN npm i pm2 -g
+RUN npm i pm2@6.0.14 -g
 RUN npm --no-update-notifier --no-fund --global install pnpm@10.33.0
 RUN pnpm --version
 
@@ -66,7 +66,7 @@ ENV CI=true
 RUN apk upgrade --no-cache && \
     apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --upgrade libcrypto3 libssl3 musl musl-utils && \
     apk --no-cache add curl && \
-    npm i pm2 -g && \
+    npm i pm2@6.0.14 -g && \
     rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 USER 1000

--- a/apps/ws/Dockerfile
+++ b/apps/ws/Dockerfile
@@ -3,7 +3,7 @@ RUN apk add --no-cache g++ make py3-pip
 ENV NX_DAEMON=false
 
 # Install global dependencies
-RUN npm --no-update-notifier --no-fund --global install pm2 pnpm@10.33.0&& \
+RUN npm --no-update-notifier --no-fund --global install pm2@6.0.14 pnpm@10.33.0&& \
     pnpm --version
 
 # Set non-root user
@@ -63,7 +63,7 @@ ENV CI=true
 
 RUN apk upgrade --no-cache && \
     apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main --upgrade libcrypto3 libssl3 musl musl-utils && \
-    npm --no-update-notifier --no-fund --global install pm2 && \
+    npm --no-update-notifier --no-fund --global install pm2@6.0.14 && \
     rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 # Set non-root user


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

PM2 has been pinned to version 6.0.14 across Docker images for five services: api, worker, ws, inbound-mail, and webhook. This resolves APM trace issues caused by a recent PM2 release that includes OpenTelemetry, which was breaking APM instrumentation. The New Relic logging configuration was also adjusted to use info-level logging instead of trace-level.

## Affected areas

- **api**: Pinned pm2 to 6.0.14 in both dev_base and prod stages; pnpm also pinned to 10.33.0 in dev_base.
- **worker**: Pinned pm2 to 6.0.14 in both dev_base and prod stages.
- **ws**: Pinned pm2 to 6.0.14 in both dev_base and prod stages; pnpm also pinned to 10.33.0 in dev_base.
- **inbound-mail**: Pinned pm2 to 6.0.14.
- **webhook**: Pinned pm2 to 6.0.14 in both dev_base and prod stages; pnpm also pinned to 10.33.0 in dev_base.

## Testing

No tests were added. The fix is a version pinning change that resolves compatibility issues in containerized deployments; APM functionality can be verified through observability dashboards in staging/production environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
