### PR TITLE
fix(api-service): await inbound mail queue persistence before SMTP ack fixes NV-7596

### DIFF
--- a/apps/inbound-mail/src/server/index.spec.ts
+++ b/apps/inbound-mail/src/server/index.spec.ts
@@ -1,0 +1,142 @@
+import net from 'node:net';
+import { InboundParseQueueService } from '@novu/application-generic';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import mailinServer from './index';
+
+/*
+ * Validates the data-loss fix in apps/inbound-mail/src/server/index.ts.
+ *
+ * Before the fix the SMTP DATA handler returned 250 OK to the client without
+ * awaiting the queue insert. If `inboundParseQueueService.add` rejected, the
+ * sender had already been told the message was accepted — silent loss.
+ *
+ * The fix awaits the entire `dataReady` chain (including `postQueue`) and
+ * propagates any failure to the SMTP layer with `responseCode: 451`, so the
+ * sending MTA receives a transient failure and retries.
+ */
+describe('Mailin SMTP DATA handler — queue persistence', () => {
+  const SMTP_HOST = '127.0.0.1';
+  const SMTP_PORT = Number(process.env.PORT || 2525);
+
+  function sendInboundMessage(): Promise<string[]> {
+    return new Promise((resolve, reject) => {
+      const socket = net.connect(SMTP_PORT, SMTP_HOST);
+      const transcript: string[] = [];
+      let buffer = '';
+
+      const dataLines = [
+        'From: <sender@example.com>',
+        'To: <support@customer.com>',
+        'Subject: Test inbound mail',
+        'Message-ID: <test-message-id@example.com>',
+        '',
+        'Hello world',
+        '.',
+      ].join('\r\n');
+
+      const script = [
+        'EHLO test.local',
+        'MAIL FROM:<sender@example.com>',
+        'RCPT TO:<support@customer.com>',
+        'DATA',
+        dataLines,
+        'QUIT',
+      ];
+      let step = 0;
+
+      socket.setEncoding('utf8');
+      socket.setTimeout(15_000, () => {
+        socket.destroy(new Error('SMTP transaction timed out'));
+      });
+
+      socket.on('data', (chunk: string) => {
+        buffer += chunk;
+        const parts = buffer.split('\r\n');
+        buffer = parts.pop() ?? '';
+        for (const line of parts) {
+          if (!line) continue;
+          transcript.push(line);
+          if (/^\d{3} /.test(line)) {
+            const next = script[step++];
+            if (next != null) {
+              socket.write(`${next}\r\n`);
+            }
+          }
+        }
+      });
+
+      socket.on('error', reject);
+      socket.on('close', () => resolve(transcript));
+    });
+  }
+
+  function findPostDataReply(transcript: string[]): string | undefined {
+    const dataIdx = transcript.findIndex((line) => /^354[ -]/.test(line));
+    if (dataIdx === -1) return undefined;
+    for (let i = dataIdx + 1; i < transcript.length; i += 1) {
+      if (/^\d{3} /.test(transcript[i])) return transcript[i];
+    }
+
+    return undefined;
+  }
+
+  before(async function before() {
+    this.timeout(30_000);
+    // main.ts auto-starts the SMTP server, but `start()` is async (Redis
+    // init). Wait for the listener to come up before driving test traffic.
+    const deadline = Date.now() + 25_000;
+    while (Date.now() < deadline) {
+      const smtp = (mailinServer as unknown as { _smtp: unknown })._smtp;
+      if (smtp) {
+        // Probe the port to ensure listen() has actually completed.
+        try {
+          await new Promise<void>((resolve, reject) => {
+            const probe = net.connect(SMTP_PORT, SMTP_HOST);
+            probe.once('connect', () => {
+              probe.end();
+              resolve();
+            });
+            probe.once('error', reject);
+            probe.setTimeout(1000, () => probe.destroy(new Error('probe timeout')));
+          });
+
+          return;
+        } catch {
+          // not ready yet
+        }
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    this.skip();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('returns SMTP 4xx (not 250) when the queue insert fails so the sender retries instead of dropping the message', async () => {
+    sinon.stub(InboundParseQueueService.prototype, 'add').rejects(new Error('Simulated queue insert failure'));
+
+    const transcript = await sendInboundMessage();
+    const postDataReply = findPostDataReply(transcript);
+
+    expect(postDataReply, `transcript: ${transcript.join(' | ')}`).to.exist;
+    const reply = postDataReply ?? '';
+    const code = Number(reply.slice(0, 3));
+    expect(code, `expected 4xx retry-eligible response, got: ${reply}`).to.be.gte(400).and.lt(500);
+    expect(reply.startsWith('250 '), `unexpected 250 OK on queue failure: ${reply}`).to.equal(false);
+  });
+
+  it('returns SMTP 250 when the queue insert succeeds', async () => {
+    sinon.stub(InboundParseQueueService.prototype, 'add').resolves(undefined as never);
+
+    const transcript = await sendInboundMessage();
+    const postDataReply = findPostDataReply(transcript);
+
+    expect(postDataReply, `transcript: ${transcript.join(' | ')}`).to.exist;
+    const reply = postDataReply ?? '';
+    expect(reply.startsWith('250 '), `expected 250 OK, got: ${reply}`).to.equal(true);
+  });
+});

--- a/apps/inbound-mail/src/server/index.spec.ts
+++ b/apps/inbound-mail/src/server/index.spec.ts
@@ -1,4 +1,6 @@
+import fs from 'node:fs';
 import net from 'node:net';
+import path from 'node:path';
 import { InboundParseQueueService } from '@novu/application-generic';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -116,9 +118,25 @@ describe('Mailin SMTP DATA handler — queue persistence', () => {
     sinon.restore();
   });
 
+  /*
+   * The Mailin server writes raw inbound emails into a tmp directory derived
+   * from the configured `tmp` setting (default `.tmp`, relative to cwd at
+   * server start time). After every test we sample the directory to assert
+   * that no temp files leaked from a failed queue insert — a sustained queue
+   * outage must not be amplifiable into a disk-exhaustion DoS.
+   */
+  const tmpDir = path.resolve(mailinServer.configuration.tmp);
+
+  function listTmpFiles(): string[] {
+    if (!fs.existsSync(tmpDir)) return [];
+
+    return fs.readdirSync(tmpDir).filter((name) => !name.startsWith('.'));
+  }
+
   it('returns SMTP 4xx (not 250) when the queue insert fails so the sender retries instead of dropping the message', async () => {
     sinon.stub(InboundParseQueueService.prototype, 'add').rejects(new Error('Simulated queue insert failure'));
 
+    const before = new Set(listTmpFiles());
     const transcript = await sendInboundMessage();
     const postDataReply = findPostDataReply(transcript);
 
@@ -127,16 +145,32 @@ describe('Mailin SMTP DATA handler — queue persistence', () => {
     const code = Number(reply.slice(0, 3));
     expect(code, `expected 4xx retry-eligible response, got: ${reply}`).to.be.gte(400).and.lt(500);
     expect(reply.startsWith('250 '), `unexpected 250 OK on queue failure: ${reply}`).to.equal(false);
+
+    /*
+     * Give the failure-path cleanup (best-effort unlink) a beat to run after
+     * the SMTP transaction terminates. Then assert that no new temp file was
+     * left behind. Without this assertion an attacker could repeatedly submit
+     * messages during a queue outage and accumulate temp files until the disk
+     * is full.
+     */
+    await new Promise((r) => setTimeout(r, 250));
+    const after = listTmpFiles().filter((name) => !before.has(name));
+    expect(after, `temp files leaked on queue-failure path: ${after.join(', ')}`).to.deep.equal([]);
   });
 
-  it('returns SMTP 250 when the queue insert succeeds', async () => {
+  it('returns SMTP 250 when the queue insert succeeds and cleans up the temp file', async () => {
     sinon.stub(InboundParseQueueService.prototype, 'add').resolves(undefined as never);
 
+    const before = new Set(listTmpFiles());
     const transcript = await sendInboundMessage();
     const postDataReply = findPostDataReply(transcript);
 
     expect(postDataReply, `transcript: ${transcript.join(' | ')}`).to.exist;
     const reply = postDataReply ?? '';
     expect(reply.startsWith('250 '), `expected 250 OK, got: ${reply}`).to.equal(true);
+
+    await new Promise((r) => setTimeout(r, 250));
+    const after = listTmpFiles().filter((name) => !before.has(name));
+    expect(after, `temp files leaked on success path: ${after.join(', ')}`).to.deep.equal([]);
   });
 });

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -477,7 +477,7 @@ class Mailin extends events.EventEmitter {
         'inbound-mail/post-queue',
         true,
         () =>
-          new Promise((resolve) => {
+          new Promise<void>((resolve, reject) => {
             logger.debug(
               { context: LOG_CONTEXT, connectionId: connection.id },
               `${connection.id} finalized message is: ${finalizedMessage}`
@@ -517,13 +517,20 @@ class Mailin extends events.EventEmitter {
               // ignore — instrumentation must never break the pipeline
             }
 
-            inboundMailService.inboundParseQueueService.add({
-              name: finalizedMessage.messageId,
-              data: finalizedMessage,
-              groupId,
-            });
-
-            return resolve();
+            return inboundMailService.inboundParseQueueService
+              .add({
+                name: finalizedMessage.messageId,
+                data: finalizedMessage,
+                groupId,
+              })
+              .then(() => resolve())
+              .catch((error) => {
+                logger.error(
+                  { err: error, context: LOG_CONTEXT, connectionId: connection.id },
+                  `${connection.id} Failed to add inbound mail to queue`
+                );
+                reject(error);
+              });
           })
       );
     }
@@ -567,8 +574,29 @@ class Mailin extends events.EventEmitter {
         });
 
         stream.on('end', () => {
-          dataReady(connection);
-          onDataCallback();
+          dataReady(connection)
+            .then(() => onDataCallback())
+            .catch((error) => {
+              nr.noticeError(error);
+              logger.error(
+                { err: error, context: LOG_CONTEXT, connectionId: connection.id },
+                `${connection.id} Inbound mail processing failed; signalling temporary failure to sender for retry`
+              );
+
+              /*
+               * Signal a transient failure (4xx) to the sending MTA so it retries
+               * delivery instead of treating the message as accepted. Without
+               * this, a queue-insert failure after an unconditional onDataCallback()
+               * would silently drop the message — sender thinks 250 OK, we have
+               * nothing persisted.
+               */
+              const smtpError: Error & { responseCode?: number } =
+                error instanceof Error ? error : new Error(String(error));
+              if (typeof smtpError.responseCode !== 'number') {
+                smtpError.responseCode = 451;
+              }
+              onDataCallback(smtpError);
+            });
         });
 
         stream.on('close', () => {

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -272,7 +272,7 @@ class Mailin extends events.EventEmitter {
               })
               .then(postQueue.bind(null, connection))
               .then(
-                () => unlinkFileBestEffort(connection).then(() => resolve()),
+                () => unlinkFile(connection).then(() => resolve()),
                 (processingError) => {
                   nr.noticeError(processingError);
                   logger.error(
@@ -289,7 +289,7 @@ class Mailin extends events.EventEmitter {
                    * downstream queue is degraded. Unlink is best-effort so a
                    * cleanup failure does not mask the original processing error.
                    */
-                  return unlinkFileBestEffort(connection).then(() => reject(processingError));
+                  return unlinkFile(connection).then(() => reject(processingError));
                 }
               )
               .finally(() => {
@@ -545,9 +545,17 @@ class Mailin extends events.EventEmitter {
           })
       );
     }
-    function unlinkFile(connection) {
+    /*
+     * Best-effort cleanup of the raw email temp file. Used on both success and
+     * failure paths so a sustained queue outage cannot be amplified into a
+     * disk-exhaustion DoS via retained temp files (NV-7596). Swallows ENOENT
+     * (the file may never have been written, e.g. if `retrieveRawEmail`
+     * failed) and logs any other unlink error without rejecting — the caller
+     * may already be propagating an upstream processing error and we don't
+     * want a cleanup failure to mask it.
+     */
+    function unlinkFile(connection): Promise<void> {
       return nr.startSegment('inbound-mail/unlink-file', true, () =>
-        /* Don't forget to unlink the tmp file. */
         fs.promises
           .unlink(connection.mailPath)
           .then(() => {
@@ -556,34 +564,13 @@ class Mailin extends events.EventEmitter {
               `${connection.id} End processing message, deleted ${connection.mailPath}`
             );
           })
-      );
-    }
-
-    /*
-     * Best-effort variant used on the failure path. Swallows ENOENT (the file
-     * may never have been written, e.g. if `retrieveRawEmail` failed) and logs
-     * any other unlink error without rejecting — the caller is already
-     * propagating an upstream processing error and we don't want to mask it
-     * with a cleanup failure. This is what prevents a sustained queue outage
-     * from being amplified into a disk-exhaustion DoS via retained temp files.
-     */
-    function unlinkFileBestEffort(connection): Promise<void> {
-      return nr.startSegment('inbound-mail/unlink-file-best-effort', true, () =>
-        fs.promises
-          .unlink(connection.mailPath)
-          .then(() => {
-            logger.info(
-              { context: LOG_CONTEXT, connectionId: connection.id },
-              `${connection.id} Cleaned up temp file after failure: ${connection.mailPath}`
-            );
-          })
           .catch((unlinkError: NodeJS.ErrnoException) => {
             if (unlinkError?.code === 'ENOENT') {
               return;
             }
             logger.warn(
               { err: unlinkError, context: LOG_CONTEXT, connectionId: connection.id },
-              `${connection.id} Failed to clean up temp file ${connection.mailPath} on failure path`
+              `${connection.id} Failed to clean up temp file ${connection.mailPath}`
             );
           })
       );

--- a/apps/inbound-mail/src/server/index.ts
+++ b/apps/inbound-mail/src/server/index.ts
@@ -271,16 +271,27 @@ class Mailin extends events.EventEmitter {
                 return finalizedMessage;
               })
               .then(postQueue.bind(null, connection))
-              .then(unlinkFile.bind(null, connection))
-              .then(() => resolve())
-              .catch((error) => {
-                nr.noticeError(error);
-                logger.error(
-                  { err: error, context: LOG_CONTEXT, connectionId: connection.id },
-                  `${connection.id} Unable to finish processing message!!`
-                );
-                reject(error);
-              })
+              .then(
+                () => unlinkFileBestEffort(connection).then(() => resolve()),
+                (processingError) => {
+                  nr.noticeError(processingError);
+                  logger.error(
+                    { err: processingError, context: LOG_CONTEXT, connectionId: connection.id },
+                    `${connection.id} Unable to finish processing message!!`
+                  );
+
+                  /*
+                   * Always clean up the temp raw email — even on the failure path.
+                   * SMTP returns 4xx so the sending MTA retries delivery, which
+                   * produces a fresh temp file. Retaining the failed file would
+                   * let an attacker amplify a queue/Redis outage into disk
+                   * exhaustion by repeatedly submitting messages while the
+                   * downstream queue is degraded. Unlink is best-effort so a
+                   * cleanup failure does not mask the original processing error.
+                   */
+                  return unlinkFileBestEffort(connection).then(() => reject(processingError));
+                }
+              )
               .finally(() => {
                 if (transaction) {
                   transaction.end();
@@ -543,6 +554,36 @@ class Mailin extends events.EventEmitter {
             logger.info(
               { context: LOG_CONTEXT, connectionId: connection.id },
               `${connection.id} End processing message, deleted ${connection.mailPath}`
+            );
+          })
+      );
+    }
+
+    /*
+     * Best-effort variant used on the failure path. Swallows ENOENT (the file
+     * may never have been written, e.g. if `retrieveRawEmail` failed) and logs
+     * any other unlink error without rejecting — the caller is already
+     * propagating an upstream processing error and we don't want to mask it
+     * with a cleanup failure. This is what prevents a sustained queue outage
+     * from being amplified into a disk-exhaustion DoS via retained temp files.
+     */
+    function unlinkFileBestEffort(connection): Promise<void> {
+      return nr.startSegment('inbound-mail/unlink-file-best-effort', true, () =>
+        fs.promises
+          .unlink(connection.mailPath)
+          .then(() => {
+            logger.info(
+              { context: LOG_CONTEXT, connectionId: connection.id },
+              `${connection.id} Cleaned up temp file after failure: ${connection.mailPath}`
+            );
+          })
+          .catch((unlinkError: NodeJS.ErrnoException) => {
+            if (unlinkError?.code === 'ENOENT') {
+              return;
+            }
+            logger.warn(
+              { err: unlinkError, context: LOG_CONTEXT, connectionId: connection.id },
+              `${connection.id} Failed to clean up temp file ${connection.mailPath} on failure path`
             );
           })
       );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Inbound SMTP server returned `250 OK` to senders before the email was actually persisted to the queue, causing silent message loss whenever queue insertion failed.

The SMTP `DATA` handler in `apps/inbound-mail/src/server/index.ts` had three bugs that compounded into data loss:

1. `dataReady(connection)` was called without `await` and `onDataCallback()` was invoked unconditionally on the next line — the SMTP transaction was acknowledged before any of the downstream parsing/queueing work had even started.
2. Inside `postQueue`, `inboundParseQueueService.add(...)` was called without `await`. The wrapping promise resolved immediately, regardless of whether the BullMQ insert succeeded.
3. The `.then(unlinkFile)` chain ran unconditionally, deleting the temp raw email even when queueing had failed.

#### Fix

- Await the entire `dataReady` chain (`raw read → parse → DKIM/SPF/spam → finalize → postQueue → unlink`) before invoking `onDataCallback`.
- In `postQueue`, properly chain `inboundParseQueueService.add(...)` and `reject` on failure so the subsequent `.then(unlinkFile)` is **skipped** (temp file preserved) and the error propagates up.
- Map any failure in the `dataReady` chain to an SMTP `4xx` (`responseCode: 451`) so the sending MTA retries delivery instead of treating the message as accepted.

#### Follow-up: prevent disk-exhaustion DoS on the failure path

Cursor's agentic security review flagged that the first iteration of the fix preserved every raw temp message file whenever queue insertion failed. Because SMTP is externally reachable, an attacker could repeatedly submit messages during a queue/Redis outage and accumulate retained files until disk is exhausted — turning a downstream availability incident into a local DoS on the inbound-mail host.

The temp file is no longer needed after the SMTP transaction ends: returning `451` causes the sending MTA to retry, which produces a fresh temp file on the next delivery attempt. There is no in-process retry that would consume the old file.

- Introduced `unlinkFileBestEffort()`: swallows `ENOENT` (the file may never have been written if `retrieveRawEmail` failed) and logs other unlink errors without rejecting, so a cleanup failure cannot mask the original processing error.
- Replaced the unconditional `.then(unlinkFile)` + uniform `.catch` with a two-arg `.then` so **both** paths always attempt cleanup:
  - success path → `unlinkFileBestEffort` → `resolve`
  - failure path → `nr.noticeError` + log → `unlinkFileBestEffort` → `reject`
- The failure error still propagates up to the SMTP layer as a `451` retry-eligible response.

```mermaid
sequenceDiagram
    participant MTA as Sending MTA
    participant SMTP as SMTP DATA handler
    participant Q as InboundParseQueue
    participant FS as Temp file

    MTA->>SMTP: DATA <body>
    SMTP->>SMTP: dataReady() — parse, DKIM/SPF/spam
    SMTP->>Q: queue.add(message)
    alt queue.add resolves
        Q-->>SMTP: ok
        SMTP->>FS: unlink(tmp)  (best-effort)
        SMTP-->>MTA: 250 OK
    else queue.add rejects
        Q-->>SMTP: error
        SMTP->>FS: unlink(tmp)  (best-effort, prevents disk-exhaustion DoS)
        SMTP-->>MTA: 451 (transient) — sender retries
    end
```

#### Tests

Added `apps/inbound-mail/src/server/index.spec.ts` driving a raw SMTP transaction against the running server and asserting:

- queue-add failure → SMTP `4xx`, no `250 OK`, **no temp file leaked**
- queue-add success → SMTP `250 OK`, temp file removed

Verified the new tests fail on the unmodified `next` branch (returns `250 OK: message queued` despite the simulated queue failure) and pass with this fix. Also verified the leak assertion fails when the failure-path cleanup is reverted (regression check: `temp files leaked on queue-failure path: <uuid>`).

```
  Mailin SMTP DATA handler — queue persistence
    ✔ returns SMTP 4xx (not 250) when the queue insert fails so the sender retries instead of dropping the message
    ✔ returns SMTP 250 when the queue insert succeeds and cleans up the temp file
  2 passing
```

### Acceptance criteria

- [x] If queue insert fails, SMTP returns a retry-eligible failure code (`451`)
- [x] Temp file is not deleted before queue insert succeeds
- [x] Temp file is cleaned up on the failure path after the SMTP decision (no disk-exhaustion DoS amplification)
- [x] Test: simulate queue failure → sender retried, no message lost, no temp file leaked

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7596](https://linear.app/novu/issue/NV-7596/bug-inbound-mail-acknowledged-to-sender-before-queue-persistence-data)

<div><a href="https://cursor.com/agents/bc-14ed82c7-003a-4329-b34f-0c7b79ca98cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14ed82c7-003a-4329-b34f-0c7b79ca98cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The inbound SMTP DATA handler now awaits the entire message processing pipeline (raw read → parse → DKIM/SPF/spam checks → queue persistence → temp-file cleanup) before sending the SMTP ACK. Queue insertion is now awaited and failures cause the handler to return a transient SMTP error (451) so sending MTAs will retry instead of silently losing messages. Temp-file cleanup is best-effort (ignores ENOENT, logs other unlink errors) and runs after processing to avoid premature deletion and disk-exhaustion DoS.

## Affected areas

**inbound-mail**: The SMTP DATA flow was hardened: dataReady is fully awaited before calling onDataCallback; postQueue now awaits InboundParseQueueService.add(...) and rejects on failure; unlinkFile was made best-effort and cleanup runs on both success and failure.

## Key technical decisions

- Processing failures map to SMTP transient 4xx (default 451) to prompt remote retry rather than acknowledging lost messages.  
- Temp-file unlinking is non-fatal (swallows ENOENT, logs others) to avoid masking processing errors while preventing disk-exhaustion DoS.  
- postQueue now propagates enqueue errors (returns Promise<void>) instead of resolving immediately.

## Testing

Added an integration-style spec (apps/inbound-mail/src/server/index.spec.ts) that performs a raw SMTP transaction, stubs queue add success/failure, asserts 250 on success and 4xx (transient) on queue failure, and verifies no temp-file leaks on either path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->