### PR TITLE
refactor(shared,dal,api,dashboard): remove unused AgentCreationSourceEnum fixes NV-7701

### DIFF
--- a/apps/api/src/app/agents/agents.controller.ts
+++ b/apps/api/src/app/agents/agents.controller.ts
@@ -167,7 +167,6 @@ export class AgentsController {
         active: body.active,
         runtime: body.runtime,
         managedRuntime: body.managedRuntime,
-        creationSource: body.creationSource,
       })
     );
   }

--- a/apps/api/src/app/agents/dtos/agent-response.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-response.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import type { AgentRuntime } from '@novu/shared';
-import { AgentCreationSourceEnum } from '@novu/shared';
 
 import { AgentBehaviorDto } from './agent-behavior.dto';
 import { AgentIntegrationSummaryDto } from './agent-integration-summary.dto';
@@ -87,12 +86,6 @@ export class AgentResponseDto {
 
   @ApiProperty()
   updatedAt: string;
-
-  @ApiPropertyOptional({
-    enum: AgentCreationSourceEnum,
-    description: 'Which section of the Novu Dashboard was used to create this agent.',
-  })
-  creationSource?: AgentCreationSourceEnum;
 
   @ApiPropertyOptional({ type: [AgentIntegrationSummaryDto] })
   integrations?: AgentIntegrationSummaryDto[];

--- a/apps/api/src/app/agents/dtos/create-agent-request.dto.ts
+++ b/apps/api/src/app/agents/dtos/create-agent-request.dto.ts
@@ -1,10 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import {
-  AgentCreationSourceEnum,
-  AgentRuntime,
-  SLUG_IDENTIFIER_REGEX,
-  slugIdentifierFormatMessage,
-} from '@novu/shared';
+import { AgentRuntime, SLUG_IDENTIFIER_REGEX, slugIdentifierFormatMessage } from '@novu/shared';
 import { Type } from 'class-transformer';
 import {
   IsBoolean,
@@ -61,13 +56,4 @@ export class CreateAgentRequestDto {
   @ValidateNested()
   @Type(() => ManagedRuntimeDto)
   managedRuntime?: ManagedRuntimeDto;
-
-  @ApiPropertyOptional({
-    enum: AgentCreationSourceEnum,
-    default: AgentCreationSourceEnum.PLATFORM,
-    description: 'Which section of the Novu Dashboard was used to create this agent.',
-  })
-  @IsOptional()
-  @IsEnum(AgentCreationSourceEnum)
-  creationSource?: AgentCreationSourceEnum;
 }

--- a/apps/api/src/app/agents/mappers/agent-response.mapper.ts
+++ b/apps/api/src/app/agents/mappers/agent-response.mapper.ts
@@ -82,7 +82,6 @@ export function toAgentResponse(agent: AgentEntity, hydration?: ManagedRuntimeHy
     devBridgeUrl: agent.devBridgeUrl,
     devBridgeActive: agent.devBridgeActive,
     runtime: agent.runtime,
-    creationSource: agent.creationSource,
     managedRuntime,
     _environmentId: agent._environmentId,
     _organizationId: agent._organizationId,

--- a/apps/api/src/app/agents/usecases/create-agent/create-agent.command.ts
+++ b/apps/api/src/app/agents/usecases/create-agent/create-agent.command.ts
@@ -1,5 +1,4 @@
 import type { AgentRuntime } from '@novu/shared';
-import { AgentCreationSourceEnum } from '@novu/shared';
 import { Type } from 'class-transformer';
 import {
   IsBoolean,
@@ -43,8 +42,4 @@ export class CreateAgentCommand extends EnvironmentWithUserCommand {
   @ValidateNested()
   @Type(() => ManagedRuntimeDto)
   managedRuntime?: ManagedRuntimeDto;
-
-  @IsOptional()
-  @IsEnum(AgentCreationSourceEnum)
-  creationSource?: AgentCreationSourceEnum;
 }

--- a/apps/api/src/app/agents/usecases/create-agent/create-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/create-agent/create-agent.usecase.ts
@@ -83,7 +83,6 @@ export class CreateAgent {
               identifier: tempIdentifier,
               description: command.description,
               active: command.active ?? true,
-              creationSource: command.creationSource,
               _environmentId: command.environmentId,
               _organizationId: command.organizationId,
             },
@@ -161,7 +160,6 @@ export class CreateAgent {
           identifier: command.identifier ?? '',
           description: command.description,
           active: command.active ?? true,
-          creationSource: command.creationSource,
           _environmentId: command.environmentId,
           _organizationId: command.organizationId,
         });

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -1,5 +1,4 @@
 import type {
-  AgentCreationSourceEnum,
   AgentRuntime,
   AgentRuntimeProviderIdEnum,
   ChannelTypeEnum,
@@ -113,7 +112,6 @@ export type CreateAgentBody = {
   active?: boolean;
   runtime?: AgentRuntime;
   managedRuntime?: ManagedRuntimeDto;
-  creationSource?: AgentCreationSourceEnum;
 };
 
 export type UpdateAgentBody = {

--- a/libs/dal/src/repositories/agent/agent.entity.ts
+++ b/libs/dal/src/repositories/agent/agent.entity.ts
@@ -1,4 +1,4 @@
-import type { AgentCreationSourceEnum, AgentRuntime, ManagedRuntimeConfigDto } from '@novu/shared';
+import type { AgentRuntime, ManagedRuntimeConfigDto } from '@novu/shared';
 import type { ChangePropsValueType } from '../../types/helpers';
 import type { EnvironmentId } from '../environment';
 import type { OrganizationId } from '../organization';
@@ -48,12 +48,6 @@ export class AgentEntity {
    * (model, systemPrompt, MCP servers, tools) is fetched from the provider on demand.
    */
   managedRuntime?: ManagedRuntimeConfig;
-
-  /**
-   * Which section of the Novu Dashboard was used to create this agent.
-   * Defaults to 'platform' for backward compatibility with existing records.
-   */
-  creationSource?: AgentCreationSourceEnum;
 
   _environmentId: EnvironmentId;
 

--- a/libs/dal/src/repositories/agent/agent.schema.ts
+++ b/libs/dal/src/repositories/agent/agent.schema.ts
@@ -41,11 +41,6 @@ const agentSchema = new Schema<AgentDBModel>(
       },
       externalAgentId: Schema.Types.String,
     },
-    creationSource: {
-      type: Schema.Types.String,
-      enum: ['platform', 'connect'],
-      default: 'platform',
-    },
     _organizationId: {
       type: Schema.Types.ObjectId,
       ref: 'Organization',

--- a/packages/shared/src/dto/agent/managed-runtime.dto.ts
+++ b/packages/shared/src/dto/agent/managed-runtime.dto.ts
@@ -2,16 +2,6 @@ import { AgentRuntimeProviderIdEnum } from '../../types/providers';
 
 export type AgentRuntime = 'self-hosted' | 'managed';
 
-/**
- * Identifies which section of the Novu Dashboard was used to create the agent.
- * - `'platform'` – created from the standard Platform section (default).
- * - `'connect'` – created from the Connect section.
- */
-export enum AgentCreationSourceEnum {
-  PLATFORM = 'platform',
-  CONNECT = 'connect',
-}
-
 export type ManagedRuntimeConfigDto = {
   /** The agent-runtime provider (e.g. 'anthropic') */
   providerId: AgentRuntimeProviderIdEnum;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Removed the `AgentCreationSourceEnum` enum and `creationSource` field from agents across the codebase. This field tracked whether agents were created through the platform UI or Connect integration. The removal is motivated by a new architectural decision: platform and Connect agents will now be scoped to separate Novu organizations, eliminating the need for application-level filtering by creation source.

## Affected areas

- **shared**: Removed `AgentCreationSourceEnum` export from the managed-runtime DTO.
- **dal**: Removed `creationSource` field from the `AgentEntity` type and MongoDB schema (`agent.schema.ts`). Existing data in MongoDB is unaffected due to mongoose strict mode.
- **api**: Removed the field from `CreateAgentRequestDto`, `AgentResponseDto`, `CreateAgentCommand`, the `CreateAgent` usecase, the agent-response mapper, and the `createAgent` controller handler.
- **dashboard**: Removed `creationSource` from the `CreateAgentBody` API client type.

## Key technical decisions

- **No data migration**: Existing `creationSource` values in MongoDB documents are ignored and harmless; new agents will not include this field.
- **No breaking changes**: The field was optional in all request/response contracts, so removal does not affect existing API consumers that don't provide or expect it.

## Testing

No new tests were added. The field was not referenced in any e2e tests, and its removal requires no validation given it was purely optional metadata that is now architecturally redundant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Remove the agent-level `creationSource` field (`AgentCreationSourceEnum` — `'platform'` / `'connect'`) from the codebase. Platform vs Connect agents will live in separate Novu organizations, so there is no need to filter on this field at the application level.

Removed from:
- `packages/shared` — drop the `AgentCreationSourceEnum` export from `dto/agent/managed-runtime.dto.ts`.
- `libs/dal` — drop the `creationSource` field from the agent entity (`agent.entity.ts`) and mongoose schema (`agent.schema.ts`).
- `apps/api/src/app/agents` — drop the field from the request DTO, response DTO, `CreateAgentCommand`, `CreateAgent` use-case, response mapper, and the `POST /agents` controller handler.
- `apps/dashboard/src/api/agents.ts` — drop the field from the `CreateAgentBody` API client type and remove the `AgentCreationSourceEnum` import.

#### Data migration

No data migration is needed. Existing `creationSource` values stored in MongoDB are harmless: with the field removed from the schema, mongoose strict mode simply ignores them on read, and the field is never written for new agents.

Context: Slack thread in `#proj-conversations` (5/18/2026).

### Screenshots

N/A — no UI changes.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

None — no `enterprise/` packages were touched.

### Special notes for your reviewer

- The auto-generated `apps/api/src/metadata.ts` does not need changes — the file in `next` does not reference `AgentCreationSourceEnum` (it is regenerated locally via `pnpm build:metadata` before tests/builds).
- Agents are excluded from the public SDK (`@ApiExcludeController()`), so `libs/internal-sdk` is unaffected.
- No e2e tests referenced `creationSource`, so existing agent e2es do not need updating.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0AQDQ4J6UU/p1779119506284579?thread_ts=1779119506.284579&cid=C0AQDQ4J6UU)

<div><a href="https://cursor.com/agents/bc-d0c5f83d-c50e-5ca5-8db5-afc0fed4d31f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0c5f83d-c50e-5ca5-8db5-afc0fed4d31f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

