### PR TITLE
refactor(api-service,dashboard): drop mcpServers from PATCH /agents/:id/runtime/config fixes NV-7735

### DIFF
--- a/apps/api/src/app/agents/agents.controller.ts
+++ b/apps/api/src/app/agents/agents.controller.ts
@@ -753,7 +753,7 @@ export class AgentsController {
       'Applies a partial update to the managed agent runtime config on the provider. ' +
       'Accepts any combination of model, systemPrompt, tools, and skills. ' +
       'MCP enablement is managed via the dedicated `POST /agents/:identifier/mcp-servers` and ' +
-      '`DELETE /agents/:identifier/mcp-servers/:mcpId` endpoints; passing `mcpServers` here is rejected with a 400. ' +
+      '`DELETE /agents/:identifier/mcp-servers/:mcpId` endpoints. ' +
       'Server-side diffing issues the minimal set of provider API calls. ' +
       'An empty body is accepted and returns the current config unchanged.',
   })
@@ -778,7 +778,6 @@ export class AgentsController {
         identifier,
         model: body.model,
         systemPrompt: body.systemPrompt,
-        mcpServers: body.mcpServers,
         tools: body.tools,
         skills: body.skills,
       })

--- a/apps/api/src/app/agents/dtos/agent-runtime-config.dto.ts
+++ b/apps/api/src/app/agents/dtos/agent-runtime-config.dto.ts
@@ -106,13 +106,6 @@ export class PatchAgentRuntimeConfigRequestDto {
   @IsString()
   systemPrompt?: string;
 
-  @ApiPropertyOptional({ type: [AgentMcpServerDto] })
-  @IsOptional()
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => AgentMcpServerDto)
-  mcpServers?: AgentMcpServerDto[];
-
   @ApiPropertyOptional({ type: [AgentToolDto] })
   @IsOptional()
   @IsArray()

--- a/apps/api/src/app/agents/e2e/agent-mcp-servers.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-mcp-servers.e2e.ts
@@ -322,19 +322,6 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
     });
   });
 
