### PR TITLE
fix(dashboard): onboarding slack configuration token field fixes NV-7796

### DIFF
--- a/apps/dashboard/src/components/agents/slack-setup-guide.tsx
+++ b/apps/dashboard/src/components/agents/slack-setup-guide.tsx
@@ -8,6 +8,7 @@ import { useSearchParams } from 'react-router-dom';
 import type { AgentResponse } from '@/api/agents';
 import { sendAgentWelcomeMessage } from '@/api/agents';
 import { slackQuickSetup } from '@/api/integrations';
+import { useConnectSubscriber } from '@/components/connect/connect-subscriber-provider';
 import { ProviderIcon } from '@/components/integrations/components/provider-icon';
 import { Button } from '@/components/primitives/button';
 import { CodeBlock } from '@/components/primitives/code-block';
@@ -17,7 +18,6 @@ import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { API_HOSTNAME } from '@/config';
 import { useAuth } from '@/context/auth/hooks';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
-import { useConnectSubscriber } from '@/components/connect/connect-subscriber-provider';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { buildAgentConnectionIdentifier } from '@/utils/connect-subscriber-id';
@@ -348,9 +348,7 @@ export function SlackSetupGuide({
   ) : null;
 
   const connectionIdentifier =
-    isUserLoaded && currentUser?._id
-      ? buildAgentConnectionIdentifier(currentUser._id, agent._id)
-      : null;
+    isUserLoaded && currentUser?._id ? buildAgentConnectionIdentifier(currentUser._id, agent._id) : null;
 
   const slackInstallConnectControl =
     isConnectSubscriberReady && connectionIdentifier && selectedIntegrationIdentifier ? (

--- a/apps/dashboard/src/components/connect/connect-subscriber-provider.tsx
+++ b/apps/dashboard/src/components/connect/connect-subscriber-provider.tsx
@@ -1,5 +1,5 @@
 import { NovuProvider } from '@novu/react';
-import { createContext, type ComponentProps, type ReactNode } from 'react';
+import { type ComponentProps, createContext, type ReactNode } from 'react';
 import { Outlet } from 'react-router-dom';
 import { useAuth } from '@/context/auth/hooks';
 import { useEnvironment } from '@/context/environment/hooks';

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -42,6 +42,7 @@ import { Landing1SignUpPage } from '@/pages/landing-1-signup';
 import { SubscribersPage } from '@/pages/subscribers';
 import { TranslationSettingsPage } from '@/pages/translation-settings-page';
 import { WebhooksPage } from '@/pages/webhooks-page';
+import { ConnectSubscriberProvider } from './components/connect/connect-subscriber-provider';
 import { CreateIntegrationSidebar } from './components/integrations/components/create-integration-sidebar';
 import { UpdateIntegrationSidebar } from './components/integrations/components/update-integration-sidebar';
 import { ChannelPreferences } from './components/workflow-editor/channel-preferences';
@@ -80,7 +81,6 @@ import { UpsertVariablePage } from './pages/upsert-variable';
 import { UsecaseSelectPage } from './pages/usecase-select-page';
 import { VariablesPage } from './pages/variables';
 import { VercelIntegrationPage } from './pages/vercel-integration-page';
-import { ConnectSubscriberProvider } from './components/connect/connect-subscriber-provider';
 import { AuthRoute, CatchAllRoute, DashboardRoute, ProtectedAuthRoute, RootRoute } from './routes';
 import { ConnectProtectedRoute } from './routes/connect-protected-route';
 import { OnboardingParentRoute } from './routes/onboarding';
@@ -157,11 +157,7 @@ const router = createBrowserRouter([
       },
       {
         path: '/onboarding',
-        element: (
-          <ConnectSubscriberProvider>
-            <OnboardingParentRoute />
-          </ConnectSubscriberProvider>
-        ),
+        element: <OnboardingParentRoute />,
         children: [
           {
             path: ROUTES.USECASE_SELECT,

--- a/apps/dashboard/src/routes/onboarding.tsx
+++ b/apps/dashboard/src/routes/onboarding.tsx
@@ -1,5 +1,6 @@
 import { Show } from '@clerk/react';
 import { AnimatedOutlet } from '@/components/animated-outlet';
+import { ConnectSubscriberProvider } from '@/components/connect/connect-subscriber-provider';
 import { AuthLayout } from '../components/auth-layout';
 import { EnvironmentProvider } from '../context/environment/environment-provider';
 
@@ -7,9 +8,11 @@ export const OnboardingParentRoute = () => {
   return (
     <Show when="signed-in">
       <EnvironmentProvider>
-        <AuthLayout>
-          <AnimatedOutlet />
-        </AuthLayout>
+        <ConnectSubscriberProvider>
+          <AuthLayout>
+            <AnimatedOutlet />
+          </AuthLayout>
+        </ConnectSubscriberProvider>
       </EnvironmentProvider>
     </Show>
   );


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The `ConnectSubscriberProvider` was repositioned to wrap the onboarding routes instead of being applied at the application root level. Additionally, the Slack setup guide's connection identifier computation was refactored to use a `buildAgentConnectionIdentifier` helper function. These changes ensure the subscriber context is properly available during the onboarding flow, fixing the missing token field in the Slack configuration step.

## Affected areas

**dashboard**: Moved `ConnectSubscriberProvider` to the onboarding route level (`OnboardingParentRoute`) within `EnvironmentProvider` to ensure subscriber context is available during the onboarding flow. Updated the main route configuration to remove the provider wrapper from the global `/onboarding` route definition. Refactored the Slack setup guide's connection identifier logic to use a helper function for cleaner conditionals. Updated imports across onboarding and provider components for consistency.

## Key technical decisions

- Nested `ConnectSubscriberProvider` inside `EnvironmentProvider` at the onboarding route level to ensure proper context availability during agent configuration. This maintains the provider hierarchy while scoping the context where it's needed.

## Testing

Manual verification through the onboarding flow screenshots is recommended to confirm the Slack token field is now properly accessible and functional during agent configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<img width="1529" height="999" alt="Screenshot 2026-05-25 at 15 22 18" src="https://github.com/user-attachments/assets/4efd213a-2558-48cb-8c7c-7d490f0059b2" />

<img width="1555" height="1005" alt="Screenshot 2026-05-25 at 15 53 14" src="https://github.com/user-attachments/assets/c7b1fe0c-02a2-4b5e-873f-d60ddaea5e9c" />
