### PR TITLE
fix(api-service): invalidate sibling email action buttons on consume

### DIFF
--- a/apps/api/src/app/agents/services/agent-email-action-token.service.ts
+++ b/apps/api/src/app/agents/services/agent-email-action-token.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { CacheService, PinoLogger } from '@novu/application-generic';
 
 const KEY_PREFIX = 'agent:email:action:';
+const MESSAGE_KEY_PREFIX = 'agent:email:action:msg:';
 const DEFAULT_TTL_SECONDS = 60 * 60 * 24 * 3; // 3 days
 /** 256 bits of entropy. Encoded as base64url → 43 URL-safe characters. */
 const TOKEN_BYTES = 32;
@@ -152,6 +153,11 @@ export class AgentEmailActionTokenService {
    * Reads the claims **without** consuming the token. Used by the GET preview route so a
    * URL prefetcher (or repeated browser visit) doesn't burn the single-use reservation.
    *
+   * Returns `null` when the message's group flag has already been claimed by a sibling
+   * button in the same email — clicking Approve invalidates Deny, so the user landing on
+   * Deny's preview link should see the same "already submitted / expired" terminal page as
+   * if they reused a consumed link.
+   *
    * @throws AgentEmailActionCacheUnavailableError when Redis is unreachable — distinct from
    *   a `null` return (which means "expired or already used") so the controller can render
    *   a retryable error instead of silently dropping the click.
@@ -166,8 +172,17 @@ export class AgentEmailActionTokenService {
     if (!raw) return null;
 
     const entry = this.parseEntry(raw);
+    if (!entry) return null;
 
-    return entry ? { claims: entry.claims, expiresAt: entry.expiresAt, mintedAt: entry.mintedAt } : null;
+    let messageClaimed: string | null | undefined;
+    try {
+      messageClaimed = await this.cacheService.get(this.messageKey(entry.claims.messageId));
+    } catch (err) {
+      throw new AgentEmailActionCacheUnavailableError('peek', err);
+    }
+    if (messageClaimed) return null;
+
+    return { claims: entry.claims, expiresAt: entry.expiresAt, mintedAt: entry.mintedAt };
   }
 
   /**
@@ -175,6 +190,15 @@ export class AgentEmailActionTokenService {
    * caller wins per token; later callers see `null` and the controller renders the
    * "already submitted" page. If downstream dispatch fails transiently, call
    * `releaseActionToken` to put the entry back so the user can retry from the same link.
+   *
+   * After the per-token GETDEL succeeds, the *message-level* group flag is claimed via
+   * `SET NX` keyed on the email's Message-ID so that every sibling button rendered in the
+   * same email stops working too — i.e. clicking Approve invalidates Deny. If a concurrent
+   * sibling already won the race for the flag (extremely narrow window: both buttons
+   * clicked within the same Redis round-trip), the per-token entry stays deleted and we
+   * return `null` so the loser sees "already submitted". We intentionally do not restore
+   * the loser's entry, since the message is already in its terminal state and reviving one
+   * orphan would only enable a spurious second peek/consume on the loser's link.
    *
    * @throws AgentEmailActionCacheUnavailableError when Redis is unreachable — distinct from
    *   a `null` return so the controller can render a retryable error instead of silently
@@ -196,15 +220,35 @@ export class AgentEmailActionTokenService {
     if (!raw) return null;
 
     const entry = this.parseEntry(raw);
+    if (!entry) return null;
 
-    return entry ? { claims: entry.claims, expiresAt: entry.expiresAt, mintedAt: entry.mintedAt } : null;
+    const remaining = entry.expiresAt - Math.floor(Date.now() / 1000);
+    // The message-level flag mirrors the natural per-token TTL so it auto-expires alongside
+    // the siblings. Clamp to >=1s — Redis rejects zero/negative TTLs on SET EX.
+    const messageTtl = Math.max(1, remaining);
+    let claimed: 'OK' | null;
+    try {
+      claimed = await client.set(this.messageKey(entry.claims.messageId), '1', 'EX', messageTtl, 'NX');
+    } catch (err) {
+      throw new AgentEmailActionCacheUnavailableError('consume', err);
+    }
+
+    if (claimed !== 'OK') {
+      // A sibling beat us to the message-level claim. The per-token entry is already gone;
+      // the message is in its terminal "consumed" state. Surface as "already submitted".
+      return null;
+    }
+
+    return { claims: entry.claims, expiresAt: entry.expiresAt, mintedAt: entry.mintedAt };
   }
 
   /**
    * Re-stores a token previously taken by `consumeActionToken` so the user can retry after
    * a transient dispatch failure. The remaining TTL is re-computed against the original
    * `expiresAt` so a token can never outlive its natural expiry. No-op if the original
-   * expiry has already passed.
+   * expiry has already passed. Also clears the message-level consumed flag set by
+   * `consume`, so sibling buttons in the same email are usable again — symmetric with the
+   * consume path.
    */
   async releaseActionToken(token: string, consumed: ConsumedActionToken): Promise<void> {
     const remaining = consumed.expiresAt - Math.floor(Date.now() / 1000);
@@ -216,10 +260,15 @@ export class AgentEmailActionTokenService {
       mintedAt: consumed.mintedAt,
     };
     await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), { ttl: remaining });
