### PR TITLE
fix(api-service): prevent cross-tenant Vercel partner integration writes fixes NV-7589

### DIFF
--- a/apps/api/src/app/partner-integrations/usecases/create-vercel-integration/create-vercel-integration.spec.ts
+++ b/apps/api/src/app/partner-integrations/usecases/create-vercel-integration/create-vercel-integration.spec.ts
@@ -103,6 +103,7 @@ describe('CreateVercelIntegration', () => {
 
     // Verify organization repository call
     assert.calledWith(organizationRepositoryMock.upsertPartnerConfiguration, {
+      userId: command.userId,
       organizationId: command.organizationId,
       configuration: {
         accessToken: 'test-token',

--- a/apps/api/src/app/partner-integrations/usecases/create-vercel-integration/create-vercel-integration.usecase.ts
+++ b/apps/api/src/app/partner-integrations/usecases/create-vercel-integration/create-vercel-integration.usecase.ts
@@ -27,6 +27,7 @@ export class CreateVercelIntegration {
       };
 
       await this.organizationRepository.upsertPartnerConfiguration({
+        userId: command.userId,
         organizationId: command.organizationId,
         configuration,
       });

--- a/apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.spec.ts
+++ b/apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.spec.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { AnalyticsService, PinoLogger } from '@novu/application-generic';
 import { CommunityUserRepository, EnvironmentRepository, MemberRepository, OrganizationRepository } from '@novu/dal';
@@ -80,6 +80,7 @@ describe('UpdateVercelIntegration', () => {
         },
       ]),
       bulkUpdatePartnerConfiguration: stub().resolves(true),
+      getUserAuthorizedOrganizationIds: stub().resolves(['org-id']),
     };
 
     analyticsServiceMock = {
@@ -411,6 +412,34 @@ describe('UpdateVercelIntegration', () => {
       assert.called(httpServiceMock.get);
       assert.called(httpServiceMock.delete);
     }
+  });
+
+  it('should reject cross-tenant writes for organizations the user is not a member of', async () => {
+    organizationRepositoryMock.getUserAuthorizedOrganizationIds.resolves(['org-id']);
+
+    let caught: unknown;
+    try {
+      await updateVercelIntegration.execute({
+        userId: session.user._id,
+        organizationId: session.organization._id,
+        environmentId: session.environment._id,
+        configurationId: 'test-config-id',
+        data: {
+          'org-id': ['project-1'],
+          // attacker injects another tenant's organization id
+          'someone-elses-org-id': ['project-evil'],
+        },
+      });
+      throw new Error('Should not reach here');
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(UnauthorizedException);
+    assert.notCalled(organizationRepositoryMock.bulkUpdatePartnerConfiguration);
+    assert.notCalled(environmentRepositoryMock.find);
+    assert.notCalled(httpServiceMock.delete);
+    assert.notCalled(httpServiceMock.post);
   });
 
   it('should handle multiple projects with environment variables', async () => {

--- a/apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.usecase.ts
+++ b/apps/api/src/app/partner-integrations/usecases/update-vercel-integration/update-vercel-integration.usecase.ts
@@ -1,5 +1,5 @@
 import { HttpService } from '@nestjs/axios';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, HttpException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { AnalyticsService, decryptApiKey, PinoLogger } from '@novu/application-generic';
 import {
   CommunityUserRepository,
@@ -55,6 +55,14 @@ export class UpdateVercelIntegration {
     try {
       const { userId, organizationId, configurationId, data: orgIdsToProjectIds } = command;
 
+      const requestedOrganizationIds = Object.keys(orgIdsToProjectIds);
+      const allowedOrganizationIds = await this.organizationRepository.getUserAuthorizedOrganizationIds(userId);
+      const allowedSet = new Set(allowedOrganizationIds);
+      const unauthorizedOrganizationIds = requestedOrganizationIds.filter((id) => !allowedSet.has(id));
+      if (unauthorizedOrganizationIds.length > 0) {
+        throw new UnauthorizedException('Not allowed to write to all requested organizations');
+      }
+
       const configuration = await this.getCurrentOrgPartnerConfiguration({
         userId,
         configurationId,
@@ -73,8 +81,7 @@ export class UpdateVercelIntegration {
         configuration,
       });
 
-      const organizationIds = Object.keys(orgIdsToProjectIds);
-      const environments = await this.getEnvironments(organizationIds);
+      const environments = await this.getEnvironments(requestedOrganizationIds);
 
       for (const env of environments) {
         const projectIds = orgIdsToProjectIds[env._organizationId];
@@ -107,6 +114,9 @@ export class UpdateVercelIntegration {
 
       return { success: true };
     } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
       throw new BadRequestException(error.message);
     }
   }

--- a/libs/dal/src/repositories/organization/community.organization.repository.ts
+++ b/libs/dal/src/repositories/organization/community.organization.repository.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedException } from '@nestjs/common';
 import { BaseRepository } from '../base-repository';
 import { CommunityMemberRepository } from '../member';
 import { IPartnerConfiguration, OrganizationDBModel, OrganizationEntity } from './organization.entity';
@@ -29,10 +30,14 @@ export class CommunityOrganizationRepository
     });
   }
 
-  private async getUsersMembersOrganizationIds(userId: string): Promise<string[]> {
+  async getUsersMembersOrganizationIds(userId: string): Promise<string[]> {
     const members = await this.memberRepository.findUserActiveMembers(userId);
 
     return members.map((member) => member._organizationId);
+  }
+
+  async getUserAuthorizedOrganizationIds(userId: string): Promise<string[]> {
+    return this.getUsersMembersOrganizationIds(userId);
   }
 
   async updateBrandingDetails(organizationId: string, branding: { color: string; logo: string }) {
@@ -90,6 +95,70 @@ export class CommunityOrganizationRepository
   }
 
   async upsertPartnerConfiguration({
+    userId,
+    organizationId,
+    configuration,
+  }: {
+    userId: string;
+    organizationId: string;
+    configuration: IPartnerConfiguration;
+  }) {
+    const allowedOrganizationIds = await this.getUsersMembersOrganizationIds(userId);
+    this.assertOrganizationsAuthorized([organizationId], allowedOrganizationIds);
+
+    return this.performUpsertPartnerConfiguration({ organizationId, configuration });
+  }
+
+  async bulkUpdatePartnerConfiguration({
+    userId,
+    data,
+    configuration,
+  }: {
+    userId: string;
+    data: Record<string, string[]>;
+    configuration: IPartnerConfiguration;
+  }) {
+    const { teamId } = configuration;
+    const allowedOrganizationIds = await this.getUsersMembersOrganizationIds(userId);
+    const requestedOrgIds = Object.keys(data);
+    this.assertOrganizationsAuthorized(requestedOrgIds, allowedOrganizationIds);
+
+    // remove all existing configurations for this team across the user's organizations
+    await this.update(
+      {
+        _id: { $in: allowedOrganizationIds },
+      },
+      {
+        $pull: {
+          partnerConfigurations: {
+            teamId,
+          },
+        },
+      }
+    );
+
+    const promises = requestedOrgIds.map((orgId) =>
+      this.performUpsertPartnerConfiguration({
+        organizationId: orgId,
+        configuration: {
+          ...configuration,
+          projectIds: data[orgId],
+        },
+      })
+    );
+
+    await Promise.all(promises);
+  }
+
+  private assertOrganizationsAuthorized(requestedOrgIds: string[], allowedOrganizationIds: string[]) {
+    const allowedSet = new Set(allowedOrganizationIds);
+    const unauthorized = requestedOrgIds.filter((id) => !allowedSet.has(id));
+    if (unauthorized.length > 0) {
+      throw new UnauthorizedException('Not allowed to write partner configuration for the requested organization(s)');
+    }
+  }
+
+  private async performUpsertPartnerConfiguration({
     organizationId,
     configuration,
   }: {
@@ -124,45 +193,5 @@ export class CommunityOrganizationRepository
     }
 
     return updateResult;
-  }
-
-  async bulkUpdatePartnerConfiguration({
-    userId,
-    data,
-    configuration,
-  }: {
-    userId: string;
-    data: Record<string, string[]>;
-    configuration: IPartnerConfiguration;
-  }) {
-    const { teamId } = configuration;
-    const organizationIds = await this.getUsersMembersOrganizationIds(userId);
-
-    // remove all existing configurations for this team
-    await this.update(
-      {
-        _id: { $in: organizationIds },
-      },
-      {
-        $pull: {
-          partnerConfigurations: {
-            teamId,
-          },
-        },
-      }
-    );
-
-    const usedOrgIds = Object.keys(data);
-    const promises = usedOrgIds.map((orgId) =>
-      this.upsertPartnerConfiguration({
-        organizationId: orgId,
-        configuration: {
-          ...configuration,
-          projectIds: data[orgId],
-        },
-      })
-    );
-
-    await Promise.all(promises);
   }
 }

--- a/libs/dal/src/repositories/organization/organization-repository.interface.ts
+++ b/libs/dal/src/repositories/organization/organization-repository.interface.ts
@@ -4,6 +4,11 @@ import { IPartnerConfiguration, OrganizationEntity } from './organization.entity
 export interface IOrganizationRepository extends IOrganizationRepositoryMongo {
   findById(id: string, select?: string): Promise<OrganizationEntity | null>;
   findUserActiveOrganizations(userId: string): Promise<OrganizationEntity[]>;
+  /**
+   * Returns the internal Novu organization IDs the user is an active member of.
+   * Used as the source of truth for cross-tenant authorization checks (e.g. partner integrations).
+   */
+  getUserAuthorizedOrganizationIds(userId: string): Promise<string[]>;
   updateBrandingDetails(
     organizationId: string,
     branding: { color: string; logo: string }
@@ -26,7 +31,11 @@ export interface IOrganizationRepository extends IOrganizationRepositoryMongo {
     modified: number;
   }>;
   findByPartnerConfigurationId(args: { userId: string; configurationId: string }): Promise<OrganizationEntity[]>;
-  upsertPartnerConfiguration(args: { organizationId: string; configuration: IPartnerConfiguration }): Promise<{
+  upsertPartnerConfiguration(args: {
+    userId: string;
+    organizationId: string;
+    configuration: IPartnerConfiguration;
+  }): Promise<{
     matched: number;
     modified: number;
   }>;

--- a/libs/dal/src/repositories/organization/organization.repository.ts
+++ b/libs/dal/src/repositories/organization/organization.repository.ts
@@ -13,6 +13,10 @@ export class OrganizationRepository implements IOrganizationRepository {
     return this.organizationRepository.findUserActiveOrganizations(userId);
   }
 
+  getUserAuthorizedOrganizationIds(userId: string): Promise<string[]> {
+    return this.organizationRepository.getUserAuthorizedOrganizationIds(userId);
+  }
+
   updateBrandingDetails(organizationId: string, branding: { color: string; logo: string }) {
     return this.organizationRepository.updateBrandingDetails(organizationId, branding);
   }
@@ -29,7 +33,7 @@ export class OrganizationRepository implements IOrganizationRepository {
     return this.organizationRepository.findByPartnerConfigurationId(args);
   }
 
-  upsertPartnerConfiguration(args: { organizationId: string; configuration: IPartnerConfiguration }) {
+  upsertPartnerConfiguration(args: { userId: string; organizationId: string; configuration: IPartnerConfiguration }) {
     return this.organizationRepository.upsertPartnerConfiguration(args);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Closes the cross-tenant secret-exfiltration vulnerability in the Vercel partner integration.

## Why

`PUT /v1/partner-integrations/vercel` accepted an arbitrary `data: Record<organizationId, projectIds[]>` map and:

1. Called `bulkUpdatePartnerConfiguration` per key — only the `$pull` was scoped to the user's orgs; the `upsertPartnerConfiguration` `$push` ran for every key, including foreign org IDs.
2. Called `getEnvironments(Object.keys(data))` and pushed the decrypted `NOVU_SECRET_KEY` of those environments to Vercel projects controlled by the attacker.

A user with `PARTNER_INTEGRATION_WRITE` in *their own* org plus a valid Vercel `configurationId` could therefore exfiltrate any other tenant's `NOVU_SECRET_KEY` by injecting the victim's `organizationId` as a key in the request body.

## How

```mermaid
sequenceDiagram
    participant Attacker
    participant UseCase as UpdateVercelIntegration
    participant Repo as OrganizationRepository
    participant Member as members collection / Clerk / Better-Auth

    Attacker->>UseCase: PUT /vercel { data: { ownOrg, victimOrg } }
    UseCase->>Repo: getUserAuthorizedOrganizationIds(userId)
    Repo->>Member: lookup memberships
    Member-->>Repo: [ownOrg]
    Repo-->>UseCase: [ownOrg]
    UseCase-->>Attacker: 401 Unauthorized
    Note over UseCase,Repo: bulkUpdate / getEnvironments never run
```

- **Use case** (`update-vercel-integration.usecase.ts`) — derives `allowedOrganizationIds` from the user's memberships *before* any write or env fetch and throws `UnauthorizedException` if `Object.keys(data)` contains anything else. `HttpException`s are now re-thrown so the 401 isn't masked as a 400.
- **DAL** — `IOrganizationRepository.upsertPartnerConfiguration` now requires `userId`, and a new `getUserAuthorizedOrganizationIds(userId)` method backs the check. `community.organization.repository.ts` validates the org against the user's `members` rows; the `$pull` in `bulkUpdatePartnerConfiguration` is scoped to those orgs (no longer to whatever the request supplied).
- **Enterprise** — matching defense-in-depth in [`packages-enterprise#cursor/fix-vercel-cross-tenant-mass-assignment-a949`](https://github.com/novuhq/packages-enterprise/compare/next...cursor/fix-vercel-cross-tenant-mass-assignment-a949):
  - **EE (Clerk)** repo validates against `getClerkOrganizationInfo`.
  - **Better-Auth** repo validates against the `auth-system-members` collection joined back to internal Novu org IDs via `externalId`.
- **Create flow** — `create-vercel-integration.usecase.ts` now also passes `userId` so the new repo signature is satisfied and `command.organizationId` is verified instead of trusted blindly.

## Test

Added regression test in `update-vercel-integration.spec.ts`:

```
✔ should reject cross-tenant writes for organizations the user is not a member of
```

asserts the use case throws `UnauthorizedException` and that `bulkUpdatePartnerConfiguration`, `EnvironmentRepository.find`, and the Vercel HTTP `delete`/`post` calls are **never** invoked when an attacker injects a foreign `organizationId`.

Full unit suite for the partner-integrations module:

```
CreateVercelIntegration
  ✔ should successfully set vercel configuration
  ✔ should throw BadRequestException when Vercel returns an error
GetVercelIntegration
  ✔ should get vercel configuration details
  ✔ should return empty array when no configurations found
GetVercelIntegrationProjects
  ✔ should get vercel projects successfully
  ✔ should throw BadRequestException when no configuration found
  ✔ should throw BadRequestException when HTTP request fails
UpdateVercelIntegration
  ✔ should update vercel configuration successfully
  ✔ should handle projects with no environment variables
  ✔ should handle projects with missing Novu environment variables
  ✔ should throw BadRequestException when configuration not found
  ✔ should handle errors during project fetch
  ✔ should handle errors during environment variable deletion
  ✔ should reject cross-tenant writes for organizations the user is not a member of
  ✔ should handle multiple projects with environment variables

15 passing
```

## Follow-ups (per acceptance criteria)

- [ ] Run the audit query from the ticket against production: any Vercel `partnerConfigurations` linked to organizations whose admin is not also an admin of the configuration's owner organization indicates past exploitation.
- [ ] Rotate any affected `NOVU_SECRET_KEY`s if anomalies are found.

## Companion PR

- Enterprise auth: https://github.com/novuhq/packages-enterprise/compare/next...cursor/fix-vercel-cross-tenant-mass-assignment-a949 (must merge first)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7589](https://linear.app/novu/issue/NV-7589/mass-assignment-vercel-partner-integration-cross-tenant-secret)

<div><a href="https://cursor.com/agents/bc-d6f58a0c-81a8-43d2-911f-26761971a949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6f58a0c-81a8-43d2-911f-26761971a949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Fixed a cross-tenant secret-exfiltration vulnerability in the Vercel partner integration that allowed attackers with PARTNER_INTEGRATION_WRITE permission to inject victim organization IDs and exfiltrate their `NOVU_SECRET_KEY`. The fix enforces per-organization authorization checks by deriving allowed organization IDs from the caller's memberships before any write or environment operation.

## Affected areas

**api**: `CreateVercelIntegration` and `UpdateVercelIntegration` usecases now pass `userId` to repository methods and validate that requested organization IDs are authorized for the caller; invalid requests throw `UnauthorizedException` instead of being masked as `BadRequestException`.

**dal**: `IOrganizationRepository` interface now requires `userId` in `upsertPartnerConfiguration` calls; added `getUserAuthorizedOrganizationIds(userId)` method to retrieve authorized organization IDs from user memberships. `CommunityOrganizationRepository` implements authorization validation in both `upsertPartnerConfiguration` and `bulkUpdatePartnerConfiguration` to prevent cross-tenant writes.

**enterprise**: Equivalent authorization validations implemented in EE repositories (Clerk and Better-Auth) to match community behavior.

## Key technical decisions

- Authorization is derived from user memberships (`members` collection rows) and checked before any write or environment operation.
- `HttpException` instances (including `UnauthorizedException`) are re-thrown as-is rather than wrapped to preserve correct HTTP status codes.
- The `bulkUpdatePartnerConfiguration` operation is scoped to only authorized organization IDs, preventing batch operations from affecting unauthorized tenants.

## Testing

Added regression test case to `UpdateVercelIntegration` suite that verifies cross-tenant write attempts are rejected with `UnauthorizedException` and that no side effects occur (no partner configuration updates, environment lookups, or Vercel API calls). Full partner-integrations unit suite (15 tests) passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->