### PR TITLE
feat(dashboard): add bneta to workflows page title fixes NV-7764

### DIFF
--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -252,8 +252,8 @@ export const WorkflowsPage = () => {
 
   return (
     <>
-      <PageMeta title="Workflows" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows</h1>}>
+      <PageMeta title="Workflows bneta" />
+      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows bneta</h1>}>
         <div className="flex h-full w-full flex-col">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-wrap items-center gap-2 py-2.5">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds "bneta" to the workflows table page title on the dashboard.

## Changes

- Updated `PageMeta` title from "Workflows" to "Workflows bneta" (browser tab shows "Workflows bneta | Novu")
- Updated the page header `h1` to match
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4c685e9-7cd0-4816-b0ca-f51128960a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4c685e9-7cd0-4816-b0ca-f51128960a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The workflows page title in the dashboard was updated to include "bneta". Both the browser tab title (via `PageMeta`) and the page header (`h1`) now display "Workflows bneta" instead of just "Workflows". This appears to be a labeling change to differentiate or identify the workflows feature with the "bneta" designation.

## Affected areas

**dashboard**: Updated the workflows page title and header in the `WorkflowsPage` component to include "bneta" branding.

## Testing

No new tests were added, as this is a simple text/label change that does not affect functionality or logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->