### PR TITLE
fix(root): allow docker CLI in cloud agent sessions fixes NV-7660

### DIFF
--- a/.cursor/scripts/install.sh
+++ b/.cursor/scripts/install.sh
@@ -48,6 +48,21 @@ ensure_tmux() {
 
 ensure_tmux
 
+ensure_docker_cli_access() {
+  if docker info >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [ ! -S /var/run/docker.sock ]; then
+    return 0
+  fi
+
+  log "Docker socket not accessible; widening permissions for agent session"
+  sudo chmod 666 /var/run/docker.sock
+}
+
+ensure_docker_cli_access
+
 link_enterprise_source() {
   if [ -L .source ] && [ -e .source ]; then
     log ".source already linked -> $(readlink .source)"

--- a/.cursor/scripts/start.sh
+++ b/.cursor/scripts/start.sh
@@ -19,8 +19,36 @@ cd "$REPO_ROOT"
 
 log() { printf '\033[35m[start]\033[0m %s\n' "$*"; }
 
+# Cloud agent shells often lack an active docker group (usermod needs re-login).
+docker_cli() {
+  if docker info >/dev/null 2>&1; then
+    docker "$@"
+
+    return $?
+  fi
+
+  sudo docker "$@"
+}
+
+ensure_docker_socket_for_agent() {
+  if docker info >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [ ! -S /var/run/docker.sock ]; then
+    return 1
+  fi
+
+  log "Docker socket not accessible; widening permissions for agent session"
+  sudo chmod 666 /var/run/docker.sock
+}
+
 ensure_docker() {
-  docker info >/dev/null 2>&1 && return 0
+  ensure_docker_socket_for_agent || true
+
+  if docker_cli info >/dev/null 2>&1; then
+    return 0
+  fi
 
   log "Starting Docker daemon..."
   sudo service docker start 2>/dev/null \
@@ -28,7 +56,10 @@ ensure_docker() {
     || (sudo dockerd >/dev/null 2>&1 &)
 
   for _ in $(seq 1 30); do
-    docker info >/dev/null 2>&1 && return 0
+    ensure_docker_socket_for_agent || true
+    if docker_cli info >/dev/null 2>&1; then
+      return 0
+    fi
     sleep 2
   done
 
@@ -53,7 +84,7 @@ wait_for_clickhouse() {
 ensure_docker
 
 log "Bringing up Docker services (mongo, redis, clickhouse, localstack)"
-docker compose -f docker/local/docker-compose.agent.yml up -d
+docker_cli compose -f docker/local/docker-compose.agent.yml up -d
 
 wait_for_clickhouse
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`start.sh` failed with `ERROR: Docker daemon did not start within 60s` even though desktop init had already started Docker successfully.

The daemon was running; the agent shell could not talk to it. `/var/run/docker.sock` is `root:docker` mode `660`, and cloud agent sessions do not get an active `docker` group (usermod in the image requires a re-login). `docker info` returned **permission denied**, so the wait loop timed out.

## Changes

- **`start.sh`**: `docker_cli` helper (uses `sudo docker` when needed) and `ensure_docker_socket_for_agent` (`chmod 666` on the socket when the daemon is up but the CLI cannot connect).
- **`install.sh`**: Same socket fix on boot so agent terminals can run `docker` without sudo after install.

## Verification

After `chmod 666` on `/var/run/docker.sock`, `docker info` succeeds and `start.sh` proceeds to `docker compose up`.

## Note

This is appropriate for ephemeral Cursor Cloud Agent VMs. The socket is only widened when the CLI cannot already connect.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c7214df-f465-4b41-90e1-685f3671dd93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c7214df-f465-4b41-90e1-685f3671dd93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Docker CLI now works reliably in cloud agent sessions by providing two mechanisms: a helper that attempts to widen socket permissions when the daemon is running but inaccessible, and a fallback that uses `sudo docker` when direct access fails. This resolves permission issues caused by the Docker socket being mode 660 while agent sessions lack docker group membership.

## Affected areas

**Cursor Cloud Agent setup** — `install.sh` now verifies Docker CLI access on boot and widens socket permissions if needed; `start.sh` wraps Docker commands with a CLI helper that falls back to `sudo docker` and adds socket remediation to the startup retry loop before bringing up compose services.

## Key technical decisions

- Socket permissions are broadened to 666 only when necessary (CLI cannot connect) and only on ephemeral agent VMs, avoiding permanent security changes.
- A `docker_cli` wrapper provides transparent fallback to `sudo docker` instead of requiring all compose invocations to be conditional on permissions.
- Socket remediation is applied both at install time and during startup to handle cases where the daemon starts after agent session initialization.

## Testing

Changes were verified manually on the affected infrastructure: after `chmod 666` on `/var/run/docker.sock`, `docker info` succeeds and start.sh proceeds to complete the compose bring-up. No new unit tests were added as this is environment-specific remediation for ephemeral VMs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->