### PR TITLE
fix(api-service): restrict inbox subscriber events to keyless workflow fixes NV-7569

### DIFF
--- a/apps/api/src/app/inbox/e2e/keyless-events.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/keyless-events.e2e.ts
@@ -1,0 +1,141 @@
+import { NotificationTemplateEntity, SubscriberRepository } from '@novu/dal';
+import { StepTypeEnum, TriggerTypeEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
+  let session: UserSession;
+  let helloWorldTemplate: NotificationTemplateEntity;
+  let otherTemplate: NotificationTemplateEntity;
+  const subscriberRepository = new SubscriberRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+
+    helloWorldTemplate = await session.createTemplate({
+      noFeedId: true,
+      triggers: [
+        {
+          identifier: 'hello-world',
+          type: TriggerTypeEnum.EVENT,
+          variables: [],
+        },
+      ],
+      steps: [
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Hello world keyless content',
+        },
+      ],
+    });
+
+    otherTemplate = await session.createTemplate({
+      noFeedId: true,
+      steps: [
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Some unrelated workflow',
+        },
+      ],
+    });
+  });
+
+  const triggerInboxEvent = (body: Record<string, unknown>) =>
+    session.testAgent.post('/v1/inbox/events').set('Authorization', `Bearer ${session.subscriberToken}`).send(body);
+
+  it('rejects requests for any workflow other than the keyless hello-world workflow', async () => {
+    const { status, body } = await triggerInboxEvent({
+      name: otherTemplate.triggers[0].identifier,
+      to: { subscriberId: session.subscriberId },
+      payload: {},
+    });
+
+    expect(status).to.equal(403);
+    expect(body.message).to.contain('hello-world');
+  });
+
+  it('rejects requests targeting another subscriber id', async () => {
+    const { status, body } = await triggerInboxEvent({
+      name: 'hello-world',
+      to: { subscriberId: 'someone-else' },
+      payload: {},
+    });
+
+    expect(status).to.equal(403);
+    expect(body.message).to.contain('themselves');
+  });
+
+  it('rejects topic-based recipient payloads', async () => {
+    const { status } = await triggerInboxEvent({
+      name: 'hello-world',
+      to: { topicKey: 'all-users', type: 'Topic' },
+      payload: {},
+    });
+
+    expect(status).to.equal(403);
+  });
+
+  it('rejects array-based recipient payloads', async () => {
+    const { status } = await triggerInboxEvent({
+      name: 'hello-world',
+      to: [{ subscriberId: session.subscriberId }, { subscriberId: 'someone-else' }],
+      payload: {},
+    });
+
+    expect(status).to.equal(403);
+  });
+
+  it('rejects string recipient that does not match the authenticated subscriber id', async () => {
+    const { status } = await triggerInboxEvent({
+      name: 'hello-world',
+      to: 'another-subscriber',
+      payload: {},
+    });
+
+    expect(status).to.equal(403);
+  });
+
+  it('triggers the hello-world workflow when the recipient is the authenticated subscriber', async () => {
+    const { status, body } = await triggerInboxEvent({
+      name: 'hello-world',
+      to: { subscriberId: session.subscriberId },
+      payload: { foo: 'bar' },
+    });
+
+    expect(status).to.equal(201);
+    expect(body.data).to.be.ok;
+
+    await session.waitForJobCompletion(helloWorldTemplate._id);
+
+    const subscriber = await subscriberRepository.findBySubscriberId(session.environment._id, session.subscriberId);
+    expect(subscriber).to.be.ok;
+  });
+
+  it('ignores user-supplied bridgeUrl, controls, overrides, actor and tenant fields', async () => {
+    const { status } = await triggerInboxEvent({
+      name: 'hello-world',
+      to: { subscriberId: session.subscriberId },
+      payload: { foo: 'bar' },
+      bridgeUrl: 'https://attacker.example.com/bridge',
+      controls: { steps: { 'evil-step': { foo: 'bar' } } },
+      overrides: { providers: { sendgrid: { templateId: 'attacker' } } },
+      actor: 'someone-else',
+      tenant: 'attacker-tenant',
+      transactionId: 'attacker-transaction-id',
+    });
+
+    expect(status).to.equal(201);
+    await session.waitForJobCompletion(helloWorldTemplate._id);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const { status } = await session.testAgent.post('/v1/inbox/events').send({
+      name: 'hello-world',
+      to: { subscriberId: session.subscriberId },
+      payload: {},
+    });
+
+    expect(status).to.equal(401);
+  });
+});

