### PR TITLE
fix(shared): preserve JSON-stringified control values containing quotes fixes NV-7638

### DIFF
--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -702,6 +702,105 @@ describe('Novu Client', () => {
       expect(body).toContain('dog');
     });
 
+    it('should preserve JSON-stringified control values whose Liquid output contains double quotes (NV-7638)', async () => {
+      const mailyBody = {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: "{% assign payload = steps.digest-step.events | map: 'payload' %}{% for item in payload limit:5 %}RFI #{{item.rfi.rfiNumber}}: {{item.rfi.question | truncate: 100}} | {% endfor %}",
+              },
+            ],
+          },
+        ],
+      };
+
+      const newWorkflow = workflow(
+        'test-workflow-nv-7638',
+        async ({ step }) => {
+          await step.digest('digest-step', async () => ({ amount: 1, unit: 'hours' }));
+          await step.email(
+            'send-email',
+            async (controls) => ({
+              body: controls.body,
+              subject: controls.subject,
+            }),
+            {
+              controlSchema: {
+                type: 'object',
+                properties: {
+                  body: { type: 'string' },
+                  subject: { type: 'string' },
+                },
+                required: ['body', 'subject'],
+                additionalProperties: false,
+              } as const,
+            }
+          );
+        },
+        {
+          payloadSchema: {
+            type: 'object',
+            properties: {},
+            additionalProperties: true,
+          } as const,
+        }
+      );
+
+      await client.addWorkflows([newWorkflow]);
+
+      const event: Event = {
+        action: PostActionEnum.EXECUTE,
+        payload: {},
+        workflowId: 'test-workflow-nv-7638',
+        stepId: 'send-email',
+        subscriber: {},
+        state: [
+          {
+            stepId: 'digest-step',
+            outputs: {
+              events: [
+                {
+                  id: 'evt-1',
+                  time: '2026-01-01T00:00:00Z',
+                  payload: { rfi: { rfiNumber: 5, question: 'Where is the "important" file?' } },
+                },
+                {
+                  id: 'evt-2',
+                  time: '2026-01-01T00:01:00Z',
+                  payload: { rfi: { rfiNumber: 6, question: "John's note" } },
+                },
+              ],
+            },
+            state: { status: 'completed', error: undefined },
+          },
+        ],
+        controls: {
+          body: JSON.stringify(mailyBody),
+          subject: 'Digest summary',
+        },
+        context: {},
+        env: testEventEnv,
+      };
+
+      const result = await client.executeWorkflow(event);
+      const { body, subject } = result.outputs;
+
+      expect(subject).toBe('Digest summary');
+      expect(typeof body).toBe('string');
+
+      // The body must still be a valid JSON string after compileControls, even though the digest
+      // payload contained a `"` character. Before NV-7638's fix, the inner quote would be left
+      // unescaped and `JSON.parse(body)` would throw.
+      const parsedBody = JSON.parse(body as string);
+      const renderedText = parsedBody.content[0].content[0].text;
+      expect(renderedText).toContain('RFI #5: Where is the "important" file?');
+      expect(renderedText).toContain("RFI #6: John's note");
+    });
+
     it('should compile array control variables to a string with single quotes', async () => {
       const newWorkflow = workflow(
         'test-workflow',

--- a/packages/framework/src/client.test.ts
+++ b/packages/framework/src/client.test.ts
@@ -702,7 +702,7 @@ describe('Novu Client', () => {
       expect(body).toContain('dog');
     });
 
-    it('should preserve JSON-stringified control values whose Liquid output contains double quotes (NV-7638)', async () => {
+    it('should preserve JSON-stringified control values whose Liquid output contains double quotes', async () => {
       const mailyBody = {
         type: 'doc',
         content: [
@@ -711,7 +711,7 @@ describe('Novu Client', () => {
             content: [
               {
                 type: 'text',
-                text: "{% assign payload = steps.digest-step.events | map: 'payload' %}{% for item in payload limit:5 %}RFI #{{item.rfi.rfiNumber}}: {{item.rfi.question | truncate: 100}} | {% endfor %}",
+                text: "{% assign payload = steps.digest-step.events | map: 'payload' %}{% for item in payload limit:5 %}#{{item.id}}: {{item.title | truncate: 100}} | {% endfor %}",
               },
             ],
           },
@@ -719,7 +719,7 @@ describe('Novu Client', () => {
       };
 
       const newWorkflow = workflow(
-        'test-workflow-nv-7638',
+        'test-workflow-json-quote',
         async ({ step }) => {
           await step.digest('digest-step', async () => ({ amount: 1, unit: 'hours' }));
           await step.email(
@@ -755,7 +755,7 @@ describe('Novu Client', () => {
       const event: Event = {
         action: PostActionEnum.EXECUTE,
         payload: {},
-        workflowId: 'test-workflow-nv-7638',
+        workflowId: 'test-workflow-json-quote',
         stepId: 'send-email',
         subscriber: {},
         state: [
@@ -766,12 +766,12 @@ describe('Novu Client', () => {
                 {
                   id: 'evt-1',
                   time: '2026-01-01T00:00:00Z',
-                  payload: { rfi: { rfiNumber: 5, question: 'Where is the "important" file?' } },
+                  payload: { id: 1, title: 'Comment on "design draft" was posted' },
                 },
                 {
                   id: 'evt-2',
                   time: '2026-01-01T00:01:00Z',
-                  payload: { rfi: { rfiNumber: 6, question: "John's note" } },
+                  payload: { id: 2, title: "Sam's review is ready" },
                 },
               ],
             },
@@ -792,13 +792,13 @@ describe('Novu Client', () => {
       expect(subject).toBe('Digest summary');
       expect(typeof body).toBe('string');
 
-      // The body must still be a valid JSON string after compileControls, even though the digest
-      // payload contained a `"` character. Before NV-7638's fix, the inner quote would be left
-      // unescaped and `JSON.parse(body)` would throw.
+      // The body must still be a valid JSON string after compileControls, even though a digest
+      // payload string contained a `"` character. Before the fix, the inner quote was left
+      // unescaped and `JSON.parse(body)` threw.
       const parsedBody = JSON.parse(body as string);
       const renderedText = parsedBody.content[0].content[0].text;
-      expect(renderedText).toContain('RFI #5: Where is the "important" file?');
-      expect(renderedText).toContain("RFI #6: John's note");
+      expect(renderedText).toContain('#1: Comment on "design draft" was posted');
+      expect(renderedText).toContain("#2: Sam's review is ready");
     });
 
     it('should compile array control variables to a string with single quotes', async () => {

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -42,7 +42,11 @@ import type {
 import { WithPassthrough } from './types/provider.types';
 import { EMOJI, log, resolveApiUrl, resolveSecretKey, sanitizeHtmlInObject } from './utils';
 import { createLiquidEngine } from './utils/liquid.utils';
-import { normalizeControlData } from './utils/normalize-controls.utils';
+import {
+  expandJsonStringControlValues,
+  normalizeControlData,
+  restoreJsonStringControlValues,
+} from './utils/normalize-controls.utils';
 import { deepMerge } from './utils/object.utils';
 import { validateData } from './validators';
 
@@ -717,7 +721,19 @@ export class Client {
 
   private async compileControls(templateControls: Record<string, unknown>, event: Event) {
     try {
-      let templateString = this.preprocessTranslationPatterns(JSON.stringify(templateControls));
+      /**
+       * Some control values (notably the Maily email `body`) are JSON.stringified before reaching
+       * the framework. If we feed them through `JSON.stringify(templateControls)` as-is, their
+       * `"` characters get doubly escaped while Liquid only single-escapes its outputs, so any
+       * rendered variable that contains a `"` corrupts the inner JSON (NV-7638).
+       *
+       * Expanding those JSON strings into real objects flattens the escaping to a single level
+       * before Liquid renders, and `restoreJsonStringControlValues` re-stringifies them after
+       * parsing the rendered template.
+       */
+      const expandedControls = expandJsonStringControlValues(templateControls) as Record<string, unknown>;
+
+      let templateString = this.preprocessTranslationPatterns(JSON.stringify(expandedControls));
       templateString = this.preprocessFilterTranslationArgs(templateString);
       const parsedTemplate = this.templateEngine.parse(templateString);
       const discoveredWorkflow = this.getWorkflow(event.workflowId);
@@ -744,9 +760,10 @@ export class Client {
       // doesn't have escaped quotes like '"foo"' then compiled string '{"body":""foo""}' is not valid JSON and parse will fail
       const repairedString = jsonrepair(withMarkers);
       const parsedControls = JSON.parse(repairedString);
+      const restoredControls = restoreJsonStringControlValues(parsedControls) as Record<string, unknown>;
       // Normalize string values in the data field that contain invalid JSON (e.g., from Liquid template variables)
       // This handles cases where Liquid outputs JavaScript object notation instead of valid JSON
-      return normalizeControlData(parsedControls);
+      return normalizeControlData(restoredControls);
     } catch (error) {
       throw new StepControlCompilationFailedError(event.workflowId, event.stepId, error);
     }

--- a/packages/framework/src/utils/normalize-controls.utils.test.ts
+++ b/packages/framework/src/utils/normalize-controls.utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeControlData } from './normalize-controls.utils';
+import {
+  expandJsonStringControlValues,
+  JSON_STRING_WRAPPER_KEY,
+  normalizeControlData,
+  restoreJsonStringControlValues,
+} from './normalize-controls.utils';
 
 describe('normalizeControlData', () => {
   it('should keep valid JSON strings in data field as-is', () => {
@@ -137,6 +142,58 @@ describe('normalizeControlData', () => {
 
     expect(result.data).toBe('plain string');
     expect(result.body).toBe('test');
+  });
+
+  it('expandJsonStringControlValues should wrap JSON-stringified objects and arrays', () => {
+    const input = {
+      body: '{"type":"doc","content":[{"type":"text","text":"hi"}]}',
+      list: '["a","b"]',
+      subject: 'plain text',
+      url: 'https://example.com',
+      bare: '{not actually json',
+      empty: '{}',
+    };
+
+    const result = expandJsonStringControlValues(input) as Record<string, any>;
+
+    expect(result.body[JSON_STRING_WRAPPER_KEY]).toBe(true);
+    expect(result.body.value).toEqual({ type: 'doc', content: [{ type: 'text', text: 'hi' }] });
+    expect(result.list[JSON_STRING_WRAPPER_KEY]).toBe(true);
+    expect(result.list.value).toEqual(['a', 'b']);
+    expect(result.subject).toBe('plain text');
+    expect(result.url).toBe('https://example.com');
+    expect(result.bare).toBe('{not actually json');
+    expect(result.empty).toBe('{}'); // too short to be a meaningful JSON object
+  });
+
+  it('restoreJsonStringControlValues should re-stringify wrapped values', () => {
+    const input = {
+      body: {
+        [JSON_STRING_WRAPPER_KEY]: true,
+        value: { type: 'doc', content: [{ type: 'text', text: 'hi "there"' }] },
+      },
+      list: { [JSON_STRING_WRAPPER_KEY]: true, value: ['a', 'b'] },
+      subject: 'plain text',
+    };
+
+    const result = restoreJsonStringControlValues(input) as Record<string, unknown>;
+
+    expect(result.body).toBe('{"type":"doc","content":[{"type":"text","text":"hi \\"there\\""}]}');
+    expect(result.list).toBe('["a","b"]');
+    expect(result.subject).toBe('plain text');
+  });
+
+  it('expand + restore round-trip preserves JSON-stringified control values', () => {
+    const input = {
+      body: '{"type":"doc","content":[{"type":"text","text":"hi \\"there\\""}]}',
+      subject: 'plain',
+    };
+
+    const expanded = expandJsonStringControlValues(input);
+    const restored = restoreJsonStringControlValues(expanded) as Record<string, unknown>;
+
+    expect(restored.body).toBe(input.body);
+    expect(restored.subject).toBe(input.subject);
   });
 
   it('should repair JSON strings with single quotes inside string values (real-world scenario)', () => {

--- a/packages/framework/src/utils/normalize-controls.utils.ts
+++ b/packages/framework/src/utils/normalize-controls.utils.ts
@@ -3,12 +3,104 @@ import { jsonrepair } from 'jsonrepair';
 /**
  * Checks if a string looks like a complete JSON structure (object or array).
  */
-function looksLikeJson(value: string): boolean {
+export function looksLikeJson(value: string): boolean {
   const trimmed = value.trim();
   return (
     ((trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'))) &&
     trimmed.length > 2
   );
+}
+
+/**
+ * Markers used to wrap pre-parsed JSON-string control values during Liquid compilation.
+ * The pre-parse step replaces a control value like `'{"type":"doc",...}'` with the parsed object,
+ * so Liquid renders against the object's leaf strings (single level of JSON escaping) instead of
+ * the doubly-escaped string-inside-a-string. After Liquid renders and the outer string is parsed,
+ * any value wrapped with these markers is JSON.stringified back to a string, restoring the
+ * original control value shape.
+ *
+ * Without this round-trip, values rendered into a JSON-stringified control value (e.g. Maily
+ * email bodies) end up with unescaped quotes when the rendered payload contains a `"` character,
+ * because Liquid's default escape only handles one level of JSON encoding.
+ */
+export const JSON_STRING_WRAPPER_KEY = '__novuJsonString';
+
+interface JsonStringWrapper {
+  [JSON_STRING_WRAPPER_KEY]: true;
+  value: unknown;
+}
+
+function isJsonStringWrapper(value: unknown): value is JsonStringWrapper {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    (value as JsonStringWrapper)[JSON_STRING_WRAPPER_KEY] === true
+  );
+}
+
+/**
+ * Recursively walks `controls` and, for every string that looks like a complete JSON object/array
+ * and parses cleanly, replaces it with a wrapper object containing the parsed value. The wrapper
+ * allows {@link restoreJsonStringControlValues} to reliably identify which values to re-stringify
+ * after Liquid has been rendered, regardless of how deeply they were nested.
+ *
+ * @returns A new controls structure with JSON strings replaced by wrapper objects.
+ */
+export function expandJsonStringControlValues(controls: unknown): unknown {
+  if (typeof controls === 'string') {
+    if (!looksLikeJson(controls)) {
+      return controls;
+    }
+    try {
+      const parsed = JSON.parse(controls);
+
+      return { [JSON_STRING_WRAPPER_KEY]: true, value: expandJsonStringControlValues(parsed) };
+    } catch {
+      return controls;
+    }
+  }
+
+  if (Array.isArray(controls)) {
+    return controls.map((item) => expandJsonStringControlValues(item));
+  }
+
+  if (controls && typeof controls === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(controls)) {
+      out[key] = expandJsonStringControlValues(value);
+    }
+
+    return out;
+  }
+
+  return controls;
+}
+
+/**
+ * Inverse of {@link expandJsonStringControlValues}. Recursively walks the rendered controls and
+ * replaces any wrapper objects with the JSON.stringified form of their `value`, restoring the
+ * original "string that contains JSON" shape.
+ */
+export function restoreJsonStringControlValues(controls: unknown): unknown {
+  if (isJsonStringWrapper(controls)) {
+    return JSON.stringify(restoreJsonStringControlValues(controls.value));
+  }
+
+  if (Array.isArray(controls)) {
+    return controls.map((item) => restoreJsonStringControlValues(item));
+  }
+
+  if (controls && typeof controls === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(controls)) {
+      out[key] = restoreJsonStringControlValues(value);
+    }
+
+    return out;
+  }
+
+  return controls;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Fixed a JSON-escaping bug that could corrupt JSON-stringified control values (notably email bodies) when Liquid rendering injected unescaped double quotes, breaking JSON.parse and email previews. The compileControls flow now expands control values that look like complete JSON into wrapped parsed structures before Liquid rendering, then restores them by re-stringifying after rendering so inner JSON keeps a single correct level of escaping.

## Affected areas
**shared (framework package)**: Updated control compilation in Client to expand/restore JSON-stringified control values around Liquid rendering; added exported utilities (looksLikeJson, expandJsonStringControlValues, restoreJsonStringControlValues, JSON_STRING_WRAPPER_KEY) to normalize-controls.utils and updated normalizeControlData usage. Added unit tests and a regression executeWorkflow test reproducing the original digest/quote scenario.

## Key technical decisions
- Non-breaking approach: only JSON-stringified control values are expanded/restored; plain HTML/Liquid bodies, primitives, and existing normalizeControlData behavior remain unchanged.  
- Recursive traversal: expand/restore helpers recursively walk nested control structures so JSON-like strings are handled at any depth.

## Testing
Added unit tests for expand/restore helpers and a new end-to-end regression test in client.test.ts that reproduces the digest-with-quotes bug; existing renderer tests continue to pass.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11095)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

When an email Liquid template iterates over `steps.<digest>.events` and a digest payload string contains a `"` character, the rendered Maily JSON body comes out with unescaped quotes and the email renderer fails to parse it back into Maily content. The user surface is "the editor preview shows the template expression breaking instead" and a malformed email body.

**Root cause:** `Client.compileControls` in `@novu/framework` runs Liquid on the result of `JSON.stringify(controls)`. The Maily email `body` is itself a JSON-stringified Maily structure, so its quotes are doubly escaped. Liquid's default `outputEscape` escapes a rendered string's `"` to `\"` once, which is correct for the outer JSON but leaves the inner (body) JSON malformed as soon as a rendered variable contains a `"`.

Concretely, with the user's body:

```liquid
{% assign payload = steps.digest-step.events | map: 'payload' %}
{% for item in payload limit:5 %}
- **RFI #{{item.rfi.rfiNumber}}**: {{item.rfi.question | truncate: 100}}
{% endfor %}
```

…the post-`JSON.parse(outer)` body string ended up containing `RFI #5: Where is the "important" file?` with literal unescaped quotes inside the text node value, so `JSON.parse(body)` threw `Expected ',' or '}' after property value in JSON at position …`.

**Fix:** before rendering, expand any control value that looks like a complete JSON object/array into the parsed structure and wrap it in a marker (`__novuJsonString`). After Liquid renders and the outer string is parsed, restore those markers by `JSON.stringify`-ing the rendered value back to a string. This keeps the JSON escaping at a single level, so Liquid's default escape stays correct regardless of which characters the rendered variable contains. Plain HTML / Liquid bodies, primitive control values, and the existing `normalizeControlData` repair path are unaffected.

Test coverage:

- `expandJsonStringControlValues` / `restoreJsonStringControlValues` unit tests + round-trip test (`packages/framework/src/utils/normalize-controls.utils.test.ts`).
- New end-to-end `client.executeWorkflow` test that mirrors the exact reproduction scenario (`packages/framework/src/client.test.ts`); without this commit it fails with the same `JSON.parse` error from the bug report.
- Existing `email-output-renderer.spec.ts` (63 cases) and the rest of the framework suite (309 cases) still pass.

### Screenshots

End-to-end validation in the dashboard preview, with a `previewPayload` containing both `Where is the "important" file?` and `John's note` for the digest events:

![Email step editor + preview sandbox JSON containing the quoted digest payload, with the rendered preview pane showing the iterated RFI list](https://cursor.com/artifacts/c/art-c981d00a-64cd-4076-b564-98aced3b8232)

![Rendered email preview showing ](https://cursor.com/artifacts/c/art-b8e1e542-3226-4216-93d4-1764ccae27d5)

Walkthrough recording of the same scenario:

<a href="https://cursor.com/agents/bc-4c0e8a16-746f-4379-90fc-436e2a425d4f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdigest_quote_dashboard_validation.mp4"><img src="https://cursor.com/artifacts/c/art-022c9950-100c-4f36-b467-46d841dff08f" alt="digest_quote_dashboard_validation.mp4" /></a>

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

n/a

### Special notes for your reviewer

- The fix lives in `compileControls` only; nothing about Liquid's `outputEscape` or the email renderer's pipeline changes, so existing escaping semantics for plain string controls are preserved.
- The `__novuJsonString` wrapper key is internal to a single render pass and is always removed in `restoreJsonStringControlValues` before controls are returned.
- `looksLikeJson` is unchanged; only its visibility was widened so the new helpers can reuse it.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7638](https://linear.app/novu/issue/NV-7638/digest-payload-breaks-email-content-at-quote-character)

<div><a href="https://cursor.com/agents/bc-4c0e8a16-746f-4379-90fc-436e2a425d4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c0e8a16-746f-4379-90fc-436e2a425d4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

