### PR TITLE
feat(api)!: enhance validation for trigger event payloads and subscribers fixes NV-7623

### DIFF
--- a/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
+++ b/apps/api/src/app/events/dtos/trigger-event-request.dto.ts
@@ -12,8 +12,10 @@ import {
 import { Type } from 'class-transformer';
 import {
   ArrayMaxSize,
+  ArrayNotEmpty,
   IsArray,
   IsDefined,
+  IsNotEmpty,
   IsObject,
   IsOptional,
   IsString,
@@ -23,6 +25,7 @@ import {
 import { SdkApiProperty } from '../../shared/framework/swagger/sdk.decorators';
 import { CreateSubscriberRequestDto } from '../../subscribers/dtos';
 import { UpdateTenantRequestDto } from '../../tenant/dtos';
+import { IsTriggerRecipientsPayload } from '../validators/is-trigger-recipients-payload.validator';
 
 export class WorkflowToStepControlValuesDto {
   /**
@@ -48,7 +51,9 @@ export class SubscriberPayloadDto extends CreateSubscriberRequestDto {}
 export class TenantPayloadDto extends UpdateTenantRequestDto {}
 
 export class TopicPayloadDto {
-  @ApiProperty()
+  @ApiProperty({ minLength: 1 })
+  @IsString()
+  @IsNotEmpty({ message: 'topicKey is required' })
   topicKey: string;
 
   @ApiProperty({
@@ -284,6 +289,7 @@ export class TriggerEventRequestDto {
             },
             {
               type: 'string',
+              minLength: 1,
               description: 'Unique identifier of a subscriber in your systems',
               example: 'SUBSCRIBER_ID',
             },
@@ -292,6 +298,7 @@ export class TriggerEventRequestDto {
       },
       {
         type: 'string',
+        minLength: 1,
         description: 'Unique identifier of a subscriber in your systems',
         example: 'SUBSCRIBER_ID',
       },
@@ -304,6 +311,7 @@ export class TriggerEventRequestDto {
     ],
   })
   @IsDefined()
+  @IsTriggerRecipientsPayload()
   to: TriggerRecipientsPayload;
 
   @ApiPropertyOptional({
@@ -358,5 +366,9 @@ export class BulkTriggerEventDto {
     isArray: true,
     type: TriggerEventRequestDto,
   })
+  @IsArray()
+  @ArrayNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => TriggerEventRequestDto)
   events: TriggerEventRequestDto[];
 }

--- a/apps/api/src/app/events/e2e/bulk-trigger.e2e.ts
+++ b/apps/api/src/app/events/e2e/bulk-trigger.e2e.ts
@@ -248,7 +248,7 @@ describe('Trigger bulk events - /v1/events/trigger/bulk (POST) #novu-v2', () => 
             name: '',
           },
           workflowId: '',
-          to: [],
+          to: [subscriber.subscriberId],
         },
       ],
     });

--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -1950,6 +1950,99 @@ describe('Trigger event - /v1/events/trigger (POST) #novu-v2', () => {
       expect(body.error).to.equal('Unprocessable Entity');
     });
 
+    it('should reject trigger when to is an object with empty subscriberId', async () => {
+      const response = await session.testAgent
+        .post('/v1/events/trigger')
+        .send({
+          name: template.triggers[0].identifier,
+          to: { subscriberId: '' },
+          payload: {},
+        })
+        .expect(422);
+
+      expect(response.body.statusCode).to.equal(422);
+      expect(response.body.message).to.equal('Validation Error');
+    });
+
+    it('should reject trigger when to is an array containing an empty subscriberId', async () => {
+      const response = await session.testAgent
+        .post('/v1/events/trigger')
+        .send({
+          name: template.triggers[0].identifier,
+          to: [{ subscriberId: subscriber.subscriberId }, { subscriberId: '' }],
+          payload: {},
+        })
+        .expect(422);
+
+      expect(response.body.statusCode).to.equal(422);
+      expect(response.body.message).to.equal('Validation Error');
+    });
+
+    it('should reject trigger when to is an empty string', async () => {
+      const response = await session.testAgent
+        .post('/v1/events/trigger')
+        .send({
+          name: template.triggers[0].identifier,
+          to: '',
+          payload: {},
+        })
+        .expect(422);
+
+      expect(response.body.statusCode).to.equal(422);
+      expect(response.body.message).to.equal('Validation Error');
+    });
+
+    it('should reject trigger when to array contains an empty string', async () => {
+      const response = await session.testAgent
+        .post('/v1/events/trigger')
+        .send({
+          name: template.triggers[0].identifier,
+          to: [subscriber.subscriberId, ''],
+          payload: {},
+        })
+        .expect(422);
+
+      expect(response.body.statusCode).to.equal(422);
+      expect(response.body.message).to.equal('Validation Error');
+    });
+
+    it('should reject trigger when to is an empty array', async () => {
+      const response = await session.testAgent
+        .post('/v1/events/trigger')
+        .send({
+          name: template.triggers[0].identifier,
+          to: [],
+          payload: {},
+        })
+        .expect(422);
+
+      expect(response.body.statusCode).to.equal(422);
+      expect(response.body.message).to.equal('Validation Error');
+    });
+
+    it('should reject bulk trigger when any event has an empty subscriberId', async () => {
+      const response = await session.testAgent
+        .post('/v1/events/trigger/bulk')
+        .send({
+          events: [
+            {
+              name: template.triggers[0].identifier,
+              to: [subscriber.subscriberId],
+              payload: {},
+            },
+            {
+              name: template.triggers[0].identifier,
+              to: [{ subscriberId: '' }],
+              payload: {},
+            },
+          ],
+        })
+        .expect(422);
+
+      expect(response.body.statusCode).to.equal(422);
+      expect(response.body.message).to.equal('Validation Error');
+    });
+
     it('should trigger with given required variables', async () => {
       template = await session.createTemplate({
         steps: [

--- a/apps/api/src/app/events/validators/is-trigger-recipients-payload.validator.ts
+++ b/apps/api/src/app/events/validators/is-trigger-recipients-payload.validator.ts
@@ -1,0 +1,80 @@
+import { TriggerRecipientsTypeEnum } from '@novu/shared';
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+/**
+ * Validates a single recipient in the `to` payload of a trigger.
+ *
+ * A recipient is valid when it is one of:
+ * - a non-empty string (subscriberId)
+ * - an object with a non-empty `subscriberId` string
+ * - a topic object with a non-empty `topicKey` string
+ *
+ * Empty strings are explicitly rejected to prevent triggers that target
+ * unidentifiable subscribers (which previously silently fell through downstream
+ * filtering and never reached anyone).
+ */
+function isValidSingleRecipient(recipient: unknown): boolean {
+  if (typeof recipient === 'string') {
+    return recipient.length > 0;
+  }
+
+  if (!recipient || typeof recipient !== 'object' || Array.isArray(recipient)) {
+    return false;
+  }
+
+  const obj = recipient as Record<string, unknown>;
+
+  if (obj.type === TriggerRecipientsTypeEnum.TOPIC) {
+    return typeof obj.topicKey === 'string' && obj.topicKey.length > 0;
+  }
+
+  if ('subscriberId' in obj) {
+    return typeof obj.subscriberId === 'string' && obj.subscriberId.length > 0;
+  }
+
+  if ('topicKey' in obj) {
+    return typeof obj.topicKey === 'string' && obj.topicKey.length > 0;
+  }
+
+  return false;
+}
+
+@ValidatorConstraint({ name: 'isTriggerRecipientsPayload', async: false })
+export class IsTriggerRecipientsPayloadConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (value === undefined || value === null) {
+      return false;
+    }
+
+    if (Array.isArray(value)) {
+      return value.length > 0 && value.every(isValidSingleRecipient);
+    }
+
+    return isValidSingleRecipient(value);
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    return (
+      `${args.property} must be a non-empty subscriberId string, an object with a non-empty subscriberId, ` +
+      `a topic object with a non-empty topicKey, or a non-empty array of those`
+    );
+  }
+}
+
+export function IsTriggerRecipientsPayload(validationOptions?: ValidationOptions) {
+  return (object: object, propertyName: string) => {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsTriggerRecipientsPayloadConstraint,
+    });
+  };
+}

