### PR TITLE
fix(api-service): resolve WhatsApp inbound subscribers via subscriber.phone fixes NV-7789

### DIFF
--- a/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
@@ -10,6 +10,7 @@ import { expect } from 'chai';
 import type { EmojiValue } from 'chat';
 import sinon from 'sinon';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
+import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
 import { AgentConfigResolver } from '../services/agent-config-resolver.service';
 import { AgentInboundHandler, InboundReactionEvent } from '../services/agent-inbound-handler.service';
 import { AgentExecutionParams, BridgeExecutorService } from '../services/bridge-executor.service';
@@ -633,6 +634,76 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
         conversation!._id
       );
       expect(activitiesAfter.length).to.equal(activitiesBefore.length);
+    });
+  });
+
+  describe('WhatsApp subscriber resolution', () => {
+    async function invokeWhatsAppInbound(phone: string, text: string) {
+      const baseConfig = await configResolver.resolve(ctx.agentId, ctx.integrationIdentifier);
+      const config = {
+        ...baseConfig,
+        platform: AgentPlatformEnum.WHATSAPP,
+      };
+      const threadId = `whatsapp:${phone}`;
+      const thread = {
+        id: threadId,
+        channelId: threadId,
+        isDM: true,
+        startTyping: async () => {},
+        subscribe: async () => {},
+        post: async () => mockSentMessage(),
+        createSentMessageFromMessage: () => mockSentMessage(),
+        toJSON: () => ({ id: threadId }),
+      };
+      const message = {
+        id: `whatsapp-msg-${Date.now()}`,
+        text,
+        author: {
+          userId: phone,
+          fullName: 'WhatsApp User',
+          userName: 'wauser',
+          isBot: false,
+        },
+        metadata: { dateSent: new Date() },
+      };
+
+      await inboundHandler.handle(ctx.agentId, config, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
+
+      return threadId;
+    }
+
+    it('should create participant as subscriber when subscriber.phone matches inbound author.userId', async () => {
+      const subscriberRepository = new SubscriberRepository();
+      const subscriber = await subscriberRepository.create({
+        subscriberId: `sub-wa-e2e-${Date.now()}`,
+        firstName: 'WhatsApp',
+        lastName: 'Subscriber',
+        phone: '+972541111111',
+        _environmentId: ctx.session.environment._id,
+        _organizationId: ctx.session.organization._id,
+      });
+
+      const threadId = await invokeWhatsAppInbound('972541111111', 'Hello from WhatsApp');
+
+      const conversation = await conversationRepository.findByPlatformThread(
+        ctx.session.environment._id,
+        ctx.session.organization._id,
+        ctx.agentId,
+        ctx.integrationId,
+        threadId
+      );
+
+      expect(conversation).to.exist;
+
+      const subParticipant = conversation!.participants.find(
+        (p) => p.type === ConversationParticipantTypeEnum.SUBSCRIBER
+      );
+      expect(subParticipant).to.exist;
+      expect(subParticipant!.id).to.equal(subscriber.subscriberId);
+
+      const activities = await activityRepository.findByConversation(ctx.session.environment._id, conversation!._id);
+      const userActivity = activities.find((a) => a.content === 'Hello from WhatsApp');
+      expect(userActivity!.senderType).to.equal(ConversationActivitySenderTypeEnum.SUBSCRIBER);
     });
   });
 });