-  describe('PATCH /v1/agents/:identifier/runtime/config', () => {
-    it('rejects mcpServers in the body to enforce the dedicated endpoint flow', async () => {
-      const { identifier } = await createManagedAgent();
-
-      const res = await session.testAgent
-        .patch(`/v1/agents/${encodeURIComponent(identifier)}/runtime/config`)
-        .send({ mcpServers: [{ externalId: 'Slack', name: 'Slack', url: 'https://mcp.slack.com/mcp' }] });
-
-      expect(res.status).to.equal(400);
-      expect(res.body.message ?? res.body.error).to.match(/mcp-servers/i);
-    });
-  });
-
   /**
    * MCP-spec OAuth flow tests.
    *

--- a/apps/api/src/app/agents/e2e/managed-agent.e2e.ts
+++ b/apps/api/src/app/agents/e2e/managed-agent.e2e.ts
@@ -751,31 +751,6 @@ describe('Managed Agents API #novu-v2', () => {
       expect(res.headers['retry-after']).to.exist;
       expect(Number(res.headers['retry-after'])).to.equal(5);
     });
-
-    // ── MCP server updates rejected on PATCH ────────────────────────────────
-    // MCP enablement now goes through POST/DELETE /agents/:id/mcp-servers
-    // (Mongo-authoritative). The PATCH /runtime/config endpoint hard rejects
-    // any `mcpServers` field with 400 to avoid racing with the new flow's
-    // cascade-deletes of `mcp_connection` rows. The catalog-level enforcement
-    // (allow-list, url overwrite) is now tested against the new endpoint in
-    // `enable-agent-mcp-server.e2e.ts`.
-    describe('mcpServers field is no longer accepted', () => {
-      it('should reject any mcpServers update with 400 and not forward to the provider', async () => {
-        const integrationId = await createAgentRuntimeIntegration();
-        const identifier = `e2e-patch-mcp-rejected-${Date.now()}`;
-        createdAgentIdentifiers.push(identifier);
-
-        await session.testAgent.post('/v1/agents').send(managedBody(identifier, integrationId));
-
-        const res = await session.testAgent.patch(`/v1/agents/${encodeURIComponent(identifier)}/runtime/config`).send({
-          mcpServers: [{ externalId: 'linear', name: 'Linear', url: 'https://mcp.linear.app/mcp' }],
-        });
-
-        expect(res.status).to.equal(400);
-        expect(mockProvider.updateConfig.called, 'updateConfig must not be called when mcpServers is supplied').to.be
-          .false;
-      });
-    });
   });
 
   // ─── POST /v1/agents — adopt existing managed agent ─────────────────────────

--- a/apps/api/src/app/agents/usecases/update-agent-runtime-config/update-agent-runtime-config.command.ts
+++ b/apps/api/src/app/agents/usecases/update-agent-runtime-config/update-agent-runtime-config.command.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty, IsString } from 'class-validator';
 import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
-import type { AgentMcpServerDto, AgentSkillInputDto, AgentToolDto } from '../../dtos/agent-runtime-config.dto';
+import type { AgentSkillInputDto, AgentToolDto } from '../../dtos/agent-runtime-config.dto';
 
 export class UpdateAgentRuntimeConfigCommand extends EnvironmentWithUserCommand {
   @IsNotEmpty()
@@ -9,7 +9,6 @@ export class UpdateAgentRuntimeConfigCommand extends EnvironmentWithUserCommand 
 
   model?: string;
   systemPrompt?: string;
-  mcpServers?: AgentMcpServerDto[];
   tools?: AgentToolDto[];
   skills?: AgentSkillInputDto[];
 }

--- a/apps/api/src/app/agents/usecases/update-agent-runtime-config/update-agent-runtime-config.usecase.ts
+++ b/apps/api/src/app/agents/usecases/update-agent-runtime-config/update-agent-runtime-config.usecase.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { decryptCredentials, getAgentRuntimeProvider, PinoLogger } from '@novu/application-generic';
 import { AgentMcpServerRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
 import { AGENT_RUNTIME_PROVIDERS } from '@novu/shared';
@@ -18,18 +18,6 @@ export class UpdateAgentRuntimeConfig {
   }
 
   async execute(command: UpdateAgentRuntimeConfigCommand): Promise<AgentRuntimeConfigResponseDto> {
-    if (command.mcpServers !== undefined) {
-      // MCP enablement now goes through POST/DELETE /agents/:id/mcp-servers,
-      // which writes Mongo first and projects to the provider. Updating the
-      // MCP list via this legacy field would race with the new flow's
-      // cascade-deletes of `mcp_connection` rows. Hard reject to make the
-      // contract explicit.
-      throw new BadRequestException(
-        'Updating mcpServers via /runtime/config is no longer supported. ' +
-          'Use POST /agents/:identifier/mcp-servers and DELETE /agents/:identifier/mcp-servers/:mcpId instead.'
-      );
-    }
-
     const agent = await this.agentRepository.findOne(
       {
         identifier: command.identifier,

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -392,7 +392,6 @@ export type AgentRuntimeConfig = {
 export type PatchAgentRuntimeConfigBody = {
   model?: string;
   systemPrompt?: string;
-  mcpServers?: AgentMcpServer[];
   tools?: AgentTool[];
   skills?: AgentSkillInputDto[];
 };


### PR DESCRIPTION
## Summary

MCP enablement is fully handled by the dedicated `POST/DELETE /agents/:identifier/mcp-servers` endpoints since [NV-7733](https://linear.app/novu/issue/NV-7733) (PR #11200). The legacy `mcpServers` field on `PATCH /agents/:identifier/runtime/config` was only kept as a runtime `BadRequestException` guard at the usecase layer. Since this surface is still under active development and not yet released, drop the field from the contract end-to-end instead of carrying backward-compat code.

Linear: [NV-7735](https://linear.app/novu/issue/NV-7735/drop-mcpservers-field-from-patch-agentsidruntimeconfig-legacy-backward) (child of NV-7733)

## What changed

- **Usecase** ([apps/api/src/app/agents/usecases/update-agent-runtime-config/update-agent-runtime-config.usecase.ts](https://github.com/novuhq/novu/blob/cursor/nv-7735-drop-mcpservers-from-runtime-config/apps/api/src/app/agents/usecases/update-agent-runtime-config/update-agent-runtime-config.usecase.ts)) — removed the `BadRequestException` guard and the now-unused import.
- **Command** ([update-agent-runtime-config.command.ts](https://github.com/novuhq/novu/blob/cursor/nv-7735-drop-mcpservers-from-runtime-config/apps/api/src/app/agents/usecases/update-agent-runtime-config/update-agent-runtime-config.command.ts)) — dropped `mcpServers` field and the `AgentMcpServerDto` type-only import.
- **Request DTO** ([agent-runtime-config.dto.ts](https://github.com/novuhq/novu/blob/cursor/nv-7735-drop-mcpservers-from-runtime-config/apps/api/src/app/agents/dtos/agent-runtime-config.dto.ts)) — dropped `mcpServers` from `PatchAgentRuntimeConfigRequestDto`.
- **Controller** ([agents.controller.ts](https://github.com/novuhq/novu/blob/cursor/nv-7735-drop-mcpservers-from-runtime-config/apps/api/src/app/agents/agents.controller.ts)) — stopped forwarding `body.mcpServers`; cleaned up the `@ApiOperation` description (removed the "rejected with a 400" sentence).
- **Dashboard client** ([apps/dashboard/src/api/agents.ts](https://github.com/novuhq/novu/blob/cursor/nv-7735-drop-mcpservers-from-runtime-config/apps/dashboard/src/api/agents.ts)) — dropped `mcpServers` from `PatchAgentRuntimeConfigBody`. No dashboard caller sets it.
- **E2E** ([managed-agent.e2e.ts](https://github.com/novuhq/novu/blob/cursor/nv-7735-drop-mcpservers-from-runtime-config/apps/api/src/app/agents/e2e/managed-agent.e2e.ts), [agent-mcp-servers.e2e.ts](https://github.com/novuhq/novu/blob/cursor/nv-7735-drop-mcpservers-from-runtime-config/apps/api/src/app/agents/e2e/agent-mcp-servers.e2e.ts)) — removed the two 400-rejection tests. The new positive flow is already covered by `enable-agent-mcp-server.e2e.ts` / `disable-agent-mcp-server.e2e.ts`.

## Caller audit (verified safe)

| Location | Status |
|---|---|
| `apps/dashboard/src/components/agents/tools-section.tsx` (only PATCH caller) | sends `{ tools }` only |
| `apps/dashboard/src/components/agents/mcps-section.tsx` / `mcps-sheet.tsx` | use the dedicated MCP endpoints |
| `playground/nextjs/src/app/agents-mcp/lib/mcp-api.ts` | uses the dedicated MCP endpoints |
| `packages/js`, `packages/react`, `packages/shared`, `enterprise/`, `apps/worker/` | no callers |
| `libs/internal-sdk` | auto-generated; picks up DTO removal on next regen |

## Intentionally not touched

- `libs/application-generic/.../i-agent-runtime-provider.ts` — `UpdateAgentRuntimeConfigInput.mcpServers` stays. It is the provider-layer projection input used by `SyncAgentMcpServers` (the new POST/DELETE flow), not the HTTP DTO.
- `AgentMcpServerDto` class — kept; still referenced by `AgentRuntimeConfigResponseDto` (GET response) and the create-agent `managedRuntime.mcpServers` provisioning path.

## Flow

```mermaid
flowchart LR
  subgraph BeforeChange[Before]
    A1["PATCH runtime/config<br/>body.mcpServers"] --> B1[UpdateAgentRuntimeConfig]
    B1 --> C1["throw BadRequestException 400"]
  end
  subgraph AfterChange[After]
    A2["PATCH runtime/config<br/>{ model, systemPrompt, tools, skills }"] --> B2[UpdateAgentRuntimeConfig]
    D2["POST mcp-servers"] --> E2[EnableAgentMcpServer]
    F2["DELETE mcp-servers/:mcpId"] --> G2[DisableAgentMcpServer]
    E2 --> H2[SyncAgentMcpServers]
    G2 --> H2
    H2 --> I2["provider.updateConfig({ mcpServers })"]
  end
```

## Test plan

- [x] Scoped biome check on the 7 touched files passes (exit 0; only pre-existing warnings).
- [x] TypeScript: no new errors introduced on touched files (pre-existing env-flag readonly issues unrelated).
- [x] `pnpm --filter @novu/api-service run check:api-property-optionality` reports nothing against `agent-runtime-config.dto.ts`.
- [ ] CI: run the two affected e2e suites
  - `apps/api/src/app/agents/e2e/managed-agent.e2e.ts`
  - `apps/api/src/app/agents/e2e/agent-mcp-servers.e2e.ts`
- [ ] CI: `npm run lint:openapi` (API running) validates the updated `@ApiOperation` description.

## Breaking changes

None for released surface. The `mcpServers` field on `PATCH /agents/:identifier/runtime/config` was rejected at runtime with 400 in the current `next`; this PR removes it from the schema entirely. Internal SDK regen will follow.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Removed the legacy mcpServers field from the PATCH /agents/:identifier/runtime/config endpoint and all related request types and callers; MCP enablement is managed only via POST/DELETE /agents/:identifier/mcp-servers. This cleans up the API contract and internal DTO/command plumbing because the field was already rejected at runtime and is now handled by explicit MCP endpoints.

## Affected areas

**api**: Dropped mcpServers from PatchAgentRuntimeConfigRequestDto, UpdateAgentRuntimeConfigCommand, and the controller patch handler; removed the usecase guard that threw BadRequest for mcpServers; removed two e2e tests that asserted 400 rejection.  
**dashboard**: Removed mcpServers from the PatchAgentRuntimeConfigBody type so dashboard clients no longer send the field.  
**tests (e2e)**: Deleted tests asserting PATCH rejects mcpServers; positive MCP enable/disable flows remain covered by dedicated e2e suites.

## Key technical decisions

- Preserved provider-layer types (UpdateAgentRuntimeConfigInput.mcpServers and AgentMcpServerDto) needed by SyncAgentMcpServers, GET responses, and agent provisioning flows.  
- No breaking changes to released surfaces—behavior is unchanged for clients because the field was previously rejected at runtime.  
- Internal SDK regeneration is planned to reflect the removed schema field.

## Testing

Removed two negative e2e tests asserting 400 rejection; positive MCP enable/disable e2e suites still provide coverage. Scoped biome and TypeScript checks passed for touched files; two e2e suites and lint:openapi remain to run in CI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->