### PR TITLE
fix(dashboard): update agent documentation links fixes NV-7791

### DIFF
--- a/apps/dashboard/src/components/agents/agent-setup-modal.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-modal.tsx
@@ -7,6 +7,7 @@ import {
   RiCornerDownLeftLine,
   RiInformation2Fill,
 } from 'react-icons/ri';
+import { AGENTS_DOCS_SETUP_URL } from '@/utils/agent-docs';
 import { Button } from '../primitives/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../primitives/dialog';
 import { VisuallyHidden } from '../primitives/visually-hidden';
@@ -102,7 +103,7 @@ export function AgentSetupModal({ isOpen, onClose, onSetupClick }: AgentSetupMod
         {/* Footer — grey background with top border */}
         <div className="border-stroke-weak flex items-center gap-3 border-t bg-[#fbfbfb] p-3">
           <a
-            href="https://docs.novu.co/agents/overview"
+            href={AGENTS_DOCS_SETUP_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="text-label-xs text-text-sub hover:text-text-strong inline-flex items-center gap-1 font-medium underline transition-colors"

--- a/apps/dashboard/src/components/agents/agents-list.tsx
+++ b/apps/dashboard/src/components/agents/agents-list.tsx
@@ -11,6 +11,7 @@ import {
   listAgents,
 } from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
+import { AGENTS_DOCS_PROVIDERS_URL } from '@/utils/agent-docs';
 import { AgentsEmptyTeaser } from '@/components/agents/agents-empty-teaser';
 import { AgentsProductionEmptyState } from '@/components/agents/agents-production-empty-state';
 import { AgentsTable } from '@/components/agents/agents-table';
@@ -302,7 +303,7 @@ export function AgentsList() {
               <TooltipContent className="max-w-60">
                 {'Add agents in your development environment. '}
                 <a
-                  href="https://docs.novu.co/platform/agents"
+                  href={AGENTS_DOCS_PROVIDERS_URL}
                   target="_blank"
                   rel="noreferrer noopener"
                   className="underline"

--- a/apps/dashboard/src/components/agents/agents-production-empty-state.tsx
+++ b/apps/dashboard/src/components/agents/agents-production-empty-state.tsx
@@ -2,6 +2,7 @@ import { RiArrowRightSLine, RiBookMarkedLine } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useAgentRoutes } from '@/hooks/use-agent-routes';
+import { AGENTS_DOCS_HOME_URL } from '@/utils/agent-docs';
 import { buildRoute } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 import { Button } from '../primitives/button';
@@ -57,7 +58,7 @@ export function AgentsProductionEmptyState() {
 
           <div className="flex items-center gap-4">
             <a
-              href="https://docs.novu.co/agents"
+              href={AGENTS_DOCS_HOME_URL}
               target="_blank"
               rel="noreferrer"
               className={cn(

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -27,6 +27,7 @@ import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { GenerationCancelledError, useGenerateManagedAgent } from '@/hooks/use-generate-managed-agent';
 import { useVerifyManagedCredentials } from '@/hooks/use-verify-managed-credentials';
+import { AGENTS_DOCS_OVERVIEW_URL } from '@/utils/agent-docs';
 import { QueryKeys } from '@/utils/query-keys';
 import { cn } from '@/utils/ui';
 import { AgentSuggestionPills } from '../onboarding/connect-agent/agent-suggestion-pills';
@@ -52,7 +53,7 @@ import {
   validateCreateAgentForm,
 } from './create-agent-fields';
 
-const DOCS_AGENTS_LEARN_MORE_HREF = 'https://docs.novu.co';
+const DOCS_AGENTS_LEARN_MORE_HREF = AGENTS_DOCS_OVERVIEW_URL;
 
 export type { CreateAgentForm } from './create-agent-fields';
 

--- a/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
+++ b/apps/dashboard/src/components/agents/setup-guide-primitives.tsx
@@ -15,6 +15,7 @@ import type { IntegrationFormData } from '@/components/integrations/types';
 import { Button, buttonVariants } from '@/components/primitives/button';
 import { showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { ExternalLink } from '@/components/shared/external-link';
+import { AGENTS_DOCS_PROVIDERS_URL } from '@/utils/agent-docs';
 import { useEnvironment } from '@/context/environment/hooks';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { useUpdateIntegration } from '@/hooks/use-update-integration';
@@ -315,7 +316,7 @@ export function ListeningStatus({
             {connectedAt ? connectedMessage : listeningMessage}
           </p>
         </div>
-        <ExternalLink href="https://docs.novu.co/agents/overview" variant="documentation">
+        <ExternalLink href={AGENTS_DOCS_PROVIDERS_URL} variant="documentation">
           Learn more in docs
         </ExternalLink>
       </div>

--- a/apps/dashboard/src/components/conversations/conversations-upgrade-cta.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-upgrade-cta.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { LinkButton } from '@/components/primitives/button-link';
 import { IS_SELF_HOSTED, SELF_HOSTED_UPGRADE_REDIRECT_URL } from '@/config';
 import { useTelemetry } from '@/hooks/use-telemetry';
+import { AGENTS_DOCS_CONVERSATIONS_URL } from '@/utils/agent-docs';
 import { ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
@@ -81,7 +82,7 @@ export function ConversationsUpgradeCta({ source, variant = 'default', className
           {IS_SELF_HOSTED ? 'Contact Sales' : 'Upgrade now'}
         </Button>
         <LinkButton asChild size="sm" leadingIcon={RiBookMarkedLine}>
-          <a href="https://docs.novu.co/agents/overview" target="_blank" rel="noreferrer noopener">
+          <a href={AGENTS_DOCS_CONVERSATIONS_URL} target="_blank" rel="noreferrer noopener">
             How does this help?
           </a>
         </LinkButton>

--- a/apps/dashboard/src/utils/agent-docs.ts
+++ b/apps/dashboard/src/utils/agent-docs.ts
@@ -1,0 +1,16 @@
+const DOCS_BASE_URL = 'https://docs.novu.co';
+
+/** Agents docs landing page. */
+export const AGENTS_DOCS_HOME_URL = `${DOCS_BASE_URL}/agents`;
+
+/** Introductory overview — replaces legacy `/agents/overview`. */
+export const AGENTS_DOCS_OVERVIEW_URL = `${DOCS_BASE_URL}/agents/get-started/what-is-aci`;
+
+/** How agents connect to Slack, Teams, email, and other providers. */
+export const AGENTS_DOCS_PROVIDERS_URL = `${DOCS_BASE_URL}/agents/get-started/agents-and-providers`;
+
+/** Conversations monitoring and cross-provider threads. */
+export const AGENTS_DOCS_CONVERSATIONS_URL = `${DOCS_BASE_URL}/agents/conversations`;
+
+/** Production setup checklist (bridge URL, integrations, inbound email). */
+export const AGENTS_DOCS_SETUP_URL = `${DOCS_BASE_URL}/agents/custom-code-agent/setup-your-agent/overview`;

--- a/packages/shared/src/consts/providers/channels/email.ts
+++ b/packages/shared/src/consts/providers/channels/email.ts
@@ -191,7 +191,7 @@ export const emailProviders: IProviderConfig[] = [
     displayName: 'Novu Email',
     channel: ChannelTypeEnum.EMAIL,
     credentials: [],
-    docReference: `https://docs.novu.co/platform/agents/email${UTM_CAMPAIGN_QUERY_PARAM}`,
+    docReference: `https://docs.novu.co/agents/get-started/agents-and-providers${UTM_CAMPAIGN_QUERY_PARAM}`,
     logoFileName: { light: 'novu.png', dark: 'novu.png' },
   },
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates agent documentation links in the dashboard to match the new `/agents` documentation structure (replacing broken paths such as `/agents/overview` and `/platform/agents`).

## Changes

- Added `apps/dashboard/src/utils/agent-docs.ts` with canonical agent docs URLs
- Updated dashboard components that linked to outdated docs paths:
  - Create agent dialog → `/agents/get-started/what-is-aci`
  - Setup guide / agents list tooltip → `/agents/get-started/agents-and-providers`
  - Agent setup modal → `/agents/custom-code-agent/setup-your-agent/overview`
  - Conversations upgrade CTA → `/agents/conversations`
  - Production empty state → `/agents`
- Updated Novu Email provider `docReference` in `packages/shared` (used by agent email setup guide)

## Mapping (old → new)

| Old URL | New URL |
|---------|---------|
| `docs.novu.co/agents/overview` | `docs.novu.co/agents/get-started/what-is-aci` (or context-specific pages below) |
| `docs.novu.co/platform/agents` | `docs.novu.co/agents/get-started/agents-and-providers` |
| `docs.novu.co` (create agent learn more) | `docs.novu.co/agents/get-started/what-is-aci` |
| `docs.novu.co/platform/agents/email` | `docs.novu.co/agents/get-started/agents-and-providers` |

## Test plan

- [x] Dashboard TypeScript check passes
- [ ] Manually verify doc links open valid pages on docs.novu.co
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7791](https://linear.app/novu/issue/NV-7791/update-agent-documentation-link-in-appsdashboard)

<div><a href="https://cursor.com/agents/bc-899f6c83-aea6-4bb5-972f-9a6feb461622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-899f6c83-aea6-4bb5-972f-9a6feb461622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR updates broken agent documentation links throughout the dashboard by centralizing them as constants. A new utility file (`apps/dashboard/src/utils/agent-docs.ts`) exports documented URLs pointing to the new `/agents` documentation structure, replacing hardcoded references to deprecated paths like `/agents/overview` and `/platform/agents`.

## Affected areas

**dashboard**: Updated six components (`CreateAgentDialog`, `AgentsList`, `AgentSetupModal`, `SetupGuidePrimitives`, `ConversationsUpgradeCta`, `AgentsProductionEmptyState`) and added a new utilities file to centralize agent documentation URLs. Components now import constants instead of using hardcoded doc URLs.

**shared**: Updated the Novu Email provider's `docReference` URL to point to the new agents documentation path.

## Key technical decisions

- Centralized documentation URLs in a new utility file (`agent-docs.ts`) to enable easier maintenance and consistency across the codebase, rather than scattering hardcoded URLs throughout components.

## Testing

TypeScript checks pass. Manual verification of documentation links on docs.novu.co is needed to confirm the new paths are accessible and properly configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->