### PR TITLE
feat(api-service): agent card+files delivery and portless agent fixes fixes NV-7721

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,7 @@
     "docker:build:depot": "pnpm --silent --workspace-root pnpm-context -- apps/api/Dockerfile | depot build --build-arg PACKAGE_PATH=apps/api - -t novu-api --load",
     "start": "pnpm start:dev",
     "start:dev": "nest start --watch",
-    "start:portless": "node ../../scripts/with-portless-env.mjs pnpm exec portless run pnpm start:dev",
+    "start:portless": "cross-env PORTLESS_INJECT_CA=1 node ../../scripts/with-portless-env.mjs pnpm exec portless run pnpm start:dev",
     "start:test": "cross-env NODE_ENV=test nest start",
     "start:debug": "nest start --debug --watch --inspect",
     "start:prod": "node dist/main.js",

--- a/apps/api/src/.example.env
+++ b/apps/api/src/.example.env
@@ -110,5 +110,7 @@ SCHEDULER_CALLBACK_API_KEY=
 # When using `pnpm dev:portless`, scripts/with-portless-env.mjs resolves these at
 # runtime via `portless get` (worktree-prefixed and proxy-port aware):
 #   API_ROOT_URL, FRONT_BASE_URL, DASHBOARD_URL, BETTER_AUTH_BASE_URL
+# It also sets NODE_EXTRA_CA_CERTS to ~/.portless/ca.pem so Node trusts portless HTTPS
+# (`portless trust` is browser-only). Used by API and worker start:portless.
 #
 # Run `PORTLESS=0 pnpm start:api:dev` to bypass the proxy without uninstalling.

