### PR TITLE
fix(dashboard): limit webhook URL input width on agent details page

### DIFF
--- a/apps/dashboard/src/components/agents/agent-integration-guides/agent-integration-guide-layout.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/agent-integration-guide-layout.tsx
@@ -187,7 +187,7 @@ export function AgentIntegrationGuideLayout({
           <label htmlFor={webhookUrlId} className="text-text-sub text-label-xs font-medium leading-5">
             Webhook URL
           </label>
-          <div className="border-stroke-soft bg-bg-white flex h-7 items-center overflow-hidden rounded-md border shadow-xs">
+          <div className="border-stroke-soft bg-bg-white flex h-7 w-full max-w-[500px] items-center overflow-hidden rounded-md border shadow-xs">
             <input
               id={webhookUrlId}
               type="text"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Limits the width of the "Webhook URL" input on the agent details > integrations tab to a max of `500px` so it no longer stretches across the entire page.

## Why

On wide screens, the webhook URL input was stretching to fill the available space, which looked off and wasted horizontal real estate. Capping at 500px keeps the field compact and visually balanced while still long enough to read most URLs without scrolling.

## Changes

- `apps/dashboard/src/components/agents/agent-integration-guides/agent-integration-guide-layout.tsx`: added `w-full max-w-[500px]` to the webhook URL input wrapper.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1778071451223839?thread_ts=1778071451.223839&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-73d87f71-2295-59f8-a9a3-aa2577555794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73d87f71-2295-59f8-a9a3-aa2577555794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The webhook URL input field on the agent details integrations tab now has a constrained maximum width of 500px instead of stretching to fill available screen space. This was achieved by adding Tailwind utility classes (`w-full max-w-[500px]`) to the input wrapper in the agent integration guide layout component, ensuring the field remains visually balanced and compact on wide displays while remaining readable.

## Affected areas

**dashboard**: Constrained the width of the webhook URL input container in the agent integrations interface to prevent layout stretching on wide screens.

## Testing

This is a visual UI adjustment that can be verified through manual testing on the agent details page at various screen widths. No unit or integration tests are necessary for a layout-only change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->