### PR TITLE
fix(dashboard): agent setup numbers fixes NV-7734

### DIFF
--- a/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
+++ b/apps/dashboard/src/components/agents/agent-code-setup-section.tsx
@@ -280,6 +280,13 @@ function BridgeConnectionStatus({ connected, onAddProvider }: { connected: boole
 type AgentCodeSetupSectionProps = {
   agent: AgentResponse;
   stepOffset: number;
+  /**
+   * Total number of steps across every visible section in the current context.
+   * Used to render the "X/Y SETUP AGENT HANDLER" section label so the count
+   * matches what the user actually sees (onboarding vs agent details, managed
+   * vs self-hosted).
+   */
+  totalSteps: number;
   providerId?: string;
   onBridgeConnected?: () => void;
   onAddProvider?: () => void;
@@ -288,6 +295,7 @@ type AgentCodeSetupSectionProps = {
 export function AgentCodeSetupSection({
   agent,
   stepOffset,
+  totalSteps,
   providerId,
   onBridgeConnected,
   onAddProvider,
@@ -310,7 +318,7 @@ export function AgentCodeSetupSection({
       <SetupStep
         index={stepOffset}
         status={deriveStepStatus(stepOffset, firstIncompleteStep)}
-        sectionLabel="2/2 SETUP AGENT HANDLER"
+        sectionLabel={`${stepOffset}/${totalSteps} SETUP AGENT HANDLER`}
         title={
           <span className="inline-flex items-center gap-1">
             Scaffold your agent project

--- a/apps/dashboard/src/components/agents/agent-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-steps.tsx
@@ -50,13 +50,13 @@ function resolveProviderSetupGuide(providerId: string) {
 
 const SESSION_KEY = (agentIdentifier: string) => `agent-setup-integration:${agentIdentifier}`;
 
-// Channel-selection step is step 3 — continues from the connect phase (steps 1-2).
-// Email is intentionally not part of the onboarding flow yet, so we go straight from 2 -> 3.
-const CHANNEL_STEP_INDEX = 3;
-const PROVIDER_GUIDE_STEP_OFFSET = CHANNEL_STEP_INDEX + 1;
+// Brain section steps (connector + template/prompt) live in `connect-agent-form` and only
+// appear in the onboarding flow above this component.
+const BRAIN_STEPS = 2;
 // Provider guides reserve up to three numbered steps; the bridge section continues from there.
 const PROVIDER_GUIDE_RESERVED_STEPS = 3;
-const BRIDGE_STEP_OFFSET = PROVIDER_GUIDE_STEP_OFFSET + PROVIDER_GUIDE_RESERVED_STEPS;
+// Self-hosted agents add three handler steps (scaffold + run + send) below the provider guide.
+const HANDLER_STEPS = 3;
 
 type AgentSetupStepsProps = {
   agent: AgentResponse;
@@ -235,15 +235,26 @@ export function AgentSetupSteps({ agent, onSetupComplete, hideAddProvider, conne
     [agentIntegrationsQuery.data?.data]
   );
 
-  const firstIncompleteStep = hasProviderSelected ? PROVIDER_GUIDE_STEP_OFFSET : CHANNEL_STEP_INDEX;
+  // Managed agents have no bridge — the setup is considered complete as soon as the chosen
+  // provider integration becomes connected. Fire onSetupComplete exactly once.
+  const isManagedRuntime = agent.runtime === 'managed';
+
+  // The brain section (connector + template) only renders in the onboarding flow above this
+  // component. On the agent details page there is no brain section, so step numbering must
+  // start at 1 here instead of continuing from 3.
+  const isOnboarding = Boolean(connectSummary);
+  const brainStepsBefore = isOnboarding ? BRAIN_STEPS : 0;
+  const handlerStepsAfter = isManagedRuntime ? 0 : HANDLER_STEPS;
+  const channelStepIndex = brainStepsBefore + 1;
+  const providerGuideStepOffset = channelStepIndex + 1;
+  const bridgeStepOffset = providerGuideStepOffset + PROVIDER_GUIDE_RESERVED_STEPS;
+  const totalSteps = brainStepsBefore + 1 + PROVIDER_GUIDE_RESERVED_STEPS + handlerStepsAfter;
+
+  const firstIncompleteStep = hasProviderSelected ? providerGuideStepOffset : channelStepIndex;
 
   const ProviderGuide = selectedProviderId ? resolveProviderSetupGuide(selectedProviderId) : null;
 
   const integrationIdentifier = selectedIntegration?.identifier ?? defaultFromAgent?.identifier;
-
-  // Managed agents have no bridge — the setup is considered complete as soon as the chosen
-  // provider integration becomes connected. Fire onSetupComplete exactly once.
-  const isManagedRuntime = agent.runtime === 'managed';
   const onSetupCompleteRef = useRef(onSetupComplete);
   onSetupCompleteRef.current = onSetupComplete;
   const setupCompleteFiredRef = useRef(false);
@@ -335,9 +346,9 @@ export function AgentSetupSteps({ agent, onSetupComplete, hideAddProvider, conne
       )}
 
       <SetupStep
-        index={CHANNEL_STEP_INDEX}
-        status={deriveStepStatus(CHANNEL_STEP_INDEX, firstIncompleteStep)}
-        sectionLabel="3/7 SETUP WHERE TO LISTEN"
+        index={channelStepIndex}
+        status={deriveStepStatus(channelStepIndex, firstIncompleteStep)}
+        sectionLabel={`${channelStepIndex}/${totalSteps} SETUP WHERE TO LISTEN`}
         title="Choose where your agent listens and communicates"
         description="Start with one provider your agent can receive and respond on and you can always add more providers as you need."
         fullWidthContent={
@@ -375,7 +386,7 @@ export function AgentSetupSteps({ agent, onSetupComplete, hideAddProvider, conne
             <ProviderGuide
               agent={agent}
               integrationId={effectiveIntegrationId}
-              stepOffset={PROVIDER_GUIDE_STEP_OFFSET}
+              stepOffset={providerGuideStepOffset}
               embedded={false}
               onStepsCompleted={handleProviderStepsCompleted}
             />
@@ -386,7 +397,8 @@ export function AgentSetupSteps({ agent, onSetupComplete, hideAddProvider, conne
       {hasConnectedIntegration && !isManagedRuntime && (
         <AgentCodeSetupSection
           agent={agent}
-          stepOffset={BRIDGE_STEP_OFFSET}
+          stepOffset={bridgeStepOffset}
+          totalSteps={totalSteps}
           providerId={selectedProviderId}
           onBridgeConnected={handleBridgeConnected}
           onAddProvider={hideAddProvider ? undefined : handleAddProvider}

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
@@ -249,6 +249,10 @@ export function ConnectAgentForm({
   const isScratchRuntime = Boolean(aiGeneration?.isScratchRuntime);
   const aiMode = aiGeneration?.mode ?? 'prompt';
   const scope: AgentScope = aiMode === 'existing' ? 'existing' : 'create';
+  // Total steps across the full onboarding flow:
+  //   brain (2) + channel (1) + provider guide (3 reserved) + handler (0 for managed, 3 for self-hosted)
+  // Managed-runtime connectors don't render the agent-handler section, so the total is 6 there.
+  const totalOnboardingSteps = isClaudeSelected ? 6 : 9;
   // The prompt/manual sub-toggle in the right-column header only exists in `'create'` scope.
   // In `'existing'` scope the segmented tabs above replace it, so we omit it entirely.
   const header = aiMode === 'existing' ? null : RIGHT_HEADER_BY_MODE[aiMode];
@@ -267,7 +271,7 @@ export function ConnectAgentForm({
       <SetupStep
         index={1}
         status="completed"
-        sectionLabel="1/7 SETUP AGENT BRAIN"
+        sectionLabel={`1/${totalOnboardingSteps} SETUP AGENT BRAIN`}
         title="Where do you want your agent?"
         description="The agent is hosted in the selected connector and Novu manages the communication across channels."
         rightContent={


### PR DESCRIPTION
### What changed? Why was the change needed?

Agents - fixed the issue with incorrect setup step numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Agent setup step numbers are now computed dynamically instead of being hardcoded. The system calculates total steps based on context (onboarding flow vs. agent details page) and agent runtime type (Claude managed vs. custom). This fixes display of incorrect step counts in the agent setup UI, ensuring users see accurate progress indicators like "1/6 SETUP AGENT BRAIN" for Claude and "1/9" for custom scaffolds.

## Affected areas

**dashboard**: Agent setup components now calculate step counts dynamically. `ConnectAgentForm` computes total onboarding steps based on whether Claude is selected (6 steps) versus other connectors (9 steps). `AgentSetupSteps` derives brain steps, provider-guide steps, and handler steps from explicit constants, then passes computed `stepOffset` values to child components. `AgentCodeSetupSection` accepts a new `totalSteps` prop to render dynamic section labels instead of fixed values.

## Key technical decisions

- Step calculation considers both onboarding context (presence of `connectSummary`) and agent runtime type (managed vs. custom).
- Introduced explicit constants for brain steps, provider-guide reserved steps, and handler steps to make the calculation logic transparent and maintainable.

## Testing

No automated tests were added. Manual verification through the UI should confirm correct step numbering displays in both onboarding flows and agent details pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<img width="1537" height="1006" alt="Screenshot 2026-05-22 at 16 46 26" src="https://github.com/user-attachments/assets/b149689d-c0f7-4b34-9980-a893a14ef66e" />

<img width="1537" height="1002" alt="Screenshot 2026-05-22 at 16 46 18" src="https://github.com/user-attachments/assets/b500e22b-4ad4-403b-9e4a-fd105f736605" />

<img width="1532" height="1001" alt="Screenshot 2026-05-22 at 16 46 11" src="https://github.com/user-attachments/assets/9c748a0b-9deb-426f-b9c9-0156e444c470" />