--- a/apps/api/src/app/inbox/e2e/keyless-events.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/keyless-events.e2e.ts
@@ -1,13 +1,34 @@
-import { NotificationTemplateEntity, SubscriberRepository } from '@novu/dal';
+import {
+  EnvironmentRepository,
+  NotificationRepository,
+  NotificationTemplateEntity,
+  SubscriberRepository,
+} from '@novu/dal';
 import { StepTypeEnum, TriggerTypeEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
+import { KEYLESS_ENVIRONMENT_PREFIX, KEYLESS_WORKFLOW_IDENTIFIER } from '../utils';
 
 describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
   let session: UserSession;
   let helloWorldTemplate: NotificationTemplateEntity;
   let otherTemplate: NotificationTemplateEntity;
   const subscriberRepository = new SubscriberRepository();
+  const environmentRepository = new EnvironmentRepository();
+  const notificationRepository = new NotificationRepository();
+
+  /**
+   * The endpoint only allows callers from a keyless environment, so simulate
+   * one by re-stamping the freshly initialized session environment with the
+   * keyless identifier prefix. The JWT references the environment's _id (not
+   * its identifier) so the existing subscriber token continues to work.
+   */
+  const markEnvironmentAsKeyless = async () => {
+    await environmentRepository.update(
+      { _id: session.environment._id },
+      { $set: { identifier: `${KEYLESS_ENVIRONMENT_PREFIX}${session.environment.identifier}` } }
+    );
+  };
 
   beforeEach(async () => {
     session = new UserSession();
@@ -17,7 +38,7 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
       noFeedId: true,
       triggers: [
         {
-          identifier: 'hello-world',
+          identifier: KEYLESS_WORKFLOW_IDENTIFIER,
           type: TriggerTypeEnum.EVENT,
           variables: [],
         },
@@ -39,6 +60,8 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
         },
       ],
     });
+
+    await markEnvironmentAsKeyless();
   });
 
   const triggerInboxEvent = (body: Record<string, unknown>) =>
@@ -52,12 +75,12 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
     });
 
     expect(status).to.equal(403);
