### PR TITLE
chore(dashboard): adjust the agent creation form fixes NV-7758

### DIFF
--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -804,11 +804,13 @@ export function CreateAgentDialog({
                   )}
                 </div>
 
-                <AgentSuggestionPills
-                  suggestions={AGENT_TEMPLATES}
-                  onSelect={handleSelectAiSuggestion}
-                  disabled={isSubmitBusy}
-                />
+                {generationMode === 'prompt' && (
+                  <AgentSuggestionPills
+                    suggestions={AGENT_TEMPLATES}
+                    onSelect={handleSelectAiSuggestion}
+                    disabled={isSubmitBusy}
+                  />
+                )}
 
                 <AnimatePresence initial={false}>
                   {isSubmitBusy && generationMode === 'prompt' && (

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
@@ -389,7 +389,7 @@ export function ConnectAgentForm({
         }
         extraContent={
           <div className="flex flex-col gap-5">
-            {usePromptUi && aiGeneration && scope === 'create' ? (
+            {usePromptUi && aiGeneration && aiMode === 'prompt' ? (
               <AgentSuggestionPills
                 suggestions={aiGeneration.suggestions}
                 onSelect={aiGeneration.onSelectSuggestion}
@@ -404,7 +404,7 @@ export function ConnectAgentForm({
                 onExternalAgentIdChange={onExternalAgentIdChange}
                 onExternalEnvironmentIdChange={onExternalEnvironmentIdChange}
               />
-            ) : isScratchMode ? (
+            ) : !usePromptUi && isScratchMode ? (
               <ScratchAgentFields
                 isColumnsLayout
                 name={name}

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
@@ -178,6 +178,18 @@ export function ConnectAgentStep({ onAgentCreated, onRuntimeChange, isManagedEna
     }
   }, [showExistingOption, templateSelection.kind]);
 
+  // Same idea for the AI flow: when the connector no longer supports linking an existing agent,
+  // collapse `'existing'` back to `'prompt'`. Otherwise the right-column form has no matching
+  // branch (existing-fields are gated on Claude, and the scope tabs that would let the user pick
+  // a new mode are hidden), so section 2 would render empty with no way to recover.
+  useEffect(() => {
+    if (!showExistingOption && generationMode === 'existing') {
+      setGenerationMode('prompt');
+      setExternalAgentId('');
+      setExternalEnvironmentId('');
+    }
+  }, [showExistingOption, generationMode]);
+
   // Auto-select the first existing integration of the chosen provider on mount / when the connector
   // changes / when integrations finish loading. If none exist, open the inline credentials section.
   // We intentionally wait for `integrations` to be defined — on the onboarding entry-point the list


### PR DESCRIPTION
### What changed? Why was the change needed?

Adjust the agent creation form, hide template pills in manual mode, fix onboarding flow form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The PR refines the agent creation form's UI rendering logic to properly handle different generation modes (prompt-based, manual, or existing agent). The form now conditionally renders suggestion pills only when users select "generate from prompt," and scratch-agent fields only render in manual creation when AI-generation is disabled. A new effect was added to handle transitioning back to prompt mode when a connector no longer supports the "existing agent" option, preventing inconsistent form states.

## Affected areas

**dashboard**: Updated three interconnected onboarding components (`create-agent-dialog.tsx`, `connect-agent-form.tsx`, `connect-agent-step.tsx`) to align conditional rendering of UI sections with the active generation mode, ensuring the form displays the correct fields and suggestion pills based on the user's selected workflow.

## Testing

No test files were added or modified. The changes are UI adjustments to conditional rendering logic that were validated through manual verification via the eight included screenshots showing the agent creation wizard in different states and modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<img width="1532" height="1002" alt="Screenshot 2026-05-25 at 11 44 36" src="https://github.com/user-attachments/assets/7dda3dd9-00fc-4843-b5d1-d6fae2586505" />
<img width="1532" height="1000" alt="Screenshot 2026-05-25 at 11 44 42" src="https://github.com/user-attachments/assets/3ed15468-cdf5-4eac-b462-1cd0be4e627d" />

<img width="1531" height="1003" alt="Screenshot 2026-05-25 at 11 44 51" src="https://github.com/user-attachments/assets/0a34406d-5f68-4bee-9345-18b9b6b0248b" />
<img width="1524" height="997" alt="Screenshot 2026-05-25 at 11 44 58" src="https://github.com/user-attachments/assets/c0046430-358a-4a3d-a72c-c3de4f2d85e0" />
<img width="1535" height="1001" alt="Screenshot 2026-05-25 at 11 45 19" src="https://github.com/user-attachments/assets/c9bc5524-92b2-421b-ac5a-e4d7ecf37af4" />
<img width="1528" height="997" alt="Screenshot 2026-05-25 at 11 45 28" src="https://github.com/user-attachments/assets/a23858f7-6865-428f-80cc-f5fe57fa635b" />
<img width="1529" height="1000" alt="Screenshot 2026-05-25 at 11 45 44" src="https://github.com/user-attachments/assets/5f59da37-d935-468b-afb8-92ce3bc86dab" />
<img width="1530" height="999" alt="Screenshot 2026-05-25 at 11 45 52" src="https://github.com/user-attachments/assets/6215c8aa-3e08-4164-b7c0-9591e629a5c5" />
