### PR TITLE
fix(dashboard): update build memory limit in package.json from 8192 to 6144

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -3,14 +3,16 @@
   "private": true,
   "version": "3.15.4",
   "type": "module",
-  "portless": { "name": "dashboard.novu" },
+  "portless": {
+    "name": "dashboard.novu"
+  },
   "scripts": {
     "start": "vite",
     "start:portless": "node ../../scripts/with-portless-env.mjs pnpm exec portless run vite",
     "start:test": "vite --mode test",
     "start:static:build": "http-server dist -p 4201 --proxy http://127.0.0.1:4201?",
     "dev": "pnpm start",
-    "build": "NODE_OPTIONS='--max-old-space-size=8192' tsc -b && NODE_OPTIONS='--max-old-space-size=8192' vite build",
+    "build": "NODE_OPTIONS='--max-old-space-size=6144' tsc -b && NODE_OPTIONS='--max-old-space-size=6144' vite build",
     "docker:build": "docker buildx build --load -f ./dockerfile -t novu-dashboard ./../.. $DOCKER_BUILD_ARGUMENTS",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",


### PR DESCRIPTION
…

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The build memory limit for the dashboard application was reduced from 8192 MB to 6144 MB in the Node.js options used during the build process. This change applies to both the TypeScript compilation (`tsc -b`) and Vite build steps in the `build` script, reducing the maximum heap size available during compilation to optimize resource usage.

## Affected areas

**dashboard** — The `build` script's `NODE_OPTIONS` configuration was updated to use a lower `--max-old-space-size` value (6144 instead of 8192 MB) for both TypeScript and Vite build steps.

## Testing

No new tests are required for this change, as it is a configuration adjustment to build tooling rather than a functional code modification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11051)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
