### PR TITLE
refactor(api-service): drop redis cache in delete-subscriber-credentials fixes NV-7645

### DIFF
--- a/apps/api/src/app/subscribers/usecases/delete-subscriber-credentials/delete-subscriber-credentials.spec.ts
+++ b/apps/api/src/app/subscribers/usecases/delete-subscriber-credentials/delete-subscriber-credentials.spec.ts
@@ -9,7 +9,6 @@ import { CheckIntegrationEMail } from '../../../integrations/usecases/check-inte
 import { CreateIntegrationCommand } from '../../../integrations/usecases/create-integration/create-integration.command';
 import { CreateIntegration } from '../../../integrations/usecases/create-integration/create-integration.usecase';
 import { SharedModule } from '../../../shared/shared.module';
-import { GetSubscriber } from '../get-subscriber/get-subscriber.usecase';
 import { DeleteSubscriberCredentialsCommand } from './delete-subscriber-credentials.command';
 import { DeleteSubscriberCredentials } from './delete-subscriber-credentials.usecase';
 
@@ -25,7 +24,6 @@ describe('Delete subscriber provider credentials', () => {
       providers: [
         DeleteSubscriberCredentials,
         UpdateSubscriberChannel,
-        GetSubscriber,
         CreateIntegration,
         CheckIntegration,
         CheckIntegrationEMail,

--- a/apps/api/src/app/subscribers/usecases/delete-subscriber-credentials/delete-subscriber-credentials.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/delete-subscriber-credentials/delete-subscriber-credentials.usecase.ts
@@ -1,7 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { AnalyticsService, buildSubscriberKey, InvalidateCacheService } from '@novu/application-generic';
 import { SubscriberRepository } from '@novu/dal';
-import { GetSubscriber, GetSubscriberCommand } from '../get-subscriber';
 import { DeleteSubscriberCredentialsCommand } from './delete-subscriber-credentials.command';
 
 @Injectable()
@@ -9,16 +8,20 @@ export class DeleteSubscriberCredentials {
   constructor(
     private invalidateCache: InvalidateCacheService,
     private subscriberRepository: SubscriberRepository,
-    private analyticsService: AnalyticsService,
-    private getSubscriberUseCase: GetSubscriber
+    private analyticsService: AnalyticsService
   ) {}
 
   async execute(command: DeleteSubscriberCredentialsCommand): Promise<void> {
-    const foundSubscriber = await this.getSubscriberUseCase.execute(
-      GetSubscriberCommand.create({
-        ...command,
-      })
+    const foundSubscriber = await this.subscriberRepository.findBySubscriberId(
+      command.environmentId,
+      command.subscriberId,
+      true,
+      '_id subscriberId'
     );
+
+    if (!foundSubscriber) {
+      throw new NotFoundException(`Subscriber '${command.subscriberId}' was not found`);
+    }
 
     await this.deleteSubscriberCredentialsOfOneProvider(
       foundSubscriber.subscriberId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`DeleteSubscriberCredentials` no longer goes through the `GetSubscriber` use-case. We only need two fields (`_id` and `subscriberId`), so the use-case now calls `SubscriberRepository.findBySubscriberId` directly with:

- `secondaryRead = true` (uses `secondaryPreferred`)
- `select = '_id subscriberId'`

## Why

`GetSubscriber.fetchSubscriber` is wrapped with `@CachedResponse` (Redis), but the delete-credentials flow:

1. Only needs `_id` + `subscriberId`.
2. Invalidates that exact subscriber cache key on the very next step.

So going through the cached use-case added a Redis round-trip and pulled a full subscriber document into memory for no benefit. Reading directly from Mongo with a projection and `secondaryPreferred` keeps behaviour identical and avoids the unnecessary cache hop.

## Behaviour

Unchanged from the consumer's perspective:

- Still throws `NotFoundException` when the subscriber doesn't exist.
- Still invalidates the subscriber cache key before the `$pull`.
- Still pulls matching `channels` and tracks `Delete Subscriber Credentials - [Subscribers]` in Mixpanel.

## Files

- `apps/api/src/app/subscribers/usecases/delete-subscriber-credentials/delete-subscriber-credentials.usecase.ts`
- `apps/api/src/app/subscribers/usecases/delete-subscriber-credentials/delete-subscriber-credentials.spec.ts` (drop `GetSubscriber` from test providers, no longer a constructor dep)

## Testing

- Mocha integration-style unit test: `pnpm test -- --grep 'Delete subscriber provider credentials'` — passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d30f6dba-5fd0-42dc-ad6b-40d6b8ba9394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d30f6dba-5fd0-42dc-ad6b-40d6b8ba9394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

DeleteSubscriberCredentials now fetches subscribers directly from SubscriberRepository instead of using the cached GetSubscriber use-case. This eliminates an unnecessary Redis round-trip since the operation only needs the subscriber's `_id` and `subscriberId` before immediately invalidating the cache. The external behavior remains unchanged—it still throws NotFoundException when the subscriber doesn't exist and invalidates the cache before updating credentials.

## Affected areas

**api**: DeleteSubscriberCredentials refactored to use `SubscriberRepository.findBySubscriberId` with `secondaryRead = true` instead of delegating to `GetSubscriber.execute()`. Removed the cached use-case dependency from constructor and updated error handling.

## Key technical decisions

- Direct repository query replaces cached use-case to avoid redundant Redis lookups for minimal data needs
- Removed `GetSubscriber` dependency injection; constructor now only injects `InvalidateCacheService`, `SubscriberRepository`, and `AnalyticsService`

## Testing

Existing Mocha unit test validates that delete subscriber provider credentials workflow still functions correctly, including Discord credential deletion and FCM device token verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11102)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->