### PR TITLE
fix(api-service): strip credentials from integration responses for API-key auth fixes NV-7640

### DIFF
--- a/apps/api/src/app/integrations/e2e/api-key-credentials-exposure.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/api-key-credentials-exposure.e2e.ts
@@ -1,0 +1,221 @@
+import { IntegrationRepository } from '@novu/dal';
+import { ChannelTypeEnum, EmailProviderIdEnum, SmsProviderIdEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+/**
+ * Regression coverage for GHSA-rgr9-mpmj-mpw8 / NV-7640:
+ * An environment API key must never receive decrypted provider credentials
+ * from the integrations endpoints, regardless of RBAC state.
+ *
+ * Session-token (JWT/dashboard) callers must keep receiving decrypted credentials
+ * so dashboard flows continue to work.
+ */
+describe('Integration credentials exposure to API-key auth - /integrations #novu-v2', () => {
+  let session: UserSession;
+  const integrationRepository = new IntegrationRepository();
+
+  beforeEach(async () => {
+    session = new UserSession();
+    await session.initialize();
+  });
+
+  describe('GET /v1/integrations', () => {
+    it('should not return credentials when authenticated with an API key', async () => {
+      const { body } = await session.testAgent
+        .get('/v1/integrations')
+        .set('authorization', `ApiKey ${session.apiKey}`);
+
+      expect(body.data.length).to.be.greaterThan(0);
+      for (const integration of body.data) {
+        expect(integration).to.not.have.property('credentials');
+      }
+    });
+
+    it('should still return decrypted credentials when authenticated via session token', async () => {
+      const { body } = await session.testAgent.get('/v1/integrations');
+
+      const sendgrid = body.data.find(
+        (integration) =>
+          integration.providerId === EmailProviderIdEnum.SendGrid &&
+          integration._environmentId === session.environment._id
+      );
+
+      expect(sendgrid, 'Expected SendGrid integration fixture').to.exist;
+      expect(sendgrid.credentials).to.exist;
+      expect(sendgrid.credentials.apiKey).to.equal('SG.123');
+      expect(sendgrid.credentials.secretKey).to.equal('abc');
+    });
+  });
+
+  describe('GET /v1/integrations/active', () => {
+    it('should not return credentials when authenticated with an API key', async () => {
+      const { body } = await session.testAgent
+        .get('/v1/integrations/active')
+        .set('authorization', `ApiKey ${session.apiKey}`);
+
+      expect(body.data.length).to.be.greaterThan(0);
+      for (const integration of body.data) {
+        expect(integration).to.not.have.property('credentials');
+      }
+    });
+
+    it('should still return decrypted credentials when authenticated via session token', async () => {
+      const { body } = await session.testAgent.get('/v1/integrations/active');
+
+      const smsIntegration = body.data.find(
+        (integration) =>
+          integration.channel === ChannelTypeEnum.SMS &&
+          integration.providerId === SmsProviderIdEnum.Twilio &&
+          integration._environmentId === session.environment._id
+      );
+
+      expect(smsIntegration, 'Expected active Twilio integration fixture').to.exist;
+      expect(smsIntegration.credentials).to.exist;
+      expect(smsIntegration.credentials.accountSid).to.equal('AC123');
+      expect(smsIntegration.credentials.token).to.equal('123');
+    });
+  });
+
+  describe('POST /v1/integrations', () => {
+    it('should not return credentials when created via API key auth', async () => {
+      await integrationRepository.deleteMany({
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        providerId: EmailProviderIdEnum.SendGrid,
+      });
+
+      const payload = {
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        credentials: { apiKey: 'SG.api-key-create', secretKey: 'secret-create' },
+        active: false,
+        check: false,
+      };
+
+      const { body } = await session.testAgent
+        .post('/v1/integrations')
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send(payload);
+
+      expect(body.data).to.exist;
+      expect(body.data).to.not.have.property('credentials');
+
+      const stored = await integrationRepository.findOne({
+        _id: body.data._id,
+        _environmentId: session.environment._id,
+      });
+      expect(stored, 'Integration should still be persisted').to.exist;
+    });
+
+    it('should still return decrypted credentials when created via session token', async () => {
+      await integrationRepository.deleteMany({
+        _organizationId: session.organization._id,
+        _environmentId: session.environment._id,
+        providerId: EmailProviderIdEnum.SendGrid,
+      });
+
+      const payload = {
+        providerId: EmailProviderIdEnum.SendGrid,
+        channel: ChannelTypeEnum.EMAIL,
+        credentials: { apiKey: 'SG.api-key-jwt', secretKey: 'secret-jwt' },
+        active: false,
+        check: false,
+      };
+
+      const { body } = await session.testAgent.post('/v1/integrations').send(payload);
+
+      expect(body.data.credentials).to.exist;
+      expect(body.data.credentials.apiKey).to.equal(payload.credentials.apiKey);
+      expect(body.data.credentials.secretKey).to.equal(payload.credentials.secretKey);
+    });
+  });
+
+  describe('PUT /v1/integrations/:integrationId', () => {
+    it('should not return credentials when updated via API key auth', async () => {
+      const { body: listBody } = await session.testAgent.get('/v1/integrations');
+      const target = listBody.data.find(
+        (integration) =>
+          integration.providerId === EmailProviderIdEnum.SendGrid &&
+          integration._environmentId === session.environment._id
+      );
+      expect(target, 'Expected SendGrid integration fixture').to.exist;
+
+      const payload = {
+        credentials: { apiKey: 'SG.api-key-update', secretKey: 'secret-update' },
+        active: true,
+        check: false,
+      };
+
+      const { body } = await session.testAgent
+        .put(`/v1/integrations/${target._id}`)
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send(payload);
+
+      expect(body.data).to.exist;
+      expect(body.data._id).to.equal(target._id);
+      expect(body.data).to.not.have.property('credentials');
+    });
+
+    it('should still return decrypted credentials when updated via session token', async () => {
+      const { body: listBody } = await session.testAgent.get('/v1/integrations');
+      const target = listBody.data.find(
+        (integration) =>
+          integration.providerId === EmailProviderIdEnum.SendGrid &&
+          integration._environmentId === session.environment._id
+      );
+      expect(target, 'Expected SendGrid integration fixture').to.exist;
+
+      const payload = {
+        credentials: { apiKey: 'SG.api-key-update-jwt', secretKey: 'secret-update-jwt' },
+        active: true,
+        check: false,
+      };
+
+      const { body } = await session.testAgent.put(`/v1/integrations/${target._id}`).send(payload);
+
+      expect(body.data.credentials).to.exist;
+      expect(body.data.credentials.apiKey).to.equal(payload.credentials.apiKey);
+      expect(body.data.credentials.secretKey).to.equal(payload.credentials.secretKey);
+    });
+  });
+
+  describe('POST /v1/integrations/:integrationId/set-primary', () => {
+    it('should not return credentials when called via API key auth', async () => {
+      const { body: listBody } = await session.testAgent.get('/v1/integrations');
+      const target = listBody.data.find(
+        (integration) =>
+          integration.providerId === EmailProviderIdEnum.SendGrid &&
+          integration._environmentId === session.environment._id
+      );
+      expect(target, 'Expected SendGrid integration fixture').to.exist;
+
+      const { body } = await session.testAgent
+        .post(`/v1/integrations/${target._id}/set-primary`)
+        .set('authorization', `ApiKey ${session.apiKey}`)
+        .send({});
+
+      expect(body.data).to.exist;
+      expect(body.data._id).to.equal(target._id);
+      expect(body.data.primary).to.equal(true);
+      expect(body.data).to.not.have.property('credentials');
+    });
+
+    it('should still return decrypted credentials when called via session token', async () => {
+      const { body: listBody } = await session.testAgent.get('/v1/integrations');
+      const target = listBody.data.find(
+        (integration) =>
+          integration.providerId === EmailProviderIdEnum.SendGrid &&
+          integration._environmentId === session.environment._id
+      );
+      expect(target, 'Expected SendGrid integration fixture').to.exist;
+
+      const { body } = await session.testAgent.post(`/v1/integrations/${target._id}/set-primary`).send({});
+
+      expect(body.data.credentials).to.exist;
+      expect(body.data.credentials.apiKey).to.equal('SG.123');
+      expect(body.data.credentials.secretKey).to.equal('abc');
+      expect(body.data.primary).to.equal(true);
+    });
+  });
+});

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -847,6 +847,16 @@ export class IntegrationsController {
   }
 
   private async canUserAccessCredentials(user: UserSessionData): Promise<boolean> {
+    /*
+     * API-key auth must never receive decrypted provider credentials, regardless of RBAC state.
+     * API keys grant ALL_PERMISSIONS in `community.auth.service.ts`, which would otherwise
+     * allow the RBAC path below to succeed and leak every stored provider secret to any
+     * caller holding an environment API key.
+     */
+    if (user.scheme === ApiAuthSchemeEnum.API_KEY) {
+      return false;
+    }
+
     const organization = await this.organizationRepository.findOne({
       _id: user.organizationId,
     });

--- a/libs/application-generic/src/dtos/integration-response.dto.ts
+++ b/libs/application-generic/src/dtos/integration-response.dto.ts
@@ -57,12 +57,14 @@ export class IntegrationResponseDto {
   })
   kind?: IntegrationKindEnum;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
-      'The credentials required for the integration to function, including API keys and other sensitive information.',
+      'The decrypted credentials required for the integration to function (e.g. provider API keys, signing secrets). ' +
+      'Only returned to dashboard/session-token callers; API-key authenticated callers receive the integration ' +
+      'metadata without this field to avoid amplifying API-key leaks into provider-credential leaks.',
     type: () => CredentialsDto,
   })
