### PR TITLE
fix(dashboard): update agent quickstart channel setup times fixes NV-7715

### DIFF
--- a/apps/dashboard/src/components/agents/provider-cards.tsx
+++ b/apps/dashboard/src/components/agents/provider-cards.tsx
@@ -25,12 +25,11 @@ import { openInNewTab } from '@/utils/url';
  * on the card. Keep in sync with provider docs / setup guides.
  */
 const PROVIDER_SETUP_TIME: Record<string, string> = {
-  [ChatProviderIdEnum.Slack]: '~ 30 seconds',
-  [EmailProviderIdEnum.NovuAgent]: '~ 2 minutes',
+  [ChatProviderIdEnum.Slack]: '~ 1 min',
   [ChatProviderIdEnum.MsTeams]: '~ 1 hour',
-  [ChatProviderIdEnum.WhatsAppBusiness]: '~ 1 hour',
+  [ChatProviderIdEnum.WhatsAppBusiness]: '~ 10 min',
+  [ChatProviderIdEnum.Telegram]: '~ 2 min',
   [ChatProviderIdEnum.Discord]: '~ 2 minutes',
-  telegram: '~ 2 minutes',
   'google-chat': '~ 2 minutes',
   linear: '~ 2 minutes',
   zoom: '~ 2 minutes',
@@ -329,7 +328,18 @@ export function ProviderCards({
   const isAgentEmailAvailable = useIsAgentEmailAvailable();
   const navigate = useNavigate();
 
-  const items = useMemo(() => buildCardItems(CONVERSATIONAL_PROVIDERS, integrations), [integrations]);
+  const conversationalProviders = useMemo(() => {
+    if (IS_SELF_HOSTED) {
+      return CONVERSATIONAL_PROVIDERS;
+    }
+
+    return CONVERSATIONAL_PROVIDERS.filter((cp) => cp.providerId !== EmailProviderIdEnum.NovuAgent);
+  }, []);
+
+  const items = useMemo(
+    () => buildCardItems(conversationalProviders, integrations),
+    [conversationalProviders, integrations]
+  );
 
   const linkedIntegrationIds = useMemo(
     () => new Set(existingLinks?.map((link) => link.integration._id) ?? []),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the estimated setup time hints on agent quickstart channel integration cards and hides Novu Email on Novu Cloud.

## Changes

- **Slack**: `~ 1 min` (was `~ 30 seconds`)
- **MS Teams**: `~ 1 hour` (unchanged; already in the available providers list)
- **WhatsApp Business**: `~ 10 min` (was `~ 1 hour`)
- **Telegram**: `~ 2 min` (unchanged)
- **Novu Email**: hidden on non–self-hosted environments because it is auto-provisioned when an agent is created

## Notes

Self-hosted deployments still show the Novu Email card so users can connect it manually when needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779189126757409?thread_ts=1779189126.757409&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-2e8d9890-33ee-560a-a055-d2e36c9b5eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e8d9890-33ee-560a-a055-d2e36c9b5eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->