### PR TITLE
feat(api-service): bump thalamus to alpha.7 and adapt to runId API changes fixes NV-7724

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -73,7 +73,7 @@
     "@novu/notifications": "workspace:*",
     "@novu/shared": "workspace:*",
     "@novu/stateless": "workspace:*",
-    "@novu/thalamus": "0.1.0-alpha.6",
+    "@novu/thalamus": "0.1.0-alpha.7",
     "@novu/testing": "workspace:*",
     "@sendgrid/mail": "^8.1.6",
     "@sentry/browser": "^8.33.1",

--- a/apps/api/src/app/agents/services/managed-agent.service.ts
+++ b/apps/api/src/app/agents/services/managed-agent.service.ts
@@ -131,7 +131,7 @@ export class ManagedAgentService {
       ? [{ role: MessageRole.USER, content: context.message?.text ?? '' }]
       : await this.buildMessagesWithHistory(context);
 
-    const newSessionId = await provider.send({
+    const { sessionId: newSessionId } = await provider.send({
       messages,
       sessionId,
       vaultIds,
@@ -681,7 +681,7 @@ export class ManagedAgentService {
 
     return createWebhookHandler({
       secret,
-      onSessionEvents: (sessionId, metadata) => ({
+      onSessionEvents: (sessionId, _runId, metadata) => ({
         onPart: (part) => {
           this.handleWebhookEvent(sessionId, metadata, part).catch((err) => {
             this.logger.error(err, `Failed to handle webhook event for session ${sessionId}`);

--- a/enterprise/workers/thalamus-observer/package.json
+++ b/enterprise/workers/thalamus-observer/package.json
@@ -13,7 +13,7 @@
     "cf-typegen": "wrangler types"
   },
   "dependencies": {
-    "@novu/thalamus": "0.1.0-alpha.6",
+    "@novu/thalamus": "0.1.0-alpha.7",
     "agents": "^0.12.4",
     "eventsource-parser": "^3.0.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,8 +416,8 @@ importers:
         specifier: workspace:*
         version: link:../../libs/testing
       '@novu/thalamus':
-        specifier: 0.1.0-alpha.6
-        version: 0.1.0-alpha.6(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))
+        specifier: 0.1.0-alpha.7
+        version: 0.1.0-alpha.7(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))
       '@sendgrid/mail':
         specifier: ^8.1.6
         version: 8.1.6
@@ -8748,8 +8748,8 @@ packages:
     resolution: {integrity: sha512-5E8EKp30Ee06FQRpax204nyZOb1uv0kW72VfZXkU/4hG4CcqDsJbfrNnUjB6xIPSvIwAAlwv76MdIAsOflkLXg==}
     engines: {node: '>=18.0.0'}
 
-  '@novu/thalamus@0.1.0-alpha.6':
-    resolution: {integrity: sha512-0gSIFO0p+ck+6Tus7EnX1R3YccNCbNMOe7im1ElhPbKj1Q2C/xd1MTT+c5tWNRL/u/0bwWFiNcUofYIuWZxWrg==}
+  '@novu/thalamus@0.1.0-alpha.7':
+    resolution: {integrity: sha512-fLzeJ0BzIC5/TvxFSBmqSyLZqZhoZObhyIS9oH0cCedzmqsaJ+8S80DcBWBcSSsOu2Dt5O4D+zuswe86uoNnrQ==}
     peerDependencies:
       '@anthropic-ai/aws-sdk': '>=0.86.0'
       '@anthropic-ai/sdk': '>=0.86.0'
@@ -34349,7 +34349,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@novu/thalamus@0.1.0-alpha.6(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))':
+  '@novu/thalamus@0.1.0-alpha.7(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))':
     optionalDependencies:
       '@anthropic-ai/sdk': 0.95.1(zod@3.25.20)
       '@aws-crypto/sha256-js': 5.2.0


### PR DESCRIPTION
## Summary

- Bumps `@novu/thalamus` from `0.1.0-alpha.6` to `0.1.0-alpha.7` (apps/api + thalamus-observer worker)
- Adapts to the breaking `send()` return type change: webhook mode now returns `{ sessionId, runId }` instead of a plain `sessionId` string
- Updates the `onSessionEvents` webhook handler factory signature to accept the new `runId` parameter (`sessionId, runId, metadata`)

Coordinated with https://github.com/novuhq/thalamus/pull/4

## Test plan

- [ ] `pnpm build` passes for `apps/api`
- [ ] Existing managed-agent e2e tests pass (send + webhook flow)
- [ ] Observer worker typecheck (`enterprise/workers/thalamus-observer`) passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

`@novu/thalamus` was upgraded from 0.1.0-alpha.6 to 0.1.0-alpha.7 across the API service and worker packages, with corresponding code updates to adapt to a breaking change in the `send()` method's return type. The method now returns an object `{ sessionId, runId }` instead of a plain sessionId string, and the webhook handler callback signature was updated to accept the new runId parameter.

## Affected areas

- **api**: Updated `@novu/thalamus` dependency to 0.1.0-alpha.7; modified ManagedAgentService to destructure `{ sessionId, runId }` from provider.send() and updated the onSessionEvents webhook handler callback signature to accept the additional runId parameter.
- **worker** (enterprise): Updated `@novu/thalamus` dependency in thalamus-observer to 0.1.0-alpha.7 to maintain version consistency.

## Key technical decisions

- Breaking API change: `send()` now returns `{ sessionId, runId }` instead of a plain sessionId string, requiring destructuring at call sites.
- onSessionEvents webhook handler signature changed to `(sessionId, runId, metadata)` to accommodate the new runId parameter from the updated Thalamus API.

## Testing

- Existing managed-agent end-to-end tests validated send + webhook flow with the updated API.
- pnpm build verification for apps/api.
- Observer worker typecheck passed for enterprise/workers/thalamus-observer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->