### PR TITLE
fix(api-service): return empty credentials object on list integrations instead of omitting the field fixes NV-7664

### DIFF
--- a/apps/api/src/app/integrations/e2e/api-key-credentials-exposure.e2e.ts
+++ b/apps/api/src/app/integrations/e2e/api-key-credentials-exposure.e2e.ts
@@ -21,14 +21,17 @@ describe('Integration credentials exposure to API-key auth - /integrations #novu
   });
 
   describe('GET /v1/integrations', () => {
-    it('should not return credentials when authenticated with an API key', async () => {
+    it('should return an empty credentials object when authenticated with an API key', async () => {
       const { body } = await session.testAgent
         .get('/v1/integrations')
         .set('authorization', `ApiKey ${session.apiKey}`);
 
       expect(body.data.length).to.be.greaterThan(0);
       for (const integration of body.data) {
-        expect(integration).to.not.have.property('credentials');
+        // Older `@novu/api` SDKs declare `credentials` as a required object in
+        // their zod schema. Returning `{}` keeps those clients working without
+        // exposing any actual credential values to API-key callers.
+        expect(integration.credentials).to.deep.equal({});
       }
     });
 
@@ -49,14 +52,14 @@ describe('Integration credentials exposure to API-key auth - /integrations #novu
   });
 
   describe('GET /v1/integrations/active', () => {
-    it('should not return credentials when authenticated with an API key', async () => {
+    it('should return an empty credentials object when authenticated with an API key', async () => {
       const { body } = await session.testAgent
         .get('/v1/integrations/active')
         .set('authorization', `ApiKey ${session.apiKey}`);
 
       expect(body.data.length).to.be.greaterThan(0);
       for (const integration of body.data) {
-        expect(integration).to.not.have.property('credentials');
+        expect(integration.credentials).to.deep.equal({});
       }
     });
 

--- a/libs/application-generic/src/usecases/get-decrypted-integrations/get-decrypted-integrations.usecase.ts
+++ b/libs/application-generic/src/usecases/get-decrypted-integrations/get-decrypted-integrations.usecase.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { IntegrationEntity, IntegrationRepository } from '@novu/dal';
+import { ICredentialsEntity, IntegrationEntity, IntegrationRepository } from '@novu/dal';
 
 import { decryptCredentials } from '../../encryption';
 import { GetDecryptedIntegrationsCommand } from './get-decrypted-integrations.command';
@@ -37,10 +37,15 @@ export class GetDecryptedIntegrations {
       .filter((integration) => integration)
       .map((integration: IntegrationEntity) => {
         if (command.returnCredentials === false) {
-          // Don't include credentials
-          const { credentials, ...integrationWithoutCredentials } = integration;
-
-          return integrationWithoutCredentials as IntegrationEntity;
+          /*
+           * Return an empty `credentials` object instead of omitting the field.
+           * Older `@novu/api` SDK versions (e.g. 3.15.0) declare `credentials` as a
+           * required object in their zod schema, so omitting it causes response
+           * validation to fail. An empty object preserves the same effective
+           * "no credentials" semantics while keeping previously released
+           * SDK clients working.
+           */
+          return { ...integration, credentials: {} as ICredentialsEntity };
         }
 
         return GetDecryptedIntegrations.getDecryptedCredentials(integration);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

When listing integrations via API key auth, the `GetDecryptedIntegrations` use case used to strip the `credentials` field entirely from each `IntegrationEntity`. This change returns an empty `{}` instead.

## Why

Already-released `@novu/api` SDK versions (e.g. **3.15.0**) declare `credentials` as a **required** object in their generated zod response schema:

```ts
credentials: CredentialsDto$inboundSchema,   // <-- required
```

When the API omits this field for API-key callers, the SDK fails with:

```
ZodError: { code: 'invalid_type', expected: 'object', received: 'undefined', path: [...], message: 'Required' }
    at safeParseResponse (.../@novu/api/src/lib/matchers.ts:303:42)
    at $do (.../@novu/api/src/funcs/integrationsList.ts:185:20)
```

(One issue per integration in the response array — three integrations → three issues.)

## Fix

Return `credentials: {}` instead of removing the field. This:
- Keeps the same effective behavior — **no secret values are exposed** to API-key callers.
- Restores compatibility with already-published SDK clients (`@novu/api@3.x`).
- Affects both `GET /v1/integrations` and `GET /v1/integrations/active` (both flow through `GetDecryptedIntegrations`).

## Tests

Updated `apps/api/src/app/integrations/e2e/api-key-credentials-exposure.e2e.ts` so that the API-key list assertions now expect `credentials` to deep-equal `{}` instead of asserting that the property is absent.

```
Integration credentials exposure to API-key auth - /integrations #novu-v2
  GET /v1/integrations
    ✔ should return an empty credentials object when authenticated with an API key
    ✔ should still return decrypted credentials when authenticated via session token
  GET /v1/integrations/active
    ✔ should return an empty credentials object when authenticated with an API key
    ✔ should still return decrypted credentials when authenticated via session token
  ...
10 passing
```

The full integrations e2e suite (94 tests) also passes.

## Scope notes

The single-integration endpoints (`POST /v1/integrations`, `PUT /v1/integrations/:id`, `POST /v1/integrations/:id/set-primary`) still strip the `credentials` field at the controller layer. They have the same vulnerability with the published SDK schema, but were intentionally left out of this PR per the request to fix list integrations only. They can be addressed in a follow-up if needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06GS20SPE0/p1778751915755239?thread_ts=1778751915.755239&cid=C06GS20SPE0)

<div><a href="https://cursor.com/agents/bc-2f88dbfd-4ac5-5150-bd19-4375126bf4c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f88dbfd-4ac5-5150-bd19-4375126bf4c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The integrations list endpoints (`GET /v1/integrations` and `GET /v1/integrations/active`) now return `credentials: {}` for API-key authenticated requests instead of omitting the field entirely. This preserves SDK compatibility with published versions that declare `credentials` as a required object, while ensuring no decrypted secrets are exposed to API-key callers.

## Affected areas

**api**: Updated the `GetDecryptedIntegrations` use case to return an empty credentials object when `returnCredentials === false`, rather than removing the field. For session-token authenticated requests, decrypted provider credentials are still returned as before.

**application-generic**: Modified the use case to conditionally set `credentials` to an empty object (cast as `ICredentialsEntity`) when credentials should not be returned, instead of stripping the field.

**api (e2e tests)**: Updated integration e2e tests to assert that `credentials` equals `{}` for API-key callers, while session-token tests continue to assert decrypted credentials are present.

## Key technical decisions

- Returning an empty object rather than omitting the field maintains the API contract expected by published SDK versions that use Zod validation.
- Single-integration endpoints (`POST`, `PUT /integrations/:id`, `POST /integrations/:id/set-primary`) intentionally remain unchanged; they continue to strip `credentials` at the controller layer and may be addressed in a follow-up.

## Testing

E2e regression tests were updated to verify that API-key callers receive `credentials: {}` while maintaining no secret exposure, and that session-token callers continue to receive decrypted credentials. The full integrations e2e suite (94 tests) passes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11128)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->