### PR TITLE
fix(root): skip pinned @novu deps in preview packages set-latest fixes NV-7731

### DIFF
--- a/scripts/set-package-dependencies.mjs
+++ b/scripts/set-package-dependencies.mjs
@@ -37,12 +37,23 @@ async function getPackageNames() {
 
 const novuPackages = new Set(await getPackageNames());
 
-// Update versions of all @novu dependencies
+// Update versions of all @novu workspace dependencies only.
+// Pinned semver versions (e.g. agent-toolkit's published @novu/api SDK) must stay unchanged.
 function updateNovuDependencies(dependencies) {
-  for (const [key] of Object.entries(dependencies || {})) {
-    if (key.startsWith('@novu/') && novuPackages.has(key)) {
-      dependencies[key] = replacement;
+  for (const [key, value] of Object.entries(dependencies || {})) {
+    if (!key.startsWith('@novu/') || !novuPackages.has(key)) {
+      continue;
     }
+
+    if (replacement === 'latest' && value !== 'workspace:*') {
+      continue;
+    }
+
+    if (replacement === 'workspace:*' && value !== 'latest') {
+      continue;
+    }
+
+    dependencies[key] = replacement;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the **Publish NPM Packages Previews** workflow failure during `preview:pkg:build`.

The preview workflow runs `pnpm run packages:set-latest` before building. That script was rewriting **every** `@novu/*` dependency that matches an nx project name—including `packages/agent-toolkit`'s pinned published SDK `@novu/api: 3.15.0` → `latest` (because `@novu/api` is also the internal-sdk nx project).

That left `package.json` out of sync with `pnpm-lock.yaml`, so a later frozen `pnpm install` (triggered during the nx build) failed with `ERR_PNPM_OUTDATED_LOCKFILE`.

## Fix

Update `scripts/set-package-dependencies.mjs` to only swap protocol values:

- `workspace:*` → `latest` when preparing previews
- `latest` → `workspace:*` when restoring

Semver-pinned dependencies (like agent-toolkit's `@novu/api: 3.15.0`) are left unchanged.

## Context

Related to NV-7693, which intentionally pinned agent-toolkit to the published `@novu/api@3.15.0` SDK instead of `workspace:*`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779346015803669?thread_ts=1779346015.803669&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-ac4bba2a-6500-56e2-a8a6-131d810c0459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac4bba2a-6500-56e2-a8a6-131d810c0459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The preview package build script was rewriting all `@novu/*` dependencies to `latest`, including intentionally pinned versions like `@novu/api@3.15.0`. This caused `package.json` to become out of sync with `pnpm-lock.yaml`, triggering lockfile validation errors during the build. Updated the script to only swap `workspace:*` ↔ `latest` for dependencies matching the monorepo's internal packages, leaving semver-pinned versions unchanged.

## Affected areas

- **scripts** (build tooling): Updated `set-package-dependencies.mjs` to conditionally rewrite only `workspace:*` protocol dependencies, preserving pinned package versions during preview builds.

## Testing

No new tests added. The fix resolves the `preview:pkg:build` workflow failure without requiring unit tests since it corrects existing script behavior to properly respect pinned dependency versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->