### PR TITLE
feat(dashboard): open conversation detail in side sheet from agent overview fixes NV-7545

### DIFF
--- a/apps/dashboard/src/components/agents/recent-conversations-section.tsx
+++ b/apps/dashboard/src/components/agents/recent-conversations-section.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { RiArrowRightLine, RiCheckboxCircleFill, RiRobot2Line } from 'react-icons/ri';
 import { Link } from 'react-router-dom';
 import type { AgentResponse } from '@/api/agents';
 import type { ConversationDto } from '@/api/conversations';
+import { ConversationDetailSheet } from '@/components/conversations/conversation-detail-sheet';
 import { ConversationStatusBadge } from '@/components/conversations/conversation-status-badge';
 import { ConversationsUpgradeCta } from '@/components/conversations/conversations-upgrade-cta';
 import { SubscriberFallbackAvatar } from '@/components/conversations/subscriber-fallback-avatar';
@@ -20,6 +22,7 @@ type RecentConversationsSectionProps = {
 
 export function RecentConversationsSection({ agent }: RecentConversationsSectionProps) {
   const { currentEnvironment } = useEnvironment();
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
 
   const conversationsPath = currentEnvironment?.slug
     ? buildRoute(ROUTES.ACTIVITY_CONVERSATIONS, { environmentSlug: currentEnvironment.slug })
@@ -44,18 +47,31 @@ export function RecentConversationsSection({ agent }: RecentConversationsSection
 
       <div className="bg-bg-white flex h-[300px] flex-col overflow-hidden rounded-md shadow-[0px_0px_0px_1px_rgba(25,28,33,0.04),0px_1px_2px_0px_rgba(25,28,33,0.06),0px_0px_2px_0px_rgba(0,0,0,0.08)]">
         {!IS_SELF_HOSTED || IS_ENTERPRISE ? (
-          <RecentConversationsContent agent={agent} />
+          <RecentConversationsContent agent={agent} onSelectConversation={setActiveConversationId} />
         ) : (
           <ConversationsUpgradeCta source="agent-overview" variant="compact" />
         )}
       </div>
+
+      <ConversationDetailSheet
+        conversationId={activeConversationId}
+        isOpen={Boolean(activeConversationId)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setActiveConversationId(null);
+          }
+        }}
+      />
     </div>
   );
 }
 