--- a/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-reply-payload.dto.ts
@@ -126,7 +126,7 @@ export class IsValidReplyContent implements ValidatorConstraintInterface {
     const fields = [content.markdown, content.card].filter((v) => v !== undefined);
     if (fields.length !== 1) return false;
 
-    if (content.files?.length && !content.markdown) return false;
+    if (content.files?.length && !content.markdown && !content.card) return false;
     if ((content.files?.length ?? 0) > MAX_FILES_PER_MESSAGE) return false;
 
     for (const file of content.files ?? []) {
@@ -142,7 +142,7 @@ export class IsValidReplyContent implements ValidatorConstraintInterface {
 
   defaultMessage(): string {
     return (
-      'Content must have exactly one of markdown or card. Files only allowed with markdown. ' +
+      'Content must have exactly one of markdown or card. Files require markdown or card. ' +
       `At most ${MAX_FILES_PER_MESSAGE} files are allowed. Each file needs exactly one of data or url. ` +
       'Inline data must be 5 MB or smaller.'
     );

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -27,6 +27,17 @@ import { AgentAttachmentStorage, type StoredAttachment } from './agent-attachmen
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
 
 const MAX_RETRIES = 2;
+
+/** Agent bridge replyUrl: use the process listen port (portless) or API_ROOT_URL. */
+function resolveAgentReplyApiOrigin(): string {
+  const listenPort = process.env.PORT;
+
+  if (listenPort) {
+    return `http://127.0.0.1:${listenPort}`;
+  }
+
+  return (process.env.API_ROOT_URL || 'http://localhost:3000').replace(/\/$/, '');
+}
 const RETRY_BASE_DELAY_MS = 500;
 const AGENTS_STORAGE_FOLDER = 'agents';
 const ATTACHMENT_SIGNING_CONCURRENCY = 4;
@@ -234,8 +245,7 @@ export class BridgeExecutorService {
     const { event, config, conversation, subscriber, history, message, platformContext, action, reaction } = params;
     const agentIdentifier = config.agentIdentifier;
 
-    const apiRootUrl = process.env.API_ROOT_URL || 'http://localhost:3000';
-    const replyUrl = `${apiRootUrl}/v1/agents/${agentIdentifier}/reply`;
+    const replyUrl = `${resolveAgentReplyApiOrigin()}/v1/agents/${agentIdentifier}/reply`;
 
     const timestamp = new Date().toISOString();
 

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -28,15 +28,17 @@ import { ResolvedAgentConfig } from './agent-config-resolver.service';
 
 const MAX_RETRIES = 2;
 
-/** Agent bridge replyUrl: use the process listen port (portless) or API_ROOT_URL. */
+/** Agent bridge replyUrl: prefer API_ROOT_URL, else localhost on PORT (default 3000). */
 function resolveAgentReplyApiOrigin(): string {
-  const listenPort = process.env.PORT;
+  const apiRootUrl = process.env.API_ROOT_URL?.replace(/\/$/, '');
 
-  if (listenPort) {
-    return `http://127.0.0.1:${listenPort}`;
+  if (apiRootUrl) {
+    return apiRootUrl;
   }
 
-  return (process.env.API_ROOT_URL || 'http://localhost:3000').replace(/\/$/, '');
+  const port = process.env.PORT || '3000';
+
+  return `http://localhost:${port}`;
 }
 const RETRY_BASE_DELAY_MS = 500;
 const AGENTS_STORAGE_FOLDER = 'agents';

--- a/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.spec.ts
@@ -43,28 +43,25 @@ describe('ChatSdkService', () => {
   }
 
   describe('prepareContentForDelivery', () => {
-    it('should reject card replies with file attachments', async () => {
+    it('should materialize files for card replies on supported platforms', async () => {
       const service = makeService();
+      const result = await (service as any).prepareContentForDelivery(
+        {
+          card: { type: 'card', title: 'Report', children: [] },
+          files: [
+            {
+              filename: 'sample.jpg',
+              mimeType: 'image/jpeg',
+              data: Buffer.from('hello').toString('base64'),
+            },
+          ],
+        },
+        'whatsapp'
+      );
 
-      try {
-        await (service as any).prepareContentForDelivery(
-          {
-            card: { type: 'card', title: 'Report', children: [] },
-            files: [
-              {
-                filename: 'sample.txt',
-                data: Buffer.from('hello').toString('base64'),
-              },
-            ],
-          },
-          'slack'
-        );
-        throw new Error('Expected prepareContentForDelivery to throw');
-      } catch (err) {
-        expect((err as Error).message).to.include(
-          'File attachments are only supported with string or markdown replies, not cards.'
-        );
-      }
+      expect(result.card).to.exist;
+      expect(Buffer.isBuffer(result.files[0].data)).to.equal(true);
+      expect(result.files[0].filename).to.equal('sample.jpg');
     });
 
     it('should convert base64 file data to a Buffer before passing content to the chat SDK', async () => {
@@ -388,41 +385,26 @@ describe('ChatSdkService', () => {
       });
     });
 
-    it('should drop files with a warning for whatsapp', async () => {
-      const logger = {
-        warn: sinon.stub(),
-        error: sinon.stub(),
-        debug: sinon.stub(),
-        info: sinon.stub(),
-        setContext: sinon.stub(),
-      };
-      const service = new ChatSdkService(
-        logger as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        {} as any,
-        { create: sinon.stub().resolves({ _id: 'm' }) } as any
-      );
-
+    it('should convert base64 file data to a Buffer for whatsapp', async () => {
+      const service = makeService();
       const result = await (service as any).prepareContentForDelivery(
         {
           markdown: 'Here is the file',
-          files: [{ filename: 'sample.txt', data: Buffer.from('hello').toString('base64') }],
+          files: [
+            {
+              filename: 'sample.txt',
+              mimeType: 'text/plain',
+              data: Buffer.from('hello').toString('base64'),
+            },
+          ],
         },
-        'whatsapp',
-        'agent-id'
+        'whatsapp'
       );
 
-      expect(result.files).to.equal(undefined);
-      expect(logger.warn.calledOnce).to.equal(true);
-      expect(logger.warn.firstCall.args[0]).to.deep.include({
-        agentId: 'agent-id',
-        platform: 'whatsapp',
-        droppedCount: 1,
-      });
+      expect(Buffer.isBuffer(result.files[0].data)).to.equal(true);
+      expect(result.files[0].data.toString()).to.equal('hello');
+      expect(result.files[0].filename).to.equal('sample.txt');
+      expect(result.files[0].mimeType).to.equal('text/plain');
     });
   });
 

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -131,8 +131,12 @@ const MAX_AGGREGATE_FILE_BYTES = 50 * 1024 * 1024;
 const MAX_INLINE_FILE_BASE64_CHARS = 7_000_000;
 const FILE_FETCH_TIMEOUT_MS = 10_000;
 const MAX_FILE_FETCH_REDIRECTS = 3;
-const SUPPORTED_FILE_PLATFORMS = new Set<string>([AgentPlatformEnum.SLACK, AgentPlatformEnum.TEAMS]);
-const UNSUPPORTED_FILE_PLATFORMS = new Set<string>([AgentPlatformEnum.EMAIL, AgentPlatformEnum.WHATSAPP]);
+const SUPPORTED_FILE_PLATFORMS = new Set<string>([
+  AgentPlatformEnum.SLACK,
+  AgentPlatformEnum.TEAMS,
+  AgentPlatformEnum.WHATSAPP,
+]);
+const UNSUPPORTED_FILE_PLATFORMS = new Set<string>([AgentPlatformEnum.EMAIL]);
 // EMAIL_ALTERNATIVES_SUPPORTED_PROVIDERS is a deliberate allowlist for providers that preserve custom MIME
 // alternatives used by Gmail reactions; Braze, Brevo, Mailgun, Mailjet, Mailtrap, Mandrill, Plunk, Postmark,
 // Resend, SparkPost, and similar providers are excluded until their SDK paths are verified.
@@ -315,12 +319,7 @@ export class ChatSdkService implements OnModuleDestroy {
     const thread = chat.thread(platformThreadId);
     const deliveryContent = await this.prepareContentForDelivery(content, platform, agentId);
 
-    const postArg = deliveryContent.card
-      ? (deliveryContent.card as unknown as AdapterPostableMessage)
-      : ({
-          markdown: deliveryContent.markdown ?? '',
-          files: deliveryContent.files,
-        } as unknown as AdapterPostableMessage);
+    const postArg = this.buildAdapterPostableMessage(deliveryContent);
 
     const sent = await thread.post(postArg).catch(toDeliveryError);
 
@@ -340,12 +339,7 @@ export class ChatSdkService implements OnModuleDestroy {
     const dmThread = await chat.openDM(platformUserId);
     const deliveryContent = await this.prepareContentForDelivery(content, config.platform, agentId);
 
-    const postArg = deliveryContent.card
-      ? (deliveryContent.card as unknown as AdapterPostableMessage)
-      : ({
-          markdown: deliveryContent.markdown ?? '',
-          files: deliveryContent.files,
-        } as unknown as AdapterPostableMessage);
+    const postArg = this.buildAdapterPostableMessage(deliveryContent);
 
     const sent = await dmThread.post(postArg).catch(toDeliveryError);
 
@@ -376,6 +370,8 @@ export class ChatSdkService implements OnModuleDestroy {
 
     const deliveryContent = await this.prepareContentForDelivery(content, platform, agentId);
 
+    const editPayload = this.buildAdapterPostableMessage(deliveryContent);
+
     let editPromise: Promise<{ id: string; threadId: string }>;
     if (deliveryContent.card) {
       editPromise = adapter.editMessage(
@@ -384,10 +380,7 @@ export class ChatSdkService implements OnModuleDestroy {
         deliveryContent.card as unknown as AdapterPostableMessage
       );
     } else {
-      editPromise = adapter.editMessage(platformThreadId, platformMessageId, {
-        markdown: deliveryContent.markdown ?? '',
-        files: deliveryContent.files,
-      } as unknown as AdapterPostableMessage);
+      editPromise = adapter.editMessage(platformThreadId, platformMessageId, editPayload);
     }
 
     const edited = await editPromise.catch(toDeliveryError);
@@ -400,13 +393,6 @@ export class ChatSdkService implements OnModuleDestroy {
     platform: string = AgentPlatformEnum.SLACK,
     agentId?: string
   ): Promise<ChatSdkReplyContent> {
-    if (content.card && content.files?.length) {
-      throw new BadRequestException({
-        error: 'attachment_failed',
-        message: 'File attachments are only supported with string or markdown replies, not cards.',
-      });
-    }
-
     if (!content.files?.length) {
       return content as ChatSdkReplyContent;
     }
@@ -473,6 +459,25 @@ export class ChatSdkService implements OnModuleDestroy {
       ...content,
       files,
     };
+  }
+
+  private buildAdapterPostableMessage(deliveryContent: ChatSdkReplyContent): AdapterPostableMessage {
+    if (deliveryContent.card) {
+      const payload: { card: unknown; files?: ChatSdkFile[] } = {
+        card: deliveryContent.card,
+      };
+
+      if (deliveryContent.files?.length) {
+        payload.files = deliveryContent.files;
+      }
+
+      return payload as unknown as AdapterPostableMessage;
+    }
+
+    return {
+      markdown: deliveryContent.markdown ?? '',
+      files: deliveryContent.files,
+    } as unknown as AdapterPostableMessage;
   }
 
   private async prepareFileForDelivery(file: FileRef, index: number): Promise<MaterializedFile> {

--- a/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
@@ -58,6 +58,18 @@ type ConnectStatus =
   | { state: 'manual_fallback'; message: string }
   | { state: 'error'; message: string };
 
+function connectStatusLabel(state: ConnectStatus['state'], manualMarkedConfigured: boolean): string {
+  if (state === 'manual_fallback') {
+    if (manualMarkedConfigured) {
+      return 'Webhook configured — send a test message';
+    }
+
+    return 'Webhook URL ready — finish in Meta';
+  }
+
+  return 'Connected — Novu is listening for messages';
+}
+
 type TestStatus =
   | { state: 'idle' }
   | { state: 'sending' }
@@ -80,6 +92,7 @@ function ConnectAndTestPanel({
   onConnected: () => void;
 }) {
   const [connectStatus, setConnectStatus] = useState<ConnectStatus>({ state: 'idle' });
+  const [manualMarkedConfigured, setManualMarkedConfigured] = useState(false);
   const [testStatus, setTestStatus] = useState<TestStatus>({ state: 'idle' });
   const [phone, setPhone] = useState('');
 
@@ -89,6 +102,7 @@ function ConnectAndTestPanel({
   useEffect(() => {
     if (!isCredentialsSaved) {
       setConnectStatus({ state: 'idle' });
+      setManualMarkedConfigured(false);
       setTestStatus({ state: 'idle' });
     }
   }, [isCredentialsSaved]);
@@ -170,12 +184,14 @@ function ConnectAndTestPanel({
     }
   }, [agent.identifier, integrationIdentifier, phone, sendTestTemplate]);
 
-  const isConnected = connectStatus.state === 'connected' || connectStatus.state === 'manual_fallback';
-  const showManualFallback = connectStatus.state === 'manual_fallback';
+  const connectAttemptFinished =
+    connectStatus.state === 'connected' || connectStatus.state === 'manual_fallback';
+  const showManualFallback = connectStatus.state === 'manual_fallback' && !manualMarkedConfigured;
+  const showTestPanel = connectStatus.state === 'connected' || manualMarkedConfigured;
 
   return (
     <div className="flex w-full max-w-[400px] flex-col gap-3">
-      {!isConnected ? (
+      {!connectAttemptFinished ? (
         <Button
           type="button"
           variant="primary"
@@ -190,9 +206,7 @@ function ConnectAndTestPanel({
       ) : (
         <div className="text-success-base flex items-center gap-1.5">
           <RiCheckLine className="size-4" />
-          <span className="text-label-xs font-medium">
-            {showManualFallback ? 'Webhook URL ready — finish in Meta' : 'Connected — Novu is listening for messages'}
-          </span>
+          <span className="text-label-xs font-medium">{connectStatusLabel(connectStatus.state, manualMarkedConfigured)}</span>
         </div>
       )}
 
@@ -205,11 +219,14 @@ function ConnectAndTestPanel({
           message={connectStatus.message}
           webhookUrl={webhookUrl}
           verifyToken={verifyToken}
-          onMarkConnected={onConnected}
+          onMarkConnected={() => {
+            setManualMarkedConfigured(true);
+            onConnected();
+          }}
         />
       ) : null}
 
-      {connectStatus.state === 'connected' ? (
+      {showTestPanel ? (
         <div className="border-stroke-soft mt-2 flex w-full flex-col gap-2 rounded-md border p-3">
           <p className="text-text-strong text-label-xs font-medium leading-4">Send yourself a test message</p>
           <p className="text-text-soft text-label-xs leading-4">

--- a/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/whatsapp-setup-guide.tsx
@@ -100,6 +100,13 @@ function ConnectAndTestPanel({
   const { mutateAsync: sendTestTemplate } = useSendWhatsAppTestTemplate();
 
   useEffect(() => {
+    setConnectStatus({ state: 'idle' });
+    setManualMarkedConfigured(false);
+    setTestStatus({ state: 'idle' });
+    setPhone('');
+  }, [integrationIdentifier]);
+
+  useEffect(() => {
     if (!isCredentialsSaved) {
       setConnectStatus({ state: 'idle' });
       setManualMarkedConfigured(false);

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -11,7 +11,7 @@
     "docker:build": "pnpm --silent --workspace-root pnpm-context -- apps/worker/Dockerfile | BULL_MQ_PRO_NPM_TOKEN=${BULL_MQ_PRO_NPM_TOKEN} docker buildx build --secret id=BULL_MQ_PRO_NPM_TOKEN --build-arg PACKAGE_PATH=apps/worker - -t novu-worker --load $DOCKER_BUILD_ARGUMENTS",
     "docker:build:depot": "pnpm --silent --workspace-root pnpm-context -- apps/worker/Dockerfile | depot build --build-arg PACKAGE_PATH=apps/worker - -t novu-worker --load",
     "start": "pnpm start:dev",
-    "start:portless": "node ../../scripts/with-portless-env.mjs pnpm start:dev",
+    "start:portless": "cross-env PORTLESS_INJECT_CA=1 node ../../scripts/with-portless-env.mjs pnpm start:dev",
     "start:dev": "nest start --watch",
     "start:test": "cross-env NODE_ENV=test nest start",
     "start:debug": "nest start --debug --watch",

--- a/packages/framework/src/resources/agent/agent.context.ts
+++ b/packages/framework/src/resources/agent/agent.context.ts
@@ -193,12 +193,12 @@ async function serializeContent(content: MessageContent, files?: FileRef[]): Pro
   if (isJSX(content)) {
     const card = toCardElement(content);
     if (card) {
-      return { card };
+      return validFiles ? { card, files: validFiles } : { card };
     }
   }
 
   if (isCardElement(content)) {
-    return { card: content };
+    return validFiles ? { card: content, files: validFiles } : { card: content };
   }
 
   throw new Error('Invalid message content — expected string or CardElement');

--- a/packages/framework/src/resources/agent/agent.types.ts
+++ b/packages/framework/src/resources/agent/agent.types.ts
@@ -131,6 +131,7 @@ export interface FileRef {
  * - `ChatElement` — interactive card built with Card(), Button(), etc.
  *
  * For file attachments, pass a `files` array as the second argument to reply()/edit().
+ * Cards and files can be combined on platforms that support it (e.g. WhatsApp sends media then the card).
  */
 export type MessageContent = string | ChatElement;
 

--- a/scripts/portless-ca-env.mjs
+++ b/scripts/portless-ca-env.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Resolve NODE_EXTRA_CA_CERTS for the portless local HTTPS proxy CA.
+ * `portless trust` only updates the OS store for browsers; Node needs this env var.
+ */
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export function resolvePortlessCaCertPath() {
+  const configured = process.env.NODE_EXTRA_CA_CERTS;
+
+  if (configured && existsSync(configured)) {
+    return configured;
+  }
+
+  const stateDir = process.env.PORTLESS_STATE_DIR || join(homedir(), '.portless');
+  const caPath = join(stateDir, 'ca.pem');
+
+  if (existsSync(caPath)) {
+    return caPath;
+  }
+
+  return undefined;
+}
+
+/** Env fragment to merge into child process env when the portless CA is available. */
+export function portlessCaEnv() {
+  const caPath = resolvePortlessCaCertPath();
+
+  if (!caPath) {
+    return {};
+  }
+
+  return { NODE_EXTRA_CA_CERTS: caPath };
+}

--- a/scripts/with-portless-env.mjs
+++ b/scripts/with-portless-env.mjs
@@ -12,6 +12,7 @@
  * Usage: node scripts/with-portless-env.mjs <command> [args...]
  */
 import { execFileSync, spawn } from 'node:child_process';
+import { portlessCaEnv } from './portless-ca-env.mjs';
 
 const SERVICES = ['api.novu', 'dashboard.novu', 'ws.novu'];
 
@@ -72,6 +73,7 @@ const env = {
   VITE_DASHBOARD_URL: dashboardUrl,
   VITE_BETTER_AUTH_BASE_URL: apiUrl,
   API_INTERNAL_ORIGIN: apiUrl,
+  ...(process.env.PORTLESS_INJECT_CA === '1' ? portlessCaEnv() : {}),
 };
 
 const [, , command, ...args] = process.argv;


### PR DESCRIPTION
### What changed? Why was the change needed?

Agent replies can now send **cards and file attachments together** (e.g. WhatsApp image + interactive card). Previously the framework dropped `files` for JSX/card replies, the API rejected `files` without markdown, and delivery only posted the card to chat adapters.

**Framework**
- `serializeContent` returns `{ card, files }` when both are present.

**API**
- Reply DTO allows `files` with `card`.
- `ChatSdkService` passes `{ card, files }` to adapters and enables WhatsApp for outbound file delivery.
- Bridge executor resolves agent reply URL from `PORT` under portless (loopback HTTP) to avoid TLS/proxy issues.

**Dashboard**
- WhatsApp setup: “Mark as configured” in manual webhook flow shows the test-message step.

**Dev (portless)**
- Optional `PORTLESS_INJECT_CA=1` sets `NODE_EXTRA_CA_CERTS` for API/worker `start:portless` scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Agent replies can now include interactive cards and file attachments together on platforms that support it (notably WhatsApp). The framework serializes replies to include both card and files; the API accepts and forwards combined {card, files} payloads to chat adapters and enables outbound WhatsApp media delivery. Bridge executor resolves agent reply callbacks from the local PORT for portless runs to avoid TLS/proxy issues. Dev scripts add an opt-in PORTLESS_INJECT_CA to inject the Portless CA into Node for loopback HTTPS during local portless runs. The WhatsApp manual webhook UI now surfaces the test-message step after “Mark as configured.”

## Affected areas

- api: Reply DTO validation relaxed to allow files alongside card or markdown; ChatSdkService builds/forwards card+files adapter payloads and treats WhatsApp as supported for outbound media; bridge-executor derives reply callback origin from PORT for portless.
- framework: serializeContent() now returns both card and files for card responses; documentation comments updated to note card+file support where available.
- dashboard: WhatsApp manual webhook setup flow updated to track “Mark as configured,” reset stale state when integrations change, and show the test-message panel when manually configured.
- worker & dev scripts: start:portless scripts updated to optionally inject portless CA via PORTLESS_INJECT_CA=1; new scripts/helpers (portless-ca-env.mjs, with-portless-env.mjs) resolve and inject NODE_EXTRA_CA_CERTS when requested.

## Key technical decisions

- Validation now permits files with either markdown or card to enable multimodal replies.
- WhatsApp is explicitly treated as a supported platform for outbound file delivery; Email remains unsupported.
- Portless reply callback origin is derived from the local PORT to avoid relying on API_ROOT_URL and to prevent TLS/proxy mismatches.
- Portless CA injection is opt-in (PORTLESS_INJECT_CA=1) to avoid changing behavior for users not using portless.

## Testing

Unit tests updated (chat-sdk.service.spec.ts) to cover card+file payloads and base64→Buffer materialization for WhatsApp; no new end-to-end tests included, so manual verification is recommended for WhatsApp media delivery and portless HTTPS behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots

N/A (backend + setup flow behavior).

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

- Card + files on WhatsApp requires a chat adapter release with `postMessageWithMedia` (tested locally with chat ≥ 4.29); published `@chat-adapter/whatsapp@4.28.1` may not include that behavior until bumped.
- Portless CA injection is opt-in via `PORTLESS_INJECT_CA=1` on `start:portless` only.

</details>

Made with [Cursor](https://cursor.com)