### PR TITLE
fix(api-service): interpolate env variables inside email layout bodies fixes NV-7559

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts
@@ -102,13 +102,13 @@ export class ConstructFrameworkWorkflow {
       _creatorId: environment._organizationId,
     } as NotificationTemplateEntity;
 
-    return workflow(LAYOUT_PREVIEW_WORKFLOW_ID, async ({ step, payload, subscriber, context }) => {
+    return workflow(LAYOUT_PREVIEW_WORKFLOW_ID, async ({ step, payload, subscriber, context, env }) => {
       await step.email(
         LAYOUT_PREVIEW_EMAIL_STEP,
         async (controlValues) => {
           return this.emailOutputRendererUseCase.execute({
             controlValues,
-            fullPayloadForRender: { payload, subscriber, context, steps: {} },
+            fullPayloadForRender: { payload, subscriber, context, steps: {}, env },
             dbWorkflow: syntheticDbWorkflow,
             organization,
             locale: subscriber.locale ?? undefined,
@@ -140,13 +140,14 @@ export class ConstructFrameworkWorkflow {
   }): Workflow {
     return workflow(
       dbWorkflow.triggers[0].identifier,
-      async ({ step, payload, subscriber, context }) => {
+      async ({ step, payload, subscriber, context, env }) => {
         const fullPayloadForRender: FullPayloadForRender = {
           workflow: dbWorkflow as unknown as Record<string, unknown>,
           payload,
           subscriber,
           context,
           steps: {},
+          env,
         };
         for (const staticStep of dbWorkflow.steps) {
           fullPayloadForRender.steps[staticStep.stepId || staticStep._templateId] = await this.constructStep({

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts
@@ -1554,6 +1554,35 @@ describe('EmailOutputRendererUsecase', () => {
       expect(getLayoutUseCaseV0.execute.calledOnce).to.be.true;
       expect(controlValuesRepositoryMock.findOne.calledOnce).to.be.true;
     });
+
+    it('should interpolate environment variables inside the layout body', async () => {
+      const layoutWithEnvVar =
+        '<html><body><img src="{{env.CDN_BASE_URL}}/logo.png" /><div>{{content}}</div></body></html>';
+      controlValuesRepositoryMock.findOne.resolves({
+        controls: { email: { body: layoutWithEnvVar } },
+      } as any);
+
+      const renderCommand: EmailOutputRendererCommand = {
+        dbWorkflow: mockDbWorkflow,
+        controlValues: {
+          subject: 'Layout Env Var Test',
+          body: simpleBodyContent,
+          layoutId: 'test_layout_id',
+        },
+        fullPayloadForRender: {
+          ...mockFullPayload,
+          payload: { name: 'John' },
+          env: { CDN_BASE_URL: 'https://cdn.example.com', name: 'Production', type: 'prod' },
+        },
+        stepId: 'fake_step_id',
+      };
+
+      const result = await emailOutputRendererUsecase.execute(renderCommand);
+
+      expect(result.body).to.include('https://cdn.example.com/logo.png');
+      expect(result.body).to.not.include('{{env.CDN_BASE_URL}}');
+      expect(result.body).to.include('Step content John');
+    });
   });
 
   describe('Layout functionality', () => {

--- a/apps/api/src/app/environments-v1/usecases/output-renderers/render-command.ts
+++ b/apps/api/src/app/environments-v1/usecases/output-renderers/render-command.ts
@@ -14,7 +14,11 @@ export class FullPayloadForRender {
   payload: Record<string, unknown>;
   context?: ContextResolved;
   steps: Record<string, unknown>; // step.stepId.unknown
-  env?: Record<string, string>;
+  /**
+   * Environment variables defined in the Novu Dashboard, merged with built-in
+   * environment system variables (`name`, `type`). Available in templates as `{{ env.X }}`.
+   */
+  env?: Record<string, unknown>;
   // this variable is used to pass the layout content to the renderer
   [LAYOUT_CONTENT_VARIABLE]?: string;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Environment variables defined in the Novu Dashboard (e.g. `{{ env.CDN_BASE_URL }}`) were available in **workflow email step bodies** and in the **standalone layout preview**, but were silently dropped when the same variables were used inside an **email layout body that was applied to a workflow email**.

This PR threads `env` through the layout render path so `{{ env.X }}` (and the system `env.name` / `env.type`) resolve correctly inside layout bodies during both workflow preview and actual email send.

Fixes NV-7559. Customer report (Discord, Pro plan, US) surfaced in [#eng-and-support](https://app.plain.com/workspace/w_01HE2X2JVN730ZBA6QZ59X8BZ8/thread/th_01KR316A4CGAHF3PXFHT82591K).

## Why

Layouts go through a different render path than email step bodies, and that path was missing `env`:

```mermaid
flowchart TD
  classDef bad fill:#fee,stroke:#c00,color:#000
  classDef good fill:#efe,stroke:#0a0,color:#000

  Bridge["Bridge event\n(includes event.env)"]

  subgraph Framework["@novu/framework client.ts"]
    CC["compileControls\nrenderVariables = { ..., env: event.env }\nLiquid render of all controls (incl. body)"]
  end

  subgraph API["EmailOutputRendererUsecase"]
    Step["renderWithLayout: step body\nbody already env-substituted by framework"]:::good
    Layout["renderWithLayout: layout body\nfetched from controlValuesRepository (raw)\n→ processBodyContent(payload = fullPayloadForRender)"]
  end

  Bridge --> CC --> Step
  Bridge --> CC --> Layout

  subgraph Construct["construct-framework-workflow.usecase.ts"]
    Before["fullPayloadForRender BEFORE\n{ workflow, payload, subscriber, context, steps }\n(no env)"]:::bad
    After["fullPayloadForRender AFTER\n{ workflow, payload, subscriber, context, steps, env }"]:::good
  end

  Layout --- Before
  Layout -.fix.-> After
```

- Step bodies work because the framework's `compileControls` injects `env` into the Liquid render variables (`packages/framework/src/client.ts ~line 737`).
- Standalone layout preview works because the layout body is sent through the framework as the synthetic step body in `LAYOUT_PREVIEW_EMAIL_STEP`.
- When a layout is applied to a workflow email step, `EmailOutputRendererUsecase.renderWithLayout` fetches the layout body straight from `controlValuesRepository` and renders it locally via `processBodyContent`. The Liquid variables it passes come from `fullPayloadForRender`, which is built in `construct-framework-workflow.usecase.ts` and **never populated `env`** (the framework callback's `env` argument was not destructured).

## How

- `apps/api/src/app/environments-v1/usecases/construct-framework-workflow/construct-framework-workflow.usecase.ts` — destructure `env` from the framework workflow callback and include it in `fullPayloadForRender` for both the layout-preview synthetic workflow and the real workflow path.
- `apps/api/src/app/environments-v1/usecases/output-renderers/render-command.ts` — widen the existing `env?: Record<string, string>` to `env?: Record<string, unknown>` to match what the framework passes (it intersects user `env` with `EnvironmentSystemVariables`), and document the field.
- No changes were needed in `EmailOutputRendererUsecase.processBodyContent` — it already forwards the full payload as Liquid render variables, so once `env` is present in `fullPayloadForRender`, `{{ env.X }}` resolves inside layout bodies (and is harmlessly redundant for step bodies, which the framework has already substituted).

## Tests

Added a new unit test in `apps/api/src/app/environments-v1/usecases/output-renderers/email-output-renderer.spec.ts`:

> `should interpolate environment variables inside the layout body`

It renders an HTML layout containing `<img src="{{env.CDN_BASE_URL}}/logo.png" />` against a `fullPayloadForRender` with `env: { CDN_BASE_URL: 'https://cdn.example.com', name: 'Production', type: 'prod' }` and asserts the resolved URL appears in the output and the raw `{{env.CDN_BASE_URL}}` does not.

Verification:

- `cd apps/api && pnpm test -- --grep "EmailOutputRendererUsecase"` → 63 passing (including the new test and all pre-existing layout / skipLayoutRendering tests).
- `cd apps/api && pnpm test -- --grep "PreviewLayoutUsecase"` → 18 passing.
- `cd apps/api && pnpm build` → ✅ TS clean.

## Risk / scope

- Pure additive change to a render-time payload — no schema changes, no migrations, no breaking API contract.
- The same `env` injection now happens for the workflow email step body too, but since the framework already substituted `{{ env.X }}` in step bodies before they reach `processBodyContent`, this is a no-op for that path.
- No `enterprise/` or `packages/` changes — does not require a rebuild beyond `apps/api`.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1778223896946569?thread_ts=1778223896.946569&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-e698087c-b439-5ce0-a31f-20254e933f33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e698087c-b439-5ce0-a31f-20254e933f33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Environment variables defined in the Novu Dashboard (e.g., `{{ env.CDN_BASE_URL }}`) are now properly interpolated in email layout bodies. Previously, they were resolved in workflow email step bodies and standalone layout previews, but not when the layout was applied to a workflow email. The fix ensures `env` is destructured and included in the `fullPayloadForRender` object passed to the EmailOutputRendererUsecase during layout rendering.

## Affected areas

- **api**: Updated the framework workflow construction to pass environment variables through `fullPayloadForRender` for both layout-preview synthetic workflows and real workflows. Widened the `env` type definition to accept non-string values. Added test coverage for environment variable interpolation in layout bodies.

## Key technical decisions

- `env` field in `FullPayloadForRender` changed from `Record<string, string>` to `Record<string, unknown>` to support non-string environment variable values.

## Testing

Added unit test in `email-output-renderer.spec.ts` verifying that environment variables interpolate correctly inside layout bodies. Existing test suites confirm no regressions: 63 EmailOutputRendererUsecase tests passing (including the new test), 18 PreviewLayoutUsecase tests passing, and TypeScript build successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->