### PR TITLE
feat(dashboard): auto sign-in for Cursor cloud agent environment fixes NV-7775

### DIFF
--- a/.cursor/rules/dashboard.mdc
+++ b/.cursor/rules/dashboard.mdc
@@ -21,7 +21,7 @@ apps/dashboard/src/api/          # API client and query definitions
 apps/dashboard/src/ee/           # Enterprise-only features
 ```
 
-**Agent sign-in:** A default user and org are pre-seeded — sign in at `http://localhost:4201/auth/sign-in`, do not go through onboarding unless asked.
+**Agent sign-in:** A default user and org are pre-seeded. In Cursor cloud agent environments (`apps/dashboard/.env.agent`), the dashboard auto signs in — open `http://localhost:4201` and wait for redirect; do not type credentials unless auto sign-in fails.
 
 | Field | Value |
 |-------|-------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Cursor Cloud specific instructions
 
-`pnpm setup:agent` has already been run. Do not run it again. The environment is fully configured: dependencies installed, enterprise packages linked, project built, `.env` files in place, Docker services running, and a default user/org seeded.
+`pnpm setup:agent` has already been run. Do not run it again. The environment is fully configured: dependencies installed, enterprise packages linked, project built, `.env` files in place, Docker services running, and a default user/org seeded. The dashboard auto signs in the pre-seeded agent user when opened in the browser (no manual login unless auto sign-in fails).
 
 ## Build
 

--- a/apps/dashboard/.env.agent
+++ b/apps/dashboard/.env.agent
@@ -45,3 +45,8 @@ VITE_REGION_FLAG_SG=🇸🇬
 VITE_EE_AUTH_PROVIDER=better-auth
 VITE_NOVU_ENTERPRISE=true
 VITE_SELF_HOSTED=true
+
+# Cursor cloud agent: auto sign-in with the pre-seeded user (scripts/seed-agent-data.mjs)
+VITE_CURSOR_AGENT_AUTO_LOGIN=true
+VITE_AGENT_SEED_EMAIL=agent@novu.co
+VITE_AGENT_SEED_PASSWORD=Agent123!@#

--- a/apps/dashboard/src/config/index.ts
+++ b/apps/dashboard/src/config/index.ts
@@ -67,3 +67,10 @@ export function getEnvVar(key: string, fallback: string = ''): string {
     fallback
   );
 }
+
+/** Cursor cloud agent only: auto sign-in with the pre-seeded dev user (see .env.agent). */
+export const CURSOR_AGENT_AUTO_LOGIN = getEnvVar('VITE_CURSOR_AGENT_AUTO_LOGIN') === 'true';
+
+export const CURSOR_AGENT_SEED_EMAIL = getEnvVar('VITE_AGENT_SEED_EMAIL');
+
+export const CURSOR_AGENT_SEED_PASSWORD = getEnvVar('VITE_AGENT_SEED_PASSWORD');

--- a/apps/dashboard/src/utils/better-auth/auth-context.ts
+++ b/apps/dashboard/src/utils/better-auth/auth-context.ts
@@ -24,6 +24,8 @@ export type AuthContextType = {
   getToken: () => Promise<string | null>;
   refreshSession: () => Promise<void>;
   has: (params: { permission: PermissionsEnum } | { role: MemberRoleEnum }) => boolean;
+  isAutoLoginPending: boolean;
+  isAutoLoginFailed: boolean;
 };
 
 export const AuthContext = createContext<AuthContextType | null>(null);

