### PR TITLE
feat(inbound-mail): trace inbound mail pipeline with custom New Relic transaction

### DIFF
--- a/apps/inbound-mail/src/server/inbound-mail.newrelic.spec.ts
+++ b/apps/inbound-mail/src/server/inbound-mail.newrelic.spec.ts
@@ -122,14 +122,14 @@ async function waitForPort(host: string, port: number, timeoutMs: number): Promi
   throw new Error(`SMTP server did not start listening on ${host}:${port} within ${timeoutMs}ms`);
 }
 
-type SmtpMessage = {
+interface SmtpMessage {
   host: string;
   port: number;
   from: string;
   to: string;
   subject: string;
   body: string;
-};
+}
 
 /**
  * Minimal SMTP client used to send a single message to the mailin SMTPServer

--- a/apps/inbound-mail/src/server/inbound-mail.newrelic.spec.ts
+++ b/apps/inbound-mail/src/server/inbound-mail.newrelic.spec.ts
@@ -1,0 +1,200 @@
+import net from 'node:net';
+import { ObservabilityBackgroundTransactionEnum } from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+const newrelic = require('newrelic');
+
+import mailinServer from './index';
+
+describe('Inbound Mail New Relic instrumentation', () => {
+  let startBackgroundTransactionStub: sinon.SinonSpy;
+  let startSegmentStub: sinon.SinonSpy;
+  let addCustomAttributesStub: sinon.SinonSpy;
+
+  before(async () => {
+    startBackgroundTransactionStub = sinon.spy(newrelic, 'startBackgroundTransaction');
+    startSegmentStub = sinon.spy(newrelic, 'startSegment');
+    addCustomAttributesStub = sinon.spy(newrelic, 'addCustomAttributes');
+
+    const port = (mailinServer as unknown as { configuration: { port: number; host: string } }).configuration.port;
+    const host = (mailinServer as unknown as { configuration: { port: number; host: string } }).configuration.host;
+    await waitForPort(host, port, 10_000);
+  });
+
+  after(() => {
+    startBackgroundTransactionStub.restore();
+    startSegmentStub.restore();
+    addCustomAttributesStub.restore();
+  });
+
+  it('should wrap the inbound mail processing pipeline in a custom New Relic background transaction', async () => {
+    const port = (mailinServer as unknown as { configuration: { port: number; host: string } }).configuration.port;
+    const host = (mailinServer as unknown as { configuration: { port: number; host: string } }).configuration.host;
+
+    await sendSmtpMessage({
+      host,
+      port,
+      from: 'tracer@example.com',
+      to: 'parse+abc-nv-e=env-nr-test@reply.novu.co',
+      subject: 'NewRelic transaction smoke test',
+      body: 'verifying the inbound mail New Relic instrumentation',
+    });
+
+    await waitFor(
+      () =>
+        startBackgroundTransactionStub
+          .getCalls()
+          .some((call) => call.args[0] === ObservabilityBackgroundTransactionEnum.INBOUND_MAIL_PROCESSING) &&
+        startSegmentStub.getCalls().some((call) => call.args[0] === 'inbound-mail/unlink-file'),
+      10_000
+    );
+
+    const txCall = startBackgroundTransactionStub
+      .getCalls()
+      .find((call) => call.args[0] === ObservabilityBackgroundTransactionEnum.INBOUND_MAIL_PROCESSING);
+
+    expect(txCall, 'expected inbound-mail background transaction to be started').to.exist;
+    expect(txCall!.args[1]).to.equal('Inbound Mail');
+    expect(txCall!.args[2]).to.be.a('function');
+
+    const segmentNames = startSegmentStub.getCalls().map((call) => call.args[0]);
+    expect(segmentNames).to.include('inbound-mail/retrieve-raw-email');
+    expect(segmentNames).to.include('inbound-mail/validate-dkim');
+    expect(segmentNames).to.include('inbound-mail/validate-spf');
+    expect(segmentNames).to.include('inbound-mail/compute-spam-score');
+    expect(segmentNames).to.include('inbound-mail/parse-email');
+    expect(segmentNames).to.include('inbound-mail/detect-language');
+    expect(segmentNames).to.include('inbound-mail/post-queue');
+    expect(segmentNames).to.include('inbound-mail/unlink-file');
+
+    const attributesCall = addCustomAttributesStub
+      .getCalls()
+      .find((call) => call.args[0] && (call.args[0] as Record<string, unknown>)['mail.from'] === 'tracer@example.com');
+    expect(attributesCall, 'expected mail.from attribute to be attached').to.exist;
+  });
+});
+
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+}
+
+async function waitForPort(host: string, port: number, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const isListening = await new Promise<boolean>((resolve) => {
+      const probe = net.createConnection({ host, port });
+      probe.once('connect', () => {
+        probe.destroy();
+        resolve(true);
+      });
+      probe.once('error', () => {
+        probe.destroy();
+        resolve(false);
+      });
+    });
+    if (isListening) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`SMTP server did not start listening on ${host}:${port} within ${timeoutMs}ms`);
+}
+
+type SmtpMessage = {
+  host: string;
+  port: number;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+};
+
+/**
+ * Minimal SMTP client used to send a single message to the mailin SMTPServer
+ * without pulling in a runtime dependency. Implements just enough of RFC 5321
+ * to negotiate EHLO → MAIL FROM → RCPT TO → DATA → QUIT.
+ */
+async function sendSmtpMessage(msg: SmtpMessage): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: msg.host, port: msg.port });
+    const queue: Array<{ command: string; expect: number }> = [
+      { command: `EHLO inbound-mail-test\r\n`, expect: 250 },
+      { command: `MAIL FROM:<${msg.from}>\r\n`, expect: 250 },
+      { command: `RCPT TO:<${msg.to}>\r\n`, expect: 250 },
+      { command: `DATA\r\n`, expect: 354 },
+      {
+        command:
+          `From: ${msg.from}\r\n` +
+          `To: ${msg.to}\r\n` +
+          `Subject: ${msg.subject}\r\n` +
+          `Message-ID: <${Date.now()}@inbound-mail-test>\r\n` +
+          `\r\n` +
+          `${msg.body}\r\n` +
+          `.\r\n`,
+        expect: 250,
+      },
+      { command: `QUIT\r\n`, expect: 221 },
+    ];
+
+    let buffer = '';
+    let waitingForGreeting = true;
+    socket.setEncoding('utf8');
+
+    const cleanup = (err?: Error) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    };
+
+    const sendNext = () => {
+      const next = queue.shift();
+      if (!next) {
+        cleanup();
+        return;
+      }
+      socket.write(next.command, (err) => {
+        if (err) cleanup(err);
+      });
+      currentExpected = next.expect;
+    };
+
+    let currentExpected = 220;
+
+    socket.on('data', (chunk) => {
+      buffer += chunk;
+      const lines = buffer.split(/\r\n/);
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (line.length < 4) continue;
+        const code = Number.parseInt(line.slice(0, 3), 10);
+        const isFinal = line[3] === ' ';
+        if (!isFinal) continue;
+
+        if (code !== currentExpected) {
+          cleanup(new Error(`Unexpected SMTP response: ${line} (expected ${currentExpected})`));
+          return;
+        }
+
+        if (waitingForGreeting) {
+          waitingForGreeting = false;
+        }
+
+        sendNext();
+      }
+    });
+
+    socket.on('error', cleanup);
+    socket.on('end', () => {
+      if (queue.length > 0) cleanup(new Error('SMTP connection closed before completion'));
+    });
+  });
+}

