### PR TITLE
feat(api-service, framework): wire email action buttons to onAction handler fixes NV-7422

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -24,3 +24,6 @@ pnpm-lock.yaml
 
 # Generator templates — not production code
 libs/automation/
+
+# Cursor have a tendency to remove the minReleaseAge when he faces it
+pnpm-workspace.yaml

--- a/apps/api/src/app/agents/agent-email-actions.controller.ts
+++ b/apps/api/src/app/agents/agent-email-actions.controller.ts
@@ -3,11 +3,14 @@ import { ApiExcludeController } from '@nestjs/swagger';
 import { PinoLogger } from '@novu/application-generic';
 import { Response } from 'express';
 import {
+  AgentEmailActionCacheUnavailableError,
   AgentEmailActionClaims,
   AgentEmailActionStyle,
   AgentEmailActionTokenService,
+  ConsumedActionToken,
+  PeekedActionToken,
 } from './services/agent-email-action-token.service';
-import { ChatSdkService } from './services/chat-sdk.service';
+import { AgentActionPreDispatchError, ChatSdkService } from './services/chat-sdk.service';
 
 const EXECUTE_PATH = '/v1/agents/email/actions/execute';
 
@@ -55,7 +58,19 @@ export class AgentEmailActionsController {
       return;
     }
 
