### PR TITLE
fix(dashboard,api-service): Telegram /start deep link on quickstart and mobile setup fixes NV-7696

### DIFF
--- a/apps/api/src/app/agents/agents.controller.ts
+++ b/apps/api/src/app/agents/agents.controller.ts
@@ -53,6 +53,7 @@ import {
 } from './dtos';
 import { ConfigureTelegramWebhookResponseDto } from './dtos/configure-telegram-webhook-response.dto';
 import { ConfigureWhatsAppWebhookResponseDto } from './dtos/configure-whatsapp-webhook-response.dto';
+import { IssueTelegramMobileLinkRequestDto } from './dtos/issue-telegram-mobile-link-request.dto';
 import { IssueTelegramMobileLinkResponseDto } from './dtos/issue-telegram-mobile-link-response.dto';
 import { IssueTelegramSubscriberLinkRequestDto } from './dtos/issue-telegram-subscriber-link-request.dto';
 import { IssueTelegramSubscriberLinkResponseDto } from './dtos/issue-telegram-subscriber-link-response.dto';
@@ -496,7 +497,8 @@ export class AgentsController {
   createTelegramMobileLink(
     @UserSession() user: UserSessionData,
     @Param('identifier') identifier: string,
-    @Param('integrationId') integrationId: string
+    @Param('integrationId') integrationId: string,
+    @Body() body?: IssueTelegramMobileLinkRequestDto
   ): Promise<IssueTelegramMobileLinkResponseDto> {
     return this.issueTelegramMobileLinkUsecase.execute(
       IssueTelegramMobileLinkCommand.create({
@@ -505,6 +507,7 @@ export class AgentsController {
         organizationId: user.organizationId,
         agentIdentifier: identifier,
         integrationId,
+        subscriberId: body?.subscriberId,
       })
     );
   }

--- a/apps/api/src/app/agents/dtos/consume-telegram-mobile-link.dto.ts
+++ b/apps/api/src/app/agents/dtos/consume-telegram-mobile-link.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, Matches } from 'class-validator';
 
 const BOT_TOKEN_PATTERN = /^\d{8,}:[A-Za-z0-9_-]{35,}$/;
@@ -27,4 +27,11 @@ export class ConsumeTelegramMobileLinkResponseDto {
 
   @ApiProperty({ type: String, description: 'Webhook URL Novu registered with Telegram' })
   webhookUrl: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Telegram `t.me/<bot>?start=<code>` deep link to link this chat to the subscriber when the mobile link was issued with a subscriberId.',
+  })
+  deepLinkUrl?: string;
 }

--- a/apps/api/src/app/agents/dtos/issue-telegram-mobile-link-request.dto.ts
+++ b/apps/api/src/app/agents/dtos/issue-telegram-mobile-link-request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class IssueTelegramMobileLinkRequestDto {
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Subscriber id to bind when the mobile setup completes. When set, the consume response includes a ' +
+      '`t.me/<bot>?start=<code>` deep link for that subscriber.',
+  })
+  @IsOptional()
+  @IsString()
+  subscriberId?: string;
+}

--- a/apps/api/src/app/agents/services/telegram-mobile-link-token.service.ts
+++ b/apps/api/src/app/agents/services/telegram-mobile-link-token.service.ts
@@ -24,6 +24,8 @@ export interface TelegramMobileLinkTokenPayload {
   aid: string;
   /** Integration id (internal Mongo `_id`). */
   iid: string;
+  /** Subscriber to link via `/start` deep link after mobile setup (optional). */
+  sid?: string;
   /** Unique token id used for single-use enforcement. */
   jti: string;
   /** Issued-at (seconds since epoch). */
@@ -76,6 +78,7 @@ export class TelegramMobileLinkTokenService {
     organizationId: string;
     agentIdentifier: string;
     integrationId: string;
+    subscriberId?: string;
   }): Promise<IssuedTelegramMobileLink> {
     const jti = randomUUID();
 
@@ -85,6 +88,7 @@ export class TelegramMobileLinkTokenService {
       aid: params.agentIdentifier,
       iid: params.integrationId,
       jti,
+      ...(params.subscriberId ? { sid: params.subscriberId } : {}),
     };
 
     const token = this.jwtService.sign(payload, {

--- a/apps/api/src/app/agents/services/telegram-mobile-link-token.service.ts
+++ b/apps/api/src/app/agents/services/telegram-mobile-link-token.service.ts
@@ -125,7 +125,10 @@ export class TelegramMobileLinkTokenService {
     } catch (err) {
       if (err instanceof InvalidTelegramMobileTokenError) throw err;
       const isExpired =
-        typeof err === 'object' && err !== null && 'name' in err && (err as { name?: string }).name === 'TokenExpiredError';
+        typeof err === 'object' &&
+        err !== null &&
+        'name' in err &&
+        (err as { name?: string }).name === 'TokenExpiredError';
       throw new InvalidTelegramMobileTokenError(isExpired ? 'expired' : 'invalid');
     }
   }

--- a/apps/api/src/app/agents/usecases/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase.ts
+++ b/apps/api/src/app/agents/usecases/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase.ts
@@ -111,9 +111,7 @@ export class ConsumeTelegramMobileLink {
       };
     } catch (err) {
       await this.tokenService.releaseJti(payload.jti);
-      this.logger.warn(
-        `Telegram mobile setup consume failed for jti=${payload.jti}: ${(err as Error).message}`
-      );
+      this.logger.warn(`Telegram mobile setup consume failed for jti=${payload.jti}: ${(err as Error).message}`);
       throw err;
     }
   }

