### PR TITLE
fix(shared): end MongoDB session in BaseRepository.withTransaction fixes NV-7603

### DIFF
--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -474,8 +474,9 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
    * Refer to https://mongoosejs.com/docs/transactions.html#note-about-parallelism-in-transactions
    */
   async withTransaction(fn: (session: ClientSession | null) => Promise<any>) {
+    const session = await this._model.db.startSession();
     try {
-      return await (await this._model.db.startSession()).withTransaction(fn);
+      return await session.withTransaction(fn);
     } catch (error) {
       // Check if the error is related to replica set requirement
       const errorMessage = error?.message?.toLowerCase() || '';
@@ -489,6 +490,8 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
       }
 
       throw error;
+    } finally {
+      await session.endSession().catch(() => {});
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`BaseRepository.withTransaction` (in `libs/dal/src/repositories/base-repository.ts`) opened a MongoDB session with `this._model.db.startSession()` and called `session.withTransaction(fn)`, but never invoked `session.endSession()`. Every successful or failed transaction therefore leaked a server-side session, gradually degrading the cluster under sustained transaction load.

This PR mirrors the pattern already used in `BaseRepositoryV2.withTransaction`: pull the session out of the try expression, run the transaction, and always end the session in `finally`. Errors from `endSession()` are swallowed so they cannot mask the original outcome.

## Why

Sessions are never closed, leading to gradual database/cluster degradation as the server-side session pool grows. Verifiable via `db.serverStatus().connections` / session counters under load.

## Diff

```diff
 async withTransaction(fn: (session: ClientSession | null) => Promise<any>) {
+    const session = await this._model.db.startSession();
     try {
-      return await (await this._model.db.startSession()).withTransaction(fn);
+      return await session.withTransaction(fn);
     } catch (error) {
       const errorMessage = error?.message?.toLowerCase() || '';
       if (
         errorMessage.includes('replica set') ||
         errorMessage.includes('transaction') ||
         error.codeName === 'IllegalOperation'
       ) {
         return await fn(null);
       }
       throw error;
+    } finally {
+      await session.endSession().catch(() => {});
     }
   }
```

## Behavior preserved

- Same return value / thrown error semantics as before for every code path.
- Same replica-set fallback (errors mentioning "replica set"/"transaction" or `codeName === 'IllegalOperation'` re-run the callback with `session = null`).
- Replica-set fallback still re-runs the original callback outside the transaction. The bug report flags that as something to revisit; intentionally left as-is here to keep this PR a minimal, low-risk fix.

## Testing

- `pnpm build` (DAL) succeeds with no TypeScript errors.
- Verified the fix end-to-end with a small script that mocks `_model.db.startSession()` / `session.withTransaction()` and counts calls. Across all four code paths — success, generic error, replica-set fallback (error contains "replica set"), and `IllegalOperation` fallback — `endSession()` is now called exactly once:

```
success path                  {"out":"ok",            "calls":{"startSession":1,"withTransaction":1,"endSession":1}}
generic error path            {"threw":"boom",        "calls":{"startSession":1,"withTransaction":1,"endSession":1}}
replica-set fallback path     {"out":"fallback:true", "calls":{"startSession":1,"withTransaction":1,"endSession":1}}
IllegalOperation fallback     {"out":"illegal:true",  "calls":{"startSession":1,"withTransaction":1,"endSession":1}}

All paths called endSession exactly once: true
```

## Out of scope

- Migrating callers off `BaseRepository` to `BaseRepositoryV2`.
- Tightening the replica-set fallback condition to a specific MongoDB error code.

fixes NV-7603
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7603](https://linear.app/novu/issue/NV-7603/bug-baserepositorywithtransaction-never-ends-mongodb-sessions-resource)

<div><a href="https://cursor.com/agents/bc-be168b3e-0601-466c-a9e0-e4c742db976d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be168b3e-0601-466c-a9e0-e4c742db976d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

`BaseRepository.withTransaction` now properly closes MongoDB sessions to prevent resource leaks. Previously, the method started a session but never called `endSession()`, causing server-side sessions to accumulate. The fix stores the session in a variable, calls `session.withTransaction(fn)` in a try block, and ensures cleanup via a new finally block that calls `session.endSession()` and suppresses any cleanup errors. The replica-set fallback behavior remains unchanged.

## Affected areas

**dal**: Fixed session lifecycle management in `BaseRepository.withTransaction`. MongoDB sessions are now properly closed in all code paths (success, generic error, replica-set fallback, and IllegalOperation fallback).

## Key technical decisions

- The finally block unconditionally calls `endSession().catch(() => {})` to ensure cleanup happens regardless of transaction outcome, following the established pattern from `BaseRepositoryV2.withTransaction`.
- Error handling for replica-set scenarios remains in the catch block, preserving fallback behavior that re-runs the callback with `session = null` when replica-set transactions are unsupported.

## Testing

The build succeeds with no TypeScript errors. Session cleanup was verified with a mocked test script confirming that `endSession()` is called exactly once across all execution paths (success, generic error, replica-set error, and IllegalOperation error).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->