### PR TITLE
feat(dashboard): integrate sni identify flow fixes NV-7698

### DIFF
--- a/apps/dashboard/src/context/identity-provider.tsx
+++ b/apps/dashboard/src/context/identity-provider.tsx
@@ -5,11 +5,13 @@ import { getRegionConfig, useRegion } from '@/context/region';
 import { useAuth } from './auth/hooks';
 import { useCustomerIo } from './customer-io/hooks';
 import { useSegment } from './segment/hooks';
+import { useSnitcher } from './snitcher/hooks';
 
 export function IdentityProvider({ children }: { children: React.ReactNode }) {
   const ldClient = useLDClient();
   const segment = useSegment();
   const customerIo = useCustomerIo();
+  const snitcher = useSnitcher();
   const { currentUser, currentOrganization } = useAuth();
   const { selectedRegion } = useRegion();
   const hasIdentifiedOrg = useRef(false);
@@ -25,6 +27,7 @@ export function IdentityProvider({ children }: { children: React.ReactNode }) {
       if (!hasIdentifiedOrg.current) {
         segment.identify(currentUser);
         customerIo.identify(currentUser);
+        snitcher.identify(currentUser, currentOrganization);
 
         sentrySetUser({
           email: currentUser.email ?? '',
@@ -70,7 +73,7 @@ export function IdentityProvider({ children }: { children: React.ReactNode }) {
     } else {
       sentrySetUser(null);
     }
-  }, [ldClient, currentOrganization, currentUser, segment, customerIo, selectedRegion]);
+  }, [ldClient, currentOrganization, currentUser, segment, customerIo, snitcher, selectedRegion]);
 
   return <>{children}</>;
 }

--- a/apps/dashboard/src/context/snitcher/hooks.ts
+++ b/apps/dashboard/src/context/snitcher/hooks.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+import { SnitcherContext } from './snitcher-provider';
+
+export const useSnitcher = () => {
+  const result = React.useContext(SnitcherContext);
+
+  if (!result) {
+    throw new Error('Context used outside of its Provider!');
+  }
+
+  return result;
+};

--- a/apps/dashboard/src/context/snitcher/index.ts
+++ b/apps/dashboard/src/context/snitcher/index.ts
@@ -1,0 +1,2 @@
+export * from './hooks';
+export * from './snitcher-provider';

--- a/apps/dashboard/src/context/snitcher/snitcher-provider.tsx
+++ b/apps/dashboard/src/context/snitcher/snitcher-provider.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { SnitcherService } from '@/utils/snitcher';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const SnitcherContext = React.createContext<SnitcherService>({} as SnitcherService);
+
+export const SnitcherProvider = ({ children }: Props) => {
+  const snitcher = React.useMemo(() => new SnitcherService(), []);
+
+  return <SnitcherContext.Provider value={snitcher}>{children}</SnitcherContext.Provider>;
+};

--- a/apps/dashboard/src/routes/root.tsx
+++ b/apps/dashboard/src/routes/root.tsx
@@ -12,6 +12,7 @@ import { EscapeKeyManagerProvider } from '@/context/escape-key-manager/escape-ke
 import { IdentityProvider } from '@/context/identity-provider';
 import { RegionProvider } from '@/context/region';
 import { SegmentProvider } from '@/context/segment';