--- a/apps/api/src/app/agents/usecases/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase.ts
+++ b/apps/api/src/app/agents/usecases/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase.ts
@@ -90,17 +90,23 @@ export class ConsumeTelegramMobileLink {
       let deepLinkUrl: string | undefined;
 
       if (payload.sid) {
-        const subscriberLink = await this.issueTelegramSubscriberLink.execute(
-          IssueTelegramSubscriberLinkCommand.create({
-            userId: 'telegram-mobile-link',
-            environmentId: payload.env,
-            organizationId: payload.org,
-            agentIdentifier: payload.aid,
-            integrationId: integration._id,
-            subscriberId: payload.sid,
-          })
-        );
-        deepLinkUrl = subscriberLink.deepLinkUrl;
+        try {
+          const subscriberLink = await this.issueTelegramSubscriberLink.execute(
+            IssueTelegramSubscriberLinkCommand.create({
+              userId: 'telegram-mobile-link',
+              environmentId: payload.env,
+              organizationId: payload.org,
+              agentIdentifier: payload.aid,
+              integrationId: integration._id,
+              subscriberId: payload.sid,
+            })
+          );
+          deepLinkUrl = subscriberLink.deepLinkUrl;
+        } catch (err) {
+          this.logger.warn(
+            `Telegram subscriber-link issue failed for integrationId=${integration._id}, subscriberId=${payload.sid}: ${(err as Error).message}`
+          );
+        }
       }
 
       return {

--- a/apps/api/src/app/agents/usecases/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase.ts
+++ b/apps/api/src/app/agents/usecases/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase.ts
@@ -15,12 +15,15 @@ import {
 } from '../../services/telegram-mobile-link-token.service';
 import { ConfigureTelegramAgentWebhookCommand } from '../configure-telegram-agent-webhook/configure-telegram-agent-webhook.command';
 import { ConfigureTelegramAgentWebhook } from '../configure-telegram-agent-webhook/configure-telegram-agent-webhook.usecase';
+import { IssueTelegramSubscriberLinkCommand } from '../issue-telegram-subscriber-link/issue-telegram-subscriber-link.command';
+import { IssueTelegramSubscriberLink } from '../issue-telegram-subscriber-link/issue-telegram-subscriber-link.usecase';
 import { ConsumeTelegramMobileLinkCommand } from './consume-telegram-mobile-link.command';
 
 export interface ConsumeTelegramMobileLinkResult {
   success: true;
   botUsername: string;
   webhookUrl: string;
+  deepLinkUrl?: string;
 }
 
 @Injectable()
@@ -29,6 +32,7 @@ export class ConsumeTelegramMobileLink {
     private readonly tokenService: TelegramMobileLinkTokenService,
     private readonly integrationRepository: IntegrationRepository,
     private readonly configureTelegramWebhookUsecase: ConfigureTelegramAgentWebhook,
+    private readonly issueTelegramSubscriberLink: IssueTelegramSubscriberLink,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -83,10 +87,27 @@ export class ConsumeTelegramMobileLink {
         })
       );
 
+      let deepLinkUrl: string | undefined;
+
+      if (payload.sid) {
+        const subscriberLink = await this.issueTelegramSubscriberLink.execute(
+          IssueTelegramSubscriberLinkCommand.create({
+            userId: 'telegram-mobile-link',
+            environmentId: payload.env,
+            organizationId: payload.org,
+            agentIdentifier: payload.aid,
+            integrationId: integration._id,
+            subscriberId: payload.sid,
+          })
+        );
+        deepLinkUrl = subscriberLink.deepLinkUrl;
+      }
+
       return {
         success: true,
         botUsername: result.botUsername,
         webhookUrl: result.webhookUrl,
+        deepLinkUrl,
       };
     } catch (err) {
       await this.tokenService.releaseJti(payload.jti);

--- a/apps/api/src/app/agents/usecases/issue-telegram-mobile-link/issue-telegram-mobile-link.command.ts
+++ b/apps/api/src/app/agents/usecases/issue-telegram-mobile-link/issue-telegram-mobile-link.command.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
 
@@ -10,4 +10,9 @@ export class IssueTelegramMobileLinkCommand extends EnvironmentWithUserCommand {
   @IsString()
   @IsNotEmpty()
   integrationId: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  subscriberId?: string;
 }

--- a/apps/api/src/app/agents/usecases/issue-telegram-mobile-link/issue-telegram-mobile-link.usecase.ts
+++ b/apps/api/src/app/agents/usecases/issue-telegram-mobile-link/issue-telegram-mobile-link.usecase.ts
@@ -74,6 +74,7 @@ export class IssueTelegramMobileLink {
       organizationId: command.organizationId,
       agentIdentifier: agent.identifier,
       integrationId: integration._id,
+      subscriberId: command.subscriberId,
     });
 
     return {

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -579,11 +579,12 @@ type TelegramMobileLinkEnvelope = { data: TelegramMobileLink };
 export async function requestTelegramMobileLink(
   environment: IEnvironment,
   agentIdentifier: string,
-  integrationId: string
+  integrationId: string,
+  subscriberId?: string
 ): Promise<TelegramMobileLink> {
   const response = await post<TelegramMobileLinkEnvelope>(
     `/agents/${encodeURIComponent(agentIdentifier)}/integrations/${encodeURIComponent(integrationId)}/telegram/mobile-link`,
-    { environment }
+    { environment, body: subscriberId ? { subscriberId } : undefined }
   );
 
   return response.data;
@@ -649,6 +650,8 @@ export type SubmitTelegramMobileCredentialsResult = {
   success: true;
   botUsername: string;
   webhookUrl: string;
+  /** Present when the mobile link was issued with a subscriberId. */
+  deepLinkUrl?: string;
 };
 
 export type SubmitTelegramMobileCredentialsError = {

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -736,11 +736,7 @@ function extractErrorCode(data: unknown): SubmitTelegramMobileCredentialsError['
       ? (message as { code?: unknown }).code
       : (data as { code?: unknown }).code;
 
-  if (
-    candidate === 'token_invalid' ||
-    candidate === 'token_expired' ||
-    candidate === 'token_already_used'
-  ) {
+  if (candidate === 'token_invalid' || candidate === 'token_expired' || candidate === 'token_already_used') {
     return candidate;
   }
 

--- a/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
+++ b/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
@@ -324,6 +324,7 @@ export function IntegrationCredentialsSidebar({
   onSaveSuccess,
   agentOnboarding,
   agentIdentifier,
+  testSubscriberId,
   submitLabel,
 }: {
   integrationId: string;
@@ -337,6 +338,8 @@ export function IntegrationCredentialsSidebar({
    * (e.g. the Telegram mobile setup QR code) inside the modal.
    */
   agentIdentifier?: string;
+  /** Quickstart test subscriber for Telegram mobile `/start` deep links. */
+  testSubscriberId?: string | null;
   submitLabel?: string;
 }) {
   const { integrations } = useFetchIntegrations();
@@ -406,6 +409,7 @@ export function IntegrationCredentialsSidebar({
           mode="update"
           agentOnboarding={agentOnboarding}
           agentIdentifier={agentIdentifier}
+          testSubscriberId={testSubscriberId}
           onFormStateChange={setFormState}
         />
       </div>

--- a/apps/dashboard/src/components/agents/telegram-mobile-setup-card.tsx
+++ b/apps/dashboard/src/components/agents/telegram-mobile-setup-card.tsx
@@ -124,6 +124,8 @@ export function TelegramMobileSetupCardShell({
 type AgentTelegramMobileSetupCardProps = {
   agentIdentifier: string;
   integrationId: string;
+  /** When set, mobile setup success returns a `/start` deep link for this subscriber. */
+  testSubscriberId?: string | null;
   disabled?: boolean;
   className?: string;
   layout?: CardLayout;
@@ -136,6 +138,7 @@ type AgentTelegramMobileSetupCardProps = {
 export function AgentTelegramMobileSetupCard({
   agentIdentifier,
   integrationId,
+  testSubscriberId,
   disabled,
   className,
   layout = 'stacked',
@@ -144,12 +147,13 @@ export function AgentTelegramMobileSetupCard({
   const environmentId = currentEnvironment?._id;
 
   const linkQuery = useQuery<TelegramMobileLink>({
-    queryKey: [MOBILE_LINK_QUERY_KEY, environmentId, agentIdentifier, integrationId],
+    queryKey: [MOBILE_LINK_QUERY_KEY, environmentId, agentIdentifier, integrationId, testSubscriberId],
     queryFn: () =>
       requestTelegramMobileLink(
         requireEnvironment(currentEnvironment, 'No environment selected'),
         agentIdentifier,
-        integrationId
+        integrationId,
+        testSubscriberId ?? undefined
       ),
     enabled: !disabled && Boolean(environmentId && agentIdentifier && integrationId),
     refetchInterval: REFRESH_INTERVAL_MS,

--- a/apps/dashboard/src/components/agents/telegram-mobile-setup-card.tsx
+++ b/apps/dashboard/src/components/agents/telegram-mobile-setup-card.tsx
@@ -3,10 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { RiFileCopyLine, RiQrCodeLine, RiRefreshLine, RiSmartphoneLine } from 'react-icons/ri';
 import QRCode from 'react-qr-code';
 import { requestTelegramMobileLink, type TelegramMobileLink } from '@/api/agents';
-import {
-  requestIntegrationStoreTelegramMobileLink,
-  type IntegrationStoreTelegramMobileLink,
-} from '@/api/integrations';
+import { type IntegrationStoreTelegramMobileLink, requestIntegrationStoreTelegramMobileLink } from '@/api/integrations';
 import { Button } from '@/components/primitives/button';
 import { showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
@@ -55,13 +52,11 @@ export function TelegramMobileSetupCardShell({
 
   if (layout === 'inline') {
     return (
-      <div className={cn('border-stroke-soft bg-bg-weak/50 flex w-full flex-row gap-3 rounded-md border p-3', className)}>
+      <div
+        className={cn('border-stroke-soft bg-bg-weak/50 flex w-full flex-row gap-3 rounded-md border p-3', className)}
+      >
         <div className="shrink-0">
-          {link ? (
-            <QrPreview link={link} isRefreshing={isRefreshing} hideMeta size={120} />
-          ) : (
-            <QrSkeleton size={120} />
-          )}
+          {link ? <QrPreview link={link} isRefreshing={isRefreshing} hideMeta size={120} /> : <QrSkeleton size={120} />}
         </div>
         <div className="flex min-w-0 flex-1 flex-col justify-between gap-2">
           <div className="flex flex-col gap-1">
@@ -70,7 +65,8 @@ export function TelegramMobileSetupCardShell({
               Set up from your phone
             </div>
             <p className="text-text-soft text-label-xs leading-4">
-              Scan or open the link on the device where BotFather sent the token and paste the entire message. Refreshes every 5 minutes.
+              Scan or open the link on the device where BotFather sent the token and paste the entire message. Refreshes
+              every 5 minutes.
             </p>
           </div>
           <div className="flex flex-col items-start gap-1.5">
@@ -97,7 +93,12 @@ export function TelegramMobileSetupCardShell({
   }
 
   return (
-    <div className={cn('border-stroke-soft bg-bg-weak/50 mt-2 flex w-full max-w-[280px] flex-col gap-2 rounded-md border p-3', className)}>
+    <div
+      className={cn(
+        'border-stroke-soft bg-bg-weak/50 mt-2 flex w-full max-w-[280px] flex-col gap-2 rounded-md border p-3',
+        className
+      )}
+    >
       <div className="text-text-strong text-label-xs flex items-center gap-1.5 font-medium">
         <RiSmartphoneLine className="size-3.5" />
         Set up from your phone
@@ -107,16 +108,10 @@ export function TelegramMobileSetupCardShell({
       </p>
 
       <div className="mt-1 flex flex-col items-center gap-2">
-        {link ? (
-          <QrPreview link={link} isRefreshing={isRefreshing} onRefresh={onRefresh} />
-        ) : (
-          <QrSkeleton />
-        )}
+        {link ? <QrPreview link={link} isRefreshing={isRefreshing} onRefresh={onRefresh} /> : <QrSkeleton />}
       </div>
 
-      {isError && (
-        <p className="text-error-base text-label-xs">Couldn&apos;t generate a setup link. Try refreshing.</p>
-      )}
+      {isError && <p className="text-error-base text-label-xs">Couldn&apos;t generate a setup link. Try refreshing.</p>}
     </div>
   );
 }
@@ -201,9 +196,7 @@ export function IntegrationStoreTelegramMobileSetupCard({
   const linkQuery = useQuery<IntegrationStoreTelegramMobileLink>({
     queryKey: [MOBILE_LINK_QUERY_KEY, 'integration-store', environmentId],
     queryFn: () =>
-      requestIntegrationStoreTelegramMobileLink(
-        requireEnvironment(currentEnvironment, 'No environment selected')
-      ),
+      requestIntegrationStoreTelegramMobileLink(requireEnvironment(currentEnvironment, 'No environment selected')),
     enabled: !disabled && Boolean(environmentId),
     refetchInterval: REFRESH_INTERVAL_MS,
     refetchOnWindowFocus: true,

--- a/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
@@ -50,7 +50,6 @@ export type TelegramSetupGuideProps = {
   embedded?: boolean;
 };
 
-
 export function TelegramSetupGuide({
   agent,
   integrationId,
@@ -107,8 +106,7 @@ export function TelegramSetupGuide({
   // Set only after a successful setWebhook call; also used to detect webhook configured
   // outside this session (e.g. mobile flow) so step 3 can still issue a subscriber link.
   const hasWebhookSecret =
-    typeof selectedIntegration?.credentials?.token === 'string' &&
-    selectedIntegration.credentials.token.length > 0;
+    typeof selectedIntegration?.credentials?.token === 'string' && selectedIntegration.credentials.token.length > 0;
 
   // Poll for credentials only while the sidebar is open AND the user hasn't saved a token yet.
   // Stops the moment the drawer closes or credentials appear.
@@ -231,9 +229,7 @@ export function TelegramSetupGuide({
   const configureErrorMessage = useMemo(() => {
     if (!configureError) return null;
 
-    return configureError instanceof Error
-      ? configureError.message
-      : 'Failed to configure webhook. Please try again.';
+    return configureError instanceof Error ? configureError.message : 'Failed to configure webhook. Please try again.';
   }, [configureError]);
 
   const stepsColumn = (
@@ -255,15 +251,14 @@ export function TelegramSetupGuide({
             </a>
             {' on Telegram and run '}
             <code className="text-text-sub rounded bg-neutral-alpha-100 px-1 font-mono text-[11px]">/newbot</code>
-            {'. Follow the prompts to choose a name and username, then copy the entire confirmation message BotFather sends.'}
+            {
+              '. Follow the prompts to choose a name and username, then copy the entire confirmation message BotFather sends.'
+            }
           </span>
         }
         rightContent={
           <div className="flex flex-col items-start gap-0">
-            <SetupButton
-              href="https://t.me/botfather"
-              leadingIcon={<RiRobot2Line className="size-3.5" />}
-            >
+            <SetupButton href="https://t.me/botfather" leadingIcon={<RiRobot2Line className="size-3.5" />}>
               Open BotFather
             </SetupButton>
             {step1Status === 'current' && <TelegramQrInline url="https://t.me/botfather" />}

--- a/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
@@ -104,6 +104,11 @@ export function TelegramSetupGuide({
 
   const hasCredentials = hasIntegrationCredentials(selectedIntegration?.credentials);
   const isCredentialsSaved = hasCredentials || credentialsSavedLocally;
+  // Set only after a successful setWebhook call; also used to detect webhook configured
+  // outside this session (e.g. mobile flow) so step 3 can still issue a subscriber link.
+  const hasWebhookSecret =
+    typeof selectedIntegration?.credentials?.token === 'string' &&
+    selectedIntegration.credentials.token.length > 0;
 
   // Poll for credentials only while the sidebar is open AND the user hasn't saved a token yet.
   // Stops the moment the drawer closes or credentials appear.
@@ -154,7 +159,9 @@ export function TelegramSetupGuide({
     },
   });
 
-  const isWebhookConfigured = Boolean(configuredWebhookUrl);
+  const isWebhookConfigured = Boolean(configuredWebhookUrl) || hasWebhookSecret;
+
+  const displayBotUsername = botUsername ?? subscriberLink?.botUsername ?? null;
 
   const {
     mutate: issueSubscriberLink,
@@ -174,6 +181,7 @@ export function TelegramSetupGuide({
       );
     },
     onSuccess: (result) => {
+      setBotUsername(result.botUsername);
       setSubscriberLink(result);
     },
     onError: (err: unknown) => {
@@ -187,11 +195,11 @@ export function TelegramSetupGuide({
 
   // Once the webhook is registered, auto-issue a subscriber-link for the
   // current dashboard user so step 3 ("Send a test message") opens a deep link
-  // that automatically links this Telegram chat to a test subscriber.
+  // that automatically links this Telegram chat to a test subscriber. Also
+  // resolves botUsername when configureTelegram did not run in this session.
   useEffect(() => {
     if (
       isWebhookConfigured &&
-      botUsername &&
       testSubscriberId &&
       !subscriberLink &&
       !isIssuingSubscriberLink &&
@@ -201,7 +209,6 @@ export function TelegramSetupGuide({
     }
   }, [
     isWebhookConfigured,
-    botUsername,
     testSubscriberId,
     subscriberLink,
     isIssuingSubscriberLink,
@@ -305,18 +312,18 @@ export function TelegramSetupGuide({
           </span>
         }
         rightContent={
-          botUsername ? (
+          displayBotUsername ? (
             <div className="flex flex-col items-start gap-0">
               <SetupButton
-                href={subscriberLink?.deepLinkUrl ?? `https://t.me/${botUsername}`}
+                href={subscriberLink?.deepLinkUrl ?? `https://t.me/${displayBotUsername}`}
                 leadingIcon={<RiSendPlaneLine className="size-3.5" />}
               >
-                {subscriberLink ? `Connect & test @${botUsername}` : `Open @${botUsername}`}
+                {subscriberLink ? `Connect & test @${displayBotUsername}` : `Open @${displayBotUsername}`}
               </SetupButton>
               {step3Status === 'current' && (
                 <TelegramQrInline
-                  url={subscriberLink?.deepLinkUrl ?? `https://t.me/${botUsername}`}
-                  username={botUsername}
+                  url={subscriberLink?.deepLinkUrl ?? `https://t.me/${displayBotUsername}`}
+                  username={displayBotUsername}
                 />
               )}
             </div>

--- a/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/telegram-setup-guide.tsx
@@ -366,6 +366,7 @@ export function TelegramSetupGuide({
           }}
           agentOnboarding
           agentIdentifier={agent.identifier}
+          testSubscriberId={testSubscriberId}
           submitLabel="Save & Connect"
         />
       </div>
@@ -386,6 +387,7 @@ export function TelegramSetupGuide({
         }}
         agentOnboarding
         agentIdentifier={agent.identifier}
+        testSubscriberId={testSubscriberId}
         submitLabel="Save & Connect"
       />
     </>

--- a/apps/dashboard/src/components/integrations/components/integration-settings.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-settings.tsx
@@ -312,7 +312,10 @@ export function IntegrationSettings({
                             key={`${credential.key}-${integration?._id || 'no-id'}`}
                             credential={
                               showTelegramPaste && credential.key === CredentialsKeyEnum.ApiToken
-                                ? { ...credential, description: 'Auto-filled from the BotFather message above, or enter it manually.' }
+                                ? {
+                                    ...credential,
+                                    description: 'Auto-filled from the BotFather message above, or enter it manually.',
+                                  }
                                 : credential
                             }
                             control={control}

--- a/apps/dashboard/src/components/integrations/components/integration-settings.tsx
+++ b/apps/dashboard/src/components/integrations/components/integration-settings.tsx
@@ -52,6 +52,8 @@ type IntegrationConfigurationProps = {
   agentOnboarding?: boolean;
   /** Agent identifier — only set during the agent-onboarding flow. */
   agentIdentifier?: string;
+  /** Quickstart test subscriber for Telegram mobile `/start` deep links. */
+  testSubscriberId?: string | null;
   onFormStateChange?: (formState: { isValid: boolean; errors: Record<string, unknown>; isDirty: boolean }) => void;
 };
 
@@ -74,6 +76,7 @@ export function IntegrationSettings({
   isReadOnly,
   agentOnboarding,
   agentIdentifier,
+  testSubscriberId,
   onFormStateChange,
 }: IntegrationConfigurationProps) {
   const navigate = useNavigate();
@@ -146,13 +149,13 @@ export function IntegrationSettings({
     if (!showTelegramPaste) return undefined;
 
     if (isAgentOnboarding && agentIdentifier && integration?._id) {
-      return { kind: 'agent', agentIdentifier, integrationId: integration._id };
+      return { kind: 'agent', agentIdentifier, integrationId: integration._id, testSubscriberId };
     }
 
     if (mode === 'create') return { kind: 'integration-store' };
 
     return undefined;
-  }, [showTelegramPaste, isAgentOnboarding, agentIdentifier, integration?._id, mode]);
+  }, [showTelegramPaste, isAgentOnboarding, agentIdentifier, integration?._id, mode, testSubscriberId]);
   const handleSlackCredentialsPaste = useSlackCredentialsPasteFallback({
     control,
     setValue,

--- a/apps/dashboard/src/components/integrations/components/telegram-credentials-paste.tsx
+++ b/apps/dashboard/src/components/integrations/components/telegram-credentials-paste.tsx
@@ -22,7 +22,7 @@ type ApplyOutcome = { token: string | null; botUsername: string | null; recogniz
  *   a new Telegram integration via the integration-store public endpoint.
  */
 export type TelegramCredentialsPasteMobileSetup =
-  | { kind: 'agent'; agentIdentifier: string; integrationId: string }
+  | { kind: 'agent'; agentIdentifier: string; integrationId: string; testSubscriberId?: string | null }
   | { kind: 'integration-store' };
 
 type TelegramCredentialsPasteProps = {
@@ -138,6 +138,7 @@ export function TelegramCredentialsPaste({
             <AgentTelegramMobileSetupCard
               agentIdentifier={mobileSetup.agentIdentifier}
               integrationId={mobileSetup.integrationId}
+              testSubscriberId={mobileSetup.testSubscriberId}
               layout="inline"
             />
           ) : (

--- a/apps/dashboard/src/components/integrations/components/telegram-credentials-paste.tsx
+++ b/apps/dashboard/src/components/integrations/components/telegram-credentials-paste.tsx
@@ -108,8 +108,7 @@ export function TelegramCredentialsPaste({
 
   if (isReadOnly) return null;
 
-  const hasApiTokenValue =
-    typeof credentials?.apiToken === 'string' && credentials.apiToken.trim().length > 0;
+  const hasApiTokenValue = typeof credentials?.apiToken === 'string' && credentials.apiToken.trim().length > 0;
   const canShowMobileSetup = Boolean(mobileSetup) && !hasApiTokenValue;
 
   return (
@@ -169,9 +168,16 @@ function PasteOutcome({ outcome, onDismiss }: { outcome: ApplyOutcome; onDismiss
         </span>
         <div className="flex flex-1 flex-col gap-0.5">
           <p className="text-text-strong text-label-xs font-medium">Couldn't find a bot token in the pasted text.</p>
-          <p className="text-text-soft text-label-xs leading-4">Paste the full message from BotFather, or enter the token manually in the field below.</p>
+          <p className="text-text-soft text-label-xs leading-4">
+            Paste the full message from BotFather, or enter the token manually in the field below.
+          </p>
         </div>
-        <button type="button" className="text-text-soft hover:text-text-strong cursor-pointer" aria-label="Dismiss" onClick={onDismiss}>
+        <button
+          type="button"
+          className="text-text-soft hover:text-text-strong cursor-pointer"
+          aria-label="Dismiss"
+          onClick={onDismiss}
+        >
           <RiCloseLine className="size-3.5" />
         </button>
       </div>
@@ -189,12 +195,16 @@ function PasteOutcome({ outcome, onDismiss }: { outcome: ApplyOutcome; onDismiss
         </p>
         {outcome.botUsername && (
           <p className="text-text-soft text-label-xs leading-4">
-            Bot username set to{' '}
-            <span className="text-text-strong font-medium">@{outcome.botUsername}</span>
+            Bot username set to <span className="text-text-strong font-medium">@{outcome.botUsername}</span>
           </p>
         )}
       </div>
-      <button type="button" className="text-text-soft hover:text-text-strong cursor-pointer" aria-label="Dismiss" onClick={onDismiss}>
+      <button
+        type="button"
+        className="text-text-soft hover:text-text-strong cursor-pointer"
+        aria-label="Dismiss"
+        onClick={onDismiss}
+      >
         <RiCloseLine className="size-3.5" />
       </button>
     </div>

--- a/apps/dashboard/src/pages/agent-telegram-mobile-setup-page.tsx
+++ b/apps/dashboard/src/pages/agent-telegram-mobile-setup-page.tsx
@@ -1,18 +1,12 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { motion } from 'motion/react';
 import { useMemo, useState } from 'react';
-import {
-  RiAlertLine,
-  RiCheckLine,
-  RiErrorWarningLine,
-  RiSendPlaneLine,
-  RiTimeLine,
-} from 'react-icons/ri';
+import { RiAlertLine, RiCheckLine, RiErrorWarningLine, RiSendPlaneLine, RiTimeLine } from 'react-icons/ri';
 import { useParams } from 'react-router-dom';
 import {
   getTelegramMobileSetupStatus,
-  submitTelegramMobileCredentials,
   type SubmitTelegramMobileCredentialsResult,
+  submitTelegramMobileCredentials,
   type TelegramMobileLinkStatus,
   TelegramMobileSubmitError,
 } from '@/api/agents';
@@ -40,9 +34,7 @@ export function AgentTelegramMobileSetupPage() {
     <PageShell>
       {!token && <InactiveLinkCard reason="invalid" />}
       {token && statusQuery.isLoading && <LoadingCard />}
-      {token && statusQuery.data && !statusQuery.data.valid && (
-        <InactiveLinkCard reason={statusQuery.data.reason} />
-      )}
+      {token && statusQuery.data && !statusQuery.data.valid && <InactiveLinkCard reason={statusQuery.data.reason} />}
       {token && statusQuery.isError && <InactiveLinkCard reason="invalid" />}
       {token && statusQuery.data?.valid && <SetupForm token={token} agentName={statusQuery.data.agentName} />}
     </PageShell>
@@ -70,7 +62,10 @@ function LoadingCard() {
   return (
     <Card>
       <div className="flex flex-col items-center gap-3 py-6">
-        <div className="border-stroke-soft border-t-text-strong size-7 animate-spin rounded-full border-2" aria-label="Loading" />
+        <div
+          className="border-stroke-soft border-t-text-strong size-7 animate-spin rounded-full border-2"
+          aria-label="Loading"
+        />
         <p className="text-text-soft text-paragraph-xs">Checking your setup link…</p>
       </div>
     </Card>
@@ -125,8 +120,8 @@ function SetupForm({ token, agentName }: SetupFormProps) {
           Finish setup for <span className="text-text-strong font-semibold">{agentName}</span>
         </h1>
         <p className="text-text-soft text-paragraph-xs leading-5">
-          Paste the message BotFather just sent you on Telegram. We&apos;ll detect the bot token and connect the
-          webhook automatically — nothing else to fill in.
+          Paste the message BotFather just sent you on Telegram. We&apos;ll detect the bot token and connect the webhook
+          automatically — nothing else to fill in.
         </p>
       </div>
 
@@ -139,12 +134,11 @@ function SetupForm({ token, agentName }: SetupFormProps) {
           simple
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
-          placeholder={'Done! Congratulations on your new bot…\n\nUse this token to access the HTTP API:\n1234567890:AAFdT8_…\n\nYou will find it at t.me/YourBot_bot.'}
+          placeholder={
+            'Done! Congratulations on your new bot…\n\nUse this token to access the HTTP API:\n1234567890:AAFdT8_…\n\nYou will find it at t.me/YourBot_bot.'
+          }
           rows={7}
-          className={cn(
-            'font-mono text-xs',
-            parsedToken && 'border-success-base ring-success-base/40 ring-1'
-          )}
+          className={cn('font-mono text-xs', parsedToken && 'border-success-base ring-success-base/40 ring-1')}
           autoFocus
           spellCheck={false}
           autoCapitalize="off"
@@ -199,7 +193,14 @@ function ParseStatus({ draft, parsedToken, parsedUsername }: ParseStatusProps) {
     <div className="text-success-base text-label-xs flex items-start gap-1.5 leading-4">
       <RiCheckLine className="mt-0.5 size-3.5 shrink-0" />
       <span>
-        Token detected{parsedUsername ? <> for <span className="font-semibold">@{parsedUsername}</span></> : null}.
+        Token detected
+        {parsedUsername ? (
+          <>
+            {' '}
+            for <span className="font-semibold">@{parsedUsername}</span>
+          </>
+        ) : null}
+        .
       </span>
     </div>
   );

--- a/apps/dashboard/src/pages/agent-telegram-mobile-setup-page.tsx
+++ b/apps/dashboard/src/pages/agent-telegram-mobile-setup-page.tsx
@@ -99,7 +99,13 @@ function SetupForm({ token, agentName }: SetupFormProps) {
   });
 
   if (submitMutation.data?.success) {
-    return <SuccessCard botUsername={submitMutation.data.botUsername} agentName={agentName} />;
+    return (
+      <SuccessCard
+        botUsername={submitMutation.data.botUsername}
+        agentName={agentName}
+        deepLinkUrl={submitMutation.data.deepLinkUrl}
+      />
+    );
   }
 
   if (submitMutation.error instanceof TelegramMobileSubmitError) {
@@ -199,8 +205,17 @@ function ParseStatus({ draft, parsedToken, parsedUsername }: ParseStatusProps) {
   );
 }
 
-function SuccessCard({ botUsername, agentName }: { botUsername: string; agentName: string }) {
-  const telegramUrl = `https://t.me/${botUsername}`;
+function SuccessCard({
+  botUsername,
+  agentName,
+  deepLinkUrl,
+}: {
+  botUsername: string;
+  agentName: string;
+  deepLinkUrl?: string;
+}) {
+  const telegramUrl = deepLinkUrl ?? `https://t.me/${botUsername}`;
+  const hasStartLink = Boolean(deepLinkUrl);
 
   return (
     <Card>
@@ -211,7 +226,9 @@ function SuccessCard({ botUsername, agentName }: { botUsername: string; agentNam
         <h1 className="text-text-strong text-paragraph-md font-semibold">@{botUsername} is connected</h1>
         <p className="text-text-soft text-paragraph-xs leading-5">
           Your Telegram bot is now wired up to <span className="text-text-strong font-medium">{agentName}</span>.
-          Open it in Telegram to send your first message — your agent will reply.
+          {hasStartLink
+            ? ' Open the link below in Telegram to link this chat and send your first test message.'
+            : ' Open it in Telegram to send your first message — your agent will reply.'}
         </p>
       </div>
 
@@ -222,7 +239,7 @@ function SuccessCard({ botUsername, agentName }: { botUsername: string; agentNam
         className="bg-text-strong text-static-white hover:bg-text-strong/90 mt-5 flex h-10 w-full items-center justify-center gap-2 rounded-10 px-3.5 text-label-sm transition"
       >
         <RiSendPlaneLine className="size-4" />
-        Open @{botUsername}
+        {hasStartLink ? `Connect & test @${botUsername}` : `Open @${botUsername}`}
       </a>
 
       <p className="text-text-soft text-label-xs mt-3 text-center">You can safely close this tab.</p>


### PR DESCRIPTION
## Summary

- **Quickstart (overview + integrations):** Treat a persisted webhook secret (`credentials.token`) as “webhook configured” so step 3 works after mobile setup or a page reload, not only after `configureTelegram` in the current session. Auto-issue a subscriber-link to resolve `botUsername` and render **Connect & test @bot** with the `t.me/...?start=<code>` QR.
- **Mobile setup flow:** When the dashboard issues a mobile-link QR from agent onboarding, embed the quickstart `testSubscriberId` in the JWT. After credentials are submitted on the phone, the API configures the webhook and returns `deepLinkUrl`; the mobile success page shows **Connect & test @bot** instead of a plain bot link.

Regression follow-up to #11163 (dropped auto-configure) and #11154 (subscriber-link flow).

```mermaid
sequenceDiagram
  participant D as Dashboard
  participant M as Mobile page
  participant API as API

  D->>API: POST mobile-link { subscriberId }
  API-->>D: QR → /agents/telegram/connect/:token
  M->>API: POST mobile-configure { token, botToken }
  API->>API: setWebhook + issue subscriber-link
  API-->>M: { botUsername, deepLinkUrl }
  M->>M: Connect & test @bot

  Note over D: Page reload / webhook secret already set
  D->>API: POST subscriber-link (testSubscriberId)
  API-->>D: deepLinkUrl, botUsername
  D->>D: Step 3 button + QR
```

## Test plan

- [ ] Agent overview → Telegram quickstart: save bot token + configure webhook (or complete mobile flow), refresh → step 3 shows **Connect & test @bot** with deep link.
- [ ] Integrations tab → Telegram setup (not connected): same button after webhook secret exists.
- [ ] Credentials drawer → scan mobile QR → paste BotFather message on phone → success shows **Connect & test @bot** (not plain Open @bot).
- [ ] Open deep link in Telegram → `/start` links chat; bot confirms; agent receives messages.
- [ ] Integration-store mobile flow (no agent): still uses plain `t.me/bot` link (no subscriber yet).

**Linear:** [NV-7696](https://linear.app/novu/issue/NV-7696/telegram-persist-chatid-via-channel-endpoints-and-start-subscriber)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Telegram mobile setup and quickstart flows now treat a persisted webhook secret (credentials.token) as "webhook configured" and auto-request/consume subscriber-links so the quickstart advances and shows the “Connect & test `@bot`” CTA and deep-link QR even after a page reload or mobile completion. The API and dashboard were updated to optionally carry a test subscriberId so mobile setup can bind a subscriber and return a t.me/<bot>?start=<code> deepLinkUrl; subscriber-link issuance is best-effort to avoid failing mobile setup.

## Affected areas
- api: Mobile-link issuance/consumption APIs accept an optional subscriberId and the consume response can include deepLinkUrl; the consume use case now best-effort issues a subscriber-link when subscriberId is present and returns botUsername/deepLinkUrl.
- dashboard: UI threads testSubscriberId through integration and agent setup components, treats stored Telegram tokens as configured (so step 3 advances), and displays the connect button/QR using either in-session botUsername or subscriber-link results.
- react: Agent quickstart, integration settings, Telegram mobile setup cards/components were updated to accept/forward testSubscriberId and to derive a single displayBotUsername from multiple sources.

## Key technical decisions
- API contract change is additive and non-breaking: IssueTelegramMobileLink now accepts subscriberId?: string and ConsumeTelegramMobileLinkResponse may include deepLinkUrl?: string.
- Subscriber-link issuance is best-effort: failure to create a subscriber-link logs a warning but does not block webhook configuration success or mobile setup completion.
- UI consolidates bot username rendering by deriving displayBotUsername from session or subscriber-link results to simplify rendering logic.

## Testing
No new automated tests included; this is a flow/UI fix. Verify manually: save a bot token or complete mobile setup, then refresh the agent quickstart or open integrations setup → step 3 should show “Connect & test `@bot`” with a working t.me/.../?start=<code> deep link (when a subscriberId was provided).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->