### PR TITLE
fix(api-service): validate bridgeUrl against SSRF helper in /bridge/sync and /bridge/validate fixes NV-7580

### DIFF
--- a/apps/api/src/.env.test
+++ b/apps/api/src/.env.test
@@ -164,3 +164,9 @@ CLICK_HOUSE_DATABASE=test_logs
 
 IS_WORKFLOW_RUN_LOGS_WRITE_ENABLED=true
 IS_WORKFLOW_RUN_TRACES_WRITE_ENABLED=true
+
+# E2E-only allowlist for the safe outbound HTTP layer. The TestBridgeServer
+# binds to 0.0.0.0; allowing it (and 127.0.0.1) here lets the SSRF-protected
+# bridge sync / validate paths reach the local fixture during tests. Outside
+# of test runs this variable is unset and the policy rejects every private IP.
+NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS=0.0.0.0,127.0.0.1,::1

--- a/apps/api/src/app/bridge/bridge.controller.ts
+++ b/apps/api/src/app/bridge/bridge.controller.ts
@@ -16,11 +16,13 @@ import {
 import { ApiExcludeController } from '@nestjs/swagger';
 import {
   AnalyticsService,
+  assertSafeOutboundUrl,
   ExternalApiAccessible,
   PreviewStep,
   PreviewStepCommand,
   RequirePermissions,
   SkipPermissionsCheck,
+  SsrfBlockedError,
   UserSession,
 } from '@novu/application-generic';
 import { ControlValuesRepository, EnvironmentRepository, NotificationTemplateRepository } from '@novu/dal';
@@ -220,6 +222,19 @@ export class BridgeController {
     @UserSession() user: UserSessionData,
     @Body() body: ValidateBridgeUrlRequestDto
   ): Promise<ValidateBridgeUrlResponseDto> {
+    // Reject SSRF candidates (loopback, link-local, cloud metadata, non-http
+    // schemes, embedded credentials) before issuing the outbound health-check.
+    // The endpoint is gated by BRIDGE_WRITE, but an authenticated operator can
+    // otherwise probe internal hosts via the API process.
+    try {
+      assertSafeOutboundUrl(body.bridgeUrl);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        return { isValid: false, error: err.message };
+      }
+      throw err;
+    }
+
     try {
       const result = await this.getBridgeStatus.execute(
         GetBridgeStatusCommand.create({

--- a/apps/api/src/app/bridge/bridge.controller.ts
+++ b/apps/api/src/app/bridge/bridge.controller.ts
@@ -240,6 +240,9 @@ export class BridgeController {
         GetBridgeStatusCommand.create({
           environmentId: user.environmentId,
           statelessBridgeUrl: body.bridgeUrl,
+          // User-supplied bridgeUrl: enforce DNS-pinned SSRF guard at connect
+          // time so IP-literal private addresses cannot reach internal hosts.
+          enforceSsrfProtection: true,
         })
       );
 

--- a/apps/api/src/app/bridge/dtos/create-bridge-request.dto.ts
+++ b/apps/api/src/app/bridge/dtos/create-bridge-request.dto.ts
@@ -1,10 +1,14 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsUrl } from 'class-validator';
 import { ICreateBridges, IWorkflowDefine } from '../usecases/sync';
 
 export class CreateBridgeRequestDto implements ICreateBridges {
   workflows: IWorkflowDefine[];
 
   @IsOptional()
-  @IsString()
+  @IsUrl({
+    require_protocol: true,
+    require_tld: false,
+    protocols: ['http', 'https'],
+  })
   bridgeUrl: string;
 }

--- a/apps/api/src/app/bridge/dtos/validate-bridge-url-request.dto.ts
+++ b/apps/api/src/app/bridge/dtos/validate-bridge-url-request.dto.ts
@@ -6,6 +6,7 @@ export class ValidateBridgeUrlRequestDto {
   @IsUrl({
     require_protocol: true,
     require_tld: false,
+    protocols: ['http', 'https'],
   })
   bridgeUrl: string;
 }

--- a/apps/api/src/app/bridge/e2e/sync.e2e.ts
+++ b/apps/api/src/app/bridge/e2e/sync.e2e.ts
@@ -785,13 +785,17 @@ describe('Bridge Sync - /bridge/sync (POST) #novu-v2', () => {
     // Locks in the connect-time DNS-pinned guard (enforceSsrfProtection:
     // true). IP-literal private addresses pass the synchronous URL check but
     // must be rejected before the TCP connect.
+    // Connect-time block returns a stable client-safe message — the
+    // resolved IP must NOT leak to the response (it's logged server-side
+    // instead).
     it('should reject bridgeUrl pointing at link-local cloud metadata IP', async () => {
       const result = await session.testAgent.post(`/v1/bridge/sync`).send({
         bridgeUrl: 'http://169.254.169.254/computeMetadata/v1/',
       });
 
       expect(result.status).to.equal(400);
-      expect(JSON.stringify(result.body)).to.match(/private or reserved IP/i);
+      expect(JSON.stringify(result.body)).to.match(/blocked by the outbound SSRF policy/i);
+      expect(JSON.stringify(result.body)).to.not.match(/169\.254\.169\.254/);
     });
 
     it('should reject bridgeUrl pointing at RFC1918 private IP', async () => {
@@ -800,7 +804,8 @@ describe('Bridge Sync - /bridge/sync (POST) #novu-v2', () => {
       });
 
       expect(result.status).to.equal(400);
-      expect(JSON.stringify(result.body)).to.match(/private or reserved IP/i);
+      expect(JSON.stringify(result.body)).to.match(/blocked by the outbound SSRF policy/i);
+      expect(JSON.stringify(result.body)).to.not.match(/10\.0\.0\.1/);
     });
   });
 
@@ -836,6 +841,19 @@ describe('Bridge Sync - /bridge/sync (POST) #novu-v2', () => {
       expect(result.status).to.equal(422);
     });
 
+    it('should report isValid false for embedded credentials', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/validate`).send({
+        bridgeUrl: 'http://attacker:pass@example.com/api/novu',
+      });
+
+      expect(result.status).to.equal(201);
+      expect(result.body.data.isValid).to.equal(false);
+      expect(result.body.data.error).to.match(/credentials/i);
+    });
+
+    // Connect-time block returns a stable client-safe message — the
+    // resolved IP must NOT leak to the response (it's logged server-side
+    // instead).
     it('should report isValid false for link-local cloud metadata IP', async () => {
       const result = await session.testAgent.post(`/v1/bridge/validate`).send({
         bridgeUrl: 'http://169.254.169.254/computeMetadata/v1/',
@@ -843,7 +861,8 @@ describe('Bridge Sync - /bridge/sync (POST) #novu-v2', () => {
 
       expect(result.status).to.equal(201);
       expect(result.body.data.isValid).to.equal(false);
-      expect(result.body.data.error).to.match(/private or reserved IP/i);
+      expect(result.body.data.error).to.match(/blocked by the outbound SSRF policy/i);
+      expect(result.body.data.error).to.not.match(/169\.254\.169\.254/);
     });
 
     it('should report isValid false for RFC1918 private IP', async () => {
@@ -853,7 +872,8 @@ describe('Bridge Sync - /bridge/sync (POST) #novu-v2', () => {
 
       expect(result.status).to.equal(201);
       expect(result.body.data.isValid).to.equal(false);
-      expect(result.body.data.error).to.match(/private or reserved IP/i);
+      expect(result.body.data.error).to.match(/blocked by the outbound SSRF policy/i);
+      expect(result.body.data.error).to.not.match(/10\.0\.0\.1/);
     });
   });
 

--- a/apps/api/src/app/bridge/e2e/sync.e2e.ts
+++ b/apps/api/src/app/bridge/e2e/sync.e2e.ts
@@ -11,7 +11,7 @@ import { expect } from 'chai';
 import getPort from 'get-port';
 import { TestBridgeServer } from '../../../../e2e/test-bridge-server';
 
-describe('Bridge Sync - /bridge/sync (POST) #novu-v2', async () => {
+describe('Bridge Sync - /bridge/sync (POST) #novu-v2', () => {
   let session: UserSession;
   const environmentRepository = new EnvironmentRepository();
   const workflowsRepository = new NotificationTemplateRepository();
@@ -781,9 +781,30 @@ describe('Bridge Sync - /bridge/sync (POST) #novu-v2', async () => {
       // before the use-case runs, so the request fails at the DTO layer (422).
       expect(result.status).to.equal(422);
     });
+
+    // Locks in the connect-time DNS-pinned guard (enforceSsrfProtection:
+    // true). IP-literal private addresses pass the synchronous URL check but
+    // must be rejected before the TCP connect.
+    it('should reject bridgeUrl pointing at link-local cloud metadata IP', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/sync`).send({
+        bridgeUrl: 'http://169.254.169.254/computeMetadata/v1/',
+      });
+
+      expect(result.status).to.equal(400);
+      expect(JSON.stringify(result.body)).to.match(/private or reserved IP/i);
+    });
+
+    it('should reject bridgeUrl pointing at RFC1918 private IP', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/sync`).send({
+        bridgeUrl: 'http://10.0.0.1/api/novu',
+      });
+
+      expect(result.status).to.equal(400);
+      expect(JSON.stringify(result.body)).to.match(/private or reserved IP/i);
+    });
   });
 
-  describe('/bridge/validate (POST)', async () => {
+  describe('/bridge/validate (POST)', () => {
     it('should report isValid false for localhost bridge URL', async () => {
       const result = await session.testAgent.post(`/v1/bridge/validate`).send({
         bridgeUrl: 'http://localhost:4000/api/novu',
@@ -813,6 +834,26 @@ describe('Bridge Sync - /bridge/sync (POST) #novu-v2', async () => {
       // schemes before the controller runs, so the request fails at the DTO
       // layer (422).
       expect(result.status).to.equal(422);
+    });
+
+    it('should report isValid false for link-local cloud metadata IP', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/validate`).send({
+        bridgeUrl: 'http://169.254.169.254/computeMetadata/v1/',
+      });
+
+      expect(result.status).to.equal(201);
+      expect(result.body.data.isValid).to.equal(false);
+      expect(result.body.data.error).to.match(/private or reserved IP/i);
+    });
+
+    it('should report isValid false for RFC1918 private IP', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/validate`).send({
+        bridgeUrl: 'http://10.0.0.1/api/novu',
+      });
+
+      expect(result.status).to.equal(201);
+      expect(result.body.data.isValid).to.equal(false);
+      expect(result.body.data.error).to.match(/private or reserved IP/i);
     });
   });
 

--- a/apps/api/src/app/bridge/e2e/sync.e2e.ts
+++ b/apps/api/src/app/bridge/e2e/sync.e2e.ts
@@ -777,7 +777,9 @@ describe('Bridge Sync - /bridge/sync (POST) #novu-v2', async () => {
         bridgeUrl: 'ftp://example.com/api/novu',
       });
 
-      expect(result.status).to.equal(400);
+      // CreateBridgeRequestDto's IsUrl validator rejects non-http schemes
+      // before the use-case runs, so the request fails at the DTO layer (422).
+      expect(result.status).to.equal(422);
     });
   });
 
@@ -807,7 +809,10 @@ describe('Bridge Sync - /bridge/sync (POST) #novu-v2', async () => {
         bridgeUrl: 'ftp://example.com/api/novu',
       });
 
-      expect(result.status).to.equal(400);
+      // ValidateBridgeUrlRequestDto's IsUrl validator rejects non-http
+      // schemes before the controller runs, so the request fails at the DTO
+      // layer (422).
+      expect(result.status).to.equal(422);
     });
   });
 

--- a/apps/api/src/app/bridge/e2e/sync.e2e.ts
+++ b/apps/api/src/app/bridge/e2e/sync.e2e.ts
@@ -741,6 +741,76 @@ describe('Bridge Sync - /bridge/sync (POST) #novu-v2', async () => {
     expect(workflows).to.deep.equal(dashboardWorkflow);
   });
 
+  describe('SSRF protection', () => {
+    // Locks in the SSRF guard — see Sync.assertSafeBridgeUrl. /bridge/sync is
+    // gated by BRIDGE_WRITE, but an authenticated operator must not be able to
+    // repoint the bridge at internal hosts (loopback name, cloud metadata) or
+    // sneak in non-http schemes / embedded credentials.
+    it('should reject bridgeUrl pointing at localhost', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/sync`).send({
+        bridgeUrl: 'http://localhost:4000/api/novu',
+      });
+
+      expect(result.status).to.equal(400);
+      expect(JSON.stringify(result.body)).to.match(/bridgeUrl/i);
+    });
+
+    it('should reject bridgeUrl pointing at cloud metadata hostname', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/sync`).send({
+        bridgeUrl: 'http://metadata.google.internal/computeMetadata/v1/',
+      });
+
+      expect(result.status).to.equal(400);
+      expect(JSON.stringify(result.body)).to.match(/bridgeUrl/i);
+    });
+
+    it('should reject bridgeUrl with embedded credentials', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/sync`).send({
+        bridgeUrl: 'http://attacker:pass@example.com/api/novu',
+      });
+
+      expect(result.status).to.equal(400);
+    });
+
+    it('should reject bridgeUrl with non-http scheme', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/sync`).send({
+        bridgeUrl: 'ftp://example.com/api/novu',
+      });
+
+      expect(result.status).to.equal(400);
+    });
+  });
+
+  describe('/bridge/validate (POST)', async () => {
+    it('should report isValid false for localhost bridge URL', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/validate`).send({
+        bridgeUrl: 'http://localhost:4000/api/novu',
+      });
+
+      expect(result.status).to.equal(201);
+      expect(result.body.data.isValid).to.equal(false);
+      expect(result.body.data.error).to.match(/localhost/i);
+    });
+
+    it('should report isValid false for cloud metadata hostname', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/validate`).send({
+        bridgeUrl: 'http://metadata.google.internal/computeMetadata/v1/',
+      });
+
+      expect(result.status).to.equal(201);
+      expect(result.body.data.isValid).to.equal(false);
+      expect(result.body.data.error).to.match(/metadata\.google\.internal/i);
+    });
+
+    it('should reject non-http scheme at the DTO layer', async () => {
+      const result = await session.testAgent.post(`/v1/bridge/validate`).send({
+        bridgeUrl: 'ftp://example.com/api/novu',
+      });
+
+      expect(result.status).to.equal(400);
+    });
+  });
+
   it('should allow syncing a workflow with same ID if original was created externally', async () => {
     const workflowId = 'external-created-workflow';
 

--- a/apps/api/src/app/bridge/usecases/get-bridge-status/get-bridge-status.command.ts
+++ b/apps/api/src/app/bridge/usecases/get-bridge-status/get-bridge-status.command.ts
@@ -2,4 +2,6 @@ import { EnvironmentLevelCommand } from '@novu/application-generic';
 
 export class GetBridgeStatusCommand extends EnvironmentLevelCommand {
   statelessBridgeUrl?: string;
+
+  enforceSsrfProtection?: boolean;
 }

--- a/apps/api/src/app/bridge/usecases/get-bridge-status/get-bridge-status.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/get-bridge-status/get-bridge-status.usecase.ts
@@ -16,6 +16,7 @@ export class GetBridgeStatus {
         workflowOrigin: ResourceOriginEnum.EXTERNAL,
         statelessBridgeUrl: command.statelessBridgeUrl,
         retriesLimit: 1,
+        enforceSsrfProtection: command.enforceSsrfProtection,
       })
     )) as ExecuteBridgeRequestDto<GetActionEnum.HEALTH_CHECK>;
   }

--- a/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
@@ -75,7 +75,17 @@ export class Sync {
   // (loopback, RFC1918, link-local 169.254.169.254, cloud metadata) and have
   // the API process leak the discovery response or the persisted URL to other
   // tenants.
-  private assertSafeBridgeUrl(bridgeUrl: string): void {
+  //
+  // The synchronous `assertSafeOutboundUrl` check rejects the obvious vectors
+  // (non-http schemes, embedded credentials, blocked hostnames). The
+  // connect-time DNS-pinned guard against IP-literal private addresses is
+  // applied later via `enforceSsrfProtection: true` on the actual outbound
+  // request — see `executeDiscover`.
+  private assertSafeBridgeUrl(bridgeUrl: string | undefined): void {
+    if (!bridgeUrl) {
+      throw new BadRequestException('bridgeUrl is required');
+    }
+
     try {
       assertSafeOutboundUrl(bridgeUrl);
     } catch (err) {
@@ -108,6 +118,10 @@ export class Sync {
         action: GetActionEnum.DISCOVER,
         retriesLimit: 1,
         workflowOrigin: ResourceOriginEnum.EXTERNAL,
+        // User-supplied bridgeUrl: pin the connection to a validated public
+        // IP and re-validate on every redirect, so IP literals like
+        // 127.0.0.1 / 169.254.169.254 / fc00::/7 cannot reach internal hosts.
+        enforceSsrfProtection: true,
       })) as DiscoverOutput;
     } catch (error) {
       if (error instanceof HttpException) {

--- a/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
+++ b/apps/api/src/app/bridge/usecases/sync/sync.usecase.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, HttpException, Injectable } from '@nestjs/common';
 import {
   AnalyticsService,
+  assertSafeOutboundUrl,
   BuildStepIssuesUsecase,
   CreateWorkflowCommandV0,
   CreateWorkflowV0,
@@ -9,6 +10,7 @@ import {
   JSONSchema,
   JSONSchemaDto,
   NotificationStep,
+  SsrfBlockedError,
   StepIssuesDto,
   UpdateWorkflowCommandV0,
   UpdateWorkflowV0,
@@ -54,6 +56,8 @@ export class Sync {
     private controlValuesRepository: ControlValuesRepository
   ) {}
   async execute(command: SyncCommand): Promise<CreateBridgeResponseDto> {
+    this.assertSafeBridgeUrl(command.bridgeUrl);
+
     const environment = await this.findEnvironment(command);
     const discover = await this.executeDiscover(command);
     this.sendAnalytics(command, environment, discover);
@@ -63,6 +67,23 @@ export class Sync {
     await this.updateBridgeUrl(command);
 
     return persistedWorkflowsInBridge;
+  }
+
+  // The sync use-case persists `bridgeUrl` on the environment and immediately
+  // performs a discovery request against it. Without an SSRF guard, an
+  // authenticated BRIDGE_WRITE caller can repoint the bridge at internal hosts
+  // (loopback, RFC1918, link-local 169.254.169.254, cloud metadata) and have
+  // the API process leak the discovery response or the persisted URL to other
+  // tenants.
+  private assertSafeBridgeUrl(bridgeUrl: string): void {
+    try {
+      assertSafeOutboundUrl(bridgeUrl);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new BadRequestException(`bridgeUrl: ${err.message}`);
+      }
+      throw err;
+    }
   }
 
   private sendAnalytics(command: SyncCommand, environment: EnvironmentEntity, discover: DiscoverOutput) {

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.command.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.command.ts
@@ -9,7 +9,7 @@ import {
   PostActionEnum,
 } from '@novu/framework/internal';
 import { ResourceOriginEnum } from '@novu/shared';
-import { IsDefined, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsDefined, IsOptional, IsString } from 'class-validator';
 import { EnvironmentLevelCommand } from '../../commands';
 
 export type BridgeError = {
@@ -48,6 +48,19 @@ export class ExecuteBridgeRequestCommand extends EnvironmentLevelCommand {
   @IsOptional()
   @IsString()
   stepResolverHash?: string;
+
+  /**
+   * Enforce SSRF protection on the outbound bridge HTTP call (DNS-pinned
+   * connect-time guard + redirect re-validation via `HttpClientService`).
+   *
+   * Use for endpoints that accept a user-controlled bridgeUrl (e.g.
+   * `/bridge/sync`, `/bridge/validate`) so attacker-controlled IP literals
+   * (loopback / RFC1918 / link-local / cloud metadata) cannot reach internal
+   * services. Leave undefined for trusted internal callers.
+   */
+  @IsOptional()
+  @IsBoolean()
+  enforceSsrfProtection?: boolean;
 }
 
 // will generate the output type based on the action

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-framework-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-framework-request.usecase.ts
@@ -117,6 +117,10 @@ export class ExecuteFrameworkRequest {
           limit: retriesLimit,
         },
         rejectUnauthorized: environment.name.toLowerCase() === 'production',
+        // Opt-in SSRF guard for user-supplied bridge URLs (sync / validate).
+        // The safe outbound layer pins the connection to a validated public
+        // IP and re-runs the policy on every redirect target.
+        enforceSsrfProtection: command.enforceSsrfProtection === true,
         onRetry: ({ statusCode, errorCode, delay }) => {
           if (statusCode) {
             this.logger.info(`Retryable status code ${statusCode} detected. Retrying in ${delay}ms`);
@@ -339,6 +343,18 @@ export class ExecuteFrameworkRequest {
               code: BRIDGE_EXECUTION_ERROR.RESPONSE_PARSE_ERROR.code,
               message: BRIDGE_EXECUTION_ERROR.RESPONSE_PARSE_ERROR.message(url),
               statusCode: HttpStatus.BAD_GATEWAY,
+            };
+            break;
+
+          case HttpClientErrorType.SSRF_BLOCKED:
+            // The safe outbound layer rejected the URL or its resolved
+            // address. Surface the underlying reason verbatim so the caller
+            // sees e.g. "Requests to private or reserved IP addresses are not
+            // allowed (resolved: 127.0.0.1)." instead of a generic message.
+            bridgeErrorData = {
+              code: error.networkCode || 'SSRF_BLOCKED',
+              message: error.message,
+              statusCode: HttpStatus.BAD_REQUEST,
             };
             break;
 

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-framework-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-framework-request.usecase.ts
@@ -347,13 +347,14 @@ export class ExecuteFrameworkRequest {
             break;
 
           case HttpClientErrorType.SSRF_BLOCKED:
-            // The safe outbound layer rejected the URL or its resolved
-            // address. Surface the underlying reason verbatim so the caller
-            // sees e.g. "Requests to private or reserved IP addresses are not
-            // allowed (resolved: 127.0.0.1)." instead of a generic message.
+            // Log the full reason (including resolved IPs / redirect targets)
+            // server-side. Return a stable, client-safe message so the
+            // endpoint can't be used as an authenticated network-recon probe
+            // — see CodeRabbit review on PR #11047.
+            this.logger.warn({ err: error }, `Blocked outbound bridge request to \`${url}\``);
             bridgeErrorData = {
               code: error.networkCode || 'SSRF_BLOCKED',
-              message: error.message,
+              message: 'The provided bridge URL is blocked by the outbound SSRF policy.',
               statusCode: HttpStatus.BAD_REQUEST,
             };
             break;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`POST /bridge/sync` and `POST /bridge/validate` previously accepted any string-shaped `bridgeUrl` and used it for outbound discovery / health-check requests with no SSRF protection or origin allowlist. Both endpoints are gated by `BRIDGE_WRITE`, but an authenticated operator could still repoint the bridge at internal hosts (loopback, RFC1918, link-local cloud metadata IPs) or sneak in non-http schemes / embedded credentials.

