### PR TITLE
fix(shared): separate MCP toolsets from builtin tools in Anthropic parsing fixes NV-7798

### DIFF
--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.spec.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.spec.ts
@@ -398,6 +398,46 @@ describe('AnthropicAgentRuntimeProvider.uploadSkill', () => {
   });
 });
 
+describe('AnthropicAgentRuntimeProvider.getConfig', () => {
+  it('does not map mcp_toolset entries into tools', async () => {
+    const provider = createAnthropicProvider(AgentRuntimeProviderIdEnum.Anthropic, { apiKey: 'test-key' });
+
+    const retrieve = jest.fn().mockResolvedValue({
+      model: 'claude-sonnet-4-5',
+      system: 'You are helpful',
+      tools: [
+        {
+          type: 'agent_toolset_20260401',
+          configs: [{ name: 'bash', enabled: true }],
+        },
+        {
+          type: 'mcp_toolset',
+          mcp_server_name: 'HubSpot',
+        },
+      ],
+      mcp_servers: [{ name: 'HubSpot', url: 'https://mcp.hubspot.com/mcp' }],
+      skills: [],
+    });
+
+    const mockClient = {
+      beta: {
+        agents: {
+          retrieve,
+        },
+      },
+    };
+
+    (provider as unknown as { buildClient: () => unknown }).buildClient = () => mockClient;
+
+    const result = await provider.getConfig('ext-agent-id');
+
+    expect(result.tools).to.deep.equal([{ externalId: 'bash', name: 'bash', type: 'builtin' }]);
+    expect(result.mcpServers).to.deep.equal([
+      { externalId: 'HubSpot', name: 'HubSpot', url: 'https://mcp.hubspot.com/mcp' },
+    ]);
+  });
+});
+
 describe('AnthropicAgentRuntimeProvider.updateConfig', () => {
   it('uses tool externalId (not display name) when serialising the toolset payload', async () => {
     const provider = createAnthropicProvider(AgentRuntimeProviderIdEnum.Anthropic, { apiKey: 'test-key' });

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.spec.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.spec.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import { mapToolset } from './anthropic-runtime.helpers';
+
+describe('mapToolset', () => {
+  it('maps enabled builtin toolset configs to AgentToolDto entries', () => {
+    const tools = mapToolset({
+      type: 'agent_toolset_20260401',
+      configs: [
+        { name: 'bash', enabled: true },
+        { name: 'read', enabled: false },
+        { name: 'web_search', enabled: true },
+      ],
+    });
+
+    expect(tools).to.deep.equal([
+      { externalId: 'bash', name: 'bash', type: 'builtin' },
+      { externalId: 'web_search', name: 'web_search', type: 'builtin' },
+    ]);
+  });
+
+  it('does not map mcp_toolset entries into tools', () => {
+    const tools = mapToolset({
+      type: 'mcp_toolset',
+      mcp_server_name: 'HubSpot',
+    });
+
+    expect(tools).to.deep.equal([]);
+  });
+});

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
@@ -194,7 +194,11 @@ export function mapMcpServer(raw: Record<string, unknown>): AgentMcpServerDto {
 
 /**
  * The agent response `tools` array contains toolset objects, not plain tool entries.
- * Flatten them into individual AgentToolDto entries for our internal representation.
+ * Flatten builtin toolset configs into individual AgentToolDto entries.
+ *
+ * `mcp_toolset` entries are intentionally ignored here — MCP servers are modeled
+ * separately via `agent.mcp_servers` (and Novu's enablement table), matching how
+ * Claude surfaces built-in tools vs MCP integrations in its own UI.
  */
 export function mapToolset(raw: Record<string, unknown>): AgentToolDto[] {
   if (raw.type === 'agent_toolset_20260401') {
@@ -205,16 +209,6 @@ export function mapToolset(raw: Record<string, unknown>): AgentToolDto[] {
         name: c.name as string,
         type: 'builtin' as const,
       }));
-  }
-
-  if (raw.type === 'mcp_toolset') {
-    return [
-      {
-        externalId: raw.mcp_server_name as string,
-        name: raw.mcp_server_name as string,
-        type: 'custom' as const,
-      },
-    ];
   }
 
   return [];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Anthropic managed agents return two kinds of entries in the `tools` array: the builtin `agent_toolset_20260401` and per-MCP `mcp_toolset` objects. We were flattening both into `config.tools`, so HubSpot, Amplitude, and other MCPs appeared under **Tools & capabilities** in the dashboard instead of only under **MCPs**.

## Changes

- Stop mapping `mcp_toolset` payloads to `AgentToolDto` in `mapToolset` — builtin tools still come from `agent_toolset_20260401`; MCPs stay on `agent.mcp_servers` / Novu’s enablement table (unchanged).
- Add unit tests for `mapToolset` and `getConfig` to lock in the separation.

## Why this is enough for the UI

`ToolsSection` renders catalog builtins plus any `custom` tools from runtime config. `McpsSection` already uses the dedicated MCP enablement API. With MCP toolsets no longer in `tools`, MCPs only show in the MCP section, matching Claude’s layout.

## Testing

- `pnpm build` in `libs/application-generic`
- Added `anthropic-runtime.helpers.spec.ts` and `getConfig` coverage in `anthropic-agent-runtime.provider.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7798](https://linear.app/novu/issue/NV-7798/separate-tools-from-mcps-in-anthropic-parsing)

<div><a href="https://cursor.com/agents/bc-002616e3-d759-4dd5-becb-7fad58611372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-002616e3-d759-4dd5-becb-7fad58611372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
The `mapToolset` function in Anthropic's runtime helpers was modified to stop mapping `mcp_toolset` entries into the tools array, ensuring builtin tools (from `agent_toolset_20260401`) continue to populate `config.tools` while MCP toolsets remain exclusively on `agent.mcp_servers`. This separation prevents MCPs from appearing in the Tools & capabilities section of the dashboard and keeps them visible only in the dedicated MCPs section.

## Affected areas
- **shared**: Modified `mapToolset` in the Anthropic agent-runtime to filter out `mcp_toolset` entries, allowing only builtin toolset configs to be flattened into tool objects.

## Key technical decisions
- MCP servers are now managed exclusively through their dedicated enablement API rather than being mixed with builtin tools in the tools array, establishing a clear separation of concerns between builtin capabilities and managed integrations.

## Testing
Unit tests were added for `mapToolset` covering both builtin toolset mapping and `mcp_toolset` filtering behavior, plus test coverage for `getConfig` to verify the separation works end-to-end. The changes were validated with `pnpm build` in `libs/application-generic`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->