### PR TITLE
perf(api-service, shared): perf of GET /v2/subscribers/:id/preferences fixes NV-7695

### DIFF
--- a/apps/api/src/app/subscribers-v2/usecases/get-subscriber-preferences/get-subscriber-preferences.usecase.ts
+++ b/apps/api/src/app/subscribers-v2/usecases/get-subscriber-preferences/get-subscriber-preferences.usecase.ts
@@ -1,12 +1,26 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { buildSlug, InMemoryLRUCacheService, InMemoryLRUCacheStore, Instrument } from '@novu/application-generic';
+import {
+  buildSlug,
+  FeatureFlagsService,
+  InMemoryLRUCacheService,
+  InMemoryLRUCacheStore,
+  Instrument,
+} from '@novu/application-generic';
 import {
   NotificationTemplateEntity,
   NotificationTemplateRepository,
+  PreferencesEntity,
+  PreferencesRepository,
   SubscriberEntity,
   SubscriberRepository,
 } from '@novu/dal';
-import { ISubscriberPreferenceResponse, ShortIsPrefixEnum, WorkflowCriticalityEnum } from '@novu/shared';
+import {
+  FeatureFlagsKeysEnum,
+  ISubscriberPreferenceResponse,
+  PreferencesTypeEnum,
+  ShortIsPrefixEnum,
+  WorkflowCriticalityEnum,
+} from '@novu/shared';
 import { plainToInstance } from 'class-transformer';
 import {
   GetSubscriberGlobalPreference,
@@ -28,6 +42,8 @@ export class GetSubscriberPreferences {
     private getSubscriberPreference: GetSubscriberPreference,
     private subscriberRepository: SubscriberRepository,
     private notificationTemplateRepository: NotificationTemplateRepository,
+    private preferencesRepository: PreferencesRepository,
+    private featureFlagsService: FeatureFlagsService,
     private inMemoryLRUCacheService: InMemoryLRUCacheService
   ) {}
 
@@ -49,8 +65,28 @@ export class GetSubscriberPreferences {
       critical: command.criticality === WorkflowCriticalityEnum.CRITICAL ? true : undefined,
     });
 
-    const globalPreference = await this.fetchGlobalPreference(command, subscriber, workflowList);
-    const workflowPreferences = await this.fetchWorkflowPreferences(command, subscriber, workflowList);
+    /*
+     * Fetch the subscriber's global preference exactly once, then hand it to the global and
+     * workflow sub-usecases. Previously the v2 endpoint triggered duplicate SUBSCRIBER_GLOBAL
+     * mongo lookups (one inside GetSubscriberGlobalPreference -> GetPreferences, one inside
+     * GetSubscriberPreference.findAllPreferences), which under concurrent load doubled the
+     * I/O and bson decode cost for the same document on every request.
+     */
+    const subscriberGlobalPreference = await this.fetchSubscriberGlobalPreferenceEntity({
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      subscriberId: subscriber._id,
+      contextKeys: command.contextKeys,
+    });
+
+    /*
+     * The two sub-fetches are independent — run them in parallel so wall-clock latency is
+     * reduced even though the cumulative CPU cost is unchanged.
+     */
+    const [globalPreference, workflowPreferences] = await Promise.all([
+      this.fetchGlobalPreference(command, subscriber, workflowList, subscriberGlobalPreference),
+      this.fetchWorkflowPreferences(command, subscriber, workflowList, subscriberGlobalPreference),
+    ]);
 
     return plainToInstance(GetSubscriberPreferencesDto, {
       global: globalPreference,
@@ -58,10 +94,46 @@ export class GetSubscriberPreferences {
     });
   }
 
