### PR TITLE
chore(root): add pnpm options to .npmrc-cloud fixes NV-7670

### DIFF
--- a/.npmrc-cloud
+++ b/.npmrc-cloud
@@ -1,3 +1,5 @@
+auto-install-peers=true
+strict-peer-dependencies=false
 @taskforcesh:registry=https://npm.taskforce.sh/
 //npm.taskforce.sh/:_authToken=${BULL_MQ_PRO_NPM_TOKEN}
 always-auth=true


### PR DESCRIPTION
## Summary

- Add `auto-install-peers=true` and `strict-peer-dependencies=false` to `.npmrc-cloud` so cloud installs behave the same as the local `.npmrc`.
- Follow-up to the pnpm v11 migration (NV-7625) — the cloud `.npmrc` was missing the two pnpm options that control peer dependency behavior.

## Change

```diff
+auto-install-peers=true
+strict-peer-dependencies=false
 @taskforcesh:registry=https://npm.taskforce.sh/
 //npm.taskforce.sh/:_authToken=${BULL_MQ_PRO_NPM_TOKEN}
 always-auth=true
```

## Test plan

- [ ] CI install on `next` succeeds with the cloud `.npmrc` settings
- [ ] Peer dependency resolution matches local `.npmrc` behavior

Fixes NV-7670

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Added two pnpm configuration options to `.npmrc-cloud`: `auto-install-peers=true` and `strict-peer-dependencies=false`. These options were included in the local `.npmrc` but were missing from the cloud-specific configuration after the pnpm v11 migration. This ensures consistent peer dependency resolution behavior across both local and cloud environments.

## Affected areas

**root**: Updated `.npmrc-cloud` to synchronize pnpm options with local configuration, restoring automatic peer dependency installation and disabling strict peer dependency enforcement for cloud builds.

## Testing

CI install verification on the `next` branch should confirm that the cloud `.npmrc` settings allow successful peer dependency resolution matching local behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11137)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->