### PR TITLE
feat(dashboard): add quick-create "+" button to agent provider header

### DIFF
--- a/apps/dashboard/src/components/agents/provider-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/provider-dropdown.tsx
@@ -633,19 +633,44 @@ export function ProviderDropdown({
   const expandedList = expandedProvider && (
     <Command>
       {/* Back header */}
-      <button
-        type="button"
-        onClick={() => setExpandedProviderId(null)}
-        className="bg-bg-weak border-stroke-weak hover:bg-bg-soft flex w-full items-center gap-1.5 border-b px-2 py-1.5 transition-colors"
-      >
-        <RiArrowLeftSLine className="text-text-soft size-3.5 shrink-0" />
-        <ProviderIcon
-          providerId={expandedProvider.providerId}
-          providerDisplayName={expandedProvider.displayName}
-          className="size-4 shrink-0"
-        />
-        <span className="text-text-sub text-label-xs font-medium leading-4">{expandedProvider.displayName}</span>
-      </button>
+      <div className="bg-bg-weak border-stroke-weak flex w-full items-center border-b">
+        <button
+          type="button"
+          onClick={() => setExpandedProviderId(null)}
+          className="hover:bg-bg-soft flex flex-1 items-center gap-1.5 px-2 py-1.5 transition-colors"
+        >
+          <RiArrowLeftSLine className="text-text-soft size-3.5 shrink-0" />
+          <ProviderIcon
+            providerId={expandedProvider.providerId}
+            providerDisplayName={expandedProvider.displayName}
+            className="size-4 shrink-0"
+          />
+          <span className="text-text-sub text-label-xs font-medium leading-4">{expandedProvider.displayName}</span>
+        </button>
+        <button
+          type="button"
+          disabled={isBusy}
+          aria-label={`Create another ${expandedProvider.displayName} integration`}
+          onClick={() => {
+            void handleSelect(
+              {
+                providerId: expandedProvider.providerId,
+                displayName: expandedProvider.displayName,
+                comingSoon: false,
+                requiresBusinessTier: expandedProvider.requiresBusinessTier,
+              },
+              expandedProvider.integrations.length
+            );
+          }}
+          className="hover:bg-bg-soft flex items-center justify-center px-2 py-1.5 transition-colors disabled:opacity-60"
+        >
+          {pendingItemKey === `${expandedProvider.providerId}-new-${expandedProvider.integrations.length}` ? (
+            <RiLoader4Line className="text-text-soft size-3.5 shrink-0 animate-spin" aria-hidden />
+          ) : (
+            <RiAddLine className="text-text-soft size-3.5 shrink-0" aria-hidden />
+          )}
+        </button>
+      </div>
 
       <CommandList className="max-h-[260px] p-1">
         <CommandEmpty className="text-text-soft text-label-xs py-4">No integrations found.</CommandEmpty>


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

A "+" button was added to the right side of the expanded provider sub-list header in the agent onboarding provider dropdown. Previously, the header only contained a back button; it now displays both a back button (left) and a new create-integration button (right). This allows users to quickly create a new integration for a provider without scrolling when many integrations exist.

## Affected areas

**dashboard**: Modified the provider dropdown component to add a quick-create button in the expanded sub-list header. The button invokes the same `handleSelect()` logic as the existing footer action, with the same loading spinner and disabled state behavior.

## Testing

No tests were added. The change is a UI enhancement that follows existing interaction patterns and reuses established handler logic, so manual verification in the agent setup flow would be sufficient.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11105)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Adds a `+` icon button on the right side of the expanded provider sub-list header (next to the back arrow and provider name) inside the agent onboarding provider dropdown — the popover shown under "What provider would you like to start with".

Behavior is identical to the existing `+ Create another <Provider> integration` footer item: it calls the same `handleSelect(...)` invocation with the provider's id, displayName, `comingSoon: false`, `requiresBusinessTier`, and `index = expandedProvider.integrations.length`. It shares the same `isBusy` disabled state and `pendingItemKey` loading spinner, so the UX is consistent across both entry points.

Why: when a provider already has several integrations, users had to scroll past the full list to reach the create-another action. Putting a `+` in the header makes the action immediately reachable.

Implementation: the back-header `<button>` was split into a `<div>` row that contains two buttons — a left back-button (flex-1, unchanged behavior) and a right `+` button — so we keep valid HTML semantics (no nested `<button>` elements).

### Screenshots

| Before | After |
| --- | --- |
| Header had only `< Slack` | Header now shows `< Slack` on the left and `+` on the right |

### Special notes for your reviewer

- Only [apps/dashboard/src/components/agents/provider-dropdown.tsx](apps/dashboard/src/components/agents/provider-dropdown.tsx) is touched.
- The sibling component `outbound-provider-select.tsx` has a similar back-header pattern but was intentionally left untouched — it's used in a different flow (outbound email selection), not the agent onboarding flow that label "What provider would you like to start with" appears in.
- `tsc --noEmit -p tsconfig.app.json` passes clean. Biome lint reports only one pre-existing warning unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)