### PR TITLE
chore(dashboard): dispatch - reuse existing agent routes fixes NV-7624

### DIFF
--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -17,8 +17,11 @@ import { InlineToast } from '@/components/primitives/inline-toast';
 import { Skeleton } from '@/components/primitives/skeleton';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useAgentRoutes } from '@/hooks/use-agent-routes';
+import { useCurrentApp } from '@/hooks/use-current-app';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { useTelemetry } from '@/hooks/use-telemetry';
+import { APP_IDS } from '@/utils/apps';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
@@ -219,10 +222,12 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
   const { currentEnvironment, readOnly, oppositeEnvironment } = useEnvironment();
   const has = useHasPermission();
   const track = useTelemetry();
-
+  const agentRoutes = useAgentRoutes();
+  const currentApp = useCurrentApp();
+  const isDispatchApp = currentApp === APP_IDS.DISPATCH;
   const canRemoveAgentIntegration = !readOnly && has({ permission: PermissionsEnum.AGENT_WRITE });
 
-  const integrationsHubPath = `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+  const integrationsHubPath = `${buildRoute(agentRoutes.detailsTab, {
     environmentSlug: currentEnvironment?.slug ?? '',
     agentIdentifier: encodeURIComponent(agent.identifier),
     agentTab: 'integrations',
@@ -236,7 +241,7 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
     }
 
     navigate(
-      `${buildRoute(ROUTES.AGENT_DETAILS_INTEGRATIONS_DETAIL, {
+      `${buildRoute(agentRoutes.integrationDetail, {
         environmentSlug: currentEnvironment.slug,
         agentIdentifier: encodeURIComponent(agent.identifier),
         integrationIdentifier: encodeURIComponent(nextIntegrationIdentifier),
@@ -289,7 +294,7 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
     }
 
     navigate(
-      `${buildRoute(ROUTES.AGENT_DETAILS_INTEGRATIONS_DETAIL, {
+      `${buildRoute(agentRoutes.integrationDetail, {
         environmentSlug: currentEnvironment.slug,
         agentIdentifier: encodeURIComponent(agent.identifier),
         integrationIdentifier: encodeURIComponent(firstIntegrationIdentifier),
@@ -298,6 +303,7 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
     );
   }, [
     agent.identifier,
+    agentRoutes.integrationDetail,
     currentEnvironment?.slug,
     linkedRows,
     listQuery.isSuccess,
@@ -331,11 +337,16 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
       const name = removed?.integration.name ?? 'Integration';
 
       showSuccessToast('Integration removed', `${name} was unlinked from this agent.`);
-      track(TelemetryEvent.AGENT_INTEGRATION_REMOVED_FROM_DASHBOARD, {
-        agentIdentifier: agent.identifier,
-        agentIntegrationId,
-        integrationIdentifier: removed?.integration.identifier,
-      });
+      track(
+        isDispatchApp
+          ? TelemetryEvent.DISPATCH_AGENT_INTEGRATION_REMOVED_FROM_DASHBOARD
+          : TelemetryEvent.AGENT_INTEGRATION_REMOVED_FROM_DASHBOARD,
+        {
+          agentIdentifier: agent.identifier,
+          agentIntegrationId,
+          integrationIdentifier: removed?.integration.identifier,
+        }
+      );
       await queryClient.invalidateQueries({
         queryKey: getAgentIntegrationsQueryKey(currentEnvironment?._id, agent.identifier),
       });
@@ -410,7 +421,7 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
               onCtaClick={() => {
                 if (!oppositeEnvironment?.slug) return;
                 navigate(
-                  buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+                  buildRoute(agentRoutes.detailsTab, {
                     environmentSlug: oppositeEnvironment.slug,
                     agentIdentifier: encodeURIComponent(agent.identifier),
                     agentTab: 'integrations',

--- a/apps/dashboard/src/components/agents/agent-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-steps.tsx
@@ -11,8 +11,9 @@ import {
   sendAgentWelcomeMessage,
 } from '@/api/agents';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
-import { buildRoute, ROUTES } from '@/utils/routes';
+import { buildRoute } from '@/utils/routes';
 import { AgentCodeSetupSection } from './agent-code-setup-section';
 import { EmailSetupGuide } from './email-setup-guide';
 import { ProviderDropdown } from './provider-dropdown';
@@ -83,6 +84,7 @@ export function AgentSetupSteps({ agent, onBridgeConnected, hideAddProvider }: A
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
+  const agentRoutes = useAgentRoutes();
   const [searchParams, setSearchParams] = useSearchParams();
   // Tracks the last conversationId for which a bridge-connected message was sent,
   // scoping dedup per conversation rather than globally for the component lifetime.
@@ -201,13 +203,13 @@ export function AgentSetupSteps({ agent, onBridgeConnected, hideAddProvider }: A
     if (!currentEnvironment?.slug) return;
 
     navigate(
-      `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+      `${buildRoute(agentRoutes.detailsTab, {
         environmentSlug: currentEnvironment.slug,
         agentIdentifier: encodeURIComponent(agent.identifier),
         agentTab: 'integrations',
       })}${location.search}`
     );
-  }, [agent.identifier, currentEnvironment?.slug, location.search, navigate]);
+  }, [agent.identifier, agentRoutes.detailsTab, currentEnvironment?.slug, location.search, navigate]);
 
   return (
     <div className="relative flex flex-col gap-10 py-6 pb-3 pl-8 pr-6">

--- a/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
+++ b/apps/dashboard/src/components/agents/agent-sidebar-widget.tsx
@@ -23,8 +23,9 @@ import { Switch } from '@/components/primitives/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { TimeDisplayHoverCard } from '@/components/time-display-hover-card';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { useHasPermission } from '@/hooks/use-has-permission';
-import { buildRoute, ROUTES } from '@/utils/routes';
+import { buildRoute } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 
 type AgentSidebarWidgetProps = {
@@ -218,6 +219,7 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
   const has = useHasPermission();
   const canWrite = has({ permission: PermissionsEnum.AGENT_WRITE });
   const canEditFields = canWrite && !readOnly;
+  const agentRoutes = useAgentRoutes();
 
   const [isDeactivateModalOpen, setIsDeactivateModalOpen] = useState(false);
 
@@ -309,7 +311,7 @@ export function AgentSidebarWidget({ agent }: AgentSidebarWidgetProps) {
           onCtaClick={() => {
             if (!oppositeEnvironment?.slug) return;
             navigate(
-              buildRoute(ROUTES.AGENT_DETAILS, {
+              buildRoute(agentRoutes.details, {
                 environmentSlug: oppositeEnvironment.slug,
                 agentIdentifier: encodeURIComponent(agent.identifier),
               })

--- a/apps/dashboard/src/components/agents/agents-empty-teaser.tsx
+++ b/apps/dashboard/src/components/agents/agents-empty-teaser.tsx
@@ -30,8 +30,8 @@ type AgentsEmptyTeaserProps = {
 
 export function AgentsEmptyTeaser({ cta }: AgentsEmptyTeaserProps) {
   return (
-    <div className="flex min-h-[min(720px,calc(100vh-8rem))] flex-col items-center justify-center px-4 py-10 md:px-8">
-      <div className="flex w-full max-w-[1133px] flex-col items-stretch gap-12">
+    <div className="flex h-full flex-col items-center justify-center px-4 py-10 md:px-8">
+      <div className="flex w-full max-w-[800px] flex-col items-stretch gap-12">
         <img
           src="/images/agents-teaser.svg"
           alt=""

--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -25,9 +25,12 @@ import { PermissionButton } from '@/components/primitives/permission-button';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useAgentRoutes } from '@/hooks/use-agent-routes';
+import { useCurrentApp } from '@/hooks/use-current-app';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { useTelemetry } from '@/hooks/use-telemetry';
-import { AGENT_DETAILS_DEFAULT_TAB, buildRoute, ROUTES } from '@/utils/routes';
+import { APP_IDS } from '@/utils/apps';
+import { AGENT_DETAILS_DEFAULT_TAB, buildRoute } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 
 const PAGE_SIZE_OPTIONS = [10, 12, 20, 50];
@@ -39,7 +42,10 @@ export function AgentsList() {
   const { currentEnvironment, readOnly } = useEnvironment();
   const has = useHasPermission();
   const track = useTelemetry();
+  const agentRoutes = useAgentRoutes();
   const canReadAgents = has({ permission: PermissionsEnum.AGENT_READ });
+  const currentApp = useCurrentApp();
+  const isDispatchApp = currentApp === APP_IDS.DISPATCH;
 
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -95,13 +101,18 @@ export function AgentsList() {
       showSuccessToast('Agent created', 'Your agent is ready to use.');
       setCreateOpen(false);
 
-      track(TelemetryEvent.AGENT_CREATED_FROM_DASHBOARD, {
-        agentIdentifier: createdAgent.identifier,
-        active: createdAgent.active,
-      });
+      track(
+        isDispatchApp
+          ? TelemetryEvent.DISPATCH_AGENT_CREATED_FROM_DASHBOARD
+          : TelemetryEvent.AGENT_CREATED_FROM_DASHBOARD,
+        {
+          agentIdentifier: createdAgent.identifier,
+          active: createdAgent.active,
+        }
+      );
 
       const environment = requireEnvironment(currentEnvironment, 'No environment selected');
-      const agentDetailsPath = `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+      const agentDetailsPath = `${buildRoute(agentRoutes.detailsTab, {
         environmentSlug: environment.slug ?? '',
         agentIdentifier: encodeURIComponent(createdAgent.identifier),
         agentTab: AGENT_DETAILS_DEFAULT_TAB,
@@ -123,7 +134,12 @@ export function AgentsList() {
       setAgentToDelete(null);
       showSuccessToast('Agent deleted', 'The agent was removed.');
 
-      track(TelemetryEvent.AGENT_DELETED_FROM_DASHBOARD, { agentIdentifier: identifier });
+      track(
+        isDispatchApp
+          ? TelemetryEvent.DISPATCH_AGENT_DELETED_FROM_DASHBOARD
+          : TelemetryEvent.AGENT_DELETED_FROM_DASHBOARD,
+        { agentIdentifier: identifier }
+      );
 
       const environment = requireEnvironment(currentEnvironment, 'No environment selected');
       const listKey = getAgentsListQueryKey(environment._id, {

--- a/apps/dashboard/src/components/agents/agents-production-empty-state.tsx
+++ b/apps/dashboard/src/components/agents/agents-production-empty-state.tsx
@@ -1,9 +1,10 @@
 import { RiArrowRightSLine, RiBookMarkedLine } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
 import { useEnvironment } from '@/context/environment/hooks';
-import { buildRoute, ROUTES } from '@/utils/routes';
-import { Button } from '../primitives/button';
+import { useAgentRoutes } from '@/hooks/use-agent-routes';
+import { buildRoute } from '@/utils/routes';
 import { cn } from '@/utils/ui';
+import { Button } from '../primitives/button';
 
 function ProductionIllustration() {
   return (
@@ -33,10 +34,11 @@ function ProductionIllustration() {
 export function AgentsProductionEmptyState() {
   const navigate = useNavigate();
   const { oppositeEnvironment } = useEnvironment();
+  const agentRoutes = useAgentRoutes();
 
   const handleSwitchToDevelopment = () => {
     if (!oppositeEnvironment?.slug) return;
-    navigate(buildRoute(ROUTES.AGENTS, { environmentSlug: oppositeEnvironment.slug }));
+    navigate(buildRoute(agentRoutes.list, { environmentSlug: oppositeEnvironment.slug }));
   };
 
   return (

--- a/apps/dashboard/src/components/agents/agents-table.tsx
+++ b/apps/dashboard/src/components/agents/agents-table.tsx
@@ -25,9 +25,10 @@ import {
 import { TablePaginationFooter } from '@/components/primitives/table-pagination-footer';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { formatDateSimple } from '@/utils/format-date';
-import { buildRoute, ROUTES } from '@/utils/routes';
+import { buildRoute } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 
 type AgentsTableProps = {
@@ -158,6 +159,7 @@ export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProp
   const canWrite = has({ permission: PermissionsEnum.AGENT_WRITE });
   const { currentEnvironment, readOnly } = useEnvironment();
   const location = useLocation();
+  const agentRoutes = useAgentRoutes();
 
   return (
     <Table isLoading={isLoading} loadingRowsCount={5} loadingRow={<AgentsTableSkeletonRow />}>
@@ -175,7 +177,7 @@ export function AgentsTable({ agents, isLoading, onRequestDelete, paginationProp
       {!isLoading && (
         <TableBody>
           {agents.map((agent) => {
-            const agentDetailsPath = `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+            const agentDetailsPath = `${buildRoute(agentRoutes.detailsTab, {
               environmentSlug: currentEnvironment?.slug ?? '',
               agentIdentifier: encodeURIComponent(agent.identifier),
               agentTab: 'overview',

--- a/apps/dashboard/src/components/agents/connected-providers-section.tsx
+++ b/apps/dashboard/src/components/agents/connected-providers-section.tsx
@@ -11,7 +11,8 @@ import {
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { Skeleton } from '@/components/primitives/skeleton';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
-import { buildRoute, ROUTES } from '@/utils/routes';
+import { useAgentRoutes } from '@/hooks/use-agent-routes';
+import { buildRoute } from '@/utils/routes';
 
 type ConnectedProvidersSectionProps = {
   agent: AgentResponse;
@@ -73,6 +74,7 @@ function ProviderCardSkeleton() {
 export function ConnectedProvidersSection({ agent }: ConnectedProvidersSectionProps) {
   const { currentEnvironment } = useEnvironment();
   const location = useLocation();
+  const agentRoutes = useAgentRoutes();
 
   const integrationsQuery = useQuery({
     queryKey: getAgentIntegrationsQueryKey(currentEnvironment?._id, agent.identifier),
@@ -85,7 +87,7 @@ export function ConnectedProvidersSection({ agent }: ConnectedProvidersSectionPr
     enabled: Boolean(currentEnvironment && agent.identifier),
   });
 
-  const integrationsTabPath = `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+  const integrationsTabPath = `${buildRoute(agentRoutes.detailsTab, {
     environmentSlug: currentEnvironment?.slug ?? '',
     agentIdentifier: encodeURIComponent(agent.identifier),
     agentTab: 'integrations',

--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -37,9 +37,11 @@ import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/primitives/tooltip';
 import { IS_SELF_HOSTED, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '@/config';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useCurrentApp } from '@/hooks/use-current-app';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { useIsAgentEmailAvailable } from '@/hooks/use-is-agent-email-available';
 import { useTelemetry } from '@/hooks/use-telemetry';
+import { APP_IDS } from '@/utils/apps';
 import { QueryKeys } from '@/utils/query-keys';
 import { ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -161,6 +163,8 @@ export function ProviderDropdown({
   const navigate = useNavigate();
   const isAgentEmailAvailable = useIsAgentEmailAvailable();
   const track = useTelemetry();
+  const currentApp = useCurrentApp();
+  const isDispatchApp = currentApp === APP_IDS.DISPATCH;
 
   const { supported: allSupported, comingSoon } = useMemo(
     () => buildDropdownItems(CONVERSATIONAL_PROVIDERS, integrations),
@@ -313,12 +317,17 @@ export function ProviderDropdown({
       if (item.providerId === EmailProviderIdEnum.NovuAgent) {
         const link = await addAgentIntegrationMutation.mutateAsync({ providerId: item.providerId });
         showSuccessToast('Integration linked', `${link.integration.name ?? 'Novu Email'} was added to this agent.`);
-        track(TelemetryEvent.AGENT_INTEGRATION_LINKED_FROM_DASHBOARD, {
-          agentIdentifier,
-          providerId: item.providerId,
-          integrationIdentifier: link.integration.identifier,
-          mode: 'novu_email',
-        });
+        track(
+          isDispatchApp
+            ? TelemetryEvent.DISPATCH_AGENT_INTEGRATION_LINKED_FROM_DASHBOARD
+            : TelemetryEvent.AGENT_INTEGRATION_LINKED_FROM_DASHBOARD,
+          {
+            agentIdentifier,
+            providerId: item.providerId,
+            integrationIdentifier: link.integration.identifier,
+            mode: 'novu_email',
+          }
+        );
         onSelect(item.providerId, link.integration as unknown as IIntegration);
         closeDropdown();
       } else if (item.integration) {
@@ -328,12 +337,17 @@ export function ProviderDropdown({
           try {
             await addAgentIntegrationMutation.mutateAsync({ integrationIdentifier: item.integration.identifier });
             showSuccessToast('Integration linked', `${item.integration.name} was added to this agent.`);
-            track(TelemetryEvent.AGENT_INTEGRATION_LINKED_FROM_DASHBOARD, {
-              agentIdentifier,
-              providerId: item.providerId,
-              integrationIdentifier: item.integration.identifier,
-              mode: 'existing_integration',
-            });
+            track(
+              isDispatchApp
+                ? TelemetryEvent.DISPATCH_AGENT_INTEGRATION_LINKED_FROM_DASHBOARD
+                : TelemetryEvent.AGENT_INTEGRATION_LINKED_FROM_DASHBOARD,
+              {
+                agentIdentifier,
+                providerId: item.providerId,
+                integrationIdentifier: item.integration.identifier,
+                mode: 'existing_integration',
+              }
+            );
           } catch (linkErr) {
             if (!isAlreadyLinkedToAgentConflict(linkErr)) {
               throw linkErr;
@@ -353,12 +367,17 @@ export function ProviderDropdown({
         });
         await addAgentIntegrationMutation.mutateAsync({ integrationIdentifier: created.identifier });
         showSuccessToast('Integration linked', `${created.name} was added to this agent.`);
-        track(TelemetryEvent.AGENT_INTEGRATION_LINKED_FROM_DASHBOARD, {
-          agentIdentifier,
-          providerId: item.providerId,
-          integrationIdentifier: created.identifier,
-          mode: 'new_integration_then_link',
-        });
+        track(
+          isDispatchApp
+            ? TelemetryEvent.DISPATCH_AGENT_INTEGRATION_LINKED_FROM_DASHBOARD
+            : TelemetryEvent.AGENT_INTEGRATION_LINKED_FROM_DASHBOARD,
+          {
+            agentIdentifier,
+            providerId: item.providerId,
+            integrationIdentifier: created.identifier,
+            mode: 'new_integration_then_link',
+          }
+        );
         onSelect(item.providerId, created);
         closeDropdown();
       }
@@ -525,7 +544,9 @@ export function ProviderDropdown({
                   {isLocked ? (
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <div tabIndex={0} role="button">{rowContent}</div>
+                        <div tabIndex={0} role="button">
+                          {rowContent}
+                        </div>
                       </TooltipTrigger>
                       <TooltipContent
                         side="right"

--- a/apps/dashboard/src/components/conversations/conversation-overview.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-overview.tsx
@@ -3,8 +3,9 @@ import { Link } from 'react-router-dom';
 import { ConversationDto } from '@/api/conversations';
 import { TimeDisplayHoverCard } from '@/components/time-display-hover-card';
 import { useEnvironment } from '@/context/environment/hooks';
+import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { getProviderSquareIconFileName } from '@/utils/provider-square-icon';
-import { buildRoute, ROUTES } from '@/utils/routes';
+import { buildRoute } from '@/utils/routes';
 import { ConversationStatusBadge } from './conversation-status-badge';
 import { SubscriberFallbackAvatar } from './subscriber-fallback-avatar';
 
@@ -25,6 +26,7 @@ function MetaRow({ label, children, isLast }: { label: string; children: React.R
 
 export function ConversationOverview({ conversation }: ConversationOverviewProps) {
   const { currentEnvironment } = useEnvironment();
+  const agentRoutes = useAgentRoutes();
   const participants = conversation.participants ?? [];
   const channels = conversation.channels ?? [];
   const subscriber = participants.find((p) => p.type === 'subscriber');
@@ -33,7 +35,7 @@ export function ConversationOverview({ conversation }: ConversationOverviewProps
   const agentIdentifier = agent?.agent?.identifier ?? agent?.id;
   const agentLink =
     agentIdentifier && currentEnvironment?.slug
-      ? buildRoute(ROUTES.AGENT_DETAILS, { environmentSlug: currentEnvironment.slug, agentIdentifier })
+      ? buildRoute(agentRoutes.details, { environmentSlug: currentEnvironment.slug, agentIdentifier })
       : undefined;
   const platforms = [...new Set(channels.map((c) => c.platform))];
 
@@ -53,10 +55,17 @@ export function ConversationOverview({ conversation }: ConversationOverviewProps
           </MetaRow>
           <MetaRow label="Thread started">
             <TimeDisplayHoverCard date={conversation.createdAt} className="font-normal">
-              {conversation.createdAt ? new Date(conversation.createdAt).toLocaleString('en-US', {
-                month: 'short', day: 'numeric', year: 'numeric',
-                hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
-              }) : '—'}
+              {conversation.createdAt
+                ? new Date(conversation.createdAt).toLocaleString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit',
+                    hour12: false,
+                  })
+                : '—'}
             </TimeDisplayHoverCard>
           </MetaRow>
           <MetaRow label="Agent">

--- a/apps/dashboard/src/components/dashboard-shell/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/dashboard-shell/dashboard-shell.tsx
@@ -1,12 +1,34 @@
-import { ReactNode, useEffect, useState } from 'react';
+import { Fragment, ReactNode, useEffect, useState } from 'react';
+import { RiSearchLine } from 'react-icons/ri';
+import { useLocation } from 'react-router-dom';
 import { HeaderNavigation } from '@/components/header-navigation/header-navigation';
 import { MobileDesktopPrompt } from '@/components/mobile-desktop-prompt';
 import { DispatchSideNavigation } from '@/components/side-navigation/dispatch-side-navigation';
 import { LegacySideNavigation } from '@/components/side-navigation/side-navigation';
+import { useEnvironment } from '@/context/environment/hooks';
 import { useCurrentApp } from '@/hooks/use-current-app';
-import { APP_IDS, type AppId } from '@/utils/apps';
+import {
+  APP_IDS,
+  type AppId,
+  DISPATCH_SECTION_LABELS,
+  type DispatchSectionId,
+  getDispatchSectionFromPathname,
+} from '@/utils/apps';
+import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
+import { useCommandPalette } from '../command-palette/hooks/use-command-palette';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '../primitives/breadcrumb';
+import { Button } from '../primitives/button';
+import { Kbd } from '../primitives/kbd';
 import { AppRail } from './app-rail';
+import { useDispatchBreadcrumbLeaf } from './use-dispatch-breadcrumb';
 
 type DashboardShellProps = {
   children: ReactNode;
@@ -30,6 +52,21 @@ function useDidAppJustSwitch(appId: AppId): boolean {
   return previousAppId !== undefined && previousAppId !== appId;
 }
 
+const DISPATCH_SECTION_ROUTES: Record<DispatchSectionId, keyof typeof ROUTES> = {
+  dashboard: 'DISPATCH_HOME',
+  agents: 'DISPATCH_AGENTS',
+  conversations: 'DISPATCH_CONVERSATIONS',
+  'api-keys': 'DISPATCH_API_KEYS',
+  settings: 'DISPATCH_SETTINGS',
+};
+
+type DispatchBreadcrumbEntry = {
+  key: string;
+  label: string;
+  icon?: ReactNode;
+  to?: string;
+};
+
 export function DashboardShell({
   children,
   headerStartItems,
@@ -39,6 +76,30 @@ export function DashboardShell({
   const appId = useCurrentApp();
   const didAppJustSwitch = useDidAppJustSwitch(appId);
   const SideNav = appId === APP_IDS.DISPATCH ? DispatchSideNavigation : LegacySideNavigation;
+  const { currentEnvironment } = useEnvironment();
+  const { openCommandPalette } = useCommandPalette();
+  const location = useLocation();
+  const dispatchLeaf = useDispatchBreadcrumbLeaf();
+  const envSlug = currentEnvironment?.slug ?? '';
+  const dispatchSection = getDispatchSectionFromPathname(location.pathname);
+  const dispatchHomeUrl = buildRoute(ROUTES.DISPATCH_HOME, { environmentSlug: envSlug });
+  const sectionRouteTemplate = ROUTES[DISPATCH_SECTION_ROUTES[dispatchSection]];
+  const sectionUrl = buildRoute(sectionRouteTemplate, { environmentSlug: envSlug });
+
+  const dispatchBreadcrumbItems: DispatchBreadcrumbEntry[] = [
+    { key: 'root', label: 'Dispatch', to: dispatchHomeUrl },
+    {
+      key: 'section',
+      label: DISPATCH_SECTION_LABELS[dispatchSection],
+      to: dispatchLeaf ? sectionUrl : undefined,
+    },
+  ];
+
+  if (dispatchLeaf) {
+    dispatchBreadcrumbItems.push({ key: 'leaf', label: dispatchLeaf.label, icon: dispatchLeaf.icon });
+  }
+
+  const dispatchLastIndex = dispatchBreadcrumbItems.length - 1;
 
   return (
     <div className="relative flex h-full w-full bg-bg-muted">
@@ -58,12 +119,64 @@ export function DashboardShell({
         </div>
       )}
       <div className="flex flex-1 flex-col m-2 overflow-y-auto overflow-x-hidden bg-bg-white rounded-md">
-        <HeaderNavigation
-          startItems={headerStartItems}
-          hideBridgeUrl={!showBridgeUrl || appId === APP_IDS.DISPATCH}
-          showMobileNav={showSideNavigation}
-          hideRestItems
-        />
+        {appId === APP_IDS.NOVU ? (
+          <HeaderNavigation
+            startItems={headerStartItems}
+            hideBridgeUrl={!showBridgeUrl}
+            showMobileNav={showSideNavigation}
+            hideRestItems
+          />
+        ) : (
+          <Breadcrumb className="min-w-0 my-3 mx-2.5">
+            <BreadcrumbList>
+              {dispatchBreadcrumbItems.map((item, index) => {
+                const isLast = index === dispatchLastIndex;
+
+                return (
+                  <Fragment key={item.key}>
+                    {index > 0 && <BreadcrumbSeparator />}
+                    <BreadcrumbItem className="min-w-0">
+                      {isLast ? (
+                        <BreadcrumbPage className="flex min-w-0 items-center gap-1.5">
+                          {item.icon}
+                          <span className="truncate">{item.label}</span>
+                        </BreadcrumbPage>
+                      ) : (
+                        <BreadcrumbLink to={item.to ?? '#'} className="flex min-w-0 items-center gap-1.5 text-text-sub">
+                          {item.icon}
+                          <span className="truncate">{item.label}</span>
+                        </BreadcrumbLink>
+                      )}
+                    </BreadcrumbItem>
+                  </Fragment>
+                );
+              })}
+              <BreadcrumbItem className="min-w-0 ml-auto">
+                <BreadcrumbPage className="flex min-w-0 items-center gap-1.5 ">
+                  <Button
+                    variant="secondary"
+                    mode="outline"
+                    className="hidden h-[26px] px-[5px] md:inline-flex"
+                    size="2xs"
+                    onClick={openCommandPalette}
+                  >
+                    <RiSearchLine className="size-3 text-text-sub" />
+                    <Kbd className="bg-bg-weak rounded-4 h-[16px]">⌘K</Kbd>
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    mode="outline"
+                    className="h-[26px] px-[5px] md:hidden"
+                    size="2xs"
+                    onClick={openCommandPalette}
+                  >
+                    <RiSearchLine className="size-3 text-text-sub" />
+                  </Button>
+                </BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        )}
         <div className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden p-2">{children}</div>
       </div>
       <MobileDesktopPrompt />

--- a/apps/dashboard/src/components/dashboard-shell/dispatch-breadcrumb-provider.tsx
+++ b/apps/dashboard/src/components/dashboard-shell/dispatch-breadcrumb-provider.tsx
@@ -1,0 +1,18 @@
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
+import { DispatchBreadcrumbContext, type DispatchBreadcrumbLeaf } from './use-dispatch-breadcrumb';
+
+type DispatchBreadcrumbProviderProps = {
+  children: ReactNode;
+};
+
+export function DispatchBreadcrumbProvider({ children }: DispatchBreadcrumbProviderProps) {
+  const [leaf, setLeafState] = useState<DispatchBreadcrumbLeaf | null>(null);
+
+  const setLeaf = useCallback((next: DispatchBreadcrumbLeaf | null) => {
+    setLeafState(next);
+  }, []);
+
+  const value = useMemo(() => ({ leaf, setLeaf }), [leaf, setLeaf]);
+
+  return <DispatchBreadcrumbContext.Provider value={value}>{children}</DispatchBreadcrumbContext.Provider>;
+}

--- a/apps/dashboard/src/components/dashboard-shell/use-dispatch-breadcrumb.ts
+++ b/apps/dashboard/src/components/dashboard-shell/use-dispatch-breadcrumb.ts
@@ -1,0 +1,36 @@
+import { createContext, type ReactNode, useContext, useEffect } from 'react';
+
+export type DispatchBreadcrumbLeaf = {
+  label: string;
+  icon?: ReactNode;
+};
+
+export type DispatchBreadcrumbContextValue = {
+  leaf: DispatchBreadcrumbLeaf | null;
+  setLeaf: (leaf: DispatchBreadcrumbLeaf | null) => void;
+};
+
+export const DispatchBreadcrumbContext = createContext<DispatchBreadcrumbContextValue | null>(null);
+
+export function useDispatchBreadcrumbLeaf(): DispatchBreadcrumbLeaf | null {
+  return useContext(DispatchBreadcrumbContext)?.leaf ?? null;
+}
+
+/**
+ * Register the trailing breadcrumb item for the current Dispatch page. Pass `null`
+ * to clear the leaf when not on a resource sub-route. The caller is responsible
+ * for memoizing the `leaf` reference so the effect only re-runs when it changes.
+ */
+export function useSetDispatchBreadcrumbLeaf(leaf: DispatchBreadcrumbLeaf | null): void {
+  const ctx = useContext(DispatchBreadcrumbContext);
+
+  useEffect(() => {
+    if (!ctx) return;
+
+    ctx.setLeaf(leaf);
+
+    return () => {
+      ctx.setLeaf(null);
+    };
+  }, [ctx, leaf]);
+}

--- a/apps/dashboard/src/components/header-navigation/header-navigation.tsx
+++ b/apps/dashboard/src/components/header-navigation/header-navigation.tsx
@@ -21,10 +21,19 @@ type HeaderNavigationProps = HTMLAttributes<HTMLDivElement> & {
   hideBridgeUrl?: boolean;
   showMobileNav?: boolean;
   hideRestItems?: boolean;
+  hidePublish?: boolean;
 };
 
 export const HeaderNavigation = (props: HeaderNavigationProps) => {
-  const { startItems, hideBridgeUrl = false, showMobileNav = false, hideRestItems = false, className, ...rest } = props;
+  const {
+    startItems,
+    hideBridgeUrl = false,
+    showMobileNav = false,
+    hideRestItems = false,
+    hidePublish = false,
+    className,
+    ...rest
+  } = props;
   const { currentEnvironment } = useEnvironment();
   const has = useHasPermission();
   const canPublish = has({ permission: PermissionsEnum.ENVIRONMENT_WRITE });
@@ -63,7 +72,7 @@ export const HeaderNavigation = (props: HeaderNavigationProps) => {
           <RiSearchLine className="size-3 text-text-sub" />
         </Button>
         <span className="hidden md:contents">
-          {currentEnvironment?.type === EnvironmentTypeEnum.DEV && canPublish && <PublishButton />}
+          {currentEnvironment?.type === EnvironmentTypeEnum.DEV && canPublish && !hidePublish && <PublishButton />}
           {!hideBridgeUrl ? <EditBridgeUrlButton /> : null}
         </span>
         {!hideRestItems && (

--- a/apps/dashboard/src/components/side-navigation/dispatch-side-navigation.tsx
+++ b/apps/dashboard/src/components/side-navigation/dispatch-side-navigation.tsx
@@ -20,7 +20,7 @@ export const DispatchSideNavigation = () => {
         <nav className="flex h-full flex-1 flex-col overflow-auto">
           <div className="flex flex-col gap-4">
             <NavigationGroup>
-              <NavigationLink to={buildEnvRoute(ROUTES.DISPATCH_HOME)}>
+              <NavigationLink to={buildEnvRoute(ROUTES.DISPATCH_HOME)} isExact>
                 <RiDashboardLine className="size-4" />
                 <span>Dashboard</span>
               </NavigationLink>

--- a/apps/dashboard/src/components/side-navigation/navigation-link.tsx
+++ b/apps/dashboard/src/components/side-navigation/navigation-link.tsx
@@ -24,13 +24,14 @@ interface NavLinkProps {
   isExternal?: boolean;
   className?: string;
   children: React.ReactNode;
+  isExact?: boolean;
 }
 
-export function NavigationLink({ to, matchPaths, isExternal, className, children }: NavLinkProps) {
+export function NavigationLink({ to, matchPaths, isExternal, className, children, isExact = false }: NavLinkProps) {
   const { pathname } = useLocation();
   const isSelected =
     pathname === to ||
-    (to && pathname.startsWith(to)) ||
+    (to && pathname.startsWith(to) && !isExact) ||
     matchPaths?.some((path) => pathname.startsWith(path));
   const variant = isSelected ? 'selected' : 'default';
   const classNames = cn(linkVariants({ variant, className }));

--- a/apps/dashboard/src/hooks/use-agent-routes.ts
+++ b/apps/dashboard/src/hooks/use-agent-routes.ts
@@ -1,0 +1,6 @@
+import { useCurrentApp } from '@/hooks/use-current-app';
+import { type AgentRouteTemplates, getAgentRouteTemplates } from '@/utils/apps';
+
+export function useAgentRoutes(): AgentRouteTemplates {
+  return getAgentRouteTemplates(useCurrentApp());
+}

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -31,7 +31,6 @@ import {
   WorkflowsPage,
 } from '@/pages';
 import {
-  DispatchAgentsPage,
   DispatchApiKeysPage,
   DispatchConversationsPage,
   DispatchDashboardPage,
@@ -608,10 +607,34 @@ const router = createBrowserRouter([
                 ),
                 children: [
                   { index: true, element: <DispatchDashboardPage /> },
-                  { path: 'agents', element: <DispatchAgentsPage /> },
-                  { path: 'conversations', element: <DispatchConversationsPage /> },
-                  { path: 'api-keys', element: <DispatchApiKeysPage /> },
-                  { path: 'settings', element: <DispatchSettingsPage /> },
+                  { path: ROUTES.DISPATCH_AGENTS, element: <AgentsPage /> },
+                  {
+                    path: ROUTES.DISPATCH_AGENT_DETAILS_INTEGRATIONS_DETAIL,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
+                        <AgentDetailsPage />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.DISPATCH_AGENT_DETAILS_TAB,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
+                        <AgentDetailsPage />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  {
+                    path: ROUTES.DISPATCH_AGENT_DETAILS,
+                    element: (
+                      <ProtectedRoute permission={PermissionsEnum.AGENT_READ}>
+                        <AgentDetailsPage />
+                      </ProtectedRoute>
+                    ),
+                  },
+                  { path: ROUTES.DISPATCH_CONVERSATIONS, element: <DispatchConversationsPage /> },
+                  { path: ROUTES.DISPATCH_API_KEYS, element: <DispatchApiKeysPage /> },
+                  { path: ROUTES.DISPATCH_SETTINGS, element: <DispatchSettingsPage /> },
                 ],
               },
 

--- a/apps/dashboard/src/pages/agent-details.tsx
+++ b/apps/dashboard/src/pages/agent-details.tsx
@@ -15,10 +15,11 @@ import {
 import { NovuApiError } from '@/api/api.client';
 import { AgentDetailsHeader } from '@/components/agents/agent-details-header';
 import { AgentIntegrationsTab } from '@/components/agents/agent-integrations-tab';
-import { AgentSetupModal } from '@/components/agents/agent-setup-modal';
 import { AgentOverviewTab } from '@/components/agents/agent-overview-tab';
+import { AgentSetupModal } from '@/components/agents/agent-setup-modal';
 import { DeleteAgentDialog } from '@/components/agents/delete-agent-dialog';
 import { DashboardLayout } from '@/components/dashboard-layout';
+import { useSetDispatchBreadcrumbLeaf } from '@/components/dashboard-shell/use-dispatch-breadcrumb';
 import { PageMeta } from '@/components/page-meta';
 import { Badge } from '@/components/primitives/badge';
 import {
@@ -34,15 +35,17 @@ import { Skeleton } from '@/components/primitives/skeleton';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/primitives/tabs';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { useAgentRoutes } from '@/hooks/use-agent-routes';
+import { useCurrentApp } from '@/hooks/use-current-app';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useTelemetry } from '@/hooks/use-telemetry';
+import { APP_IDS } from '@/utils/apps';
 import {
   AGENT_DETAILS_DEFAULT_TAB,
   AGENT_DETAILS_TABS,
   type AgentDetailsTab,
   buildRoute,
   parseAgentDetailsTab,
-  ROUTES,
 } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 
@@ -90,12 +93,15 @@ export function AgentDetailsPage() {
   const queryClient = useQueryClient();
   const { currentEnvironment, readOnly } = useEnvironment();
   const isConversationalAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
+  const currentApp = useCurrentApp();
+  const isDispatchApp = currentApp === APP_IDS.DISPATCH;
+  const agentRoutes = useAgentRoutes();
   const [agentToDelete, setAgentToDelete] = useState<AgentResponse | null>(null);
   const [setupModalDismissed, setSetupModalDismissed] = useState(false);
   const track = useTelemetry();
   const lastAgentDetailsTelemetryKey = useRef<string | null>(null);
 
-  const agentsListPath = buildRoute(ROUTES.AGENTS, {
+  const agentsListPath = buildRoute(agentRoutes.list, {
     environmentSlug: currentEnvironment?.slug ?? '',
   });
 
@@ -105,13 +111,37 @@ export function AgentDetailsPage() {
     enabled: Boolean(currentEnvironment && agentIdentifier && isConversationalAgentsEnabled),
   });
 
+  let agentBreadcrumbLabel: string | null = null;
+
+  if (agentQuery.error instanceof NovuApiError && agentQuery.error.status === 404) {
+    agentBreadcrumbLabel = 'Not found';
+  } else if (agentQuery.data) {
+    agentBreadcrumbLabel = agentQuery.data.name;
+  }
+
+  const dispatchBreadcrumbLeaf = useMemo(() => {
+    if (!isDispatchApp || !agentBreadcrumbLabel) return null;
+
+    return {
+      label: agentBreadcrumbLabel,
+      icon: <RiRobot2Line className="text-text-sub size-4 shrink-0" aria-hidden />,
+    };
+  }, [isDispatchApp, agentBreadcrumbLabel]);
+
+  useSetDispatchBreadcrumbLeaf(dispatchBreadcrumbLeaf);
+
   const deleteMutation = useMutation({
     mutationFn: (identifier: string) =>
       deleteAgent(requireEnvironment(currentEnvironment, 'No environment selected'), identifier),
     onSuccess: async (_, identifier) => {
       setAgentToDelete(null);
       showSuccessToast('Agent deleted', 'The agent was removed.');
-      track(TelemetryEvent.AGENT_DELETED_FROM_DASHBOARD, { agentIdentifier: identifier });
+      track(
+        isDispatchApp
+          ? TelemetryEvent.DISPATCH_AGENT_DELETED_FROM_DASHBOARD
+          : TelemetryEvent.AGENT_DELETED_FROM_DASHBOARD,
+        { agentIdentifier: identifier }
+      );
       await queryClient.invalidateQueries({ queryKey: [AGENTS_LIST_QUERY_KEY] });
       navigate(agentsListPath);
     },
@@ -165,19 +195,35 @@ export function AgentDetailsPage() {
 
     lastAgentDetailsTelemetryKey.current = dedupeKey;
 
-    track(TelemetryEvent.AGENT_DETAILS_PAGE_VISITED, {
-      agentIdentifier: agentQuery.data.identifier,
-      tab: currentTab,
-      integrationIdentifier: integrationIdentifier ?? undefined,
-    });
+    track(
+      isDispatchApp ? TelemetryEvent.DISPATCH_AGENT_DETAILS_PAGE_VISITED : TelemetryEvent.AGENT_DETAILS_PAGE_VISITED,
+      {
+        agentIdentifier: agentQuery.data.identifier,
+        tab: currentTab,
+        integrationIdentifier: integrationIdentifier ?? undefined,
+      }
+    );
 
     if (integrationIdentifier) {
-      track(TelemetryEvent.AGENT_INTEGRATION_GUIDE_VIEWED, {
-        agentIdentifier: agentQuery.data.identifier,
-        integrationIdentifier,
-      });
+      track(
+        isDispatchApp
+          ? TelemetryEvent.DISPATCH_AGENT_INTEGRATION_GUIDE_VIEWED
+          : TelemetryEvent.AGENT_INTEGRATION_GUIDE_VIEWED,
+        {
+          agentIdentifier: agentQuery.data.identifier,
+          integrationIdentifier,
+        }
+      );
     }
-  }, [agentIdentifier, agentQuery.data, currentTab, integrationIdentifier, isConversationalAgentsEnabled, track]);
+  }, [
+    agentIdentifier,
+    agentQuery.data,
+    currentTab,
+    integrationIdentifier,
+    isDispatchApp,
+    isConversationalAgentsEnabled,
+    track,
+  ]);
 
   if (!isConversationalAgentsEnabled) {
     return <Navigate to={agentsListPath} replace />;
@@ -191,7 +237,7 @@ export function AgentDetailsPage() {
     return (
       <Navigate
         replace
-        to={`${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+        to={`${buildRoute(agentRoutes.detailsTab, {
           environmentSlug: currentEnvironment.slug,
           agentIdentifier: encodeURIComponent(agentIdentifier),
           agentTab: AGENT_DETAILS_DEFAULT_TAB,
@@ -220,7 +266,7 @@ export function AgentDetailsPage() {
     }
 
     navigate(
-      `${buildRoute(ROUTES.AGENT_DETAILS_TAB, {
+      `${buildRoute(agentRoutes.detailsTab, {
         environmentSlug: currentEnvironment.slug,
         agentIdentifier: encodeURIComponent(agent.identifier),
         agentTab: value,

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -411,10 +411,6 @@ export function AgentsPage() {
   const track = useTelemetry();
 
   useEffect(() => {
-    if (!isDispatchApp) {
-      return;
-    }
-
     track(isDispatchApp ? TelemetryEvent.DISPATCH_AGENTS_PAGE_VISITED : TelemetryEvent.AGENTS_PAGE_VISITED);
   }, [isDispatchApp, track]);
 

--- a/apps/dashboard/src/pages/agents.tsx
+++ b/apps/dashboard/src/pages/agents.tsx
@@ -29,8 +29,10 @@ import { Separator } from '@/components/primitives/separator';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { DismissButton, Icon as TagIcon, Root as TagRoot } from '@/components/primitives/tag';
 import { Textarea } from '@/components/primitives/textarea';
+import { useCurrentApp } from '@/hooks/use-current-app';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useTelemetry } from '@/hooks/use-telemetry';
+import { APP_IDS } from '@/utils/apps';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
 
@@ -404,15 +406,17 @@ function AgentsEarlyAccessDialog({ open, onOpenChange }: AgentsEarlyAccessDialog
 export function AgentsPage() {
   const [earlyAccessOpen, setEarlyAccessOpen] = useState(false);
   const isConversationalAgentsEnabled = useFeatureFlag(FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED, false);
+  const currentApp = useCurrentApp();
+  const isDispatchApp = currentApp === APP_IDS.DISPATCH;
   const track = useTelemetry();
 
   useEffect(() => {
-    if (!isConversationalAgentsEnabled) {
+    if (!isDispatchApp) {
       return;
     }
 
-    track(TelemetryEvent.AGENTS_PAGE_VISITED);
-  }, [isConversationalAgentsEnabled, track]);
+    track(isDispatchApp ? TelemetryEvent.DISPATCH_AGENTS_PAGE_VISITED : TelemetryEvent.AGENTS_PAGE_VISITED);
+  }, [isDispatchApp, track]);
 
   return (
     <>

--- a/apps/dashboard/src/pages/dispatch/dispatch-agents.tsx
+++ b/apps/dashboard/src/pages/dispatch/dispatch-agents.tsx
@@ -1,5 +1,0 @@
-import { DispatchPlaceholder } from './dispatch-placeholder';
-
-export function DispatchAgentsPage() {
-  return <DispatchPlaceholder section="Agents" />;
-}

--- a/apps/dashboard/src/pages/dispatch/dispatch-conversations.tsx
+++ b/apps/dashboard/src/pages/dispatch/dispatch-conversations.tsx
@@ -1,5 +1,14 @@
-import { DispatchPlaceholder } from './dispatch-placeholder';
+import { ConversationsContent } from '@/components/conversations/conversations-content';
+import { DashboardLayout } from '@/components/dashboard-layout';
+import { PageMeta } from '@/components/page-meta';
 
 export function DispatchConversationsPage() {
-  return <DispatchPlaceholder section="Conversations" />;
+  return (
+    <>
+      <PageMeta title="Conversations" />
+      <DashboardLayout headerStartItems={<h1 className="text-foreground-950">Conversations</h1>}>
+        <ConversationsContent contentHeight="h-[calc(100vh-140px)]" />
+      </DashboardLayout>
+    </>
+  );
 }

--- a/apps/dashboard/src/pages/dispatch/index.ts
+++ b/apps/dashboard/src/pages/dispatch/index.ts
@@ -1,4 +1,3 @@
-export { DispatchAgentsPage } from './dispatch-agents';
 export { DispatchApiKeysPage } from './dispatch-api-keys';
 export { DispatchConversationsPage } from './dispatch-conversations';
 export { DispatchDashboardPage } from './dispatch-dashboard';

--- a/apps/dashboard/src/routes/dispatch-protected-route.tsx
+++ b/apps/dashboard/src/routes/dispatch-protected-route.tsx
@@ -1,6 +1,7 @@
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
+import { DispatchBreadcrumbProvider } from '@/components/dashboard-shell/dispatch-breadcrumb-provider';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { buildRoute, ROUTES } from '@/utils/routes';
@@ -21,5 +22,5 @@ export function DispatchProtectedRoute({ children }: DispatchProtectedRouteProps
     return <Navigate to={fallback} replace />;
   }
 
-  return <>{children}</>;
+  return <DispatchBreadcrumbProvider>{children}</DispatchBreadcrumbProvider>;
 }

--- a/apps/dashboard/src/utils/apps.ts
+++ b/apps/dashboard/src/utils/apps.ts
@@ -33,3 +33,62 @@ export const APP_LABELS: Record<AppId, string> = {
   novu: 'Platform',
   dispatch: 'Dispatch',
 };
+
+export type AgentRouteTemplates = {
+  list: string;
+  details: string;
+  detailsTab: string;
+  integrationDetail: string;
+};
+
+const AGENT_ROUTE_TEMPLATES: Record<AppId, AgentRouteTemplates> = {
+  novu: {
+    list: ROUTES.AGENTS,
+    details: ROUTES.AGENT_DETAILS,
+    detailsTab: ROUTES.AGENT_DETAILS_TAB,
+    integrationDetail: ROUTES.AGENT_DETAILS_INTEGRATIONS_DETAIL,
+  },
+  dispatch: {
+    list: ROUTES.DISPATCH_AGENTS,
+    details: ROUTES.DISPATCH_AGENT_DETAILS,
+    detailsTab: ROUTES.DISPATCH_AGENT_DETAILS_TAB,
+    integrationDetail: ROUTES.DISPATCH_AGENT_DETAILS_INTEGRATIONS_DETAIL,
+  },
+};
+
+export function getAgentRouteTemplates(appId: AppId): AgentRouteTemplates {
+  return AGENT_ROUTE_TEMPLATES[appId];
+}
+
+export type DispatchSectionId = 'dashboard' | 'agents' | 'conversations' | 'api-keys' | 'settings';
+
+export const DISPATCH_SECTION_LABELS: Record<DispatchSectionId, string> = {
+  dashboard: 'Dashboard',
+  agents: 'Agents',
+  conversations: 'Conversations',
+  'api-keys': 'API Keys',
+  settings: 'Settings',
+};
+
+const DISPATCH_SEGMENT_TO_SECTION: Record<string, DispatchSectionId> = {
+  agents: 'agents',
+  conversations: 'conversations',
+  'api-keys': 'api-keys',
+  settings: 'settings',
+};
+
+export function getDispatchSectionFromPathname(pathname: string): DispatchSectionId {
+  const match = pathname.match(/^\/env\/[^/]+\/dispatch(?:\/([^/]+))?/);
+
+  if (!match) {
+    return 'dashboard';
+  }
+
+  const firstSegment = match[1];
+
+  if (!firstSegment) {
+    return 'dashboard';
+  }
+
+  return DISPATCH_SEGMENT_TO_SECTION[firstSegment] ?? 'dashboard';
+}

--- a/apps/dashboard/src/utils/routes.ts
+++ b/apps/dashboard/src/utils/routes.ts
@@ -84,6 +84,11 @@ export const ROUTES = {
   AGENT_DETAILS_TAB: '/env/:environmentSlug/agents/:agentIdentifier/:agentTab',
   DISPATCH_HOME: '/env/:environmentSlug/dispatch',
   DISPATCH_AGENTS: '/env/:environmentSlug/dispatch/agents',
+  DISPATCH_AGENT_DETAILS: '/env/:environmentSlug/dispatch/agents/:agentIdentifier',
+  /** Must be registered before DISPATCH_AGENT_DETAILS_TAB so `.../integrations/:integrationIdentifier` is not parsed as a tab name. */
+  DISPATCH_AGENT_DETAILS_INTEGRATIONS_DETAIL:
+    '/env/:environmentSlug/dispatch/agents/:agentIdentifier/integrations/:integrationIdentifier',
+  DISPATCH_AGENT_DETAILS_TAB: '/env/:environmentSlug/dispatch/agents/:agentIdentifier/:agentTab',
   DISPATCH_CONVERSATIONS: '/env/:environmentSlug/dispatch/conversations',
   DISPATCH_API_KEYS: '/env/:environmentSlug/dispatch/api-keys',
   DISPATCH_SETTINGS: '/env/:environmentSlug/dispatch/settings',

--- a/apps/dashboard/src/utils/telemetry.ts
+++ b/apps/dashboard/src/utils/telemetry.ts
@@ -121,4 +121,12 @@ export enum TelemetryEvent {
   AGENT_INTEGRATION_LINKED_FROM_DASHBOARD = 'Agent integration linked from dashboard',
   AGENT_INTEGRATION_GUIDE_VIEWED = 'Agent integration setup guide viewed',
   AGENT_INTEGRATION_REMOVED_FROM_DASHBOARD = 'Agent integration removed from dashboard',
+
+  DISPATCH_AGENTS_PAGE_VISITED = 'Agents page visited - [Dispatch]',
+  DISPATCH_AGENT_DETAILS_PAGE_VISITED = 'Agent details page visited - [Dispatch]',
+  DISPATCH_AGENT_CREATED_FROM_DASHBOARD = 'Agent created from dashboard - [Dispatch]',
+  DISPATCH_AGENT_DELETED_FROM_DASHBOARD = 'Agent deleted from dashboard - [Dispatch]',
+  DISPATCH_AGENT_INTEGRATION_LINKED_FROM_DASHBOARD = 'Agent integration linked from dashboard - [Dispatch]',
+  DISPATCH_AGENT_INTEGRATION_GUIDE_VIEWED = 'Agent integration setup guide viewed - [Dispatch]',
+  DISPATCH_AGENT_INTEGRATION_REMOVED_FROM_DASHBOARD = 'Agent integration removed from dashboard - [Dispatch]',
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

Dashboard - reuse existing agent routes for the Dispatch project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The Dashboard now reuses the shared agent routes and components for the Dispatch app instead of placeholder pages. Routing and navigation for agents (list, details, integrations) are generated from the app context so Dispatch renders the same agent UI while emitting Dispatch-specific telemetry and breadcrumb behavior.

## Affected areas

**dashboard**: Reworked agent routing and pages to use a new app-aware routing hook; introduced `useAgentRoutes()` and replaced hardcoded `ROUTES.*` usages across agent components, pages, and navigation. Added dispatch-aware breadcrumbs and converted several dispatch placeholder pages to real dashboard pages (Conversations, Agents wiring). Updated telemetry to emit Dispatch-specific events where appropriate. Refined navigation link matching and small layout tweaks in agent teasers/widgets.

## Key technical decisions

- App-context routing: added `getAgentRouteTemplates(appId)` and `useAgentRoutes()` so shared components build URLs per app (Dispatch vs Novu).  
- Separate telemetry: added Dispatch-specific `TelemetryEvent` entries to distinguish Dispatch agent lifecycle and integration events from dashboard events.  
- Breadcrumbs: introduced `DispatchBreadcrumbProvider` and hooks to let nested pages set a dispatch-specific breadcrumb leaf without prop drilling.  
- Dispatch section parsing: added `DISPATCH_SECTION_LABELS` and `getDispatchSectionFromPathname()` to map dispatch URL segments to named sections.  
- Navigation matching: added `isExact` to `NavigationLink` to control prefix matching for accurate link highlighting.

## Testing

No new automated tests were added; changes are routing, wiring, and telemetry-focused and should be verified manually in the Dispatch app (navigation, breadcrumbs, agent pages, and telemetry emissions). Existing shared component tests continue to apply.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11074)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots


https://github.com/user-attachments/assets/bfed0202-46b5-4e30-babe-bdf4ed8ebd6b


