### PR TITLE
feat(dashboard): warn when inbound domain uses apex MX fixes NV-7513

### DIFF
--- a/apps/dashboard/src/components/domains/add-domain-dialog.tsx
+++ b/apps/dashboard/src/components/domains/add-domain-dialog.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
+import { ApexDomainMxWarning } from '@/components/domains/apex-domain-mx-warning';
 import { Button } from '@/components/primitives/button';
 import {
   Dialog,
@@ -16,6 +17,7 @@ import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { useAuth } from '@/context/auth/hooks';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useCreateDomain } from '@/hooks/use-domains';
+import { isApexInboundDomain } from '@/utils/inbound-domain';
 import { buildRoute, ROUTES } from '@/utils/routes';
 
 type AddDomainFormData = {
@@ -49,6 +51,8 @@ export function AddDomainDialog({ open, onOpenChange }: AddDomainDialogProps) {
   const form = useForm<AddDomainFormData>({
     defaultValues: { name: '' },
   });
+  const domainName = form.watch('name');
+  const showApexDomainWarning = isApexInboundDomain(domainName);
 
   const onSubmit = async (data: AddDomainFormData) => {
     setIsPending(true);
@@ -104,6 +108,7 @@ export function AddDomainDialog({ open, onOpenChange }: AddDomainDialogProps) {
                 </FormItem>
               )}
             />
+            {showApexDomainWarning && <ApexDomainMxWarning />}
             <DialogFooter>
               <Button type="submit" disabled={isPending}>
                 {isPending ? 'Setting up...' : 'Setup domain'}

--- a/apps/dashboard/src/components/domains/add-domain-dialog.tsx
+++ b/apps/dashboard/src/components/domains/add-domain-dialog.tsx
@@ -17,7 +17,7 @@ import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { useAuth } from '@/context/auth/hooks';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useCreateDomain } from '@/hooks/use-domains';
-import { isApexInboundDomain } from '@/utils/inbound-domain';
+import { DOMAIN_NAME_PATTERN, isApexInboundDomain } from '@/utils/inbound-domain';
 import { buildRoute, ROUTES } from '@/utils/routes';
 
 type AddDomainFormData = {
@@ -94,7 +94,7 @@ export function AddDomainDialog({ open, onOpenChange }: AddDomainDialogProps) {
               rules={{
                 required: 'Domain name is required',
                 pattern: {
-                  value: /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i,
+                  value: DOMAIN_NAME_PATTERN,
                   message: 'Enter a valid domain name (e.g. example.com)',
                 },
               }}

--- a/apps/dashboard/src/components/domains/apex-domain-mx-warning.tsx
+++ b/apps/dashboard/src/components/domains/apex-domain-mx-warning.tsx
@@ -1,0 +1,17 @@
+import { InlineToast } from '@/components/primitives/inline-toast';
+import { cn } from '@/utils/ui';
+
+type ApexDomainMxWarningProps = {
+  className?: string;
+};
+
+export function ApexDomainMxWarning({ className }: ApexDomainMxWarningProps) {
+  return (
+    <InlineToast
+      className={cn(className)}
+      variant="warning"
+      title="Warning:"
+      description="Adding an MX record at your root domain routes all inbound email to Novu. Other mail services (such as Google Workspace or Microsoft 365) will stop receiving email for this domain. Use a subdomain like inbound.example.com if you need both."
+    />
+  );
+}

--- a/apps/dashboard/src/pages/domain-detail.tsx
+++ b/apps/dashboard/src/pages/domain-detail.tsx
@@ -23,6 +23,7 @@ import {
   DetailsSidebarRow,
   ExpandableDetailsTextarea,
 } from '@/components/details-sidebar';
+import { ApexDomainMxWarning } from '@/components/domains/apex-domain-mx-warning';
 import { DomainRouting, type DomainRoutingHandle } from '@/components/domains/domain-routing';
 import { PageMeta } from '@/components/page-meta';
 import { AnimatedBadgeDot, Badge } from '@/components/primitives/badge';
@@ -65,6 +66,7 @@ import { useDeleteDomain } from '@/hooks/use-domains';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { parseDomainMetadataJson } from '@/utils/domain-metadata';
+import { isApexInboundDomain } from '@/utils/inbound-domain';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 
@@ -159,6 +161,7 @@ export function DomainDetailPage() {
   const domainConnectError = searchParams.get('error_description') ?? searchParams.get('error');
   const domainConnectProviderName = domainConnectStatus?.providerName ?? 'your DNS provider';
   const canWriteDomains = has({ permission: PermissionsEnum.ORG_SETTINGS_WRITE });
+  const showApexDomainMxWarning = domain ? isApexInboundDomain(domain.name) : false;
 
   const domainsHref = currentEnvironment?.slug
     ? buildRoute(ROUTES.DOMAINS, { environmentSlug: currentEnvironment.slug })
@@ -611,6 +614,8 @@ export function DomainDetailPage() {
                   <p className="text-xs font-medium text-foreground-400">
                     Add the following MX record at your DNS provider:
                   </p>
+
+                  {showApexDomainMxWarning && <ApexDomainMxWarning />}
 
                   <Table containerClassname="rounded-none border-0 shadow-none overflow-visible">
                     <TableHeader className="shadow-none [&>tr>th]:bg-bg-weak [&>tr>th]:border-stroke-weak [&>tr>th]:border-y [&>tr>th:first-child]:rounded-l-lg [&>tr>th:first-child]:border-l [&>tr>th:last-child]:rounded-r-lg [&>tr>th:last-child]:border-r">

--- a/apps/dashboard/src/utils/inbound-domain.ts
+++ b/apps/dashboard/src/utils/inbound-domain.ts
@@ -1,4 +1,4 @@
-const DOMAIN_NAME_PATTERN = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i;
+export const DOMAIN_NAME_PATTERN = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i;
 
 export function normalizeInboundDomainName(domainName: string): string {
   return domainName.trim().toLowerCase().replace(/\.$/, '');

--- a/apps/dashboard/src/utils/inbound-domain.ts
+++ b/apps/dashboard/src/utils/inbound-domain.ts
@@ -1,0 +1,24 @@
+const DOMAIN_NAME_PATTERN = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i;
+
+export function normalizeInboundDomainName(domainName: string): string {
+  return domainName.trim().toLowerCase().replace(/\.$/, '');
+}
+
+export function isValidInboundDomainName(domainName: string): boolean {
+  return DOMAIN_NAME_PATTERN.test(normalizeInboundDomainName(domainName));
+}
+
+/**
+ * True when the inbound domain is the zone apex (e.g. acme.com), not a subdomain (e.g. inbound.acme.com).
+ */
+export function isApexInboundDomain(domainName: string): boolean {
+  const normalized = normalizeInboundDomainName(domainName);
+
+  if (!isValidInboundDomainName(normalized)) {
+    return false;
+  }
+
+  const labels = normalized.split('.').filter(Boolean);
+
+  return labels.length <= 2;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a warning when users configure inbound email on a root/apex domain (e.g. `acme.com`) instead of a subdomain (e.g. `inbound.acme.com`). The warning explains that adding the required MX record routes all inbound email to Novu and stops other mail services (Google Workspace, Microsoft 365, etc.) from receiving mail for that domain.

## Changes

- **`isApexInboundDomain` utility** — detects apex domains using the same label-count heuristic as domain-connect discovery fallback.
- **`ApexDomainMxWarning` component** — shared `InlineToast` warning copy.
- **Add domain dialog** — shows the warning while typing a valid apex domain before setup.
- **Domain detail page** — shows the warning above the MX DNS records table for apex domains.

## Why

MX records at the zone apex take over all inbound mail for the domain. Users who already use another provider for company email need a clear nudge to prefer a subdomain when they want both.

## Testing

- Dashboard typecheck: `npx tsc -b` in `apps/dashboard` passes.
- Manual: enter `example.com` in Add domain → warning appears; enter `inbound.example.com` → warning hidden. On domain detail for an apex domain, warning appears above MX table.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7513](https://linear.app/novu/issue/NV-7513/mx-record-adding-should-have-a-warning-that-adding-this-will-stop-all)

<div><a href="https://cursor.com/agents/bc-6c3d21c3-b41c-4c29-af38-470ba9d63d78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c3d21c3-b41c-4c29-af38-470ba9d63d78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added a dashboard warning when users configure inbound email on an apex/root domain (e.g., acme.com) instead of a subdomain (e.g., inbound.acme.com). The UI now detects apex domains and surfaces an InlineToast warning that adding MX records at the zone apex routes all inbound mail to Novu and can prevent other mail services (Google Workspace, Microsoft 365, etc.) from receiving mail for that domain, nudging users to prefer a subdomain for inbound mail.

## Affected areas

**dashboard**: Introduced a shared inbound-domain utility (DOMAIN_NAME_PATTERN, normalize/validate helpers, and isApexInboundDomain), added a reusable ApexDomainMxWarning component (InlineToast), and conditionally display the warning in the Add Domain dialog and Domain Detail page when an apex domain is detected. Validation now reuses DOMAIN_NAME_PATTERN instead of an inline regex.

## Key technical decisions

- Apex detection uses a simple label-count heuristic (≤2 dot-separated labels after normalization) to match the existing domain-connect discovery fallback behavior.  
- The warning is exposed as a shared InlineToast component to keep messaging and styling consistent across screens.

## Testing

TypeScript typecheck for the dashboard passed (npx tsc -b in apps/dashboard). Verification was manual: entering example.com in Add Domain shows the warning, inbound.example.com hides it, and the Domain Detail page displays the warning above MX records for apex domains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->