+import { SnitcherProvider } from '@/context/snitcher';
 import { RootRouteErrorFallback } from '@/routes/root-route-error-fallback';
 
 const queryClient = new QueryClient({
@@ -51,19 +52,21 @@ const RootRouteInternal = () => {
         <ClerkProvider>
           <SegmentProvider>
             <CustomerIoProvider>
-              <AuthProvider>
-                <RegionProvider>
-                  <IdentityProvider>
-                    <HelmetProvider>
-                      <TooltipProvider delayDuration={100}>
-                        <EscapeKeyManagerProvider>
-                          <Outlet />
-                        </EscapeKeyManagerProvider>
-                      </TooltipProvider>
-                    </HelmetProvider>
-                  </IdentityProvider>
-                </RegionProvider>
-              </AuthProvider>
+              <SnitcherProvider>
+                <AuthProvider>
+                  <RegionProvider>
+                    <IdentityProvider>
+                      <HelmetProvider>
+                        <TooltipProvider delayDuration={100}>
+                          <EscapeKeyManagerProvider>
+                            <Outlet />
+                          </EscapeKeyManagerProvider>
+                        </TooltipProvider>
+                      </HelmetProvider>
+                    </IdentityProvider>
+                  </RegionProvider>
+                </AuthProvider>
+              </SnitcherProvider>
             </CustomerIoProvider>
           </SegmentProvider>
         </ClerkProvider>

--- a/apps/dashboard/src/utils/snitcher.ts
+++ b/apps/dashboard/src/utils/snitcher.ts
@@ -1,0 +1,62 @@
+import type { IOrganizationEntity, IUserEntity } from '@novu/shared';
+
+type SnitcherIdentifyTraits = Record<string, unknown>;
+
+type SnitcherGlobal = {
+  identify: (email: string, traits?: SnitcherIdentifyTraits) => void;
+  track?: (event: string, properties?: Record<string, unknown>) => void;
+};
+
+declare global {
+  interface Window {
+    Snitcher?: SnitcherGlobal;
+  }
+}
+
+export class SnitcherService {
+  private get _snitcher(): SnitcherGlobal | undefined {
+    if (typeof window === 'undefined') return undefined;
+
+    return window.Snitcher;
+  }
+
+  identify(user: IUserEntity, organization?: IOrganizationEntity, extraTraits?: SnitcherIdentifyTraits) {
+    if (!this.isEnabled() || !user?.email) return;
+
+    const traits: SnitcherIdentifyTraits = {
+      name: [user.firstName, user.lastName].filter(Boolean).join(' ').trim() || undefined,
+      first_name: user.firstName,
+      last_name: user.lastName,
+      user_id: user._id,
+      ...(organization
+        ? {
+            company: organization.name,
+            company_id: organization._id,
+            plan: organization.apiServiceLevel,
+            organization_created_at: organization.createdAt,
+          }
+        : {}),
+      ...(extraTraits || {}),
+    };
+
+    try {
+      this._snitcher?.identify(user.email, traits);
+    } catch (error) {
+      console.error('Snitcher identify failed', error);
+    }
+  }
+
+  track(event: string, properties?: Record<string, unknown>) {
+    if (!this.isEnabled()) return;
+
+    try {
+      this._snitcher?.track?.(event, properties);
+    } catch (error) {
+      console.error('Snitcher track failed', error);
+    }
+  }
+
+  isEnabled(): boolean {
+    return typeof window !== 'undefined' && typeof this._snitcher?.identify === 'function';
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR adds Snitcher analytics integration to the dashboard. A new `SnitcherService` utility class handles identify and track operations; the service is wrapped in a React context provider following existing patterns. The authentication flow now calls `snitcher.identify(email, traits)` alongside Segment and Customer.io identification, passing user details (email, name, user ID) and organization information (company, company ID, plan). Integration is disabled gracefully when the Snitcher tracker is not loaded via GTM.

## Affected areas

- **dashboard**: Added `SnitcherService` utility with identify/track methods; added `SnitcherProvider` context and `useSnitcher` hook; integrated Snitcher identification into the identity provider's auth flow; wired the provider into the root route's provider tree.

## Key technical decisions

- `SnitcherService.isEnabled()` checks `typeof window.Snitcher?.identify === 'function'`, making all Snitcher calls silent no-ops when GTM hasn't loaded the tracker.
- Identify calls are wrapped in try/catch to prevent failures from breaking the auth bootstrap flow.
- Identification is gated by the existing `hasIdentifiedOrg` flag to ensure one identification per session.

## Testing

No tests were added. Since this is a tracking-only integration with graceful degradation (isEnabled check) and error handling (try/catch), manual verification of GTM integration and error resilience is appropriate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Integrates the [Snitcher identify flow](https://docs.snitcher.com/product/tracker/identify-users) in `apps/dashboard`, mirroring how Segment and Customer.io are wired up today. The Snitcher tracker is loaded globally via Google Tag Manager, so this PR adds the client-side glue that calls `Snitcher.identify(email, traits)` once we know who the authenticated user is.

What's added:

- `apps/dashboard/src/utils/snitcher.ts` — a `SnitcherService` that safely wraps `window.Snitcher` (no-op when GTM hasn't loaded the tracker, e.g. self-hosted / local dev).
- `apps/dashboard/src/context/snitcher/` — `SnitcherProvider` + `useSnitcher` hook, matching the existing Segment / Customer.io pattern.
- `apps/dashboard/src/routes/root.tsx` — wires the provider into the root tree alongside the other analytics providers.
- `apps/dashboard/src/context/identity-provider.tsx` — calls `snitcher.identify(currentUser, currentOrganization)` from the same `useEffect` that already drives the Segment / Customer.io / Sentry identify calls, so the user is identified once per session as soon as both `currentUser` and `currentOrganization` are available.

Traits forwarded to Snitcher (email is the primary identifier):

```js
Snitcher.identify(user.email, {
  name, first_name, last_name, user_id,
  company, company_id, plan, organization_created_at,
});
```

### Screenshots

N/A — no UI changes; this is a tracking-only integration that fires after authentication.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None.

### Special notes for your reviewer

- `SnitcherService.isEnabled()` checks `typeof window.Snitcher?.identify === 'function'`, so when GTM doesn't inject the tracker (self-hosted, local dev without GTM, ad-blockers) the calls are silent no-ops — same defensive pattern used in `customer-io.ts`.
- All identify calls are wrapped in `try/catch` so a Snitcher failure can never break the auth bootstrap flow.
- `identify` is gated by `hasIdentifiedOrg` like the other providers, so we identify once per session rather than on every render.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779110441243559?thread_ts=1779110441.243559&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-140ea5e6-d01d-56b8-87a4-ecc10076afa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-140ea5e6-d01d-56b8-87a4-ecc10076afa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

