### PR TITLE
fix(dashboard): polish Clerk last-used auth badge appearance fixes NV-7747

### DIFF
--- a/apps/dashboard/src/utils/clerk-appearance.ts
+++ b/apps/dashboard/src/utils/clerk-appearance.ts
@@ -1,7 +1,40 @@
 import type { ClerkAppearanceTheme } from '@clerk/shared/types';
 
+const lastAuthenticationStrategyBadgeLight = {
+  fontSize: '10px',
+  fontWeight: '500',
+  lineHeight: '1',
+  height: 'auto',
+  minHeight: 'unset',
+  padding: '2px 6px',
+  background: 'hsl(var(--neutral-100))',
+  color: 'hsl(var(--neutral-500))',
+  border: '1px solid hsl(var(--neutral-200))',
+  borderRadius: '4px',
+  boxShadow: 'none',
+  letterSpacing: 'normal',
+  transform: 'translate(8px, calc(-50% - 1px))',
+} as const;
+
+const lastAuthenticationStrategyBadgeDark = {
+  fontSize: '10px',
+  fontWeight: '500',
+  lineHeight: '1',
+  height: 'auto',
+  minHeight: 'unset',
+  padding: '2px 6px',
+  background: 'rgba(255, 255, 255, 0.08)',
+  color: 'rgba(255, 255, 255, 0.55)',
+  border: '1px solid rgba(255, 255, 255, 0.12)',
+  borderRadius: '4px',
+  boxShadow: 'none',
+  letterSpacing: 'normal',
+  transform: 'translate(8px, calc(-50% - 1px))',
+} as const;
+
 export const clerkSignupAppearance: ClerkAppearanceTheme = {
   elements: {
+    lastAuthenticationStrategyBadge: lastAuthenticationStrategyBadgeLight,
     headerTitle: {
       fontWeight: '500',
     },
@@ -24,6 +57,7 @@ export const clerkSignupAppearance: ClerkAppearanceTheme = {
 
 export const clerkLandingSignupAppearance: ClerkAppearanceTheme = {
   elements: {
+    lastAuthenticationStrategyBadge: lastAuthenticationStrategyBadgeDark,
     headerTitle: {
       fontWeight: '500',
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Styles the Clerk "Last used" badge on sign-in and sign-up OAuth buttons via the `lastAuthenticationStrategyBadge` appearance key. The default badge looked heavy due to a fixed height (~18px), gradient background, and double border shadow.

## Changes

- Added compact badge styles in `clerk-appearance.ts` for light auth pages (sign-in, sign-up, create organization)
- Added a dark-theme variant for the landing signup flow
- Replaced gradient/shadow with neutral background, smaller type (10px), `height: auto`, and tighter padding

## Verification

- Sign in at `/auth/sign-in` after using an OAuth provider once; confirm the badge is smaller and visually subtle on the last-used button
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779517845706129?thread_ts=1779517845.706129&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-207cac3b-387a-5c29-bf5e-69f1dff10093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-207cac3b-387a-5c29-bf5e-69f1dff10093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The Clerk "Last used" badge styling was refined by introducing reusable theme constants (light and dark variants) for the `lastAuthenticationStrategyBadge` appearance property. The badge now uses a neutral background, smaller font (10px), auto height, and tighter padding instead of the previous gradient/shadow approach, making it more visually subtle and less heavy.

## Affected areas
- **dashboard**: Refactored `clerk-appearance.ts` to extract badge styling into reusable light and dark theme constants, applied to the sign-in/sign-up/create organization flows and the landing signup flow respectively.

## Testing
Manual verification is required. Sign in at `/auth/sign-in` after using an OAuth provider once to confirm the badge appears smaller and visually subtle on the last-used button.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->