### PR TITLE
fix(api-service): enforce subscriber ownership on inbox subscription preferences fixes NV-7644

### DIFF
--- a/apps/api/src/app/inbox/e2e/update-subscription-workflow-preferences.e2e.ts
+++ b/apps/api/src/app/inbox/e2e/update-subscription-workflow-preferences.e2e.ts
@@ -181,6 +181,60 @@ describe('Update subscription workflow preferences - /inbox/subscriptions/:subsc
     expect(update2.body.data.enabled).to.equal(false);
   });
 
+  it('should reject attempts to plant preferences on another subscriber\'s subscription (IDOR)', async () => {
+    const topicKey = `topic-${Date.now()}`;
+    const victimSubscriptionIdentifier = `victim-subscription-${Date.now()}`;
+    const workflow = await session.createTemplate({
+      noFeedId: true,
+      steps: [
+        {
+          type: StepTypeEnum.IN_APP,
+          content: 'Test notification content',
+        },
+      ],
+    });
+
+    // Victim (the default session subscriber) creates a topic subscription
+    const subscriptionResponse = await createSubscription({
+      session,
+      topicKey,
+      body: { identifier: victimSubscriptionIdentifier },
+    });
+    expect(subscriptionResponse.status, 'Victim subscription should be created').to.equal(201);
+
+    // An attacker (a different authenticated subscriber in the same env) initializes a session
+    const attackerSubscriberId = `attacker-${Date.now()}`;
+    const attackerInit = await session.testAgent.post('/v1/widgets/session/initialize').send({
+      applicationIdentifier: session.environment.identifier,
+      subscriberId: attackerSubscriberId,
+      firstName: 'Attacker',
+    });
+    expect(attackerInit.status, 'Attacker should be able to initialize an inbox session').to.equal(201);
+    const attackerToken = attackerInit.body.data.token;
+
+    // The attacker attempts to plant a preference against the victim's subscription
+    const attack = await session.testAgent
+      .patch(`/v1/inbox/subscriptions/${victimSubscriptionIdentifier}/preferences/${workflow._id}`)
+      .send({ enabled: false })
+      .set('Authorization', `Bearer ${attackerToken}`);
+
+    expect(attack.status, 'Cross-subscriber preference write must be rejected').to.equal(404);
+
+    // The victim's preference must remain unaffected (still default-enabled)
+    const victimList = await session.testAgent
+      .get(`/v1/inbox/topics/${topicKey}/subscriptions`)
+      .set('Authorization', `Bearer ${session.subscriberToken}`);
+    const victimSubscription: SubscriptionResponseDto = victimList.body.data[0];
+
+    if (victimSubscription.preferences && victimSubscription.preferences.length > 0) {
+      const planted = victimSubscription.preferences.find((p) => p.workflow?.id === workflow._id);
+      expect(
+        planted?.enabled,
+        'Victim subscription must not have a preference planted by another subscriber'
+      ).to.not.equal(false);
+    }
+  });
+
   it('should return external subscriptionIdentifier (not internal MongoDB ID) in response', async () => {
     const topicKey = `topic-${Date.now()}`;
     const subscriptionIdentifier = `subscription-${Date.now()}`;

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.spec.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.spec.ts
@@ -170,6 +170,44 @@ describe('UpdatePreferences', () => {
     });
   });
 
