### PR TITLE
chore(root): bump @novu/framework and novu package versions

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@novu/framework",
-  "version": "2.10.1-alpha.5",
+  "version": "2.10.1-alpha.6",
   "description": "The Code-First Notifications Workflow SDK.",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/cjs/index.d.cts",

--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.8.1-rc.6",
+  "version": "2.8.1-rc.7",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Bump `@novu/framework` from `2.10.1-alpha.5` to `2.10.1-alpha.6`
- Bump `novu` CLI from `2.8.1-rc.6` to `2.8.1-rc.7`

## Test plan
- [ ] CI passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Bumped two package versions in the monorepo: @novu/framework from 2.10.1-alpha.5 to 2.10.1-alpha.6, and the novu CLI package from 2.8.1-rc.6 to 2.8.1-rc.7. These are patch-level version increments to the respective prerelease versions with no functional code changes.

## Affected areas

**framework**: Version bumped in package.json as part of the release preparation cycle.

**novu**: CLI package version incremented in package.json as part of the release preparation cycle.

## Testing

No new tests are required for version bumps. CI must pass to validate the changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->