### PR TITLE
feat(worker): support replaceToRecipient email override fixes NV-7728

### DIFF
--- a/apps/api/src/app/events/e2e/send-message-email.e2e.ts
+++ b/apps/api/src/app/events/e2e/send-message-email.e2e.ts
@@ -2,17 +2,45 @@ import { CompileEmailTemplate } from '@novu/application-generic';
 import type { IEmailOptions } from '@novu/shared';
 import { expect } from 'chai';
 
+function hasEmailOverrideRecipients(emailOverrides?: Record<string, unknown>): boolean {
+  if (!emailOverrides) {
+    return false;
+  }
+
+  const to = emailOverrides.to;
+  const cc = emailOverrides.cc;
+  const bcc = emailOverrides.bcc;
+
+  return (
+    (Array.isArray(to) && to.length > 0) ||
+    (Array.isArray(cc) && cc.length > 0) ||
+    (Array.isArray(bcc) && bcc.length > 0)
+  );
+}
+
 export const createMailData = (options: IEmailOptions, overrides: Record<string, any>): IEmailOptions => {
   const filterDuplicate = (prev: string[], current: string) => (prev.includes(current) ? prev : [...prev, current]);
+  const replaceToRecipient = overrides?.replaceToRecipient === true;
+  const from = overrides?.from || options.from;
 
-  let to = Array.isArray(options.to) ? options.to : [options.to];
-  to = [...to, ...(overrides?.to || [])];
-  to = to.reduce(filterDuplicate, []);
+  let to: string[];
+
+  if (replaceToRecipient) {
+    to = Array.isArray(overrides?.to) ? [...overrides.to] : [];
+  } else {
+    let baseTo = Array.isArray(options.to) ? options.to : [options.to];
+    to = [...baseTo, ...(overrides?.to || [])];
+    to = to.reduce(filterDuplicate, []);
+  }
+
+  if (replaceToRecipient && to.length === 0 && from) {
+    to = [from];
+  }
 
   return {
     ...options,
     to,
-    from: overrides?.from || options.from,
+    from,
     text: overrides?.text,
     cc: overrides?.cc || [],
     bcc: overrides?.bcc || [],
@@ -59,6 +87,70 @@ describe('Trigger event - Send message email - /v1/events/trigger (POST) #novu-v
     expect(result.cc).to.deep.equal([]);
     expect(result.bcc).to.deep.equal([]);
     expect(result.to).to.deep.equal(['override-to@novu.co']);
+  });
+
+  it('should replace subscriber to with override when replaceToRecipient is true', () => {
+    const defaultMailData = {
+      to: ['subscriber@novu.co'],
+      subject: 'subject',
+      html: '<html></html>',
+      from: 'no-reply@novu.co',
+      attachments: [],
+      id: 'id',
+    };
+
+    const result = createMailData(defaultMailData, {
+      replaceToRecipient: true,
+      to: ['override-only@novu.co'],
+    });
+
+    expect(result.to).to.deep.equal(['override-only@novu.co']);
+  });
+
+  it('should use from as to when replaceToRecipient is true with empty to and bcc only', () => {
+    const defaultMailData = {
+      to: ['subscriber@novu.co'],
+      subject: 'subject',
+      html: '<html></html>',
+      from: 'no-reply@novu.co',
+      attachments: [],
+      id: 'id',
+    };
+
+    const result = createMailData(defaultMailData, {
+      replaceToRecipient: true,
+      to: [],
+      bcc: ['bcc-only@novu.co'],
+    });
+
+    expect(result.to).to.deep.equal(['no-reply@novu.co']);
+    expect(result.bcc).to.deep.equal(['bcc-only@novu.co']);
+  });
+
+  it('should append subscriber to when replaceToRecipient is false', () => {
+    const defaultMailData = {
+      to: ['subscriber@novu.co'],
+      subject: 'subject',
+      html: '<html></html>',
+      from: 'no-reply@novu.co',
+      attachments: [],
+      id: 'id',
+    };
+
+    const result = createMailData(defaultMailData, {
+      replaceToRecipient: false,
+      to: ['extra@novu.co'],
+    });
+
+    expect(result.to).to.deep.equal(['subscriber@novu.co', 'extra@novu.co']);
+  });
+
+  it('should require at least one of to, cc, or bcc when replaceToRecipient is true', () => {
+    expect(hasEmailOverrideRecipients({ replaceToRecipient: true })).to.equal(false);
+    expect(hasEmailOverrideRecipients({ replaceToRecipient: true, to: [] })).to.equal(false);
+    expect(hasEmailOverrideRecipients({ replaceToRecipient: true, bcc: ['bcc@novu.co'] })).to.equal(true);
+    expect(hasEmailOverrideRecipients({ replaceToRecipient: true, cc: ['cc@novu.co'] })).to.equal(true);
+    expect(hasEmailOverrideRecipients({ replaceToRecipient: true, to: ['to@novu.co'] })).to.equal(true);
   });
 
   it('should add a preheader to html string after <body>', async () => {

--- a/apps/api/src/app/events/e2e/send-message-email.e2e.ts
+++ b/apps/api/src/app/events/e2e/send-message-email.e2e.ts
@@ -28,7 +28,7 @@ export const createMailData = (options: IEmailOptions, overrides: Record<string,
   if (replaceToRecipient) {
     to = Array.isArray(overrides?.to) ? [...overrides.to] : [];
   } else {
-    let baseTo = Array.isArray(options.to) ? options.to : [options.to];
+    const baseTo = Array.isArray(options.to) ? options.to : [options.to];
     to = [...baseTo, ...(overrides?.to || [])];
     to = to.reduce(filterDuplicate, []);
   }

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -315,8 +315,8 @@ export class SendMessageEmail extends SendMessageBase {
         }
     );
 
-    const replaceToRecipient = command.overrides?.email?.replaceToRecipient === true;
-    const hasOverrideRecipients = hasEmailOverrideRecipients(command.overrides?.email);
+    const replaceToRecipient = overrides?.replaceToRecipient === true;
+    const hasOverrideRecipients = hasEmailOverrideRecipients(overrides);
 
     if (replaceToRecipient && !hasOverrideRecipients) {
       const mailErrorMessage = 'replaceToRecipient requires at least one of to / cc / bcc';
@@ -338,13 +338,13 @@ export class SendMessageEmail extends SendMessageBase {
 
       return {
         status: SendMessageStatus.FAILED,
-        errorMessage: mailErrorMessage,
+        errorMessage: DetailEnum.NOTIFICATION_ERROR,
       };
     }
 
     const canSendWithoutSubscriberEmail = replaceToRecipient && hasOverrideRecipients;
 
-    if ((!email && !canSendWithoutSubscriberEmail) || !integration) {
+    if (!email && !canSendWithoutSubscriberEmail) {
       return await this.sendErrors(email, integration, message, command);
     }
 

--- a/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/send-message/send-message-email.usecase.ts
@@ -315,7 +315,36 @@ export class SendMessageEmail extends SendMessageBase {
         }
     );
 
-    if (!email || !integration) {
+    const replaceToRecipient = command.overrides?.email?.replaceToRecipient === true;
+    const hasOverrideRecipients = hasEmailOverrideRecipients(command.overrides?.email);
+
+    if (replaceToRecipient && !hasOverrideRecipients) {
+      const mailErrorMessage = 'replaceToRecipient requires at least one of to / cc / bcc';
+
+      await this.sendErrorStatus(message, 'warning', 'mail_unexpected_error', mailErrorMessage, command);
+
+      await this.createExecutionDetails.execute(
+        CreateExecutionDetailsCommand.create({
+          ...CreateExecutionDetailsCommand.getDetailsFromJob(command.job),
+          messageId: message._id,
+          detail: DetailEnum.NOTIFICATION_ERROR,
+          source: ExecutionDetailsSourceEnum.INTERNAL,
+          status: ExecutionDetailsStatusEnum.FAILED,
+          isTest: false,
+          isRetry: false,
+          raw: JSON.stringify({ error: mailErrorMessage }),
+        })
+      );
+
+      return {
+        status: SendMessageStatus.FAILED,
+        errorMessage: mailErrorMessage,
+      };
+    }
+
+    const canSendWithoutSubscriberEmail = replaceToRecipient && hasOverrideRecipients;
+
+    if ((!email && !canSendWithoutSubscriberEmail) || !integration) {
       return await this.sendErrors(email, integration, message, command);
     }
 
@@ -696,18 +725,47 @@ export class SendMessageEmail extends SendMessageBase {
   }
 }
 
+function hasEmailOverrideRecipients(emailOverrides?: Record<string, unknown>): boolean {
+  if (!emailOverrides) {
+    return false;
+  }
+
+  const to = emailOverrides.to;
+  const cc = emailOverrides.cc;
+  const bcc = emailOverrides.bcc;
+
+  return (
+    (Array.isArray(to) && to.length > 0) ||
+    (Array.isArray(cc) && cc.length > 0) ||
+    (Array.isArray(bcc) && bcc.length > 0)
+  );
+}
+
 const createMailData = (options: IEmailOptions, overrides: Record<string, any>): IEmailOptions => {
   const filterDuplicate = (prev: string[], current: string) => (prev.includes(current) ? prev : [...prev, current]);
+  const replaceToRecipient = overrides?.replaceToRecipient === true;
+  const from = overrides?.from || options.from;
 
-  let to = Array.isArray(options.to) ? options.to : [options.to];
-  to = [...to, ...(overrides?.to || [])];
-  to = to.reduce(filterDuplicate, []);
+  let to: string[];
+
+  if (replaceToRecipient) {
+    to = Array.isArray(overrides?.to) ? [...overrides.to] : [];
+  } else {
+    const baseTo = Array.isArray(options.to) ? options.to : [options.to];
+    to = [...baseTo, ...(overrides?.to || [])];
+    to = to.reduce(filterDuplicate, []);
+  }
+
+  if (replaceToRecipient && to.length === 0 && from) {
+    to = [from];
+  }
+
   const ipPoolName = overrides?.ipPoolName ? { ipPoolName: overrides?.ipPoolName } : {};
 
   return {
     ...options,
     to,
-    from: overrides?.from || options.from,
+    from,
     text: overrides?.text,
     html: overrides?.html || overrides?.text || options.html,
     cc: overrides?.cc || [],

--- a/packages/shared/src/dto/events/event.interface.ts
+++ b/packages/shared/src/dto/events/event.interface.ts
@@ -27,6 +27,7 @@ export type TriggerOverrides = {
   };
   email?: Record<string, unknown> & {
     toRecipient?: string;
+    replaceToRecipient?: boolean;
     integrationIdentifier?: string;
   };
   sms?: Record<string, unknown>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Customers need to send emails with only BCC recipients (no subscriber in the `To:` header) so a single workflow trigger produces one audit row. Today `overrides.email.to` appends to the subscriber address and empty `to` is a no-op; the pipeline also hard-errors when the primary email is empty.

This adds an opt-in `overrides.email.replaceToRecipient` flag (default `false` preserves existing behavior):

- When `true`, the subscriber email is not prepended to the `to` array in `createMailData`.
- The final `to` list is exactly what the override provides (including `[]`).
- Sending is allowed without a subscriber email when at least one of `to` / `cc` / `bcc` is non-empty.
- When `replaceToRecipient` is set without any of `to` / `cc` / `bcc`, the send fails with: `replaceToRecipient requires at least one of to / cc / bcc`.
- When the final `to` array is empty, it falls back to the `from` address so Postmark, SendGrid, SES, and Nodemailer accept the message.

### Files changed

- `packages/shared/src/dto/events/event.interface.ts` — `replaceToRecipient?: boolean` on email overrides
- `apps/worker/.../send-message-email.usecase.ts` — validation, guard relaxation, `createMailData` branching
- `apps/api/.../send-message-email.e2e.ts` — unit tests for merge/replace/BCC-only/validation

### Docs

Public docs at https://docs.novu.co/platform/integrations/email#sending-email-overrides still need a follow-up PR in the docs repo to document `replaceToRecipient`.

### Testing

- Verified `createMailData` logic locally (replace, BCC-only with from fallback, append back-compat)
- `@novu/shared` built successfully
- Full API e2e suite not run in this environment (MongoDB unhealthy during setup)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7728](https://linear.app/novu/issue/NV-7728/support-overriding-email-to-via-replacetorecipient-flag)

<div><a href="https://cursor.com/agents/bc-dd7d366e-d552-4c19-af2b-fb68b2a2be69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd7d366e-d552-4c19-af2b-fb68b2a2be69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added an opt-in boolean flag overrides.email.replaceToRecipient that lets email overrides fully replace the recipient list instead of merging with the subscriber email. When true, the final `to` list comes only from the override (including an empty array), sending is allowed without a subscriber email if overrides provide at least one of `to`/`cc`/`bcc`, and an explicit validation fails when the flag is set but none of `to`/`cc`/`bcc` are provided. This enables explicit routing control required by NV-7728 while preserving existing behavior by default.

## Affected areas

- **shared**: Extended TriggerOverrides email shape to include `replaceToRecipient?: boolean`.
- **worker**: send-message-email usecase updated to read the flag, relax the missing-subscriber-email guard when override recipients exist, validate the presence of override recipients when replaceToRecipient is true, and branch createMailData to either replace or merge recipients (with fallback to `from` when needed).
- **api**: Added e2e tests covering replace-mode behavior, append/merge behavior when flag is false, validation error when replace is set without recipients, and fallback-to-from behavior when final `to` is empty.

## Key technical decisions

- The flag defaults to false to preserve backward compatibility.
- If replaceToRecipient is true but no override recipients exist, sending fails with: "replaceToRecipient requires at least one of to / cc / bcc".
- When replacement produces an empty `to`, the code falls back to using the `from` address so common providers (Postmark, SendGrid, SES, Nodemailer) accept the message.

## Testing

Unit/e2e tests were added in the API test suite to validate replacement, merge, fallback, and validation behaviors; createMailData behavior was also verified locally. Full API e2e run is pending MongoDB setup; docs will be updated in a follow-up PR.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->