### PR TITLE
fix(api-service): scope list integrations to API key env fixes NV-7631

### DIFF
--- a/apps/api/src/app/integrations/e2e/get-active-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/get-active-integration.e2e.ts
@@ -1,4 +1,4 @@
-import { IntegrationEntity } from '@novu/dal';
+import { EnvironmentRepository, IntegrationEntity } from '@novu/dal';
 import { ChannelTypeEnum, EmailProviderIdEnum, SmsProviderIdEnum } from '@novu/shared';
 import { IntegrationService, UserSession } from '@novu/testing';
 import { expect } from 'chai';
@@ -6,6 +6,7 @@ import { expect } from 'chai';
 describe('Get Active Integrations - Multi-Provider Configuration - /integrations/active (GET) #novu-v2', () => {
   let session: UserSession;
   const integrationService = new IntegrationService();
+  const envRepository = new EnvironmentRepository();
 
   beforeEach(async () => {
     session = new UserSession();
@@ -97,6 +98,35 @@ describe('Get Active Integrations - Multi-Provider Configuration - /integrations
     expect(allOrgSelectedIntegrations.length).to.equal(2);
     expect(allEnvSelectedIntegrations.length).to.equal(1);
     expect(allEnvNotSelectedIntegrations.length).to.equal(1);
+  });
+
+  describe('API key authentication is scoped to the key environment', () => {
+    it('should only return active integrations for the API key environment', async () => {
+      const activeIntegrations: IntegrationEntity[] = (
+        await session.testAgent.get(`/v1/integrations/active`).set('authorization', `ApiKey ${session.apiKey}`)
+      ).body.data;
+
+      expect(activeIntegrations.length).to.be.greaterThan(0);
+      for (const integration of activeIntegrations) {
+        expect(integration.active).to.equal(true);
+        expect(integration._environmentId).to.equal(session.environment._id);
+      }
+    });
+
+    it('should still return active integrations from all environments when authenticated via session', async () => {
+      const activeIntegrations: IntegrationEntity[] = (await session.testAgent.get(`/v1/integrations/active`)).body
+        .data;
+      const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      expect(prodEnv?._id, 'Expected Production environment fixture').to.exist;
+
+      const fromOtherEnvs = activeIntegrations.filter(
+        (integration) => integration._environmentId !== session.environment._id
+      );
+      const fromProd = activeIntegrations.filter((integration) => integration._environmentId === prodEnv!._id);
+
+      expect(fromOtherEnvs.length).to.be.greaterThan(0);
+      expect(fromProd.length).to.be.greaterThan(0);
+    });
   });
 });
 

--- a/apps/api/src/app/integrations/e2e/get-integration.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/get-integration.e2e.ts
@@ -1,10 +1,11 @@
-import { IntegrationEntity } from '@novu/dal';
+import { EnvironmentRepository, IntegrationEntity } from '@novu/dal';
 import { ChannelTypeEnum, EmailProviderIdEnum, SmsProviderIdEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
 describe('Get Integrations - /integrations (GET) #novu-v2', () => {
   let session: UserSession;
+  const envRepository = new EnvironmentRepository();
 
   beforeEach(async () => {
     session = new UserSession();
@@ -84,5 +85,32 @@ describe('Get Integrations - /integrations (GET) #novu-v2', () => {
     expect(customSmtp?.credentials?.tlsOptions).to.instanceOf(Object);
     expect(customSmtp?.credentials?.tlsOptions).to.eql(nodeMailerProviderPayload.credentials.tlsOptions);
     expect(customSmtp?.active).to.equal(true);
+  });
+
+  describe('API key authentication is scoped to the key environment', () => {
+    it('should only return integrations for the API key environment', async () => {
+      const allIntegrations: IntegrationEntity[] = (
+        await session.testAgent.get(`/v1/integrations`).set('authorization', `ApiKey ${session.apiKey}`)
+      ).body.data;
+
+      expect(allIntegrations.length).to.be.greaterThan(0);
+      for (const integration of allIntegrations) {
+        expect(integration._environmentId).to.equal(session.environment._id);
+      }
+    });
+
+    it('should still return integrations from all environments when authenticated via session', async () => {
+      const integrations: IntegrationEntity[] = (await session.testAgent.get(`/v1/integrations`)).body.data;
+      const prodEnv = await envRepository.findOne({ name: 'Production', _organizationId: session.organization._id });
+      expect(prodEnv?._id, 'Expected Production environment fixture').to.exist;
+
+      const fromOtherEnvs = integrations.filter(
+        (integration) => integration._environmentId !== session.environment._id
+      );
+      const fromProd = integrations.filter((integration) => integration._environmentId === prodEnv!._id);
+
+      expect(fromOtherEnvs.length).to.be.greaterThan(0);
+      expect(fromProd.length).to.be.greaterThan(0);
+    });
   });
 });

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -155,6 +155,7 @@ export class IntegrationsController {
         organizationId: user.organizationId,
         userId: user._id,
         returnCredentials: canAccessCredentials,
+        scopeToEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
       })
     );
   }
@@ -181,6 +182,7 @@ export class IntegrationsController {
         organizationId: user.organizationId,
         userId: user._id,
         returnCredentials: canAccessCredentials,
+        scopeToEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY,
       })
     );
   }

