### PR TITLE
fix(api-service): validate environment bridge URLs fixes NV-7752

### DIFF
--- a/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.e2e.ts
+++ b/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.e2e.ts
@@ -42,6 +42,17 @@ describe('Update Environment - /environments (PUT)', async () => {
       expect(storedUrl).to.not.equal(bridgeUrl);
     }
 
+    it('should persist a safe public bridge.url to bridge and echo', async () => {
+      const bridgeUrl = 'https://example.com/api/novu';
+
+      await updateBridgeUrl(bridgeUrl).expect(200);
+
+      const environment = await environmentRepository.findOne({ _id: session.environment._id });
+
+      expect(environment?.bridge?.url).to.equal(bridgeUrl);
+      expect(environment?.echo?.url).to.equal(bridgeUrl);
+    });
+
     it('should reject bridge.url pointing at localhost', async () => {
       const bridgeUrl = 'http://localhost:4000/api/novu';
       const result = await updateBridgeUrl(bridgeUrl);

--- a/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.e2e.ts
+++ b/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.e2e.ts
@@ -43,11 +43,13 @@ describe('Update Environment - /environments (PUT)', async () => {
     }
 
     it('should reject bridge.url pointing at localhost', async () => {
-      const result = await updateBridgeUrl('http://localhost:4000/api/novu');
+      const bridgeUrl = 'http://localhost:4000/api/novu';
+      const result = await updateBridgeUrl(bridgeUrl);
 
       expect(result.status).to.equal(400);
-      expect(JSON.stringify(result.body)).to.match(/bridge\.url/i);
-      await expectBridgeUrlNotStored('http://localhost:4000/api/novu');
+      expect(JSON.stringify(result.body)).to.match(/blocked by the outbound SSRF policy/i);
+      expect(JSON.stringify(result.body)).to.not.match(/localhost/i);
+      await expectBridgeUrlNotStored(bridgeUrl);
     });
 
     it('should reject bridge.url pointing at cloud metadata hostname', async () => {
@@ -55,7 +57,8 @@ describe('Update Environment - /environments (PUT)', async () => {
       const result = await updateBridgeUrl(bridgeUrl);
 
       expect(result.status).to.equal(400);
-      expect(JSON.stringify(result.body)).to.match(/bridge\.url/i);
+      expect(JSON.stringify(result.body)).to.match(/blocked by the outbound SSRF policy/i);
+      expect(JSON.stringify(result.body)).to.not.match(/metadata\.google\.internal/i);
       await expectBridgeUrlNotStored(bridgeUrl);
     });
 
@@ -64,7 +67,7 @@ describe('Update Environment - /environments (PUT)', async () => {
       const result = await updateBridgeUrl(bridgeUrl);
 
       expect(result.status).to.equal(400);
-      expect(JSON.stringify(result.body)).to.match(/bridge\.url/i);
+      expect(JSON.stringify(result.body)).to.match(/blocked by the outbound SSRF policy/i);
       await expectBridgeUrlNotStored(bridgeUrl);
     });
 
@@ -73,7 +76,8 @@ describe('Update Environment - /environments (PUT)', async () => {
       const result = await updateBridgeUrl(bridgeUrl);
 
       expect(result.status).to.equal(400);
-      expect(JSON.stringify(result.body)).to.match(/bridge\.url/i);
+      expect(JSON.stringify(result.body)).to.match(/blocked by the outbound SSRF policy/i);
+      expect(JSON.stringify(result.body)).to.not.match(/169\.254\.169\.254/);
       await expectBridgeUrlNotStored(bridgeUrl);
     });
 
@@ -92,6 +96,7 @@ describe('Update Environment - /environments (PUT)', async () => {
 
       const environment = await environmentRepository.findOne({ _id: session.environment._id });
       expect(environment?.bridge?.url || '').to.equal('');
+      expect(environment?.echo?.url || '').to.equal('');
     });
   });
 });

--- a/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.e2e.ts
+++ b/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.e2e.ts
@@ -1,9 +1,11 @@
+import { EnvironmentRepository } from '@novu/dal';
 import { UserSession } from '@novu/testing';
 import { expect } from 'chai';
 import { UpdateEnvironmentRequestDto } from '../../dtos/update-environment-request.dto';
 
 describe('Update Environment - /environments (PUT)', async () => {
   let session: UserSession;
+  const environmentRepository = new EnvironmentRepository();
 
   before(async () => {
     session = new UserSession();
@@ -12,14 +14,84 @@ describe('Update Environment - /environments (PUT)', async () => {
 
   it('should update environment entity correctly', async () => {
     const updatePayload: UpdateEnvironmentRequestDto = {
-      name: 'New Name',
-      identifier: 'New Identifier',
+      identifier: 'updated-environment-identifier',
+      color: '#3366ff',
     };
 
     await session.testAgent.put(`/v1/environments/${session.environment._id}`).send(updatePayload).expect(200);
     const { body } = await session.testAgent.get('/v1/environments/me');
 
-    expect(body.data.name).to.eq(updatePayload.name);
     expect(body.data.identifier).to.equal(updatePayload.identifier);
+    expect(body.data.color).to.equal(updatePayload.color);
+  });
+
+  // Locks in SSRF validation on `bridge.url` before it is persisted. Without
+  // this guard, environment write access could store internal targets that the
+  // worker later reaches with SSRF protection disabled.
+  describe('bridge.url SSRF protection', () => {
+    async function updateBridgeUrl(bridgeUrl: string) {
+      return session.testAgent.put(`/v1/environments/${session.environment._id}`).send({
+        bridge: { url: bridgeUrl },
+      });
+    }
+
+    async function expectBridgeUrlNotStored(bridgeUrl: string): Promise<void> {
+      const environment = await environmentRepository.findOne({ _id: session.environment._id });
+      const storedUrl = environment?.bridge?.url || environment?.echo?.url || '';
+
+      expect(storedUrl).to.not.equal(bridgeUrl);
+    }
+
+    it('should reject bridge.url pointing at localhost', async () => {
+      const result = await updateBridgeUrl('http://localhost:4000/api/novu');
+
+      expect(result.status).to.equal(400);
+      expect(JSON.stringify(result.body)).to.match(/bridge\.url/i);
+      await expectBridgeUrlNotStored('http://localhost:4000/api/novu');
+    });
+
+    it('should reject bridge.url pointing at cloud metadata hostname', async () => {
+      const bridgeUrl = 'http://metadata.google.internal/computeMetadata/v1/';
+      const result = await updateBridgeUrl(bridgeUrl);
+
+      expect(result.status).to.equal(400);
+      expect(JSON.stringify(result.body)).to.match(/bridge\.url/i);
+      await expectBridgeUrlNotStored(bridgeUrl);
+    });
+
+    it('should reject bridge.url with embedded credentials', async () => {
+      const bridgeUrl = 'http://attacker:pass@example.com/api/novu';
+      const result = await updateBridgeUrl(bridgeUrl);
+
+      expect(result.status).to.equal(400);
+      expect(JSON.stringify(result.body)).to.match(/bridge\.url/i);
+      await expectBridgeUrlNotStored(bridgeUrl);
+    });
+
+    it('should reject bridge.url pointing at link-local cloud metadata IP', async () => {
+      const bridgeUrl = 'http://169.254.169.254/computeMetadata/v1/';
+      const result = await updateBridgeUrl(bridgeUrl);
+
+      expect(result.status).to.equal(400);
+      expect(JSON.stringify(result.body)).to.match(/bridge\.url/i);
+      await expectBridgeUrlNotStored(bridgeUrl);
+    });
+
+    it('should accept clearing bridge.url', async () => {
+      await session.testAgent
+        .put(`/v1/environments/${session.environment._id}`)
+        .send({ bridge: { url: 'https://example.com/api/novu' } })
+        .expect(200);
+
+      const cleared = await session.testAgent
+        .put(`/v1/environments/${session.environment._id}`)
+        .send({ bridge: { url: '' } })
+        .expect(200);
+
+      expect(cleared.status).to.equal(200);
+
+      const environment = await environmentRepository.findOne({ _id: session.environment._id });
+      expect(environment?.bridge?.url || '').to.equal('');
+    });
   });
 });

--- a/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.usecase.ts
@@ -4,14 +4,24 @@ import {
   UnauthorizedException,
   UnprocessableEntityException,
 } from '@nestjs/common';
-import { assertSafeOutboundUrl, resolvePublicAddresses, SsrfBlockedError } from '@novu/application-generic';
+import {
+  assertSafeOutboundUrl,
+  PinoLogger,
+  resolvePublicAddresses,
+  SsrfBlockedError,
+} from '@novu/application-generic';
 import { EnvironmentEntity, EnvironmentRepository } from '@novu/dal';
 import { EnvironmentEnum, PROTECTED_ENVIRONMENTS } from '@novu/shared';
 import { UpdateEnvironmentCommand } from './update-environment.command';
 
 @Injectable()
 export class UpdateEnvironment {
-  constructor(private environmentRepository: EnvironmentRepository) {}
+  constructor(
+    private environmentRepository: EnvironmentRepository,
+    private logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
 
   async execute(command: UpdateEnvironmentCommand) {
     const environment = await this.environmentRepository.findOne({
@@ -84,7 +94,8 @@ export class UpdateEnvironment {
       await resolvePublicAddresses(parsed.hostname, { useCache: true });
     } catch (err) {
       if (err instanceof SsrfBlockedError) {
-        throw new BadRequestException(`bridge.url: ${err.message}`);
+        this.logger.warn({ err, bridgeUrl }, 'Blocked bridge.url update by outbound SSRF policy');
+        throw new BadRequestException('bridge.url is blocked by the outbound SSRF policy.');
       }
       throw err;
     }

--- a/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.usecase.ts
@@ -1,4 +1,10 @@
-import { Injectable, UnauthorizedException, UnprocessableEntityException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  UnauthorizedException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { assertSafeOutboundUrl, resolvePublicAddresses, SsrfBlockedError } from '@novu/application-generic';
 import { EnvironmentEntity, EnvironmentRepository } from '@novu/dal';
 import { EnvironmentEnum, PROTECTED_ENVIRONMENTS } from '@novu/shared';
 import { UpdateEnvironmentCommand } from './update-environment.command';
@@ -49,8 +55,14 @@ export class UpdateEnvironment {
     }
 
     if (command.bridge) {
-      updatePayload['echo.url'] = command.bridge?.url || '';
-      updatePayload['bridge.url'] = command.bridge?.url || '';
+      const bridgeUrl = command.bridge?.url || '';
+
+      if (bridgeUrl) {
+        await this.assertSafeBridgeUrl(bridgeUrl);
+      }
+
+      updatePayload['echo.url'] = bridgeUrl;
+      updatePayload['bridge.url'] = bridgeUrl;
     }
 
     return await this.environmentRepository.update(
@@ -60,5 +72,21 @@ export class UpdateEnvironment {
       },
       { $set: updatePayload }
     );
+  }
+
+  // Persisted bridge URLs are later used by the worker for EXTERNAL-origin
+  // workflow EXECUTE calls. Reject SSRF candidates before they are stored so
+  // an environment write cannot repoint outbound bridge traffic at internal
+  // hosts (loopback, RFC1918, link-local metadata, embedded credentials).
+  private async assertSafeBridgeUrl(bridgeUrl: string): Promise<void> {
+    try {
+      const parsed = assertSafeOutboundUrl(bridgeUrl);
+      await resolvePublicAddresses(parsed.hostname, { useCache: true });
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new BadRequestException(`bridge.url: ${err.message}`);
+      }
+      throw err;
+    }
   }
 }

--- a/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.usecase.ts
+++ b/apps/api/src/app/environments-v1/usecases/update-environment/update-environment.usecase.ts
@@ -94,10 +94,24 @@ export class UpdateEnvironment {
       await resolvePublicAddresses(parsed.hostname, { useCache: true });
     } catch (err) {
       if (err instanceof SsrfBlockedError) {
-        this.logger.warn({ err, bridgeUrl }, 'Blocked bridge.url update by outbound SSRF policy');
+        this.logger.warn(
+          {
+            ssrfReason: err.reason,
+            bridgeUrlHost: this.getBridgeUrlHostForLog(bridgeUrl),
+          },
+          'Blocked bridge.url update by outbound SSRF policy'
+        );
         throw new BadRequestException('bridge.url is blocked by the outbound SSRF policy.');
       }
       throw err;
+    }
+  }
+
+  private getBridgeUrlHostForLog(bridgeUrl: string): string | undefined {
+    try {
+      return new URL(bridgeUrl).hostname;
+    } catch {
+      return undefined;
     }
   }
 }

--- a/apps/api/src/app/layouts-v2/e2e/preview-layout.e2e.ts
+++ b/apps/api/src/app/layouts-v2/e2e/preview-layout.e2e.ts
@@ -25,7 +25,9 @@ describe('Preview Layout #novu-v2', () => {
         _id: session.environment._id,
       },
       {
-        bridge: { url: `http://localhost:${process.env.PORT}/v1/environments/${session.environment._id}/bridge` },
+        bridge: {
+          url: `http://127.0.0.1:${process.env.PORT}/v1/environments/${session.environment._id}/bridge`,
+        },
       }
     );
   });

--- a/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
+++ b/apps/api/src/app/workflows-v2/e2e/generate-preview.e2e.ts
@@ -2034,7 +2034,9 @@ describe('Workflow Step Preview - POST /:workflowId/step/:stepId/preview #novu-v
         _id: session.environment._id,
       },
       {
-        bridge: { url: `http://localhost:${process.env.PORT}/v1/environments/${session.environment._id}/bridge` },
+        bridge: {
+          url: `http://127.0.0.1:${process.env.PORT}/v1/environments/${session.environment._id}/bridge`,
+        },
       }
     );
   }

--- a/apps/worker/src/.env.test
+++ b/apps/worker/src/.env.test
@@ -99,5 +99,5 @@ IS_PUSH_UNREAD_COUNT_ENABLED=true
 IS_CONTEXT_PREFERENCES_ENABLED=true
 IS_WORKFLOW_RUN_TRACES_WRITE_ENABLED=true
 
-# Allow TestBridgeServer / local API bridge fixtures during e2e (mirrors apps/api/src/.env.test).
+# Allow TestBridgeServer (http://0.0.0.0:<port>) and local API bridge fixtures during e2e.
 NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS=0.0.0.0,127.0.0.1,::1

--- a/apps/worker/src/.env.test
+++ b/apps/worker/src/.env.test
@@ -98,3 +98,6 @@ IS_WORKFLOW_RUN_LOGS_WRITE_ENABLED=true
 IS_PUSH_UNREAD_COUNT_ENABLED=true
 IS_CONTEXT_PREFERENCES_ENABLED=true
 IS_WORKFLOW_RUN_TRACES_WRITE_ENABLED=true
+
+# Allow TestBridgeServer / local API bridge fixtures during e2e (mirrors apps/api/src/.env.test).
+NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS=0.0.0.0,127.0.0.1,::1

--- a/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/execute-bridge-job/execute-bridge-job.usecase.ts
@@ -238,14 +238,11 @@ export class ExecuteBridgeJob {
       environmentId,
       organizationId,
       stepResolverHash,
-      // Stateless flow: the bridgeUrl was attached by the trigger caller and
-      // travelled with the queued job. Re-apply the DNS-pinned SSRF guard on
-      // every step's EXECUTE so the worker cannot be coerced into reaching
-      // internal hosts even if a job slips past the API-side validation
-      // (e.g. queued by an older API release before the guard landed).
-      // Stateful jobs (no `statelessBridgeUrl`) target the environment's
-      // configured bridge URL, which is validated when it is set.
-      enforceSsrfProtection: !!statelessBridgeUrl,
+      // Re-apply the DNS-pinned SSRF guard on every EXTERNAL bridge EXECUTE
+      // (stateless bridgeUrl on the job, or the environment's stored bridge
+      // URL). This blocks internal hosts even if a malicious URL was persisted
+      // before validation landed or queued by an older API release.
+      enforceSsrfProtection: !!statelessBridgeUrl || workflowOrigin === ResourceOriginEnum.EXTERNAL,
       processError: async (response) => {
         await this.createExecutionDetails.execute({
           ...CreateExecutionDetailsCommand.getDetailsFromJob(job),

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.command.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-bridge-request.command.ts
@@ -50,13 +50,12 @@ export class ExecuteBridgeRequestCommand extends EnvironmentLevelCommand {
   stepResolverHash?: string;
 
   /**
-   * Enforce SSRF protection on the outbound bridge HTTP call (DNS-pinned
+   * Force SSRF protection on the outbound bridge HTTP call (DNS-pinned
    * connect-time guard + redirect re-validation via `HttpClientService`).
    *
-   * Use for endpoints that accept a user-controlled bridgeUrl (e.g.
-   * `/bridge/sync`, `/bridge/validate`) so attacker-controlled IP literals
-   * (loopback / RFC1918 / link-local / cloud metadata) cannot reach internal
-   * services. Leave undefined for trusted internal callers.
+   * `ExecuteFrameworkRequest` also enables the guard automatically for
+   * stateless bridge URLs and EXTERNAL-origin workflows. Set explicitly when
+   * a caller needs the guard outside those cases.
    */
   @IsOptional()
   @IsBoolean()

--- a/libs/application-generic/src/usecases/execute-bridge-request/execute-framework-request.usecase.ts
+++ b/libs/application-generic/src/usecases/execute-bridge-request/execute-framework-request.usecase.ts
@@ -106,6 +106,11 @@ export class ExecuteFrameworkRequest {
 
     this.logger.debug(`Making bridge request to \`${url}\``);
 
+    const enforceSsrfProtection =
+      command.enforceSsrfProtection === true ||
+      !!command.statelessBridgeUrl ||
+      command.workflowOrigin === ResourceOriginEnum.EXTERNAL;
+
     try {
       const response = await this.httpClient.request<ExecuteBridgeRequestDto<T>>({
         url,
@@ -117,10 +122,11 @@ export class ExecuteFrameworkRequest {
           limit: retriesLimit,
         },
         rejectUnauthorized: environment.name.toLowerCase() === 'production',
-        // Opt-in SSRF guard for user-supplied bridge URLs (sync / validate).
-        // The safe outbound layer pins the connection to a validated public
-        // IP and re-runs the policy on every redirect target.
-        enforceSsrfProtection: command.enforceSsrfProtection === true,
+        // DNS-pinned SSRF guard for user- or environment-controlled bridge
+        // targets (stateless bridgeUrl, EXTERNAL origin, or explicit opt-in).
+        // The safe outbound layer pins the connection to a validated public IP
+        // and re-runs the policy on every redirect target.
+        enforceSsrfProtection,
         onRetry: ({ statusCode, errorCode, delay }) => {
           if (statusCode) {
             this.logger.info(`Retryable status code ${statusCode} detected. Retrying in ${delay}ms`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes a stored SSRF path where `PUT /v1/environments/:id` could persist a malicious `bridge.url` and the worker would later call it with SSRF protection disabled for environment-configured bridges.

## Changes

- **`UpdateEnvironment`**: validate `bridge.url` with `assertSafeOutboundUrl` + `resolvePublicAddresses` before writing to MongoDB (blocks loopback, metadata hosts, private IPs, credentials, non-http schemes).
- **`ExecuteFrameworkRequest`**: automatically enable DNS-pinned SSRF protection for `EXTERNAL` workflows and stateless bridge URLs (in addition to explicit opt-in).
- **`ExecuteBridgeJob`**: pass `enforceSsrfProtection` for all `EXTERNAL` bridge EXECUTE calls, not only stateless jobs.
- **Tests**: e2e coverage for rejected/allowed `bridge.url` updates on the environments API.

## Security impact

Attackers with environment write access can no longer store internal/metadata targets as the environment bridge URL and rely on the worker to fetch them without SSRF checks.

## Verification

```bash
cd apps/api && pnpm exec cross-env NODE_ENV=test CI_EE_TEST=true CLERK_ENABLED=true \
  mocha --require ./swc-register.js --exit --file e2e/setup.ts 'src/**/update-environment.e2e.ts'
```

All 6 tests in that file pass locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7752](https://linear.app/novu/issue/NV-7752/validate-environment-bridge-urls-to-prevent-stored-ssrf)

<div><a href="https://cursor.com/agents/bc-d8f21b7a-2b88-493e-90f5-bb563a6fef8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8f21b7a-2b88-493e-90f5-bb563a6fef8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
This PR closes a stored SSRF vector by validating environment.bridge.url at write-time and expanding runtime SSRF guards. The API now blocks unsafe bridge URLs (loopback, metadata hosts, private IPs, credential-embedded URLs, non-HTTP schemes) before persisting them; the runtime enables DNS-pinned SSRF protection for EXTERNAL-origin workflows and stateless bridge URLs; and worker bridge executions enforce SSRF protection for EXTERNAL bridge calls. Logging was tightened to avoid exposing raw URLs/credentials.

## Affected areas
- **api**: Validates and rejects unsafe `bridge.url` in UpdateEnvironment using assertSafeOutboundUrl + resolvePublicAddresses before writing to MongoDB, returning a safe 400 on block and logging only the hostname/reason.
- **worker**: `ExecuteBridgeJob` now enforces SSRF protection for all EXTERNAL-origin bridge executions (not just stateless jobs).
- **application-generic**: `ExecuteFrameworkRequest` precomputes/passes an `enforceSsrfProtection` flag (true for explicit opt-in, stateless bridge URLs, or EXTERNAL-origin workflows); command docs updated to reflect behavior.
- **tests / e2e**: Added e2e coverage for UpdateEnvironment (six scenarios) asserting rejected/accepted bridge URL updates and verifying persistence; adjusted local test fixtures to use 127.0.0.1 and added NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS to worker test env to allow local loopback for fixtures.
- **layouts/workflows e2e helpers**: Switched test bridge hostnames from `localhost` to `127.0.0.1` to match the stricter SSRF checks.

## Key technical decisions
- Block unsafe bridge URLs at write-time in the API to prevent persisted SSRF attacks and simplify runtime enforcement.
- Default to DNS-pinned (connect-time) SSRF protection for EXTERNAL-origin workflows to cover queued/legacy execution paths while allowing explicit opt-in when appropriate.
- Sanitize logs/responses: return client-safe 400 messages and log only hostname/reason to avoid leaking credentials or full URLs.

## Testing
Added new e2e tests for UpdateEnvironment (six cases) covering invalid bridge URLs and clearing/accepting values; developer verified all tests locally. Worker test env was updated to allow local loopback for bridge fixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->