### PR TITLE
fix(api-service): scope integration identifier override to current environment fixes NV-7718

### DIFF
--- a/libs/application-generic/src/usecases/select-integration/select-integration.spec.ts
+++ b/libs/application-generic/src/usecases/select-integration/select-integration.spec.ts
@@ -184,7 +184,7 @@ describe('select integration', () => {
     const userId = 'userId';
     const identifier = 'prod-integration-identifier';
 
-    findOneMock.mockImplementation(() => null);
+    findOneMock.mockImplementationOnce(() => null);
 
     const integration = await useCase.execute(
       SelectIntegrationCommand.create({
@@ -217,7 +217,7 @@ describe('select integration', () => {
     const userId = 'userId';
     const identifier = 'dev-integration-identifier';
 
-    findOneMock.mockImplementation(() => ({
+    findOneMock.mockImplementationOnce(() => ({
       ...testIntegration,
       _environmentId: environmentId,
       identifier,

--- a/libs/application-generic/src/usecases/select-integration/select-integration.spec.ts
+++ b/libs/application-generic/src/usecases/select-integration/select-integration.spec.ts
@@ -177,4 +177,75 @@ describe('select integration', () => {
       );
     }
   );
+
+  it('should scope identifier override query to the current environment', async () => {
+    const environmentId = 'dev-env-id';
+    const organizationId = 'organizationId';
+    const userId = 'userId';
+    const identifier = 'prod-integration-identifier';
+
+    findOneMock.mockImplementation(() => null);
+
+    const integration = await useCase.execute(
+      SelectIntegrationCommand.create({
+        channelType: ChannelTypeEnum.EMAIL,
+        environmentId,
+        organizationId,
+        userId,
+        identifier,
+        filterData: {},
+      })
+    );
+
+    expect(findOneMock).toHaveBeenCalledWith(
+      {
+        _organizationId: organizationId,
+        _environmentId: environmentId,
+        channel: ChannelTypeEnum.EMAIL,
+        identifier,
+        active: true,
+      },
+      undefined,
+      { query: { sort: { createdAt: -1 } } }
+    );
+    expect(integration).toBeUndefined();
+  });
+
+  it('should return integration when identifier belongs to the same environment', async () => {
+    const environmentId = 'dev-env-id';
+    const organizationId = 'organizationId';
+    const userId = 'userId';
+    const identifier = 'dev-integration-identifier';
+
+    findOneMock.mockImplementation(() => ({
+      ...testIntegration,
+      _environmentId: environmentId,
+      identifier,
+    }));
+
+    const integration = await useCase.execute(
+      SelectIntegrationCommand.create({
+        channelType: ChannelTypeEnum.EMAIL,
+        environmentId,
+        organizationId,
+        userId,
+        identifier,
+        filterData: {},
+      })
+    );
+
+    expect(findOneMock).toHaveBeenCalledWith(
+      {
+        _organizationId: organizationId,
+        _environmentId: environmentId,
+        channel: ChannelTypeEnum.EMAIL,
+        identifier,
+        active: true,
+      },
+      undefined,
+      { query: { sort: { createdAt: -1 } } }
+    );
+    expect(integration).not.toBeUndefined();
+    expect(integration?.identifier).toEqual(identifier);
+  });
 });

--- a/libs/application-generic/src/usecases/select-integration/select-integration.usecase.ts
+++ b/libs/application-generic/src/usecases/select-integration/select-integration.usecase.ts
@@ -86,6 +86,7 @@ export class SelectIntegration {
     const query: Partial<IntegrationEntity> & { _organizationId: string } = command.identifier
       ? {
           _organizationId: command.organizationId,
+          _environmentId: command.environmentId,
           channel: command.channelType,
           identifier: command.identifier,
           active: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

When a workflow trigger includes an `integrationIdentifier` override (e.g., `overrides.email.integrationIdentifier`), the `SelectIntegration` use case previously resolved the integration using only `_organizationId`, `channel`, `identifier`, and `active: true` — **omitting the `_environmentId` filter**.

This allowed a development environment workflow to successfully use a production environment integration identifier in overrides, which is a cross-environment security concern.

**The fix** adds `_environmentId: command.environmentId` to the query in `getPrimaryIntegration` when an identifier override is provided, ensuring the lookup is scoped to the same environment as the workflow trigger. If the identifier doesn't match an integration in the current environment, the trigger will fail (as expected).

This matches the behavior already used in:
- The default (non-override) integration selection path
- `UpdateSubscriberChannel` when resolving by identifier

**Before (org-scoped, allows cross-environment):**
```typescript
{
  _organizationId: command.organizationId,
  channel: command.channelType,
  identifier: command.identifier,
  active: true,
}
```

**After (environment-scoped):**
```typescript
{
  _organizationId: command.organizationId,
  _environmentId: command.environmentId,
  channel: command.channelType,
  identifier: command.identifier,
  active: true,
}
```

### Screenshots

N/A — backend logic change only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

- The existing e2e test `should trigger message with override integration identifier` creates a new integration in the **same** environment and uses its identifier as override, so it remains valid with this fix.
- Unit tests added to verify query construction includes `_environmentId` when an identifier is provided.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7718](https://linear.app/novu/issue/NV-7718/using-production-integration-identifier-in-development-overrides)

<div><a href="https://cursor.com/agents/bc-b14b4afe-0ba8-487e-913b-5254631267f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b14b4afe-0ba8-487e-913b-5254631267f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The SelectIntegration use case now scopes integration identifier overrides to the workflow's environment. When an override like overrides.email.integrationIdentifier is provided, the repository query now includes _environmentId: command.environmentId so identifier-based lookups only resolve integrations in the same environment as the workflow trigger. This prevents workflows in one environment from resolving integrations from another (e.g., dev resolving prod).

## Affected areas

**application-generic (api)**: Updated the SelectIntegration use case to include environment scoping when resolving identifier overrides; added unit tests to assert that identifier overrides are constrained to the current environment and that cross-environment identifiers do not resolve.

## Key technical decisions

- If no matching integration exists in the current environment for a provided identifier, the trigger will fail rather than falling back to an integration in another environment, aligning behavior with the default integration selection path and UpdateSubscriberChannel.

## Testing

Added unit tests covering two scenarios: identifier belongs to a different environment (returns undefined) and identifier matches an integration in the same environment (returns the integration). Existing e2e tests remain valid because they create integrations in the same environment as the workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->