This PR adds three layers of defense, all built on existing SSRF helpers (`assertSafeOutboundUrl`, `safeOutboundJsonRequest` via `HttpClientService`'s `enforceSsrfProtection`):

- **DTO layer (422)** — `apps/api/src/app/bridge/dtos/{create-bridge-request,validate-bridge-url-request}.dto.ts` now enforce `IsUrl({ require_protocol: true, protocols: ['http', 'https'] })`, so non-http schemes are rejected before the controller runs.
- **Synchronous URL guard (400)** — `Sync.assertSafeBridgeUrl` and `validateBridgeUrl` run `assertSafeOutboundUrl` before any I/O. Catches blocked hostnames (`localhost`, `metadata.google.internal`), embedded credentials, and unsupported schemes; converts `SsrfBlockedError` into `BadRequestException` (sync) / `{ isValid: false, error }` (validate). The sync guard also rejects an absent `bridgeUrl` with a clear message, so undefined input never reaches the helper.
- **Connect-time DNS-pinned guard (400)** — `ExecuteBridgeRequestCommand` now exposes an `enforceSsrfProtection` flag that propagates through `ExecuteFrameworkRequest` to `HttpClientService.request({ enforceSsrfProtection: true })`. Both `/bridge/sync` and `/bridge/validate` opt in. The safe outbound layer pins the connection to a validated public IP and re-validates every redirect target, so IP-literal private addresses (`http://127.0.0.1`, `http://169.254.169.254`, `http://10.0.0.1`, `fc00::/7`) cannot reach internal services. `executeFrameworkRequest.handleResponseError` has a dedicated `SSRF_BLOCKED` case that **logs the underlying reason server-side** and returns a **stable client-safe message** (`"The provided bridge URL is blocked by the outbound SSRF policy."`). The resolved IP / redirect target is never echoed back to the caller, so the endpoint can't be used as an authenticated network-recon probe.

The `BRIDGE_WRITE` permission gate is preserved on both endpoints. No new helpers were introduced — everything builds on `assertSafeOutboundUrl` / `safeOutboundJsonRequest` / `HttpClientService.enforceSsrfProtection`, which are already used by the agents update use-case, the workflow `test-http-endpoint` use-case, and the worker `execute-http-request-step` use-case.

## Why

Linear: NV-7580. Same SSRF-safe URL helper now protects the bridge sync/validate routes. The connect-time DNS-pinned guard closes the IP-literal gap that was called out in the security review on the previous revision; the response-message sanitization closes the network-recon gap raised by CodeRabbit.

## Threat coverage

| Attack vector | Where it's blocked | Response surface |
|---|---|---|
| `ftp://example.com/...`, `file:///etc/passwd` | DTO `IsUrl({ protocols: ['http','https'] })` | 422 (validation error) |
| `http://localhost:4000/...` | `assertSafeOutboundUrl` (preflight) | 400 (sync) / `{ isValid: false, error: 'Requests to "localhost" are not allowed.' }` (validate) |
| `http://metadata.google.internal/...` | same | same |
| `http://attacker:pass@example.com/...` | same | same |
| `http://127.0.0.1:9100/admin` | `enforceSsrfProtection` connect-time DNS guard | 400 / `{ isValid: false }` with sanitized `"blocked by the outbound SSRF policy"` — resolved IP only in server logs |
| `http://169.254.169.254/computeMetadata/v1/` | same (link-local cloud metadata) | same |
| `http://10.0.0.1/api/novu` | same (RFC1918) | same |
| `http://[::1]/`, `http://[fc00::1]/` | same (IPv6 loopback / ULA) | same |

## Test allowlist

Plumbing the connect-time guard would have broken existing e2e fixtures that bind `TestBridgeServer` to `http://0.0.0.0:<port>`, since `0.0.0.0` is in the private-IP set. Rather than weakening the policy in production, `apps/api/src/.env.test` now sets `NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS=0.0.0.0,127.0.0.1,::1`. This variable is already honoured by `safeOutboundRequest`'s `resolveWithTestAllowList` and is unset outside test runs, so the policy stays strict in dev/staging/prod.

## Tests

12 new e2e cases in `apps/api/src/app/bridge/e2e/sync.e2e.ts` covering both routes:

- DTO/syntax: `localhost`, `metadata.google.internal`, embedded credentials, ftp scheme.
- Connect-time DNS-pinned guard: link-local cloud metadata IP, RFC1918 IP — assertions verify the response carries the sanitized message **and** does NOT include the resolved IP in plain text.

Local run with the allowlist in place — full sync.e2e.ts (27/27) and health-check.e2e.ts (4/4) pass, including the existing `TestBridgeServer`-backed tests on `http://0.0.0.0:<port>`.

```text
Bridge Sync - /bridge/sync (POST) #novu-v2
  ...
  SSRF protection
    ✔ should reject bridgeUrl pointing at localhost
    ✔ should reject bridgeUrl pointing at cloud metadata hostname
    ✔ should reject bridgeUrl with embedded credentials
    ✔ should reject bridgeUrl with non-http scheme
    ✔ should reject bridgeUrl pointing at link-local cloud metadata IP
    ✔ should reject bridgeUrl pointing at RFC1918 private IP
  /bridge/validate (POST)
    ✔ should report isValid false for localhost bridge URL
    ✔ should report isValid false for cloud metadata hostname
    ✔ should reject non-http scheme at the DTO layer
    ✔ should report isValid false for embedded credentials
    ✔ should report isValid false for link-local cloud metadata IP
    ✔ should report isValid false for RFC1918 private IP

27 passing (7s)
```

## Review notes

- `enforceSsrfProtection` is opt-in via the new command flag — other callers of `ExecuteBridgeRequest` (worker `execute-bridge-job`, events `parse-event-request`) keep their current behaviour. Wiring those paths up is the right follow-up under NV-7562.
- The safe outbound path bypasses got's retry/onRetry; `HttpClientService` already logs a warning when both are set together. `/bridge/sync` and `/bridge/validate` use `retriesLimit: 1`, so retries-via-got are not load-bearing here.
- Synchronous-preflight messages (e.g. `Requests to "localhost" are not allowed.`) intentionally still echo the user-supplied hostname back — that hostname came from the caller and reveals nothing they didn't already know. Only the DNS-resolved IP from the connect-time guard is sanitized.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7580](https://linear.app/novu/issue/NV-7580/bridgeurl-validate-bridgesync-and-bridgevalidate-inputs)

<div><a href="https://cursor.com/agents/bc-3b062b25-a593-4d2e-bec7-828f61fb0843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b062b25-a593-4d2e-bec7-828f61fb0843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added SSRF protections and stricter URL validation to bridge endpoints so user-supplied bridgeUrl is validated and blocked before any outbound I/O. DTOs now reject non-http(s) schemes; sync and validate flows run an upfront SSRF guard that converts SSRF blocks into existing API responses (400 for sync, {isValid:false, error} for validate). Connect-time protection was made opt-in via an enforceSsrfProtection flag which pins connections to vetted public IPs and re-validates redirects. Error messages are logged in full server-side but return a stable client-safe message.

## Affected areas

**api**: Bridge controller, sync usecase and validate endpoint now call SSRF guards (assertSafeBridgeUrl/assertSafeOutboundUrl) upfront; SsrfBlockedError is translated to BadRequest for synchronous sync flows and to { isValid:false, error } for validate; DTOs (CreateBridgeRequestDto, ValidateBridgeUrlRequestDto) enforce http/https URLs.

**libs/application-generic**: ExecuteBridgeRequestCommand and ExecuteFrameworkRequest usecase gained an optional enforceSsrfProtection boolean which opts-in connect-time SSRF protections (IP pinning, redirect re-validation); framework executor maps HttpClient SS RF_BLOCKED errors into unified BridgeRequestError/400 while preserving original error as the cause.

**apps/api tests & env**: Added e2e coverage for many SSRF cases and DTO rejections (11 new e2e cases) and introduced NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS in test env to allow specific local IPs during tests.

## Key technical decisions

- Defense-in-depth: combine DTO-level scheme validation (422) with runtime SSRF guards (400) to stop unsafe URLs early.  
- Opt-in connect-time protection: enforceSsrfProtection prevents breaking other callers while allowing user-controlled URL flows to opt in.  
- Error handling: server logs full SSRF reasons but returns sanitized, stable client messages to avoid leaking internal network info.

## Testing

Added comprehensive e2e tests (covers DTO rejections and connect-time guard scenarios); local test runs pass with the test allowlist configured.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11047)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->