### PR TITLE
feat(root): add Linux support to dev-environment-setup.sh fixes NV-7555

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf **/build **/dist **/node_modules",
     "clean:cache": "pnpm nx reset && pnpm store prune",
     "commit": "cz",
-    "dev-environment-setup": "sh ./scripts/dev-environment-setup.sh",
+    "dev-environment-setup": "./scripts/dev-environment-setup.sh",
     "dev:portless": "mprocs",
     "docker:build": "pnpm -r --if-present --parallel docker:build",
     "g:module": "hygen module new --name=$pnpm_config_name",

--- a/scripts/dev-environment-setup.sh
+++ b/scripts/dev-environment-setup.sh
@@ -68,7 +68,11 @@ detect_os () {
             ;;
         Linux)
             OS_TYPE="Linux"
-            SHELL_PROFILE="$HOME/.bashrc"
+            case "$(basename "${SHELL:-bash}")" in
+                zsh) SHELL_PROFILE="${ZDOTDIR:-$HOME}/.zshrc" ;;
+                bash|sh) SHELL_PROFILE="$HOME/.bashrc" ;;
+                *) SHELL_PROFILE="$HOME/.profile" ;;
+            esac
             if [ -f /etc/os-release ]; then
                 DISTRO_FAMILY="$(
                     . /etc/os-release
@@ -248,7 +252,13 @@ install_linux_base_deps () {
         return 1
     fi
 
-    linux_pkg_install lsof iproute2 2>/dev/null || linux_pkg_install lsof || true
+    if [[ "$DISTRO_FAMILY" == "debian" ]]; then
+        linux_pkg_install lsof iproute2 || true
+    elif [[ "$DISTRO_FAMILY" == "rhel" ]]; then
+        linux_pkg_install lsof iproute || true
+    else
+        linux_pkg_install lsof || true
+    fi
 
     success_message "Linux base dependencies"
 }
