### PR TITLE
feat(api-service,dashboard): tool progress plan cards and activity timeline fixes NV-7741

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -73,7 +73,7 @@
     "@novu/notifications": "workspace:*",
     "@novu/shared": "workspace:*",
     "@novu/stateless": "workspace:*",
-    "@novu/thalamus": "0.1.0-alpha.7",
+    "@novu/thalamus": "0.1.0-alpha.8",
     "@novu/testing": "workspace:*",
     "@sendgrid/mail": "^8.1.6",
     "@sentry/browser": "^8.33.1",

--- a/apps/api/src/app/agents/agents-webhook.controller.ts
+++ b/apps/api/src/app/agents/agents-webhook.controller.ts
@@ -12,6 +12,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
+import { PinoLogger } from '@novu/application-generic';
 import type { Signal } from '@novu/framework';
 import { UserSessionData } from '@novu/shared';
 import { Request, Response } from 'express';
@@ -26,7 +27,6 @@ import { ChatSdkService } from './services/chat-sdk.service';
 import { ManagedAgentService } from './services/managed-agent.service';
 import { HandleAgentReplyCommand } from './usecases/handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from './usecases/handle-agent-reply/handle-agent-reply.usecase';
-import { sendWebResponse, toWebRequest } from './utils/express-to-web-request';
 
 @Controller('/agents')
 @UseGuards(AgentConversationEnabledGuard)
