### PR TITLE
fix(dashboard): add tooltip to Bridge URL warning icon fixes NV-7547

### DIFF
--- a/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
+++ b/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
@@ -93,11 +93,14 @@ function BridgeUrlSection({ agent, canWrite, isUpdatePending, onUpdate, readOnly
           {!displayUrl && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="inline-flex cursor-pointer">
+                <span className="inline-flex cursor-help" tabIndex={0} aria-label="Bridge URL not configured">
                   <RiAlertFill className="size-3.5 text-orange-500" />
                 </span>
               </TooltipTrigger>
-              <TooltipContent>Bridge URL is required for the agent to receive messages</TooltipContent>
+              <TooltipContent>
+                Set the public URL of your deployed agent server so it can receive messages outside of local
+                mode
+              </TooltipContent>
             </Tooltip>
           )}
         </span>

--- a/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
+++ b/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { RiAlertFill } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import type { AgentResponse, UpdateAgentBody } from '@/api/agents';
 import { getAgentDetailQueryKey, updateAgent } from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
@@ -89,7 +90,16 @@ function BridgeUrlSection({ agent, canWrite, isUpdatePending, onUpdate, readOnly
       <div className="flex h-8 items-center justify-between gap-2 px-1.5">
         <span className="text-text-soft text-label-xs font-medium shrink-0 flex items-center gap-0.5">
           Bridge URL
-          {!displayUrl && <RiAlertFill className="size-3.5 text-orange-500" />}
+          {!displayUrl && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex cursor-pointer">
+                  <RiAlertFill className="size-3.5 text-orange-500" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Bridge URL is required for the agent to receive messages</TooltipContent>
+            </Tooltip>
+          )}
         </span>
         <div className="relative flex h-8 min-w-0 flex-1 items-center justify-end">
           <AnimatePresence mode="wait">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Added a hover tooltip to the Bridge URL warning icon (orange `RiAlertFill`) on the agent detail sidebar. When the Bridge URL is not configured, hovering over the warning icon now shows: **"Bridge URL is required for the agent to receive messages"**.

Previously, the warning icon had no hover state, making it unclear to users why there was a warning indicator next to the Bridge URL field.

## How it works

Wrapped the existing `RiAlertFill` icon in the `Tooltip` / `TooltipTrigger` / `TooltipContent` Radix primitives already available in the codebase. The tooltip only renders when `displayUrl` is falsy (i.e., Bridge URL is not configured).

## Screenshot

![Tooltip on Bridge URL warning icon](https://cursor.com/artifacts/c/art-e656726c-6a11-45e9-be9e-cdf8c6ed86dd)

## Video Demo

<a href="https://cursor.com/agents/bc-faa62bcf-aa8c-4adf-a9cc-b9003a0840af/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbridge_url_tooltip_hover_demo.mp4"><img src="https://cursor.com/artifacts/c/art-a0e3d91b-a0cc-4c70-bc83-241456c88828" alt="bridge_url_tooltip_hover_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7547](https://linear.app/novu/issue/NV-7547/missing-on-hover-state-that-explain-the-issue)

<div><a href="https://cursor.com/agents/bc-faa62bcf-aa8c-4adf-a9cc-b9003a0840af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-faa62bcf-aa8c-4adf-a9cc-b9003a0840af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added a hover tooltip to the Bridge URL warning icon in the agent detail sidebar so users see why the alert appears. When the Bridge URL is not configured, hovering the orange alert icon now shows: "Bridge URL is required for the agent to receive messages". This fixes confusion from the previous icon-only state by providing immediate, accessible guidance to configure the Bridge URL.

## Affected areas

**dashboard**: The agent detail sidebar UI (BridgeUrlSection) now wraps the existing RiAlertFill icon in Radix UI Tooltip primitives and conditionally renders the tooltip only when the Bridge URL (displayUrl) is absent.

## Testing

Manual verification was performed (screenshot and demo video included in the PR). No automated tests were added because this is a small, conditional UI/UX improvement using existing tooltip primitives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->