### PR TITLE
feat(api-service): capture agents and chat-sdk errors in Sentry fixes NV-7794

### DIFF
--- a/apps/api/src/app/agents/agent-email-actions.controller.ts
+++ b/apps/api/src/app/agents/agent-email-actions.controller.ts
@@ -10,6 +10,7 @@ import {
   ConsumedActionToken,
   PeekedActionToken,
 } from './services/agent-email-action-token.service';
+import { captureAgentException, captureAgentWarning } from './utils/capture-agent-sentry';
 import { AgentActionPreDispatchError, ChatSdkService } from './services/chat-sdk.service';
 
 const EXECUTE_PATH = '/v1/agents/email/actions/execute';
@@ -64,6 +65,7 @@ export class AgentEmailActionsController {
     } catch (err) {
       if (err instanceof AgentEmailActionCacheUnavailableError) {
         this.logger.warn(err, 'Cache unavailable while peeking agent email action token');
+        captureAgentWarning(err, { component: 'agent-email-actions', operation: 'peek-action-token' });
         this.sendHtml(res, HttpStatus.SERVICE_UNAVAILABLE, renderTryAgainPage());
 
         return;
@@ -118,6 +120,7 @@ export class AgentEmailActionsController {
     } catch (err) {
       if (err instanceof AgentEmailActionCacheUnavailableError) {
         this.logger.warn(err, 'Cache unavailable while consuming agent email action token');
+        captureAgentWarning(err, { component: 'agent-email-actions', operation: 'consume-action-token' });
         this.sendHtml(res, HttpStatus.SERVICE_UNAVAILABLE, renderTryAgainPage());
 
         return;
@@ -137,6 +140,13 @@ export class AgentEmailActionsController {
       await this.chatSdkService.processEmailAction(claims);
     } catch (err) {
       this.logger.error(err, `Failed to process agent email action ${claims.actionId} for agent ${claims.agentId}`);
+      captureAgentException(err, {
+        component: 'agent-email-actions',
+        operation: 'process-email-action',
+        agentId: claims.agentId,
+        integrationIdentifier: claims.integrationIdentifier,
+        extra: { actionId: claims.actionId, preDispatch: err instanceof AgentActionPreDispatchError },
+      });
 
       // Only re-release the token when the failure is provably *pre-dispatch* (token
       // validation, config resolution, adapter setup) — at which point no user-facing side
@@ -147,6 +157,11 @@ export class AgentEmailActionsController {
       if (err instanceof AgentActionPreDispatchError) {
         await this.tokenService.releaseActionToken(token, consumed).catch((releaseErr) => {
           this.logger.warn(releaseErr, `Failed to release agent email action token after pre-dispatch failure`);
+          captureAgentWarning(releaseErr, {
+            component: 'agent-email-actions',
+            operation: 'release-action-token',
+            agentId: claims.agentId,
+          });
         });
       }
 

--- a/apps/api/src/app/agents/filters/agent-runtime-exception.filter.ts
+++ b/apps/api/src/app/agents/filters/agent-runtime-exception.filter.ts
@@ -13,6 +13,7 @@ import {
   PinoLogger,
 } from '@novu/application-generic';
 import type { Response } from 'express';
+import { captureAgentException } from '../utils/capture-agent-sentry';
 
 function httpStatusFromError(err: AgentRuntimeError): number {
   if (err instanceof AgentRuntimeUnauthorizedError) return HttpStatus.UNAUTHORIZED;
@@ -56,6 +57,16 @@ export class AgentRuntimeExceptionFilter implements ExceptionFilter {
         { code, providerId: exception.providerId, requestId: exception.requestId, message: exception.message },
         'Agent runtime provider error'
       );
+      captureAgentException(exception, {
+        component: 'agent-runtime-exception-filter',
+        operation: 'provider-error',
+        extra: {
+          code,
+          providerId: exception.providerId,
+          requestId: exception.requestId,
+          statusCode,
+        },
+      });
     }
 
     if (exception instanceof AgentRuntimeRateLimitedError) {

--- a/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
+++ b/apps/api/src/app/agents/services/agent-attachment-storage.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { PinoLogger, StorageService } from '@novu/application-generic';
 import type { Attachment } from 'chat';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
+import { captureAgentWarning } from '../utils/capture-agent-sentry';
 
 export interface StoredAttachment {
   type: string;
@@ -151,6 +152,7 @@ export class AgentAttachmentStorage {
         }
       } catch (err) {
         this.logger.warn(err, 'Inbound attachment processing failed');
+        captureAgentWarning(err, { component: 'agent-attachment-storage', operation: 'store-inbound' });
       }
     }
 
@@ -232,6 +234,7 @@ export class AgentAttachmentStorage {
         await this.storageService.uploadFile(storageKey, buffer, mimeType);
       } catch (err) {
         this.logger.warn(err, 'Failed to upload inbound attachment');
+        captureAgentWarning(err, { component: 'agent-attachment-storage', operation: 'upload-inbound' });
 
         return null;
       }
@@ -241,6 +244,7 @@ export class AgentAttachmentStorage {
         url = await this.storageService.getReadSignedUrl(storageKey, READ_URL_TTL_SECONDS);
       } catch (err) {
         this.logger.warn(err, 'Failed to sign inbound attachment after upload');
+        captureAgentWarning(err, { component: 'agent-attachment-storage', operation: 'sign-inbound-after-upload' });
       }
 
       return {
@@ -253,6 +257,7 @@ export class AgentAttachmentStorage {
       };
     } catch (err) {
       this.logger.warn(err, 'Failed to store inbound attachment');
+      captureAgentWarning(err, { component: 'agent-attachment-storage', operation: 'store-one' });
 
       return null;
     }

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -18,6 +18,7 @@ import type { AgentAction } from '@novu/framework';
 import { ENDPOINT_TYPES } from '@novu/shared';
 import type { CardChild, CardElement, EmojiValue, Message, Thread } from 'chat';
 import { trackAgentInboundAction, trackAgentInboundMessage, trackAgentInboundReaction } from '../agent-analytics';
+import { captureAgentException, captureAgentWarning } from '../utils/capture-agent-sentry';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { AgentPlatformEnum, PLATFORMS_WITH_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
 import { LinkTelegramChatToSubscriberCommand } from '../usecases/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.command';
@@ -264,6 +265,7 @@ export class AgentInboundHandler implements OnModuleInit {
       })
       .catch((err) => {
         this.logger.warn(err, `[agent:${agentId}] Subscriber resolution failed, continuing without subscriber`);
+        captureAgentWarning(err, { component: 'agent-inbound-handler', operation: 'resolve-subscriber', agentId });
 
         return null;
       });
@@ -357,6 +359,11 @@ export class AgentInboundHandler implements OnModuleInit {
         )
         .catch((err) => {
           this.logger.warn(err, `[agent:${agentId}] Failed to store firstPlatformMessageId`);
+          captureAgentWarning(err, {
+            component: 'agent-inbound-handler',
+            operation: 'store-first-platform-message-id',
+            agentId,
+          });
         });
     }
 
@@ -371,6 +378,11 @@ export class AgentInboundHandler implements OnModuleInit {
           .addReaction(ACKNOWLEDGE_FALLBACK_EMOJI)
           .catch((err) => {
             this.logger.warn(err, `[agent:${agentId}] Failed to add ack reaction to first message`);
+            captureAgentWarning(err, {
+              component: 'agent-inbound-handler',
+              operation: 'add-ack-reaction',
+              agentId,
+            });
           });
       }
     }
@@ -454,6 +466,11 @@ export class AgentInboundHandler implements OnModuleInit {
               lookupErr,
               `[agent:${config.agentIdentifier}] Failed to resolve dashboard URL for no-bridge reply`
             );
+            captureAgentWarning(lookupErr, {
+              component: 'agent-inbound-handler',
+              operation: 'resolve-dashboard-url',
+              agentIdentifier: config.agentIdentifier,
+            });
           }
         }
 
@@ -535,6 +552,11 @@ export class AgentInboundHandler implements OnModuleInit {
           await this.safePostInboundReply(thread, SUBSCRIBER_LINK_INVALID_REPLY, agentId, message);
         } else {
           this.logger.error(err, `[agent:${agentId}] Unexpected failure linking Telegram chat to subscriber`);
+          captureAgentException(err, {
+            component: 'agent-inbound-handler',
+            operation: 'link-telegram-subscriber',
+            agentId,
+          });
           await this.safePostInboundReply(thread, SUBSCRIBER_LINK_INVALID_REPLY, agentId, message);
         }
       }
@@ -565,6 +587,11 @@ export class AgentInboundHandler implements OnModuleInit {
         err,
         `[agent:${agentId}] Failed to post Telegram subscriber-link reply for inbound message ${message.id ?? '<unknown>'}`
       );
+      captureAgentWarning(err, {
+        component: 'agent-inbound-handler',
+        operation: 'post-telegram-subscriber-link-reply',
+        agentId,
+      });
     }
   }
 