--- a/apps/api/src/app/integrations/usecases/get-integrations/get-integrations.command.ts
+++ b/apps/api/src/app/integrations/usecases/get-integrations/get-integrations.command.ts
@@ -5,4 +5,13 @@ export class GetIntegrationsCommand extends EnvironmentWithUserCommand {
   @IsBoolean()
   @IsOptional()
   returnCredentials?: boolean;
+
+  /**
+   * When true, restrict the query to integrations within `environmentId` only.
+   * Default behavior returns integrations across every environment of the
+   * organization (legacy JWT/session behavior).
+   */
+  @IsBoolean()
+  @IsOptional()
+  scopeToEnvironment?: boolean;
 }

--- a/apps/api/src/app/integrations/usecases/get-integrations/get-integrations.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/get-integrations/get-integrations.usecase.ts
@@ -15,6 +15,7 @@ export class GetIntegrations {
         userId: command.userId,
         environmentId: command.environmentId,
         returnCredentials: command.returnCredentials,
+        scopeToEnvironment: command.scopeToEnvironment,
       })
     );
   }

--- a/libs/application-generic/src/usecases/get-active-integration/get-active-integration.command.ts
+++ b/libs/application-generic/src/usecases/get-active-integration/get-active-integration.command.ts
@@ -5,4 +5,13 @@ export class GetActiveIntegrationsCommand extends EnvironmentWithUserCommand {
   @IsBoolean()
   @IsOptional()
   returnCredentials?: boolean;
+
+  /**
+   * When true, restrict the query to integrations within `environmentId` only.
+   * Default behavior returns active integrations across every environment of
+   * the organization (legacy JWT/session behavior).
+   */
+  @IsBoolean()
+  @IsOptional()
+  scopeToEnvironment?: boolean;
 }

--- a/libs/application-generic/src/usecases/get-active-integration/get-active-integration.usecase.ts
+++ b/libs/application-generic/src/usecases/get-active-integration/get-active-integration.usecase.ts
@@ -15,6 +15,7 @@ export class GetActiveIntegrations {
         userId: command.userId,
         active: true,
         returnCredentials: command.returnCredentials,
+        scopeToEnvironment: command.scopeToEnvironment,
       })
     );
 

--- a/libs/application-generic/src/usecases/get-decrypted-integrations/get-decrypted-integrations.command.ts
+++ b/libs/application-generic/src/usecases/get-decrypted-integrations/get-decrypted-integrations.command.ts
@@ -22,6 +22,15 @@ export class GetDecryptedIntegrationsCommand extends EnvironmentWithUserCommand 
   @IsBoolean()
   @IsOptional()
   returnCredentials?: boolean;