--- a/apps/dashboard/src/utils/better-auth/index.tsx
+++ b/apps/dashboard/src/utils/better-auth/index.tsx
@@ -23,6 +23,7 @@ import {
 import { AuthContext, type BetterAuthOrganization, type BetterAuthUser } from './auth-context';
 import { ROLE_PERMISSIONS } from './role-permissions';
 import { Show } from './show';
+import { useCursorAgentAutoLogin } from './use-cursor-agent-auto-login';
 
 export { Show };
 
@@ -120,18 +121,40 @@ export function ClerkProvider({ children }: { children: React.ReactNode }) {
     [memberRole]
   );
 
+  const isLoaded = !isPending && !isOrgLoading;
+  const isSignedIn = !!user;
+
+  const { isAutoLoginPending, isAutoLoginFailed } = useCursorAgentAutoLogin({
+    isLoaded,
+    isSignedIn,
+    refreshSession,
+  });
+
   const value = useMemo(
     () => ({
       user,
       organization: organization || null,
       memberRole,
-      isLoaded: !isPending && !isOrgLoading,
+      isLoaded,
       signOut,
       getToken,
       refreshSession,
       has,
+      isAutoLoginPending,
+      isAutoLoginFailed,
     }),
-    [user, organization, memberRole, isPending, isOrgLoading, refreshSession, signOut, getToken, has]
+    [
+      user,
+      organization,
+      memberRole,
+      isLoaded,
+      refreshSession,
+      signOut,
+      getToken,
+      has,
+      isAutoLoginPending,
+      isAutoLoginFailed,
+    ]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
@@ -332,6 +355,18 @@ export function RedirectToSignIn() {
 }
 
 export function SignIn() {
+  const context = useContext(AuthContext);
+  const isAutoLoginPending = context?.isAutoLoginPending ?? false;
+  const isAutoLoginFailed = context?.isAutoLoginFailed ?? false;
+
+  if (isAutoLoginPending && !isAutoLoginFailed) {
+    return (
+      <div className="mx-auto w-full max-w-md pt-12 text-center">
+        <p className="text-sm text-foreground-600">Signing in to the agent environment…</p>
+      </div>
+    );
+  }
+
   return <SignInComponent />;
 }
 

--- a/apps/dashboard/src/utils/better-auth/use-cursor-agent-auto-login.ts
+++ b/apps/dashboard/src/utils/better-auth/use-cursor-agent-auto-login.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react';
+import { CURSOR_AGENT_AUTO_LOGIN, CURSOR_AGENT_SEED_EMAIL, CURSOR_AGENT_SEED_PASSWORD } from '@/config';
+import { authClient } from './client';
+
+type AutoLoginStatus = 'idle' | 'pending' | 'failed';
+
+export function useCursorAgentAutoLogin({
+  isLoaded,
+  isSignedIn,
+  refreshSession,
+}: {
+  isLoaded: boolean;
+  isSignedIn: boolean;
+  refreshSession: () => Promise<void>;
+}) {
+  const [status, setStatus] = useState<AutoLoginStatus>('idle');
+  const attemptedRef = useRef(false);
+
+  useEffect(() => {
+    if (!CURSOR_AGENT_AUTO_LOGIN) {
+      return;
+    }
+
+    if (!CURSOR_AGENT_SEED_EMAIL || !CURSOR_AGENT_SEED_PASSWORD) {
+      console.warn(
+        '[cursor-agent] VITE_CURSOR_AGENT_AUTO_LOGIN is enabled but VITE_AGENT_SEED_EMAIL or VITE_AGENT_SEED_PASSWORD is missing'
+      );
+
+      return;
+    }
+
+    if (!isLoaded || isSignedIn || attemptedRef.current) {
+      return;
+    }
+
+    attemptedRef.current = true;
+    setStatus('pending');
+
+    async function runAutoLogin() {
+      try {
+        const { data, error } = await authClient.signIn.email({
+          email: CURSOR_AGENT_SEED_EMAIL,
+          password: CURSOR_AGENT_SEED_PASSWORD,
+        });
+
+        if (error || !data?.token) {
+          throw new Error(error?.message || 'Auto sign-in failed');
+        }
+
+        localStorage.setItem('better-auth-session-token', data.token);
+        await refreshSession();
+        setStatus('idle');
+      } catch (err) {
+        console.warn('[cursor-agent] Auto sign-in failed; use the sign-in form.', err);
+        attemptedRef.current = false;
+        setStatus('failed');
+      }
+    }
+
+    void runAutoLogin();
+  }, [isLoaded, isSignedIn, refreshSession]);
+
+  return {
+    isAutoLoginPending: CURSOR_AGENT_AUTO_LOGIN && status === 'pending',
+    isAutoLoginFailed: CURSOR_AGENT_AUTO_LOGIN && status === 'failed',
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cursor cloud agents already get a pre-seeded Better Auth user via `pnpm seed:agent`, but still had to manually type credentials in the browser. This adds an agent-only auto sign-in path gated by `VITE_CURSOR_AGENT_AUTO_LOGIN` in `apps/dashboard/.env.agent`.

## How it works

1. On dashboard load, when `VITE_CURSOR_AGENT_AUTO_LOGIN=true` and seed credentials are present, the Better Auth provider calls `signIn.email` with the pre-seeded user.
2. The session token is stored in `localStorage` (same as manual sign-in).
3. The sign-in page shows a short “Signing in…” message instead of the form while auto sign-in runs; the manual form remains as a fallback if auto sign-in fails.

## Configuration (agent environments only)

Set in `apps/dashboard/.env.agent` (merged into `.env` on agent boot):

- `VITE_CURSOR_AGENT_AUTO_LOGIN=true`
- `VITE_AGENT_SEED_EMAIL=agent@novu.co`
- `VITE_AGENT_SEED_PASSWORD=Agent123!@#`

These vars are **not** enabled for normal local or production builds.

## Verification

- Confirmed API sign-in works for the seeded credentials.
- After merging env keys, restart the dashboard dev server so Vite picks up the new `VITE_*` variables.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af8d8176-4b40-4c06-8e10-50148167e0ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af8d8176-4b40-4c06-8e10-50148167e0ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->