@@ -614,6 +641,11 @@ export class AgentInboundHandler implements OnModuleInit {
               err,
               `[agent:${agentId}] Subscriber resolution failed for reaction, continuing without subscriber`
             );
+            captureAgentWarning(err, {
+              component: 'agent-inbound-handler',
+              operation: 'resolve-subscriber-reaction',
+              agentId,
+            });
 
             return null;
           })
@@ -685,6 +717,11 @@ export class AgentInboundHandler implements OnModuleInit {
           err,
           `[agent:${agentId}] Subscriber resolution failed for action, continuing without subscriber`
         );
+        captureAgentWarning(err, {
+          component: 'agent-inbound-handler',
+          operation: 'resolve-subscriber-action',
+          agentId,
+        });
 
         return null;
       });

--- a/apps/api/src/app/agents/services/bridge-executor.service.ts
+++ b/apps/api/src/app/agents/services/bridge-executor.service.ts
@@ -23,6 +23,7 @@ import type {
 import { AgentEventEnum } from '@novu/framework';
 import { HttpHeaderKeysEnum } from '@novu/framework/internal';
 import type { Message } from 'chat';
+import { captureAgentException, captureAgentWarning } from '../utils/capture-agent-sentry';
 import { AgentAttachmentStorage, type StoredAttachment } from './agent-attachment-storage.service';
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
 
@@ -133,8 +134,18 @@ export class BridgeExecutorService {
 
       this.fireWithRetries(bridgeUrl, payload, secretKey, agentIdentifier).catch((err) => {
         this.logger.error(err, `[agent:${agentIdentifier}] Bridge delivery failed after ${MAX_RETRIES + 1} attempts`);
+        captureAgentException(err, {
+          component: 'bridge-executor',
+          operation: 'bridge-delivery',
+          agentIdentifier,
+        });
         params.onBridgeFailure?.(err instanceof Error ? err : new Error(String(err))).catch((callbackErr) => {
           this.logger.warn(callbackErr, `[agent:${agentIdentifier}] onBridgeFailure callback threw`);
+          captureAgentWarning(callbackErr, {
+            component: 'bridge-executor',
+            operation: 'on-bridge-failure-callback',
+            agentIdentifier,
+          });
         });
       });
     } catch (err) {
@@ -143,6 +154,11 @@ export class BridgeExecutorService {
       }
 
       this.logger.error(err, `[agent:${agentIdentifier}] Bridge setup failed — skipping bridge call`);
+      captureAgentException(err, {
+        component: 'bridge-executor',
+        operation: 'bridge-setup',
+        agentIdentifier,
+      });
     }
   }
 
