### PR TITLE
ci(root): replace pnpm install with pnpm ci in GitHub Actions

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: 🛟 Install dependencies
       shell: bash
-      run: pnpm install --frozen-lockfile
+      run: pnpm ci
 
     - name: Install wait-on plugin
       shell: bash

--- a/.github/workflows/contributor-checks.yml
+++ b/.github/workflows/contributor-checks.yml
@@ -69,7 +69,7 @@ jobs:
           cache-dependency-path: "pnpm-lock.yaml"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm ci
 
       - name: Reset Nx cache
         run: npx nx reset || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -327,7 +327,7 @@ jobs:
 
       - name: Install Dependencies
         shell: bash
-        run: pnpm install --frozen-lockfile
+        run: pnpm ci
       - name: Run ClickHouse Migrations
         working-directory: apps/api
         env:
@@ -371,7 +371,7 @@ jobs:
 
       - name: Install Dependencies
         shell: bash
-        run: pnpm install --frozen-lockfile
+        run: pnpm ci
 
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/.github/workflows/prepare-enterprise-self-hosted-release.yml
+++ b/.github/workflows/prepare-enterprise-self-hosted-release.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: Install Dependencies
         shell: bash
-        run: pnpm install --frozen-lockfile
+        run: pnpm ci
 
       - name: Symlink Enterprise Packages
         shell: bash

--- a/.github/workflows/prepare-self-hosted-release.yml
+++ b/.github/workflows/prepare-self-hosted-release.yml
@@ -148,7 +148,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm ci
 
       - name: Setup Docker
         uses: crazy-max/ghaction-setup-docker@69b561f709cbd934060981d481ccfc316cfb77b7 # v2

--- a/.github/workflows/preview-packages.yml
+++ b/.github/workflows/preview-packages.yml
@@ -35,7 +35,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm ci
 
       - name: Teach Novu preview packages to work with latest dependencies
         run: pnpm run packages:set-latest

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          pnpm install --frozen-lockfile
+          pnpm ci
           pnpm nx --version
           pnpm list nx
 
@@ -235,7 +235,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          pnpm install --frozen-lockfile
+          pnpm ci
 
       - name: Build packages
         env:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Replaces all `pnpm install` / `pnpm install --frozen-lockfile` calls in GitHub Actions workflows with `pnpm ci`.

pnpm 11 introduced `pnpm ci` (aliases: `clean-install`, `ic`, `install-clean`) which runs `pnpm clean` followed by `pnpm install --frozen-lockfile`. This ensures reproducible builds in CI/CD by removing existing `node_modules` before installing, preventing stale dependency issues that can cause lockfile conflicts (as reported in the preview-packages publish workflow).

**Files changed (7):**
- `.github/actions/setup-project/action.yml`
- `.github/workflows/contributor-checks.yml`
- `.github/workflows/deploy.yml` (2 occurrences)
- `.github/workflows/prepare-enterprise-self-hosted-release.yml`
- `.github/workflows/prepare-self-hosted-release.yml`
- `.github/workflows/preview-packages.yml`
- `.github/workflows/release-packages.yml` (2 occurrences)

**Two occurrences intentionally left unchanged:**
- `setup-project-minimal/action.yml` — uses `--filter=root --ignore-scripts` flags not supported by `pnpm ci`
- `contributor-checks.yml` line 146 — user-facing local dev instructions in a PR comment template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Replaced `pnpm install` and `pnpm install --frozen-lockfile` with `pnpm ci` across GitHub Actions workflows. pnpm 11 introduced `pnpm ci` (clean-install), which runs `pnpm clean` followed by `pnpm install --frozen-lockfile`, removing existing `node_modules` before installing to ensure reproducible CI/CD builds and prevent stale dependency/lockfile conflicts.

## Affected areas

**CI/CD workflows**: Updated 7 GitHub Actions workflows to use `pnpm ci` during dependency installation—`contributor-checks.yml`, `deploy.yml`, `release-packages.yml`, `preview-packages.yml`, `prepare-self-hosted-release.yml`, `prepare-enterprise-self-hosted-release.yml`, and `setup-project/action.yml`.

## Key technical decisions

- Two occurrences were intentionally left unchanged: `setup-project-minimal/action.yml` uses `--filter=root --ignore-scripts` flags not supported by `pnpm ci`, and `contributor-checks.yml` line 146 contains user-facing local development instructions in a PR comment template.

## Testing

No tests required. This is a CI-only change with no functional impact on application code or user-facing features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots

N/A — CI-only change, no visual impact.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

This is a straightforward find-and-replace. The `pnpm ci` command is equivalent to `pnpm clean && pnpm install --frozen-lockfile`, so behavior is identical except that `node_modules` are cleaned first, which addresses the lockfile staleness issues seen with pnpm 11.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06DU7A7BPV/p1779353198698849?thread_ts=1779353198.698849&cid=C06DU7A7BPV)

<div><a href="https://cursor.com/agents/bc-d8e54ff3-98fc-5815-8eba-0eb4768895b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8e54ff3-98fc-5815-8eba-0eb4768895b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

