### PR TITLE
chore(root): upgrade getsentry/action-release to v3.6.0 fixes NV-7714

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -474,7 +474,7 @@ jobs:
           path: apps/${{ matrix.service }}
 
       - name: Create Sentry release
-        uses: getsentry/action-release@a74facf8a080ecbdf1cb355f16743530d712abb7 # v1
+        uses: getsentry/action-release@5657c9e888b4e2cc85f4d29143ea4131fde4a73a # v3.6.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades the pinned `getsentry/action-release` GitHub Action in the deploy workflow from v1 (`a74facf8`) to v3.6.0 (`5657c9e`).

## Why

Release 3.6.0 pins GitHub Actions to full-length commit SHAs in the upstream action, fixing transient pinned version issues that could affect reliability of Sentry release creation during deploys.

## Changes

- `.github/workflows/deploy.yml`: `getsentry/action-release@5657c9e888b4e2cc85f4d29143ea4131fde4a73a` (# v3.6.0)

## Testing

- Workflow-only change; no application code affected.
- Existing `sentry_release` job inputs (`version`, `environment`, etc.) remain compatible with action v3.x.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779186818129909?thread_ts=1779186818.129909&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-b5fd6b32-2a97-5cfa-8f7d-f8d9e4e87df2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5fd6b32-2a97-5cfa-8f7d-f8d9e4e87df2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `getsentry/action-release` GitHub Action in the deploy workflow was upgraded from v1 to v3.6.0, pinned to the full-length commit SHA. This update addresses transient pinning issues in the upstream action that could affect Sentry release creation during deploys. All existing job configuration and environment variables remain compatible.

## Affected areas

This is a CI/CD infrastructure change with no impact to application code or monorepo scopes.

## Testing

No tests are needed. This is a GitHub Actions workflow update to fix upstream action behavior. The appropriate validation is verifying the deploy workflow executes successfully with the new action version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->