### PR TITLE
fix(root): install tmux for Cursor cloud agent terminals fixes NV-7660

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     sudo \
+    tmux \
     wget \
  && rm -rf /var/lib/apt/lists/*
 
@@ -94,4 +95,4 @@ RUN mkdir -p /home/ubuntu/.pnpm-store /home/ubuntu/.pnpm-cache \
  && pnpm config set fetch-retries 3
 
 LABEL org.novu.purpose="cursor-cloud-agent" \
-      org.novu.image-version="2.0.1"
+      org.novu.image-version="2.0.2"

--- a/.cursor/scripts/install.sh
+++ b/.cursor/scripts/install.sh
@@ -36,6 +36,18 @@ ensure_exec_daemon_dirs() {
 
 ensure_exec_daemon_dirs
 
+ensure_tmux() {
+  if command -v tmux >/dev/null 2>&1; then
+    return 0
+  fi
+
+  log "Installing tmux (required for Cursor terminal sessions)"
+  sudo apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tmux
+}
+
+ensure_tmux
+
 link_enterprise_source() {
   if [ -L .source ] && [ -e .source ]; then
     log ".source already linked -> $(readlink .source)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After the `/opt/cursor` ownership fix, environment startup still failed during desktop init with:

```text
bash: line 4: tmux: command not found
```

Cursor runs desktop init and `environment.json` **terminals** (API, Worker, Dashboard, WebSocket) inside **tmux**. The slim NV-7660 agent Dockerfile did not include it.

## Changes

- **`.cursor/Dockerfile`**: Add `tmux` to base apt packages (image version `2.0.2`).
- **`.cursor/scripts/install.sh`**: Install `tmux` on boot if missing (helps existing snapshots before image rebuild).

## Verification

`tmux 3.2a` installs cleanly on Ubuntu 22.04 after `apt-get update`.

## Follow-up

Rebuild or refresh the Cloud Agent environment snapshot so the Dockerfile layer is baked in.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c7214df-f465-4b41-90e1-685f3671dd93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c7214df-f465-4b41-90e1-685f3671dd93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The Cursor cloud agent Docker image now includes `tmux`, which is required for running desktop initialization and environment terminals (API, Worker, Dashboard, WebSocket). The package was added to the Dockerfile's base Ubuntu packages and also included as a fallback installation in the startup script to support existing snapshots before the image rebuild is complete.

## Affected areas

**`.cursor`** — The Cursor cloud agent infrastructure was updated to install `tmux` (version 3.2a on Ubuntu 22.04). The Dockerfile now includes `tmux` in its base `apt-get` package list (image version bumped to 2.0.2), and `install.sh` adds an `ensure_tmux` function that verifies the package is available and installs it if missing during boot.

## Key technical decisions

- **Dual installation approach**: `tmux` is baked into the Dockerfile for forward compatibility, with a fallback installation in `install.sh` to support existing snapshots that haven't picked up the new image layer yet.

## Testing

Manual verification confirmed that `tmux 3.2a` installs cleanly on Ubuntu 22.04 after `apt-get update`. No unit or e2e tests are needed for this infrastructure-level change. A follow-up will rebuild or refresh the Cloud Agent environment snapshot to bake in the Dockerfile layer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->