### PR TITLE
fix(api-service): drop bridgeUrl from inbox /events DTO fixes NV-7579

### DIFF
--- a/apps/api/src/app/inbox/dtos/inbox-trigger-event-request.dto.ts
+++ b/apps/api/src/app/inbox/dtos/inbox-trigger-event-request.dto.ts
@@ -1,0 +1,48 @@
+import { ApiExtraModels, ApiProperty, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
+import { TriggerRecipientsPayload } from '@novu/shared';
+import { IsDefined, IsObject, IsOptional, IsString } from 'class-validator';
+import { SubscriberPayloadDto } from '../../events/dtos/trigger-event-request.dto';
+
+/**
+ * Request DTO for the inbox `/events` endpoint. Intentionally a minimal,
+ * inbox-only contract that does **not** expose `bridgeUrl`, `controls`,
+ * `overrides`, `actor`, `tenant`, `transactionId`, `context` or any other
+ * field that could be abused by a subscriber JWT to drive server-side bridge
+ * requests or escalate privileges. Compare with `TriggerEventRequestDto`,
+ * which is reserved for trusted (API-key authenticated) callers.
+ */
+@ApiExtraModels(SubscriberPayloadDto)
+export class InboxTriggerEventRequestDto {
+  @ApiProperty({
+    description:
+      'The trigger identifier of the workflow you wish to send. For inbox subscribers this must be the keyless demo workflow.',
+    example: 'hello-world',
+  })
+  @IsString()
+  @IsDefined()
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'Custom payload forwarded to the workflow.',
+    type: 'object',
+    additionalProperties: true,
+  })
+  @IsObject()
+  @IsOptional()
+  payload?: Record<string, unknown>;
+
+  @ApiProperty({
+    description:
+      'Recipient of the inbox event. Must resolve to the authenticated subscriber; topic and array recipients are rejected by the use case.',
+    oneOf: [
+      {
+        type: 'string',
+        description: 'Subscriber id of the authenticated inbox session.',
+        example: 'SUBSCRIBER_ID',
+      },
+      { $ref: getSchemaPath(SubscriberPayloadDto) },
+    ],
+  })
+  @IsDefined()
+  to: TriggerRecipientsPayload;
+}

