### PR TITLE
fix(shared): block RFC6598 shared address space in SSRF guard fixes NV-7730

### DIFF
--- a/libs/application-generic/src/utils/ssrf-url-validation.ts
+++ b/libs/application-generic/src/utils/ssrf-url-validation.ts
@@ -64,6 +64,7 @@ const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
 });
 
 export function isPrivateIp(ip: string): boolean {
+  const sharedAddressSecondOctet = '(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])';
   const privateRanges = [
     /^0\.0\.0\.0$/i,
     /^127\./,
@@ -71,11 +72,14 @@ export function isPrivateIp(ip: string): boolean {
     /^172\.(1[6-9]|2[0-9]|3[01])\./,
     /^192\.168\./,
     /^169\.254\./,
+    /* RFC6598 shared address space (100.64.0.0/10) — cloud metadata, CGNAT */
+    new RegExp(`^100\\.${sharedAddressSecondOctet}\\.`),
     /^::ffff:127\./i,
     /^::ffff:10\./i,
     /^::ffff:172\.(1[6-9]|2[0-9]|3[01])\./i,
     /^::ffff:192\.168\./i,
     /^::ffff:169\.254\./i,
+    new RegExp(`^::ffff:100\\.${sharedAddressSecondOctet}\\.`, 'i'),
     /^::1$/i,
     /^f[cd][0-9a-f]{2}:/i,
     /^::ffff:f[cd][0-9a-f]{2}:/i,

--- a/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
+++ b/packages/shared/src/utils/safe-outbound-http-drift.spec.ts
@@ -61,6 +61,10 @@ describe('safe outbound HTTP — shared vs application-generic drift check', () 
       '192.168.1.1',
       // Link-local v4 / metadata
       '169.254.169.254',
+      // RFC6598 shared address space (100.64.0.0/10)
+      '100.64.0.1',
+      '100.100.100.200',
+      '100.127.255.255',
       // Public IPv4
       '1.1.1.1',
       '8.8.8.8',
@@ -76,6 +80,7 @@ describe('safe outbound HTTP — shared vs application-generic drift check', () 
       '::ffff:10.0.0.1',
       '::ffff:192.168.1.1',
       '::ffff:169.254.1.1',
+      '::ffff:100.100.100.200',
       // Public IPv6
       '2001:4860:4860::8888',
     ];

--- a/packages/shared/src/utils/ssrf-url-validation.spec.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.spec.ts
@@ -16,6 +16,11 @@ describe('ssrf-url-validation', () => {
       expect(isPrivateIp('172.31.255.255')).toBe(true);
       expect(isPrivateIp('192.168.1.1')).toBe(true);
       expect(isPrivateIp('169.254.1.1')).toBe(true);
+      expect(isPrivateIp('100.64.0.1')).toBe(true);
+      expect(isPrivateIp('100.100.100.200')).toBe(true);
+      expect(isPrivateIp('100.127.255.255')).toBe(true);
+      expect(isPrivateIp('100.63.255.255')).toBe(false);
+      expect(isPrivateIp('100.128.0.1')).toBe(false);
     });
 
     it('should detect IPv6 private, loopback, and link-local addresses', () => {
@@ -33,6 +38,7 @@ describe('ssrf-url-validation', () => {
       expect(isPrivateIp('::ffff:10.0.0.1')).toBe(true);
       expect(isPrivateIp('::ffff:192.168.1.1')).toBe(true);
       expect(isPrivateIp('::ffff:169.254.1.1')).toBe(true);
+      expect(isPrivateIp('::ffff:100.100.100.200')).toBe(true);
       expect(isPrivateIp('::ffff:fe80::1')).toBe(true);
     });
 
@@ -52,6 +58,16 @@ describe('ssrf-url-validation', () => {
       const result = await validateUrlSsrf('https://ssrf-link-local-test.invalid/file.txt');
 
       expect(result).toBe('Requests to private or reserved IP addresses are not allowed (resolved: fe80::1).');
+    });
+
+    it('should block hostnames that resolve to RFC6598 shared address space', async () => {
+      vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '100.100.100.200', family: 4 }] as never);
+
+      const result = await validateUrlSsrf('https://ssrf-shared-address-test.invalid/latest/meta-data/');
+
+      expect(result).toBe(
+        'Requests to private or reserved IP addresses are not allowed (resolved: 100.100.100.200).'
+      );
     });
   });
 });