--- a/apps/api/src/app/subscribers/dtos/create-subscriber-request.dto.ts
+++ b/apps/api/src/app/subscribers/dtos/create-subscriber-request.dto.ts
@@ -49,6 +49,7 @@ export class CreateSubscriberRequestDto extends BaseSubscriberFieldsDto {
   @ApiProperty({
     description:
       'The internal identifier you used to create this subscriber, usually correlates to the id the user in your systems',
+    minLength: 1,
   })
   @IsString()
   @IsDefined()


### PR DESCRIPTION
### What changed? Why was the change needed?

- Added validation for non-empty subscriberId and topicKey in TriggerEventRequestDto and BulkTriggerEventDto.
- Introduced IsTriggerRecipientsPayload validator to enforce recipient structure.
- Updated tests to cover scenarios for empty recipient fields and invalid payloads.
- Ensured CreateSubscriberRequestDto requires a non-empty identifier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The PR tightens validation for trigger event payloads and subscriber data. It requires non-empty `subscriberId` and `topicKey` fields in trigger event DTOs, introduces a new `IsTriggerRecipientsPayload` validator to enforce valid recipient structure (non-empty strings or objects with non-empty subscriber/topic identifiers), and updates the `CreateSubscriberRequestDto` to document the minimum length requirement for subscriber identifiers.

## Affected areas
- **api**: Updated `TriggerEventRequestDto` and `BulkTriggerEventDto` to enforce validation on recipient payloads and require non-empty event arrays. Added the new `IsTriggerRecipientsPayload` validator class to validate recipient structure. Updated `CreateSubscriberRequestDto` Swagger metadata to reflect the non-empty identifier requirement. Added comprehensive e2e tests for `/v1/events/trigger` and `/v1/events/trigger/bulk` endpoints to verify rejection of invalid recipient payloads (empty strings, empty arrays, objects with empty identifiers) with 422 Validation Error responses.

## Key technical decisions
- Introduced a new class-validator decorator (`IsTriggerRecipientsPayload`) that validates recipients as either a non-empty string, an array of non-empty strings, or objects with either `subscriberId` or `topicKey` as non-empty strings, explicitly rejecting undefined, null, and empty values.

## Testing
E2e tests were added for both single trigger and bulk trigger endpoints to verify that requests with empty or malformed recipient identifiers are rejected with a 422 Validation Error status, covering cases including empty strings, empty arrays, and objects with empty identifier fields.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11066)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
