### PR TITLE
feat(api-service,dashboard): enable Vercel Domain Connect for inbound email fixes NV-7726

### DIFF
--- a/apps/api/src/app/domains/services/domain-connect-discovery.service.ts
+++ b/apps/api/src/app/domains/services/domain-connect-discovery.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
 import { lastValueFrom } from 'rxjs';
 import {
+  buildDnsProviderDomainConnectDiscovery,
   buildDomainConnectSettingsUrl,
   buildTemplateSupportUrl,
   type DomainConnectProviderSettings,
@@ -26,7 +27,10 @@ export class DomainConnectDiscoveryService {
     this.logger.setContext(this.constructor.name);
   }
 
-  async discoverDomainConnectHost(domainName: string): Promise<DomainConnectDiscovery | undefined> {
+  async discoverDomainConnectHost(
+    domainName: string,
+    dnsProvider?: string
+  ): Promise<DomainConnectDiscovery | undefined> {
     for (const candidate of getDomainConnectDiscoveryCandidates(domainName)) {
       try {
         const records = await dnsPromises.resolveTxt(`_domainconnect.${candidate}`);
@@ -43,6 +47,17 @@ export class DomainConnectDiscoveryService {
 
         this.logger.warn({ err: error, domainName: candidate }, 'Failed to discover Domain Connect provider');
       }
+    }
+
+    const dnsProviderDiscovery = buildDnsProviderDomainConnectDiscovery(domainName, dnsProvider);
+
+    if (dnsProviderDiscovery) {
+      this.logger.debug(
+        { domainName, dnsProvider, providerHost: dnsProviderDiscovery.providerHost },
+        'Using recognized DNS provider for Domain Connect discovery'
+      );
+
+      return dnsProviderDiscovery;
     }
 
     return undefined;

--- a/apps/api/src/app/domains/usecases/create-domain-connect-apply-url/create-domain-connect-apply-url.usecase.ts
+++ b/apps/api/src/app/domains/usecases/create-domain-connect-apply-url/create-domain-connect-apply-url.usecase.ts
@@ -41,7 +41,10 @@ export class CreateDomainConnectApplyUrl {
       throw new BadRequestException('Domain Connect auto-configuration is not enabled.');
     }
 
-    const discovery = await this.domainConnectDiscoveryService.discoverDomainConnectHost(domain.name);
+    const discovery = await this.domainConnectDiscoveryService.discoverDomainConnectHost(
+      domain.name,
+      domain.dnsProvider
+    );
 
     if (!discovery || !isSupportedDomainConnectHost(discovery.providerHost)) {
       throw new BadRequestException('Domain Connect auto-configuration is not available for this DNS provider.');

--- a/apps/api/src/app/domains/usecases/domain-connect.usecase.spec.ts
+++ b/apps/api/src/app/domains/usecases/domain-connect.usecase.spec.ts
@@ -138,6 +138,26 @@ describe('Domain Connect usecases', () => {
     );
   });
 
+  it('falls back to Vercel Domain Connect when DNS provider is recognized but TXT discovery is missing', async () => {
+    domainRepositoryMock.findOne.resolves({ ...domain, dnsProvider: 'Vercel' });
+    domainConnectDiscoveryServiceMock.discoverDomainConnectHost.resolves({
+      domainName: 'example.com',
+      providerHost: 'domainconnect.vercel.com',
+    });
+    const usecase = new GetDomainConnectStatus(
+      domainRepositoryMock,
+      featureFlagsServiceMock,
+      domainConnectDiscoveryServiceMock
+    );
+
+    const result = await usecase.execute(command);
+
+    expect(result.available).to.equal(true);
+    expect(
+      domainConnectDiscoveryServiceMock.discoverDomainConnectHost.calledWith('example.com', 'Vercel')
+    ).to.equal(true);
+  });
+
   it('uses discovered root domain provider settings for submitted subdomains', async () => {
     domainRepositoryMock.findOne.resolves({ ...domain, name: 'inbound.example.com' });
     domainConnectDiscoveryServiceMock.discoverDomainConnectHost.resolves({

--- a/apps/api/src/app/domains/usecases/get-domain-connect-status/get-domain-connect-status.usecase.ts
+++ b/apps/api/src/app/domains/usecases/get-domain-connect-status/get-domain-connect-status.usecase.ts
@@ -52,7 +52,10 @@ export class GetDomainConnectStatus {
       };
     }
 
-    const discovery = await this.domainConnectDiscoveryService.discoverDomainConnectHost(domain.name);
+    const discovery = await this.domainConnectDiscoveryService.discoverDomainConnectHost(
+      domain.name,
+      domain.dnsProvider
+    );
 
     if (!discovery) {
       return {

--- a/apps/api/src/app/domains/utils/domain-connect.spec.ts
+++ b/apps/api/src/app/domains/utils/domain-connect.spec.ts
@@ -3,6 +3,7 @@ import type { DomainEntity } from '@novu/dal';
 import { expect } from 'chai';
 import {
   areProviderSettingsUrlsAllowed,
+  buildDnsProviderDomainConnectDiscovery,
   buildDomainConnectApplyUrl,
   buildDomainConnectSettingsUrl,
   getDomainConnectDiscoveryCandidates,
@@ -56,6 +57,21 @@ describe('Domain Connect utils', () => {
     expect(buildDomainConnectSettingsUrl('grossman.io', 'api.cloudflare.com')).to.equal(
       'https://api.cloudflare.com/client/v4/domainconnect/v2/grossman.io/settings'
     );
+    expect(buildDomainConnectSettingsUrl('example.com', 'domainconnect.vercel.com')).to.equal(
+      'https://domainconnect.vercel.com/v2/example.com/settings'
+    );
+  });
+
+  it('maps recognized DNS providers to Domain Connect discovery hosts', () => {
+    expect(buildDnsProviderDomainConnectDiscovery('inbound.example.com', 'Vercel')).to.deep.equal({
+      domainName: 'example.com',
+      providerHost: 'domainconnect.vercel.com',
+    });
+    expect(buildDnsProviderDomainConnectDiscovery('inbound.example.com', 'Cloudflare')).to.deep.equal({
+      domainName: 'example.com',
+      providerHost: 'domainconnect.cloudflare.com',
+    });
+    expect(buildDnsProviderDomainConnectDiscovery('example.com', 'Amazon Route 53')).to.equal(undefined);
   });
 
   it('returns likely root-domain discovery candidates before the submitted subdomain', () => {

--- a/apps/api/src/app/domains/utils/domain-connect.ts
+++ b/apps/api/src/app/domains/utils/domain-connect.ts
@@ -13,6 +13,17 @@ export const SUPPORTED_DOMAIN_CONNECT_HOSTS: Record<string, string> = {
   'domainconnect.vercel.com': 'Vercel',
 };
 
+/** Domain Connect host used when NS-based DNS provider detection matches a supported provider. */
+export const DNS_PROVIDER_DOMAIN_CONNECT_HOSTS: Record<string, string> = {
+  Cloudflare: 'domainconnect.cloudflare.com',
+  Vercel: 'domainconnect.vercel.com',
+};
+
+export interface DomainConnectDiscoveryResult {
+  domainName: string;
+  providerHost: string;
+}
+
 const ALLOWED_PROVIDER_URL_HOSTS: Record<string, string[]> = {
   Cloudflare: ['cloudflare.com'],
   Vercel: ['vercel.com'],
@@ -75,6 +86,32 @@ export function isSupportedDomainConnectHost(host: string): boolean {
 
 export function getProviderNameForHost(host: string): string | undefined {
   return SUPPORTED_DOMAIN_CONNECT_HOSTS[getDomainConnectHostname(host)];
+}
+
+export function buildDnsProviderDomainConnectDiscovery(
+  domainName: string,
+  dnsProvider?: string
+): DomainConnectDiscoveryResult | undefined {
+  if (!dnsProvider) {
+    return undefined;
+  }
+
+  const providerHost = DNS_PROVIDER_DOMAIN_CONNECT_HOSTS[dnsProvider];
+
+  if (!providerHost || !isSupportedDomainConnectHost(providerHost)) {
+    return undefined;
+  }
+
+  const connectDomainName = getDomainConnectDiscoveryCandidates(domainName)[0];
+
+  if (!connectDomainName) {
+    return undefined;
+  }
+
+  return {
+    domainName: connectDomainName,
+    providerHost,
+  };
 }
 
 export function buildDomainConnectSettingsUrl(domainName: string, host: string): string {

--- a/apps/dashboard/src/pages/domain-detail.tsx
+++ b/apps/dashboard/src/pages/domain-detail.tsx
@@ -554,7 +554,7 @@ export function DomainDetailPage() {
                       (!hasSubmittedDomainConnectReturn || hasDomainConnectFailure) && (
                         <AutoConfigureButton
                           providerName={domainConnectProviderName}
-                          providerSlug={domain?.dnsProvider}
+                          providerSlug={domain?.dnsProvider?.toLowerCase()}
                           isLoading={startDomainAutoConfigure.isPending}
                           disabled={!canWriteDomains || startDomainAutoConfigure.isPending}
                           onClick={handleAutoConfigure}
@@ -764,7 +764,9 @@ type AutoConfigureButtonProps = {
 
 function AutoConfigureButton({ providerName, providerSlug, isLoading, disabled, onClick }: AutoConfigureButtonProps) {
   const ProviderIcon = getProviderIcon(providerSlug);
-  const isCloudflare = providerSlug?.toLowerCase() === 'cloudflare';
+  const normalizedProviderSlug = providerSlug?.toLowerCase();
+  const isCloudflare = normalizedProviderSlug === 'cloudflare';
+  const isVercel = normalizedProviderSlug === 'vercel';
 
   return (
     <button
@@ -776,7 +778,12 @@ function AutoConfigureButton({ providerName, providerSlug, isLoading, disabled, 
     >
       {ProviderIcon && (
         <ProviderIcon
-          className={cn('size-4 shrink-0', isCloudflare ? 'text-[#f38020]' : 'text-text-strong')}
+          className={cn(
+            'size-4 shrink-0',
+            isCloudflare && 'text-[#f38020]',
+            isVercel && 'text-foreground-950',
+            !isCloudflare && !isVercel && 'text-text-strong'
+          )}
           aria-hidden
         />
       )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends inbound email Domain Connect so domains managed by **Vercel DNS** can use the approved Novu template, not only domains discovered via `_domainconnect` TXT records (which already worked for Cloudflare).

## What changed

- **DNS provider fallback discovery**: When NS detection stores `dnsProvider` as `Vercel` or `Cloudflare`, discovery falls back to `domainconnect.vercel.com` / `domainconnect.cloudflare.com` if TXT lookup does not return a provider host.
- **Use cases**: `GetDomainConnectStatus` and `CreateDomainConnectApplyUrl` pass `domain.dnsProvider` into discovery.
- **Dashboard**: Auto-configure button shows the Vercel icon when the domain’s DNS provider is Vercel.

Existing Vercel support (signed apply URLs, allowlisted `vercel.com` endpoints, template checks) is unchanged; this wires it to recognized Vercel nameservers.

## Flow

```mermaid
sequenceDiagram
  participant API as API
  participant DNS as DNS
  participant Vercel as Vercel Domain Connect

  API->>DNS: Resolve _domainconnect TXT
  alt TXT record found
    DNS-->>API: provider host
  else TXT missing and dnsProvider is Vercel
    API-->>API: Use domainconnect.vercel.com
  end
  API->>Vercel: GET /v2/{domain}/settings
  API->>Vercel: Check template + build signed apply URL
```

## Testing

- `Domain Connect utils` and `Domain Connect usecases` unit specs (18 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779197844667909?thread_ts=1779197844.667909&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-79e79b4c-3ea8-5622-8a8d-40392ae998eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79e79b4c-3ea8-5622-8a8d-40392ae998eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Extended Domain Connect support for inbound email to handle Vercel-managed domains without `_domainconnect` TXT records. When DNS provider detection identifies Vercel or Cloudflare, discovery now falls back to `domainconnect.vercel.com` or `domainconnect.cloudflare.com` respectively. The discovery service and usecases now accept and forward the stored DNS provider for more intelligent fallback routing. The dashboard auto-configure button now displays the appropriate DNS provider icon when applicable.

## Affected areas

**api**: Domain Connect discovery service now accepts an optional `dnsProvider` parameter and attempts provider-specific discovery before falling back to TXT-record-based lookup. `GetDomainConnectStatus` and `CreateDomainConnectApplyUrl` usecases now pass the domain's `dnsProvider` to discovery. A new `buildDnsProviderDomainConnectDiscovery` utility maps recognized DNS providers (Vercel, Cloudflare) to their Domain Connect endpoints.

**dashboard**: The domain detail page's auto-configure button now receives and displays the correct provider icon based on the domain's DNS provider, with Vercel and Cloudflare getting branded icons.

## Key technical decisions

- New `DNS_PROVIDER_DOMAIN_CONNECT_HOSTS` mapping defines Domain Connect hosts for supported providers, enabling future expansion.
- DNS provider fallback is attempted before TXT discovery to avoid unnecessary DNS lookups when provider is already known.
- Provider icon selection on dashboard uses normalized DNS provider value for reliable matching.

## Testing

Unit tests added to domain connect utilities and usecases validate DNS provider-to-host mapping, verify fallback discovery when TXT records are absent, and ensure proper parameter propagation through the discovery flow (18 passing tests).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->