-    expect(body.message).to.contain('hello-world');
+    expect(body.message).to.contain(KEYLESS_WORKFLOW_IDENTIFIER);
   });
 
   it('rejects requests targeting another subscriber id', async () => {
     const { status, body } = await triggerInboxEvent({
-      name: 'hello-world',
+      name: KEYLESS_WORKFLOW_IDENTIFIER,
       to: { subscriberId: 'someone-else' },
       payload: {},
     });
@@ -68,7 +91,7 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
 
   it('rejects topic-based recipient payloads', async () => {
     const { status } = await triggerInboxEvent({
-      name: 'hello-world',
+      name: KEYLESS_WORKFLOW_IDENTIFIER,
       to: { topicKey: 'all-users', type: 'Topic' },
       payload: {},
     });
@@ -78,7 +101,7 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
 
   it('rejects array-based recipient payloads', async () => {
     const { status } = await triggerInboxEvent({
-      name: 'hello-world',
+      name: KEYLESS_WORKFLOW_IDENTIFIER,
       to: [{ subscriberId: session.subscriberId }, { subscriberId: 'someone-else' }],
       payload: {},
     });
@@ -88,7 +111,7 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
 
   it('rejects string recipient that does not match the authenticated subscriber id', async () => {
     const { status } = await triggerInboxEvent({
-      name: 'hello-world',
+      name: KEYLESS_WORKFLOW_IDENTIFIER,
       to: 'another-subscriber',
       payload: {},
     });
@@ -96,9 +119,26 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
     expect(status).to.equal(403);
   });
 
+  it('rejects callers from a non-keyless environment even when the workflow id matches', async () => {
+    // Restore the original (non-keyless) identifier so the env check fails.
+    await environmentRepository.update(
+      { _id: session.environment._id },
+      { $set: { identifier: session.environment.identifier } }
+    );
+
+    const { status, body } = await triggerInboxEvent({
+      name: KEYLESS_WORKFLOW_IDENTIFIER,
+      to: { subscriberId: session.subscriberId },
+      payload: {},
+    });
+
+    expect(status).to.equal(403);
+    expect(body.message).to.contain('keyless');
+  });
+
   it('triggers the hello-world workflow when the recipient is the authenticated subscriber', async () => {
     const { status, body } = await triggerInboxEvent({
-      name: 'hello-world',
+      name: KEYLESS_WORKFLOW_IDENTIFIER,
       to: { subscriberId: session.subscriberId },
       payload: { foo: 'bar' },
     });
@@ -112,9 +152,11 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
     expect(subscriber).to.be.ok;
   });
 
-  it('ignores user-supplied bridgeUrl, controls, overrides, actor and tenant fields', async () => {
+  it('ignores user-supplied bridgeUrl, controls, overrides, actor, tenant and transactionId fields', async () => {
+    const attackerTransactionId = 'attacker-transaction-id';
+
     const { status } = await triggerInboxEvent({
-      name: 'hello-world',
+      name: KEYLESS_WORKFLOW_IDENTIFIER,
       to: { subscriberId: session.subscriberId },
       payload: { foo: 'bar' },
       bridgeUrl: 'https://attacker.example.com/bridge',
@@ -122,16 +164,30 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
       overrides: { providers: { sendgrid: { templateId: 'attacker' } } },
       actor: 'someone-else',
       tenant: 'attacker-tenant',
-      transactionId: 'attacker-transaction-id',
+      transactionId: attackerTransactionId,
     });
 
     expect(status).to.equal(201);
     await session.waitForJobCompletion(helloWorldTemplate._id);
+
+    const notifications = await notificationRepository.find({
+      _environmentId: session.environment._id,
+      _templateId: helloWorldTemplate._id,
+    });
+
+    expect(notifications.length).to.be.greaterThan(0);
+
+    for (const notification of notifications) {
+      // The attacker-supplied transactionId is dropped server-side; the
+      // controller assigns its own value. If the field were forwarded the
+      // notification would be persisted with the attacker's id.
+      expect(notification.transactionId).to.not.equal(attackerTransactionId);
+    }
   });
 
   it('rejects unauthenticated requests', async () => {
     const { status } = await session.testAgent.post('/v1/inbox/events').send({
-      name: 'hello-world',
+      name: KEYLESS_WORKFLOW_IDENTIFIER,
       to: { subscriberId: session.subscriberId },
       payload: {},
     });

--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -2,7 +2,6 @@ import {
   Body,
   Controller,
   Delete,
-  ForbiddenException,
   Get,
   Headers,
   HttpCode,
@@ -18,13 +17,7 @@ import {
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiExcludeController } from '@nestjs/swagger';
-import {
-  AddressingTypeEnum,
-  MessageActionStatusEnum,
-  PreferenceLevelEnum,
-  TriggerRequestCategoryEnum,
-  UserSessionData,
-} from '@novu/shared';
+import { MessageActionStatusEnum, PreferenceLevelEnum, UserSessionData } from '@novu/shared';
 import { ListChannelConnectionsQueryDto } from '../channel-connections/dtos/list-channel-connections-query.dto';
 import { DeleteChannelConnectionCommand } from '../channel-connections/usecases/delete-channel-connection/delete-channel-connection.command';
 import { DeleteChannelConnection } from '../channel-connections/usecases/delete-channel-connection/delete-channel-connection.usecase';
@@ -41,8 +34,6 @@ import { ListChannelEndpointsCommand } from '../channel-endpoints/usecases/list-
 import { ListChannelEndpoints } from '../channel-endpoints/usecases/list-channel-endpoints/list-channel-endpoints.usecase';
 import { TriggerEventRequestDto } from '../events/dtos';
 import { TriggerEventResponseDto } from '../events/dtos/trigger-event-response.dto';
-import { ParseEventRequestMulticastCommand } from '../events/usecases/parse-event-request';
-import { ParseEventRequest } from '../events/usecases/parse-event-request/parse-event-request.usecase';
 import { GenerateChatOAuthUrlResponseDto } from '../integrations/dtos/generate-chat-oauth-url-response.dto';
 import { GenerateConnectOauthUrlRequestDto } from '../integrations/dtos/generate-connect-oauth-url-request.dto';
 import { GenerateLinkUserOauthUrlRequestDto } from '../integrations/dtos/generate-link-user-oauth-url-request.dto';
@@ -101,6 +92,8 @@ import { SessionCommand } from './usecases/session/session.command';
 import { Session } from './usecases/session/session.usecase';
 import { SnoozeNotificationCommand } from './usecases/snooze-notification/snooze-notification.command';
 import { SnoozeNotification } from './usecases/snooze-notification/snooze-notification.usecase';
+import { TriggerKeylessEventCommand } from './usecases/trigger-keyless-event/trigger-keyless-event.command';
+import { TriggerKeylessEvent } from './usecases/trigger-keyless-event/trigger-keyless-event.usecase';
 import { UnsnoozeNotificationCommand } from './usecases/unsnooze-notification/unsnooze-notification.command';
 import { UnsnoozeNotification } from './usecases/unsnooze-notification/unsnooze-notification.usecase';
 import { UpdateAllNotificationsCommand } from './usecases/update-all-notifications/update-all-notifications.command';
@@ -109,7 +102,6 @@ import { UpdateNotificationActionCommand } from './usecases/update-notification-
 import { UpdateNotificationAction } from './usecases/update-notification-action/update-notification-action.usecase';
 import { UpdatePreferencesCommand } from './usecases/update-preferences/update-preferences.command';
 import { UpdatePreferences } from './usecases/update-preferences/update-preferences.usecase';
-import { KEYLESS_WORKFLOW_IDENTIFIER } from './utils';
 import type { InboxPreference } from './utils/types';
 
 @ApiCommonResponses()
@@ -130,7 +122,7 @@ export class InboxController {
     private snoozeNotificationUsecase: SnoozeNotification,
     private unsnoozeNotificationUsecase: UnsnoozeNotification,
     private markNotificationsAsSeenUsecase: MarkNotificationsAsSeen,
-    private parseEventRequest: ParseEventRequest,
+    private triggerKeylessEventUsecase: TriggerKeylessEvent,
     private getSubscriberGlobalPreference: GetSubscriberGlobalPreference,
     private deleteNotificationUsecase: DeleteNotification,
     private deleteAllNotificationsUsecase: DeleteAllNotifications,
@@ -635,9 +627,11 @@ export class InboxController {
   /**
    * Triggers the keyless / demo "hello-world" workflow for the authenticated
    * subscriber. The endpoint is intentionally restricted: an inbox subscriber
-   * JWT can only fire the keyless demo workflow and only target itself as the
-   * recipient. Any attempt to trigger a different workflow id or specify a
-   * different recipient is rejected to prevent privilege escalation.
+   * JWT can only fire the keyless demo workflow, only target itself as the
+   * recipient, and only when the caller belongs to a keyless environment. Any
+   * attempt to trigger a different workflow id, target another recipient, or
+   * call from a non-keyless environment is rejected to prevent privilege
+   * escalation. The actual validation lives in `TriggerKeylessEvent`.
    */
   @KeylessAccessible()
   @UseGuards(AuthGuard('subscriberJwt'))
@@ -647,52 +641,18 @@ export class InboxController {
     @Body() body: TriggerEventRequestDto,
     @Req() req: RequestWithReqId
   ): Promise<TriggerEventResponseDto> {
-    if (body.name !== KEYLESS_WORKFLOW_IDENTIFIER) {
-      throw new ForbiddenException(`Inbox subscribers may only trigger the "${KEYLESS_WORKFLOW_IDENTIFIER}" workflow.`);
-    }
-
-    if (!this.isSelfRecipient(body.to, subscriberSession.subscriberId)) {
-      throw new ForbiddenException('Inbox subscribers may only trigger notifications for themselves.');
-    }
-
-    const result = await this.parseEventRequest.execute(
-      ParseEventRequestMulticastCommand.create({
-        userId: subscriberSession._id,
+    return this.triggerKeylessEventUsecase.execute(
+      TriggerKeylessEventCommand.create({
         environmentId: subscriberSession._environmentId,
         organizationId: subscriberSession._organizationId,
-        identifier: KEYLESS_WORKFLOW_IDENTIFIER,
-        payload: body.payload || {},
-        overrides: {},
-        to: { subscriberId: subscriberSession.subscriberId },
-        addressingType: AddressingTypeEnum.MULTICAST,
-        requestCategory: TriggerRequestCategoryEnum.SINGLE,
+        subscriberId: subscriberSession.subscriberId,
+        contextKeys: subscriberSession.contextKeys,
+        workflowIdentifier: body.name,
+        recipient: body.to,
+        payload: body.payload,
         requestId: req._nvRequestId,
       })
     );
-
-    return result as unknown as TriggerEventResponseDto;
-  }
-
-  /**
-   * Validates that the recipient described by `to` resolves to a single
-   * subscriber and that subscriber matches the authenticated session. Topic and
-   * array-based recipients are rejected outright because they could be used to
-   * notify other subscribers in the environment.
-   */
-  private isSelfRecipient(to: TriggerEventRequestDto['to'], subscriberId: string): boolean {
-    if (typeof to === 'string') {
-      return to === subscriberId;
-    }
-
-    if (Array.isArray(to)) {
-      return false;
-    }
-
-    if (to && typeof to === 'object' && 'subscriberId' in to && typeof to.subscriberId === 'string') {
-      return to.subscriberId === subscriberId;
-    }
-
-    return false;
   }
 
   @UseGuards(AuthGuard('subscriberJwt'))

--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
   Headers,
   HttpCode,
@@ -52,7 +53,7 @@ import { GenerateLinkUserOauthUrl } from '../integrations/usecases/generate-chat
 import { ExcludeFromIdempotency } from '../shared/framework/exclude-from-idempotency';
 import { ApiCommonResponses } from '../shared/framework/response.decorator';
 import { KeylessAccessible } from '../shared/framework/swagger/keyless.security';
-import { SubscriberSession, UserSession } from '../shared/framework/user.decorator';
+import { SubscriberSession } from '../shared/framework/user.decorator';
 import { RequestWithReqId } from '../shared/middleware/request-id.middleware';
 import {
   GetSubscriberGlobalPreference,
@@ -108,6 +109,7 @@ import { UpdateNotificationActionCommand } from './usecases/update-notification-
 import { UpdateNotificationAction } from './usecases/update-notification-action/update-notification-action.usecase';
 import { UpdatePreferencesCommand } from './usecases/update-preferences/update-preferences.command';
 import { UpdatePreferences } from './usecases/update-preferences/update-preferences.usecase';
+import { KEYLESS_WORKFLOW_IDENTIFIER } from './utils';
 import type { InboxPreference } from './utils/types';
 
 @ApiCommonResponses()
@@ -630,36 +632,67 @@ export class InboxController {
     );
   }
 
+  /**
+   * Triggers the keyless / demo "hello-world" workflow for the authenticated
+   * subscriber. The endpoint is intentionally restricted: an inbox subscriber
+   * JWT can only fire the keyless demo workflow and only target itself as the
+   * recipient. Any attempt to trigger a different workflow id or specify a
+   * different recipient is rejected to prevent privilege escalation.
+   */
   @KeylessAccessible()
   @UseGuards(AuthGuard('subscriberJwt'))
   @Post('/events')
   async keylessEvents(
-    @UserSession() user: UserSessionData,
+    @SubscriberSession() subscriberSession: SubscriberSession,
     @Body() body: TriggerEventRequestDto,
     @Req() req: RequestWithReqId
   ): Promise<TriggerEventResponseDto> {
+    if (body.name !== KEYLESS_WORKFLOW_IDENTIFIER) {
+      throw new ForbiddenException(`Inbox subscribers may only trigger the "${KEYLESS_WORKFLOW_IDENTIFIER}" workflow.`);
+    }
+
+    if (!this.isSelfRecipient(body.to, subscriberSession.subscriberId)) {
+      throw new ForbiddenException('Inbox subscribers may only trigger notifications for themselves.');
+    }
+
     const result = await this.parseEventRequest.execute(
       ParseEventRequestMulticastCommand.create({
-        userId: user._id,
-        environmentId: user.environmentId,
-        organizationId: user.organizationId,
-        identifier: body.name,
+        userId: subscriberSession._id,
+        environmentId: subscriberSession._environmentId,
+        organizationId: subscriberSession._organizationId,
+        identifier: KEYLESS_WORKFLOW_IDENTIFIER,
         payload: body.payload || {},
-        overrides: body.overrides || {},
-        to: body.to,
-        actor: body.actor,
-        tenant: body.tenant,
-        context: body.context,
-        transactionId: body.transactionId,
+        overrides: {},
+        to: { subscriberId: subscriberSession.subscriberId },
         addressingType: AddressingTypeEnum.MULTICAST,
         requestCategory: TriggerRequestCategoryEnum.SINGLE,
-        bridgeUrl: body.bridgeUrl,
-        controls: body.controls,
         requestId: req._nvRequestId,
       })
     );
 
     return result as unknown as TriggerEventResponseDto;
+  }
+
+  /**
+   * Validates that the recipient described by `to` resolves to a single
+   * subscriber and that subscriber matches the authenticated session. Topic and
+   * array-based recipients are rejected outright because they could be used to
+   * notify other subscribers in the environment.
+   */
+  private isSelfRecipient(to: TriggerEventRequestDto['to'], subscriberId: string): boolean {
+    if (typeof to === 'string') {
+      return to === subscriberId;
+    }
+
+    if (Array.isArray(to)) {
+      return false;
+    }
+
+    if (to && typeof to === 'object' && 'subscriberId' in to && typeof to.subscriberId === 'string') {
+      return to.subscriberId === subscriberId;
+    }
+
+    return false;
   }
 
   @UseGuards(AuthGuard('subscriberJwt'))

--- a/apps/api/src/app/inbox/usecases/index.ts
+++ b/apps/api/src/app/inbox/usecases/index.ts
@@ -27,6 +27,7 @@ import { MarkNotificationsAsSeen } from './mark-notifications-as-seen/mark-notif
 import { NotificationsCount } from './notifications-count/notifications-count.usecase';
 import { Session } from './session/session.usecase';
 import { SnoozeNotification } from './snooze-notification/snooze-notification.usecase';
+import { TriggerKeylessEvent } from './trigger-keyless-event/trigger-keyless-event.usecase';
 import { UnsnoozeNotification } from './unsnooze-notification/unsnooze-notification.usecase';
 import { UpdateAllNotifications } from './update-all-notifications/update-all-notifications.usecase';
 import { UpdateNotificationAction } from './update-notification-action/update-notification-action.usecase';
@@ -48,6 +49,7 @@ export const USE_CASES = [
   UpdatePreferences,
   BulkUpdatePreferences,
   SnoozeNotification,
+  TriggerKeylessEvent,
   UnsnoozeNotification,
   DeleteNotification,
   DeleteManyNotifications,

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -66,7 +66,7 @@ import { ScheduleDto } from '../../../shared/dtos/schedule';
 import { isHmacValid } from '../../../shared/helpers/is-valid-hmac';
 import { SubscriberDto, SubscriberSessionRequestDto } from '../../dtos/subscriber-session-request.dto';
 import { SubscriberSessionResponseDto } from '../../dtos/subscriber-session-response.dto';
-import { AnalyticsEventsEnum } from '../../utils';
+import { AnalyticsEventsEnum, KEYLESS_SUBSCRIBER_ID, KEYLESS_WORKFLOW_IDENTIFIER } from '../../utils';
 import { validateContextHmacEncryption, validateHmacEncryption } from '../../utils/encryption';
 import { NotificationsCountCommand } from '../notifications-count/notifications-count.command';
 import { NotificationsCount } from '../notifications-count/notifications-count.usecase';
@@ -356,7 +356,7 @@ export class Session {
 
   private buildPlatformSubscriber(requestData: SubscriberSessionRequestDto): SubscriberDto {
     if (!requestData.applicationIdentifier || this.isKeylessApplication(requestData.applicationIdentifier)) {
-      return { subscriberId: 'keyless-subscriber-id' };
+      return { subscriberId: KEYLESS_SUBSCRIBER_ID };
     }
 
     return this.extractSubscriberInfo(requestData);
@@ -726,7 +726,7 @@ export class Session {
       triggers: [
         {
           type: 'event',
-          identifier: 'hello-world',
+          identifier: KEYLESS_WORKFLOW_IDENTIFIER,
           variables: [
             { name: 'subject', type: 'string' },
             { name: 'body', type: 'string' },

--- a/apps/api/src/app/inbox/usecases/session/session.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/session/session.usecase.ts
@@ -41,11 +41,11 @@ import {
   ContextPayload,
   ControlValuesLevelEnum,
   CustomDataType,
+  EnvironmentTypeEnum,
   FeatureFlagsKeysEnum,
   FeatureNameEnum,
   getFeatureForTierAsNumber,
   InAppProviderIdEnum,
-  EnvironmentTypeEnum,
   PreferenceLevelEnum,
   PreferencesTypeEnum,
   ResourceOriginEnum,
@@ -66,7 +66,12 @@ import { ScheduleDto } from '../../../shared/dtos/schedule';
 import { isHmacValid } from '../../../shared/helpers/is-valid-hmac';
 import { SubscriberDto, SubscriberSessionRequestDto } from '../../dtos/subscriber-session-request.dto';
 import { SubscriberSessionResponseDto } from '../../dtos/subscriber-session-response.dto';
-import { AnalyticsEventsEnum, KEYLESS_SUBSCRIBER_ID, KEYLESS_WORKFLOW_IDENTIFIER } from '../../utils';
+import {
+  AnalyticsEventsEnum,
+  KEYLESS_ENVIRONMENT_PREFIX,
+  KEYLESS_SUBSCRIBER_ID,
+  KEYLESS_WORKFLOW_IDENTIFIER,
+} from '../../utils';
 import { validateContextHmacEncryption, validateHmacEncryption } from '../../utils/encryption';
 import { NotificationsCountCommand } from '../notifications-count/notifications-count.command';
 import { NotificationsCount } from '../notifications-count/notifications-count.usecase';
@@ -80,7 +85,7 @@ const MAX_NOTIFICATIONS_COUNT = 100;
 
 @Injectable()
 export class Session {
-  private readonly KEYLESS_ENVIRONMENT_PREFIX = 'pk_keyless_';
+  private readonly KEYLESS_ENVIRONMENT_PREFIX = KEYLESS_ENVIRONMENT_PREFIX;
 
   constructor(
     private environmentRepository: EnvironmentRepository,

--- a/apps/api/src/app/inbox/usecases/trigger-keyless-event/trigger-keyless-event.command.ts
+++ b/apps/api/src/app/inbox/usecases/trigger-keyless-event/trigger-keyless-event.command.ts
@@ -1,0 +1,19 @@
+import { IsDefined, IsNotEmpty, IsObject, IsOptional, IsString } from 'class-validator';
+import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
+
+export class TriggerKeylessEventCommand extends EnvironmentWithSubscriber {
+  @IsNotEmpty()
+  @IsString()
+  readonly workflowIdentifier: string;
+
+  @IsDefined()
+  readonly recipient: unknown;
+
+  @IsOptional()
+  @IsObject()
+  readonly payload?: Record<string, unknown>;
+
+  @IsNotEmpty()
+  @IsString()
+  readonly requestId: string;
+}

--- a/apps/api/src/app/inbox/usecases/trigger-keyless-event/trigger-keyless-event.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/trigger-keyless-event/trigger-keyless-event.usecase.ts
@@ -1,0 +1,122 @@
+import { ForbiddenException, Injectable, InternalServerErrorException } from '@nestjs/common';
+import { LogDecorator, PinoLogger } from '@novu/application-generic';
+import { EnvironmentEntity, EnvironmentRepository } from '@novu/dal';
+import { AddressingTypeEnum, TriggerRequestCategoryEnum } from '@novu/shared';
+import { TriggerEventResponseDto } from '../../../events/dtos/trigger-event-response.dto';
+import { ParseEventRequest, ParseEventRequestMulticastCommand } from '../../../events/usecases/parse-event-request';
+import { KEYLESS_ENVIRONMENT_PREFIX, KEYLESS_WORKFLOW_IDENTIFIER } from '../../utils';
+import { TriggerKeylessEventCommand } from './trigger-keyless-event.command';
+
+/**
+ * Triggers the keyless / demo "hello-world" workflow for an inbox subscriber
+ * session. The endpoint backing this use case is intentionally restricted: an
+ * inbox subscriber JWT can only fire the keyless demo workflow, only target
+ * itself as the recipient, and only when the caller belongs to a keyless
+ * environment. This prevents the inbox JWT (which is meant for end-user inbox
+ * UI) from being used to spam arbitrary workflows or recipients.
+ */
+@Injectable()
+export class TriggerKeylessEvent {
+  constructor(
+    private readonly parseEventRequest: ParseEventRequest,
+    private readonly environmentRepository: EnvironmentRepository,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  @LogDecorator()
+  async execute(command: TriggerKeylessEventCommand): Promise<TriggerEventResponseDto> {
+    if (command.workflowIdentifier !== KEYLESS_WORKFLOW_IDENTIFIER) {
+      throw new ForbiddenException(`Inbox subscribers may only trigger the "${KEYLESS_WORKFLOW_IDENTIFIER}" workflow.`);
+    }
+
+    if (!this.isSelfRecipient(command.recipient, command.subscriberId)) {
+      throw new ForbiddenException('Inbox subscribers may only trigger notifications for themselves.');
+    }
+
+    const environment = await this.assertKeylessEnvironment(command.environmentId);
+    const userId = this.resolveKeylessUserId(environment);
+
+    const result = await this.parseEventRequest.execute(
+      ParseEventRequestMulticastCommand.create({
+        userId,
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        identifier: KEYLESS_WORKFLOW_IDENTIFIER,
+        payload: command.payload || {},
+        overrides: {},
+        to: { subscriberId: command.subscriberId },
+        addressingType: AddressingTypeEnum.MULTICAST,
+        requestCategory: TriggerRequestCategoryEnum.SINGLE,
+        requestId: command.requestId,
+      })
+    );
+
+    return result as unknown as TriggerEventResponseDto;
+  }
+
+  /**
+   * Validates that the request originates from a keyless / demo environment.
+   * Customer environments must never be reachable through this endpoint, even
+   * if they happen to host a workflow named `hello-world`.
+   */
+  private async assertKeylessEnvironment(environmentId: string): Promise<EnvironmentEntity> {
+    const environment = await this.environmentRepository.findOne({ _id: environmentId });
+
+    if (!environment) {
+      throw new ForbiddenException('Environment not found for inbox subscriber.');
+    }
+
+    if (!environment.identifier?.startsWith(KEYLESS_ENVIRONMENT_PREFIX)) {
+      throw new ForbiddenException('Inbox events can only be triggered from a keyless environment.');
+    }
+
+    return environment;
+  }
+
+  /**
+   * The keyless environment is provisioned by `Session.processKeyless` with a
+   * single API key whose `_userId` is the demo user that owns the workflow.
+   * Reusing that user id keeps audit / analytics / feature-flag attribution
+   * pointed at a real `UserEntity` instead of leaking the subscriber id into
+   * the trigger pipeline.
+   */
+  private resolveKeylessUserId(environment: EnvironmentEntity): string {
+    const keylessUserId = environment.apiKeys?.[0]?._userId;
+
+    if (!keylessUserId) {
+      this.logger.error({ environmentId: environment._id }, 'Keyless environment has no API key owner.');
+      throw new InternalServerErrorException('Keyless environment is misconfigured.');
+    }
+
+    return keylessUserId;
+  }
+
+  /**
+   * Validates that the recipient described by `to` resolves to a single
+   * subscriber and that subscriber matches the authenticated session. Topic
+   * and array-based recipients are rejected outright because they could be
+   * used to notify other subscribers in the environment.
+   */
+  private isSelfRecipient(to: unknown, subscriberId: string): boolean {
+    if (typeof to === 'string') {
+      return to === subscriberId;
+    }
+
+    if (Array.isArray(to)) {
+      return false;
+    }
+
+    if (
+      to !== null &&
+      typeof to === 'object' &&
+      'subscriberId' in to &&
+      typeof (to as { subscriberId: unknown }).subscriberId === 'string'
+    ) {
+      return (to as { subscriberId: string }).subscriberId === subscriberId;
+    }
+
+    return false;
+  }
+}

--- a/apps/api/src/app/inbox/utils/index.ts
+++ b/apps/api/src/app/inbox/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './analytics';
+export * from './keyless.constants';

--- a/apps/api/src/app/inbox/utils/keyless.constants.ts
+++ b/apps/api/src/app/inbox/utils/keyless.constants.ts
@@ -1,0 +1,13 @@
+/**
+ * The trigger identifier of the demo workflow that is created for keyless
+ * environments. Inbox subscriber JWTs are only allowed to trigger this workflow
+ * via the `/inbox/events` endpoint. Keep in sync with the workflow created in
+ * `Session.createWorkflowsUsecase`.
+ */
+export const KEYLESS_WORKFLOW_IDENTIFIER = 'hello-world';
+
+/**
+ * The hard-coded subscriber id used for the keyless / demo flow. See
+ * `Session.buildPlatformSubscriber`.
+ */
+export const KEYLESS_SUBSCRIBER_ID = 'keyless-subscriber-id';

--- a/apps/api/src/app/inbox/utils/keyless.constants.ts
+++ b/apps/api/src/app/inbox/utils/keyless.constants.ts
@@ -11,3 +11,11 @@ export const KEYLESS_WORKFLOW_IDENTIFIER = 'hello-world';
  * `Session.buildPlatformSubscriber`.
  */
 export const KEYLESS_SUBSCRIBER_ID = 'keyless-subscriber-id';
+
+/**
+ * Application identifier prefix used for keyless / demo environments. Both the
+ * inbox session use case (which provisions the env) and the inbox events
+ * endpoint (which is restricted to keyless callers) rely on this prefix to
+ * tell keyless environments apart from real customer ones.
+ */
+export const KEYLESS_ENVIRONMENT_PREFIX = 'pk_keyless_';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The `POST /v1/inbox/events` endpoint was guarded only by the inbox subscriber JWT (`AuthGuard('subscriberJwt')`) and forwarded the user-supplied `name`, `to`, `bridgeUrl`, `controls`, `overrides`, `actor`, `tenant`, `transactionId` and `context` straight into the trigger pipeline. A valid inbox JWT (intended for end-user inbox UI) could therefore trigger any workflow in the environment for any subscriber, allowing notification spam, abuse of paid channels (SMS, email, push), and execution of internal workflows that were never meant to be subscriber-callable.

This change scopes the endpoint to the keyless / demo flow only:

- only `hello-world` (the workflow the keyless `Session` use case provisions) is allowed; any other identifier is rejected with `403`.
- the recipient is forced to the authenticated `subscriberSession.subscriberId`; topic, array, and mismatched single-subscriber payloads are rejected with `403`.
- the caller's environment is verified to be a keyless environment (identifier starts with `pk_keyless_`); calls from real customer environments are rejected with `403` even if a `hello-world` workflow happens to exist there.
- `userId` for the downstream `ParseEventRequestMulticastCommand` is resolved from the keyless environment's API-key owner rather than the subscriber id, so audit / analytics / feature-flag attribution receives a real `UserEntity`.
- user-controlled `bridgeUrl`, `controls`, `overrides`, `actor`, `tenant`, `transactionId`, and `context` fields are dropped server-side. (Note: the `bridgeUrl` removal also addresses the related concern tracked in NV-7562.)

The validation + trigger orchestration is encapsulated in a new `TriggerKeylessEvent` use case under `apps/api/src/app/inbox/usecases/trigger-keyless-event/` so the controller stays free of business logic / DB access (per the CQRS convention in `.cursor/rules/api.mdc`).

The shared workflow identifier (`hello-world`), demo subscriber id (`keyless-subscriber-id`), and environment prefix (`pk_keyless_`) live in `apps/api/src/app/inbox/utils/keyless.constants.ts` so the controller restriction stays in lockstep with the workflow created by `Session.createWorkflowsUsecase` and the env created by `Session.processKeyless`.

The keyless front-end (`packages/js/src/api/inbox-service.ts#triggerHelloWorldEvent`) only ever posts the `hello-world` name with the keyless subscriber id from a keyless application, so legitimate usage is unaffected.

The e2e suite (`apps/api/src/app/inbox/e2e/keyless-events.e2e.ts`) covers the regression cases:
- arbitrary workflow id rejected
- arbitrary subscriber id rejected
- topic / array recipients rejected
- string recipient that doesn't match the session rejected
- non-keyless environment rejected even with a matching workflow id
- happy path for `hello-world` triggered against the authenticated subscriber
- attacker-supplied `transactionId` is dropped (asserted against the persisted `Notification`)
- unauthenticated requests rejected with `401`

### Screenshots

N/A — backend security hardening, no UI surface.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None.

### Special notes for your reviewer

- The cloud agent VM had a broken Docker → host networking path (mongoose / MongoClient connections from the host were accepted at TCP layer but immediately reset before any wire-protocol traffic, while `mongosh` from inside the container worked). API e2e tests therefore could not be executed end-to-end in this environment. The repository was confirmed to type-check (`pnpm tsc --noEmit` on `apps/api` shows no new errors in the touched files) and `pnpm build` succeeded. Please run `pnpm test:e2e:novu-v2` against `keyless-events.e2e.ts` in CI / a working environment.
- The `UserSession` decorator import was removed from `inbox.controller.ts` since the only consumer (`keylessEvents`) now correctly uses `SubscriberSession`. The `UserSessionData` type import is preserved because two other endpoints still cast their fabricated user object to it.
- See related issue NV-7562 for the broader `bridgeUrl` cleanup; this PR drops `bridgeUrl` from the inbox events path as a side benefit but does not otherwise touch that surface.
- Review iteration: the second commit on this branch addresses the keyless-environment validation gap raised by both the Cursor security review and CodeRabbit (medium severity), the `userId` correctness concern from CodeRabbit, and tightens the e2e suite per CodeRabbit's suggestions.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7569](https://linear.app/novu/issue/NV-7569/security-subscriber-jwt-can-trigger-arbitrary-workflows-for-arbitrary)

<div><a href="https://cursor.com/agents/bc-af1558fd-9450-4c86-881e-0e56a8a37d2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af1558fd-9450-4c86-881e-0e56a8a37d2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The POST /v1/inbox/events endpoint was locked down to the keyless/demo flow: it only accepts the demo workflow identifier and forces the recipient to the authenticated subscriber, dropping attacker-controlled fields (bridgeUrl, controls, overrides, actor, tenant, transactionId, context). This prevents inbox JWTs from triggering arbitrary workflows or targeting other subscribers and aligns keyless values with session provisioning to avoid drift.

## Affected areas

**api**: The inbox events handler now uses a SubscriberSession, routes requests through a new TriggerKeylessEvent use case that enforces workflow and recipient constraints, and drops forwarded execution/context fields; session provisioning was updated to import shared keyless constants; a new keyless.constants.ts centralizes KEYLESS_WORKFLOW_IDENTIFIER, KEYLESS_SUBSCRIBER_ID, and KEYLESS_ENVIRONMENT_PREFIX. A new e2e test suite validates rejection cases, happy path, and field-stripping behavior.

## Key technical decisions

- Centralized keyless identifiers in shared constants to keep Session provisioning and the endpoint in sync and prevent drift.  
- Introduced TriggerKeylessEvent use case to encapsulate validation and orchestration for the keyless flow.  
- Enforced environment-level keyless detection via KEYLESS_ENVIRONMENT_PREFIX and used 403 (Forbidden) for invalid workflow/recipient attempts.

## Testing

Added comprehensive e2e tests (apps/api/src/app/inbox/e2e/keyless-events.e2e.ts) covering rejection scenarios (non-keyless env, non-hello-world workflow, cross-subscriber targeting, invalid recipient shapes), successful triggering for the authenticated subscriber, and verification that attacker-supplied fields are ignored; CI/E2E must run these tests in an environment that can simulate keyless envs as noted in the PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->