-    const peeked = await this.tokenService.peekActionToken(token);
+    let peeked: PeekedActionToken | null;
+    try {
+      peeked = await this.tokenService.peekActionToken(token);
+    } catch (err) {
+      if (err instanceof AgentEmailActionCacheUnavailableError) {
+        this.logger.warn(err, 'Cache unavailable while peeking agent email action token');
+        this.sendHtml(res, HttpStatus.SERVICE_UNAVAILABLE, renderTryAgainPage());
+
+        return;
+      }
+      throw err;
+    }
+
     if (!peeked) {
       this.sendHtml(
         res,
@@ -95,8 +110,21 @@ export class AgentEmailActionsController {
 
     // Atomic single-use claim: consume returns the entry exactly once across all concurrent
     // callers (Redis GETDEL). Any other click — prefetcher, refresh, second tab — receives
-    // null and is shown the "already submitted" page.
-    const consumed = await this.tokenService.consumeActionToken(token);
+    // null and is shown the "already submitted" page. A *cache* failure is distinct from a
+    // null result and surfaces as a typed error so we don't silently drop valid clicks.
+    let consumed: ConsumedActionToken | null;
+    try {
+      consumed = await this.tokenService.consumeActionToken(token);
+    } catch (err) {
+      if (err instanceof AgentEmailActionCacheUnavailableError) {
+        this.logger.warn(err, 'Cache unavailable while consuming agent email action token');
+        this.sendHtml(res, HttpStatus.SERVICE_UNAVAILABLE, renderTryAgainPage());
+
+        return;
+      }
+      throw err;
+    }
+
     if (!consumed) {
       this.sendHtml(res, HttpStatus.OK, renderAlreadySubmittedPage());
 
@@ -109,12 +137,19 @@ export class AgentEmailActionsController {
       await this.chatSdkService.processEmailAction(claims);
     } catch (err) {
       this.logger.error(err, `Failed to process agent email action ${claims.actionId} for agent ${claims.agentId}`);
-      // Re-store the entry so the user can retry from the same email link instead of seeing
-      // "Already submitted". The remaining TTL is preserved against the original `expiresAt`
-      // so a token can never outlive its natural expiry.
-      await this.tokenService.releaseActionToken(token, consumed).catch((releaseErr) => {
-        this.logger.warn(releaseErr, `Failed to release agent email action token after dispatch error`);
-      });
+
+      // Only re-release the token when the failure is provably *pre-dispatch* (token
+      // validation, config resolution, adapter setup) — at which point no user-facing side
+      // effects have run and a retry is safe. For any other error, the agent's onAction
+      // handler may have executed partial work; replaying the token would let that
+      // non-idempotent work run twice, so the user is shown a terminal error and must
+      // recover via a fresh email if needed.
+      if (err instanceof AgentActionPreDispatchError) {
+        await this.tokenService.releaseActionToken(token, consumed).catch((releaseErr) => {
+          this.logger.warn(releaseErr, `Failed to release agent email action token after pre-dispatch failure`);
+        });
+      }
+
       this.sendHtml(
         res,
         HttpStatus.OK,
@@ -583,6 +618,21 @@ function renderAlreadySubmittedPage(): string {
 </div>`;
 
   return pageShell('Already submitted', body);
+}
+
+/** Rendered when the action-token cache is unreachable (Redis outage). Distinct from the
+ *  "Already submitted" terminal page — the token is *not* consumed, so the user can refresh
+ *  this page once service is restored and the link will still work. */
+function renderTryAgainPage(): string {
+  const body = `
+<div class="card" data-state="try-again">
+  <div class="info-icon" aria-hidden="true">↻</div>
+  <h1 class="message-heading">We're having trouble right now</h1>
+  <p class="intro">Please try again in a moment. Your action link is still valid — no need to come back to the email.</p>
+  <a class="secondary" href="javascript:void(0)" onclick="location.reload();return false;">Try again</a>
+</div>`;
+
+  return pageShell("We're having trouble right now", body);
 }
 
 function renderErrorPage(params: { title: string; message: string }): string {

--- a/apps/api/src/app/agents/agent-email-actions.controller.ts
+++ b/apps/api/src/app/agents/agent-email-actions.controller.ts
@@ -2,7 +2,11 @@ import { Body, Controller, Get, HttpStatus, Post, Query, Res } from '@nestjs/com
 import { ApiExcludeController } from '@nestjs/swagger';
 import { PinoLogger } from '@novu/application-generic';
 import { Response } from 'express';
-import { AgentEmailActionTokenService } from './services/agent-email-action-token.service';
+import {
+  AgentEmailActionClaims,
+  AgentEmailActionStyle,
+  AgentEmailActionTokenService,
+} from './services/agent-email-action-token.service';
 import { ChatSdkService } from './services/chat-sdk.service';
 
 const EXECUTE_PATH = '/v1/agents/email/actions/execute';
@@ -23,6 +27,10 @@ const EXECUTE_PATH = '/v1/agents/email/actions/execute';
  * The URL carries only an opaque random token — the action context (agent/environment/org
  * IDs, recipient address, action id/value) lives server-side in Redis so it never ends up
  * in third-party email scanner logs, browser history, or proxy access logs.
+ *
+ * The execute endpoint serves two clients: the form-submit path (browsers without JS) and
+ * an XHR path the inline JS uses to swap the card in place without a full reload. The XHR
+ * path is keyed on `X-Requested-With: XMLHttpRequest`; both return the same HTML bodies.
  */
 @Controller('/agents/email/actions')
 @ApiExcludeController()
@@ -41,21 +49,21 @@ export class AgentEmailActionsController {
       this.sendHtml(
         res,
         HttpStatus.BAD_REQUEST,
-        renderErrorPage('Invalid link', 'This action link is missing or malformed.')
+        renderErrorPage({ title: 'Invalid link', message: 'This action link is missing or malformed.' })
       );
 
       return;
     }
 
-    const claims = await this.tokenService.peekActionToken(token);
-    if (!claims) {
+    const peeked = await this.tokenService.peekActionToken(token);
+    if (!peeked) {
       this.sendHtml(
         res,
         HttpStatus.OK,
-        renderErrorPage(
-          'Link expired',
-          'This action link is no longer valid. It may have expired or already been used.'
-        )
+        renderErrorPage({
+          title: 'Link expired',
+          message: 'This action link is no longer valid. It may have expired or already been used.',
+        })
       );
 
       return;
@@ -65,7 +73,8 @@ export class AgentEmailActionsController {
       res,
       HttpStatus.OK,
       renderConfirmPage({
-        label: claims.label || claims.actionId,
+        claims: peeked.claims,
+        mintedAt: peeked.mintedAt,
         token,
         executeUrl: EXECUTE_PATH,
       })
@@ -75,7 +84,11 @@ export class AgentEmailActionsController {
   @Post('/execute')
   async execute(@Body('t') token: string | undefined, @Res() res: Response): Promise<void> {
     if (!token) {
-      this.sendHtml(res, HttpStatus.BAD_REQUEST, renderErrorPage('Invalid request', 'Missing action token.'));
+      this.sendHtml(
+        res,
+        HttpStatus.BAD_REQUEST,
+        renderErrorPage({ title: 'Invalid request', message: 'Missing action token.' })
+      );
 
       return;
     }
@@ -98,23 +111,23 @@ export class AgentEmailActionsController {
       this.logger.error(err, `Failed to process agent email action ${claims.actionId} for agent ${claims.agentId}`);
       // Re-store the entry so the user can retry from the same email link instead of seeing
       // "Already submitted". The remaining TTL is preserved against the original `expiresAt`
-      // so a token can never outlive its natural 3-day expiry.
+      // so a token can never outlive its natural expiry.
       await this.tokenService.releaseActionToken(token, consumed).catch((releaseErr) => {
         this.logger.warn(releaseErr, `Failed to release agent email action token after dispatch error`);
       });
       this.sendHtml(
         res,
         HttpStatus.OK,
-        renderErrorPage(
-          'Something went wrong',
-          'We could not submit this action. Please try again from the email, or contact your agent operator.'
-        )
+        renderErrorPage({
+          title: 'Something went wrong',
+          message: 'We could not submit this action. Please try again from the email, or contact your agent operator.',
+        })
       );
 
       return;
     }
 
-    this.sendHtml(res, HttpStatus.OK, renderSuccessPage({ label: claims.label || claims.actionId }));
+    this.sendHtml(res, HttpStatus.OK, renderSuccessPage({ claims }));
   }
 
   private sendHtml(res: Response, status: HttpStatus, body: string): void {
@@ -128,6 +141,10 @@ export class AgentEmailActionsController {
   }
 }
 
+// ===========================================================================================
+// HTML rendering helpers
+// ===========================================================================================
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -135,6 +152,56 @@ function escapeHtml(value: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+/** Generates 1–2 letter initials from an agent name. Falls back to `?` for empty input. */
+function computeInitials(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return '?';
+  const words = trimmed.split(/\s+/).filter(Boolean).slice(0, 2);
+  const initials = words
+    .map((w) => Array.from(w)[0] ?? '')
+    .join('')
+    .toUpperCase();
+
+  return initials || (trimmed[0] ?? '?').toUpperCase();
+}
+
+/** Deterministic light-mode background/foreground pair chosen from a small palette. The same
+ *  seed always returns the same pair so an agent's avatar is stable across emails. */
+function avatarPalette(seed: string): { bgLight: string; fgLight: string; bgDark: string; fgDark: string } {
+  const palette = [
+    { bgLight: '#fef3c7', fgLight: '#92400e', bgDark: '#451a03', fgDark: '#fcd34d' }, // amber
+    { bgLight: '#dbeafe', fgLight: '#1e40af', bgDark: '#172554', fgDark: '#93c5fd' }, // blue
+    { bgLight: '#dcfce7', fgLight: '#166534', bgDark: '#052e16', fgDark: '#86efac' }, // green
+    { bgLight: '#fce7f3', fgLight: '#9d174d', bgDark: '#500724', fgDark: '#f9a8d4' }, // pink
+    { bgLight: '#ede9fe', fgLight: '#5b21b6', bgDark: '#2e1065', fgDark: '#c4b5fd' }, // violet
+    { bgLight: '#fef9c3', fgLight: '#854d0e', bgDark: '#422006', fgDark: '#fde047' }, // yellow
+    { bgLight: '#cffafe', fgLight: '#155e75', bgDark: '#083344', fgDark: '#67e8f9' }, // cyan
+    { bgLight: '#ffe4e6', fgLight: '#9f1239', bgDark: '#4c0519', fgDark: '#fda4af' }, // rose
+  ];
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+
+  return palette[Math.abs(hash) % palette.length] as (typeof palette)[number];
+}
+
+function formatRelativeSent(mintedAt: number): string {
+  const secondsAgo = Math.max(0, Math.floor(Date.now() / 1000) - mintedAt);
+  if (secondsAgo < 60) return 'just now';
+  if (secondsAgo < 3600) {
+    const m = Math.floor(secondsAgo / 60);
+
+    return `${m} min ago`;
+  }
+  if (secondsAgo < 86400) {
+    const h = Math.floor(secondsAgo / 3600);
+
+    return `${h}h ago`;
+  }
+  const d = Math.floor(secondsAgo / 86400);
+
+  return `${d}d ago`;
 }
 
 const PAGE_STYLES = `
@@ -153,27 +220,65 @@ const PAGE_STYLES = `
   }
   .card {
     background: #ffffff;
-    border-radius: 12px;
-    padding: 40px 32px;
+    border: 1px solid #e4e4e7;
+    border-radius: 16px;
+    padding: 32px;
     width: 100%;
     max-width: 440px;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 16px rgba(0,0,0,0.06);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 8px 24px rgba(0,0,0,0.06);
     text-align: center;
     animation: fadeIn 240ms ease-out both;
   }
-  h1 { margin: 0 0 8px; font-size: 20px; font-weight: 600; }
-  p { margin: 0 0 24px; color: #52525b; font-size: 14px; line-height: 1.5; }
-  .label {
-    display: inline-block;
-    margin-bottom: 24px;
-    padding: 8px 14px;
-    background: #f4f4f5;
-    border-radius: 6px;
-    color: #18181b;
+  .avatar {
+    width: 56px;
+    height: 56px;
+    margin: 0 auto 14px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 18px;
+    letter-spacing: -0.2px;
+    background: var(--avatar-bg, #f4f4f5);
+    color: var(--avatar-fg, #52525b);
+  }
+  .agent-name {
+    font-size: 13px;
+    color: #71717a;
+    margin: 0 0 6px;
     font-weight: 500;
-    font-size: 14px;
-    max-width: 100%;
+  }
+  h1.action-headline {
+    margin: 0 0 8px;
+    font-size: 22px;
+    font-weight: 600;
+    line-height: 1.3;
+    color: #18181b;
     overflow-wrap: anywhere;
+  }
+  h1.message-heading { margin: 0 0 8px; font-size: 20px; font-weight: 600; }
+  p.intro { margin: 0 0 24px; color: #52525b; font-size: 14px; line-height: 1.5; }
+  p.danger-warning {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0 0 24px;
+    padding: 8px 12px;
+    background: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+  }
+  p.danger-warning::before {
+    content: '';
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #dc2626;
   }
   button.primary {
     appearance: none;
@@ -182,14 +287,57 @@ const PAGE_STYLES = `
     background: #18181b;
     color: #ffffff;
     padding: 12px 20px;
-    border-radius: 8px;
+    border-radius: 10px;
     font-size: 14px;
     font-weight: 500;
     width: 100%;
-    transition: background 120ms ease;
+    transition: background 120ms ease, transform 120ms ease, opacity 200ms ease;
   }
   button.primary:hover { background: #27272a; }
-  .footer { margin-top: 20px; font-size: 12px; color: #a1a1aa; }
+  button.primary:active { transform: translateY(1px); }
+  button.primary:disabled {
+    opacity: 0.7;
+    cursor: progress;
+    background: #18181b;
+  }
+  button.primary.danger { background: #dc2626; }
+  button.primary.danger:hover { background: #b91c1c; }
+  button.primary .spinner {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border: 2px solid rgba(255,255,255,0.3);
+    border-top-color: #ffffff;
+    border-radius: 50%;
+    margin-right: 8px;
+    vertical-align: -2px;
+    animation: spin 700ms linear infinite;
+  }
+  a.secondary,
+  button.secondary {
+    appearance: none;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    color: #71717a;
+    font-size: 13px;
+    font-weight: 500;
+    margin-top: 14px;
+    padding: 4px 8px;
+    text-decoration: none;
+    display: inline-block;
+    border-radius: 6px;
+    transition: color 120ms ease, background 120ms ease;
+    font-family: inherit;
+  }
+  a.secondary:hover, button.secondary:hover { color: #18181b; background: #f4f4f5; }
+  .footer {
+    margin-top: 24px;
+    padding-top: 16px;
+    border-top: 1px solid #f4f4f5;
+    font-size: 12px;
+    color: #a1a1aa;
+  }
   .check {
     width: 64px;
     height: 64px;
@@ -220,16 +368,51 @@ const PAGE_STYLES = `
     background: #f4f4f5;
     color: #52525b;
     font-size: 28px;
+    font-weight: 500;
     display: flex;
     align-items: center;
     justify-content: center;
   }
+  .cancel-hint {
+    display: none;
+    margin-top: 12px;
+    font-size: 12px;
+    color: #71717a;
+  }
+  .cancel-hint.visible { display: block; }
+  .card.swapping { animation: none; opacity: 0; transform: translateY(4px); transition: opacity 200ms ease, transform 200ms ease; }
   @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
   @keyframes pop { 0% { transform: scale(0.6); opacity: 0; } 60% { transform: scale(1.06); opacity: 1; } 100% { transform: scale(1); opacity: 1; } }
   @keyframes stroke { to { stroke-dashoffset: 0; } }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  @media (prefers-color-scheme: dark) {
+    body { background: #0a0a0a; color: #fafafa; }
+    .card { background: #18181b; border-color: #27272a; box-shadow: 0 1px 2px rgba(0,0,0,0.4), 0 8px 24px rgba(0,0,0,0.4); }
+    .avatar { background: var(--avatar-bg-dark, #27272a); color: var(--avatar-fg-dark, #d4d4d8); }
+    .agent-name { color: #a1a1aa; }
+    h1.action-headline, h1.message-heading { color: #fafafa; }
+    p.intro { color: #a1a1aa; }
+    p.danger-warning { background: #450a0a; color: #fca5a5; border-color: #7f1d1d; }
+    p.danger-warning::before { background: #f87171; }
+    button.primary { background: #fafafa; color: #18181b; }
+    button.primary:hover { background: #e4e4e7; }
+    button.primary:disabled { background: #fafafa; }
+    button.primary.danger { background: #dc2626; color: #ffffff; }
+    button.primary.danger:hover { background: #b91c1c; }
+    button.primary .spinner { border-color: rgba(0,0,0,0.25); border-top-color: #18181b; }
+    button.primary.danger .spinner { border-color: rgba(255,255,255,0.3); border-top-color: #ffffff; }
+    a.secondary, button.secondary { color: #a1a1aa; }
+    a.secondary:hover, button.secondary:hover { color: #fafafa; background: #27272a; }
+    .footer { color: #71717a; border-top-color: #27272a; }
+    .check { background: #052e16; }
+    .check svg path { stroke: #34d399; }
+    .info-icon { background: #27272a; color: #a1a1aa; }
+    .cancel-hint { color: #a1a1aa; }
+  }
 `;
 
-function pageShell(title: string, body: string): string {
+function pageShell(title: string, body: string, inlineScript?: string): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -237,38 +420,155 @@ function pageShell(title: string, body: string): string {
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="robots" content="noindex,nofollow" />
 <meta name="referrer" content="no-referrer" />
+<meta name="color-scheme" content="light dark" />
 <title>${escapeHtml(title)}</title>
 <style>${PAGE_STYLES}</style>
 </head>
-<body>${body}</body>
+<body>${body}${inlineScript ? `<script>${inlineScript}</script>` : ''}</body>
 </html>`;
 }
 
-function renderConfirmPage(params: { label: string; token: string; executeUrl: string }): string {
-  const body = `
-<div class="card">
-  <h1>Confirm action</h1>
-  <p>You're about to submit the following action to the agent. This cannot be undone.</p>
-  <div class="label">${escapeHtml(params.label)}</div>
-  <form method="POST" action="${escapeHtml(params.executeUrl)}" autocomplete="off">
-    <input type="hidden" name="t" value="${escapeHtml(params.token)}" />
-    <button type="submit" class="primary">Confirm ${escapeHtml(params.label)}</button>
-  </form>
-  <div class="footer">Sent by your Novu agent</div>
-</div>`;
+function renderAvatar(agentName: string): string {
+  const initials = computeInitials(agentName);
+  const palette = avatarPalette(agentName);
+  const style = `--avatar-bg:${palette.bgLight};--avatar-fg:${palette.fgLight};--avatar-bg-dark:${palette.bgDark};--avatar-fg-dark:${palette.fgDark};`;
 
-  return pageShell(`Confirm: ${params.label}`, body);
+  return `<div class="avatar" style="${style}" aria-hidden="true">${escapeHtml(initials)}</div>`;
 }
 
-function renderSuccessPage(params: { label: string }): string {
+function renderFooter(agentName: string, mintedAt: number): string {
+  return `<div class="footer">Sent ${escapeHtml(formatRelativeSent(mintedAt))} by ${escapeHtml(agentName)}</div>`;
+}
+
+function buttonStyleClass(style: AgentEmailActionStyle | undefined): string {
+  return style === 'danger' ? 'primary danger' : 'primary';
+}
+
+interface ConfirmPageParams {
+  claims: AgentEmailActionClaims;
+  mintedAt: number;
+  token: string;
+  executeUrl: string;
+}
+
+function renderConfirmPage(params: ConfirmPageParams): string {
+  const { claims, mintedAt, token, executeUrl } = params;
+  const label = claims.label || claims.actionId;
+  const isDanger = claims.style === 'danger';
+  const danger = isDanger ? `<p class="danger-warning">This action cannot be undone.</p>` : '';
+
   const body = `
-<div class="card">
+<div class="card" data-state="confirm">
+  ${renderAvatar(claims.agentName)}
+  <p class="agent-name">${escapeHtml(claims.agentName)}</p>
+  <h1 class="action-headline">${escapeHtml(label)}</h1>
+  ${danger}
+  <form id="agent-action-form" method="POST" action="${escapeHtml(executeUrl)}" autocomplete="off">
+    <input type="hidden" name="t" value="${escapeHtml(token)}" />
+    <button type="submit" class="${buttonStyleClass(claims.style)}" data-submit-label="Confirm" data-busy-label="Submitting…">
+      <span class="label">Confirm</span>
+    </button>
+    <div>
+      <button type="button" class="secondary" id="cancel-btn">Cancel</button>
+      <div class="cancel-hint" id="cancel-hint">Close this tab to cancel — no action will be taken.</div>
+    </div>
+  </form>
+  ${renderFooter(claims.agentName, mintedAt)}
+</div>`;
+
+  return pageShell(`Confirm: ${label}`, body, CONFIRM_PAGE_SCRIPT);
+}
+
+/** Inlined on every confirm page. Adds:
+ *   1. Submit-button loading state (disables + spinner, prevents double-submit).
+ *   2. fetch()-based submit so the success card swaps in place without a full reload.
+ *   3. "Cancel" button that attempts window.close() and falls back to a hint.
+ *  Falls back gracefully when JS is disabled — the plain form POST still works.
+ */
+const CONFIRM_PAGE_SCRIPT = `
+(function () {
+  var form = document.getElementById('agent-action-form');
+  var cancelBtn = document.getElementById('cancel-btn');
+  var cancelHint = document.getElementById('cancel-hint');
+  if (!form) return;
+
+  var submitBtn = form.querySelector('button[type="submit"]');
+  var labelSpan = submitBtn ? submitBtn.querySelector('.label') : null;
+
+  function setBusy() {
+    if (!submitBtn) return;
+    submitBtn.disabled = true;
+    if (labelSpan) {
+      labelSpan.innerHTML = '<span class="spinner" aria-hidden="true"></span>' + (submitBtn.getAttribute('data-busy-label') || 'Submitting…');
+    }
+  }
+
+  function swapCard(html) {
+    var doc = new DOMParser().parseFromString(html, 'text/html');
+    var newCard = doc.querySelector('.card');
+    if (!newCard) { window.location.reload(); return; }
+
+    var current = document.querySelector('.card');
+    if (!current) { document.body.appendChild(newCard); return; }
+
+    current.classList.add('swapping');
+    setTimeout(function () {
+      current.replaceWith(newCard);
+    }, 200);
+  }
+
+  form.addEventListener('submit', function (e) {
+    if (!window.fetch) return; // graceful fallback to plain form POST
+    e.preventDefault();
+    setBusy();
+
+    fetch(form.action, {
+      method: 'POST',
+      body: new FormData(form),
+      headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'text/html' },
+      credentials: 'same-origin',
+    })
+      .then(function (r) { return r.text(); })
+      .then(swapCard)
+      .catch(function () {
+        // Network failure — fall back to a hard reload so the server can render an error page.
+        form.submit();
+      });
+  });
+
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', function () {
+      // window.close() works only on tabs opened by script. Attempt it; if the tab is still
+      // here a moment later, surface a hint instead.
+      window.close();
+      setTimeout(function () {
+        if (!document.hidden && cancelHint) cancelHint.classList.add('visible');
+      }, 150);
+    });
+  }
+})();
+`;
+
+interface SuccessPageParams {
+  claims: AgentEmailActionClaims;
+}
+
+function renderSuccessPage(params: SuccessPageParams): string {
+  const { claims } = params;
+  const label = claims.label || claims.actionId;
+
+  // Inline onclick on the close link so it works in both the full-page-load path AND the
+  // XHR-swap path (scripts inserted via DOMParser/replaceWith don't auto-execute, but inline
+  // event handler attributes are honored).
+  const body = `
+<div class="card" data-state="success">
   <div class="check">
     <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12.5l4.5 4.5L19 7" /></svg>
   </div>
-  <h1>Action submitted</h1>
-  <p>Your agent received <strong>${escapeHtml(params.label)}</strong> and is processing it.</p>
-  <div class="footer">You can close this tab.</div>
+  <h1 class="message-heading">Action submitted</h1>
+  <p class="intro"><strong>${escapeHtml(claims.agentName)}</strong> received <strong>${escapeHtml(label)}</strong> and is processing it.</p>
+  <a class="secondary" href="javascript:void(0)" onclick="try{window.close();}catch(e){}setTimeout(function(){if(!document.hidden){var h=this&&this.nextElementSibling;if(h)h.classList.add('visible');}}.bind(this),150);return false;">← Close this tab</a>
+  <div class="cancel-hint">You can close this tab manually.</div>
 </div>`;
 
   return pageShell('Action submitted', body);
@@ -276,22 +576,22 @@ function renderSuccessPage(params: { label: string }): string {
 
 function renderAlreadySubmittedPage(): string {
   const body = `
-<div class="card">
+<div class="card" data-state="already-submitted">
   <div class="info-icon" aria-hidden="true">✓</div>
-  <h1>Already submitted</h1>
-  <p>This action has already been received. You can close this tab.</p>
+  <h1 class="message-heading">Already submitted</h1>
+  <p class="intro">This action has already been received. You can close this tab.</p>
 </div>`;
 
   return pageShell('Already submitted', body);
 }
 
-function renderErrorPage(title: string, message: string): string {
+function renderErrorPage(params: { title: string; message: string }): string {
   const body = `
-<div class="card">
+<div class="card" data-state="error">
   <div class="info-icon" aria-hidden="true">!</div>
-  <h1>${escapeHtml(title)}</h1>
-  <p>${escapeHtml(message)}</p>
+  <h1 class="message-heading">${escapeHtml(params.title)}</h1>
+  <p class="intro">${escapeHtml(params.message)}</p>
 </div>`;
 
-  return pageShell(title, body);
+  return pageShell(params.title, body);
 }

--- a/apps/api/src/app/agents/agent-email-actions.controller.ts
+++ b/apps/api/src/app/agents/agent-email-actions.controller.ts
@@ -98,6 +98,13 @@ export class AgentEmailActionsController {
       await this.chatSdkService.processEmailAction(claims);
     } catch (err) {
       this.logger.error(err, `Failed to process agent email action ${claims.actionId} for agent ${claims.agentId}`);
+      // Release the single-use claim so the user can retry from the same email link instead of
+      // seeing "Already submitted". The claim is taken *before* dispatch (not after) to keep
+      // the prefetcher/double-click race window closed; rolling back on transient failure is
+      // the safer of the two trade-offs.
+      await this.tokenService.releaseSingleUse(claims.jti).catch((releaseErr) => {
+        this.logger.warn(releaseErr, `Failed to release single-use claim for ${claims.jti} after dispatch error`);
+      });
       this.sendHtml(
         res,
         HttpStatus.OK,
@@ -114,7 +121,13 @@ export class AgentEmailActionsController {
   }
 
   private sendHtml(res: Response, status: HttpStatus, body: string): void {
-    res.status(status).type('text/html; charset=utf-8').send(body);
+    res
+      .status(status)
+      .setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, private')
+      .setHeader('Pragma', 'no-cache')
+      .setHeader('Expires', '0')
+      .type('text/html; charset=utf-8')
+      .send(body);
   }
 }
 

--- a/apps/api/src/app/agents/agent-email-actions.controller.ts
+++ b/apps/api/src/app/agents/agent-email-actions.controller.ts
@@ -2,10 +2,7 @@ import { Body, Controller, Get, HttpStatus, Post, Query, Res } from '@nestjs/com
 import { ApiExcludeController } from '@nestjs/swagger';
 import { PinoLogger } from '@novu/application-generic';
 import { Response } from 'express';
-import {
-  AgentEmailActionTokenService,
-  type VerifiedAgentEmailActionClaims,
-} from './services/agent-email-action-token.service';
+import { AgentEmailActionTokenService } from './services/agent-email-action-token.service';
 import { ChatSdkService } from './services/chat-sdk.service';
 
 const EXECUTE_PATH = '/v1/agents/email/actions/execute';
@@ -15,11 +12,17 @@ const EXECUTE_PATH = '/v1/agents/email/actions/execute';
  * rendered inside agent-sent emails. The click flow is intentionally two-step to defeat
  * URL-prefetchers in email clients (Outlook Safe Links, Mimecast, etc.):
  *
- *   GET  /v1/agents/email/actions/preview?t=<jwt>  — verify token, render confirm HTML.
- *                                                    Does NOT mutate any state.
- *   POST /v1/agents/email/actions/execute          — verify, single-use claim, dispatch
- *                                                    to chat SDK's processAction, render
- *                                                    animated success HTML.
+ *   GET  /v1/agents/email/actions/preview?t=<token>  — peek (read-only), render confirm HTML.
+ *                                                      Does NOT mutate any state, so a
+ *                                                      prefetcher's GET can't burn the token.
+ *   POST /v1/agents/email/actions/execute            — atomic single-use consume, dispatch
+ *                                                      to chat SDK's processAction, render
+ *                                                      animated success HTML. Re-stores the
+ *                                                      token on transient dispatch failure.
+ *
+ * The URL carries only an opaque random token — the action context (agent/environment/org
+ * IDs, recipient address, action id/value) lives server-side in Redis so it never ends up
+ * in third-party email scanner logs, browser history, or proxy access logs.
  */
 @Controller('/agents/email/actions')
 @ApiExcludeController()
@@ -44,25 +47,29 @@ export class AgentEmailActionsController {
       return;
     }
 
-    try {
-      const claims = this.tokenService.verifyActionToken(token);
+    const claims = await this.tokenService.peekActionToken(token);
+    if (!claims) {
       this.sendHtml(
         res,
         HttpStatus.OK,
-        renderConfirmPage({
-          label: claims.label || claims.actionId,
-          token,
-          executeUrl: EXECUTE_PATH,
-        })
+        renderErrorPage(
+          'Link expired',
+          'This action link is no longer valid. It may have expired or already been used.'
+        )
       );
-    } catch (err) {
-      this.logger.debug({ err }, 'Rejecting agent email action preview');
-      this.sendHtml(
-        res,
-        HttpStatus.OK,
-        renderErrorPage('Link expired', 'This action link is no longer valid. It may have expired.')
-      );
+
+      return;
     }
+
+    this.sendHtml(
+      res,
+      HttpStatus.OK,
+      renderConfirmPage({
+        label: claims.label || claims.actionId,
+        token,
+        executeUrl: EXECUTE_PATH,
+      })
+    );
   }
 
   @Post('/execute')
@@ -73,37 +80,27 @@ export class AgentEmailActionsController {
       return;
     }
 
-    let claims: VerifiedAgentEmailActionClaims;
-    try {
-      claims = this.tokenService.verifyActionToken(token);
-    } catch (err) {
-      this.logger.debug({ err }, 'Rejecting agent email action execute');
-      this.sendHtml(
-        res,
-        HttpStatus.OK,
-        renderErrorPage('Link expired', 'This action link is no longer valid. It may have expired.')
-      );
+    // Atomic single-use claim: consume returns the entry exactly once across all concurrent
+    // callers (Redis GETDEL). Any other click — prefetcher, refresh, second tab — receives
+    // null and is shown the "already submitted" page.
+    const consumed = await this.tokenService.consumeActionToken(token);
+    if (!consumed) {
+      this.sendHtml(res, HttpStatus.OK, renderAlreadySubmittedPage());
 
       return;
     }
 
-    const claimed = await this.tokenService.claimSingleUse(claims.jti, claims.exp);
-    if (!claimed) {
-      this.sendHtml(res, HttpStatus.OK, renderAlreadySubmittedPage({ label: claims.label || claims.actionId }));
-
-      return;
-    }
+    const { claims } = consumed;
 
     try {
       await this.chatSdkService.processEmailAction(claims);
     } catch (err) {
       this.logger.error(err, `Failed to process agent email action ${claims.actionId} for agent ${claims.agentId}`);
-      // Release the single-use claim so the user can retry from the same email link instead of
-      // seeing "Already submitted". The claim is taken *before* dispatch (not after) to keep
-      // the prefetcher/double-click race window closed; rolling back on transient failure is
-      // the safer of the two trade-offs.
-      await this.tokenService.releaseSingleUse(claims.jti).catch((releaseErr) => {
-        this.logger.warn(releaseErr, `Failed to release single-use claim for ${claims.jti} after dispatch error`);
+      // Re-store the entry so the user can retry from the same email link instead of seeing
+      // "Already submitted". The remaining TTL is preserved against the original `expiresAt`
+      // so a token can never outlive its natural 3-day expiry.
+      await this.tokenService.releaseActionToken(token, consumed).catch((releaseErr) => {
+        this.logger.warn(releaseErr, `Failed to release agent email action token after dispatch error`);
       });
       this.sendHtml(
         res,
@@ -277,12 +274,12 @@ function renderSuccessPage(params: { label: string }): string {
   return pageShell('Action submitted', body);
 }
 
-function renderAlreadySubmittedPage(params: { label: string }): string {
+function renderAlreadySubmittedPage(): string {
   const body = `
 <div class="card">
   <div class="info-icon" aria-hidden="true">✓</div>
   <h1>Already submitted</h1>
-  <p>The action <strong>${escapeHtml(params.label)}</strong> has already been received. You can close this tab.</p>
+  <p>This action has already been received. You can close this tab.</p>
 </div>`;
 
   return pageShell('Already submitted', body);

--- a/apps/api/src/app/agents/agent-email-actions.controller.ts
+++ b/apps/api/src/app/agents/agent-email-actions.controller.ts
@@ -1,0 +1,287 @@
+import { Body, Controller, Get, HttpStatus, Post, Query, Res } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import { PinoLogger } from '@novu/application-generic';
+import { Response } from 'express';
+import {
+  AgentEmailActionTokenService,
+  type VerifiedAgentEmailActionClaims,
+} from './services/agent-email-action-token.service';
+import { ChatSdkService } from './services/chat-sdk.service';
+
+const EXECUTE_PATH = '/v1/agents/email/actions/execute';
+
+/**
+ * Public, unauthenticated endpoints that handle clicks from `<Button>` action elements
+ * rendered inside agent-sent emails. The click flow is intentionally two-step to defeat
+ * URL-prefetchers in email clients (Outlook Safe Links, Mimecast, etc.):
+ *
+ *   GET  /v1/agents/email/actions/preview?t=<jwt>  — verify token, render confirm HTML.
+ *                                                    Does NOT mutate any state.
+ *   POST /v1/agents/email/actions/execute          — verify, single-use claim, dispatch
+ *                                                    to chat SDK's processAction, render
+ *                                                    animated success HTML.
+ */
+@Controller('/agents/email/actions')
+@ApiExcludeController()
+export class AgentEmailActionsController {
+  constructor(
+    private readonly tokenService: AgentEmailActionTokenService,
+    private readonly chatSdkService: ChatSdkService,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  @Get('/preview')
+  async preview(@Query('t') token: string | undefined, @Res() res: Response): Promise<void> {
+    if (!token) {
+      this.sendHtml(
+        res,
+        HttpStatus.BAD_REQUEST,
+        renderErrorPage('Invalid link', 'This action link is missing or malformed.')
+      );
+
+      return;
+    }
+
+    try {
+      const claims = this.tokenService.verifyActionToken(token);
+      this.sendHtml(
+        res,
+        HttpStatus.OK,
+        renderConfirmPage({
+          label: claims.label || claims.actionId,
+          token,
+          executeUrl: EXECUTE_PATH,
+        })
+      );
+    } catch (err) {
+      this.logger.debug({ err }, 'Rejecting agent email action preview');
+      this.sendHtml(
+        res,
+        HttpStatus.OK,
+        renderErrorPage('Link expired', 'This action link is no longer valid. It may have expired.')
+      );
+    }
+  }
+
+  @Post('/execute')
+  async execute(@Body('t') token: string | undefined, @Res() res: Response): Promise<void> {
+    if (!token) {
+      this.sendHtml(res, HttpStatus.BAD_REQUEST, renderErrorPage('Invalid request', 'Missing action token.'));
+
+      return;
+    }
+
+    let claims: VerifiedAgentEmailActionClaims;
+    try {
+      claims = this.tokenService.verifyActionToken(token);
+    } catch (err) {
+      this.logger.debug({ err }, 'Rejecting agent email action execute');
+      this.sendHtml(
+        res,
+        HttpStatus.OK,
+        renderErrorPage('Link expired', 'This action link is no longer valid. It may have expired.')
+      );
+
+      return;
+    }
+
+    const claimed = await this.tokenService.claimSingleUse(claims.jti, claims.exp);
+    if (!claimed) {
+      this.sendHtml(res, HttpStatus.OK, renderAlreadySubmittedPage({ label: claims.label || claims.actionId }));
+
+      return;
+    }
+
+    try {
+      await this.chatSdkService.processEmailAction(claims);
+    } catch (err) {
+      this.logger.error(err, `Failed to process agent email action ${claims.actionId} for agent ${claims.agentId}`);
+      this.sendHtml(
+        res,
+        HttpStatus.OK,
+        renderErrorPage(
+          'Something went wrong',
+          'We could not submit this action. Please try again from the email, or contact your agent operator.'
+        )
+      );
+
+      return;
+    }
+
+    this.sendHtml(res, HttpStatus.OK, renderSuccessPage({ label: claims.label || claims.actionId }));
+  }
+
+  private sendHtml(res: Response, status: HttpStatus, body: string): void {
+    res.status(status).type('text/html; charset=utf-8').send(body);
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const PAGE_STYLES = `
+  *,*::before,*::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    background: #f7f7f8;
+    color: #18181b;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    -webkit-font-smoothing: antialiased;
+  }
+  .card {
+    background: #ffffff;
+    border-radius: 12px;
+    padding: 40px 32px;
+    width: 100%;
+    max-width: 440px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 16px rgba(0,0,0,0.06);
+    text-align: center;
+    animation: fadeIn 240ms ease-out both;
+  }
+  h1 { margin: 0 0 8px; font-size: 20px; font-weight: 600; }
+  p { margin: 0 0 24px; color: #52525b; font-size: 14px; line-height: 1.5; }
+  .label {
+    display: inline-block;
+    margin-bottom: 24px;
+    padding: 8px 14px;
+    background: #f4f4f5;
+    border-radius: 6px;
+    color: #18181b;
+    font-weight: 500;
+    font-size: 14px;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+  }
+  button.primary {
+    appearance: none;
+    border: 0;
+    cursor: pointer;
+    background: #18181b;
+    color: #ffffff;
+    padding: 12px 20px;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    width: 100%;
+    transition: background 120ms ease;
+  }
+  button.primary:hover { background: #27272a; }
+  .footer { margin-top: 20px; font-size: 12px; color: #a1a1aa; }
+  .check {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 20px;
+    border-radius: 50%;
+    background: #ecfdf5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: pop 360ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  .check svg { width: 32px; height: 32px; }
+  .check svg path {
+    stroke: #059669;
+    stroke-width: 3;
+    fill: none;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-dasharray: 48;
+    stroke-dashoffset: 48;
+    animation: stroke 420ms 200ms ease-out forwards;
+  }
+  .info-icon {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 20px;
+    border-radius: 50%;
+    background: #f4f4f5;
+    color: #52525b;
+    font-size: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+  @keyframes pop { 0% { transform: scale(0.6); opacity: 0; } 60% { transform: scale(1.06); opacity: 1; } 100% { transform: scale(1); opacity: 1; } }
+  @keyframes stroke { to { stroke-dashoffset: 0; } }
+`;
+
+function pageShell(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex,nofollow" />
+<meta name="referrer" content="no-referrer" />
+<title>${escapeHtml(title)}</title>
+<style>${PAGE_STYLES}</style>
+</head>
+<body>${body}</body>
+</html>`;
+}
+
+function renderConfirmPage(params: { label: string; token: string; executeUrl: string }): string {
+  const body = `
+<div class="card">
+  <h1>Confirm action</h1>
+  <p>You're about to submit the following action to the agent. This cannot be undone.</p>
+  <div class="label">${escapeHtml(params.label)}</div>
+  <form method="POST" action="${escapeHtml(params.executeUrl)}" autocomplete="off">
+    <input type="hidden" name="t" value="${escapeHtml(params.token)}" />
+    <button type="submit" class="primary">Confirm ${escapeHtml(params.label)}</button>
+  </form>
+  <div class="footer">Sent by your Novu agent</div>
+</div>`;
+
+  return pageShell(`Confirm: ${params.label}`, body);
+}
+
+function renderSuccessPage(params: { label: string }): string {
+  const body = `
+<div class="card">
+  <div class="check">
+    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12.5l4.5 4.5L19 7" /></svg>
+  </div>
+  <h1>Action submitted</h1>
+  <p>Your agent received <strong>${escapeHtml(params.label)}</strong> and is processing it.</p>
+  <div class="footer">You can close this tab.</div>
+</div>`;
+
+  return pageShell('Action submitted', body);
+}
+
+function renderAlreadySubmittedPage(params: { label: string }): string {
+  const body = `
+<div class="card">
+  <div class="info-icon" aria-hidden="true">✓</div>
+  <h1>Already submitted</h1>
+  <p>The action <strong>${escapeHtml(params.label)}</strong> has already been received. You can close this tab.</p>
+</div>`;
+
+  return pageShell('Already submitted', body);
+}
+
+function renderErrorPage(title: string, message: string): string {
+  const body = `
+<div class="card">
+  <div class="info-icon" aria-hidden="true">!</div>
+  <h1>${escapeHtml(title)}</h1>
+  <p>${escapeHtml(message)}</p>
+</div>`;
+
+  return pageShell(title, body);
+}

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
 import {
   ChannelConnectionRepository,
   ChannelEndpointRepository,
@@ -9,11 +10,13 @@ import {
 import { AuthModule } from '../auth/auth.module';
 import { EventsModule } from '../events/events.module';
 import { SharedModule } from '../shared/shared.module';
+import { AgentEmailActionsController } from './agent-email-actions.controller';
 import { AgentsController } from './agents.controller';
 import { AgentsWebhookController } from './agents-webhook.controller';
 import { AgentAttachmentStorage } from './services/agent-attachment-storage.service';
 import { AgentConfigResolver } from './services/agent-config-resolver.service';
 import { AgentConversationService } from './services/agent-conversation.service';
+import { AgentEmailActionTokenService } from './services/agent-email-action-token.service';
 import { AgentInboundHandler } from './services/agent-inbound-handler.service';
 import { AgentSubscriberResolver } from './services/agent-subscriber-resolver.service';
 import { BridgeExecutorService } from './services/bridge-executor.service';
@@ -21,8 +24,15 @@ import { ChatSdkService } from './services/chat-sdk.service';
 import { USE_CASES } from './usecases';
 
 @Module({
-  imports: [SharedModule, AuthModule, EventsModule],
-  controllers: [AgentsController, AgentsWebhookController],
+  imports: [
+    SharedModule,
+    AuthModule,
+    EventsModule,
+    JwtModule.register({
+      secret: process.env.JWT_SECRET,
+    }),
+  ],
+  controllers: [AgentsController, AgentsWebhookController, AgentEmailActionsController],
   providers: [
     ...USE_CASES,
     ChannelConnectionRepository,
@@ -33,6 +43,7 @@ import { USE_CASES } from './usecases';
     AgentConfigResolver,
     AgentSubscriberResolver,
     AgentConversationService,
+    AgentEmailActionTokenService,
     AgentInboundHandler,
     BridgeExecutorService,
     ChatSdkService,

--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
 import {
   ChannelConnectionRepository,
   ChannelEndpointRepository,
@@ -24,14 +23,7 @@ import { ChatSdkService } from './services/chat-sdk.service';
 import { USE_CASES } from './usecases';
 
 @Module({
-  imports: [
-    SharedModule,
-    AuthModule,
-    EventsModule,
-    JwtModule.register({
-      secret: process.env.JWT_SECRET,
-    }),
-  ],
+  imports: [SharedModule, AuthModule, EventsModule],
   controllers: [AgentsController, AgentsWebhookController, AgentEmailActionsController],
   providers: [
     ...USE_CASES,

--- a/apps/api/src/app/agents/services/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-config-resolver.service.ts
@@ -45,6 +45,8 @@ export interface ResolvedAgentConfig {
   environmentId: string;
   organizationId: string;
   agentIdentifier: string;
+  /** Human-readable display name; used in email-action confirmation UI. */
+  agentName: string;
   integrationIdentifier: string;
   integrationId: string;
   acknowledgeOnReceived: boolean;
@@ -188,6 +190,7 @@ export class AgentConfigResolver {
       environmentId,
       organizationId,
       agentIdentifier: agent.identifier,
+      agentName: agent.name,
       integrationIdentifier,
       integrationId: integration._id,
       acknowledgeOnReceived: agent.behavior?.acknowledgeOnReceived !== false,

--- a/apps/api/src/app/agents/services/agent-email-action-token.service.ts
+++ b/apps/api/src/app/agents/services/agent-email-action-token.service.ts
@@ -1,12 +1,19 @@
-import { randomUUID } from 'node:crypto';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
+import { randomBytes } from 'node:crypto';
+import { Injectable } from '@nestjs/common';
 import { CacheService, PinoLogger } from '@novu/application-generic';
 
-const TOKEN_AUDIENCE = 'agent_email_action';
-const TOKEN_ISSUER = 'novu_api';
-const DEFAULT_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+const KEY_PREFIX = 'agent:email:action:';
+const DEFAULT_TTL_SECONDS = 60 * 60 * 24 * 3; // 3 days
+/** 256 bits of entropy. Encoded as base64url → 43 URL-safe characters. */
+const TOKEN_BYTES = 32;
 
+/**
+ * Action context forwarded to the agent's `onAction` handler when a recipient clicks an
+ * email button. Stored server-side keyed by an opaque token so none of these fields ever
+ * appear in the URL — internal IDs (`environmentId`, `organizationId`, `agentId`) and the
+ * recipient address (`userIdentifier`) would otherwise be readable by any party that sees
+ * the link (corporate email scanners, server logs, browser history, mail archives).
+ */
 export interface AgentEmailActionClaims {
   /** Mongo `_id` of the agent. Used to look up cached chat instance + resolve config. */
   agentId: string;
@@ -27,13 +34,20 @@ export interface AgentEmailActionClaims {
   label?: string;
   /** Email address of the recipient — used as `platformUserId` for subscriber resolution. */
   userIdentifier: string;
-  /** Unique token id for single-use enforcement. */
-  jti: string;
 }
 
-export interface VerifiedAgentEmailActionClaims extends AgentEmailActionClaims {
-  /** Seconds since epoch when this token expires. Used to compute the single-use Redis TTL. */
-  exp: number;
+interface StoredEntry {
+  claims: AgentEmailActionClaims;
+  /** Epoch seconds when the entry was due to naturally expire. Used to recompute the
+   *  remaining TTL when a token is restored after a transient dispatch failure. */
+  expiresAt: number;
+}
+
+/** Returned from `consumeActionToken`; carries `expiresAt` so a transient failure can
+ *  re-store the entry without extending its lifetime past the original expiry. */
+export interface ConsumedActionToken {
+  claims: AgentEmailActionClaims;
+  expiresAt: number;
 }
 
 @Injectable()
@@ -41,22 +55,25 @@ export class AgentEmailActionTokenService {
   private readonly ttlSeconds: number;
 
   constructor(
-    private readonly jwtService: JwtService,
     private readonly cacheService: CacheService,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
-    const raw = process.env.AGENT_EMAIL_ACTION_JWT_TTL;
+    const raw = process.env.AGENT_EMAIL_ACTION_TOKEN_TTL;
     const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
     this.ttlSeconds = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_SECONDS;
   }
 
-  async signActionToken(claims: Omit<AgentEmailActionClaims, 'jti'>): Promise<{ token: string; url: string }> {
-    const jti = randomUUID();
-    const token = await this.jwtService.signAsync(
-      { ...claims, jti },
-      { issuer: TOKEN_ISSUER, audience: TOKEN_AUDIENCE, expiresIn: this.ttlSeconds }
-    );
+  /**
+   * Mints a fresh opaque action token and stores the full claims server-side. The URL
+   * embedded in the email body carries only the random token, never the claims themselves.
+   */
+  async signActionToken(claims: AgentEmailActionClaims): Promise<{ token: string; url: string }> {
+    const token = randomBytes(TOKEN_BYTES).toString('base64url');
+    const expiresAt = Math.floor(Date.now() / 1000) + this.ttlSeconds;
+    const entry: StoredEntry = { claims, expiresAt };
+
+    await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), { ttl: this.ttlSeconds });
 
     const base = (process.env.API_ROOT_URL ?? '').replace(/\/$/, '');
     if (!base) {
@@ -67,44 +84,70 @@ export class AgentEmailActionTokenService {
     return { token, url };
   }
 
-  verifyActionToken(token: string): VerifiedAgentEmailActionClaims {
-    try {
-      return this.jwtService.verify<VerifiedAgentEmailActionClaims>(token, {
-        issuer: TOKEN_ISSUER,
-        audience: TOKEN_AUDIENCE,
-      });
-    } catch (err) {
-      this.logger.debug({ err }, 'Failed to verify agent email action token');
-      throw new UnauthorizedException('Invalid or expired action link');
+  /**
+   * Reads the claims **without** consuming the token. Used by the GET preview route so a
+   * URL prefetcher (or repeated browser visit) doesn't burn the single-use reservation.
+   */
+  async peekActionToken(token: string): Promise<AgentEmailActionClaims | null> {
+    const raw = await this.cacheService.get(this.storageKey(token));
+    if (!raw) return null;
+
+    return this.parseEntry(raw)?.claims ?? null;
+  }
+
+  /**
+   * Atomically reads **and deletes** the entry. This is the single-use claim — only one
+   * caller wins per token; later callers see `null` and the controller renders the
+   * "already submitted" page. If downstream dispatch fails transiently, call
+   * `releaseActionToken` to put the entry back so the user can retry from the same link.
+   */
+  async consumeActionToken(token: string): Promise<ConsumedActionToken | null> {
+    const client = this.cacheService.client;
+    if (!client) {
+      this.logger.error('Cache client unavailable — cannot consume agent email action token');
+
+      return null;
     }
+
+    // GETDEL: atomic read+delete (Redis 6.2+, native ioredis support).
+    const raw = await client.getdel(this.storageKey(token));
+    if (!raw) return null;
+
+    const entry = this.parseEntry(raw);
+
+    return entry ? { claims: entry.claims, expiresAt: entry.expiresAt } : null;
   }
 
   /**
-   * Atomically reserves the token's `jti` as used. Returns `true` on first call and `false`
-   * on every subsequent call — defending against email-client URL prefetchers (Outlook Safe
-   * Links, Mimecast etc.) and against accidental double-submits.
-   *
-   * The TTL matches the token's remaining lifetime; once the JWT expires, the marker would be
-   * rejected by signature/exp anyway, so we don't need the marker to outlive the token.
+   * Re-stores a token previously taken by `consumeActionToken` so the user can retry after
+   * a transient dispatch failure. The remaining TTL is re-computed against the original
+   * `expiresAt` so a token can never outlive its natural expiry. No-op if the original
+   * expiry has already passed.
    */
-  async claimSingleUse(jti: string, exp: number): Promise<boolean> {
-    const nowSeconds = Math.floor(Date.now() / 1000);
-    const ttl = Math.max(60, exp - nowSeconds);
-    const result = await this.cacheService.setIfNotExist(this.singleUseKey(jti), '1', { ttl });
+  async releaseActionToken(token: string, consumed: ConsumedActionToken): Promise<void> {
+    const remaining = consumed.expiresAt - Math.floor(Date.now() / 1000);
+    if (remaining <= 0) return;
 
-    return result === 'OK';
+    const entry: StoredEntry = { claims: consumed.claims, expiresAt: consumed.expiresAt };
+    await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), { ttl: remaining });
   }
 
-  /**
-   * Releases a single-use reservation made by `claimSingleUse`. Called after a transient
-   * dispatch failure so the user can retry the action via the same link instead of seeing
-   * "Already submitted". Safe to call even if the key has already expired.
-   */
-  async releaseSingleUse(jti: string): Promise<void> {
-    await this.cacheService.del(this.singleUseKey(jti));
+  private storageKey(token: string): string {
+    return `${KEY_PREFIX}${token}`;
   }
 
-  private singleUseKey(jti: string): string {
-    return `agent:email:action:used:${jti}`;
+  private parseEntry(raw: string): StoredEntry | null {
+    try {
+      const parsed = JSON.parse(raw) as StoredEntry;
+      if (!parsed || typeof parsed !== 'object' || !parsed.claims || typeof parsed.expiresAt !== 'number') {
+        return null;
+      }
+
+      return parsed;
+    } catch (err) {
+      this.logger.warn({ err }, 'Failed to parse stored agent email action token entry');
+
+      return null;
+    }
   }
 }

--- a/apps/api/src/app/agents/services/agent-email-action-token.service.ts
+++ b/apps/api/src/app/agents/services/agent-email-action-token.service.ts
@@ -6,6 +6,10 @@ const KEY_PREFIX = 'agent:email:action:';
 const DEFAULT_TTL_SECONDS = 60 * 60 * 24 * 3; // 3 days
 /** 256 bits of entropy. Encoded as base64url → 43 URL-safe characters. */
 const TOKEN_BYTES = 32;
+/** Hosts where plaintext HTTP is acceptable because the link never leaves the developer's
+ *  loopback interface. Every other host must use https — the action token is bearer
+ *  authority and intercepting it in transit is equivalent to dispatching the action. */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
 
 /**
  * Action context forwarded to the agent's `onAction` handler when a recipient clicks an
@@ -75,13 +79,40 @@ export class AgentEmailActionTokenService {
 
     await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), { ttl: this.ttlSeconds });
 
-    const base = (process.env.API_ROOT_URL ?? '').replace(/\/$/, '');
-    if (!base) {
-      throw new Error('API_ROOT_URL is not configured — cannot build email action URL');
-    }
-    const url = `${base}/v1/agents/email/actions/preview?t=${encodeURIComponent(token)}`;
+    const url = `${this.resolveApiBaseUrl()}/v1/agents/email/actions/preview?t=${encodeURIComponent(token)}`;
 
     return { token, url };
+  }
+
+  /**
+   * Resolves and validates the API base URL from `API_ROOT_URL`. Throws when the env var
+   * is unset, malformed, or carries a non-https scheme on a non-loopback host — the latter
+   * because the action token in the URL grants action-execution authority and must not
+   * travel over plaintext HTTP. Loopback hosts are exempted so local development works
+   * with `API_ROOT_URL=http://127.0.0.1:3000`.
+   */
+  private resolveApiBaseUrl(): string {
+    const baseRaw = (process.env.API_ROOT_URL ?? '').replace(/\/$/, '');
+    if (!baseRaw) {
+      throw new Error('API_ROOT_URL is not configured — cannot build email action URL');
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(baseRaw);
+    } catch {
+      throw new Error(`API_ROOT_URL is not a valid URL: ${baseRaw}`);
+    }
+
+    const isLoopback = LOOPBACK_HOSTS.has(parsed.hostname);
+    if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isLoopback)) {
+      throw new Error(
+        `API_ROOT_URL must use https:// (got ${parsed.protocol}//${parsed.hostname}). ` +
+          'Email action tokens grant action-execution authority and must not travel over plaintext HTTP.'
+      );
+    }
+
+    return baseRaw;
   }
 
   /**

--- a/apps/api/src/app/agents/services/agent-email-action-token.service.ts
+++ b/apps/api/src/app/agents/services/agent-email-action-token.service.ts
@@ -18,11 +18,15 @@ const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
  * recipient address (`userIdentifier`) would otherwise be readable by any party that sees
  * the link (corporate email scanners, server logs, browser history, mail archives).
  */
+export type AgentEmailActionStyle = 'primary' | 'danger' | 'default';
+
 export interface AgentEmailActionClaims {
   /** Mongo `_id` of the agent. Used to look up cached chat instance + resolve config. */
   agentId: string;
   /** Stable agent identifier slug (mirrors what the dashboard URLs use). */
   agentIdentifier: string;
+  /** Human-readable agent display name; shown on the confirmation page. */
+  agentName: string;
   integrationIdentifier: string;
   environmentId: string;
   organizationId: string;
@@ -36,6 +40,9 @@ export interface AgentEmailActionClaims {
   value?: string;
   /** Display label shown on the confirmation page; not security-sensitive. */
   label?: string;
+  /** Echoes the source `<Button style="…">`. Drives the destructive-action UI on the
+   *  confirmation page (red button + "cannot be undone" copy) when `'danger'`. */
+  style?: AgentEmailActionStyle;
   /** Email address of the recipient — used as `platformUserId` for subscriber resolution. */
   userIdentifier: string;
 }
@@ -45,14 +52,21 @@ interface StoredEntry {
   /** Epoch seconds when the entry was due to naturally expire. Used to recompute the
    *  remaining TTL when a token is restored after a transient dispatch failure. */
   expiresAt: number;
+  /** Epoch seconds when the token was minted. Surfaced through peek/consume so the
+   *  confirmation page can show a relative "Sent N min ago" footer. */
+  mintedAt: number;
 }
 
-/** Returned from `consumeActionToken`; carries `expiresAt` so a transient failure can
- *  re-store the entry without extending its lifetime past the original expiry. */
-export interface ConsumedActionToken {
+/** Returned from `peekActionToken` and `consumeActionToken`. Carries `expiresAt` so a
+ *  transient failure can re-store the entry without extending its lifetime past the
+ *  original expiry, and `mintedAt` for relative-time rendering. */
+export interface PeekedActionToken {
   claims: AgentEmailActionClaims;
   expiresAt: number;
+  mintedAt: number;
 }
+
+export type ConsumedActionToken = PeekedActionToken;
 
 @Injectable()
 export class AgentEmailActionTokenService {
@@ -74,8 +88,9 @@ export class AgentEmailActionTokenService {
    */
   async signActionToken(claims: AgentEmailActionClaims): Promise<{ token: string; url: string }> {
     const token = randomBytes(TOKEN_BYTES).toString('base64url');
-    const expiresAt = Math.floor(Date.now() / 1000) + this.ttlSeconds;
-    const entry: StoredEntry = { claims, expiresAt };
+    const mintedAt = Math.floor(Date.now() / 1000);
+    const expiresAt = mintedAt + this.ttlSeconds;
+    const entry: StoredEntry = { claims, expiresAt, mintedAt };
 
     await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), { ttl: this.ttlSeconds });
 
@@ -119,11 +134,13 @@ export class AgentEmailActionTokenService {
    * Reads the claims **without** consuming the token. Used by the GET preview route so a
    * URL prefetcher (or repeated browser visit) doesn't burn the single-use reservation.
    */
-  async peekActionToken(token: string): Promise<AgentEmailActionClaims | null> {
+  async peekActionToken(token: string): Promise<PeekedActionToken | null> {
     const raw = await this.cacheService.get(this.storageKey(token));
     if (!raw) return null;
 
-    return this.parseEntry(raw)?.claims ?? null;
+    const entry = this.parseEntry(raw);
+
+    return entry ? { claims: entry.claims, expiresAt: entry.expiresAt, mintedAt: entry.mintedAt } : null;
   }
 
   /**
@@ -146,7 +163,7 @@ export class AgentEmailActionTokenService {
 
     const entry = this.parseEntry(raw);
 
-    return entry ? { claims: entry.claims, expiresAt: entry.expiresAt } : null;
+    return entry ? { claims: entry.claims, expiresAt: entry.expiresAt, mintedAt: entry.mintedAt } : null;
   }
 
   /**
@@ -159,7 +176,11 @@ export class AgentEmailActionTokenService {
     const remaining = consumed.expiresAt - Math.floor(Date.now() / 1000);
     if (remaining <= 0) return;
 
-    const entry: StoredEntry = { claims: consumed.claims, expiresAt: consumed.expiresAt };
+    const entry: StoredEntry = {
+      claims: consumed.claims,
+      expiresAt: consumed.expiresAt,
+      mintedAt: consumed.mintedAt,
+    };
     await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), { ttl: remaining });
   }
 
@@ -169,12 +190,18 @@ export class AgentEmailActionTokenService {
 
   private parseEntry(raw: string): StoredEntry | null {
     try {
-      const parsed = JSON.parse(raw) as StoredEntry;
-      if (!parsed || typeof parsed !== 'object' || !parsed.claims || typeof parsed.expiresAt !== 'number') {
+      const parsed = JSON.parse(raw) as Partial<StoredEntry>;
+      if (
+        !parsed ||
+        typeof parsed !== 'object' ||
+        !parsed.claims ||
+        typeof parsed.expiresAt !== 'number' ||
+        typeof parsed.mintedAt !== 'number'
+      ) {
         return null;
       }
 
-      return parsed;
+      return parsed as StoredEntry;
     } catch (err) {
       this.logger.warn({ err }, 'Failed to parse stored agent email action token entry');
 

--- a/apps/api/src/app/agents/services/agent-email-action-token.service.ts
+++ b/apps/api/src/app/agents/services/agent-email-action-token.service.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from 'node:crypto';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { CacheService, PinoLogger } from '@novu/application-generic';
+
+const TOKEN_AUDIENCE = 'agent_email_action';
+const TOKEN_ISSUER = 'novu_api';
+const DEFAULT_TTL_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
+export interface AgentEmailActionClaims {
+  /** Mongo `_id` of the agent. Used to look up cached chat instance + resolve config. */
+  agentId: string;
+  /** Stable agent identifier slug (mirrors what the dashboard URLs use). */
+  agentIdentifier: string;
+  integrationIdentifier: string;
+  environmentId: string;
+  organizationId: string;
+  /** Encoded thread id from the email adapter's ThreadResolver. */
+  threadId: string;
+  /** RFC-5322 Message-ID of the email the button was rendered in. */
+  messageId: string;
+  /** `id` of the clicked `<Button>` — forwarded to onAction. */
+  actionId: string;
+  /** Optional `value` of the clicked `<Button>` — forwarded to onAction. */
+  value?: string;
+  /** Display label shown on the confirmation page; not security-sensitive. */
+  label?: string;
+  /** Email address of the recipient — used as `platformUserId` for subscriber resolution. */
+  userIdentifier: string;
+  /** Unique token id for single-use enforcement. */
+  jti: string;
+}
+
+export interface VerifiedAgentEmailActionClaims extends AgentEmailActionClaims {
+  /** Seconds since epoch when this token expires. Used to compute the single-use Redis TTL. */
+  exp: number;
+}
+
+@Injectable()
+export class AgentEmailActionTokenService {
+  private readonly ttlSeconds: number;
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly cacheService: CacheService,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+    const raw = process.env.AGENT_EMAIL_ACTION_JWT_TTL;
+    const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+    this.ttlSeconds = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_SECONDS;
+  }
+
+  async signActionToken(claims: Omit<AgentEmailActionClaims, 'jti'>): Promise<{ token: string; url: string }> {
+    const jti = randomUUID();
+    const token = await this.jwtService.signAsync(
+      { ...claims, jti },
+      { issuer: TOKEN_ISSUER, audience: TOKEN_AUDIENCE, expiresIn: this.ttlSeconds }
+    );
+
+    const base = (process.env.API_ROOT_URL ?? '').replace(/\/$/, '');
+    if (!base) {
+      throw new Error('API_ROOT_URL is not configured — cannot build email action URL');
+    }
+    const url = `${base}/v1/agents/email/actions/preview?t=${encodeURIComponent(token)}`;
+
+    return { token, url };
+  }
+
+  verifyActionToken(token: string): VerifiedAgentEmailActionClaims {
+    try {
+      return this.jwtService.verify<VerifiedAgentEmailActionClaims>(token, {
+        issuer: TOKEN_ISSUER,
+        audience: TOKEN_AUDIENCE,
+      });
+    } catch (err) {
+      this.logger.debug({ err }, 'Failed to verify agent email action token');
+      throw new UnauthorizedException('Invalid or expired action link');
+    }
+  }
+
+  /**
+   * Atomically reserves the token's `jti` as used. Returns `true` on first call and `false`
+   * on every subsequent call — defending against email-client URL prefetchers (Outlook Safe
+   * Links, Mimecast etc.) and against accidental double-submits.
+   *
+   * The TTL matches the token's remaining lifetime; once the JWT expires, the marker would be
+   * rejected by signature/exp anyway, so we don't need the marker to outlive the token.
+   */
+  async claimSingleUse(jti: string, exp: number): Promise<boolean> {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const ttl = Math.max(60, exp - nowSeconds);
+    const result = await this.cacheService.setIfNotExist(`agent:email:action:used:${jti}`, '1', { ttl });
+
+    return result === 'OK';
+  }
+}

--- a/apps/api/src/app/agents/services/agent-email-action-token.service.ts
+++ b/apps/api/src/app/agents/services/agent-email-action-token.service.ts
@@ -90,8 +90,21 @@ export class AgentEmailActionTokenService {
   async claimSingleUse(jti: string, exp: number): Promise<boolean> {
     const nowSeconds = Math.floor(Date.now() / 1000);
     const ttl = Math.max(60, exp - nowSeconds);
-    const result = await this.cacheService.setIfNotExist(`agent:email:action:used:${jti}`, '1', { ttl });
+    const result = await this.cacheService.setIfNotExist(this.singleUseKey(jti), '1', { ttl });
 
     return result === 'OK';
+  }
+
+  /**
+   * Releases a single-use reservation made by `claimSingleUse`. Called after a transient
+   * dispatch failure so the user can retry the action via the same link instead of seeing
+   * "Already submitted". Safe to call even if the key has already expired.
+   */
+  async releaseSingleUse(jti: string): Promise<void> {
+    await this.cacheService.del(this.singleUseKey(jti));
+  }
+
+  private singleUseKey(jti: string): string {
+    return `agent:email:action:used:${jti}`;
   }
 }

--- a/apps/api/src/app/agents/services/agent-email-action-token.service.ts
+++ b/apps/api/src/app/agents/services/agent-email-action-token.service.ts
@@ -68,6 +68,24 @@ export interface PeekedActionToken {
 
 export type ConsumedActionToken = PeekedActionToken;
 
+/**
+ * Thrown when the Redis-backed action-token cache is unreachable. Distinguishable from a
+ * null `peek`/`consume` result (which means "expired or already used") so the controller
+ * can render a retryable "try again" page instead of the terminal "already submitted"
+ * page that would otherwise silently drop valid clicks during a cache outage.
+ */
+export class AgentEmailActionCacheUnavailableError extends Error {
+  readonly cacheUnavailable = true as const;
+
+  constructor(operation: 'peek' | 'consume' | 'release', cause?: unknown) {
+    super(`Agent email action token cache unavailable during ${operation}`);
+    this.name = 'AgentEmailActionCacheUnavailableError';
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
 @Injectable()
 export class AgentEmailActionTokenService {
   private readonly ttlSeconds: number;
@@ -133,9 +151,18 @@ export class AgentEmailActionTokenService {
   /**
    * Reads the claims **without** consuming the token. Used by the GET preview route so a
    * URL prefetcher (or repeated browser visit) doesn't burn the single-use reservation.
+   *
+   * @throws AgentEmailActionCacheUnavailableError when Redis is unreachable — distinct from
+   *   a `null` return (which means "expired or already used") so the controller can render
+   *   a retryable error instead of silently dropping the click.
    */
   async peekActionToken(token: string): Promise<PeekedActionToken | null> {
-    const raw = await this.cacheService.get(this.storageKey(token));
+    let raw: string | null | undefined;
+    try {
+      raw = await this.cacheService.get(this.storageKey(token));
+    } catch (err) {
+      throw new AgentEmailActionCacheUnavailableError('peek', err);
+    }
     if (!raw) return null;
 
     const entry = this.parseEntry(raw);
@@ -148,17 +175,24 @@ export class AgentEmailActionTokenService {
    * caller wins per token; later callers see `null` and the controller renders the
    * "already submitted" page. If downstream dispatch fails transiently, call
    * `releaseActionToken` to put the entry back so the user can retry from the same link.
+   *
+   * @throws AgentEmailActionCacheUnavailableError when Redis is unreachable — distinct from
+   *   a `null` return so the controller can render a retryable error instead of silently
+   *   dropping valid clicks during an outage.
    */
   async consumeActionToken(token: string): Promise<ConsumedActionToken | null> {
     const client = this.cacheService.client;
     if (!client) {
-      this.logger.error('Cache client unavailable — cannot consume agent email action token');
-
-      return null;
+      throw new AgentEmailActionCacheUnavailableError('consume');
     }
 
     // GETDEL: atomic read+delete (Redis 6.2+, native ioredis support).
-    const raw = await client.getdel(this.storageKey(token));
+    let raw: string | null;
+    try {
+      raw = await client.getdel(this.storageKey(token));
+    } catch (err) {
+      throw new AgentEmailActionCacheUnavailableError('consume', err);
+    }
     if (!raw) return null;
 
     const entry = this.parseEntry(raw);

--- a/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
@@ -28,7 +28,7 @@ describe('ChatSdkService', () => {
       setContext: sinon.stub(),
     };
 
-    return new ChatSdkService(logger as any, {} as any, {} as any, {} as any, {} as any);
+    return new ChatSdkService(logger as any, {} as any, {} as any, {} as any, {} as any, {} as any);
   }
 
   describe('prepareContentForDelivery', () => {
@@ -348,7 +348,7 @@ describe('ChatSdkService', () => {
         info: sinon.stub(),
         setContext: sinon.stub(),
       };
-      const service = new ChatSdkService(logger as any, {} as any, {} as any, {} as any, {} as any);
+      const service = new ChatSdkService(logger as any, {} as any, {} as any, {} as any, {} as any, {} as any);
 
       const result = await (service as any).prepareContentForDelivery(
         {
@@ -376,7 +376,7 @@ describe('ChatSdkService', () => {
         info: sinon.stub(),
         setContext: sinon.stub(),
       };
-      const service = new ChatSdkService(logger as any, {} as any, {} as any, {} as any, {} as any);
+      const service = new ChatSdkService(logger as any, {} as any, {} as any, {} as any, {} as any, {} as any);
 
       const result = await (service as any).prepareContentForDelivery(
         {
@@ -417,7 +417,14 @@ describe('ChatSdkService', () => {
           active: true,
         }),
       };
-      const service = new ChatSdkService(logger as any, {} as any, {} as any, {} as any, integrationRepository as any);
+      const service = new ChatSdkService(
+        logger as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        integrationRepository as any,
+        {} as any
+      );
       const sendEmail = (service as any).buildSendEmailCallback(
         {
           environmentId: 'env-id',
@@ -478,7 +485,14 @@ describe('ChatSdkService', () => {
           active: true,
         }),
       };
-      const service = new ChatSdkService(logger as any, {} as any, {} as any, {} as any, integrationRepository as any);
+      const service = new ChatSdkService(
+        logger as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        integrationRepository as any,
+        {} as any
+      );
       const sendEmail = (service as any).buildSendEmailCallback(
         {
           environmentId: 'env-id',

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -66,6 +66,25 @@ function wrapMsgId(id: string): string {
 }
 
 /**
+ * Thrown by `ChatSdkService.processEmailAction` when a failure is provably pre-dispatch —
+ * i.e. token validation, agent-config lookup, or chat/adapter setup failed before the chat
+ * SDK had a chance to invoke the agent's `onAction` handler. Callers can safely retry these
+ * via single-use token release. Any other error (including raw exceptions out of
+ * `chat.processAction`) MUST be treated as potentially post-dispatch and not replayed.
+ */
+export class AgentActionPreDispatchError extends Error {
+  readonly preDispatch = true as const;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'AgentActionPreDispatchError';
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+/**
  * Extracts the recipient email address from an encoded email thread ID. The email adapter's
  * ThreadResolver encodes thread IDs as `email:<encodedRecipient>:<rootMessageIdHash>`; we
  * reverse that here so the token claims can carry the recipient as the `platformUserId` used
@@ -201,26 +220,43 @@ export class ChatSdkService implements OnModuleDestroy {
    * Dispatches a verified email-button click into the chat SDK so it flows through the same
    * `chat.onAction` → `AgentInboundHandler.handleAction` → bridge `onAction` path that
    * inbound platforms (Slack/Teams) already use. Called from the public email-action endpoint
-   * after JWT verification and single-use replay protection.
+   * after token verification and single-use replay protection.
+   *
+   * The implementation is split into a *pre-dispatch* phase (config resolution, chat-instance
+   * lookup, adapter availability check) and a *dispatch* phase (`chat.processAction`). Errors
+   * raised by the pre-dispatch phase are wrapped in `AgentActionPreDispatchError` so the
+   * controller can safely release the single-use token and let the user retry. Errors raised
+   * by the dispatch phase propagate as-is — by then the chat SDK may have already invoked the
+   * agent's `onAction` handler with partial side effects, and re-releasing the token would
+   * permit a replay that duplicates non-idempotent downstream work.
    */
   async processEmailAction(claims: AgentEmailActionClaims): Promise<void> {
     const { agentId, integrationIdentifier } = claims;
-    const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
 
-    if (config.platform !== AgentPlatformEnum.EMAIL) {
-      throw new BadRequestException(
-        `Agent ${agentId} integration ${integrationIdentifier} is not configured for the email platform`
-      );
+    let chat: Chat;
+    let emailAdapter: ReturnType<Chat['getAdapter']>;
+    try {
+      const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
+
+      if (config.platform !== AgentPlatformEnum.EMAIL) {
+        throw new BadRequestException(
+          `Agent ${agentId} integration ${integrationIdentifier} is not configured for the email platform`
+        );
+      }
+
+      const instanceKey = `${agentId}:${integrationIdentifier}`;
+      chat = await this.getOrCreate(instanceKey, agentId, config.platform, config);
+
+      emailAdapter = chat.getAdapter(AgentPlatformEnum.EMAIL);
+      if (!emailAdapter) {
+        throw new BadRequestException(`Email adapter not available for agent ${agentId}`);
+      }
+    } catch (err) {
+      throw new AgentActionPreDispatchError('Failed to resolve agent context before dispatching email action', err);
     }
 
-    const instanceKey = `${agentId}:${integrationIdentifier}`;
-    const chat = await this.getOrCreate(instanceKey, agentId, config.platform, config);
-
-    const emailAdapter = chat.getAdapter(AgentPlatformEnum.EMAIL);
-    if (!emailAdapter) {
-      throw new BadRequestException(`Email adapter not available for agent ${agentId}`);
-    }
-
+    // From here on, the chat SDK may have already invoked the user's `onAction` handler by
+    // the time an error is raised — do NOT retry these failures via token re-release.
     await chat.processAction(
       {
         adapter: emailAdapter,

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -1104,11 +1104,12 @@ export class ChatSdkService implements OnModuleDestroy {
             senderName,
             signingSecret: credentials.secretKey,
             sendEmail: this.buildSendEmailCallback(config, outboundIntegrationId),
-            actionUrlBuilder: async ({ threadId, messageId, actionId, value, label }) => {
+            actionUrlBuilder: async ({ threadId, messageId, actionId, value, label, style }) => {
               const userIdentifier = extractRecipientFromThreadId(threadId);
               const { url } = await this.actionTokenService.signActionToken({
                 agentId,
                 agentIdentifier: config.agentIdentifier,
+                agentName: config.agentName,
                 integrationIdentifier: config.integrationIdentifier,
                 environmentId: config.environmentId,
                 organizationId: config.organizationId,
@@ -1117,6 +1118,7 @@ export class ChatSdkService implements OnModuleDestroy {
                 actionId,
                 value,
                 label,
+                style,
                 userIdentifier,
               });
 

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -23,6 +23,7 @@ import type { FileRef, ReplyContentDto } from '../dtos/agent-reply-payload.dto';
 import { esmImport } from '../utils/esm-import';
 import { sendWebResponse, toWebRequest } from '../utils/express-to-web-request';
 import { AgentConfigResolver, AgentConfigResolveSource, ResolvedAgentConfig } from './agent-config-resolver.service';
+import { AgentEmailActionClaims, AgentEmailActionTokenService } from './agent-email-action-token.service';
 import { AgentInboundHandler } from './agent-inbound-handler.service';
 
 function getErrorResponseBody(err: unknown): unknown {
@@ -62,6 +63,21 @@ function wrapMsgId(id: string): string {
   const trimmed = id.trim();
 
   return trimmed.startsWith('<') && trimmed.endsWith('>') ? trimmed : `<${trimmed}>`;
+}
+
+/**
+ * Extracts the recipient email address from an encoded email thread ID. The email adapter's
+ * ThreadResolver encodes thread IDs as `email:<encodedRecipient>:<rootMessageIdHash>`; we
+ * reverse that here so the token claims can carry the recipient as the `platformUserId` used
+ * for subscriber resolution on the click handler side.
+ */
+function extractRecipientFromThreadId(threadId: string): string {
+  const parts = threadId.split(':');
+  if (parts.length !== 3 || parts[0] !== 'email' || !parts[1]) {
+    throw new Error(`Cannot extract recipient from invalid email thread id: ${threadId}`);
+  }
+
+  return decodeURIComponent(parts[1]);
 }
 
 /**
@@ -141,7 +157,8 @@ export class ChatSdkService implements OnModuleDestroy {
     private readonly cacheService: CacheService,
     private readonly agentConfigResolver: AgentConfigResolver,
     private readonly inboundHandler: AgentInboundHandler,
-    private readonly integrationRepository: IntegrationRepository
+    private readonly integrationRepository: IntegrationRepository,
+    private readonly actionTokenService: AgentEmailActionTokenService
   ) {
     this.logger.setContext(this.constructor.name);
     this.instances = new LRUCache<string, CachedChat>({
@@ -178,6 +195,50 @@ export class ChatSdkService implements OnModuleDestroy {
     const webResponse = await handler(webRequest);
 
     await sendWebResponse(webResponse, res);
+  }
+
+  /**
+   * Dispatches a verified email-button click into the chat SDK so it flows through the same
+   * `chat.onAction` → `AgentInboundHandler.handleAction` → bridge `onAction` path that
+   * inbound platforms (Slack/Teams) already use. Called from the public email-action endpoint
+   * after JWT verification and single-use replay protection.
+   */
+  async processEmailAction(claims: AgentEmailActionClaims): Promise<void> {
+    const { agentId, integrationIdentifier } = claims;
+    const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
+
+    if (config.platform !== AgentPlatformEnum.EMAIL) {
+      throw new BadRequestException(
+        `Agent ${agentId} integration ${integrationIdentifier} is not configured for the email platform`
+      );
+    }
+
+    const instanceKey = `${agentId}:${integrationIdentifier}`;
+    const chat = await this.getOrCreate(instanceKey, agentId, config.platform, config);
+
+    const emailAdapter = chat.getAdapter(AgentPlatformEnum.EMAIL);
+    if (!emailAdapter) {
+      throw new BadRequestException(`Email adapter not available for agent ${agentId}`);
+    }
+
+    await chat.processAction(
+      {
+        adapter: emailAdapter,
+        actionId: claims.actionId,
+        value: claims.value,
+        messageId: claims.messageId,
+        threadId: claims.threadId,
+        user: {
+          userId: claims.userIdentifier,
+          userName: claims.userIdentifier,
+          fullName: claims.userIdentifier,
+          isBot: false,
+          isMe: false,
+        },
+        raw: {},
+      },
+      undefined
+    );
   }
 
   async onModuleDestroy() {
@@ -762,7 +823,7 @@ export class ChatSdkService implements OnModuleDestroy {
     config: ResolvedAgentConfig,
     adapterFingerprint: string
   ): Promise<Chat> {
-    const chat = await this.createChatInstance(instanceKey, platform, config);
+    const chat = await this.createChatInstance(instanceKey, agentId, platform, config);
     await chat.initialize();
     const cached: CachedChat = { chat, config, adapterFingerprint };
     this.registerEventHandlers(agentId, cached);
@@ -931,6 +992,7 @@ export class ChatSdkService implements OnModuleDestroy {
 
   private async createChatInstance(
     instanceKey: string,
+    agentId: string,
     platform: AgentPlatformEnum,
     config: ResolvedAgentConfig
   ): Promise<Chat> {
@@ -939,7 +1001,7 @@ export class ChatSdkService implements OnModuleDestroy {
       esmImport('@chat-adapter/state-ioredis'),
     ]);
 
-    const adapters = await this.buildAdapters(platform, config);
+    const adapters = await this.buildAdapters(agentId, platform, config);
     const client = this.cacheService.client;
     if (!client) {
       throw new Error('Cache in-memory provider client is not available for Conversational SDK state adapter');
@@ -967,6 +1029,7 @@ export class ChatSdkService implements OnModuleDestroy {
   }
 
   private async buildAdapters(
+    agentId: string,
     platform: AgentPlatformEnum,
     config: ResolvedAgentConfig
   ): Promise<Record<string, unknown>> {
@@ -1041,6 +1104,24 @@ export class ChatSdkService implements OnModuleDestroy {
             senderName,
             signingSecret: credentials.secretKey,
             sendEmail: this.buildSendEmailCallback(config, outboundIntegrationId),
+            actionUrlBuilder: async ({ threadId, messageId, actionId, value, label }) => {
+              const userIdentifier = extractRecipientFromThreadId(threadId);
+              const { url } = await this.actionTokenService.signActionToken({
+                agentId,
+                agentIdentifier: config.agentIdentifier,
+                integrationIdentifier: config.integrationIdentifier,
+                environmentId: config.environmentId,
+                organizationId: config.organizationId,
+                threadId,
+                messageId,
+                actionId,
+                value,
+                label,
+                userIdentifier,
+              });
+
+              return url;
+            },
           }),
         };
       }

--- a/packages/chat-adapter-email/src/adapter.ts
+++ b/packages/chat-adapter-email/src/adapter.ts
@@ -147,7 +147,6 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
   async postMessage(threadId: string, message: AdapterPostableMessage): Promise<RawMessage<NovuEmailRawMessage>> {
     const normalized = this.normalizeMessage(message);
     const decoded = this.threadResolver.decodeThreadId(threadId);
-    const rendered = await renderMessage(normalized);
 
     const agentAddress = await this.threadResolver.getAgentAddress(threadId);
     if (!agentAddress) {
@@ -156,7 +155,17 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
 
     const fromHeader = this.config.senderName ? `${this.config.senderName} <${agentAddress}>` : agentAddress;
 
+    // Mint the Message-ID before rendering so action-button URLs in the email body can sign
+    // a token bound to this specific email; the chat SDK's processAction lookup later in the
+    // click handler uses the same Message-ID to locate the originating thread/message.
     const messageId = generateMessageId(agentAddress);
+    const buildActionUrl = this.config.actionUrlBuilder;
+    const rendered = await renderMessage({
+      ...normalized,
+      ...(normalized.card && buildActionUrl
+        ? { actionContext: { threadId, messageId, buildActionUrl } }
+        : {}),
+    });
     const replyHeaders = await this.threadResolver.getReplyHeaders(threadId);
     const storedSubject = await this.threadResolver.getSubject(threadId);
     const subject = storedSubject

--- a/packages/chat-adapter-email/src/adapter.ts
+++ b/packages/chat-adapter-email/src/adapter.ts
@@ -162,9 +162,7 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
     const buildActionUrl = this.config.actionUrlBuilder;
     const rendered = await renderMessage({
       ...normalized,
-      ...(normalized.card && buildActionUrl
-        ? { actionContext: { threadId, messageId, buildActionUrl } }
-        : {}),
+      ...(normalized.card && buildActionUrl ? { actionContext: { threadId, messageId, buildActionUrl } } : {}),
     });
     const replyHeaders = await this.threadResolver.getReplyHeaders(threadId);
     const storedSubject = await this.threadResolver.getSubject(threadId);
@@ -187,6 +185,14 @@ export class NovuEmailAdapterImpl implements Adapter<NovuEmailThreadId, NovuEmai
 
     const sentMessageId = result.messageId || messageId;
     await this.threadResolver.trackMessage(threadId, sentMessageId);
+    // Action tokens embedded in the email body are bound to the locally minted `messageId`.
+    // When a provider rewrites Message-ID, `sentMessageId` differs — track the minted ID too
+    // so the action-token's correlation survives (the user's `onAction(action, ctx)` receives
+    // `action.sourceMessageId = messageId`, and any platform-message lookup keyed on either
+    // value resolves back to the same thread).
+    if (sentMessageId !== messageId) {
+      await this.threadResolver.trackMessage(threadId, messageId);
+    }
 
     const raw: NovuEmailRawMessage = {
       id: sentMessageId,

--- a/packages/chat-adapter-email/src/card-renderer.tsx
+++ b/packages/chat-adapter-email/src/card-renderer.tsx
@@ -12,6 +12,7 @@ import {
 } from '@react-email/components';
 import { render } from '@react-email/render';
 import React from 'react';
+import type { ActionUrlBuilder } from './types.js';
 
 /**
  * Matches the Chat SDK CardElement / CardChild shapes.
@@ -19,6 +20,8 @@ import React from 'react';
  */
 export interface CardNode {
   type: string;
+  /** Set on `button` nodes — the `id` prop of the source `<Button>`. */
+  id?: string;
   title?: string;
   subtitle?: string;
   content?: string;
@@ -44,13 +47,96 @@ function safeUrl(value: string | undefined): string | undefined {
   }
 }
 
-function renderChildren(children: CardNode[] | undefined): React.ReactNode {
-  if (!children || children.length === 0) return null;
-
-  return children.map((child, i) => <React.Fragment key={i}>{renderNode(child)}</React.Fragment>);
+interface RenderContext {
+  /** Pre-resolved action URLs keyed by reference to the `button` CardNode. */
+  resolvedActionUrls?: Map<CardNode, string>;
 }
 
-function renderNode(node: CardNode): React.ReactNode {
+interface ActionContext {
+  threadId: string;
+  messageId: string;
+  buildActionUrl: ActionUrlBuilder;
+}
+
+function getNodeId(node: CardNode): string | undefined {
+  if (typeof node.id === 'string' && node.id.length > 0) return node.id;
+  const propsId = node.props?.id;
+
+  return typeof propsId === 'string' && propsId.length > 0 ? propsId : undefined;
+}
+
+function getNodeValue(node: CardNode): string | undefined {
+  if (typeof node.value === 'string') return node.value;
+  const propsValue = node.props?.value;
+
+  return typeof propsValue === 'string' ? propsValue : undefined;
+}
+
+function getNodeLabel(node: CardNode): string | undefined {
+  if (typeof node.label === 'string') return node.label;
+  const propsLabel = node.props?.label;
+
+  return typeof propsLabel === 'string' ? propsLabel : undefined;
+}
+
+function collectActionButtons(node: CardNode, out: CardNode[]): void {
+  if (node.type === 'button' && getNodeId(node) && !safeUrl(node.url)) {
+    out.push(node);
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) collectActionButtons(child, out);
+  }
+}
+
+/**
+ * Walks the card tree, calls `buildActionUrl` for every `button` node that has an `id`
+ * and no explicit `url`, and returns a Map keyed by node reference. Pre-resolved up-front
+ * because `@react-email/render` walks the tree synchronously.
+ */
+async function resolveActionUrls(
+  card: CardNode,
+  action: ActionContext
+): Promise<Map<CardNode, string>> {
+  const buttons: CardNode[] = [];
+  collectActionButtons(card, buttons);
+  if (buttons.length === 0) return new Map();
+
+  const entries = await Promise.all(
+    buttons.map(async (node) => {
+      const url = await action.buildActionUrl({
+        threadId: action.threadId,
+        messageId: action.messageId,
+        actionId: getNodeId(node) as string,
+        value: getNodeValue(node),
+        label: getNodeLabel(node),
+      });
+
+      return [node, url] as const;
+    })
+  );
+
+  return new Map(entries);
+}
+
+function renderChildren(children: CardNode[] | undefined, ctx: RenderContext): React.ReactNode {
+  if (!children || children.length === 0) return null;
+
+  return children.map((child, i) => (
+    <React.Fragment key={i}>{renderNode(child, ctx)}</React.Fragment>
+  ));
+}
+
+const BUTTON_STYLE = {
+  padding: '8px 16px',
+  margin: '4px',
+  backgroundColor: '#0066cc',
+  color: '#ffffff',
+  borderRadius: '4px',
+  fontSize: '14px',
+  textDecoration: 'none',
+} as const;
+
+function renderNode(node: CardNode, ctx: RenderContext): React.ReactNode {
   switch (node.type) {
     case 'card':
       return (
@@ -64,7 +150,7 @@ function renderNode(node: CardNode): React.ReactNode {
             <Text style={{ margin: '0 0 12px', color: '#666666' }}>{node.subtitle}</Text>
           )}
           {safeUrl(node.imageUrl) && <Img src={safeUrl(node.imageUrl)} alt="" style={{ maxWidth: '100%', marginBottom: '12px' }} />}
-          {renderChildren(node.children)}
+          {renderChildren(node.children, ctx)}
         </Container>
       );
 
@@ -84,56 +170,55 @@ function renderNode(node: CardNode): React.ReactNode {
       );
 
     case 'actions':
-      return <Section style={{ margin: '12px 0' }}>{renderChildren(node.children)}</Section>;
+      return <Section style={{ margin: '12px 0' }}>{renderChildren(node.children, ctx)}</Section>;
 
     case 'link-button':
       return (
-        <Button href={safeUrl(node.url) ?? '#'} style={{ padding: '8px 16px', margin: '4px', backgroundColor: '#0066cc', color: '#ffffff', borderRadius: '4px', fontSize: '14px', textDecoration: 'none' }}>
-          {node.label || ''}
+        <Button href={safeUrl(node.url) ?? '#'} style={BUTTON_STYLE}>
+          {getNodeLabel(node) || ''}
         </Button>
       );
 
-    case 'button':
-      if (node.url && safeUrl(node.url)) {
-        return (
-          <Button href={safeUrl(node.url)} style={{ padding: '8px 16px', margin: '4px', backgroundColor: '#0066cc', color: '#ffffff', borderRadius: '4px', fontSize: '14px', textDecoration: 'none' }}>
-            {node.label || ''}
-          </Button>
-        );
-      }
+    case 'button': {
+      const resolved = ctx.resolvedActionUrls?.get(node);
+      const href = resolved ?? safeUrl(node.url) ?? '#';
 
       return (
-        <Button href="#" style={{ padding: '8px 16px', margin: '4px', backgroundColor: '#0066cc', color: '#ffffff', borderRadius: '4px', fontSize: '14px', textDecoration: 'none' }}>
-          {node.label || ''}
+        <Button href={href} style={BUTTON_STYLE}>
+          {getNodeLabel(node) || ''}
         </Button>
       );
+    }
 
     case 'link':
-      return <Link href={safeUrl(node.url) ?? '#'} style={{ color: '#0066cc' }}>{node.label || ''}</Link>;
+      return <Link href={safeUrl(node.url) ?? '#'} style={{ color: '#0066cc' }}>{getNodeLabel(node) || ''}</Link>;
 
     case 'section':
-      return <Section style={{ margin: '8px 0' }}>{renderChildren(node.children)}</Section>;
+      return <Section style={{ margin: '8px 0' }}>{renderChildren(node.children, ctx)}</Section>;
 
     case 'field':
       return (
         <Text style={{ margin: '4px 0' }}>
-          <strong>{node.label || ''}</strong>: {node.value || ''}
+          <strong>{getNodeLabel(node) || ''}</strong>: {node.value || ''}
         </Text>
       );
 
     case 'fields':
-      return <Section style={{ margin: '8px 0' }}>{renderChildren(node.children)}</Section>;
+      return <Section style={{ margin: '8px 0' }}>{renderChildren(node.children, ctx)}</Section>;
 
     default:
-      return <Text style={{ margin: '4px 0' }}>{node.content || node.label || ''}</Text>;
+      return <Text style={{ margin: '4px 0' }}>{node.content || getNodeLabel(node) || ''}</Text>;
   }
 }
 
-export async function renderCard(card: CardNode): Promise<string> {
+export async function renderCard(card: CardNode, action?: ActionContext): Promise<string> {
+  const resolvedActionUrls = action ? await resolveActionUrls(card, action) : undefined;
+  const ctx: RenderContext = { resolvedActionUrls };
+
   const emailComponent = (
     <Html>
       <Body style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif", color: '#333333', margin: '0 auto', maxWidth: '600px' }}>
-        {renderNode(card)}
+        {renderNode(card, ctx)}
       </Body>
     </Html>
   );

--- a/packages/chat-adapter-email/src/card-renderer.tsx
+++ b/packages/chat-adapter-email/src/card-renderer.tsx
@@ -12,7 +12,7 @@ import {
 } from '@react-email/components';
 import { render } from '@react-email/render';
 import React from 'react';
-import type { ActionUrlBuilder } from './types.js';
+import type { ActionButtonStyle, ActionUrlBuilder } from './types.js';
 
 /**
  * Matches the Chat SDK CardElement / CardChild shapes.
@@ -79,6 +79,13 @@ function getNodeLabel(node: CardNode): string | undefined {
   return typeof propsLabel === 'string' ? propsLabel : undefined;
 }
 
+function getNodeStyle(node: CardNode): ActionButtonStyle | undefined {
+  const raw = typeof node.style === 'string' ? node.style : node.props?.style;
+  if (raw === 'primary' || raw === 'danger' || raw === 'default') return raw;
+
+  return undefined;
+}
+
 function collectActionButtons(node: CardNode, out: CardNode[]): void {
   if (node.type === 'button' && getNodeId(node) && !safeUrl(node.url)) {
     out.push(node);
@@ -109,6 +116,7 @@ async function resolveActionUrls(
         actionId: getNodeId(node) as string,
         value: getNodeValue(node),
         label: getNodeLabel(node),
+        style: getNodeStyle(node),
       });
 
       return [node, url] as const;

--- a/packages/chat-adapter-email/src/index.ts
+++ b/packages/chat-adapter-email/src/index.ts
@@ -3,6 +3,7 @@ import { NovuEmailAdapterImpl } from './adapter.js';
 import type { NovuEmailAdapterConfig, NovuEmailRawMessage, NovuEmailThreadId } from './types.js';
 
 export type {
+  ActionButtonStyle,
   ActionUrlBuilder,
   EmailWebhookPayload,
   NovuEmailAdapterConfig,

--- a/packages/chat-adapter-email/src/index.ts
+++ b/packages/chat-adapter-email/src/index.ts
@@ -3,6 +3,7 @@ import { NovuEmailAdapterImpl } from './adapter.js';
 import type { NovuEmailAdapterConfig, NovuEmailRawMessage, NovuEmailThreadId } from './types.js';
 
 export type {
+  ActionUrlBuilder,
   EmailWebhookPayload,
   NovuEmailAdapterConfig,
   NovuEmailAttachment,

--- a/packages/chat-adapter-email/src/message-renderer.ts
+++ b/packages/chat-adapter-email/src/message-renderer.ts
@@ -2,11 +2,21 @@ import type { Root } from 'chat';
 import type { CardNode } from './card-renderer.js';
 import { extractTextFromCard, renderCard } from './card-renderer.js';
 import { EmailFormatConverter } from './format-converter.js';
+import type { ActionUrlBuilder } from './types.js';
 
 interface RenderInput {
   text?: string;
   formatted?: Root;
   card?: CardNode;
+  /**
+   * When present, action buttons (`<Button id="…">`) inside `card` will have their
+   * `href` resolved by `buildActionUrl`. Omit for non-actionable messages.
+   */
+  actionContext?: {
+    threadId: string;
+    messageId: string;
+    buildActionUrl: ActionUrlBuilder;
+  };
 }
 
 interface RenderOutput {
@@ -18,7 +28,7 @@ const converter = new EmailFormatConverter();
 
 export async function renderMessage(input: RenderInput): Promise<RenderOutput> {
   if (input.card) {
-    const html = await renderCard(input.card);
+    const html = await renderCard(input.card, input.actionContext);
     const text = extractTextFromCard(input.card) || input.text || '';
 
     return { html, text };

--- a/packages/chat-adapter-email/src/types.ts
+++ b/packages/chat-adapter-email/src/types.ts
@@ -7,7 +7,22 @@ export interface NovuEmailAdapterConfig {
   senderName?: string;
   signingSecret: string;
   sendEmail: (params: SendEmailParams) => Promise<{ messageId?: string }>;
+  /**
+   * Resolves a URL for an interactive `<Button id="…">` rendered inside an outbound email.
+   * Called once per button before the email HTML is rendered. When omitted, action buttons
+   * fall back to the legacy `href="#"` (no-op) behavior — `<LinkButton url="…">` always uses
+   * its explicit URL and is never passed to this builder.
+   */
+  actionUrlBuilder?: ActionUrlBuilder;
 }
+
+export type ActionUrlBuilder = (params: {
+  threadId: string;
+  messageId: string;
+  actionId: string;
+  value?: string;
+  label?: string;
+}) => Promise<string>;
 
 export type EmailAlternative = IEmailAlternative;
 

--- a/packages/chat-adapter-email/src/types.ts
+++ b/packages/chat-adapter-email/src/types.ts
@@ -16,12 +16,17 @@ export interface NovuEmailAdapterConfig {
   actionUrlBuilder?: ActionUrlBuilder;
 }
 
+export type ActionButtonStyle = 'primary' | 'danger' | 'default';
+
 export type ActionUrlBuilder = (params: {
   threadId: string;
   messageId: string;
   actionId: string;
   value?: string;
   label?: string;
+  /** Echoes the `<Button style="…">` prop so the click-confirmation page can render a
+   *  destructive variant (red button + warning copy) when appropriate. */
+  style?: ActionButtonStyle;
 }) => Promise<string>;
 
 export type EmailAlternative = IEmailAlternative;


### PR DESCRIPTION
### What changed? Why was the change needed?

Today, when a Novu Agent sends an email rendered as a `<Card>` with `<Button>` action elements, the email HTML produces `<a href="#">…</a>` and clicks do nothing. Other channels (Slack/Teams/in-app) already deliver clicks through `chat.processAction` → `chat.onAction` → `AgentInboundHandler.handleAction` → bridge → user's `onAction` handler — but email had no equivalent path.

Each action button now gets a unique **opaque random token** in its URL, pointing at a new public API endpoint. All action context (agent/environment/org IDs, recipient address, action id/value, button style) lives **server-side in Redis** keyed by that token — nothing about the action is recoverable from the URL alone, so corporate email scanners, browser history, proxy logs, and mail archives never see the recipient address or internal Novu identifiers.

The flow is intentionally **two-step** to defeat email-client URL prefetchers (Outlook Safe Links, Mimecast, etc.):

```
Email click → GET  /v1/agents/email/actions/preview?t=<opaque-token>
                   ├─ peek (read-only) — does NOT mutate state, so a prefetcher's
                   │  GET can't burn the single-use reservation
                   └─ render confirm HTML
User clicks → POST /v1/agents/email/actions/execute
                   ├─ atomic single-use consume (Redis GETDEL)
                   ├─ chat.processAction({ adapter: emailAdapter, ... })
                   │    └─ existing onAction listener → handleAction → bridge → user's onAction
                   └─ render animated success HTML
```

The existing `cached.chat.onAction(...)` registration in `ChatSdkService.registerEventHandlers` carries the click into `AgentInboundHandler.handleAction` with the original button's `id` and `value` intact — **no changes to that handler are needed**.

### Code areas

**chat-adapter-email package**
- `NovuEmailAdapterConfig` accepts an optional `actionUrlBuilder` callback (per-button URL minting).
- `card-renderer.tsx` pre-walks the card tree, extracts `id` / `value` / `label` / `style` from each `<Button>`, resolves URLs asynchronously, then renders the React tree synchronously.
- `adapter.postMessage` now mints the local `messageId` *before* rendering so token claims bind to the exact email; also tracks the minted ID in the thread resolver when the provider rewrites Message-ID, so the JWT-style `sourceMessageId` contract holds.

**API**
- `AgentEmailActionTokenService` — mints opaque 32-byte base64url tokens (`randomBytes(32)`), stores claims server-side via `CacheService`, exposes `peek` / `consume` / `release`. `consume` is atomic via Redis `GETDEL`.
- `AgentEmailActionsController` — public GET preview + POST execute, with inline server-rendered HTML pages.
- `ChatSdkService.processEmailAction(claims)` — public entrypoint that dispatches via `chat.processAction` so email flows reuse the existing onAction plumbing. Split into a *pre-dispatch* phase (config/adapter setup; throws `AgentActionPreDispatchError`) and the *dispatch* phase, so only pre-dispatch failures are retryable.
- `ResolvedAgentConfig` now carries `agentName` (populated from `agent.name`) — used for the confirmation page header and monogram.

### Security

- **No PII or internal IDs in the URL.** Tokens are random; claims live in Redis. Email scanners and access logs see nothing useful.
- **Single-use** via atomic Redis `GETDEL` — concurrent clicks resolve cleanly (one wins, the rest see "already submitted").
- **Two-step flow.** GET preview is read-only; the action only runs after explicit POST. Prefetchers can't auto-execute.
- **HTTPS enforced.** `API_ROOT_URL` is parsed and validated at token-sign time; non-HTTPS schemes throw, except for loopback hosts (localhost / 127.0.0.1 / ::1) so local dev still works.
- **No caching.** All HTML responses set `Cache-Control: no-store, no-cache, must-revalidate, private`, `Pragma: no-cache`, `Expires: 0`.
- **3-day TTL.** Configurable via `AGENT_EMAIL_ACTION_TOKEN_TTL` (seconds).
- **Retry only on pre-dispatch failures.** If `chat.processAction(...)` throws, the agent's `onAction` may have already executed partial work — re-releasing the token would risk replaying non-idempotent side effects. The release path is gated on a typed `AgentActionPreDispatchError` raised only by the config/adapter-setup phase.
- **Cache outages surface a retry page**, not "already submitted". `AgentEmailActionCacheUnavailableError` is thrown by peek/consume when Redis is unreachable; the controller renders an HTTP 503 "Try again" page that preserves the token.

### UX

- Per-agent **monogram avatar** (initials from `agent.name`, deterministic color from one of 8 palette pairs).
- Agent name shown above the action label.
- **Style-aware destructive UI** — `<Button style="danger">` renders a red Confirm button + "This action cannot be undone" warning chip. Non-destructive actions skip the warning entirely.
- **Loading state** — Confirm button disables, label swaps to "Submitting…" with an inline spinner, prevents double-submit.
- **Smooth in-place swap** — submit goes via `fetch()`; only the `.card` element is replaced with a fade-out → fade-in transition. Plain form-POST fallback when JS is disabled.
- **Cancel** secondary button — attempts `window.close()`, falls back to a visible hint.
- **Dark mode** via `@media (prefers-color-scheme: dark)`, including dark variants of the avatar palette and the danger styling.
- **Relative-time footer** — "Sent N min ago by `<Agent Name>`".

### Screenshots

<!-- TODO before un-drafting: screencast of confirm → spinner → success animation, plus dark-mode + danger-style variants. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- **Verification I haven't done yet (since this is draft)**: end-to-end run from a real `send-test-email` against an agent whose `onMessage` returns a card with `<Button id="approve" value="123">Approve</Button>`. I'd like to confirm the bridge log shows the click landing in `onAction` with `{ id: 'approve', value: '123' }`, and visually verify the success-screen animation.
- **`agentId` plumbing**: `createChatInstance` and `buildAdapters` now take `agentId` so the email adapter's `actionUrlBuilder` closure can mint tokens bound to the right Mongo `_id`. This is the only signature change to existing internal methods; no public API on `ChatSdkService` was renamed.
- **Test fixture change**: `chat-sdk.service.spec.ts` bumps 5 manual `new ChatSdkService(...)` calls to pass an extra `{} as any` for the `AgentEmailActionTokenService` constructor argument.
- **HTML templates** are inline tagged template literals (no template engine). Each page weighs in around ~5 KB, has `<meta name="robots" content="noindex,nofollow" />` and `<meta name="referrer" content="no-referrer" />`, and the inline JS gracefully no-ops if `window.fetch` is unavailable.
- **Replay-UX trade-off**: when a corporate prefetcher follows the GET preview link, the user later clicking the same link still sees the confirm page (preview is idempotent). On POST, only one client can win the atomic `GETDEL`; the rest see "already submitted". Prefetchers don't POST, so this is robust in practice.
- **TTL rename**: previous (unmerged) commits on this branch used `AGENT_EMAIL_ACTION_JWT_TTL`. The variable is renamed to `AGENT_EMAIL_ACTION_TOKEN_TTL` to match the JWT → opaque-token semantic change. No external deployment has ever depended on the old name.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
