### PR TITLE
fix(api-service): scope Azure setup OAuth reads/writes by _environmentId

### DIFF
--- a/apps/api/src/app/integrations/usecases/azure-setup-oauth-callback/azure-setup-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/azure-setup-oauth-callback/azure-setup-oauth-callback.usecase.ts
@@ -113,55 +113,43 @@ export class AzureSetupOauthCallback {
   }
 
   private async decodeAndVerifyState(state: string): Promise<AzureSetupStateData> {
-    let preliminaryData: Partial<AzureSetupStateData>;
+    let payload: string;
+    let signature: string;
+    let data: AzureSetupStateData;
 
     try {
-      const { payload } = splitOAuthState(state);
-      preliminaryData = JSON.parse(payload);
+      ({ payload, signature } = splitOAuthState(state));
+      data = JSON.parse(payload) as AzureSetupStateData;
     } catch {
       throw new BadRequestException('Invalid Azure setup OAuth state');
     }
 
-    if (!preliminaryData.environmentId || !preliminaryData.organizationId) {
+    if (!data.environmentId || !data.organizationId) {
       throw new BadRequestException('Azure setup state missing required fields');
     }
 
     const environment = await this.environmentRepository.findOne({
-      _id: preliminaryData.environmentId,
-      _organizationId: preliminaryData.organizationId,
+      _id: data.environmentId,
+      _organizationId: data.organizationId,
     });
 
     if (!environment?.apiKeys?.length) {
-      throw new NotFoundException(`Environment ${preliminaryData.environmentId} not found`);
+      throw new NotFoundException(`Environment ${data.environmentId} not found`);
     }
 
     const signingKey = environment.apiKeys[0].key;
 
     try {
-      const { payload, signature } = splitOAuthState(state);
       const expectedSignature = createHash(signingKey, payload);
 
       if (signature !== expectedSignature) {
         throw new Error('Signature mismatch');
       }
 
-      const data = JSON.parse(payload) as AzureSetupStateData;
-
       const FIFTEEN_MINUTES = 15 * 60 * 1000;
 
       if (Date.now() - data.timestamp > FIFTEEN_MINUTES) {
         throw new Error('State expired');
-      }
-
-      // Defense-in-depth: ensure the environmentId in the signed payload matches
-      // the environment used to derive the signing key, so a replayed/tampered state
-      // from a different environment of the same org cannot pass signature verification
-      // and then target a different environment's integration on the write path.
-      if (
-        data.environmentId !== preliminaryData.environmentId ||
-        data.organizationId !== preliminaryData.organizationId
-      ) {
-        throw new Error('State environment/organization mismatch');
       }
 
       return data;

--- a/apps/api/src/app/integrations/usecases/azure-setup-oauth-callback/azure-setup-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/azure-setup-oauth-callback/azure-setup-oauth-callback.usecase.ts
@@ -153,6 +153,17 @@ export class AzureSetupOauthCallback {
         throw new Error('State expired');
       }
 
+      // Defense-in-depth: ensure the environmentId in the signed payload matches
+      // the environment used to derive the signing key, so a replayed/tampered state
+      // from a different environment of the same org cannot pass signature verification
+      // and then target a different environment's integration on the write path.
+      if (
+        data.environmentId !== preliminaryData.environmentId ||
+        data.organizationId !== preliminaryData.organizationId
+      ) {
+        throw new Error('State environment/organization mismatch');
+      }
+
       return data;
     } catch {
       throw new BadRequestException('Invalid or expired Azure setup OAuth state');
@@ -230,6 +241,7 @@ export class AzureSetupOauthCallback {
   ): Promise<{ appId: string; secretValue: string; tenantId: string }> {
     const integration = await this.integrationRepository.findOne({
       _id: stateData.integrationId,
+      _environmentId: stateData.environmentId,
       _organizationId: stateData.organizationId,
     });
 
@@ -394,6 +406,7 @@ export class AzureSetupOauthCallback {
     await this.integrationRepository.update(
       {
         _id: stateData.integrationId,
+        _environmentId: stateData.environmentId,
         _organizationId: stateData.organizationId,
       },
       { $set: { credentials } }
@@ -458,6 +471,7 @@ export class AzureSetupOauthCallback {
 
       const integration = await this.integrationRepository.findOne({
         _id: stateData.integrationId,
+        _environmentId: stateData.environmentId,
         _organizationId: stateData.organizationId,
       });
 
@@ -594,7 +608,11 @@ export class AzureSetupOauthCallback {
       }
 
       await this.integrationRepository.update(
-        { _id: stateData.integrationId, _organizationId: stateData.organizationId },
+        {
+          _id: stateData.integrationId,
+          _environmentId: stateData.environmentId,
+          _organizationId: stateData.organizationId,
+        },
         { $set: fields }
       );
     } catch (err) {
@@ -650,6 +668,7 @@ export class AzureSetupOauthCallback {
 
     const integration = await this.integrationRepository.findOne({
       _id: stateData.integrationId,
+      _environmentId: stateData.environmentId,
       _organizationId: stateData.organizationId,
     });
 
@@ -678,6 +697,7 @@ export class AzureSetupOauthCallback {
     try {
       const integration = await this.integrationRepository.findOne({
         _id: stateData.integrationId,
+        _environmentId: stateData.environmentId,
         _organizationId: stateData.organizationId,
       });
 

--- a/apps/api/src/app/integrations/usecases/generate-azure-setup-oauth-url/generate-azure-setup-oauth-url.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/generate-azure-setup-oauth-url/generate-azure-setup-oauth-url.usecase.ts
@@ -43,6 +43,7 @@ export class GenerateAzureSetupOauthUrl {
   async execute(command: GenerateAzureSetupOauthUrlCommand): Promise<string> {
     const integration = await this.integrationRepository.findOne({
       _id: command.integrationId,
+      _environmentId: command.environmentId,
       _organizationId: command.organizationId,
     });
 


### PR DESCRIPTION
## What

All `integrationRepository.findOne` and `.update` calls in the Azure Quick Setup OAuth flow were filtering only by `_id + _organizationId`. This allowed a user with `INTEGRATION_WRITE` in one environment to overwrite credentials for an integration in a **different environment of the same org** — the bot's MEDIUM-severity review finding.

## Attack scenario (now closed)

1. User has `INTEGRATION_WRITE` in env A (e.g. dev).
2. They call `GET /v1/integrations/{prodIntegrationId}/msteams-azure-setup/oauth-url` — the use case found the integration by org ID only, so it returned a valid URL with state signed by env A's key embedding the prod integration ID.
3. After completing Azure consent, the callback verified the env A signature (matches), then ran `saveCredentials` and `writeProvisioning` filtered only by `{ _id, _organizationId }`, overwriting the **prod integration's** credentials with the attacker's Azure app registration.

## Changes

```mermaid
sequenceDiagram
    participant User
    participant Controller
    participant GenerateUrl as GenerateAzureSetupOauthUrl
    participant Callback as AzureSetupOauthCallback
    participant DB as IntegrationRepository

    User->>Controller: GET /:integrationId/msteams-azure-setup/oauth-url
    Controller->>GenerateUrl: execute(integrationId, environmentId, organizationId)
    GenerateUrl->>DB: findOne({ _id, _environmentId ✅, _organizationId })
    Note over DB: Before fix: only _id + _organizationId

    User->>Controller: GET /chat/oauth/azure-setup/callback?state=...
    Controller->>Callback: execute(state)
    Callback->>Callback: decodeAndVerifyState (verify sig + env/org match ✅)
    Callback->>DB: findOne({ _id, _environmentId ✅, _organizationId }) ×5
    Callback->>DB: update({ _id, _environmentId ✅, _organizationId }) ×2
    Note over DB: Before fix: all sites omitted _environmentId
```

**`azure-setup-oauth-callback.usecase.ts`** — 7 sites:
- `createAppRegistration` → `findOne` now includes `_environmentId`
- `saveCredentials` → `update` now includes `_environmentId`
- `tryDeployBotService` → `findOne` (bot name lookup) now includes `_environmentId`
- `writeProvisioning` → `update` now includes `_environmentId`
- `resolveWebhookEndpoint` → `findOne` (integration identifier) now includes `_environmentId`
- `tryUploadTeamsApp` → `findOne` (app zip) now includes `_environmentId`
- `decodeAndVerifyState` → added explicit assertion that `data.environmentId === preliminaryData.environmentId` and `data.organizationId === preliminaryData.organizationId` after signature verification (defense-in-depth)

**`generate-azure-setup-oauth-url.usecase.ts`** — 1 site:
- Initial integration lookup now scoped by `_environmentId`, preventing an env-A user from even minting a valid OAuth URL for an env-B integration

## Testing

- The `_environmentId` field is indexed on the integrations collection — no performance impact.
- Existing happy-path behavior is unchanged for users who operate within a single environment (all IDs match as before).
- A cross-environment attempt now results in a `NotFoundException` at URL generation time, and a no-op write (0 matched documents) at the callback write path.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR prevents cross-environment credential overwrites in the Azure Quick Setup OAuth flow by scoping integration repository lookups and updates to include _environmentId. It also strengthens OAuth state validation by asserting the decoded environmentId and organizationId match preliminary state data. The change ensures a user with permissions in one environment cannot generate OAuth URLs or overwrite integrations belonging to another environment within the same organization.

## Affected areas

**api** (integrations): Added _environmentId filters to integrationRepository.findOne and .update calls in the Azure OAuth flow (URL generation and callback handling), covering app registration creation, credential saving, ARM deployment checks, provisioning writes, webhook resolution, and Teams app upload logic; state decoding now explicitly asserts environment and organization consistency.

## Key technical decisions

- Defense-in-depth: explicit assertion that decoded state.environmentId === preliminaryData.environmentId and organizationId matches before token exchange.  
- Reused existing _environmentId index on the integrations collection to avoid performance regressions.  
- No public API changes or new packages introduced.

## Testing

No automated tests added in this PR; behavior preserves happy-path for single-environment users, while cross-environment attempts now fail early (URL generation returns NotFoundException) and produce no-op writes on callback (0 matched documents). Manual verification recommended for multi-environment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->