### PR TITLE
fix(api,worker): apply SSRF guard to /v1/events/trigger bridgeUrl path (fixes NV-7627)

### DIFF
--- a/apps/api/src/app/events/e2e/trigger-event-ssrf.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event-ssrf.e2e.ts
@@ -1,0 +1,152 @@
+import { JobRepository } from '@novu/dal';
+import { UserSession } from '@novu/testing';
+import axios, { AxiosResponse } from 'axios';
+import { expect } from 'chai';
+import getPort from 'get-port';
+import { TestBridgeServer } from '../../../../e2e/test-bridge-server';
+
+const eventTriggerPath = '/v1/events/trigger';
+
+// Locks in the SSRF guard on the stateless `bridgeUrl` field that the
+// `POST /v1/events/trigger` endpoint accepts (used by the local Studio /
+// CLI to perform a one-off DISCOVER against a developer-supplied bridge).
+//
+// Without this guard, a caller with EVENT_WRITE could repoint the trigger
+// at internal hosts (loopback name, RFC1918 / link-local IP literals, cloud
+// metadata, embedded credentials, non-http schemes) and have both the API
+// process and downstream worker EXECUTE calls fan out to those targets.
+// See `Sync.assertSafeBridgeUrl` for the matching check on /bridge/sync.
+describe('Trigger Event SSRF protection - /v1/events/trigger (POST) #novu-v2', () => {
+  let session: UserSession;
+  const jobRepository = new JobRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  async function trigger(bridgeUrl: string): Promise<AxiosResponse> {
+    return axios.post(
+      `${session.serverUrl}${eventTriggerPath}`,
+      {
+        name: 'ssrf-test-workflow',
+        to: { subscriberId: session.subscriberId, email: 'ssrf@example.com' },
+        payload: {},
+        bridgeUrl,
+      },
+      {
+        headers: { authorization: `ApiKey ${session.apiKey}` },
+        validateStatus: () => true,
+      }
+    );
+  }
+
+  async function expectNoQueuedBridgeJob(): Promise<void> {
+    const jobs = await jobRepository.find({
+      _environmentId: session.environment._id,
+      'step.bridgeUrl': { $exists: true, $ne: null },
+    });
+    expect(jobs.length, 'no stateless bridge job should be queued for a blocked URL').to.equal(0);
+  }
+
+  it('should reject bridgeUrl pointing at localhost', async () => {
+    const result = await trigger('http://localhost:4000/api/novu');
+
+    expect(result.status).to.equal(400);
+    expect(JSON.stringify(result.data)).to.match(/bridgeUrl/i);
+    await expectNoQueuedBridgeJob();
+  });
+
+  it('should reject bridgeUrl pointing at cloud metadata hostname', async () => {
+    const result = await trigger('http://metadata.google.internal/computeMetadata/v1/');
+
+    expect(result.status).to.equal(400);
+    expect(JSON.stringify(result.data)).to.match(/bridgeUrl/i);
+    await expectNoQueuedBridgeJob();
+  });
+
+  it('should reject bridgeUrl with embedded credentials', async () => {
+    const result = await trigger('http://attacker:pass@example.com/api/novu');
+
+    expect(result.status).to.equal(400);
+    expect(JSON.stringify(result.data)).to.match(/bridgeUrl/i);
+    await expectNoQueuedBridgeJob();
+  });
+
+  it('should reject bridgeUrl with non-http scheme', async () => {
+    const result = await trigger('ftp://example.com/api/novu');
+
+    expect(result.status).to.equal(400);
+    expect(JSON.stringify(result.data)).to.match(/bridgeUrl/i);
+    await expectNoQueuedBridgeJob();
+  });
+
+  // Connect-time block: IP literal passes the synchronous URL policy but
+  // must be rejected by the DNS-pinned guard before the TCP connect, and
+  // the resolved IP must NOT leak into the response.
+  it('should reject bridgeUrl pointing at link-local cloud metadata IP', async () => {
+    const result = await trigger('http://169.254.169.254/computeMetadata/v1/');
+
+    expect(result.status).to.equal(400);
+    expect(JSON.stringify(result.data)).to.match(/blocked by the outbound SSRF policy/i);
+    expect(JSON.stringify(result.data)).to.not.match(/169\.254\.169\.254/);
+    await expectNoQueuedBridgeJob();
+  });
+
+  it('should reject bridgeUrl pointing at RFC1918 private IP', async () => {
+    const result = await trigger('http://10.0.0.1/api/novu');
+
+    expect(result.status).to.equal(400);
+    expect(JSON.stringify(result.data)).to.match(/blocked by the outbound SSRF policy/i);
+    expect(JSON.stringify(result.data)).to.not.match(/10\.0\.0\.1/);
+    await expectNoQueuedBridgeJob();
+  });
+
+  // Sanity: a request without `bridgeUrl` must still complete the regular
+  // (non-stateless) trigger pipeline without being touched by the SSRF guard.
+  it('should accept triggers without a bridgeUrl', async () => {
+    const result = await axios.post(
+      `${session.serverUrl}${eventTriggerPath}`,
+      {
+        name: 'ssrf-test-workflow',
+        to: { subscriberId: session.subscriberId, email: 'ssrf@example.com' },
+        payload: {},
+      },
+      {
+        headers: { authorization: `ApiKey ${session.apiKey}` },
+        validateStatus: () => true,
+      }
+    );
+
+    // The workflow doesn't exist in this test session, so the trigger is
+    // expected to be unprocessable, but it must NOT be rejected as an SSRF
+    // violation (would surface as 400 + "bridgeUrl: ..." instead).
+    expect([201, 422]).to.include(result.status);
+    if (result.status === 400) {
+      expect(JSON.stringify(result.data)).to.not.match(/bridgeUrl/i);
+    }
+  });
+
+  // Sanity: confirm a benign bridgeUrl pointing at the local TestBridgeServer
+  // (allowed via NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS in .env.test) is not
+  // blocked by the new guard. Without this, a regression that over-blocks
+  // local fixtures would silently break the rest of the bridge-trigger
+  // suite.
+  it('should not reject bridgeUrl that resolves to a test-allow-listed IP', async () => {
+    const port = await getPort();
+    const bridgeServer = new TestBridgeServer(port);
+    try {
+      await bridgeServer.start({ workflows: [] });
+
+      const result = await trigger(`${bridgeServer.serverPath}/novu`);
+
+      // The bridge server has no workflow with this identifier, so the
+      // trigger surfaces a 422 (workflow_not_found) — but it must NOT be
+      // rejected with a 400 SSRF error.
+      expect(result.status).to.not.equal(400);
+      expect(JSON.stringify(result.data)).to.not.match(/blocked by the outbound SSRF policy/i);
+    } finally {
+      await bridgeServer.stop();
+    }
+  });
+});