@@ -353,14 +363,13 @@ check_nvm () {
 
 install_node () {
     NODE_JS_VERSION="22.22.1"
-    REQUIRED_NODE_MAJOR="22"
 
     SKIP="$(check_nvm)"
 
     if [[ -z "$SKIP" ]]; then
         load_nvm
         TEST_CMD=$(execute_command_without_error_print "node --version")
-        if [[ -z "$TEST_CMD" ]] || [[ "$TEST_CMD" == *"command not found"* ]] || [[ "$TEST_CMD" != v${REQUIRED_NODE_MAJOR}.* ]]; then
+        if [[ -z "$TEST_CMD" ]] || [[ "$TEST_CMD" == *"command not found"* ]] || [[ "$TEST_CMD" != "v${NODE_JS_VERSION}" ]]; then
             installing_dependency "Node.js v$NODE_JS_VERSION"
 
             nvm install "$NODE_JS_VERSION"
@@ -413,7 +422,7 @@ install_pnpm () {
     PNPM_VERSION="11.0.9"
     load_nvm
     TEST_PNPM_CMD=$(execute_command_without_error_print "pnpm --version")
-    if [[ -z "$TEST_PNPM_CMD" ]] || [[ "$TEST_PNPM_CMD" == *"command not found"* ]]; then
+    if [[ -z "$TEST_PNPM_CMD" ]] || [[ "$TEST_PNPM_CMD" == *"command not found"* ]] || [[ "$TEST_PNPM_CMD" != "$PNPM_VERSION" ]]; then
          installing_dependency "PNPM $PNPM_VERSION"
          npm install -g "pnpm@$PNPM_VERSION"
 
@@ -497,7 +506,14 @@ install_docker_linux () {
     fi
 
     if ! docker info &>/dev/null; then
-        sudo chmod 666 /var/run/docker.sock 2>/dev/null || true
+        if [[ -S /var/run/docker.sock ]]; then
+            sudo chown root:docker /var/run/docker.sock 2>/dev/null || true
+            sudo chmod 660 /var/run/docker.sock 2>/dev/null || true
+        fi
+        if ! docker info &>/dev/null; then
+            echo "Docker is installed, but this shell does not have access to the daemon yet."
+            echo "Run 'newgrp docker' or log out and back in, then retry."
+        fi
     fi
 
     AFTER_INSTALL_TEST_CMD=$(execute_command_without_error_print "docker --version")

--- a/scripts/dev-environment-setup.sh
+++ b/scripts/dev-environment-setup.sh
@@ -1,13 +1,17 @@
-#!/bin/sh
+#!/bin/bash
+set -uo pipefail
 
-exec </dev/tty
+[ -t 0 ] || exec </dev/tty
 
 APPLE_CHIP='Apple'
-#INTEL_CHIP='Intel'
 NEGATIVE_RESPONSE="No"
 POSITIVE_RESPONSE="Yes"
 
-#ZSHRC="$HOME/.zshrc"
+OS_TYPE=""
+DISTRO_FAMILY=""
+SHELL_PROFILE=""
+NOVU_REPO_PATH=""
+
 ZPROFILE="$HOME/.zprofile"
 
 error_message () {
@@ -56,35 +60,118 @@ execute_command_without_error_print () {
     $1 2> /dev/null
 }
 
+detect_os () {
+    case "$(uname -s)" in
+        Darwin)
+            OS_TYPE="Darwin"
+            SHELL_PROFILE="$ZPROFILE"
+            ;;
+        Linux)
+            OS_TYPE="Linux"
+            SHELL_PROFILE="$HOME/.bashrc"
+            if [ -f /etc/os-release ]; then
+                DISTRO_FAMILY="$(
+                    . /etc/os-release
+                    case "$ID_LIKE $ID" in
+                        *debian*|*ubuntu*) echo debian ;;
+                        *rhel*|*fedora*|*centos*|*amzn*) echo rhel ;;
+                        *) echo unknown ;;
+                    esac
+                )"
+            else
+                DISTRO_FAMILY="unknown"
+            fi
+            ;;
+        *)
+            OS_TYPE="unsupported"
+            ;;
+    esac
+}
+
+rhel_pkg_manager () {
+    if command -v dnf &>/dev/null; then
+        echo dnf
+    else
+        echo yum
+    fi
+}
+
+_pkg_updated=0
+linux_pkg_update () {
+    if [[ $_pkg_updated -eq 0 ]]; then
+        echo "Updating system package index…"
+        if [[ "$DISTRO_FAMILY" == "debian" ]]; then
+            sudo apt-get update -y
+        elif [[ "$DISTRO_FAMILY" == "rhel" ]]; then
+            sudo "$(rhel_pkg_manager)" makecache -y
+        fi
+        _pkg_updated=1
+    fi
+}
+
+linux_pkg_install () {
+    if [[ "$DISTRO_FAMILY" == "debian" ]]; then
+        linux_pkg_update
+        sudo apt-get install -y "$@"
+    elif [[ "$DISTRO_FAMILY" == "rhel" ]]; then
+        linux_pkg_update
+        sudo "$(rhel_pkg_manager)" install -y "$@"
+    else
+        echo "Unsupported Linux distribution. Supported families: Debian/Ubuntu and RHEL/Fedora/CentOS/Amazon Linux."
+        return 1
+    fi
+}
+
 get_cpu () {
-    SYSTEM_CPU_BRAND='machdep.cpu.brand.string'
-    sysctl -a | grep $SYSTEM_CPU_BRAND | cut -f2 -d":"
+    if [[ "$OS_TYPE" == "Darwin" ]]; then
+        SYSTEM_CPU_BRAND='machdep.cpu.brand.string'
+        sysctl -a | grep "$SYSTEM_CPU_BRAND" | cut -f2 -d":"
+    fi
 }
 
 refresh_shell() {
-    # Refresh shell to apply changes in current session
-    source "$ZPROFILE"
-    exec $SHELL
+    if [[ -f "$SHELL_PROFILE" ]]; then
+        # shellcheck source=/dev/null
+        source "$SHELL_PROFILE"
+    fi
+    if [[ -f "$HOME/.nvm/nvm.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "$HOME/.nvm/nvm.sh"
+    fi
 }
 
 get_user_groups() {
-    # Get user groups
-    read -r -a USER_GROUP <<< "$(groups $USER)"
+    read -r -a USER_GROUP <<< "$(groups "$USER")"
 }
 
 set_user_dir_ownership() {
-    USER_GROUP="$(get_user_groups)"
+    get_user_groups
     sudo chown -R "$USER":"${USER_GROUP[0]}" "$1"
 }
 
 set_user_ownership() {
-    USER_GROUP="$(get_user_groups)"
+    get_user_groups
     sudo chown "$USER":"${USER_GROUP[0]}" "$1"
 }
 
 set_user_permissions() {
     sudo chmod 644 "$1"
     set_user_ownership "$1"
+}
+
+append_to_shell_profile() {
+    local entry="$1"
+    if ! grep -qF "$entry" "$SHELL_PROFILE" 2>/dev/null; then
+        echo "$entry" >> "$SHELL_PROFILE"
+    fi
+}
+
+load_nvm() {
+    export NVM_DIR="$HOME/.nvm"
+    if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+        # shellcheck source=/dev/null
+        source "$NVM_DIR/nvm.sh"
+    fi
 }
 
 install_apple_chip_dependencies () {
@@ -107,7 +194,7 @@ install_apple_chip_dependencies () {
 install_xcode () {
   echo ""
   echo "❓ Do you want to install Xcode? ($POSITIVE_RESPONSE / $NEGATIVE_RESPONSE)"
-  read -p " > " RESPONSE
+  read -r -p " > " RESPONSE
   echo ""
 
   if [[ "$RESPONSE" == "$POSITIVE_RESPONSE" ]]; then
@@ -124,7 +211,7 @@ install_xcode () {
   if [[ "$RESPONSE" == "$NEGATIVE_RESPONSE" ]]; then
 	  echo ""
 	  echo "❓ Do you want to update Xcode? ($POSITIVE_RESPONSE / $NEGATIVE_RESPONSE)"
-    read -p " > " RESPONSE
+    read -r -p " > " RESPONSE
 	  echo ""
 
     if [[ "$RESPONSE" == "$POSITIVE_RESPONSE" ]]; then
@@ -149,34 +236,36 @@ install_macosx_dependencies () {
     set_macosx_generics
 }
 
-install_os_dependencies () {
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        installing_dependency "Linux dependencies"
-        echo "//TODO"
-	  install_novu_tools
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        installing_dependency "MacOsx dependencies"
-        install_macosx_dependencies
-        install_novu_tools
-    else
-        echo "OS not supported"
+install_linux_base_deps () {
+    if [[ "$DISTRO_FAMILY" == "unknown" ]]; then
+        echo "Cannot install base packages: unsupported Linux distribution."
+        return 1
     fi
+
+    installing_dependency "Linux base dependencies"
+    if ! linux_pkg_install curl ca-certificates gnupg git; then
+        error_message "Linux base dependencies"
+        return 1
+    fi
+
+    linux_pkg_install lsof iproute2 2>/dev/null || linux_pkg_install lsof || true
+
+    success_message "Linux base dependencies"
 }
 
 check_homebrew () {
     TEST_BREW_CMD=$(execute_command_without_error_print "brew --version")
 
-    if [[ -z "$TEST_BREW_CMD" ]] || [[ "$TEST_BREW_CMD" == "zsh: command not found: brew" ]]; then
+    if [[ -z "$TEST_BREW_CMD" ]] || [[ "$TEST_BREW_CMD" == *"command not found"* ]]; then
         error_message "Homebrew"
-        echo "⛔️ Homebrew is a hard dependency for this tool"
+        echo "⛔️ Homebrew is a hard dependency for this tool on macOS"
     fi
 }
-
 
 install_homebrew () {
     TEST_BREW_CMD=$(execute_command_without_error_print "brew --version")
 
-    if [[ -z "$TEST_BREW_CMD" ]] || [[ "$TEST_BREW_CMD" == "zsh: command not found: brew" ]]; then
+    if [[ -z "$TEST_BREW_CMD" ]] || [[ "$TEST_BREW_CMD" == *"command not found"* ]]; then
         installing_dependency "Homebrew"
 	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
@@ -188,16 +277,14 @@ install_homebrew () {
 	CMD=$(execute_command_without_error_print "$PARAM_TO_CMD")
 
         if [[ -z $CMD ]]; then
-	    # Add the Brew paths to the shell profile
             echo "$ENTRY" | sudo tee -a "$ZPROFILE"
 
-            # As executing `tee` as sudo changes ownership and permissions we roll them back appropriately
 	    set_user_permissions "$ZPROFILE"
 	    source "$ZPROFILE"
         fi
 
         AFTER_INSTALL_TEST_CMD=$(execute_command_without_error_print "brew --version")
-        if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == "zsh: command not found: brew" ]]; then
+        if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == *"command not found"* ]]; then
 	    error_message "Homebrew"
 	    exit 1
         else
@@ -213,7 +300,6 @@ install_homebrew_recipes () {
     SKIP="$(check_homebrew)"
 
     if [[ -z "$SKIP" ]]; then
-        # Update Homebrew recipes
         echo "Update and Upgrade Homebrew"
         brew update
         brew upgrade
@@ -231,11 +317,10 @@ make_zsh_default_shell () {
     fi
 }
 
-# Depends on Git so depends on having Xcode installed
 install_ohmyzsh () {
     echo ""
     echo "❓ Do you want to install Oh My Zsh! ? ($POSITIVE_RESPONSE / $NEGATIVE_RESPONSE)"
-    read -p " > " RESPONSE
+    read -r -p " > " RESPONSE
     echo ""
 
     if [[ "$RESPONSE" == "$POSITIVE_RESPONSE" ]]; then
@@ -257,65 +342,66 @@ install_ohmyzsh () {
 }
 
 check_nvm () {
+    load_nvm
     TEST_NVM_CMD=$(execute_command_without_error_print "nvm --version")
 
-    if [[ -z "$TEST_NVM_CMD" ]] || [[ "$TEST_NVM_CMD" == "zsh: command not found: nvm" ]]; then
+    if [[ -z "$TEST_NVM_CMD" ]] || [[ "$TEST_NVM_CMD" == *"command not found"* ]]; then
         error_message "NVM"
         echo "⛔️ NVM is a hard dependency for this tool"
     fi
 }
 
 install_node () {
-    NODE_JS_VERSION="v22.22.1"
+    NODE_JS_VERSION="22.22.1"
     REQUIRED_NODE_MAJOR="22"
 
     SKIP="$(check_nvm)"
 
     if [[ -z "$SKIP" ]]; then
+        load_nvm
         TEST_CMD=$(execute_command_without_error_print "node --version")
-        if [[ -z "$TEST_CMD" ]] || [[ "$TEST_CMD" == "zsh: command not found: node" ]] || [[ "$TEST_CMD" != v${REQUIRED_NODE_MAJOR}.* ]]; then
-            installing_dependency "Node.js $NODE_JS_VERSION"
+        if [[ -z "$TEST_CMD" ]] || [[ "$TEST_CMD" == *"command not found"* ]] || [[ "$TEST_CMD" != v${REQUIRED_NODE_MAJOR}.* ]]; then
+            installing_dependency "Node.js v$NODE_JS_VERSION"
 
-            nvm install $NODE_JS_VERSION
-            nvm alias default $NODE_JS_VERSION
+            nvm install "$NODE_JS_VERSION"
+            nvm alias default "$NODE_JS_VERSION"
+            load_nvm
 	    TEST_NODE_CMD=$(execute_command_without_error_print "node --version")
 
-            if [[ -z "$TEST_NODE_CMD" ]] || [[ "$TEST_NODE_CMD" == "zsh: command not found: node" ]]; then
+            if [[ -z "$TEST_NODE_CMD" ]] || [[ "$TEST_NODE_CMD" == *"command not found"* ]]; then
                 error_message "Node.js"
 	    else
-                success_message "Node.js $NODE_JS_VERSION"
+                success_message "Node.js v$NODE_JS_VERSION"
             fi
          else
-            already_installed_message "Node.js $NODE_JS_VERSION"
+            already_installed_message "Node.js v$NODE_JS_VERSION"
          fi
     else
-        skip_message "Node.js $NODE_JS_VERSION"
+        skip_message "Node.js v$NODE_JS_VERSION"
         echo "$SKIP"
     fi
 }
 
-
-# NVM is a Node.js version manager
-# Make sure that you have installed ZSH previously, so NVM can automatically inject the executable to PATH in the .zshrc config file.
 install_nvm () {
     NVM_DIR="$HOME/.nvm"
-    LATEST_NVM_VERSION="v0.39.2"
+    LATEST_NVM_VERSION="v0.39.7"
 
+    load_nvm
     TEST_CMD=$(execute_command_without_error_print "nvm --version")
-    if [[ -z "$TEST_CMD" ]] || [[ "$TEST_CMD" == "zsh: command not found: nvm" ]]; then
+    if [[ -z "$TEST_CMD" ]] || [[ "$TEST_CMD" == *"command not found"* ]]; then
         installing_dependency "NVM"
         URL="https://raw.githubusercontent.com/nvm-sh/nvm/$LATEST_NVM_VERSION/install.sh"
         echo "Downloading NVM from $URL"
-	/bin/bash -c "$(curl -fsSL $URL)"
+	/bin/bash -c "$(curl -fsSL "$URL")"
 
-	# Loads NVM
-	source "$NVM_DIR/nvm.sh"
-	#source $ZSHRC
+	load_nvm
 
         AFTER_INSTALL_TEST_CMD=$(execute_command_without_error_print "nvm --version")
-        if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == "zsh: command not found: nvm" ]]; then
+        if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == *"command not found"* ]]; then
 	    error_message "NVM"
         else
+            append_to_shell_profile 'export NVM_DIR="$HOME/.nvm"'
+            append_to_shell_profile '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"'
             success_message "NVM"
         fi
     else
@@ -323,16 +409,16 @@ install_nvm () {
     fi
 }
 
-# PNPM is the package manager used in Novu's monorepo
 install_pnpm () {
-    PNPM_VERSION="8.9.0"
+    PNPM_VERSION="11.0.9"
+    load_nvm
     TEST_PNPM_CMD=$(execute_command_without_error_print "pnpm --version")
-    if [[ -z "$TEST_PNPM_CMD" ]] || [[ "$TEST_PNPM_CMD" == "zsh: command not found: pnpm" ]]; then
+    if [[ -z "$TEST_PNPM_CMD" ]] || [[ "$TEST_PNPM_CMD" == *"command not found"* ]]; then
          installing_dependency "PNPM $PNPM_VERSION"
-         npm install -g pnpm@$PNPM_VERSION
+         npm install -g "pnpm@$PNPM_VERSION"
 
 	 AFTER_INSTALL_TEST_CMD=$(execute_command_without_error_print "pnpm --version")
-    	 if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == "zsh: command not found: pnpm" ]]; then
+    	 if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == *"command not found"* ]]; then
              error_message "PNPM"
          else
              success_message "PNPM $PNPM_VERSION"
@@ -342,17 +428,17 @@ install_pnpm () {
     fi
 }
 
-install_docker () {
+install_docker_macos () {
     SKIP="$(check_homebrew)"
 
     if [[ -z "$SKIP" ]]; then
         TEST_DOCKER_CMD=$(execute_command_without_error_print "docker --version")
 
-        if [[ -z "$TEST_DOCKER_CMD" ]] || [[ "$TEST_DOCKER_CMD" == "zsh: command not found: docker" ]]; then
+        if [[ -z "$TEST_DOCKER_CMD" ]] || [[ "$TEST_DOCKER_CMD" == *"command not found"* ]]; then
             installing_dependency "Docker"
-    	    brew install docker
+    	    brew install --cask docker
     	    AFTER_INSTALL_TEST_CMD=$(execute_command_without_error_print "docker --version")
-    	    if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == "zsh: command not found: docker" ]]; then
+    	    if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == *"command not found"* ]]; then
                 error_message "Docker"
             else
                 success_message "Docker"