+  @Instrument()
+  private async fetchSubscriberGlobalPreferenceEntity({
+    environmentId,
+    organizationId,
+    subscriberId,
+    contextKeys,
+  }: {
+    environmentId: string;
+    organizationId: string;
+    subscriberId: string;
+    contextKeys?: string[];
+  }): Promise<PreferencesEntity | null> {
+    const useContextFiltering = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+      defaultValue: false,
+      organization: { _id: organizationId },
+    });
+
+    const contextQuery = this.preferencesRepository.buildContextExactMatchQuery(contextKeys, {
+      enabled: useContextFiltering,
+    });
+
+    return this.preferencesRepository.findOne(
+      {
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        _subscriberId: subscriberId,
+        type: PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
+        ...contextQuery,
+      },
+      undefined,
+      { readPreference: 'secondaryPreferred' as const }
+    );
+  }
+
   private async fetchGlobalPreference(
     command: GetSubscriberPreferencesCommand,
     subscriber: SubscriberEntity,
-    workflowList: NotificationTemplateEntity[]
+    workflowList: NotificationTemplateEntity[],
+    subscriberGlobalPreference: PreferencesEntity | null
   ): Promise<SubscriberGlobalPreferenceDto> {
     const { preference } = await this.getSubscriberGlobalPreference.execute(
       GetSubscriberGlobalPreferenceCommand.create({
@@ -72,6 +144,7 @@ export class GetSubscriberPreferences {
         contextKeys: command.contextKeys,
         subscriber,
         workflowList,
+        subscriberGlobalPreference,
       })
     );
 
@@ -83,7 +156,8 @@ export class GetSubscriberPreferences {
   private async fetchWorkflowPreferences(
     command: GetSubscriberPreferencesCommand,
     subscriber: SubscriberEntity,
-    workflowList: NotificationTemplateEntity[]
+    workflowList: NotificationTemplateEntity[],
+    subscriberGlobalPreference: PreferencesEntity | null
   ) {
     const subscriberWorkflowPreferences = await this.getSubscriberPreference.execute(
       GetSubscriberPreferenceCommand.create({
@@ -95,6 +169,7 @@ export class GetSubscriberPreferences {
         contextKeys: command.contextKeys,
         subscriber,
         workflowList,
+        subscriberGlobalPreference,
       })
     );
 

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-global-preference/get-subscriber-global-preference.command.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-global-preference/get-subscriber-global-preference.command.ts
@@ -1,4 +1,4 @@
-import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
+import { NotificationTemplateEntity, PreferencesEntity, SubscriberEntity } from '@novu/dal';
 import { IsBoolean, IsDefined, IsOptional } from 'class-validator';
 import { EnvironmentWithSubscriber } from '../../../shared/commands/project.command';
 
@@ -12,4 +12,12 @@ export class GetSubscriberGlobalPreferenceCommand extends EnvironmentWithSubscri
 
   @IsOptional()
   workflowList?: NotificationTemplateEntity[];
+
+  /**
+   * Optional pre-fetched SUBSCRIBER_GLOBAL preference entity. When provided, the use-case
+   * will skip the database lookup and use this value to build the response. Pass `null`
+   * (and not `undefined`) to explicitly indicate that no entity was found.
+   */
+  @IsOptional()
+  subscriberGlobalPreference?: PreferencesEntity | null;
 }

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-global-preference/get-subscriber-global-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-global-preference/get-subscriber-global-preference.usecase.ts
@@ -37,6 +37,7 @@ export class GetSubscriberGlobalPreference {
       organizationId: command.organizationId,
       subscriberId: subscriber._id,
       contextKeys: command.contextKeys,
+      subscriberGlobalPreference: command.subscriberGlobalPreference,
     });
 
     const channelsWithDefaults = this.buildDefaultPreferences(subscriberGlobalPreference.channels);

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.command.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.command.ts
@@ -1,5 +1,5 @@
 import { EnvironmentWithSubscriber } from '@novu/application-generic';
-import { NotificationTemplateEntity, SubscriberEntity } from '@novu/dal';
+import { NotificationTemplateEntity, PreferencesEntity, SubscriberEntity } from '@novu/dal';
 import { SeverityLevelEnum, WorkflowCriticalityEnum } from '@novu/shared';
 import { IsArray, IsBoolean, IsDefined, IsEnum, IsOptional, IsString } from 'class-validator';
 
@@ -27,4 +27,13 @@ export class GetSubscriberPreferenceCommand extends EnvironmentWithSubscriber {
 
   @IsOptional()
   workflowList?: NotificationTemplateEntity[];
+
+  /**
+   * Optional pre-fetched SUBSCRIBER_GLOBAL preference entity. When provided, the use-case
+   * will reuse this value instead of issuing its own SUBSCRIBER_GLOBAL mongo lookup inside
+   * {@link findAllPreferences}. Pass `null` (and not `undefined`) to indicate that no
+   * entity was found.
+   */
+  @IsOptional()
+  subscriberGlobalPreference?: PreferencesEntity | null;
 }

--- a/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
+++ b/apps/api/src/app/subscribers/usecases/get-subscriber-preference/get-subscriber-preference.usecase.ts
@@ -75,6 +75,7 @@ export class GetSubscriberPreference {
       contextKeys: command.contextKeys,
       subscriberId: subscriber._id,
       workflowIds,
+      preFetchedSubscriberGlobalPreference: command.subscriberGlobalPreference,
     });
 
     const allWorkflowPreferences = [
@@ -258,12 +259,14 @@ export class GetSubscriberPreference {
     subscriberId,
     workflowIds,
     contextKeys,
+    preFetchedSubscriberGlobalPreference,
   }: {
     environmentId: string;
     organizationId: string;
     subscriberId: string;
     workflowIds: string[];
     contextKeys?: string[];
+    preFetchedSubscriberGlobalPreference?: PreferencesEntity | null;
   }) {
     const baseQuery = {
       _environmentId: environmentId,
@@ -280,6 +283,27 @@ export class GetSubscriberPreference {
     const contextQuery = this.preferencesRepository.buildContextExactMatchQuery(contextKeys, {
       enabled: useContextFiltering,
     });
+
+    /*
+     * When the caller already fetched the SUBSCRIBER_GLOBAL preference (e.g. the v2
+     * /preferences endpoint, which also exposes it on the response), skip the duplicate
+     * mongo query. Under concurrent load this duplicate fetch is one of the larger CPU/IO
+     * sources because every preferences call hits both this code path and
+     * `GetSubscriberGlobalPreference` for the same document.
+     */
+    const subscriberGlobalPreferenceQuery: Promise<PreferencesEntity[]> =
+      preFetchedSubscriberGlobalPreference !== undefined
+        ? Promise.resolve(preFetchedSubscriberGlobalPreference ? [preFetchedSubscriberGlobalPreference] : [])
+        : this.preferencesRepository.find(
+            {
+              ...baseQuery,
+              _subscriberId: subscriberId,
+              type: PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
+              ...contextQuery,
+            },
+            undefined,
+            readOptions
+          );
 
     const [
       workflowResourcePreferences,
@@ -316,16 +340,7 @@ export class GetSubscriberPreference {
         undefined,
         readOptions
       ),
-      this.preferencesRepository.find(
-        {
-          ...baseQuery,
-          _subscriberId: subscriberId,
-          type: PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
-          ...contextQuery,
-        },
-        undefined,
-        readOptions
-      ),
+      subscriberGlobalPreferenceQuery,
     ]);
 
     return {

--- a/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/get-preferences/get-preferences.usecase.ts
@@ -78,14 +78,23 @@ export class GetPreferences {
     organizationId: string;
     subscriberId: string;
     contextKeys?: string[];
+    /**
+     * Optionally pass a pre-fetched SUBSCRIBER_GLOBAL preferences entity so the caller
+     * can hydrate the global preference response without issuing another mongo query.
+     * Pass `null` (and not `undefined`) to indicate "we looked and there is none".
+     */
+    subscriberGlobalPreference?: PreferencesEntity | null;
   }): Promise<{
     enabled: boolean;
     channels: IPreferenceChannels;
     schedule?: Schedule;
   }> {
-    const result = await this.safeExecute(command);
+    const subscriberGlobalPreference =
+      command.subscriberGlobalPreference !== undefined
+        ? command.subscriberGlobalPreference
+        : await this.findSubscriberGlobalPreferenceFromDb(command);
 
-    if (!result) {
+    if (!subscriberGlobalPreference) {
       return {
         channels: {
           email: true,
@@ -100,9 +109,49 @@ export class GetPreferences {
 
     return {
       enabled: true,
-      channels: GetPreferences.mapWorkflowPreferencesToChannelPreferences(result.preferences),
-      schedule: result.schedule,
+      channels: GetPreferences.mapWorkflowPreferencesToChannelPreferences(
+        subscriberGlobalPreference.preferences as WorkflowPreferencesPartial
+      ),
+      schedule: subscriberGlobalPreference.schedule,
     };
+  }
+
+  /**
+   * Targeted single-query fetch of the SUBSCRIBER_GLOBAL preferences for a subscriber.
+   *
+   * Historically this code path went through {@link safeExecute}/{@link execute}, which
+   * issues 4 mongo queries (workflow resource + user, subscriber workflow, subscriber
+   * global). When the caller only wants the subscriber's global preference there is no
+   * templateId, so the 3 workflow-scoped queries return nothing and just burn CPU and
+   * a connection on the secondary. This method bypasses that path entirely.
+   */
+  private async findSubscriberGlobalPreferenceFromDb(command: {
+    environmentId: string;
+    organizationId: string;
+    subscriberId: string;
+    contextKeys?: string[];
+  }): Promise<PreferencesEntity | null> {
+    const useContextFiltering = await this.featureFlagsService.getFlag({
+      key: FeatureFlagsKeysEnum.IS_CONTEXT_PREFERENCES_ENABLED,
+      defaultValue: false,
+      organization: { _id: command.organizationId },
+    });
+
+    const contextQuery = this.preferencesRepository.buildContextExactMatchQuery(command.contextKeys, {
+      enabled: useContextFiltering,
+    });
+
+    return this.preferencesRepository.findOne(
+      {
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+        _subscriberId: command.subscriberId,
+        type: PreferencesTypeEnum.SUBSCRIBER_GLOBAL,
+        ...contextQuery,
+      },
+      undefined,
+      { readPreference: 'secondaryPreferred' as const }
+    );
   }
 
   public async safeExecute(command: GetPreferencesCommand): Promise<GetPreferencesResponseDto> {

--- a/libs/application-generic/src/usecases/merge-preferences/merge-preferences.usecase.ts
+++ b/libs/application-generic/src/usecases/merge-preferences/merge-preferences.usecase.ts
@@ -26,22 +26,33 @@ export class MergePreferences {
    * Ensures that `all.enabled` defaults to `true` if undefined.
    * Without this, if the `all` object is missing or `enabled` is undefined,
    * the merge result could incorrectly resolve to `false`, while the intended fallback is `true`.
+   *
+   * Performance note: this method is called for every preference of every workflow during
+   * the subscriber-preferences fetch (`MergePreferences.execute`). The previous
+   * implementation always allocated a shallow clone of `preference` and `preference.preferences`
+   * even when no normalization was needed; under concurrent load this accounted for a
+   * meaningful share of the request's CPU time. We now short-circuit and return the
+   * original reference when the input already satisfies the invariant.
    */
   private static ensureDefaultAllEnabled(preference: PreferencesEntity | undefined): PreferencesEntity | undefined {
     if (!preference?.preferences) {
       return preference;
     }
 
-    const normalized = { ...preference, preferences: { ...preference.preferences } };
-
-    if (normalized.preferences.all && normalized.preferences.all.enabled === undefined) {
-      normalized.preferences.all = {
-        ...normalized.preferences.all,
-        enabled: true,
-      };
+    if (!preference.preferences.all || preference.preferences.all.enabled !== undefined) {
+      return preference;
     }
 
-    return normalized;
+    return {
+      ...preference,
+      preferences: {
+        ...preference.preferences,
+        all: {
+          ...preference.preferences.all,
+          enabled: true,
+        },
+      },
+    };
   }
 
   public static execute(command: MergePreferencesCommand): GetPreferencesResponseDto {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The Express transaction
`WebTransaction/Expressjs/GET//v2/subscribers/:subscriberId/preferences` was
spiking node CPU under concurrent load. Tracing the call graph surfaced three
recurring sources of avoidable per-request CPU + IO work:

1. **`GetPreferences.getSubscriberGlobalPreference` went through the full
   4-query merge pipeline** even when the caller only needs the
   `SUBSCRIBER_GLOBAL` document. With no `templateId` in the command, the path
   issued two workflow-resource/user lookups and a SUBSCRIBER_WORKFLOW lookup
   with `_templateId: undefined` that always returned nothing — three useless
   Mongo round-trips, plus the bson decode + class-transformer mapping for
   their empty results, on every preferences call.
2. **The v2 endpoint fetched the `SUBSCRIBER_GLOBAL` document twice**: once
   via `GetSubscriberGlobalPreference` → `GetPreferences.getSubscriberGlobalPreference`,
   and again inside `GetSubscriberPreference.findAllPreferences` (which fetches
   all four preference types for the workflow-level computation). It also
   awaited the two sub-usecases sequentially despite them being independent.
3. **`MergePreferences.ensureDefaultAllEnabled` allocated a shallow clone of
   its input on every call**, including when the input was already normalized.
   The merge runs once per workflow per request (×4 preference slots), so on
   environments with a few hundred workflows this dominated the request's
   short-lived allocation cost.

**Changes**

- `libs/application-generic/get-preferences`:
  - `getSubscriberGlobalPreference` now does a single targeted
    `SUBSCRIBER_GLOBAL` `findOne` instead of going through `execute`. The
    behavior (defaults when no entity exists, schedule passthrough, channel
    mapping) is preserved.
  - The method accepts an optional already-fetched `subscriberGlobalPreference`
    entity so callers that already hold it can skip the lookup entirely. `null`
    means "we looked, none found", `undefined` keeps the legacy fetch behavior.
- `libs/application-generic/merge-preferences`:
  - `ensureDefaultAllEnabled` returns the original reference when no
    normalization is required, avoiding the unconditional shallow clones.
- `apps/api/subscribers/get-subscriber-global-preference` and
  `apps/api/subscribers/get-subscriber-preference`:
  - Both commands gained an optional `subscriberGlobalPreference?: PreferencesEntity | null`
    field; when present, the usecases skip their own `SUBSCRIBER_GLOBAL` query.
- `apps/api/subscribers-v2/get-subscriber-preferences`:
  - Fetches the `SUBSCRIBER_GLOBAL` entity once at the orchestrator level and
    passes it into both sub-usecases.
  - Runs the global + workflow preference computations in `Promise.all` since
    they have no dependency on each other.

**Net effect per request** (single subscriber, `IS_PREFERENCE_FETCH_OPTIMIZATION_ENABLED` off):

| | Before | After |
| --- | --- | --- |
| Preference mongo round-trips | 8 (4 useful + 4 useless) | 4 (all useful) |
| Subscriber-global document fetches | 2 | 1 |
| Per-preference shallow clones in `ensureDefaultAllEnabled` | always | only when normalization is needed |
| Sub-usecase awaits | sequential | parallel |

```mermaid
sequenceDiagram
    autonumber
    participant C as Controller
    participant V as v2 GetSubscriberPreferences
    participant G as GetSubscriberGlobalPreference
    participant P as GetPreferences
    participant W as GetSubscriberPreference
    participant M as Mongo (preferences)

    Note over C,M: Before
    C->>V: execute
    V->>G: execute
    G->>P: getSubscriberGlobalPreference (no templateId)
    P->>M: 4 queries (3 useless + 1 useful)
    V->>W: execute
    W->>M: 4 queries (incl. SUBSCRIBER_GLOBAL again)

    Note over C,M: After
    C->>V: execute
    V->>M: 1 query – SUBSCRIBER_GLOBAL once
    par
        V->>G: execute (pre-fetched entity)
        G->>P: hydrate, no mongo
    and
        V->>W: execute (pre-fetched entity)
        W->>M: 3 queries (no duplicate SUBSCRIBER_GLOBAL)
    end
```

**Compatibility**

- All command additions are optional fields, so existing callers
  (`inbox`, `widgets`, `get-preferences-by-level`, subscriber v1) keep their
  current behavior.
- Response shapes are unchanged.

### Special notes for your reviewer

End-to-end verification on this branch was limited to typecheck across
`@novu/api`, `@novu/worker`, and `@novu/application-generic`. The dev VM's
mongoose connections to the local Mongo container were failing independently
of this change (TCP connect succeeds but the wire-protocol handshake is reset
before any bytes arrive; `mongosh` only works when run _inside_ the
container), so the in-repo e2e suite couldn't run. The recommended additional
verification is to load-test the endpoint on a real environment, or run the
`apps/api` `get-subscriber-preferences.e2e.ts` / `patch-subscriber-preferences.e2e.ts`
suites in CI.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7695](https://linear.app/novu/issue/NV-7695/investigate-performance-issue-in-concurrent-preferences-calls)

<div><a href="https://cursor.com/agents/bc-bfbe1d99-4189-4375-be9a-4e65553e0ba1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfbe1d99-4189-4375-be9a-4e65553e0ba1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The GET /v2/subscribers/:subscriberId/preferences endpoint was optimized to eliminate redundant database queries and unnecessary memory allocations. The subscriber's global preferences document is now fetched once at the orchestrator level and reused across sub-operations, which are run concurrently instead of sequentially. Additionally, the preference merging logic now avoids unconditional shallow clones when no normalization is needed.

## Affected areas

**api**: The v2 subscriber preferences endpoint now fetches the SUBSCRIBER_GLOBAL document once and passes it into both the global and workflow preference sub-usecases. The global and workflow preference computations run concurrently via `Promise.all`. Sub-usecases (GetSubscriberGlobalPreference and GetSubscriberPreference) accept an optional pre-fetched global preference parameter to skip redundant queries.

**application-generic**: GetPreferences.getSubscriberGlobalPreference now supports an optional pre-fetched entity parameter and issues only a targeted SUBSCRIBER_GLOBAL lookup when needed, instead of running the full 4-query merge pipeline. MergePreferences.ensureDefaultAllEnabled returns the original reference when no normalization is required, eliminating unnecessary allocations.

## Key technical decisions

- New optional `subscriberGlobalPreference?: PreferencesEntity | null` parameter added to commands and use-cases to distinguish "not provided" (undefined) from "explicitly not found" (null), enabling callers to skip redundant queries.
- The targeted SUBSCRIBER_GLOBAL lookup applies context-key exact-match filtering when `IS_CONTEXT_PREFERENCES_ENABLED` feature flag is active.
- Reference-preserving behavior in `ensureDefaultAllEnabled` reduces memory pressure across workflows that invoke preference merging.

## Testing

End-to-end verification was limited to typecheck across packages. Load testing or running specific e2e suites in CI is recommended to validate the performance improvements in a production-like environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->