### PR TITLE
fix(root): pre-create ubuntu-owned /opt/cursor dirs for exec-daemon fixes NV-7660

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -72,6 +72,14 @@ RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash ubuntu \
  && echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu \
  && chmod 0440 /etc/sudoers.d/ubuntu
 
+# exec-daemon (runs as ubuntu) mkdir+chmods these on startup; root-owned dirs cause EPERM.
+RUN mkdir -p /opt/cursor/artifacts/assets \
+             /opt/cursor/artifacts/.cursor \
+             /opt/cursor/recording-staging \
+             /opt/cursor/logs \
+ && chown -R ubuntu:ubuntu /opt/cursor \
+ && chmod -R 0777 /opt/cursor
+
 USER ubuntu
 WORKDIR /home/ubuntu
 
@@ -86,4 +94,4 @@ RUN mkdir -p /home/ubuntu/.pnpm-store /home/ubuntu/.pnpm-cache \
  && pnpm config set fetch-retries 3
 
 LABEL org.novu.purpose="cursor-cloud-agent" \
-      org.novu.image-version="2.0.0"
+      org.novu.image-version="2.0.1"

--- a/.cursor/scripts/install.sh
+++ b/.cursor/scripts/install.sh
@@ -16,6 +16,26 @@ cd "$REPO_ROOT"
 
 log() { printf '\033[36m[install]\033[0m %s\n' "$*"; }
 
+ensure_exec_daemon_dirs() {
+  local artifacts_owner
+  artifacts_owner="$(stat -c '%U' /opt/cursor/artifacts 2>/dev/null || echo '')"
+
+  if [ "$artifacts_owner" = "ubuntu" ]; then
+    return 0
+  fi
+
+  log "Preparing /opt/cursor dirs for exec-daemon (screen recording + artifacts)"
+  sudo mkdir -p \
+    /opt/cursor/artifacts/assets \
+    /opt/cursor/artifacts/.cursor \
+    /opt/cursor/recording-staging \
+    /opt/cursor/logs
+  sudo chown -R ubuntu:ubuntu /opt/cursor
+  sudo chmod -R 0777 /opt/cursor
+}
+
+ensure_exec_daemon_dirs
+
 link_enterprise_source() {
   if [ -L .source ] && [ -e .source ]; then
     log ".source already linked -> $(readlink .source)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloud agent startup logged errors creating `/opt/cursor/artifacts/` and `/opt/cursor/recording-staging/` because `exec-daemon` runs as `ubuntu` and calls `chmodSync` on those paths after `mkdirSync`. When the platform creates them as **root-owned** first, `chmod` fails with `EPERM` even though the directories exist.

## Changes

- **`.cursor/Dockerfile`**: Pre-create `/opt/cursor/{artifacts,recording-staging,logs}` (plus `artifacts/assets` and `artifacts/.cursor`) with `ubuntu:ubuntu` ownership and `0777` permissions before switching to the non-root user.
- **`.cursor/scripts/install.sh`**: Idempotent fallback that fixes ownership on every agent boot (helps existing snapshots without rebuilding the image).

## Verification

Reproduced locally: `chmod` as `ubuntu` on a root-owned directory fails with `EPERM`. After `chown ubuntu:ubuntu`, the same mkdir+chmod sequence succeeds.

## Notes on other log lines

| Log | Severity |
|-----|----------|
| `ENOENT` for `.cloud-plugin-manifest*.json` | Transient race while the plugin cache is still warming; files appear shortly after boot |
| `OTLPExporterError: Trace spans collection is not enabled` | Account/feature flag on Cursor telemetry; does not block the agent |
| `Warning: could not find self.pem` (noVNC) | Expected without TLS certs for local VNC proxy |

## Follow-up

Rebuild or refresh the Cloud Agent environment snapshot so the Dockerfile layer is baked into new machines.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c7214df-f465-4b41-90e1-685f3671dd93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c7214df-f465-4b41-90e1-685f3671dd93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The Cursor agent Docker image now pre-creates required `/opt/cursor/` directories with proper ownership and permissions at build time. A startup script function was also added to ensure these directories remain correctly owned, preventing permission errors when exec-daemon (running as the `ubuntu` user) attempts to manage artifacts, staging, and logs directories.

## Affected areas

**`.cursor`**: The Dockerfile now creates `/opt/cursor/{artifacts,recording-staging,logs}` and subdirectories (`artifacts/assets`, `artifacts/.cursor`) with `ubuntu:ubuntu` ownership and `0777` permissions before switching to the non-root user. The install script includes a new `ensure_exec_daemon_dirs()` function that runs at startup to verify and fix ownership on existing snapshots, ensuring the fix applies even to agents booted from older image snapshots. The image version label was bumped from `2.0.0` to `2.0.1`.

## Key technical decisions

- Directory creation happens before the `USER ubuntu` directive in the Dockerfile, allowing root to set proper ownership and broad permissions that survive the user context switch.
- The startup function is idempotent and exits early if directories are already ubuntu-owned, minimizing overhead on each boot.
- Fallback ownership fix in the install script targets existing cloud snapshots that may not have the Dockerfile change baked in.

## Testing

The PR includes local verification reproducing the original EPERM error and confirming the fix allows the mkdir+chmod sequence to succeed when directories are owned by ubuntu. No new unit or integration tests were added, as this is an environmental fix for infrastructure setup rather than application logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->