### PR TITLE
feat(dashboard): agent setup send-step titles and Slack copy button

### DIFF
--- a/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
@@ -1,4 +1,4 @@
-import { ChatProviderIdEnum } from '@novu/shared';
+import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { Loader } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
@@ -117,18 +117,37 @@ function getProviderSlackMessage(agentName: string): string {
   return `Hey @${agentName}, can you help me?`;
 }
 
+function getProviderSendTitle(providerId: string | undefined): string {
+  switch (providerId) {
+    case ChatProviderIdEnum.Slack:
+      return 'Send a message to the Slack App on Slack';
+    case ChatProviderIdEnum.MsTeams:
+      return 'Send a message to the bot on MS Teams';
+    case ChatProviderIdEnum.WhatsAppBusiness:
+      return 'Send a message on WhatsApp';
+    case EmailProviderIdEnum.NovuAgent:
+      return 'Send an email to the agent';
+    default:
+      return 'Send a message to test the connection';
+  }
+}
+
 function getProviderSendDescription(providerId: string | undefined, agentName: string): string {
   switch (providerId) {
     case ChatProviderIdEnum.Slack:
       return `Open your Slack workspace and send a message to ${agentName}. Make sure to send in a channel or directly to the bot.`;
+    case ChatProviderIdEnum.MsTeams:
+      return `Open Microsoft Teams and send a message to ${agentName} in a channel or direct chat.`;
     case ChatProviderIdEnum.WhatsAppBusiness:
       return `Send a message to your WhatsApp number to test the connection.`;
+    case EmailProviderIdEnum.NovuAgent:
+      return `Send an email to your agent's configured address to test the connection.`;
     default:
       return `Send a message to your bot from the connected provider to test the connection.`;
   }
 }
 
-function CopySlackMessageButton({ agentName }: { agentName: string }) {
+export function CopySlackMessageButton({ agentName }: { agentName: string }) {
   const [copied, setCopied] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -334,7 +353,7 @@ export function AgentCodeSetupSection({
       <SetupStep
         index={stepOffset + 2}
         status={deriveStepStatus(stepOffset + 2, firstIncompleteStep)}
-        title="Send a message to the Slack App on Slack"
+        title={getProviderSendTitle(providerId)}
         description={getProviderSendDescription(providerId, agent.name)}
         rightContent={
           providerId === ChatProviderIdEnum.Slack ? <CopySlackMessageButton agentName={agent.name} /> : undefined

--- a/apps/dashboard/src/components/agents/slack-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/slack-setup-guide.tsx
@@ -22,6 +22,7 @@ import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { apiHostnameManager } from '@/utils/api-hostname-manager';
 import { QueryKeys } from '@/utils/query-keys';
 import { cn } from '@/utils/ui';
+import { CopySlackMessageButton } from './agent-code-setup-section';
 import type { SetupMode } from './setup-guide-primitives';
 import {
   IntegrationCredentialsSidebar,
@@ -471,6 +472,7 @@ export function SlackSetupGuide({
             {' from the suggestions, then send a message. You should see the agent respond.'}
           </span>
         }
+        rightContent={<CopySlackMessageButton agentName={agent.name} />}
       />
     </>
   );


### PR DESCRIPTION
## Summary

Improves the agent connection flow on the dashboard so the "send a message to verify" setup step matches the connected provider and Slack onboarding exposes the same sample-message copy action.

## Changes

- Add `getProviderSendTitle()` so the third setup step title reflects Slack, MS Teams, WhatsApp Business, Novu email agent, or a generic fallback instead of always saying Slack.
- Extend `getProviderSendDescription()` with Teams and Novu email agent–specific guidance.
- Export `CopySlackMessageButton` from `agent-code-setup-section.tsx` and reuse it in `SlackSetupGuide` via `rightContent` so users can copy the suggested mention message during Slack-specific onboarding.

## Testing

- [ ] Smoke-tested agent setup UI for Slack (copy button in code setup + Slack guide step).

## Notes

- No Linear ticket was linked for this change.

## Breaking changes

None.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The agent setup flow now displays provider-specific titles and descriptions in the send-step section instead of generic Slack-branded text. The CopySlackMessageButton component is exported and reused in the Slack setup guide to allow copying suggested mention messages during onboarding.

## Affected areas

**dashboard**: Modified agent setup components to introduce dynamic, provider-aware UI text (getProviderSendTitle and getProviderSendDescription functions) for the send step, and refactored the Slack copy button into a reusable exported component integrated into the Slack setup guide.

## Key technical decisions

- CopySlackMessageButton is now exported as a public component from agent-code-setup-section.tsx, enabling reuse across other setup guide pages (e.g., SlackSetupGuide).
- Provider-specific functions (getProviderSendTitle, getProviderSendDescription) handle title and guidance text based on the provider (Slack, MS Teams, WhatsApp Business, Novu email agent).

## Testing

Smoke testing was performed on the agent setup UI for Slack to verify the copy button appears in both the code setup section and the Slack guide step. No new unit or e2e tests were added, as changes are UI-focused and covered by existing smoke testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->