--- a/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
+++ b/apps/api/src/app/events/usecases/parse-event-request/parse-event-request.usecase.ts
@@ -1,8 +1,9 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { Injectable, UnprocessableEntityException } from '@nestjs/common';
+import { BadRequestException, Injectable, UnprocessableEntityException } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import type { EventType, RequestTraceInput } from '@novu/application-generic';
 import {
+  assertSafeOutboundUrl,
   ExecuteBridgeRequest,
   ExecuteBridgeRequestCommand,
   ExecuteBridgeRequestDto,
@@ -15,6 +16,7 @@ import {
   LogRepository,
   mapEventTypeToTitle,
   PinoLogger,
+  SsrfBlockedError,
   StorageHelperService,
   TraceLogRepository,
   WorkflowQueueService,
@@ -294,16 +296,47 @@ export class ParseEventRequest {
       return null;
     }
 
+    this.assertSafeBridgeUrl(command.bridgeUrl);
+
     const discover = (await this.executeBridgeRequest.execute(
       ExecuteBridgeRequestCommand.create({
         statelessBridgeUrl: command.bridgeUrl,
         environmentId: command.environmentId,
         action: GetActionEnum.DISCOVER,
         workflowOrigin: ResourceOriginEnum.EXTERNAL,
+        // User-supplied stateless bridgeUrl: pin the connection to a validated
+        // public IP and re-validate every redirect so IP literals like
+        // 127.0.0.1 / 169.254.169.254 / fc00::/7 cannot reach internal hosts.
+        // The downstream EXECUTE call from the worker enforces the same guard
+        // — see `apps/worker/src/app/workflow/usecases/execute-bridge-job`.
+        enforceSsrfProtection: true,
       })
     )) as ExecuteBridgeRequestDto<GetActionEnum.DISCOVER>;
 
     return discover?.workflows?.find((findWorkflow) => findWorkflow.workflowId === command.identifier) || null;
+  }
+
+  // The trigger pipeline performs an outbound DISCOVER request against the
+  // caller-supplied `bridgeUrl` (stateless workflow flow used by the local
+  // Studio / CLI), and then persists that URL onto the queued workflow job
+  // so the worker re-uses it for every step's EXECUTE call. Without an SSRF
+  // guard, a caller with EVENT_WRITE can repoint the bridge at internal
+  // hosts (loopback, RFC1918, link-local 169.254.169.254, cloud metadata)
+  // and have the API + worker process fan out to those targets.
+  //
+  // The synchronous `assertSafeOutboundUrl` check rejects the obvious vectors
+  // (non-http schemes, embedded credentials, blocked hostnames). The
+  // connect-time DNS-pinned guard against IP-literal private addresses is
+  // applied via `enforceSsrfProtection: true` on the actual outbound request.
+  private assertSafeBridgeUrl(bridgeUrl: string): void {
+    try {
+      assertSafeOutboundUrl(bridgeUrl);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new BadRequestException(`bridgeUrl: ${err.message}`);
+      }
+      throw err;
+    }
   }
 
   @Instrument()

