### PR TITLE
fix(root): enhance value escaping for .env format to handle special characters and multi-line values

### DIFF
--- a/scripts/dotenvcreate.mjs
+++ b/scripts/dotenvcreate.mjs
@@ -104,13 +104,25 @@ async function getSecretValue(secretName) {
 
 // Function to escape or quote values for .env format
 function escapeValue(value) {
-  // If the value contains special characters or spaces, quote it
-  if (value && /[ \t"=$]/.test(value)) {
-    // Escape backslashes and double quotes, then wrap the value in quotes
-    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  if (value === undefined || value === null) {
+    return '';
   }
 
-  return value;
+  const stringValue = String(value);
+
+  // Quote when the value contains whitespace, quotes, equals, dollar signs, or line breaks.
+  // Multi-line values (e.g. PEM keys) must be encoded on a single line so dotenv parses them
+  // back into a single env var; we convert real newlines/CRs into literal `\n`/`\r` sequences,
+  // which dotenv expands inside double quotes when reading the file.
+  if (/[ \t"=$\r\n]/.test(stringValue)) {
+    return `"${stringValue
+      .replace(/\r\n/g, '\\n')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/"/g, '\\"')}"`;
+  }
+
+  return stringValue;
 }
 
 // Function to update or add to .env file with new key-value pairs (for cloud enterprise)


### PR DESCRIPTION

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The `escapeValue()` function in `scripts/dotenvcreate.mjs` now properly handles special characters and multi-line values when generating `.env` files. It normalizes `undefined`/`null` to empty strings, converts all inputs to strings, and quotes values containing whitespace, quotes, equals signs, dollar signs, or line breaks. When quoting, actual newlines and carriage returns are converted to literal `\n` and `\r` escape sequences, and double quotes are escaped as `\"`. This ensures multi-line values (such as PEM keys) are correctly encoded on a single line and properly expanded by dotenv parsers.

## Affected areas

**Root infrastructure** — The `.env` file generation utility for enterprise deployments now correctly escapes special characters and multi-line values, improving compatibility with dotenv parsing.

## Testing

No new tests were added. The change is a utility script enhancement with straightforward escaping logic that can be verified through manual testing of .env file generation with special characters and multi-line content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
