### PR TITLE
fix(api-service): enforce JWT contextKeys on inbox channel routes fixes NV-7647

### DIFF
--- a/apps/api/src/app/channel-connections/usecases/get-channel-connection/get-channel-connection.command.ts
+++ b/apps/api/src/app/channel-connections/usecases/get-channel-connection/get-channel-connection.command.ts
@@ -1,8 +1,17 @@
-import { IsDefined, IsString } from 'class-validator';
+import { IsArray, IsDefined, IsOptional, IsString } from 'class-validator';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class GetChannelConnectionCommand extends EnvironmentCommand {
   @IsDefined()
   @IsString()
   identifier: string;
+
+  @IsOptional()
+  @IsString()
+  subscriberId?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  contextKeys?: string[];
 }

--- a/apps/api/src/app/channel-connections/usecases/get-channel-connection/get-channel-connection.usecase.ts
+++ b/apps/api/src/app/channel-connections/usecases/get-channel-connection/get-channel-connection.usecase.ts
@@ -21,6 +21,14 @@ export class GetChannelConnection {
       identifier: command.identifier,
     };
 
+    if (command.subscriberId) {
+      query.subscriberId = command.subscriberId;
+    }
+
+    if (command.contextKeys !== undefined) {
+      Object.assign(query, this.channelConnectionRepository.buildContextExactMatchQuery(command.contextKeys));
+    }
+
     const channelConnection = await this.channelConnectionRepository.findOne(query);
 
     if (!channelConnection) {

--- a/apps/api/src/app/channel-connections/usecases/list-channel-connections/list-channel-connections.usecase.ts
+++ b/apps/api/src/app/channel-connections/usecases/list-channel-connections/list-channel-connections.usecase.ts
@@ -42,7 +42,13 @@ export class ListChannelConnections {
     }
 
     if (command.contextKeys !== undefined) {
-      Object.assign(filter, this.channelConnectionRepository.buildContextExactMatchQuery(command.contextKeys));
+      // Apply context filter under `$and` so it survives the cursor-pagination
+      // helper, which sets its own top-level `$or` and would otherwise drop
+      // the `$or` form returned for the empty/default-context case.
+      filter.$and = [
+        ...(filter.$and ?? []),
+        this.channelConnectionRepository.buildContextExactMatchQuery(command.contextKeys),
+      ];
     }
 
     let channelConnection: ChannelConnectionEntity | null = null;

--- a/apps/api/src/app/channel-connections/usecases/list-channel-connections/list-channel-connections.usecase.ts
+++ b/apps/api/src/app/channel-connections/usecases/list-channel-connections/list-channel-connections.usecase.ts
@@ -42,8 +42,7 @@ export class ListChannelConnections {
     }
 
     if (command.contextKeys !== undefined) {
-      const contextQuery = this.channelConnectionRepository.buildContextExactMatchQuery(command.contextKeys);
-      filter.contextKeys = contextQuery.contextKeys;
+      Object.assign(filter, this.channelConnectionRepository.buildContextExactMatchQuery(command.contextKeys));
     }
 
     let channelConnection: ChannelConnectionEntity | null = null;

--- a/apps/api/src/app/channel-endpoints/usecases/get-channel-endpoint/get-channel-endpoint.command.ts
+++ b/apps/api/src/app/channel-endpoints/usecases/get-channel-endpoint/get-channel-endpoint.command.ts
@@ -1,8 +1,17 @@
-import { IsDefined, IsString } from 'class-validator';
+import { IsArray, IsDefined, IsOptional, IsString } from 'class-validator';
 import { EnvironmentCommand } from '../../../shared/commands/project.command';
 
 export class GetChannelEndpointCommand extends EnvironmentCommand {
   @IsDefined()
   @IsString()
   identifier: string;
+
+  @IsOptional()
+  @IsString()
+  subscriberId?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  contextKeys?: string[];
 }

--- a/apps/api/src/app/channel-endpoints/usecases/get-channel-endpoint/get-channel-endpoint.usecase.ts
+++ b/apps/api/src/app/channel-endpoints/usecases/get-channel-endpoint/get-channel-endpoint.usecase.ts
@@ -1,6 +1,12 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InstrumentUsecase } from '@novu/application-generic';
-import { ChannelEndpointEntity, ChannelEndpointRepository } from '@novu/dal';
+import {
+  ChannelEndpointDBModel,
+  ChannelEndpointEntity,
+  ChannelEndpointRepository,
+  EnforceEnvOrOrgIds,
+} from '@novu/dal';
+import { FilterQuery } from 'mongoose';
 import { GetChannelEndpointCommand } from './get-channel-endpoint.command';
 
 @Injectable()