--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
@@ -238,6 +238,14 @@ export class ExecuteBridgeJob {
       environmentId,
       organizationId,
       stepResolverHash,
+      // Stateless flow: the bridgeUrl was attached by the trigger caller and
+      // travelled with the queued job. Re-apply the DNS-pinned SSRF guard on
+      // every step's EXECUTE so the worker cannot be coerced into reaching
+      // internal hosts even if a job slips past the API-side validation
+      // (e.g. queued by an older API release before the guard landed).
+      // Stateful jobs (no `statelessBridgeUrl`) target the environment's
+      // configured bridge URL, which is validated when it is set.
+      enforceSsrfProtection: !!statelessBridgeUrl,
       processError: async (response) => {
         await this.createExecutionDetails.execute({
           ...CreateExecutionDetailsCommand.getDetailsFromJob(job),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Extended SSRF protections to the stateless `bridgeUrl` parameter in `POST /v1/events/trigger` (and related bulk/broadcast endpoints). Previously, SSRF guards only covered `POST /v1/bridge/sync` and `/bridge/validate`. Now the API validates `bridgeUrl` synchronously before issuing a DISCOVER request, and the worker enforces it at job execution, preventing access to loopback addresses, cloud metadata endpoints, and private IP ranges.

## Affected areas

- **api**: Updated `ParseEventRequest` usecase to call `assertSafeBridgeUrl()` before DISCOVER, mapping `SsrfBlockedError` to a 400 `BadRequestException` with a `bridgeUrl` error message, and passing `enforceSsrfProtection: true` to block IP literals and re-validate redirects.
- **worker**: Updated `ExecuteBridgeJob` to pass `enforceSsrfProtection: true` when a stateless `bridgeUrl` is present, applying DNS-pinned protection at job execution for queued jobs.

## Key technical decisions

- The guard only applies when a caller explicitly supplies a `bridgeUrl` parameter; requests without it are unaffected.
- Worker-side enforcement is defense-in-depth for jobs queued before API-side validation completes.
- API rejects unsafe URLs with a 400 response before any outbound SSRF attempts (loopback, cloud metadata, embedded credentials, non-HTTP schemes, and RFC1918 private IPs).

## Testing

Added comprehensive e2e regression test suite (`trigger-event-ssrf.e2e.ts`) covering loopback hostnames, cloud-metadata hostnames, embedded credentials, non-HTTP schemes, link-local IPs, RFC1918 private IPs, and sanity cases (triggers without `bridgeUrl` and allow-listed test servers). 8 new tests passing; 27 existing bridge sync e2e tests remain passing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11082)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The earlier SSRF fix (PR #11047 / NV-7580) only applied `assertSafeOutboundUrl` + DNS-pinned `enforceSsrfProtection: true` to `POST /v1/bridge/sync` and `POST /v1/bridge/validate`. The same `bridgeUrl` field is still accepted on `POST /v1/events/trigger` (and `/trigger/bulk`, `/trigger/broadcast`, all of which fan out through `ParseEventRequest`) and used for stateless workflow discovery without any SSRF guard.

Reproducer verified on `next` (commit `8274ba22f0`) and on the user-reported 3.15.0 instance:

1. `POST /v1/bridge/sync` with `bridgeUrl=http://localhost:<port>/novu` is correctly rejected with `400 bridgeUrl: ...`.
2. `POST /v1/events/trigger` with the **same** `bridgeUrl` returns `201` and the local bridge receives the inbound `DISCOVER`. The discovered workflow then travels with the queued job and the worker re-uses the URL for every step's `EXECUTE` call — also without any guard.

So a caller with `EVENT_WRITE` could still repoint the trigger at internal hosts (loopback name, RFC1918 / link-local IP literals, cloud metadata, embedded credentials, non-http schemes) and have both the API process and the worker fan out signed bridge requests against attacker-controlled targets.

This change applies the same pattern as the sync/validate fix to the trigger pipeline:

- **`apps/api/.../parse-event-request.usecase.ts`** — synchronously `assertSafeOutboundUrl` the `bridgeUrl` (mapping `SsrfBlockedError` to a 400 `bridgeUrl: <reason>` `BadRequestException`) before the DISCOVER outbound, and pass `enforceSsrfProtection: true` so IP literals are blocked at connect time and every redirect is re-validated.
- **`apps/worker/.../execute-bridge-job.usecase.ts`** — pass `enforceSsrfProtection: true` whenever `statelessBridgeUrl` is set so the per-step `EXECUTE` call from the worker is also DNS-pinned, even if a job slipped past the API-side validation (e.g. queued by an older API release before the guard landed). Stateful jobs (no `statelessBridgeUrl`) continue to use the environment's configured bridge URL, which is validated when it is set, so behavior is unchanged for them.

Adds e2e regression coverage in `apps/api/src/app/events/e2e/trigger-event-ssrf.e2e.ts` for: loopback hostname, cloud-metadata hostname, embedded credentials, non-http scheme, link-local cloud-metadata IP literal, RFC1918 private IP, plus sanity tests that triggers without `bridgeUrl` and against the test-allow-listed local `TestBridgeServer` still work and that no stateless bridge job is queued for blocked URLs.

### Test results

- New file: `apps/api/src/app/events/e2e/trigger-event-ssrf.e2e.ts` — 8 passing.
- Existing `apps/api/src/app/bridge/e2e/sync.e2e.ts` (the prior SSRF guard) — 27 passing, no regression.

```
  Trigger Event SSRF protection - /v1/events/trigger (POST) #novu-v2
    ✔ should reject bridgeUrl pointing at localhost
    ✔ should reject bridgeUrl pointing at cloud metadata hostname
    ✔ should reject bridgeUrl with embedded credentials
    ✔ should reject bridgeUrl with non-http scheme
    ✔ should reject bridgeUrl pointing at link-local cloud metadata IP
    ✔ should reject bridgeUrl pointing at RFC1918 private IP
    ✔ should accept triggers without a bridgeUrl
    ✔ should not reject bridgeUrl that resolves to a test-allow-listed IP

  8 passing (5s)
```

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None — fix is contained in OSS `apps/api` and `apps/worker`.

### Special notes for your reviewer

- The guard only fires when the caller supplies `bridgeUrl` on the trigger body (the stateless workflow path used by the local Studio / CLI). Triggers without `bridgeUrl` are completely unchanged. The dev-studio happy path uses tunneled `*.novu.sh` URLs which pass `assertSafeOutboundUrl` and the DNS-pinned guard.
- The connect-time block returns the same stable, client-safe message as `/bridge/sync` (`"blocked by the outbound SSRF policy"`) — the resolved IP is logged server-side via `executeFrameworkRequest`'s existing `HttpClientErrorType.SSRF_BLOCKED` branch and never echoed to the client.
- The worker guard (`enforceSsrfProtection: !!statelessBridgeUrl`) is defense-in-depth against jobs queued before the API-side guard landed; once the API has been upgraded and the queue has drained, no blocked URLs should reach the worker.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1778567238678029?thread_ts=1778567238.678029&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-ed40e2ef-c795-5200-adce-96eaf3e263fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed40e2ef-c795-5200-adce-96eaf3e263fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

