### PR TITLE
feat(api-service): default Inbox HMAC on for non-dev environments fixes NV-7593

### DIFF
--- a/apps/api/src/app/environments-v1/e2e/environments.controller.e2e.ts
+++ b/apps/api/src/app/environments-v1/e2e/environments.controller.e2e.ts
@@ -1,5 +1,6 @@
 import { Novu } from '@novu/api';
-import { ApiServiceLevelEnum, EnvironmentEnum } from '@novu/shared';
+import { IntegrationRepository } from '@novu/dal';
+import { ApiServiceLevelEnum, ChannelTypeEnum, EnvironmentEnum, InAppProviderIdEnum } from '@novu/shared';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 import { expectSdkExceptionGeneric, initNovuClassSdkInternalAuth } from '../../shared/helpers/e2e/sdk/e2e-sdk.helper';
@@ -22,6 +23,28 @@ describe('Env Controller', async () => {
         expect(result).to.be.ok;
         expect(result.name).to.equal(name);
       });
+    });
+
+    it('should default the in-app integration HMAC to ON for non-dev environments (NV-7593)', async () => {
+      await session.updateOrganizationServiceLevel(ApiServiceLevelEnum.BUSINESS);
+
+      const { environmentRequestDto } = generateRandomEnvRequest();
+      const createdEnv = await novuClient.environments.create(environmentRequestDto);
+      expect(createdEnv.result).to.be.ok;
+
+      const integrationRepository = new IntegrationRepository();
+      const inAppIntegration = await integrationRepository.findOne({
+        _organizationId: session.organization._id,
+        _environmentId: createdEnv.result?.id!,
+        providerId: InAppProviderIdEnum.Novu,
+        channel: ChannelTypeEnum.IN_APP,
+      });
+
+      expect(inAppIntegration, 'in-app integration should be provisioned for the new environment').to.be.ok;
+      expect(
+        inAppIntegration?.credentials?.hmac,
+        'HMAC must default to true for non-dev environments to prevent inbox session HMAC fail-open'
+      ).to.equal(true);
     });
 
     [ApiServiceLevelEnum.PRO, ApiServiceLevelEnum.FREE].forEach((serviceLevel) => {

--- a/apps/api/src/app/environments-v1/usecases/create-environment/create-environment.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/create-environment/create-environment.usecase.ts
@@ -117,6 +117,7 @@ export class CreateEnvironment {
         organizationId: environment._organizationId,
         userId: command.userId,
         name: environment.name,
+        environmentType: environment.type,
       })
     );
 

--- a/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.command.ts
+++ b/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.command.ts
@@ -1,4 +1,4 @@
-import { ChannelTypeEnum, EnvironmentEnum } from '@novu/shared';
+import { ChannelTypeEnum, EnvironmentEnum, EnvironmentTypeEnum } from '@novu/shared';
 import { IsArray, IsEnum, IsOptional } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
@@ -9,4 +9,15 @@ export class CreateNovuIntegrationsCommand extends EnvironmentWithUserCommand {
   @IsArray()
   @IsEnum(ChannelTypeEnum, { each: true })
   readonly channels?: ChannelTypeEnum[];
+
+  /**
+   * Type of the environment the integrations are being created for. Used to decide
+   * secure-by-default behavior such as enabling HMAC on the in-app integration for
+   * non-dev (production) environments. Left optional for backwards compatibility –
+   * when omitted, the in-app integration falls back to the previous, less strict
+   * defaults (HMAC off), which is appropriate for ad-hoc/keyless flows.
+   */
+  @IsOptional()
+  @IsEnum(EnvironmentTypeEnum)
+  readonly environmentType?: EnvironmentTypeEnum;
 }

