### PR TITLE
fix(api-service): catch floating ClickHouse write in exception filter fixes NV-7613

### DIFF
--- a/apps/api/src/exception-filter.spec.ts
+++ b/apps/api/src/exception-filter.spec.ts
@@ -1,0 +1,145 @@
+import { ArgumentsHost, BadRequestException, HttpStatus } from '@nestjs/common';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { AllExceptionsFilter } from './exception-filter';
+
+function buildLogRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    url: '/v1/test',
+    originalUrl: '/v1/test',
+    path: '/v1/test',
+    hostname: 'localhost',
+    method: 'GET',
+    headers: { 'user-agent': 'mocha' },
+    route: { path: '/v1/test' },
+    body: {},
+    _nvRequestId: 'req_123',
+    _shouldLogAnalytics: true,
+    user: {
+      _id: 'u1',
+      organizationId: 'o1',
+      environmentId: 'e1',
+      scheme: 'Bearer',
+    },
+    ...overrides,
+  };
+}
+
+type LoggerStub = {
+  error: sinon.SinonStub;
+  warn: sinon.SinonStub;
+};
+
+type RequestLogRepositoryStub = {
+  create: sinon.SinonStub;
+};
+
+function buildHost({
+  request,
+  response,
+}: {
+  request: Record<string, unknown>;
+  response: { status: sinon.SinonStub; json: sinon.SinonStub };
+}): ArgumentsHost {
+  const httpHost = {
+    getRequest: () => request,
+    getResponse: () => response,
+    getNext: () => undefined,
+  };
+
+  return {
+    switchToHttp: () => httpHost,
+  } as unknown as ArgumentsHost;
+}
+
+describe('AllExceptionsFilter', () => {
+  let logger: LoggerStub;
+  let requestLogRepository: RequestLogRepositoryStub;
+  let filter: AllExceptionsFilter;
+  let unhandledRejections: unknown[];
+  let unhandledRejectionListener: (reason: unknown) => void;
+
+  beforeEach(() => {
+    logger = {
+      error: sinon.stub(),
+      warn: sinon.stub(),
+    };
+    requestLogRepository = {
+      create: sinon.stub(),
+    };
+    filter = new AllExceptionsFilter(logger as never, requestLogRepository as never);
+
+    unhandledRejections = [];
+    unhandledRejectionListener = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', unhandledRejectionListener);
+  });
+
+  afterEach(() => {
+    process.removeListener('unhandledRejection', unhandledRejectionListener);
+    sinon.restore();
+  });
+
+  it('should send the error response without awaiting the analytics log write', async () => {
+    requestLogRepository.create.returns(new Promise(() => {}));
+
+    const status = sinon.stub().returnsThis();
+    const json = sinon.stub().returnsThis();
+    const response = { status, json };
+    const request = buildLogRequest();
+    process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
+
+    const host = buildHost({ request, response });
+    const exception = new BadRequestException('boom');
+
+    await filter.catch(exception, host);
+
+    expect(status.calledWith(HttpStatus.BAD_REQUEST)).to.equal(true);
+    expect(json.calledOnce).to.equal(true);
+    expect(requestLogRepository.create.calledOnce).to.equal(true);
+  });
+
+  it('should catch a rejected ClickHouse write and log a warning instead of producing an unhandled rejection', async () => {
+    const failure = new Error('clickhouse unavailable');
+    requestLogRepository.create.rejects(failure);
+
+    const status = sinon.stub().returnsThis();
+    const json = sinon.stub().returnsThis();
+    const response = { status, json };
+    const request = buildLogRequest();
+    process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
+
+    const host = buildHost({ request, response });
+    const exception = new BadRequestException('boom');
+
+    await filter.catch(exception, host);
+
+    // Allow the floating .catch handler to run.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(status.calledWith(HttpStatus.BAD_REQUEST)).to.equal(true);
+    expect(json.calledOnce).to.equal(true);
+    expect(requestLogRepository.create.calledOnce).to.equal(true);
+    expect(logger.warn.calledOnce).to.equal(true);
+    const [logContext, logMessage] = logger.warn.firstCall.args;
+    expect(logContext).to.deep.equal({ err: failure });
+    expect(logMessage).to.equal('Failed to log analytics to ClickHouse after retries');
+    expect(unhandledRejections).to.deep.equal([]);
+  });
+
+  it('should not call the request log repository when analytics logging is not enabled', async () => {
+    const status = sinon.stub().returnsThis();
+    const json = sinon.stub().returnsThis();
+    const response = { status, json };
+    const request = buildLogRequest({ _shouldLogAnalytics: false });
+    process.env.IS_ANALYTICS_LOGS_ENABLED = 'true';
+
+    const host = buildHost({ request, response });
+
+    await filter.catch(new BadRequestException('boom'), host);
+
+    expect(requestLogRepository.create.called).to.equal(false);
+  });
+});

--- a/apps/api/src/exception-filter.ts
+++ b/apps/api/src/exception-filter.ts
@@ -56,17 +56,23 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const user = req.user as UserSessionData;
     const basicLog = buildLog(request, statusCode, errorDto, user);
 