@@ -475,6 +491,7 @@ export class BridgeExecutorService {
       return url;
     } catch (err) {
       this.logger.warn(err, 'Failed to sign agent attachment for history; omitting from bridge payload');
+      captureAgentWarning(err, { component: 'bridge-executor', operation: 'sign-history-attachment' });
 
       return null;
     }
@@ -528,6 +545,7 @@ export class BridgeExecutorService {
       return url;
     } catch (err) {
       this.logger.warn(err, 'Failed to sign stored attachment; omitting from bridge payload');
+      captureAgentWarning(err, { component: 'bridge-executor', operation: 'sign-stored-attachment' });
 
       return null;
     }

--- a/apps/api/src/app/agents/services/chat-sdk.service.ts
+++ b/apps/api/src/app/agents/services/chat-sdk.service.ts
@@ -24,6 +24,7 @@ import { Request as ExpressRequest, Response as ExpressResponse } from 'express'
 import { LRUCache } from 'lru-cache';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
 import type { FileRef, ReplyContentDto } from '../dtos/agent-reply-payload.dto';
+import { captureAgentException, captureAgentWarning } from '../utils/capture-agent-sentry';
 import { esmImport } from '../utils/esm-import';
 import { sendWebResponse, toWebRequest } from '../utils/express-to-web-request';
 import { AgentConfigResolver, AgentConfigResolveSource, ResolvedAgentConfig } from './agent-config-resolver.service';