--- a/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.usecase.spec.ts
+++ b/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.usecase.spec.ts
@@ -1,0 +1,81 @@
+import { FeatureFlagsService } from '@novu/application-generic';
+import { IntegrationRepository } from '@novu/dal';
+import { ChannelTypeEnum, EnvironmentEnum, EnvironmentTypeEnum, InAppProviderIdEnum } from '@novu/shared';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { CreateIntegration } from '../create-integration/create-integration.usecase';
+import { SetIntegrationAsPrimary } from '../set-integration-as-primary/set-integration-as-primary.usecase';
+import { CreateNovuIntegrationsCommand } from './create-novu-integrations.command';
+import { CreateNovuIntegrations } from './create-novu-integrations.usecase';
+
+describe('CreateNovuIntegrations - in-app HMAC defaults', () => {
+  let useCase: CreateNovuIntegrations;
+  let createIntegration: sinon.SinonStubbedInstance<CreateIntegration>;
+  let integrationRepository: sinon.SinonStubbedInstance<IntegrationRepository>;
+  let setIntegrationAsPrimary: sinon.SinonStubbedInstance<SetIntegrationAsPrimary>;
+  let featureFlagsService: sinon.SinonStubbedInstance<FeatureFlagsService>;
+
+  const baseCommandFields = {
+    environmentId: 'env-id',
+    organizationId: 'org-id',
+    userId: 'user-id',
+    name: EnvironmentEnum.PRODUCTION,
+    channels: [ChannelTypeEnum.IN_APP],
+  } as const;
+
+  beforeEach(() => {
+    createIntegration = sinon.createStubInstance(CreateIntegration);
+    integrationRepository = sinon.createStubInstance(IntegrationRepository);
+    setIntegrationAsPrimary = sinon.createStubInstance(SetIntegrationAsPrimary);
+    featureFlagsService = sinon.createStubInstance(FeatureFlagsService);
+
+    integrationRepository.count.resolves(0);
+    featureFlagsService.getFlag.resolves(false);
+    createIntegration.execute.resolves({ _id: 'integration-id' } as any);
+
+    useCase = new CreateNovuIntegrations(
+      createIntegration as any,
+      integrationRepository as any,
+      setIntegrationAsPrimary as any,
+      featureFlagsService as any
+    );
+  });
+
+  it('should enable HMAC by default for the in-app integration when the environment is PROD', async () => {
+    await useCase.execute(
+      CreateNovuIntegrationsCommand.create({
+        ...baseCommandFields,
+        environmentType: EnvironmentTypeEnum.PROD,
+      })
+    );
+
+    expect(createIntegration.execute.calledOnce).to.equal(true);
+    const passedCommand = createIntegration.execute.firstCall.args[0];
+    expect(passedCommand.providerId).to.equal(InAppProviderIdEnum.Novu);
+    expect(passedCommand.channel).to.equal(ChannelTypeEnum.IN_APP);
+    expect(passedCommand.credentials).to.deep.equal({ hmac: true });
+  });
+
+  it('should NOT enable HMAC by default for the in-app integration when the environment is DEV', async () => {
+    await useCase.execute(
+      CreateNovuIntegrationsCommand.create({
+        ...baseCommandFields,
+        name: EnvironmentEnum.DEVELOPMENT,
+        environmentType: EnvironmentTypeEnum.DEV,
+      })
+    );
+
+    expect(createIntegration.execute.calledOnce).to.equal(true);
+    const passedCommand = createIntegration.execute.firstCall.args[0];
+    expect(passedCommand.credentials).to.equal(undefined);
+  });
+
+  it('should NOT enable HMAC when environmentType is omitted (keyless/legacy callers)', async () => {
+    await useCase.execute(CreateNovuIntegrationsCommand.create(baseCommandFields));
+
+    expect(createIntegration.execute.calledOnce).to.equal(true);
+    const passedCommand = createIntegration.execute.firstCall.args[0];
+    expect(passedCommand.credentials).to.equal(undefined);
+  });
+});

