### PR TITLE
fix(api-service): use agent name and inbox address as default email sender fixes NV-7707

### DIFF
--- a/apps/api/src/app/agents/dtos/agent-integration-response.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-integration-response.dto.ts
@@ -36,6 +36,13 @@ export class AgentIntegrationResponseIntegrationDto {
 
   @ApiPropertyOptional({
     description:
+      'Default email From display name for this agent (NovuAgent integrations only). ' +
+      'Falls back to the agent name when not explicitly stored on the integration credentials.',
+  })
+  defaultSenderName?: string;
+
+  @ApiPropertyOptional({
+    description:
       'When true, the worker drops inbound mail addressed to this agent on the shared `agentconnect.sh` domain. ' +
       'Custom-domain routes still deliver. Only meaningful on cloud-enabled NovuAgent integrations.',
   })

--- a/apps/api/src/app/agents/mappers/agent-response.mapper.ts
+++ b/apps/api/src/app/agents/mappers/agent-response.mapper.ts
@@ -166,6 +166,10 @@ export function toAgentIntegrationResponse(
   agent: SharedInboxAgentContext
 ): AgentIntegrationResponseDto {
   const sharedInboundAddress = resolveSharedInboxAddress(agent, integration);
+  const defaultSenderName =
+    integration.providerId === EmailProviderIdEnum.NovuAgent
+      ? integration.credentials?.senderName || agent.name
+      : undefined;
 
   return {
     _id: link._id,
@@ -178,6 +182,7 @@ export function toAgentIntegrationResponse(
       channel: integration.channel,
       active: integration.active,
       sharedInboundAddress,
+      defaultSenderName,
       sharedInboxDisabled:
         integration.providerId === EmailProviderIdEnum.NovuAgent
           ? Boolean(integration.credentials?.sharedInboxDisabled)

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -70,6 +70,10 @@ function wrapMsgId(id: string): string {
   return trimmed.startsWith('<') && trimmed.endsWith('>') ? trimmed : `<${trimmed}>`;
 }
 
+function resolveAgentEmailSenderName(config: ResolvedAgentConfig): string {
+  return config.credentials.senderName?.trim() || config.agentName;
+}
+
 /**
  * Thrown by `ChatSdkService.processEmailAction` when a failure is provably pre-dispatch —
  * i.e. token validation, agent-config lookup, or chat/adapter setup failed before the chat
@@ -909,6 +913,7 @@ export class ChatSdkService implements OnModuleDestroy {
       inboxRoutingKey: c.inboxRoutingKey ?? null,
       sharedInboxDisabled: c.sharedInboxDisabled ?? null,
       senderName: c.senderName ?? null,
+      agentName: config.agentName,
     });
   }
 
@@ -1008,8 +1013,9 @@ export class ChatSdkService implements OnModuleDestroy {
         ? config.credentials.fromAddressOverride?.trim() || undefined
         : undefined;
       const outboundFrom = (decrypted.from as string | undefined)?.trim() || undefined;
-      const effectiveFrom = overrideFrom || outboundFrom || agentInboundAddress;
+      const effectiveFrom = overrideFrom || agentInboundAddress || outboundFrom;
       const replyToHeader = effectiveFrom !== agentInboundAddress ? agentInboundAddress : undefined;
+      const senderName = resolveAgentEmailSenderName(config);
 
       const mailFactory = new MailFactory();
       const handler = mailFactory.getHandler({ ...integration, credentials: decrypted }, effectiveFrom);
@@ -1022,7 +1028,7 @@ export class ChatSdkService implements OnModuleDestroy {
         alternatives: params.alternatives,
         from: effectiveFrom,
         ...(replyToHeader ? { replyTo: replyToHeader } : {}),
-        senderName: config.credentials.senderName || undefined,
+        senderName,
         headers: {
           ...(params.messageId ? { 'Message-ID': wrapMsgId(params.messageId) } : {}),
           ...(params.inReplyTo ? { 'In-Reply-To': wrapMsgId(params.inReplyTo) } : {}),
@@ -1128,6 +1134,7 @@ export class ChatSdkService implements OnModuleDestroy {
     }
 
     const from = buildAgentSharedInbox(config.credentials.emailSlugPrefix, config.credentials.inboxRoutingKey);
+    const senderName = resolveAgentEmailSenderName(config);
 
     // The Novu demo integration row's stored credentials are empty by design —
     // the real API key lives in the deployment's env so a single Novu-managed
@@ -1138,7 +1145,7 @@ export class ChatSdkService implements OnModuleDestroy {
       credentials: {
         apiKey: process.env.NOVU_EMAIL_INTEGRATION_API_KEY,
         from,
-        senderName: config.credentials.senderName || 'Novu',
+        senderName,
         ipPoolName: 'Demo',
       },
     };
@@ -1153,7 +1160,7 @@ export class ChatSdkService implements OnModuleDestroy {
       text: params.text,
       alternatives: params.alternatives,
       from,
-      senderName: config.credentials.senderName || undefined,
+      senderName,
       headers: {
         ...(params.messageId ? { 'Message-ID': wrapMsgId(params.messageId) } : {}),
         ...(params.inReplyTo ? { 'In-Reply-To': wrapMsgId(params.inReplyTo) } : {}),
@@ -1312,7 +1319,7 @@ export class ChatSdkService implements OnModuleDestroy {
         };
       }
       case AgentPlatformEnum.EMAIL: {
-        const { senderName, outboundIntegrationId } = credentials;
+        const { outboundIntegrationId } = credentials;
 
         if (!credentials.secretKey) {
           throw new BadRequestException('Email agent integration requires secretKey credentials');
@@ -1322,7 +1329,7 @@ export class ChatSdkService implements OnModuleDestroy {
 
         return {
           email: createNovuEmailAdapter({
-            senderName,
+            senderName: resolveAgentEmailSenderName(config),
             signingSecret: credentials.secretKey,
             sendEmail: this.buildSendEmailCallback(config, outboundIntegrationId),
             actionUrlBuilder: async ({ threadId, messageId, actionId, value, label, style }) => {

--- a/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.spec.ts
+++ b/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.spec.ts
@@ -69,7 +69,6 @@ describe('FindOrCreateNovuEmail usecase', () => {
       find: stub().resolves([]),
       findOne: stub(),
       create: stub(),
-      update: stub().resolves({}),
     };
     agentIntegrationRepo = {
       find: stub().resolves([]),
@@ -226,7 +225,6 @@ describe('FindOrCreateNovuEmail usecase', () => {
       expect(integrationRepo.create.called).to.equal(false);
       // Only the existing-link lookup happens; we never query for the default outbound integration.
       expect(integrationRepo.findOne.calledOnce).to.equal(true);
-      expect(integrationRepo.update.calledOnce).to.equal(true);
     });
   });
 });

--- a/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.spec.ts
+++ b/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.spec.ts
@@ -69,6 +69,7 @@ describe('FindOrCreateNovuEmail usecase', () => {
       find: stub().resolves([]),
       findOne: stub(),
       create: stub(),
+      update: stub().resolves({}),
     };
     agentIntegrationRepo = {
       find: stub().resolves([]),
@@ -142,6 +143,7 @@ describe('FindOrCreateNovuEmail usecase', () => {
       expect(createArg.credentials.outboundIntegrationId).to.equal('sendgrid-id');
       expect(createArg.credentials.emailSlugPrefix).to.be.a('string');
       expect(createArg.credentials.inboxRoutingKey).to.be.a('string');
+      expect(createArg.credentials.senderName).to.equal('My Agent');
     });
 
     it("falls back to the env's Novu demo email integration when no primary custom integration exists", async () => {
@@ -224,6 +226,7 @@ describe('FindOrCreateNovuEmail usecase', () => {
       expect(integrationRepo.create.called).to.equal(false);
       // Only the existing-link lookup happens; we never query for the default outbound integration.
       expect(integrationRepo.findOne.calledOnce).to.equal(true);
+      expect(integrationRepo.update.calledOnce).to.equal(true);
     });
   });
 });

--- a/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.usecase.ts
@@ -83,14 +83,22 @@ export class FindOrCreateNovuEmail {
     }
 
     const existing = await this.findExistingLink(agent, environmentId, organizationId);
-    if (existing) return { response: existing, provisionedNewLink: false };
+    if (existing) {
+      await this.backfillSenderNameIfMissing(agent, environmentId, organizationId, existing.response, existing.integration);
+
+      return { response: existing.response, provisionedNewLink: false };
+    }
 
     const emailSlugPrefix = this.deriveEmailSlugPrefix(agent);
     const defaultOutboundIntegrationId = await this.resolveDefaultOutboundIntegrationId(environmentId, organizationId);
 
     return this.agentIntegrationRepository.withTransaction(async (session) => {
       const recheck = await this.findExistingLink(agent, environmentId, organizationId);
-      if (recheck) return { response: recheck, provisionedNewLink: false };
+      if (recheck) {
+        await this.backfillSenderNameIfMissing(agent, environmentId, organizationId, recheck.response, recheck.integration);
+
+        return { response: recheck.response, provisionedNewLink: false };
+      }
 
       const displayName = providers.find((p) => p.id === EmailProviderIdEnum.NovuAgent)?.displayName ?? 'Novu Email';
       const identifier = `${slugify(displayName)}-${shortid.generate()}`;
@@ -99,6 +107,7 @@ export class FindOrCreateNovuEmail {
         displayName,
         identifier,
         emailSlugPrefix,
+        senderName: agent.name,
         outboundIntegrationId: defaultOutboundIntegrationId,
         environmentId,
         organizationId,
@@ -122,6 +131,7 @@ export class FindOrCreateNovuEmail {
     displayName,
     identifier,
     emailSlugPrefix,
+    senderName,
     outboundIntegrationId,
     environmentId,
     organizationId,
@@ -130,6 +140,7 @@ export class FindOrCreateNovuEmail {
     displayName: string;
     identifier: string;
     emailSlugPrefix: string;
+    senderName: string;
     outboundIntegrationId: string;
     environmentId: string;
     organizationId: string;
@@ -148,6 +159,7 @@ export class FindOrCreateNovuEmail {
               emailSlugPrefix,
               inboxRoutingKey,
               outboundIntegrationId,
+              senderName,
             },
             configurations: {},
             name: displayName,
@@ -243,7 +255,7 @@ export class FindOrCreateNovuEmail {
     agent: Pick<AgentEntity, '_id' | 'identifier' | 'name'>,
     environmentId: string,
     organizationId: string
-  ): Promise<AgentIntegrationResponseDto | null> {
+  ): Promise<{ response: AgentIntegrationResponseDto; integration: IntegrationEntity } | null> {
     const agentId = agent._id;
     const links = await this.agentIntegrationRepository.find(
       { _agentId: agentId, _environmentId: environmentId, _organizationId: organizationId },
@@ -270,7 +282,10 @@ export class FindOrCreateNovuEmail {
     const link = links.find((l) => l._integrationId === emailIntegration._id);
     if (!link) return null;
 
-    return toAgentIntegrationResponse(link, emailIntegration, agent);
+    return {
+      response: toAgentIntegrationResponse(link, emailIntegration, agent),
+      integration: emailIntegration,
+    };
   }
 
   private async createLink(
@@ -308,6 +323,34 @@ export class FindOrCreateNovuEmail {
     );
 
     return toAgentIntegrationResponse(link, integration, agent);
+  }
+
+  /**
+   * Older NovuAgent rows were provisioned without `credentials.senderName`.
+   * Backfill from the agent display name so outbound email and the dashboard
+   * show the correct From name without requiring a manual integration edit.
+   */
+  private async backfillSenderNameIfMissing(
+    agent: Pick<AgentEntity, '_id' | 'identifier' | 'name'>,
+    environmentId: string,
+    organizationId: string,
+    response: AgentIntegrationResponseDto,
+    integration: Pick<IntegrationEntity, '_id' | 'credentials'>
+  ): Promise<void> {
+    if (integration.credentials?.senderName) {
+      return;
+    }
+
+    await this.integrationRepository.update(
+      {
+        _id: integration._id,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      },
+      { $set: { 'credentials.senderName': agent.name } }
+    );
+
+    response.integration.defaultSenderName = agent.name;
   }
 
   private async enforceEmailTier(organizationId: string): Promise<void> {

--- a/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/find-or-create-novu-email/find-or-create-novu-email.usecase.ts
@@ -83,22 +83,14 @@ export class FindOrCreateNovuEmail {
     }
 
     const existing = await this.findExistingLink(agent, environmentId, organizationId);
-    if (existing) {
-      await this.backfillSenderNameIfMissing(agent, environmentId, organizationId, existing.response, existing.integration);
-
-      return { response: existing.response, provisionedNewLink: false };
-    }
+    if (existing) return { response: existing, provisionedNewLink: false };
 
     const emailSlugPrefix = this.deriveEmailSlugPrefix(agent);
     const defaultOutboundIntegrationId = await this.resolveDefaultOutboundIntegrationId(environmentId, organizationId);
 
     return this.agentIntegrationRepository.withTransaction(async (session) => {
       const recheck = await this.findExistingLink(agent, environmentId, organizationId);
-      if (recheck) {
-        await this.backfillSenderNameIfMissing(agent, environmentId, organizationId, recheck.response, recheck.integration);
-
-        return { response: recheck.response, provisionedNewLink: false };
-      }
+      if (recheck) return { response: recheck, provisionedNewLink: false };
 
       const displayName = providers.find((p) => p.id === EmailProviderIdEnum.NovuAgent)?.displayName ?? 'Novu Email';
       const identifier = `${slugify(displayName)}-${shortid.generate()}`;
@@ -255,7 +247,7 @@ export class FindOrCreateNovuEmail {
     agent: Pick<AgentEntity, '_id' | 'identifier' | 'name'>,
     environmentId: string,
     organizationId: string
-  ): Promise<{ response: AgentIntegrationResponseDto; integration: IntegrationEntity } | null> {
+  ): Promise<AgentIntegrationResponseDto | null> {
     const agentId = agent._id;
     const links = await this.agentIntegrationRepository.find(
       { _agentId: agentId, _environmentId: environmentId, _organizationId: organizationId },
@@ -282,10 +274,7 @@ export class FindOrCreateNovuEmail {
     const link = links.find((l) => l._integrationId === emailIntegration._id);
     if (!link) return null;
 
-    return {
-      response: toAgentIntegrationResponse(link, emailIntegration, agent),
-      integration: emailIntegration,
-    };
+    return toAgentIntegrationResponse(link, emailIntegration, agent);
   }
 
   private async createLink(
@@ -323,34 +312,6 @@ export class FindOrCreateNovuEmail {
     );
 
     return toAgentIntegrationResponse(link, integration, agent);
-  }
-
-  /**
-   * Older NovuAgent rows were provisioned without `credentials.senderName`.
-   * Backfill from the agent display name so outbound email and the dashboard
-   * show the correct From name without requiring a manual integration edit.
-   */
-  private async backfillSenderNameIfMissing(
-    agent: Pick<AgentEntity, '_id' | 'identifier' | 'name'>,
-    environmentId: string,
-    organizationId: string,
-    response: AgentIntegrationResponseDto,
-    integration: Pick<IntegrationEntity, '_id' | 'credentials'>
-  ): Promise<void> {
-    if (integration.credentials?.senderName) {
-      return;
-    }
-
-    await this.integrationRepository.update(
-      {
-        _id: integration._id,
-        _environmentId: environmentId,
-        _organizationId: organizationId,
-      },
-      { $set: { 'credentials.senderName': agent.name } }
-    );
-
-    response.integration.defaultSenderName = agent.name;
   }
 
   private async enforceEmailTier(organizationId: string): Promise<void> {

--- a/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
@@ -1,6 +1,13 @@
 import { BadGatewayException, BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
-import { AnalyticsService, decryptCredentials, InstrumentUsecase, MailFactory } from '@novu/application-generic';
-import { AgentIntegrationRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
+import {
+  AnalyticsService,
+  buildAgentSharedInbox,
+  decryptCredentials,
+  InstrumentUsecase,
+  isAgentSharedInboxEnabled,
+  MailFactory,
+} from '@novu/application-generic';
+import { AgentIntegrationRepository, AgentRepository, IntegrationEntity, IntegrationRepository } from '@novu/dal';
 import { ChannelTypeEnum, EmailProviderIdEnum, IEmailOptions } from '@novu/shared';
 
 import { trackAgentTestEmailSent } from '../../agent-analytics';
@@ -8,6 +15,29 @@ import { SendAgentTestEmailCommand } from './send-agent-test-email.command';
 
 function escapeHtml(text: string): string {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function resolveAgentInboundFrom(emailIntegration: IntegrationEntity): string | undefined {
+  const slug = emailIntegration.credentials?.emailSlugPrefix;
+  const inboxRoutingKey = emailIntegration.credentials?.inboxRoutingKey;
+  if (!isAgentSharedInboxEnabled() || !slug || !inboxRoutingKey) {
+    return undefined;
+  }
+
+  try {
+    return buildAgentSharedInbox(slug, inboxRoutingKey);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveAgentSenderName(emailIntegration: IntegrationEntity, agentName: string): string {
+  const stored = emailIntegration.credentials?.senderName;
+  if (typeof stored === 'string' && stored.trim()) {
+    return stored.trim();
+  }
+
+  return agentName;
 }
 
 @Injectable()
@@ -58,14 +88,19 @@ export class SendAgentTestEmail {
     }
 
     const outboundIntegrationId = emailIntegration.credentials?.outboundIntegrationId as string | undefined;
+    const agentInboundFrom = resolveAgentInboundFrom(emailIntegration);
+    const senderName = resolveAgentSenderName(emailIntegration, agent.name);
 
     const senderIntegration = await this.findSenderIntegration(
       command.environmentId,
       command.organizationId,
-      outboundIntegrationId
+      outboundIntegrationId,
+      { agentInboundFrom, senderName }
     );
+    const outboundFrom = senderIntegration.credentials?.from as string | undefined;
+    const from = agentInboundFrom || outboundFrom;
     const mailFactory = new MailFactory();
-    const handler = mailFactory.getHandler(senderIntegration, senderIntegration.credentials?.from as string);
+    const handler = mailFactory.getHandler(senderIntegration, from);
 
     const escapedName = escapeHtml(agent.name);
     const mailOptions: IEmailOptions = {
@@ -83,8 +118,8 @@ export class SendAgentTestEmail {
         '</p>',
         '</div>',
       ].join(''),
-      from: senderIntegration.credentials?.from as string,
-      senderName: (senderIntegration.credentials?.senderName as string) || 'Novu',
+      from,
+      senderName,
     };
 
     await handler.send(mailOptions).catch((err) => {
@@ -107,7 +142,12 @@ export class SendAgentTestEmail {
     return { success: true };
   }
 
-  private async findSenderIntegration(environmentId: string, organizationId: string, outboundIntegrationId?: string) {
+  private async findSenderIntegration(
+    environmentId: string,
+    organizationId: string,
+    outboundIntegrationId: string | undefined,
+    delivery: { agentInboundFrom?: string; senderName: string }
+  ) {
     if (!outboundIntegrationId) {
       throw new BadRequestException('Agent has no outbound email integration configured.');
     }
@@ -134,8 +174,8 @@ export class SendAgentTestEmail {
         ...configured,
         credentials: {
           apiKey: process.env.NOVU_EMAIL_INTEGRATION_API_KEY,
-          from: 'no-reply@novu.co',
-          senderName: 'Novu',
+          from: delivery.agentInboundFrom ?? 'no-reply@novu.co',
+          senderName: delivery.senderName,
           ipPoolName: 'Demo',
         },
       };

--- a/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
+++ b/apps/api/src/app/agents/usecases/send-agent-test-email/send-agent-test-email.usecase.ts
@@ -20,7 +20,8 @@ function escapeHtml(text: string): string {
 function resolveAgentInboundFrom(emailIntegration: IntegrationEntity): string | undefined {
   const slug = emailIntegration.credentials?.emailSlugPrefix;
   const inboxRoutingKey = emailIntegration.credentials?.inboxRoutingKey;
-  if (!isAgentSharedInboxEnabled() || !slug || !inboxRoutingKey) {
+  const sharedInboxDisabled = Boolean(emailIntegration.credentials?.sharedInboxDisabled);
+  if (!isAgentSharedInboxEnabled() || !slug || !inboxRoutingKey || sharedInboxDisabled) {
     return undefined;
   }
 

--- a/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
@@ -156,7 +156,7 @@ export class UpdateAgent {
         _environmentId: environmentId,
         _organizationId: organizationId,
       },
-      '_integrationId'
+      ['_integrationId']
     );
 
     const integrationIds = links.map((link) => link._integrationId).filter(Boolean);

--- a/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { assertSafeOutboundUrl, resolvePublicAddresses, SsrfBlockedError } from '@novu/application-generic';
-import { AgentRepository, EnvironmentRepository } from '@novu/dal';
-import { EnvironmentTypeEnum } from '@novu/shared';
+import { AgentIntegrationRepository, AgentRepository, EnvironmentRepository, IntegrationRepository } from '@novu/dal';
+import { EmailProviderIdEnum, EnvironmentTypeEnum } from '@novu/shared';
 import type { AgentResponseDto } from '../../dtos';
 import { toAgentResponse } from '../../mappers/agent-response.mapper';
 import { UpdateAgentCommand } from './update-agent.command';
@@ -10,7 +10,9 @@ import { UpdateAgentCommand } from './update-agent.command';
 export class UpdateAgent {
   constructor(
     private readonly agentRepository: AgentRepository,
-    private readonly environmentRepository: EnvironmentRepository
+    private readonly environmentRepository: EnvironmentRepository,
+    private readonly agentIntegrationRepository: AgentIntegrationRepository,
+    private readonly integrationRepository: IntegrationRepository
   ) {}
 
   async execute(command: UpdateAgentCommand): Promise<AgentResponseDto> {
@@ -111,6 +113,10 @@ export class UpdateAgent {
       { $set }
     );
 
+    if (command.name !== undefined) {
+      await this.syncNovuAgentSenderName(existing._id, command.environmentId, command.organizationId, command.name);
+    }
+
     const updated = await this.agentRepository.findById(
       {
         _id: existing._id,
@@ -136,6 +142,37 @@ export class UpdateAgent {
     if (environment?.type === EnvironmentTypeEnum.PROD) {
       throw new ForbiddenException(message);
     }
+  }
+
+  private async syncNovuAgentSenderName(
+    agentId: string,
+    environmentId: string,
+    organizationId: string,
+    senderName: string
+  ): Promise<void> {
+    const links = await this.agentIntegrationRepository.find(
+      {
+        _agentId: agentId,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+      },
+      '_integrationId'
+    );
+
+    const integrationIds = links.map((link) => link._integrationId).filter(Boolean);
+    if (integrationIds.length === 0) {
+      return;
+    }
+
+    await this.integrationRepository.update(
+      {
+        _id: { $in: integrationIds } as unknown as string,
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        providerId: EmailProviderIdEnum.NovuAgent,
+      },
+      { $set: { 'credentials.senderName': senderName } }
+    );
   }
 
   private async assertSafeBridgeUrl(url: string | undefined | null, field: string): Promise<void> {

--- a/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/update-agent/update-agent.usecase.ts
@@ -2,6 +2,7 @@ import { BadRequestException, ForbiddenException, Injectable, NotFoundException 
 import { assertSafeOutboundUrl, resolvePublicAddresses, SsrfBlockedError } from '@novu/application-generic';
 import { AgentIntegrationRepository, AgentRepository, EnvironmentRepository, IntegrationRepository } from '@novu/dal';
 import { EmailProviderIdEnum, EnvironmentTypeEnum } from '@novu/shared';
+import type { ClientSession } from 'mongoose';
 import type { AgentResponseDto } from '../../dtos';
 import { toAgentResponse } from '../../mappers/agent-response.mapper';
 import { UpdateAgentCommand } from './update-agent.command';
@@ -104,17 +105,29 @@ export class UpdateAgent {
       $set.devBridgeActive = command.devBridgeActive;
     }
 
-    await this.agentRepository.updateOne(
-      {
-        _id: existing._id,
-        _environmentId: command.environmentId,
-        _organizationId: command.organizationId,
-      },
-      { $set }
-    );
+    const nameChanged = command.name !== undefined && command.name !== existing.name;
+    const agentQuery = {
+      _id: existing._id,
+      _environmentId: command.environmentId,
+      _organizationId: command.organizationId,
+    };
 
-    if (command.name !== undefined) {
-      await this.syncNovuAgentSenderName(existing._id, command.environmentId, command.organizationId, command.name);
+    if (nameChanged) {
+      await this.agentRepository.withTransaction(async (session) => {
+        if (Object.keys($set).length > 0) {
+          await this.agentRepository.update(agentQuery, { $set }, session ? { session } : {});
+        }
+
+        await this.syncNovuAgentSenderName(
+          existing._id,
+          command.environmentId,
+          command.organizationId,
+          command.name!,
+          session
+        );
+      });
+    } else if (Object.keys($set).length > 0) {
+      await this.agentRepository.updateOne(agentQuery, { $set });
     }
 
     const updated = await this.agentRepository.findById(
@@ -148,7 +161,8 @@ export class UpdateAgent {
     agentId: string,
     environmentId: string,
     organizationId: string,
-    senderName: string
+    senderName: string,
+    session: ClientSession | null = null
   ): Promise<void> {
     const links = await this.agentIntegrationRepository.find(
       {
@@ -156,7 +170,8 @@ export class UpdateAgent {
         _environmentId: environmentId,
         _organizationId: organizationId,
       },
-      ['_integrationId']
+      ['_integrationId'],
+      { session }
     );
 
     const integrationIds = links.map((link) => link._integrationId).filter(Boolean);
@@ -171,7 +186,8 @@ export class UpdateAgent {
         _organizationId: organizationId,
         providerId: EmailProviderIdEnum.NovuAgent,
       },
-      { $set: { 'credentials.senderName': senderName } }
+      { $set: { 'credentials.senderName': senderName } },
+      session ? { session } : {}
     );
   }
 

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -226,6 +226,11 @@ export type AgentIntegrationEmbedded = {
    */
   sharedInboundAddress?: string;
   /**
+   * Default email From display name for NovuAgent integrations.
+   * Mirrors `credentials.senderName`, falling back to the agent name when unset.
+   */
+  defaultSenderName?: string;
+  /**
    * Cloud only. When `true`, the worker drops inbound mail addressed to this
    * agent on the shared `agentconnect.sh` domain. Custom-domain routes still
    * deliver. Only meaningful on the NovuAgent integration.

--- a/apps/dashboard/src/components/agents/agent-integration-guides/email-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/email-agent-integration-guide.tsx
@@ -70,7 +70,11 @@ export function EmailAgentIntegrationGuide({
                 agent={agent}
               />
             ) : null}
-            <EmailConfigurationCardBody agent={agent} integrationId={integrationId} />
+            <EmailConfigurationCardBody
+              agent={agent}
+              integrationId={integrationId}
+              defaultSenderName={integrationLink?.integration?.defaultSenderName}
+            />
           </div>
         </div>
       ) : null}

--- a/apps/dashboard/src/components/agents/email-configuration-card.tsx
+++ b/apps/dashboard/src/components/agents/email-configuration-card.tsx
@@ -17,7 +17,11 @@ export type EmailConfigurationCardProps = {
 /**
  * Outbound / sender rows for embedding inside a parent shell (merged email card).
  */
-export function EmailConfigurationCardBody({ agent, integrationId }: EmailConfigurationCardProps) {
+export function EmailConfigurationCardBody({
+  agent,
+  integrationId,
+  defaultSenderName,
+}: EmailConfigurationCardProps & { defaultSenderName?: string }) {
   const { integrations } = useFetchIntegrations();
   const emailIntegration = useMemo(
     () => integrations?.find((i) => i._id === integrationId && i.providerId === EmailProviderIdEnum.NovuAgent),
@@ -55,11 +59,12 @@ export function EmailConfigurationCardBody({ agent, integrationId }: EmailConfig
 
       <CardRow
         title="Sender address"
-        description="By default, replies use your sending provider's From address. Override it to send from another address. Reply-To always routes back to the agent so subscriber replies stay in the thread."
+        description="By default, replies send from the agent inbox address using the agent name as the From display name. Override the address to send from another email. Reply-To always routes back to the agent so subscriber replies stay in the thread."
       >
         <SenderAddressOverride
           serverEnabled={serverUseFromAddressOverride}
           serverValue={serverFromAddressOverride}
+          defaultSenderName={defaultSenderName || agent.name}
           outboundFromAddress={outboundFromAddress}
           inboundAddresses={inboundAddresses}
           onSave={saveSenderOverride}

--- a/apps/dashboard/src/components/agents/sender-address-override.tsx
+++ b/apps/dashboard/src/components/agents/sender-address-override.tsx
@@ -7,6 +7,7 @@ import { Switch } from '@/components/primitives/switch';
 export type SenderAddressOverrideProps = {
   serverEnabled: boolean;
   serverValue: string;
+  defaultSenderName: string;
   outboundFromAddress: string;
   inboundAddresses: string[];
   onSave: (params: { enabled: boolean; value: string }) => Promise<void>;
@@ -26,6 +27,7 @@ export type SenderAddressOverrideProps = {
 export function SenderAddressOverride({
   serverEnabled,
   serverValue,
+  defaultSenderName,
   outboundFromAddress,
   inboundAddresses,
   onSave,
@@ -63,13 +65,13 @@ export function SenderAddressOverride({
   const canSave = !disabled && isDirty && !isSaving && !hasInvalidValue;
 
   // Mirror the resolution in apps/api/src/app/agents/services/chat-sdk.service.ts
-  // buildSendEmailCallback: override > outbound.from > agent inbound. When the
+  // buildSendEmailCallback: override > agent inbound > outbound.from. When the
   // override is locked (demo sender), the override is server-side ignored, so
   // we drop it from the preview to match the address subscribers will actually
   // see in their inbox.
   const previewOverride = !disabled && enabled ? trimmedValue : '';
   const fallbackInbound = inboundAddresses[0] ?? '';
-  const resolvedFrom = previewOverride || outboundFromAddress || fallbackInbound;
+  const resolvedFrom = previewOverride || fallbackInbound || outboundFromAddress;
   const resolvedReplyTo = resolvedFrom && resolvedFrom !== fallbackInbound ? fallbackInbound : '';
 
   async function handleSave() {
@@ -127,7 +129,7 @@ export function SenderAddressOverride({
         </div>
       )}
 
-      <AddressPreview from={resolvedFrom} replyTo={resolvedReplyTo} />
+      <AddressPreview fromName={defaultSenderName} from={resolvedFrom} replyTo={resolvedReplyTo} />
 
       {disabled && disabledReason ? (
         <p className="text-text-soft text-paragraph-xs leading-4">{disabledReason}</p>
@@ -151,13 +153,24 @@ export function SenderAddressOverride({
   );
 }
 
-function AddressPreview({ from, replyTo }: { from: string; replyTo: string }) {
+function AddressPreview({ fromName, from, replyTo }: { fromName: string; from: string; replyTo: string }) {
+  const fromDisplay = from ? formatFromHeader(fromName, from) : '';
+
   return (
     <div className="border-stroke-soft bg-bg-weak flex flex-col gap-1 rounded-md border px-2.5 py-2">
-      <PreviewRow label="From" value={from || 'Not configured yet'} muted={!from} />
+      <PreviewRow label="From name" value={fromName || 'Not configured yet'} muted={!fromName} />
+      <PreviewRow label="From" value={fromDisplay || 'Not configured yet'} muted={!from} />
       <PreviewRow label="Reply-To" value={replyTo || 'Not set (replies go to From)'} muted={!replyTo} />
     </div>
   );
+}
+
+function formatFromHeader(name: string, email: string): string {
+  if (!name) {
+    return email;
+  }
+
+  return `${name} <${email}>`;
 }
 
 function PreviewRow({ label, value, muted }: { label: string; value: string; muted: boolean }) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes agent email replies using the wrong From display name and address (e.g. provider defaults like `support@novu.co` / `Inbound Test`) instead of the agent identity.

## Changes

### API
- **Provision** `credentials.senderName` from the agent name when creating a NovuAgent email integration
- **Sync** `senderName` when an agent is renamed
- **Outbound email defaults** in `chat-sdk.service.ts`:
  - From address: custom override → shared inbox address → outbound provider address
  - Display name: stored `senderName` → agent name (used by demo sender and custom providers)
- **Test emails** use the same From name/address resolution as live agent replies
- Expose `defaultSenderName` on agent integration link responses (falls back to agent name in the mapper when unset)

### Dashboard
- Email integration **sender preview** shows **From name** and formatted **From** address
- Copy updated to reflect agent inbox + agent name as the default sender

## Verification

- `FindOrCreateNovuEmail` and `sendViaNovuDemoProvider` unit tests pass locally
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7707](https://linear.app/novu/issue/NV-7707/default-inbox-uses-inbound-test-as-sender-name-instead-of-the-agent)

<div><a href="https://cursor.com/agents/bc-2281eee7-c2b1-40f2-bb89-0ac43e524081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2281eee7-c2b1-40f2-bb89-0ac43e524081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Agent email replies could show provider defaults (e.g., support@novu.co / "Inbound Test") instead of the agent’s identity. This PR makes agent inbox address and agent name the default sender for agent replies and test emails: new NovuAgent integrations persist credentials.senderName from the agent name, agent renames sync that senderName to related integrations, and outbound email selection now prefers explicit overrides → shared/inbound address → provider address while resolving the From display name from stored senderName (falling back to agent.name). Dashboard previews and copy were updated to reflect this behavior.

## Affected areas

- api: New/updated logic to provision credentials.senderName for NovuAgent integrations, transactional sync of senderName on agent rename, updated chat-sdk outbound and test-email flows to resolve From address/name with the new precedence, and agent integration responses now include defaultSenderName.
- dashboard: Integration UI accepts defaultSenderName, shows a From name + formatted address preview, and updates explanatory copy to state agent inbox + agent name are used by default.

## Key technical decisions

- From-address precedence: explicit sender override → shared/inbound address → provider outbound address.
- From display name precedence: integration.credentials.senderName → agent.name; test-send and demo-provider flows use the same resolution for consistency.
- Agent rename propagation is performed within a transaction and only when the name actually changes to avoid unnecessary updates.

## Testing

Unit tests were updated/verified locally (FindOrCreateNovuEmail and sendViaNovuDemoProvider) to assert credentials.senderName; behavior covered by existing unit tests and manual UI verification of the preview.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->