### PR TITLE
fix(shared): reject step _templateId from another workflow on update fixes NV-7606

### DIFF
--- a/apps/api/src/app/workflows-v1/e2e/update-notification-template.e2e.ts
+++ b/apps/api/src/app/workflows-v1/e2e/update-notification-template.e2e.ts
@@ -409,6 +409,98 @@ describe('Update workflow by id - /workflows/:workflowId (PUT) #novu-v0', async 
     expect(updatedTemplate.steps[0].replyCallback?.url).to.equal('acme-corp.com/webhook');
   });
 
+  it('should reject step _templateId that belongs to another workflow', async () => {
+    const notificationTemplateService = new NotificationTemplateService(
+      session.user._id,
+      session.organization._id,
+      session.environment._id
+    );
+
+    const workflowA = await notificationTemplateService.createTemplate({
+      steps: [{ type: StepTypeEnum.IN_APP, content: 'Workflow A step' }],
+    });
+    const workflowB = await notificationTemplateService.createTemplate({
+      steps: [{ type: StepTypeEnum.IN_APP, content: 'Workflow B step' }],
+    });
+
+    const foreignTemplateId = workflowB.steps[0]._templateId;
+
+    const update: IUpdateNotificationTemplateDto = {
+      steps: [
+        {
+          _templateId: foreignTemplateId,
+          template: {
+            type: StepTypeEnum.IN_APP,
+            content: 'Hijacked content from workflow A update',
+          },
+        } as INotificationTemplateStep,
+      ],
+    };
+
+    const { body } = await session.testAgent.put(`/v1/workflows/${workflowA._id}`).send(update);
+
+    expect(body.statusCode).to.equal(400);
+    expect(body.message).to.equal(`Template ${foreignTemplateId} does not belong to this workflow`);
+  });
+
+  it('should reject variant _templateId that belongs to another workflow', async () => {
+    const notificationTemplateService = new NotificationTemplateService(
+      session.user._id,
+      session.organization._id,
+      session.environment._id
+    );
+
+    const workflowA = await notificationTemplateService.createTemplate({
+      steps: [{ type: StepTypeEnum.IN_APP, content: 'Workflow A step' }],
+    });
+    const workflowB = await notificationTemplateService.createTemplate({
+      steps: [{ type: StepTypeEnum.IN_APP, content: 'Workflow B step' }],
+    });
+
+    const foreignTemplateId = workflowB.steps[0]._templateId;
+
+    const update: IUpdateNotificationTemplateDto = {
+      steps: [
+        {
+          _templateId: workflowA.steps[0]._templateId,
+          template: {
+            type: StepTypeEnum.IN_APP,
+            content: 'Workflow A step content',
+          },
+          variants: [
+            {
+              _templateId: foreignTemplateId,
+              filters: [
+                {
+                  isNegated: false,
+                  type: 'GROUP',
+                  value: FieldLogicalOperatorEnum.AND,
+                  children: [
+                    {
+                      on: FilterPartTypeEnum.TENANT,
+                      field: 'name',
+                      value: 'Titans',
+                      operator: FieldOperatorEnum.EQUAL,
+                    },
+                  ],
+                },
+              ],
+              template: {
+                type: StepTypeEnum.IN_APP,
+                content: 'Hijacked variant content',
+              },
+            },
+          ],
+        } as INotificationTemplateStep,
+      ],
+    };
+
+    const { body } = await session.testAgent.put(`/v1/workflows/${workflowA._id}`).send(update);
+
+    expect(body.statusCode).to.equal(400);
+    expect(body.message).to.equal(`Template ${foreignTemplateId} does not belong to this workflow`);
+  });
+
   it('should not able to update step with invalid action', async () => {
     const notificationTemplateService = new NotificationTemplateService(
       session.user._id,

--- a/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
+++ b/libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts
@@ -142,11 +142,18 @@ export class UpdateWorkflowV0 {
       existingTemplate._id
     );
 
+    const allowedTemplateIds = this.buildAllowedTemplateIds(existingTemplate.steps);
+
     const workflowUpdate = async (session?: ClientSession | null) => {
       if (command.steps) {
         updatePayload = this.updateTriggers(updatePayload, command.steps);
 
-        updatePayload.steps = await this.updateMessageTemplates(command.steps, command, parentChangeId);
+        updatePayload.steps = await this.updateMessageTemplates(
+          command.steps,
+          command,
+          parentChangeId,
+          allowedTemplateIds
+        );
 
         await this.deleteRemovedSteps(existingTemplate.steps, command, parentChangeId);
       }
@@ -404,11 +411,45 @@ export class UpdateWorkflowV0 {
     }
   }
 
+  /**
+   * Build the set of template IDs that belong to the workflow being updated, including
+   * variant template IDs. The set is later used to reject client payloads that point a
+   * step (or variant) at a `_templateId` belonging to a different workflow, which would
+   * otherwise allow cross-workflow data corruption via `UpdateMessageTemplate`.
+   */
+  private buildAllowedTemplateIds(existingSteps: NotificationStepEntity[] | NotificationStepData[] | undefined): Set<
+    string
+  > {
+    const allowed = new Set<string>();
+    for (const step of existingSteps || []) {
+      if (step._templateId) {
+        allowed.add(step._templateId.toString());
+      }
+      const variants = (step as NotificationStepEntity).variants || [];
+      for (const variant of variants) {
+        if (variant._templateId) {
+          allowed.add(variant._templateId.toString());
+        }
+      }
+    }
+
+    return allowed;
+  }
+
+  private assertTemplateBelongsToWorkflow(templateId: string | undefined, allowedTemplateIds: Set<string>) {
+    if (!templateId) return;
+
+    if (!allowedTemplateIds.has(templateId.toString())) {
+      throw new BadRequestException(`Template ${templateId} does not belong to this workflow`);
+    }
+  }
+
   @Instrument()
   private async updateMessageTemplates(
     steps: NotificationStep[],
     command: UpdateWorkflowCommandV0,
-    parentChangeId: string
+    parentChangeId: string,
+    allowedTemplateIds: Set<string>
   ) {
     let parentStepId: string | null = null;
     const templateMessages: NotificationStepEntity[] = [];
@@ -420,7 +461,7 @@ export class UpdateWorkflowV0 {
         throw new BadRequestException(`Something un-expected happened, template couldn't be found`);
       }
 
-      const updatedVariants = await this.updateVariants(message.variants, command, parentChangeId!);
+      const updatedVariants = await this.updateVariants(message.variants, command, parentChangeId!, allowedTemplateIds);
 
       const messageTemplatePayload: CreateMessageTemplateCommand | UpdateMessageTemplateCommand = {
         type: message.template.type,
@@ -446,6 +487,8 @@ export class UpdateWorkflowV0 {
         workflowType: command.type,
       };
 
+      this.assertTemplateBelongsToWorkflow(message._templateId, allowedTemplateIds);
+
       let messageTemplateExist = message._templateId;
 
       if (!messageTemplateExist && isBridgeWorkflow(command.type)) {
@@ -460,7 +503,7 @@ export class UpdateWorkflowV0 {
       const updatedTemplate = messageTemplateExist
         ? await this.updateMessageTemplate.execute(
             UpdateMessageTemplateCommand.create({
-              templateId: message._templateId!,
+              templateId: messageTemplateExist,
               ...messageTemplatePayload,
             })
           )
@@ -620,7 +663,8 @@ export class UpdateWorkflowV0 {
   private async updateVariants(
     variants: NotificationStepVariantCommand[] | undefined,
     command: UpdateWorkflowCommandV0,
-    parentChangeId: string
+    parentChangeId: string,
+    allowedTemplateIds: Set<string>
   ): Promise<NotificationStepData[]> {
     if (!variants?.length) return [];
 
@@ -651,11 +695,13 @@ export class UpdateWorkflowV0 {
         workflowType: command.type,
       };
 
+      this.assertTemplateBelongsToWorkflow(variant._templateId, allowedTemplateIds);
+
       const messageTemplateExist = variant._templateId;
       const updatedVariant = messageTemplateExist
         ? await this.updateMessageTemplate.execute(
             UpdateMessageTemplateCommand.create({
-              templateId: variant._templateId!,
+              templateId: messageTemplateExist,
               ...messageTemplatePayload,
             })
           )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`UpdateWorkflowV0` previously forwarded the client-supplied step `_templateId` (and variant `_templateId`) directly to `UpdateMessageTemplate`, which only scopes by environment + organization. As a result, a workflow update could mutate a message template that belonged to a **different workflow** in the same environment and then attach that template to the current workflow — a cross-workflow data corruption vector.

This PR scopes template updates to templates that already belong to the workflow being updated.

## How

In `libs/application-generic/src/usecases/update-workflow-v0/update-workflow.usecase.ts`:

- Before processing the update, build the set of allowed template IDs from `existingTemplate.steps` (including each step's `variants`).
- In `updateMessageTemplates` and `updateVariants`, reject any incoming `_templateId` that is not in the allowed set with a `BadRequestException`.
- While in the area, fix a latent bug where the bridge fallback path was passing the (potentially undefined) client-supplied `message._templateId!` instead of the resolved `messageTemplateExist` to `UpdateMessageTemplateCommand`.

```ts
const allowedTemplateIds = this.buildAllowedTemplateIds(existingTemplate.steps);
// ...
this.assertTemplateBelongsToWorkflow(message._templateId, allowedTemplateIds);
```

## Tests

Added two regression tests in `apps/api/src/app/workflows-v1/e2e/update-notification-template.e2e.ts`:

1. `should reject step _templateId that belongs to another workflow` — workflow A update sent with workflow B's step `_templateId` returns `400`.
2. `should reject variant _templateId that belongs to another workflow` — same vector through `step.variants[]._templateId`.

Both tests, plus the existing 9 tests in the suite, pass:

```
Update workflow by id - /workflows/:workflowId (PUT) #novu-v0
  ✔ should update the workflow
  ✔ should throw error if trigger identifier already exists
  ✔ should update the trigger identifier
  ✔ should generate new variables on update
  ✔ should update the contentType and active of a message
  ✔ should be able to update empty message content
  ✔ should update the steps
  ✔ should update reply callbacks
  ✔ should reject step _templateId that belongs to another workflow
  ✔ should reject variant _templateId that belongs to another workflow
  ✔ should not able to update step with invalid action

11 passing
```

## Acceptance Criteria

- [x] Workflow update rejects `_templateId` not in this workflow's existing step/variant template set
- [x] Regression test: workflow A's update with workflow B's `_templateId` → 400
- [ ] Audit existing data for cross-references that may have been created before the fix — left for follow-up; recommend a one-off script to find `MessageTemplate` documents whose `_id` is referenced by a `NotificationTemplate.steps[]._templateId` or `NotificationTemplate.steps[].variants[]._templateId` of a different `NotificationTemplate`.

Fixes NV-7606

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7606](https://linear.app/novu/issue/NV-7606/bug-workflow-update-trusts-client-templateid-can-mutate-templates-of)

<div><a href="https://cursor.com/agents/bc-c963ec63-aacc-4571-a392-f52e2718ee8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c963ec63-aacc-4571-a392-f52e2718ee8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

UpdateWorkflowV0 now validates that step and variant `_templateId` values belong to the current workflow being updated, rather than allowing mutation of templates from other workflows in the same environment. The system computes allowed template IDs from existing workflow steps and variants, then rejects any incoming `_templateId` not in that set with a 400 error.

## Affected areas

**api** — UpdateWorkflowV0 usecase now validates template ownership during workflow updates by building an allowed set of template IDs from existing steps and variants, and rejecting cross-workflow template references.

**application-generic** — Added validation helpers (`buildAllowedTemplateIds`, `assertTemplateBelongsToWorkflow`) to enforce template ID ownership checks. Fixed a bug where the bridge fallback path passed the client-supplied `messageTemplateId` instead of the resolved template object.

## Key technical decisions

- Template ID validation occurs at the usecase layer before message template updates are processed, preventing unauthorized cross-workflow mutations.
- Rejected template IDs return a `BadRequestException` with a clear error message indicating the template does not belong to the workflow.

## Testing

Added two e2e regression tests in the update-notification-template suite validating that workflow updates reject step and variant `_templateId` values belonging to other workflows (both return 400 with appropriate error messages). Test suite shows 11 passing tests including the new regressions.

Fixes NV-7606.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->