### PR TITLE
fix(shared): drain ClickHouse batch buffers on shutdown fixes NV-7608

### DIFF
--- a/libs/application-generic/src/services/analytic-logs/clickhouse-batch.service.spec.ts
+++ b/libs/application-generic/src/services/analytic-logs/clickhouse-batch.service.spec.ts
@@ -8,12 +8,22 @@ type MockClickHouseService = {
   client: ClickHouseClient | undefined;
 };
 
+const FAST_SHUTDOWN_DRAIN_TIMEOUT_MS = '500';
+const FAST_SHUTDOWN_DRAIN_RETRY_DELAY_MS = '5';
+
 describe('ClickHouseBatchService', () => {
   let service: ClickHouseBatchService;
   let clickhouseService: MockClickHouseService;
   let logger: jest.Mocked<PinoLogger>;
+  let originalDrainTimeout: string | undefined;
+  let originalDrainRetryDelay: string | undefined;
 
   beforeEach(async () => {
+    originalDrainTimeout = process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_TIMEOUT_MS;
+    originalDrainRetryDelay = process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_RETRY_DELAY_MS;
+    process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_TIMEOUT_MS = FAST_SHUTDOWN_DRAIN_TIMEOUT_MS;
+    process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_RETRY_DELAY_MS = FAST_SHUTDOWN_DRAIN_RETRY_DELAY_MS;
+
     clickhouseService = {
       insert: jest.fn().mockResolvedValue(undefined),
       client: {} as ClickHouseClient,
@@ -29,7 +39,11 @@ describe('ClickHouseBatchService', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        ClickHouseBatchService,
+        {
+          provide: ClickHouseBatchService,
+          useFactory: (chSvc: ClickHouseService, log: PinoLogger) => new ClickHouseBatchService(chSvc, log, []),
+          inject: [ClickHouseService, PinoLogger],
+        },
         {
           provide: ClickHouseService,
           useValue: clickhouseService,
@@ -46,7 +60,24 @@ describe('ClickHouseBatchService', () => {
   });
 
   afterEach(async () => {
-    await service.onModuleDestroy();
+    if (!service['isShuttingDown']) {
+      // Force any hung insert mocks (e.g. from backpressure tests) to resolve
+      // so the shutdown drain can complete instead of timing out.
+      clickhouseService.insert.mockReset();
+      clickhouseService.insert.mockResolvedValue(undefined);
+      await service.onModuleDestroy();
+    }
+
+    if (originalDrainTimeout === undefined) {
+      delete process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_TIMEOUT_MS;
+    } else {
+      process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_TIMEOUT_MS = originalDrainTimeout;
+    }
+    if (originalDrainRetryDelay === undefined) {
+      delete process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_RETRY_DELAY_MS;
+    } else {
+      process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_RETRY_DELAY_MS = originalDrainRetryDelay;
+    }
   });
 
   describe('add', () => {
@@ -86,7 +117,10 @@ describe('ClickHouseBatchService', () => {
 
       const stats = service.getBufferStats();
       expect(stats).toHaveLength(0);
-      expect(logger.warn).toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ table: 'test_table' }),
+        'ClickHouse batch service is shutting down, dropping row'
+      );
     });
 
     it('should not add rows when ClickHouse client is not initialized', async () => {
@@ -269,20 +303,20 @@ describe('ClickHouseBatchService', () => {
         .mockRejectedValueOnce(new Error('Connection failed'))
         .mockResolvedValueOnce(undefined);
 
-      const config = { maxBatchSize: 10, flushIntervalMs: 10000 };
+      const config = { maxBatchSize: 10, flushIntervalMs: 10000, retryDelayMs: 1 };
 
       await service.add('test_table', { id: '1' }, config);
 
       await service.flush('test_table');
 
       expect(clickhouseService.insert).toHaveBeenCalledTimes(3);
-      expect(logger.warn).toHaveBeenCalledTimes(2);
+      expect(logger.warn).toHaveBeenCalled();
     });
 
-    it('should log error after max retries', async () => {
+    it('should re-queue rows on persistent failure so they are not lost', async () => {
       clickhouseService.insert.mockRejectedValue(new Error('Persistent failure'));
 
-      const config = { maxBatchSize: 10, flushIntervalMs: 10000 };
+      const config = { maxBatchSize: 10, flushIntervalMs: 10000, retryDelayMs: 1 };
 
       await service.add('test_table', { id: '1' }, config);
 
@@ -293,6 +327,7 @@ describe('ClickHouseBatchService', () => {
 
       const stats = service.getBufferStats();
       expect(stats[0].metrics.totalFailed).toBe(1);
+      expect(stats[0].bufferSize).toBe(1);
     });
 
     it('should respect custom retry configuration', async () => {
@@ -302,7 +337,7 @@ describe('ClickHouseBatchService', () => {
         maxBatchSize: 10,
         flushIntervalMs: 10000,
         maxRetries: 1,
-        retryDelayMs: 500,
+        retryDelayMs: 1,
       };
 
       await service.add('test_table', { id: '1' }, config);
@@ -323,36 +358,124 @@ describe('ClickHouseBatchService', () => {
 
       jest.advanceTimersByTime(1000);
 
-      await new Promise((resolve) => setImmediate(resolve));
+      jest.useRealTimers();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(clickhouseService.insert).toHaveBeenCalledWith('test_table', [{ id: '1' }], undefined);
-
-      jest.useRealTimers();
     });
   });
 
-  describe('onModuleDestroy', () => {
-    it('should flush all buffers and clear timers', async () => {
+  describe('shutdown drain', () => {
+    it('should set isShuttingDown flag', async () => {
+      await service.beforeApplicationShutdown('SIGTERM');
+
+      expect(service['isShuttingDown']).toBe(true);
+    });
+
+    it('should flush all buffers and clear timers on graceful shutdown', async () => {
       const config = { maxBatchSize: 10, flushIntervalMs: 10000 };
 
       await service.add('table1', { id: '1' }, config);
       await service.add('table2', { id: '2' }, config);
 
-      await service.onModuleDestroy();
+      await service.beforeApplicationShutdown('SIGTERM');
 
-      expect(clickhouseService.insert).toHaveBeenCalledTimes(2);
+      expect(clickhouseService.insert).toHaveBeenCalledWith('table1', [{ id: '1' }], undefined);
+      expect(clickhouseService.insert).toHaveBeenCalledWith('table2', [{ id: '2' }], undefined);
       expect(service.getBufferStats()).toHaveLength(0);
-      expect(logger.info).toHaveBeenCalledWith('Starting graceful shutdown of ClickHouse batch service');
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ signal: 'SIGTERM' }),
+        'Starting graceful shutdown of ClickHouse batch service'
+      );
       expect(logger.info).toHaveBeenCalledWith('ClickHouse batch service shutdown complete');
     });
 
-    it('should set isShuttingDown flag', async () => {
+    it('should be idempotent across onModuleDestroy and beforeApplicationShutdown', async () => {
+      const config = { maxBatchSize: 10, flushIntervalMs: 10000 };
+
+      await service.add('test_table', { id: '1' }, config);
+
+      await service.beforeApplicationShutdown('SIGTERM');
       await service.onModuleDestroy();
 
-      expect(service['isShuttingDown']).toBe(true);
+      expect(clickhouseService.insert).toHaveBeenCalledTimes(1);
     });
 
-    it('should wait for all queues to complete during shutdown', async () => {
+    it('should retry buffered rows when ClickHouse is unavailable then recovers during shutdown', async () => {
+      let callCount = 0;
+      clickhouseService.insert.mockImplementation(async () => {
+        callCount += 1;
+        if (callCount <= 4) {
+          throw new Error('ClickHouse unavailable');
+        }
+      });
+
+      const config = {
+        maxBatchSize: 10,
+        flushIntervalMs: 10000,
+        maxRetries: 0,
+        retryDelayMs: 1,
+      };
+
+      await service.add('test_table', { id: '1' }, config);
+      await service.add('test_table', { id: '2' }, config);
+
+      await service.beforeApplicationShutdown('SIGTERM');
+
+      // First 4 attempts fail, 5th succeeds with both rows preserved.
+      expect(callCount).toBeGreaterThanOrEqual(5);
+      expect(clickhouseService.insert).toHaveBeenLastCalledWith('test_table', [{ id: '1' }, { id: '2' }], undefined);
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ attempts: expect.any(Number) }),
+        'All ClickHouse buffers drained successfully'
+      );
+    });
+
+    it('should log structured row loss when drain timeout is reached', async () => {
+      process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_TIMEOUT_MS = '50';
+      process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_RETRY_DELAY_MS = '5';
+
+      const localModule: TestingModule = await Test.createTestingModule({
+        providers: [
+          {
+            provide: ClickHouseBatchService,
+            useFactory: (chSvc: ClickHouseService, log: PinoLogger) => new ClickHouseBatchService(chSvc, log, []),
+            inject: [ClickHouseService, PinoLogger],
+          },
+          { provide: ClickHouseService, useValue: clickhouseService },
+          { provide: PinoLogger, useValue: logger },
+        ],
+      }).compile();
+
+      const localService = localModule.get<ClickHouseBatchService>(ClickHouseBatchService);
+      await localService.onModuleInit();
+
+      clickhouseService.insert.mockRejectedValue(new Error('ClickHouse permanently down'));
+
+      const config = {
+        maxBatchSize: 10,
+        flushIntervalMs: 10000,
+        maxRetries: 0,
+        retryDelayMs: 1,
+      };
+
+      await localService.add('lost_table', { id: '1' }, config);
+      await localService.add('lost_table', { id: '2' }, config);
+      await localService.add('lost_table', { id: '3' }, config);
+
+      await localService.beforeApplicationShutdown('SIGTERM');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rowsLost: 3,
+          tablesAffected: expect.arrayContaining([expect.objectContaining({ table: 'lost_table', bufferSize: 3 })]),
+        }),
+        'Shutdown drain timeout reached: analytic rows could not be flushed to ClickHouse'
+      );
+    });
+
+    it('should wait for in-flight flushes to complete during shutdown', async () => {
       const config = { maxBatchSize: 10, flushIntervalMs: 10000 };
 
       let resolveInsert: (() => void) | undefined;
@@ -367,13 +490,13 @@ describe('ClickHouseBatchService', () => {
       await service.add('test_table', { id: '1' }, config);
       const flushPromise = service.flush('test_table');
 
-      const destroyPromise = service.onModuleDestroy();
+      const shutdownPromise = service.beforeApplicationShutdown('SIGTERM');
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await new Promise((resolve) => setTimeout(resolve, 30));
 
       if (resolveInsert) resolveInsert();
       await flushPromise;
-      await destroyPromise;
+      await shutdownPromise;
 
       expect(clickhouseService.insert).toHaveBeenCalled();
       expect(service.getBufferStats()).toHaveLength(0);
@@ -400,8 +523,6 @@ describe('ClickHouseBatchService', () => {
         table: 'table1',
         bufferSize: 2,
         maxBatchSize: 10,
-        writeQueueSize: 0,
-        writeQueuePending: 0,
         flushQueueSize: 0,
         flushQueuePending: 0,
       });
@@ -412,8 +533,6 @@ describe('ClickHouseBatchService', () => {
         table: 'table2',
         bufferSize: 1,
         maxBatchSize: 20,
-        writeQueueSize: 0,
-        writeQueuePending: 0,
         flushQueueSize: 0,
         flushQueuePending: 0,
       });

--- a/libs/application-generic/src/services/analytic-logs/clickhouse-batch.service.ts
+++ b/libs/application-generic/src/services/analytic-logs/clickhouse-batch.service.ts
@@ -1,4 +1,4 @@
-import { BeforeApplicationShutdown, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { BeforeApplicationShutdown, Injectable, OnModuleDestroy, OnModuleInit, Optional } from '@nestjs/common';
 import { ObservabilityBackgroundTransactionEnum } from '@novu/shared';
 import { PinoLogger } from 'nestjs-pino';
 import PQueue from 'p-queue';
@@ -49,6 +49,12 @@ const DEFAULT_BACKPRESSURE_MODE: 'drop' | 'block' = 'drop';
 const DEFAULT_BACKPRESSURE_TIMEOUT_MS = 1500;
 const SHUTDOWN_POLL_INTERVAL_MS = 10_000;
 const SHUTDOWN_MAX_ATTEMPTS = 10;
+// Total time we are willing to spend draining the buffers during shutdown
+// before giving up and logging the row count loss for observability.
+const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 30_000;
+// Time to wait between drain iterations when ClickHouse is unavailable
+// to give the upstream a chance to recover before the next attempt.
+const DEFAULT_SHUTDOWN_DRAIN_RETRY_DELAY_MS = 1000;
 
 /**
  * Batches and flushes rows to ClickHouse with concurrent write safety.
@@ -82,13 +88,28 @@ const SHUTDOWN_MAX_ATTEMPTS = 10;
 @Injectable()
 export class ClickHouseBatchService implements OnModuleDestroy, OnModuleInit, BeforeApplicationShutdown {
   private buffers: Map<string, TableBuffer> = new Map();
+  private isShuttingDown = false;
+  private shutdownDrainTimeoutMs: number = DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS;
+  private shutdownDrainRetryDelayMs: number = DEFAULT_SHUTDOWN_DRAIN_RETRY_DELAY_MS;
 
   constructor(
     private readonly clickhouseService: ClickHouseService,
     private readonly logger: PinoLogger,
-    private readonly queueServices: QueueBaseService[] = []
+    @Optional() private readonly queueServices: QueueBaseService[] = []
   ) {
     this.logger.setContext(ClickHouseBatchService.name);
+
+    const drainTimeoutEnv = process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_TIMEOUT_MS;
+    const parsedDrainTimeout = drainTimeoutEnv ? parseInt(drainTimeoutEnv, 10) : NaN;
+    if (Number.isFinite(parsedDrainTimeout) && parsedDrainTimeout > 0) {
+      this.shutdownDrainTimeoutMs = parsedDrainTimeout;
+    }
+
+    const drainRetryDelayEnv = process.env.CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_RETRY_DELAY_MS;
+    const parsedDrainRetryDelay = drainRetryDelayEnv ? parseInt(drainRetryDelayEnv, 10) : NaN;
+    if (Number.isFinite(parsedDrainRetryDelay) && parsedDrainRetryDelay >= 0) {
+      this.shutdownDrainRetryDelayMs = parsedDrainRetryDelay;
+    }
   }
 
   async onModuleInit(): Promise<void> {
@@ -96,6 +117,12 @@ export class ClickHouseBatchService implements OnModuleDestroy, OnModuleInit, Be
   }
 
   async add<T extends Record<string, unknown>>(table: string, row: T, config: BatchConfig): Promise<void> {
+    if (this.isShuttingDown) {
+      this.logger.warn({ table }, 'ClickHouse batch service is shutting down, dropping row');
+
+      return;
+    }
+
     if (!this.clickhouseService.client) {
       this.logger.debug({ table }, 'ClickHouse client not initialized, skipping batch add');
 
@@ -347,25 +374,127 @@ export class ClickHouseBatchService implements OnModuleDestroy, OnModuleInit, Be
   }
 
   async onModuleDestroy(): Promise<void> {
-    this.logger.debug('ClickHouse batch service onModuleDestroy called (no-op)');
+    if (this.isShuttingDown) {
+      this.logger.debug('ClickHouse batch service onModuleDestroy called while already shutting down');
+
+      return;
+    }
+
+    await this.beforeApplicationShutdown('onModuleDestroy');
   }
 
   async beforeApplicationShutdown(signal?: string): Promise<void> {
+    if (this.isShuttingDown) {
+      this.logger.debug({ signal }, 'ClickHouse batch service shutdown already in progress, skipping');
+
+      return;
+    }
+
+    this.isShuttingDown = true;
     this.logger.info({ signal }, 'Starting graceful shutdown of ClickHouse batch service');
 
-    for (const [table, buffer] of this.buffers.entries()) {
-      clearInterval(buffer.timer);
-      this.logger.debug({ table }, 'Cleared flush timer for table');
-    }
+    this.clearTimers();
 
     await this.waitForActiveJobsToComplete();
 
-    await this.flushAll();
-    await this.waitForAllQueues();
+    await this.drainBuffers();
 
     this.buffers.clear();
 
     this.logger.info('ClickHouse batch service shutdown complete');
+  }
+
+  /**
+   * Repeatedly flushes all table buffers until they are empty or the drain
+   * timeout is reached. Failed flushes re-queue rows back into the buffer,
+   * so this loop keeps retrying until either ClickHouse comes back online
+   * or we exhaust the shutdown budget.
+   *
+   * We always enqueue a flush and wait for the queue to drain at least once
+   * to allow any in-flight flush (or one we just enqueued) to either succeed
+   * or re-queue its rows on failure before we evaluate the buffer state.
+   */
+  private async drainBuffers(): Promise<void> {
+    const startedAt = Date.now();
+    let attempt = 0;
+
+    while (true) {
+      attempt++;
+      const elapsed = Date.now() - startedAt;
+
+      this.logger.info(
+        {
+          attempt,
+          totalBufferedRows: this.totalBufferedRows(),
+          elapsedMs: elapsed,
+          timeoutMs: this.shutdownDrainTimeoutMs,
+        },
+        'Draining ClickHouse buffers during shutdown'
+      );
+
+      await this.flushAll();
+      await this.waitForAllQueues();
+
+      if (!this.hasBufferedRows()) {
+        this.logger.info({ attempts: attempt }, 'All ClickHouse buffers drained successfully');
+
+        return;
+      }
+
+      const elapsedAfterFlush = Date.now() - startedAt;
+
+      if (elapsedAfterFlush >= this.shutdownDrainTimeoutMs) {
+        const breakdown = this.getBufferedRowsBreakdown();
+        const totalRowsLost = breakdown.reduce((sum, entry) => sum + entry.bufferSize, 0);
+
+        this.logger.error(
+          {
+            rowsLost: totalRowsLost,
+            tablesAffected: breakdown,
+            elapsedMs: elapsedAfterFlush,
+            timeoutMs: this.shutdownDrainTimeoutMs,
+            attempts: attempt,
+          },
+          'Shutdown drain timeout reached: analytic rows could not be flushed to ClickHouse'
+        );
+
+        return;
+      }
+
+      await this.sleep(this.shutdownDrainRetryDelayMs);
+    }
+  }
+
+  private clearTimers(): void {
+    for (const [table, buffer] of this.buffers.entries()) {
+      clearInterval(buffer.timer);
+      this.logger.debug({ table }, 'Cleared flush timer for table');
+    }
+  }
+
+  private hasBufferedRows(): boolean {
+    for (const buffer of this.buffers.values()) {
+      if (buffer.rows.length > 0) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private totalBufferedRows(): number {
+    let total = 0;
+    for (const buffer of this.buffers.values()) {
+      total += buffer.rows.length;
+    }
+
+    return total;
+  }
+
+  private getBufferedRowsBreakdown(): Array<{ table: string; bufferSize: number }> {
+    return Array.from(this.buffers.entries())
+      .filter(([, buffer]) => buffer.rows.length > 0)
+      .map(([table, buffer]) => ({ table, bufferSize: buffer.rows.length }));
   }
 
   private async waitForActiveJobsToComplete(): Promise<void> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ClickHouseBatchService.beforeApplicationShutdown` flushed once, awaited the queue, then unconditionally cleared `this.buffers`. Because `flushTable` resolves successfully even after re-queueing rows whose retry budget was exhausted, any rows that failed the *final* flush during a deploy were silently dropped on the floor.

This PR makes shutdown drain the buffers properly:

- Set an `isShuttingDown` flag so `add()` bails (with a warning) instead of accepting rows that would never be flushed.
- Drain in a loop, awaiting in-flight flushes before evaluating buffer state, so re-queued rows from failed flushes are retried until ClickHouse recovers or the drain budget is exhausted.
- On timeout, log a structured error that names the lost row count and per-table breakdown for observability.
- Default drain budget is `30s`, configurable via `CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_TIMEOUT_MS` and `CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_RETRY_DELAY_MS`.

```mermaid
sequenceDiagram
  participant App as App (SIGTERM)
  participant Svc as ClickHouseBatchService
  participant CH as ClickHouse
  App->>Svc: beforeApplicationShutdown
  Svc->>Svc: isShuttingDown = true; clearTimers
  loop until empty or timeout
    Svc->>CH: flushAll + waitForAllQueues
    alt insert ok
      CH-->>Svc: success
    else insert fails (final retry)
      CH-->>Svc: error
      Svc->>Svc: re-queue rows back into buffer
      Svc->>Svc: sleep(retryDelay)
    end
  end
  alt drained
    Svc-->>App: shutdown complete
  else timed out
    Svc->>Svc: log.error rowsLost + tablesAffected
  end
```

## Acceptance criteria

- [x] Shutdown retries until ClickHouse comes back or the timeout is hit
- [x] On timeout, logs the loss with row count and per-table breakdown
- [x] Test: simulate ClickHouse down during shutdown → rows recovered when CH returns

## Tests

The existing spec was broken since it landed (Nest couldn't resolve the `QueueBaseService[]` constructor parameter, and asserted on non-existent fields like `writeQueueSize`). Repaired the harness via a `useFactory` provider, marked the optional `QueueBaseService[]` arg with `@Optional`, and added coverage for:

- shutdown flag prevents new rows from being added
- shutdown is idempotent across `onModuleDestroy` and `beforeApplicationShutdown`
- rows re-queued from a failing flush are recovered when ClickHouse returns mid-shutdown
- structured `rowsLost` / `tablesAffected` logging on timeout
- in-flight flush completes before shutdown returns

```
PASS  src/services/analytic-logs/clickhouse-batch.service.spec.ts
Tests: 29 passed, 29 total
```

## Risks

Behavior change: shutdown can now block for up to `CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_TIMEOUT_MS` (default 30s) when ClickHouse is unreachable. This is intentional — without it, rows are silently dropped on every deploy where the final flush attempt fails. Callers that need a tighter shutdown can lower the env var.

`onModuleDestroy` previously was a no-op; it now delegates to the same drain path so direct uses of NestJS `close()` also benefit.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7608](https://linear.app/novu/issue/NV-7608/bug-clickhouse-buffered-rows-lost-during-shutdown-after-final-flush)

<div><a href="https://cursor.com/agents/bc-a1a5850a-2ae4-4087-9306-ffde38853360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1a5850a-2ae4-4087-9306-ffde38853360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
Fixed ClickHouse batch buffer handling during application shutdown. Previously, the service flushed buffers once and immediately cleared them, causing rows that failed to flush to be silently dropped. The fix implements a drain loop that retries failed rows with a configurable timeout, rejects new rows during shutdown, and logs structured errors when rows are lost.

## Affected areas
**shared**: The `ClickHouseBatchService` now tracks shutdown state, implements a configurable drain-and-retry loop during `beforeApplicationShutdown()`, and exposes two new environment variables (`CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_TIMEOUT_MS` and `CLICKHOUSE_BATCH_SHUTDOWN_DRAIN_RETRY_DELAY_MS`) for controlling shutdown behavior with sensible defaults (30s drain budget).

## Key technical decisions
- Added `isShuttingDown` flag to reject new rows during graceful shutdown with a warning log.
- Implemented `drainBuffers()` loop that repeatedly flushes and waits for in-flight operations to complete, re-evaluating buffer state until empty or timeout.
- Shutdown can now block up to the configured timeout (default 30 seconds) when ClickHouse is unreachable; `onModuleDestroy()` delegates to the drain path if not already shutting down.
- Constructor updated to make `queueServices` optional with `@Optional()` decorator.

## Testing
Added comprehensive unit test coverage including shutdown flag behavior, idempotent shutdown across lifecycle hooks, recovery of re-queued rows when ClickHouse recovers mid-shutdown, structured timeout logging, and in-flight flush coordination. Test harness was updated to use a factory provider for `ClickHouseBatchService`. All 29 tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->