@@ -366,17 +452,82 @@ install_docker () {
     fi
 }
 
-install_aws_cli () {
+install_docker_linux () {
+    TEST_DOCKER_CMD=$(execute_command_without_error_print "docker --version")
+
+    if [[ -n "$TEST_DOCKER_CMD" ]] && [[ "$TEST_DOCKER_CMD" != *"command not found"* ]]; then
+        already_installed_message "Docker"
+        return 0
+    fi
+
+    installing_dependency "Docker"
+
+    if [[ "$DISTRO_FAMILY" == "debian" ]]; then
+        linux_pkg_install ca-certificates curl gnupg lsb-release
+        sudo install -m 0755 -d /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg 2>/dev/null || \
+            curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        sudo chmod a+r /etc/apt/keyrings/docker.gpg
+        local codename docker_distro os_id
+        os_id="$(. /etc/os-release; echo "$ID")"
+        codename="$(. /etc/os-release; echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")"
+        docker_distro="ubuntu"
+        if [[ "$os_id" == "debian" ]]; then
+            docker_distro="debian"
+        fi
+        echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/${docker_distro} \
+          ${codename} stable" | \
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        sudo apt-get update -y
+        linux_pkg_install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    elif [[ "$DISTRO_FAMILY" == "rhel" ]]; then
+        linux_pkg_install yum-utils
+        sudo "$(rhel_pkg_manager)" config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+        linux_pkg_install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        sudo systemctl enable --now docker 2>/dev/null || sudo service docker start 2>/dev/null || true
+    else
+        error_message "Docker"
+        return 1
+    fi
+
+    if ! groups "$USER" | grep -q '\bdocker\b'; then
+        sudo usermod -aG docker "$USER"
+        echo "Note: Added $USER to the docker group. You may need to log out and back in for group changes to apply."
+    fi
+
+    if ! docker info &>/dev/null; then
+        sudo chmod 666 /var/run/docker.sock 2>/dev/null || true
+    fi
+
+    AFTER_INSTALL_TEST_CMD=$(execute_command_without_error_print "docker --version")
+    if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == *"command not found"* ]]; then
+        error_message "Docker"
+        return 1
+    fi
+
+    success_message "Docker"
+}
+
+install_docker () {
+    if [[ "$OS_TYPE" == "Darwin" ]]; then
+        install_docker_macos
+    elif [[ "$OS_TYPE" == "Linux" ]]; then
+        install_docker_linux
+    fi
+}
+
+install_aws_cli_macos () {
     FILE_DESTINATION="$HOME/AWSCLIV2.pkg"
     TEST_AWS_CMD=$(execute_command_without_error_print "aws --version")
 
-    if [[ -z "$TEST_AWS_CMD" ]] || [[ "$TEST_AWS_CMD" == "zsh: command not found: aws" ]]; then
+    if [[ -z "$TEST_AWS_CMD" ]] || [[ "$TEST_AWS_CMD" == *"command not found"* ]]; then
         installing_dependency "AWS CLI"
         curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "$FILE_DESTINATION"
         sudo installer -pkg "$FILE_DESTINATION" -target /
 
         AFTER_INSTALL_TEST_CMD=$(execute_command_without_error_print "aws --version")
-    	if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == "zsh: command not found: aws" ]]; then
+    	if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == *"command not found"* ]]; then
             error_message "AWS CLI"
         else
             success_message "AWS CLI"
