### PR TITLE
fix: gate Telegram webhook configuration to resolve race condition

### DIFF
--- a/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
@@ -112,7 +112,11 @@ export function TelegramSetupGuide({
 
   const hasCredentials = hasIntegrationCredentials(selectedIntegration?.credentials);
   const isCredentialsSaved = hasCredentials || credentialsSavedLocally;
-
+  // Set only after a successful setWebhook call; prevents the dashboard from
+  // re-registering a webhook the mobile flow already configured.
+  const hasWebhookSecret =
+    typeof selectedIntegration?.credentials?.token === 'string' &&
+    selectedIntegration.credentials.token.length > 0;
   // Poll for credentials only while the sidebar is open AND the user hasn't saved a token yet.
   // Stops the moment the drawer closes or credentials appear.
   useEffect(() => {
@@ -173,19 +177,18 @@ export function TelegramSetupGuide({
     configureTelegram();
   }, [configureTelegram]);
 
-  // When credentials already exist (e.g. user revisiting the guide, or the
-  // mobile flow just dropped a token onto the integration), auto-configure
-  // once so botUsername is populated and the QR code is available for step 3.
+  // Auto-configure only when a Bot Token exists but no webhook secret yet.
   useEffect(() => {
     if (
       hasCredentials &&
+      !hasWebhookSecret &&
       !isWebhookConfigured &&
       !isConfiguring &&
       !autoConfigureAttemptedRef.current
     ) {
       runConfigureTelegram();
     }
-  }, [hasCredentials, isWebhookConfigured, isConfiguring, runConfigureTelegram]);
+  }, [hasCredentials, hasWebhookSecret, isWebhookConfigured, isConfiguring, runConfigureTelegram]);
 
   const {
     mutate: issueSubscriberLink,


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed? Why was the change needed?

The `TelegramSetupGuide` component now derives an explicit `hasWebhookSecret` state from the selected integration's stored Telegram token presence. This gates the auto-configuration webhook effect to prevent race conditions where the mobile flow and dashboard both attempt to register the webhook simultaneously. The auto-configure effect now requires that credentials exist, the webhook secret is missing, the webhook is not yet configured, and no configure attempt is in progress—preventing duplicate webhook registration when the mobile flow has already set the token.

## Affected areas

- **dashboard**: Added `TelegramSetupGuide` component that manages the Telegram bot setup workflow with gated webhook configuration to resolve race conditions between mobile and dashboard token submission flows.

## Testing

No tests are referenced in this change. The fix addresses a runtime race condition that would typically require integration or end-to-end tests to verify, particularly testing concurrent mobile and dashboard token submission flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
