### PR TITLE
feat(dashboard): add bneta to workflows page title fixes NV-7763

### DIFF
--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -252,8 +252,8 @@ export const WorkflowsPage = () => {
 
   return (
     <>
-      <PageMeta title="Workflows" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows</h1>}>
+      <PageMeta title="Workflows bneta" />
+      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows bneta</h1>}>
         <div className="flex h-full w-full flex-col">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-wrap items-center gap-2 py-2.5">

--- a/apps/dashboard/tests/manage-workflows.e2e.ts
+++ b/apps/dashboard/tests/manage-workflows.e2e.ts
@@ -19,7 +19,7 @@ test('manage workflows', async ({ page }) => {
 
   const workflowsPage = new WorkflowsPage(page);
   await workflowsPage.goTo();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`Workflows bneta | Novu Cloud Dashboard`);
 
   await workflowsPage.createWorkflowBtnClick();
 
@@ -171,7 +171,7 @@ test('manage workflows', async ({ page }) => {
 
   // Navigate back to workflows page
   await workflowEditorPage.clickWorkflowsBreadcrumb();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`Workflows bneta | Novu Cloud Dashboard`);
 
   // Verify workflow exists and status
   const workflowElement = await workflowsPage.getWorkflowElement(workflowNameUpdated);

--- a/apps/dashboard/tests/sync-workflow.e2e.ts
+++ b/apps/dashboard/tests/sync-workflow.e2e.ts
@@ -55,7 +55,7 @@ test('sync workflow', async ({ page }) => {
   // go to the workflows page
   const workflowsPage = new WorkflowsPage(page);
   await workflowsPage.goTo();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`Workflows bneta | Novu Cloud Dashboard`);
 
   // check the workflow
   const workflowElement = await workflowsPage.getWorkflowElement(workflowId);
@@ -133,7 +133,7 @@ test('sync workflow', async ({ page }) => {
 
   // go to the workflows page
   await workflowEditorPage.clickWorkflowsBreadcrumb();
-  await expect(page).toHaveTitle(`Workflows | Novu Cloud Dashboard`);
+  await expect(page).toHaveTitle(`Workflows bneta | Novu Cloud Dashboard`);
 
   // check the delete workflow button
   await workflowsPage.clickWorkflowActionsMenu(workflowId);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds "bneta" to the workflows table page title on the dashboard, including the browser tab (`PageMeta`) and the in-page header (`h1`).

## Changes

- Updated `WorkflowsPage` title from "Workflows" to "Workflows bneta"
- Updated related Playwright e2e title assertions for the workflows list page

## Testing

- Manual: visit the workflows list page and confirm the header and tab title show "Workflows bneta"
- E2E: `manage-workflows.e2e.ts` and `sync-workflow.e2e.ts` title expectations updated
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0193ca5-e0c2-4b3a-93b4-fc5ead5e393b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0193ca5-e0c2-4b3a-93b4-fc5ead5e393b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->