### PR TITLE
fix(dashboard): filter email integration by environment in step preview fixes NV-7717

### DIFF
--- a/apps/dashboard/src/components/workflow-editor/steps/use-editor-preview.tsx
+++ b/apps/dashboard/src/components/workflow-editor/steps/use-editor-preview.tsx
@@ -65,7 +65,15 @@ export const useEditorPreview = ({ workflowSlug, stepSlug, controlValues, payloa
     isPending: isPreviewPending,
     isFetching,
   } = useQuery({
-    queryKey: [QueryKeys.previewStep, workflowSlug, stepSlug, debouncedControlValues, editorValue, payloadSchema],
+    queryKey: [
+      QueryKeys.previewStep,
+      currentEnvironment?._id,
+      workflowSlug,
+      stepSlug,
+      debouncedControlValues,
+      editorValue,
+      payloadSchema,
+    ],
     queryFn: async ({ signal }) => {
       if (!parsedEditorPayload) {
         throw new Error('Invalid JSON in editor');

--- a/apps/dashboard/src/hooks/use-primary-email-integration.ts
+++ b/apps/dashboard/src/hooks/use-primary-email-integration.ts
@@ -1,5 +1,6 @@
 import { ChannelTypeEnum, IIntegration } from '@novu/shared';
 import { useMemo } from 'react';
+import { useEnvironment } from '../context/environment/hooks';
 import { useFetchIntegrations } from './use-fetch-integrations';
 
 type PrimaryEmailIntegrationResult = {
@@ -10,15 +11,20 @@ type PrimaryEmailIntegrationResult = {
 };
 
 export function usePrimaryEmailIntegration(): PrimaryEmailIntegrationResult {
+  const { currentEnvironment } = useEnvironment();
   const { integrations, isLoading } = useFetchIntegrations();
 
   const primaryEmailIntegration = useMemo(() => {
     if (!integrations) return undefined;
 
     return integrations.find(
-      (integration) => integration.channel === ChannelTypeEnum.EMAIL && integration.active && integration.primary
+      (integration) =>
+        integration._environmentId === currentEnvironment?._id &&
+        integration.channel === ChannelTypeEnum.EMAIL &&
+        integration.active &&
+        integration.primary
     );
-  }, [integrations]);
+  }, [integrations, currentEnvironment?._id]);
 
   return {
     senderEmail: primaryEmailIntegration?.credentials?.from,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The workflow email step preview was showing the wrong environment's integration values for `senderName` and `from` fields. When viewing a Production environment workflow email step with "Use provider defaults" enabled, the preview displayed Development environment sender values.

**Root cause:** The `usePrimaryEmailIntegration` hook picked the first primary active email integration from the full list returned by `GET /integrations`. Since this endpoint returns integrations from all environments for JWT/session auth (intentional legacy behavior), and `.find()` had no environment filter, it would return whichever primary email integration appeared first in the array — often the Development one since it's typically created first.

**Fix:**
1. Added `_environmentId` filter in `usePrimaryEmailIntegration` to match only integrations belonging to the current environment
2. Added `currentEnvironment._id` to the preview step query key in `useEditorPreview` to prevent stale cache when switching environments

```mermaid
flowchart LR
    A[GET /integrations] -->|returns all envs| B[usePrimaryEmailIntegration]
    B -->|"Before: .find(primary && email)"| C[❌ May pick wrong env]
    B -->|"After: .find(envId match && primary && email)"| D[✅ Correct env integration]
```

### Screenshots

N/A — logic-only fix, no visual changes to the UI components themselves.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- The `GET /integrations` endpoint intentionally returns cross-environment integrations for JWT auth (there's even an e2e test asserting this). The fix is client-side filtering rather than changing the API behavior, which keeps the blast radius minimal.
- The query key fix in `use-editor-preview.tsx` is a secondary improvement that prevents stale preview cache when switching environments.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7717](https://linear.app/novu/issue/NV-7717/email-step-preview-uses-wrong-environment-integration-values)

<div><a href="https://cursor.com/agents/bc-ea3f7bab-9828-4326-917f-b864116fb4cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea3f7bab-9828-4326-917f-b864116fb4cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The email integration selection logic for workflow step previews was updated to scope to the current environment. Previously, `usePrimaryEmailIntegration` selected the first matching primary email integration without filtering by environment, causing the email preview to potentially display sender values (senderName and from) from integrations in a different environment. The fix adds environment filtering to both the integration selection logic and the preview cache key to ensure consistency when switching environments.

## Affected areas

**dashboard**: Modified `usePrimaryEmailIntegration` hook to filter integrations by matching `_environmentId` to the current environment, ensuring only environment-scoped integrations are selected. Updated `useEditorPreview` to include the current environment ID in the query cache key, preventing stale preview data when switching environments.

## Testing

No tests were added. This is a client-side filtering fix to existing hooks without API contract changes, so manual verification is sufficient to confirm the email preview now displays the correct environment-specific integration values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->