### PR TITLE
feat(dashboard): add Show component to better-auth clerk shim fixes NV-7767

### DIFF
--- a/apps/dashboard/src/utils/better-auth/auth-context.ts
+++ b/apps/dashboard/src/utils/better-auth/auth-context.ts
@@ -1,0 +1,29 @@
+import { MemberRoleEnum, PermissionsEnum } from '@novu/shared';
+import { createContext } from 'react';
+
+export type BetterAuthUser = {
+  id: string;
+  email: string;
+  name: string;
+  image?: string;
+  emailVerified: boolean;
+};
+
+export type BetterAuthOrganization = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+export type AuthContextType = {
+  user: BetterAuthUser | null;
+  organization: BetterAuthOrganization | null;
+  memberRole: MemberRoleEnum | null;
+  isLoaded: boolean;
+  signOut: () => Promise<void>;
+  getToken: () => Promise<string | null>;
+  refreshSession: () => Promise<void>;
+  has: (params: { permission: PermissionsEnum } | { role: MemberRoleEnum }) => boolean;
+};
+
+export const AuthContext = createContext<AuthContextType | null>(null);

--- a/apps/dashboard/src/utils/better-auth/index.tsx
+++ b/apps/dashboard/src/utils/better-auth/index.tsx
@@ -1,5 +1,5 @@
 import { FeatureFlagsKeysEnum, MemberRoleEnum, PermissionsEnum } from '@novu/shared';
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { ROUTES } from '@/utils/routes';
@@ -20,34 +20,11 @@ import {
   UserProfile as UserProfileComponent,
   VerifyEmail as VerifyEmailComponent,
 } from './components';
+import { AuthContext, type BetterAuthOrganization, type BetterAuthUser } from './auth-context';
 import { ROLE_PERMISSIONS } from './role-permissions';
+import { Show } from './show';
 