-    try {
-      if (basicLog) {
-        this.requestLogRepository.create(basicLog, {
-          organizationId: user?.organizationId,
-          environmentId: user?.environmentId,
-          userId: user?._id,
-        });
-      }
-    } catch (err) {
-      this.logger.warn({ err }, 'Failed to log analytics to ClickHouse after retries');
-    }
+    if (!basicLog) return;
+
+    /**
+     * Fire-and-forget the ClickHouse write so a slow or failing analytics
+     * pipeline never blocks the error response. The `.catch` handler is
+     * required to prevent unhandled promise rejections from escaping to
+     * the runtime when the underlying ClickHouse write rejects.
+     */
+    this.requestLogRepository
+      .create(basicLog, {
+        organizationId: user?.organizationId,
+        environmentId: user?.environmentId,
+        userId: user?._id,
+      })
+      .catch((err) => {
+        this.logger.warn({ err }, 'Failed to log analytics to ClickHouse after retries');
+      });
   }
 
   private async shouldRun(ctx: HttpArgumentsHost): Promise<boolean> {

--- a/biome.json
+++ b/biome.json
@@ -39,6 +39,9 @@
   },
   "linter": {
     "enabled": true,
+    "domains": {
+      "project": "recommended"
+    },
     "rules": {
       "recommended": true,
       "a11y": {
@@ -106,6 +109,9 @@
         "useIterableCallbackReturn": "warn",
         "noArrayIndexKey": "off",
         "noPrototypeBuiltins": "off"
+      },
+      "nursery": {
+        "noFloatingPromises": "warn"
       }
     }
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The global exception filter (`apps/api/src/exception-filter.ts`) wrapped `requestLogRepository.create(...)` inside a `try`/`catch` but never `await`ed the call. ClickHouse rejections produced during error handling therefore escaped the `catch` block as **unhandled promise rejections**, which can crash the API process during a ClickHouse outage — at the worst possible time, while the filter is already handling another exception.

This PR replaces the silent floating Promise with an explicit fire-and-forget that attaches a `.catch` handler, and turns on Biome's `noFloatingPromises` lint rule as defense-in-depth.

## Changes

- `apps/api/src/exception-filter.ts`: drop the unreachable `try`/`catch` and `await` it back through a `.catch` on the analytics write. The error response is no longer coupled to the ClickHouse round-trip, and a rejected write is now logged via `PinoLogger.warn` instead of escaping to the runtime.
- `apps/api/src/exception-filter.spec.ts`: new Mocha/Sinon spec covering the three cases — happy path (response sent without awaiting the write), failure path (rejection is caught & logged, no `unhandledRejection` event), and disabled path (no write is attempted).
- `biome.json`: enable the `project` domain and turn on `lint/nursery/noFloatingPromises` as a `warn`. The rule needs the project domain to fire, and `warn` keeps CI green while still surfacing unawaited Promises in new code (the codebase has ~263 pre-existing offenders that can be cleaned up incrementally).

## Why fire-and-forget instead of `await`

Per the issue description, "Option B avoids slowing down the error response." Awaiting a slow ClickHouse write inside the exception filter would add latency to every 5xx response; fire-and-forget with an attached rejection handler matches existing intent (the original code clearly *meant* to be non-blocking — it just got the syntax wrong).

## Acceptance criteria

- [x] No floating promise from the request log write.
- [x] Test that simulates a ClickHouse rejection during error handling and asserts it is caught, logged, and never raised as an `unhandledRejection`.
- [x] `noFloatingPromises` lint rule enabled project-wide as defense in depth.

## Verification

Sanity-checked the new test catches the original bug by stashing the fix and re-running — the rejection-path test fails with a `FATAL: Unhandled promise rejection` (clickhouse unavailable) and Mocha exits non-zero, which is exactly the production crash mode the issue describes. With the fix applied, all three new specs pass:

```
  AllExceptionsFilter
    ✔ should send the error response without awaiting the analytics log write
    ✔ should catch a rejected ClickHouse write and log a warning instead of producing an unhandled rejection
    ✔ should not call the request log repository when analytics logging is not enabled

  3 passing
```

Full `apps/api` unit suite: 476 passing, 1 pre-existing failure in `preferences.spec.ts` unrelated to this change (verified by re-running on `next` before applying these commits).

Biome lint of the touched files reports no new errors or warnings introduced by the diff.

## Follow-up (out of scope)

The issue notes that the analytics mapper passes the full request/response DTOs through `sanitizePayload`, which only stringify+truncates — sensitive fields like trigger overrides, subscriber data, and tokens can still land in ClickHouse on error paths. Worth a separate ticket for key-level redaction.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7613](https://linear.app/novu/issue/NV-7613/bug-exception-filter-has-unawaited-clickhouse-write-unhandled)

<div><a href="https://cursor.com/agents/bc-6926e7b7-b509-42ac-9ec5-66cf0160e0be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6926e7b7-b509-42ac-9ec5-66cf0160e0be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR fixes an unhandled promise rejection in the global exception filter's analytics logging. Previously, the ClickHouse write operation (`requestLogRepository.create(...)`) was not awaited, allowing rejections to become unhandled promise rejections that could crash the API. The change converts the floating promise into an explicit fire-and-forget pattern with a `.catch()` handler to log failures without delaying the error response.

## Affected areas

**api**: The `AllExceptionsFilter.createAnalyticsLog` method now uses a non-blocking fire-and-forget pattern for ClickHouse writes with explicit error handling via `.catch()` instead of a synchronous try/catch wrapper. New unit tests validate that responses are sent without awaiting the write, rejected writes are caught and logged without triggering unhandledRejection events, and disabled analytics logging is respected.

**linter configuration**: Enabled the `noFloatingPromises` lint rule in biome.json as a warning to surface similar unawaited promises during development while keeping CI green.

## Key technical decisions

- Fire-and-forget pattern with explicit `.catch()` handler instead of await to prevent blocking error responses on ClickHouse failures
- Enabled `noFloatingPromises` as a warn-level rule in biome.json to catch similar issues early without breaking the build

## Testing

Added 3 new unit test cases covering (1) response sent without awaiting the write, (2) rejected ClickHouse write caught and logged with no unhandledRejection event, and (3) analytics not attempted when disabled. All new tests pass; full api unit suite shows 476 passing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->