### PR TITLE
fix(dashboard): Telegram setup webhook loop and hide BotFather paste fixes NV-7694

### DIFF
--- a/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
@@ -62,12 +62,20 @@ export function TelegramSetupGuide({
   const { currentEnvironment } = useEnvironment();
   const queryClient = useQueryClient();
 
+  // Guards the auto-configure effect below from looping on failure. Without it,
+  // a failed configureTelegram() (e.g. Telegram setWebhook rate-limit) would
+  // leave isWebhookConfigured=false and isConfiguring=false, and the effect
+  // would immediately re-fire — generating an unbounded burst of webhook
+  // registration attempts and getting rate-limited further by Telegram.
+  const autoConfigureAttemptedRef = useRef(false);
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset when the watched integration changes
   useEffect(() => {
     setIsConnected(false);
     setCredentialsSavedLocally(false);
     setConfiguredWebhookUrl(null);
     setBotUsername(null);
+    autoConfigureAttemptedRef.current = false;
   }, [integrationId]);
 
   const handleConnected = useCallback(() => {
@@ -139,13 +147,28 @@ export function TelegramSetupGuide({
 
   const isWebhookConfigured = Boolean(configuredWebhookUrl);
 
-  // When credentials already exist (e.g. user revisiting the guide), auto-configure the webhook
-  // so botUsername is populated and the QR code is available for step 3.
+  // Every code path that fires the webhook configuration goes through this
+  // helper so the auto-configure effect cannot also fire after a manual
+  // attempt fails. See autoConfigureAttemptedRef above for the rate-limit
+  // loop this prevents.
+  const runConfigureTelegram = useCallback(() => {
+    autoConfigureAttemptedRef.current = true;
+    configureTelegram();
+  }, [configureTelegram]);
+
+  // When credentials already exist (e.g. user revisiting the guide, or the
+  // mobile flow just dropped a token onto the integration), auto-configure
+  // once so botUsername is populated and the QR code is available for step 3.
   useEffect(() => {
-    if (hasCredentials && !isWebhookConfigured && !isConfiguring) {
-      configureTelegram();
+    if (
+      hasCredentials &&
+      !isWebhookConfigured &&
+      !isConfiguring &&
+      !autoConfigureAttemptedRef.current
+    ) {
+      runConfigureTelegram();
     }
-  }, [hasCredentials, integrationId, isWebhookConfigured, isConfiguring, configureTelegram]);
+  }, [hasCredentials, isWebhookConfigured, isConfiguring, runConfigureTelegram]);
 
   const base = stepOffset;
 
@@ -288,7 +311,7 @@ export function TelegramSetupGuide({
           onClose={() => setIsCredentialsSidebarOpen(false)}
           onSaveSuccess={() => {
             setCredentialsSavedLocally(true);
-            configureTelegram();
+            runConfigureTelegram();
           }}
           agentOnboarding
           agentIdentifier={agent.identifier}
@@ -308,7 +331,7 @@ export function TelegramSetupGuide({
         onClose={() => setIsCredentialsSidebarOpen(false)}
         onSaveSuccess={() => {
           setCredentialsSavedLocally(true);
-          configureTelegram();
+          runConfigureTelegram();
         }}
         agentOnboarding
         agentIdentifier={agent.identifier}

--- a/apps/dashboard/src/components/integrations/components/integration-settings.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-settings.tsx
@@ -131,7 +131,14 @@ export function IntegrationSettings({
   const isSlackOnboarding = isAgentOnboarding && provider.id === ChatProviderIdEnum.Slack;
   const isWhatsAppOnboarding = isAgentOnboarding && provider.id === ChatProviderIdEnum.WhatsAppBusiness;
   const isTelegramProvider = provider.id === ChatProviderIdEnum.Telegram;
-  const showTelegramPaste = isTelegramProvider && !isReadOnly;
+  // The BotFather paste helper is an onboarding affordance — once the integration
+  // already has a saved bot token, the textarea and mobile QR card are noise
+  // (and the "Auto-filled from the BotFather message above…" hint becomes
+  // misleading), so hide all of it and fall back to the regular API token field.
+  const telegramApiToken = integration?.credentials?.[CredentialsKeyEnum.ApiToken];
+  const hasExistingTelegramToken =
+    isTelegramProvider && typeof telegramApiToken === 'string' && telegramApiToken.trim().length > 0;
+  const showTelegramPaste = isTelegramProvider && !isReadOnly && !hasExistingTelegramToken;
   // Picks the QR variant: agent flow when we already have agent + integration,
   // integration-store flow in the create flow where neither exists yet, none
   // otherwise (e.g. plain edit of a non-agent Telegram integration).


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Fixed a Telegram webhook configuration loop where failed mutation attempts (e.g., Telegram rate-limits) could trigger repeated webhook registration. Introduced a per-integration guard ref (`autoConfigureAttemptedRef`) to limit webhook auto-configuration to one attempt per integration lifecycle. Refactored webhook configuration into a shared `runConfigureTelegram` helper used by all entry points (auto-configure and manual save). Additionally, hid the BotFather credential paste UI when the integration already has a saved API token, reducing unnecessary UX hints and mobile query mounts.

## Affected areas

**dashboard**: Telegram integration setup now guards against repeated webhook registration attempts via a ref-based lifecycle check. The BotFather paste helper and mobile QR UI are conditionally hidden when an existing token is already saved, appearing only during initial onboarding.

## Key technical decisions

- Per-integration ref guard limits webhook registration to one per integration lifecycle, reset when `integrationId` changes.
- Consolidated webhook configuration entry points (auto-configure and manual save) through a `runConfigureTelegram` helper to ensure consistent guard application.
- UI visibility of BotFather paste field keys off saved `integration.credentials.apiToken` rather than dirty form state to prevent flashing after token rotation.

## Testing

Manual verification per test plan: confirm no burst of `/telegram/configure` requests after mobile token submit, validate BotFather UI is hidden for existing tokens, and ensure it appears for new integrations. No automated tests were added, as the fix is behavioral guard logic best validated through integration flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- **`TelegramSetupGuide`**: The auto-configure `useEffect` could call `configureTelegramAgentWebhook` repeatedly when the mutation failed (for example after Telegram rate-limited a redundant `setWebhook` right after the mobile landing page had already registered the webhook). A per-integration ref plus a shared `runConfigureTelegram` helper limits webhook registration attempts to one per integration lifecycle (reset when `integrationId` changes), including manual save paths.
- **`IntegrationSettings`**: The BotFather confirmation / mobile QR block is onboarding-only; it is hidden when the integration already has a saved `apiToken`, so the hint about “paste above” does not mislead and the mobile link query does not mount unnecessarily.

Linear: https://linear.app/novu/issue/NV-7694

### Screenshots

N/A (conditional UI visibility; no visual redesign).

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None.

### Special notes for your reviewer

- Confirm behavior when rotating a token: user clears/changes the api token field in the form — if defaultValues still had token from server, paste may stay hidden until they understand they edit the credential field below; the change keys off **saved** `integration.credentials.apiToken`, not dirty form state.

</details>

## Test plan

- [ ] Agent Telegram quick start after mobile token submit: no burst of `/telegram/configure` requests; optional error toast at most once if Telegram still rate-limits.
- [ ] Credentials sidebar for Telegram integration that already has a token: no BotFather textarea / mobile QR; standard API token field still present.
- [ ] New Telegram integration (create flow or empty token): BotFather paste + mobile QR still appear.


Made with [Cursor](https://cursor.com)