### PR TITLE
fix(root): generate API metadata in agent build fixes NV-7765

### DIFF
--- a/.cursor/rules/infrastructure.mdc
+++ b/.cursor/rules/infrastructure.mdc
@@ -29,4 +29,4 @@ alwaysApply: false
 - Real-time features: API + Worker + `pnpm start:ws`
 - Full stack: `docker compose` + all of the above
 
-Run `pnpm build` before starting services only if changes were made to `libs/`, `packages/`, or `enterprise/`. Cloud agent install/update uses `pnpm build:agents`, which skips `apps/` (apps build when their dev servers start).
+Run `pnpm build` before starting services only if changes were made to `libs/`, `packages/`, or `enterprise/`. Cloud agent install/update uses `pnpm build:agents`, which skips full app builds but still runs `@novu/api-service:build:metadata` (apps otherwise build when their dev servers start).

--- a/.cursor/scripts/install.sh
+++ b/.cursor/scripts/install.sh
@@ -215,6 +215,7 @@ ensure_env apps/dashboard/.env
 # Incremental build via Nx cache. After a `git pull` only projects whose
 # inputs changed are rebuilt; everything else is a cache hit (~seconds).
 # Apps are excluded — they compile on demand when dev servers start.
+# API OpenAPI metadata is still generated (required by nest start --watch).
 log "Building workspace dependencies (incremental via Nx cache, apps excluded)"
 pnpm build:agents
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:v2": "nx run-many --target=build --all --projects=@novu/api-service,@novu/worker,@novu/ws,@novu/dashboard,tag:type:package",
     "build:webhook": "nx build @novu/webhook",
     "prebuild:agents": "nx run-many --target=prebuild --all --exclude=tag:type:app",
-    "build:agents": "nx run-many --target=build --all --exclude=tag:type:app,nextjs,nestjs",
+    "build:agents": "nx run-many --target=build --all --exclude=tag:type:app,nextjs,nestjs && nx run @novu/api-service:build:metadata",
     "build:worker": "nx build @novu/worker",
     "build:ws": "nx build @novu/ws",
     "build": "nx run-many --target=build --all --exclude=nextjs,nestjs",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #11236. Excluding apps from `pnpm build:agents` skipped generation of `apps/api/src/metadata.ts`, which caused `pnpm start:api:dev` to fail with `Cannot find module '../../../../metadata'`.

## Changes

- Append `nx run @novu/api-service:build:metadata` to `build:agents` (lightweight; no full API compile)
- Document this in `install.sh` and `infrastructure.mdc`

## Verification

```bash
rm -f apps/api/src/metadata.ts
pnpm build:agents   # or: pnpm nx run @novu/api-service:build:metadata
test -f apps/api/src/metadata.ts
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-386e2092-4a1e-4419-a950-ddc2616612ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-386e2092-4a1e-4419-a950-ddc2616612ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `build:agents` script was updated to include API metadata generation. After running the agent builds, the script now also executes `nx run `@novu/api-service`:build:metadata` to ensure `apps/api/src/metadata.ts` is created. This fixes a "Cannot find module" error when running `pnpm start:api:dev` after building agents, since excluding apps from the build previously skipped metadata generation entirely.

## Affected areas

**root**: Updated the `build:agents` script to append metadata generation as a lightweight follow-up step, and added clarifying comments in `.cursor/scripts/install.sh` and `.cursor/rules/infrastructure.mdc` to document that metadata generation still occurs even when full app builds are excluded.

## Testing

No new tests added. This is a build script fix verified manually by running `pnpm build:agents` and confirming that `apps/api/src/metadata.ts` is created without requiring a full API compilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->