### PR TITLE
fix(api-service): scope integration create/update to API key env fixes NV-7628

### DIFF
--- a/apps/api/src/app/events/e2e/trigger-event.e2e.ts
+++ b/apps/api/src/app/events/e2e/trigger-event.e2e.ts
@@ -4,7 +4,6 @@ import { SubscriberPayloadDto } from '@novu/api/src/models/components/subscriber
 import { ClickHouseService, DetailEnum, QueryBuilder, Trace, TraceLogRepository } from '@novu/application-generic';
 import {
   CommunityOrganizationRepository,
-  EnvironmentRepository,
   ExecutionDetailsRepository,
   IntegrationRepository,
   JobRepository,
@@ -61,7 +60,6 @@ describe('Trigger event - /v1/events/trigger (POST) #novu-v2', () => {
   const integrationRepository = new IntegrationRepository();
   const jobRepository = new JobRepository();
   const executionDetailsRepository = new ExecutionDetailsRepository();
-  const environmentRepository = new EnvironmentRepository();
   const tenantRepository = new TenantRepository();
   let novuClient: Novu;
 
@@ -2701,16 +2699,10 @@ describe('Trigger event - /v1/events/trigger (POST) #novu-v2', () => {
         expect(messages.length).to.be.equal(1);
         expect(messages[0].providerId).to.be.equal(EmailProviderIdEnum.SendGrid);
 
-        const prodEnv = await environmentRepository.findOne({
-          name: 'Production',
-          _organizationId: session.organization._id,
-        });
-
         const payload: CreateIntegrationRequestDto = {
           providerId: EmailProviderIdEnum.Mailgun,
           channel: 'email',
           credentials: { apiKey: '123', secretKey: 'abc' },
-          environmentId: prodEnv?._id,
           active: true,
           check: false,
         };

--- a/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
@@ -648,6 +648,62 @@ describe('Create Integration - /integration (POST) #novu-v2', () => {
     );
     process.env.NOVU_SMS_INTEGRATION_ACCOUNT_SID = oldNovuSmsIntegrationAccountSid;
   });
+
+  describe('API key authentication is scoped to the key environment', () => {
+    it('should forbid creating with a different `_environmentId` when authenticated via API key', async () => {
+      const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+
+      const payload = {
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        _environmentId: prodEnv?._id,
+        check: false,
+      };
+
+      const { body } = await session.testAgent
+        .post('/v1/integrations')
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send(payload);
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('API key authentication is scoped to a single environment');
+    });
+
+    it('should allow creating without `_environmentId` (defaults to API key environment) via API key', async () => {
+      const payload = {
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        check: false,
+      };
+
+      const {
+        body: { data },
+      } = await session.testAgent
+        .post('/v1/integrations')
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send(payload);
+
+      expect(data._environmentId).to.equal(session.environment._id);
+    });
+
+    it('should allow creating with the same `_environmentId` as the API key environment', async () => {
+      const payload = {
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        _environmentId: session.environment._id,
+        check: false,
+      };
+
+      const {
+        body: { data },
+      } = await session.testAgent
+        .post('/v1/integrations')
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send(payload);
+
+      expect(data._environmentId).to.equal(session.environment._id);
+    });
+  });
 });
 
 async function insertIntegrationTwice(

--- a/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/create-integration.e2e.ts
@@ -652,11 +652,12 @@ describe('Create Integration - /integration (POST) #novu-v2', () => {
   describe('API key authentication is scoped to the key environment', () => {
     it('should forbid creating with a different `_environmentId` when authenticated via API key', async () => {
       const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      expect(prodEnv?._id, 'Expected Production environment fixture').to.exist;
 
       const payload = {
         providerId: EmailProviderIdEnum.SendGrid,
         channel: ChannelTypeEnum.EMAIL,
-        _environmentId: prodEnv?._id,
+        _environmentId: prodEnv!._id,
         check: false,
       };
 

--- a/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
@@ -1020,4 +1020,124 @@ describe('Update Integration - /integrations/:integrationId (PUT) #novu-v2', () 
     expect(second.active).to.equal(true);
     expect(second.priority).to.equal(1);
   });
+
+  describe('API key authentication is scoped to the key environment', () => {
+    it('should forbid updating with a different `_environmentId` when authenticated via API key', async () => {
+      const integrationOne = await integrationRepository.create({
+        name: 'Test',
+        identifier: 'identifier-api-key-other-env',
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        active: false,
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+      });
+      const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+
+      const payload = {
+        _environmentId: prodEnv?._id,
+        check: false,
+      };
+
+      const { body } = await session.testAgent
+        .put(`/v1/integrations/${integrationOne._id}`)
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send(payload);
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('API key authentication is scoped to a single environment');
+
+      const untouched = await integrationRepository.findOne({
+        _id: integrationOne._id,
+        _environmentId: session.environment._id,
+      });
+      expect(untouched?._environmentId).to.equal(session.environment._id);
+    });
+
+    it('should allow updating with the same `_environmentId` as the API key environment', async () => {
+      const integrationOne = await integrationRepository.create({
+        name: 'Test',
+        identifier: 'identifier-api-key-same-env',
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        active: false,
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+      });
+
+      const payload = {
+        _environmentId: session.environment._id,
+        name: 'Renamed via API key',
+        check: false,
+      };
+
+      const {
+        body: { data },
+      } = await session.testAgent
+        .put(`/v1/integrations/${integrationOne._id}`)
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send(payload);
+
+      expect(data.name).to.equal('Renamed via API key');
+      expect(data._environmentId).to.equal(session.environment._id);
+    });
+
+    it('should forbid updating an integration that lives in a different environment when authenticated via API key', async () => {
+      const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      const otherEnvironmentIntegration = await integrationRepository.create({
+        name: 'OtherEnv',
+        identifier: 'other-env-update-api-key',
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        active: false,
+        _organizationId: session.organization._id,
+        _environmentId: prodEnv!._id,
+      });
+
+      const payload = {
+        name: 'Should not change',
+        check: false,
+      };
+
+      const { body } = await session.testAgent
+        .put(`/v1/integrations/${otherEnvironmentIntegration._id}`)
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send(payload);
+
+      expect(body.statusCode).to.equal(403);
+      expect(body.message).to.contain('API key authentication is scoped to a single environment');
+
+      const untouched = await integrationRepository.findOne({
+        _id: otherEnvironmentIntegration._id,
+        _environmentId: prodEnv!._id,
+      });
+      expect(untouched?.name).to.equal('OtherEnv');
+    });
+
+    it('should still allow JWT-authenticated requests to update integrations in another environment', async () => {
+      const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      const otherEnvironmentIntegration = await integrationRepository.create({
+        name: 'OtherEnv',
+        identifier: 'other-env-update-jwt',
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        active: false,
+        _organizationId: session.organization._id,
+        _environmentId: prodEnv!._id,
+      });
+
+      const payload = {
+        _environmentId: prodEnv!._id,
+        name: 'Renamed via JWT',
+        check: false,
+      };
+
+      const {
+        body: { data },
+      } = await session.testAgent.put(`/v1/integrations/${otherEnvironmentIntegration._id}`).send(payload);
+
+      expect(data.name).to.equal('Renamed via JWT');
+      expect(data._environmentId).to.equal(prodEnv!._id);
+    });
+  });
 });

--- a/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/update-integration.e2e.ts
@@ -1033,9 +1033,10 @@ describe('Update Integration - /integrations/:integrationId (PUT) #novu-v2', () 
         _environmentId: session.environment._id,
       });
       const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      expect(prodEnv?._id, 'Expected Production environment fixture').to.exist;
 
       const payload = {
-        _environmentId: prodEnv?._id,
+        _environmentId: prodEnv!._id,
         check: false,
       };
 
@@ -1084,6 +1085,7 @@ describe('Update Integration - /integrations/:integrationId (PUT) #novu-v2', () 
 
     it('should forbid updating an integration that lives in a different environment when authenticated via API key', async () => {
       const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      expect(prodEnv?._id, 'Expected Production environment fixture').to.exist;
       const otherEnvironmentIntegration = await integrationRepository.create({
         name: 'OtherEnv',
         identifier: 'other-env-update-api-key',
@@ -1116,6 +1118,7 @@ describe('Update Integration - /integrations/:integrationId (PUT) #novu-v2', () 
 
     it('should still allow JWT-authenticated requests to update integrations in another environment', async () => {
       const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      expect(prodEnv?._id, 'Expected Production environment fixture').to.exist;
       const otherEnvironmentIntegration = await integrationRepository.create({
         name: 'OtherEnv',
         identifier: 'other-env-update-jwt',

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -4,6 +4,7 @@ import {
   ClassSerializerInterceptor,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
   Param,
   Post,
@@ -27,6 +28,7 @@ import {
 } from '@novu/application-generic';
 import { CommunityOrganizationRepository } from '@novu/dal';
 import {
+  ApiAuthSchemeEnum,
   ApiServiceLevelEnum,
   ChannelTypeEnum,
   FeatureFlagsKeysEnum,
@@ -227,6 +229,8 @@ export class IntegrationsController {
     @Body() body: CreateIntegrationRequestDto
   ): Promise<IntegrationResponseDto> {
     try {
+      this.assertEnvironmentScopedForApiKey(user, body._environmentId);
+
       const canAccessCredentials = await this.canUserAccessCredentials(user);
       const integration = await this.createIntegrationUsecase.execute(
         CreateIntegrationCommand.create({
@@ -280,6 +284,8 @@ export class IntegrationsController {
     @Body() body: UpdateIntegrationRequestDto
   ): Promise<IntegrationResponseDto> {
     try {
+      this.assertEnvironmentScopedForApiKey(user, body._environmentId);
+
       const canAccessCredentials = await this.canUserAccessCredentials(user);
       const integration = await this.updateIntegrationUsecase.execute(
         UpdateIntegrationCommand.create({
@@ -295,6 +301,7 @@ export class IntegrationsController {
           check: body.check ?? false,
           conditions: body.conditions,
           configurations: body.configurations,
+          restrictToUserEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
         })
       );
 
@@ -821,6 +828,19 @@ export class IntegrationsController {
         connectionIdentifier: body.connectionIdentifier,
       })
     );
+  }
+
+  private assertEnvironmentScopedForApiKey(user: UserSessionData, requestedEnvironmentId?: string): void {
+    if (user.scheme !== ApiAuthSchemeEnum.API_KEY) {
+      return;
+    }
+
+    if (requestedEnvironmentId && requestedEnvironmentId !== user.environmentId) {
+      throw new ForbiddenException(
+        'API key authentication is scoped to a single environment and cannot target a different `_environmentId`. ' +
+          'Use an API key from the target environment, or authenticate with a session token.'
+      );
+    }
   }
 
   private async canUserAccessCredentials(user: UserSessionData): Promise<boolean> {

--- a/apps/api/src/app/integrations/usecases/update-integration/update-integration.command.ts
+++ b/apps/api/src/app/integrations/usecases/update-integration/update-integration.command.ts
@@ -1,6 +1,15 @@
 import { MessageFilter } from '@novu/application-generic';
 import { IConfigurations, ICredentialsDto } from '@novu/shared';
-import { IsArray, IsDefined, IsMongoId, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsDefined,
+  IsMongoId,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
 
 import { OrganizationCommand } from '../../../shared/commands/organization.command';
 
@@ -41,4 +50,14 @@ export class UpdateIntegrationCommand extends OrganizationCommand {
   @IsOptional()
   @IsObject()
   configurations?: IConfigurations;
+
+  /**
+   * When true, the existing integration must belong to `userEnvironmentId` for the
+   * update to succeed. Used when the request is authenticated with an API key, since
+   * an API key is bound to a single environment and must not be able to mutate
+   * integrations that live in a different environment of the same organization.
+   */
+  @IsOptional()
+  @IsBoolean()
+  restrictToUserEnvironment?: boolean;
 }

--- a/apps/api/src/app/integrations/usecases/update-integration/update-integration.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/update-integration/update-integration.usecase.ts
@@ -1,4 +1,11 @@
-import { BadRequestException, ConflictException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { AnalyticsService, decryptCredentials, encryptCredentials, PinoLogger } from '@novu/application-generic';
 import { EnvironmentRepository, IntegrationEntity, IntegrationRepository } from '@novu/dal';
 import { CHANNELS_WITH_PRIMARY } from '@novu/shared';
@@ -100,6 +107,14 @@ export class UpdateIntegration {
     });
     if (!existingIntegration) {
       throw new NotFoundException(`Entity with id ${command.integrationId} not found`);
+    }
+
+    if (command.restrictToUserEnvironment && existingIntegration._environmentId !== command.userEnvironmentId) {
+      throw new ForbiddenException(
+        'API key authentication is scoped to a single environment and cannot update an integration ' +
+          "that belongs to a different environment. Use an API key from the integration's environment, " +
+          'or authenticate with a session token.'
+      );
     }
 
     if (command.environmentId && command.environmentId !== existingIntegration._environmentId) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The `POST /v1/integrations` and `PUT /v1/integrations/:integrationId` endpoints accept an optional `_environmentId` field in the request body and use it as the integration's environment, regardless of how the request is authenticated. That is fine for JWT (dashboard) sessions because the user has access to every environment in their organization, but it is unsafe for API key authentication: an API key is bound to a single environment and must not be allowed to mutate integrations in another environment of the same organization.

This PR enforces that scoping for API-key-authenticated requests while keeping the existing cross-env behavior for JWT/Bearer sessions.

### Concrete impact before this change

With an API key for environment **A**, a caller could:

1. `POST /v1/integrations` with `_environmentId = <env B id>` — the integration was created in env B.
2. `PUT /v1/integrations/:id` with `_environmentId = <env B id>` — the integration was moved into env B.
3. `PUT /v1/integrations/:id` for an integration that already lived in env B — succeeded, because the use case only filtered by `_organizationId`.

## How

- `IntegrationsController.createIntegration` and `updateIntegrationById` now call `assertEnvironmentScopedForApiKey(user, body._environmentId)`. If `user.scheme === ApiAuthSchemeEnum.API_KEY` and `body._environmentId` differs from `user.environmentId`, a `403 Forbidden` is thrown.
- `UpdateIntegrationCommand` gains a `restrictToUserEnvironment` flag. The controller sets it to `true` when the request is API-key-authenticated; `UpdateIntegration` then rejects updates whose existing integration lives in a different environment than the API key's.
- JWT sessions hit the same code paths with `restrictToUserEnvironment === false`, preserving today's cross-environment behavior used by the dashboard.

## Tests

New e2e cases added to `apps/api/src/app/integrations/e2e/{create,update}-integration.e2e.ts`:

- API key cannot specify a different `_environmentId` (POST and PUT) → 403.
- API key can specify the same `_environmentId` (POST and PUT) → 200/201.
- API key cannot update an integration that lives in a different env (PUT) → 403, integration is unchanged.
- JWT session can still update an integration in another environment.

```text
Update Integration - /integrations/:integrationId (PUT) #novu-v2
  ...
  API key authentication is scoped to the key environment
    ✔ should forbid updating with a different `_environmentId` when authenticated via API key
    ✔ should allow updating with the same `_environmentId` as the API key environment
    ✔ should forbid updating an integration that lives in a different environment when authenticated via API key
    ✔ should still allow JWT-authenticated requests to update integrations in another environment

27 passing (5s)

Create Integration - /integration (POST) #novu-v2
  ...
  API key authentication is scoped to the key environment
    ✔ should forbid creating with a different `_environmentId` when authenticated via API key
    ✔ should allow creating without `_environmentId` (defaults to API key environment) via API key
    ✔ should allow creating with the same `_environmentId` as the API key environment

25 passing (10s)
```

## Compatibility

- Existing dashboard flows are unchanged (JWT sessions).
- API-key callers that were (incorrectly) targeting another environment will now receive a `403`. The error message guides them to use the correct API key or a session token.
- No DTO/SDK signature changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1778568524477089?thread_ts=1778568524.477089&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-b43b456c-924c-503b-952a-779f6c70b530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b43b456c-924c-503b-952a-779f6c70b530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

API-key-authenticated requests can no longer create or update integrations in environments other than the environment bound to the API key. Controllers now validate any requested _environmentId for API-key requests and return 403 Forbidden on mismatch. JWT/Bearer (dashboard) sessions retain existing cross-environment behavior. This prevents API keys scoped to one environment from moving or creating integrations in other environments.

## Affected areas

**api**: Integration controller and usecase logic enforce environment scoping for API-key-authenticated requests; a new optional flag on the update command (`restrictToUserEnvironment`) drives enforcement without changing DTOs or SDK signatures. Controllers call a shared `assertEnvironmentScopedForApiKey()` check for create/update flows.

## Key technical decisions

- Enforcement occurs in the controller/usecase flow using a `restrictToUserEnvironment` flag so JWT sessions remain unrestricted and DTOs remain unchanged.
- The API returns 403 with guidance when API-key callers attempt cross-environment operations rather than silently permitting them.

## Testing

Added end-to-end tests covering create and update flows: they assert API-key requests are blocked for cross-environment attempts (403), succeed when targeting the API key’s environment, and confirm JWT-authenticated requests still allow cross-environment updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11083)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->