@@ -212,6 +213,7 @@ export class ChatSdkService implements OnModuleDestroy {
       dispose: (cached, key) => {
         cached.chat.shutdown().catch((err) => {
           this.logger.error(err, `Failed to shut down evicted Chat instance ${key}`);
+          captureAgentException(err, { component: 'chat-sdk', operation: 'shutdown-evicted', extra: { instanceKey: key } });
         });
       },
     });
@@ -309,6 +311,7 @@ export class ChatSdkService implements OnModuleDestroy {
         await cached.chat.shutdown();
       } catch (err) {
         this.logger.error(err, `Failed to shut down Chat instance ${key}`);
+        captureAgentException(err, { component: 'chat-sdk', operation: 'shutdown', extra: { instanceKey: key } });
       }
     });
 
@@ -1130,6 +1133,11 @@ export class ChatSdkService implements OnModuleDestroy {
         return buildAgentSharedInbox(slug, inboxRoutingKey);
       } catch (err) {
         this.logger.warn({ err, agentId: config.agentId }, 'Falling back to params.from - shared inbox build failed');
+        captureAgentWarning(err, {
+          component: 'chat-sdk',
+          operation: 'resolve-agent-inbound-address',
+          agentId: config.agentId,
+        });
       }
     }
 
@@ -1256,6 +1264,12 @@ export class ChatSdkService implements OnModuleDestroy {
         { err, environmentId: config.environmentId, agentId: config.agentId },
         'Failed to persist Novu demo email message for quota accounting'
       );
+      captureAgentWarning(err, {
+        component: 'chat-sdk',
+        operation: 'persist-demo-email-quota',
+        agentId: config.agentId,
+        extra: { environmentId: config.environmentId },
+      });
     }
 
     return { messageId: messageIdForReturn };
@@ -1294,8 +1308,18 @@ export class ChatSdkService implements OnModuleDestroy {
     return {
       debug: (msg: string, ctx?: Record<string, unknown>) => this.logger.debug(ctx ?? {}, msg),
       info: (msg: string, ctx?: Record<string, unknown>) => this.logger.info(ctx ?? {}, msg),
-      warn: (msg: string, ctx?: Record<string, unknown>) => this.logger.warn(ctx ?? {}, msg),
-      error: (msg: string, ctx?: Record<string, unknown>) => this.logger.error(ctx ?? {}, msg),
+      warn: (msg: string, ctx?: Record<string, unknown>) => {
+        this.logger.warn(ctx ?? {}, msg);
+        if (ctx?.err) {
+          captureAgentWarning(ctx.err, { component: 'chat-sdk', operation: 'chat-state-warn', extra: { message: msg } });
+        }
+      },
+      error: (msg: string, ctx?: Record<string, unknown>) => {
+        this.logger.error(ctx ?? {}, msg);
+        if (ctx?.err) {
+          captureAgentException(ctx.err, { component: 'chat-sdk', operation: 'chat-state-error', extra: { message: msg } });
+        }
+      },
     };
   }
 
@@ -1436,6 +1460,7 @@ export class ChatSdkService implements OnModuleDestroy {
         await callbacks.onMessage(agentId, cached.config, thread, message);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling new mention`);
+        captureAgentException(err, { component: 'chat-sdk', operation: 'on-new-mention', agentId });
       }
     });
 
@@ -1444,6 +1469,7 @@ export class ChatSdkService implements OnModuleDestroy {
         await callbacks.onMessage(agentId, cached.config, thread, message);
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling subscribed message`);
+        captureAgentException(err, { component: 'chat-sdk', operation: 'on-subscribed-message', agentId });
       }
     });
 
