### PR TITLE
fix(dashboard): highlight Activity Feed nav when on conversations page fixes NV-7546

### DIFF
--- a/apps/dashboard/src/components/side-navigation/navigation-link.tsx
+++ b/apps/dashboard/src/components/side-navigation/navigation-link.tsx
@@ -20,14 +20,18 @@ const linkVariants = cva(
 
 interface NavLinkProps {
   to?: string;
+  matchPaths?: string[];
   isExternal?: boolean;
   className?: string;
   children: React.ReactNode;
 }
 
-export function NavigationLink({ to, isExternal, className, children }: NavLinkProps) {
+export function NavigationLink({ to, matchPaths, isExternal, className, children }: NavLinkProps) {
   const { pathname } = useLocation();
-  const isSelected = pathname === to || (to && pathname.startsWith(to));
+  const isSelected =
+    pathname === to ||
+    (to && pathname.startsWith(to)) ||
+    matchPaths?.some((path) => pathname.startsWith(path));
   const variant = isSelected ? 'selected' : 'default';
   const classNames = cn(linkVariants({ variant, className }));
 

--- a/apps/dashboard/src/components/side-navigation/side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/side-navigation.tsx
@@ -225,6 +225,16 @@ export const SideNavigation = () => {
                           })
                         : undefined
                     }
+                    matchPaths={
+                      currentEnvironment?.slug
+                        ? [
+                            buildRoute(ROUTES.ACTIVITY_FEED, { environmentSlug: currentEnvironment.slug }),
+                            buildRoute(ROUTES.ACTIVITY_WORKFLOW_RUNS, { environmentSlug: currentEnvironment.slug }),
+                            buildRoute(ROUTES.ACTIVITY_REQUESTS, { environmentSlug: currentEnvironment.slug }),
+                            buildRoute(ROUTES.ACTIVITY_CONVERSATIONS, { environmentSlug: currentEnvironment.slug }),
+                          ]
+                        : undefined
+                    }
                   >
                     <RiBarChartBoxLine className="size-4" />
                     <span>Activity Feed</span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

When clicking a conversation from the Agent detail page, the user is redirected to the Activity Feed's "Agent conversations" tab at `/activity/conversations`. However, the sidebar "Activity Feed" navigation item was not highlighted because `NavigationLink` only matched against its `to` prop (`/activity-feed` or `/activity/workflow-runs`), neither of which is a prefix of `/activity/conversations`.

## How it was fixed

- Added a `matchPaths` prop to `NavigationLink` that accepts additional path prefixes to check when determining the selected state.
- Passed all four activity route prefixes (`ACTIVITY_FEED`, `ACTIVITY_WORKFLOW_RUNS`, `ACTIVITY_REQUESTS`, `ACTIVITY_CONVERSATIONS`) to the Activity Feed nav link so it highlights on any activity sub-route.

## Files changed

- `apps/dashboard/src/components/side-navigation/navigation-link.tsx` — added `matchPaths` prop and updated `isSelected` logic
- `apps/dashboard/src/components/side-navigation/side-navigation.tsx` — passed `matchPaths` to the Activity Feed `NavigationLink`

## Screenshots

Activity Feed highlighted on `/activity/conversations`:

![Activity Feed highlighted on conversations page](https://cursor.com/artifacts/c/art-f42b5ed3-0be0-4c59-88ec-e08e9387e414)

Activity Feed highlighted on `/activity/workflow-runs`:

![Activity Feed highlighted on workflow runs page](https://cursor.com/artifacts/c/art-05db7a59-bdd6-4f5b-bba8-5bc52da7c7be)

Activity Feed highlighted on `/activity-feed`:

![Activity Feed highlighted on activity-feed page](https://cursor.com/artifacts/c/art-7536a4c5-6d10-4bcc-84f0-66052efb6aa7)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7546](https://linear.app/novu/issue/NV-7546/missing-navigation-select-on-conversation-click-in-agent-page)

<div><a href="https://cursor.com/agents/bc-6c00ac0b-e5d0-46a1-9e03-077e3e532926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c00ac0b-e5d0-46a1-9e03-077e3e532926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `NavigationLink` component now supports partial-path matching via an optional `matchPaths` prop, allowing multiple route patterns to trigger the active state. The Activity Feed sidebar item was updated to use this new prop, highlighting on all activity sub-routes (`/activity-feed`, `/activity/workflow-runs`, `/activity/requests`, `/activity/conversations`) instead of failing to highlight when navigating to the conversations page.

## Affected areas

- **dashboard**: Added `matchPaths` prop to the `NavigationLink` component to support multiple path prefixes for active state matching. Updated the Activity Feed navigation item to highlight on all activity-related routes.

## Testing

The PR includes manual verification screenshots demonstrating the Activity Feed sidebar item remains highlighted when navigating to conversations, workflow-runs, and activity-feed pages. No automated tests were added for this UI component enhancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->