### PR TITLE
fix(api-service): skip bridge dispatch for managed agent link-button actions fixes NV-7780

### DIFF
--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
@@ -39,6 +39,7 @@ describe('AgentInboundHandler', () => {
       linkTelegramExecute?: sinon.SinonStub;
       startCodeConsume?: sinon.SinonStub;
       findTelegramEndpointByIdentity?: sinon.SinonStub;
+      agentFindOne?: sinon.SinonStub;
     } = {}
   ) {
     const logger = makeLogger();
@@ -62,9 +63,13 @@ describe('AgentInboundHandler', () => {
     };
     const managedAgentService = {
       dispatch: sinon.stub().resolves(undefined),
+      confirmToolApproval: sinon.stub().resolves(undefined),
+    };
+    const chatSdkService = {
+      registerInboundCallbacks: sinon.stub(),
     };
     const agentRepository = {
-      findOne: sinon.stub().resolves(null),
+      findOne: overrides.agentFindOne ?? sinon.stub().resolves(null),
     };
     const environmentRepository = {
       findOne: sinon.stub().resolves(null),
@@ -92,6 +97,7 @@ describe('AgentInboundHandler', () => {
       conversationService as any,
       bridgeExecutor as any,
       managedAgentService as any,
+      chatSdkService as any,
       agentRepository as any,
       subscriberRepository as any,
       environmentRepository as any,
@@ -437,6 +443,54 @@ describe('AgentInboundHandler', () => {
 
       expect(linkTelegramChatToSubscriber.execute.called).to.equal(false);
       expect(conversationService.createOrGetConversation.calledOnce).to.equal(true);
+    });
+  });
+
+  function makeActionThread() {
+    return {
+      id: 'thread1',
+      channelId: 'channel1',
+      isDM: false,
+    };
+  }
+
+  describe('handleAction', () => {
+    it('should skip bridge dispatch for link-button actions', async () => {
+      const { handler, bridgeExecutor } = makeHandler();
+      const thread = makeActionThread();
+      const action = { id: 'link-https://access.stripe.com/mcp/oauth2/authorize', value: undefined };
+
+      await handler.handleAction('agent1', config as any, thread as any, action as any, 'user1');
+
+      expect(bridgeExecutor.execute.called).to.equal(false);
+    });
+
+    it('should skip bridge dispatch for managed agents on non-link actions', async () => {
+      const { handler, bridgeExecutor } = makeHandler({
+        agentFindOne: sinon.stub().resolves({
+          _id: 'agent1',
+          runtime: 'managed',
+          managedRuntime: { providerId: 'anthropic', _integrationId: 'int1', externalAgentId: 'ext1' },
+        }),
+      });
+      const thread = makeActionThread();
+      const action = { id: 'custom-action', value: 'yes' };
+
+      await handler.handleAction('agent1', config as any, thread as any, action as any, 'user1');
+
+      expect(bridgeExecutor.execute.called).to.equal(false);
+    });
+
+    it('should forward self-hosted agent actions to the bridge', async () => {
+      const { handler, bridgeExecutor } = makeHandler();
+      const thread = makeActionThread();
+      const action = { id: 'ack', value: undefined };
+
+      await handler.handleAction('agent1', config as any, thread as any, action as any, 'user1');
+
+      expect(bridgeExecutor.execute.calledOnce).to.equal(true);
+      expect(bridgeExecutor.execute.firstCall.args[0].event).to.equal(AgentEventEnum.ON_ACTION);
+      expect(bridgeExecutor.execute.firstCall.args[0].action).to.deep.equal(action);
     });
   });
 

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -110,6 +110,15 @@ function parseToolApprovalActionId(id: string | undefined): { approved: boolean;
   return { approved: verdict === 'approve', toolUseId };
 }
 
+/**
+ * Action-id shape emitted by the chat SDK when a card `link-button` is clicked.
+ * The platform opens `url` in the user's browser; no bridge `onAction` dispatch
+ * is required (and managed agents never have a bridge URL configured).
+ */
+function isLinkButtonActionId(id: string | undefined): boolean {
+  return typeof id === 'string' && id.startsWith('link-');
+}
+
 function getMessageRawEvent(message: Message): Record<string, unknown> | undefined {
   const raw = asRecord(message.raw);
 
@@ -749,6 +758,20 @@ export class AgentInboundHandler implements OnModuleInit {
         approved: toolApproval.approved,
       });
 
+      return;
+    }
+
+    if (isLinkButtonActionId(action.id)) {
+      return;
+    }
+
+    const agent = await this.agentRepository.findOne({ _id: agentId, _environmentId: config.environmentId }, [
+      '_id',
+      'runtime',
+      'managedRuntime',
+    ]);
+
+    if (agent?.runtime === 'managed' && agent.managedRuntime) {
       return;
     }
 

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -761,6 +761,16 @@ export class AgentInboundHandler implements OnModuleInit {
       return;
     }
 
+    // Managed agents do not use the self-hosted bridge and never configure bridgeUrl.
+    // Card interactions today are limited to Novu-internal flows only:
+    //   • mcp-approval:* — Approve/Deny tool-use (handled above)
+    //   • link-*         — link-button opens url in the browser; chat SDK still
+    //                      emits onAction but no server-side handler is needed
+    // Generic button clicks (custom ids, user-defined cards) are not supported
+    // on managed runtime yet — there is no bridge onAction and no managed-runtime
+    // action router to resume the provider session.
+    // TODO: route general managed-agent button clicks through ManagedAgentService
+    // (e.g. resume parked session / dispatch to runtime) instead of no-oping here.
     if (isLinkButtonActionId(action.id)) {
       return;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `NoBridgeUrlError` when users click card link-buttons (e.g. MCP OAuth "Connect Stripe") on managed agents.

Managed agents route inbound **messages** through `ManagedAgentService` and never configure a bridge URL. **Actions** were always forwarded to `BridgeExecutorService`, so link-button clicks (`link-<url>` action ids from the chat SDK) logged errors even though the OAuth URL opened correctly in the browser.

## Changes

- Return early in `handleAction` for `link-*` action ids (platform opens the URL; no bridge `onAction` needed)
- Return early for managed-runtime agents on remaining actions after `mcp-approval:*` routing
- Add unit tests for link-button, managed-agent, and self-hosted action paths
- Fix `AgentInboundHandler` spec constructor stub order after `ChatSdkService` was added to the handler

## Flow (after fix)

```mermaid
flowchart TD
  A[chat.onAction] --> B{action id}
  B -->|mcp-approval:*| C[confirmToolApproval]
  B -->|link-*| D[return - URL opens in browser]
  B -->|other| E{managed runtime?}
  E -->|yes| F[return - no bridge]
  E -->|no| G[BridgeExecutor ON_ACTION]
```

## Test plan

- [x] `pnpm test -- --grep handleAction` (3 new tests passing)
- [ ] Click MCP OAuth Connect link-button on a managed agent in staging — no `NoBridgeUrlError` in API logs
- [ ] Self-hosted agent button actions still reach bridge `onAction`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b367a6e2-e2cd-4df5-b305-4b1141a68e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b367a6e2-e2cd-4df5-b305-4b1141a68e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Agent inbound action handling was updated to avoid dispatching bridge onAction for link-button clicks and for managed-runtime agents, preventing NoBridgeUrlError when users click OAuth or other URL buttons on managed agents. Link-button actions (ids starting with "link-") now return early; after MCP approval routing, managed agents also short-circuit so bridge execution only runs for applicable self-hosted agents.

## Affected areas

**api**: Updated AgentInboundHandler to detect link-button action IDs and to short-circuit bridge dispatch for agents running in the managed runtime; added helper logic (isLinkButtonActionId) and adjusted routing after mcp-approval handling. Added unit tests and adjusted the test harness to stub agent lookup and managed-agent behaviors.

## Testing

Added three unit tests for AgentInboundHandler covering link-button actions (no bridge dispatch), managed-agent non-link actions (no bridge dispatch), and self-hosted agent actions (forwarded to bridge as ON_ACTION). Tests pass locally; manual verification planned in staging to confirm MCP OAuth buttons on managed agents no longer log NoBridgeUrlError while self-hosted agent actions continue to reach the bridge.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->