### PR TITLE
feat(root): support 1Password Environments for local secrets fixes NV-7651

### DIFF
--- a/apps/api/src/config/env.config.ts
+++ b/apps/api/src/config/env.config.ts
@@ -1,7 +1,18 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { getContextPath, getEnvFileNameForNodeEnv, NovuComponentEnum } from '@novu/shared';
 import dotenv from 'dotenv';
 
-dotenv.config({ path: path.join(__dirname, '..', getEnvFileNameForNodeEnv(process.env.NODE_ENV)) });
+// Local override at apps/api/.env — resolves identically from compiled
+// (apps/api/dist/config) and ts-node (apps/api/src/config) contexts.
+// Used by devs who mount secrets there (e.g. 1Password Environments local
+// .env files). In Docker/CI/staging/prod this file does not exist, so we
+// fall back to the standard NODE_ENV-based file copied into dist/ at build.
+const localOverridePath = path.join(__dirname, '..', '..', '.env');
+const defaultPath = path.join(__dirname, '..', getEnvFileNameForNodeEnv(process.env.NODE_ENV));
+
+dotenv.config({
+  path: fs.existsSync(localOverridePath) ? localOverridePath : defaultPath,
+});
 
 export const CONTEXT_PATH = getContextPath(NovuComponentEnum.API);

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -117,6 +117,9 @@ export default defineConfig(({ mode }) => {
       headers: {
         'Document-Policy': 'js-profiling',
       },
+      watch: {
+        ignored: ['**/.env'],
+      },
     },
     optimizeDeps: {
       include: ['@novu/api'],

--- a/apps/inbound-mail/src/config/env.config.ts
+++ b/apps/inbound-mail/src/config/env.config.ts
@@ -1,7 +1,18 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { getContextPath, getEnvFileNameForNodeEnv, NovuComponentEnum } from '@novu/shared';
 import dotenv from 'dotenv';
 
-dotenv.config({ path: path.join(__dirname, '..', '..', getEnvFileNameForNodeEnv(process.env.NODE_ENV)) });
+// Local override at apps/inbound-mail/.env. Used by devs who mount secrets
+// there (e.g. 1Password Environments local .env files). In Docker/CI/staging/
+// prod this file does not exist, so we fall back to the standard NODE_ENV-
+// based file. Path arithmetic matches the existing default (one extra `..`
+// vs. nest-cli apps because inbound-mail is built with tsc, not nest-cli).
+const localOverridePath = path.join(__dirname, '..', '..', '.env');
+const defaultPath = path.join(__dirname, '..', '..', getEnvFileNameForNodeEnv(process.env.NODE_ENV));
+
+dotenv.config({
+  path: fs.existsSync(localOverridePath) ? localOverridePath : defaultPath,
+});
 
 export const CONTEXT_PATH = getContextPath(NovuComponentEnum.INBOUND_MAIL);

--- a/apps/worker/src/config/env.config.ts
+++ b/apps/worker/src/config/env.config.ts
@@ -1,7 +1,18 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { getContextPath, getEnvFileNameForNodeEnv, NovuComponentEnum } from '@novu/shared';
 import dotenv from 'dotenv';
 
-dotenv.config({ path: path.join(__dirname, '..', getEnvFileNameForNodeEnv(process.env.NODE_ENV)) });
+// Local override at apps/worker/.env — resolves identically from compiled
+// (apps/worker/dist/config) and ts-node (apps/worker/src/config) contexts.
+// Used by devs who mount secrets there (e.g. 1Password Environments local
+// .env files). In Docker/CI/staging/prod this file does not exist, so we
+// fall back to the standard NODE_ENV-based file copied into dist/ at build.
+const localOverridePath = path.join(__dirname, '..', '..', '.env');
+const defaultPath = path.join(__dirname, '..', getEnvFileNameForNodeEnv(process.env.NODE_ENV));
+
+dotenv.config({
+  path: fs.existsSync(localOverridePath) ? localOverridePath : defaultPath,
+});
 
 export const CONTEXT_PATH = getContextPath(NovuComponentEnum.API);

--- a/apps/ws/src/config/env.config.ts
+++ b/apps/ws/src/config/env.config.ts
@@ -1,9 +1,18 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { getContextPath, getEnvFileNameForNodeEnv, NovuComponentEnum } from '@novu/shared';
 import dotenv from 'dotenv';
 
+// Local override at apps/ws/.env — resolves identically from compiled
+// (apps/ws/dist/config) and ts-node (apps/ws/src/config) contexts.
+// Used by devs who mount secrets there (e.g. 1Password Environments local
+// .env files). In Docker/CI/staging/prod this file does not exist, so we
+// fall back to the standard NODE_ENV-based file copied into dist/ at build.
+const localOverridePath = path.join(__dirname, '..', '..', '.env');
+const defaultPath = path.join(__dirname, '..', getEnvFileNameForNodeEnv(process.env.NODE_ENV));
+
 dotenv.config({
-  path: path.join(__dirname, '..', getEnvFileNameForNodeEnv(process.env.NODE_ENV)),
+  path: fs.existsSync(localOverridePath) ? localOverridePath : defaultPath,
 });
 
 export const CONTEXT_PATH = getContextPath(NovuComponentEnum.WS);


### PR DESCRIPTION
## What Changed

Each backend service's `env.config.ts` now checks for an opt-in override at `apps/<svc>/.env` (one level *above* `src/`) before the existing `NODE_ENV`-based load path. If the override exists, `dotenv` reads it; otherwise the service falls back to the unchanged default flow.

Affected services: `api`, `worker`, `ws`, `inbound-mail`. `apps/dashboard/vite.config.ts` also tells Vite to ignore `.env` filesystem events to avoid the FIFO restart loop documented by 1Password.

## Why

Devs using [1Password Environments local `.env` files](https://developer.1password.com/docs/environments/local-env-file) can't mount secrets at the existing `apps/<svc>/src/.env` path because:

1. The mount is a UNIX named pipe (FIFO). `nest-cli.json` lists `.env` as a build asset; the asset copier doesn't handle FIFOs and silently emits an empty `dist/.env`, so `dotenv` loads nothing at runtime.
2. `nest start --watch` watches `src/` and FIFO open/close events trigger restart loops (same issue 1Password's docs flag for Vite).
3. IDEs holding the file open compete with the dev server for the FIFO's one-shot read.

Net effect: `pnpm start:api:dev` fails with missing env vars even though `cat apps/api/src/.env` works.

Linear: [NV-7651](https://linear.app/novu/issue/NV-7651/support-1password-environments-local-env-files-for-backend-services)

## How

```typescript
const localOverridePath = path.join(__dirname, '..', '..', '.env');
const defaultPath = path.join(__dirname, '..', getEnvFileNameForNodeEnv(process.env.NODE_ENV));

dotenv.config({
  path: fs.existsSync(localOverridePath) ? localOverridePath : defaultPath,
});
```

Key safety properties:

- `fs.existsSync` only `stat`s the inode — does **not** open or read the FIFO, so it doesn't burn the one-shot pipe.
- The override path is one directory above `src/`, outside everything `nest-cli` watches or copies.
- `**/.env` is already in `.gitignore` (line 104) so the mount can't be accidentally committed.

```mermaid
flowchart TD
    Start[pnpm start:&lt;svc&gt;:dev] --> Check{apps/&lt;svc&gt;/.env<br/>exists?}
    Check -->|yes — 1P dev| Override[Load from FIFO<br/>one read per process]
    Check -->|no — everyone else| Default[Load from dist/.env*<br/>via NODE_ENV]
    Override --> Boot[Service boots]
    Default --> Boot
```

## Behavior matrix

| Environment | `apps/<svc>/.env` exists? | Loader uses |
|---|---|---|
| Docker image | no | `dist/.env.production` (unchanged) |
| Staging / prod runtime | no | real `process.env` from k8s/secrets manager (unchanged) |
| CI | no | `dist/.env.test` etc. (unchanged) |
| Local non-1P contributor | no | `dist/.env` (unchanged) |
| Local 1P dev | yes (FIFO) | the FIFO, one read per process start |

## Out of scope

- `apps/dashboard` env loading itself (separate Vite-managed flow; only the watcher exclusion is included here).
- `apps/webhook` (inactive per `AGENTS.md`).

## Docs

Developer-facing setup guide drafted in Notion: [Local secrets via 1Password Environments (Draft)](https://www.notion.so/35fd03ad838f8122b485e0f87e1bd7f3) — will be moved out of draft and linked from the engineering wiki once this lands.

## Test plan

- [x] Non-1P flow unchanged: `git status` shows no other modifications; default path arithmetic identical to pre-PR for every service when no override file exists.
- [ ] Reviewer runs `pnpm start:api:dev` on a fresh clone (no `apps/api/.env`) and confirms env vars load from `dist/.env` as before.
- [ ] 1P reviewer mounts FIFO at `apps/api/.env`, runs `pnpm start:api:dev`, sees one auth prompt, and the API boots with secrets.
- [ ] Same check for `worker`, `ws`, `inbound-mail` if they run those locally.
- [ ] Docker image build for one service produces a working container (the existing CI image build is sufficient evidence here — no env-loading code path changes).

## Breaking changes

None. The override is opt-in by file presence and inert in every environment that doesn't have `apps/<svc>/.env` mounted.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Added support for 1Password Environment local `.env` files through an opt-in override mechanism. Backend services (api, worker, ws, inbound-mail) now check for a local `.env` file at `apps/<svc>/.env` and use it when present; otherwise they fall back to the standard NODE_ENV-based configuration. This prevents 1Password's FIFO-mounted `.env` files from causing watch restart loops and missing environment variables during local development.

## Affected areas

**api**: Updated `env.config.ts` to conditionally load `apps/api/.env` if it exists, otherwise uses the NODE_ENV-based path.

**worker**: Updated `env.config.ts` to support a local override at `apps/worker/.env` with fallback to the default path.

**ws**: Updated `env.config.ts` to check for `apps/ws/.env` and use it when present, maintaining the existing fallback behavior.

**inbound-mail**: Updated `env.config.ts` to load from `apps/inbound-mail/.env` when available, otherwise using the NODE_ENV-based path.

**dashboard**: Updated `vite.config.ts` to ignore `**/.env` filesystem events during dev server watching, preventing FIFO-triggered restart loops.

## Key technical decisions

- The override file is located outside `dist/` and watch/copy targets, making it opt-in and preventing nest-cli conflicts.
- Path resolution uses `fs.existsSync` (inode stat only) to avoid consuming 1Password's FIFO.
- No changes to Docker, CI, or existing non-1Password contributor workflows.

## Testing

Manual verification included in PR description; no automated test suite changes required as this is a development-only configuration feature enabled by file presence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11108)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->