--- a/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-webhook.e2e.ts
@@ -655,17 +655,7 @@ describe('Agent Webhook - inbound flow #novu-v2', () => {
         createSentMessageFromMessage: () => mockSentMessage(),
         toJSON: () => ({ id: threadId }),
       };
-      const message = {
-        id: `whatsapp-msg-${Date.now()}`,
-        text,
-        author: {
-          userId: phone,
-          fullName: 'WhatsApp User',
-          userName: 'wauser',
-          isBot: false,
-        },
-        metadata: { dateSent: new Date() },
-      };
+      const message = mockMessage({ userId: phone, text, fullName: 'WhatsApp User' });
 
       await inboundHandler.handle(ctx.agentId, config, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
 

--- a/apps/api/src/app/agents/services/agent-subscriber-resolver.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-subscriber-resolver.service.spec.ts
@@ -73,21 +73,6 @@ describe('AgentSubscriberResolver', () => {
         .equal(true);
     });
 
-    it('should resolve when inbound phone has no + and subscriber has no +', async () => {
-      const { resolver, subscriberRepository } = makeResolver({
-        findByPhone: sinon.stub().resolves([{ subscriberId: 'sub-1' }]),
-      });
-
-      const result = await resolver.resolve({
-        ...baseParams,
-        platform: AgentPlatformEnum.WHATSAPP,
-        platformUserId: '972541111111',
-      });
-
-      expect(result).to.equal('sub-1');
-      expect(subscriberRepository.findByPhone.firstCall.args[2]).to.deep.equal(['+972541111111', '972541111111']);
-    });
-
     it('should return null when no subscriber matches', async () => {
       const { resolver } = makeResolver({
         findByPhone: sinon.stub().resolves([]),
@@ -147,20 +132,6 @@ describe('AgentSubscriberResolver', () => {
       expect(result).to.equal('sub-slack');
       expect(channelEndpointRepository.findByPlatformIdentity.calledOnce).to.equal(true);
       expect(subscriberRepository.findByPhone.called).to.equal(false);
-    });
-
-    it('should not call subscriber repository for WhatsApp', async () => {
-      const { resolver, subscriberRepository } = makeResolver({
-        findByPhone: sinon.stub().resolves([{ subscriberId: 'sub-wa' }]),
-      });
-
-      await resolver.resolve({
-        ...baseParams,
-        platform: AgentPlatformEnum.WHATSAPP,
-        platformUserId: '15557654321',
-      });
-
-      expect(subscriberRepository.findByPhone.calledOnce).to.equal(true);
     });
   });
 });

--- a/apps/api/src/app/agents/services/agent-subscriber-resolver.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-subscriber-resolver.service.spec.ts
@@ -1,0 +1,166 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
+import { AgentSubscriberResolver } from './agent-subscriber-resolver.service';
+
+describe('AgentSubscriberResolver', () => {
+  const baseParams = {
+    environmentId: 'env-1',
+    organizationId: 'org-1',
+    integrationIdentifier: 'integration-main',
+  };
+
+  function makeResolver(
+    overrides: {
+      findByPlatformIdentity?: sinon.SinonStub;
+      findByPhone?: sinon.SinonStub;
+    } = {}
+  ) {
+    const channelEndpointRepository = {
+      findByPlatformIdentity: overrides.findByPlatformIdentity ?? sinon.stub().resolves(null),
+    };
+    const subscriberRepository = {
+      findByPhone: overrides.findByPhone ?? sinon.stub().resolves([]),
+    };
+    const logger = {
+      setContext: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      debug: sinon.stub(),
+      info: sinon.stub(),
+    };
+
+    const resolver = new AgentSubscriberResolver(
+      channelEndpointRepository as any,
+      subscriberRepository as any,
+      logger as any
+    );
+
+    return { resolver, channelEndpointRepository, subscriberRepository, logger };
+  }
+
+  describe('WhatsApp phone resolution', () => {
+    it('should resolve when inbound phone has no + and subscriber has +', async () => {
+      const { resolver, subscriberRepository, channelEndpointRepository } = makeResolver({
+        findByPhone: sinon.stub().resolves([{ subscriberId: 'sub-1' }]),
+      });
+
+      const result = await resolver.resolve({
+        ...baseParams,
+        platform: AgentPlatformEnum.WHATSAPP,
+        platformUserId: '972541111111',
+      });
+
+      expect(result).to.equal('sub-1');
+      expect(subscriberRepository.findByPhone.calledOnceWith('env-1', 'org-1', ['+972541111111', '972541111111'])).to
+        .equal(true);
+      expect(channelEndpointRepository.findByPlatformIdentity.called).to.equal(false);
+    });
+
+    it('should resolve when inbound phone has + and subscriber has +', async () => {
+      const { resolver, subscriberRepository } = makeResolver({
+        findByPhone: sinon.stub().resolves([{ subscriberId: 'sub-1' }]),
+      });
+
+      const result = await resolver.resolve({
+        ...baseParams,
+        platform: AgentPlatformEnum.WHATSAPP,
+        platformUserId: '+972541111111',
+      });
+
+      expect(result).to.equal('sub-1');
+      expect(subscriberRepository.findByPhone.calledOnceWith('env-1', 'org-1', ['+972541111111', '972541111111'])).to
+        .equal(true);
+    });
+
+    it('should resolve when inbound phone has no + and subscriber has no +', async () => {
+      const { resolver, subscriberRepository } = makeResolver({
+        findByPhone: sinon.stub().resolves([{ subscriberId: 'sub-1' }]),
+      });
+
+      const result = await resolver.resolve({
+        ...baseParams,
+        platform: AgentPlatformEnum.WHATSAPP,
+        platformUserId: '972541111111',
+      });
+
+      expect(result).to.equal('sub-1');
+      expect(subscriberRepository.findByPhone.firstCall.args[2]).to.deep.equal(['+972541111111', '972541111111']);
+    });
+
+    it('should return null when no subscriber matches', async () => {
+      const { resolver } = makeResolver({
+        findByPhone: sinon.stub().resolves([]),
+      });
+
+      const result = await resolver.resolve({
+        ...baseParams,
+        platform: AgentPlatformEnum.WHATSAPP,
+        platformUserId: '972541111111',
+      });
+
+      expect(result).to.equal(null);
+    });
+
+    it('should warn and return first match when multiple subscribers share the phone', async () => {
+      const { resolver, logger } = makeResolver({
+        findByPhone: sinon.stub().resolves([{ subscriberId: 'sub-1' }, { subscriberId: 'sub-2' }]),
+      });
+
+      const result = await resolver.resolve({
+        ...baseParams,
+        platform: AgentPlatformEnum.WHATSAPP,
+        platformUserId: '972541111111',
+      });
+
+      expect(result).to.equal('sub-1');
+      expect(logger.warn.calledOnce).to.equal(true);
+    });
+
+    it('should return null for empty platformUserId without DB call', async () => {
+      const { resolver, subscriberRepository, channelEndpointRepository } = makeResolver();
+
+      const result = await resolver.resolve({
+        ...baseParams,
+        platform: AgentPlatformEnum.WHATSAPP,
+        platformUserId: '   ',
+      });
+
+      expect(result).to.equal(null);
+      expect(subscriberRepository.findByPhone.called).to.equal(false);
+      expect(channelEndpointRepository.findByPlatformIdentity.called).to.equal(false);
+    });
+  });
+
+  describe('channel endpoint resolution', () => {
+    it('should resolve Slack via channel endpoints', async () => {
+      const { resolver, channelEndpointRepository, subscriberRepository } = makeResolver({
+        findByPlatformIdentity: sinon.stub().resolves({ subscriberId: 'sub-slack' }),
+      });
+
+      const result = await resolver.resolve({
+        ...baseParams,
+        platform: AgentPlatformEnum.SLACK,
+        platformUserId: 'U_LINKED',
+      });
+
+      expect(result).to.equal('sub-slack');
+      expect(channelEndpointRepository.findByPlatformIdentity.calledOnce).to.equal(true);
+      expect(subscriberRepository.findByPhone.called).to.equal(false);
+    });
+
+    it('should not call subscriber repository for WhatsApp', async () => {
+      const { resolver, subscriberRepository } = makeResolver({
+        findByPhone: sinon.stub().resolves([{ subscriberId: 'sub-wa' }]),
+      });
+
+      await resolver.resolve({
+        ...baseParams,
+        platform: AgentPlatformEnum.WHATSAPP,
+        platformUserId: '15557654321',
+      });
+
+      expect(subscriberRepository.findByPhone.calledOnce).to.equal(true);
+    });
+  });
+});

--- a/apps/api/src/app/agents/services/agent-subscriber-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-subscriber-resolver.service.ts
@@ -77,11 +77,6 @@ export class AgentSubscriberResolver {
   }): Promise<string | null> {
     const { environmentId, organizationId, platformUserId } = params;
     const phoneCandidates = getPhoneLookupCandidates(platformUserId);
-
-    if (phoneCandidates.length === 0) {
-      return null;
-    }
-
     const matches = await this.subscriberRepository.findByPhone(environmentId, organizationId, phoneCandidates);
 
     if (matches.length > 1) {

--- a/apps/api/src/app/agents/services/agent-subscriber-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-subscriber-resolver.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
-import { ChannelEndpointRepository } from '@novu/dal';
+import { ChannelEndpointRepository, SubscriberRepository } from '@novu/dal';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
+import { getPhoneLookupCandidates } from '../utils/phone-normalization';
 import { PLATFORM_ENDPOINT_CONFIG } from '../utils/platform-endpoint-config';
 
 export interface ResolveSubscriberParams {
@@ -16,6 +17,7 @@ export interface ResolveSubscriberParams {
 export class AgentSubscriberResolver {
   constructor(
     private readonly channelEndpointRepository: ChannelEndpointRepository,
+    private readonly subscriberRepository: SubscriberRepository,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
@@ -23,6 +25,19 @@ export class AgentSubscriberResolver {
 
   async resolve(params: ResolveSubscriberParams): Promise<string | null> {
     const { environmentId, organizationId, platform, platformUserId, integrationIdentifier } = params;
+
+    if (!platformUserId.trim()) {
+      return null;
+    }
+
+    if (platform === AgentPlatformEnum.WHATSAPP) {
+      return this.resolveWhatsAppSubscriber({
+        environmentId,
+        organizationId,
+        platformUserId,
+      });
+    }
+
     const endpointConfig = PLATFORM_ENDPOINT_CONFIG[platform];
 
     if (!endpointConfig) {
@@ -51,6 +66,39 @@ export class AgentSubscriberResolver {
     this.logger.debug(
       `No subscriber linked for platform user ${platform}:${platformUserId} (integration: ${integrationIdentifier})`
     );
+
+    return null;
+  }
+
+  private async resolveWhatsAppSubscriber(params: {
+    environmentId: string;
+    organizationId: string;
+    platformUserId: string;
+  }): Promise<string | null> {
+    const { environmentId, organizationId, platformUserId } = params;
+    const phoneCandidates = getPhoneLookupCandidates(platformUserId);
+
+    if (phoneCandidates.length === 0) {
+      return null;
+    }
+
+    const matches = await this.subscriberRepository.findByPhone(environmentId, organizationId, phoneCandidates);
+
+    if (matches.length > 1) {
+      this.logger.warn(
+        `Multiple subscribers (${matches.length}) share phone ${platformUserId} in environment ${environmentId} — using first match`
+      );
+    }
+
+    const subscriber = matches[0];
+
+    if (subscriber) {
+      this.logger.debug(`Resolved WhatsApp phone ${platformUserId} → subscriber ${subscriber.subscriberId}`);
+
+      return subscriber.subscriberId;
+    }
+
+    this.logger.debug(`No subscriber found for WhatsApp phone ${platformUserId}`);
 
     return null;
   }

--- a/apps/api/src/app/agents/usecases/send-whatsapp-test-template/send-whatsapp-test-template.usecase.ts
+++ b/apps/api/src/app/agents/usecases/send-whatsapp-test-template/send-whatsapp-test-template.usecase.ts
@@ -14,6 +14,7 @@ import {
   type MetaErrorSummary,
   sendWhatsAppTemplate,
 } from '../../../integrations/usecases/whatsapp/whatsapp-graph-api.utils';
+import { normalizePhoneForMeta } from '../../utils/phone-normalization';
 import { SendWhatsAppTestTemplateCommand } from './send-whatsapp-test-template.command';
 
 const TEMPLATE_NAME = 'hello_world';
@@ -44,12 +45,6 @@ export interface SendWhatsAppTestTemplateResult {
   success: boolean;
   messageId?: string;
   error?: SendWhatsAppTestTemplateError;
-}
-
-function normalizeRecipient(value: string): string {
-  const trimmed = value.trim();
-  // Meta accepts E.164 without the + sign.
-  return trimmed.startsWith('+') ? trimmed.slice(1) : trimmed;
 }
 
 @Injectable()
@@ -149,7 +144,7 @@ export class SendWhatsAppTestTemplate {
       response = await sendWhatsAppTemplate({
         accessToken,
         phoneNumberId,
-        to: normalizeRecipient(subscriberPhone),
+        to: normalizePhoneForMeta(subscriberPhone),
         templateName: TEMPLATE_NAME,
         languageCode: TEMPLATE_LANGUAGE,
       });

--- a/apps/api/src/app/agents/utils/phone-normalization.ts
+++ b/apps/api/src/app/agents/utils/phone-normalization.ts
@@ -6,7 +6,7 @@ export function getPhoneLookupCandidates(platformUserId: string): string[] {
   }
 
   const withPlus = trimmed.startsWith('+') ? trimmed : `+${trimmed}`;
-  const withoutPlus = trimmed.startsWith('+') ? trimmed.slice(1) : trimmed;
+  const withoutPlus = normalizePhoneForMeta(trimmed);
 
   return [...new Set([withPlus, withoutPlus])];
 }

--- a/apps/api/src/app/agents/utils/phone-normalization.ts
+++ b/apps/api/src/app/agents/utils/phone-normalization.ts
@@ -1,0 +1,18 @@
+export function getPhoneLookupCandidates(platformUserId: string): string[] {
+  const trimmed = platformUserId.trim();
+
+  if (!trimmed) {
+    return [];
+  }
+
+  const withPlus = trimmed.startsWith('+') ? trimmed : `+${trimmed}`;
+  const withoutPlus = trimmed.startsWith('+') ? trimmed.slice(1) : trimmed;
+
+  return [...new Set([withPlus, withoutPlus])];
+}
+
+export function normalizePhoneForMeta(value: string): string {
+  const trimmed = value.trim();
+
+  return trimmed.startsWith('+') ? trimmed.slice(1) : trimmed;
+}

--- a/apps/api/src/app/agents/utils/platform-endpoint-config.ts
+++ b/apps/api/src/app/agents/utils/platform-endpoint-config.ts
@@ -15,10 +15,6 @@ export const PLATFORM_ENDPOINT_CONFIG: Partial<Record<AgentPlatformEnum, Platfor
     endpointType: ENDPOINT_TYPES.MS_TEAMS_USER,
     identityField: 'userId',
   },
-  [AgentPlatformEnum.WHATSAPP]: {
-    endpointType: ENDPOINT_TYPES.PHONE,
-    identityField: 'phoneNumber',
-  },
   // Telegram subscriber resolution is DM-only: for 1:1 chats with the bot,
   // Telegram's chat.id equals the sender's user.id, so the chatId stored on
   // telegram_chat endpoints is also the value of message.author.userId on inbound.

--- a/libs/dal/src/repositories/subscriber/subscriber.repository.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.repository.ts
@@ -28,6 +28,26 @@ export class SubscriberRepository extends BaseRepository<SubscriberDBModel, Subs
     );
   }
 
+  async findByPhone(
+    environmentId: string,
+    organizationId: string,
+    phoneCandidates: string[]
+  ): Promise<SubscriberEntity[]> {
+    if (phoneCandidates.length === 0) {
+      return [];
+    }
+
+    return this.find(
+      {
+        _environmentId: environmentId,
+        _organizationId: organizationId,
+        phone: { $in: phoneCandidates },
+      },
+      undefined,
+      { limit: 2 }
+    );
+  }
+
   async bulkCreateSubscribers(
     subscribers: ISubscribersDefine[],
     environmentId: EnvironmentId,

--- a/libs/dal/src/repositories/subscriber/subscriber.repository.ts
+++ b/libs/dal/src/repositories/subscriber/subscriber.repository.ts
@@ -43,7 +43,7 @@ export class SubscriberRepository extends BaseRepository<SubscriberDBModel, Subs
         _organizationId: organizationId,
         phone: { $in: phoneCandidates },
       },
-      undefined,
+      'subscriberId',
       { limit: 2 }
     );
   }


### PR DESCRIPTION
## Summary

- Resolve WhatsApp inbound senders via `subscriber.phone` instead of `channel_endpoints` (type: phone)
- Add shared phone normalization (`+`/no-`+` candidates) aligned with outbound Meta formatting
- Add `SubscriberRepository.findByPhone()` with exact match and duplicate detection (`limit: 2`)
- Remove WhatsApp from `PLATFORM_ENDPOINT_CONFIG`; Slack/Teams/Telegram unchanged

## Why

Meta webhooks send `message.author.userId` without a leading `+` (e.g. `972541111111`), while Novu stores phones as E.164 with `+` on the subscriber entity. The previous channel-endpoint lookup never matched real subscriber data.

```mermaid
flowchart LR
  webhook[WhatsApp webhook] --> chatSdk[ChatSdkService]
  chatSdk --> inbound[AgentInboundHandler]
  inbound --> resolver[AgentSubscriberResolver]
  resolver -->|"Slack/Teams/Telegram"| endpoints[channel_endpoints]
  resolver -->|"WhatsApp"| subs[subscriber.phone lookup]
```

## Test plan

- [x] Unit: `AgentSubscriberResolver` — normalization, Slack vs WhatsApp paths, empty input, duplicate warn
- [x] E2e: `agent-webhook.e2e.ts` — handler resolves subscriber participant when `subscriber.phone` matches inbound `author.userId`
- [x] `pnpm --filter @novu/dal build`

## Linear

https://linear.app/novu/issue/NV-7789/resolve-whatsapp-inbound-subscribers-via-subscriberphone


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

WhatsApp inbound messages are now resolved to subscribers by matching the inbound author.userId against subscriber.phone (phone number matching) instead of using channel endpoints. Shared phone normalization was added to generate lookup candidates (E.164 with `+` and Meta form without `+`) so Meta webhook ids match stored phones. A new DAL method findByPhone(...) performs an exact match (returns up to 2 results for duplicate detection). WhatsApp was removed from the generic platform endpoint configuration because it does not use channel endpoints.

## Affected areas

**api**: AgentSubscriberResolver now injects SubscriberRepository and uses a dedicated WhatsApp phone-lookup path that normalizes platform user IDs before querying; shared phone-normalization utilities (getPhoneLookupCandidates, normalizePhoneForMeta) were added; the WhatsApp test template use case now uses the shared normalizer; unit and E2E tests were added/updated to cover the new resolution behavior.

**dal**: SubscriberRepository gained findByPhone(environmentId, organizationId, phoneCandidates) returning up to 2 matching subscribers (selecting only subscriberId to minimize payload).

## Key technical decisions

- Lookup uses two de-duplicated candidates (with and without leading `+`) to reconcile Meta webhook author IDs with stored E.164 values.  
- Query result is limited to 2 to detect duplicates; when multiples are found the resolver logs a warning and picks the first match.  
- WhatsApp was removed from PLATFORM_ENDPOINT_CONFIG to avoid using channel-endpoint resolution for Meta inbound messages.

## Testing

New unit tests for AgentSubscriberResolver (normalization, Slack vs WhatsApp paths, empty input, duplicate warn) and an E2E webhook test verifying subscriber participant resolution when subscriber.phone matches inbound author.userId.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->