--- a/apps/api/src/app/inbox/e2e/keyless-events.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/keyless-events.e2e.ts
@@ -186,15 +186,23 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
   });
 
   it('does not allow a subscriber-controlled bridgeUrl to drive an outbound bridge request', async () => {
+    const attackerHost = 'attacker.example.com';
     let bridgeRequestUrl: string | undefined;
     const originalFetch = global.fetch;
     // Wrap fetch so that any bridge request triggered by `bridgeUrl` would be
     // observable in this test. After the route fix, no fetch should ever land
     // on the attacker-controlled host.
     global.fetch = (async (input: any, init?: any) => {
-      const url = typeof input === 'string' ? input : input?.url;
-      if (typeof url === 'string' && url.includes('attacker.example.com')) {
-        bridgeRequestUrl = url;
+      const rawUrl = typeof input === 'string' ? input : input?.url;
+      if (typeof rawUrl === 'string') {
+        try {
+          const parsed = new URL(rawUrl);
+          if (parsed.hostname === attackerHost) {
+            bridgeRequestUrl = rawUrl;
+          }
+        } catch {
+          // ignore non-absolute URLs
+        }
       }
 
       return originalFetch(input as any, init);
@@ -205,7 +213,7 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
         name: KEYLESS_WORKFLOW_IDENTIFIER,
         to: { subscriberId: session.subscriberId },
         payload: { foo: 'bar' },
-        bridgeUrl: 'https://attacker.example.com/bridge',
+        bridgeUrl: `https://${attackerHost}/bridge`,
       });
 
       expect(status).to.equal(201);

--- a/apps/api/src/app/inbox/e2e/keyless-events.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/keyless-events.e2e.ts
@@ -185,6 +185,38 @@ describe('Keyless Inbox Events - /inbox/events (POST) #novu-v2', async () => {
     }
   });
 
+  it('does not allow a subscriber-controlled bridgeUrl to drive an outbound bridge request', async () => {
+    let bridgeRequestUrl: string | undefined;
+    const originalFetch = global.fetch;
+    // Wrap fetch so that any bridge request triggered by `bridgeUrl` would be
+    // observable in this test. After the route fix, no fetch should ever land
+    // on the attacker-controlled host.
+    global.fetch = (async (input: any, init?: any) => {
+      const url = typeof input === 'string' ? input : input?.url;
+      if (typeof url === 'string' && url.includes('attacker.example.com')) {
+        bridgeRequestUrl = url;
+      }
+
+      return originalFetch(input as any, init);
+    }) as typeof global.fetch;
+
+    try {
+      const { status } = await triggerInboxEvent({
+        name: KEYLESS_WORKFLOW_IDENTIFIER,
+        to: { subscriberId: session.subscriberId },
+        payload: { foo: 'bar' },
+        bridgeUrl: 'https://attacker.example.com/bridge',
+      });
+
+      expect(status).to.equal(201);
+      await session.waitForJobCompletion(helloWorldTemplate._id);
+
+      expect(bridgeRequestUrl, 'attacker bridgeUrl must not trigger an outbound request').to.be.undefined;
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
   it('rejects unauthenticated requests', async () => {
     const { status } = await session.testAgent.post('/v1/inbox/events').send({
       name: KEYLESS_WORKFLOW_IDENTIFIER,

--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -14,6 +14,7 @@ import {
   Req,
   UseGuards,
   UseInterceptors,
+  ValidationPipe,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiExcludeController } from '@nestjs/swagger';
@@ -32,7 +33,6 @@ import { GetChannelEndpointCommand } from '../channel-endpoints/usecases/get-cha
 import { GetChannelEndpoint } from '../channel-endpoints/usecases/get-channel-endpoint/get-channel-endpoint.usecase';
 import { ListChannelEndpointsCommand } from '../channel-endpoints/usecases/list-channel-endpoints/list-channel-endpoints.command';
 import { ListChannelEndpoints } from '../channel-endpoints/usecases/list-channel-endpoints/list-channel-endpoints.usecase';
-import { TriggerEventRequestDto } from '../events/dtos';
 import { TriggerEventResponseDto } from '../events/dtos/trigger-event-response.dto';
 import { GenerateChatOAuthUrlResponseDto } from '../integrations/dtos/generate-chat-oauth-url-response.dto';
 import { GenerateConnectOauthUrlRequestDto } from '../integrations/dtos/generate-connect-oauth-url-request.dto';
@@ -65,6 +65,7 @@ import {
 import { InboxListChannelEndpointsResponseDto } from './dtos/inbox-channel-endpoint-response.dto';
 import { mapChannelConnectionToInboxDto, mapChannelEndpointToInboxDto } from './dtos/inbox-dto.mapper';
 import { InboxNotificationDto } from './dtos/inbox-notification.dto';
+import { InboxTriggerEventRequestDto } from './dtos/inbox-trigger-event-request.dto';
 import { MarkNotificationsAsSeenRequestDto } from './dtos/mark-notifications-as-seen-request.dto';
 import { SnoozeNotificationRequestDto } from './dtos/snooze-notification-request.dto';
 import { SubscriberSessionRequestDto } from './dtos/subscriber-session-request.dto';
@@ -632,13 +633,21 @@ export class InboxController {
    * attempt to trigger a different workflow id, target another recipient, or
    * call from a non-keyless environment is rejected to prevent privilege
    * escalation. The actual validation lives in `TriggerKeylessEvent`.
+   *
+   * Uses `InboxTriggerEventRequestDto` (a minimal, inbox-only DTO) instead of
+   * the full `TriggerEventRequestDto` so subscriber-controlled fields such as
+   * `bridgeUrl`, `controls`, `overrides`, `actor`, `tenant`, `transactionId`
+   * and `context` cannot reach this route. The per-route `ValidationPipe` with
+   * `whitelist: true` actively strips any extra fields before the handler runs
+   * so a subscriber JWT can never drive signed outbound bridge requests.
    */
   @KeylessAccessible()
   @UseGuards(AuthGuard('subscriberJwt'))
   @Post('/events')
   async keylessEvents(
     @SubscriberSession() subscriberSession: SubscriberSession,
-    @Body() body: TriggerEventRequestDto,
+    @Body(new ValidationPipe({ transform: true, whitelist: true, forbidUnknownValues: false }))
+    body: InboxTriggerEventRequestDto,
     @Req() req: RequestWithReqId
   ): Promise<TriggerEventResponseDto> {
     return this.triggerKeylessEventUsecase.execute(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The inbox `POST /inbox/events` endpoint previously accepted `TriggerEventRequestDto` from a subscriber JWT. That DTO carries `bridgeUrl`, so a subscriber-level token could force the API to make signed outbound requests to attacker-chosen URLs — a subscriber → server-side request primitive.

This PR introduces a minimal, inbox-only `InboxTriggerEventRequestDto` that exposes **only** `name`, `payload` and `to`. The `/events` route now binds against this DTO with a per-route `ValidationPipe({ whitelist: true })`, so any subscriber-supplied extra fields — `bridgeUrl`, `controls`, `overrides`, `actor`, `tenant`, `transactionId`, `context`, … — are stripped before reaching the use case.

## Why

`TriggerKeylessEvent` already discards `bridgeUrl` today, but the typed DTO still advertised it as part of the inbox contract. By switching to a dedicated DTO + whitelist validation we make the boundary explicit, defense-in-depth: even if a future change started forwarding the body verbatim, `bridgeUrl` would already have been stripped.

## Changes

- New `apps/api/src/app/inbox/dtos/inbox-trigger-event-request.dto.ts` — minimal inbox-only request DTO (no `bridgeUrl`).
- `apps/api/src/app/inbox/inbox.controller.ts` — `keylessEvents` now binds to `InboxTriggerEventRequestDto` and uses `ValidationPipe({ whitelist: true })` to actively strip unknown fields. Removed unused `TriggerEventRequestDto` import.
- `apps/api/src/app/inbox/e2e/keyless-events.e2e.ts` — added a test that wraps `global.fetch` and asserts that a subscriber-supplied `bridgeUrl` never produces an outbound request to the attacker host.

## Testing

```
pnpm exec mocha --grep '#novu-v2' 'src/**/keyless-events.e2e{,-ee}.ts'
```

```
  Keyless Inbox Events - /inbox/events (POST) #novu-v2
    ✔ rejects requests for any workflow other than the keyless hello-world workflow
    ✔ rejects requests targeting another subscriber id
    ✔ rejects topic-based recipient payloads
    ✔ rejects array-based recipient payloads
    ✔ rejects string recipient that does not match the authenticated subscriber id
    ✔ rejects callers from a non-keyless environment even when the workflow id matches
    ✔ triggers the hello-world workflow when the recipient is the authenticated subscriber
    ✔ ignores user-supplied bridgeUrl, controls, overrides, actor, tenant and transactionId fields
    ✔ does not allow a subscriber-controlled bridgeUrl to drive an outbound bridge request
    ✔ rejects unauthenticated requests

  10 passing
```

Full inbox e2e suite (`src/app/inbox/**/*.e2e{,-ee}.ts`) — 176 passing.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7579](https://linear.app/novu/issue/NV-7579/bridgeurl-remove-from-inboxevents-subscriber-jwt-must-not-drive-server)

<div><a href="https://cursor.com/agents/bc-61ae0b7f-5ab0-415c-9ba1-0450d5f06cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61ae0b7f-5ab0-415c-9ba1-0450d5f06cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The inbox POST /inbox/events endpoint now rejects subscriber-supplied fields that could cause the API to make signed outbound requests to attacker-controlled URLs. A new minimal InboxTriggerEventRequestDto (only name, payload, and to) replaces the broader TriggerEventRequestDto for the keyless inbox route, and a per-route ValidationPipe with whitelist: true strips any extra subscriber-supplied fields (e.g., bridgeUrl, controls, overrides, actor, tenant, transactionId, context).

## Affected areas

**api**: The inbox controller now binds the keyless /inbox/events route to a new inbox-specific DTO and applies a per-route ValidationPipe({ transform: true, whitelist: true }), a new DTO file was added, and an e2e test was added to ensure subscriber-supplied bridgeUrl values do not trigger outbound requests.

## Key technical decisions

- Introduced a dedicated, minimal inbox-only DTO to make the security boundary explicit and avoid advertising fields subscribers must not control.
- Applied a per-route ValidationPipe with whitelist: true for defense-in-depth so unknown fields are stripped before use-case execution.

## Testing

Added an e2e test wrapping global.fetch to assert that a subscriber-supplied bridgeUrl pointing to an attacker host does not produce any outbound requests; inbox e2e tests pass (keyless tests: 10 passing; full inbox suite: 176 passing).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11046)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->