### PR TITLE
fix(dashboard): show shared agent inbox in sender preview fixes NV-7707

### DIFF
--- a/apps/dashboard/src/components/agents/agent-integration-guides/email-agent-integration-guide.tsx
+++ b/apps/dashboard/src/components/agents/agent-integration-guides/email-agent-integration-guide.tsx
@@ -74,6 +74,7 @@ export function EmailAgentIntegrationGuide({
               agent={agent}
               integrationId={integrationId}
               defaultSenderName={integrationLink?.integration?.defaultSenderName}
+              sharedInboundAddress={integrationLink?.integration?.sharedInboundAddress}
             />
           </div>
         </div>

--- a/apps/dashboard/src/components/agents/email-configuration-card.tsx
+++ b/apps/dashboard/src/components/agents/email-configuration-card.tsx
@@ -21,7 +21,8 @@ export function EmailConfigurationCardBody({
   agent,
   integrationId,
   defaultSenderName,
-}: EmailConfigurationCardProps & { defaultSenderName?: string }) {
+  sharedInboundAddress,
+}: EmailConfigurationCardProps & { defaultSenderName?: string; sharedInboundAddress?: string }) {
   const { integrations } = useFetchIntegrations();
   const emailIntegration = useMemo(
     () => integrations?.find((i) => i._id === integrationId && i.providerId === EmailProviderIdEnum.NovuAgent),
@@ -65,6 +66,7 @@ export function EmailConfigurationCardBody({
           serverEnabled={serverUseFromAddressOverride}
           serverValue={serverFromAddressOverride}
           defaultSenderName={defaultSenderName || agent.name}
+          sharedInboundAddress={sharedInboundAddress}
           outboundFromAddress={outboundFromAddress}
           inboundAddresses={inboundAddresses}
           onSave={saveSenderOverride}
@@ -103,8 +105,8 @@ function CardRow({
     <div
       className={
         divider
-          ? 'border-stroke-weak flex items-start justify-between gap-4 border-b p-3'
-          : 'flex items-start justify-between gap-4 p-3'
+          ? 'border-stroke-weak flex items-start justify-between gap-6 border-b p-3'
+          : 'flex items-start justify-between gap-6 p-3'
       }
     >
       <div className="flex max-w-[350px] min-w-0 flex-1 flex-col gap-1">

--- a/apps/dashboard/src/components/agents/email-inbox-card.tsx
+++ b/apps/dashboard/src/components/agents/email-inbox-card.tsx
@@ -334,7 +334,7 @@ function CardRow({
   return (
     <div
       className={cn(
-        'flex items-start justify-between gap-4 p-3',
+        'flex items-start justify-between gap-6 p-3',
         divider && 'border-stroke-weak border-b',
         disabled && 'opacity-60'
       )}

--- a/apps/dashboard/src/components/agents/sender-address-override.tsx
+++ b/apps/dashboard/src/components/agents/sender-address-override.tsx
@@ -8,6 +8,8 @@ export type SenderAddressOverrideProps = {
   serverEnabled: boolean;
   serverValue: string;
   defaultSenderName: string;
+  /** Cloud shared inbox (`slug-key@agentconnect.sh`) — used when no custom-domain routes exist. */
+  sharedInboundAddress?: string;
   outboundFromAddress: string;
   inboundAddresses: string[];
   onSave: (params: { enabled: boolean; value: string }) => Promise<void>;
@@ -28,6 +30,7 @@ export function SenderAddressOverride({
   serverEnabled,
   serverValue,
   defaultSenderName,
+  sharedInboundAddress,
   outboundFromAddress,
   inboundAddresses,
   onSave,
@@ -70,9 +73,12 @@ export function SenderAddressOverride({
   // we drop it from the preview to match the address subscribers will actually
   // see in their inbox.
   const previewOverride = !disabled && enabled ? trimmedValue : '';
+  const sharedInbound = sharedInboundAddress?.trim() ?? '';
   const fallbackInbound = inboundAddresses[0] ?? '';
-  const resolvedFrom = previewOverride || fallbackInbound || outboundFromAddress;
-  const resolvedReplyTo = resolvedFrom && resolvedFrom !== fallbackInbound ? fallbackInbound : '';
+  const agentInboundAddress = sharedInbound || fallbackInbound;
+  const resolvedFrom = previewOverride || agentInboundAddress || outboundFromAddress;
+  const resolvedReplyTo =
+    resolvedFrom && agentInboundAddress && resolvedFrom !== agentInboundAddress ? agentInboundAddress : '';
 
   async function handleSave() {
     if (!canSave) return;
@@ -175,8 +181,8 @@ function formatFromHeader(name: string, email: string): string {
 
 function PreviewRow({ label, value, muted }: { label: string; value: string; muted: boolean }) {
   return (
-    <div className="flex items-baseline gap-2.5">
-      <span className="text-text-soft text-[10px] w-[52px] shrink-0 font-medium uppercase leading-4 whitespace-nowrap">
+    <div className="grid grid-cols-[4.5rem_minmax(0,1fr)] items-baseline gap-x-3 gap-y-0">
+      <span className="text-text-soft text-[10px] shrink-0 font-medium uppercase leading-4">
         {label}
       </span>
       <span


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a visual bug on the agent email integration detail page where the sender address preview showed the Novu demo provider address (`support@novu.co`) instead of the agent's shared `agentconnect.sh` inbox, even though delivery already used the correct address.

## Changes

- Pass `sharedInboundAddress` from the integration link into `SenderAddressOverride` and prefer it in the preview resolver (aligned with `chat-sdk.service.ts`: override → agent inbox → outbound provider).
- Widen preview label/value columns with a small CSS grid and `gap-x-3` so "From name" / "From" / "Reply-To" rows read clearly.
- Increase spacing between description and controls columns in email integration card rows (`gap-6`).

## Verification

- Open an agent with Novu Email connected, shared inbox enabled, and demo sender selected.
- In **Integrations → Novu Email → Sender address**, the preview **From** row should show `{agent name} <{slug-key}@…agentconnect.sh>` instead of `support@novu.co`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779296237450779?thread_ts=1779296237.450779&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-11df97c8-5519-53e5-9551-11d30d35832f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11df97c8-5519-53e5-9551-11d30d35832f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR fixes a visual bug on the agent email integration detail page where the sender address preview showed the Novu demo provider address (support@novu.co) instead of the agent's shared inbox address. The fix wires `sharedInboundAddress` from the integration link into the preview resolver so the preview matches actual email delivery behavior. CSS adjustments improve spacing in preview rows and card columns for better readability.

## Affected areas

**dashboard**
- Email agent integration guide component now passes `sharedInboundAddress` to the email configuration card
- Email configuration card and sender address override components accept and use the shared inbound address in preview resolution, following the precedence chain: override → agent inbox → outbound provider (matching `chat-sdk.service.ts`)
- Preview layout switched from flex to CSS grid for better alignment of multi-line address fields ("From name", "From", "Reply-To" rows)
- Card row spacing increased from `gap-4` to `gap-6` for clearer separation between description and controls in email inbox and integration cards

## Testing

No automated tests were added. The fix requires manual verification: open an agent with Novu Email connected, shared inbox enabled, and demo sender selected, then confirm that Integrations → Novu Email → Sender address preview displays `{agent name} <{slug-key}@…agentconnect.sh>` instead of `support@novu.co`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->