### PR TITLE
feat(dashboard): make provider cards clickable on agent overview page fixes NV-7534

### DIFF
--- a/apps/dashboard/src/components/agents/connected-providers-section.tsx
+++ b/apps/dashboard/src/components/agents/connected-providers-section.tsx
@@ -18,14 +18,14 @@ type ConnectedProvidersSectionProps = {
   agent: AgentResponse;
 };
 
-function ProviderCard({ link }: { link: AgentIntegrationLink }) {
+function ProviderCard({ link, to }: { link: AgentIntegrationLink; to: string }) {
   const providerMeta = novuProviders.find((p) => p.id === link.integration.providerId);
   const displayName = providerMeta?.displayName ?? link.integration.name;
 
   return (
-    <div className="flex min-w-[150px] max-w-[160px] flex-1 flex-col gap-1.5">
+    <Link to={to} className="flex min-w-[150px] max-w-[160px] flex-1 flex-col gap-1.5">
       <div
-        className="border-stroke-soft/50 flex min-h-[80px] items-center justify-center rounded-lg border-[0.5px] px-6 py-4"
+        className="border-stroke-soft/50 flex min-h-[80px] items-center justify-center rounded-lg border-[0.5px] px-6 py-4 transition-colors hover:border-stroke-soft"
         style={{
           backgroundImage:
             'linear-gradient(22deg, rgba(200,200,200,0) 51%, rgba(200,200,200,0.1) 88%), linear-gradient(90deg, rgba(251,251,251,0.1) 0%, rgba(251,251,251,0.1) 100%), linear-gradient(90deg, #fff 0%, #fff 100%)',
@@ -36,7 +36,7 @@ function ProviderCard({ link }: { link: AgentIntegrationLink }) {
         </div>
       </div>
       <span className="text-text-strong text-label-xs font-medium leading-4">{displayName}</span>
-    </div>
+    </Link>
   );
 }
 
@@ -121,7 +121,15 @@ export function ConnectedProvidersSection({ agent }: ConnectedProvidersSectionPr
           ) : (
             <>
               {links.map((link) => (
-                <ProviderCard key={link._id} link={link} />
+                <ProviderCard
+                  key={link._id}
+                  link={link}
+                  to={`${buildRoute(agentRoutes.integrationDetail, {
+                    environmentSlug: currentEnvironment?.slug ?? '',
+                    agentIdentifier: encodeURIComponent(agent.identifier),
+                    integrationIdentifier: encodeURIComponent(link.integration.identifier),
+                  })}${location.search}`}
+                />
               ))}
               <AddProviderCard to={integrationsTabPath} />
             </>

--- a/apps/dashboard/src/components/agents/connected-providers-section.tsx
+++ b/apps/dashboard/src/components/agents/connected-providers-section.tsx
@@ -23,7 +23,10 @@ function ProviderCard({ link, to }: { link: AgentIntegrationLink; to: string }) 
   const displayName = providerMeta?.displayName ?? link.integration.name;
 
   return (
-    <Link to={to} className="flex min-w-[150px] max-w-[160px] flex-1 flex-col gap-1.5">
+    <Link
+      to={to}
+      className="flex min-w-[150px] max-w-[160px] flex-1 flex-col gap-1.5 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
       <div
         className="border-stroke-soft/50 flex min-h-[80px] items-center justify-center rounded-lg border-[0.5px] px-6 py-4 transition-colors hover:border-stroke-soft"
         style={{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Made the provider cards in the "Connected channels" section on the agent overview page clickable. Previously, the provider cards (e.g., Novu Email, MSTeams, Slack) were static and non-interactive, which felt inconsistent with the rest of the UI. Now clicking a provider card navigates the user to the corresponding integration detail page.

The change wraps the `ProviderCard` component with a React Router `<Link>` that builds the correct integration detail URL using the existing `agentRoutes.integrationDetail` route template.

**Route pattern:** `/env/:environmentSlug/agents/:agentIdentifier/integrations/:integrationIdentifier`

### Screenshots

**Before (provider cards on overview page):**

![Agent overview page showing Connected Channels section with clickable provider cards](https://cursor.com/artifacts/c/art-e1feb3aa-71d3-4e94-af3a-0ad3edfd201a)

**After clicking Slack provider card (navigates to integration detail):**

![Integration detail page after clicking Slack provider card](https://cursor.com/artifacts/c/art-d77c54a3-7017-47ed-9d4e-448dd14663a2)

**Video demo:**

<a href="https://cursor.com/agents/bc-eba0ee85-0f7d-45b5-9c7e-ee95d3ca70ea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclickable_provider_cards_navigation.mp4"><img src="https://cursor.com/artifacts/c/art-31a0872a-46d5-46fa-850b-6ce727e9546d" alt="clickable_provider_cards_navigation.mp4" /></a>

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- The `AddProviderCard` component was already wrapped in a `Link`; this change brings the same pattern to `ProviderCard`.
- Added a subtle `hover:border-stroke-soft` transition on hover to provide visual feedback that the card is interactive.
- The `to` prop is built identically to how the integrations tab builds its navigation URLs.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7534](https://linear.app/novu/issue/NV-7534/none-clickable-provier-component)

<div><a href="https://cursor.com/agents/bc-eba0ee85-0f7d-45b5-9c7e-ee95d3ca70ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eba0ee85-0f7d-45b5-9c7e-ee95d3ca70ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Provider cards in the "Connected channels" section on the agent overview page are now interactive links. Each ProviderCard is wrapped with a React Router Link that navigates to the integration detail page for that provider (preserving query parameters). A subtle hover border transition and a focus-visible ring were added to indicate interactivity and improve keyboard accessibility.

## Affected areas

**dashboard** — The ConnectedProvidersSection now supplies navigation URLs to ProviderCard; ProviderCard was updated to accept a `to` prop and render a React Router Link around the card content. Links are built from the existing `agentRoutes.integrationDetail` pattern using `environmentSlug`, `agentIdentifier`, and `integrationIdentifier` (URL-encoded) and preserve `location.search`.

## Key technical decisions

- Reused the existing Link-wrapping pattern from AddProviderCard to keep behavior consistent.
- Identifiers are encoded with `encodeURIComponent` and current query params are preserved to avoid URL issues.
- Added focus-visible styling to provider links to maintain keyboard accessibility.

## Testing

No automated tests were added; the change is a UI navigation/UX enhancement that should be validated via manual testing or existing end-to-end tests that cover agent integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->