--- a/packages/shared/src/utils/ssrf-url-validation.ts
+++ b/packages/shared/src/utils/ssrf-url-validation.ts
@@ -45,13 +45,14 @@ const DNS_CACHE = new LRUCache<string, dns.LookupAddress[]>({
 });
 
 /**
- * Returns true for IPs that are loopback, RFC1918 private, link-local,
- * unique-local IPv6 (fc00::/7), IPv6 loopback/link-local, IPv4-mapped IPv6 of any of these,
- * or the unspecified 0.0.0.0 address.
+ * Returns true for IPs that are loopback, RFC1918 private, RFC6598 shared (CGNAT),
+ * link-local, unique-local IPv6 (fc00::/7), IPv6 loopback/link-local, IPv4-mapped
+ * IPv6 of any of these, or the unspecified 0.0.0.0 address.
  *
  * Used to reject SSRF candidates at validation **and** at connect time.
  */
 export function isPrivateIp(ip: string): boolean {
+  const sharedAddressSecondOctet = '(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])';
   const privateRanges = [
     /^0\.0\.0\.0$/i,
     /^127\./,
@@ -59,11 +60,14 @@ export function isPrivateIp(ip: string): boolean {
     /^172\.(1[6-9]|2[0-9]|3[01])\./,
     /^192\.168\./,
     /^169\.254\./,
+    /* RFC6598 shared address space (100.64.0.0/10) — cloud metadata, CGNAT */
+    new RegExp(`^100\\.${sharedAddressSecondOctet}\\.`),
     /^::ffff:127\./i,
     /^::ffff:10\./i,
     /^::ffff:172\.(1[6-9]|2[0-9]|3[01])\./i,
     /^::ffff:192\.168\./i,
     /^::ffff:169\.254\./i,
+    new RegExp(`^::ffff:100\\.${sharedAddressSecondOctet}\\.`, 'i'),
     /^::1$/i,
     /* ULA fc00::/7 (fc00–fdff first hextet) */
     /^f[cd][0-9a-f]{2}:/i,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The SSRF guard `isPrivateIp` / `validateUrlSsrf` did not block RFC6598 shared address space (`100.64.0.0/10`). That range includes cloud metadata endpoints such as Alibaba Cloud's `100.100.100.200`, so features protected by this guard could still reach internal metadata services when a hostname resolved to an address in that range.

This PR adds `100.64.0.0/10` (and IPv4-mapped IPv6 equivalents) to the private/reserved IP regex list in both mirrored implementations:

- `packages/shared/src/utils/ssrf-url-validation.ts`
- `libs/application-generic/src/utils/ssrf-url-validation.ts`

## Why this matters

The guard is used before server-side outbound requests in:

- Workflow HTTP request steps (`execute-http-request-step.usecase.ts`)
- Webhook filter conditions (`conditions-filter.usecase.ts`)
- `safeOutboundRequest` / `HttpClientService` (via shared `isPrivateIp`)

Blocking `100.64.0.0/10` closes the gap for CGNAT and cloud-provider metadata services in that range.

## Testing

- Added unit tests for `100.64.0.1`, `100.100.100.200`, boundary cases (`100.63.x`, `100.128.x`), and IPv4-mapped IPv6
- Added `validateUrlSsrf` test for DNS resolution to `100.100.100.200`
- Updated drift test cases to keep shared and application-generic copies in sync
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d251e85-87ad-4472-9273-7b5a5e6ddb79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d251e85-87ad-4472-9273-7b5a5e6ddb79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The SSRF guard functions `isPrivateIp` and `validateUrlSsrf` now block the RFC6598 shared address space (100.64.0.0/10) and its IPv4-mapped IPv6 equivalents. This prevents potential access to CGNAT networks and cloud metadata endpoints (such as Alibaba Cloud's 100.100.100.200) via workflow HTTP steps and webhook filters.

## Affected areas

**shared** — Updated `isPrivateIp` in `ssrf-url-validation.ts` to detect the 100.64.0.0/10 range via regex pattern matching, covering both plain IPv4 and `::ffff:` IPv4-mapped IPv6 addresses.

**application-generic** — Mirrored the same changes to the inlined copy of `ssrf-url-validation.ts` to maintain consistency between implementations.

## Testing

Unit tests added cover new IP addresses (100.64.0.1, 100.100.100.200), boundary cases (100.63.x, 100.128.x), IPv4-mapped IPv6 forms, and DNS resolution scenarios where hostnames resolve to blocked addresses. A drift test was added to verify `isPrivateIp` results remain synchronized between the shared and application-generic implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->