--- a/apps/inbound-mail/src/server/inbound-mail.newrelic.spec.ts
+++ b/apps/inbound-mail/src/server/inbound-mail.newrelic.spec.ts
@@ -68,10 +68,28 @@ describe('Inbound Mail New Relic instrumentation', () => {
     expect(segmentNames).to.include('inbound-mail/post-queue');
     expect(segmentNames).to.include('inbound-mail/unlink-file');
 
-    const attributesCall = addCustomAttributesStub
-      .getCalls()
-      .find((call) => call.args[0] && (call.args[0] as Record<string, unknown>)['mail.from'] === 'tracer@example.com');
-    expect(attributesCall, 'expected mail.from attribute to be attached').to.exist;
+    const allAttributeKeys = new Set<string>();
+    for (const call of addCustomAttributesStub.getCalls()) {
+      const payload = call.args[0] as Record<string, unknown> | undefined;
+      if (!payload) continue;
+      for (const key of Object.keys(payload)) {
+        allAttributeKeys.add(key);
+      }
+    }
+
+    expect(allAttributeKeys, 'expected non-PII connection attribute to be attached').to.include('mail.connectionId');
+    expect(allAttributeKeys, 'expected envelope recipient count attribute to be attached').to.include(
+      'mail.envelopeRecipientCount'
+    );
+    expect(allAttributeKeys, 'expected DKIM result attribute to be attached').to.include('mail.dkim');
+    expect(allAttributeKeys, 'expected SPF result attribute to be attached').to.include('mail.spf');
+    expect(allAttributeKeys, 'expected spam score attribute to be attached').to.include('mail.spamScore');
+    expect(allAttributeKeys, 'expected queue route type attribute to be attached').to.include('mail.queue.routeType');
+
+    const piiKeys = ['mail.from', 'mail.to', 'mail.remoteAddress', 'mail.clientHostname', 'mail.messageId'];
+    for (const piiKey of piiKeys) {
+      expect(allAttributeKeys, `did not expect PII attribute ${piiKey} to be attached`).to.not.include(piiKey);
+    }
   });
 });
 

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import { BullMqService } from '@novu/application-generic';
+import { ObservabilityBackgroundTransactionEnum } from '@novu/shared';
 import Promise from 'bluebird';
 import dns from 'dns';
 import events from 'events';
