### PR TITLE
fix(api-service): use DASHBOARD_URL for MCP OAuth DCR client metadata fixes NV-7786

### DIFF
--- a/apps/api/src/app/agents/usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase.ts
+++ b/apps/api/src/app/agents/usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase.ts
@@ -253,7 +253,7 @@ export class GenerateMcpOAuthUrl {
     registrationClientUri?: string;
   }> {
     const { asMetadata, oauthConfig, scopes } = args;
-    const frontBase = process.env.FRONT_BASE_URL?.replace(/\/$/, '');
+    const frontBase = process.env.DASHBOARD_URL?.replace(/\/$/, '');
 
     try {
       return await this.discoveryService.registerClient(asMetadata, {

--- a/apps/api/src/app/agents/usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase.ts
+++ b/apps/api/src/app/agents/usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase.ts
@@ -253,7 +253,7 @@ export class GenerateMcpOAuthUrl {
     registrationClientUri?: string;
   }> {
     const { asMetadata, oauthConfig, scopes } = args;
-    const frontBase = process.env.DASHBOARD_URL?.replace(/\/$/, '');
+    const frontBase = (process.env.DASHBOARD_URL ?? process.env.FRONT_BASE_URL)?.replace(/\/$/, '');
 
     try {
       return await this.discoveryService.registerClient(asMetadata, {


### PR DESCRIPTION
## Summary

- Use `DASHBOARD_URL` instead of `FRONT_BASE_URL` when registering MCP OAuth DCR clients, so `client_uri` and `logo_uri` sent to the authorization server point at the canonical dashboard URL.
- Follow-up to NV-7736, which applied the same env var alignment for the MCP OAuth post-callback redirect.

## Test plan

- [ ] Start MCP OAuth flow for a DCR-backed catalog MCP (e.g. Sentry)
- [ ] Confirm DCR registration succeeds and the authorize URL is returned
- [ ] Complete OAuth and verify callback redirect still lands on the dashboard result page


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The MCP OAuth DCR client registration now uses the DASHBOARD_URL environment variable (trimmed of trailing slash) instead of FRONT_BASE_URL when building client_uri and logo_uri for Dynamic Client Registration. This ensures DCR-registered clients point to the canonical dashboard URL so post-callback redirects and client metadata consistently target the dashboard (aligns with NV-7736).

## Affected areas

**api**: Updated the MCP OAuth DCR client registration logic in the GenerateMcpOAuthUrl use case to source the base URL from process.env.DASHBOARD_URL rather than process.env.FRONT_BASE_URL, changing the client_uri and optional logo_uri values sent to authorization servers.

## Testing

Manual verification: start an MCP OAuth flow for a DCR-backed catalog MCP (e.g., Sentry), confirm DCR registration succeeds and an authorize URL is returned, complete the OAuth flow, and verify the callback redirect lands on the dashboard result page. No automated tests were added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->