### PR TITLE
fix(api-service,dashboard): managed agent provider delete correctness and UX

### DIFF
--- a/apps/api/src/app/agents/usecases/delete-agent/delete-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/delete-agent/delete-agent.usecase.ts
@@ -1,10 +1,25 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { AnalyticsService, decryptCredentials, getAgentRuntimeProvider } from '@novu/application-generic';
+import type { ManagedRuntimeConfig } from '@novu/dal';
 import { AgentIntegrationRepository, AgentRepository, IntegrationRepository } from '@novu/dal';
+import type { AgentRuntime } from '@novu/shared';
 
 import { trackAgentDeleted } from '../../agent-analytics';
 import { CleanupNovuEmail } from '../cleanup-novu-email/cleanup-novu-email.usecase';
 import { DeleteAgentCommand } from './delete-agent.command';
+
+function scopedManagedRuntimeForProviderDelete(agent: {
+  runtime?: AgentRuntime;
+  managedRuntime?: ManagedRuntimeConfig;
+}): ManagedRuntimeConfig | null {
+  const { managedRuntime } = agent;
+
+  if (agent.runtime === 'self-hosted' || !managedRuntime?.externalAgentId || !managedRuntime._integrationId) {
+    return null;
+  }
+
+  return managedRuntime;
+}
 
 @Injectable()
 export class DeleteAgent {
@@ -32,8 +47,16 @@ export class DeleteAgent {
 
     const shouldDeleteFromProvider = command.deleteFromProvider === true;
 
-    if (agent.runtime === 'managed' && agent.managedRuntime && shouldDeleteFromProvider) {
-      await this.deleteFromProvider(agent.managedRuntime, command);
+    const managedRuntimeForDeletion = scopedManagedRuntimeForProviderDelete(agent);
+
+    if (shouldDeleteFromProvider && agent.runtime === 'managed' && !managedRuntimeForDeletion) {
+      throw new UnprocessableEntityException(
+        'This managed runtime agent record is missing provider linkage. Uncheck delete-from-provider or fix the agent, then retry.'
+      );
+    }
+
+    if (shouldDeleteFromProvider && managedRuntimeForDeletion) {
+      await this.deleteFromProvider(managedRuntimeForDeletion, command);
     }
 
     await this.agentRepository.withTransaction(async (session) => {
@@ -81,13 +104,17 @@ export class DeleteAgent {
     );
 
     if (!integration) {
-      return;
+      throw new NotFoundException(
+        `Integration "${managedRuntime._integrationId}" was not found. The managed agent cannot be archived on the provider without that integration; fix or remove the linkage, or retry without delete-from-provider if you only need to remove the Novu record.`
+      );
     }
 
     const decryptedCredentials = decryptCredentials(integration.credentials);
 
     if (!decryptedCredentials.apiKey) {
-      return;
+      throw new UnprocessableEntityException(
+        `Integration "${managedRuntime._integrationId}" has no API key configured, so we cannot archive the managed agent upstream. Restore credentials or omit delete-from-provider.`
+      );
     }
 
     const runtimeProvider = getAgentRuntimeProvider(managedRuntime.providerId, decryptedCredentials.apiKey);

--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -15,7 +15,7 @@ import { AgentsEmptyTeaser } from '@/components/agents/agents-empty-teaser';
 import { AgentsProductionEmptyState } from '@/components/agents/agents-production-empty-state';
 import { AgentsTable } from '@/components/agents/agents-table';
 import { CreateAgentDialog, CreateAgentForm } from '@/components/agents/create-agent-dialog';
-import { DeleteAgentDialog } from '@/components/agents/delete-agent-dialog';
+import { DeleteAgentDialog, shouldShowManagedAgentProviderDeleteOption } from '@/components/agents/delete-agent-dialog';
 import { ListNoResults } from '@/components/list-no-results';
 import { Button } from '@/components/primitives/button';
 import { FacetedFormFilter } from '@/components/primitives/form/faceted-filter/facated-form-filter';
@@ -389,7 +389,7 @@ export function AgentsList() {
         agentName={agentToDelete?.name ?? ''}
         agentIdentifier={agentToDelete?.identifier ?? ''}
         isDeleting={deleteMutation.isPending}
-        isManagedRuntime={agentToDelete?.runtime === 'managed'}
+        isManagedRuntime={shouldShowManagedAgentProviderDeleteOption(agentToDelete)}
       />
     </>
   );

--- a/apps/dashboard/src/components/agents/delete-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/delete-agent-dialog.tsx
@@ -1,7 +1,22 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { AgentResponse } from '@/api/agents';
 import { ConfirmationModal } from '@/components/confirmation-modal';
 import { Checkbox } from '@/components/primitives/checkbox';
 import { Label } from '@/components/primitives/label';
+
+export function shouldShowManagedAgentProviderDeleteOption(
+  agent: Pick<AgentResponse, 'runtime' | 'managedRuntime'> | null | undefined
+): boolean {
+  if (!agent) {
+    return false;
+  }
+
+  if (agent.runtime === 'self-hosted') {
+    return false;
+  }
+
+  return agent.runtime === 'managed' || Boolean(agent.managedRuntime);
+}
 
 type DeleteAgentDialogProps = {
   open: boolean;
@@ -23,6 +38,14 @@ export function DeleteAgentDialog({
   isManagedRuntime,
 }: DeleteAgentDialogProps) {
   const [deleteFromProvider, setDeleteFromProvider] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    setDeleteFromProvider(Boolean(isManagedRuntime));
+  }, [open, isManagedRuntime]);
 
   function handleOpenChange(isOpen: boolean) {
     if (!isOpen) {

--- a/apps/dashboard/src/pages/agent-details.tsx
+++ b/apps/dashboard/src/pages/agent-details.tsx
@@ -17,7 +17,7 @@ import { AgentDetailsHeader } from '@/components/agents/agent-details-header';
 import { AgentIntegrationsTab } from '@/components/agents/agent-integrations-tab';
 import { AgentOverviewTab } from '@/components/agents/agent-overview-tab';
 import { AgentSetupModal } from '@/components/agents/agent-setup-modal';
-import { DeleteAgentDialog } from '@/components/agents/delete-agent-dialog';
+import { DeleteAgentDialog, shouldShowManagedAgentProviderDeleteOption } from '@/components/agents/delete-agent-dialog';
 import { DashboardLayout } from '@/components/dashboard-layout';
 import { useSetConnectBreadcrumbLeaf } from '@/components/dashboard-shell/use-connect-breadcrumb';
 import { PageMeta } from '@/components/page-meta';
@@ -394,7 +394,7 @@ export function AgentDetailsPage() {
               agentName={agentToDelete?.name ?? ''}
               agentIdentifier={agentToDelete?.identifier ?? ''}
               isDeleting={deleteMutation.isPending}
-              isManagedRuntime={agentToDelete?.runtime === 'managed'}
+              isManagedRuntime={shouldShowManagedAgentProviderDeleteOption(agentToDelete)}
             />
 
             <AgentSetupModal


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigation showed two main reasons the provider-side delete appeared broken:

1. **Silent API skips** — When `deleteFromProvider=true`, the delete use case returned early without calling Anthropic if the integration row was missing or had no decrypted API key, but **still deleted the Novu agent**. The dashboard showed success while the upstream agent stayed (or archiving never ran).

2. **Too-narrow eligibility** — The checkbox and API gate required `runtime === 'managed'` only. Documents with `managedRuntime` populated but a missing or inconsistent `runtime` field hid the checkbox and skipped provider archiving even though the API receives `deleteFromProvider=true`.

## Changes

- **API (`DeleteAgent`)**: Throw `NotFoundException` / `UnprocessableEntityException` with actionable messages instead of silently continuing when upstream archive prerequisites fail. Extend provider-archive eligibility to any non–self-hosted agent with usable `managedRuntime` identifiers (`scopedManagedRuntimeForProviderDelete`), while keeping self-hosted agents out of provider calls.
- **Dashboard**: Align “show managed provider delete option” with the same heuristic via `shouldShowManagedAgentProviderDeleteOption`. Default the checkbox to **checked** whenever that option appears so callers do not omit `deleteFromProvider` by accident.

Anthropic still only exposes **`archive`** for beta agents ([SDK](https://github.com/anthropics/anthropic-sdk-typescript)); agents may remain visible under archived/history views in Claude Console. That is separate from Novu mistakenly reporting success without ever calling upstream.

### Linear ticket

Linear MCP authentication was unavailable in this environment — please link the appropriate **`NOV-*`** ticket in the PR title per repo convention (`fixes NOV-…`).

## Testing notes

Not run in CI here (pnpm/Node toolchain mismatch on the agent runner). Recommend: delete a managed agent with the checkbox on and verify the DELETE request includes `deleteFromProvider=true`; confirm upstream archive call errors surface as API errors instead of a silent Novu-only delete.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12967e0b-8a93-4212-be72-b6b2666adbbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12967e0b-8a93-4212-be72-b6b2666adbbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

