### PR TITLE
fix(api-service): prevent blind SSRF in SNS subscription confirmation fixes NV-7756

### DIFF
--- a/enterprise/packages/api/package.json
+++ b/enterprise/packages/api/package.json
@@ -9,7 +9,8 @@
     "build:watch": "node_modules/.bin/tsc -w -p tsconfig.json",
     "check": "biome check .",
     "check:fix": "biome check --write .",
-    "lint": "echo 'skip lint in the ci'"
+    "lint": "echo 'skip lint in the ci'",
+    "test": "mocha --require ts-node/register --extension ts 'src/**/*.spec.ts'"
   },
   "dependencies": {
     "@novu/application-generic": "workspace:*",
@@ -21,7 +22,8 @@
     "class-transformer": "0.5.1",
     "class-validator": "0.14.1",
     "@novu/testing": "workspace:*",
-    "express": "^5.0.1"
+    "express": "^5.0.1",
+    "sns-validator": "^0.3.5"
   },
   "devDependencies": {
     "@nestjs/testing": "11.1.21",
@@ -29,6 +31,7 @@
     "@types/mocha": "^10.0.8",
     "@types/node": "^22.0.0",
     "@types/sinon": "^9.0.0",
+    "@types/sns-validator": "^0.3.3",
     "chai": "^4.2.0",
     "mocha": "^10.2.0",
     "rxjs": "7.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2061,6 +2061,9 @@ importers:
       express:
         specifier: ^5.0.1
         version: 5.0.1
+      sns-validator:
+        specifier: ^0.3.5
+        version: 0.3.5
     devDependencies:
       '@nestjs/testing':
         specifier: 11.1.21
@@ -2077,6 +2080,9 @@ importers:
       '@types/sinon':
         specifier: ^9.0.0
         version: 9.0.11
+      '@types/sns-validator':
+        specifier: ^0.3.3
+        version: 0.3.3
       chai:
         specifier: ^4.2.0
         version: 4.4.1
@@ -31027,7 +31033,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       jose: 6.1.3
       kysely: 0.28.17
       nanostores: 1.2.0
@@ -44801,7 +44807,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.5)
+      better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.6
       jose: 6.1.3
       kysely: 0.28.17
@@ -44819,15 +44825,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
-
-  better-call@1.3.2(zod@4.3.5):
-    dependencies:
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.0
-    optionalDependencies:
-      zod: 4.3.5
 
   better-call@1.3.2(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **NV-7756** — unauthenticated blind SSRF via the inbound webhooks SNS subscription confirmation interceptor.

## Problem

`SnsSubscriptionInterceptor` processed `SubscriptionConfirmation` requests before authentication and called `fetch(SubscribeURL)` on attacker-controlled URLs, enabling blind SSRF against internal services and cloud metadata endpoints.

## Solution

1. **Integration validation** — require a real environment/integration with inbound webhooks enabled before handling confirmations
2. **SNS signature verification** — validate message structure, replay window, signing cert URL, and cryptographic signature (`sns-validator`) before confirming
3. **SubscribeURL allowlist** — only allow HTTPS AWS SNS confirmation URLs with `Action=ConfirmSubscription` and a valid SNS topic ARN

## Enterprise submodule (required for green CI)

**Merge order:** enterprise PR first, then this PR.

| Repo | Branch | Submodule / commit |
|------|--------|-------------------|
| `packages-enterprise` | `cursor/fix-sns-subscription-ssrf-6a80` → `next` | `cf76ace` |
| `novu` (this PR) | `cursor/fix-sns-subscription-ssrf-6a80` | points at `cf76ace` |

Open enterprise PR: https://github.com/novuhq/packages-enterprise/compare/next...cursor/fix-sns-subscription-ssrf-6a80

`validate-submodule-sync` fails until `cf76ace` is on `packages-enterprise` `next` (CI compares `.source` HEAD to remote `next` HEAD). This is expected for cross-repo submodule changes.

## Testing

- `cd enterprise/packages/api && pnpm test`
- `cd enterprise/packages/api && pnpm build:esm`

## Security flow

```mermaid
sequenceDiagram
    participant Attacker
    participant API as Inbound Webhooks API
    participant DB as MongoDB
    participant SNS as AWS SNS

    Attacker->>API: POST SubscriptionConfirmation + malicious SubscribeURL
    API->>DB: Validate environment + integration
    alt Invalid integration
        API-->>Attacker: 404 Not Found
    else Invalid signature or URL
        API-->>Attacker: 403 Forbidden
    else Valid AWS SNS confirmation
        API->>SNS: GET allowed SubscribeURL
        API-->>Attacker: 200 OK
    end
```
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7756](https://linear.app/novu/issue/NV-7756/unauthenticated-sns-subscription-confirmation-causes-blind-ssrf)

<div><a href="https://cursor.com/agents/bc-ec1fa9c1-e168-4031-9a84-e36126a26a80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec1fa9c1-e168-4031-9a84-e36126a26a80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
This PR hardens SNS inbound webhook subscription confirmation to prevent unauthenticated blind SSRF (NV-7756). Confirmation handling now requires a valid enterprise integration context, verifies SNS message structure and cryptographic signature, and allowlists SubscribeURL to only AWS SNS HTTPS confirmation URLs. The implementation lives in the enterprise submodule; the public OSS surface receives packaging and test-script updates to support the enterprise change.

## Affected areas
- enterprise: Submodule update implementing the SSRF fixes (integration validation, SNS signature verification, SubscribeURL allowlisting) — requires the matching enterprise PR/commit for CI to pass.
- enterprise/packages/api: Added runtime dependency sns-validator (^0.3.5) and dev typing `@types/sns-validator` (^0.3.3); updated scripts (build uses check-ee.mjs, plus new lint and test scripts) to enable EE build/test flows.

## Key technical decisions
- Uses the sns-validator package to cryptographically validate SNS messages and signing certificate URLs before confirming subscriptions.
- Restricts SubscribeURL to HTTPS AWS SNS confirmation URLs with Action=ConfirmSubscription and valid topic ARNs.
- Confirms subscriptions only when a real environment/integration with inbound webhooks is present to prevent unauthenticated processing.

## Testing
Enterprise tests/runbooks: run enterprise/packages/api: pnpm test and pnpm build:esm for local verification; unit tests for SNS validation and SSRF scenarios should be present/added in the enterprise submodule.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->