--- a/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.usecase.ts
@@ -7,6 +7,7 @@ import {
   ChatProviderIdEnum,
   EmailProviderIdEnum,
   EnvironmentEnum,
+  EnvironmentTypeEnum,
   FeatureFlagsKeysEnum,
   InAppProviderIdEnum,
 } from '@novu/shared';
@@ -79,6 +80,18 @@ export class CreateNovuIntegrations {
       });
 
       const name = isV2Enabled ? 'Novu Inbox' : 'Novu In-App';
+
+      /*
+       * Default the Inbox (in-app) integration to HMAC-enabled for any
+       * non-dev environment. This is a secure-by-default posture so that
+       * production Inbox deployments cannot be initialized for an arbitrary
+       * subscriberId without a valid `subscriberHash` (see NV-7593). Dev
+       * environments – and ad-hoc/keyless flows that do not pass an
+       * environment type – keep the previous HMAC-off default so local
+       * development remains friction-free.
+       */
+      const shouldEnableHmacByDefault = command.environmentType === EnvironmentTypeEnum.PROD;
+
       await this.createIntegration.execute(
         CreateIntegrationCommand.create({
           name,
@@ -89,6 +102,7 @@ export class CreateNovuIntegrations {
           userId: command.userId,
           environmentId: command.environmentId,
           organizationId: command.organizationId,
+          credentials: shouldEnableHmacByDefault ? { hmac: true } : undefined,
         })
       );
     }

--- a/apps/api/src/app/organization/usecases/create-organization/sync-external-organization/sync-external-organization.usecase.ts
+++ b/apps/api/src/app/organization/usecases/create-organization/sync-external-organization/sync-external-organization.usecase.ts
@@ -65,6 +65,7 @@ export class SyncExternalOrganization {
         organizationId: devEnv._organizationId,
         userId: command.userId,
         name: devEnv.name,
+        environmentType: devEnv.type,
       })
     );
 
@@ -101,6 +102,7 @@ export class SyncExternalOrganization {
         organizationId: prodEnv._organizationId,
         userId: command.userId,
         name: prodEnv.name,
+        environmentType: prodEnv.type,
       })
     );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Defaults the Novu Inbox (in-app) integration's `credentials.hmac` to **`true`** whenever it is auto-provisioned for a non-dev (production) environment — i.e. the `Production` environment auto-created for a brand new organization, and any custom production environment created via the environments API.

Dev environments and ad-hoc / keyless flows keep the previous HMAC-off default so local development stays friction-free.

This closes the easy attack surface on newly-provisioned production environments: knowing `applicationIdentifier` + `subscriberId` is no longer enough to mint an inbox JWT for an arbitrary subscriber, because the public `/v1/inbox/session` flow already enforces `subscriberHash` when `integration.credentials.hmac` is enabled.

> Note: existing production environments that were created before this change still keep their current (potentially HMAC-off) credentials — this PR only changes the default at *creation time*. A separate change / migration would be needed to retroactively flip the flag on existing production integrations, and the broader "fail-closed" hardening of `session.usecase.ts` is tracked under the parent ticket.

## Changes

- **`CreateNovuIntegrationsCommand`** – adds an optional `environmentType: EnvironmentTypeEnum` field so the use case knows whether the environment being provisioned is `dev` or `prod`.
- **`CreateNovuIntegrations.createInAppIntegration`** – when `environmentType === PROD`, passes `credentials: { hmac: true }` to `CreateIntegration`. Otherwise behavior is unchanged (HMAC off / undefined, which is the previous default).
- **`CreateEnvironment`** – forwards `environment.type` so the freshly-created environment's auto-provisioned in-app integration gets the right HMAC default.
- **`SyncExternalOrganization`** – same forwarding for the dev + prod envs that get bootstrapped when a new organization is synced from the external auth provider.
- **Inbox session flow / dashboard UI** – no changes required: `session.usecase.ts` already validates `subscriberHash` whenever the in-app integration has `credentials.hmac === true`, and the dashboard's integration settings already exposes the HMAC switch (the `Hmac` field is in `novuInAppConfig`).

