### PR TITLE
ci(root): add aggregator gate for PR pipeline

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -277,6 +277,12 @@ jobs:
   #
   # Skipped jobs are treated as success. Failure or cancellation of any
   # required dependency will fail the gate.
+  #
+  # IMPORTANT: the `needs:` list below must contain every other job in this
+  # workflow. The first step in this job parses this very file and fails
+  # the run if the list ever drifts (a job is added/removed but `needs:`
+  # is not updated). That guard prevents the gate from going falsely green
+  # because of a forgotten dependency.
   pr-checks-passed:
     name: PR Checks Passed
     runs-on: ubuntu-latest
@@ -292,6 +298,59 @@ jobs:
       - validate_openapi
       - test_e2e_api
     steps:
+      - name: Checkout workflow source
+        uses: actions/checkout@v5
+        with:
+          # We only need the workflow file itself to validate the needs list.
+          fetch-depth: 1
+          sparse-checkout: |
+            .github/workflows/on-pr.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Validate aggregator `needs` list matches workflow jobs
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet pyyaml
+          python3 <<'PY'
+          import pathlib, sys, yaml
+
+          AGGREGATOR = "pr-checks-passed"
+          WORKFLOW = pathlib.Path(".github/workflows/on-pr.yml")
+
+          workflow = yaml.safe_load(WORKFLOW.read_text())
+          jobs = workflow.get("jobs", {}) or {}
+
+          if AGGREGATOR not in jobs:
+              print(f"::error file={WORKFLOW}::aggregator job '{AGGREGATOR}' not found")
+              sys.exit(1)
+
+          declared = set(jobs[AGGREGATOR].get("needs", []) or [])
+          expected = set(jobs) - {AGGREGATOR}
+
+          missing = sorted(expected - declared)
+          extra = sorted(declared - expected)
+
+          if missing:
+              print(
+                  f"::error file={WORKFLOW}::pr-checks-passed.needs is missing jobs "
+                  f"that exist in the workflow: {missing}. "
+                  "Add them so the gate can't go falsely green."
+              )
+          if extra:
+              print(
+                  f"::error file={WORKFLOW}::pr-checks-passed.needs lists jobs that "
+                  f"don't exist in the workflow: {extra}. Remove them."
+              )
+
+          if missing or extra:
+              sys.exit(1)
+
+          print(
+              f"pr-checks-passed.needs correctly covers all {len(expected)} "
+              "other jobs in the workflow."
+          )
+          PY
+
       - name: Verify required jobs succeeded or were skipped
         env:
           NEEDS_JSON: ${{ toJson(needs) }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -308,48 +308,51 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Validate aggregator `needs` list matches workflow jobs
+        # Uses `yq` and `jq`, both pre-installed on GitHub-hosted ubuntu
+        # runners — no `pip install` or other dependency setup, so the
+        # check runs in well under a second.
+        env:
+          WORKFLOW: .github/workflows/on-pr.yml
+          AGGREGATOR: pr-checks-passed
         run: |
           set -euo pipefail
-          python3 -m pip install --quiet pyyaml
-          python3 <<'PY'
-          import pathlib, sys, yaml
 
-          AGGREGATOR = "pr-checks-passed"
-          WORKFLOW = pathlib.Path(".github/workflows/on-pr.yml")
+          workflow_json=$(yq -o=json '.' "$WORKFLOW")
 
-          workflow = yaml.safe_load(WORKFLOW.read_text())
-          jobs = workflow.get("jobs", {}) or {}
+          if ! echo "$workflow_json" | jq -e --arg agg "$AGGREGATOR" '.jobs[$agg]' > /dev/null; then
+            echo "::error file=$WORKFLOW::aggregator job '$AGGREGATOR' not found in workflow"
+            exit 1
+          fi
 
-          if AGGREGATOR not in jobs:
-              print(f"::error file={WORKFLOW}::aggregator job '{AGGREGATOR}' not found")
-              sys.exit(1)
+          diff_json=$(echo "$workflow_json" | jq --arg agg "$AGGREGATOR" '
+            .jobs as $jobs
+            | ($jobs[$agg].needs // []) as $declared
+            | ($jobs | keys | map(select(. != $agg))) as $expected
+            | {
+                missing: ($expected - $declared),
+                extra:   ($declared - $expected),
+                total:   ($expected | length)
+              }
+          ')
 
-          declared = set(jobs[AGGREGATOR].get("needs", []) or [])
-          expected = set(jobs) - {AGGREGATOR}
+          missing=$(echo "$diff_json" | jq -r '.missing | join(", ")')
+          extra=$(echo "$diff_json"   | jq -r '.extra   | join(", ")')
+          total=$(echo "$diff_json"   | jq -r '.total')
 
-          missing = sorted(expected - declared)
-          extra = sorted(declared - expected)
+          status=0
+          if [ -n "$missing" ]; then
+            echo "::error file=$WORKFLOW::$AGGREGATOR.needs is missing jobs that exist in the workflow: $missing. Add them so the gate can't go falsely green."
+            status=1
+          fi
+          if [ -n "$extra" ]; then
+            echo "::error file=$WORKFLOW::$AGGREGATOR.needs lists jobs that don't exist in the workflow: $extra. Remove them."
+            status=1
+          fi
 
-          if missing:
-              print(
-                  f"::error file={WORKFLOW}::pr-checks-passed.needs is missing jobs "
-                  f"that exist in the workflow: {missing}. "
-                  "Add them so the gate can't go falsely green."
-              )
-          if extra:
-              print(
-                  f"::error file={WORKFLOW}::pr-checks-passed.needs lists jobs that "
-                  f"don't exist in the workflow: {extra}. Remove them."
-              )
-
-          if missing or extra:
-              sys.exit(1)
-
-          print(
-              f"pr-checks-passed.needs correctly covers all {len(expected)} "
-              "other jobs in the workflow."
-          )
-          PY
+          if [ "$status" -eq 0 ]; then
+            echo "$AGGREGATOR.needs correctly covers all $total other jobs in the workflow."
+          fi
+          exit "$status"
 
       - name: Verify required jobs succeeded or were skipped
         env:

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -268,6 +268,47 @@ jobs:
       ee: true
     secrets: inherit
 
+  # Aggregator / "all-green" gate. This job depends on every other job in
+  # this workflow and reports a single success/failure status that can be
+  # used as the one required status check in branch protection (and for
+  # GitHub auto-merge). It must always run so that even when a dependency
+  # is skipped — e.g. dynamic jobs that have nothing to do because no
+  # affected projects were detected — the gate still produces a result.
+  #
+  # Skipped jobs are treated as success. Failure or cancellation of any
+  # required dependency will fail the gate.
+  pr-checks-passed:
+    name: PR Checks Passed
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - dependency-review
+      - find-flags
+      - get-affected
+      - test_unit_providers
+      - test_unit_packages
+      - test_unit_libs
+      - test_unit_services
+      - validate_openapi
+      - test_e2e_api
+    steps:
+      - name: Verify required jobs succeeded or were skipped
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          set -euo pipefail
+          echo "Aggregated job results:"
+          echo "$NEEDS_JSON" | jq -r 'to_entries[] | "  - \(.key): \(.value.result)"'
+
+          failed=$(echo "$NEEDS_JSON" | jq -r '[to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key] | join(", ")')
+
+          if [ -n "$failed" ]; then
+            echo "::error::The following required jobs failed or were cancelled: $failed"
+            exit 1
+          fi
+
+          echo "All required jobs passed (or were skipped because they were not affected)."
+
   #test_e2e_dashboard:
   #  name: E2E test Dashboard app
   #  needs: [get-affected]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What

Adds a single aggregator job — `PR Checks Passed` — to the `Check pull request` workflow (`.github/workflows/on-pr.yml`). The job depends on every other job in the workflow (including the ones that fan out dynamically based on `nx affected`), runs unconditionally (`if: ${{ always() }}`), and produces one success/failure status that summarizes the entire pipeline.

This is the standard "all-green" gate pattern. It lets us:

- Mark a single status check (`PR Checks Passed`) as **required** in GitHub branch protection, instead of trying to enumerate jobs whose names depend on which projects a PR touches.
- Safely enable **auto-merge**, because GitHub now has one stable check name to wait on.

### How the gate decides

Inside the `pr-checks-passed` job there are two steps:

1. **Drift guard.** Sparse-checks-out the workflow file and uses `yq` + `jq` (both pre-installed on GitHub-hosted ubuntu runners — no `pip install`, no network) to verify that `pr-checks-passed.needs` contains exactly the set of every other top-level job id in the workflow. If a maintainer adds/removes a job and forgets to update `needs:`, the run fails with a clear `::error::` listing the missing or extra job ids — so the gate **cannot** silently go falsely green just because someone forgot to add a new job. Locally measured at ~18 ms end-to-end.
2. **Result aggregation.** Inspects `${{ toJson(needs) }}` and:
   - Treats `success` **and** `skipped` as passing — so when an `nx affected` matrix is empty for a given PR and the corresponding job is skipped, the gate still goes green.
   - Fails (with a clear `::error::` message listing the offending jobs) if any required dependency reports `failure` or `cancelled`.

Sample of the bash that runs in the result-aggregation step:

```bash
failed=$(echo "$NEEDS_JSON" | jq -r '[to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key] | join(", ")')
if [ -n "$failed" ]; then
  echo "::error::The following required jobs failed or were cancelled: $failed"
  exit 1
fi
```

### Branch protection / auto-merge follow-up (manual, repo settings)

After this lands on `next`, in **Settings → Branches → Branch protection** for `next` (and `main`/`prod`):

1. Remove any individual `on-pr.yml` jobs from the required-status-checks list (they have unstable / dynamic names).
2. Add **`PR Checks Passed`** as a required status check.
3. Optionally also keep these stable, always-running checks required:
   - `Check for .only in tests` (from `check-only.yml`)
   - `Validate PR titles` (from `conventional-commit.yml`)
   - `Check branches` (from `on-pr-change.yml`)
4. Enable **Allow auto-merge** in repo settings.

Everything dynamic is then covered by the single gate.

### Why not a third-party action?

A hand-written script keeps the gate trivially auditable and avoids adding another action to the supply chain — but the logic is the same as `re-actors/alls-green`. Skipped is treated as success on purpose.

### Tested

Both the result-aggregation logic and the drift guard were unit-tested locally:

**Result aggregation**

| Case | Expected | Result |
| --- | --- | --- |
| all `success` / `skipped` | pass | pass |
| one `failure` | fail (lists `b`) | fail |
| one `cancelled` + one `failure` | fail (lists `a, b`) | fail |
| all `skipped` | pass | pass |

**Drift guard** (using `yq` + `jq`, no installs)

| Case | Expected | Result |
| --- | --- | --- |
| baseline workflow as-is | pass | pass (~18 ms) |
| job removed from `needs:` | fail, names the missing job | fail (`validate_openapi`) |
| typo / unknown id in `needs:` | fail, names the extra entry | fail (`ghost_job`) |
| brand-new job added without updating `needs:` | fail, names the new job | fail (`lint_something`) |

Real validation will also happen on this PR's own pipeline run — a new `PR Checks Passed` check appears alongside the existing jobs.

### Notes

- The drift guard makes "forgot to add the new job to `pr-checks-passed.needs`" a CI failure rather than a silent false-green, so the static `needs:` list is now self-policing.
- The guard does a sparse checkout of just the workflow file, so it adds negligible time to the run.
- No package installs, no Python, no network: only `yq` and `jq`, both pre-installed on `ubuntu-latest`.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1778168888273509?thread_ts=1778168888.273509&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-e4a4315d-73ae-5cc8-9033-1ea635eff2d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4a4315d-73ae-5cc8-9033-1ea635eff2d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**What changed**

Added a new CI aggregator job "pr-checks-passed" to the PR pipeline that always runs and depends on every other top-level job in the workflow. It validates that its declared `needs:` exactly matches the workflow jobs (failing the run on drift) and then aggregates dependency results into a single success/failure status (treating `success` and `skipped` as passing, failing on `failure` or `cancelled`). This consolidates many dynamic checks into one stable gate to simplify branch-protection and enable safer auto-merge.

**Affected areas**

- **CI (root)**: .github/workflows/on-pr.yml gains the `pr-checks-passed` job which declares explicit `needs:` on all top-level jobs, performs a drift guard against the workflow file, and aggregates dependency results into one pass/fail status.

**Key technical decisions**

- The drift-guard and aggregation use a small handwritten shell script (yq + jq) for auditability and to avoid extra supply-chain/npm/Python action dependencies; this replaces a prior PyYAML pip-based approach.
- The job runs with `if: ${{ always() }}` so it observes final job states even after failures.
- The workflow includes a guard that fails the run if the aggregator’s `needs:` set drifts from the workflow job list, requiring manual updates and follow-up branch-protection changes to mark `PR Checks Passed` required and remove unstable/dynamic job checks.

**Testing**

Author ran local unit-style tests covering drift and aggregation scenarios (including all-success/skip, single failure, cancellation, and drift cases); final, real-world validation will occur when this PR's pipeline runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->