### PR TITLE
fix(api-service): scope widgets markAs response to authenticated subscriber fixes NV-7648

### DIFF
--- a/apps/api/src/app/widgets/e2e/mark-as.e2e.ts
+++ b/apps/api/src/app/widgets/e2e/mark-as.e2e.ts
@@ -61,4 +61,66 @@ describe('Mark as Seen - /widgets/messages/markAs (POST) #novu-v0', async () => 
     expect(modifiedMessage.seen).to.equal(true);
     expect(modifiedMessage.lastSeenDate).to.be.ok;
   });
+
+  it('should not leak another subscribers message via markAs response', async () => {
+    const attackerSubscriberId = SubscriberRepository.createObjectId();
+    const victimSubscriberId = SubscriberRepository.createObjectId();
+
+    const attackerInit = await session.testAgent
+      .post('/v1/widgets/session/initialize')
+      .send({
+        applicationIdentifier: session.environment.identifier,
+        subscriberId: attackerSubscriberId,
+        firstName: 'Attacker',
+        lastName: 'User',
+        email: 'attacker@example.com',
+      })
+      .expect(201);
+    const attackerToken = attackerInit.body.data.token;
+
+    const victimInit = await session.testAgent
+      .post('/v1/widgets/session/initialize')
+      .send({
+        applicationIdentifier: session.environment.identifier,
+        subscriberId: victimSubscriberId,
+        firstName: 'Victim',
+        lastName: 'User',
+        email: 'victim@example.com',
+      })
+      .expect(201);
+    const victimInternalId = victimInit.body.data.profile._id;
+
+    await novuClient.trigger({ workflowId: template.triggers[0].identifier, to: attackerSubscriberId });
+    await novuClient.trigger({ workflowId: template.triggers[0].identifier, to: victimSubscriberId });
+    await session.waitForJobCompletion(template._id);
+
+    const victimMessages = await messageRepository.findBySubscriberChannel(
+      session.environment._id,
+      victimInternalId,
+      ChannelTypeEnum.IN_APP
+    );
+    const victimMessageId = victimMessages[0]._id;
+
+    expect(victimMessages[0].seen).to.equal(false);
+
+    const response = await axios.post(
+      `http://127.0.0.1:${process.env.PORT}/v1/widgets/messages/markAs`,
+      { messageId: victimMessageId, mark: { seen: true } },
+      {
+        headers: {
+          Authorization: `Bearer ${attackerToken}`,
+        },
+      }
+    );
+
+    expect(response.data.data).to.be.an('array').that.is.empty;
+
+    const victimMessageAfter = (await messageRepository.findOne({
+      _id: victimMessageId,
+      _environmentId: session.environment._id,
+    })) as MessageEntity;
+
+    expect(victimMessageAfter.seen).to.equal(false);
+    expect(victimMessageAfter.lastSeenDate).to.be.not.ok;
+  });
 });

--- a/apps/api/src/app/widgets/usecases/mark-message-as/mark-message-as.usecase.ts
+++ b/apps/api/src/app/widgets/usecases/mark-message-as/mark-message-as.usecase.ts
@@ -55,6 +55,7 @@ export class MarkMessageAs {
 
     const updatedMessages = await this.messageRepository.find({
       _environmentId: command.environmentId,
+      _subscriberId: subscriber._id,
       _id: {
         $in: command.messageIds,
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`POST /v1/widgets/messages/markAs` re-read updated messages by `_id` and `_environmentId` only, omitting the `_subscriberId` filter. The state mutation was correctly scoped to the authenticated subscriber, but the response (and the downstream analytics traces, mixpanel events, and webhook fires that consume the same array) could include another subscriber's message when the caller submitted a foreign `messageId`.

## Change

- Add `_subscriberId: subscriber._id` to the `messageRepository.find` re-read in `mark-message-as.usecase.ts`. The downstream `prepareTrace`, `updateServices`, and `sendWebhookForMessages` consume the same `updatedMessages` array and inherit the fix.
- Add an e2e regression in `mark-as.e2e.ts`: subscriber A submits subscriber B's `messageId` and the response must be empty with the victim's state unchanged. Verified the test fails before the fix and passes after.

## Audited adjacent legacy widget routes

- `mark-all-messages-as` — already scoped via `markAllMessagesAs({ subscriberId })`.
- `mark-message-as-by-mark` — already scoped via `changeMessagesStatus` (both the update and the readback filter on `_subscriberId`).
- `update-message-actions` (`/messages/:messageId/actions/:type`) — the scoped `update` returns `modified: 0` for a foreign `messageId` and throws `BadRequestException` before the final re-read, so the response is not exploitable. No change here.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7648](https://linear.app/novu/issue/NV-7648/security-legacy-widgets-markas-route-leaks-another-subscribers)

<div><a href="https://cursor.com/agents/bc-d4c91b7e-57ee-45cc-9f1f-ea5957a10c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c91b7e-57ee-45cc-9f1f-ea5957a10c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Fixed a cross-subscriber message isolation vulnerability in the `POST /v1/widgets/messages/markAs` endpoint. The endpoint was re-reading updated messages by `_id` and `_environmentId` only, which allowed an authenticated subscriber to view and trigger analytics/webhooks for another subscriber's messages if they submitted a foreign message ID. The fix adds the `_subscriberId` filter to the post-update message re-read, ensuring only messages belonging to the authenticated subscriber are returned.

## Affected areas

**api**: Modified the `MarkMessageAs.execute` usecase to scope the message lookup to the authenticated subscriber, and added an e2e regression test verifying that cross-subscriber message access is blocked. The downstream analytics, webhook firing, and trace preparation functions inherit the fix automatically since they consume the same filtered message array.

## Key technical decisions

- The `_subscriberId` filter is added to the `messageRepository.find` query in the re-read operation, not the initial state mutation, because the state update itself was already correctly scoped. This minimal change prevents the response payload from leaking foreign subscriber messages.
- Adjacent widget routes (`mark-all-messages-as`, `mark-message-as-by-mark`, `update-message-actions`) were audited and confirmed to already have proper subscriber isolation in place.

## Testing

Added an e2e regression test that verifies a subscriber cannot mark another subscriber's message as seen. The test creates two subscribers, triggers messages for both, then attempts to mark the victim's message using the attacker's authentication token and confirms the response is empty with the victim's message remaining unseen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11109)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->