## Acceptance criteria

- [x] Production environments require valid `subscriberHash` *for newly provisioned envs* (because the in-app integration is now created with `hmac: true` by default).
- [x] No-HMAC mode is explicit and dashboard-visible — the existing `Security HMAC encryption` switch on the Novu Inbox integration settings page lets users opt out for non-prod / debugging needs, and the flag is now disabled by default in production.
- [x] Regression test: creating a non-dev environment provisions an in-app integration with `credentials.hmac === true` (added e2e + unit tests).

## Tests

- **Unit (`apps/api/src/app/integrations/usecases/create-novu-integrations/create-novu-integrations.usecase.spec.ts`)** – covers three branches:
  - `environmentType: PROD` → in-app integration created with `credentials: { hmac: true }`
  - `environmentType: DEV` → no credentials override (HMAC stays off)
  - `environmentType` omitted (keyless / legacy callers) → no credentials override
- **E2E (`apps/api/src/app/environments-v1/e2e/environments.controller.e2e.ts`)** – creates a fresh non-dev env via the SDK and asserts the resulting Novu in-app integration has `credentials.hmac === true`.

Both pass locally:

```
CreateNovuIntegrations - in-app HMAC defaults
  ✔ should enable HMAC by default for the in-app integration when the environment is PROD
  ✔ should NOT enable HMAC by default for the in-app integration when the environment is DEV
  ✔ should NOT enable HMAC when environmentType is omitted (keyless/legacy callers)
3 passing

Env Controller > Create Env
  ✔ should default the in-app integration HMAC to ON for non-dev environments (NV-7593)
1 passing
```

The pre-existing `Update Env Protection` SDK response-validation failures in `environments.controller.e2e.ts` reproduce on `next` without this PR's changes and are unrelated.

## Risk

Low. The only behavioral change is the default value of `credentials.hmac` on newly-provisioned in-app integrations for production environments. Existing integrations are untouched; the inbox session flow already correctly handles `hmac: true`. Callers that need HMAC off in production (e.g. a customer mid-migration) can still toggle the switch from the dashboard's integration settings.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7593](https://linear.app/novu/issue/NV-7593/hmac-fail-open-inbox-session-can-mint-jwts-for-arbitrary-subscriberid)

<div><a href="https://cursor.com/agents/bc-176a8684-c5ed-4c2c-a640-0c41e0daad55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-176a8684-c5ed-4c2c-a640-0c41e0daad55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR changes the default HMAC credential for Novu's in-app (Inbox) integration from disabled to enabled when auto-provisioning integrations for production environments. By setting `credentials.hmac: true` at integration creation time for PROD environments only, newly-provisioned production environments gain protection against unauthorized JWT minting for arbitrary subscribers. Dev environments and legacy keyless flows preserve the previous non-HMAC default. Existing production integrations are unaffected.

## Affected areas

**api**: The integration creation flow now accepts an optional `environmentType` parameter and uses it to conditionally set HMAC=true for production Inbox integrations. Environment creation and organization sync were updated to pass the environment type when provisioning integrations, enabling secure-by-default behavior at creation time.

**tests**: Added unit test coverage for HMAC default behavior across PROD, DEV, and unspecified environment types, plus an e2e regression test verifying that newly-created non-dev environments auto-provision in-app integrations with HMAC enabled.

## Key technical decisions

- `environmentType` parameter added as optional to `CreateNovuIntegrationsCommand` to maintain backward compatibility with legacy keyless callers.
- HMAC defaults are applied only at integration creation time; the change does not modify existing production environments or integrate into existing dashboard/session flows.

## Testing

Unit tests cover the three branches of HMAC default behavior (PROD environment, DEV environment, and missing environmentType parameter). An e2e regression test verifies that creating a non-dev environment provisions an in-app integration with `credentials.hmac === true`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11121)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->