+    await this.cacheService.del(this.messageKey(consumed.claims.messageId));
   }
 
   private storageKey(token: string): string {
     return `${KEY_PREFIX}${token}`;
+  }
+
+  private messageKey(messageId: string): string {
+    return `${MESSAGE_KEY_PREFIX}${messageId}`;
   }
 
   private parseEntry(raw: string): StoredEntry | null {


### PR DESCRIPTION
### What changed? Why was the change needed?

Follow-up to #11075. That PR mints a single-use opaque token per `<Button>` rendered in an agent email, so each button could be consumed independently. The intended single-use semantics held for an individual button, but a **set** of buttons in the same email did not behave as a unit:

- An email asking "Approve or Deny?" rendered two buttons, two tokens.
- User clicks **Approve** → its token is GETDEL'd, the action dispatches.
- User clicks **Deny** afterwards → its token is **still live**, consume succeeds, and the agent's `onAction` runs again with the opposite intent.

The fix scopes invalidation to the email's `Message-ID`. When `consume` succeeds, it atomically claims a message-level flag via:

```
SET agent:email:action:msg:<messageId> 1 EX <remaining> NX
```

`peek` and `consume` both check this flag and return `null` when set, so any later click on a sibling button in the same email renders the existing **"Already submitted"** terminal page.

#### Why `messageId` as the group key

The chat-adapter-email already mints the `Message-ID` *before* rendering the card precisely so token claims bind to the exact email (see commit message on [fd4d0fe](https://github.com/novuhq/novu/pull/11075/commits/fd4d0fe9a791c3f2febca220e85bad58337dffcf)). Reusing it as the group key requires no new field in `AgentEmailActionClaims`, no plumbing through `ActionUrlBuilder`, and no changes to `chat-adapter-email`. The fix lives in a single file.

#### Race safety

If two siblings POST simultaneously:
1. Both win their respective per-token `GETDEL` (different keys).
2. Only one wins the `SET NX` on the message flag.
3. The loser's per-token entry is **intentionally not restored** — the message is already in its terminal "consumed" state, and reviving the orphan would only enable a spurious second peek/consume on the loser's link. The loser sees "Already submitted", same as if their click had landed a millisecond later.

#### Symmetry with `releaseActionToken`

The transient pre-dispatch failure path now also clears the message flag, so a retry from the original email link still works for the user *and* re-enables the siblings — symmetric with `consume`.

### Code areas

- [`agent-email-action-token.service.ts`](https://github.com/novuhq/novu/blob/fix/email-action-sibling-invalidation/apps/api/src/app/agents/services/agent-email-action-token.service.ts)
  - `peekActionToken`: also fetches `agent:email:action:msg:<messageId>`; returns `null` if set.
  - `consumeActionToken`: after the per-token GETDEL, atomically `SET NX` the message flag with the entry's remaining TTL; if the claim fails, return `null`.
  - `releaseActionToken`: also `DEL`s the message flag.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- **No claims-schema change.** `messageId` is already on `AgentEmailActionClaims`, so existing tokens in Redis from before this deploy still work — they'll simply lack a corresponding message-flag entry, which is the unclaimed state.
- **TTL on the message flag** mirrors the per-token `remaining` TTL (clamped to >=1s since Redis rejects zero/negative TTLs on `SET EX`). It auto-expires alongside the siblings, so no manual cleanup is needed.
- **Cache outage** during the message-flag operations is wrapped in `AgentEmailActionCacheUnavailableError`, same as the existing per-token paths, so the controller renders the same retryable 503 page rather than silently dropping valid clicks.
- **Considered alternative**: a separate randomly-generated `groupId` plumbed through `ActionUrlBuilder` → `signActionToken`. Identical runtime behavior but required edits to `chat-adapter-email/src/types.ts`, `card-renderer.tsx`, and the closure in `chat-sdk.service.ts`. Rejected as strictly larger for no functional gain — the PR's existing "Message-ID binds the email" invariant is exactly the right scope.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR fixes a bug introduced in #11075 where email action buttons had single-use tokens but sibling buttons in the same email remained usable after one was consumed. The fix scopes invalidation to the email's Message-ID: when a token is successfully consumed, the service atomically sets a message-level Redis flag that invalidates all sibling buttons in that email, rendering subsequent clicks as "Already submitted."

## Affected areas

**api**: The agent email action token service (`agent-email-action-token.service.ts`) now enforces message-level invalidation alongside per-token consumption. `peekActionToken` checks for a message-level flag and returns null if a sibling has already claimed the email. `consumeActionToken` uses atomic `SET NX` to set the message-level flag keyed on Message-ID after the per-token GETDEL. `releaseActionToken` clears the message flag to enable retries after transient failures.

## Key technical decisions

- **Message-level grouping via Message-ID**: Reuses the existing RFC-5322 Message-ID field as the group key, requiring no schema or database changes.
- **Atomic race handling**: Uses Redis `SET NX` to ensure only the first sibling wins the message flag; losers observe `null` without entry restoration.
- **TTL coupling**: Message flag TTL is computed from the consumed token's remaining lifetime (clamped to ≥1s), ensuring auto-cleanup alongside siblings.
- **Cache outage semantics**: Wraps cache errors in `AgentEmailActionCacheUnavailableError` to distinguish transient failures from expired/consumed tokens, enabling proper error page rendering.

## Testing

No new tests are added. The changes are isolated to the token service's three core methods (peek, consume, release) and would benefit from unit tests covering concurrent sibling clicks and TTL behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11088)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->