@@ -9,11 +15,21 @@ export class GetChannelEndpoint {
 
   @InstrumentUsecase()
   async execute(command: GetChannelEndpointCommand): Promise<ChannelEndpointEntity> {
-    const channelEndpoint = await this.channelEndpointRepository.findOne({
+    const query: FilterQuery<ChannelEndpointDBModel> & EnforceEnvOrOrgIds = {
       identifier: command.identifier,
       _organizationId: command.organizationId,
       _environmentId: command.environmentId,
-    });
+    };
+
+    if (command.subscriberId) {
+      query.subscriberId = command.subscriberId;
+    }
+
+    if (command.contextKeys !== undefined) {
+      Object.assign(query, this.channelEndpointRepository.buildContextExactMatchQuery(command.contextKeys));
+    }
+
+    const channelEndpoint = await this.channelEndpointRepository.findOne(query);
 
     if (!channelEndpoint) {
       throw new NotFoundException(`Channel endpoint with identifier '${command.identifier}' not found`);

--- a/apps/api/src/app/channel-endpoints/usecases/list-channel-endpoints/list-channel-endpoints.usecase.ts
+++ b/apps/api/src/app/channel-endpoints/usecases/list-channel-endpoints/list-channel-endpoints.usecase.ts
@@ -42,7 +42,13 @@ export class ListChannelEndpoints {
     }
 
     if (command.contextKeys !== undefined) {
-      Object.assign(filter, this.channelEndpointRepository.buildContextExactMatchQuery(command.contextKeys));
+      // Apply context filter under `$and` so it survives the cursor-pagination
+      // helper, which sets its own top-level `$or` and would otherwise drop
+      // the `$or` form returned for the empty/default-context case.
+      filter.$and = [
+        ...(filter.$and ?? []),
+        this.channelEndpointRepository.buildContextExactMatchQuery(command.contextKeys),
+      ];
     }
 
     let channelEndpoint: ChannelEndpointEntity | null = null;

--- a/apps/api/src/app/channel-endpoints/usecases/list-channel-endpoints/list-channel-endpoints.usecase.ts
+++ b/apps/api/src/app/channel-endpoints/usecases/list-channel-endpoints/list-channel-endpoints.usecase.ts
@@ -42,8 +42,7 @@ export class ListChannelEndpoints {
     }
 
     if (command.contextKeys !== undefined) {
-      const contextQuery = this.channelEndpointRepository.buildContextExactMatchQuery(command.contextKeys);
-      filter.contextKeys = contextQuery.contextKeys;
+      Object.assign(filter, this.channelEndpointRepository.buildContextExactMatchQuery(command.contextKeys));
     }
 
     let channelEndpoint: ChannelEndpointEntity | null = null;

--- a/apps/api/src/app/inbox/e2e/context-aware-channel-connections.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/context-aware-channel-connections.e2e.ts
@@ -1,0 +1,271 @@
+import { ChannelConnectionRepository, ChannelEndpointRepository, IntegrationRepository } from '@novu/dal';
+import { ChannelTypeEnum, ChatProviderIdEnum, ContextPayload, ENDPOINT_TYPES, InAppProviderIdEnum } from '@novu/shared';
+import { UserSession } from '@novu/testing';
+import { expect } from 'chai';
+
+const channelConnectionRepository = new ChannelConnectionRepository();
+const channelEndpointRepository = new ChannelEndpointRepository();
+const integrationRepository = new IntegrationRepository();
+
+const CONTEXT_A: ContextPayload = { tenant: 'tenant-a', project: 'project-a' };
+const CONTEXT_B: ContextPayload = { tenant: 'tenant-b', project: 'project-b' };
+
+describe('Context-aware inbox channel resources - /inbox/channel-* #novu-v2', () => {
+  let session: UserSession;
+  let contextAToken: string;
+  let contextBToken: string;
+  let slackIntegrationIdentifier: string;
+
+  beforeEach(async () => {
+    (process.env as Record<string, string>).IS_CONTEXT_PREFERENCES_ENABLED = 'true';
+
+    session = new UserSession();
+    await session.initialize();
+
+    const agent = session.testAgent;
+    session.testAgent = {
+      get: (url: string) => agent.get(url).set('Novu-Client-Version', '@novu/js@3.13.0'),
+      post: (url: string) => agent.post(url).set('Novu-Client-Version', '@novu/js@3.13.0'),
+      patch: (url: string) => agent.patch(url).set('Novu-Client-Version', '@novu/js@3.13.0'),
+      delete: (url: string) => agent.delete(url).set('Novu-Client-Version', '@novu/js@3.13.0'),
+    } as any;
+
+    await ensureInAppIntegrationActive(session.environment._id, session.environment._organizationId);
+    slackIntegrationIdentifier = await createSlackIntegration(session);
+
+    const sessionA = await initializeSessionWithContext(session, CONTEXT_A);
+    expect(sessionA.status).to.equal(201);
+    contextAToken = sessionA.body.data.token;
+
+    const sessionB = await initializeSessionWithContext(session, CONTEXT_B);
+    expect(sessionB.status).to.equal(201);
+    contextBToken = sessionB.body.data.token;
+  });
+
+  describe('Channel connections', () => {
+    it('should not leak channel connections from another context when listing', async () => {
+      const connectionA = await createConnection(session, slackIntegrationIdentifier, [
+        'project:project-a',
+        'tenant:tenant-a',
+      ]);
+      const connectionB = await createConnection(session, slackIntegrationIdentifier, [
+        'project:project-b',
+        'tenant:tenant-b',
+      ]);
+
+      const listA = await listChannelConnections(session, contextAToken);
+      expect(listA.status).to.equal(200);
+      expect(listA.body.data).to.have.lengthOf(1);
+      expect(listA.body.data[0].identifier).to.equal(connectionA.identifier);
+
+      const listB = await listChannelConnections(session, contextBToken);
+      expect(listB.status).to.equal(200);
+      expect(listB.body.data).to.have.lengthOf(1);
+      expect(listB.body.data[0].identifier).to.equal(connectionB.identifier);
+    });
+
+    it('should ignore caller-supplied contextKeys query param and use JWT context for list', async () => {
+      const connectionA = await createConnection(session, slackIntegrationIdentifier, [
+        'project:project-a',
+        'tenant:tenant-a',
+      ]);
+      await createConnection(session, slackIntegrationIdentifier, ['project:project-b', 'tenant:tenant-b']);
+
+      const listAttempt = await session.testAgent
+        .get('/v1/inbox/channel-connections?contextKeys=project:project-b&contextKeys=tenant:tenant-b')
+        .set('Authorization', `Bearer ${contextAToken}`);
+
+      expect(listAttempt.status).to.equal(200);
+      expect(listAttempt.body.data).to.have.lengthOf(1);
+      expect(listAttempt.body.data[0].identifier).to.equal(connectionA.identifier);
+    });
+
+    it('should return 404 when retrieving a channel connection that belongs to another context', async () => {
+      const connectionB = await createConnection(session, slackIntegrationIdentifier, [
+        'project:project-b',
+        'tenant:tenant-b',
+      ]);
+
+      const getA = await getChannelConnection(session, connectionB.identifier, contextAToken);
+      expect(getA.status).to.equal(404);
+
+      const getB = await getChannelConnection(session, connectionB.identifier, contextBToken);
+      expect(getB.status).to.equal(200);
+      expect(getB.body.data.identifier).to.equal(connectionB.identifier);
+    });
+
+    it('should not allow deleting a channel connection from another context', async () => {
+      const connectionB = await createConnection(session, slackIntegrationIdentifier, [
+        'project:project-b',
+        'tenant:tenant-b',
+      ]);
+
+      const deleteAttempt = await deleteChannelConnection(session, connectionB.identifier, contextAToken);
+      expect(deleteAttempt.status).to.equal(404);
+
+      const stillThere = await channelConnectionRepository.findOne({
+        _environmentId: session.environment._id,
+        _organizationId: session.organization._id,
+        identifier: connectionB.identifier,
+      });
+      expect(stillThere).to.exist;
+
+      const ownDelete = await deleteChannelConnection(session, connectionB.identifier, contextBToken);
+      expect(ownDelete.status).to.equal(204);
+
+      const removed = await channelConnectionRepository.findOne({
+        _environmentId: session.environment._id,
+        _organizationId: session.organization._id,
+        identifier: connectionB.identifier,
+      });
+      expect(removed).to.be.null;
+    });
+  });
+
+  describe('Channel endpoints', () => {
+    it('should not leak channel endpoints from another context when listing', async () => {
+      const endpointA = await createEndpoint(session, slackIntegrationIdentifier, [
+        'project:project-a',
+        'tenant:tenant-a',
+      ]);
+      const endpointB = await createEndpoint(session, slackIntegrationIdentifier, [
+        'project:project-b',
+        'tenant:tenant-b',
+      ]);
+
+      const listA = await listChannelEndpoints(session, contextAToken);
+      expect(listA.status).to.equal(200);
+      expect(listA.body.data).to.have.lengthOf(1);
+      expect(listA.body.data[0].identifier).to.equal(endpointA.identifier);
+
+      const listB = await listChannelEndpoints(session, contextBToken);
+      expect(listB.status).to.equal(200);
+      expect(listB.body.data).to.have.lengthOf(1);
+      expect(listB.body.data[0].identifier).to.equal(endpointB.identifier);
+    });
+
+    it('should not allow deleting a channel endpoint from another context', async () => {
+      const endpointB = await createEndpoint(session, slackIntegrationIdentifier, [
+        'project:project-b',
+        'tenant:tenant-b',
+      ]);
+
+      const deleteAttempt = await deleteChannelEndpoint(session, endpointB.identifier, contextAToken);
+      expect(deleteAttempt.status).to.equal(404);
+
+      const stillThere = await channelEndpointRepository.findOne({
+        _environmentId: session.environment._id,
+        _organizationId: session.organization._id,
+        identifier: endpointB.identifier,
+      });
+      expect(stillThere).to.exist;
+
+      const ownDelete = await deleteChannelEndpoint(session, endpointB.identifier, contextBToken);
+      expect(ownDelete.status).to.equal(204);
+
+      const removed = await channelEndpointRepository.findOne({
+        _environmentId: session.environment._id,
+        _organizationId: session.organization._id,
+        identifier: endpointB.identifier,
+      });
+      expect(removed).to.be.null;
+    });
+  });
+
+  async function createConnection(userSession: UserSession, integrationIdentifier: string, contextKeys: string[]) {
+    return channelConnectionRepository.create({
+      _environmentId: userSession.environment._id,
+      _organizationId: userSession.organization._id,
+      identifier: `conn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      integrationIdentifier,
+      providerId: ChatProviderIdEnum.Slack,
+      channel: ChannelTypeEnum.CHAT,
+      subscriberId: userSession.subscriberId,
+      contextKeys,
+      workspace: { id: `T${Date.now()}`, name: 'Test' },
+      auth: { accessToken: `xoxb-${Date.now()}` },
+    });
+  }
+
+  async function createEndpoint(userSession: UserSession, integrationIdentifier: string, contextKeys: string[]) {
+    return channelEndpointRepository.create({
+      _environmentId: userSession.environment._id,
+      _organizationId: userSession.organization._id,
+      identifier: `ep-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      integrationIdentifier,
+      providerId: ChatProviderIdEnum.Slack,
+      channel: ChannelTypeEnum.CHAT,
+      subscriberId: userSession.subscriberId,
+      contextKeys,
+      type: ENDPOINT_TYPES.SLACK_CHANNEL,
+      endpoint: { channelId: `C${Date.now()}` },
+    });
+  }
+});
+
+async function initializeSessionWithContext(session: UserSession, context?: ContextPayload) {
+  return await session.testAgent.post('/v1/inbox/session').send({
+    applicationIdentifier: session.environment.identifier,
+    subscriberId: session.subscriberId,
+    context,
+  });
+}
+
+async function ensureInAppIntegrationActive(environmentId: string, organizationId: string) {
+  await integrationRepository.update(
+    {
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+      providerId: InAppProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.IN_APP,
+      active: true,
+    },
+    {
+      $set: {
+        'credentials.hmac': false,
+        active: true,
+      },
+    }
+  );
+}
+
+async function createSlackIntegration(session: UserSession): Promise<string> {
+  const identifier = `slack-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  await integrationRepository.create({
+    _organizationId: session.organization._id,
+    _environmentId: session.environment._id,
+    providerId: ChatProviderIdEnum.Slack,
+    channel: ChannelTypeEnum.CHAT,
+    credentials: {},
+    active: true,
+    identifier,
+  });
+
+  return identifier;
+}
+
+async function listChannelConnections(session: UserSession, token: string) {
+  return await session.testAgent.get('/v1/inbox/channel-connections').set('Authorization', `Bearer ${token}`);
+}
+
+async function getChannelConnection(session: UserSession, identifier: string, token: string) {
+  return await session.testAgent
+    .get(`/v1/inbox/channel-connections/${identifier}`)
+    .set('Authorization', `Bearer ${token}`);
+}
+
+async function deleteChannelConnection(session: UserSession, identifier: string, token: string) {
+  return await session.testAgent
+    .delete(`/v1/inbox/channel-connections/${identifier}`)
+    .set('Authorization', `Bearer ${token}`);
+}
+
+async function listChannelEndpoints(session: UserSession, token: string) {
+  return await session.testAgent.get('/v1/inbox/channel-endpoints').set('Authorization', `Bearer ${token}`);
+}
+
+async function deleteChannelEndpoint(session: UserSession, identifier: string, token: string) {
+  return await session.testAgent
+    .delete(`/v1/inbox/channel-endpoints/${identifier}`)
+    .set('Authorization', `Bearer ${token}`);
+}

--- a/apps/api/src/app/inbox/e2e/context-aware-channel-connections.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/context-aware-channel-connections.e2e.ts
@@ -14,6 +14,7 @@ describe('Context-aware inbox channel resources - /inbox/channel-* #novu-v2', ()
   let session: UserSession;
   let contextAToken: string;
   let contextBToken: string;
+  let noContextToken: string;
   let slackIntegrationIdentifier: string;
 
   beforeEach(async () => {
@@ -40,6 +41,10 @@ describe('Context-aware inbox channel resources - /inbox/channel-* #novu-v2', ()
     const sessionB = await initializeSessionWithContext(session, CONTEXT_B);
     expect(sessionB.status).to.equal(201);
     contextBToken = sessionB.body.data.token;
+
+    const sessionNoContext = await initializeSessionWithContext(session);
+    expect(sessionNoContext.status).to.equal(201);
+    noContextToken = sessionNoContext.body.data.token;
   });
 
   describe('Channel connections', () => {
@@ -94,6 +99,28 @@ describe('Context-aware inbox channel resources - /inbox/channel-* #novu-v2', ()
       expect(getB.body.data.identifier).to.equal(connectionB.identifier);
     });
 
+    it('should not leak other-context channel connections when cursor pagination is used', async () => {
+      const connectionDefault = await createConnection(session, slackIntegrationIdentifier, []);
+      const connectionB1 = await createConnection(session, slackIntegrationIdentifier, [
+        'project:project-b',
+        'tenant:tenant-b',
+      ]);
+      const connectionB2 = await createConnection(session, slackIntegrationIdentifier, [
+        'project:project-b',
+        'tenant:tenant-b',
+      ]);
+
+      const listNoContext = await session.testAgent
+        .get(`/v1/inbox/channel-connections?limit=10&after=${connectionB2._id}`)
+        .set('Authorization', `Bearer ${noContextToken}`);
+
+      expect(listNoContext.status).to.equal(200);
+      const identifiers = (listNoContext.body.data as Array<{ identifier: string }>).map((d) => d.identifier);
+      expect(identifiers).to.not.include(connectionB1.identifier);
+      expect(identifiers).to.not.include(connectionB2.identifier);
+      expect(identifiers).to.include(connectionDefault.identifier);
+    });
+
     it('should not allow deleting a channel connection from another context', async () => {
       const connectionB = await createConnection(session, slackIntegrationIdentifier, [
         'project:project-b',
@@ -142,6 +169,28 @@ describe('Context-aware inbox channel resources - /inbox/channel-* #novu-v2', ()
       expect(listB.status).to.equal(200);
       expect(listB.body.data).to.have.lengthOf(1);
       expect(listB.body.data[0].identifier).to.equal(endpointB.identifier);
+    });
+
+    it('should not leak other-context channel endpoints when cursor pagination is used', async () => {
+      const endpointDefault = await createEndpoint(session, slackIntegrationIdentifier, []);
+      const endpointB1 = await createEndpoint(session, slackIntegrationIdentifier, [
+        'project:project-b',
+        'tenant:tenant-b',
+      ]);
+      const endpointB2 = await createEndpoint(session, slackIntegrationIdentifier, [
+        'project:project-b',
+        'tenant:tenant-b',
+      ]);
+
+      const listNoContext = await session.testAgent
+        .get(`/v1/inbox/channel-endpoints?limit=10&after=${endpointB2._id}`)
+        .set('Authorization', `Bearer ${noContextToken}`);
+
+      expect(listNoContext.status).to.equal(200);
+      const identifiers = (listNoContext.body.data as Array<{ identifier: string }>).map((d) => d.identifier);
+      expect(identifiers).to.not.include(endpointB1.identifier);
+      expect(identifiers).to.not.include(endpointB2.identifier);
+      expect(identifiers).to.include(endpointDefault.identifier);
     });
 
     it('should not allow deleting a channel endpoint from another context', async () => {

--- a/apps/api/src/app/inbox/e2e/context-aware-channel-connections.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/context-aware-channel-connections.e2e.ts
@@ -16,8 +16,10 @@ describe('Context-aware inbox channel resources - /inbox/channel-* #novu-v2', ()
   let contextBToken: string;
   let noContextToken: string;
   let slackIntegrationIdentifier: string;
+  let previousContextPrefFlag: string | undefined;
 
   beforeEach(async () => {
+    previousContextPrefFlag = process.env.IS_CONTEXT_PREFERENCES_ENABLED;
     (process.env as Record<string, string>).IS_CONTEXT_PREFERENCES_ENABLED = 'true';
 
     session = new UserSession();
@@ -45,6 +47,15 @@ describe('Context-aware inbox channel resources - /inbox/channel-* #novu-v2', ()
     const sessionNoContext = await initializeSessionWithContext(session);
     expect(sessionNoContext.status).to.equal(201);
     noContextToken = sessionNoContext.body.data.token;
+  });
+
+  afterEach(() => {
+    const env = process.env as Record<string, string | undefined>;
+    if (previousContextPrefFlag === undefined) {
+      delete env.IS_CONTEXT_PREFERENCES_ENABLED;
+    } else {
+      env.IS_CONTEXT_PREFERENCES_ENABLED = previousContextPrefFlag;
+    }
   });
 
   describe('Channel connections', () => {
@@ -267,7 +278,6 @@ async function ensureInAppIntegrationActive(environmentId: string, organizationI
       _organizationId: organizationId,
       providerId: InAppProviderIdEnum.Novu,
       channel: ChannelTypeEnum.IN_APP,
-      active: true,
     },
     {
       $set: {

--- a/apps/api/src/app/inbox/inbox.controller.ts
+++ b/apps/api/src/app/inbox/inbox.controller.ts
@@ -683,7 +683,7 @@ export class InboxController {
         orderDirection: query.orderDirection,
         orderBy: query.orderBy || 'createdAt',
         includeCursor: query.includeCursor,
-        contextKeys: query.contextKeys,
+        contextKeys: subscriberSession.contextKeys,
         channel: query.channel,
         providerId: query.providerId,
         integrationIdentifier: query.integrationIdentifier,
@@ -703,17 +703,7 @@ export class InboxController {
     @SubscriberSession() subscriberSession: SubscriberSession,
     @Param('identifier') identifier: string
   ): Promise<InboxChannelConnectionResponseDto> {
-    const channelConnection = await this.getChannelConnectionUsecase.execute(
-      GetChannelConnectionCommand.create({
-        environmentId: subscriberSession._environmentId,
-        organizationId: subscriberSession._organizationId,
-        identifier,
-      })
-    );
-
-    if (channelConnection.subscriberId && channelConnection.subscriberId !== subscriberSession.subscriberId) {
-      throw new NotFoundException(`Channel connection not found: ${identifier}`);
-    }
+    const channelConnection = await this.loadChannelConnectionForSubscriber(subscriberSession, identifier);
 
     return mapChannelConnectionToInboxDto(channelConnection);
   }
@@ -725,17 +715,7 @@ export class InboxController {
     @SubscriberSession() subscriberSession: SubscriberSession,
     @Param('identifier') identifier: string
   ): Promise<void> {
-    const channelConnection = await this.getChannelConnectionUsecase.execute(
-      GetChannelConnectionCommand.create({
-        environmentId: subscriberSession._environmentId,
-        organizationId: subscriberSession._organizationId,
-        identifier,
-      })
-    );
-
-    if (channelConnection.subscriberId && channelConnection.subscriberId !== subscriberSession.subscriberId) {
-      throw new NotFoundException(`Channel connection not found: ${identifier}`);
-    }
+    await this.loadChannelConnectionForSubscriber(subscriberSession, identifier);
 
     await this.deleteChannelConnectionUsecase.execute(
       DeleteChannelConnectionCommand.create({
@@ -744,6 +724,25 @@ export class InboxController {
         identifier,
       })
     );
+  }
+
+  private async loadChannelConnectionForSubscriber(subscriberSession: SubscriberSession, identifier: string) {
+    try {
+      return await this.getChannelConnectionUsecase.execute(
+        GetChannelConnectionCommand.create({
+          environmentId: subscriberSession._environmentId,
+          organizationId: subscriberSession._organizationId,
+          identifier,
+          subscriberId: subscriberSession.subscriberId,
+          contextKeys: subscriberSession.contextKeys,
+        })
+      );
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException(`Channel connection not found: ${identifier}`);
+      }
+      throw error;
+    }
   }
 
   @UseGuards(AuthGuard('subscriberJwt'))
@@ -765,7 +764,7 @@ export class InboxController {
         orderDirection: query.orderDirection,
         orderBy: query.orderBy || 'createdAt',
         includeCursor: query.includeCursor,
-        contextKeys: query.contextKeys,
+        contextKeys: subscriberSession.contextKeys,
         channel: query.channel,
         providerId: query.providerId,
         integrationIdentifier: query.integrationIdentifier,
@@ -787,16 +786,21 @@ export class InboxController {
     @SubscriberSession() subscriberSession: SubscriberSession,
     @Param('identifier') identifier: string
   ): Promise<void> {
-    const channelEndpoint = await this.getChannelEndpointUsecase.execute(
-      GetChannelEndpointCommand.create({
-        environmentId: subscriberSession._environmentId,
-        organizationId: subscriberSession._organizationId,
-        identifier,
-      })
-    );
-
-    if (channelEndpoint.subscriberId && channelEndpoint.subscriberId !== subscriberSession.subscriberId) {
-      throw new NotFoundException(`Channel endpoint not found: ${identifier}`);
+    try {
+      await this.getChannelEndpointUsecase.execute(
+        GetChannelEndpointCommand.create({
+          environmentId: subscriberSession._environmentId,
+          organizationId: subscriberSession._organizationId,
+          identifier,
+          subscriberId: subscriberSession.subscriberId,
+          contextKeys: subscriberSession.contextKeys,
+        })
+      );
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new NotFoundException(`Channel endpoint not found: ${identifier}`);
+      }
+      throw error;
     }
 
     await this.deleteChannelEndpointUsecase.execute(

--- a/libs/dal/src/repositories/base-repository-v2.ts
+++ b/libs/dal/src/repositories/base-repository-v2.ts
@@ -621,8 +621,9 @@ export class BaseRepositoryV2<T_DBModel, T_MappedEntity, T_Enforcement> {
 
     let reverseResults = false;
 
+    let cursorOr: Record<string, unknown>[] | undefined;
     if (before) {
-      paginationQuery.$or = [
+      cursorOr = [
         {
           [sortBy]: isDesc
             ? { [includeCursor ? '$gte' : '$gt']: before.sortBy }
@@ -641,7 +642,7 @@ export class BaseRepositoryV2<T_DBModel, T_MappedEntity, T_Enforcement> {
       ];
       reverseResults = true;
     } else if (after) {
-      paginationQuery.$or = [
+      cursorOr = [
         {
           [sortBy]: isDesc
             ? { [includeCursor ? '$lte' : '$lt']: after.sortBy }
@@ -658,6 +659,21 @@ export class BaseRepositoryV2<T_DBModel, T_MappedEntity, T_Enforcement> {
           ],
         },
       ];
+    }
+
+    if (cursorOr) {
+      // Combine the cursor-walking `$or` with any pre-existing top-level `$or`
+      // from the caller's query under `$and`, so neither is silently dropped.
+      if (paginationQuery.$or) {
+        paginationQuery.$and = [
+          ...(paginationQuery.$and ?? []),
+          { $or: paginationQuery.$or },
+          { $or: cursorOr },
+        ];
+        delete paginationQuery.$or;
+      } else {
+        paginationQuery.$or = cursorOr;
+      }
     }
 
     // When a select is provided, silently inject the pagination fields so cursor

--- a/libs/dal/src/repositories/base-repository-v2.ts
+++ b/libs/dal/src/repositories/base-repository-v2.ts
@@ -20,6 +20,21 @@ import {
   SelectInput,
 } from './projection.types';
 
+/**
+ * Merge a cursor-walking `$or` clause into `target` without dropping an existing
+ * top-level `$or` from the caller's query. When both are present, both are
+ * preserved by moving each under an entry in `$and` (which Mongo evaluates as
+ * an implicit AND with the rest of the query).
+ */
+function mergeTopLevelOr(target: Record<string, any>, incomingOr: Record<string, unknown>[]): void {
+  if (target.$or) {
+    target.$and = [...(target.$and ?? []), { $or: target.$or }, { $or: incomingOr }];
+    delete target.$or;
+  } else {
+    target.$or = incomingOr;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Options interfaces
 // ---------------------------------------------------------------------------
@@ -662,18 +677,7 @@ export class BaseRepositoryV2<T_DBModel, T_MappedEntity, T_Enforcement> {
     }
 
     if (cursorOr) {
-      // Combine the cursor-walking `$or` with any pre-existing top-level `$or`
-      // from the caller's query under `$and`, so neither is silently dropped.
-      if (paginationQuery.$or) {
-        paginationQuery.$and = [
-          ...(paginationQuery.$and ?? []),
-          { $or: paginationQuery.$or },
-          { $or: cursorOr },
-        ];
-        delete paginationQuery.$or;
-      } else {
-        paginationQuery.$or = cursorOr;
-      }
+      mergeTopLevelOr(paginationQuery, cursorOr);
     }
 
     // When a select is provided, silently inject the pagination fields so cursor
@@ -738,7 +742,7 @@ export class BaseRepositoryV2<T_DBModel, T_MappedEntity, T_Enforcement> {
 
     if (before) {
       const nextQuery: any = { ...query };
-      nextQuery.$or = [
+      mergeTopLevelOr(nextQuery, [
         { [sortBy]: isDesc ? { $lt: lastItem[sortBy] } : { $gt: lastItem[sortBy] } },
         {
           $and: [
@@ -746,7 +750,7 @@ export class BaseRepositoryV2<T_DBModel, T_MappedEntity, T_Enforcement> {
             { [paginateField]: isDesc ? { $lt: lastItem[paginateField] } : { $gt: lastItem[paginateField] } },
           ],
         },
-      ];
+      ]);
 
       const maybeNext = await this.MongooseModel.findOne(nextQuery)
         .sort({ [sortBy]: sortValue, [paginateField]: sortValue })
@@ -756,7 +760,7 @@ export class BaseRepositoryV2<T_DBModel, T_MappedEntity, T_Enforcement> {
       if (maybeNext) nextCursor = lastItem[paginateField].toString();
     } else {
       const prevQuery: any = { ...query };
-      prevQuery.$or = [
+      mergeTopLevelOr(prevQuery, [
         { [sortBy]: isDesc ? { $gt: firstItem[sortBy] } : { $lt: firstItem[sortBy] } },
         {
           $and: [
@@ -764,7 +768,7 @@ export class BaseRepositoryV2<T_DBModel, T_MappedEntity, T_Enforcement> {
             { [paginateField]: isDesc ? { $gt: firstItem[paginateField] } : { $lt: firstItem[paginateField] } },
           ],
         },
-      ];
+      ]);
 
       const maybePrev = await this.MongooseModel.findOne(prevQuery)
         .sort({ [sortBy]: sortValue, [paginateField]: sortValue })

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -15,6 +15,21 @@ import {
 import { DalException } from '../shared';
 
 /**
+ * Merge a cursor-walking `$or` clause into `target` without dropping an existing
+ * top-level `$or` from the caller's query. When both are present, both are
+ * preserved by moving each under an entry in `$and` (which Mongo evaluates as
+ * an implicit AND with the rest of the query).
+ */
+function mergeTopLevelOr(target: Record<string, any>, incomingOr: Record<string, unknown>[]): void {
+  if (target.$or) {
+    target.$and = [...(target.$and ?? []), { $or: target.$or }, { $or: incomingOr }];
+    delete target.$or;
+  } else {
+    target.$or = incomingOr;
+  }
+}
+
+/**
  * @deprecated Use BaseRepositoryV2 instead. BaseRepositoryV2 enforces required
  * field selection via a mandatory `select` parameter and provides auto-inferred
  * return types based on the selected fields (Pick<Entity, Keys>).
@@ -575,18 +590,7 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
     }
 
     if (cursorOr) {
-      // Combine the cursor-walking `$or` with any pre-existing top-level `$or`
-      // from the caller's query under `$and`, so neither is silently dropped.
-      if (paginationQuery.$or) {
-        paginationQuery.$and = [
-          ...(paginationQuery.$and ?? []),
-          { $or: paginationQuery.$or },
-          { $or: cursorOr },
-        ];
-        delete paginationQuery.$or;
-      } else {
-        paginationQuery.$or = cursorOr;
-      }
+      mergeTopLevelOr(paginationQuery, cursorOr);
     }
 
     let builder = this.MongooseModel.find(paginationQuery)
@@ -651,7 +655,7 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
     if (before) {
       const nextQuery: any = { ...query };
 
-      nextQuery.$or = [
+      mergeTopLevelOr(nextQuery, [
         {
           [sortBy]: isDesc ? { $lt: lastItem[sortBy] } : { $gt: lastItem[sortBy] },
         },
@@ -663,7 +667,7 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
             },
           ],
         },
-      ];
+      ]);
 
       const maybeNext = await this.MongooseModel.findOne(nextQuery)
         .sort({ [sortBy]: sortValue, [paginateField]: sortValue })
@@ -676,7 +680,7 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
     } else {
       const prevQuery: any = { ...query };
 
-      prevQuery.$or = [
+      mergeTopLevelOr(prevQuery, [
         {
           [sortBy]: isDesc ? { $gt: firstItem[sortBy] } : { $lt: firstItem[sortBy] },
         },
@@ -686,7 +690,7 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
             { [paginateField]: isDesc ? { $gt: firstItem[paginateField] } : { $lt: firstItem[paginateField] } },
           ],
         },
-      ];
+      ]);
 
       const maybePrev = await this.MongooseModel.findOne(prevQuery)
         .sort({ [sortBy]: sortValue, [paginateField]: sortValue })

--- a/libs/dal/src/repositories/base-repository.ts
+++ b/libs/dal/src/repositories/base-repository.ts
@@ -532,8 +532,9 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
 
     let reverseResults = false;
 
+    let cursorOr: Record<string, unknown>[] | undefined;
     if (before) {
-      paginationQuery.$or = [
+      cursorOr = [
         {
           [sortBy]: isDesc
             ? { [includeCursor ? '$gte' : '$gt']: before.sortBy }
@@ -554,7 +555,7 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
       // Reverse sort order for backwards pagination
       reverseResults = true;
     } else if (after) {
-      paginationQuery.$or = [
+      cursorOr = [
         {
           [sortBy]: isDesc
             ? { [includeCursor ? '$lte' : '$lt']: after.sortBy }
@@ -571,6 +572,21 @@ export class BaseRepository<T_DBModel, T_MappedEntity, T_Enforcement> {
           ],
         },
       ];
+    }
+
+    if (cursorOr) {
+      // Combine the cursor-walking `$or` with any pre-existing top-level `$or`
+      // from the caller's query under `$and`, so neither is silently dropped.
+      if (paginationQuery.$or) {
+        paginationQuery.$and = [
+          ...(paginationQuery.$and ?? []),
+          { $or: paginationQuery.$or },
+          { $or: cursorOr },
+        ];
+        delete paginationQuery.$or;
+      } else {
+        paginationQuery.$or = cursorOr;
+      }
     }
 
     let builder = this.MongooseModel.find(paginationQuery)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The inbox subscriber routes for channel connections and channel endpoints were treating `contextKeys` as caller-supplied input rather than authoritative JWT state. In multi-context deployments where a `subscriberId` is shared across contexts, a subscriber JWT minted for context A could list, retrieve, and delete resources that belong to context B.

This PR routes the inbox controller through `subscriberSession.contextKeys` (JWT-bound) for all five affected routes and pushes the auth check down into the use cases so the lookup itself enforces it.

## Changes

- `GetChannelConnection` / `GetChannelEndpoint` use cases accept optional `subscriberId` and `contextKeys` and filter the lookup. When the resource doesn't match, they throw `NotFoundException` — no post-hoc check needed.
- Inbox controller passes `subscriberSession.contextKeys` (not `query.contextKeys`) when listing channel connections and channel endpoints.
- Inbox controller passes `subscriberSession.subscriberId` and `subscriberSession.contextKeys` when retrieving / deleting a channel connection or deleting a channel endpoint.
- `ListChannelConnections` / `ListChannelEndpoints` use cases now spread `buildContextExactMatchQuery(...)` into the filter so the empty-context case (`contextKeys: []` → `$or` form) is honored correctly.
- The admin-facing `ChannelConnections` / `ChannelEndpoints` controllers are unchanged — the new command fields are optional, so existing callers continue to work without context filtering.

## Tests

New e2e test `context-aware-channel-connections.e2e.ts` mirrors the reporter's PoC: two contexts share a `subscriberId`, each owns a connection/endpoint, and a context-A JWT cannot list / get / delete the context-B resource.

```
Context-aware inbox channel resources - /inbox/channel-* #novu-v2
  Channel connections
    ✔ should not leak channel connections from another context when listing
    ✔ should ignore caller-supplied contextKeys query param and use JWT context for list
    ✔ should return 404 when retrieving a channel connection that belongs to another context
    ✔ should not allow deleting a channel connection from another context
  Channel endpoints
    ✔ should not leak channel endpoints from another context when listing
    ✔ should not allow deleting a channel endpoint from another context

6 passing
```

The existing admin `channel-connections` / `channel-endpoints` e2e suites (35 tests) and the inbox `context-aware-topic-subscriptions` suite (14 tests) continue to pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7647](https://linear.app/novu/issue/NV-7647/security-subscriber-jwt-can-enumerate-and-delete-channel-connections)

<div><a href="https://cursor.com/agents/bc-239b33e8-9b58-41a1-9a57-bc4ada9f3e43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-239b33e8-9b58-41a1-9a57-bc4ada9f3e43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Inbox subscriber routes for channel connections and endpoints now treat JWT-bound contextKeys (subscriberSession.contextKeys) as authoritative instead of trusting caller-supplied query parameters. Use cases were updated to accept optional subscriberId and contextKeys and apply exact-match context filters during lookups, ensuring a subscriber JWT from one context cannot list/get/delete resources belonging to another context. Cursor-pagination was adjusted so paging logic preserves caller-provided $or context filters instead of overwriting them.

## Affected areas

- **api**: Inbox controller now derives contextKeys from the authenticated subscriber session for list/get/delete of channel connections and endpoints; controller handlers route lookups through subscriber-aware use cases that accept optional subscriberId and contextKeys and enforce context exact-match filtering.
- **libs/dal**: Cursor-based pagination (base-repository and base-repository-v2) now merges cursor-generated $or clauses with any caller $or under an $and so pagination does not clobber context $or filters.
- **apps/api (tests)**: New inbox e2e suite (context-aware-channel-connections.e2e.ts) validating context isolation for channel connections and endpoints across multiple JWT contexts, including pagination behavior.

## Key technical decisions

- Enforce context membership inside use cases/data-access via exact-match context queries so authorization is applied at lookup time rather than relying on controller checks.
- Keep subscriberId and contextKeys optional on command DTOs to maintain admin/backwards compatibility and avoid breaking existing controllers.
- Preserve admin-facing controllers unchanged; inbox-specific handlers now pass JWT-bound context and subscriber identifiers to use cases.

## Testing

Added a new inbox e2e suite reproducing the PoC: multiple contexts sharing a subscriberId where cross-context list/get/delete are denied (404) and same-context operations succeed; existing admin and inbox e2e suites continue to pass.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11111)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->