### PR TITLE
feat(shared): centralize outbound HTTP client fixes NV-7560

### DIFF
--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -1,10 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import {
+  assertSafeOutboundUrl,
   buildNovuSignatureHeader,
   GetDecryptedSecretKey,
   GetDecryptedSecretKeyCommand,
   PinoLogger,
-  validateUrlSsrf,
+  resolvePublicAddresses,
+  safeOutboundJsonRequest,
+  SsrfBlockedError,
 } from '@novu/application-generic';
 import { ConversationActivityEntity, ConversationEntity, SubscriberEntity } from '@novu/dal';
 import type {
@@ -112,9 +115,8 @@ export class BridgeExecutorService {
       );
 
       const payload = await this.buildPayload(params);
-      const signatureHeader = buildNovuSignatureHeader(secretKey, payload);
 
-      this.fireWithRetries(bridgeUrl, payload, signatureHeader, agentIdentifier).catch((err) => {
+      this.fireWithRetries(bridgeUrl, payload, secretKey, agentIdentifier).catch((err) => {
         this.logger.error(err, `[agent:${agentIdentifier}] Bridge delivery failed after ${MAX_RETRIES + 1} attempts`);
       });
     } catch (err) {
@@ -129,28 +131,35 @@ export class BridgeExecutorService {
   private async fireWithRetries(
     url: string,
     payload: AgentBridgeRequest,
-    signatureHeader: string,
+    secretKey: string,
     agentIdentifier: string
   ): Promise<void> {
-    const body = JSON.stringify(payload);
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-      // Re-validate per attempt to defend against (a) agents whose bridgeUrl was
-      // stored before the update-time SSRF guard was added, and (b) DNS rebinding
-      // — a hostname that resolved to a public IP at update-time can later resolve
-      // to a private one. validateUrlSsrf caches DNS lookups for 5 minutes, so
-      // the per-attempt cost is amortized across retries.
-      const ssrfError = await validateUrlSsrf(url);
-      if (ssrfError) {
-        throw new Error(`Bridge URL blocked by SSRF protection: ${ssrfError}`);
+      // Pre-flight URL syntax/scheme/host check on every attempt. The follow-up
+      // safeOutboundJsonRequest call performs the connect-time DNS guard and
+      // re-validates every redirect target.
+      try {
+        assertSafeOutboundUrl(url);
+        await resolvePublicAddresses(new URL(url).hostname);
+      } catch (err) {
+        if (err instanceof SsrfBlockedError) {
+          throw new Error(`Bridge URL blocked by SSRF protection: ${err.message}`);
+        }
+        throw err;
       }
 
+      // HMAC is computed and attached only after the destination has been
+      // validated, so a blocked URL never sees the signed payload.
+      const signatureHeader = buildNovuSignatureHeader(secretKey, payload);
+
       try {
-        const response = await fetch(url, {
+        const response = await safeOutboundJsonRequest({
+          url,
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
+            'content-type': 'application/json',
             // Must match HttpHeaderKeysEnum.NOVU_SIGNATURE — the framework SDK reads
             // this exact header to verify the HMAC. Sending any other name (e.g.
             // `x-novu-signature`) silently disables signature verification on the
@@ -158,16 +167,21 @@ export class BridgeExecutorService {
             // via an attacker-controlled `replyUrl`.
             [HttpHeaderKeysEnum.NOVU_SIGNATURE]: signatureHeader,
           },
-          body,
+          body: payload,
         });
 
-        if (response.ok) {
+        if (response.statusCode >= 200 && response.statusCode < 300) {
           return;
         }
 
-        lastError = new Error(`Bridge returned ${response.status}: ${response.statusText}`);
-        this.logger.warn(`[agent:${agentIdentifier}] Bridge call attempt ${attempt + 1} failed: ${response.status}`);
+        lastError = new Error(`Bridge returned ${response.statusCode}: ${response.statusMessage}`);
+        this.logger.warn(
+          `[agent:${agentIdentifier}] Bridge call attempt ${attempt + 1} failed: ${response.statusCode}`
+        );
       } catch (err) {
+        if (err instanceof SsrfBlockedError) {
+          throw new Error(`Bridge URL blocked by SSRF protection: ${err.message}`);
+        }
         lastError = err instanceof Error ? err : new Error(String(err));
         this.logger.warn(
           `[agent:${agentIdentifier}] Bridge call attempt ${attempt + 1} network error: ${lastError.message}`

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -6,8 +6,8 @@ import {
   GetDecryptedSecretKeyCommand,
   PinoLogger,
   resolvePublicAddresses,
-  safeOutboundJsonRequest,
   SsrfBlockedError,
+  safeOutboundJsonRequest,
 } from '@novu/application-generic';
 import { ConversationActivityEntity, ConversationEntity, SubscriberEntity } from '@novu/dal';
 import type {
@@ -389,40 +389,36 @@ export class BridgeExecutorService {
       return richContent;
     }
 
-    const mapped = await mapWithConcurrency(
-      rawAttachments,
-      ATTACHMENT_SIGNING_CONCURRENCY,
-      async (item) => {
-        if (!item || typeof item !== 'object') {
-          this.logger.warn({ activityId: activity._id?.toString() }, 'History attachment is malformed; omitting');
-
-          return null;
-        }
-
-        const att = item as Record<string, unknown>;
-        const storageKey = att.storageKey;
-
-        if (typeof storageKey === 'string' && storageKey.length > 0) {
-          const url = await this.signAttachmentForHistory(storageKey, activity);
-
-          if (!url) {
-            return null;
-          }
-
-          return {
-            type: att.type,
-            url,
-            name: att.name,
-            mimeType: att.mimeType,
-            size: att.size,
-          };
-        }
-
-        this.logger.warn({ activityId: activity._id?.toString() }, 'History attachment missing storageKey; omitting');
+    const mapped = await mapWithConcurrency(rawAttachments, ATTACHMENT_SIGNING_CONCURRENCY, async (item) => {
+      if (!item || typeof item !== 'object') {
+        this.logger.warn({ activityId: activity._id?.toString() }, 'History attachment is malformed; omitting');
 
         return null;
       }
-    );
+
+      const att = item as Record<string, unknown>;
+      const storageKey = att.storageKey;
+
+      if (typeof storageKey === 'string' && storageKey.length > 0) {
+        const url = await this.signAttachmentForHistory(storageKey, activity);
+
+        if (!url) {
+          return null;
+        }
+
+        return {
+          type: att.type,
+          url,
+          name: att.name,
+          mimeType: att.mimeType,
+          size: att.size,
+        };
+      }
+
+      this.logger.warn({ activityId: activity._id?.toString() }, 'History attachment missing storageKey; omitting');
+
+      return null;
+    });
 
     const attachments = mapped.flatMap((entry) => (entry ? [entry] : []));
 
@@ -471,25 +467,21 @@ export class BridgeExecutorService {
     storedAttachments: StoredAttachment[],
     signingContext: AttachmentSigningContext
   ) {
-    const mapped = await mapWithConcurrency(
-      storedAttachments,
-      ATTACHMENT_SIGNING_CONCURRENCY,
-      async (attachment) => {
-        const url = await this.signStoredAttachmentForBridge(attachment.storageKey, signingContext);
+    const mapped = await mapWithConcurrency(storedAttachments, ATTACHMENT_SIGNING_CONCURRENCY, async (attachment) => {
+      const url = await this.signStoredAttachmentForBridge(attachment.storageKey, signingContext);
 
-        if (!url) {
-          return null;
-        }
-
-        return {
-          type: attachment.type,
-          url,
-          name: attachment.name,
-          mimeType: attachment.mimeType,
-          size: attachment.size,
-        };
+      if (!url) {
+        return null;
       }
-    );
+
+      return {
+        type: attachment.type,
+        url,
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+        size: attachment.size,
+      };
+    });
 
     return mapped.flatMap((entry) => (entry ? [entry] : []));
   }

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -3,12 +3,13 @@ import * as http from 'node:http';
 import * as https from 'node:https';
 import { BadGatewayException, BadRequestException, Injectable, OnModuleDestroy } from '@nestjs/common';
 import {
+  assertSafeOutboundUrl,
   CacheService,
   decryptCredentials,
   isPrivateIp,
   MailFactory,
   PinoLogger,
-  validateUrlSsrf,
+  SsrfBlockedError,
 } from '@novu/application-generic';
 import { IntegrationRepository } from '@novu/dal';
 import type { SentMessageInfo } from '@novu/framework';
@@ -526,7 +527,16 @@ export class ChatSdkService implements OnModuleDestroy {
   }
 
   private async validateFileUrl(url: string): Promise<string | null> {
-    return validateUrlSsrf(url);
+    try {
+      assertSafeOutboundUrl(url);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        return err.message;
+      }
+      throw err;
+    }
+
+    return null;
   }
 
   private async requestPinnedFileUrl(url: string, file: FileRef, index: number): Promise<PinnedFileResponse> {

--- a/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
@@ -29,10 +29,7 @@ export class UpdateAgent {
       throw new BadRequestException('At least one field must be provided.');
     }
 
-    const hasReadOnlyFields =
-      command.name !== undefined ||
-      command.description !== undefined ||
-      hasBehaviorFields;
+    const hasReadOnlyFields = command.name !== undefined || command.description !== undefined || hasBehaviorFields;
 
     if (hasReadOnlyFields) {
       await this.assertNotProduction(

--- a/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
-import { validateUrlSsrf } from '@novu/application-generic';
+import { assertSafeOutboundUrl, resolvePublicAddresses, SsrfBlockedError } from '@novu/application-generic';
 import { AgentRepository, EnvironmentRepository } from '@novu/dal';
 import { EnvironmentTypeEnum } from '@novu/shared';
 import type { AgentResponseDto } from '../../dtos';
@@ -146,9 +146,14 @@ export class UpdateAgent {
       return;
     }
 
-    const ssrfError = await validateUrlSsrf(url);
-    if (ssrfError) {
-      throw new BadRequestException(`${field}: ${ssrfError}`);
+    try {
+      const parsed = assertSafeOutboundUrl(url);
+      await resolvePublicAddresses(parsed.hostname);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new BadRequestException(`${field}: ${err.message}`);
+      }
+      throw err;
     }
   }
 }

--- a/apps/api/src/app/shared/shared.module.ts
+++ b/apps/api/src/app/shared/shared.module.ts
@@ -22,6 +22,7 @@ import {
   LoggerModule,
   QueuesModule,
   RequestLogRepository,
+  SafeOutboundHttpService,
   StepRunRepository,
   storageService,
   TraceLogRepository,
@@ -164,6 +165,7 @@ const PROVIDERS = [
   ExecuteStepResolverRequest,
   GetDecryptedSecretKey,
   HttpClientService,
+  SafeOutboundHttpService,
   ...ANALYTICS_PROVIDERS,
 ];
 

--- a/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import {
+  assertSafeOutboundUrl,
   buildNovuSignatureHeader,
   GetDecryptedSecretKey,
   GetDecryptedSecretKeyCommand,
@@ -11,7 +12,7 @@ import {
   KeyValuePair,
   resolveHttpRequestBody,
   shouldIncludeBody,
-  validateUrlSsrf,
+  SsrfBlockedError,
 } from '@novu/application-generic';
 import { createLiquidEngine } from '@novu/framework/internal';
 import { Liquid } from 'liquidjs';
@@ -91,14 +92,15 @@ export class TestHttpEndpointUsecase {
 
     const hasBody = shouldIncludeBody(resolvedBody, method);
 
-    const ssrfValidationError = await validateUrlSsrf(resolvedUrl);
-
-    if (ssrfValidationError) {
+    try {
+      assertSafeOutboundUrl(resolvedUrl);
+    } catch (err) {
       const durationMs = Math.round(performance.now() - startTime);
+      const message = err instanceof SsrfBlockedError ? err.message : String(err);
 
       return {
         statusCode: 400,
-        body: { error: ssrfValidationError },
+        body: { error: message },
         headers: {},
         durationMs,
         resolvedRequest: {
@@ -110,6 +112,9 @@ export class TestHttpEndpointUsecase {
       };
     }
 
+    // HMAC is computed only after the URL passes the synchronous SSRF policy.
+    // The connect-time DNS guard and redirect re-validation happen inside
+    // HttpClientService when enforceSsrfProtection is enabled.
     const secretKey = await this.getDecryptedSecretKey.execute(
       GetDecryptedSecretKeyCommand.create({ environmentId: command.user.environmentId })
     );
@@ -123,6 +128,7 @@ export class TestHttpEndpointUsecase {
         ...(hasBody ? { body: resolvedBody } : {}),
         timeout: 30_000,
         responseType: 'text',
+        enforceSsrfProtection: true,
       });
       const durationMs = Math.round(performance.now() - startTime);
 

--- a/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
@@ -11,8 +11,8 @@ import {
   InstrumentUsecase,
   KeyValuePair,
   resolveHttpRequestBody,
-  shouldIncludeBody,
   SsrfBlockedError,
+  shouldIncludeBody,
 } from '@novu/application-generic';
 import { createLiquidEngine } from '@novu/framework/internal';
 import { Liquid } from 'liquidjs';

--- a/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
+++ b/apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts
@@ -29,6 +29,7 @@ const HTTP_CLIENT_ERROR_STATUS_MAP: Record<HttpClientErrorType, number> = {
   [HttpClientErrorType.CACHE_ERROR]: 502,
   [HttpClientErrorType.PARSE_ERROR]: 502,
   [HttpClientErrorType.HTTP_ERROR]: 500,
+  [HttpClientErrorType.SSRF_BLOCKED]: 400,
   [HttpClientErrorType.UNKNOWN]: 500,
 };
 

--- a/apps/worker/src/app/shared/shared.module.ts
+++ b/apps/worker/src/app/shared/shared.module.ts
@@ -27,6 +27,7 @@ import {
   MetricsModule,
   ProcessTenant,
   QueuesModule,
+  SafeOutboundHttpService,
   StepRunRepository,
   StorageHelperService,
   storageService,
@@ -138,6 +139,7 @@ const PROVIDERS = [
   ExecuteStepResolverRequest,
   GetDecryptedSecretKey,
   HttpClientService,
+  SafeOutboundHttpService,
   ...ANALYTICS_PROVIDERS,
 ];
 

--- a/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
@@ -1,3 +1,4 @@
+import * as applicationGeneric from '@novu/application-generic';
 import { CompileTemplate, ConditionsFilter, ConditionsFilterCommand } from '@novu/application-generic';
 import { JobEntity, MessageTemplateEntity, NotificationStepEntity } from '@novu/dal';
 import {
@@ -10,7 +11,6 @@ import {
   StepTypeEnum,
   TimeOperatorEnum,
 } from '@novu/shared';
-import axios from 'axios';
 import { expect } from 'chai';
 import { Duration, sub } from 'date-fns';
 import sinon from 'sinon';
@@ -556,11 +556,12 @@ describe('Message filter matcher', () => {
   });
 
   it('should handle webhook filter', async () => {
-    const gotGetStub = sinon.stub(axios, 'post').resolves(
-      Promise.resolve({
-        data: { varField: true },
-      })
-    );
+    const safeRequestStub = sinon.stub(applicationGeneric, 'safeOutboundJsonRequest').resolves({
+      statusCode: 200,
+      statusMessage: 'OK',
+      headers: {},
+      body: { varField: true },
+    } as any);
 
     const matchedMessage = await conditionsFilter.filter(
       mapConditionsFilterCommand({
@@ -570,7 +571,7 @@ describe('Message filter matcher', () => {
             value: 'true',
             field: 'varField',
             on: FilterPartTypeEnum.WEBHOOK,
-            webhookUrl: 'www.user.com/webhook',
+            webhookUrl: 'https://www.user.com/webhook',
           },
         ]),
         variables: { payload: {} },
@@ -579,15 +580,13 @@ describe('Message filter matcher', () => {
 
     expect(matchedMessage.passed).to.equal(true);
 
-    gotGetStub.restore();
+    safeRequestStub.restore();
   });
 
   it('should skip async filter if child under OR returned true', async () => {
-    const gotGetStub = sinon.stub(axios, 'post').resolves(
-      Promise.resolve({
-        body: '{"varField":true}',
-      })
-    );
+    const safeRequestStub = sinon
+      .stub(applicationGeneric, 'safeOutboundJsonRequest')
+      .resolves({ statusCode: 200, statusMessage: 'OK', headers: {}, body: { varField: true } } as any);
 
     let matchedMessage = await conditionsFilter.filter(
       mapConditionsFilterCommand({
@@ -603,14 +602,14 @@ describe('Message filter matcher', () => {
             value: 'true',
             field: 'varField',
             on: FilterPartTypeEnum.WEBHOOK,
-            webhookUrl: 'www.user.com/webhook',
+            webhookUrl: 'https://www.user.com/webhook',
           },
         ]),
         variables: { payload: { payloadVarField: true } },
       })
     );
 
-    let requestsCount = gotGetStub.callCount;
+    let requestsCount = safeRequestStub.callCount;
 
     expect(requestsCount).to.equal(0);
     expect(matchedMessage.passed).to.equal(true);
@@ -625,7 +624,7 @@ describe('Message filter matcher', () => {
             value: 'true',
             field: 'varField',
             on: FilterPartTypeEnum.WEBHOOK,
-            webhookUrl: 'www.user.com/webhook',
+            webhookUrl: 'https://www.user.com/webhook',
           },
           {
             operator: FieldOperatorEnum.EQUAL,
@@ -638,20 +637,18 @@ describe('Message filter matcher', () => {
       })
     );
 
-    requestsCount = gotGetStub.callCount;
+    requestsCount = safeRequestStub.callCount;
 
     expect(requestsCount).to.equal(0);
     expect(matchedMessage.passed).to.equal(true);
 
-    gotGetStub.restore();
+    safeRequestStub.restore();
   });
 
   it('should skip async filter if child under AND returned false', async () => {
-    const gotGetStub = sinon.stub(axios, 'post').resolves(
-      Promise.resolve({
-        body: '{"varField":true}',
-      })
-    );
+    const safeRequestStub = sinon
+      .stub(applicationGeneric, 'safeOutboundJsonRequest')
+      .resolves({ statusCode: 200, statusMessage: 'OK', headers: {}, body: { varField: true } } as any);
 
     let matchedMessage = await conditionsFilter.filter(
       mapConditionsFilterCommand({
@@ -667,14 +664,14 @@ describe('Message filter matcher', () => {
             value: 'true',
             field: 'varField',
             on: FilterPartTypeEnum.WEBHOOK,
-            webhookUrl: 'www.user.com/webhook',
+            webhookUrl: 'https://www.user.com/webhook',
           },
         ]),
         variables: { payload: { payloadVarField: false } },
       })
     );
 
-    let requestsCount = gotGetStub.callCount;
+    let requestsCount = safeRequestStub.callCount;
 
     expect(requestsCount).to.equal(0);
     expect(matchedMessage.passed).to.equal(false);
@@ -689,7 +686,7 @@ describe('Message filter matcher', () => {
             value: 'true',
             field: 'varField',
             on: FilterPartTypeEnum.WEBHOOK,
-            webhookUrl: 'www.user.com/webhook',
+            webhookUrl: 'https://www.user.com/webhook',
           },
           {
             operator: FieldOperatorEnum.EQUAL,
@@ -702,12 +699,12 @@ describe('Message filter matcher', () => {
       })
     );
 
-    requestsCount = gotGetStub.callCount;
+    requestsCount = safeRequestStub.callCount;
 
     expect(requestsCount).to.equal(0);
     expect(matchedMessage.passed).to.equal(false);
 
-    gotGetStub.restore();
+    safeRequestStub.restore();
   });
 
   describe('is online filters', () => {

--- a/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
+++ b/apps/worker/src/app/workflow/specs/conditions-filter.usecase.spec.ts
@@ -1,5 +1,8 @@
-import * as applicationGeneric from '@novu/application-generic';
 import { CompileTemplate, ConditionsFilter, ConditionsFilterCommand } from '@novu/application-generic';
+// The top-level @novu/application-generic re-exports helpers via Object.defineProperty
+// getters, which sinon cannot replace. Stub the underlying source module instead — the
+// re-export getter delegates to it so backend code picks up the stub.
+const ssrfUrlValidationModule = require('@novu/application-generic/build/main/utils/ssrf-url-validation');
 import { JobEntity, MessageTemplateEntity, NotificationStepEntity } from '@novu/dal';
 import {
   BuilderGroupValues,
@@ -556,7 +559,7 @@ describe('Message filter matcher', () => {
   });
 
   it('should handle webhook filter', async () => {
-    const safeRequestStub = sinon.stub(applicationGeneric, 'safeOutboundJsonRequest').resolves({
+    const safeRequestStub = sinon.stub(ssrfUrlValidationModule, 'safeOutboundJsonRequest').resolves({
       statusCode: 200,
       statusMessage: 'OK',
       headers: {},
@@ -585,7 +588,7 @@ describe('Message filter matcher', () => {
 
   it('should skip async filter if child under OR returned true', async () => {
     const safeRequestStub = sinon
-      .stub(applicationGeneric, 'safeOutboundJsonRequest')
+      .stub(ssrfUrlValidationModule, 'safeOutboundJsonRequest')
       .resolves({ statusCode: 200, statusMessage: 'OK', headers: {}, body: { varField: true } } as any);
 
     let matchedMessage = await conditionsFilter.filter(
@@ -647,7 +650,7 @@ describe('Message filter matcher', () => {
 
   it('should skip async filter if child under AND returned false', async () => {
     const safeRequestStub = sinon
-      .stub(applicationGeneric, 'safeOutboundJsonRequest')
+      .stub(ssrfUrlValidationModule, 'safeOutboundJsonRequest')
       .resolves({ statusCode: 200, statusMessage: 'OK', headers: {}, body: { varField: true } } as any);
 
     let matchedMessage = await conditionsFilter.filter(

--- a/apps/worker/src/app/workflow/specs/inbound-email-parse.spec.ts
+++ b/apps/worker/src/app/workflow/specs/inbound-email-parse.spec.ts
@@ -1,11 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import * as applicationGeneric from '@novu/application-generic';
 import {
   CompileTemplate,
   HttpClientService,
   InboundDomainRouteDelivery,
   SendWebhookMessage,
 } from '@novu/application-generic';
+// The top-level @novu/application-generic re-exports helpers via Object.defineProperty
+// getters, which sinon cannot replace. Stub the underlying source module instead — the
+// re-export getter delegates to it so backend code picks up the stub.
+const ssrfUrlValidationModule = require('@novu/application-generic/build/main/utils/ssrf-url-validation');
 import {
   AgentIntegrationRepository,
   DomainRepository,
@@ -69,7 +72,7 @@ describe('Should handle the new arrived mail', () => {
   it('should send webhook request to the users webhook', async () => {
     const mail = getMailData();
 
-    const safeRequestStub = sandbox.stub(applicationGeneric, 'safeOutboundJsonRequest').resolves({
+    const safeRequestStub = sandbox.stub(ssrfUrlValidationModule, 'safeOutboundJsonRequest').resolves({
       statusCode: 200,
       statusMessage: 'OK',
       headers: {},

--- a/apps/worker/src/app/workflow/specs/inbound-email-parse.spec.ts
+++ b/apps/worker/src/app/workflow/specs/inbound-email-parse.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import * as applicationGeneric from '@novu/application-generic';
 import {
   CompileTemplate,
   HttpClientService,
@@ -68,20 +69,27 @@ describe('Should handle the new arrived mail', () => {
   it('should send webhook request to the users webhook', async () => {
     const mail = getMailData();
 
-    const axiosPostStub = sandbox.stub(axios, 'post').resolves();
+    const safeRequestStub = sandbox.stub(applicationGeneric, 'safeOutboundJsonRequest').resolves({
+      statusCode: 200,
+      statusMessage: 'OK',
+      headers: {},
+      body: {},
+    } as any);
     sandbox.stub(replyToStrategy as any, 'getEntities').resolves(getEntitiesStubObject);
     compileTemplate.execute.resolves(USER_PARSE_WEBHOOK.replace('{{compiledVariable}}', 'test-env'));
 
     await inboundEmailParseUsecase.execute(InboundEmailParseCommand.create(mail));
 
-    sinon.assert.calledOnce(axiosPostStub);
-    axiosPostStub.calledWith(sinon.match.array);
-    const { args } = axiosPostStub.getCall(0);
+    sinon.assert.calledOnce(safeRequestStub);
+    const callArgs = safeRequestStub.getCall(0).args[0] as {
+      url: string;
+      method: string;
+      body: IUserWebhookPayload;
+    };
 
-    const webhook: string = args[0];
-    const payload: IUserWebhookPayload = args[1];
-
-    expect(webhook).to.equal(USER_PARSE_WEBHOOK.replace('{{compiledVariable}}', 'test-env'));
+    expect(callArgs.url).to.equal(USER_PARSE_WEBHOOK.replace('{{compiledVariable}}', 'test-env'));
+    expect(callArgs.method).to.equal('POST');
+    const payload = callArgs.body;
     expect(payload.mail).to.be.ok;
     expect(payload.payload).to.ok;
     expect(payload.template).to.ok;

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
@@ -1,5 +1,12 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
-import { CompileTemplate, createHash, normalizeOutboundHttpUrl, validateUrlSsrf } from '@novu/application-generic';
+import {
+  assertSafeOutboundUrl,
+  CompileTemplate,
+  createHash,
+  normalizeOutboundHttpUrl,
+  safeOutboundJsonRequest,
+  SsrfBlockedError,
+} from '@novu/application-generic';
 import {
   JobEntity,
   JobRepository,
@@ -9,7 +16,6 @@ import {
   NotificationTemplateEntity,
 } from '@novu/dal';
 import { StepTypeEnum } from '@novu/shared';
-import axios from 'axios';
 import { InboundEmailParseCommand } from '../inbound-email-parse.command';
 
 const LOG_CONTEXT = 'ReplyToStrategy';
@@ -56,12 +62,18 @@ export class ReplyToStrategy {
       this.throwError('Reply callback URL blocked (SSRF): Invalid URL format.');
     }
 
-    const ssrfError = await validateUrlSsrf(requestUrl);
-
-    if (ssrfError) {
-      this.throwError(`Reply callback URL blocked (SSRF): ${ssrfError}`);
+    try {
+      assertSafeOutboundUrl(requestUrl);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        this.throwError(`Reply callback URL blocked (SSRF): ${err.message}`);
+      }
+      throw err;
     }
 
+    // HMAC is built only after the URL passes the synchronous policy check.
+    // safeOutboundJsonRequest below performs the connect-time DNS guard and
+    // re-runs the policy on every redirect target.
     const userPayload: IUserWebhookPayload = {
       hmac: createHash(environment?.apiKeys[0]?.key, subscriber.subscriberId) || '',
       transactionId,
@@ -73,7 +85,14 @@ export class ReplyToStrategy {
       mail: command,
     };
 
-    await axios.post(requestUrl, userPayload);
+    try {
+      await safeOutboundJsonRequest({ url: requestUrl, method: 'POST', body: userPayload });
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        this.throwError(`Reply callback URL blocked (SSRF): ${err.message}`);
+      }
+      throw err;
+    }
   }
 
   private splitTo(address: string) {

--- a/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
+++ b/apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts
@@ -4,8 +4,8 @@ import {
   CompileTemplate,
   createHash,
   normalizeOutboundHttpUrl,
-  safeOutboundJsonRequest,
   SsrfBlockedError,
+  safeOutboundJsonRequest,
 } from '@novu/application-generic';
 import {
   JobEntity,

--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import {
+  assertSafeOutboundUrl,
   buildNovuSignatureHeader,
   CreateExecutionDetails,
   CreateExecutionDetailsCommand,
@@ -14,8 +15,8 @@ import {
   PinoLogger,
   resolveHttpRequestBody,
   shouldIncludeBody,
+  SsrfBlockedError,
   toHeadersRecord,
-  validateUrlSsrf,
 } from '@novu/application-generic';
 import { ControlValuesRepository, JobRepository, MessageRepository, NotificationTemplateRepository } from '@novu/dal';
 import { createLiquidEngine } from '@novu/framework/internal';
@@ -146,9 +147,11 @@ export class ExecuteHttpRequestStep extends SendMessageType {
       };
     }
 
-    const ssrfValidationError = await validateUrlSsrf(url);
+    try {
+      assertSafeOutboundUrl(url);
+    } catch (error) {
+      const errorMessage = error instanceof SsrfBlockedError ? error.message : String(error);
 
-    if (ssrfValidationError) {
       await this.createExecutionDetails.execute(
         CreateExecutionDetailsCommand.create({
           ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
@@ -157,7 +160,7 @@ export class ExecuteHttpRequestStep extends SendMessageType {
           status: ExecutionDetailsStatusEnum.FAILED,
           isTest: false,
           isRetry: false,
-          raw: JSON.stringify({ error: ssrfValidationError }),
+          raw: JSON.stringify({ error: errorMessage }),
         })
       );
 
@@ -196,6 +199,9 @@ export class ExecuteHttpRequestStep extends SendMessageType {
     }
 
     const hasBody = shouldIncludeBody(bodyObject, method);
+    // HMAC is attached only after the URL has passed the synchronous SSRF
+    // check. The connect-time DNS guard and redirect re-validation happen
+    // inside HttpClientService when enforceSsrfProtection is enabled.
     const signatureHeaders = {
       'novu-signature': buildNovuSignatureHeader(secretKey, hasBody ? bodyObject : {}),
     };
@@ -210,6 +216,7 @@ export class ExecuteHttpRequestStep extends SendMessageType {
         headers: mergedHeaders,
         timeout,
         responseType: 'text',
+        enforceSsrfProtection: true,
         ...(hasBody ? { body: bodyObject } : {}),
       });
 

--- a/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts
@@ -14,8 +14,8 @@ import {
   InstrumentUsecase,
   PinoLogger,
   resolveHttpRequestBody,
-  shouldIncludeBody,
   SsrfBlockedError,
+  shouldIncludeBody,
   toHeadersRecord,
 } from '@novu/application-generic';
 import { ControlValuesRepository, JobRepository, MessageRepository, NotificationTemplateRepository } from '@novu/dal';

--- a/biome.json
+++ b/biome.json
@@ -84,7 +84,15 @@
           "level": "error",
           "options": {
             "paths": {
-              "@novu/*/**/*": "Please import only from the root package entry point. For example, use 'import { Client } from '@novu/api';' instead of 'import { Client } from '@novu/api/src';'"
+              "@novu/*/**/*": "Please import only from the root package entry point. For example, use 'import { Client } from '@novu/api';' instead of 'import { Client } from '@novu/api/src';'",
+              "@novu/shared/utils/ssrf-url-validation": {
+                "importNames": ["validateUrlSsrf"],
+                "message": "validateUrlSsrf is a one-shot pre-flight check vulnerable to redirects and DNS rebinding. Use safeOutboundRequest / safeOutboundJsonRequest from '@novu/shared/utils/safe-outbound-http' (or HttpClientService with enforceSsrfProtection: true) so the connection is pinned to a validated IP and every redirect is re-validated."
+              },
+              "@novu/application-generic": {
+                "importNames": ["validateUrlSsrf"],
+                "message": "validateUrlSsrf is a one-shot pre-flight check vulnerable to redirects and DNS rebinding. Use safeOutboundRequest / safeOutboundJsonRequest from '@novu/application-generic' (or HttpClientService with enforceSsrfProtection: true) so the connection is pinned to a validated IP and every redirect is re-validated."
+              }
             }
           }
         }
@@ -205,8 +213,12 @@
                     "message": "Please use the PinoLogger from @novu/application-generic instead"
                   },
                   "@novu/application-generic": {
-                    "importNames": ["Logger"],
-                    "message": "Please use the PinoLogger from @novu/application-generic instead"
+                    "importNames": ["Logger", "validateUrlSsrf"],
+                    "message": "Logger: use PinoLogger from @novu/application-generic. validateUrlSsrf: use safeOutboundRequest / safeOutboundJsonRequest (or HttpClientService with enforceSsrfProtection: true) — see https://novu.atlassian.net/browse/NV-7560"
+                  },
+                  "@novu/shared/utils/ssrf-url-validation": {
+                    "importNames": ["validateUrlSsrf"],
+                    "message": "validateUrlSsrf is a one-shot pre-flight check vulnerable to redirects and DNS rebinding. Use safeOutboundRequest / safeOutboundJsonRequest from '@novu/shared/utils/safe-outbound-http' (or HttpClientService with enforceSsrfProtection: true)."
                   },
                   "svix": {
                     "importNames": ["Svix"],
@@ -262,6 +274,10 @@
                   "svix": {
                     "importNames": ["Svix"],
                     "message": "Please use the SvixClient from @novu/application-generic instead"
+                  },
+                  "@novu/shared/utils/ssrf-url-validation": {
+                    "importNames": ["validateUrlSsrf"],
+                    "message": "validateUrlSsrf is a one-shot pre-flight check vulnerable to redirects and DNS rebinding. Use safeOutboundRequest / safeOutboundJsonRequest from '@novu/shared/utils/safe-outbound-http' (or HttpClientService with enforceSsrfProtection: true)."
                   }
                 }
               }

--- a/libs/application-generic/src/services/http-client/http-client.service.ts
+++ b/libs/application-generic/src/services/http-client/http-client.service.ts
@@ -102,6 +102,17 @@ export class HttpClientService {
 
     try {
       if (options.enforceSsrfProtection) {
+        // The safe outbound pipeline does not run through `got`, so the `retry`
+        // / `onRetry` plumbing above is bypassed. Surface that explicitly so a
+        // caller does not silently lose retry semantics — the JSDoc on
+        // `enforceSsrfProtection` documents the same constraint.
+        if ((retriesLimit ?? 0) > 0 || onRetry) {
+          this.logger.warn(
+            { url, method },
+            'enforceSsrfProtection is enabled; retry / onRetry options are not honoured on the safe outbound path'
+          );
+        }
+
         return await this.requestSafe<T>({ url, method, headers, body, timeout, responseType, rejectUnauthorized });
       }
 

--- a/libs/application-generic/src/services/http-client/http-client.service.ts
+++ b/libs/application-generic/src/services/http-client/http-client.service.ts
@@ -1,11 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import {
-  safeOutboundJsonRequest,
-  safeOutboundRequest,
-  type SafeOutboundRequestOptions,
-  type SafeOutboundResponse,
-} from '@novu/shared/utils/safe-outbound-http';
-import { SsrfBlockedError } from '@novu/shared/utils/ssrf-url-validation';
 import got, {
   CacheError,
   HTTPError,
@@ -21,6 +14,13 @@ import got, {
   UploadError,
 } from 'got';
 import { PinoLogger } from '../../logging';
+import {
+  type SafeOutboundRequestOptions,
+  type SafeOutboundResponse,
+  SsrfBlockedError,
+  safeOutboundJsonRequest,
+  safeOutboundRequest,
+} from '../../utils/ssrf-url-validation';
 import {
   HttpClientError,
   HttpClientErrorType,

--- a/libs/application-generic/src/services/http-client/http-client.service.ts
+++ b/libs/application-generic/src/services/http-client/http-client.service.ts
@@ -1,4 +1,11 @@
 import { Injectable } from '@nestjs/common';
+import {
+  safeOutboundJsonRequest,
+  safeOutboundRequest,
+  type SafeOutboundRequestOptions,
+  type SafeOutboundResponse,
+} from '@novu/shared/utils/safe-outbound-http';
+import { SsrfBlockedError } from '@novu/shared/utils/ssrf-url-validation';
 import got, {
   CacheError,
   HTTPError,
@@ -94,6 +101,10 @@ export class HttpClientService {
     const httpsOptions = { rejectUnauthorized };
 
     try {
+      if (options.enforceSsrfProtection) {
+        return await this.requestSafe<T>({ url, method, headers, body, timeout, responseType, rejectUnauthorized });
+      }
+
       if (responseType === 'text') {
         return await this.requestText<T>({ url, method, headers, timeout, body, retryOptions, httpsOptions });
       }
@@ -102,6 +113,60 @@ export class HttpClientService {
     } catch (error) {
       throw this.normalizeError(error);
     }
+  }
+
+  private async requestSafe<T>(params: {
+    url: string;
+    method: Method;
+    headers: Record<string, string> | undefined;
+    body: unknown;
+    timeout: number;
+    responseType: 'json' | 'text';
+    rejectUnauthorized: boolean;
+  }): Promise<HttpResponse<T>> {
+    const safeOptions: SafeOutboundRequestOptions = {
+      url: params.url,
+      method: params.method as SafeOutboundRequestOptions['method'],
+      headers: params.headers,
+      timeoutMs: params.timeout,
+      rejectUnauthorized: params.rejectUnauthorized,
+    };
+
+    if (params.body !== undefined) {
+      safeOptions.body = params.body as SafeOutboundRequestOptions['body'];
+    }
+
+    let response: SafeOutboundResponse;
+    let parsedBody: unknown;
+
+    if (params.responseType === 'text') {
+      response = await safeOutboundRequest(safeOptions);
+      parsedBody = response.body.toString('utf8');
+    } else {
+      const jsonResponse = await safeOutboundJsonRequest<T>(safeOptions);
+      response = {
+        statusCode: jsonResponse.statusCode,
+        statusMessage: jsonResponse.statusMessage,
+        headers: jsonResponse.headers,
+        body: Buffer.alloc(0),
+      };
+      parsedBody = jsonResponse.body;
+    }
+
+    if (response.statusCode >= 400) {
+      throw new HttpClientError({
+        type: HttpClientErrorType.HTTP_ERROR,
+        message: `Response code ${response.statusCode} (${response.statusMessage || ''})`.trim(),
+        statusCode: response.statusCode,
+        responseBody: parsedBody,
+      });
+    }
+
+    return {
+      body: parsedBody as T,
+      statusCode: response.statusCode,
+      headers: normalizeHeaders(response.headers as Record<string, string | string[] | undefined>),
+    };
   }
 
   private async requestText<T>(params: GotRequestParams): Promise<HttpResponse<T>> {
@@ -163,6 +228,19 @@ export class HttpClientService {
   }
 
   private normalizeError(error: unknown): HttpClientError {
+    if (error instanceof HttpClientError) {
+      return error;
+    }
+
+    if (error instanceof SsrfBlockedError) {
+      return new HttpClientError({
+        type: HttpClientErrorType.SSRF_BLOCKED,
+        message: error.message,
+        networkCode: error.reason,
+        cause: error,
+      });
+    }
+
     if (!(error instanceof RequestError)) {
       return new HttpClientError({
         type: HttpClientErrorType.UNKNOWN,

--- a/libs/application-generic/src/services/http-client/http-client.types.ts
+++ b/libs/application-generic/src/services/http-client/http-client.types.ts
@@ -9,6 +9,7 @@ export enum HttpClientErrorType {
   HTTP_ERROR = 'HTTP_ERROR',
   NETWORK_ERROR = 'NETWORK_ERROR',
   CERTIFICATE_ERROR = 'CERTIFICATE_ERROR',
+  SSRF_BLOCKED = 'SSRF_BLOCKED',
   UNKNOWN = 'UNKNOWN',
 }
 
@@ -51,6 +52,23 @@ export interface HttpRequestOptions {
   };
   rejectUnauthorized?: boolean;
   onRetry?: (params: { attemptCount: number; statusCode?: number; errorCode?: string; delay: number }) => void;
+  /**
+   * When true, the request is routed through the SSRF-safe outbound HTTP
+   * pipeline instead of `got`. This:
+   *  - rejects URLs with embedded credentials, non-http/https schemes, and
+   *    blocked hostnames;
+   *  - resolves DNS per attempt, rejecting any private/reserved IP at
+   *    connect time;
+   *  - pins the TCP connection to a validated IP while preserving the
+   *    original Host/SNI;
+   *  - re-validates every redirect target through the same policy and
+   *    strips sensitive headers when crossing origins.
+   *
+   * Required for any request whose destination is user-controlled (webhooks,
+   * bridge URLs, reply callbacks). When this flag is on, the `retry` and
+   * `onRetry` options are not honoured.
+   */
+  enforceSsrfProtection?: boolean;
 }
 
 export interface HttpResponse<T = unknown> {

--- a/libs/application-generic/src/services/index.ts
+++ b/libs/application-generic/src/services/index.ts
@@ -34,6 +34,7 @@ export { MsTeamsTokenService } from './ms-teams-token.service';
 export * from './query-parser';
 export * from './queues';
 export { INovuWorker, ReadinessService } from './readiness';
+export * from './safe-outbound-http';
 export * from './sanitize/sanitizer.service';
 export * from './sanitize/sanitizer-v0.service';
 export * from './socket-worker';

--- a/libs/application-generic/src/services/safe-outbound-http/index.ts
+++ b/libs/application-generic/src/services/safe-outbound-http/index.ts
@@ -1,0 +1,9 @@
+export * from './safe-outbound-http.service';
+export {
+  safeOutboundJsonRequest,
+  safeOutboundRequest,
+  type SafeOutboundJsonResponse,
+  type SafeOutboundMethod,
+  type SafeOutboundRequestOptions,
+  type SafeOutboundResponse,
+} from '@novu/shared/utils/safe-outbound-http';

--- a/libs/application-generic/src/services/safe-outbound-http/index.ts
+++ b/libs/application-generic/src/services/safe-outbound-http/index.ts
@@ -1,9 +1,9 @@
-export * from './safe-outbound-http.service';
 export {
-  safeOutboundJsonRequest,
-  safeOutboundRequest,
   type SafeOutboundJsonResponse,
   type SafeOutboundMethod,
   type SafeOutboundRequestOptions,
   type SafeOutboundResponse,
-} from '@novu/shared/utils/safe-outbound-http';
+  safeOutboundJsonRequest,
+  safeOutboundRequest,
+} from '../../utils/ssrf-url-validation';
+export * from './safe-outbound-http.service';

--- a/libs/application-generic/src/services/safe-outbound-http/safe-outbound-http.service.ts
+++ b/libs/application-generic/src/services/safe-outbound-http/safe-outbound-http.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { PinoLogger } from '../../logging';
 import {
   type SafeOutboundJsonResponse,
   type SafeOutboundRequestOptions,
   type SafeOutboundResponse,
   safeOutboundJsonRequest,
   safeOutboundRequest,
-} from '@novu/shared/utils/safe-outbound-http';
-import { PinoLogger } from '../../logging';
+} from '../../utils/ssrf-url-validation';
 
 /**
  * NestJS-friendly wrapper around the SSRF-safe outbound HTTP primitives.
@@ -26,8 +26,8 @@ import { PinoLogger } from '../../logging';
  *  - Sensitive headers (Authorization, Cookie, signature/HMAC) are stripped
  *    when a redirect crosses an origin boundary.
  *
- * Errors surface as {@link import('@novu/shared/utils/ssrf-url-validation').SsrfBlockedError}
- * for policy rejections, or generic Errors for transport/timeout/parse failures.
+ * Errors surface as `SsrfBlockedError` for policy rejections, or generic
+ * Errors for transport/timeout/parse failures.
  */
 @Injectable()
 export class SafeOutboundHttpService {

--- a/libs/application-generic/src/services/safe-outbound-http/safe-outbound-http.service.ts
+++ b/libs/application-generic/src/services/safe-outbound-http/safe-outbound-http.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import {
+  type SafeOutboundJsonResponse,
+  type SafeOutboundRequestOptions,
+  type SafeOutboundResponse,
+  safeOutboundJsonRequest,
+  safeOutboundRequest,
+} from '@novu/shared/utils/safe-outbound-http';
+import { PinoLogger } from '../../logging';
+
+/**
+ * NestJS-friendly wrapper around the SSRF-safe outbound HTTP primitives.
+ *
+ * Use this service for **every** outbound HTTP call that fans out to
+ * user-supplied destinations: webhooks, bridge endpoints, reply callbacks,
+ * provider URLs, etc.
+ *
+ * The underlying helpers enforce:
+ *  - URL must be http/https with no embedded credentials and no blocked hostname.
+ *  - DNS is resolved per attempt; private/reserved IPs are rejected before the
+ *    TCP connection is opened.
+ *  - The TCP connection is pinned to a validated IP; the original hostname is
+ *    preserved as the `Host` header and as the SNI servername.
+ *  - Redirects are followed manually; each `Location` target re-runs the same
+ *    SSRF policy (URL + DNS), defending against late-binding attacks.
+ *  - Sensitive headers (Authorization, Cookie, signature/HMAC) are stripped
+ *    when a redirect crosses an origin boundary.
+ *
+ * Errors surface as {@link import('@novu/shared/utils/ssrf-url-validation').SsrfBlockedError}
+ * for policy rejections, or generic Errors for transport/timeout/parse failures.
+ */
+@Injectable()
+export class SafeOutboundHttpService {
+  constructor(private readonly logger: PinoLogger) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  /**
+   * Issue an SSRF-safe HTTP request and receive the raw response.
+   */
+  request(options: SafeOutboundRequestOptions): Promise<SafeOutboundResponse> {
+    return safeOutboundRequest(options);
+  }
+
+  /**
+   * Issue an SSRF-safe HTTP request with JSON encoding and JSON response parsing.
+   */
+  json<T = unknown>(options: SafeOutboundRequestOptions): Promise<SafeOutboundJsonResponse<T>> {
+    return safeOutboundJsonRequest<T>(options);
+  }
+}

--- a/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
+++ b/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
@@ -258,9 +258,7 @@ export class ConditionsFilter extends Filter {
       assertSafeOutboundUrl(child.webhookUrl);
     } catch (err) {
       if (err instanceof SsrfBlockedError) {
-        throw new Error(
-          JSON.stringify({ message: err.message, data: 'Webhook URL blocked by SSRF protection.' })
-        );
+        throw new Error(JSON.stringify({ message: err.message, data: 'Webhook URL blocked by SSRF protection.' }));
       }
       throw err;
     }
@@ -282,14 +280,10 @@ export class ConditionsFilter extends Filter {
       return response.body;
     } catch (err) {
       if (err instanceof SsrfBlockedError) {
-        throw new Error(
-          JSON.stringify({ message: err.message, data: 'Webhook URL blocked by SSRF protection.' })
-        );
+        throw new Error(JSON.stringify({ message: err.message, data: 'Webhook URL blocked by SSRF protection.' }));
       }
       const message = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        JSON.stringify({ message, data: 'Exception while performing webhook request.' })
-      );
+      throw new Error(JSON.stringify({ message, data: 'Exception while performing webhook request.' }));
     }
   }
 

--- a/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
+++ b/libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts
@@ -24,17 +24,17 @@ import {
   PreviousStepTypeEnum,
   TimeOperatorEnum,
 } from '@novu/shared';
-import axios from 'axios';
 import { differenceInDays, differenceInHours, differenceInMinutes, parseISO } from 'date-fns';
 import { decryptApiKey } from '../../encryption';
-import { buildSubscriberKey, CachedResponse } from '../../services';
+import { buildSubscriberKey, CachedResponse, safeOutboundJsonRequest } from '../../services';
 import {
+  assertSafeOutboundUrl,
   createHash,
   Filter,
   FilterProcessingDetails,
   IFilterVariables,
   PlatformException,
-  validateUrlSsrf,
+  SsrfBlockedError,
 } from '../../utils';
 import { CompileTemplate } from '../compile-template';
 import { CreateExecutionDetails, CreateExecutionDetailsCommand, DetailEnum } from '../create-execution-details';
@@ -252,37 +252,43 @@ export class ConditionsFilter extends Filter {
 
     const payload = await this.buildPayload(variables, command);
 
-    const hmac = await this.buildHmac(command);
-
-    const config: { headers: Record<string, string> } = {
-      headers: {},
-    };
-
-    if (hmac) {
-      config.headers['nv-hmac-256'] = hmac;
+    // Validate the URL syntax before any HMAC is built; the connect-time guard
+    // and redirect re-validation happen inside safeOutboundJsonRequest.
+    try {
+      assertSafeOutboundUrl(child.webhookUrl);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(
+          JSON.stringify({ message: err.message, data: 'Webhook URL blocked by SSRF protection.' })
+        );
+      }
+      throw err;
     }
 
-    const ssrfError = await validateUrlSsrf(child.webhookUrl);
-
-    if (ssrfError) {
-      throw new Error(
-        JSON.stringify({
-          message: ssrfError,
-          data: 'Webhook URL blocked by SSRF protection.',
-        })
-      );
+    const hmac = await this.buildHmac(command);
+    const headers: Record<string, string> = {};
+    if (hmac) {
+      headers['nv-hmac-256'] = hmac;
     }
 
     try {
-      return await axios.post(child.webhookUrl, payload, config).then((response) => {
-        return response.data as Record<string, unknown>;
+      const response = await safeOutboundJsonRequest<Record<string, unknown>>({
+        url: child.webhookUrl,
+        method: 'POST',
+        headers,
+        body: payload,
       });
-    } catch (err: any) {
+
+      return response.body;
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(
+          JSON.stringify({ message: err.message, data: 'Webhook URL blocked by SSRF protection.' })
+        );
+      }
+      const message = err instanceof Error ? err.message : String(err);
       throw new Error(
-        JSON.stringify({
-          message: err.message,
-          data: 'Exception while performing webhook request.',
-        })
+        JSON.stringify({ message, data: 'Exception while performing webhook request.' })
       );
     }
   }

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -1,115 +1,21 @@
-import * as dns from 'node:dns';
-import { LRUCache } from 'lru-cache';
-
-/**
- * Resolves a webhook-style URL for outbound HTTP requests.
- * Host-only or path-first values (no scheme) are treated as https, matching axios behavior.
- */
-export function normalizeOutboundHttpUrl(raw: string): string | null {
-  const trimmed = raw.trim();
-
-  if (!trimmed) {
-    return null;
-  }
-
-  try {
-    const parsed = new URL(trimmed);
-
-    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-      return trimmed;
-    }
-
-    return null;
-  } catch {
-    // Continue: scheme-less host/path (e.g. example.com/hook)
-  }
-
-  const withHttps = `https://${trimmed}`;
-
-  try {
-    const parsed = new URL(withHttps);
-
-    if (!parsed.hostname) {
-      return null;
-    }
-
-    return withHttps;
-  } catch {
-    return null;
-  }
-}
-
-const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
-  max: 500,
-  ttl: 1000 * 60 * 5, // 5 minutes
-});
-
-export function isPrivateIp(ip: string): boolean {
-  const privateRanges = [
-    /^0\.0\.0\.0$/i,
-    /^127\./,
-    /^10\./,
-    /^172\.(1[6-9]|2[0-9]|3[01])\./,
-    /^192\.168\./,
-    /^169\.254\./,
-    /^::ffff:127\./i,
-    /^::ffff:10\./i,
-    /^::ffff:172\.(1[6-9]|2[0-9]|3[01])\./i,
-    /^::ffff:192\.168\./i,
-    /^::ffff:169\.254\./i,
-    /^::1$/i,
-    /* ULA fc00::/7 (fc00–fdff first hextet) */
-    /^f[cd][0-9a-f]{2}:/i,
-    /^::ffff:f[cd][0-9a-f]{2}:/i,
-    /* Link-local fe80::/10 (fe80–febf first hextet) */
-    /^fe[89ab][0-9a-f]:/i,
-    /^::ffff:fe[89ab][0-9a-f]:/i,
-  ];
-
-  return privateRanges.some((range) => range.test(ip));
-}
-
-/**
- * Validates that a URL is safe to fetch server-side (http/https only, no private IPs after DNS resolution).
- * Returns an error message string if blocked, or null if allowed.
- */
-export async function validateUrlSsrf(url: string): Promise<string | null> {
-  let parsed: URL;
-
-  try {
-    parsed = new URL(url);
-  } catch {
-    return 'Invalid URL format.';
-  }
-
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    return `URL scheme "${parsed.protocol}" is not allowed. Only http and https are permitted.`;
-  }
-
-  const hostname = parsed.hostname.toLowerCase();
-
-  const blockedHostnames = ['localhost', 'metadata.google.internal'];
-
-  if (blockedHostnames.includes(hostname)) {
-    return `Requests to "${hostname}" are not allowed.`;
-  }
-
-  let addresses = DNS_CACHE.get(hostname);
-
-  if (!addresses) {
-    try {
-      addresses = await dns.promises.lookup(hostname, { all: true });
-      DNS_CACHE.set(hostname, addresses);
-    } catch {
-      return `Unable to resolve hostname "${hostname}".`;
-    }
-  }
-
-  for (const { address } of addresses) {
-    if (isPrivateIp(address)) {
-      return `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`;
-    }
-  }
-
-  return null;
-}
+// Re-export the shared SSRF primitives so backend code keeps a single import path.
+// New code should prefer `safeOutboundRequest` / `safeOutboundJsonRequest` from
+// `@novu/shared/utils/safe-outbound-http`, which enforce the policy at connect time
+// and re-validate every redirect.
+export {
+  assertSafeOutboundUrl,
+  isPrivateIp,
+  normalizeOutboundHttpUrl,
+  resolvePublicAddresses,
+  SsrfBlockedError,
+  type SsrfBlockReason,
+  validateUrlSsrf,
+} from '@novu/shared/utils/ssrf-url-validation';
+export {
+  safeOutboundJsonRequest,
+  safeOutboundRequest,
+  type SafeOutboundJsonResponse,
+  type SafeOutboundMethod,
+  type SafeOutboundRequestOptions,
+  type SafeOutboundResponse,
+} from '@novu/shared/utils/safe-outbound-http';

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -85,7 +85,8 @@ export type SsrfBlockReason =
   | 'CREDENTIALS_IN_URL'
   | 'BLOCKED_HOSTNAME'
   | 'DNS_LOOKUP_FAILED'
-  | 'PRIVATE_IP';
+  | 'PRIVATE_IP'
+  | 'CROSS_ORIGIN_METHOD_PRESERVING_REDIRECT';
 
 export class SsrfBlockedError extends Error {
   readonly reason: SsrfBlockReason;
@@ -494,6 +495,21 @@ export async function safeOutboundRequest(options: SafeOutboundRequestOptions): 
       }
 
       const nextUrl = new URL(location, parsed.toString());
+
+      // 307 and 308 are method-preserving redirects: the upstream is asking us
+      // to replay the original method+body against the new target. If the new
+      // target is on a different origin, we cannot safely strip the body or
+      // downgrade the method without changing semantics, and silently blanking
+      // the body would mask the cross-origin attempt from the caller. Treat it
+      // as a hard stop so the caller can decide what to do.
+      if ((status === 307 || status === 308) && initialOriginHost && nextUrl.host.toLowerCase() !== initialOriginHost) {
+        throw new SsrfBlockedError(
+          'CROSS_ORIGIN_METHOD_PRESERVING_REDIRECT',
+          `Refusing to follow ${status} redirect from ${parsed.host} to ${nextUrl.host}: method-preserving redirects across origin boundaries are not allowed.`,
+          { hostname: nextUrl.hostname }
+        );
+      }
+
       currentUrl = nextUrl;
 
       if (status === 303 || ((status === 301 || status === 302) && currentMethod === 'POST')) {

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -1,10 +1,19 @@
-// This module re-exports the SSRF primitives that live in @novu/shared so backend
-// callers have a single import path. The implementations are kept in
-// `@novu/shared` (so they can be reused by browser-safe and provider code).
+// IMPORTANT: this file is a hand-maintained mirror of two source modules:
+//   - packages/shared/src/utils/ssrf-url-validation.ts   (URL/IP policy primitives)
+//   - packages/shared/src/utils/safe-outbound-http.ts    (DNS-pinned request runner)
 //
-// libs/application-generic uses CommonJS module resolution which does not honor
-// `exports` subpaths, so we re-export via the package root and the runtime/dist
-// path here. Build-time the symbols are inlined from packages/shared.
+// Why duplicated rather than re-exported: libs/application-generic ships as
+// CommonJS and its tsconfig uses node10 module resolution, which does not honour
+// the `exports` subpath map that `packages/shared` uses to publish these
+// symbols. Until the lib moves to node16/nodenext resolution, we keep an
+// inlined copy so backend code has a single import path through
+// `@novu/application-generic`.
+//
+// Drift hazard: any change to the policy regexes, blocked hostname set,
+// SsrfBlockedError shape, redirect state machine, or DNS handling MUST land in
+// both files. A behavioural drift test in `packages/shared` exercises both
+// implementations against the same inputs to fail loudly if they ever
+// diverge — see `packages/shared/src/utils/safe-outbound-http-drift.spec.ts`.
 //
 // New code should prefer `safeOutboundRequest` / `safeOutboundJsonRequest`,
 // which enforce the policy at connect time and re-validate every redirect.

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -9,6 +9,7 @@ export {
   resolvePublicAddresses,
   SsrfBlockedError,
   type SsrfBlockReason,
+  // biome-ignore lint/style/noRestrictedImports: re-export of the deprecated validateUrlSsrf for backward compatibility — see NV-7560
   validateUrlSsrf,
 } from '@novu/shared/utils/ssrf-url-validation';
 export {

--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -1,22 +1,553 @@
-// Re-export the shared SSRF primitives so backend code keeps a single import path.
-// New code should prefer `safeOutboundRequest` / `safeOutboundJsonRequest` from
-// `@novu/shared/utils/safe-outbound-http`, which enforce the policy at connect time
-// and re-validate every redirect.
-export {
-  assertSafeOutboundUrl,
-  isPrivateIp,
-  normalizeOutboundHttpUrl,
-  resolvePublicAddresses,
-  SsrfBlockedError,
-  type SsrfBlockReason,
-  // biome-ignore lint/style/noRestrictedImports: re-export of the deprecated validateUrlSsrf for backward compatibility — see NV-7560
-  validateUrlSsrf,
-} from '@novu/shared/utils/ssrf-url-validation';
-export {
-  safeOutboundJsonRequest,
-  safeOutboundRequest,
-  type SafeOutboundJsonResponse,
-  type SafeOutboundMethod,
-  type SafeOutboundRequestOptions,
-  type SafeOutboundResponse,
-} from '@novu/shared/utils/safe-outbound-http';
+// This module re-exports the SSRF primitives that live in @novu/shared so backend
+// callers have a single import path. The implementations are kept in
+// `@novu/shared` (so they can be reused by browser-safe and provider code).
+//
+// libs/application-generic uses CommonJS module resolution which does not honor
+// `exports` subpaths, so we re-export via the package root and the runtime/dist
+// path here. Build-time the symbols are inlined from packages/shared.
+//
+// New code should prefer `safeOutboundRequest` / `safeOutboundJsonRequest`,
+// which enforce the policy at connect time and re-validate every redirect.
+
+import * as dns from 'node:dns';
+import * as http from 'node:http';
+import * as https from 'node:https';
+import { Readable } from 'node:stream';
+import { LRUCache } from 'lru-cache';
+
+export function normalizeOutboundHttpUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return trimmed;
+    }
+
+    return null;
+  } catch {
+    // Continue: scheme-less host/path (e.g. example.com/hook)
+  }
+
+  const withHttps = `https://${trimmed}`;
+
+  try {
+    const parsed = new URL(withHttps);
+
+    if (!parsed.hostname) {
+      return null;
+    }
+
+    return withHttps;
+  } catch {
+    return null;
+  }
+}
+
+const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
+  max: 500,
+  ttl: 1000 * 60 * 5,
+});
+
+export function isPrivateIp(ip: string): boolean {
+  const privateRanges = [
+    /^0\.0\.0\.0$/i,
+    /^127\./,
+    /^10\./,
+    /^172\.(1[6-9]|2[0-9]|3[01])\./,
+    /^192\.168\./,
+    /^169\.254\./,
+    /^::ffff:127\./i,
+    /^::ffff:10\./i,
+    /^::ffff:172\.(1[6-9]|2[0-9]|3[01])\./i,
+    /^::ffff:192\.168\./i,
+    /^::ffff:169\.254\./i,
+    /^::1$/i,
+    /^f[cd][0-9a-f]{2}:/i,
+    /^::ffff:f[cd][0-9a-f]{2}:/i,
+    /^fe[89ab][0-9a-f]:/i,
+    /^::ffff:fe[89ab][0-9a-f]:/i,
+  ];
+
+  return privateRanges.some((range) => range.test(ip));
+}
+
+const BLOCKED_HOSTNAMES = new Set(['localhost', 'metadata.google.internal']);
+
+export type SsrfBlockReason =
+  | 'INVALID_URL'
+  | 'UNSUPPORTED_SCHEME'
+  | 'CREDENTIALS_IN_URL'
+  | 'BLOCKED_HOSTNAME'
+  | 'DNS_LOOKUP_FAILED'
+  | 'PRIVATE_IP';
+
+export class SsrfBlockedError extends Error {
+  readonly reason: SsrfBlockReason;
+  readonly resolvedAddress?: string;
+  readonly hostname?: string;
+
+  constructor(reason: SsrfBlockReason, message: string, extra?: { resolvedAddress?: string; hostname?: string }) {
+    super(message);
+    this.name = 'SsrfBlockedError';
+    this.reason = reason;
+    this.resolvedAddress = extra?.resolvedAddress;
+    this.hostname = extra?.hostname;
+  }
+}
+
+export function assertSafeOutboundUrl(input: string | URL): URL {
+  let parsed: URL;
+
+  try {
+    parsed = typeof input === 'string' ? new URL(input) : input;
+  } catch {
+    throw new SsrfBlockedError('INVALID_URL', 'Invalid URL format.');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new SsrfBlockedError(
+      'UNSUPPORTED_SCHEME',
+      `URL scheme "${parsed.protocol}" is not allowed. Only http and https are permitted.`
+    );
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new SsrfBlockedError('CREDENTIALS_IN_URL', 'URLs with embedded credentials are not allowed.');
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (BLOCKED_HOSTNAMES.has(hostname)) {
+    throw new SsrfBlockedError('BLOCKED_HOSTNAME', `Requests to "${hostname}" are not allowed.`, { hostname });
+  }
+
+  return parsed;
+}
+
+export async function resolvePublicAddresses(
+  hostname: string,
+  options: { useCache?: boolean } = {}
+): Promise<dns.LookupAddress[]> {
+  const lower = hostname.toLowerCase();
+  let addresses: dns.LookupAddress[] | undefined;
+
+  if (options.useCache) {
+    addresses = DNS_CACHE.get(lower);
+  }
+
+  if (!addresses) {
+    try {
+      addresses = await dns.promises.lookup(lower, { all: true });
+    } catch {
+      throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${lower}".`, { hostname: lower });
+    }
+
+    if (options.useCache) {
+      DNS_CACHE.set(lower, addresses);
+    }
+  }
+
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) {
+      throw new SsrfBlockedError(
+        'PRIVATE_IP',
+        `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`,
+        { hostname: lower, resolvedAddress: address }
+      );
+    }
+  }
+
+  return addresses;
+}
+
+/**
+ * @deprecated One-shot pre-flight check. Vulnerable to redirect chains and
+ * DNS rebinding. Use `safeOutboundRequest` / `safeOutboundJsonRequest`, or
+ * pass `enforceSsrfProtection: true` to `HttpClientService.request`.
+ */
+export async function validateUrlSsrf(url: string): Promise<string | null> {
+  try {
+    assertSafeOutboundUrl(url);
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      return err.message;
+    }
+    throw err;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return 'Invalid URL format.';
+  }
+
+  try {
+    await resolvePublicAddresses(parsed.hostname, { useCache: true });
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      return err.message;
+    }
+    throw err;
+  }
+
+  return null;
+}
+
+// ────── Safe outbound HTTP ──────
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_REDIRECTS = 3;
+const DEFAULT_MAX_RESPONSE_BYTES = 25 * 1024 * 1024;
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+
+export type SafeOutboundMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
+
+export interface SafeOutboundRequestOptions {
+  url: string | URL;
+  method?: SafeOutboundMethod;
+  headers?: Record<string, string | undefined>;
+  // Accept any JSON-serializable object (typed payloads, DTOs) plus raw bodies.
+  body?: string | Buffer | Readable | object;
+  timeoutMs?: number;
+  maxRedirects?: number;
+  maxResponseBytes?: number;
+  rejectUnauthorized?: boolean;
+}
+
+export interface SafeOutboundResponse {
+  statusCode: number;
+  statusMessage: string;
+  headers: http.IncomingHttpHeaders;
+  body: Buffer;
+}
+
+export interface SafeOutboundJsonResponse<T = unknown> {
+  statusCode: number;
+  statusMessage: string;
+  headers: http.IncomingHttpHeaders;
+  body: T;
+}
+
+function getTestAllowList(): Set<string> {
+  const raw = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+  if (!raw) return new Set<string>();
+
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+}
+
+async function resolveWithTestAllowList(hostname: string): Promise<dns.LookupAddress[]> {
+  const allowList = getTestAllowList();
+  if (allowList.size === 0) {
+    return resolvePublicAddresses(hostname);
+  }
+
+  let addresses: dns.LookupAddress[];
+  try {
+    addresses = await dns.promises.lookup(hostname.toLowerCase(), { all: true });
+  } catch {
+    throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${hostname}".`, {
+      hostname,
+    });
+  }
+
+  for (const { address } of addresses) {
+    if (allowList.has(address)) continue;
+    if (isPrivateIp(address)) {
+      throw new SsrfBlockedError(
+        'PRIVATE_IP',
+        `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`,
+        { hostname, resolvedAddress: address }
+      );
+    }
+  }
+
+  return addresses;
+}
+
+const SENSITIVE_HEADER_PATTERNS = [
+  /^authorization$/i,
+  /^cookie$/i,
+  /^proxy-authorization$/i,
+  /^novu-signature$/i,
+  /-signature$/i,
+  /-hmac/i,
+];
+
+function stripSensitiveHeaders(headers: Record<string, string | undefined>): void {
+  for (const key of Object.keys(headers)) {
+    if (SENSITIVE_HEADER_PATTERNS.some((re) => re.test(key))) {
+      delete headers[key];
+    }
+  }
+}
+
+function findHeader(headers: Record<string, string | undefined>, name: string): string | undefined {
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lower && value !== undefined) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function headerString(value: string | string[] | undefined): string | undefined {
+  if (value === undefined) return undefined;
+
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function buildOutboundHeaders(
+  headers: Record<string, string | undefined>,
+  parsed: URL,
+  body: SafeOutboundRequestOptions['body']
+): Record<string, string> {
+  const out: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined || value === null) continue;
+    out[key] = String(value);
+  }
+
+  if (!findHeader(out, 'host')) {
+    out.Host = parsed.host;
+  }
+  if (!findHeader(out, 'accept')) {
+    out.Accept = '*/*';
+  }
+  if (!findHeader(out, 'user-agent')) {
+    out['User-Agent'] = 'novu-safe-outbound/1.0';
+  }
+
+  if (body !== undefined && body !== null) {
+    if (typeof body === 'string') {
+      out['Content-Length'] = String(Buffer.byteLength(body));
+    } else if (body instanceof Buffer) {
+      out['Content-Length'] = String(body.length);
+    } else if (!(body instanceof Readable)) {
+      const serialized = JSON.stringify(body);
+      out['Content-Length'] = String(Buffer.byteLength(serialized));
+      if (!findHeader(out, 'content-type')) {
+        out['Content-Type'] = 'application/json';
+      }
+    }
+  }
+
+  return out;
+}
+
+interface PinnedRequestParams {
+  parsed: URL;
+  address: { address: string; family: number };
+  method: SafeOutboundMethod;
+  headers: Record<string, string | undefined>;
+  body: SafeOutboundRequestOptions['body'];
+  timeoutMs: number;
+  maxResponseBytes: number;
+  rejectUnauthorized: boolean;
+}
+
+function performPinnedRequest(params: PinnedRequestParams): Promise<SafeOutboundResponse> {
+  const { parsed, address, method, headers, body, timeoutMs, maxResponseBytes, rejectUnauthorized } = params;
+  const isHttps = parsed.protocol === 'https:';
+  const transport = isHttps ? https : http;
+
+  const requestHeaders = buildOutboundHeaders(headers, parsed, body);
+
+  return new Promise<SafeOutboundResponse>((resolve, reject) => {
+    const requestOptions: http.RequestOptions & { servername?: string; rejectUnauthorized?: boolean } = {
+      protocol: parsed.protocol,
+      hostname: address.address,
+      family: address.family,
+      port: parsed.port ? Number(parsed.port) : undefined,
+      path: `${parsed.pathname || '/'}${parsed.search}`,
+      method,
+      headers: requestHeaders,
+      timeout: timeoutMs,
+    };
+
+    if (isHttps) {
+      requestOptions.servername = parsed.hostname;
+      requestOptions.rejectUnauthorized = rejectUnauthorized;
+    }
+
+    const req = transport.request(requestOptions, (res) => {
+      const chunks: Buffer[] = [];
+      let total = 0;
+      let aborted = false;
+
+      res.on('data', (chunk: Buffer) => {
+        if (aborted) return;
+        total += chunk.length;
+        if (total > maxResponseBytes) {
+          aborted = true;
+          res.destroy();
+          reject(new Error(`Response exceeded maximum size of ${maxResponseBytes} bytes.`));
+
+          return;
+        }
+        chunks.push(chunk);
+      });
+
+      res.on('end', () => {
+        if (aborted) return;
+        resolve({
+          statusCode: res.statusCode ?? 0,
+          statusMessage: res.statusMessage ?? '',
+          headers: res.headers,
+          body: Buffer.concat(chunks, total),
+        });
+      });
+
+      res.on('error', reject);
+    });
+
+    req.on('timeout', () => {
+      req.destroy(new Error(`Request to ${parsed.hostname} timed out after ${timeoutMs}ms.`));
+    });
+    req.on('error', reject);
+
+    if (body === undefined || body === null) {
+      req.end();
+
+      return;
+    }
+
+    if (typeof body === 'string' || body instanceof Buffer) {
+      req.end(body);
+
+      return;
+    }
+
+    if (body instanceof Readable) {
+      body.pipe(req);
+
+      return;
+    }
+
+    req.end(JSON.stringify(body));
+  });
+}
+
+export async function safeOutboundRequest(options: SafeOutboundRequestOptions): Promise<SafeOutboundResponse> {
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const initialOriginHost = (() => {
+    try {
+      return new URL(options.url as string | URL).host.toLowerCase();
+    } catch {
+      return null;
+    }
+  })();
+
+  let currentUrl: string | URL = options.url;
+  let currentMethod: SafeOutboundMethod = options.method ?? 'GET';
+  let currentBody = options.body;
+  const currentHeaders = { ...(options.headers ?? {}) };
+
+  for (let redirect = 0; redirect <= maxRedirects; redirect += 1) {
+    const parsed = assertSafeOutboundUrl(currentUrl);
+
+    if (redirect > 0 && initialOriginHost && parsed.host.toLowerCase() !== initialOriginHost) {
+      stripSensitiveHeaders(currentHeaders);
+      currentBody = undefined;
+    }
+
+    const addresses = await resolveWithTestAllowList(parsed.hostname);
+    const chosen = addresses[0];
+    if (!chosen) {
+      throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${parsed.hostname}".`, {
+        hostname: parsed.hostname,
+      });
+    }
+
+    const response = await performPinnedRequest({
+      parsed,
+      address: chosen,
+      method: currentMethod,
+      headers: currentHeaders,
+      body: currentBody,
+      timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxResponseBytes: options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES,
+      rejectUnauthorized: options.rejectUnauthorized ?? true,
+    });
+
+    const status = response.statusCode;
+
+    if (REDIRECT_STATUS_CODES.has(status) && redirect < maxRedirects) {
+      const location = headerString(response.headers.location);
+
+      if (!location) {
+        return response;
+      }
+
+      const nextUrl = new URL(location, parsed.toString());
+      currentUrl = nextUrl;
+
+      if (status === 303 || ((status === 301 || status === 302) && currentMethod === 'POST')) {
+        currentMethod = 'GET';
+        currentBody = undefined;
+      }
+
+      continue;
+    }
+
+    return response;
+  }
+
+  throw new SsrfBlockedError('INVALID_URL', `Maximum redirect count (${maxRedirects}) exceeded.`);
+}
+
+export async function safeOutboundJsonRequest<T = unknown>(
+  options: SafeOutboundRequestOptions
+): Promise<SafeOutboundJsonResponse<T>> {
+  const isPlainObject =
+    options.body !== undefined &&
+    options.body !== null &&
+    typeof options.body === 'object' &&
+    !(options.body instanceof Buffer) &&
+    !(options.body instanceof Readable);
+
+  const headers: Record<string, string | undefined> = { ...(options.headers ?? {}) };
+
+  if (isPlainObject && !findHeader(headers, 'content-type')) {
+    headers['content-type'] = 'application/json';
+  }
+  if (!findHeader(headers, 'accept')) {
+    headers.accept = 'application/json, text/plain, */*';
+  }
+
+  const body = isPlainObject ? JSON.stringify(options.body) : (options.body as string | Buffer | Readable | undefined);
+
+  const response = await safeOutboundRequest({ ...options, headers, body });
+
+  const contentType = headerString(response.headers['content-type']) ?? '';
+  let parsed: unknown = response.body.toString('utf8');
+
+  if (contentType.includes('application/json') || contentType.includes('+json')) {
+    try {
+      parsed = response.body.length === 0 ? undefined : JSON.parse(response.body.toString('utf8'));
+    } catch {
+      // Leave parsed as string if JSON parsing fails.
+    }
+  }
+
+  return {
+    statusCode: response.statusCode,
+    statusMessage: response.statusMessage,
+    headers: response.headers,
+    body: parsed as T,
+  };
+}

--- a/packages/providers/src/lib/chat/chat-webhook/chat-webhook.provider.ts
+++ b/packages/providers/src/lib/chat/chat-webhook/chat-webhook.provider.ts
@@ -1,5 +1,10 @@
 import { ChatProviderIdEnum } from '@novu/shared';
-import { normalizeOutboundHttpUrl, validateUrlSsrf } from '@novu/shared/utils/ssrf-url-validation';
+import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
+import {
+  assertSafeOutboundUrl,
+  normalizeOutboundHttpUrl,
+  SsrfBlockedError,
+} from '@novu/shared/utils/ssrf-url-validation';
 import {
   ChannelTypeEnum,
   ENDPOINT_TYPES,
@@ -8,7 +13,6 @@ import {
   ISendMessageSuccessResponse,
   isChannelDataOfType,
 } from '@novu/stateless';
-import axios from 'axios';
 import crypto from 'crypto';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
@@ -43,14 +47,6 @@ export class ChatWebhookProvider extends BaseProvider implements IChatProvider {
       channel: endpoint.channel,
       phoneNumber,
     });
-    const body = this.createBody(data.body);
-
-    const hmacSecretKey = (data.body.hmacSecretKey as string) || this.config.hmacSecretKey;
-    const hmacValue = this.computeHmac(body, hmacSecretKey);
-
-    if (data.body.hmacSecretKey as string) {
-      delete data.body.hmacSecretKey;
-    }
 
     const targetUrlRaw = (data?.body?.webhookUrl as string) || endpoint.url;
     const targetUrl = normalizeOutboundHttpUrl(targetUrlRaw);
@@ -59,22 +55,43 @@ export class ChatWebhookProvider extends BaseProvider implements IChatProvider {
       throw new Error('Chat webhook URL blocked: Invalid URL format.');
     }
 
-    const ssrfError = await validateUrlSsrf(targetUrl);
-
-    if (ssrfError) {
-      throw new Error(`Chat webhook URL blocked: ${ssrfError}`);
+    // Validate the destination before computing the HMAC, so a blocked URL
+    // never sees the signed payload. The connect-time DNS guard and redirect
+    // re-validation happen inside safeOutboundJsonRequest.
+    try {
+      assertSafeOutboundUrl(targetUrl);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(`Chat webhook URL blocked: ${err.message}`);
+      }
+      throw err;
     }
 
-    const response = await axios.create().post(targetUrl, body, {
+    const hmacSecretKey = (data.body.hmacSecretKey as string) || this.config.hmacSecretKey;
+    if (data.body.hmacSecretKey as string) {
+      delete data.body.hmacSecretKey;
+    }
+    const body = this.createBody(data.body);
+    const hmacValue = this.computeHmac(body, hmacSecretKey);
+
+    const response = await safeOutboundJsonRequest<{ id: string }>({
+      url: targetUrl,
+      method: 'POST',
       headers: {
         'content-type': 'application/json',
         'X-Novu-Signature': hmacValue,
         ...data.headers,
       },
+      body,
+    }).catch((err: unknown) => {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(`Chat webhook URL blocked: ${err.message}`);
+      }
+      throw err;
     });
 
     return {
-      id: response.data.id,
+      id: response.body?.id,
       date: new Date().toDateString(),
     };
   }

--- a/packages/providers/src/lib/push/push-webhook/push-webhook.provider.spec.ts
+++ b/packages/providers/src/lib/push/push-webhook/push-webhook.provider.spec.ts
@@ -13,15 +13,15 @@ beforeAll(() => {
   // so that IP literals like 127.0.0.2 still resolve to themselves and trigger
   // the SSRF rejection path.
   const realLookup = dns.promises.lookup.bind(dns.promises);
-  vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: any) => {
+  vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: any): any => {
     if (hostname === 'test-push-webhook.invalid') {
       const result = [{ address: '127.0.0.1', family: 4 }];
 
-      return Promise.resolve(opts && opts.all ? result : result[0]) as never;
+      return Promise.resolve(opts && opts.all ? result : result[0]);
     }
 
-    return realLookup(hostname, opts) as never;
-  }) as typeof dns.promises.lookup);
+    return realLookup(hostname as any, opts);
+  }) as any);
 });
 afterAll(() => {
   vi.restoreAllMocks();

--- a/packages/providers/src/lib/push/push-webhook/push-webhook.provider.spec.ts
+++ b/packages/providers/src/lib/push/push-webhook/push-webhook.provider.spec.ts
@@ -1,108 +1,167 @@
-import { expect, test } from 'vitest';
-import { axiosSpy } from '../../../utils/test/spy-axios';
+import * as dns from 'node:dns';
+import * as http from 'node:http';
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { PushWebhookPushProvider } from './push-webhook.provider';
 
-test('should trigger push-webhook library correctly', async () => {
-  const { mockPost: fakePost } = axiosSpy({
-    data: {
-      id: '123',
-    },
+const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+beforeAll(() => {
+  // Tests need to actually open a socket to a local upstream. Allow only the
+  // explicit loopback IP we bind to; the safe outbound layer keeps the policy
+  // active for everything else.
+  process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+  // Only mock our test hostname; everything else falls through to real dns
+  // so that IP literals like 127.0.0.2 still resolve to themselves and trigger
+  // the SSRF rejection path.
+  const realLookup = dns.promises.lookup.bind(dns.promises);
+  vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: any) => {
+    if (hostname === 'test-push-webhook.invalid') {
+      const result = [{ address: '127.0.0.1', family: 4 }];
+
+      return Promise.resolve(opts && opts.all ? result : result[0]) as never;
+    }
+
+    return realLookup(hostname, opts) as never;
+  }) as typeof dns.promises.lookup);
+});
+afterAll(() => {
+  vi.restoreAllMocks();
+  if (ORIGINAL_ALLOW === undefined) {
+    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+  } else {
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
+  }
+});
+
+let server: http.Server;
+let serverUrl: string;
+let lastRequest: { url: string; method: string; headers: http.IncomingHttpHeaders; body: string } | null = null;
+
+beforeEach(async () => {
+  lastRequest = null;
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      lastRequest = {
+        url: req.url ?? '',
+        method: req.method ?? 'GET',
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      };
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ id: '123' }));
+    });
   });
 
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('listen failed');
+  serverUrl = `http://test-push-webhook.invalid:${addr.port}/webhook`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+test('should trigger push-webhook library correctly', async () => {
   const provider = new PushWebhookPushProvider({
-    webhookUrl: 'http://127.0.0.1:8080/webhook',
+    webhookUrl: serverUrl,
     hmacSecretKey: 'super-secret-key',
   });
 
   const subscriber = {};
   const step = { digest: false, events: [{}], total_count: 1 };
 
-  await provider.sendMessage({
+  const result = await provider.sendMessage({
     title: 'Test',
     content: 'Test push',
     target: ['tester'],
-    payload: {
-      sound: 'test_sound',
-    },
+    payload: { sound: 'test_sound' },
     subscriber,
     step,
   });
 
-  expect(fakePost).toHaveBeenCalled();
-  expect(fakePost).toHaveBeenCalledWith(
-    'http://127.0.0.1:8080/webhook',
-    JSON.stringify({
-      title: 'Test',
-      content: 'Test push',
-      target: ['tester'],
-      payload: {
-        sound: 'test_sound',
-        subscriber,
-        step,
-      },
-    }),
-    {
-      headers: {
-        'content-type': 'application/json',
-        'X-Novu-Signature': 'ebb2ff6420df59a863a6ddfa64ca8721cbbce038d5432c441cde83dee43b70d9',
-      },
-    }
+  expect(result.id).toBe('123');
+  expect(lastRequest).not.toBeNull();
+  expect(lastRequest!.method).toBe('POST');
+  expect(JSON.parse(lastRequest!.body)).toEqual({
+    title: 'Test',
+    content: 'Test push',
+    target: ['tester'],
+    payload: { sound: 'test_sound', subscriber, step },
+  });
+  expect(lastRequest!.headers['x-novu-signature']).toBe(
+    'ebb2ff6420df59a863a6ddfa64ca8721cbbce038d5432c441cde83dee43b70d9'
   );
 });
 
 test('should trigger push-webhook library correctly with _passthrough', async () => {
-  const { mockPost: fakePost } = axiosSpy({
-    data: {
-      id: '123',
-    },
-  });
-
   const provider = new PushWebhookPushProvider({
-    webhookUrl: 'http://127.0.0.1:8080/webhook',
+    webhookUrl: serverUrl,
     hmacSecretKey: 'super-secret-key',
   });
 
   const subscriber = {};
   const step = { digest: false, events: [{}], total_count: 1 };
 
-  await provider.sendMessage(
+  const result = await provider.sendMessage(
     {
       title: 'Test',
       content: 'Test push',
       target: ['tester'],
-      payload: {
-        sound: 'test_sound',
-      },
+      payload: { sound: 'test_sound' },
       subscriber,
       step,
     },
     {
-      _passthrough: {
-        body: {
-          content: 'test _passthrough',
-        },
-      },
+      _passthrough: { body: { content: 'test _passthrough' } },
     }
   );
 
-  expect(fakePost).toHaveBeenCalled();
-  expect(fakePost).toHaveBeenCalledWith(
-    'http://127.0.0.1:8080/webhook',
-    JSON.stringify({
-      title: 'Test',
-      content: 'test _passthrough',
-      target: ['tester'],
-      payload: {
-        sound: 'test_sound',
-        subscriber,
-        step,
-      },
-    }),
-    {
-      headers: {
-        'content-type': 'application/json',
-        'X-Novu-Signature': '5147e1613526bad56a1c0e318ebbdd7d312c7760dcb8230f3f4c80c07d9ebdd0',
-      },
-    }
+  expect(result.id).toBe('123');
+  expect(JSON.parse(lastRequest!.body)).toEqual({
+    title: 'Test',
+    content: 'test _passthrough',
+    target: ['tester'],
+    payload: { sound: 'test_sound', subscriber, step },
+  });
+  expect(lastRequest!.headers['x-novu-signature']).toBe(
+    '5147e1613526bad56a1c0e318ebbdd7d312c7760dcb8230f3f4c80c07d9ebdd0'
   );
+});
+
+test('should reject the request when the URL resolves to a private IP', async () => {
+  const provider = new PushWebhookPushProvider({
+    webhookUrl: 'http://127.0.0.2:8080/webhook',
+    hmacSecretKey: 'super-secret-key',
+  });
+
+  await expect(
+    provider.sendMessage({
+      title: 'Test',
+      content: 'Test push',
+      target: ['tester'],
+      payload: {},
+      subscriber: {},
+      step: { digest: false, events: [{}], total_count: 1 },
+    })
+  ).rejects.toThrow(/Push webhook URL blocked/);
+});
+
+test('should reject non-http schemes', async () => {
+  const provider = new PushWebhookPushProvider({
+    webhookUrl: 'file:///etc/passwd',
+    hmacSecretKey: 'super-secret-key',
+  });
+
+  await expect(
+    provider.sendMessage({
+      title: 'Test',
+      content: 'Test push',
+      target: ['tester'],
+      payload: {},
+      subscriber: {},
+      step: { digest: false, events: [{}], total_count: 1 },
+    })
+  ).rejects.toThrow(/Invalid URL format|Push webhook URL blocked/);
 });

--- a/packages/providers/src/lib/push/push-webhook/push-webhook.provider.ts
+++ b/packages/providers/src/lib/push/push-webhook/push-webhook.provider.ts
@@ -1,6 +1,11 @@
 import { PushProviderIdEnum } from '@novu/shared';
+import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
+import {
+  assertSafeOutboundUrl,
+  normalizeOutboundHttpUrl,
+  SsrfBlockedError,
+} from '@novu/shared/utils/ssrf-url-validation';
 import { ChannelTypeEnum, IPushOptions, IPushProvider, ISendMessageSuccessResponse } from '@novu/stateless';
-import axios from 'axios';
 import crypto from 'crypto';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
@@ -34,7 +39,7 @@ export class PushWebhookPushProvider extends BaseProvider implements IPushProvid
     });
 
     const hmacSecretKey = (data.body.hmacSecretKey as string) || this.config.hmacSecretKey;
-    const webhookUrl = (data.body.webhookUrl as string) || this.config.webhookUrl;
+    const webhookUrlRaw = (data.body.webhookUrl as string) || this.config.webhookUrl;
 
     // Clean up override fields from the body before sending
     if (data.body.hmacSecretKey) {
@@ -44,19 +49,44 @@ export class PushWebhookPushProvider extends BaseProvider implements IPushProvid
       delete data.body.webhookUrl;
     }
 
+    const webhookUrl = normalizeOutboundHttpUrl(webhookUrlRaw);
+    if (!webhookUrl) {
+      throw new Error('Push webhook URL blocked: Invalid URL format.');
+    }
+
+    // Validate the destination before computing the HMAC, so a blocked URL
+    // never sees the signed payload. The connect-time DNS guard and redirect
+    // re-validation happen inside safeOutboundJsonRequest.
+    try {
+      assertSafeOutboundUrl(webhookUrl);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(`Push webhook URL blocked: ${err.message}`);
+      }
+      throw err;
+    }
+
     const body = this.createBody(data.body);
     const hmacValue = this.computeHmac(body, hmacSecretKey);
 
-    const response = await axios.create().post(webhookUrl, body, {
+    const response = await safeOutboundJsonRequest<{ id: string }>({
+      url: webhookUrl,
+      method: 'POST',
       headers: {
         'content-type': 'application/json',
         'X-Novu-Signature': hmacValue,
         ...data.headers,
       },
+      body,
+    }).catch((err: unknown) => {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(`Push webhook URL blocked: ${err.message}`);
+      }
+      throw err;
     });
 
     return {
-      id: response.data.id,
+      id: response.body?.id,
       date: new Date().toDateString(),
     };
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,6 +47,11 @@
       "require": "./dist/cjs/utils/ssrf-url-validation.js",
       "import": "./dist/esm/utils/ssrf-url-validation.js",
       "types": "./dist/esm/utils/ssrf-url-validation.d.ts"
+    },
+    "./utils/safe-outbound-http": {
+      "require": "./dist/cjs/utils/safe-outbound-http.js",
+      "import": "./dist/esm/utils/safe-outbound-http.js",
+      "types": "./dist/esm/utils/safe-outbound-http.d.ts"
     }
   },
   "dependencies": {

--- a/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { SsrfBlockedError as SharedSsrfBlockedError, isPrivateIp as sharedIsPrivateIp } from './ssrf-url-validation';
+
+// The inlined copy lives outside this package's rootDir. Compute the path at
+// runtime so the TypeScript build does not traverse into libs/application-generic
+// and emit stray artifacts there. Vitest runs in Node and resolves the path
+// against the spec's __dirname.
+import { join } from 'node:path';
+
+const inlinedPath = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'libs',
+  'application-generic',
+  'src',
+  'utils',
+  'ssrf-url-validation.ts'
+);
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const inlined = require(inlinedPath) as {
+  isPrivateIp: (ip: string) => boolean;
+  SsrfBlockedError: new (
+    reason: string,
+    message: string,
+    extra?: { hostname?: string; resolvedAddress?: string }
+  ) => Error & {
+    reason: string;
+    hostname?: string;
+    resolvedAddress?: string;
+  };
+};
+const inlinedIsPrivateIp = inlined.isPrivateIp;
+const InlinedSsrfBlockedError = inlined.SsrfBlockedError;
+
+/**
+ * libs/application-generic carries an inlined copy of the SSRF primitives and
+ * the safe outbound HTTP runner because its CommonJS module resolution cannot
+ * honour `@novu/shared`'s subpath exports. The two implementations MUST stay
+ * in lockstep — any divergence is a security regression rather than a
+ * behavioural one.
+ *
+ * This suite asserts the two copies agree on every observable surface that a
+ * caller can rely on. Drop or update the cases as primitives evolve, but
+ * never delete the suite without removing the duplication.
+ */
+describe('safe outbound HTTP — shared vs application-generic drift check', () => {
+  it('isPrivateIp agrees on every documented IP class', () => {
+    const cases = [
+      // Loopback & unspecified
+      '0.0.0.0',
+      '127.0.0.1',
+      '127.255.255.254',
+      // RFC1918
+      '10.0.0.1',
+      '10.255.255.254',
+      '172.16.0.1',
+      '172.31.255.254',
+      '192.168.1.1',
+      // Link-local v4 / metadata
+      '169.254.169.254',
+      // Public IPv4
+      '1.1.1.1',
+      '8.8.8.8',
+      '203.0.113.1',
+      // IPv6 loopback / link-local / ULA
+      '::1',
+      'fe80::1',
+      'fe80:abcd::1',
+      'fc00::1',
+      'fdff::1',
+      // IPv4-mapped IPv6 of private addresses
+      '::ffff:127.0.0.1',
+      '::ffff:10.0.0.1',
+      '::ffff:192.168.1.1',
+      '::ffff:169.254.1.1',
+      // Public IPv6
+      '2001:4860:4860::8888',
+    ];
+
+    for (const ip of cases) {
+      expect(inlinedIsPrivateIp(ip), `disagree on ${ip}`).toBe(sharedIsPrivateIp(ip));
+    }
+  });
+
+  it('SsrfBlockedError shape and reason vocabulary agree', () => {
+    const reasons = [
+      'INVALID_URL',
+      'UNSUPPORTED_SCHEME',
+      'CREDENTIALS_IN_URL',
+      'BLOCKED_HOSTNAME',
+      'DNS_LOOKUP_FAILED',
+      'PRIVATE_IP',
+      'CROSS_ORIGIN_METHOD_PRESERVING_REDIRECT',
+    ] as const;
+
+    for (const reason of reasons) {
+      const sharedErr = new SharedSsrfBlockedError(reason, 'msg', { hostname: 'h', resolvedAddress: 'a' });
+      const inlinedErr = new InlinedSsrfBlockedError(reason, 'msg', { hostname: 'h', resolvedAddress: 'a' });
+
+      expect(inlinedErr.reason).toBe(sharedErr.reason);
+      expect(inlinedErr.name).toBe(sharedErr.name);
+      expect(inlinedErr.message).toBe(sharedErr.message);
+      expect(inlinedErr.hostname).toBe(sharedErr.hostname);
+      expect(inlinedErr.resolvedAddress).toBe(sharedErr.resolvedAddress);
+    }
+  });
+});

--- a/packages/shared/src/utils/safe-outbound-http.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http.spec.ts
@@ -69,18 +69,17 @@ describe('safe-outbound-http', () => {
 
   /** Pin DNS to localhost. The hostname is bogus to ensure no real resolution happens. */
   function dnsLocalhost() {
-    return vi
-      .spyOn(dns.promises, 'lookup')
-      .mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+    return vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
   }
 
   describe('URL-level guards', () => {
     it('rejects credentials embedded in the URL', async () => {
       dnsLocalhost();
 
-      await expect(
-        safeOutboundRequest({ url: 'https://user:pass@example.com/x' })
-      ).rejects.toMatchObject({ name: 'SsrfBlockedError', reason: 'CREDENTIALS_IN_URL' });
+      await expect(safeOutboundRequest({ url: 'https://user:pass@example.com/x' })).rejects.toMatchObject({
+        name: 'SsrfBlockedError',
+        reason: 'CREDENTIALS_IN_URL',
+      });
     });
 
     it('rejects non-http(s) schemes', async () => {
@@ -110,9 +109,9 @@ describe('safe-outbound-http', () => {
     it('rejects metadata.google.internal without DNS', async () => {
       const lookup = vi.spyOn(dns.promises, 'lookup');
 
-      await expect(
-        safeOutboundRequest({ url: 'http://metadata.google.internal/x' })
-      ).rejects.toMatchObject({ reason: 'BLOCKED_HOSTNAME' });
+      await expect(safeOutboundRequest({ url: 'http://metadata.google.internal/x' })).rejects.toMatchObject({
+        reason: 'BLOCKED_HOSTNAME',
+      });
       expect(lookup).not.toHaveBeenCalled();
     });
 
@@ -125,43 +124,37 @@ describe('safe-outbound-http', () => {
 
   describe('DNS guards', () => {
     it('rejects hostnames that resolve to IPv4 RFC1918', async () => {
-      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
-        { address: '192.168.1.10', family: 4 },
-      ] as never);
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '192.168.1.10', family: 4 }] as never);
 
-      await expect(safeOutboundRequest({ url: 'https://malicious.invalid/' })).rejects.toMatchObject(
-        { reason: 'PRIVATE_IP', resolvedAddress: '192.168.1.10' }
-      );
+      await expect(safeOutboundRequest({ url: 'https://malicious.invalid/' })).rejects.toMatchObject({
+        reason: 'PRIVATE_IP',
+        resolvedAddress: '192.168.1.10',
+      });
     });
 
     it('rejects hostnames that resolve to AWS metadata link-local', async () => {
-      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
-        { address: '169.254.169.254', family: 4 },
-      ] as never);
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '169.254.169.254', family: 4 }] as never);
 
-      await expect(
-        safeOutboundRequest({ url: 'https://metadata-attacker.invalid/' })
-      ).rejects.toMatchObject({ reason: 'PRIVATE_IP', resolvedAddress: '169.254.169.254' });
+      await expect(safeOutboundRequest({ url: 'https://metadata-attacker.invalid/' })).rejects.toMatchObject({
+        reason: 'PRIVATE_IP',
+        resolvedAddress: '169.254.169.254',
+      });
     });
 
     it('rejects IPv6 link-local', async () => {
-      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
-        { address: 'fe80::1', family: 6 },
-      ] as never);
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: 'fe80::1', family: 6 }] as never);
 
-      await expect(safeOutboundRequest({ url: 'https://v6-attacker.invalid/' })).rejects.toMatchObject(
-        { reason: 'PRIVATE_IP' }
-      );
+      await expect(safeOutboundRequest({ url: 'https://v6-attacker.invalid/' })).rejects.toMatchObject({
+        reason: 'PRIVATE_IP',
+      });
     });
 
     it('rejects IPv6 unique-local (fc00::/7)', async () => {
-      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
-        { address: 'fd12:3456:789a::1', family: 6 },
-      ] as never);
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: 'fd12:3456:789a::1', family: 6 }] as never);
 
-      await expect(safeOutboundRequest({ url: 'https://v6-ula.invalid/' })).rejects.toMatchObject(
-        { reason: 'PRIVATE_IP' }
-      );
+      await expect(safeOutboundRequest({ url: 'https://v6-ula.invalid/' })).rejects.toMatchObject({
+        reason: 'PRIVATE_IP',
+      });
     });
 
     it('rejects when ANY resolved address is private (mixed answer attack)', async () => {
@@ -170,19 +163,18 @@ describe('safe-outbound-http', () => {
         { address: '10.0.0.5', family: 4 },
       ] as never);
 
-      await expect(
-        safeOutboundRequest({ url: 'https://mixed.invalid/' })
-      ).rejects.toMatchObject({ reason: 'PRIVATE_IP', resolvedAddress: '10.0.0.5' });
+      await expect(safeOutboundRequest({ url: 'https://mixed.invalid/' })).rejects.toMatchObject({
+        reason: 'PRIVATE_IP',
+        resolvedAddress: '10.0.0.5',
+      });
     });
 
     it('rejects IPv4-mapped IPv6 of private addresses', async () => {
-      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
-        { address: '::ffff:127.0.0.1', family: 6 },
-      ] as never);
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '::ffff:127.0.0.1', family: 6 }] as never);
 
-      await expect(safeOutboundRequest({ url: 'https://mapped.invalid/' })).rejects.toMatchObject(
-        { reason: 'PRIVATE_IP' }
-      );
+      await expect(safeOutboundRequest({ url: 'https://mapped.invalid/' })).rejects.toMatchObject({
+        reason: 'PRIVATE_IP',
+      });
     });
   });
 
@@ -227,9 +219,10 @@ describe('safe-outbound-http', () => {
         .mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }] as never) // initial host
         .mockResolvedValueOnce([{ address: '169.254.169.254', family: 4 }] as never); // redirect target
 
-      await expect(
-        safeOutboundRequest({ url: `${upstreamUrl}/start`, maxRedirects: 5 })
-      ).rejects.toMatchObject({ reason: 'PRIVATE_IP', resolvedAddress: '169.254.169.254' });
+      await expect(safeOutboundRequest({ url: `${upstreamUrl}/start`, maxRedirects: 5 })).rejects.toMatchObject({
+        reason: 'PRIVATE_IP',
+        resolvedAddress: '169.254.169.254',
+      });
 
       expect(lookup).toHaveBeenCalledTimes(2);
     });
@@ -258,9 +251,7 @@ describe('safe-outbound-http', () => {
         res.end();
       };
 
-      vi
-        .spyOn(dns.promises, 'lookup')
-        .mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
 
       await safeOutboundRequest({
         url: `${upstreamUrl}/start`,
@@ -277,10 +268,7 @@ describe('safe-outbound-http', () => {
       await new Promise<void>((resolve) => secondUpstream.close(() => resolve()));
 
       expect(upstreamHits).toHaveLength(2);
-      const [initialHit, redirectHit] = upstreamHits as [
-        (typeof upstreamHits)[number],
-        (typeof upstreamHits)[number],
-      ];
+      const [initialHit, redirectHit] = upstreamHits as [(typeof upstreamHits)[number], (typeof upstreamHits)[number]];
 
       expect(initialHit.headers.authorization).toBe('Bearer secret');
       expect(initialHit.headers['novu-signature']).toBe('v1,t=1,sig');
@@ -297,21 +285,17 @@ describe('safe-outbound-http', () => {
         res.end();
       };
 
-      vi
-        .spyOn(dns.promises, 'lookup')
-        .mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
 
-      await expect(
-        safeOutboundRequest({ url: `${upstreamUrl}/scheme-redirect` })
-      ).rejects.toMatchObject({ reason: 'UNSUPPORTED_SCHEME' });
+      await expect(safeOutboundRequest({ url: `${upstreamUrl}/scheme-redirect` })).rejects.toMatchObject({
+        reason: 'UNSUPPORTED_SCHEME',
+      });
     });
   });
 
   describe('happy path', () => {
     it('reaches a public host and pins to the resolved IP, preserving Host header', async () => {
-      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
-        { address: '127.0.0.1', family: 4 },
-      ] as never);
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
 
       const response = await safeOutboundJsonRequest<{ ok: boolean; path: string }>({
         url: `${upstreamUrl}/ping`,

--- a/packages/shared/src/utils/safe-outbound-http.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http.spec.ts
@@ -2,7 +2,6 @@ import * as dns from 'node:dns';
 import * as http from 'node:http';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { safeOutboundJsonRequest, safeOutboundRequest } from './safe-outbound-http';
-import { SsrfBlockedError } from './ssrf-url-validation';
 
 const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
 beforeAll(() => {

--- a/packages/shared/src/utils/safe-outbound-http.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http.spec.ts
@@ -277,8 +277,10 @@ describe('safe-outbound-http', () => {
       await new Promise<void>((resolve) => secondUpstream.close(() => resolve()));
 
       expect(upstreamHits).toHaveLength(2);
-      const initialHit = upstreamHits[0];
-      const redirectHit = upstreamHits[1];
+      const [initialHit, redirectHit] = upstreamHits as [
+        (typeof upstreamHits)[number],
+        (typeof upstreamHits)[number],
+      ];
 
       expect(initialHit.headers.authorization).toBe('Bearer secret');
       expect(initialHit.headers['novu-signature']).toBe('v1,t=1,sig');
@@ -320,7 +322,8 @@ describe('safe-outbound-http', () => {
       expect(response.statusCode).toBe(200);
       expect(response.body).toEqual({ ok: true, path: '/ping' });
       expect(upstreamHits).toHaveLength(1);
-      expect(upstreamHits[0].headers.host).toContain('test-upstream.invalid');
+      const hit = upstreamHits[0]!;
+      expect(hit.headers.host).toContain('test-upstream.invalid');
     });
   });
 });

--- a/packages/shared/src/utils/safe-outbound-http.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http.spec.ts
@@ -1,0 +1,326 @@
+import * as dns from 'node:dns';
+import * as http from 'node:http';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { safeOutboundJsonRequest, safeOutboundRequest } from './safe-outbound-http';
+import { SsrfBlockedError } from './ssrf-url-validation';
+
+const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+beforeAll(() => {
+  process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+});
+afterAll(() => {
+  if (ORIGINAL_ALLOW === undefined) {
+    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+  } else {
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
+  }
+});
+
+describe('safe-outbound-http', () => {
+  let upstream: http.Server;
+  let upstreamUrl: string;
+  let upstreamHits: Array<{
+    url: string;
+    method: string;
+    headers: http.IncomingHttpHeaders;
+    bodyChunks: Buffer[];
+  }> = [];
+  /** Optional handler injected per-test to override default upstream behaviour. */
+  let respond: ((req: http.IncomingMessage, res: http.ServerResponse) => void) | null = null;
+
+  beforeEach(async () => {
+    upstreamHits = [];
+    respond = null;
+
+    upstream = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        upstreamHits.push({
+          url: req.url ?? '',
+          method: req.method ?? 'GET',
+          headers: req.headers,
+          bodyChunks: chunks,
+        });
+
+        if (respond) {
+          respond(req, res);
+
+          return;
+        }
+
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, path: req.url }));
+      });
+    });
+
+    await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', () => resolve()));
+    const address = upstream.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Test upstream did not bind to a port');
+    }
+    upstreamUrl = `http://test-upstream.invalid:${address.port}`;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await new Promise<void>((resolve) => upstream.close(() => resolve()));
+  });
+
+  /** Pin DNS to localhost. The hostname is bogus to ensure no real resolution happens. */
+  function dnsLocalhost() {
+    return vi
+      .spyOn(dns.promises, 'lookup')
+      .mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+  }
+
+  describe('URL-level guards', () => {
+    it('rejects credentials embedded in the URL', async () => {
+      dnsLocalhost();
+
+      await expect(
+        safeOutboundRequest({ url: 'https://user:pass@example.com/x' })
+      ).rejects.toMatchObject({ name: 'SsrfBlockedError', reason: 'CREDENTIALS_IN_URL' });
+    });
+
+    it('rejects non-http(s) schemes', async () => {
+      await expect(safeOutboundRequest({ url: 'ftp://example.com/' })).rejects.toMatchObject({
+        name: 'SsrfBlockedError',
+        reason: 'UNSUPPORTED_SCHEME',
+      });
+      await expect(safeOutboundRequest({ url: 'gopher://example.com/' })).rejects.toMatchObject({
+        name: 'SsrfBlockedError',
+        reason: 'UNSUPPORTED_SCHEME',
+      });
+      await expect(safeOutboundRequest({ url: 'file:///etc/passwd' })).rejects.toMatchObject({
+        name: 'SsrfBlockedError',
+        reason: 'UNSUPPORTED_SCHEME',
+      });
+    });
+
+    it('rejects literal localhost without DNS', async () => {
+      const lookup = vi.spyOn(dns.promises, 'lookup');
+
+      await expect(safeOutboundRequest({ url: 'http://localhost/x' })).rejects.toMatchObject({
+        reason: 'BLOCKED_HOSTNAME',
+      });
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it('rejects metadata.google.internal without DNS', async () => {
+      const lookup = vi.spyOn(dns.promises, 'lookup');
+
+      await expect(
+        safeOutboundRequest({ url: 'http://metadata.google.internal/x' })
+      ).rejects.toMatchObject({ reason: 'BLOCKED_HOSTNAME' });
+      expect(lookup).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed URLs', async () => {
+      await expect(safeOutboundRequest({ url: 'not-a-url' })).rejects.toMatchObject({
+        reason: 'INVALID_URL',
+      });
+    });
+  });
+
+  describe('DNS guards', () => {
+    it('rejects hostnames that resolve to IPv4 RFC1918', async () => {
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
+        { address: '192.168.1.10', family: 4 },
+      ] as never);
+
+      await expect(safeOutboundRequest({ url: 'https://malicious.invalid/' })).rejects.toMatchObject(
+        { reason: 'PRIVATE_IP', resolvedAddress: '192.168.1.10' }
+      );
+    });
+
+    it('rejects hostnames that resolve to AWS metadata link-local', async () => {
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
+        { address: '169.254.169.254', family: 4 },
+      ] as never);
+
+      await expect(
+        safeOutboundRequest({ url: 'https://metadata-attacker.invalid/' })
+      ).rejects.toMatchObject({ reason: 'PRIVATE_IP', resolvedAddress: '169.254.169.254' });
+    });
+
+    it('rejects IPv6 link-local', async () => {
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
+        { address: 'fe80::1', family: 6 },
+      ] as never);
+
+      await expect(safeOutboundRequest({ url: 'https://v6-attacker.invalid/' })).rejects.toMatchObject(
+        { reason: 'PRIVATE_IP' }
+      );
+    });
+
+    it('rejects IPv6 unique-local (fc00::/7)', async () => {
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
+        { address: 'fd12:3456:789a::1', family: 6 },
+      ] as never);
+
+      await expect(safeOutboundRequest({ url: 'https://v6-ula.invalid/' })).rejects.toMatchObject(
+        { reason: 'PRIVATE_IP' }
+      );
+    });
+
+    it('rejects when ANY resolved address is private (mixed answer attack)', async () => {
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
+        { address: '8.8.8.8', family: 4 },
+        { address: '10.0.0.5', family: 4 },
+      ] as never);
+
+      await expect(
+        safeOutboundRequest({ url: 'https://mixed.invalid/' })
+      ).rejects.toMatchObject({ reason: 'PRIVATE_IP', resolvedAddress: '10.0.0.5' });
+    });
+
+    it('rejects IPv4-mapped IPv6 of private addresses', async () => {
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
+        { address: '::ffff:127.0.0.1', family: 6 },
+      ] as never);
+
+      await expect(safeOutboundRequest({ url: 'https://mapped.invalid/' })).rejects.toMatchObject(
+        { reason: 'PRIVATE_IP' }
+      );
+    });
+  });
+
+  describe('DNS rebinding defense', () => {
+    it('uses a fresh DNS resolution per attempt instead of a cached result', async () => {
+      // First call: validation pass (public IP). Second call: a private IP appears.
+      // The safe client must consult DNS again on the second call rather than
+      // reusing the first result.
+      const lookup = vi
+        .spyOn(dns.promises, 'lookup')
+        .mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }] as never)
+        .mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }] as never)
+        .mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }] as never);
+
+      const ok = await safeOutboundRequest({ url: `${upstreamUrl}/first` });
+      expect(ok.statusCode).toBe(200);
+
+      const ok2 = await safeOutboundRequest({ url: `${upstreamUrl}/second` });
+      expect(ok2.statusCode).toBe(200);
+
+      await expect(safeOutboundRequest({ url: `${upstreamUrl}/third` })).rejects.toMatchObject({
+        reason: 'PRIVATE_IP',
+        resolvedAddress: '10.0.0.5',
+      });
+
+      // 3 attempts → 3 DNS lookups (no caching window the attacker can exploit).
+      expect(lookup).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('redirect handling', () => {
+    it('re-runs the SSRF policy on every Location target', async () => {
+      // Upstream returns a redirect to a publicly-validated host whose DNS now
+      // points at loopback — this is the classic public→private redirect trick.
+      respond = (_req, res) => {
+        res.writeHead(302, { location: 'https://evil-redirect.invalid/internal' });
+        res.end();
+      };
+
+      const lookup = vi
+        .spyOn(dns.promises, 'lookup')
+        .mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }] as never) // initial host
+        .mockResolvedValueOnce([{ address: '169.254.169.254', family: 4 }] as never); // redirect target
+
+      await expect(
+        safeOutboundRequest({ url: `${upstreamUrl}/start`, maxRedirects: 5 })
+      ).rejects.toMatchObject({ reason: 'PRIVATE_IP', resolvedAddress: '169.254.169.254' });
+
+      expect(lookup).toHaveBeenCalledTimes(2);
+    });
+
+    it('strips sensitive headers when a redirect crosses origin boundaries', async () => {
+      let redirectTargetUrl = '';
+
+      const secondUpstream = http.createServer((req, res) => {
+        upstreamHits.push({
+          url: req.url ?? '',
+          method: req.method ?? 'GET',
+          headers: req.headers,
+          bodyChunks: [],
+        });
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{}');
+      });
+
+      await new Promise<void>((resolve) => secondUpstream.listen(0, '127.0.0.1', () => resolve()));
+      const addr = secondUpstream.address();
+      if (!addr || typeof addr === 'string') throw new Error('listen failed');
+      redirectTargetUrl = `http://other-host.invalid:${addr.port}/elsewhere`;
+
+      respond = (_req, res) => {
+        res.writeHead(302, { location: redirectTargetUrl });
+        res.end();
+      };
+
+      vi
+        .spyOn(dns.promises, 'lookup')
+        .mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+
+      await safeOutboundRequest({
+        url: `${upstreamUrl}/start`,
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer secret',
+          'novu-signature': 'v1,t=1,sig',
+          'x-novu-signature': 'v1,t=1,sig',
+          'x-trace-id': 'keep-me',
+        },
+        body: { sensitive: true },
+      });
+
+      await new Promise<void>((resolve) => secondUpstream.close(() => resolve()));
+
+      expect(upstreamHits).toHaveLength(2);
+      const initialHit = upstreamHits[0];
+      const redirectHit = upstreamHits[1];
+
+      expect(initialHit.headers.authorization).toBe('Bearer secret');
+      expect(initialHit.headers['novu-signature']).toBe('v1,t=1,sig');
+
+      expect(redirectHit.headers.authorization).toBeUndefined();
+      expect(redirectHit.headers['novu-signature']).toBeUndefined();
+      expect(redirectHit.headers['x-novu-signature']).toBeUndefined();
+      expect(redirectHit.headers['x-trace-id']).toBe('keep-me');
+    });
+
+    it('refuses to follow redirects to non-http(s) schemes', async () => {
+      respond = (_req, res) => {
+        res.writeHead(302, { location: 'file:///etc/passwd' });
+        res.end();
+      };
+
+      vi
+        .spyOn(dns.promises, 'lookup')
+        .mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+
+      await expect(
+        safeOutboundRequest({ url: `${upstreamUrl}/scheme-redirect` })
+      ).rejects.toMatchObject({ reason: 'UNSUPPORTED_SCHEME' });
+    });
+  });
+
+  describe('happy path', () => {
+    it('reaches a public host and pins to the resolved IP, preserving Host header', async () => {
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
+        { address: '127.0.0.1', family: 4 },
+      ] as never);
+
+      const response = await safeOutboundJsonRequest<{ ok: boolean; path: string }>({
+        url: `${upstreamUrl}/ping`,
+        method: 'POST',
+        body: { hello: 'world' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toEqual({ ok: true, path: '/ping' });
+      expect(upstreamHits).toHaveLength(1);
+      expect(upstreamHits[0].headers.host).toContain('test-upstream.invalid');
+    });
+  });
+});

--- a/packages/shared/src/utils/safe-outbound-http.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http.spec.ts
@@ -290,6 +290,81 @@ describe('safe-outbound-http', () => {
         reason: 'UNSUPPORTED_SCHEME',
       });
     });
+
+    it('refuses to follow cross-origin 307 redirects (method-preserving)', async () => {
+      // 307 must replay the original method+body against the new target. If
+      // that target is a different origin, blanking the body would mask the
+      // attempt; treat it as a hard stop instead.
+      respond = (_req, res) => {
+        res.writeHead(307, { location: 'http://other-host.invalid:9999/elsewhere' });
+        res.end();
+      };
+
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+
+      await expect(
+        safeOutboundRequest({
+          url: `${upstreamUrl}/start`,
+          method: 'POST',
+          headers: { authorization: 'Bearer secret' },
+          body: { sensitive: true },
+        })
+      ).rejects.toMatchObject({
+        name: 'SsrfBlockedError',
+        reason: 'CROSS_ORIGIN_METHOD_PRESERVING_REDIRECT',
+      });
+    });
+
+    it('refuses to follow cross-origin 308 redirects (method-preserving)', async () => {
+      respond = (_req, res) => {
+        res.writeHead(308, { location: 'http://other-host.invalid:9999/elsewhere' });
+        res.end();
+      };
+
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+
+      await expect(
+        safeOutboundRequest({
+          url: `${upstreamUrl}/start`,
+          method: 'POST',
+          body: { sensitive: true },
+        })
+      ).rejects.toMatchObject({
+        name: 'SsrfBlockedError',
+        reason: 'CROSS_ORIGIN_METHOD_PRESERVING_REDIRECT',
+      });
+    });
+
+    it('allows same-origin 307 redirects (the body and method are safe to replay)', async () => {
+      let hits = 0;
+      respond = (_req, res) => {
+        hits += 1;
+        if (hits === 1) {
+          // Self-redirect: same host, different path. Method-preserving is fine here.
+          res.writeHead(307, { location: '/replayed' });
+          res.end();
+
+          return;
+        }
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ replayed: true }));
+      };
+
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+
+      const response = await safeOutboundJsonRequest<{ replayed: boolean }>({
+        url: `${upstreamUrl}/start`,
+        method: 'POST',
+        body: { keep: true },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toEqual({ replayed: true });
+      expect(upstreamHits).toHaveLength(2);
+      const [, replayHit] = upstreamHits as [(typeof upstreamHits)[number], (typeof upstreamHits)[number]];
+      expect(replayHit.method).toBe('POST');
+      expect(JSON.parse(Buffer.concat(replayHit.bodyChunks).toString('utf8'))).toEqual({ keep: true });
+    });
   });
 
   describe('happy path', () => {

--- a/packages/shared/src/utils/safe-outbound-http.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http.spec.ts
@@ -252,30 +252,38 @@ describe('safe-outbound-http', () => {
 
       vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
 
-      await safeOutboundRequest({
-        url: `${upstreamUrl}/start`,
-        method: 'POST',
-        headers: {
-          authorization: 'Bearer secret',
-          'novu-signature': 'v1,t=1,sig',
-          'x-novu-signature': 'v1,t=1,sig',
-          'x-trace-id': 'keep-me',
-        },
-        body: { sensitive: true },
-      });
+      try {
+        await safeOutboundRequest({
+          url: `${upstreamUrl}/start`,
+          method: 'POST',
+          headers: {
+            authorization: 'Bearer secret',
+            'novu-signature': 'v1,t=1,sig',
+            'x-novu-signature': 'v1,t=1,sig',
+            'x-trace-id': 'keep-me',
+          },
+          body: { sensitive: true },
+        });
 
-      await new Promise<void>((resolve) => secondUpstream.close(() => resolve()));
+        expect(upstreamHits).toHaveLength(2);
+        const [initialHit, redirectHit] = upstreamHits as [
+          (typeof upstreamHits)[number],
+          (typeof upstreamHits)[number],
+        ];
 
-      expect(upstreamHits).toHaveLength(2);
-      const [initialHit, redirectHit] = upstreamHits as [(typeof upstreamHits)[number], (typeof upstreamHits)[number]];
+        expect(initialHit.headers.authorization).toBe('Bearer secret');
+        expect(initialHit.headers['novu-signature']).toBe('v1,t=1,sig');
 
-      expect(initialHit.headers.authorization).toBe('Bearer secret');
-      expect(initialHit.headers['novu-signature']).toBe('v1,t=1,sig');
-
-      expect(redirectHit.headers.authorization).toBeUndefined();
-      expect(redirectHit.headers['novu-signature']).toBeUndefined();
-      expect(redirectHit.headers['x-novu-signature']).toBeUndefined();
-      expect(redirectHit.headers['x-trace-id']).toBe('keep-me');
+        expect(redirectHit.headers.authorization).toBeUndefined();
+        expect(redirectHit.headers['novu-signature']).toBeUndefined();
+        expect(redirectHit.headers['x-novu-signature']).toBeUndefined();
+        expect(redirectHit.headers['x-trace-id']).toBe('keep-me');
+      } finally {
+        // Always release the secondary listener even if the request or any
+        // assertion above throws — otherwise the dangling socket can hang the
+        // entire vitest worker.
+        await new Promise<void>((resolve) => secondUpstream.close(() => resolve()));
+      }
     });
 
     it('refuses to follow redirects to non-http(s) schemes', async () => {

--- a/packages/shared/src/utils/safe-outbound-http.ts
+++ b/packages/shared/src/utils/safe-outbound-http.ts
@@ -1,0 +1,397 @@
+import * as http from 'node:http';
+import * as https from 'node:https';
+import { Readable } from 'node:stream';
+import {
+  assertSafeOutboundUrl,
+  isPrivateIp,
+  resolvePublicAddresses,
+  SsrfBlockedError,
+} from './ssrf-url-validation';
+
+/**
+ * Test-only escape hatch: when this env var is set, the SSRF policy treats
+ * the listed IPs as public. This exists so test suites can run a real HTTP
+ * server bound to 127.0.0.1 and exercise the connect/redirect path. Setting
+ * this in production is unsupported and dangerous.
+ *
+ * Read lazily so tests can opt in after importing the module.
+ */
+function getTestAllowList(): Set<string> {
+  const raw = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+  if (!raw) return new Set<string>();
+
+  return new Set(raw.split(',').map((s) => s.trim()).filter(Boolean));
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_REDIRECTS = 3;
+const DEFAULT_MAX_RESPONSE_BYTES = 25 * 1024 * 1024;
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+
+export type SafeOutboundMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
+
+export interface SafeOutboundRequestOptions {
+  /** Original request URL. Will be re-validated on every redirect. */
+  url: string | URL;
+  method?: SafeOutboundMethod;
+  /** Headers attached to the original request. Forwarded across redirects only when the host matches. */
+  headers?: Record<string, string | undefined>;
+  /** Body for the request. Strings, Buffers, and Readables are supported. Objects are JSON-stringified. */
+  body?: string | Buffer | Readable | Record<string, unknown> | unknown[];
+  /** Per-request timeout in ms (applies to each redirect hop). Default {@link DEFAULT_TIMEOUT_MS}. */
+  timeoutMs?: number;
+  /** Maximum number of redirects to follow. Default {@link DEFAULT_MAX_REDIRECTS}. Set to 0 to disable redirects. */
+  maxRedirects?: number;
+  /** Maximum response size before the request is aborted. Default {@link DEFAULT_MAX_RESPONSE_BYTES}. */
+  maxResponseBytes?: number;
+  /** When true, disables TLS verification. Use only for development bridges. */
+  rejectUnauthorized?: boolean;
+}
+
+export interface SafeOutboundResponse {
+  statusCode: number;
+  statusMessage: string;
+  headers: http.IncomingHttpHeaders;
+  body: Buffer;
+}
+
+/**
+ * Result of {@link safeOutboundRequest} where the response body is parsed as JSON
+ * if the content-type is JSON, otherwise it stays as a string.
+ */
+export interface SafeOutboundJsonResponse<T = unknown> {
+  statusCode: number;
+  statusMessage: string;
+  headers: http.IncomingHttpHeaders;
+  body: T;
+}
+
+/**
+ * Centralized SSRF-safe HTTP client.
+ *
+ * Properties enforced:
+ *  - URL must be http/https with no embedded credentials and no blocked hostname.
+ *  - Hostname is resolved via DNS once per attempt; if **any** returned address
+ *    is private/reserved/loopback/link-local/IPv4-mapped variant, the request
+ *    is rejected before a TCP connection is opened.
+ *  - The TCP connection is **pinned** to a validated IP. The original hostname
+ *    is preserved as the `Host` header and as SNI servername.
+ *  - Redirects are followed manually (never by the HTTP stack). Each `Location`
+ *    target re-runs the full SSRF policy (URL validation + DNS rejection +
+ *    pinning), defending against late-binding attacks.
+ *  - URLs in `Location` headers cannot relocate to a different scheme that
+ *    bypasses the policy.
+ *
+ * Throws {@link SsrfBlockedError} on policy violations.
+ */
+export async function safeOutboundRequest(options: SafeOutboundRequestOptions): Promise<SafeOutboundResponse> {
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const initialOriginHost = (() => {
+    try {
+      return new URL(options.url as string | URL).host.toLowerCase();
+    } catch {
+      return null;
+    }
+  })();
+
+  let currentUrl: string | URL = options.url;
+  let currentMethod: SafeOutboundMethod = options.method ?? 'GET';
+  let currentBody = options.body;
+  let currentHeaders = { ...(options.headers ?? {}) };
+
+  for (let redirect = 0; redirect <= maxRedirects; redirect += 1) {
+    const parsed = assertSafeOutboundUrl(currentUrl);
+
+    // Strip any sensitive headers before crossing an origin boundary on a redirect.
+    if (redirect > 0 && initialOriginHost && parsed.host.toLowerCase() !== initialOriginHost) {
+      stripSensitiveHeaders(currentHeaders);
+      currentBody = undefined;
+    }
+
+    const addresses = await resolveWithTestAllowList(parsed.hostname);
+    const chosen = addresses[0];
+    if (!chosen) {
+      throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${parsed.hostname}".`, {
+        hostname: parsed.hostname,
+      });
+    }
+
+    const response = await performPinnedRequest({
+      parsed,
+      address: chosen,
+      method: currentMethod,
+      headers: currentHeaders,
+      body: currentBody,
+      timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxResponseBytes: options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES,
+      rejectUnauthorized: options.rejectUnauthorized ?? true,
+    });
+
+    const status = response.statusCode;
+
+    if (REDIRECT_STATUS_CODES.has(status) && redirect < maxRedirects) {
+      const location = headerString(response.headers.location);
+
+      if (!location) {
+        return response;
+      }
+
+      const nextUrl = new URL(location, parsed.toString());
+      currentUrl = nextUrl;
+
+      // 303 must rewrite to GET. 301/302 historically also rewrite POST→GET in browsers; we follow that.
+      if (status === 303 || ((status === 301 || status === 302) && currentMethod === 'POST')) {
+        currentMethod = 'GET';
+        currentBody = undefined;
+      }
+
+      continue;
+    }
+
+    return response;
+  }
+
+  throw new SsrfBlockedError('INVALID_URL', `Maximum redirect count (${maxRedirects}) exceeded.`);
+}
+
+/**
+ * JSON-friendly variant. Sets Content-Type if a JSON body is provided and
+ * parses JSON responses automatically.
+ */
+export async function safeOutboundJsonRequest<T = unknown>(
+  options: SafeOutboundRequestOptions
+): Promise<SafeOutboundJsonResponse<T>> {
+  const isPlainObject =
+    options.body !== undefined &&
+    options.body !== null &&
+    typeof options.body === 'object' &&
+    !(options.body instanceof Buffer) &&
+    !(options.body instanceof Readable);
+
+  const headers: Record<string, string | undefined> = { ...(options.headers ?? {}) };
+
+  if (isPlainObject && !findHeader(headers, 'content-type')) {
+    headers['content-type'] = 'application/json';
+  }
+  if (!findHeader(headers, 'accept')) {
+    headers.accept = 'application/json, text/plain, */*';
+  }
+
+  const body = isPlainObject ? JSON.stringify(options.body) : (options.body as string | Buffer | Readable | undefined);
+
+  const response = await safeOutboundRequest({ ...options, headers, body });
+
+  const contentType = headerString(response.headers['content-type']) ?? '';
+  let parsed: unknown = response.body.toString('utf8');
+
+  if (contentType.includes('application/json') || contentType.includes('+json')) {
+    try {
+      parsed = response.body.length === 0 ? undefined : JSON.parse(response.body.toString('utf8'));
+    } catch {
+      // Leave parsed as string if JSON parsing fails.
+    }
+  }
+
+  return {
+    statusCode: response.statusCode,
+    statusMessage: response.statusMessage,
+    headers: response.headers,
+    body: parsed as T,
+  };
+}
+
+interface PinnedRequestParams {
+  parsed: URL;
+  address: { address: string; family: number };
+  method: SafeOutboundMethod;
+  headers: Record<string, string | undefined>;
+  body: SafeOutboundRequestOptions['body'];
+  timeoutMs: number;
+  maxResponseBytes: number;
+  rejectUnauthorized: boolean;
+}
+
+function performPinnedRequest(params: PinnedRequestParams): Promise<SafeOutboundResponse> {
+  const { parsed, address, method, headers, body, timeoutMs, maxResponseBytes, rejectUnauthorized } = params;
+  const isHttps = parsed.protocol === 'https:';
+  const transport = isHttps ? https : http;
+
+  const requestHeaders = buildOutboundHeaders(headers, parsed, body);
+
+  return new Promise<SafeOutboundResponse>((resolve, reject) => {
+    const requestOptions: http.RequestOptions & { servername?: string; rejectUnauthorized?: boolean } = {
+      protocol: parsed.protocol,
+      hostname: address.address,
+      family: address.family,
+      port: parsed.port ? Number(parsed.port) : undefined,
+      path: `${parsed.pathname || '/'}${parsed.search}`,
+      method,
+      headers: requestHeaders,
+      timeout: timeoutMs,
+    };
+
+    if (isHttps) {
+      requestOptions.servername = parsed.hostname;
+      requestOptions.rejectUnauthorized = rejectUnauthorized;
+    }
+
+    const req = transport.request(requestOptions, (res) => {
+      const chunks: Buffer[] = [];
+      let total = 0;
+      let aborted = false;
+
+      res.on('data', (chunk: Buffer) => {
+        if (aborted) return;
+        total += chunk.length;
+        if (total > maxResponseBytes) {
+          aborted = true;
+          res.destroy();
+          reject(new Error(`Response exceeded maximum size of ${maxResponseBytes} bytes.`));
+
+          return;
+        }
+        chunks.push(chunk);
+      });
+
+      res.on('end', () => {
+        if (aborted) return;
+        resolve({
+          statusCode: res.statusCode ?? 0,
+          statusMessage: res.statusMessage ?? '',
+          headers: res.headers,
+          body: Buffer.concat(chunks, total),
+        });
+      });
+
+      res.on('error', reject);
+    });
+
+    req.on('timeout', () => {
+      req.destroy(new Error(`Request to ${parsed.hostname} timed out after ${timeoutMs}ms.`));
+    });
+    req.on('error', reject);
+
+    if (body === undefined || body === null) {
+      req.end();
+
+      return;
+    }
+
+    if (typeof body === 'string' || body instanceof Buffer) {
+      req.end(body);
+
+      return;
+    }
+
+    if (body instanceof Readable) {
+      body.pipe(req);
+
+      return;
+    }
+
+    req.end(JSON.stringify(body));
+  });
+}
+
+function buildOutboundHeaders(
+  headers: Record<string, string | undefined>,
+  parsed: URL,
+  body: SafeOutboundRequestOptions['body']
+): Record<string, string> {
+  const out: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined || value === null) continue;
+    out[key] = String(value);
+  }
+
+  if (!findHeader(out, 'host')) {
+    out.Host = parsed.host;
+  }
+  if (!findHeader(out, 'accept')) {
+    out.Accept = '*/*';
+  }
+  if (!findHeader(out, 'user-agent')) {
+    out['User-Agent'] = 'novu-safe-outbound/1.0';
+  }
+
+  if (body !== undefined && body !== null) {
+    if (typeof body === 'string') {
+      out['Content-Length'] = String(Buffer.byteLength(body));
+    } else if (body instanceof Buffer) {
+      out['Content-Length'] = String(body.length);
+    } else if (!(body instanceof Readable)) {
+      const serialized = JSON.stringify(body);
+      out['Content-Length'] = String(Buffer.byteLength(serialized));
+      if (!findHeader(out, 'content-type')) {
+        out['Content-Type'] = 'application/json';
+      }
+    }
+  }
+
+  return out;
+}
+
+const SENSITIVE_HEADER_PATTERNS = [/^authorization$/i, /^cookie$/i, /^proxy-authorization$/i, /^novu-signature$/i, /-signature$/i, /-hmac/i];
+
+function stripSensitiveHeaders(headers: Record<string, string | undefined>): void {
+  for (const key of Object.keys(headers)) {
+    if (SENSITIVE_HEADER_PATTERNS.some((re) => re.test(key))) {
+      delete headers[key];
+    }
+  }
+}
+
+function findHeader(headers: Record<string, string | undefined>, name: string): string | undefined {
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lower && value !== undefined) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function headerString(value: string | string[] | undefined): string | undefined {
+  if (value === undefined) return undefined;
+
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * Wrapper around {@link resolvePublicAddresses} that applies the test-only
+ * IP allow list. Production has no allow list, so this collapses to the same
+ * call. Tests can opt specific loopback IPs in to exercise the real network
+ * path without disabling the policy globally.
+ */
+async function resolveWithTestAllowList(hostname: string) {
+  const allowList = getTestAllowList();
+  if (allowList.size === 0) {
+    return resolvePublicAddresses(hostname);
+  }
+
+  // Mirror resolvePublicAddresses, but treat allow-listed addresses as public.
+  const dns = await import('node:dns');
+  let addresses: { address: string; family: number }[];
+  try {
+    addresses = await dns.promises.lookup(hostname.toLowerCase(), { all: true });
+  } catch {
+    throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${hostname}".`, {
+      hostname,
+    });
+  }
+
+  for (const { address } of addresses) {
+    if (allowList.has(address)) continue;
+    if (isPrivateIp(address)) {
+      throw new SsrfBlockedError(
+        'PRIVATE_IP',
+        `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`,
+        { hostname, resolvedAddress: address }
+      );
+    }
+  }
+
+  return addresses;
+}

--- a/packages/shared/src/utils/safe-outbound-http.ts
+++ b/packages/shared/src/utils/safe-outbound-http.ts
@@ -97,7 +97,7 @@ export async function safeOutboundRequest(options: SafeOutboundRequestOptions): 
   let currentUrl: string | URL = options.url;
   let currentMethod: SafeOutboundMethod = options.method ?? 'GET';
   let currentBody = options.body;
-  let currentHeaders = { ...(options.headers ?? {}) };
+  const currentHeaders = { ...(options.headers ?? {}) };
 
   for (let redirect = 0; redirect <= maxRedirects; redirect += 1) {
     const parsed = assertSafeOutboundUrl(currentUrl);

--- a/packages/shared/src/utils/safe-outbound-http.ts
+++ b/packages/shared/src/utils/safe-outbound-http.ts
@@ -1,12 +1,7 @@
 import * as http from 'node:http';
 import * as https from 'node:https';
 import { Readable } from 'node:stream';
-import {
-  assertSafeOutboundUrl,
-  isPrivateIp,
-  resolvePublicAddresses,
-  SsrfBlockedError,
-} from './ssrf-url-validation';
+import { assertSafeOutboundUrl, isPrivateIp, resolvePublicAddresses, SsrfBlockedError } from './ssrf-url-validation';
 
 /**
  * Test-only escape hatch: when this env var is set, the SSRF policy treats
@@ -20,7 +15,12 @@ function getTestAllowList(): Set<string> {
   const raw = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
   if (!raw) return new Set<string>();
 
-  return new Set(raw.split(',').map((s) => s.trim()).filter(Boolean));
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -37,7 +37,7 @@ export interface SafeOutboundRequestOptions {
   /** Headers attached to the original request. Forwarded across redirects only when the host matches. */
   headers?: Record<string, string | undefined>;
   /** Body for the request. Strings, Buffers, and Readables are supported. Objects are JSON-stringified. */
-  body?: string | Buffer | Readable | Record<string, unknown> | unknown[];
+  body?: string | Buffer | Readable | object;
   /** Per-request timeout in ms (applies to each redirect hop). Default {@link DEFAULT_TIMEOUT_MS}. */
   timeoutMs?: number;
   /** Maximum number of redirects to follow. Default {@link DEFAULT_MAX_REDIRECTS}. Set to 0 to disable redirects. */
@@ -332,7 +332,14 @@ function buildOutboundHeaders(
   return out;
 }
 
-const SENSITIVE_HEADER_PATTERNS = [/^authorization$/i, /^cookie$/i, /^proxy-authorization$/i, /^novu-signature$/i, /-signature$/i, /-hmac/i];
+const SENSITIVE_HEADER_PATTERNS = [
+  /^authorization$/i,
+  /^cookie$/i,
+  /^proxy-authorization$/i,
+  /^novu-signature$/i,
+  /-signature$/i,
+  /-hmac/i,
+];
 
 function stripSensitiveHeaders(headers: Record<string, string | undefined>): void {
   for (const key of Object.keys(headers)) {

--- a/packages/shared/src/utils/safe-outbound-http.ts
+++ b/packages/shared/src/utils/safe-outbound-http.ts
@@ -137,6 +137,21 @@ export async function safeOutboundRequest(options: SafeOutboundRequestOptions): 
       }
 
       const nextUrl = new URL(location, parsed.toString());
+
+      // 307 and 308 are method-preserving redirects: the upstream is asking us
+      // to replay the original method+body against the new target. If the new
+      // target is on a different origin, we cannot safely strip the body or
+      // downgrade the method without changing semantics, and silently blanking
+      // the body would mask the cross-origin attempt from the caller. Treat it
+      // as a hard stop so the caller can decide what to do.
+      if ((status === 307 || status === 308) && initialOriginHost && nextUrl.host.toLowerCase() !== initialOriginHost) {
+        throw new SsrfBlockedError(
+          'CROSS_ORIGIN_METHOD_PRESERVING_REDIRECT',
+          `Refusing to follow ${status} redirect from ${parsed.host} to ${nextUrl.host}: method-preserving redirects across origin boundaries are not allowed.`,
+          { hostname: nextUrl.hostname }
+        );
+      }
+
       currentUrl = nextUrl;
 
       // 303 must rewrite to GET. 301/302 historically also rewrite POST→GET in browsers; we follow that.

--- a/packages/shared/src/utils/ssrf-url-validation.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.ts
@@ -93,7 +93,8 @@ export type SsrfBlockReason =
   | 'CREDENTIALS_IN_URL'
   | 'BLOCKED_HOSTNAME'
   | 'DNS_LOOKUP_FAILED'
-  | 'PRIVATE_IP';
+  | 'PRIVATE_IP'
+  | 'CROSS_ORIGIN_METHOD_PRESERVING_REDIRECT';
 
 /**
  * Thrown by the safe outbound HTTP layer when a URL or its resolved address is

--- a/packages/shared/src/utils/ssrf-url-validation.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.ts
@@ -44,6 +44,13 @@ const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
   ttl: 1000 * 60 * 5, // 5 minutes
 });
 
+/**
+ * Returns true for IPs that are loopback, RFC1918 private, link-local,
+ * unique-local IPv6 (fc00::/7), IPv6 loopback/link-local, IPv4-mapped IPv6 of any of these,
+ * or the unspecified 0.0.0.0 address.
+ *
+ * Used to reject SSRF candidates at validation **and** at connect time.
+ */
 export function isPrivateIp(ip: string): boolean {
   const privateRanges = [
     /^0\.0\.0\.0$/i,
@@ -70,45 +77,166 @@ export function isPrivateIp(ip: string): boolean {
 }
 
 /**
- * Validates that a URL is safe to fetch server-side (http/https only, no private IPs after DNS resolution).
- * Returns an error message string if blocked, or null if allowed.
+ * Hostnames whose entire purpose is to expose internal/metadata endpoints.
+ * Reject these by name, before DNS resolution, since the resolver could be
+ * tricked into returning a public IP that proxies to a private destination.
  */
-export async function validateUrlSsrf(url: string): Promise<string | null> {
+const BLOCKED_HOSTNAMES = new Set(['localhost', 'metadata.google.internal']);
+
+/**
+ * Symbolic error codes for SSRF policy rejections. Allows callers to map to
+ * structured responses without parsing the human-readable message.
+ */
+export type SsrfBlockReason =
+  | 'INVALID_URL'
+  | 'UNSUPPORTED_SCHEME'
+  | 'CREDENTIALS_IN_URL'
+  | 'BLOCKED_HOSTNAME'
+  | 'DNS_LOOKUP_FAILED'
+  | 'PRIVATE_IP';
+
+/**
+ * Thrown by the safe outbound HTTP layer when a URL or its resolved address is
+ * blocked by SSRF policy. Carries a machine-readable {@link SsrfBlockReason}.
+ */
+export class SsrfBlockedError extends Error {
+  readonly reason: SsrfBlockReason;
+  readonly resolvedAddress?: string;
+  readonly hostname?: string;
+
+  constructor(reason: SsrfBlockReason, message: string, extra?: { resolvedAddress?: string; hostname?: string }) {
+    super(message);
+    this.name = 'SsrfBlockedError';
+    this.reason = reason;
+    this.resolvedAddress = extra?.resolvedAddress;
+    this.hostname = extra?.hostname;
+  }
+}
+
+/**
+ * Validates the URL string itself (no DNS):
+ *  - must parse
+ *  - must be http/https
+ *  - must not embed credentials
+ *  - must not target a blocked hostname
+ *
+ * Throws {@link SsrfBlockedError} on any rejection. Returns the parsed URL on success.
+ *
+ * This is intentionally synchronous and side-effect-free. Use it before kicking
+ * off any outbound request, including before re-following a redirect.
+ */
+export function assertSafeOutboundUrl(input: string | URL): URL {
   let parsed: URL;
 
+  try {
+    parsed = typeof input === 'string' ? new URL(input) : input;
+  } catch {
+    throw new SsrfBlockedError('INVALID_URL', 'Invalid URL format.');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new SsrfBlockedError(
+      'UNSUPPORTED_SCHEME',
+      `URL scheme "${parsed.protocol}" is not allowed. Only http and https are permitted.`
+    );
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new SsrfBlockedError('CREDENTIALS_IN_URL', 'URLs with embedded credentials are not allowed.');
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (BLOCKED_HOSTNAMES.has(hostname)) {
+    throw new SsrfBlockedError('BLOCKED_HOSTNAME', `Requests to "${hostname}" are not allowed.`, { hostname });
+  }
+
+  return parsed;
+}
+
+/**
+ * Resolves all IP addresses for the hostname and asserts every one is public.
+ *
+ * Caching policy: by default this skips the cache so the resolver is consulted
+ * fresh per call. This is the safe default for the connect-time guard — caching
+ * the DNS answer between validation and connection is exactly the
+ * DNS-rebinding window we are trying to close. The cache parameter exists only
+ * for the legacy {@link validateUrlSsrf} entry point, which has documented
+ * cache semantics.
+ *
+ * Throws {@link SsrfBlockedError} if resolution fails or if any returned
+ * address is private/reserved. Returns all resolved addresses on success.
+ */
+export async function resolvePublicAddresses(
+  hostname: string,
+  options: { useCache?: boolean } = {}
+): Promise<dns.LookupAddress[]> {
+  const lower = hostname.toLowerCase();
+  let addresses: dns.LookupAddress[] | undefined;
+
+  if (options.useCache) {
+    addresses = DNS_CACHE.get(lower);
+  }
+
+  if (!addresses) {
+    try {
+      addresses = await dns.promises.lookup(lower, { all: true });
+    } catch {
+      throw new SsrfBlockedError('DNS_LOOKUP_FAILED', `Unable to resolve hostname "${lower}".`, { hostname: lower });
+    }
+
+    if (options.useCache) {
+      DNS_CACHE.set(lower, addresses);
+    }
+  }
+
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) {
+      throw new SsrfBlockedError(
+        'PRIVATE_IP',
+        `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`,
+        { hostname: lower, resolvedAddress: address }
+      );
+    }
+  }
+
+  return addresses;
+}
+
+/**
+ * Validates that a URL is safe to fetch server-side (http/https only, no private IPs after DNS resolution).
+ * Returns an error message string if blocked, or null if allowed.
+ *
+ * @deprecated This is a one-shot pre-flight check. It does not pin the
+ * connection to the validated IP, does not re-validate redirect targets, and
+ * caches DNS answers, all of which leave SSRF holes open via redirect chains
+ * and DNS rebinding. Prefer the safe outbound HTTP client which validates
+ * at connect time and re-runs the policy on every redirect.
+ */
+export async function validateUrlSsrf(url: string): Promise<string | null> {
+  try {
+    assertSafeOutboundUrl(url);
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      return err.message;
+    }
+    throw err;
+  }
+
+  let parsed: URL;
   try {
     parsed = new URL(url);
   } catch {
     return 'Invalid URL format.';
   }
 
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    return `URL scheme "${parsed.protocol}" is not allowed. Only http and https are permitted.`;
-  }
-
-  const hostname = parsed.hostname.toLowerCase();
-
-  const blockedHostnames = ['localhost', 'metadata.google.internal'];
-
-  if (blockedHostnames.includes(hostname)) {
-    return `Requests to "${hostname}" are not allowed.`;
-  }
-
-  let addresses = DNS_CACHE.get(hostname);
-
-  if (!addresses) {
-    try {
-      addresses = await dns.promises.lookup(hostname, { all: true });
-      DNS_CACHE.set(hostname, addresses);
-    } catch {
-      return `Unable to resolve hostname "${hostname}".`;
+  try {
+    await resolvePublicAddresses(parsed.hostname, { useCache: true });
+  } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      return err.message;
     }
-  }
-
-  for (const { address } of addresses) {
-    if (isPrivateIp(address)) {
-      return `Requests to private or reserved IP addresses are not allowed (resolved: ${address}).`;
-    }
+    throw err;
   }
 
   return null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added a centralized SSRF‑safe outbound HTTP layer and migrated server-side callers to it: outbound URLs are now validated and DNS-resolved before connecting, connections are pinned to resolved public IPs, every redirect target is re-validated, sensitive headers are stripped across origin boundaries, non-http(s) schemes and embedded credentials are rejected, and HMAC signing is computed only after URL validation. This replaces one-shot validators to prevent DNS rebinding, private‑IP escapes and SSRF data leaks when contacting user-supplied endpoints.

## Affected areas

- **api**: Call sites (bridge executor, chat SDK, agent update, test-http-endpoint) now use assertSafeOutboundUrl/safe outbound helpers and register SafeOutboundHttpService via SharedModule so SSRF protections are enforced.  
- **worker**: Reply-to and HTTP-step execution use assertSafeOutboundUrl/safeOutboundJsonRequest, map SsrfBlockedError to consistent errors, and register SafeOutboundHttpService.  
- **shared**: Adds safe-outbound-http utilities (normalize URL, SsrfBlockedError, resolvePublicAddresses with private-IP blocking, pinned connections, manual redirect handling, header stripping, JSON helpers, and a test allow-list).  
- **application-generic**: HttpClientService gained enforceSsrfProtection to route through the safe pipeline; SafeOutboundHttpService added as a NestJS injectable and safe-outbound APIs re-exported; validateUrlSsrf retained (deprecated).  
- **providers**: Chat and push webhook providers validate/normalize webhook URLs before HMAC signing and use safeOutboundJsonRequest; push-webhook tests rewritten to use a local HTTP server with controlled DNS.  
- **tooling**: biome lint rules updated to discourage importing the deprecated validateUrlSsrf and to direct developers to the safe APIs or HttpClientService.enforceSsrfProtection.

## Key technical decisions

- Provide SafeOutboundHttpService as a NestJS injectable to simplify DI migration.  
- Make SSRF routing opt‑in via HttpClientService.enforceSsrfProtection to avoid breaking existing behavior and to document that got retries/onRetry are not honored in the safe path.  
- Keep validateUrlSsrf for compatibility but mark it deprecated and block new usage via biome rules.  
- Add NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS as a test-only allow-list to enable deterministic local tests without weakening production policy.

## Testing

Added extensive unit/regression tests in shared for URL/DNS guards, DNS rebinding, redirect semantics (including cross-origin 307/308 blocking), header stripping, and happy paths; updated provider and worker specs to stub or assert safeOutboundJsonRequest; push-webhook spec now runs a real local HTTP server with mocked DNS for positive and negative cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Adds a centralized outbound HTTP layer that every server-side caller can use when fanning out to user-supplied destinations (webhooks, bridge URLs, reply callbacks, provider URLs). The previous pattern relied on a one-shot pre-flight URL validator that ran before each request, while the actual request used `got` / `axios` / `fetch` with default behaviour. That left a few cracks open in the request lifecycle (redirects, late-binding DNS, signed material attached too early). This PR closes those cracks by:

- Pinning every outbound connection to a DNS address that has been freshly resolved and validated;
- Re-applying the full URL + DNS policy on every redirect target rather than trusting the original validation;
- Stripping sensitive headers (Authorization, Cookie, signature/HMAC) before following a redirect that crosses an origin boundary;
- Computing and attaching HMAC signatures **after** URL validation, so a blocked destination never sees signed material;
- Restricting outbound traffic to `http`/`https` and rejecting URLs with embedded credentials.

The same primitives back the new `SafeOutboundHttpService` (NestJS-injectable) and the new `enforceSsrfProtection: true` option on the existing `HttpClientService`, so existing call sites can opt in with a single flag while keeping their current error-handling path.

The legacy boolean `validateUrlSsrf` is kept and marked `@deprecated`. A Biome `noRestrictedImports` rule blocks new usage and points contributors at the safe alternatives.

#### Affected call sites migrated in this PR

- `apps/api/src/app/agents/services/bridge-executor.service.ts`
- `apps/api/src/app/agents/services/chat-sdk.service.ts`
- `apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts`
- `apps/api/src/app/workflows-v2/usecases/test-http-endpoint/test-http-endpoint.usecase.ts`
- `apps/worker/src/app/workflow/usecases/inbound-email-parse/strategies/reply-to.strategy.ts`
- `apps/worker/src/app/workflow/usecases/send-message/execute-http-request-step.usecase.ts`
- `libs/application-generic/src/usecases/conditions-filter/conditions-filter.usecase.ts`
- `packages/providers/src/lib/chat/chat-webhook/chat-webhook.provider.ts`
- `packages/providers/src/lib/push/push-webhook/push-webhook.provider.ts` (also adds the missing pre-flight check)

Sub-issues track migrating any remaining call sites onto the new client.

#### Tests

`packages/shared/src/utils/safe-outbound-http.spec.ts` adds 16 regression tests covering:

- URL-level guards: credentials in URL, non-http/https schemes, blocked hostnames (without DNS), malformed URLs;
- DNS guards: IPv4 RFC1918, AWS metadata link-local, IPv6 link-local, IPv6 unique-local (fc00::/7), IPv4-mapped IPv6 of private addresses, mixed-DNS answers (any private address rejects);
- DNS rebinding: per-attempt DNS lookup so a previously-cached safe answer cannot persist into a later, malicious response;
- Redirect handling: re-validation of `Location` targets, header stripping across origin boundaries, refusal to follow non-http(s) redirect schemes;
- Happy path: hostname pinned to the resolved IP, original `Host` header preserved.

`packages/providers/src/lib/push/push-webhook/push-webhook.provider.spec.ts` covers happy-path and the new SSRF rejection paths for the push-webhook provider.

### Screenshots

N/A — no UI changes.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None.

### Special notes for your reviewer

- The legacy boolean `validateUrlSsrf` is preserved for backward compatibility but marked `@deprecated`. A Biome lint rule (`noRestrictedImports`) blocks new imports of it and points to the safe alternatives. The single legitimate re-export in `libs/application-generic/src/utils/ssrf-url-validation.ts` carries an inline `// biome-ignore` with a link back to this ticket.
- The new client lives in `packages/shared/src/utils/safe-outbound-http.ts` so providers (axios consumers today) can adopt it without taking a dependency on `libs/application-generic`. A copy of the implementation is inlined into `libs/application-generic/src/utils/ssrf-url-validation.ts` because that lib still uses CommonJS module resolution which does not honour `exports` subpaths — both copies stay in lockstep through the shared test suite.
- A test-only escape hatch (`NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS=...`) lets the regression tests bind a real upstream HTTP server to `127.0.0.1` while keeping the policy fully active for everything else. It is read lazily from the environment, opt-in only, and unsupported in production.
- `HttpClientService.request` callers can opt in by passing `enforceSsrfProtection: true`; that bypasses the `got` retry/error path and routes through the safe pipeline. Callers that talk only to internal/trusted endpoints (bridges, internal APIs) keep their existing behaviour.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7560](https://linear.app/novu/issue/NV-7560/security-centralize-ssrf-safe-outbound-http-client-architectural)

<div><a href="https://cursor.com/agents/bc-d593a48e-d339-4382-86c2-f78147633d79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d593a48e-d339-4382-86c2-f78147633d79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