@@ -1468,6 +1494,12 @@ export class ChatSdkService implements OnModuleDestroy {
         );
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling action ${event.actionId}`);
+        captureAgentException(err, {
+          component: 'chat-sdk',
+          operation: 'on-action',
+          agentId,
+          extra: { actionId: event.actionId },
+        });
       }
     });
 
@@ -1483,6 +1515,7 @@ export class ChatSdkService implements OnModuleDestroy {
         });
       } catch (err) {
         this.logger.error(err, `[agent:${agentId}] Error handling reaction`);
+        captureAgentException(err, { component: 'chat-sdk', operation: 'on-reaction', agentId });
       }
     });
   }

--- a/apps/api/src/app/agents/services/managed-agent-event-handler.ts
+++ b/apps/api/src/app/agents/services/managed-agent-event-handler.ts
@@ -10,6 +10,7 @@ import {
   type Response as ThalamusResponse,
 } from '@novu/thalamus';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
+import { captureAgentException, captureAgentWarning } from '../utils/capture-agent-sentry';
 import { GenerateMcpOAuthUrlCommand } from '../usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.command';
 import { GenerateMcpOAuthUrl } from '../usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase';
 import { HandleAgentReplyCommand } from '../usecases/handle-agent-reply/handle-agent-reply.command';
@@ -72,6 +73,11 @@ export class ManagedAgentEventHandler {
           );
         } catch (err) {
           this.logger.error(err, `onToolUseStart failed: session=${sessionId}`);
+          captureAgentException(err, {
+            component: 'managed-agent-event-handler',
+            operation: 'on-tool-use-start',
+            sessionId,
+          });
         }
       },
 
@@ -95,6 +101,11 @@ export class ManagedAgentEventHandler {
           );
         } catch (err) {
           this.logger.error(err, `onToolUseDone failed: session=${sessionId}`);
+          captureAgentException(err, {
+            component: 'managed-agent-event-handler',
+            operation: 'on-tool-use-done',
+            sessionId,
+          });
         }
       },
 
@@ -113,6 +124,11 @@ export class ManagedAgentEventHandler {
           );
         } catch (err) {
           this.logger.error(err, `onToolUseResult failed: session=${sessionId}`);
+          captureAgentException(err, {
+            component: 'managed-agent-event-handler',
+            operation: 'on-tool-use-result',
+            sessionId,
+          });
         }
       },
 
@@ -155,6 +171,11 @@ export class ManagedAgentEventHandler {
           );
         } catch (err) {
           this.logger.error(err, `onFinish failed: session=${sessionId}`);
+          captureAgentException(err, {
+            component: 'managed-agent-event-handler',
+            operation: 'on-finish',
+            sessionId,
+          });
           throw err;
         }
       },
@@ -164,6 +185,11 @@ export class ManagedAgentEventHandler {
           await this.handleErrorEvent(metadata, sessionId, event.error, baseFields, runId);
         } catch (err) {
           this.logger.error(err, `onError handler failed: session=${sessionId}`);
+          captureAgentException(err, {
+            component: 'managed-agent-event-handler',
+            operation: 'on-error-handler',
+            sessionId,
+          });
         }
       },
     };
@@ -234,6 +260,11 @@ export class ManagedAgentEventHandler {
       );
     } catch (err) {
       this.logger.error(err, `Failed to deliver error message for session ${sessionId}`);
+      captureAgentException(err, {
+        component: 'managed-agent-event-handler',
+        operation: 'deliver-error-message',
+        sessionId,
+      });
     }
   }
 
@@ -302,6 +333,12 @@ export class ManagedAgentEventHandler {
         },
         'GenerateMcpOAuthUrl failed; falling back to plain-text MCP-init error'
       );
+      captureAgentWarning(err, {
+        component: 'managed-agent-event-handler',
+        operation: 'generate-mcp-oauth-url',
+        sessionId,
+        agentIdentifier: metadata.agentIdentifier,
+      });
 
       return false;
     }
@@ -320,6 +357,11 @@ export class ManagedAgentEventHandler {
       );
     } catch (err) {
       this.logger.error(err, `Failed to deliver Connect card for session ${sessionId}`);
+      captureAgentException(err, {
+        component: 'managed-agent-event-handler',
+        operation: 'deliver-connect-card',
+        sessionId,
+      });
 
       return false;
     }
@@ -356,6 +398,11 @@ export class ManagedAgentEventHandler {
       );
     } catch (err) {
       this.logger.error(err, `Failed to deliver anonymous-user MCP reply for session ${sessionId}`);
+      captureAgentException(err, {
+        component: 'managed-agent-event-handler',
+        operation: 'deliver-anonymous-mcp-reply',
+        sessionId,
+      });
 
       return false;
     }
@@ -383,6 +430,11 @@ export class ManagedAgentEventHandler {
           { err: err instanceof Error ? err.message : String(err), sessionId },
           'getPendingToolApproval failed; cannot render Approve/Deny card'
         );
+        captureAgentWarning(err, {
+          component: 'managed-agent-event-handler',
+          operation: 'get-pending-tool-approval',
+          sessionId,
+        });
 
         return false;
       }
@@ -411,6 +463,11 @@ export class ManagedAgentEventHandler {
       );
     } catch (err) {
       this.logger.error(err, `Failed to deliver tool-approval card for session ${sessionId}`);
+      captureAgentException(err, {
+        component: 'managed-agent-event-handler',
+        operation: 'deliver-tool-approval-card',
+        sessionId,
+      });
 
       return false;
     }
@@ -455,6 +512,11 @@ export class ManagedAgentEventHandler {
         { err: err instanceof Error ? err.message : String(err), conversationId: metadata.conversationId },
         'Failed to resolve subscriberId from conversation participants'
       );
+      captureAgentWarning(err, {
+        component: 'managed-agent-event-handler',
+        operation: 'resolve-subscriber-from-conversation',
+        extra: { conversationId: metadata.conversationId },
+      });
 
       return undefined;
     }

--- a/apps/api/src/app/agents/utils/capture-agent-sentry.ts
+++ b/apps/api/src/app/agents/utils/capture-agent-sentry.ts
@@ -8,7 +8,7 @@ import {
 } from '@novu/application-generic';
 import { captureException } from '@sentry/node';
 
-export type AgentSentryContext = {
+export interface AgentSentryContext {
   component: string;
   operation?: string;
   agentId?: string;
@@ -17,7 +17,7 @@ export type AgentSentryContext = {
   platform?: string;
   sessionId?: string;
   extra?: Record<string, unknown>;
-};
+}
 
 function isSentryEnabled(): boolean {
   return Boolean(process.env.SENTRY_DSN);

--- a/apps/api/src/app/agents/utils/capture-agent-sentry.ts
+++ b/apps/api/src/app/agents/utils/capture-agent-sentry.ts
@@ -1,0 +1,87 @@
+import { HttpException } from '@nestjs/common';
+import {
+  AgentRuntimeBadRequestError,
+  AgentRuntimeForbiddenError,
+  AgentRuntimeNotFoundError,
+  AgentRuntimeRateLimitedError,
+  AgentRuntimeUnauthorizedError,
+} from '@novu/application-generic';
+import { captureException } from '@sentry/node';
+
+export type AgentSentryContext = {
+  component: string;
+  operation?: string;
+  agentId?: string;
+  agentIdentifier?: string;
+  integrationIdentifier?: string;
+  platform?: string;
+  sessionId?: string;
+  extra?: Record<string, unknown>;
+};
+
+function isSentryEnabled(): boolean {
+  return Boolean(process.env.SENTRY_DSN);
+}
+
+function toError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+function shouldSkipCapture(err: unknown): boolean {
+  if (err instanceof HttpException) {
+    const status = err.getStatus();
+
+    if (status >= 400 && status < 500) {
+      return true;
+    }
+  }
+
+  if (
+    err instanceof AgentRuntimeUnauthorizedError ||
+    err instanceof AgentRuntimeForbiddenError ||
+    err instanceof AgentRuntimeBadRequestError ||
+    err instanceof AgentRuntimeNotFoundError ||
+    err instanceof AgentRuntimeRateLimitedError
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function buildScope(context: AgentSentryContext, level: 'error' | 'warning') {
+  return {
+    level,
+    tags: {
+      feature: 'agents',
+      component: context.component,
+      ...(context.operation ? { operation: context.operation } : {}),
+      ...(context.agentId ? { agentId: context.agentId } : {}),
+      ...(context.agentIdentifier ? { agentIdentifier: context.agentIdentifier } : {}),
+      ...(context.platform ? { platform: context.platform } : {}),
+    },
+    extra: {
+      ...(context.integrationIdentifier ? { integrationIdentifier: context.integrationIdentifier } : {}),
+      ...(context.sessionId ? { sessionId: context.sessionId } : {}),
+      ...context.extra,
+    },
+  };
+}
+
+/** Report unexpected agent failures to Sentry (skipped when SENTRY_DSN is unset). */
+export function captureAgentException(err: unknown, context: AgentSentryContext): void {
+  if (!isSentryEnabled() || shouldSkipCapture(err)) {
+    return;
+  }
+
+  captureException(toError(err), buildScope(context, 'error'));
+}
+
+/** Report degraded-but-handled agent paths to Sentry at warning level. */
+export function captureAgentWarning(err: unknown, context: AgentSentryContext): void {
+  if (!isSentryEnabled() || shouldSkipCapture(err)) {
+    return;
+  }
+
+  captureException(toError(err), buildScope(context, 'warning'));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Agent and chat-sdk code paths were catching failures, logging them with Pino, and continuing — but those errors never reached Sentry. This adds a small shared helper and wires `captureException` alongside existing logs so operational issues are trackable in production.

## Changes

- **`capture-agent-sentry.ts`**: `captureAgentException` / `captureAgentWarning` helpers (respect `SENTRY_DSN`, skip expected 4xx / agent-runtime client errors, tag with `feature: agents` + component/operation).
- **`chat-sdk.service.ts`**: inbound event handlers, shutdown failures, shared-inbox fallback, demo quota persistence, and chat-state adapter logger.
- **`agent-inbound-handler.service.ts`**: subscriber resolution, ack reactions, Telegram linking, and related degraded paths.
- **`bridge-executor.service.ts`**: bridge delivery/setup failures and attachment signing.
- **`managed-agent-event-handler.ts`**: webhook tool/finish/error handlers and MCP card delivery.
- **`agent-attachment-storage.service.ts`**, **`agent-email-actions.controller.ts`**, **`agent-runtime-exception.filter.ts`**: matching capture at existing warn/error sites.

## Testing

- `pnpm exec tsc -p tsconfig.build.json --noEmit` in `apps/api` (passes)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779707109205349?thread_ts=1779707109.205349&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-eb2f7630-b763-545c-b37b-eae643526999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb2f7630-b763-545c-b37b-eae643526999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added centralized Sentry instrumentation for agent and chat-sdk error paths so operational failures that were previously only logged to Pino are now reported to Sentry. A new helper module exposes captureAgentException and captureAgentWarning which conditionally send events (respecting SENTRY_DSN and filtering expected 4xx / known agent-runtime client errors), and these helpers are wired into existing catch/warn sites across agent services to make production issues observable without changing control flow.

## Affected areas

**api**: Introduced apps/api/src/app/agents/utils/capture-agent-sentry.ts and integrated its helpers across agent-related services and controllers—chat-sdk (inbound handlers, shutdowns, shared-inbox fallback, demo quota persistence, chat-state logger), agent-inbound-handler (subscriber resolution, acks, Telegram linking), bridge-executor (delivery/setup and attachment signing), managed-agent-event-handler (tool lifecycle, finish/error handlers, MCP/card delivery), agent-attachment-storage (upload/sign/store warnings), agent-email-actions.controller (token peek/consume/process/release failures), and agent-runtime-exception.filter (runtime provider errors).

## Key technical decisions

- Instrumentation is no-op when SENTRY_DSN is unset and excludes expected client errors (HttpException 4xx and specific AgentRuntime* client errors) to avoid noise.  
- Events are tagged with feature/component/operation and enriched with contextual fields (agentId, integrationIdentifier, providerId, requestId, etc.) for actionable telemetry.  
- Non-Error throwables are normalized to Error via stringification before reporting.

## Testing

Type-checking passed: pnpm exec tsc -p tsconfig.build.json --noEmit in apps/api. No new unit or integration tests were added; changes are instrumentation-only and preserve existing control flow and error semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->