### PR TITLE
feat(dashboard): add BETA badge to Agents sidebar nav

### DIFF
--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
 import * as dns from 'node:dns';
 import * as http from 'node:http';
 import * as https from 'node:https';
@@ -134,8 +133,6 @@ type PinnedFileResponse = {
 
 @Injectable()
 export class ChatSdkService implements OnModuleDestroy {
-  /** Dedupes ON_MESSAGE dispatch when the chat SDK fires both mention and subscribed handlers for one webhook. */
-  private readonly webhookMessageDedupStore = new AsyncLocalStorage<Set<string>>();
   private readonly instances: LRUCache<string, CachedChat>;
   private readonly pendingCreations = new Map<string, Promise<Chat>>();
 
@@ -170,12 +167,9 @@ export class ChatSdkService implements OnModuleDestroy {
     }
 
     const webRequest = toWebRequest(req);
+    const webResponse = await handler(webRequest);
 
-    await this.webhookMessageDedupStore.run(new Set<string>(), async () => {
-      const webResponse = await handler(webRequest);
-
-      await sendWebResponse(webResponse, res);
-    });
+    await sendWebResponse(webResponse, res);
   }
 
   async onModuleDestroy() {
@@ -1047,36 +1041,11 @@ export class ChatSdkService implements OnModuleDestroy {
     }
   }
 
-  private async dispatchWebhookInboundMessage(
-    agentId: string,
-    cached: CachedChat,
-    thread: Thread,
-    message: Message
-  ): Promise<void> {
-    const dedup = this.webhookMessageDedupStore.getStore();
-    const messageId = message.id;
-
-    if (!messageId) {
-      await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
-
-      return;
-    }
-
-    const key = `${thread.id}:${messageId}`;
-
-    if (dedup?.has(key)) {
-      return;
-    }
-
-    dedup?.add(key);
-    await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
-  }
-
   private registerEventHandlers(agentId: string, cached: CachedChat) {
     cached.chat.onNewMention(async (thread: Thread, message: Message) => {
       try {
         await thread.subscribe();
-        await this.dispatchWebhookInboundMessage(agentId, cached, thread, message);
+        await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling new mention`);
       }
@@ -1084,7 +1053,7 @@ export class ChatSdkService implements OnModuleDestroy {
 
     cached.chat.onSubscribedMessage(async (thread: Thread, message: Message) => {
       try {
-        await this.dispatchWebhookInboundMessage(agentId, cached, thread, message);
+        await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling subscribed message`);
       }

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import * as dns from 'node:dns';
 import * as http from 'node:http';
 import * as https from 'node:https';
@@ -133,6 +134,8 @@ type PinnedFileResponse = {
 
 @Injectable()
 export class ChatSdkService implements OnModuleDestroy {
+  /** Dedupes ON_MESSAGE dispatch when the chat SDK fires both mention and subscribed handlers for one webhook. */
+  private readonly webhookMessageDedupStore = new AsyncLocalStorage<Set<string>>();
   private readonly instances: LRUCache<string, CachedChat>;
   private readonly pendingCreations = new Map<string, Promise<Chat>>();
 
@@ -167,8 +170,12 @@ export class ChatSdkService implements OnModuleDestroy {
     }
 
     const webRequest = toWebRequest(req);
-    const webResponse = await handler(webRequest);
-    await sendWebResponse(webResponse, res);
+
+    await this.webhookMessageDedupStore.run(new Set<string>(), async () => {
+      const webResponse = await handler(webRequest);
+
+      await sendWebResponse(webResponse, res);
+    });
   }
 
   async onModuleDestroy() {
@@ -1040,11 +1047,36 @@ export class ChatSdkService implements OnModuleDestroy {
     }
   }
 
+  private async dispatchWebhookInboundMessage(
+    agentId: string,
+    cached: CachedChat,
+    thread: Thread,
+    message: Message
+  ): Promise<void> {
+    const dedup = this.webhookMessageDedupStore.getStore();
+    const messageId = message.id;
+
+    if (!messageId) {
+      await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
+
+      return;
+    }
+
+    const key = `${thread.id}:${messageId}`;
+
+    if (dedup?.has(key)) {
+      return;
+    }
+
+    dedup?.add(key);
+    await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
+  }
+
   private registerEventHandlers(agentId: string, cached: CachedChat) {
     cached.chat.onNewMention(async (thread: Thread, message: Message) => {
       try {
         await thread.subscribe();
-        await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
+        await this.dispatchWebhookInboundMessage(agentId, cached, thread, message);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling new mention`);
       }
@@ -1052,7 +1084,7 @@ export class ChatSdkService implements OnModuleDestroy {
 
     cached.chat.onSubscribedMessage(async (thread: Thread, message: Message) => {
       try {
-        await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
+        await this.dispatchWebhookInboundMessage(agentId, cached, thread, message);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling subscribed message`);
       }

--- a/apps/dashboard/src/components/side-navigation/side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/side-navigation.tsx
@@ -142,7 +142,12 @@ export const SideNavigation = () => {
                 }
               >
                 <RiRobot2Line className="size-4" />
-                <span>Agents</span>
+                <span>
+                  Agents{' '}
+                  <Badge variant="lighter" className="text-xs">
+                    BETA
+                  </Badge>
+                </span>
               </NavigationLink>
             </NavigationGroup>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **BETA** label next to **Agents** in the left sidebar (`Badge` + `variant="lighter"`), matching the existing **Contexts** nav item.

## Why

Surfaces that Agents is still in beta directly in primary navigation.

## Testing

- [ ] Open the dashboard and confirm **Agents** shows a BETA badge in the sidebar (next to Workflows / above Content).

Linear: link NOV ticket when available (`fixes NOV-XXX` in title if required by repo checks).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c16737d-b517-4d5b-b370-1381a8a602f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c16737d-b517-4d5b-b370-1381a8a602f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR adds a visible BETA label to the Agents item in the dashboard's primary sidebar navigation so users can see Agents is still in beta. An unrelated chat-sdk webhook deduplication change previously present in this branch was reverted and is not part of this PR.

## Affected areas

**dashboard**: Updated the left-side navigation to render a `Badge` (with `variant="lighter"`) next to the Agents nav item so "Agents" displays a "BETA" label in the primary nav.

**api**: No functional changes remain — an out-of-scope chat-sdk webhook dedup change that appeared in the branch was reverted per review feedback, so the API behavior is unchanged by this PR.

## Testing

- Manual verification for the dashboard: open the app and confirm the Agents nav item shows the BETA badge (positioned next to Workflows/above Content). No automated tests were added.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11055)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->