### PR TITLE
feat(dashboard): use claude-sonnet-4-6 as default model for managed agent provisioning fixes NV-7777

### DIFF
--- a/apps/dashboard/src/hooks/use-create-agent-mutation.ts
+++ b/apps/dashboard/src/hooks/use-create-agent-mutation.ts
@@ -125,7 +125,7 @@ export function useCreateAgentMutation() {
                 managedRuntime: {
                   integrationId,
                   providerId: AgentRuntimeProviderIdEnum.Anthropic,
-                  model: 'claude-opus-4-5',
+                  model: 'claude-sonnet-4-6',
                   systemPrompt: managedOverrides?.systemPrompt ?? instructions ?? undefined,
                   tools: managedOverrides?.tools ?? CLAUDE_BUILTIN_TOOLS.map((tool) => tool.type),
                   ...(managedOverrides?.mcpServers ? { mcpServers: managedOverrides.mcpServers } : {}),

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts
@@ -39,7 +39,7 @@ import type {
 } from '../i-agent-runtime-provider';
 
 const PROVIDER_ID = AgentRuntimeProviderIdEnum.Anthropic;
-const DEFAULT_MODEL = 'claude-sonnet-4-5';
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
 /** Single retry jitter window in ms */
 const RETRY_JITTER_MS = 500;
 /** Timeout for config calls in ms */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switches the default model for new managed Claude agents from `claude-opus-4-5` / `claude-sonnet-4-5` to `claude-sonnet-4-6`.

## Changes

| File | Before | After |
|------|--------|-------|
| `apps/dashboard/src/hooks/use-create-agent-mutation.ts` | `claude-opus-4-5` | `claude-sonnet-4-6` |
| `libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.ts` | `claude-sonnet-4-5` | `claude-sonnet-4-6` |

### How the default is applied

When a user creates a new managed Claude agent from the dashboard:

1. The **dashboard hook** (`use-create-agent-mutation.ts`) explicitly sets the `model` field in the `managedRuntime` payload to `claude-sonnet-4-6`.
2. If the `model` field is omitted from the API request entirely, the **backend fallback** (`DEFAULT_MODEL` in `anthropic-agent-runtime.provider.ts`) now resolves to `claude-sonnet-4-6` as well.

No changes to the DTOs, enums, or E2E tests are required — model is a free-form `string` field, and the E2E tests that reference `claude-opus-4-5` are testing explicit user-supplied values (not defaults).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0AQDQ4J6UU/p1779629106372839?thread_ts=1779629106.372839&cid=C0AQDQ4J6UU)

<div><a href="https://cursor.com/agents/bc-769399e8-2310-57ba-9339-cdb203f69f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-769399e8-2310-57ba-9339-cdb203f69f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The default model for managed Claude agents has been updated from `claude-sonnet-4-5` to `claude-sonnet-4-6`. This change ensures new agents created through the dashboard use the newer model version, and establishes the same fallback default for API requests that don't explicitly specify a model.

## Affected areas

- **dashboard**: Updated the default model in the agent creation mutation hook to `claude-sonnet-4-6`.
- **application-generic**: Updated the Anthropic agent runtime's DEFAULT_MODEL constant to `claude-sonnet-4-6`.

## Testing

No tests were added. The `model` field is a free-form string, and existing E2E tests validate explicit user-supplied model values rather than defaults, so no test updates are required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->