-function RecentConversationsContent({ agent }: { agent: AgentResponse }) {
-  const { currentEnvironment } = useEnvironment();
+type RecentConversationsContentProps = {
+  agent: AgentResponse;
+  onSelectConversation: (conversationId: string) => void;
+};
 
+function RecentConversationsContent({ agent, onSelectConversation }: RecentConversationsContentProps) {
   const { conversations, isLoading, isError } = useFetchConversations({
     limit: RECENT_CONVERSATIONS_DISPLAY_LIMIT,
     filters: { agentId: agent.identifier },
@@ -89,7 +105,7 @@ function RecentConversationsContent({ agent }: { agent: AgentResponse }) {
     <ul className="flex flex-1 flex-col divide-y divide-stroke-soft overflow-auto">
       {conversations.map((conversation) => (
         <li key={conversation._id}>
-          <RecentConversationItem conversation={conversation} environmentSlug={currentEnvironment?.slug} />
+          <RecentConversationItem conversation={conversation} onSelect={onSelectConversation} />
         </li>
       ))}
     </ul>
@@ -98,21 +114,26 @@ function RecentConversationsContent({ agent }: { agent: AgentResponse }) {
 
 type RecentConversationItemProps = {
   conversation: ConversationDto;
-  environmentSlug: string | undefined;
+  onSelect: (conversationId: string) => void;
 };
 
-function RecentConversationItem({ conversation, environmentSlug }: RecentConversationItemProps) {
+function RecentConversationItem({ conversation, onSelect }: RecentConversationItemProps) {
   const subscriber = getSubscriberLabel(conversation);
   const subscriberParticipant = (conversation.participants ?? []).find((p) => p.type === 'subscriber');
   const subscriberAvatar = subscriberParticipant?.subscriber?.avatar;
   const isFailed = conversation.status === 'failed';
 
-  const baseClassName = 'flex flex-col gap-1.5 px-3 py-2';
-  const interactiveClassName =
-    'group transition-colors hover:bg-neutral-50 focus-visible:bg-neutral-50 focus-visible:outline-none';
+  const handleSelect = () => onSelect(conversation.identifier);
 
-  const content = (
-    <>
+  return (
+    <button
+      type="button"
+      onClick={handleSelect}
+      className={cn(
+        'group flex w-full flex-col gap-1.5 px-3 py-2 text-left transition-colors',
+        'hover:bg-neutral-50 focus-visible:bg-neutral-50 focus-visible:outline-none'
+      )}
+    >
       <div className="flex items-center gap-8">
         <div className="flex min-w-0 flex-1 items-center gap-1">
           <RiCheckboxCircleFill
@@ -151,19 +172,7 @@ function RecentConversationItem({ conversation, environmentSlug }: RecentConvers
           <ConversationStatusBadge status={conversation.status} />
         </div>
       </div>
-    </>
-  );
-
-  if (!environmentSlug) {
-    return <div className={baseClassName}>{content}</div>;
-  }
-
-  const detailPath = `${buildRoute(ROUTES.ACTIVITY_CONVERSATIONS, { environmentSlug })}?conversationItemId=${encodeURIComponent(conversation.identifier)}`;
-
-  return (
-    <Link to={detailPath} className={cn(baseClassName, interactiveClassName)}>
-      {content}
-    </Link>
+    </button>
   );
 }
 

--- a/apps/dashboard/src/components/conversations/conversation-detail-sheet.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-detail-sheet.tsx
@@ -1,0 +1,28 @@
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/primitives/sheet';
+import { VisuallyHidden } from '@/components/primitives/visually-hidden';
+import { ConversationDetail } from './conversation-detail';
+
+type ConversationDetailSheetProps = {
+  conversationId: string | null;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function ConversationDetailSheet({ conversationId, isOpen, onOpenChange }: ConversationDetailSheetProps) {
+  return (
+    <Sheet open={isOpen} onOpenChange={onOpenChange}>
+      <SheetContent
+        className="bg-bg-weak flex w-full flex-col gap-0 p-0 sm:max-w-[640px] [&_[data-close-button]]:hidden"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <VisuallyHidden>
+          <SheetTitle>Conversation details</SheetTitle>
+          <SheetDescription>Details and timeline for the selected conversation.</SheetDescription>
+        </VisuallyHidden>
+        {conversationId ? (
+          <ConversationDetail conversationId={conversationId} onClose={() => onOpenChange(false)} />
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Replaces the redirect-to-activity-feed behavior on the **agent overview "Recent conversations"** list with an in-place side sheet that renders the same conversation detail UI.

Clicking a row no longer navigates the user away from the agent details page — instead the conversation overview, participants and timeline open as a right-side sheet. Closing the sheet keeps the user exactly where they were.

## Why

The agent conversation list is reused on multiple pages (e.g. agent overview's recent conversations). The current "click → navigate to activity feed" flow is jarring; the requirement is to open the detail panel seamlessly from where the row was clicked.

## How

- New reusable component `apps/dashboard/src/components/conversations/conversation-detail-sheet.tsx` — wraps the existing `ConversationDetail` inside the `Sheet` primitive, hides the duplicate built-in close button so only the conversation header's close X is shown.
- `apps/dashboard/src/components/agents/recent-conversations-section.tsx` — the row is now a `<button>` that sets local `activeConversationId` state instead of a `<Link>` that builds an `ACTIVITY_CONVERSATIONS` URL with `conversationItemId`. The "View all" affordance still navigates to the full activity feed view.
- No API, route, or query-key changes. Inline detail panel on the activity feed and the dispatch dashboard (which already opens detail in place via `ConversationsContent`) are unchanged.

## Scope

- Changes are limited to `apps/dashboard`. No package builds or schema migrations required.
- TypeScript + Biome both clean for the touched files.

## Walkthrough

End-to-end recording on `localhost:4201` showing: row click opens the sheet → close → click another row → close (URL unchanged throughout):

<a href="https://cursor.com/agents/bc-9495ab96-c061-4dbb-b650-5611f3e9b3d3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_overview_conversation_sheet_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-80d59c79-928c-4779-a491-81174cfd217e" alt="agent_overview_conversation_sheet_walkthrough.mp4" /></a>

Before clicking — agent overview with the "Recent conversations" list:

![Agent overview before click](https://cursor.com/artifacts/c/art-6ffbccfb-3ea5-492a-bbc2-3c3edb618445)

After clicking a row — conversation detail opens as a side sheet, agent overview remains in the background, URL unchanged:

![Conversation sheet open](https://cursor.com/artifacts/c/art-ef15f789-097d-46c0-9087-83c17fff6593)

Switching to a different row swaps the sheet content in place:

![Sheet with second conversation](https://cursor.com/artifacts/c/art-e41a7852-9710-4d6c-8b60-41e51d4dfef3)

After closing — back to the agent overview, no navigation occurred:

![Agent overview after close](https://cursor.com/artifacts/c/art-b5515b06-98a9-42c6-8044-5dae592c33f9)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7545](https://linear.app/novu/issue/NV-7545/allow-to-open-a-side-bar-on-conversation-click-instead-of-a-redirect)

<div><a href="https://cursor.com/agents/bc-9495ab96-c061-4dbb-b650-5611f3e9b3d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9495ab96-c061-4dbb-b650-5611f3e9b3d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Conversation detail viewing in the agent overview now uses an in-place right-side sheet instead of navigating away to the activity feed. A new reusable `ConversationDetailSheet` component wraps the existing `ConversationDetail` UI in a Sheet primitive. The recent conversations list changed from using navigational links to button-based selection with local state management, allowing users to view conversation details while staying on the agent details page.

## Affected areas

**dashboard**: The `RecentConversationsSection` component now manages active conversation state and renders a side sheet. A new reusable `ConversationDetailSheet` component wraps conversation details in a Sheet UI with proper accessibility markers and close button visibility rules.

## Key technical decisions

- Created a reusable `ConversationDetailSheet` component to encapsulate the Sheet + ConversationDetail pattern, enabling easy reuse across other dashboard areas.
- Kept the "View all" link functional for navigating to the full activity feed, maintaining user access to the complete conversation history.

## Testing

Manual GUI walkthrough verified the new behavior on localhost:4201. No new unit or e2e tests were added; this change involves only component composition and state management without introducing new business logic or API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11123)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->