### PR TITLE
chore(root): add ffmpeg libavutil58 for screen recording fixes NV-7773

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -11,20 +11,22 @@
 # multi-repo environment clones it next to `novu/`; `.cursor/scripts/install.sh`
 # wires `.source` -> the sibling clone so `pnpm symlink:submodules` works.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Base toolchain
+# Base toolchain (+ ffmpeg for Cursor screen recording / polished-renderer libavutil58)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     build-essential \
     ca-certificates \
     curl \
+    ffmpeg \
     git \
     gnupg \
     iptables \
     jq \
+    libavutil58 \
     lsb-release \
     openssh-client \
     python3 \
@@ -95,4 +97,4 @@ RUN mkdir -p /home/ubuntu/.pnpm-store /home/ubuntu/.pnpm-cache \
  && pnpm config set fetch-retries 3
 
 LABEL org.novu.purpose="cursor-cloud-agent" \
-      org.novu.image-version="2.0.2"
+      org.novu.image-version="2.0.3"

--- a/.cursor/scripts/install.sh
+++ b/.cursor/scripts/install.sh
@@ -47,6 +47,23 @@ ensure_tmux() {
 
 ensure_tmux
 
+ensure_screen_recording_deps() {
+  if ldconfig -p 2>/dev/null | grep -q 'libavutil\.so\.58'; then
+    return 0
+  fi
+
+  if ! apt-cache show libavutil58 >/dev/null 2>&1; then
+    log "WARN: libavutil58 unavailable on this image; rebuild .cursor/Dockerfile (Ubuntu 24.04+) for screen recording"
+    return 0
+  fi
+
+  log "Installing ffmpeg runtime (libavutil58) for screen recording"
+  sudo apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ffmpeg libavutil58
+}
+
+ensure_screen_recording_deps
+
 ensure_docker_cli_access() {
   if docker info >/dev/null 2>&1; then
     return 0

--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -252,8 +252,8 @@ export const WorkflowsPage = () => {
 
   return (
     <>
-      <PageMeta title="Workflows" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows</h1>}>
+      <PageMeta title="Workflows bneta" />
+      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows bneta</h1>}>
         <div className="flex h-full w-full flex-col">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-wrap items-center gap-2 py-2.5">

--- a/apps/dashboard/src/pages/workflows.tsx
+++ b/apps/dashboard/src/pages/workflows.tsx
@@ -252,8 +252,8 @@ export const WorkflowsPage = () => {
 
   return (
     <>
-      <PageMeta title="Workflows bneta" />
-      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows bneta</h1>}>
+      <PageMeta title="Workflows" />
+      <DashboardLayout headerStartItems={<h1 className="text-foreground-950 flex items-center gap-1">Workflows</h1>}>
         <div className="flex h-full w-full flex-col">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-wrap items-center gap-2 py-2.5">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Cursor cloud agent screen recording save failures (`libavutil.so.58: cannot open shared object file`) by installing the FFmpeg runtime required by `polished-renderer`.

## Changes

- **`.cursor/Dockerfile`**: Upgrade base image from Ubuntu 22.04 → 24.04; install `ffmpeg` and `libavutil58`; bump image version to `2.0.3`
- **`.cursor/scripts/install.sh`**: Add `ensure_screen_recording_deps` to install missing libs on agent boot when the image has not been rebuilt yet
- **Reverted** the temporary workflows page title (`bneta`) change

## Notes

Ubuntu 22.04 only ships `libavutil56`; `libavutil58` requires Ubuntu 24.04 (noble). Noble packages cannot be installed on jammy without libc conflicts, so the base image upgrade is required.

After the image rebuilds, `RecordScreen` → `SAVE_RECORDING` should work without the polished-renderer native binding error.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85c6b906-1347-4034-a6a2-48d9eb4a7e9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85c6b906-1347-4034-a6a2-48d9eb4a7e9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR introduces a comprehensive Cursor cloud agent configuration for the Novu development environment. It adds Docker and initialization infrastructure to support running Cursor as a background agent, including a Dockerfile that upgrades the base image to Ubuntu 24.04 and installs ffmpeg/libavutil58 for screen recording support, along with installation and startup scripts that configure dependencies, Docker access, and Git settings.

## Affected areas

**infrastructure**: Added `.cursor/Dockerfile` (Ubuntu 24.04 base image with ffmpeg, libavutil58, Node 22, pnpm, TypeScript, and Docker), `.cursor/scripts/install.sh` (agent initialization with dependency checks, environment variable setup, and symlink management for multi-repo enterprise support), and `.cursor/scripts/start.sh` (startup orchestration). Also added Cursor rules, commands, skills, and environment configuration files to guide agent behavior and code quality standards.

## Key technical decisions

- Ubuntu 24.04 base image chosen to support ffmpeg/libavutil58 requirements (vs. Ubuntu 22.04).
- Runtime dependency check function `ensure_screen_recording_deps()` added to gracefully handle missing screen recording libraries and warn if Dockerfile rebuild is needed.
- Dockerfile uses `fuse-overlayfs` storage driver for nested container support.
- Agent runs as non-root `ubuntu` user with Docker group access via sudoers passthrough.
- Enterprise multi-repo support: symlinks `.source` to sibling `packages-enterprise` repo for shared code reuse.

## Testing

Infrastructure changes are manual verification only—no unit or e2e tests apply to Dockerfile/script additions. The Cursor agent integration is verified by deployment and use within the Cursor cloud environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->