### PR TITLE
perf(api-service): updat trace query flow

### DIFF
--- a/apps/api/src/app/activity/usecases/get-request/get-request.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-request/get-request.usecase.ts
@@ -1,9 +1,12 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { QueryBuilder, RequestLog, RequestLogRepository, Trace, TraceLogRepository } from '@novu/application-generic';
+import { subDays } from 'date-fns';
 import { GetRequestResponseDto, TraceResponseDto } from '../../dtos/get-request.response.dto';
 import { mapTraceToResponseDto } from '../../shared/mappers';
 import { requestLogSelectColumns, traceSelectColumns } from '../../shared/select.const';
 import { GetRequestCommand } from './get-request.command';
+
+const TRACE_AFTER_BUFFER_DAYS = 1;
 
 @Injectable()
 export class GetRequest {
@@ -34,6 +37,14 @@ export class GetRequest {
     traceQueryBuilder.whereEquals('entity_id', command.requestId);
     traceQueryBuilder.whereEquals('entity_type', 'request');
     traceQueryBuilder.whereEquals('organization_id', command.organizationId);
+
+    // Traces for a request can never pre-date the request itself; bound the scan
+    // by the request's creation time (with a buffer for clock skew) so ClickHouse
+    // can prune partitions and skip granules on the `toDate(created_at)` sort key.
+    if (request.data.created_at) {
+      const requestCreatedAt = new Date(`${request.data.created_at} UTC`);
+      traceQueryBuilder.whereGreaterThanOrEqual('created_at', subDays(requestCreatedAt, TRACE_AFTER_BUFFER_DAYS));
+    }
 
     const traceResult = await this.traceLogRepository.find({
       where: traceQueryBuilder.build(),

--- a/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
+++ b/apps/api/src/app/activity/usecases/get-workflow-run/get-workflow-run.usecase.ts
@@ -11,9 +11,12 @@ import {
 } from '@novu/application-generic';
 import { JobEntity, JobRepository } from '@novu/dal';
 import { StepTypeEnum } from '@novu/shared';
+import { subDays } from 'date-fns';
 import { GetWorkflowRunResponseDto, StepRunDto } from '../../dtos/workflow-run-response.dto';
 import { mapTraceToExecutionDetailDto, mapWorkflowRunStatusToDto } from '../../shared/mappers';
 import { GetWorkflowRunCommand } from './get-workflow-run.command';
+
+const TRACE_AFTER_BUFFER_DAYS = 1;
 
 const workflowRunSelectColumns = [
   'workflow_run_id',
@@ -221,7 +224,11 @@ export class GetWorkflowRun {
       }
 
       const stepRunIds = stepRunsResult.data.map((stepRun) => stepRun.step_run_id);
-      const executionDetailsByStepRunId = await this.getExecutionDetailsByEntityId(stepRunIds, command);
+      const executionDetailsByStepRunId = await this.getExecutionDetailsByEntityId(
+        stepRunIds,
+        command,
+        workflowRun.created_at ? new Date(`${workflowRun.created_at} UTC`) : undefined
+      );
 
       // BACKWARD COMPATIBILITY: Check if any step runs are missing digest data
       // TODO: Remove this logic as part of task nv-6576 once all step runs have digest data stored
@@ -259,22 +266,33 @@ export class GetWorkflowRun {
 
   private async getExecutionDetailsByEntityId(
     entityIds: string[],
-    command: GetWorkflowRunCommand
+    command: GetWorkflowRunCommand,
+    /**
+     * Lower bound for the trace `created_at` scan. Should be the parent workflow run's
+     * creation time — traces (e.g. message_seen, delivery callbacks) can arrive long
+     * after, but never before, the workflow run that produced them. Passing this lets
+     * ClickHouse prune partitions and skip granules on the `toDate(created_at)` sort key.
+     */
+    workflowRunCreatedAt?: Date
   ): Promise<Map<string, TraceFetchResult[]>> {
     if (entityIds.length === 0) {
       return new Map();
     }
 
     try {
-      const traceQuery = new QueryBuilder<Trace>({
+      const traceQueryBuilder = new QueryBuilder<Trace>({
         environmentId: command.environmentId,
       })
         .whereIn('entity_id', entityIds)
         .whereEquals('entity_type', 'step_run')
-        .build();
+        .whereEquals('organization_id', command.organizationId);
+
+      if (workflowRunCreatedAt) {
+        traceQueryBuilder.whereGreaterThanOrEqual('created_at', subDays(workflowRunCreatedAt, TRACE_AFTER_BUFFER_DAYS));
+      }
 
       const traceResult = await this.traceLogRepository.find({
-        where: traceQuery,
+        where: traceQueryBuilder.build(),
         orderBy: 'created_at',
         orderDirection: 'ASC',
         select: traceSelectColumns,

--- a/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity-feed/get-activity-feed.usecase.ts
@@ -23,10 +23,12 @@ import {
   FeatureNameEnum,
   getFeatureForTierAsNumber,
 } from '@novu/shared';
+import { subDays } from 'date-fns';
 import { ActivitiesResponseDto, ActivityNotificationResponseDto } from '../../dtos/activities-response.dto';
 import { GetActivityFeedCommand } from './get-activity-feed.command';
 import { mapFeedItemToDto } from './map-feed-item-to.dto';
 
+const TRACE_AFTER_BUFFER_DAYS = 1;
 const traceFindColumns = ['entity_id', 'id', 'status', 'title', 'raw_data', 'created_at'] as const;
 type TraceFindResult = Pick<Trace, (typeof traceFindColumns)[number]>;
 
@@ -334,13 +336,22 @@ export class GetActivityFeed {
       return new Map();
     }
 
-    const traceQuery = new QueryBuilder<Trace>({
+    // Only bound by `after`, not `before`: traces (e.g. message_seen, delivery callbacks)
+    // can arrive long after the workflow run was created, but never before it.
+    // Subtract a small buffer to absorb clock skew between the API and trace ingestion.
+    const traceQueryBuilder = new QueryBuilder<Trace>({
       environmentId: command.environmentId,
     })
       .whereIn('entity_id', entityIds)
       .whereEquals('entity_type', 'step_run')
-      .whereEquals('organization_id', command.organizationId)
-      .build();
+      .whereEquals('organization_id', command.organizationId);
+
+    if (command.after) {
+      const afterWithBuffer = subDays(new Date(command.after), TRACE_AFTER_BUFFER_DAYS);
+      traceQueryBuilder.whereGreaterThanOrEqual('created_at', afterWithBuffer);
+    }
+
+    const traceQuery = traceQueryBuilder.build();
 
     const traceResult = await this.traceLogRepository.find({
       where: traceQuery,

--- a/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
+++ b/apps/api/src/app/notifications/usecases/get-activity/get-activity.usecase.ts
@@ -27,10 +27,13 @@ import {
   StepTypeEnum,
   TriggerTypeEnum,
 } from '@novu/shared';
+import { subDays } from 'date-fns';
 
 import { ActivityNotificationResponseDto } from '../../dtos/activities-response.dto';
 import { mapFeedItemToDto } from '../get-activity-feed/map-feed-item-to.dto';
 import { GetActivityCommand } from './get-activity.command';
+
+const TRACE_AFTER_BUFFER_DAYS = 1;
 
 const workflowRunSelectColumns = [
   'workflow_run_id',
@@ -108,11 +111,14 @@ export class GetActivity {
       }),
     ]);
 
-    this.logger.debug({
-      tracesEnabled,
-      stepRunsEnabled,
-      workflowRunsEnabled,
-    }, 'feature flags');
+    this.logger.debug(
+      {
+        tracesEnabled,
+        stepRunsEnabled,
+        workflowRunsEnabled,
+      },
+      'feature flags'
+    );
 
     let feedItem: NotificationFeedItemEntity | null = null;
 
@@ -163,21 +169,32 @@ export class GetActivity {
 
   private async getExecutionDetailsByEntityId(
     entityIds: string[],
-    command: GetActivityCommand
+    command: GetActivityCommand,
+    /**
+     * Lower bound for the trace `created_at` scan. Should be the parent notification's
+     * creation time — traces (e.g. message_seen, delivery callbacks) can arrive long
+     * after, but never before, the workflow run that produced them. Passing this lets
+     * ClickHouse prune partitions and skip granules on the `toDate(created_at)` sort key.
+     */
+    notificationCreatedAt?: Date
   ): Promise<Map<string, ExecutionDetailFeedItem[]>> {
     if (entityIds.length === 0) {
       return new Map();
     }
 
-    const traceQuery = new QueryBuilder<Trace>({
+    const traceQueryBuilder = new QueryBuilder<Trace>({
       environmentId: command.environmentId,
     })
       .whereIn('entity_id', entityIds)
       .whereEquals('entity_type', 'step_run')
-      .build();
+      .whereEquals('organization_id', command.organizationId);
+
+    if (notificationCreatedAt) {
+      traceQueryBuilder.whereGreaterThanOrEqual('created_at', subDays(notificationCreatedAt, TRACE_AFTER_BUFFER_DAYS));
+    }
 
     const traceResult = await this.traceLogRepository.find({
-      where: traceQuery,
+      where: traceQueryBuilder.build(),
       orderBy: 'created_at',
       orderDirection: 'ASC',
       select: traceSelectColumns,
@@ -240,7 +257,11 @@ export class GetActivity {
     }
 
     const stepRunIds = stepRunsResult.data.map((stepRun) => stepRun.step_run_id);
-    const executionDetailsByStepRunId = await this.getExecutionDetailsByEntityId(stepRunIds, command);
+    const executionDetailsByStepRunId = await this.getExecutionDetailsByEntityId(
+      stepRunIds,
+      command,
+      feedItem.createdAt ? new Date(feedItem.createdAt) : undefined
+    );
 
     return stepRunsResult.data.map((stepRun) => mapStepRunToJob(stepRun, executionDetailsByStepRunId));
   }
@@ -384,7 +405,11 @@ export class GetActivity {
         return feedItem;
       }
 
-      const executionDetailsByJobId = await this.getExecutionDetailsByEntityId(jobIds, command);
+      const executionDetailsByJobId = await this.getExecutionDetailsByEntityId(
+        jobIds,
+        command,
+        feedItem.createdAt ? new Date(feedItem.createdAt) : undefined
+      );
 
       feedItem.jobs = feedItem.jobs.map((job) => {
         const executionDetails = executionDetailsByJobId.get(job._id) || [];


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The PR optimizes trace query performance by bounding ClickHouse scans to a time range starting from when the parent entity (request, workflow run, or activity) was created. A 1-day buffer is subtracted to account for clock skew between services. This prevents trace logs from before the parent entity existed from being scanned, reducing unnecessary I/O on the trace database.

## Affected areas

**api**: Updated `GetRequest`, `GetWorkflowRun`, `GetActivity`, and `GetActivityFeed` use cases to apply lower-bound filters on trace `created_at` timestamps using the parent entity's creation time minus the buffer.

## Key technical decisions

- Imported `subDays` from `date-fns` to calculate the time-window boundary; `subDays` was already a dependency in the project.
- Introduced a `TRACE_AFTER_BUFFER_DAYS = 1` constant in affected use cases to standardize the clock-skew buffer across all trace queries.
- Applied conditional `whereGreaterThanOrEqual('created_at', ...)` filters only when the parent entity's creation timestamp is available, maintaining backward compatibility.

## Testing

No test changes are mentioned in the provided summary. The optimization is a query-only change that should not affect the functional behavior of the API—trace records returned should remain identical, just with reduced scan time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