@@ -35,21 +35,15 @@ export class AgentsWebhookController {
   constructor(
     private chatSdkService: ChatSdkService,
     private handleAgentReplyUsecase: HandleAgentReply,
-    private managedAgentService: ManagedAgentService
-  ) {}
+    private managedAgentService: ManagedAgentService,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   @Post('/events')
   async handleThalamusEvent(@Req() req: Request, @Res() res: Response) {
-    const handler = this.managedAgentService.getWebhookHandler();
-    if (!handler) {
-      res.status(503).json({ error: 'Webhook handler not configured' });
-
-      return;
-    }
-
-    const webRequest = toWebRequest(req);
-    const webResponse = await handler.handle(webRequest);
-    await sendWebResponse(webResponse, res);
+    await this.managedAgentService.handleWebhook(req, res);
   }
 
   @Post('/:agentId/reply')

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, type OnModuleInit } from '@nestjs/common';
 import { AnalyticsService, PinoLogger } from '@novu/application-generic';
 import {
   AgentRepository,
@@ -22,6 +22,7 @@ import { ResolvedAgentConfig } from './agent-config-resolver.service';
 import { AgentConversationService, getInboundActivityPreview } from './agent-conversation.service';
 import { AgentSubscriberResolver } from './agent-subscriber-resolver.service';
 import { BridgeExecutorService, type BridgeReaction, NoBridgeUrlError } from './bridge-executor.service';
+import { ChatSdkService } from './chat-sdk.service';
 import { ManagedAgentService } from './managed-agent.service';
 import { TelegramStartCodeService } from './telegram-start-code.service';
 
@@ -218,13 +219,14 @@ export interface InboundReactionEvent {
 }
 
 @Injectable()
-export class AgentInboundHandler {
+export class AgentInboundHandler implements OnModuleInit {
   constructor(
     private readonly logger: PinoLogger,
     private readonly subscriberResolver: AgentSubscriberResolver,
     private readonly conversationService: AgentConversationService,
     private readonly bridgeExecutor: BridgeExecutorService,
     private readonly managedAgentService: ManagedAgentService,
+    private readonly chatSdkService: ChatSdkService,
     private readonly agentRepository: AgentRepository,
     private readonly subscriberRepository: SubscriberRepository,
     private readonly environmentRepository: EnvironmentRepository,
@@ -235,6 +237,15 @@ export class AgentInboundHandler {
     private readonly linkTelegramChatToSubscriber: LinkTelegramChatToSubscriber
   ) {
     this.logger.setContext(this.constructor.name);
+  }
+
+  onModuleInit() {
+    this.chatSdkService.registerInboundCallbacks({
+      onMessage: (agentId, config, thread, message) =>
+        this.handle(agentId, config, thread, message, AgentEventEnum.ON_MESSAGE),
+      onAction: (agentId, config, thread, action, userId) => this.handleAction(agentId, config, thread, action, userId),
+      onReaction: (agentId, config, event) => this.handleReaction(agentId, config, event),
+    });
   }
 
   async handle(

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -17,19 +17,30 @@ import {
   SsrfBlockedError,
 } from '@novu/application-generic';
 import { IntegrationEntity, IntegrationRepository, MessageRepository } from '@novu/dal';
-import type { SentMessageInfo } from '@novu/framework';
+import type { AgentAction, SentMessageInfo } from '@novu/framework';
 import { ChannelTypeEnum, EmailProviderIdEnum, type IEmailOptions } from '@novu/shared';
-import type { AdapterPostableMessage, Chat, EmojiValue, Message, ReactionEvent, Thread } from 'chat';
+import type { AdapterPostableMessage, Chat, EmojiValue, Message, PlanModel, ReactionEvent, Thread } from 'chat';
 import { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import { LRUCache } from 'lru-cache';
-import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
 import type { FileRef, ReplyContentDto } from '../dtos/agent-reply-payload.dto';
 import { esmImport } from '../utils/esm-import';
 import { sendWebResponse, toWebRequest } from '../utils/express-to-web-request';
 import { AgentConfigResolver, AgentConfigResolveSource, ResolvedAgentConfig } from './agent-config-resolver.service';
 import { AgentEmailActionClaims, AgentEmailActionTokenService } from './agent-email-action-token.service';
-import { AgentInboundHandler } from './agent-inbound-handler.service';
+import type { InboundReactionEvent } from './agent-inbound-handler.service';
+
+export interface InboundCallbacks {
+  onMessage: (agentId: string, config: ResolvedAgentConfig, thread: Thread, message: Message) => Promise<void>;
+  onAction: (
+    agentId: string,
+    config: ResolvedAgentConfig,
+    thread: Thread,
+    action: AgentAction,
+    userId: string
+  ) => Promise<void>;
+  onReaction: (agentId: string, config: ResolvedAgentConfig, event: InboundReactionEvent) => Promise<void>;
+}
 
 function getErrorResponseBody(err: unknown): unknown {
   if (!err || typeof err !== 'object') {
@@ -183,12 +194,12 @@ type PinnedFileResponse = {
 export class ChatSdkService implements OnModuleDestroy {
   private readonly instances: LRUCache<string, CachedChat>;
   private readonly pendingCreations = new Map<string, Promise<Chat>>();
+  private inboundCallbacks: InboundCallbacks | null = null;
 
   constructor(
     private readonly logger: PinoLogger,
     private readonly cacheService: CacheService,
     private readonly agentConfigResolver: AgentConfigResolver,
-    private readonly inboundHandler: AgentInboundHandler,
     private readonly integrationRepository: IntegrationRepository,
     private readonly actionTokenService: AgentEmailActionTokenService,
     private readonly calculateLimitNovuIntegration: CalculateLimitNovuIntegration,
@@ -305,6 +316,10 @@ export class ChatSdkService implements OnModuleDestroy {
     this.instances.clear();
   }
 
+  registerInboundCallbacks(callbacks: InboundCallbacks): void {
+    this.inboundCallbacks = callbacks;
+  }
+
   async postToConversation(
     agentId: string,
     integrationIdentifier: string,
@@ -390,6 +405,47 @@ export class ChatSdkService implements OnModuleDestroy {
     const edited = await editPromise.catch(toDeliveryError);
 
     return { messageId: edited.id, platformThreadId: edited.threadId };
+  }
+
+  async postPlanObject(
+    agentId: string,
+    integrationIdentifier: string,
+    platform: string,
+    platformThreadId: string,
+    model: PlanModel
+  ): Promise<SentMessageInfo | null> {
+    const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
+    const instanceKey = `${agentId}:${integrationIdentifier}`;
+    const chat = await this.getOrCreate(instanceKey, agentId, config.platform, config);
+
+    const adapter = chat.getAdapter(platform);
+    if (typeof adapter.postObject !== 'function') {
+      return null;
+    }
+
+    const sent = await adapter.postObject(platformThreadId, 'plan', model).catch(toDeliveryError);
+
+    return { messageId: sent.id, platformThreadId: sent.threadId };
+  }
+
+  async editPlanObject(
+    agentId: string,
+    integrationIdentifier: string,
+    platform: string,
+    platformThreadId: string,
+    platformMessageId: string,
+    model: PlanModel
+  ): Promise<void> {
+    const config = await this.agentConfigResolver.resolve(agentId, integrationIdentifier);
+    const instanceKey = `${agentId}:${integrationIdentifier}`;
+    const chat = await this.getOrCreate(instanceKey, agentId, config.platform, config);
+
+    const adapter = chat.getAdapter(platform);
+    if (typeof adapter.editObject !== 'function') {
+      return;
+    }
+
+    await adapter.editObject(platformThreadId, platformMessageId, 'plan', model).catch(toDeliveryError);
   }
 
   private async prepareContentForDelivery(
@@ -1366,10 +1422,18 @@ export class ChatSdkService implements OnModuleDestroy {
   }
 
   private registerEventHandlers(agentId: string, cached: CachedChat) {
+    if (!this.inboundCallbacks) {
+      this.logger.warn(`[agent:${agentId}] No inbound callbacks registered, skipping event handler setup`);
+
+      return;
+    }
+
+    const callbacks = this.inboundCallbacks;
+
     cached.chat.onNewMention(async (thread: Thread, message: Message) => {
       try {
         await thread.subscribe();
-        await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
+        await callbacks.onMessage(agentId, cached.config, thread, message);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling new mention`);
       }
@@ -1377,7 +1441,7 @@ export class ChatSdkService implements OnModuleDestroy {
 
     cached.chat.onSubscribedMessage(async (thread: Thread, message: Message) => {
       try {
-        await this.inboundHandler.handle(agentId, cached.config, thread, message, AgentEventEnum.ON_MESSAGE);
+        await callbacks.onMessage(agentId, cached.config, thread, message);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling subscribed message`);
       }
@@ -1391,7 +1455,7 @@ export class ChatSdkService implements OnModuleDestroy {
           return;
         }
 
-        await this.inboundHandler.handleAction(
+        await callbacks.onAction(
           agentId,
           cached.config,
           event.thread as Thread,
@@ -1409,7 +1473,7 @@ export class ChatSdkService implements OnModuleDestroy {
 
     cached.chat.onReaction(async (event: ReactionEvent) => {
       try {
-        await this.inboundHandler.handleReaction(agentId, cached.config, {
+        await callbacks.onReaction(agentId, cached.config, {
           emoji: event.emoji,
           added: event.added,
           messageId: event.messageId,

--- a/apps/api/src/app/agents/services/managed-agent.service.ts
+++ b/apps/api/src/app/agents/services/managed-agent.service.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { Injectable, type OnModuleInit } from '@nestjs/common';
 import type { PendingToolApproval } from '@novu/application-generic';
 import {
   decryptCredentials,
@@ -11,6 +11,7 @@ import {
   AgentRepository,
   ConversationActivityRepository,
   ConversationActivitySenderTypeEnum,
+  ConversationActivityTypeEnum,
   ConversationParticipantTypeEnum,
   ConversationRepository,
   IntegrationRepository,
@@ -23,17 +24,19 @@ import {
   type Message,
   MessageRole,
   SessionExpiredError,
-  type StreamPart,
   type Response as ThalamusResponse,
   thalamus,
   type WebhookProvider,
 } from '@novu/thalamus';
 import { createWebhookHandler, type WebhookHandler } from '@novu/thalamus/webhook';
+import type { Request, Response } from 'express';
 import { LRUCache } from 'lru-cache';
 import { GenerateMcpOAuthUrlCommand } from '../usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.command';
 import { GenerateMcpOAuthUrl } from '../usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase';
 import { HandleAgentReplyCommand } from '../usecases/handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from '../usecases/handle-agent-reply/handle-agent-reply.usecase';
+import { HandleToolProgressCommand } from '../usecases/handle-tool-progress/handle-tool-progress.command';
+import { HandleToolProgress } from '../usecases/handle-tool-progress/handle-tool-progress.usecase';
 import type { AgentExecutionParams } from './bridge-executor.service';
 
 /**
@@ -101,17 +104,17 @@ const TOOL_APPROVAL_ACTION_PREFIX = 'mcp-approval' as const;
 const PARKED_SESSION_ERROR_PATTERN = /waiting on responses to events/i;
 
 @Injectable()
-export class ManagedAgentService {
+export class ManagedAgentService implements OnModuleInit {
   private readonly providers: LRUCache<string, CachedRuntime>;
-  private readonly webhookHandler: WebhookHandler | undefined;
+  private webhookHandler: WebhookHandler | undefined;
 
   constructor(
     private readonly agentRepository: AgentRepository,
     private readonly integrationRepository: IntegrationRepository,
     private readonly conversationRepository: ConversationRepository,
     private readonly conversationActivityRepository: ConversationActivityRepository,
-    @Inject(forwardRef(() => HandleAgentReply))
     private readonly handleAgentReply: HandleAgentReply,
+    private readonly handleToolProgress: HandleToolProgress,
     private readonly generateMcpOAuthUrl: GenerateMcpOAuthUrl,
     private readonly logger: PinoLogger
   ) {
@@ -120,6 +123,9 @@ export class ManagedAgentService {
       max: MAX_CACHED_PROVIDERS,
       ttl: PROVIDER_TTL_MS,
     });
+  }
+
+  onModuleInit() {
     this.webhookHandler = this.initWebhookHandler();
   }
 
@@ -152,66 +158,52 @@ export class ManagedAgentService {
     );
   }
 
-  getWebhookHandler(): WebhookHandler | undefined {
-    return this.webhookHandler;
-  }
-
-  async handleWebhookEvent(sessionId: string, metadata: Record<string, string>, event: StreamPart): Promise<void> {
-    if (!metadata.conversationId || !metadata.environmentId || !metadata.organizationId) {
-      this.logger.error(`Webhook event missing required metadata: session=${sessionId}`);
+  async handleWebhook(req: Request, res: Response): Promise<void> {
+    if (!this.webhookHandler) {
+      res.status(503).json({ error: 'Webhook handler not configured' });
 
       return;
     }
 
-    switch (event.type) {
-      case 'finish': {
-        // `requires-action` means the session is parked on Anthropic's side
-        // waiting for a `user.tool_confirmation`. Posting `event.response.content`
-        // here would push an empty string to the chat platform (Slack 502 /
-        // `no_text`) AND leave the user with no surface to approve. Render
-        // an Approve/Deny card from the pending tool details and short-circuit
-        // the normal reply path — `confirmToolApproval` resumes the session.
-        if (event.response.finishReason === 'requires-action') {
-          const runtimeProvider = await this.tryGetRuntimeProvider(metadata);
-          if (runtimeProvider) {
-            const delivered = await this.tryDeliverToolApprovalCard(
-              metadata,
-              sessionId,
-              runtimeProvider,
-              extractPendingToolApproval(event.response)
-            );
+    const rawBody = (req as Request & { rawBody?: Buffer }).rawBody?.toString('utf-8') ?? JSON.stringify(req.body);
+    const signature = req.headers['x-thalamus-signature'] as string | undefined;
 
-            if (delivered) {
-              return;
-            }
-          }
-        }
+    const result = await this.webhookHandler.handleRaw(rawBody, signature ?? null);
 
-        await this.handleAgentReply.execute(
-          HandleAgentReplyCommand.create({
-            userId: 'system',
-            environmentId: metadata.environmentId,
-            organizationId: metadata.organizationId,
-            conversationId: metadata.conversationId,
-            agentIdentifier: metadata.agentIdentifier ?? '',
-            integrationIdentifier: metadata.integrationIdentifier ?? '',
-            reply: { markdown: event.response.content },
-          })
-        );
-        break;
-      }
-
-      case 'error': {
-        await this.handleErrorEvent(metadata, sessionId, event.error);
-        break;
-      }
-
-      default:
-        break;
+    res.status(result.status);
+    if (result.body) {
+      res.setHeader('Content-Type', 'application/json');
+      res.send(result.body);
+    } else {
+      res.end();
     }
   }
 
-  private async handleErrorEvent(metadata: Record<string, string>, sessionId: string, error: Error): Promise<void> {
+  private buildBaseFields(metadata: Record<string, string>) {
+    return {
+      userId: 'system',
+      environmentId: metadata.environmentId,
+      organizationId: metadata.organizationId,
+      conversationId: metadata.conversationId,
+      agentIdentifier: metadata.agentIdentifier ?? '',
+      integrationIdentifier: metadata.integrationIdentifier ?? '',
+    };
+  }
+
+  private async handleErrorEvent(
+    metadata: Record<string, string>,
+    sessionId: string,
+    error: Error,
+    baseCommand: {
+      userId: string;
+      environmentId: string;
+      organizationId: string;
+      conversationId: string;
+      agentIdentifier: string;
+      integrationIdentifier: string;
+    },
+    runId: string
+  ): Promise<void> {
     if (error instanceof SessionExpiredError) {
       this.logger.warn(`Session ${sessionId} expired, clearing for next message`);
       await this.conversationRepository.clearExternalSessionId(metadata.environmentId, metadata.conversationId);
@@ -256,15 +248,10 @@ export class ManagedAgentService {
 
     try {
       await this.handleAgentReply.execute(
-        HandleAgentReplyCommand.create({
-          userId: 'system',
-          organizationId: metadata.organizationId,
-          environmentId: metadata.environmentId,
-          conversationId: metadata.conversationId,
-          agentIdentifier: metadata.agentIdentifier ?? '',
-          integrationIdentifier: metadata.integrationIdentifier ?? '',
-          reply: { markdown: message },
-        })
+        HandleAgentReplyCommand.create({ ...baseCommand, reply: { markdown: message } })
+      );
+      await this.handleToolProgress.execute(
+        HandleToolProgressCommand.create({ ...baseCommand, toolProgress: { runId, action: 'fail' } })
       );
     } catch (err) {
       this.logger.error(err, `Failed to deliver error message for session ${sessionId}`);
@@ -557,7 +544,7 @@ export class ManagedAgentService {
       messages: [],
       sessionId,
       vaultIds,
-      toolResults: [{ toolUseId: params.toolUseId, approved: params.approved }],
+      toolResults: [{ toolUseId: params.toolUseId, approved: params.approved, content: [] }],
       webhookMetadata: this.buildWebhookMetadata({
         conversationId: params.conversationId,
         environmentId: params.environmentId,
@@ -681,13 +668,121 @@ export class ManagedAgentService {
 
     return createWebhookHandler({
       secret,
-      onSessionEvents: (sessionId, _runId, metadata) => ({
-        onPart: (part) => {
-          this.handleWebhookEvent(sessionId, metadata, part).catch((err) => {
-            this.logger.error(err, `Failed to handle webhook event for session ${sessionId}`);
-          });
-        },
-      }),
+      onSessionEvents: (sessionId, runId, metadata) => {
+        if (!metadata.conversationId || !metadata.environmentId || !metadata.organizationId) {
+          this.logger.error(`Webhook event missing required metadata: session=${sessionId}`);
+
+          return {};
+        }
+
+        const baseFields = this.buildBaseFields(metadata);
+
+        return {
+          onToolUseStart: async (event) => {
+            try {
+              await this.handleToolProgress.execute(
+                HandleToolProgressCommand.create({
+                  ...baseFields,
+                  toolProgress: {
+                    runId,
+                    action: 'tool-use',
+                    toolUseId: event.toolUseId,
+                    toolName: event.toolName,
+                    status: 'running',
+                  },
+                })
+              );
+            } catch (err) {
+              this.logger.error(err, `onToolUseStart failed: session=${sessionId}`);
+            }
+          },
+
+          onToolUseDone: async (event) => {
+            try {
+              if (!event.input || Object.keys(event.input).length === 0) {
+                return;
+              }
+              await this.handleToolProgress.execute(
+                HandleToolProgressCommand.create({
+                  ...baseFields,
+                  toolProgress: {
+                    runId,
+                    action: 'tool-use',
+                    toolUseId: event.toolUseId,
+                    toolName: event.toolName,
+                    status: 'running',
+                    toolInput: event.input,
+                  },
+                })
+              );
+            } catch (err) {
+              this.logger.error(err, `onToolUseDone failed: session=${sessionId}`);
+            }
+          },
+
+          onToolUseResult: async (event) => {
+            try {
+              await this.handleToolProgress.execute(
+                HandleToolProgressCommand.create({
+                  ...baseFields,
+                  toolProgress: {
+                    runId,
+                    action: 'tool-use',
+                    toolUseId: event.toolUseId,
+                    status: event.isError ? 'error' : 'complete',
+                  },
+                })
+              );
+            } catch (err) {
+              this.logger.error(err, `onToolUseResult failed: session=${sessionId}`);
+            }
+          },
+
+          onFinish: async (event) => {
+            try {
+              // `requires-action` means the session is parked on Anthropic's side
+              // waiting for a `user.tool_confirmation`. Posting `event.response.content`
+              // here would push an empty string to the chat platform (Slack 502 /
+              // `no_text`) AND leave the user with no surface to approve. Render
+              // an Approve/Deny card from the pending tool details and short-circuit
+              // the normal reply path — `confirmToolApproval` resumes the session.
+              if (event.response.finishReason === 'requires-action') {
+                const runtimeProvider = await this.tryGetRuntimeProvider(metadata);
+                if (runtimeProvider) {
+                  const delivered = await this.tryDeliverToolApprovalCard(
+                    metadata,
+                    sessionId,
+                    runtimeProvider,
+                    extractPendingToolApproval(event.response)
+                  );
+
+                  if (delivered) {
+                    return;
+                  }
+                }
+              }
+
+              await this.handleAgentReply.execute(
+                HandleAgentReplyCommand.create({ ...baseFields, reply: { markdown: event.response.content } })
+              );
+              await this.handleToolProgress.execute(
+                HandleToolProgressCommand.create({ ...baseFields, toolProgress: { runId, action: 'complete' } })
+              );
+            } catch (err) {
+              this.logger.error(err, `onFinish failed: session=${sessionId}`);
+              throw err;
+            }
+          },
+
+          onError: async (event) => {
+            try {
+              await this.handleErrorEvent(metadata, sessionId, event.error, baseFields, runId);
+            } catch (err) {
+              this.logger.error(err, `onError handler failed: session=${sessionId}`);
+            }
+          },
+        };
+      },
     });
   }
 
@@ -698,10 +793,13 @@ export class ManagedAgentService {
       50
     );
 
-    const messages: Message[] = history.reverse().map((entry) => ({
-      role: entry.senderType === ConversationActivitySenderTypeEnum.AGENT ? MessageRole.ASSISTANT : MessageRole.USER,
-      content: entry.content,
-    }));
+    const messages: Message[] = history
+      .filter((entry) => entry.type !== ConversationActivityTypeEnum.SIGNAL)
+      .reverse()
+      .map((entry) => ({
+        role: entry.senderType === ConversationActivitySenderTypeEnum.AGENT ? MessageRole.ASSISTANT : MessageRole.USER,
+        content: entry.content,
+      }));
 
     messages.push({ role: MessageRole.USER, content: context.message?.text ?? '' });
 

--- a/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-agent-reply/handle-agent-reply.usecase.ts
@@ -1,12 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import {
-  BadRequestException,
-  ForbiddenException,
-  forwardRef,
-  Inject,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { AnalyticsService, PinoLogger } from '@novu/application-generic';
 import {
   AgentRepository,
@@ -34,7 +27,6 @@ export class HandleAgentReply {
   constructor(
     private readonly agentRepository: AgentRepository,
     private readonly subscriberRepository: SubscriberRepository,
-    @Inject(forwardRef(() => ChatSdkService))
     private readonly chatSdkService: ChatSdkService,
     private readonly bridgeExecutor: BridgeExecutorService,
     private readonly agentConfigResolver: AgentConfigResolver,
@@ -47,10 +39,6 @@ export class HandleAgentReply {
   }
 
   async execute(command: HandleAgentReplyCommand): Promise<SentMessageInfo | null> {
-    // TODO(managed-agents): When agent.runtime === 'managed', branch here to call
-    // IAgentRuntimeProvider.runConversationTurn(externalAgentId, userMessage) instead of
-    // routing through the self-hosted bridge. This is deferred to a future PR by the runtime team.
-
     if (command.reply && command.edit) {
       throw new BadRequestException('Only one of reply or edit can be provided');
     }

--- a/apps/api/src/app/agents/usecases/handle-tool-progress/handle-tool-progress.command.ts
+++ b/apps/api/src/app/agents/usecases/handle-tool-progress/handle-tool-progress.command.ts
@@ -1,0 +1,28 @@
+import { IsNotEmpty, IsObject, IsString } from 'class-validator';
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export interface ToolProgressPayload {
+  runId: string;
+  action: 'tool-use' | 'complete' | 'fail';
+  toolUseId?: string;
+  toolName?: string;
+  status?: 'running' | 'complete' | 'error';
+  toolInput?: Record<string, unknown>;
+}
+
+export class HandleToolProgressCommand extends EnvironmentWithUserCommand {
+  @IsString()
+  @IsNotEmpty()
+  conversationId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  agentIdentifier: string;
+
+  @IsString()
+  @IsNotEmpty()
+  integrationIdentifier: string;
+
+  @IsObject()
+  toolProgress: ToolProgressPayload;
+}

--- a/apps/api/src/app/agents/usecases/handle-tool-progress/handle-tool-progress.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-tool-progress/handle-tool-progress.usecase.ts
@@ -1,0 +1,271 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PinoLogger, shortId } from '@novu/application-generic';
+import {
+  ConversationActivityEntity,
+  ConversationActivityRepository,
+  type ConversationChannel,
+  type ConversationEntity,
+} from '@novu/dal';
+import type { PlanModel, PlanTaskStatus } from 'chat';
+import { AgentConversationService } from '../../services/agent-conversation.service';
+import { ChatSdkService } from '../../services/chat-sdk.service';
+import { HandleToolProgressCommand, type ToolProgressPayload } from './handle-tool-progress.command';
+
+interface ToolTask {
+  toolUseId: string;
+  toolName: string;
+  status: PlanTaskStatus;
+  details?: string;
+}
+
+@Injectable()
+export class HandleToolProgress {
+  constructor(
+    private readonly activityRepository: ConversationActivityRepository,
+    private readonly conversationService: AgentConversationService,
+    private readonly chatSdkService: ChatSdkService,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  async execute(command: HandleToolProgressCommand): Promise<void> {
+    const conversation = await this.conversationService.getConversation(
+      command.conversationId,
+      command.environmentId,
+      command.organizationId
+    );
+    if (!conversation) {
+      throw new NotFoundException('Conversation not found');
+    }
+
+    const channel = this.conversationService.getPrimaryChannel(conversation);
+    const { toolProgress } = command;
+
+    const existingActivities = await this.activityRepository.findToolActivitiesByRunId(
+      command.environmentId,
+      command.conversationId,
+      toolProgress.runId
+    );
+
+    if (toolProgress.action === 'tool-use') {
+      await this.handleToolUse(command, conversation, channel, toolProgress, existingActivities);
+
+      return;
+    }
+
+    await this.handleFinalize(command, conversation, channel, toolProgress, existingActivities);
+  }
+
+  private async handleToolUse(
+    command: HandleToolProgressCommand,
+    conversation: ConversationEntity,
+    channel: ConversationChannel,
+    toolProgress: ToolProgressPayload,
+    existingActivities: ConversationActivityEntity[]
+  ): Promise<void> {
+    if (!toolProgress.toolUseId || !toolProgress.status) {
+      return;
+    }
+
+    const tasks = this.collectTasks(existingActivities);
+    const existing = tasks.get(toolProgress.toolUseId);
+    const toolName = toolProgress.toolName || existing?.toolName || 'Tool';
+    const status: PlanTaskStatus = toolProgress.status === 'running' ? 'in_progress' : toolProgress.status;
+    const details = formatToolInputSummary(toolProgress.toolInput) || existing?.details;
+
+    tasks.set(toolProgress.toolUseId, { toolUseId: toolProgress.toolUseId, toolName, status, details });
+
+    const model = this.toModel('Thinking…', tasks, false);
+    const planMessageId = await this.postOrEditPlan(
+      conversation,
+      channel,
+      command,
+      this.findPlanMessageId(existingActivities),
+      model
+    );
+
+    await this.persistToolActivity(command, channel, toolProgress, toolName, details, planMessageId);
+  }
+
+  private async handleFinalize(
+    command: HandleToolProgressCommand,
+    conversation: ConversationEntity,
+    channel: ConversationChannel,
+    toolProgress: ToolProgressPayload,
+    existingActivities: ConversationActivityEntity[]
+  ): Promise<void> {
+    const planMessageId = this.findPlanMessageId(existingActivities);
+    if (!existingActivities.length || !planMessageId) {
+      return;
+    }
+
+    const finalStatus: PlanTaskStatus = toolProgress.action === 'fail' ? 'error' : 'complete';
+    const title = toolProgress.action === 'fail' ? 'Something went wrong' : 'Finished thinking';
+
+    const tasks = this.collectTasks(existingActivities);
+    for (const task of tasks.values()) {
+      task.status = finalStatus;
+    }
+
+    await this.postOrEditPlan(conversation, channel, command, planMessageId, this.toModel(title, tasks, true));
+  }
+
+  private async postOrEditPlan(
+    conversation: ConversationEntity,
+    channel: ConversationChannel,
+    command: HandleToolProgressCommand,
+    existingMessageId: string | undefined,
+    model: PlanModel
+  ): Promise<string | undefined> {
+    try {
+      if (existingMessageId) {
+        await this.chatSdkService.editPlanObject(
+          conversation._agentId,
+          command.integrationIdentifier,
+          channel.platform,
+          channel.platformThreadId,
+          existingMessageId,
+          model
+        );
+
+        return existingMessageId;
+      }
+
+      const sent = await this.chatSdkService.postPlanObject(
+        conversation._agentId,
+        command.integrationIdentifier,
+        channel.platform,
+        channel.platformThreadId,
+        model
+      );
+
+      return sent?.messageId;
+    } catch (err) {
+      this.logger.warn(err, 'Failed to post/edit plan card');
+
+      return undefined;
+    }
+  }
+
+  private async persistToolActivity(
+    command: HandleToolProgressCommand,
+    channel: ConversationChannel,
+    toolProgress: ToolProgressPayload,
+    toolName: string,
+    details: string | undefined,
+    planMessageId: string | undefined
+  ): Promise<void> {
+    await this.activityRepository.createSignalActivity({
+      identifier: `act_${shortId(12)}`,
+      conversationId: command.conversationId,
+      platform: channel.platform,
+      integrationId: channel._integrationId,
+      platformThreadId: channel.platformThreadId,
+      agentId: command.agentIdentifier,
+      content: `Tool: ${toolName} (${toolProgress.status})`,
+      signalData: {
+        type: 'tool-use',
+        payload: {
+          runId: toolProgress.runId,
+          planMessageId,
+          toolUseId: toolProgress.toolUseId,
+          toolName,
+          status: toolProgress.status,
+          ...(details ? { details } : {}),
+        },
+      },
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+    });
+  }
+
+  private findPlanMessageId(activities: ConversationActivityEntity[]): string | undefined {
+    for (const activity of activities) {
+      const id = activity.signalData?.payload?.planMessageId;
+      if (typeof id === 'string' && id) return id;
+    }
+
+    return undefined;
+  }
+
+  private collectTasks(activities: ConversationActivityEntity[]): Map<string, ToolTask> {
+    const tasks = new Map<string, ToolTask>();
+
+    for (const activity of activities) {
+      const payload = activity.signalData?.payload;
+      if (!payload?.toolUseId || !payload?.toolName || !payload?.status) continue;
+
+      const toolUseId = String(payload.toolUseId);
+      const rawStatus = String(payload.status);
+      const status: PlanTaskStatus = rawStatus === 'running' ? 'in_progress' : (rawStatus as PlanTaskStatus);
+      const details = typeof payload.details === 'string' ? payload.details : undefined;
+      const existing = tasks.get(toolUseId);
+
+      const isFinalStatus = status === 'complete' || status === 'error';
+      const shouldReplace = !existing || isFinalStatus;
+
+      if (shouldReplace) {
+        tasks.set(toolUseId, {
+          toolUseId,
+          toolName: String(payload.toolName),
+          status,
+          details: details || existing?.details,
+        });
+      } else if (details && !existing.details) {
+        existing.details = details;
+      }
+    }
+
+    return tasks;
+  }
+
+  private toModel(title: string, tasks: Map<string, ToolTask>, isFinalized: boolean): PlanModel {
+    const planTasks = [...tasks.values()].map((t) => ({
+      id: t.toolUseId,
+      title: t.toolName,
+      status: t.status,
+      ...(t.details ? { details: { markdown: t.details } } : {}),
+    }));
+
+    const hasInProgress = planTasks.some((t) => t.status === 'in_progress');
+    if (!isFinalized && !hasInProgress) {
+      planTasks.push({ id: '__thinking__', title: 'Thinking…', status: 'in_progress' as PlanTaskStatus });
+    }
+
+    return { title, tasks: planTasks };
+  }
+}
+
+const SUMMARY_KEY_PRIORITY = ['query', 'command', 'path', 'action'];
+const MAX_DETAIL_LENGTH = 200;
+
+function formatToolInputSummary(input: Record<string, unknown> | undefined): string | undefined {
+  if (!input || typeof input !== 'object') return undefined;
+
+  const keys = Object.keys(input);
+  if (keys.length === 0) return undefined;
+
+  if (keys.length === 1) {
+    return truncate(String(input[keys[0]]), MAX_DETAIL_LENGTH);
+  }
+
+  const primaryKey = keys.find((k) => SUMMARY_KEY_PRIORITY.includes(k));
+  if (primaryKey) {
+    return truncate(String(input[primaryKey]), MAX_DETAIL_LENGTH);
+  }
+
+  const pairs = keys.slice(0, 3).map((k) => {
+    const val = typeof input[k] === 'string' ? input[k] : JSON.stringify(input[k]);
+
+    return `${k}: ${val}`;
+  });
+
+  return truncate(pairs.join(', '), MAX_DETAIL_LENGTH);
+}
+
+function truncate(str: string, max: number): string {
+  if (str.length <= max) return str;
+
+  return `${str.slice(0, max - 1)}…`;
+}

--- a/apps/api/src/app/agents/usecases/index.ts
+++ b/apps/api/src/app/agents/usecases/index.ts
@@ -15,6 +15,7 @@ import { GetAgentRuntimeConfig } from './get-agent-runtime-config/get-agent-runt
 import { GetMcpConnectionStatus } from './get-mcp-connection-status/get-mcp-connection-status.usecase';
 import { GetTelegramMobileLinkStatus } from './get-telegram-mobile-link-status/get-telegram-mobile-link-status.usecase';
 import { HandleAgentReply } from './handle-agent-reply/handle-agent-reply.usecase';
+import { HandleToolProgress } from './handle-tool-progress/handle-tool-progress.usecase';
 import { IssueTelegramMobileLink } from './issue-telegram-mobile-link/issue-telegram-mobile-link.usecase';
 import { IssueTelegramSubscriberLink } from './issue-telegram-subscriber-link/issue-telegram-subscriber-link.usecase';
 import { LinkTelegramChatToSubscriber } from './link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.usecase';
@@ -72,6 +73,7 @@ export const USE_CASES = [
   UpdateAgentIntegration,
   RemoveAgentIntegration,
   HandleAgentReply,
+  HandleToolProgress,
   ProvisionManagedAgent,
   SendAgentTestEmail,
   SendAgentWelcomeMessage,

--- a/apps/dashboard/src/components/conversations/conversation-timeline.tsx
+++ b/apps/dashboard/src/components/conversations/conversation-timeline.tsx
@@ -17,6 +17,7 @@ import { buildRoute, ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 import { ConversationStatusBadge } from './conversation-status-badge';
 import { SubscriberFallbackAvatar } from './subscriber-fallback-avatar';
+import { ToolProgressCard } from './tool-progress-card';
 
 type ConversationTimelineProps = {
   activities: ConversationActivityDto[];
@@ -248,6 +249,41 @@ function ResolvedFooter({ totalCount }: { totalCount: number }) {
   );
 }
 
+type TimelineEntry =
+  | { type: 'single'; key: string; activity: ConversationActivityDto }
+  | { type: 'tool-progress'; key: string; activities: ConversationActivityDto[] };
+
+function isToolUseSignal(activity: ConversationActivityDto): boolean {
+  return activity.type === 'signal' && activity.signalData?.type === 'tool-use';
+}
+
+function groupActivitiesForTimeline(activities: ConversationActivityDto[]): TimelineEntry[] {
+  const result: TimelineEntry[] = [];
+  const toolGroups = new Map<string, ConversationActivityDto[]>();
+
+  for (const activity of activities) {
+    if (isToolUseSignal(activity)) {
+      const runId = String((activity.signalData?.payload as Record<string, unknown>)?.runId ?? '');
+      if (!runId) {
+        result.push({ type: 'single', key: activity._id, activity });
+        continue;
+      }
+
+      let group = toolGroups.get(runId);
+      if (!group) {
+        group = [];
+        toolGroups.set(runId, group);
+        result.push({ type: 'tool-progress', key: `tools-${runId}`, activities: group });
+      }
+      group.push(activity);
+    } else {
+      result.push({ type: 'single', key: activity._id, activity });
+    }
+  }
+
+  return result;
+}
+
 export function ConversationTimeline({
   activities,
   isLoading,
@@ -292,10 +328,16 @@ export function ConversationTimeline({
       </div>
 
       <div className="flex flex-col">
-        {activities.map((activity, index) => (
-          <Fragment key={activity._id}>
+        {groupActivitiesForTimeline(activities).map((entry, index) => (
+          <Fragment key={entry.key}>
             {index > 0 && <TimelineDivider />}
-            {activity.type === 'message' ? <MessageCard activity={activity} /> : <InlineLogRow activity={activity} />}
+            {entry.type === 'tool-progress' ? (
+              <ToolProgressCard activities={entry.activities} />
+            ) : entry.activity.type === 'message' ? (
+              <MessageCard activity={entry.activity} />
+            ) : (
+              <InlineLogRow activity={entry.activity} />
+            )}
           </Fragment>
         ))}
 

--- a/apps/dashboard/src/components/conversations/tool-progress-card.tsx
+++ b/apps/dashboard/src/components/conversations/tool-progress-card.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react';
+import { RiArrowDownSLine, RiCheckLine, RiCloseLine, RiLoader4Line, RiRobot2Line } from 'react-icons/ri';
+import { ConversationActivityDto } from '@/api/conversations';
+import { cn } from '@/utils/ui';
+
+type ToolUseSummary = {
+  toolUseId: string;
+  toolName: string;
+  status: string;
+  details?: string;
+};
+
+function groupToolActivities(activities: ConversationActivityDto[]): ToolUseSummary[] {
+  const tools = new Map<string, ToolUseSummary>();
+
+  for (const activity of activities) {
+    const payload = activity.signalData?.payload as Record<string, unknown> | undefined;
+    if (!payload?.toolUseId) continue;
+
+    const toolUseId = String(payload.toolUseId);
+    const existing = tools.get(toolUseId);
+    const status = String(payload.status ?? 'running');
+    const details = typeof payload.details === 'string' ? payload.details : undefined;
+
+    if (!existing) {
+      tools.set(toolUseId, { toolUseId, toolName: String(payload.toolName ?? 'Tool'), status, details });
+    } else {
+      if (status === 'complete' || status === 'error') {
+        existing.status = status;
+      }
+      if (details && !existing.details) {
+        existing.details = details;
+      }
+    }
+  }
+
+  return [...tools.values()];
+}
+
+function formatTimestamp(dateStr: string | undefined): string {
+  if (!dateStr?.trim()) return '—';
+
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return '—';
+
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase();
+  const year = String(d.getFullYear()).slice(2);
+  const time = d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
+
+  return `${day} ${month} ${year}, ${time}`;
+}
+
+function ToolStatusIcon({ status }: { status: string }) {
+  if (status === 'complete') {
+    return <RiCheckLine className="text-success-base size-3 shrink-0" />;
+  }
+  if (status === 'error') {
+    return <RiCloseLine className="text-destructive size-3 shrink-0" />;
+  }
+
+  return <RiLoader4Line className="text-text-soft size-3 shrink-0 animate-spin" />;
+}
+
+type ToolProgressCardProps = {
+  activities: ConversationActivityDto[];
+};
+
+export function ToolProgressCard({ activities }: ToolProgressCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const tools = useMemo(() => groupToolActivities(activities), [activities]);
+  const lastTimestamp = activities[activities.length - 1]?.createdAt;
+
+  if (tools.length === 0) return null;
+
+  const allComplete = tools.every((t) => t.status === 'complete' || t.status === 'error');
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full cursor-pointer items-center gap-1 overflow-hidden py-0.5 pl-[11px]"
+      >
+        <RiRobot2Line className="text-text-soft size-3.5 shrink-0" />
+        <span className="text-text-sub text-label-xs font-medium">
+          {allComplete ? `Used ${tools.length} ${tools.length === 1 ? 'tool' : 'tools'}` : 'Using tools…'}
+        </span>
+        <RiArrowDownSLine
+          className={cn('text-text-soft size-3.5 shrink-0 transition-transform', expanded && 'rotate-180')}
+        />
+        <span className="text-text-soft font-code shrink-0 text-[11px] leading-normal">•</span>
+        <span className="text-text-soft shrink-0 text-[10px] font-medium leading-[14px]">
+          {formatTimestamp(lastTimestamp)}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="ml-[18px] border-stroke-soft border-l">
+          {tools.map((tool) => (
+            <div key={tool.toolUseId} className="flex items-center gap-1.5 py-[3px] pl-2.5">
+              <ToolStatusIcon status={tool.status} />
+              <span className="text-text-sub text-label-xs font-medium truncate">{tool.toolName}</span>
+              {tool.details && (
+                <span className="text-text-soft text-label-xs min-w-0 truncate font-normal">{tool.details}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/enterprise/workers/thalamus-observer/package.json
+++ b/enterprise/workers/thalamus-observer/package.json
@@ -13,7 +13,7 @@
     "cf-typegen": "wrangler types"
   },
   "dependencies": {
-    "@novu/thalamus": "0.1.0-alpha.7",
+    "@novu/thalamus": "0.1.0-alpha.8",
     "agents": "^0.12.4",
     "eventsource-parser": "^3.0.8"
   },

--- a/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
+++ b/libs/dal/src/repositories/conversation-activity/conversation-activity.repository.ts
@@ -120,6 +120,7 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
     agentId: string;
     content: string;
     signalData: ConversationActivitySignalData;
+    platformMessageId?: string;
     environmentId: string;
     organizationId: string;
   }): Promise<ConversationActivityEntity> {
@@ -134,9 +135,28 @@ export class ConversationActivityRepository extends BaseRepositoryV2<
       senderId: params.agentId,
       content: params.content,
       signalData: params.signalData,
+      platformMessageId: params.platformMessageId,
       _environmentId: params.environmentId,
       _organizationId: params.organizationId,
     });
+  }
+
+  async findToolActivitiesByRunId(
+    environmentId: string,
+    conversationId: string,
+    runId: string
+  ): Promise<ConversationActivityEntity[]> {
+    return this.find(
+      {
+        _environmentId: environmentId,
+        _conversationId: conversationId,
+        type: ConversationActivityTypeEnum.SIGNAL,
+        'signalData.type': 'tool-use',
+        'signalData.payload.runId': runId,
+      } as FilterQuery<ConversationActivityDBModel> & EnforceEnvOrOrgIds,
+      '*',
+      { sort: { createdAt: 1 } }
+    );
   }
 
   async listActivities({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,8 +416,8 @@ importers:
         specifier: workspace:*
         version: link:../../libs/testing
       '@novu/thalamus':
-        specifier: 0.1.0-alpha.7
-        version: 0.1.0-alpha.7(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))
+        specifier: 0.1.0-alpha.8
+        version: 0.1.0-alpha.8(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))
       '@sendgrid/mail':
         specifier: ^8.1.6
         version: 8.1.6
@@ -8754,8 +8754,8 @@ packages:
     resolution: {integrity: sha512-5E8EKp30Ee06FQRpax204nyZOb1uv0kW72VfZXkU/4hG4CcqDsJbfrNnUjB6xIPSvIwAAlwv76MdIAsOflkLXg==}
     engines: {node: '>=18.0.0'}
 
-  '@novu/thalamus@0.1.0-alpha.7':
-    resolution: {integrity: sha512-fLzeJ0BzIC5/TvxFSBmqSyLZqZhoZObhyIS9oH0cCedzmqsaJ+8S80DcBWBcSSsOu2Dt5O4D+zuswe86uoNnrQ==}
+  '@novu/thalamus@0.1.0-alpha.8':
+    resolution: {integrity: sha512-KJDKD3NPBoyIOuHe2heZPsDF1zlQuZCbXUbyP/P1AaRMBLPEh6rX5zZ75i6hsDg37Kfu3osUWKuM4rXSarD/OA==}
     peerDependencies:
       '@anthropic-ai/aws-sdk': '>=0.86.0'
       '@anthropic-ai/sdk': '>=0.86.0'
@@ -34355,7 +34355,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@novu/thalamus@0.1.0-alpha.7(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))':
+  '@novu/thalamus@0.1.0-alpha.8(@anthropic-ai/sdk@0.95.1(zod@3.25.20))(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.4.3)(openai@6.17.0(ws@8.20.1)(zod@3.25.20))':
     optionalDependencies:
       '@anthropic-ai/sdk': 0.95.1(zod@3.25.20)
       '@aws-crypto/sha256-js': 5.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -188,6 +188,7 @@ allowBuilds:
   '@nestjs/core': true
   '@newrelic/fn-inspect': true
   '@newrelic/native-metrics': true
+  '@novu/thalamus': true
   '@sentry/cli': true
   '@sentry/profiling-node': true
   '@sveltejs/kit': true
@@ -211,4 +212,3 @@ allowBuilds:
   sharp: true
   unrs-resolver: true
   workerd: true
-  '@novu/thalamus': true


### PR DESCRIPTION
## Summary

- **API**: Add `HandleToolProgress` usecase that manages plan card lifecycle (create → edit → finalize) via tool-use signal activities persisted in `ConversationActivity`
- **API**: Wire `onToolUseStart`, `onToolUseDone`, `onToolUseResult`, `onFinish`, `onError` webhook callbacks in `ManagedAgentService` with proper error handling (log + swallow for non-critical tool progress, log + re-throw for critical `onFinish`)
- **API**: Add `findToolActivitiesByRunId` query to `ConversationActivityRepository`; filter all SIGNAL activities from LLM conversation history
- **Dashboard**: Group tool-use signal activities by `runId` into a collapsible `ToolProgressCard` in the conversation timeline, showing tool names, statuses, and input details
- **Infra**: Bump `@novu/thalamus` to `0.1.0-alpha.8` (step-start/done events, structured `ToolResultContent`); remove local link override

## Test plan

- [ ] Send a message to a managed agent that triggers tool use (e.g. web search, bash) and verify the plan card appears in Slack with pulsing "Thinking…" animation
- [ ] Verify plan card updates as each tool completes (checkmark status)
- [ ] Verify plan card shows "Finished thinking" with all tools marked complete after agent replies
- [ ] Open conversation timeline in dashboard and verify tool-use signals are grouped into a single collapsible card per run
- [ ] Expand the card and verify tool names and input details are shown
- [ ] Verify non-tool-use signals (trigger, resolve) still render as inline log rows
- [ ] Verify no `console.log` debug output in API logs
- [ ] Verify errors from webhook handlers appear in API logs via PinoLogger


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR implements end-to-end tool progress tracking for managed agents. It adds a HandleToolProgress usecase to manage plan cards through the tool lifecycle (create, update, finalize) driven by tool-use signal activities persisted during agent runs. The dashboard groups signals by runId into collapsible ToolProgressCards showing tool names and statuses. Webhook callbacks in ManagedAgentService wire tool lifecycle events to the progress handler with proper error handling.

## Affected areas

- **api**: Added HandleToolProgress usecase and refactored webhook handling in ManagedAgentService to register callbacks for tool lifecycle events (onToolUseStart, onToolUseDone, onToolUseResult, onFinish, onError); updated ChatSdkService to support plan object posting/editing and inbound callback registration; revised AgentInboundHandler to implement OnModuleInit and wire chat callbacks; simplified AgentsWebhookController to delegate to ManagedAgentService.handleWebhook.
- **dashboard**: Introduced ToolProgressCard component and updated ConversationTimeline to group tool-use signal activities by runId, rendering them as collapsible cards with tool names, statuses, and input details.
- **dal**: Extended ConversationActivityRepository with findToolActivitiesByRunId query to retrieve tool-use signals and updated createSignalActivity to capture platformMessageId.
- **workers** (enterprise): Updated thalamus-observer package.json dependency.

## Key technical decisions

- Tool progress lifecycle is driven by tool-use signal activities persisted in ConversationActivity rather than maintaining separate state.
- Plan cards are created/edited via ChatSdkService's postPlanObject/editPlanObject methods when posting/editing platform messages.
- SIGNAL-type activities are filtered from LLM conversation history to prevent tool signals from being fed back as agent context.
- Webhook handler errors are logged and swallowed for non-critical tool progress operations; onFinish errors are logged and re-thrown.
- `@novu/thalamus` updated to 0.1.0-alpha.8 (adds step-start/step-done events and structured ToolResultContent).

## Testing

The PR includes a detailed manual test plan covering tool-use triggering, plan card appearance and updates in Slack, dashboard timeline grouping behavior, and API logging validation. No new unit or e2e tests were added; verification relies on manual testing via managed agent flows in the dashboard and messaging integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->