+
+  /**
+   * When true, restrict the query to integrations within `environmentId` only.
+   * Default behavior (false/undefined) returns integrations across every
+   * environment of the organization (legacy JWT/session behavior).
+   */
+  @IsBoolean()
+  @IsOptional()
+  scopeToEnvironment?: boolean;
 }
 
 export class GetEnvironmentDecryptedIntegrationsCommand extends EnvironmentWithUserCommand {

--- a/libs/application-generic/src/usecases/get-decrypted-integrations/get-decrypted-integrations.usecase.ts
+++ b/libs/application-generic/src/usecases/get-decrypted-integrations/get-decrypted-integrations.usecase.ts
@@ -13,6 +13,10 @@ export class GetDecryptedIntegrations {
       _organizationId: command.organizationId,
     };
 
+    if (command.scopeToEnvironment) {
+      query._environmentId = command.environmentId;
+    }
+
     if (command.active) {
       query.active = command.active;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The `/v1/integrations` and `/v1/integrations/active` endpoints now respect environment boundaries when called with API key authentication. Previously, they returned integrations across all organization environments regardless of auth method. A new optional `scopeToEnvironment` flag restricts results to the API key's environment. JWT/session-based auth retains the original cross-environment behavior. The flag defaults to false, ensuring backward compatibility for existing callers.

## Affected areas
- **api**: `IntegrationsController` now sets `scopeToEnvironment: true` when the caller authenticated via API key, and passes this flag through the integration retrieval commands.
- **application-generic**: `GetIntegrationsCommand`, `GetActiveIntegrationsCommand`, and `GetDecryptedIntegrationsCommand` now carry the `scopeToEnvironment` flag; `GetDecryptedIntegrations.execute` conditionally adds `_environmentId` to the Mongo query when the flag is set.

## Key technical decisions
- **Opt-in scoping**: The flag is optional to avoid breaking changes in existing callers (worker task selection, workflow generation, etc.).
- **Auth-scheme detection**: Environment scoping is enabled only for `ApiAuthSchemeEnum.API_KEY` auth, leaving JWT/session behavior unchanged.

## Testing
New E2E tests cover both authentication modes for `/v1/integrations` and `/v1/integrations/active`: API key authentication returns only environment-scoped integrations, while JWT/session authentication continues to return all organization environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11089)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

`GET /v1/integrations` and `GET /v1/integrations/active` previously returned integrations across **all environments** of the organization because `GetDecryptedIntegrations` only filtered by `_organizationId` and silently ignored the `environmentId` on its command.

API keys are environment-scoped (one key per environment), so a `Development` API key was leaking `Production` integrations (and vice versa). JWT/session auth is org-scoped, so cross-environment listing remains valid for the dashboard.

This PR introduces a `scopeToEnvironment` opt-in flag and flips it on in the controller only when the caller authenticated with an API key:

- `IntegrationsController.listIntegrations` and `getActiveIntegrations` pass `scopeToEnvironment: user.scheme === ApiAuthSchemeEnum.API_KEY`.
- `GetIntegrationsCommand`, `GetActiveIntegrationsCommand`, and `GetDecryptedIntegrationsCommand` carry the flag through.
- `GetDecryptedIntegrations.execute` adds `_environmentId` to the Mongo query when the flag is set.

All existing callers in `libs/application-generic` (worker `select-integration`, `stream-workflow-generation`, `workflows-v1` status) do **not** opt into the flag, so their behavior is unchanged.

### Screenshots

N/A — backend-only change.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- The flag is opt-in (`scopeToEnvironment?: boolean`) so legacy callers see no behavior change.
- Added E2E tests cover both auth modes for `/v1/integrations` and `/v1/integrations/active`:
  - API key → only env-scoped rows
  - JWT/session → still returns all envs (existing behavior preserved)
- Follows the same pattern as #11083 (create/update integration scoping).

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc1bb72f-feef-4be2-8bc3-d9faa093ecf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc1bb72f-feef-4be2-8bc3-d9faa093ecf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

