### PR TITLE
feat(dashboard): use org name in agent creation modal placeholders (fixes NV-7622)

### DIFF
--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -1,6 +1,6 @@
 import { SLUG_IDENTIFIER_REGEX, slugIdentifierFormatMessage, slugify } from '@novu/shared';
 import type { FormEvent, ReactNode } from 'react';
-import { useId, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 import { RiArrowRightSLine, RiCloseLine, RiExternalLinkLine, RiInformationFill } from 'react-icons/ri';
 import type { CreateAgentBody } from '@/api/agents';
 import { Button } from '@/components/primitives/button';
@@ -9,8 +9,18 @@ import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } fr
 import { Hint, HintIcon } from '@/components/primitives/hint';
 import { Input } from '@/components/primitives/input';
 import { Textarea } from '@/components/primitives/textarea';
+import { useAuth } from '@/context/auth/hooks';
 
 const DOCS_AGENTS_LEARN_MORE_HREF = 'https://docs.novu.co';
+const DEFAULT_AGENT_NAME_PLACEHOLDER_ORG = 'Acme';
+
+function capitalizeOrgName(name: string) {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
 
 type CreateAgentDialogProps = {
   open: boolean;
@@ -40,6 +50,19 @@ export function CreateAgentDialog({ open, onOpenChange, onSubmit, isSubmitting }
   const nameId = `${formId}-name`;
   const identifierId = `${formId}-identifier`;
   const descriptionId = `${formId}-description`;
+
+  const { currentOrganization } = useAuth();
+
+  const { namePlaceholder, identifierPlaceholder } = useMemo(() => {
+    const trimmedOrgName = currentOrganization?.name?.trim() ?? '';
+    const displayOrgName = trimmedOrgName ? capitalizeOrgName(trimmedOrgName) : DEFAULT_AGENT_NAME_PLACEHOLDER_ORG;
+    const slugOrgName = slugify(displayOrgName) || slugify(DEFAULT_AGENT_NAME_PLACEHOLDER_ORG);
+
+    return {
+      namePlaceholder: `e.g. ${displayOrgName} Copilot`,
+      identifierPlaceholder: `e.g. ${slugOrgName}-copilot`,
+    };
+  }, [currentOrganization?.name]);
 
   const [name, setName] = useState('');
   const [identifier, setIdentifier] = useState('');
@@ -156,7 +179,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSubmit, isSubmitting }
                       setErrors((prev) => ({ ...prev, identifier: undefined }));
                     }
                   }}
-                  placeholder="e.g. Wine Sommelier Agent"
+                  placeholder={namePlaceholder}
                   hasError={Boolean(errors.name)}
                   aria-invalid={errors.name ? true : undefined}
                   aria-describedby={errors.name ? `${nameId}-error` : undefined}
@@ -180,7 +203,7 @@ export function CreateAgentDialog({ open, onOpenChange, onSubmit, isSubmitting }
                     setIsIdentifierTouched(true);
                     setErrors((prev) => ({ ...prev, identifier: undefined }));
                   }}
-                  placeholder="e.g. wine-sommelier-agent"
+                  placeholder={identifierPlaceholder}
                   hasError={Boolean(errors.identifier)}
                   aria-invalid={errors.identifier ? true : undefined}
                   aria-describedby={


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & Why

The *Add agent* modal in the dashboard used `e.g. Wine Sommelier Agent` as the placeholder for the Agent name field — a very specific use-case example that doesn't represent how most customers think about agents.

This PR replaces the static example with a dynamic one based on the user's current organization:

- **Agent name** placeholder → `e.g. {OrgName} Copilot` (org name capitalized word-by-word)
- **Identifier** placeholder → `e.g. {org-name}-copilot` (slugified)
- When the organization isn't loaded yet, both fall back to a neutral default (`Acme Copilot` / `acme-copilot`).

## Changes

- `apps/dashboard/src/components/agents/create-agent-dialog.tsx`
  - Pulls `currentOrganization` from `useAuth()`.
  - Computes both placeholders inside a `useMemo`, capitalizing each word of the org name and slugifying it for the identifier.
  - Replaces the two hard-coded placeholders with the computed values.

## Testing

- `pnpm exec tsc -b` (full dashboard typecheck) passes.
- `pnpm exec biome check src/components/agents/create-agent-dialog.tsx` passes.
- Manual verification in the running dashboard: signed in as the seeded `Agent Organization` user, opened the Agents page, clicked **Create agent**, and confirmed the placeholders render as `e.g. Agent Organization Copilot` and `e.g. agent-organization-copilot`.

![Add agent modal with dynamic org-name placeholders](https://cursor.com/artifacts/c/art-bc3ee805-539b-4c59-a97c-2e9615e830e5)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1778168888273509?thread_ts=1778168888.273509&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-d743c8fd-c969-5721-9bdc-7a10b02afdd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d743c8fd-c969-5721-9bdc-7a10b02afdd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The "Add agent" modal dialog now derives example placeholders from the current organization name instead of using hardcoded defaults. The agent name placeholder displays "e.g. {OrgName} Copilot" (with word-by-word capitalization), and the identifier placeholder shows "e.g. {org-name}-copilot" (using slugified form). When the organization isn't loaded, both fall back to "Acme Copilot" and "acme-copilot" respectively.

## Affected areas

**dashboard**: Modified the `CreateAgentDialog` component to compute dynamic placeholders from the authenticated user's organization using `useAuth()` and a useMemo hook. The placeholders are generated by capitalizing the organization name for display and slugifying it for the identifier field.

## Testing

Typecheck (`pnpm exec tsc -b`) and linting (`pnpm exec biome check`) pass successfully. Manual verification confirmed the placeholders render correctly when signed in as the seeded "Agent Organization" user.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11065)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->