### PR TITLE
fix(api-service): use DASHBOARD_URL for MCP OAuth post-callback redirect fixes NV-7736

### DIFF
--- a/apps/api/src/app/agents/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/agents-mcp-oauth.controller.ts
@@ -74,7 +74,7 @@ export class AgentsMcpOAuthController {
 }
 
 function buildPostCallbackRedirect(status: 'connected' | 'error', message?: string): string | undefined {
-  const base = process.env.FRONT_BASE_URL?.replace(/\/$/, '');
+  const base = process.env.DASHBOARD_URL?.replace(/\/$/, '');
   if (!base) return undefined;
 
   const params = new URLSearchParams({ status });


### PR DESCRIPTION
## Summary
- Switch MCP OAuth post-callback redirect from `FRONT_BASE_URL` to `DASHBOARD_URL`
- Aligns with other dashboard link patterns in the API service (invites, password reset, agent inbound handler, etc.)

## Test plan
- [ ] Complete an MCP OAuth flow in Novu-managed mode with `DASHBOARD_URL` configured
- [ ] Verify successful callback redirects to `/agents/mcp/oauth/result?status=connected`
- [ ] Verify failed callback redirects to `/agents/mcp/oauth/result?status=error&reason=...`
- [ ] Verify fallback HTML page still renders when `DASHBOARD_URL` is unset


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The MCP OAuth post-callback redirect now uses the `DASHBOARD_URL` environment variable instead of `FRONT_BASE_URL` to determine the target URL after OAuth completion. Users are redirected to `/agents/mcp/oauth/result?status=connected` or `/agents/mcp/oauth/result?status=error&reason=...` based on the callback result. If `DASHBOARD_URL` is unset, the controller falls back to rendering a simple HTML page that closes the window.

## Affected areas
**api**: Modified the MCP OAuth callback controller to use `DASHBOARD_URL` (with trailing slash trimming) as the base URL for post-OAuth redirects, aligning with how other dashboard links (invites, password reset, agent inbound handler) are configured in the API service.

## Key technical decisions
- The change maintains backward compatibility by preserving fallback HTML rendering when `DASHBOARD_URL` is not configured, ensuring the OAuth flow remains functional across different deployment modes.

## Testing
Manual verification needed to confirm OAuth callback redirects correctly to the dashboard when `DASHBOARD_URL` is configured, with proper query parameters for success (`status=connected`) and failure (`status=error&reason=...`) cases. The fallback HTML page should also be verified when `DASHBOARD_URL` is unset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->