-  credentials: CredentialsDto;
+  credentials?: CredentialsDto;
 
   @ApiPropertyOptional({
     description: 'The configurations required for enabling the additional configurations of the integration.',

--- a/libs/internal-sdk/src/models/components/integrationresponsedto.ts
+++ b/libs/internal-sdk/src/models/components/integrationresponsedto.ts
@@ -65,9 +65,9 @@ export type IntegrationResponseDto = {
    */
   channel: IntegrationResponseDtoChannel;
   /**
-   * The credentials required for the integration to function, including API keys and other sensitive information.
+   * The decrypted credentials required for the integration to function (e.g. provider API keys, signing secrets). Only returned to dashboard/session-token callers; API-key authenticated callers receive the integration metadata without this field to avoid amplifying API-key leaks into provider-credential leaks.
    */
-  credentials: CredentialsDto;
+  credentials?: CredentialsDto | undefined;
   /**
    * The configurations required for enabling the additional configurations of the integration.
    */
@@ -116,7 +116,7 @@ export const IntegrationResponseDto$inboundSchema: z.ZodType<
   identifier: z.string(),
   providerId: z.string(),
   channel: IntegrationResponseDtoChannel$inboundSchema,
-  credentials: CredentialsDto$inboundSchema,
+  credentials: CredentialsDto$inboundSchema.optional(),
   configurations: ConfigurationsDto$inboundSchema.optional(),
   active: z.boolean(),
   deleted: z.boolean(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes [GHSA-rgr9-mpmj-mpw8](https://github.com/novuhq/novu/security/advisories/GHSA-rgr9-mpmj-mpw8): an environment-scoped API key currently receives decrypted provider credentials (Mailgun keys, Twilio tokens, SMTP passwords, signing secrets, etc.) from the integration endpoints. Any leak of a Novu API key therefore amplifies into a leak of every provider secret the customer has stored.

## Root cause

`canUserAccessCredentials(user)` in `apps/api/src/app/integrations/integrations.controller.ts` returned `true` for all API-key callers:

- RBAC disabled → unconditional `true`.
- RBAC enabled → `user.permissions.includes(INTEGRATION_WRITE)`, but API keys are issued `ALL_PERMISSIONS` in `community.auth.service.ts`, so the RBAC path is also `true`.

That flag is passed as `returnCredentials` into `GetDecryptedIntegrations.execute`, which then returns cleartext credentials.

## Fix

Block API-key callers from receiving cleartext credentials, regardless of RBAC state. The downstream usecase (`GetDecryptedIntegrations`) already strips `credentials` when `returnCredentials === false`, and POST/PUT/set-primary already strip `credentials` in their else-branches, so the single guard closes all five affected endpoints.

```ts
private async canUserAccessCredentials(user: UserSessionData): Promise<boolean> {
  if (user.scheme === ApiAuthSchemeEnum.API_KEY) {
    return false;
  }
  // existing RBAC logic unchanged
}
```

JWT/session-token callers (dashboard) are unchanged and keep receiving decrypted credentials.

Because the `credentials` field now disappears from API-key responses, the second commit marks `IntegrationResponseDto.credentials` as `@ApiPropertyOptional` in the shared DTO and propagates the change to the generated internal SDK component schema (`credentials?: CredentialsDto`, Zod `.optional()`), so SDK callers no longer fail response validation when authenticating via API key.

## Affected endpoints

- `GET /v1/integrations`
- `GET /v1/integrations/active`
- `POST /v1/integrations`
- `PUT /v1/integrations/:integrationId`
- `POST /v1/integrations/:integrationId/set-primary`

## Tests

New E2E suite `apps/api/src/app/integrations/e2e/api-key-credentials-exposure.e2e.ts` asserts, for each of the five endpoints:

- API-key auth → response items have no `credentials` field.
- JWT/session auth → response items still contain the expected decrypted `credentials`.

```
Integration credentials exposure to API-key auth - /integrations #novu-v2
  GET /v1/integrations
    ✔ should not return credentials when authenticated with an API key
    ✔ should still return decrypted credentials when authenticated via session token
  GET /v1/integrations/active
    ✔ should not return credentials when authenticated with an API key
    ✔ should still return decrypted credentials when authenticated via session token
  POST /v1/integrations
    ✔ should not return credentials when created via API key auth
    ✔ should still return decrypted credentials when created via session token
  PUT /v1/integrations/:integrationId
    ✔ should not return credentials when updated via API key auth
    ✔ should still return decrypted credentials when updated via session token
  POST /v1/integrations/:integrationId/set-primary
    ✔ should not return credentials when called via API key auth
    ✔ should still return decrypted credentials when called via session token

10 passing
```

Existing integration E2E suites (`get-integration`, `get-active-integration`, `create-integration`, `update-integration`, `set-itegration-as-primary`) also still pass — 84 tests green together.

## Out of scope

- Introducing a JWT-only `POST /v1/integrations/:id/reveal-credentials` endpoint — deferred as a follow-up rather than a blocker for this fix.
- Auditing other `@ExternalApiAccessible()` routes for secret-bearing fields — tracked under the env-scoping security cluster.

## Disclosure

Coordinate with the reporter on GHSA-rgr9-mpmj-mpw8 after this lands in production.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7640](https://linear.app/novu/issue/NV-7640/security-api-key-auth-receives-decrypted-integration-credentials-from)

<div><a href="https://cursor.com/agents/bc-e6e732a1-a8b5-48c6-a2e5-665f166d11a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6e732a1-a8b5-48c6-a2e5-665f166d11a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Blocked API-key authenticated callers from receiving decrypted integration credentials by making canUserAccessCredentials() return false for the API_KEY auth scheme. This prevents API keys (which may be issued with broad permissions or used when RBAC is disabled) from leaking sensitive provider credentials; JWT/session-token callers keep the previous behavior. The responses and SDK schemas were adjusted so credentials may be omitted for API-key callers.

## Affected areas

**api**: Controller logic updated (IntegrationsController.canUserAccessCredentials) to deny credential access for API-key auth and ensure downstream handlers strip credentials for API-key requests.  
**shared / libs/application-generic**: IntegrationResponseDto updated to mark credentials as optional and Swagger metadata adjusted to document that decrypted credentials are only returned to dashboard/session-token callers.  
**internal-sdk / libs/internal-sdk**: Generated model and Zod schema changed so IntegrationResponseDto.credentials is optional, reflecting the API contract change.  
**tests (apps/api)**: Added a new E2E regression suite that asserts API-key-authenticated responses omit the credentials field across five integration endpoints and that session/JWT responses still include decrypted credentials.

## Key technical decisions

- Use an explicit auth-scheme check (user.scheme === ApiAuthSchemeEnum.API_KEY) to deny credential access to API keys rather than relying solely on RBAC/feature flags, providing defense-in-depth.  
- Make credentials optional in response/SDK types to align the OpenAPI/SDK surface with runtime behavior (omitting sensitive fields for API-key callers).

## Testing

Added a focused E2E suite (10 new tests) asserting credential omission for API-key auth across GET/POST/PUT/set-primary integration endpoints; existing integration E2E suites remain passing. Manual/coordination steps for disclosure are tracked separately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11098)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->