### PR TITLE
fix(dashboard): agent channels setup completion state fixes NV-7713

### DIFF
--- a/apps/dashboard/src/components/agents/agent-integration-guides/resolve-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/resolve-agent-integration-guide.tsx
@@ -1,10 +1,11 @@
 import { ChatProviderIdEnum, EmailProviderIdEnum } from '@novu/shared';
+import { useEffect, useState } from 'react';
 import type { AgentIntegrationLink, AgentResponse } from '@/api/agents';
 import { isAgentIntegrationConnected } from '@/components/agents/is-agent-integration-connected';
 import { SetupGuideCard } from '@/components/agents/setup-guide-card';
 import { SlackSetupGuide } from '@/components/agents/slack-setup-guide';
-import { TelegramSetupGuide } from '@/components/agents/telegram-setup-guide';
 import { TeamsSetupGuide } from '@/components/agents/teams-setup-guide';
+import { TelegramSetupGuide } from '@/components/agents/telegram-setup-guide';
 import { WhatsAppSetupGuide } from '@/components/agents/whatsapp-setup-guide';
 import { AgentIntegrationGuideHeader } from './agent-integration-guide-layout';
 import { EmailAgentIntegrationGuide } from './email-agent-integration-guide';
@@ -89,7 +90,27 @@ export function ResolveAgentIntegrationGuide({
 }: ResolveAgentIntegrationGuideProps) {
   const providerId = integrationLink.integration.providerId;
 
-  if (providerId === ChatProviderIdEnum.Slack && !integrationLink.connectedAt) {
+  // Once the user opens an unconnected integration, keep showing the setup guide so the
+  // "Connected" success state (confetti + listening status) stays visible after the
+  // backend reports `connectedAt`. Stickiness is scoped to a single integration at a
+  // time — switching to a different provider clears it, and a fresh mount (page
+  // refresh / leaving the tab) reverts to the management view for already-connected
+  // integrations.
+  const [stickySetupId, setStickySetupId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!integrationLink.connectedAt) {
+      setStickySetupId(integrationLink._id);
+
+      return;
+    }
+
+    setStickySetupId((prev) => (prev === integrationLink._id ? prev : null));
+  }, [integrationLink._id, integrationLink.connectedAt]);
+
+  const showSetupGuide = !integrationLink.connectedAt || stickySetupId === integrationLink._id;
+
+  if (providerId === ChatProviderIdEnum.Slack && showSetupGuide) {
     return (
       <SetupGuideWithHeader
         providerId={providerId}
@@ -118,7 +139,7 @@ export function ResolveAgentIntegrationGuide({
     );
   }
 
-  if (providerId === ChatProviderIdEnum.MsTeams && !integrationLink.connectedAt) {
+  if (providerId === ChatProviderIdEnum.MsTeams && showSetupGuide) {
     return (
       <SetupGuideWithHeader
         providerId={providerId}
@@ -147,7 +168,7 @@ export function ResolveAgentIntegrationGuide({
     );
   }
 
-  if (providerId === ChatProviderIdEnum.Telegram && !integrationLink.connectedAt) {
+  if (providerId === ChatProviderIdEnum.Telegram && showSetupGuide) {
     return (
       <SetupGuideWithHeader
         providerId={providerId}
@@ -176,7 +197,7 @@ export function ResolveAgentIntegrationGuide({
     );
   }
 
-  if (providerId === ChatProviderIdEnum.WhatsAppBusiness && !integrationLink.connectedAt) {
+  if (providerId === ChatProviderIdEnum.WhatsAppBusiness && showSetupGuide) {
     return (
       <SetupGuideWithHeader
         providerId={providerId}


### PR DESCRIPTION
### What changed? Why was the change needed?

Fixed agent channels setup completion state was disappearing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The agent channels setup completion state now persists after connection. When a user opens an unconnected integration's setup guide, it remains visible even after the backend marks it as connected (`connectedAt` is set), allowing the success state (confetti and listening status) to display. The sticky state resets when switching to a different integration or on page reload.

## Affected areas

**dashboard**: Updated the `ResolveAgentIntegrationGuide` component to introduce sticky setup guide behavior via a new `stickySetupId` state and effect that controls whether to show the setup view or management view. This affects Slack, MS Teams, Telegram, and WhatsApp Business integrations.

## Testing

No tests were added. This fix requires manual verification that the setup guide remains visible during the connection completion flow and that the sticky state correctly resets when switching between different integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots


https://github.com/user-attachments/assets/ab5b220d-d5d3-416a-bb80-8095fdfdf836

