### PR TITLE
fix(api-service): default conversation title for empty inbound messages fixes NV-7514

### DIFF
--- a/apps/api/src/app/agents/services/agent-conversation.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.spec.ts
@@ -1,7 +1,13 @@
 import { ConversationParticipantTypeEnum, ConversationRepository, ConversationStatusEnum } from '@novu/dal';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { AgentConversationService } from './agent-conversation.service';
+import {
+  AgentConversationService,
+  DEFAULT_CONVERSATION_TITLE,
+  getConversationTitle,
+  getInboundActivityPreview,
+  INBOUND_ATTACHMENT_ONLY_PREVIEW,
+} from './agent-conversation.service';
 
 describe('AgentConversationService', () => {
   function makeLogger() {
@@ -28,6 +34,59 @@ describe('AgentConversationService', () => {
       firstMessageText: 'hello',
     };
   }
+
+  describe('getConversationTitle', () => {
+    it('returns trimmed text truncated to 200 characters', () => {
+      const longText = 'a'.repeat(250);
+
+      expect(getConversationTitle(`  ${longText}  `)).to.equal('a'.repeat(200));
+    });
+
+    it('returns default title when preview text is empty', () => {
+      expect(getConversationTitle('')).to.equal(DEFAULT_CONVERSATION_TITLE);
+      expect(getConversationTitle('   ')).to.equal(DEFAULT_CONVERSATION_TITLE);
+    });
+  });
+
+  describe('getInboundActivityPreview', () => {
+    it('returns attachment preview when message has no text but has attachments', () => {
+      expect(getInboundActivityPreview('', { hasPlatformAttachments: true })).to.equal(
+        INBOUND_ATTACHMENT_ONLY_PREVIEW
+      );
+    });
+
+    it('returns empty string when there is no text and no attachments', () => {
+      expect(getInboundActivityPreview('')).to.equal('');
+      expect(getInboundActivityPreview('   ')).to.equal('');
+    });
+  });
+
+  it('uses a non-empty title when creating a conversation from empty inbound text', async () => {
+    const findByPlatformThread = sinon.stub().resolves(null);
+    const create = sinon.stub().resolves({
+      _id: 'new-conv',
+      participants: [],
+      channels: [],
+      status: ConversationStatusEnum.ACTIVE,
+    });
+
+    const conversationRepository = {
+      findByPlatformThread,
+      create,
+      updateStatus: sinon.stub(),
+      updateParticipants: sinon.stub(),
+    } as unknown as ConversationRepository;
+
+    const service = new AgentConversationService(conversationRepository, {} as any, makeLogger() as any);
+
+    await service.createOrGetConversation({
+      ...baseCreateParams(),
+      firstMessageText: '',
+    });
+
+    expect(create.calledOnce).to.equal(true);
+    expect(create.firstCall.args[0].title).to.equal(DEFAULT_CONVERSATION_TITLE);
+  });
 
   it('scopes createOrGetConversation lookup by agent id and integration id', async () => {
     const findByPlatformThread = sinon.stub().resolves(null);

--- a/apps/api/src/app/agents/services/agent-conversation.service.ts
+++ b/apps/api/src/app/agents/services/agent-conversation.service.ts
@@ -14,6 +14,17 @@ import {
 import type { TriggerRecipientsPayload } from '@novu/shared';
 
 export const INBOUND_ATTACHMENT_ONLY_PREVIEW = '[Attachment]';
+export const DEFAULT_CONVERSATION_TITLE = 'Untitled conversation';
+
+export function getConversationTitle(firstMessageText: string): string {
+  const trimmed = firstMessageText.trim();
+
+  if (trimmed.length === 0) {
+    return DEFAULT_CONVERSATION_TITLE;
+  }
+
+  return trimmed.slice(0, 200);
+}
 
 export function getInboundActivityPreview(
   content: string | undefined,
@@ -162,7 +173,7 @@ export class AgentConversationService {
         },
       ],
       status: ConversationStatusEnum.ACTIVE,
-      title: params.firstMessageText.slice(0, 200),
+      title: getConversationTitle(params.firstMessageText),
       metadata: {},
       _environmentId: environmentId,
       _organizationId: organizationId,

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -98,6 +98,27 @@ function getMessageRawEvent(message: Message): Record<string, unknown> | undefin
   return asRecord(raw?.event) ?? raw;
 }
 
+function resolveInboundFirstMessageText(platform: AgentPlatformEnum, message: Message): string {
+  const preview = getInboundActivityPreview(message.text, {
+    hasPlatformAttachments: Boolean(message.attachments?.length),
+  });
+
+  if (preview.trim().length > 0) {
+    return preview;
+  }
+
+  if (platform === AgentPlatformEnum.EMAIL) {
+    const raw = asRecord(message.raw);
+    const subject = typeof raw?.subject === 'string' ? raw.subject.trim() : '';
+
+    if (subject.length > 0) {
+      return subject;
+    }
+  }
+
+  return preview;
+}
+
 function getInboundPlatformThreadId(platform: AgentPlatformEnum, thread: Thread, message: Message): string {
   const rawEvent = getMessageRawEvent(message);
   const rawThreadTs = rawEvent?.thread_ts;
@@ -246,9 +267,7 @@ export class AgentInboundHandler {
       participantId,
       participantType,
       platformUserId: message.author.userId,
-      firstMessageText: getInboundActivityPreview(message.text, {
-        hasPlatformAttachments: Boolean(message.attachments?.length),
-      }),
+      firstMessageText: resolveInboundFirstMessageText(config.platform, message),
     });
 
     const senderType = subscriberId


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a `ValidationError` when creating agent conversations from inbound messages with no usable preview text (for example, emails with no subject and no body).

## Root cause

`AgentConversationService.createOrGetConversation` set `title` from `firstMessageText.slice(0, 200)`. When inbound preview text was empty, Mongoose rejected the document because `title` is required and an empty string does not satisfy that constraint.

This commonly happens for email webhooks where the chat adapter maps only body text (`raw.text` / stripped HTML) to `message.text`, not the email subject.

## Changes

- Add `getConversationTitle()` to fall back to `Untitled conversation` when preview text is empty (matches dashboard display).
- For email inbound, use `raw.subject` as the conversation title when body preview is empty but subject is present.
- Add unit tests for title/preview helpers and empty-title conversation creation.

## Testing

- `npx mocha --no-config src/app/agents/services/agent-conversation.service.spec.ts` (7 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7514](https://linear.app/novu/issue/NV-7514/error-with-title-required)

<div><a href="https://cursor.com/agents/bc-919e2637-0ecb-40c8-ab8d-b3b02168343f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-919e2637-0ecb-40c8-ab8d-b3b02168343f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Fixed a ValidationError that occurred when creating agent conversations from inbound messages with no usable preview text (e.g., emails with no subject or body). When conversation title was required but received an empty string, Mongoose validation rejected the document. The fix introduces a `getConversationTitle()` helper that defaults to "Untitled conversation" when preview text is empty, and prefers the email subject over body preview for email-based inbound messages.

## Affected areas

**api**: Added `DEFAULT_CONVERSATION_TITLE` constant and `getConversationTitle()` helper to `agent-conversation.service.ts` to replace inline title slicing logic. Updated `AgentConversationService.createOrGetConversation()` to use the new helper. Modified `agent-inbound-handler.service.ts` to compute `firstMessageText` by preferring `raw.subject` for EMAIL platform inbound messages when body preview is empty, falling back to the inbound preview text otherwise.

## Testing

Added comprehensive unit tests in `agent-conversation.service.spec.ts` covering `getConversationTitle()` (whitespace trimming and 200-character truncation), `getInboundActivityPreview()` (attachment-only and empty-string edge cases), and a new `createOrGetConversation()` test confirming that empty inbound text results in a conversation using `DEFAULT_CONVERSATION_TITLE`. All mocha unit tests pass (7 passing).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->