### PR TITLE
fix(api-service): prevent mass-assignment of tenant ids in bulk subscriber upsert fixes NV-7591

### DIFF
--- a/apps/api/src/app/subscribers/e2e/bulk-create-subscribers.e2e.ts
+++ b/apps/api/src/app/subscribers/e2e/bulk-create-subscribers.e2e.ts
@@ -1,7 +1,9 @@
 import { Novu } from '@novu/api';
 import { SubscriberEntity, SubscriberRepository } from '@novu/dal';
 import { SubscribersService, UserSession } from '@novu/testing';
+import axios from 'axios';
 import { expect } from 'chai';
+import { Types } from 'mongoose';
 import { expectSdkValidationExceptionGeneric, initNovuClassSdk } from '../../shared/helpers/e2e/sdk/e2e-sdk.helper';
 
 describe('Bulk create subscribers - /v1/subscribers/bulk (POST) #novu-v2', () => {
@@ -151,5 +153,61 @@ describe('Bulk create subscribers - /v1/subscribers/bulk (POST) #novu-v2', () =>
     expect(secondResponseData.created[0].subscriberId).to.equal(newSubscriber1.subscriberId);
     expect(secondResponseData.created[1].subscriberId).to.equal(newSubscriber2.subscriberId);
     expect(secondResponseData.updated[0].subscriberId).to.equal(existingSubscriber.subscriberId);
+  });
+
+  it('should ignore _environmentId and _organizationId fields in bulk subscriber items', async () => {
+    const foreignEnvironmentId = new Types.ObjectId().toString();
+    const foreignOrganizationId = new Types.ObjectId().toString();
+
+    const originalEnvironmentId = subscriber._environmentId;
+    const originalOrganizationId = subscriber._organizationId;
+
+    const response = await axios.post(
+      `${session.serverUrl}/v1/subscribers/bulk`,
+      {
+        subscribers: [
+          {
+            subscriberId: subscriber.subscriberId,
+            firstName: 'updated-first-name',
+            _environmentId: foreignEnvironmentId,
+            _organizationId: foreignOrganizationId,
+          },
+          {
+            subscriberId: 'cross-tenant-create-test',
+            firstName: 'new',
+            email: 'new@test.co',
+            _environmentId: foreignEnvironmentId,
+            _organizationId: foreignOrganizationId,
+          },
+        ],
+      },
+      {
+        headers: { authorization: `ApiKey ${session.apiKey}` },
+      }
+    );
+
+    expect(response.status).to.equal(201);
+
+    const updatedSubscriber = await subscriberRepository.findBySubscriberId(
+      session.environment._id,
+      subscriber.subscriberId
+    );
+    expect(updatedSubscriber?.firstName).to.equal('updated-first-name');
+    expect(updatedSubscriber?._environmentId).to.equal(originalEnvironmentId);
+    expect(updatedSubscriber?._organizationId).to.equal(originalOrganizationId);
+
+    const createdSubscriber = await subscriberRepository.findBySubscriberId(
+      session.environment._id,
+      'cross-tenant-create-test'
+    );
+    expect(createdSubscriber).to.be.ok;
+    expect(createdSubscriber?._environmentId).to.equal(session.environment._id);
+    expect(createdSubscriber?._organizationId).to.equal(session.organization._id);
+
+    const leakedSubscriber = await subscriberRepository.findBySubscriberId(
+      foreignEnvironmentId,
+      'cross-tenant-create-test'
+    );
+    expect(leakedSubscriber).to.equal(null);
   });
 });