@@ -15,6 +16,8 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { InboundMailService } from './inbound-mail.service';
 import logger from './logger';
+
+const nr = require('newrelic');
 
 const LOG_CONTEXT = 'Mailin';
 
@@ -168,167 +171,245 @@ class Mailin extends events.EventEmitter {
     }
 
     function dataReady(connection) {
-      logger.info(
-        { context: LOG_CONTEXT, connectionId: connection.id },
-        `${connection.id} Processing message from ${connection.envelope.mailFrom.address}`
-      );
+      return new Promise<void>((resolve, reject) => {
+        nr.startBackgroundTransaction(
+          ObservabilityBackgroundTransactionEnum.INBOUND_MAIL_PROCESSING,
+          'Inbound Mail',
+          () => {
+            const transaction = nr.getTransaction();
 
-      return retrieveRawEmail(connection)
-        .then((rawEmail) =>
-          Promise.all([
-            rawEmail,
-            validateDkim(connection, rawEmail),
-            validateSpf(connection),
-            computeSpamScore(connection, rawEmail),
-            parseEmail(connection),
-          ])
-        )
-        .then(([rawEmail, isDkimValid, isSpfValid, spamScore, parsedEmail]) =>
-          Promise.all([
-            connection,
-            rawEmail,
-            isDkimValid,
-            isSpfValid,
-            spamScore,
-            parsedEmail,
-            detectLanguage(connection, parsedEmail.text),
-          ])
-        )
-        .then(function ([connectionFinalize, rawEmail, isDkimValid, isSpfValid, spamScore, parsedEmail, language]) {
-          const args = [connectionFinalize, rawEmail, isDkimValid, isSpfValid, spamScore, parsedEmail, language];
+            try {
+              nr.addCustomAttributes({
+                'mail.connectionId': connection.id,
+                'mail.from': connection.envelope?.mailFrom?.address,
+                'mail.to': Array.isArray(connection.envelope?.rcptTo)
+                  ? connection.envelope.rcptTo.map((rcpt) => rcpt.address).join(',')
+                  : undefined,
+                'mail.remoteAddress': connection.remoteAddress,
+                'mail.clientHostname': connection.clientHostname,
+              });
+            } catch (attributeError) {
+              logger.warn(
+                { err: attributeError, context: LOG_CONTEXT, connectionId: connection.id },
+                'Failed to attach inbound mail New Relic attributes'
+              );
+            }
 
-          return finalizeMessage.apply(this, args);
-        })
-        .then(postQueue.bind(null, connection))
-        .then(unlinkFile.bind(null, connection))
-        .catch((error) => {
-          logger.error(
-            { err: error, context: LOG_CONTEXT, connectionId: connection.id },
-            `${connection.id} Unable to finish processing message!!`
-          );
-          throw error;
-        });
-    }
+            logger.info(
+              { context: LOG_CONTEXT, connectionId: connection.id },
+              `${connection.id} Processing message from ${connection.envelope.mailFrom.address}`
+            );
 
-    function retrieveRawEmail(connection) {
-      return fs.promises.readFile(connection.mailPath).then((rawEmail) => rawEmail.toString());
-    }
+            return retrieveRawEmail(connection)
+              .then((rawEmail) =>
+                Promise.all([
+                  rawEmail,
+                  validateDkim(connection, rawEmail),
+                  validateSpf(connection),
+                  computeSpamScore(connection, rawEmail),
+                  parseEmail(connection),
+                ])
+              )
+              .then(([rawEmail, isDkimValid, isSpfValid, spamScore, parsedEmail]) =>
+                Promise.all([
+                  connection,
+                  rawEmail,
+                  isDkimValid,
+                  isSpfValid,
+                  spamScore,
+                  parsedEmail,
+                  detectLanguage(connection, parsedEmail.text),
+                ])
+              )
+              .then(function ([
+                connectionFinalize,
+                rawEmail,
+                isDkimValid,
+                isSpfValid,
+                spamScore,
+                parsedEmail,
+                language,
+              ]) {
+                const args = [connectionFinalize, rawEmail, isDkimValid, isSpfValid, spamScore, parsedEmail, language];
 
-    function validateDkim(connection, rawEmail) {
-      if (configuration.disableDkim) {
-        return Promise.resolve(false);
-      }
+                return finalizeMessage.apply(this, args);
+              })
+              .then((finalizedMessage) => {
+                try {
+                  nr.addCustomAttributes({
+                    'mail.messageId': finalizedMessage?.messageId,
+                    'mail.dkim': finalizedMessage?.dkim,
+                    'mail.spf': finalizedMessage?.spf,
+                    'mail.spamScore': finalizedMessage?.spamScore,
+                    'mail.language': finalizedMessage?.language,
+                    'mail.attachmentCount': Array.isArray(finalizedMessage?.attachments)
+                      ? finalizedMessage.attachments.length
+                      : 0,
+                  });
+                } catch (attributeError) {
+                  logger.warn(
+                    { err: attributeError, context: LOG_CONTEXT, connectionId: connection.id },
+                    'Failed to attach inbound mail finalized New Relic attributes'
+                  );
+                }
 
-      logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Validating dkim.`);
-
-      return mailUtilities.validateDkimAsync(rawEmail).catch((err) => {
-        logger.error(
-          { err, context: LOG_CONTEXT, connectionId: connection.id },
-          `${connection.id} Unable to validate dkim. Consider dkim as failed.`
+                return finalizedMessage;
+              })
+              .then(postQueue.bind(null, connection))
+              .then(unlinkFile.bind(null, connection))
+              .then(() => resolve())
+              .catch((error) => {
+                nr.noticeError(error);
+                logger.error(
+                  { err: error, context: LOG_CONTEXT, connectionId: connection.id },
+                  `${connection.id} Unable to finish processing message!!`
+                );
+                reject(error);
+              })
+              .finally(() => {
+                if (transaction) {
+                  transaction.end();
+                }
+              });
+          }
         );
-
-        return false;
       });
     }
 
-    function validateSpf(connection) {
-      if (configuration.disableSpf) {
-        return Promise.resolve(false);
-      }
+    function retrieveRawEmail(connection) {
+      return nr.startSegment('inbound-mail/retrieve-raw-email', true, () =>
+        fs.promises.readFile(connection.mailPath).then((rawEmail) => rawEmail.toString())
+      );
+    }
 
-      logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Validating spf.`);
+    function validateDkim(connection, rawEmail) {
+      return nr.startSegment('inbound-mail/validate-dkim', true, () => {
+        if (configuration.disableDkim) {
+          return Promise.resolve(false);
+        }
 
-      /* Get ip and host. */
-      return mailUtilities
-        .validateSpfAsync(connection.remoteAddress, connection.from, connection.clientHostname)
-        .catch((err) => {
+        logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Validating dkim.`);
+
+        return mailUtilities.validateDkimAsync(rawEmail).catch((err) => {
           logger.error(
             { err, context: LOG_CONTEXT, connectionId: connection.id },
-            `${connection.id} Unable to validate spf. Consider spf as failed.`
+            `${connection.id} Unable to validate dkim. Consider dkim as failed.`
           );
 
           return false;
         });
+      });
+    }
+
+    function validateSpf(connection) {
+      return nr.startSegment('inbound-mail/validate-spf', true, () => {
+        if (configuration.disableSpf) {
+          return Promise.resolve(false);
+        }
+
+        logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Validating spf.`);
+
+        /* Get ip and host. */
+        return mailUtilities
+          .validateSpfAsync(connection.remoteAddress, connection.from, connection.clientHostname)
+          .catch((err) => {
+            logger.error(
+              { err, context: LOG_CONTEXT, connectionId: connection.id },
+              `${connection.id} Unable to validate spf. Consider spf as failed.`
+            );
+
+            return false;
+          });
+      });
     }
 
     function computeSpamScore(connection, rawEmail) {
-      if (configuration.disableSpamScore) {
-        return Promise.resolve(0.0);
-      }
+      return nr.startSegment('inbound-mail/compute-spam-score', true, () => {
+        if (configuration.disableSpamScore) {
+          return Promise.resolve(0.0);
+        }
 
-      return mailUtilities.computeSpamScoreAsync(rawEmail).catch((err) => {
-        logger.error(
-          { err, context: LOG_CONTEXT, connectionId: connection.id },
-          `${connection.id} Unable to compute spam score. Set spam score to 0.`
-        );
+        return mailUtilities.computeSpamScoreAsync(rawEmail).catch((err) => {
+          logger.error(
+            { err, context: LOG_CONTEXT, connectionId: connection.id },
+            `${connection.id} Unable to compute spam score. Set spam score to 0.`
+          );
 
-        return 0.0;
+          return 0.0;
+        });
       });
     }
 
     function parseEmail(connection) {
-      return new Promise((resolve) => {
-        logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Parsing email.`);
+      return nr.startSegment(
+        'inbound-mail/parse-email',
+        true,
+        () =>
+          new Promise((resolve) => {
+            logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Parsing email.`);
 
-        /* Prepare the mail parser. */
-        const mailParser = new MailParser();
+            /* Prepare the mail parser. */
+            const mailParser = new MailParser();
 
-        mailParser.on('end', (mail) => {
-          /*
-           * logger.verbose(util.inspect(mail, {
-           * depth: 5
-           * }));
-           */
+            mailParser.on('end', (mail) => {
+              /*
+               * logger.verbose(util.inspect(mail, {
+               * depth: 5
+               * }));
+               */
 
-          /*
-           * Make sure that both text and html versions of the
-           * body are available.
-           */
-          if (!mail.text && !mail.html) {
-            mail.text = '';
-            mail.html = '<div></div>';
-          } else if (!mail.html) {
-            mail.html = _this._convertTextToHtml(mail.text);
-          } else if (!mail.text) {
-            mail.text = _this._convertHtmlToText(mail.html);
-          }
+              /*
+               * Make sure that both text and html versions of the
+               * body are available.
+               */
+              if (!mail.text && !mail.html) {
+                mail.text = '';
+                mail.html = '<div></div>';
+              } else if (!mail.html) {
+                mail.html = _this._convertTextToHtml(mail.text);
+              } else if (!mail.text) {
+                mail.text = _this._convertHtmlToText(mail.html);
+              }
 
-          return resolve(mail);
-        });
+              return resolve(mail);
+            });
 
-        /* Stream the written email to the parser. */
-        fs.createReadStream(connection.mailPath).pipe(mailParser);
-      });
+            /* Stream the written email to the parser. */
+            fs.createReadStream(connection.mailPath).pipe(mailParser);
+          })
+      );
     }
 
     function detectLanguage(connection, text) {
-      logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Detecting language.`);
+      return nr.startSegment('inbound-mail/detect-language', true, () => {
+        logger.verbose({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Detecting language.`);
 
-      let language = '';
+        let language = '';
 
-      const languageDetector = new LanguageDetect();
-      const potentialLanguages = languageDetector.detect(text, 2);
-      if (potentialLanguages.length !== 0) {
-        logger.verbose(
-          { context: LOG_CONTEXT, connectionId: connection.id },
-          `Potential languages: ${util.inspect(potentialLanguages, {
-            depth: 5,
-          })}`
-        );
+        const languageDetector = new LanguageDetect();
+        const potentialLanguages = languageDetector.detect(text, 2);
+        if (potentialLanguages.length !== 0) {
+          logger.verbose(
+            { context: LOG_CONTEXT, connectionId: connection.id },
+            `Potential languages: ${util.inspect(potentialLanguages, {
+              depth: 5,
+            })}`
+          );
 
-        /*
-         * Use the first detected language.
-         * potentialLanguages = [['english', 0.5969], ['hungarian', 0.40563]]
-         */
-        language = potentialLanguages[0][0];
-      } else {
-        logger.info(
-          { context: LOG_CONTEXT, connectionId: connection.id },
-          `${connection.id} Unable to detect language for the current message.`
-        );
-      }
+          /*
+           * Use the first detected language.
+           * potentialLanguages = [['english', 0.5969], ['hungarian', 0.40563]]
+           */
+          language = potentialLanguages[0][0];
+        } else {
+          logger.info(
+            { context: LOG_CONTEXT, connectionId: connection.id },
+            `${connection.id} Unable to detect language for the current message.`
+          );
+        }
 
-      return language;
+        return language;
+      });
     }
 
     function finalizeMessage(connection, rawEmail, isDkimValid, isSpfValid, spamScore, parsedEmail, language) {
@@ -377,44 +458,65 @@ class Mailin extends events.EventEmitter {
     }
 
     function postQueue(connection, finalizedMessage) {
-      return new Promise((resolve) => {
-        logger.debug(
-          { context: LOG_CONTEXT, connectionId: connection.id },
-          `${connection.id} finalized message is: ${finalizedMessage}`
-        );
+      return nr.startSegment(
+        'inbound-mail/post-queue',
+        true,
+        () =>
+          new Promise((resolve) => {
+            logger.debug(
+              { context: LOG_CONTEXT, connectionId: connection.id },
+              `${connection.id} finalized message is: ${finalizedMessage}`
+            );
 
-        logger.info({ context: LOG_CONTEXT, connectionId: connection.id }, `${connection.id} Adding mail to queue `);
+            logger.info(
+              { context: LOG_CONTEXT, connectionId: connection.id },
+              `${connection.id} Adding mail to queue `
+            );
 
-        const toAddress = getAddressTo(finalizedMessage);
-        const parts: string[] = toAddress.split('@');
-        const username: string = parts[0];
-        const domainPart: string = parts[1];
+            const toAddress = getAddressTo(finalizedMessage);
+            const parts: string[] = toAddress.split('@');
+            const username: string = parts[0];
+            const domainPart: string = parts[1];
 
-        /*
-         * Legacy reply-to addresses encode the environmentId in the username segment
-         * (e.g. parse+txnId-nv-e=envId@domain). For plain domain-route addresses
-         * (e.g. support@customer.com) fall back to the domain part as the groupId
-         * so BullMQ can still bucket concurrent jobs by domain.
-         */
-        const groupId = username.includes('-nv-e=') ? username.split('-nv-e=').at(-1) : domainPart;
+            /*
+             * Legacy reply-to addresses encode the environmentId in the username segment
+             * (e.g. parse+txnId-nv-e=envId@domain). For plain domain-route addresses
+             * (e.g. support@customer.com) fall back to the domain part as the groupId
+             * so BullMQ can still bucket concurrent jobs by domain.
+             */
+            const groupId = username.includes('-nv-e=') ? username.split('-nv-e=').at(-1) : domainPart;
 
-        inboundMailService.inboundParseQueueService.add({
-          name: finalizedMessage.messageId,
-          data: finalizedMessage,
-          groupId,
-        });
+            try {
+              nr.addCustomAttributes({
+                'mail.queue.groupId': groupId,
+                'mail.queue.recipientDomain': domainPart,
+              });
+            } catch {
+              // ignore — instrumentation must never break the pipeline
+            }
 
-        return resolve();
-      });
+            inboundMailService.inboundParseQueueService.add({
+              name: finalizedMessage.messageId,
+              data: finalizedMessage,
+              groupId,
+            });
+
+            return resolve();
+          })
+      );
     }
     function unlinkFile(connection) {
-      /* Don't forget to unlink the tmp file. */
-      return fs.promises.unlink(connection.mailPath).then(() => {
-        logger.info(
-          { context: LOG_CONTEXT, connectionId: connection.id },
-          `${connection.id} End processing message, deleted ${connection.mailPath}`
-        );
-      });
+      return nr.startSegment('inbound-mail/unlink-file', true, () =>
+        /* Don't forget to unlink the tmp file. */
+        fs.promises
+          .unlink(connection.mailPath)
+          .then(() => {
+            logger.info(
+              { context: LOG_CONTEXT, connectionId: connection.id },
+              `${connection.id} End processing message, deleted ${connection.mailPath}`
+            );
+          })
+      );
     }
 
     let _session;
@@ -455,6 +557,7 @@ class Mailin extends events.EventEmitter {
           _this.emit('error', connection, error);
         });
       } catch (error) {
+        nr.noticeError(error);
         logger.error({ err: error, context: LOG_CONTEXT }, 'Exception occurred while performing onData callback');
       }
     }

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -179,14 +179,20 @@ class Mailin extends events.EventEmitter {
             const transaction = nr.getTransaction();
 
             try {
+              /*
+               * Attach only non-PII / non-attacker-controlled metadata. Sender and
+               * recipient addresses, client IPs, and HELO hostnames are intentionally
+               * omitted so attacker-controlled inbound SMTP traffic cannot leak
+               * personal/network identifiers into our APM backend. Use connectionId
+               * to correlate with our own pino logs when investigating an incident.
+               */
               nr.addCustomAttributes({
                 'mail.connectionId': connection.id,
-                'mail.from': connection.envelope?.mailFrom?.address,
-                'mail.to': Array.isArray(connection.envelope?.rcptTo)
-                  ? connection.envelope.rcptTo.map((rcpt) => rcpt.address).join(',')
-                  : undefined,
-                'mail.remoteAddress': connection.remoteAddress,
-                'mail.clientHostname': connection.clientHostname,
+                'mail.envelopeRecipientCount': Array.isArray(connection.envelope?.rcptTo)
+                  ? connection.envelope.rcptTo.length
+                  : 0,
+                'mail.hasEnvelopeFrom': Boolean(connection.envelope?.mailFrom?.address),
+                'mail.transmissionType': connection.secure ? 'secure' : 'plain',
               });
             } catch (attributeError) {
               logger.warn(
@@ -236,14 +242,23 @@ class Mailin extends events.EventEmitter {
               })
               .then((finalizedMessage) => {
                 try {
+                  /*
+                   * Only operational/aggregate metadata — no Message-ID (can echo
+                   * sender content), no addresses, no headers. These are safe to
+                   * export to APM regardless of how attacker-controlled the
+                   * underlying email is.
+                   */
                   nr.addCustomAttributes({
-                    'mail.messageId': finalizedMessage?.messageId,
                     'mail.dkim': finalizedMessage?.dkim,
                     'mail.spf': finalizedMessage?.spf,
                     'mail.spamScore': finalizedMessage?.spamScore,
                     'mail.language': finalizedMessage?.language,
                     'mail.attachmentCount': Array.isArray(finalizedMessage?.attachments)
                       ? finalizedMessage.attachments.length
+                      : 0,
+                    'mail.hasInReplyTo': Boolean(finalizedMessage?.inReplyTo),
+                    'mail.referencesCount': Array.isArray(finalizedMessage?.references)
+                      ? finalizedMessage.references.length
                       : 0,
                   });
                 } catch (attributeError) {
@@ -484,12 +499,19 @@ class Mailin extends events.EventEmitter {
              * (e.g. support@customer.com) fall back to the domain part as the groupId
              * so BullMQ can still bucket concurrent jobs by domain.
              */
-            const groupId = username.includes('-nv-e=') ? username.split('-nv-e=').at(-1) : domainPart;
+            const isLegacyReplyToRoute = username.includes('-nv-e=');
+            const groupId = isLegacyReplyToRoute ? username.split('-nv-e=').at(-1) : domainPart;
 
             try {
+              /*
+               * Only emit groupId when it's a Novu-internal environmentId (legacy
+               * reply-to route). For domain-routed mail the groupId is the
+               * recipient's domain — that's tenant/PII-adjacent metadata, so we
+               * report only the routing strategy instead of the domain itself.
+               */
               nr.addCustomAttributes({
-                'mail.queue.groupId': groupId,
-                'mail.queue.recipientDomain': domainPart,
+                'mail.queue.routeType': isLegacyReplyToRoute ? 'reply-to' : 'domain',
+                ...(isLegacyReplyToRoute ? { 'mail.queue.environmentId': groupId } : {}),
               });
             } catch {
               // ignore — instrumentation must never break the pipeline

--- a/packages/shared/src/config/job-queue.ts
+++ b/packages/shared/src/config/job-queue.ts
@@ -22,6 +22,7 @@ export enum ObservabilityBackgroundTransactionEnum {
   WS_SOCKET_HANDLE_DISCONNECT = 'ws_socket_handle_disconnect',
   CRON_JOB_QUEUE = 'cron-job-queue',
   CLICKHOUSE_BATCH_FLUSH = 'clickhouse-batch-flush',
+  INBOUND_MAIL_PROCESSING = 'inbound-mail-processing',
 }
 
 export enum JobCronNameEnum {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a custom New Relic background transaction (`inbound-mail-processing`) around the inbound mail processing pipeline so the SMTP-driven flows in `apps/inbound-mail` are now visible in New Relic alongside the rest of the platform.

## Why

The inbound mail service recently started loading the New Relic agent, but because its work is driven by SMTP (not HTTP) no transactions were ever recorded. As a result, throughput, latency, and error visibility for inbound mail processing were missing from APM. This change introduces an explicit background transaction that mirrors how the worker / ws / cron services already report custom transactions.

## What changes

- `packages/shared`: add `INBOUND_MAIL_PROCESSING = 'inbound-mail-processing'` to `ObservabilityBackgroundTransactionEnum` so the transaction name lives next to the existing observability identifiers.
- `apps/inbound-mail/src/server/index.ts`:
  - Wrap the entire `dataReady` pipeline (read raw email → DKIM/SPF/spam → parse → language detect → finalize → enqueue → unlink) in `nr.startBackgroundTransaction(INBOUND_MAIL_PROCESSING, 'Inbound Mail', …)` and end the transaction in `finally`.
  - Wrap each pipeline step in `nr.startSegment(...)` so each phase is reported as a sub-segment: `inbound-mail/retrieve-raw-email`, `inbound-mail/validate-dkim`, `inbound-mail/validate-spf`, `inbound-mail/compute-spam-score`, `inbound-mail/parse-email`, `inbound-mail/detect-language`, `inbound-mail/post-queue`, `inbound-mail/unlink-file`.
  - Attach **non-PII / non-attacker-controlled** custom attributes via `nr.addCustomAttributes`. Inbound SMTP traffic is attacker-controlled, so addresses, IPs, HELO hostnames and Message-IDs are intentionally **not** exported; we only emit safe aggregates and Novu-internal identifiers:
    - `mail.connectionId` (random per-connection UUID — for correlating with our own pino logs)
    - `mail.envelopeRecipientCount`, `mail.hasEnvelopeFrom`, `mail.transmissionType`
    - `mail.dkim`, `mail.spf`, `mail.spamScore`, `mail.language`, `mail.attachmentCount`
    - `mail.hasInReplyTo`, `mail.referencesCount`
    - `mail.queue.routeType` (`'reply-to'` or `'domain'`) — and `mail.queue.environmentId` only when the route is the legacy reply-to route where the value is a Novu-internal env id (never the recipient's domain)
  - Report errors through `nr.noticeError` both inside the pipeline catch handler and inside the `onData` exception path.
- `apps/inbound-mail/src/server/inbound-mail.newrelic.spec.ts` (new): spec that boots the mailin server (via the existing `e2e/setup.ts`), sends an SMTP message via a small raw-socket client (no new dependency), and asserts:
  - `nr.startBackgroundTransaction` was called with `INBOUND_MAIL_PROCESSING` / `'Inbound Mail'`
  - All eight expected `nr.startSegment` names were recorded
  - The canonical non-PII attribute set is present (`mail.connectionId`, `mail.envelopeRecipientCount`, `mail.dkim`, `mail.spf`, `mail.spamScore`, `mail.queue.routeType`)
  - The disallowed PII keys `mail.from` / `mail.to` / `mail.remoteAddress` / `mail.clientHostname` / `mail.messageId` are **not** attached

## Flow

```mermaid
sequenceDiagram
  participant SMTP as SMTP client
  participant Server as Mailin SMTPServer
  participant NR as New Relic
  participant Pipeline as dataReady pipeline
  participant Queue as InboundParseQueue (BullMQ)

  SMTP->>Server: DATA stream
  Server->>NR: startBackgroundTransaction(INBOUND_MAIL_PROCESSING)
  NR->>Pipeline: invoke handler
  Pipeline->>NR: addCustomAttributes(non-PII mail.*)
  Pipeline->>NR: startSegment(retrieve-raw-email)
  Pipeline->>NR: startSegment(validate-dkim / validate-spf / compute-spam-score / parse-email)
  Pipeline->>NR: startSegment(detect-language)
  Pipeline->>NR: startSegment(post-queue)
  Pipeline->>Queue: add(finalizedMessage)
  Pipeline->>NR: startSegment(unlink-file)
  Pipeline->>NR: transaction.end()
```

## Testing

- `pnpm --filter @novu/shared build` — passes (esm build + circular-dep check).
- `cd apps/inbound-mail && pnpm build` — passes.
- `cd apps/inbound-mail && pnpm lint` — passes (only pre-existing warnings).
- `cd apps/inbound-mail && pnpm test` — the new `Inbound Mail New Relic instrumentation` spec is green and confirms both the canonical non-PII attribute set and the absence of all PII keys. The pre-existing `inbound-mail.service.spec.ts` is flaky on the base `next` branch in this environment (verified by reverting my changes and reproducing the same `obliterate` timeout) and is unrelated to this PR.
- Manual end-to-end: started `apps/inbound-mail` against the local Redis with `NEW_RELIC_APP_NAME` / `NEW_RELIC_LICENSE_KEY` set, sent an SMTP message via nodemailer to port 2525, and confirmed in the logs that the full pipeline (`Receiving message → Processing message → Adding mail to queue → BullMQ enqueue → End processing message`) completes successfully with the New Relic agent loaded — proving the wrapping is fully transparent to the existing flow.

## Risk / blast radius

- Changes are confined to `apps/inbound-mail` plus a single additive enum value in `packages/shared`.
- No behavior changes to the SMTP pipeline itself: the New Relic helpers are pass-through wrappers, and all `nr.*` attribute calls are guarded with `try/catch` so instrumentation can never break processing.
- Other consumers of `ObservabilityBackgroundTransactionEnum` are unaffected (additive enum).
- No PII / attacker-controlled inbound SMTP content is exported to APM — `mail.connectionId` is the only correlator, intentionally a per-connection random UUID.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1778145892125099?thread_ts=1778145892.125099&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-25a9b7e3-719b-51eb-a88d-4fcfbe254146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25a9b7e3-719b-51eb-a88d-4fcfbe254146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Inbound-mail now emits explicit New Relic APM instrumentation so SMTP-driven message flows are visible in monitoring. The per-message pipeline is wrapped in a background transaction and each major step is instrumented as a performance segment; non-PII mail metadata and validation scores are attached as custom attributes and errors are reported to New Relic without altering pipeline behavior.

## Affected areas

**apps/inbound-mail**: The mail processing server wraps end-to-end message handling in a New Relic background transaction (`INBOUND_MAIL_PROCESSING`) and instruments eight segments (retrieve-raw-email, validate-dkim, validate-spf, compute-spam-score, parse-email, detect-language, post-queue, unlink-file). Custom attributes now attach safe, non-PII aggregates (connectionId, envelopeRecipientCount, hasEnvelopeFrom, transmissionType, dkim, spf, spamScore, language, attachmentCount, hasInReplyTo, referencesCount, queue.routeType, and conditional queue.environmentId) while explicitly avoiding attacker-controlled PII (addresses, IPs, HELO, Message-IDs). Failures to add attributes are logged as warnings; failures in instrumentation do not change pipeline semantics. Errors in processing are reported with nr.noticeError.

**packages/shared**: Added a new enum member `INBOUND_MAIL_PROCESSING = 'inbound-mail-processing'` to ObservabilityBackgroundTransactionEnum for the new background transaction.

## Key technical decisions

- New Relic calls are guarded so missing/disabled instrumentation cannot affect message processing.  
- Attribute attachment errors are caught and downgraded to warnings to avoid breaking the pipeline.  
- PII is deliberately excluded; only aggregated/non-PII attributes are exported.

## Testing

Adds an integration-style test (apps/inbound-mail/src/server/inbound-mail.newrelic.spec.ts) that boots the server, sends an SMTP message over TCP, stubs New Relic APIs, and asserts the background transaction, all segments, presence of canonical non-PII attributes, and absence of disallowed PII keys; manual end-to-end verification with the New Relic agent was also performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->