### PR TITLE
fix(api-service): use transaction session in DeleteTopicSubscriptions and scope by org fixes NV-7607

### DIFF
--- a/apps/api/src/app/topics-v2/usecases/delete-topic-subscriptions/delete-topic-subscriptions.spec.ts
+++ b/apps/api/src/app/topics-v2/usecases/delete-topic-subscriptions/delete-topic-subscriptions.spec.ts
@@ -1,0 +1,152 @@
+import {
+  PreferencesRepository,
+  SubscriberEntity,
+  SubscriberRepository,
+  TopicEntity,
+  TopicRepository,
+  TopicSubscribersEntity,
+  TopicSubscribersRepository,
+} from '@novu/dal';
+import { PreferencesTypeEnum } from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { DeleteTopicSubscriptionsCommand } from './delete-topic-subscriptions.command';
+import { DeleteTopicSubscriptionsUsecase } from './delete-topic-subscriptions.usecase';
+
+describe('DeleteTopicSubscriptionsUsecase', () => {
+  const validEnvId = '507f1f77bcf86cd799439011';
+  const validOrgId = '507f1f77bcf86cd799439012';
+  const validTopicId = '507f1f77bcf86cd799439013';
+  const validSubscriberInternalId = '507f1f77bcf86cd799439014';
+  const validSubscriptionId = '507f1f77bcf86cd799439015';
+  const externalSubscriberId = 'external-subscriber-1';
+  const topicKey = 'test-topic';
+
+  let topicRepositoryMock: sinon.SinonStubbedInstance<TopicRepository>;
+  let topicSubscribersRepositoryMock: sinon.SinonStubbedInstance<TopicSubscribersRepository>;
+  let subscriberRepositoryMock: sinon.SinonStubbedInstance<SubscriberRepository>;
+  let preferencesRepositoryMock: sinon.SinonStubbedInstance<PreferencesRepository>;
+
+  let usecase: DeleteTopicSubscriptionsUsecase;
+
+  const fakeSession = { id: 'fake-session' } as any;
+
+  const mockTopic = {
+    _id: validTopicId,
+    _organizationId: validOrgId,
+    _environmentId: validEnvId,
+    key: topicKey,
+    name: 'Test Topic',
+  } as TopicEntity;
+
+  const mockSubscriber = {
+    _id: validSubscriberInternalId,
+    _organizationId: validOrgId,
+    _environmentId: validEnvId,
+    subscriberId: externalSubscriberId,
+  } as SubscriberEntity;
+
+  const mockSubscription = {
+    _id: validSubscriptionId,
+    _organizationId: validOrgId,
+    _environmentId: validEnvId,
+    _topicId: validTopicId,
+    _subscriberId: validSubscriberInternalId,
+    topicKey,
+    externalSubscriberId,
+  } as TopicSubscribersEntity;
+
+  beforeEach(() => {
+    topicRepositoryMock = sinon.createStubInstance(TopicRepository);
+    topicSubscribersRepositoryMock = sinon.createStubInstance(TopicSubscribersRepository);
+    subscriberRepositoryMock = sinon.createStubInstance(SubscriberRepository);
+    preferencesRepositoryMock = sinon.createStubInstance(PreferencesRepository);
+
+    topicRepositoryMock.findTopicByKey.resolves(mockTopic);
+    subscriberRepositoryMock.searchByExternalSubscriberIds.resolves([mockSubscriber]);
+    topicSubscribersRepositoryMock.find.resolves([mockSubscription]);
+
+    // @ts-expect-error Mock withTransaction to invoke the callback with our fake session
+    topicSubscribersRepositoryMock.withTransaction = sinon
+      .stub()
+      .callsFake(async (callback: (session: unknown) => Promise<unknown>) => callback(fakeSession));
+
+    preferencesRepositoryMock.delete.resolves({ acknowledged: true, deletedCount: 1 } as any);
+    topicSubscribersRepositoryMock.delete.resolves({ acknowledged: true, deletedCount: 1 } as any);
+
+    usecase = new DeleteTopicSubscriptionsUsecase(
+      topicRepositoryMock as any,
+      topicSubscribersRepositoryMock as any,
+      subscriberRepositoryMock as any,
+      preferencesRepositoryMock as any
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  function createCommand(): DeleteTopicSubscriptionsCommand {
+    return DeleteTopicSubscriptionsCommand.create({
+      environmentId: validEnvId,
+      organizationId: validOrgId,
+      userId: 'user-id',
+      topicKey,
+      subscriptions: [{ subscriberId: externalSubscriberId }],
+    });
+  }
+
+  it('passes the transaction session to the preferences delete and scopes by organization', async () => {
+    await usecase.execute(createCommand());
+
+    expect(preferencesRepositoryMock.delete.calledOnce).to.equal(true);
+    const [filter, options] = preferencesRepositoryMock.delete.firstCall.args;
+    expect(filter).to.deep.include({
+      _environmentId: validEnvId,
+      _organizationId: validOrgId,
+      type: PreferencesTypeEnum.SUBSCRIPTION_SUBSCRIBER_WORKFLOW,
+    });
+    expect(filter._topicSubscriptionId).to.deep.equal({ $in: [validSubscriptionId] });
+    expect(options).to.deep.equal({ session: fakeSession });
+  });
+
+  it('passes the transaction session to the topic subscribers delete and scopes by organization', async () => {
+    await usecase.execute(createCommand());
+
+    expect(topicSubscribersRepositoryMock.delete.calledOnce).to.equal(true);
+    const [filter, options] = topicSubscribersRepositoryMock.delete.firstCall.args;
+    expect(filter).to.deep.include({
+      _environmentId: validEnvId,
+      _organizationId: validOrgId,
+    });
+    expect(filter._id).to.deep.equal({ $in: [validSubscriptionId] });
+    expect(options).to.deep.equal({ session: fakeSession });
+  });
+
+  it('uses a single transaction for both deletes (preferences first, then subscribers)', async () => {
+    await usecase.execute(createCommand());
+
+    expect(topicSubscribersRepositoryMock.withTransaction.calledOnce).to.equal(true);
+    expect(preferencesRepositoryMock.delete.calledBefore(topicSubscribersRepositoryMock.delete)).to.equal(true);
+  });
+
+  it('rolls back by surfacing the error when the second delete fails inside the transaction', async () => {
+    const failure = new Error('subscription delete failed');
+    topicSubscribersRepositoryMock.delete.rejects(failure);
+
+    let caught: Error | undefined;
+    try {
+      await usecase.execute(createCommand());
+    } catch (err) {
+      caught = err as Error;
+    }
+
+    expect(caught).to.equal(failure);
+    expect(preferencesRepositoryMock.delete.calledOnce).to.equal(true);
+    expect(topicSubscribersRepositoryMock.delete.calledOnce).to.equal(true);
+    const [, prefOptions] = preferencesRepositoryMock.delete.firstCall.args;
+    const [, subOptions] = topicSubscribersRepositoryMock.delete.firstCall.args;
+    expect(prefOptions).to.deep.equal({ session: fakeSession });
+    expect(subOptions).to.deep.equal({ session: fakeSession });
+  });
+});

--- a/apps/api/src/app/topics-v2/usecases/delete-topic-subscriptions/delete-topic-subscriptions.usecase.ts
+++ b/apps/api/src/app/topics-v2/usecases/delete-topic-subscriptions/delete-topic-subscriptions.usecase.ts
@@ -325,19 +325,27 @@ export class DeleteTopicSubscriptionsUsecase {
     command: DeleteTopicSubscriptionsCommand,
     existingSubscriptions: TopicSubscribersEntity[]
   ): Promise<void> {
-    await this.topicSubscribersRepository.withTransaction(async () => {
+    await this.topicSubscribersRepository.withTransaction(async (session) => {
       const subscriptionIds = existingSubscriptions.map((sub) => sub._id);
 
-      await this.preferencesRepository.delete({
-        _environmentId: command.environmentId,
-        _topicSubscriptionId: { $in: subscriptionIds },
-        type: PreferencesTypeEnum.SUBSCRIPTION_SUBSCRIBER_WORKFLOW,
-      });
+      await this.preferencesRepository.delete(
+        {
+          _environmentId: command.environmentId,
+          _organizationId: command.organizationId,
+          _topicSubscriptionId: { $in: subscriptionIds },
+          type: PreferencesTypeEnum.SUBSCRIPTION_SUBSCRIBER_WORKFLOW,
+        },
+        { session }
+      );
 
-      await this.topicSubscribersRepository.delete({
-        _organizationId: command.organizationId,
-        _id: { $in: subscriptionIds },
-      });
+      await this.topicSubscribersRepository.delete(
+        {
+          _environmentId: command.environmentId,
+          _organizationId: command.organizationId,
+          _id: { $in: subscriptionIds },
+        },
+        { session }
+      );
     });
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`DeleteTopicSubscriptionsUsecase.performDeletion` wrapped both deletes in `topicSubscribersRepository.withTransaction`, but the callback ignored the provided session. Both `preferencesRepository.delete` and `topicSubscribersRepository.delete` ran outside the transaction, so a failure of the second delete could not roll back the first — leaving subscriptions without their associated workflow preferences (or vice versa).

## Why

If preferences are deleted but the subscription delete fails, you end up with subscriptions that have no associated workflow preferences (inconsistent state on partial failure). Additionally, the preferences delete query was missing `_organizationId` scoping.

## Changes

- `apps/api/src/app/topics-v2/usecases/delete-topic-subscriptions/delete-topic-subscriptions.usecase.ts`
  - `withTransaction(async (session) => …)` — accept the session.
  - Pass `{ session }` to both `preferencesRepository.delete` and `topicSubscribersRepository.delete` so they participate in the transaction.
  - Add `_organizationId` to both delete filters (and `_environmentId` to the topic-subscribers delete) for proper org/env scoping.
- `apps/api/src/app/topics-v2/usecases/delete-topic-subscriptions/delete-topic-subscriptions.spec.ts`
  - New unit spec covering: session is propagated to both deletes, org scoping is applied, both deletes share a single transaction, and an error from the second delete propagates out (so the transaction rolls back).

## Acceptance criteria

- [x] Both deletes participate in the transaction (session forwarded)
- [x] Test: simulate failure on the second delete → first delete's session is the same and the error propagates so the transaction rolls back
- [x] Both queries scoped by `_organizationId`

## Tests

Unit:

```
DeleteTopicSubscriptionsUsecase
  ✔ passes the transaction session to the preferences delete and scopes by organization
  ✔ passes the transaction session to the topic subscribers delete and scopes by organization
  ✔ uses a single transaction for both deletes (preferences first, then subscribers)
  ✔ rolls back by surfacing the error when the second delete fails inside the transaction

4 passing
```

E2E (existing `delete-topic-subscriptions.e2e.ts`):

```
Delete topic subscriptions - /v2/topics/:topicKey/subscriptions (DELETE) #novu-v2
  ✔ should delete a single subscription from a topic
  ✔ should delete multiple subscriptions from a topic
  ✔ should handle partial success when deleting subscriptions
  ✔ should handle deleting from a non-existent topic

4 passing
```

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7607](https://linear.app/novu/issue/NV-7607/bug-deletetopicsubscriptions-transaction-callback-ignores-the-session)

<div><a href="https://cursor.com/agents/bc-6c73ead2-b8a7-481f-8bc5-73560590af2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c73ead2-b8a7-481f-8bc5-73560590af2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Fixed a transaction isolation bug in `DeleteTopicSubscriptionsUsecase.performDeletion` where delete operations were not participating in the transaction despite being wrapped with `topicSubscribersRepository.withTransaction`. The session callback parameter was being ignored, causing both the preferences and topic-subscribers deletes to execute outside the transaction. Additionally, the preferences delete lacked organizational scoping. The fix ensures both deletes receive and use the transaction session, adds `_organizationId` scoping to both operations, and adds `_environmentId` to the topic-subscribers delete for proper environment isolation.

## Affected areas

**api**: `DeleteTopicSubscriptionsUsecase` now correctly propagates the transaction session to both delete operations, preventing potential data inconsistency if one delete succeeds and the other fails. Delete filters are now scoped by organization and environment to ensure proper multi-tenant isolation.

## Key technical decisions

- Both delete operations now explicitly pass `{ session }` to participate in the same database transaction, ensuring atomicity.
- Delete filters include organization and environment identifiers to prevent cross-organization data leakage.

## Testing

Added unit tests covering transaction session propagation to both deletes, organization scoping, single transaction usage, and rollback behavior when the second delete fails. Existing E2E tests continue to pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->