### PR TITLE
ci(root): date-based Linear release names for cloud staging/prod fixes NV-7663

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -551,6 +551,11 @@ jobs:
   linear_release_cloud:
     # Cloud uses two continuous Linear pipelines: staging and production.
     # Each successful deploy syncs a completed release to the matching pipeline.
+    #
+    # The release `name` is date-based (`YYYY-MM-DD HH:MM UTC · <environment>`),
+    # so releases are easy to scan in the Linear UI. The commit SHA is preserved
+    # on the release via the `version` field (the Linear Release Action has no
+    # `description` input — see https://github.com/linear/linear-release-action).
     name: Linear Release (Cloud)
     needs: [deploy, prepare-matrix]
     runs-on: ubuntu-latest
@@ -570,6 +575,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Compute date-based release name
+        id: release_meta
+        env:
+          DEPLOY_ENVIRONMENT: ${{ github.event.inputs.environment }}
+        run: |
+          release_name="$(date -u +'%Y-%m-%d %H:%M UTC') · ${DEPLOY_ENVIRONMENT}"
+          echo "name=${release_name}" >> "$GITHUB_OUTPUT"
+
       - name: Sync staging release to Linear
         if: |
           github.event.inputs.environment == 'staging' ||
@@ -577,6 +590,7 @@ jobs:
         uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_CLOUD_STAGING }}
+          name: ${{ steps.release_meta.outputs.name }}
           version: ${{ github.sha }}
 
       - name: Sync production release to Linear
@@ -584,4 +598,5 @@ jobs:
         uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b  # pinned v0 ref
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_CLOUD_PROD }}
+          name: ${{ steps.release_meta.outputs.name }}
           version: ${{ github.sha }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The Linear Release (Cloud) workflow job in `.github/workflows/deploy.yml` was updated to generate date-based release names in UTC timestamp format (`YYYY-MM-DD HH:MM UTC · <environment>`) instead of using the commit SHA. A new step computes this name dynamically and passes it to both staging and production Linear release syncs, while the commit SHA is retained as the version field for tracking purposes.

## Affected areas
**CI/CD (GitHub Actions)**: Updated the `linear_release_cloud` job to compute and apply date-based release names for cloud staging and production deployments, improving release identification in Linear without affecting self-hosted pipeline naming conventions.

## Testing
No tests required. This is a workflow configuration change that affects CI/CD release naming only. The existing CI/CD pipeline execution serves as the verification mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11127)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The Linear release pipelines for cloud **staging** and **production** were passing `version: ${{ github.sha }}` to `linear/linear-release-action` without an explicit `name`, so the full commit hash surfaced as the release name in the Linear UI. Long SHAs are hard to scan when browsing recent releases.

This PR makes the `linear_release_cloud` job in `.github/workflows/deploy.yml`:

- Compute a date-based release name (`YYYY-MM-DD HH:MM UTC · <environment>`) — readable, sortable, and self-describing across the staging/staging-sg and per-region production deploys that share each Linear pipeline.
- Pass that string as `name:` to both the staging and production sync steps.
- Keep `version: ${{ github.sha }}` so the commit hash is still attached to each release as the version identifier.

A few examples of the resulting release names in Linear:

- `2026-05-14 09:30 UTC · staging`
- `2026-05-14 09:31 UTC · staging-sg`
- `2026-05-14 12:05 UTC · production-us`
- `2026-05-14 12:05 UTC · production-us-and-eu`

### Notes on the hash

The original task mentioned writing the hash "in the description if possible." The [`linear/linear-release-action`](https://github.com/linear/linear-release-action) does not expose a `description` input (and the CLI it wraps has no `--description` flag either — see [the README inputs table](https://github.com/linear/linear-release-action#inputs)). The pipeline access keys are scoped to their pipelines, not the general Linear GraphQL API, so updating the description via an extra step is not a guaranteed path.

The cleanest hash-preserving alternative — and what this PR does — is to keep the SHA on the release as the `version` field. Linear surfaces the version next to the name in the release list, so the hash is still discoverable; it just stops being the headline label.

### Screenshots

N/A — CI-only change.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- Only the cloud release pipelines change. The self-hosted Community/Enterprise pipelines (`linear-release-community.yml`, `linear-release-enterprise.yml`, `prepare-self-hosted-release.yml`, `prepare-enterprise-self-hosted-release.yml`) already use semver-style names (`v1.2.3`) and are not touched.
- `actionlint` reports no new errors on `.github/workflows/deploy.yml` (the single pre-existing warning about the top-level `description:` key is unrelated to this diff).
- The `name` is a label — it is not used by the action for targeting. Targeting is keyed off `version`, so multiple deploys at the same minute are still safely deduplicated by SHA.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3a22d19-ced7-4aea-9b6c-ed4c41086ab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3a22d19-ced7-4aea-9b6c-ed4c41086ab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

