### PR TITLE
feat(shared): rename AgentCreationSourceEnum DISPATCH to CONNECT fixes NV-7649

### DIFF
--- a/libs/dal/src/repositories/agent/agent.schema.ts
+++ b/libs/dal/src/repositories/agent/agent.schema.ts
@@ -43,7 +43,7 @@ const agentSchema = new Schema<AgentDBModel>(
     },
     creationSource: {
       type: Schema.Types.String,
-      enum: ['platform', 'dispatch'],
+      enum: ['platform', 'connect'],
       default: 'platform',
     },
     _organizationId: {

--- a/packages/shared/src/dto/agent/managed-runtime.dto.ts
+++ b/packages/shared/src/dto/agent/managed-runtime.dto.ts
@@ -5,11 +5,11 @@ export type AgentRuntime = 'self-hosted' | 'managed';
 /**
  * Identifies which section of the Novu Dashboard was used to create the agent.
  * - `'platform'` – created from the standard Platform section (default).
- * - `'dispatch'` – created from the Dispatch feature (under development).
+ * - `'connect'` – created from the Connect section.
  */
 export enum AgentCreationSourceEnum {
   PLATFORM = 'platform',
-  DISPATCH = 'dispatch',
+  CONNECT = 'connect',
 }
 
 export type ManagedRuntimeConfigDto = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Renamed the `AgentCreationSourceEnum.DISPATCH` enum member to `AgentCreationSourceEnum.CONNECT`, changing the persisted string value from `'dispatch'` to `'connect'`.

### Files modified

- **`packages/shared/src/dto/agent/managed-runtime.dto.ts`** — Renamed `DISPATCH = 'dispatch'` → `CONNECT = 'connect'` and updated the JSDoc comment.
- **`libs/dal/src/repositories/agent/agent.schema.ts`** — Updated the Mongoose `enum` constraint from `['platform', 'dispatch']` to `['platform', 'connect']`.

### Why

Per the Linear issue, the team decided to use "platform" and "connect" as the agent creation source identifiers instead of "platform" and "dispatch".

### Verification

- `@novu/shared`, `@novu/dal`, and `@novu/api-service` all build successfully with zero TypeScript errors.
- No other files reference `AgentCreationSourceEnum.DISPATCH` by member name; all consumers use the enum type or `AgentCreationSourceEnum.PLATFORM`, so no additional code changes were needed.

### Breaking changes

Existing database records with `creationSource: 'dispatch'` will no longer match the Mongoose enum validation. If any such records exist, a data migration may be needed to update them to `'connect'`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7649](https://linear.app/novu/issue/NV-7649/rename-the-agentcreationsourceenum-from-dispatch-to-connect)

<div><a href="https://cursor.com/agents/bc-65555985-96a3-42c8-8ca8-7da230c73dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65555985-96a3-42c8-8ca8-7da230c73dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Renamed `AgentCreationSourceEnum.DISPATCH` to `AgentCreationSourceEnum.CONNECT`, updating the persisted string value from `'dispatch'` to `'connect'`. This change aligns agent creation source identifiers with the decision in Linear issue NV-7649 to use "platform" and "connect" as the standard source options.

## Affected areas

- **shared**: Updated `AgentCreationSourceEnum` in `managed-runtime.dto.ts` to replace the `DISPATCH` member with `CONNECT` and updated JSDoc comments.
- **dal**: Updated the Mongoose schema's `creationSource` field enum validation in `agent.schema.ts` from `['platform', 'dispatch']` to `['platform', 'connect']`.

## Key technical decisions

- **Breaking change**: Existing database records with `creationSource: 'dispatch'` will no longer pass Mongoose enum validation and require a data migration to update them to `'connect'`.
- No consuming code required changes, as downstream references use the enum type directly or reference `AgentCreationSourceEnum.PLATFORM`, not the removed `DISPATCH` member.

## Testing

Build verification confirms the changes compile with zero TypeScript errors. No tests were added because this is a direct enum rename with no logic changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11104)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->