### PR TITLE
fix(dashboard): link View integration store to selected integration update page fixes NV-7784

### DIFF
--- a/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
+++ b/apps/dashboard/src/components/agents/agent-integrations-tab.tsx
@@ -234,8 +234,6 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
     agentTab: 'integrations',
   })}${location.search}`;
 
-  const integrationsStorePath = ROUTES.INTEGRATIONS;
-
   const navigateToGuide = (nextIntegrationIdentifier: string) => {
     if (!currentEnvironment?.slug) {
       return;
@@ -374,6 +372,11 @@ export function AgentIntegrationsTab({ agent, integrationIdentifier }: AgentInte
     integrationIdentifier != null
       ? links.find((link) => link.integration.identifier === integrationIdentifier)
       : undefined;
+
+  const integrationsStorePath = selectedIntegration
+    ? buildRoute(ROUTES.INTEGRATIONS_UPDATE, { integrationId: selectedIntegration.integration._id })
+    : ROUTES.INTEGRATIONS;
+
   const selectedIntegrationUpdatedAtMs =
     selectedIntegration != null ? Date.parse(selectedIntegration.updatedAt) : undefined;
   const lastUpdatedParts = listQuery.isSuccess


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

On the agent channels page, when a provider integration is selected, the "View integration store" button now navigates to that specific integration's update page (`/integrations/{id}/update`) instead of always navigating to the generic integration store (`/integrations`).

When no integration is selected, the button still falls back to the integration store.

## Why

The previous behavior forced users to manually find their integration in the store after clicking the quick action. Now, clicking "View integration store" while viewing a connected integration takes you directly to its configuration page, which is the expected UX per NV-7784.

## Screenshot

![View integration store button linking to specific integration update page](https://cursor.com/artifacts/c/art-cc2ae2b1-ee22-41e1-a378-02171d293abf)

The status bar shows the link points to `/integrations/6a13fcedfba8df94898ce5b0/update` (the selected integration's update page).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7784](https://linear.app/novu/issue/NV-7784/agent-page-open-selected-integration)

<div><a href="https://cursor.com/agents/bc-ae78883b-f60d-4f70-a730-e58d1b523eac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae78883b-f60d-4f70-a730-e58d1b523eac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The "View integration store" button in the Agent integrations view now navigates contextually. When an integration is selected, it routes directly to that integration's update page (`/integrations/{integrationId}/update`); otherwise, it falls back to the generic integration store page (`/integrations`). This eliminates the need for users to manually search for their integration after clicking the button.

## Affected areas

**dashboard**: Updated the agent integrations tab component to dynamically determine the destination URL for the "View integration store" button based on whether an integration is currently selected.

## Testing

No tests were added. The change is a simple conditional routing update that can be validated through manual testing on the agent integrations page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->