@@ -390,55 +541,185 @@ install_aws_cli () {
     fi
 }
 
+install_aws_cli_linux () {
+    TEST_AWS_CMD=$(execute_command_without_error_print "aws --version")
+
+    if [[ -n "$TEST_AWS_CMD" ]] && [[ "$TEST_AWS_CMD" != *"command not found"* ]]; then
+        already_installed_message "AWS CLI"
+        return 0
+    fi
+
+    installing_dependency "AWS CLI"
+
+    local arch zip_name tmp_dir
+    case "$(uname -m)" in
+        x86_64) arch="x86_64" ;;
+        aarch64|arm64) arch="aarch64" ;;
+        *)
+            error_message "AWS CLI"
+            echo "Unsupported architecture for AWS CLI install: $(uname -m)"
+            return 1
+            ;;
+    esac
+
+    zip_name="awscli-exe-linux-${arch}.zip"
+    tmp_dir=$(mktemp -d)
+    if ! command -v unzip &>/dev/null; then
+        linux_pkg_install unzip
+    fi
+    curl -fsSL "https://awscli.amazonaws.com/${zip_name}" -o "${tmp_dir}/${zip_name}"
+    unzip -q "${tmp_dir}/${zip_name}" -d "${tmp_dir}"
+    sudo "${tmp_dir}/aws/install" --update
+    rm -rf "${tmp_dir}"
+
+    AFTER_INSTALL_TEST_CMD=$(execute_command_without_error_print "aws --version")
+    if [[ -z "$AFTER_INSTALL_TEST_CMD" ]] || [[ "$AFTER_INSTALL_TEST_CMD" == *"command not found"* ]]; then
+        error_message "AWS CLI"
+        return 1
+    fi
+
+    success_message "AWS CLI"
+}
+
+install_aws_cli () {
+    if [[ "$OS_TYPE" == "Darwin" ]]; then
+        install_aws_cli_macos
+    elif [[ "$OS_TYPE" == "Linux" ]]; then
+        install_aws_cli_linux
+    fi
+}
+
+port_in_use () {
+    local port="$1"
+    if [[ "$OS_TYPE" == "Linux" ]]; then
+        ss -ltn 2>/dev/null | grep -q ":${port} "
+        return $?
+    fi
+
+    lsof -Pi ":${port}" -sTCP:LISTEN -t >/dev/null 2>&1
+}
+
+run_docker_compose () {
+    local compose_file="$1"
+
+    if docker compose version &>/dev/null; then
+        if docker info &>/dev/null; then
+            docker compose -f "$compose_file" up -d
+            return $?
+        fi
+        if groups "$USER" | grep -q '\bdocker\b'; then
+            sg docker -c "docker compose -f \"$compose_file\" up -d"
+            return $?
+        fi
+        sudo docker compose -f "$compose_file" up -d
+        return $?
+    fi
+
+    if command -v docker-compose &>/dev/null; then
+        docker-compose -f "$compose_file" up -d
+        return $?
+    fi
+
+    echo "Neither 'docker compose' nor 'docker-compose' is available."
+    return 1
+}
+
+resolve_novu_repo_path () {
+    if [[ -n "$NOVU_REPO_PATH" ]] && [[ -d "$NOVU_REPO_PATH" ]]; then
+        echo "$NOVU_REPO_PATH"
+        return 0
+    fi
+
+    if [[ -f "$(pwd)/package.json" ]] && [[ -d "$(pwd)/apps/api" ]] && grep -q '"setup:project"' "$(pwd)/package.json" 2>/dev/null; then
+        echo "$(pwd)"
+        return 0
+    fi
+
+    echo ""
+    return 1
+}
+
 start_database() {
-  # Check if brew is installed
-  command -v brew > /dev/null 2>&1
+    local novu_folder
+    novu_folder="$(resolve_novu_repo_path)"
 
-  # Initialize flag
-  already_installed=0
+    if [[ -z "$novu_folder" ]]; then
+        echo ""
+        echo "❓ Enter the path to your Novu repository (or press Enter to skip database startup):"
+        read -r -p " > " novu_folder
+        echo ""
+        if [[ -z "$novu_folder" ]]; then
+            skip_message "Docker Infrastructure"
+            return 0
+        fi
+    fi
 
-  if [ $? -eq 0 ]; then
+    if [[ ! -d "$novu_folder" ]]; then
+        echo "Repository path does not exist: $novu_folder"
+        return 1
+    fi
 
+    cd "$novu_folder" || return 1
 
-      # Check if mongodb is installed
-      brew ls --versions mongodb > /dev/null
-      if [ $? -eq 0 ]; then
-        echo "Warning: MongoDB is already installed via brew. Please uninstall it first."
-        already_installed=1
-      fi
+    local already_installed=0
 
-      # Check if redis is installed
-      brew ls --versions redis > /dev/null
-      if [ $? -eq 0 ]; then
-        echo "Warning: Redis is already installed via brew. Please uninstall it first."
-        already_installed=1
-      fi
-  else
-      echo "brew is not installed, checking default ports for MongoDB and Redis"
-      # Check MongoDB (port 27017) and Redis (port 6379)
-      if lsof -Pi :27017 -sTCP:LISTEN -t >/dev/null ; then
-        echo "Warning: MongoDB is running on port 27017. Please stop it first."
-        already_installed=1
-      fi
-      if lsof -Pi :6379 -sTCP:LISTEN -t >/dev/null ; then
-        echo "Warning: Redis is running on port 6379. Please stop it first."
-        already_installed=1
-      fi
-  fi
+    if command -v brew &>/dev/null; then
+        if brew ls --versions mongodb &>/dev/null; then
+            echo "Warning: MongoDB is already installed via brew. Please uninstall it first."
+            already_installed=1
+        fi
 
-  # Only copy the example env file and start Docker Compose if both MongoDB and Redis are not already installed
-  if [ $already_installed -ne 1 ]; then
-      # Copy the example env file
-      cp ./docker/.env.example ./docker/local/development/.env
+        if brew ls --versions redis &>/dev/null; then
+            echo "Warning: Redis is already installed via brew. Please uninstall it first."
+            already_installed=1
+        fi
+    else
+        echo "Checking default ports for MongoDB and Redis"
+        if port_in_use 27017; then
+            echo "Warning: MongoDB is running on port 27017. Please stop it first."
+            already_installed=1
+        fi
+        if port_in_use 6379; then
+            echo "Warning: Redis is running on port 6379. Please stop it first."
+            already_installed=1
+        fi
+    fi
 
-      # Start Docker Compose detached
-      docker-compose -f ./docker/local/development/docker-compose.yml up -d
+    if [[ $already_installed -ne 1 ]]; then
+        local env_dest="./docker/local/.env"
+        local env_example="./docker/.env.example"
+        local compose_file="./docker/local/docker-compose.yml"
 
-      start_success_message "Docker Infrastructure"
-  else
-      echo "We recommend removing mongodb and redis databases from brew with 'brew remove <package_name>'."
-      echo "To manually start the containerized databases by going to /docker in the novu project"
-  fi
+        if [[ ! -f "$compose_file" ]]; then
+            echo "Docker compose file not found at $compose_file"
+            return 1
+        fi
+
+        if [[ -f "$env_dest" ]]; then
+            echo "Keeping existing $env_dest (not overwriting)."
+        elif [[ -f "$env_example" ]]; then
+            cp "$env_example" "$env_dest"
+            echo "Created $env_dest from $env_example"
+        fi
+
+        if ! run_docker_compose "$compose_file"; then
+            if [[ "$OS_TYPE" == "Linux" ]] && ! docker info &>/dev/null; then
+                echo "⚠️  Docker daemon is not reachable. If you were just added to the docker group, run: newgrp docker"
+                echo "Then start databases manually:"
+                echo "  cd \"$novu_folder\" && docker compose -f docker/local/docker-compose.yml up -d"
+            fi
+            return 1
+        fi
+
+        start_success_message "Docker Infrastructure"
+    else
+        if [[ "$OS_TYPE" == "Darwin" ]]; then
+            echo "We recommend removing mongodb and redis databases from brew with 'brew remove <package_name>'."
+        else
+            echo "Stop the services using ports 27017 and 6379, then run:"
+            echo "  cd \"$novu_folder\" && docker compose -f docker/local/docker-compose.yml up -d"
+        fi
+    fi
 }
 
 check_git () {
@@ -454,25 +735,45 @@ check_git () {
 
 }
 
+install_git_linux () {
+    TEST_GIT_CMD=$(execute_command_without_error_print "git --version")
+    if [[ -n "$TEST_GIT_CMD" ]] && [[ "$TEST_GIT_CMD" != *"command not found"* ]]; then
+        already_installed_message "Git"
+        return 0
+    fi
+
+    installing_dependency "Git"
+    if linux_pkg_install git; then
+        success_message "Git"
+    else
+        error_message "Git"
+        return 1
+    fi
+}
+
 clone_monorepo () {
     SKIP="$(check_git)"
 
     if [[ -z "$SKIP" ]]; then
         echo ""
         echo "❓ Do you want to clone Novu's monorepo? ($POSITIVE_RESPONSE / $NEGATIVE_RESPONSE)"
-        read -p " > " RESPONSE
+        read -r -p " > " RESPONSE
 	echo ""
 
     	if [[ "$RESPONSE" == "$POSITIVE_RESPONSE" ]]; then
-            REPOSITORY="git@github.com:novuhq/novu.git"
+            REPOSITORY="https://github.com/novuhq/novu.git"
             DESTINATION_FOLDER="$HOME/Dev"
             NOVU_FOLDER="$DESTINATION_FOLDER/novu"
 
-            [[ ! -d "$DESTINATION_FOLDER" ]] && mkdir "$DESTINATION_FOLDER"
+            [[ ! -d "$DESTINATION_FOLDER" ]] && mkdir -p "$DESTINATION_FOLDER"
             if [[ ! -d "$NOVU_FOLDER" ]]; then
-                git clone "$REPOSITORY $NOVU_FOLDER"
+                git clone "$REPOSITORY" "$NOVU_FOLDER"
+                NOVU_REPO_PATH="$NOVU_FOLDER"
+                export NOVU_REPO_PATH
 	        success_message "Novu monorepo"
             else
+                NOVU_REPO_PATH="$NOVU_FOLDER"
+                export NOVU_REPO_PATH
                 already_installed_message "Novu monorepo"
             fi
         fi
@@ -482,8 +783,7 @@ clone_monorepo () {
     fi
 }
 
-# Novu set of tools chosen
-install_novu_tools () {
+install_novu_tools_macos () {
     check_git
     make_zsh_default_shell
     install_ohmyzsh
@@ -494,24 +794,40 @@ install_novu_tools () {
     install_pnpm
     install_docker
     install_aws_cli
-    start_database
+}
+
+install_novu_tools_linux () {
+    install_git_linux
+    install_nvm
+    install_node
+    install_pnpm
+    install_docker
+    install_aws_cli
 }
 
 install_os_dependencies () {
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    if [[ "$OS_TYPE" == "Linux" ]]; then
         echo "Install 🐧 Linux dependencies"
-        echo "//TODO"
-	install_novu_tools
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        install_linux_base_deps
+        install_novu_tools_linux
+    elif [[ "$OS_TYPE" == "Darwin" ]]; then
         echo "Install 👿 MacOSx dependencies"
         install_macosx_dependencies
-        install_novu_tools
+        install_novu_tools_macos
     else
         echo "OS not supported"
+        exit 1
     fi
 }
 
 # Entry point
+detect_os
+echo "Detected OS: $OS_TYPE${DISTRO_FAMILY:+ ($DISTRO_FAMILY)}"
 install_os_dependencies
 clone_monorepo
+start_database
 refresh_shell
+
+echo ""
+echo "🎉 Dev environment setup finished."
+echo "Next: cd into your Novu repo and run pnpm setup:project (or npm run setup:project)."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

The `dev-environment-setup.sh` script only worked on macOS (Homebrew, Xcode, zsh). Linux users hit failures because the Linux branch was a stub that still ran macOS-only tooling.

This change adds full Linux support for Debian/Ubuntu and RHEL/Fedora/CentOS/Amazon Linux families while preserving the existing macOS flow.

### Changes

- **OS detection**: Detect Darwin vs Linux and classify Linux distros via `/etc/os-release` (Debian vs RHEL families).
- **Linux installers**: Install base packages, Git, Docker (official Docker CE repo), and AWS CLI (architecture-aware zip) using `apt-get` or `dnf`/`yum`.
- **Shared Node tooling**: NVM, Node.js v22.22.1, and pnpm v11.0.9 aligned with `package.json` / `CONTRIBUTING.md`.
- **macOS preserved**: Xcode, Rosetta, Homebrew, Oh My Zsh, and `.pkg` AWS CLI paths unchanged.
- **Database startup**: Run after clone; use correct `docker/local/docker-compose.yml` paths; support `docker compose` and `docker-compose`; avoid overwriting an existing `docker/local/.env`.
- **Docker permissions**: On Linux, try `sg docker` or socket permissions when the user was just added to the `docker` group.
- **Script invocation**: `package.json` runs `./scripts/dev-environment-setup.sh` so the `#!/bin/bash` shebang is honored (fixes bash-only syntax that failed under `sh`).

### Testing

- `bash -n scripts/dev-environment-setup.sh` — syntax check passed
- Verified OS detection on Linux (Debian family) and repo path resolution from the monorepo root
- Manual end-to-end runs on macOS and representative Debian/RHEL systems are recommended (interactive system provisioning)

Fixes NV-7555
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7555](https://linear.app/novu/issue/NV-7555/bug-report-dev-environment-setupsh-no-linux-support)

<div><a href="https://cursor.com/agents/bc-f34cecf9-2e8f-4f48-a9d2-9cc74e9f68b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f34cecf9-2e8f-4f48-a9d2-9cc74e9f68b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The dev-environment-setup script was refactored to add full Linux support while keeping macOS behavior. It now detects OS and Linux distro families (Debian vs RHEL), installs platform-appropriate base packages, Git, Docker (official Docker CE repos), and the AWS CLI (architecture-aware ZIP on Linux), and installs shared Node tooling (NVM, Node v22.22.1, pnpm v11.0.9). Database startup, Docker Compose invocation, docker group/permission handling, and shell-profile persistence were improved. The package.json script now runs the script directly to honor the #!/bin/bash shebang.

## Affected areas

root — Updated package.json to invoke ./scripts/dev-environment-setup.sh; scripts/dev-environment-setup.sh was extensively refactored to add OS/distro detection, idempotent shell-profile updates, Linux/Debian/RHEL package manager helpers, platform-specific installers for Docker and AWS CLI, exact Node/pnpm version enforcement, safer docker socket handling, repository cloning ordering, and robust docker-compose orchestration for starting local databases.

## Key technical decisions

- Detect Linux distro via /etc/os-release and map to debian or rhel families to pick apt vs dnf/yum flows.  
- Install Docker on Linux from the official Docker CE repositories; use Homebrew cask on macOS.  
- Install AWS CLI on Linux via architecture-specific ZIP; macOS retains .pkg flow.  
- Enforce exact Node v22.22.1 and pnpm v11.0.9 to match package.json/CONTRIBUTING.md.  
- Prefer modern docker compose CLI with fallback to docker-compose and use group-aware execution (sg docker) or guided permission fixes; remove world-writable docker.sock fallback.  
- Defer database startup until after repo clone and avoid overwriting existing docker/local/.env files.

## Testing

Bash syntax check (bash -n) passed; OS detection and repo path resolution were verified. Manual end-to-end testing was exercised on macOS and representative Debian/RHEL systems; further manual verification is recommended before merge.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->