### PR TITLE
fix(api-service): scope conversation thread lookup by agent and integration

### DIFF
--- a/apps/api/src/app/agents/e2e/agent-slack-roundtrip.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-slack-roundtrip.e2e.ts
@@ -262,6 +262,8 @@ describe('Agent Slack Roundtrip - emulate.dev #novu-v2', () => {
     const conversation = await conversationRepository.findByPlatformThread(
       ctx.session.environment._id,
       ctx.session.organization._id,
+      ctx.agentId,
+      ctx.integrationId,
       `slack:${channel.id}:${threadTs}`
     );
     expect(conversation, 'inbound conversation persisted').to.exist;
@@ -483,6 +485,8 @@ describe('Agent Slack Roundtrip - emulate.dev #novu-v2', () => {
     const conversation = await conversationRepository.findByPlatformThread(
       ctx.session.environment._id,
       ctx.session.organization._id,
+      ctx.agentId,
+      ctx.integrationId,
       `slack:${channel.id}:${ts}`
     );
     expect(conversation, 'conversation persisted').to.exist;
@@ -529,6 +533,8 @@ describe('Agent Slack Roundtrip - emulate.dev #novu-v2', () => {
     const conversation = await conversationRepository.findByPlatformThread(
       ctx.session.environment._id,
       ctx.session.organization._id,
+      ctx.agentId,
+      ctx.integrationId,
       `slack:${channel.id}:${threadTs}`
     );
     expect(conversation, 'conversation exists').to.exist;

--- a/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
@@ -120,6 +120,8 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       const conversation = await conversationRepository.findByPlatformThread(
         ctx.session.environment._id,
         ctx.session.organization._id,
+        ctx.agentId,
+        ctx.integrationId,
         threadId
       );
 
@@ -166,6 +168,8 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       const conversation = await conversationRepository.findByPlatformThread(
         ctx.session.environment._id,
         ctx.session.organization._id,
+        ctx.agentId,
+        ctx.integrationId,
         threadId
       );
 
@@ -193,6 +197,8 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       const conversation = await conversationRepository.findByPlatformThread(
         ctx.session.environment._id,
         ctx.session.organization._id,
+        ctx.agentId,
+        ctx.integrationId,
         threadId
       );
 
@@ -320,6 +326,8 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       const conversation = await conversationRepository.findByPlatformThread(
         ctx.session.environment._id,
         ctx.session.organization._id,
+        ctx.agentId,
+        ctx.integrationId,
         threadId
       );
       expect(conversation!.status).to.equal(ConversationStatusEnum.ACTIVE);
@@ -336,6 +344,8 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       const reopened = await conversationRepository.findByPlatformThread(
         ctx.session.environment._id,
         ctx.session.organization._id,
+        ctx.agentId,
+        ctx.integrationId,
         threadId
       );
       expect(reopened!.status).to.equal(ConversationStatusEnum.ACTIVE);
@@ -351,6 +361,8 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       let conversation = await conversationRepository.findByPlatformThread(
         ctx.session.environment._id,
         ctx.session.organization._id,
+        ctx.agentId,
+        ctx.integrationId,
         threadId
       );
       const platformUserParticipant = conversation!.participants.find(
@@ -375,6 +387,8 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       conversation = await conversationRepository.findByPlatformThread(
         ctx.session.environment._id,
         ctx.session.organization._id,
+        ctx.agentId,
+        ctx.integrationId,
         threadId
       );
 
@@ -481,6 +495,8 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
       const conversation = await conversationRepository.findByPlatformThread(
         ctx.session.environment._id,
         ctx.session.organization._id,
+        ctx.agentId,
+        ctx.integrationId,
         threadId
       );
       const activitiesBefore = await activityRepository.findByConversation(

--- a/apps/api/src/app/agents/services/agent-conversation.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.spec.ts
@@ -1,0 +1,77 @@
+import { ConversationParticipantTypeEnum, ConversationRepository, ConversationStatusEnum } from '@novu/dal';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { AgentConversationService } from './agent-conversation.service';
+
+describe('AgentConversationService', () => {
+  function makeLogger() {
+    return {
+      setContext: sinon.stub(),
+      debug: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      info: sinon.stub(),
+    };
+  }
+
+  function baseCreateParams() {
+    return {
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      agentId: 'agent-a',
+      platform: 'telegram',
+      integrationId: 'integration-a',
+      platformThreadId: '999888777',
+      participantId: 'telegram:111',
+      participantType: ConversationParticipantTypeEnum.PLATFORM_USER,
+      platformUserId: '111',
+      firstMessageText: 'hello',
+    };
+  }
+
+  it('scopes createOrGetConversation lookup by agent id and integration id', async () => {
+    const findByPlatformThread = sinon.stub().resolves(null);
+    const create = sinon.stub().resolves({
+      _id: 'new-conv',
+      participants: [],
+      channels: [],
+      status: ConversationStatusEnum.ACTIVE,
+    });
+
+    const conversationRepository = {
+      findByPlatformThread,
+      create,
+      updateStatus: sinon.stub(),
+      updateParticipants: sinon.stub(),
+    } as unknown as ConversationRepository;
+
+    const service = new AgentConversationService(conversationRepository, {} as any, makeLogger() as any);
+
+    await service.createOrGetConversation(baseCreateParams());
+
+    expect(findByPlatformThread.calledOnce).to.equal(true);
+    expect(findByPlatformThread.firstCall.args).to.deep.equal([
+      'env-1',
+      'org-1',
+      'agent-a',
+      'integration-a',
+      '999888777',
+    ]);
+  });
+
+  it('delegates findByPlatformThread to the repository with agent and integration', async () => {
+    const findByPlatformThread = sinon.stub().resolves(null);
+    const conversationRepository = {
+      findByPlatformThread,
+      create: sinon.stub(),
+      updateStatus: sinon.stub(),
+      updateParticipants: sinon.stub(),
+    } as unknown as ConversationRepository;
+
+    const service = new AgentConversationService(conversationRepository, {} as any, makeLogger() as any);
+
+    await service.findByPlatformThread('e', 'o', 'agent-x', 'int-x', 'thread-z');
+
+    expect(findByPlatformThread.calledOnceWithExactly('e', 'o', 'agent-x', 'int-x', 'thread-z')).to.equal(true);
+  });
+});

--- a/apps/api/src/app/agents/services/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.ts
@@ -125,6 +125,8 @@ export class AgentConversationService {
     const existing = await this.conversationRepository.findByPlatformThread(
       environmentId,
       organizationId,
+      params.agentId,
+      params.integrationId,
       platformThreadId
     );
 
@@ -275,9 +277,17 @@ export class AgentConversationService {
   async findByPlatformThread(
     environmentId: string,
     organizationId: string,
+    agentId: string,
+    integrationId: string,
     platformThreadId: string
   ): Promise<ConversationEntity | null> {
-    return this.conversationRepository.findByPlatformThread(environmentId, organizationId, platformThreadId);
+    return this.conversationRepository.findByPlatformThread(
+      environmentId,
+      organizationId,
+      agentId,
+      integrationId,
+      platformThreadId
+    );
   }
 
   async setFirstPlatformMessageId(

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -9,21 +9,21 @@ import {
   EnvironmentRepository,
   SubscriberRepository,
 } from '@novu/dal';
-import { ENDPOINT_TYPES } from '@novu/shared';
 import type { AgentAction } from '@novu/framework';
+import { ENDPOINT_TYPES } from '@novu/shared';
 import type { CardChild, CardElement, EmojiValue, Message, Thread } from 'chat';
 import { trackAgentInboundAction, trackAgentInboundMessage, trackAgentInboundReaction } from '../agent-analytics';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { AgentPlatformEnum, PLATFORMS_WITH_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
-import { LinkTelegramChatToSubscriber } from '../usecases/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.usecase';
 import { LinkTelegramChatToSubscriberCommand } from '../usecases/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.command';
+import { LinkTelegramChatToSubscriber } from '../usecases/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.usecase';
 import { AgentAttachmentStorage, type StoredAttachment } from './agent-attachment-storage.service';
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
-import { TelegramStartCodeService } from './telegram-start-code.service';
 import { AgentConversationService, getInboundActivityPreview } from './agent-conversation.service';
 import { AgentSubscriberResolver } from './agent-subscriber-resolver.service';
 import { BridgeExecutorService, type BridgeReaction, NoBridgeUrlError } from './bridge-executor.service';
 import { ManagedExecutorService } from './managed-executor.service';
+import { TelegramStartCodeService } from './telegram-start-code.service';
 
 /**
  * `/start <payload>` is Telegram's deep-link mechanism. Telegram delivers it as
@@ -547,6 +547,8 @@ export class AgentInboundHandler {
     const conversation = await this.conversationService.findByPlatformThread(
       config.environmentId,
       config.organizationId,
+      config.agentId,
+      config.integrationId,
       threadId
     );
 

--- a/libs/dal/src/repositories/conversation/conversation.repository.ts
+++ b/libs/dal/src/repositories/conversation/conversation.repository.ts
@@ -38,16 +38,29 @@ export class ConversationRepository extends BaseRepositoryV2<
     super(Conversation, ConversationEntity);
   }
 
+  /**
+   * Resolves a conversation for an inbound platform thread. Must be scoped by
+   * agent and integration so Telegram private-chat IDs (same numeric chat.id
+   * across different bots) do not collide across agents in one environment.
+   */
   async findByPlatformThread(
     environmentId: string,
     organizationId: string,
+    agentId: string,
+    integrationId: string,
     platformThreadId: string
   ): Promise<ConversationEntity | null> {
     return this.findOne(
       {
         _environmentId: environmentId,
         _organizationId: organizationId,
-        'channels.platformThreadId': platformThreadId,
+        _agentId: agentId,
+        channels: {
+          $elemMatch: {
+            platformThreadId,
+            _integrationId: integrationId,
+          },
+        },
       },
       '*'
     );


### PR DESCRIPTION
## Summary

- **Root cause:** `ConversationRepository.findByPlatformThread` matched only `environmentId`, `organizationId`, and `channels.platformThreadId`. Telegram private DMs use the same numeric `chat.id` for the same human across different bots, so a second agent could reuse the first agent’s conversation row.
- **Change:** Lookups now require **`_agentId`** and a **`channels.$elemMatch`** on **`_integrationId`** + **`platformThreadId`**. `AgentConversationService.createOrGetConversation` and `findByPlatformThread` pass agent and integration; inbound **reactions** use `config.agentId` / `config.integrationId`. Agent e2e helpers were updated to pass `ctx.agentId` and `ctx.integrationId`.
- **Tests:** `agent-conversation.service.spec.ts` asserts the scoped repository call shape.

```mermaid
flowchart LR
  subgraph before [Before]
    Q1["find: env + org + threadId"]
  end
  subgraph after [After]
    Q2["find: env + org + agentId + integrationId + threadId"]
  end
  before --> after
```

## Linear

Linear MCP was not available from this environment, so the PR title does **not** yet include `fixes NV-<id>`. Please **create or link the Linear issue** and edit the title to: `fix(api-service): scope conversation thread lookup by agent and integration fixes NV-<id>` (per `.cursor/rules/pullrequest.mdc`).

## Test plan

- [x] `cd apps/api && pnpm test -- --grep AgentConversationService`
- [x] `cd libs/dal && pnpm build`
- [ ] Agent webhook e2e / Slack roundtrip e2e (if CI does not cover them on this branch)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The conversation thread lookup was narrowed in scope to prevent collisions across agents and integrations. Previously, `ConversationRepository.findByPlatformThread` matched only on `environmentId`, `organizationId`, and `channels.platformThreadId`, causing conversations to cross-reference between different agents when platforms (like Telegram) reuse numeric IDs across bots. The fix adds `agentId` and `integrationId` to the lookup criteria and uses `$elemMatch` to ensure both platform thread and integration are matched together.

## Affected areas

- **dal**: `ConversationRepository.findByPlatformThread` now requires `agentId` and `integrationId` parameters and scopes the channel lookup with `$elemMatch` on both `_integrationId` and `platformThreadId`.
- **api**: `AgentConversationService.findByPlatformThread` and `createOrGetConversation` updated to accept and pass through `agentId` and `integrationId`. `AgentInboundHandlerService.handleReaction` now extracts and forwards these fields from config. All agent e2e tests updated to provide scoped lookup parameters.

## Key technical decisions

- **Breaking change**: Method signature of `findByPlatformThread` expanded to require `agentId` and `integrationId` parameters — all callers must be updated to provide these identifiers.
- **Database query pattern**: Uses MongoDB `$elemMatch` to atomically match both integration and thread within a single channel array element, ensuring correctness across multi-channel conversations.

## Testing

Added new unit test suite for `AgentConversationService` verifying the scoped repository call shape. Updated existing e2e tests to pass required agent and integration identifiers in conversation lookups. Manual verification of unit tests and libs/dal rebuild completed; agent webhook and Slack roundtrip e2e tests remain to be verified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->