### PR TITLE
fix(api-service): add reaction events to Slack app manifests fixes NV-7478

### DIFF
--- a/apps/api/src/app/integrations/usecases/slack-quick-setup/slack-quick-setup.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/slack-quick-setup/slack-quick-setup.usecase.ts
@@ -138,6 +138,8 @@ export class SlackQuickSetup {
             'member_joined_channel',
             'assistant_thread_started',
             'assistant_thread_context_changed',
+            'reaction_added',
+            'reaction_removed',
           ],
         },
         interactivity: {

--- a/apps/dashboard/src/components/agents/slack-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/slack-setup-guide.tsx
@@ -115,6 +115,8 @@ settings:
       - member_joined_channel
       - assistant_thread_started
       - assistant_thread_context_changed
+      - reaction_added
+      - reaction_removed
   interactivity:
     is_enabled: true
     request_url: "${webhookHandlerUrlQuoted}"


### PR DESCRIPTION
## Summary

- The Slack app manifests (both the dashboard YAML template and the API quick-setup JSON builder) declared `reactions:read` / `reactions:write` OAuth scopes but never subscribed to the `reaction_added` and `reaction_removed` bot events.
- Without those event subscriptions, Slack silently drops reaction webhooks, so the agent `onReaction` handler never fires.
- Adds `reaction_added` and `reaction_removed` to the `bot_events` list in both manifest locations.

> **Note for existing Slack apps:** Apps that were already installed with the old manifest will need to manually add these two events under **Event Subscriptions → Subscribe to bot events** in the Slack API dashboard, then reinstall the app to the workspace.

## Test plan

- [ ] Create a new Slack agent using quick-setup and verify the generated manifest includes `reaction_added` and `reaction_removed` under bot events
- [ ] Create a new Slack agent using manual setup and verify the displayed YAML manifest includes both events
- [ ] Add a reaction to a bot message in Slack and confirm the `onReaction` handler fires
- [ ] Remove a reaction and confirm `onReaction` fires with `added: false`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR adds missing Slack bot event subscriptions to both Slack app manifest builders (quick-setup and manual YAML). The app previously declared OAuth scopes for reactions (reactions:read, reactions:write) but never subscribed to the corresponding bot events (reaction_added, reaction_removed), causing Slack to drop reaction webhooks. This PR adds those two bot event subscriptions to both manifest configurations so the onReaction handler fires correctly when reactions are added or removed.

## Affected areas

**api**: Updated `SlackQuickSetup.buildManifest()` to include `reaction_added` and `reaction_removed` in the `settings.event_subscriptions.bot_events` array of the programmatic manifest sent to Slack's API.

**dashboard**: Updated `buildSlackManifestYaml()` to include `reaction_added` and `reaction_removed` under `settings.event_subscriptions.bot_events` in the YAML manifest template used for manual setup.

## Testing

Manual testing is recommended: verify the generated quick-setup manifest includes both reaction events, confirm the YAML manifest includes them, and verify that adding/removing a reaction to a bot message correctly triggers the onReaction handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->