### PR TITLE
feat(dashboard): nest provider instances in agent and outbound pickers

### DIFF
--- a/apps/dashboard/src/components/agents/outbound-provider-select.tsx
+++ b/apps/dashboard/src/components/agents/outbound-provider-select.tsx
@@ -6,7 +6,14 @@ import {
 } from '@novu/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
-import { RiAddLine, RiExpandUpDownLine, RiLoader4Line, RiSearchLine } from 'react-icons/ri';
+import {
+  RiAddLine,
+  RiArrowLeftSLine,
+  RiArrowRightSLine,
+  RiExpandUpDownLine,
+  RiLoader4Line,
+  RiSearchLine,
+} from 'react-icons/ri';
 import { createIntegration } from '@/api/integrations';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import {
@@ -24,7 +31,13 @@ import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { QueryKeys } from '@/utils/query-keys';
 import { cn } from '@/utils/ui';
 
-type OutboundDropdownItem = {
+type OutboundProviderType = {
+  providerId: string;
+  displayName: string;
+  integrations: IIntegration[];
+};
+
+type OutboundInstanceItem = {
   providerId: string;
   displayName: string;
   integration?: IIntegration;
@@ -33,7 +46,7 @@ type OutboundDropdownItem = {
 const EXCLUDED_OUTBOUND_PROVIDERS = new Set<string>([EmailProviderIdEnum.NovuAgent, EmailProviderIdEnum.Novu]);
 const OUTBOUND_EMAIL_PROVIDERS = emailProviderConfigs.filter((p) => !EXCLUDED_OUTBOUND_PROVIDERS.has(p.id));
 
-function buildOutboundItems(allIntegrations: IIntegration[] | undefined): OutboundDropdownItem[] {
+function buildOutboundItems(allIntegrations: IIntegration[] | undefined): OutboundProviderType[] {
   const integrationsByProvider = new Map<string, IIntegration[]>();
   for (const i of allIntegrations ?? []) {
     if (i.channel !== ChannelTypeEnum.EMAIL) continue;
@@ -43,27 +56,19 @@ function buildOutboundItems(allIntegrations: IIntegration[] | undefined): Outbou
     integrationsByProvider.set(i.providerId, list);
   }
 
-  const items: OutboundDropdownItem[] = [];
-  for (const cfg of OUTBOUND_EMAIL_PROVIDERS) {
-    const existing = integrationsByProvider.get(cfg.id);
-    if (existing?.length) {
-      for (const integration of existing) {
-        items.push({
-          providerId: cfg.id,
-          displayName: integration.name || cfg.displayName,
-          integration,
-        });
-      }
-    }
-    items.push({ providerId: cfg.id, displayName: cfg.displayName });
-  }
-
-  return items;
+  return OUTBOUND_EMAIL_PROVIDERS.map((cfg) => ({
+    providerId: cfg.id,
+    displayName: cfg.displayName,
+    integrations: integrationsByProvider.get(cfg.id) ?? [],
+  }));
 }
 
-function getItemKey(item: OutboundDropdownItem, index: number): string {
+function getInstanceKey(item: OutboundInstanceItem, index: number): string {
   return item.integration ? `${item.providerId}-${item.integration._id}` : `${item.providerId}-new-${index}`;
 }
+
+const groupHeadingClassName =
+  '**:[[cmdk-group-heading]]:text-text-soft **:[[cmdk-group-heading]]:text-label-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:leading-4 **:[[cmdk-group-heading]]:px-1 **:[[cmdk-group-heading]]:py-1';
 
 export function OutboundProviderSelect({
   selectedId,
@@ -76,18 +81,34 @@ export function OutboundProviderSelect({
 }) {
   const [open, setOpen] = useState(false);
   const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const [expandedProviderId, setExpandedProviderId] = useState<string | null>(null);
   const { integrations } = useFetchIntegrations();
   const { currentEnvironment } = useEnvironment();
   const queryClient = useQueryClient();
 
-  const items = useMemo(() => buildOutboundItems(integrations), [integrations]);
+  const providerTypes = useMemo(() => buildOutboundItems(integrations), [integrations]);
 
-  const selected = useMemo(
-    () => (selectedId ? items.find((i) => i.integration?._id === selectedId) : undefined),
-    [items, selectedId]
+  const expandedProvider = useMemo(
+    () => (expandedProviderId ? (providerTypes.find((p) => p.providerId === expandedProviderId) ?? null) : null),
+    [expandedProviderId, providerTypes]
   );
 
+  const selected = useMemo(() => {
+    if (!selectedId) return undefined;
+    for (const pt of providerTypes) {
+      const match = pt.integrations.find((i) => i._id === selectedId);
+      if (match) return { providerId: pt.providerId, displayName: match.name || pt.displayName };
+    }
+
+    return undefined;
+  }, [providerTypes, selectedId]);
+
   const isBusy = pendingKey !== null;
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) setExpandedProviderId(null);
+  }
 
   const createMutation = useMutation({
     mutationFn: async (vars: { providerId: string; name: string }) => {
@@ -109,7 +130,7 @@ export function OutboundProviderSelect({
     },
   });
 
-  async function handleSelect(item: OutboundDropdownItem, index: number) {
+  async function handleSelect(item: OutboundInstanceItem, index: number) {
     if (isBusy) return;
     if (!currentEnvironment?._id) {
       showErrorToast('No environment selected.', 'Cannot select provider');
@@ -117,7 +138,7 @@ export function OutboundProviderSelect({
       return;
     }
 
-    const key = getItemKey(item, index);
+    const key = getInstanceKey(item, index);
     setPendingKey(key);
 
     try {
@@ -137,6 +158,7 @@ export function OutboundProviderSelect({
         onSelect(created._id);
       }
       setOpen(false);
+      setExpandedProviderId(null);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Could not select provider.';
       showErrorToast(message, 'Selection failed');
@@ -144,6 +166,152 @@ export function OutboundProviderSelect({
       setPendingKey(null);
     }
   }
+
+  const collapsedList = (
+    <Command>
+      <div className="bg-bg-weak border-stroke-weak flex items-center gap-2 border-b py-1.5 pl-3 pr-3">
+        <CommandInput
+          placeholder="Search provider"
+          size="xs"
+          disabled={isBusy}
+          inputRootClassName="min-w-0 flex-1 rounded-none border-none bg-transparent shadow-none divide-none before:ring-0 has-[input:focus]:shadow-none has-[input:focus]:ring-0 focus-within:shadow-none focus-within:ring-0"
+          inputWrapperClassName="h-4 min-h-4 bg-transparent px-0 py-0 hover:[&:not(&:has(input:focus))]:bg-transparent has-[input:disabled]:bg-transparent"
+          className="text-text-sub text-label-xs leading-4 placeholder:text-text-sub h-4 min-h-4 py-0"
+        />
+        <RiSearchLine className="text-text-soft size-3 shrink-0" />
+      </div>
+      <CommandList className="max-h-[260px] p-1">
+        <CommandEmpty className="text-text-soft text-label-xs py-4">No email providers found.</CommandEmpty>
+        <CommandGroup heading="Email providers" className={groupHeadingClassName}>
+          {providerTypes.map((pt) => {
+            const hasInstances = pt.integrations.length > 0;
+            const isAnyInstanceSelected = pt.integrations.some((i) => i._id === selectedId);
+
+            return (
+              <CommandItem
+                key={pt.providerId}
+                value={`${pt.displayName} ${pt.providerId}`}
+                disabled={isBusy}
+                onSelect={() => {
+                  if (isBusy) return;
+                  if (hasInstances) {
+                    setExpandedProviderId(pt.providerId);
+
+                    return;
+                  }
+                  void handleSelect({ providerId: pt.providerId, displayName: pt.displayName }, 0);
+                }}
+                className={cn('flex items-center gap-2 rounded-md p-1', isAnyInstanceSelected && 'bg-bg-muted')}
+              >
+                <div className="flex w-full min-w-0 items-center gap-1">
+                  <ProviderIcon
+                    providerId={pt.providerId}
+                    providerDisplayName={pt.displayName}
+                    className="size-4 shrink-0"
+                  />
+                  <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-medium leading-4">
+                    {pt.displayName}
+                  </span>
+                  {hasInstances && (
+                    <span className="text-text-soft flex items-center gap-0.5 text-[10px] leading-[15px] shrink-0">
+                      {pt.integrations.length === 1 ? '1 connected' : `${pt.integrations.length} connected`}
+                      <RiArrowRightSLine className="size-3" />
+                    </span>
+                  )}
+                </div>
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+
+  const expandedList = expandedProvider && (
+    <Command>
+      <button
+        type="button"
+        onClick={() => setExpandedProviderId(null)}
+        className="bg-bg-weak border-stroke-weak hover:bg-bg-soft flex w-full items-center gap-1.5 border-b px-2 py-1.5 transition-colors"
+      >
+        <RiArrowLeftSLine className="text-text-soft size-3.5 shrink-0" />
+        <ProviderIcon
+          providerId={expandedProvider.providerId}
+          providerDisplayName={expandedProvider.displayName}
+          className="size-4 shrink-0"
+        />
+        <span className="text-text-sub text-label-xs font-medium leading-4">{expandedProvider.displayName}</span>
+      </button>
+
+      <CommandList className="max-h-[260px] p-1">
+        <CommandEmpty className="text-text-soft text-label-xs py-4">No integrations found.</CommandEmpty>
+
+        <CommandGroup heading="Existing" className={groupHeadingClassName}>
+          {expandedProvider.integrations.map((integration, index) => {
+            const item: OutboundInstanceItem = {
+              providerId: expandedProvider.providerId,
+              displayName: integration.name || expandedProvider.displayName,
+              integration,
+            };
+            const key = getInstanceKey(item, index);
+            const isRowPending = pendingKey === key;
+
+            return (
+              <CommandItem
+                key={key}
+                value={`${integration.name ?? expandedProvider.displayName} ${integration.identifier}`}
+                disabled={isBusy}
+                onSelect={() => void handleSelect(item, index)}
+                className={cn(
+                  'flex items-center gap-2 rounded-md p-1',
+                  integration._id === selectedId && 'bg-bg-muted'
+                )}
+              >
+                <div className="flex w-full min-w-0 items-center gap-1">
+                  <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-medium leading-4">
+                    {integration.name || expandedProvider.displayName}
+                  </span>
+                  {isRowPending ? (
+                    <RiLoader4Line className="text-text-soft size-3 shrink-0 animate-spin" aria-hidden />
+                  ) : (
+                    <span
+                      className="font-code text-text-soft max-w-[min(7.5rem,45%)] min-w-0 shrink truncate text-[10px] leading-[15px] tracking-[-0.2px]"
+                      title={integration.identifier}
+                    >
+                      {integration.identifier}
+                    </span>
+                  )}
+                </div>
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+
+        <div className="bg-stroke-weak mx-1 my-1 h-px" role="presentation" />
+
+        <CommandItem
+          value={`create new ${expandedProvider.displayName}`}
+          disabled={isBusy}
+          onSelect={() =>
+            void handleSelect(
+              { providerId: expandedProvider.providerId, displayName: expandedProvider.displayName },
+              expandedProvider.integrations.length
+            )
+          }
+          className="flex items-center gap-1.5 rounded-md p-1"
+        >
+          {pendingKey === `${expandedProvider.providerId}-new-${expandedProvider.integrations.length}` ? (
+            <RiLoader4Line className="text-text-soft size-3 shrink-0 animate-spin" aria-hidden />
+          ) : (
+            <RiAddLine className="text-text-soft size-3 shrink-0" aria-hidden />
+          )}
+          <span className="text-text-sub text-label-xs font-medium leading-4">
+            Create another {expandedProvider.displayName} integration
+          </span>
+        </CommandItem>
+      </CommandList>
+    </Command>
+  );
 
   return (
     <div className={cn('flex w-full flex-col gap-1', !hideLabel && 'min-w-[300px]')}>
@@ -157,7 +325,7 @@ export function OutboundProviderSelect({
       )}
 
       <div className={cn('w-full', !hideLabel && 'max-w-[320px]')}>
-        <Popover open={open} onOpenChange={setOpen}>
+        <Popover open={open} onOpenChange={handleOpenChange}>
           <PopoverTrigger asChild>
             <button
               type="button"
@@ -195,66 +363,7 @@ export function OutboundProviderSelect({
             )}
             align="start"
           >
-            <Command>
-              <div className="bg-bg-weak border-stroke-weak flex items-center gap-2 border-b py-1.5 pl-3 pr-3">
-                <CommandInput
-                  placeholder="Search provider"
-                  size="xs"
-                  disabled={isBusy}
-                  inputRootClassName="min-w-0 flex-1 rounded-none border-none bg-transparent shadow-none divide-none before:ring-0 has-[input:focus]:shadow-none has-[input:focus]:ring-0 focus-within:shadow-none focus-within:ring-0"
-                  inputWrapperClassName="h-4 min-h-4 bg-transparent px-0 py-0 hover:[&:not(&:has(input:focus))]:bg-transparent has-[input:disabled]:bg-transparent"
-                  className="text-text-sub text-label-xs leading-4 placeholder:text-text-sub h-4 min-h-4 py-0"
-                />
-                <RiSearchLine className="text-text-soft size-3 shrink-0" />
-              </div>
-              <CommandList className="max-h-[260px] p-1">
-                <CommandEmpty className="text-text-soft text-label-xs py-4">No email providers found.</CommandEmpty>
-                <CommandGroup
-                  heading="Email providers"
-                  className="**:[[cmdk-group-heading]]:text-text-soft **:[[cmdk-group-heading]]:text-label-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:leading-4 **:[[cmdk-group-heading]]:px-1 **:[[cmdk-group-heading]]:py-1"
-                >
-                  {items.map((item, index) => {
-                    const key = getItemKey(item, index);
-                    const isRowPending = pendingKey === key;
-
-                    return (
-                      <CommandItem
-                        key={key}
-                        value={`${item.displayName} ${item.providerId}${item.integration ? ` ${item.integration.identifier}` : ''}`}
-                        disabled={isBusy}
-                        onSelect={() => {
-                          void handleSelect(item, index);
-                        }}
-                        className={cn(
-                          'flex items-center gap-2 rounded-md p-1',
-                          item.integration?._id === selectedId && 'bg-bg-muted'
-                        )}
-                      >
-                        <div className="flex flex-1 items-center gap-1">
-                          <ProviderIcon
-                            providerId={item.providerId}
-                            providerDisplayName={item.displayName}
-                            className="size-4 shrink-0"
-                          />
-                          <span className="text-text-sub text-label-xs flex-1 font-medium leading-4">
-                            {item.displayName}
-                          </span>
-                        </div>
-                        {isRowPending && (
-                          <RiLoader4Line className="text-text-soft size-3 shrink-0 animate-spin" aria-hidden />
-                        )}
-                        {!isRowPending && item.integration && (
-                          <span className="font-code text-text-sub shrink-0 text-[10px] leading-[15px] tracking-[-0.2px]">
-                            {item.integration.identifier}
-                          </span>
-                        )}
-                        {!isRowPending && !item.integration && <RiAddLine className="text-text-soft size-3 shrink-0" />}
-                      </CommandItem>
-                    );
-                  })}
-                </CommandGroup>
-              </CommandList>
-            </Command>
+            {expandedProvider ? expandedList : collapsedList}
           </PopoverContent>
         </Popover>
       </div>

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -11,6 +11,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 import {
   RiAddLine,
+  RiArrowLeftSLine,
+  RiArrowRightSLine,
   RiExpandUpDownLine,
   RiExternalLinkLine,
   RiLoader4Line,
@@ -44,6 +46,17 @@ import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
 import { openInNewTab } from '@/utils/url';
 
+/** One row per provider type in the collapsed list. */
+type ProviderTypeItem = {
+  providerId: string;
+  displayName: string;
+  comingSoon: boolean;
+  requiresBusinessTier: boolean;
+  /** All existing integrations for this provider type (empty = none yet). */
+  integrations: IIntegration[];
+};
+
+/** A single integration instance shown inside the expanded sub-list. */
 type DropdownItem = {
   providerId: string;
   displayName: string;
@@ -80,60 +93,40 @@ function buildDropdownItems(
     integrationsByProvider.set(integration.providerId, list);
   }
 
-  const supported: DropdownItem[] = [];
-  const comingSoon: DropdownItem[] = [];
+  const supported: ProviderTypeItem[] = [];
+  const comingSoon: ProviderTypeItem[] = [];
 
   for (const cp of conversationalProviders) {
     const providerConfig = novuProviders.find((p) => p.id === cp.providerId);
+    const displayName = providerConfig?.displayName || cp.displayName;
 
     if (cp.comingSoon) {
       comingSoon.push({
         providerId: cp.providerId,
-        displayName: cp.displayName,
+        displayName,
         comingSoon: true,
         requiresBusinessTier: false,
+        integrations: [],
       });
       continue;
     }
 
-    const existing = integrationsByProvider.get(cp.providerId);
-
-    if (cp.providerId === EmailProviderIdEnum.NovuAgent) {
-      // NovuAgent is 1:1 with the agent — never list existing integrations
-      // (they belong to other agents). Always offer a single "create new" row.
-      supported.push({
-        providerId: cp.providerId,
-        displayName: providerConfig?.displayName || cp.displayName,
-        comingSoon: false,
-        requiresBusinessTier: cp.requiresBusinessTier ?? false,
-      });
-      continue;
-    }
-
-    if (existing?.length) {
-      for (const integration of existing) {
-        supported.push({
-          providerId: cp.providerId,
-          displayName: integration.name || providerConfig?.displayName || cp.displayName,
-          comingSoon: false,
-          requiresBusinessTier: cp.requiresBusinessTier ?? false,
-          integration,
-        });
-      }
-    }
+    const existing = integrationsByProvider.get(cp.providerId) ?? [];
 
     supported.push({
       providerId: cp.providerId,
-      displayName: providerConfig?.displayName || cp.displayName,
+      displayName,
       comingSoon: false,
       requiresBusinessTier: cp.requiresBusinessTier ?? false,
+      // NovuAgent is 1:1 per agent — never surface existing integrations from other agents.
+      integrations: cp.providerId === EmailProviderIdEnum.NovuAgent ? [] : existing,
     });
   }
 
   return { supported, comingSoon };
 }
 
-function getSupportedItemKey(item: DropdownItem, index: number): string {
+function getInstanceItemKey(item: DropdownItem, index: number): string {
   if (item.integration) {
     return `${item.providerId}-${item.integration._id}`;
   }
@@ -161,6 +154,7 @@ export function ProviderDropdown({
 }: ProviderDropdownProps) {
   const [open, setOpen] = useState(false);
   const [pendingItemKey, setPendingItemKey] = useState<string | null>(null);
+  const [expandedProviderId, setExpandedProviderId] = useState<string | null>(null);
   const { integrations } = useFetchIntegrations();
   const { currentEnvironment } = useEnvironment();
   const queryClient = useQueryClient();
@@ -176,24 +170,25 @@ export function ProviderDropdown({
   const supported = useMemo(() => {
     let items = allSupported;
 
-    const linkedNovuAgent = integrations?.find(
-      (i) => i.providerId === EmailProviderIdEnum.NovuAgent && linkedIntegrationIds?.has(i._id)
-    );
-    if (linkedNovuAgent) {
-      const cfg = novuProviders.find((p) => p.id === linkedNovuAgent.providerId);
-      items = items.map((item) =>
-        item.providerId === EmailProviderIdEnum.NovuAgent && !item.integration
-          ? {
-              ...item,
-              displayName: linkedNovuAgent.name || cfg?.displayName || item.displayName,
-              integration: linkedNovuAgent as IIntegration,
-            }
-          : item
-      );
-    }
-
     if (excludeLinked && linkedIntegrationIds?.size) {
-      items = items.filter((item) => !item.integration || !linkedIntegrationIds.has(item.integration._id));
+      items = items
+        .map((item) => ({
+          ...item,
+          integrations: item.integrations.filter((i) => !linkedIntegrationIds.has(i._id)),
+        }))
+        .filter((item) => {
+          // Keep providers that still have unlinked instances OR have no instances (create path).
+          // NovuAgent: keep only if it has no linked instance yet.
+          if (item.providerId === EmailProviderIdEnum.NovuAgent) {
+            const linkedNovuAgent = integrations?.find(
+              (i) => i.providerId === EmailProviderIdEnum.NovuAgent && linkedIntegrationIds.has(i._id)
+            );
+
+            return !linkedNovuAgent;
+          }
+
+          return true;
+        });
     }
 
     return items;
@@ -201,8 +196,12 @@ export function ProviderDropdown({
 
   const selected = useMemo(() => {
     if (selectedIntegrationId) {
-      const fromList = supported.find((item) => item.integration?._id === selectedIntegrationId);
-      if (fromList) return fromList;
+      for (const item of supported) {
+        const match = item.integrations.find((i) => i._id === selectedIntegrationId);
+        if (match) {
+          return { providerId: item.providerId, displayName: match.name || item.displayName };
+        }
+      }
 
       const fromAll = integrations?.find((i) => i._id === selectedIntegrationId);
       if (fromAll) {
@@ -211,8 +210,6 @@ export function ProviderDropdown({
         return {
           providerId: fromAll.providerId,
           displayName: fromAll.name || cfg?.displayName || fromAll.providerId,
-          comingSoon: false,
-          requiresBusinessTier: false,
         };
       }
     }
@@ -221,16 +218,23 @@ export function ProviderDropdown({
       const cfg = novuProviders.find((p) => p.id === fallbackProviderId);
 
       if (cfg) {
-        return {
-          providerId: cfg.id,
-          displayName: cfg.displayName,
-          comingSoon: false,
-        };
+        return { providerId: cfg.id, displayName: cfg.displayName };
       }
     }
 
     return undefined;
   }, [selectedIntegrationId, fallbackProviderId, supported, integrations]);
+
+  /** The provider type currently shown in the expanded sub-list view. */
+  const expandedProvider = useMemo(
+    () => (expandedProviderId ? (supported.find((p) => p.providerId === expandedProviderId) ?? null) : null),
+    [expandedProviderId, supported]
+  );
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) setExpandedProviderId(null);
+  }
 
   const isBusy = pendingItemKey !== null;
 
@@ -287,7 +291,7 @@ export function ProviderDropdown({
 
     const environmentId = environment._id;
 
-    const itemKey = getSupportedItemKey(item, index);
+    const itemKey = getInstanceItemKey(item, index);
     setPendingItemKey(itemKey);
 
     async function invalidateAgentLinkQueries() {
@@ -298,6 +302,11 @@ export function ProviderDropdown({
       await queryClient.invalidateQueries({
         queryKey: getAgentDetailQueryKey(environmentId, agentIdentifier),
       });
+    }
+
+    function closeDropdown() {
+      setOpen(false);
+      setExpandedProviderId(null);
     }
 
     try {
@@ -311,7 +320,7 @@ export function ProviderDropdown({
           mode: 'novu_email',
         });
         onSelect(item.providerId, link.integration as unknown as IIntegration);
-        setOpen(false);
+        closeDropdown();
       } else if (item.integration) {
         const alreadyLinked = linkedIntegrationIds?.has(item.integration._id);
 
@@ -333,7 +342,7 @@ export function ProviderDropdown({
         }
 
         onSelect(item.providerId, item.integration);
-        setOpen(false);
+        closeDropdown();
       } else {
         const channel = PROVIDER_ID_TO_CHANNEL_MAP[item.providerId];
         const uniqueName = channel === ChannelTypeEnum.CHAT ? (agentName ?? agentIdentifier) : item.displayName;
@@ -351,14 +360,14 @@ export function ProviderDropdown({
           mode: 'new_integration_then_link',
         });
         onSelect(item.providerId, created);
-        setOpen(false);
+        closeDropdown();
       }
 
       await invalidateAgentLinkQueries();
     } catch (err) {
       if (item.integration && isAlreadyLinkedToAgentConflict(err)) {
         onSelect(item.providerId, item.integration);
-        setOpen(false);
+        closeDropdown();
         await invalidateAgentLinkQueries();
 
         return;
@@ -398,188 +407,300 @@ export function ProviderDropdown({
     </button>
   );
 
+  const groupHeadingClassName =
+    '**:[[cmdk-group-heading]]:text-text-soft **:[[cmdk-group-heading]]:text-label-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:leading-4 **:[[cmdk-group-heading]]:px-1 **:[[cmdk-group-heading]]:py-1';
+
+  /** Collapsed view — one row per provider type. */
+  const collapsedList = (
+    <Command>
+      <div className="bg-bg-weak border-stroke-weak flex items-center gap-2 border-b py-1.5 pl-3 pr-3">
+        <CommandInput
+          placeholder="Search provider"
+          size="xs"
+          disabled={isBusy}
+          inputRootClassName="min-w-0 flex-1 rounded-none border-none bg-transparent shadow-none divide-none before:ring-0 has-[input:focus]:shadow-none has-[input:focus]:ring-0 focus-within:shadow-none focus-within:ring-0"
+          inputWrapperClassName="h-4 min-h-4 bg-transparent px-0 py-0 hover:[&:not(&:has(input:focus))]:bg-transparent has-[input:disabled]:bg-transparent"
+          className="text-text-sub text-label-xs leading-4 placeholder:text-text-sub h-4 min-h-4 py-0"
+        />
+        <RiSearchLine className="text-text-soft size-3 shrink-0" />
+      </div>
+
+      <CommandList className="max-h-[260px] p-1">
+        <CommandEmpty className="text-text-soft text-label-xs py-4">No providers found.</CommandEmpty>
+
+        {supported.length > 0 && (
+          <CommandGroup heading="Providers" className={groupHeadingClassName}>
+            {supported.map((providerType) => {
+              const isLocked = providerType.requiresBusinessTier && !isAgentEmailAvailable;
+              const hasInstances = providerType.integrations.length > 0;
+              const isNovuAgent = providerType.providerId === EmailProviderIdEnum.NovuAgent;
+              const isAnyInstanceSelected = providerType.integrations.some((i) => i._id === selectedIntegrationId);
+
+              const rowContent = (
+                <div className="flex w-full min-w-0 items-center gap-1 break-normal">
+                  <ProviderIcon
+                    providerId={providerType.providerId}
+                    providerDisplayName={providerType.displayName}
+                    className="size-4 shrink-0"
+                  />
+                  <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-medium leading-4">
+                    {providerType.displayName}
+                  </span>
+
+                  {isLocked && (
+                    <div className="flex items-center gap-1 rounded bg-red-50 px-1.5 py-0.5">
+                      <RiLockStarLine className="size-2.5 text-pink-600" />
+                      <span
+                        className="text-[9px] font-semibold uppercase leading-none"
+                        style={{
+                          background: 'linear-gradient(225deg, #FF884D 23.17%, #E300BD 80.17%)',
+                          WebkitBackgroundClip: 'text',
+                          WebkitTextFillColor: 'transparent',
+                          backgroundClip: 'text',
+                        }}
+                      >
+                        Team+
+                      </span>
+                    </div>
+                  )}
+
+                  {!isLocked && hasInstances && !isNovuAgent && (
+                    <span className="text-text-soft flex items-center gap-0.5 text-[10px] leading-[15px] shrink-0">
+                      {providerType.integrations.length === 1
+                        ? '1 connected'
+                        : `${providerType.integrations.length} connected`}
+                      <RiArrowRightSLine className="size-3" />
+                    </span>
+                  )}
+                </div>
+              );
+
+              function handleTypeRowSelect() {
+                if (isBusy || isLocked) return;
+
+                if (!isNovuAgent && hasInstances) {
+                  // Expand to show instances sub-list.
+                  setExpandedProviderId(providerType.providerId);
+
+                  return;
+                }
+
+                // 0 instances (or NovuAgent) — create immediately.
+                void handleSelect(
+                  {
+                    providerId: providerType.providerId,
+                    displayName: providerType.displayName,
+                    comingSoon: false,
+                    requiresBusinessTier: providerType.requiresBusinessTier,
+                  },
+                  0
+                );
+              }
+
+              return (
+                <CommandItem
+                  key={providerType.providerId}
+                  value={`${providerType.displayName} ${providerType.providerId}`}
+                  disabled={isBusy || isLocked}
+                  onSelect={handleTypeRowSelect}
+                  className={cn(
+                    'flex min-w-0 items-center gap-2 rounded-md p-1',
+                    isAnyInstanceSelected && 'bg-bg-muted',
+                    isLocked && '!pointer-events-auto opacity-60'
+                  )}
+                >
+                  {isLocked ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>{rowContent}</TooltipTrigger>
+                      <TooltipContent
+                        side="right"
+                        align="start"
+                        variant="light"
+                        size="lg"
+                        className="flex w-64 flex-col items-start gap-3 border border-neutral-100 p-2 shadow-md"
+                      >
+                        <div className="flex items-center gap-1 rounded bg-red-50 px-2 py-1">
+                          <RiLockStarLine className="h-3 w-3 text-pink-600" />
+                          <span
+                            className="text-[10px] font-medium uppercase leading-normal"
+                            style={{
+                              background: 'linear-gradient(225deg, #FF884D 23.17%, #E300BD 80.17%)',
+                              WebkitBackgroundClip: 'text',
+                              WebkitTextFillColor: 'transparent',
+                              backgroundClip: 'text',
+                            }}
+                          >
+                            Team feature
+                          </span>
+                        </div>
+                        <div className="flex flex-col items-start gap-3">
+                          <p className="text-xs text-neutral-500">
+                            Agent email requires the Team plan. Upgrade to connect an inbound email address.
+                          </p>
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setOpen(false);
+                              setExpandedProviderId(null);
+                              if (IS_SELF_HOSTED) {
+                                openInNewTab(
+                                  `${SELF_HOSTED_UPGRADE_REDIRECT_URL}?utm_campaign=agent_email_integration`
+                                );
+                              } else {
+                                navigate(`${ROUTES.SETTINGS_BILLING}?utm_source=agent_provider_dropdown`);
+                              }
+                            }}
+                            className="flex items-center gap-1 text-xs font-medium text-neutral-900 hover:underline"
+                          >
+                            Upgrade plan <RiExternalLinkLine className="h-3 w-3" />
+                          </button>
+                        </div>
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    rowContent
+                  )}
+                </CommandItem>
+              );
+            })}
+          </CommandGroup>
+        )}
+
+        {comingSoon.length > 0 && (
+          <CommandGroup heading="Coming soon" className={groupHeadingClassName}>
+            {comingSoon.map((item) => (
+              <CommandItem
+                key={item.providerId}
+                value={`${item.displayName} ${item.providerId}`}
+                disabled
+                className="flex items-center gap-2 rounded-md p-1 opacity-50"
+              >
+                <div className="flex flex-1 items-center gap-1">
+                  <ProviderIcon
+                    providerId={item.providerId}
+                    providerDisplayName={item.displayName}
+                    className="size-4 shrink-0"
+                  />
+                  <span className="text-text-sub text-label-xs flex-1 font-medium leading-4">{item.displayName}</span>
+                </div>
+                <span className="font-code text-text-soft shrink-0 text-[10px] leading-[15px]">soon</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </Command>
+  );
+
+  /** Expanded sub-list — instances of a specific provider type + "Create another" footer. */
+  const expandedList = expandedProvider && (
+    <Command>
+      {/* Back header */}
+      <button
+        type="button"
+        onClick={() => setExpandedProviderId(null)}
+        className="bg-bg-weak border-stroke-weak hover:bg-bg-soft flex w-full items-center gap-1.5 border-b px-2 py-1.5 transition-colors"
+      >
+        <RiArrowLeftSLine className="text-text-soft size-3.5 shrink-0" />
+        <ProviderIcon
+          providerId={expandedProvider.providerId}
+          providerDisplayName={expandedProvider.displayName}
+          className="size-4 shrink-0"
+        />
+        <span className="text-text-sub text-label-xs font-medium leading-4">{expandedProvider.displayName}</span>
+      </button>
+
+      <CommandList className="max-h-[260px] p-1">
+        <CommandEmpty className="text-text-soft text-label-xs py-4">No integrations found.</CommandEmpty>
+
+        <CommandGroup heading="Existing" className={groupHeadingClassName}>
+          {expandedProvider.integrations.map((integration, index) => {
+            const item: DropdownItem = {
+              providerId: expandedProvider.providerId,
+              displayName: integration.name || expandedProvider.displayName,
+              comingSoon: false,
+              requiresBusinessTier: expandedProvider.requiresBusinessTier,
+              integration,
+            };
+            const itemKey = getInstanceItemKey(item, index);
+            const isRowPending = pendingItemKey === itemKey;
+
+            return (
+              <CommandItem
+                key={itemKey}
+                value={`${integration.name ?? expandedProvider.displayName} ${integration.identifier}`}
+                disabled={isBusy}
+                onSelect={() => void handleSelect(item, index)}
+                className={cn(
+                  'flex min-w-0 items-center gap-2 rounded-md p-1',
+                  integration._id === selectedIntegrationId && 'bg-bg-muted'
+                )}
+              >
+                <div className="flex w-full min-w-0 items-center gap-1">
+                  <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-medium leading-4">
+                    {integration.name || expandedProvider.displayName}
+                  </span>
+                  {isRowPending ? (
+                    <RiLoader4Line className="text-text-soft size-3 shrink-0 animate-spin" aria-hidden />
+                  ) : (
+                    <span
+                      className="font-code text-text-soft max-w-[min(7.5rem,45%)] min-w-0 shrink truncate text-[10px] leading-[15px] tracking-[-0.2px]"
+                      title={integration.identifier}
+                    >
+                      {integration.identifier}
+                    </span>
+                  )}
+                </div>
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+
+        {/* Separator + Create another footer */}
+        <div className="bg-stroke-weak mx-1 my-1 h-px" role="presentation" />
+
+        <CommandItem
+          value={`create new ${expandedProvider.displayName}`}
+          disabled={isBusy}
+          onSelect={() => {
+            void handleSelect(
+              {
+                providerId: expandedProvider.providerId,
+                displayName: expandedProvider.displayName,
+                comingSoon: false,
+                requiresBusinessTier: expandedProvider.requiresBusinessTier,
+              },
+              expandedProvider.integrations.length
+            );
+          }}
+          className="flex items-center gap-1.5 rounded-md p-1"
+        >
+          {pendingItemKey === `${expandedProvider.providerId}-new-${expandedProvider.integrations.length}` ? (
+            <RiLoader4Line className="text-text-soft size-3 shrink-0 animate-spin" aria-hidden />
+          ) : (
+            <RiAddLine className="text-text-soft size-3 shrink-0" aria-hidden />
+          )}
+          <span className="text-text-sub text-label-xs font-medium leading-4">
+            Create another {expandedProvider.displayName} integration
+          </span>
+        </CommandItem>
+      </CommandList>
+    </Command>
+  );
+
   const popoverContent = (
     <PopoverContent
       className="w-(--radix-popover-trigger-width) max-w-[320px] min-w-[220px] overflow-hidden p-0"
       align="start"
     >
-      <Command>
-        <div className="bg-bg-weak border-stroke-weak flex items-center gap-2 border-b py-1.5 pl-3 pr-3">
-          <CommandInput
-            placeholder="Search provider"
-            size="xs"
-            disabled={isBusy}
-            inputRootClassName="min-w-0 flex-1 rounded-none border-none bg-transparent shadow-none divide-none before:ring-0 has-[input:focus]:shadow-none has-[input:focus]:ring-0 focus-within:shadow-none focus-within:ring-0"
-            inputWrapperClassName="h-4 min-h-4 bg-transparent px-0 py-0 hover:[&:not(&:has(input:focus))]:bg-transparent has-[input:disabled]:bg-transparent"
-            className="text-text-sub text-label-xs leading-4 placeholder:text-text-sub h-4 min-h-4 py-0"
-          />
-          <RiSearchLine className="text-text-soft size-3 shrink-0" />
-        </div>
-
-        <CommandList className="max-h-[260px] p-1">
-          <CommandEmpty className="text-text-soft text-label-xs py-4">No providers found.</CommandEmpty>
-
-          {supported.length > 0 && (
-            <CommandGroup
-              heading="Providers"
-              className="**:[[cmdk-group-heading]]:text-text-soft **:[[cmdk-group-heading]]:text-label-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:leading-4 **:[[cmdk-group-heading]]:px-1 **:[[cmdk-group-heading]]:py-1"
-            >
-              {supported.map((item, index) => {
-                const itemKey = getSupportedItemKey(item, index);
-                const isRowPending = pendingItemKey === itemKey;
-                const isLocked = item.requiresBusinessTier && !isAgentEmailAvailable;
-
-                const rowContent = (
-                  <div className="flex w-full min-w-0 items-center gap-1 break-normal">
-                    <ProviderIcon
-                      providerId={item.providerId}
-                      providerDisplayName={item.displayName}
-                      className="size-4 shrink-0"
-                    />
-                    <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-medium leading-4">
-                      {item.displayName}
-                    </span>
-
-                    {isRowPending && (
-                      <RiLoader4Line className="text-text-soft size-3 shrink-0 animate-spin" aria-hidden />
-                    )}
-                    {!isRowPending && isLocked && (
-                      <div className="flex items-center gap-1 rounded bg-red-50 px-1.5 py-0.5">
-                        <RiLockStarLine className="size-2.5 text-pink-600" />
-                        <span
-                          className="text-[9px] font-semibold uppercase leading-none"
-                          style={{
-                            background: 'linear-gradient(225deg, #FF884D 23.17%, #E300BD 80.17%)',
-                            WebkitBackgroundClip: 'text',
-                            WebkitTextFillColor: 'transparent',
-                            backgroundClip: 'text',
-                          }}
-                        >
-                          Team+
-                        </span>
-                      </div>
-                    )}
-                    {!isRowPending &&
-                      !isLocked &&
-                      item.integration &&
-                      item.providerId !== EmailProviderIdEnum.NovuAgent && (
-                        <span
-                          className="font-code text-text-sub max-w-[min(7.5rem,38%)] min-w-0 shrink truncate text-[10px] leading-[15px] tracking-[-0.2px]"
-                          title={item.integration.identifier}
-                        >
-                          {item.integration.identifier}
-                        </span>
-                      )}
-                    {!isRowPending && !isLocked && !item.integration && (
-                      <RiAddLine className="text-text-soft size-3 shrink-0" />
-                    )}
-                  </div>
-                );
-
-                return (
-                  <CommandItem
-                    key={itemKey}
-                    value={`${item.displayName} ${item.providerId}${item.integration ? ` ${item.integration.identifier}` : ''}`}
-                    disabled={isBusy || isLocked}
-                    onSelect={() => {
-                      void handleSelect(item, index);
-                    }}
-                    className={cn(
-                      'flex min-w-0 items-center gap-2 rounded-md p-1',
-                      item.integration?._id === selectedIntegrationId && 'bg-bg-muted',
-                      isLocked && '!pointer-events-auto opacity-60'
-                    )}
-                  >
-                    {isLocked ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>{rowContent}</TooltipTrigger>
-                        <TooltipContent
-                          side="right"
-                          align="start"
-                          variant="light"
-                          size="lg"
-                          className="flex w-64 flex-col items-start gap-3 border border-neutral-100 p-2 shadow-md"
-                        >
-                          <div className="flex items-center gap-1 rounded bg-red-50 px-2 py-1">
-                            <RiLockStarLine className="h-3 w-3 text-pink-600" />
-                            <span
-                              className="text-[10px] font-medium uppercase leading-normal"
-                              style={{
-                                background: 'linear-gradient(225deg, #FF884D 23.17%, #E300BD 80.17%)',
-                                WebkitBackgroundClip: 'text',
-                                WebkitTextFillColor: 'transparent',
-                                backgroundClip: 'text',
-                              }}
-                            >
-                              Team feature
-                            </span>
-                          </div>
-                          <div className="flex flex-col items-start gap-3">
-                            <p className="text-xs text-neutral-500">
-                              Agent email requires the Team plan. Upgrade to connect an inbound email address.
-                            </p>
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setOpen(false);
-                                if (IS_SELF_HOSTED) {
-                                  openInNewTab(
-                                    `${SELF_HOSTED_UPGRADE_REDIRECT_URL}?utm_campaign=agent_email_integration`
-                                  );
-                                } else {
-                                  navigate(`${ROUTES.SETTINGS_BILLING}?utm_source=agent_provider_dropdown`);
-                                }
-                              }}
-                              className="flex items-center gap-1 text-xs font-medium text-neutral-900 hover:underline"
-                            >
-                              Upgrade plan <RiExternalLinkLine className="h-3 w-3" />
-                            </button>
-                          </div>
-                        </TooltipContent>
-                      </Tooltip>
-                    ) : (
-                      rowContent
-                    )}
-                  </CommandItem>
-                );
-              })}
-            </CommandGroup>
-          )}
-
-          {comingSoon.length > 0 && (
-            <CommandGroup
-              heading="Coming soon"
-              className="**:[[cmdk-group-heading]]:text-text-soft **:[[cmdk-group-heading]]:text-label-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:leading-4 **:[[cmdk-group-heading]]:px-1 **:[[cmdk-group-heading]]:py-1"
-            >
-              {comingSoon.map((item) => (
-                <CommandItem
-                  key={item.providerId}
-                  value={`${item.displayName} ${item.providerId}`}
-                  disabled
-                  className="flex items-center gap-2 rounded-md p-1 opacity-50"
-                >
-                  <div className="flex flex-1 items-center gap-1">
-                    <ProviderIcon
-                      providerId={item.providerId}
-                      providerDisplayName={item.displayName}
-                      className="size-4 shrink-0"
-                    />
-                    <span className="text-text-sub text-label-xs flex-1 font-medium leading-4">{item.displayName}</span>
-                  </div>
-                  <span className="font-code text-text-soft shrink-0 text-[10px] leading-[15px]">soon</span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          )}
-        </CommandList>
-      </Command>
+      {expandedProvider ? expandedList : collapsedList}
     </PopoverContent>
   );
 
   if (renderTrigger) {
     return (
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>{renderTrigger({ isBusy })}</PopoverTrigger>
         {popoverContent}
       </Popover>
@@ -596,7 +717,7 @@ export function ProviderDropdown({
       </div>
 
       <div className="w-full max-w-[320px]">
-        <Popover open={open} onOpenChange={setOpen}>
+        <Popover open={open} onOpenChange={handleOpenChange}>
           <PopoverTrigger asChild>{defaultTrigger}</PopoverTrigger>
           {popoverContent}
         </Popover>

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -434,7 +434,9 @@ export function ProviderDropdown({
               const isLocked = providerType.requiresBusinessTier && !isAgentEmailAvailable;
               const hasInstances = providerType.integrations.length > 0;
               const isNovuAgent = providerType.providerId === EmailProviderIdEnum.NovuAgent;
-              const isAnyInstanceSelected = providerType.integrations.some((i) => i._id === selectedIntegrationId);
+              const isAnyInstanceSelected =
+                providerType.integrations.some((i) => i._id === selectedIntegrationId) ||
+                (isNovuAgent && selected?.providerId === EmailProviderIdEnum.NovuAgent);
 
               const rowContent = (
                 <div className="flex w-full min-w-0 items-center gap-1 break-normal">
@@ -476,16 +478,26 @@ export function ProviderDropdown({
               );
 
               function handleTypeRowSelect() {
-                if (isBusy || isLocked) return;
+                if (isBusy) return;
+
+                if (isLocked) {
+                  setOpen(false);
+                  setExpandedProviderId(null);
+                  if (IS_SELF_HOSTED) {
+                    openInNewTab(`${SELF_HOSTED_UPGRADE_REDIRECT_URL}?utm_campaign=agent_email_integration`);
+                  } else {
+                    navigate(`${ROUTES.SETTINGS_BILLING}?utm_source=agent_provider_dropdown`);
+                  }
+
+                  return;
+                }
 
                 if (!isNovuAgent && hasInstances) {
-                  // Expand to show instances sub-list.
                   setExpandedProviderId(providerType.providerId);
 
                   return;
                 }
 
-                // 0 instances (or NovuAgent) — create immediately.
                 void handleSelect(
                   {
                     providerId: providerType.providerId,
@@ -501,7 +513,8 @@ export function ProviderDropdown({
                 <CommandItem
                   key={providerType.providerId}
                   value={`${providerType.displayName} ${providerType.providerId}`}
-                  disabled={isBusy || isLocked}
+                  disabled={isBusy}
+                  aria-disabled={isLocked || undefined}
                   onSelect={handleTypeRowSelect}
                   className={cn(
                     'flex min-w-0 items-center gap-2 rounded-md p-1',
@@ -511,7 +524,9 @@ export function ProviderDropdown({
                 >
                   {isLocked ? (
                     <Tooltip>
-                      <TooltipTrigger asChild>{rowContent}</TooltipTrigger>
+                      <TooltipTrigger asChild>
+                        <div tabIndex={0} role="button">{rowContent}</div>
+                      </TooltipTrigger>
                       <TooltipContent
                         side="right"
                         align="start"


### PR DESCRIPTION
## Summary

The agent provider picker (`ProviderDropdown`) and outbound email picker (`OutboundProviderSelect`) previously listed every integration instance as its own row next to a “new” row that was only hinted by a small `+` on the right. That mixed two jobs (pick a provider type vs pick an instance) and made “create new” easy to misunderstand.

This PR uses a **two-level flow**:

1. **Collapsed list** — One row per provider type. If there are existing integrations, the row shows `N connected` and a chevron; choosing it opens a drill-in view.
2. **Expanded list** — Lists existing instances (name + identifier) and a footer action: **Create another {Provider} integration** (label + icon).

**Novu Agent email** stays a single implicit row: no instance list from other agents; selecting it still creates/links as before.

## Files touched

- `apps/dashboard/src/components/agents/provider-dropdown.tsx`
- `apps/dashboard/src/components/agents/outbound-provider-select.tsx`

## Breaking changes

None (component props and external behaviour for parents are unchanged).

## Screenshots

UI-only change — please attach before/after captures of the collapsed popover and the expanded instance list when reviewing.

## Reviewer flow

```mermaid
flowchart TD
  A[Open popover] --> B{Provider has integrations?}
  B -->|No| C[Select creates or links immediately]
  B -->|Yes| D[Expanded sub-list]
  D --> E[Choose an instance]
  D --> F[Create another integration]
  E --> G[Complete selection]
  F --> G
```

<img width="392" height="364" alt="image" src="https://github.com/user-attachments/assets/db51c03e-d5c3-49ca-a54e-e7767081a275" />

<img width="357" height="380" alt="image" src="https://github.com/user-attachments/assets/6c4ce2fa-c956-499d-b3ee-4881ca052b4e" />

<img width="362" height="383" alt="image" src="https://github.com/user-attachments/assets/c171aa8a-ad41-4d7b-953b-0a425436ae02" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The agent provider picker (ProviderDropdown) and outbound email picker (OutboundProviderSelect) were refactored from a flat list into a two-level flow: a collapsed provider list (one row per provider showing "N connected") and an expanded per-provider view that lists existing integration instances plus a "Create another {Provider}" action. This separates provider-type selection from instance selection, improving discovery and making create/link flows clearer. Novu Agent email remains an implicit single row and behaves as before.

## Affected areas
**dashboard**: Updated ProviderDropdown and OutboundProviderSelect to support hierarchical provider browsing and per-provider expansion. Internal state now tracks expandedProviderId and per-instance pending/loading states; rendering was restructured to include back navigation, group headings, provider icons, search, and inline creation flows. New internal types (e.g., OutboundProviderType, OutboundInstanceItem, ProviderTypeItem) model the provider→instances shape. Component public APIs were intentionally kept unchanged. Accessibility and keyboard behavior fixes were applied for the locked Team+ row and NovuAgent selection edge cases.

## Key technical decisions
- Keep public component signatures unchanged while migrating to an internal two-pane model to avoid breaking parent code.
- Introduced provider-level grouping and instance keys to replace previous flat item-keying, and added environment-aware creation flows that invalidate integrations queries after creation.

## Testing
No automated tests were added in this PR; manual verification is recommended for: collapsed provider listing, provider expansion and back navigation, selecting existing instances vs. creating a new integration, NovuAgent selection edge cases, and keyboard/ARIA behavior for disabled Team+ rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->