+  it('should throw NotFoundException when the subscriptionIdentifier is not owned by the authenticated subscriber', async () => {
+    const command = {
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      subscriberId: 'test-mockSubscriber',
+      contextKeys: [],
+      level: PreferenceLevelEnum.TEMPLATE,
+      workflowIdOrIdentifier: '6447aff3d89122e250412c28',
+      subscriptionIdentifier: 'someone-elses-subscription',
+      all: { enabled: false },
+      includeInactiveChannels: false,
+    };
+
+    subscriberRepositoryMock.findBySubscriberId.resolves(mockedSubscriber);
+    getWorkflowByIdsUsecase.execute.resolves(mockedWorkflow);
+    featureFlagsServiceMock.getFlag.resolves(false);
+    topicSubscribersRepositoryMock.buildContextExactMatchQuery = sinon.stub().returns({}) as any;
+    topicSubscribersRepositoryMock.findOne.resolves(null);
+
+    let caught: any;
+    try {
+      await updatePreferences.execute(command);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.exist;
+    expect(caught.message).to.contain('someone-elses-subscription');
+    expect(upsertPreferencesMock.upsertTopicSubscriptionPreferences.called).to.equal(false);
+    expect(upsertPreferencesMock.upsertSubscriberWorkflowPreferences.called).to.equal(false);
+
+    const findOneCalls = topicSubscribersRepositoryMock.findOne.getCalls();
+    expect(findOneCalls.length).to.be.greaterThan(0);
+    for (const call of findOneCalls) {
+      expect(call.args[0]).to.have.property('_subscriberId', mockedSubscriber._id);
+    }
+  });
+
   it('should update subscriber preference when using workflow identifier', async () => {
     const command = {
       environmentId: 'env-1',

--- a/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
+++ b/apps/api/src/app/inbox/usecases/update-preferences/update-preferences.usecase.ts
@@ -67,7 +67,7 @@ export class UpdatePreferences {
     if (!subscriber) throw new NotFoundException(`Subscriber with id: ${command.subscriberId} is not found`);
 
     const workflow = await this.getWorkflow(command);
-    const internalSubscriptionId = await this.getSubscriptionId(command);
+    const internalSubscriptionId = await this.getSubscriptionId(command, subscriber);
 
     let newPreference: InboxPreference | null = null;
 
@@ -112,7 +112,10 @@ export class UpdatePreferences {
     return workflow;
   }
 
-  private async getSubscriptionId(command: UpdatePreferencesCommand): Promise<string | undefined> {
+  private async getSubscriptionId(
+    command: UpdatePreferencesCommand,
+    subscriber: Pick<SubscriberEntity, '_id'>
+  ): Promise<string | undefined> {
     if (command.level !== PreferenceLevelEnum.TEMPLATE || !command.subscriptionIdentifier) {
       return undefined;
     }
@@ -138,25 +141,34 @@ export class UpdatePreferences {
       enabled: useContextFiltering,
     });
 
-    // Try to find by identifier first
+    // Enforce ownership: the subscription must belong to the authenticated subscriber.
+    // Without this filter, any authenticated subscriber could resolve another subscriber's
+    // topic subscription by identifier and plant preferences against it (CWE-639).
     let subscription = await this.topicSubscribersRepository.findOne({
       _environmentId: command.environmentId,
       _organizationId: command.organizationId,
+      _subscriberId: subscriber._id,
       identifier,
       ...contextQuery,
     });
 
-    // If not found by identifier, try by _id (in case subscriptionIdentifier is actually an _id)
     if (!subscription && BaseRepository.isInternalId(command.subscriptionIdentifier)) {
       subscription = await this.topicSubscribersRepository.findOne({
         _environmentId: command.environmentId,
         _organizationId: command.organizationId,
+        _subscriberId: subscriber._id,
         _id: command.subscriptionIdentifier,
         ...contextQuery,
       });
     }
 
-    return subscription?._id?.toString();
+    if (!subscription) {
+      throw new NotFoundException(
+        `Subscription with identifier: ${command.subscriptionIdentifier} is not found for the authenticated subscriber`
+      );
+    }
+
+    return subscription._id?.toString();
   }
 
   @Instrument()

--- a/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/subscriber-job-bound/subscriber-job-bound.usecase.ts
@@ -168,7 +168,12 @@ export class SubscriberJobBound {
     }
 
     if (topics && topics.length > 0) {
-      const evaluatedTopics = await this.evaluateTopicPreferences(command, topics, template._id);
+      const evaluatedTopics = await this.evaluateTopicPreferences(
+        command,
+        topics,
+        template._id,
+        subscriberProcessed._id
+      );
 
       if (evaluatedTopics === null) {
         return;
@@ -373,7 +378,8 @@ export class SubscriberJobBound {
   private async evaluateTopicPreferences(
     command: SubscriberJobBoundCommand,
     topics: SubscriberTopicPreference[],
-    templateId: string
+    templateId: string,
+    subscriberId: string
   ): Promise<SubscriberTopicPreference[] | null> {
     const evaluatedTopics: SubscriberTopicPreference[] = [];
     let filteredCount = 0;
@@ -388,7 +394,8 @@ export class SubscriberJobBound {
         command,
         topic._topicSubscriptionId,
         topic.subscriptionIdentifier,
-        templateId
+        templateId,
+        subscriberId
       );
 
       if (!evaluationResult.result) {
@@ -424,7 +431,8 @@ export class SubscriberJobBound {
     command: SubscriberJobBoundCommand,
     internalSubscriptionId: string,
     subscriptionIdentifier: string,
-    templateId: string
+    templateId: string,
+    subscriberId: string
   ): Promise<TopicPreferenceEvaluation> {
     try {
       const useContextFiltering = await this.featureFlagsService.getFlag({
@@ -437,9 +445,12 @@ export class SubscriberJobBound {
         enabled: useContextFiltering,
       });
 
+      // Defense in depth: scope the preference lookup to the authenticated subscriber
+      // so any cross-bound (forged) records that may exist in the database are ignored.
       const subscriptionPreference = await this.preferencesRepository.findOne({
         _environmentId: command.environmentId,
         _organizationId: command.organizationId,
+        _subscriberId: subscriberId,
         _templateId: templateId,
         _topicSubscriptionId: internalSubscriptionId,
         type: PreferencesTypeEnum.SUBSCRIPTION_SUBSCRIBER_WORKFLOW,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`PATCH /v1/inbox/subscriptions/:subscriptionIdentifier/preferences/:workflowIdOrIdentifier` did not verify that the target topic subscription belongs to the authenticated subscriber, allowing one subscriber to plant `SUBSCRIPTION_SUBSCRIBER_WORKFLOW` preferences on another subscriber's subscription. The worker would then honor the forged record, silently suppressing notifications for the victim.

## Fix

- **API (`apps/api`)**: `UpdatePreferences.getSubscriptionId` now filters topic subscription lookups by `_subscriberId` and throws `404 NotFound` when the subscription is not owned by the authenticated subscriber, so no preference write occurs against a foreign subscription.
- **Worker (`apps/worker`)**: `SubscriberJobBound.evaluateSubscriptionPreferences` now filters the `SUBSCRIPTION_SUBSCRIBER_WORKFLOW` preference lookup by `_subscriberId`, neutralizing any cross-bound records that may already exist (no migration needed).

## Tests

- Added unit test asserting `UpdatePreferences` rejects updates against subscriptions not owned by the caller and does not call any upsert.
- Added e2e regression (`update-subscription-workflow-preferences.e2e.ts`): a second authenticated subscriber attempting to update the first subscriber's subscription preferences receives `404` and the victim's preferences remain unchanged.

All existing inbox unit tests and the `update-subscription-workflow-preferences`, `update-preferences`, and `context-aware-topic-subscriptions` e2e suites pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7644](https://linear.app/novu/issue/NV-7644/security-inbox-subscriber-can-plant-workflow-preferences-on-another)

<div><a href="https://cursor.com/agents/bc-862da832-da61-421e-b430-d4c9dc66b63a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-862da832-da61-421e-b430-d4c9dc66b63a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Fixed an IDOR vulnerability in the inbox subscription preferences endpoint. Previously, an authenticated subscriber could create `SUBSCRIPTION_SUBSCRIBER_WORKFLOW` preferences on another subscriber's subscription, causing the worker to honor the forged record and suppress notifications for the victim. The API now validates that topic subscriptions belong to the authenticated subscriber before accepting preference updates, and the worker scopes preference lookups by subscriber ID to neutralize any existing cross-bound records.

## Affected areas

**api**: `UpdatePreferences` usecase now passes the authenticated subscriber into the subscription ID resolution helper, which filters topic subscription lookups by `_subscriberId` and returns `404 NotFound` when the subscription is not owned by the caller.

**worker**: `SubscriberJobBound` usecase now passes `subscriberId` through to `evaluateSubscriptionPreferences`, which includes `_subscriberId` in preference repository lookups to prevent cross-subscriber records from being evaluated.

## Key technical decisions

- Defense-in-depth validation: both API and worker enforce subscriber ownership, so existing forged records cannot be exploited even if the API validation is bypassed.
- No database migration required; worker-side filtering neutralizes any existing cross-bound preference records.
- No API contract changes; the endpoint continues to return `404 NotFound` as expected, preventing information leakage.

## Testing

- **Unit test**: Added to `UpdatePreferences` to verify that updates against subscriptions not owned by the caller are rejected and no upsert occurs.
- **E2E test** (`update-subscription-workflow-preferences.e2e.ts`): Verifies that a second authenticated subscriber attempting to update another subscriber's subscription preferences receives `404` and the victim's preferences remain unchanged.
- All existing inbox unit tests and related e2e suites (`update-subscription-workflow-preferences`, `update-preferences`, `context-aware-topic-subscriptions`) pass.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11117)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->