### PR TITLE
fix(dashboard): drop Telegram auto-configure on credential detection (fixes NV-7706)

### DIFF
--- a/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
@@ -78,20 +78,12 @@ export function TelegramSetupGuide({
     return `${user.externalId}:agent-quickstart:${agent._id}`;
   }, [user?.externalId, agent._id]);
 
-  // Guards the auto-configure effect below from looping on failure. Without it,
-  // a failed configureTelegram() (e.g. Telegram setWebhook rate-limit) would
-  // leave isWebhookConfigured=false and isConfiguring=false, and the effect
-  // would immediately re-fire — generating an unbounded burst of webhook
-  // registration attempts and getting rate-limited further by Telegram.
-  const autoConfigureAttemptedRef = useRef(false);
-
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset when the watched integration changes
   useEffect(() => {
     setIsConnected(false);
     setCredentialsSavedLocally(false);
     setConfiguredWebhookUrl(null);
     setBotUsername(null);
-    autoConfigureAttemptedRef.current = false;
     setSubscriberLink(null);
   }, [integrationId]);
 
@@ -112,11 +104,7 @@ export function TelegramSetupGuide({
 
   const hasCredentials = hasIntegrationCredentials(selectedIntegration?.credentials);
   const isCredentialsSaved = hasCredentials || credentialsSavedLocally;
-  // Set only after a successful setWebhook call; prevents the dashboard from
-  // re-registering a webhook the mobile flow already configured.
-  const hasWebhookSecret =
-    typeof selectedIntegration?.credentials?.token === 'string' &&
-    selectedIntegration.credentials.token.length > 0;
+
   // Poll for credentials only while the sidebar is open AND the user hasn't saved a token yet.
   // Stops the moment the drawer closes or credentials appear.
   useEffect(() => {
@@ -145,7 +133,7 @@ export function TelegramSetupGuide({
     }
   }, [hasCredentials, isCredentialsSidebarOpen]);
 
-  const { mutate: configureTelegram, isPending: isConfiguring, error: configureError } = useMutation({
+  const { mutate: configureTelegram, error: configureError } = useMutation({
     mutationFn: () =>
       configureTelegramAgentWebhook(
         requireEnvironment(currentEnvironment, 'No environment selected'),
@@ -167,28 +155,6 @@ export function TelegramSetupGuide({
   });
 
   const isWebhookConfigured = Boolean(configuredWebhookUrl);
-
-  // Every code path that fires the webhook configuration goes through this
-  // helper so the auto-configure effect cannot also fire after a manual
-  // attempt fails. See autoConfigureAttemptedRef above for the rate-limit
-  // loop this prevents.
-  const runConfigureTelegram = useCallback(() => {
-    autoConfigureAttemptedRef.current = true;
-    configureTelegram();
-  }, [configureTelegram]);
-
-  // Auto-configure only when a Bot Token exists but no webhook secret yet.
-  useEffect(() => {
-    if (
-      hasCredentials &&
-      !hasWebhookSecret &&
-      !isWebhookConfigured &&
-      !isConfiguring &&
-      !autoConfigureAttemptedRef.current
-    ) {
-      runConfigureTelegram();
-    }
-  }, [hasCredentials, hasWebhookSecret, isWebhookConfigured, isConfiguring, runConfigureTelegram]);
 
   const {
     mutate: issueSubscriberLink,
@@ -389,7 +355,7 @@ export function TelegramSetupGuide({
           onClose={() => setIsCredentialsSidebarOpen(false)}
           onSaveSuccess={() => {
             setCredentialsSavedLocally(true);
-            runConfigureTelegram();
+            configureTelegram();
           }}
           agentOnboarding
           agentIdentifier={agent.identifier}
@@ -409,7 +375,7 @@ export function TelegramSetupGuide({
         onClose={() => setIsCredentialsSidebarOpen(false)}
         onSaveSuccess={() => {
           setCredentialsSavedLocally(true);
-          runConfigureTelegram();
+          configureTelegram();
         }}
         agentOnboarding
         agentIdentifier={agent.identifier}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Follow-up to #11162 (NV-7694).

That PR tried to gate the dashboard's auto-configure effect with a derived `hasWebhookSecret` (`credentials.token` present), but the gate is unreliable — `credentials.token` is the webhook secret written by `ConfigureTelegramAgentWebhook` only after the dashboard's next refetch decrypts/sees it. The polling pass that first sees the new bot token frequently still observes an empty `token`, fires `configureTelegramAgentWebhook` a second time, and re-creates the original race condition with the mobile flow.

The correct fix is to remove the auto-configure path entirely. Configure now only happens through the two intentional code paths that already exist:

1. **Mobile flow (other tab)** — `ConsumeTelegramMobileLink` already calls `ConfigureTelegramAgentWebhook` server-side after persisting the bot token, so the dashboard doesn't need to repeat the call when its polling notices the credentials. The dashboard just closes the sidebar and shows the "Bot token saved from your phone" toast.
2. **Integration sidebar** — clicking **Save & Connect** still calls `configureTelegram()` from `onSaveSuccess`.

Also drops dead code that only existed to support the removed effect:

- `autoConfigureAttemptedRef` (only consumer was the auto-configure effect's loop-guard)
- `runConfigureTelegram` wrapper (only purpose was setting that ref)
- `hasWebhookSecret` derivation
- `isPending: isConfiguring` from the mutation (no remaining consumers, biome `noUnusedVariables`)

### Screenshots

N/A — pure behavior removal in `apps/dashboard/src/components/agents/telegram-setup-guide.tsx`. The visible UX is identical when the user follows either intentional path; the only observable difference is that the dashboard no longer fires a duplicate `POST /telegram/configure` after the mobile flow lands its token via polling.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

Worth confirming the desired UX after a successful **mobile** flow: with auto-configure removed, the dashboard polling that detects the new credentials will close the sidebar and show the success toast, but step 3's QR / "Open @bot" button (which is keyed off the `botUsername` returned by the dashboard's own `configureTelegram` call) will not render until the user re-opens the guide and presses Save & Connect — or relies on the mobile success card to test the bot. This matches the user's explicit request that the dashboard never silently re-issue a configure request, but is the one behavioral regression to be aware of. If we want step 3 to be fully populated after a mobile-only completion, a follow-up should expose `botUsername` on the integration record (or via the mobile-link consume response) instead of recomputing it via `setWebhook + getMe`.

</details>

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779129229424349?thread_ts=1779129229.424349&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-dbcbe8b5-5cfa-594f-bdd7-08abb8aea296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbcbe8b5-5cfa-594f-bdd7-08abb8aea296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR removes the dashboard's automatic webhook configuration trigger that fired when polling detected newly-saved Telegram credentials. Previously, an auto-configure effect would call `ConfigureTelegramAgentWebhook` whenever credentials appeared during polling, creating a race condition with the mobile flow which already registers the webhook server-side. This duplicate request was caused by an unreliable gate that checked for webhook secrets, which are written only after configuration completes, causing polling to repeatedly detect missing secrets and retrigger configuration.

## Affected areas

**dashboard**: The `TelegramSetupGuide` component no longer includes the polling-triggered auto-configure effect. Webhook configuration now happens explicitly through two paths: (1) the mobile flow's `ConsumeTelegramMobileLink`, which calls `ConfigureTelegramAgentWebhook` server-side after persisting the bot token, and (2) the integration sidebar's "Save & Connect" button, which invokes `configureTelegram()` in `onSaveSuccess` handlers for both embedded and non-embedded layouts. The component removes dead code including `autoConfigureAttemptedRef`, `runConfigureTelegram` wrapper, `hasWebhookSecret` derivation, and the `isPending` state previously used as `isConfiguring` from the mutation.

## Key technical decisions

- Webhook configuration is now purely declarative: it occurs only when users explicitly save credentials via the sidebar or when the mobile flow completes server-side, eliminating the race condition from automatic polling-based triggers.
- The dashboard no longer exposes mutation pending state for the configure operation, simplifying state management.

## Testing

No new tests were added. The component's visible UX remains unchanged for the intended configuration paths; only the duplicate background POST request after mobile completion is eliminated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->