### PR TITLE
refactor(api-service,dashboard): nest agents public routes under /agents/public fixes NV-7692

### DIFF
--- a/apps/api/src/app/agents/agents-public.controller.ts
+++ b/apps/api/src/app/agents/agents-public.controller.ts
@@ -18,18 +18,19 @@ import {
 } from './usecases/get-telegram-mobile-link-status/get-telegram-mobile-link-status.usecase';
 
 /**
- * Public, unauthenticated endpoints for the Telegram mobile setup landing page.
+ * Public, unauthenticated agent endpoints (no session). Add provider-specific
+ * route groups under this controller — today only Telegram mobile configure.
  *
- * Authorization is carried entirely by a signed, single-use, short-lived JWT
- * embedded in the request — the dashboard issues these tokens through the
- * authed `/agents/:id/integrations/:iid/telegram/mobile-link` endpoint.
+ * Telegram: authorization is a signed, single-use, short-lived JWT in the
+ * request; the dashboard issues it via authed
+ * `POST /agents/:id/integrations/:iid/telegram/mobile-link`.
  *
- * Mounted under `/v1/agents/telegram/mobile-configure*` paths so they cannot
- * collide with the authed `/v1/agents/:identifier/*` routes.
+ * Base path `/v1/agents/public` keeps these routes separate from authed
+ * `/v1/agents/:identifier/*`.
  */
 @ThrottlerCategory(ApiRateLimitCategoryEnum.CONFIGURATION)
 @ApiCommonResponses()
-@Controller('/agents/telegram/mobile-configure')
+@Controller('/agents/public')
 @ApiExcludeController()
 export class AgentsPublicController {
   constructor(
@@ -37,7 +38,7 @@ export class AgentsPublicController {
     private readonly consumeTelegramMobileLinkUsecase: ConsumeTelegramMobileLink
   ) {}
 
-  @Get('/status')
+  @Get('telegram/mobile-configure/status')
   @HttpCode(HttpStatus.OK)
   @ApiResponse(TelegramMobileLinkStatusResponseDto, 200)
   @ApiOperation({
@@ -52,7 +53,7 @@ export class AgentsPublicController {
     );
   }
 
-  @Post('/')
+  @Post('telegram/mobile-configure')
   @HttpCode(HttpStatus.OK)
   @ApiResponse(ConsumeTelegramMobileLinkResponseDto, 200)
   @ApiOperation({

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -603,7 +603,7 @@ export async function getTelegramMobileSetupStatus(
   token: string,
   signal?: AbortSignal
 ): Promise<TelegramMobileLinkStatus> {
-  const url = `${getApiBaseUrl()}/v1/agents/telegram/mobile-configure/status?token=${encodeURIComponent(token)}`;
+  const url = `${getApiBaseUrl()}/v1/agents/public/telegram/mobile-configure/status?token=${encodeURIComponent(token)}`;
   const response = await fetch(url, {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },
@@ -644,7 +644,7 @@ export async function submitTelegramMobileCredentials(
   token: string,
   botToken: string
 ): Promise<SubmitTelegramMobileCredentialsResult> {
-  const url = `${getApiBaseUrl()}/v1/agents/telegram/mobile-configure`;
+  const url = `${getApiBaseUrl()}/v1/agents/public/telegram/mobile-configure`;
   const response = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Telegram mobile configuration endpoints were relocated from the generic agents route to a dedicated public agents namespace. The `AgentsPublicController` was remounted under `/agents/public`, moving endpoints from `/v1/agents/telegram/mobile-configure` to `/v1/agents/public/telegram/mobile-configure`. This creates a single, consistent prefix for all provider-specific public agent routes going forward.

## Affected areas

- **api**: The `AgentsPublicController` was remounted with its routes now nested under the `/agents/public` prefix. Telegram mobile-configure GET (status) and POST (consume) endpoints were reorganized accordingly.
- **dashboard**: The Telegram mobile setup API client methods now call the public routes at `/v1/agents/public/telegram/mobile-configure` instead of the previous paths.

## Key technical decisions

- **Breaking change**: External callers must update their endpoints from `/v1/agents/telegram/mobile-configure` to `/v1/agents/public/telegram/mobile-configure`.
- **Coordinated deployment required**: API and dashboard must be deployed together to ensure the mobile Telegram landing page continues to work.
- **Single prefix for extensibility**: The `/agents/public` prefix establishes a consistent pattern for future provider-specific public agent routes.

## Testing

No additional tests are mentioned in the changes. The route restructuring is a routing-level refactoring with preserved handler implementations, so existing tests covering these endpoints should remain valid.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- `AgentsPublicController` now mounts at `/agents/public` with Telegram mobile setup under `telegram/mobile-configure/*` instead of putting `telegram` at the controller root. This keeps a single home for future public, provider-specific agent routes without renaming the controller.
- Dashboard API client URLs updated to `/v1/agents/public/telegram/mobile-configure` (status GET and consume POST).

**Breaking change:** Any external callers of the old paths (`/v1/agents/telegram/mobile-configure`) must switch to the new URLs.

- Linear: https://linear.app/novu/issue/NV-7692/refactor-agents-public-routes-agentspublic-prefix-for-provider

### Screenshots

Not applicable (non-visual API path change).

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None.

### Special notes for your reviewer

Deploy API and dashboard together so the mobile Telegram landing page keeps working.

</details>

Made with [Cursor](https://cursor.com)