### PR TITLE
fix(api-service): require ORG_SETTINGS_WRITE on EE branding & rename routes fixes NV-7588

### DIFF
--- a/apps/api/src/app/organization/ee.organization.controller.ts
+++ b/apps/api/src/app/organization/ee.organization.controller.ts
@@ -63,6 +63,7 @@ export class EEOrganizationController {
   @ApiOperation({
     summary: 'Update organization branding details',
   })
+  @RequirePermissions(PermissionsEnum.ORG_SETTINGS_WRITE)
   async updateBrandingDetails(@UserSession() user: UserSessionData, @Body() body: UpdateBrandingDetailsDto) {
     return await this.updateBrandingDetailsUsecase.execute(
       UpdateBrandingDetailsCommand.create({
@@ -86,6 +87,7 @@ export class EEOrganizationController {
   @ApiOperation({
     summary: 'Rename organization name',
   })
+  @RequirePermissions(PermissionsEnum.ORG_SETTINGS_WRITE)
   async renameOrganization(@UserSession() user: UserSessionData, @Body() body: RenameOrganizationDto) {
     return await this.renameOrganizationUsecase.execute(
       RenameOrganizationCommand.create({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `@RequirePermissions(PermissionsEnum.ORG_SETTINGS_WRITE)` to two routes on `EEOrganizationController`:

- `PUT /organizations/branding` (`updateBrandingDetails`)
- `PATCH /organizations/` (`renameOrganization`)

## Why

When Clerk or Better Auth is enabled, organization routes are served by `EEOrganizationController`. The branding and rename handlers were marked `@ExternalApiAccessible()` but lacked `@RequirePermissions(ORG_SETTINGS_WRITE)`, unlike the adjacent `GET/PATCH /organizations/settings` routes. As a result, any org member (regardless of role) could modify branding or rename the organization.

This brings the two deprecated handlers in line with the permission gate already enforced on `PATCH /organizations/settings`.

## Notes

- `@ExternalApiAccessible()` is intentionally preserved to avoid silently breaking existing API key consumers of these still-exposed (though deprecated) routes. Tightening or removing external API access can be revisited as part of the broader deprecation plan.
- The non-EE `OrganizationController` is unaffected: it is only mounted when neither Clerk nor Better Auth is in use, where the permission system does not apply in the same way.

## Acceptance criteria

- [x] Non-admin (or principal without `ORG_SETTINGS_WRITE`) gets 403 on branding/rename — enforced via the `RequirePermissions` guard, identical to the existing `PATCH /organizations/settings` route.
- [x] Settings-related routes are uniformly gated.

Fixes NV-7588
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7588](https://linear.app/novu/issue/NV-7588/rbac-ee-org-branding-rename-routes-missing-org-settings-write)

<div><a href="https://cursor.com/agents/bc-7a3eafdf-6c32-41f2-808f-0548c0a8467c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a3eafdf-6c32-41f2-808f-0548c0a8467c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened access controls on organization settings endpoints by enforcing required write permissions for updating organization branding and renaming the organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->