-type BetterAuthUser = {
-  id: string;
-  email: string;
-  name: string;
-  image?: string;
-  emailVerified: boolean;
-};
-
-type BetterAuthOrganization = {
-  id: string;
-  name: string;
-  slug: string;
-};
-
-type AuthContextType = {
-  user: BetterAuthUser | null;
-  organization: BetterAuthOrganization | null;
-  memberRole: MemberRoleEnum | null;
-  isLoaded: boolean;
-  signOut: () => Promise<void>;
-  getToken: () => Promise<string | null>;
-  refreshSession: () => Promise<void>;
-  has: (params: { permission: PermissionsEnum } | { role: MemberRoleEnum }) => boolean;
-};
-
-const AuthContext = createContext<AuthContextType | null>(null);
+export { Show };
 
 export function ClerkProvider({ children }: { children: React.ReactNode }) {
   const { data: sessionData, isPending, refetch } = authClient.useSession();

--- a/apps/dashboard/src/utils/better-auth/show.tsx
+++ b/apps/dashboard/src/utils/better-auth/show.tsx
@@ -1,4 +1,4 @@
-import type { ShowWhenCondition } from '@clerk/shared/types';
+import type { CheckAuthorizationWithCustomPermissions, ShowWhenCondition } from '@clerk/shared/types';
 import { MemberRoleEnum, PermissionsEnum } from '@novu/shared';
 import React, { useContext } from 'react';
 import { AuthContext } from './auth-context';
@@ -8,6 +8,22 @@ type ShowProps = {
   fallback?: React.ReactNode;
   children: React.ReactNode;
 };
+
+function toClerkHas(
+  has: (params: { permission: PermissionsEnum } | { role: MemberRoleEnum }) => boolean
+): CheckAuthorizationWithCustomPermissions {
+  return (params) => {
+    if ('permission' in params && params.permission !== undefined) {
+      return has({ permission: params.permission as PermissionsEnum });
+    }
+
+    if ('role' in params && params.role !== undefined) {
+      return has({ role: params.role as MemberRoleEnum });
+    }
+
+    return false;
+  };
+}
 
 function evaluateShowCondition(
   when: ShowWhenCondition,
@@ -23,15 +39,15 @@ function evaluateShowCondition(
   }
 
   if (typeof when === 'function') {
-    return when(has);
+    return when(toClerkHas(has));
   }
 
-  if ('permission' in when) {
-    return has({ permission: when.permission });
+  if ('permission' in when && when.permission !== undefined) {
+    return has({ permission: when.permission as PermissionsEnum });
   }
 
-  if ('role' in when) {
-    return has({ role: when.role });
+  if ('role' in when && when.role !== undefined) {
+    return has({ role: when.role as MemberRoleEnum });
   }
 
   return false;

--- a/apps/dashboard/src/utils/better-auth/show.tsx
+++ b/apps/dashboard/src/utils/better-auth/show.tsx
@@ -1,0 +1,55 @@
+import type { ShowWhenCondition } from '@clerk/shared/types';
+import { MemberRoleEnum, PermissionsEnum } from '@novu/shared';
+import React, { useContext } from 'react';
+import { AuthContext } from './auth-context';
+
+type ShowProps = {
+  when: ShowWhenCondition;
+  fallback?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+function evaluateShowCondition(
+  when: ShowWhenCondition,
+  has: (params: { permission: PermissionsEnum } | { role: MemberRoleEnum }) => boolean,
+  isSignedIn: boolean
+): boolean {
+  if (when === 'signed-in') {
+    return isSignedIn;
+  }
+
+  if (when === 'signed-out') {
+    return !isSignedIn;
+  }
+
+  if (typeof when === 'function') {
+    return when(has);
+  }
+
+  if ('permission' in when) {
+    return has({ permission: when.permission });
+  }
+
+  if ('role' in when) {
+    return has({ role: when.role });
+  }
+
+  return false;
+}
+
+export function Show({ when, fallback, children }: ShowProps) {
+  const context = useContext(AuthContext);
+
+  if (!context?.isLoaded) {
+    return null;
+  }
+
+  const isSignedIn = !!context.user;
+  const shouldShow = evaluateShowCondition(when, context.has, isSignedIn);
+
+  if (!shouldShow) {
+    return fallback ? <>{fallback}</> : null;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the missing `Show` component to the better-auth `@clerk/react` shim so enterprise builds with `VITE_EE_AUTH_PROVIDER=better-auth` match Clerk's conditional rendering API.

This was briefly included in #11227 to unblock Netlify; that PR now only covers the better-auth security upgrade. This PR implements `Show` properly in dedicated modules.

## Changes

- `auth-context.ts` — shared auth context types and `AuthContext` (avoids circular imports)
- `show.tsx` — `Show` component using Clerk's `ShowWhenCondition` type
- `index.tsx` — re-exports `Show` from the shim entrypoint

## Behavior

`Show` mirrors Clerk usage across the dashboard:

- `when="signed-in"` / `when="signed-out"` — session gating for routes (`protected-route`, `auth`, `onboarding`)
- `when={{ permission }}` / `when={{ role }}` / predicate — RBAC via `Protect`

Renders `null` while auth is loading; optional `fallback` when the condition is not met.

## Verification

- `pnpm --filter @novu/dashboard exec tsc --noEmit`
- `VITE_EE_AUTH_PROVIDER=better-auth VITE_NOVU_ENTERPRISE=true pnpm exec vite build` (dashboard)

## Related

- #11227 — better-auth CVE upgrade (Show removed from that branch)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779621615729469?thread_ts=1779621615.729469&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-088d4975-a59e-52f6-90a9-48662750efd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-088d4975-a59e-52f6-90a9-48662750efd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Added a missing Show component to the better-auth `@clerk/react` shim and moved shared auth types into a dedicated auth-context module so enterprise dashboard builds (VITE_EE_AUTH_PROVIDER=better-auth) match Clerk’s conditional rendering API. This restores session gating and RBAC checks (signed-in/signed-out, permission, role, and predicate forms) and prevents type/circular-import issues that were breaking Netlify/Vite builds.

## Affected areas
**dashboard**: Introduced shared auth types (BetterAuthUser, BetterAuthOrganization, AuthContextType) in apps/dashboard/src/utils/better-auth/auth-context.ts and implemented Show in show.tsx, with index.tsx re-exporting it; Show evaluates Clerk-like ShowWhenCondition rules and defers rendering until auth is loaded.

## Key technical decisions
- Extracted auth context types to a separate module to avoid circular imports between provider and components.
- Aligned Show’s types/signature with Clerk’s authorization API (handles broader CheckAuthorization params) to resolve TypeScript mismatches seen in CI.
- Show renders null while auth is loading and accepts an optional fallback when conditions are not met to avoid layout shifts.

## Testing
Verified via TypeScript compilation (pnpm --filter `@novu/dashboard` exec tsc --noEmit) and an enterprise dashboard build (VITE_EE_AUTH_PROVIDER=better-auth VITE_NOVU_ENTERPRISE=true pnpm exec vite build); fixes address the TS2345/TS2322 errors observed in the Netlify build log.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->