--- a/libs/dal/src/repositories/subscriber/subscriber.repository.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.repository.ts
@@ -34,12 +34,16 @@ export class SubscriberRepository extends BaseRepository<SubscriberDBModel, Subs
     organizationId: OrganizationId
   ): Promise<BulkCreateSubscriberEntity> {
     const bulkWriteOps = subscribers.map((subscriber) => {
-      const { subscriberId, ...rest } = subscriber;
+      const updatableFields = pickUpdatableSubscriberFields(subscriber);
 
       return {
         updateOne: {
-          filter: { subscriberId, _environmentId: environmentId, _organizationId: organizationId },
-          update: { $set: { ...rest, deleted: false } },
+          filter: {
+            subscriberId: subscriber.subscriberId,
+            _environmentId: environmentId,
+            _organizationId: organizationId,
+          },
+          update: { $set: { ...updatableFields, deleted: false } },
           upsert: true,
         },
       };
@@ -277,6 +281,29 @@ export class SubscriberRepository extends BaseRepository<SubscriberDBModel, Subs
 
 function mapToSubscriberObject(subscriberId: string) {
   return { subscriberId };
+}
+
+const UPDATABLE_SUBSCRIBER_FIELDS: readonly (keyof ISubscribersDefine)[] = [
+  'firstName',
+  'lastName',
+  'email',
+  'phone',
+  'avatar',
+  'locale',
+  'data',
+  'channels',
+  'timezone',
+];
+
+function pickUpdatableSubscriberFields(subscriber: ISubscribersDefine): Partial<ISubscribersDefine> {
+  const result: Partial<ISubscribersDefine> = {};
+  for (const field of UPDATABLE_SUBSCRIBER_FIELDS) {
+    if (field in subscriber) {
+      (result as Record<string, unknown>)[field] = subscriber[field];
+    }
+  }
+
+  return result;
 }
 
 function regExpEscape(literalString: string): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`SubscriberRepository.bulkCreateSubscribers` previously destructured only `subscriberId` from each input item and wrote everything else into `$set`:

```ts
const { subscriberId, ...rest } = subscriber;
return { ..., update: { $set: { ...rest, deleted: false } } };
```

Combined with the global `ValidationPipe` not having `whitelist: true` enabled, a request body could carry extra fields like `_environmentId` / `_organizationId`. For an existing subscriber matched in the caller's environment, the update would overwrite ownership fields to arbitrary `ObjectId`s, corrupting cross-tenant data.

This PR replaces the implicit "spread-the-rest" pattern with an explicit allowlist of mutable subscriber fields:

```ts
const UPDATABLE_SUBSCRIBER_FIELDS = [
  'firstName', 'lastName', 'email', 'phone', 'avatar',
  'locale', 'data', 'channels', 'timezone',
];
```

Only fields in this allowlist make it into `$set`. Anything else in the input (including `_environmentId`, `_organizationId`, `_id`, `deleted`, `createdAt`, etc.) is silently ignored at the data layer.

## Why

Defense in depth against the parent mass-assignment issue. Even when validation pipes change or when SDK clients evolve, the repository now refuses to write tenant-ownership fields from untrusted input.

## Tests

Added a regression test in `apps/api/src/app/subscribers/e2e/bulk-create-subscribers.e2e.ts` that:

1. Sends a bulk upsert with `_environmentId` / `_organizationId` set to foreign `ObjectId`s — both for an existing subscriber (update path) and a brand-new `subscriberId` (insert path). The test calls the API directly via `axios` to bypass any SDK client-side stripping of unknown fields.
2. Verifies the existing subscriber's tenant fields stayed unchanged.
3. Verifies the newly created subscriber landed in the caller's environment/organization, not the foreign one.
4. Verifies no document leaked into the foreign environment.

The new test passes locally:

```
✔ should ignore _environmentId and _organizationId fields in bulk subscriber items
```

The flake on `should recreate deleted subscribers` (HTTP 429 on the bulk endpoint when the suite is run in isolation) is pre-existing — it reproduces on `next` without these changes.

## Acceptance criteria

- [x] `_environmentId` / `_organizationId` in bulk subscriber items have no effect.
- [x] Regression test: bulk upsert with foreign env/org IDs leaves data intact.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7591](https://linear.app/novu/issue/NV-7591/mass-assignment-bulk-subscriber-upsert-allows-tenant-ownership)

<div><a href="https://cursor.com/agents/bc-121d4d6d-f91b-41cf-bcbf-1a957ffee7bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-121d4d6d-f91b-41cf-bcbf-1a957ffee7bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `bulkCreateSubscribers` method in the subscriber repository was hardened to prevent mass-assignment of tenant fields during bulk upsert operations. Previously, all input fields except `subscriberId` were spread into the MongoDB `$set` operation, allowing extra fields like `_environmentId` and `_organizationId` to overwrite tenant ownership for existing subscribers. The fix introduces an explicit allowlist of updatable subscriber fields (`firstName`, `lastName`, `email`, `phone`, `avatar`, `locale`, `data`, `channels`, `timezone`) and ignores all other input at the data layer, ensuring tenant scoping cannot be bypassed.

## Affected areas

- **dal**: `SubscriberRepository.bulkCreateSubscribers` now filters bulk upsert payloads through a typed `UPDATABLE_SUBSCRIBER_FIELDS` allowlist and includes a helper function `pickUpdatableSubscriberFields` to enforce which fields can be updated.

- **api**: Added a regression e2e test in `bulk-create-subscribers.e2e.ts` that verifies bulk items with injected `_environmentId`/`_organizationId` fields cannot affect tenant scoping, covering both update and insert paths.

## Key technical decisions

- Implemented an explicit allowlist pattern rather than a blocklist, reducing the risk of future mass-assignment regressions and making safe-by-default behavior clear to maintainers.

## Testing

A new regression e2e test was added that directly calls the bulk API endpoint via axios to verify the vulnerability is fixed, confirming existing subscribers retain their original tenant fields and newly created subscribers are isolated within the caller's environment/organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->