### PR TITLE
feat(api-service,dashboard): default agent outbound email to env primary integration fixes NV-7685

### DIFF
--- a/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
@@ -644,13 +644,26 @@ describe('ChatSdkService', () => {
       messageId: '<mid@example.com>',
     };
 
+    const demoIntegration = {
+      _id: 'novu-demo-id',
+      _environmentId: 'env-id',
+      _organizationId: 'org-id',
+      providerId: EmailProviderIdEnum.Novu,
+      channel: ChannelTypeEnum.EMAIL,
+      name: 'Novu Email',
+      identifier: 'novu-email-demo',
+      active: true,
+      primary: true,
+      credentials: {},
+    };
+
     it('throws when Novu demo email credentials are not configured', async () => {
       delete process.env.NOVU_EMAIL_INTEGRATION_API_KEY;
       const messageCreate = sinon.stub().resolves({ _id: 'msg-1' });
       const service = makeSendViaService({ messageCreate });
 
       try {
-        await (service as any).sendViaNovuDemoProvider(demoConfig, demoParams);
+        await (service as any).sendViaNovuDemoProvider(demoConfig, demoParams, demoIntegration);
         throw new Error('Expected sendViaNovuDemoProvider to throw');
       } catch (err) {
         expect(err).to.be.instanceOf(BadRequestException);
@@ -665,7 +678,7 @@ describe('ChatSdkService', () => {
       const sendStub = sinon.stub().resolves({ id: 'sg-123' });
       sinon.stub(MailFactory.prototype, 'getHandler').returns({ send: sendStub });
 
-      const result = await (service as any).sendViaNovuDemoProvider(demoConfig, demoParams);
+      const result = await (service as any).sendViaNovuDemoProvider(demoConfig, demoParams, demoIntegration);
 
       expect(result).to.deep.equal({ messageId: 'sg-123' });
       expect(sendStub.calledOnce).to.equal(true);
@@ -690,7 +703,7 @@ describe('ChatSdkService', () => {
       const service = makeSendViaService({ calculateLimit, messageCreate });
 
       try {
-        await (service as any).sendViaNovuDemoProvider(demoConfig, demoParams);
+        await (service as any).sendViaNovuDemoProvider(demoConfig, demoParams, demoIntegration);
         throw new Error('Expected sendViaNovuDemoProvider to throw');
       } catch (err) {
         expect(err).to.be.instanceOf(BadRequestException);

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -939,31 +939,10 @@ export class ChatSdkService implements OnModuleDestroy {
     messageId?: string;
   }) => Promise<{ messageId?: string }> {
     return async (params) => {
-      // No user-attached outbound provider: fall back to the Novu demo sender on the
-      // shared agent inbox domain. Cloud-only - self-hosted keeps the legacy "must
-      // configure outbound" error to preserve existing behavior. The demo sender
-      // *requires* a usable shared inbox to round-trip replies, so we also refuse
-      // when the user has explicitly disabled the shared inbox for this agent.
       if (!outboundIntegrationId) {
-        if (
-          !isAgentSharedInboxEnabled() ||
-          !config.credentials.emailSlugPrefix ||
-          !config.credentials.inboxRoutingKey
-        ) {
-          throw new BadRequestException(
-            'Email agent integration requires an outbound email provider (outboundIntegrationId). ' +
-              'Configure one in the agent email setup.'
-          );
-        }
-
-        if (config.credentials.sharedInboxDisabled) {
-          throw new BadRequestException(
-            'The Novu demo sender requires the shared inbox to be enabled. ' +
-              'Re-enable it or attach an outbound email provider.'
-          );
-        }
-
-        return this.sendViaNovuDemoProvider(config, params);
+        throw new BadRequestException(
+          'Email agent integration is missing outboundIntegrationId. Reconfigure the agent email setup.'
+        );
       }
 
       const integration = await this.integrationRepository.findOne({
@@ -989,6 +968,10 @@ export class ChatSdkService implements OnModuleDestroy {
         throw new BadRequestException(
           `Outbound email integration ${outboundIntegrationId} (${integration.providerId}) is inactive`
         );
+      }
+
+      if (integration.providerId === EmailProviderIdEnum.Novu) {
+        return this.sendViaNovuDemoProvider(config, params, integration);
       }
 
       const hasUnsupportedAlternatives =
@@ -1096,10 +1079,16 @@ export class ChatSdkService implements OnModuleDestroy {
   }
 
   /**
-   * Outbound demo path: no user-attached email provider is configured. We
-   * send via the Novu demo provider with `From = {slug}-{agentId}@<shared-domain>`
-   * so replies route back to the same inbox. Quota-gated by the same
-   * per-environment 300/month cap as workflow notification emails.
+   * Outbound demo path: the agent is wired to the bundled Novu Email demo
+   * provider row. We override the integration's stored credentials with the
+   * cloud demo API key (`NOVU_EMAIL_INTEGRATION_API_KEY`) and force `From` to
+   * `{slug}-{inboxRoutingKey}@<shared-domain>` so replies route back to the
+   * same inbox. Quota-gated by the same per-environment 300/month cap as
+   * workflow notification emails.
+   *
+   * Refuses to send when the shared inbox prerequisites aren't met because
+   * the demo path can't recover a Reply-To without it — at that point the
+   * user must attach a real outbound email provider.
    */
   private async sendViaNovuDemoProvider(
     config: ResolvedAgentConfig,
@@ -1113,8 +1102,23 @@ export class ChatSdkService implements OnModuleDestroy {
       inReplyTo?: string;
       references?: string;
       messageId?: string;
-    }
+    },
+    integration: IntegrationEntity
   ): Promise<{ messageId?: string }> {
+    if (!isAgentSharedInboxEnabled() || !config.credentials.emailSlugPrefix || !config.credentials.inboxRoutingKey) {
+      throw new BadRequestException(
+        'Email agent integration requires either a shared agent inbox or a custom outbound email provider. ' +
+          'Configure one in the agent email setup.'
+      );
+    }
+
+    if (config.credentials.sharedInboxDisabled) {
+      throw new BadRequestException(
+        'The Novu demo sender requires the shared inbox to be enabled. ' +
+          'Re-enable it or attach an outbound email provider.'
+      );
+    }
+
     const limit = await this.calculateLimitNovuIntegration.execute({
       channelType: ChannelTypeEnum.EMAIL,
       environmentId: config.environmentId,
@@ -1132,34 +1136,24 @@ export class ChatSdkService implements OnModuleDestroy {
       );
     }
 
-    const from = buildAgentSharedInbox(config.credentials.emailSlugPrefix!, config.credentials.inboxRoutingKey!);
+    const from = buildAgentSharedInbox(config.credentials.emailSlugPrefix, config.credentials.inboxRoutingKey);
 
-    const syntheticId = `synthetic-${config.environmentId}`;
-
-    const syntheticIntegration: IntegrationEntity = {
-      _id: syntheticId,
-      _environmentId: config.environmentId,
-      _organizationId: config.organizationId,
-      providerId: EmailProviderIdEnum.Novu,
-      channel: ChannelTypeEnum.EMAIL,
-      name: 'Novu Email (demo)',
-      identifier: syntheticId,
-      active: true,
-      primary: false,
+    // The Novu demo integration row's stored credentials are empty by design —
+    // the real API key lives in the deployment's env so a single Novu-managed
+    // SendGrid account fans out across every org's demo sender. We rebuild
+    // credentials on every send rather than mutating the row.
+    const demoIntegration: IntegrationEntity = {
+      ...integration,
       credentials: {
         apiKey: process.env.NOVU_EMAIL_INTEGRATION_API_KEY,
         from,
         senderName: config.credentials.senderName || 'Novu',
         ipPoolName: 'Demo',
       },
-      configurations: {},
-      deleted: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    } as unknown as IntegrationEntity;
+    };
 
     const mailFactory = new MailFactory();
-    const handler = mailFactory.getHandler(syntheticIntegration, from);
+    const handler = mailFactory.getHandler(demoIntegration, from);
 
     const mailOptions: IEmailOptions = {
       to: [params.to],

--- a/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.spec.ts
+++ b/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.spec.ts
@@ -1,3 +1,4 @@
+import { ConflictException } from '@nestjs/common';
 import type { AgentEntity, IntegrationEntity } from '@novu/dal';
 import { ApiServiceLevelEnum, ChannelTypeEnum, EmailProviderIdEnum, NOVU_PROVIDERS } from '@novu/shared';
 import { expect } from 'chai';
@@ -115,7 +116,6 @@ describe('FindOrCreateNovuEmail usecase', () => {
 
       // First findOne: lookup of the primary custom email integration.
       integrationRepo.findOne.onFirstCall().resolves(primaryCustomIntegration);
-      // Second findOne: NovuAgent integration creation succeeds.
       integrationRepo.create.resolves({
         _id: 'novu-agent-int-id',
         providerId: EmailProviderIdEnum.NovuAgent,
@@ -128,13 +128,13 @@ describe('FindOrCreateNovuEmail usecase', () => {
 
       await buildUsecase().execute(AGENT_ID, ENV_ID, ORG_ID);
 
-      const lookupQuery = integrationRepo.findOne.firstCall.args[0];
-      expect(lookupQuery._environmentId).to.equal(ENV_ID);
-      expect(lookupQuery._organizationId).to.equal(ORG_ID);
-      expect(lookupQuery.channel).to.equal(ChannelTypeEnum.EMAIL);
-      expect(lookupQuery.active).to.equal(true);
-      expect(lookupQuery.primary).to.equal(true);
-      expect(lookupQuery.providerId).to.deep.equal({ $nin: NOVU_PROVIDERS });
+      const primaryQuery = integrationRepo.findOne.firstCall.args[0];
+      expect(primaryQuery._environmentId).to.equal(ENV_ID);
+      expect(primaryQuery._organizationId).to.equal(ORG_ID);
+      expect(primaryQuery.channel).to.equal(ChannelTypeEnum.EMAIL);
+      expect(primaryQuery.active).to.equal(true);
+      expect(primaryQuery.primary).to.equal(true);
+      expect(primaryQuery.providerId).to.deep.equal({ $nin: NOVU_PROVIDERS });
 
       expect(integrationRepo.create.calledOnce).to.equal(true);
       const createArg = integrationRepo.create.firstCall.args[0];
@@ -144,8 +144,19 @@ describe('FindOrCreateNovuEmail usecase', () => {
       expect(createArg.credentials.inboxRoutingKey).to.be.a('string');
     });
 
-    it('omits outboundIntegrationId when no active primary custom email integration exists, falling back to the demo sender at send-time', async () => {
+    it("falls back to the env's Novu demo email integration when no primary custom integration exists", async () => {
+      const novuDemoIntegration = {
+        _id: 'novu-demo-id',
+        providerId: EmailProviderIdEnum.Novu,
+        channel: ChannelTypeEnum.EMAIL,
+        active: true,
+        primary: true,
+      } as IntegrationEntity;
+
+      // First findOne: no primary custom email integration.
       integrationRepo.findOne.onFirstCall().resolves(null);
+      // Second findOne: Novu demo integration exists.
+      integrationRepo.findOne.onSecondCall().resolves(novuDemoIntegration);
       integrationRepo.create.resolves({
         _id: 'novu-agent-int-id',
         providerId: EmailProviderIdEnum.NovuAgent,
@@ -158,8 +169,26 @@ describe('FindOrCreateNovuEmail usecase', () => {
 
       await buildUsecase().execute(AGENT_ID, ENV_ID, ORG_ID);
 
+      const demoQuery = integrationRepo.findOne.secondCall.args[0];
+      expect(demoQuery.providerId).to.equal(EmailProviderIdEnum.Novu);
+      expect(demoQuery.active).to.equal(true);
+
       const createArg = integrationRepo.create.firstCall.args[0];
-      expect(createArg.credentials).to.not.have.property('outboundIntegrationId');
+      expect(createArg.credentials.outboundIntegrationId).to.equal('novu-demo-id');
+    });
+
+    it('throws when neither a primary custom integration nor a Novu demo integration is available', async () => {
+      integrationRepo.findOne.onFirstCall().resolves(null);
+      integrationRepo.findOne.onSecondCall().resolves(null);
+
+      try {
+        await buildUsecase().execute(AGENT_ID, ENV_ID, ORG_ID);
+        throw new Error('Expected ConflictException');
+      } catch (err) {
+        expect(err).to.be.instanceOf(ConflictException);
+      }
+
+      expect(integrationRepo.create.called).to.equal(false);
     });
 
     it('does not lookup or change outboundIntegrationId when an existing NovuAgent link is returned', async () => {
@@ -193,7 +222,7 @@ describe('FindOrCreateNovuEmail usecase', () => {
 
       expect(result.provisionedNewLink).to.equal(false);
       expect(integrationRepo.create.called).to.equal(false);
-      // Only the existing-link lookup happens; we never query for the primary custom integration.
+      // Only the existing-link lookup happens; we never query for the default outbound integration.
       expect(integrationRepo.findOne.calledOnce).to.equal(true);
     });
   });

--- a/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.spec.ts
+++ b/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.spec.ts
@@ -1,0 +1,200 @@
+import type { AgentEntity, IntegrationEntity } from '@novu/dal';
+import { ApiServiceLevelEnum, ChannelTypeEnum, EmailProviderIdEnum, NOVU_PROVIDERS } from '@novu/shared';
+import { expect } from 'chai';
+import { restore, stub } from 'sinon';
+
+import { FindOrCreateNovuEmail } from './find-or-create-novu-email.usecase';
+
+const ENV_ID = 'env-id';
+const ORG_ID = 'org-id';
+const AGENT_ID = 'agent-id';
+
+function makeAgent(overrides: Partial<AgentEntity> = {}): AgentEntity {
+  return {
+    _id: AGENT_ID,
+    name: 'My Agent',
+    identifier: 'my-agent',
+    description: '',
+    behavior: undefined,
+    active: true,
+    _environmentId: ENV_ID,
+    _organizationId: ORG_ID,
+    ...overrides,
+  } as AgentEntity;
+}
+
+describe('FindOrCreateNovuEmail usecase', () => {
+  let integrationRepo: {
+    find: sinon.SinonStub;
+    findOne: sinon.SinonStub;
+    create: sinon.SinonStub;
+  };
+  let agentIntegrationRepo: {
+    find: sinon.SinonStub;
+    findOne: sinon.SinonStub;
+    create: sinon.SinonStub;
+    withTransaction: sinon.SinonStub;
+  };
+  let organizationRepo: {
+    findById: sinon.SinonStub;
+  };
+  let agentRepo: {
+    findOne: sinon.SinonStub;
+  };
+
+  let savedNovuEnterprise: string | undefined;
+  let savedSelfHosted: string | undefined;
+  let savedSharedDomain: string | undefined;
+
+  function buildUsecase() {
+    return new FindOrCreateNovuEmail(
+      integrationRepo as any,
+      agentIntegrationRepo as any,
+      organizationRepo as any,
+      agentRepo as any
+    );
+  }
+
+  beforeEach(() => {
+    savedNovuEnterprise = process.env.NOVU_ENTERPRISE;
+    savedSelfHosted = process.env.IS_SELF_HOSTED;
+    savedSharedDomain = process.env.NOVU_AGENT_SHARED_INBOUND_DOMAIN;
+
+    process.env.NOVU_ENTERPRISE = 'true';
+    delete process.env.IS_SELF_HOSTED;
+    process.env.NOVU_AGENT_SHARED_INBOUND_DOMAIN = 'agentconnect.sh';
+
+    integrationRepo = {
+      find: stub().resolves([]),
+      findOne: stub(),
+      create: stub(),
+    };
+    agentIntegrationRepo = {
+      find: stub().resolves([]),
+      findOne: stub().resolves(null),
+      create: stub().resolves({
+        _id: 'link-id',
+        _agentId: AGENT_ID,
+        _integrationId: 'novu-agent-int-id',
+        _environmentId: ENV_ID,
+        _organizationId: ORG_ID,
+        connectedAt: null,
+      }),
+      withTransaction: stub().callsFake(async (fn: (session: null) => Promise<unknown>) => fn(null)),
+    };
+    organizationRepo = {
+      findById: stub().resolves({ apiServiceLevel: ApiServiceLevelEnum.BUSINESS }),
+    };
+    agentRepo = {
+      findOne: stub().resolves(makeAgent()),
+    };
+  });
+
+  afterEach(() => {
+    if (savedNovuEnterprise === undefined) delete process.env.NOVU_ENTERPRISE;
+    else process.env.NOVU_ENTERPRISE = savedNovuEnterprise;
+
+    if (savedSelfHosted === undefined) delete process.env.IS_SELF_HOSTED;
+    else process.env.IS_SELF_HOSTED = savedSelfHosted;
+
+    if (savedSharedDomain === undefined) delete process.env.NOVU_AGENT_SHARED_INBOUND_DOMAIN;
+    else process.env.NOVU_AGENT_SHARED_INBOUND_DOMAIN = savedSharedDomain;
+
+    restore();
+  });
+
+  describe('outbound integration default', () => {
+    it("uses the env's active primary custom email integration as the default outboundIntegrationId on first provision", async () => {
+      const primaryCustomIntegration = {
+        _id: 'sendgrid-id',
+        providerId: 'sendgrid',
+        channel: ChannelTypeEnum.EMAIL,
+        active: true,
+        primary: true,
+      } as IntegrationEntity;
+
+      // First findOne: lookup of the primary custom email integration.
+      integrationRepo.findOne.onFirstCall().resolves(primaryCustomIntegration);
+      // Second findOne: NovuAgent integration creation succeeds.
+      integrationRepo.create.resolves({
+        _id: 'novu-agent-int-id',
+        providerId: EmailProviderIdEnum.NovuAgent,
+        channel: ChannelTypeEnum.EMAIL,
+        identifier: 'novu-email-xxx',
+        name: 'Novu Email',
+        active: true,
+        credentials: {},
+      });
+
+      await buildUsecase().execute(AGENT_ID, ENV_ID, ORG_ID);
+
+      const lookupQuery = integrationRepo.findOne.firstCall.args[0];
+      expect(lookupQuery._environmentId).to.equal(ENV_ID);
+      expect(lookupQuery._organizationId).to.equal(ORG_ID);
+      expect(lookupQuery.channel).to.equal(ChannelTypeEnum.EMAIL);
+      expect(lookupQuery.active).to.equal(true);
+      expect(lookupQuery.primary).to.equal(true);
+      expect(lookupQuery.providerId).to.deep.equal({ $nin: NOVU_PROVIDERS });
+
+      expect(integrationRepo.create.calledOnce).to.equal(true);
+      const createArg = integrationRepo.create.firstCall.args[0];
+      expect(createArg.providerId).to.equal(EmailProviderIdEnum.NovuAgent);
+      expect(createArg.credentials.outboundIntegrationId).to.equal('sendgrid-id');
+      expect(createArg.credentials.emailSlugPrefix).to.be.a('string');
+      expect(createArg.credentials.inboxRoutingKey).to.be.a('string');
+    });
+
+    it('omits outboundIntegrationId when no active primary custom email integration exists, falling back to the demo sender at send-time', async () => {
+      integrationRepo.findOne.onFirstCall().resolves(null);
+      integrationRepo.create.resolves({
+        _id: 'novu-agent-int-id',
+        providerId: EmailProviderIdEnum.NovuAgent,
+        channel: ChannelTypeEnum.EMAIL,
+        identifier: 'novu-email-xxx',
+        name: 'Novu Email',
+        active: true,
+        credentials: {},
+      });
+
+      await buildUsecase().execute(AGENT_ID, ENV_ID, ORG_ID);
+
+      const createArg = integrationRepo.create.firstCall.args[0];
+      expect(createArg.credentials).to.not.have.property('outboundIntegrationId');
+    });
+
+    it('does not lookup or change outboundIntegrationId when an existing NovuAgent link is returned', async () => {
+      const existingLink = {
+        _id: 'link-id',
+        _agentId: AGENT_ID,
+        _integrationId: 'existing-novu-agent-int-id',
+        _environmentId: ENV_ID,
+        _organizationId: ORG_ID,
+        connectedAt: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      const existingNovuAgentIntegration = {
+        _id: 'existing-novu-agent-int-id',
+        providerId: EmailProviderIdEnum.NovuAgent,
+        channel: ChannelTypeEnum.EMAIL,
+        identifier: 'novu-email-existing',
+        name: 'Novu Email',
+        active: true,
+        credentials: {
+          emailSlugPrefix: 'my-agent',
+          inboxRoutingKey: 'abcd1234',
+        },
+      };
+      agentIntegrationRepo.find.resolves([existingLink]);
+      // Lookup of the NovuAgent integration linked to the agent (in findExistingLink).
+      integrationRepo.findOne.onFirstCall().resolves(existingNovuAgentIntegration);
+
+      const result = await buildUsecase().execute(AGENT_ID, ENV_ID, ORG_ID);
+
+      expect(result.provisionedNewLink).to.equal(false);
+      expect(integrationRepo.create.called).to.equal(false);
+      // Only the existing-link lookup happens; we never query for the primary custom integration.
+      expect(integrationRepo.findOne.calledOnce).to.equal(true);
+    });
+  });
+});

--- a/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.usecase.ts
@@ -86,10 +86,7 @@ export class FindOrCreateNovuEmail {
     if (existing) return { response: existing, provisionedNewLink: false };
 
     const emailSlugPrefix = this.deriveEmailSlugPrefix(agent);
-    const defaultOutboundIntegrationId = await this.findActivePrimaryCustomEmailIntegrationId(
-      environmentId,
-      organizationId
-    );
+    const defaultOutboundIntegrationId = await this.resolveDefaultOutboundIntegrationId(environmentId, organizationId);
 
     return this.agentIntegrationRepository.withTransaction(async (session) => {
       const recheck = await this.findExistingLink(agent, environmentId, organizationId);
@@ -133,7 +130,7 @@ export class FindOrCreateNovuEmail {
     displayName: string;
     identifier: string;
     emailSlugPrefix: string;
-    outboundIntegrationId: string | null;
+    outboundIntegrationId: string;
     environmentId: string;
     organizationId: string;
     session: ClientSession | null;
@@ -150,7 +147,7 @@ export class FindOrCreateNovuEmail {
               secretKey: encryptSecret(randomBytes(32).toString('hex')),
               emailSlugPrefix,
               inboxRoutingKey,
-              ...(outboundIntegrationId ? { outboundIntegrationId } : {}),
+              outboundIntegrationId,
             },
             configurations: {},
             name: displayName,
@@ -173,19 +170,27 @@ export class FindOrCreateNovuEmail {
   }
 
   /**
-   * On first auto-provision, default the agent's outbound sender to the env's
-   * existing primary email integration when one is configured. Otherwise we
-   * leave `outboundIntegrationId` unset and let the dashboard / runtime fall
-   * back to the rate-limited Novu demo sender. Excludes Novu-owned providers
-   * (the demo provider and the inbound-only NovuAgent integration itself) so
-   * we never select a sender that can't actually deliver outbound mail at
-   * scale or, worse, points at the inbound side.
+   * Resolve the integration id we persist as the agent's default outbound
+   * sender. Preference order:
+   *
+   *   1. The env's active primary email integration that isn't Novu-owned
+   *      (i.e. an integration the user explicitly wired up for production
+   *      sending — SendGrid, Resend, …). Identified by `primary: true` on the
+   *      email channel, excluding `NOVU_PROVIDERS` so we never accidentally
+   *      pick the inbound-only NovuAgent row or the demo provider here.
+   *   2. The env's bundled Novu Email demo integration row, auto-seeded for
+   *      Development environments alongside the org. It's quota-limited but
+   *      lets the agent reply out of the box without any user configuration.
+   *
+   * We deliberately throw when neither exists rather than persisting an empty
+   * sentinel: every downstream path (send-agent-test-email + chat-sdk's
+   * `buildSendEmailCallback`) now assumes a concrete integration id, and a
+   * misconfigured env (custom non-prod env with no email seeded) is surfaced
+   * loudly so the user can fix it instead of silently routing through a
+   * synthetic demo that may also be unavailable.
    */
-  private async findActivePrimaryCustomEmailIntegrationId(
-    environmentId: string,
-    organizationId: string
-  ): Promise<string | null> {
-    const integration = await this.integrationRepository.findOne({
+  private async resolveDefaultOutboundIntegrationId(environmentId: string, organizationId: string): Promise<string> {
+    const primaryCustom = await this.integrationRepository.findOne({
       _environmentId: environmentId,
       _organizationId: organizationId,
       channel: ChannelTypeEnum.EMAIL,
@@ -193,8 +198,20 @@ export class FindOrCreateNovuEmail {
       primary: true,
       providerId: { $nin: NOVU_PROVIDERS } as unknown as string,
     });
+    if (primaryCustom) return primaryCustom._id;
 
-    return integration?._id ?? null;
+    const novuDemo = await this.integrationRepository.findOne({
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+      channel: ChannelTypeEnum.EMAIL,
+      providerId: EmailProviderIdEnum.Novu,
+      active: true,
+    });
+    if (novuDemo) return novuDemo._id;
+
+    throw new ConflictException(
+      'No outbound email integration available for this environment. Activate the Novu Email demo provider or configure a primary email integration.'
+    );
   }
 
   /**

--- a/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.usecase.ts
@@ -27,6 +27,7 @@ import {
   EmailProviderIdEnum,
   FeatureNameEnum,
   getFeatureForTierAsBoolean,
+  NOVU_PROVIDERS,
   providers,
   slugify,
 } from '@novu/shared';
@@ -85,6 +86,10 @@ export class FindOrCreateNovuEmail {
     if (existing) return { response: existing, provisionedNewLink: false };
 
     const emailSlugPrefix = this.deriveEmailSlugPrefix(agent);
+    const defaultOutboundIntegrationId = await this.findActivePrimaryCustomEmailIntegrationId(
+      environmentId,
+      organizationId
+    );
 
     return this.agentIntegrationRepository.withTransaction(async (session) => {
       const recheck = await this.findExistingLink(agent, environmentId, organizationId);
@@ -97,6 +102,7 @@ export class FindOrCreateNovuEmail {
         displayName,
         identifier,
         emailSlugPrefix,
+        outboundIntegrationId: defaultOutboundIntegrationId,
         environmentId,
         organizationId,
         session,
@@ -119,6 +125,7 @@ export class FindOrCreateNovuEmail {
     displayName,
     identifier,
     emailSlugPrefix,
+    outboundIntegrationId,
     environmentId,
     organizationId,
     session,
@@ -126,6 +133,7 @@ export class FindOrCreateNovuEmail {
     displayName: string;
     identifier: string;
     emailSlugPrefix: string;
+    outboundIntegrationId: string | null;
     environmentId: string;
     organizationId: string;
     session: ClientSession | null;
@@ -142,6 +150,7 @@ export class FindOrCreateNovuEmail {
               secretKey: encryptSecret(randomBytes(32).toString('hex')),
               emailSlugPrefix,
               inboxRoutingKey,
+              ...(outboundIntegrationId ? { outboundIntegrationId } : {}),
             },
             configurations: {},
             name: displayName,
@@ -161,6 +170,31 @@ export class FindOrCreateNovuEmail {
     }
 
     throw lastError ?? new Error('Failed to mint a unique inboxRoutingKey after retries');
+  }
+
+  /**
+   * On first auto-provision, default the agent's outbound sender to the env's
+   * existing primary email integration when one is configured. Otherwise we
+   * leave `outboundIntegrationId` unset and let the dashboard / runtime fall
+   * back to the rate-limited Novu demo sender. Excludes Novu-owned providers
+   * (the demo provider and the inbound-only NovuAgent integration itself) so
+   * we never select a sender that can't actually deliver outbound mail at
+   * scale or, worse, points at the inbound side.
+   */
+  private async findActivePrimaryCustomEmailIntegrationId(
+    environmentId: string,
+    organizationId: string
+  ): Promise<string | null> {
+    const integration = await this.integrationRepository.findOne({
+      _environmentId: environmentId,
+      _organizationId: organizationId,
+      channel: ChannelTypeEnum.EMAIL,
+      active: true,
+      primary: true,
+      providerId: { $nin: NOVU_PROVIDERS } as unknown as string,
+    });
+
+    return integration?._id ?? null;
   }
 
   /**

--- a/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
@@ -108,33 +108,30 @@ export class SendAgentTestEmail {
   }
 
   private async findSenderIntegration(environmentId: string, organizationId: string, outboundIntegrationId?: string) {
-    if (outboundIntegrationId) {
-      const configured = await this.integrationRepository.findOne({
-        _id: outboundIntegrationId,
-        _environmentId: environmentId,
-        _organizationId: organizationId,
-        channel: ChannelTypeEnum.EMAIL,
-        active: true,
-      });
-
-      if (!configured) {
-        throw new BadRequestException('Configured outbound integration not found or inactive.');
-      }
-
-      return { ...configured, credentials: decryptCredentials(configured.credentials ?? {}) };
+    if (!outboundIntegrationId) {
+      throw new BadRequestException('Agent has no outbound email integration configured.');
     }
 
-    const novuDemo = await this.integrationRepository.findOne({
+    const configured = await this.integrationRepository.findOne({
+      _id: outboundIntegrationId,
       _environmentId: environmentId,
       _organizationId: organizationId,
-      providerId: EmailProviderIdEnum.Novu,
       channel: ChannelTypeEnum.EMAIL,
       active: true,
     });
 
-    if (novuDemo) {
+    if (!configured) {
+      throw new BadRequestException('Configured outbound integration not found or inactive.');
+    }
+
+    // The Novu demo email integration is provisioned alongside each org but
+    // ships with empty stored credentials — the real SendGrid API key lives in
+    // the deployment's `NOVU_EMAIL_INTEGRATION_API_KEY` env var. Mirror the
+    // runtime resolution in chat-sdk.service.ts so test emails go through the
+    // same demo plumbing as actual agent replies.
+    if (configured.providerId === EmailProviderIdEnum.Novu) {
       return {
-        ...novuDemo,
+        ...configured,
         credentials: {
           apiKey: process.env.NOVU_EMAIL_INTEGRATION_API_KEY,
           from: 'no-reply@novu.co',
@@ -144,18 +141,6 @@ export class SendAgentTestEmail {
       };
     }
 
-    const anyEmailProvider = await this.integrationRepository.findOne({
-      _environmentId: environmentId,
-      _organizationId: organizationId,
-      channel: ChannelTypeEnum.EMAIL,
-      active: true,
-      providerId: { $nin: [EmailProviderIdEnum.NovuAgent, EmailProviderIdEnum.Novu] } as unknown as string,
-    });
-
-    if (!anyEmailProvider) {
-      throw new BadRequestException('No active email provider available to send the test email.');
-    }
-
-    return { ...anyEmailProvider, credentials: decryptCredentials(anyEmailProvider.credentials ?? {}) };
+    return { ...configured, credentials: decryptCredentials(configured.credentials ?? {}) };
   }
 }

--- a/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
@@ -121,18 +121,6 @@ export class SendAgentTestEmail {
         throw new BadRequestException('Configured outbound integration not found or inactive.');
       }
 
-      if (configured.providerId === EmailProviderIdEnum.Novu) {
-        return {
-          ...configured,
-          credentials: {
-            apiKey: process.env.NOVU_EMAIL_INTEGRATION_API_KEY,
-            from: 'no-reply@novu.co',
-            senderName: 'Novu',
-            ipPoolName: 'Demo',
-          },
-        };
-      }
-
       return { ...configured, credentials: decryptCredentials(configured.credentials ?? {}) };
     }
 

--- a/apps/dashboard/src/components/agents/email-configuration-card.tsx
+++ b/apps/dashboard/src/components/agents/email-configuration-card.tsx
@@ -63,6 +63,8 @@ export function EmailConfigurationCardBody({ agent, integrationId }: EmailConfig
           outboundFromAddress={outboundFromAddress}
           inboundAddresses={inboundAddresses}
           onSave={saveSenderOverride}
+          disabled={isOutboundDemo}
+          disabledReason="Custom From addresses are only supported with your own email provider. Connect SendGrid, Resend, or another provider above to enable this."
         />
       </CardRow>
     </>

--- a/apps/dashboard/src/components/agents/outbound-provider-select.tsx
+++ b/apps/dashboard/src/components/agents/outbound-provider-select.tsx
@@ -43,12 +43,6 @@ type OutboundInstanceItem = {
   integration?: IIntegration;
 };
 
-// Sentinel persisted on the agent's NovuAgent integration credentials when the
-// user opts into the bundled Novu Email demo sender. The API treats an empty
-// outboundIntegrationId as "use the demo provider" (see chat-sdk.service.ts), so
-// we mirror that here instead of inventing a new string.
-const DEMO_OUTBOUND_VALUE = '';
-
 const DEMO_PROVIDER_CONFIG = emailProviderConfigs.find((p) => p.id === EmailProviderIdEnum.Novu);
 const DEMO_PROVIDER_DISPLAY_NAME = DEMO_PROVIDER_CONFIG?.displayName ?? 'Novu Email';
 
@@ -110,16 +104,23 @@ export function OutboundProviderSelect({
     [expandedProviderId, providerTypes]
   );
 
-  // The agent uses the Novu demo provider whenever no real outbound integration
-  // is attached, so an empty/undefined selectedId surfaces as the demo being
-  // preselected.
-  const isDemoSelected = !selectedId;
+  // The env's bundled Novu Email demo integration row (auto-seeded for
+  // Development environments alongside the org). When the agent's outbound
+  // points here, the runtime overrides credentials with the cloud demo API
+  // key and rate-limits via the shared quota. Hidden from the dropdown when
+  // the env doesn't have a demo row at all (custom non-prod envs).
+  const novuDemoIntegration = useMemo(
+    () => integrations?.find((i) => i.channel === ChannelTypeEnum.EMAIL && i.providerId === EmailProviderIdEnum.Novu),
+    [integrations]
+  );
+
+  const isDemoSelected = Boolean(novuDemoIntegration) && selectedId === novuDemoIntegration?._id;
 
   const selected = useMemo(() => {
-    if (isDemoSelected) {
+    if (isDemoSelected && novuDemoIntegration) {
       return {
         providerId: EmailProviderIdEnum.Novu,
-        displayName: DEMO_PROVIDER_DISPLAY_NAME,
+        displayName: novuDemoIntegration.name || DEMO_PROVIDER_DISPLAY_NAME,
         isDemo: true,
       };
     }
@@ -130,7 +131,7 @@ export function OutboundProviderSelect({
     }
 
     return undefined;
-  }, [providerTypes, selectedId, isDemoSelected]);
+  }, [providerTypes, selectedId, isDemoSelected, novuDemoIntegration]);
 
   const isBusy = pendingKey !== null;
 
@@ -198,7 +199,8 @@ export function OutboundProviderSelect({
 
   function handleSelectDemo() {
     if (isBusy) return;
-    onSelect(DEMO_OUTBOUND_VALUE);
+    if (!novuDemoIntegration) return;
+    onSelect(novuDemoIntegration._id);
     setOpen(false);
     setExpandedProviderId(null);
   }
@@ -218,27 +220,29 @@ export function OutboundProviderSelect({
       </div>
       <CommandList className="max-h-[260px] p-1">
         <CommandEmpty className="text-text-soft text-label-xs py-4">No email providers found.</CommandEmpty>
-        <CommandGroup heading="Default · for testing" className={groupHeadingClassName}>
-          <CommandItem
-            key="__demo__"
-            value={`${DEMO_PROVIDER_DISPLAY_NAME} demo novu email`}
-            disabled={isBusy}
-            onSelect={handleSelectDemo}
-            className={cn('flex items-center gap-2 rounded-md p-1', isDemoSelected && 'bg-bg-muted')}
-          >
-            <div className="flex w-full min-w-0 items-center gap-1">
-              <ProviderIcon
-                providerId={EmailProviderIdEnum.Novu}
-                providerDisplayName={DEMO_PROVIDER_DISPLAY_NAME}
-                className="size-4 shrink-0"
-              />
-              <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-medium leading-4">
-                {DEMO_PROVIDER_DISPLAY_NAME}
-              </span>
-              <DemoBadge />
-            </div>
-          </CommandItem>
-        </CommandGroup>
+        {novuDemoIntegration ? (
+          <CommandGroup heading="Default · for testing" className={groupHeadingClassName}>
+            <CommandItem
+              key="__demo__"
+              value={`${DEMO_PROVIDER_DISPLAY_NAME} demo novu email`}
+              disabled={isBusy}
+              onSelect={handleSelectDemo}
+              className={cn('flex items-center gap-2 rounded-md p-1', isDemoSelected && 'bg-bg-muted')}
+            >
+              <div className="flex w-full min-w-0 items-center gap-1">
+                <ProviderIcon
+                  providerId={EmailProviderIdEnum.Novu}
+                  providerDisplayName={DEMO_PROVIDER_DISPLAY_NAME}
+                  className="size-4 shrink-0"
+                />
+                <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-medium leading-4">
+                  {novuDemoIntegration.name || DEMO_PROVIDER_DISPLAY_NAME}
+                </span>
+                <DemoBadge />
+              </div>
+            </CommandItem>
+          </CommandGroup>
+        ) : null}
         <CommandGroup heading="Production providers" className={groupHeadingClassName}>
           {providerTypes.map((pt) => {
             const hasInstances = pt.integrations.length > 0;

--- a/apps/dashboard/src/components/agents/outbound-provider-select.tsx
+++ b/apps/dashboard/src/components/agents/outbound-provider-select.tsx
@@ -111,15 +111,9 @@ export function OutboundProviderSelect({
   );
 
   // The agent uses the Novu demo provider whenever no real outbound integration
-  // is attached. Mirror that in the UI: an empty/undefined selectedId surfaces
-  // as the demo being preselected, and legacy rows that point at a real Novu
-  // demo integration are normalized to the same display.
-  const isDemoSelected = useMemo(() => {
-    if (!selectedId) return true;
-    const integration = integrations?.find((i) => i._id === selectedId);
-
-    return integration?.providerId === EmailProviderIdEnum.Novu;
-  }, [integrations, selectedId]);
+  // is attached, so an empty/undefined selectedId surfaces as the demo being
+  // preselected.
+  const isDemoSelected = !selectedId;
 
   const selected = useMemo(() => {
     if (isDemoSelected) {

--- a/apps/dashboard/src/components/agents/outbound-provider-select.tsx
+++ b/apps/dashboard/src/components/agents/outbound-provider-select.tsx
@@ -110,7 +110,10 @@ export function OutboundProviderSelect({
   // key and rate-limits via the shared quota. Hidden from the dropdown when
   // the env doesn't have a demo row at all (custom non-prod envs).
   const novuDemoIntegration = useMemo(
-    () => integrations?.find((i) => i.channel === ChannelTypeEnum.EMAIL && i.providerId === EmailProviderIdEnum.Novu),
+    () =>
+      integrations?.find(
+        (i) => i.channel === ChannelTypeEnum.EMAIL && i.providerId === EmailProviderIdEnum.Novu && i.active === true
+      ),
     [integrations]
   );
 

--- a/apps/dashboard/src/components/agents/sender-address-override.tsx
+++ b/apps/dashboard/src/components/agents/sender-address-override.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useId, useRef, useState } from 'react';
 import { Button } from '@/components/primitives/button';
 import { Input } from '@/components/primitives/input';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
@@ -10,6 +10,17 @@ export type SenderAddressOverrideProps = {
   outboundFromAddress: string;
   inboundAddresses: string[];
   onSave: (params: { enabled: boolean; value: string }) => Promise<void>;
+  /**
+   * Locks the override controls when the agent is wired to a sender that
+   * physically can't honour a custom From — currently the bundled Novu demo
+   * provider, which sends from the shared agent inbox and ignores
+   * `useFromAddressOverride` / `fromAddressOverride` entirely
+   * (see chat-sdk.service.ts buildSendEmailCallback). Server state is left
+   * intact so a previously saved override snaps back the moment the user
+   * attaches a real outbound provider.
+   */
+  disabled?: boolean;
+  disabledReason?: ReactNode;
 };
 
 export function SenderAddressOverride({
@@ -18,6 +29,8 @@ export function SenderAddressOverride({
   outboundFromAddress,
   inboundAddresses,
   onSave,
+  disabled = false,
+  disabledReason,
 }: SenderAddressOverrideProps) {
   const switchId = useId();
   const inputId = useId();
@@ -47,11 +60,14 @@ export function SenderAddressOverride({
   const trimmedValue = value.trim();
   const isDirty = enabled !== serverEnabled || trimmedValue !== serverValue.trim();
   const hasInvalidValue = enabled && trimmedValue.length > 0 && !isValidEmail(trimmedValue);
-  const canSave = isDirty && !isSaving && !hasInvalidValue;
+  const canSave = !disabled && isDirty && !isSaving && !hasInvalidValue;
 
   // Mirror the resolution in apps/api/src/app/agents/services/chat-sdk.service.ts
-  // buildSendEmailCallback: override > outbound.from > agent inbound.
-  const previewOverride = enabled ? trimmedValue : '';
+  // buildSendEmailCallback: override > outbound.from > agent inbound. When the
+  // override is locked (demo sender), the override is server-side ignored, so
+  // we drop it from the preview to match the address subscribers will actually
+  // see in their inbox.
+  const previewOverride = !disabled && enabled ? trimmedValue : '';
   const fallbackInbound = inboundAddresses[0] ?? '';
   const resolvedFrom = previewOverride || outboundFromAddress || fallbackInbound;
   const resolvedReplyTo = resolvedFrom && resolvedFrom !== fallbackInbound ? fallbackInbound : '';
@@ -71,16 +87,25 @@ export function SenderAddressOverride({
     }
   }
 
+  const labelClassName = disabled
+    ? 'text-text-soft text-label-xs font-medium leading-4'
+    : 'text-text-sub text-label-xs cursor-pointer font-medium leading-4';
+
   return (
     <div className="flex w-full flex-col gap-2">
       <div className="flex w-full items-center justify-between gap-2">
-        <label htmlFor={switchId} className="text-text-sub text-label-xs cursor-pointer font-medium leading-4">
+        <label htmlFor={switchId} className={labelClassName}>
           Use a custom From address
         </label>
-        <Switch id={switchId} checked={enabled} onCheckedChange={setEnabled} disabled={isSaving} />
+        <Switch
+          id={switchId}
+          checked={enabled && !disabled}
+          onCheckedChange={setEnabled}
+          disabled={isSaving || disabled}
+        />
       </div>
 
-      {enabled && (
+      {enabled && !disabled && (
         <div className="flex w-full flex-col gap-1">
           <Input
             id={inputId}
@@ -104,7 +129,11 @@ export function SenderAddressOverride({
 
       <AddressPreview from={resolvedFrom} replyTo={resolvedReplyTo} />
 
-      {isDirty && (
+      {disabled && disabledReason ? (
+        <p className="text-text-soft text-paragraph-xs leading-4">{disabledReason}</p>
+      ) : null}
+
+      {!disabled && isDirty && (
         <div className="flex justify-end">
           <Button
             variant="primary"

--- a/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
+++ b/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
@@ -1,6 +1,5 @@
 import {
   DomainRouteTypeEnum,
-  EmailProviderIdEnum,
   emailProviders as emailProviderConfigs,
   type IEnvironment,
   type IIntegration,
@@ -165,9 +164,9 @@ export function useEmailSetupCredentials({
   // An empty outboundId is the API contract for "fall back to the Novu demo
   // sender" (see chat-sdk.service.ts and send-agent-test-email.usecase.ts), so
   // we surface it the same way to the UI as an explicitly-selected demo
-  // integration. Both shapes mean: no real outbound provider, no credentials
-  // step, rate-limited delivery.
-  const isOutboundDemo = !outboundId || outboundIntegration?.providerId === EmailProviderIdEnum.Novu;
+  // integration: no real outbound provider, no credentials step, rate-limited
+  // delivery.
+  const isOutboundDemo = !outboundId;
   const needsCredentialsStep = Boolean(outboundIntegration) && !isOutboundDemo;
   const hasOutboundCredentials = useMemo(() => {
     if (!outboundIntegration) return false;

--- a/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
+++ b/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
@@ -1,5 +1,6 @@
 import {
   DomainRouteTypeEnum,
+  EmailProviderIdEnum,
   emailProviders as emailProviderConfigs,
   type IEnvironment,
   type IIntegration,
@@ -161,12 +162,13 @@ export function useEmailSetupCredentials({
     () => (outboundId ? integrations?.find((i) => i._id === outboundId) : undefined),
     [integrations, outboundId]
   );
-  // An empty outboundId is the API contract for "fall back to the Novu demo
-  // sender" (see chat-sdk.service.ts and send-agent-test-email.usecase.ts), so
-  // we surface it the same way to the UI as an explicitly-selected demo
-  // integration: no real outbound provider, no credentials step, rate-limited
-  // delivery.
-  const isOutboundDemo = !outboundId;
+  // The Novu Email demo integration row carries `providerId === Novu` and is
+  // auto-seeded for Development envs. When the agent points here, the runtime
+  // overrides credentials with the cloud demo API key (see
+  // chat-sdk.service.ts sendViaNovuDemoProvider and send-agent-test-email
+  // findSenderIntegration), so we surface it as "demo selected" in the UI:
+  // no credentials step, rate-limited delivery.
+  const isOutboundDemo = outboundIntegration?.providerId === EmailProviderIdEnum.Novu;
   const needsCredentialsStep = Boolean(outboundIntegration) && !isOutboundDemo;
   const hasOutboundCredentials = useMemo(() => {
     if (!outboundIntegration) return false;

--- a/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
+++ b/apps/dashboard/src/components/agents/use-email-setup-credentials.ts
@@ -168,7 +168,8 @@ export function useEmailSetupCredentials({
   // chat-sdk.service.ts sendViaNovuDemoProvider and send-agent-test-email
   // findSenderIntegration), so we surface it as "demo selected" in the UI:
   // no credentials step, rate-limited delivery.
-  const isOutboundDemo = outboundIntegration?.providerId === EmailProviderIdEnum.Novu;
+  const isOutboundDemo =
+    outboundIntegration?.providerId === EmailProviderIdEnum.Novu && outboundIntegration.active === true;
   const needsCredentialsStep = Boolean(outboundIntegration) && !isOutboundDemo;
   const hasOutboundCredentials = useMemo(() => {
     if (!outboundIntegration) return false;


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

When provisioning a new NovuAgent email integration, the system now automatically assigns an outbound provider by looking up the environment's active, primary custom email integration first, then falling back to the bundled Novu demo integration. Previously, newly created integrations had no default outbound provider set. The dashboard now prevents users from saving a custom "From" address override when using the demo sender, with clear messaging that custom addresses require a real email provider. Unreachable fallback logic for demo providers has been cleaned up across the codebase.

## Affected areas

**api**: `FindOrCreateNovuEmail` usecase now queries for a default outbound integration at provision time and persists it to credentials. `SendAgentTestEmail` no longer falls back to any available provider when outbound integration is missing—it now requires an explicit configuration. `ChatSdkService` explicitly routes Novu demo integrations through the demo send path and enforces shared-inbox prerequisites.

**dashboard**: `SenderAddressOverride` component supports disabled state via new `disabled` and `disabledReason` props, preventing custom address configuration when demo sender is active. `OutboundProviderSelect` derives demo integration from fetched integrations list rather than sentinel values. `EmailConfigurationCard` and `use-email-setup-credentials` now coordinate to lock the custom address override when outbound provider is the Novu demo.

## Key technical decisions

- Empty-string sentinel for demo is removed from the dashboard; demo is now identified by the presence and selection of the actual Novu integration row.
- `outboundIntegrationId` is now required on new NovuAgent integrations (defaulted by `FindOrCreateNovuEmail`); the lookup is idempotent and runs once before the DB transaction.
- Inactive Novu email integrations are no longer treated as demo providers, preventing them from bypassing credential setup.

## Testing

New unit test spec added for `FindOrCreateNovuEmail` covering four scenarios: primary custom present, primary custom absent with demo fallback, neither available (throws ConflictException), and existing link (skips query). Existing `ChatSdkService` tests updated to pass demo integration object to relevant test cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes [NV-7685](https://linear.app/novu/issue/NV-7685/default-agent-outbound-email-to-env-primary-integration).

The agent's NovuAgent email integration always defaulted `outboundIntegrationId` to the empty-string sentinel — the API contract for "use the rate-limited Novu demo sender" — even when the org already had a real primary email provider configured. New agents had to manually pick their own provider in the "Send emails via" dropdown to escape the demo cap.

This PR:

- **`FindOrCreateNovuEmail`**: at first auto-provision (called by `CreateAgent` and `AddAgentIntegration`), look up the env's `active=true, primary=true, providerId NOT IN NOVU_PROVIDERS` email integration and persist its id as `credentials.outboundIntegrationId` on the new NovuAgent integration. Falls through to leaving the field unset when no primary custom integration exists, so the existing demo fallback path is untouched. The lookup happens once before the transaction so we don't hold an unnecessary read inside it. Idempotent — only runs on the create branch, never on the find-existing branch.
- **`SenderAddressOverride`**: new optional `disabled` + `disabledReason` props. When the agent is on the demo sender, the "Use a custom From address" toggle is locked, the input/save controls aren't rendered, and the address preview drops the override out of the `From` resolution. `chat-sdk.service.ts buildSendEmailCallback` ignores `fromAddressOverride` on the demo path — the lock makes that contract explicit instead of letting users save a value that would silently no-op. Server state is left intact so a saved override snaps back the moment the user attaches a real outbound provider.
- **Cleanup of dead "Novu provider id = demo" branches**: dropped from `OutboundProviderSelect.isDemoSelected`, `useEmailSetupCredentials.isOutboundDemo`, and `SendAgentTestEmail.findSenderIntegration`. With the dashboard's `EXCLUDED_OUTBOUND_PROVIDERS` filter and the new auto-provision `$nin: NOVU_PROVIDERS` query, `outboundIntegrationId` can only ever be an empty-string sentinel or a real custom-provider id — never a Novu demo provider id — so those branches were unreachable.

Tests: 3-case unit spec for `FindOrCreateNovuEmail` covering primary-custom-present, primary-custom-absent, and existing-link paths.

### Screenshots

<!-- N/A — server change for new agents, plus a small disabled-state for the existing override toggle. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- None — no changes in `enterprise/`. -->

### Special notes for your reviewer

- Intentionally scoped to fresh provisioning. Existing agents with empty `outboundIntegrationId` are not migrated; their users can still pick a provider via the dashboard dropdown and that choice is persisted via `useUpdateIntegration`.
- The runtime send paths (`chat-sdk.service.ts buildSendEmailCallback` and `SendAgentTestEmail.findSenderIntegration`) already prefer `outboundIntegrationId` over the demo when set, so deliveries use the user's primary provider end-to-end on day one — no follow-up wiring needed.
- The empty-id fallback in `findSenderIntegration` (look up Novu demo integration → fall back to any active email provider) is intentionally left intact. Rewriting it to mirror `chat-sdk.service.ts`'s synthetic-integration approach is a bigger architectural change beyond this PR's scope.

</details>


Made with [Cursor](https://cursor.com)