### PR TITLE
fix(api-service): Stop exposing password reset token fields in user APIs fixes NV-7754

### DIFF
--- a/apps/api/src/app/user/dtos/user-response.dto.ts
+++ b/apps/api/src/app/user/dtos/user-response.dto.ts
@@ -10,12 +10,6 @@ export class UserResponseDto implements IUserEntity {
   @ApiProperty()
   _id: string;
 
-  @ApiPropertyOptional()
-  resetToken?: string;
-
-  @ApiPropertyOptional()
-  resetTokenDate?: string;
-
   @ApiProperty()
   firstName?: string | null;
 

--- a/apps/api/src/app/user/e2e/get-me.e2e.ts
+++ b/apps/api/src/app/user/e2e/get-me.e2e.ts
@@ -1,3 +1,4 @@
+import { CommunityUserRepository } from '@novu/dal';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 
@@ -18,5 +19,21 @@ describe('User Profile #novu-v0-os', async () => {
     expect(me.firstName).to.equal(session.user.firstName);
     expect(me.lastName).to.equal(session.user.lastName);
     expect(me.email).to.equal(session.user.email);
+  });
+
+  it('should not expose password reset token fields', async () => {
+    await session.testAgent.post('/v1/auth/reset/request').send({
+      email: session.user.email,
+    });
+
+    const found = await new CommunityUserRepository().findById(session.user._id);
+
+    expect(found?.resetToken).to.be.ok;
+    expect(found?.resetTokenDate).to.be.ok;
+
+    const { body } = await session.testAgent.get('/v1/users/me').expect(200);
+
+    expect(body.data.resetToken).to.be.undefined;
+    expect(body.data.resetTokenDate).to.be.undefined;
   });
 });

--- a/apps/api/src/app/user/usecases/base-user-profile.usecase.ts
+++ b/apps/api/src/app/user/usecases/base-user-profile.usecase.ts
@@ -5,8 +5,6 @@ export class BaseUserProfileUsecase {
   protected mapToDto(user: UserEntity): UserResponseDto {
     const {
       _id,
-      resetToken,
-      resetTokenDate,
       firstName,
       lastName,
       email,
@@ -20,8 +18,6 @@ export class BaseUserProfileUsecase {
 
     return {
       _id,
-      resetToken,
-      resetTokenDate,
       firstName,
       lastName,
       email,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes `resetToken` and `resetTokenDate` from user profile API responses. These fields were included in `UserResponseDto` and mapped in `BaseUserProfileUsecase.mapToDto()`, which caused them to leak on `GET /v1/users/me` and profile update endpoints.

## Changes

- Removed `resetToken` and `resetTokenDate` from `UserResponseDto` (OpenAPI schema)
- Removed mapping of those fields in `BaseUserProfileUsecase`
- Added e2e regression test ensuring reset token fields are not returned from `/v1/users/me` even when a reset token exists in the database

## Security impact

Password reset state and timing should not be exposed via authenticated user APIs. The underlying reset flow in auth endpoints is unchanged; only the user profile response surface is tightened.

## Breaking change

Clients that relied on `resetToken` or `resetTokenDate` in user profile responses will no longer receive them. These fields were not part of the public `IUserEntity` interface in `@novu/shared`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7754](https://linear.app/novu/issue/NV-7754/stop-exposing-password-reset-token-fields-in-user-apis)

<div><a href="https://cursor.com/agents/bc-9df4134e-2715-4a56-a052-15bf2bb61e9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9df4134e-2715-4a56-a052-15bf2bb61e9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `resetToken` and `resetTokenDate` fields were removed from user profile API responses to prevent exposure of password reset state and timing information. While the authentication reset flow remains unchanged, the `GET /v1/users/me` endpoint and profile update endpoints no longer return these sensitive fields in the response.

## Affected areas

**api**: Removed the optional `resetToken` and `resetTokenDate` properties from `UserResponseDto` (OpenAPI schema), and eliminated the mapping of these fields in `BaseUserProfileUsecase.mapToDto()`.

## Key technical decisions

- **Breaking change**: Clients relying on `resetToken` or `resetTokenDate` in user profile responses will no longer receive these fields. These were not part of the public `IUserEntity` interface in `@novu/shared`, limiting external impact.
- **Security fix**: Prevents authenticated users from inferring password reset state or timing via API responses.

## Testing

Added an e2e regression test in `get-me.e2e.ts` that verifies the `/v1/users/me` endpoint does not expose reset token fields, even when a reset token exists in the database. The test triggers a password reset request, confirms the token is stored, then validates it is not returned in the response.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->