### PR TITLE
feat(api-service,dashboard,shared): GitHub App install + authorize in one redirect fixes NV-TBD

### DIFF
--- a/apps/api/src/.example.env
+++ b/apps/api/src/.example.env
@@ -66,11 +66,22 @@ GITHUB_API_TOKEN=
 
 # MCP novu-app credentials (mcp_connection authMode='novu-app').
 # Novu Cloud pre-fills these from the platform GitHub App. Self-hosters
-# register their own GitHub App (with "Expiring user tokens" enabled so
-# refresh tokens are issued) and set the resulting client_id / secret here;
-# leave blank to surface "Coming soon." in the picker for GitHub MCP.
+# register their own GitHub App and set the resulting values here; leave
+# blank to surface "Coming soon." in the picker for GitHub MCP.
+#
+# GitHub App settings checklist (all required for the install-and-authorize
+# redirect to return a `code` alongside `installation_id`):
+#   - "Where can this GitHub App be installed?" → Any account
+#   - "Request user authorization (OAuth) during installation" → ON
+#   - "Expire user authorization tokens" → ON (refresh-token issuance)
+#   - "Callback URL" → `{FRONT_BASE_URL}/v1/agents/mcp/oauth/callback`
+#
+# `NOVU_GITHUB_MCP_APP_SLUG` is the public slug from the App's URL — e.g.
+# `novu-mcp` for `https://github.com/apps/novu-mcp`. Used to build the
+# install URL `/apps/<slug>/installations/new`.
 NOVU_GITHUB_MCP_APP_CLIENT_ID=
 NOVU_GITHUB_MCP_APP_CLIENT_SECRET=
+NOVU_GITHUB_MCP_APP_SLUG=
 
 IS_API_RATE_LIMITING_ENABLED=false
 API_RATE_LIMIT_COST_SINGLE=

--- a/apps/api/src/app/agents/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/agents-mcp-oauth.controller.ts
@@ -4,8 +4,18 @@ import { ApiRateLimitCategoryEnum } from '@novu/shared';
 import { Response } from 'express';
 
 import { ThrottlerCategory } from '../rate-limiting/guards';
-import { McpOAuthCallbackCommand } from './usecases/mcp-oauth-callback/mcp-oauth-callback.command';
+import {
+  McpOAuthCallbackCommand,
+  type McpOAuthSetupAction,
+} from './usecases/mcp-oauth-callback/mcp-oauth-callback.command';
 import { McpOAuthCallback } from './usecases/mcp-oauth-callback/mcp-oauth-callback.usecase';
+
+/**
+ * `setup_action` values GitHub returns on the install-and-authorize
+ * redirect. Anything else is treated as the param being absent so we don't
+ * persist garbage onto the connection row.
+ */
+const SETUP_ACTION_WHITELIST = new Set<McpOAuthSetupAction>(['install', 'update', 'request']);
 
 const SUCCESS_FALLBACK_HTML = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Connection complete</title></head><body><p>Connection complete. You can close this window.</p><script>window.close();</script></body></html>`;
 const ERROR_FALLBACK_HTML = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Connection failed</title></head><body><p>Connection failed. You can close this window and try again.</p><script>window.close();</script></body></html>`;
@@ -40,7 +50,9 @@ export class AgentsMcpOAuthController {
     @Query('code') code?: string,
     @Query('error') error?: string,
     @Query('error_description') errorDescription?: string,
-    @Query('iss') iss?: string
+    @Query('iss') iss?: string,
+    @Query('installation_id') installationId?: string,
+    @Query('setup_action') setupAction?: string
   ): Promise<void> {
     if (!state) {
       throw new BadRequestException('Missing required OAuth parameter: state');
@@ -48,12 +60,23 @@ export class AgentsMcpOAuthController {
 
     const callbackError = error ? `${error}${errorDescription ? ` - ${errorDescription}` : ''}` : undefined;
 
+    // Reject `setup_action` values outside the documented set rather than
+    // forwarding them onto the command — GitHub's docs are stable but a
+    // malicious redirect could append `setup_action=evil` to the callback
+    // URL and we don't want that bypassing the command-level whitelist.
+    const normalizedSetupAction =
+      setupAction && SETUP_ACTION_WHITELIST.has(setupAction as McpOAuthSetupAction)
+        ? (setupAction as McpOAuthSetupAction)
+        : undefined;
+
     const result = await this.mcpOAuthCallbackUsecase.execute(
       McpOAuthCallbackCommand.create({
         state,
         providerCode: code,
         error: callbackError,
         iss,
+        installationId,
+        setupAction: normalizedSetupAction,
       })
     );
 

--- a/apps/api/src/app/agents/agents.controller.ts
+++ b/apps/api/src/app/agents/agents.controller.ts
@@ -54,6 +54,7 @@ import {
   ListAgentMcpServersResponseDto,
   ListAgentsQueryDto,
   ListAgentsResponseDto,
+  ListMcpInstallationsResponseDto,
   McpConnectionResponseDto,
   MigrateAgentRuntimeRequestDto,
   PatchAgentRuntimeConfigRequestDto,
@@ -117,6 +118,8 @@ import { ListAgentMcpServersCommand } from './usecases/list-agent-mcp-servers/li
 import { ListAgentMcpServers } from './usecases/list-agent-mcp-servers/list-agent-mcp-servers.usecase';
 import { ListAgentsCommand } from './usecases/list-agents/list-agents.command';
 import { ListAgents } from './usecases/list-agents/list-agents.usecase';
+import { ListMcpInstallationsCommand } from './usecases/list-mcp-installations/list-mcp-installations.command';
+import { ListMcpInstallations } from './usecases/list-mcp-installations/list-mcp-installations.usecase';
 import { MigrateAgentRuntimeCommand } from './usecases/migrate-agent-runtime/migrate-agent-runtime.command';
 import { MigrateAgentRuntime } from './usecases/migrate-agent-runtime/migrate-agent-runtime.usecase';
 import { RemoveAgentIntegrationCommand } from './usecases/remove-agent-integration/remove-agent-integration.command';
@@ -169,6 +172,7 @@ export class AgentsController {
     private readonly enableAgentMcpServerUsecase: EnableAgentMcpServer,
     private readonly disableAgentMcpServerUsecase: DisableAgentMcpServer,
     private readonly listAgentMcpServersUsecase: ListAgentMcpServers,
+    private readonly listMcpInstallationsUsecase: ListMcpInstallations,
     private readonly generateMcpOAuthUrlUsecase: GenerateMcpOAuthUrl,
     private readonly getMcpConnectionStatusUsecase: GetMcpConnectionStatus,
     private readonly configureTelegramAgentWebhookUsecase: ConfigureTelegramAgentWebhook,
@@ -1001,6 +1005,35 @@ export class AgentsController {
   ): Promise<McpConnectionResponseDto | null> {
     return this.getMcpConnectionStatusUsecase.execute(
       GetMcpConnectionStatusCommand.create({
+        userId: user._id,
+        environmentId: user.environmentId,
+        organizationId: user.organizationId,
+        agentIdentifier: identifier,
+        mcpId,
+        subscriberId,
+      })
+    );
+  }
+
+  @Get('/:identifier/mcp-servers/:mcpId/installations')
+  @ApiResponse(ListMcpInstallationsResponseDto)
+  @ApiOperation({
+    summary: 'List GitHub-App installations the subscriber token can act on',
+    description:
+      'Calls `GET /user/installations` against GitHub with the subscriber\u2019s stored access token and returns the live list ' +
+      'plus "Manage on GitHub" deep links. Only applicable to MCPs that use the GitHub App + Installation flow (currently `github`). ' +
+      'When the token has been revoked upstream the connection is flipped to `expired` and the response carries that status.',
+  })
+  @ApiNotFoundResponse({ description: 'Agent, MCP enablement, or subscriber not found.' })
+  @RequirePermissions(PermissionsEnum.AGENT_READ)
+  listMcpInstallations(
+    @UserSession() user: UserSessionData,
+    @Param('identifier') identifier: string,
+    @Param('mcpId') mcpId: string,
+    @Query('subscriberId') subscriberId: string
+  ): Promise<ListMcpInstallationsResponseDto> {
+    return this.listMcpInstallationsUsecase.execute(
+      ListMcpInstallationsCommand.create({
         userId: user._id,
         environmentId: user.environmentId,
         organizationId: user.organizationId,

--- a/apps/api/src/app/agents/dtos/mcp-server.dto.ts
+++ b/apps/api/src/app/agents/dtos/mcp-server.dto.ts
@@ -115,3 +115,55 @@ export class GenerateMcpOAuthUrlResponseDto {
   @ApiProperty({ description: 'Fully-qualified URL the dashboard should redirect the user to.' })
   authorizeUrl: string;
 }
+
+/**
+ * One GitHub-App installation the subscriber's token can act on. Returned
+ * by `GET /agents/:id/mcp-servers/:mcpId/installations` for catalog
+ * entries that opt into the install-and-authorize redirect (currently just
+ * `github`).
+ *
+ * The `manageUrl` deep-links the user back to GitHub's settings page so
+ * they can add/remove repos from the installation without re-running the
+ * full OAuth dance. Org installs land on the org's settings page; user
+ * installs land on the user's installations page.
+ */
+export class McpInstallationAccountDto {
+  @ApiProperty({ description: 'Account login (user handle or org slug).' })
+  login: string;
+
+  @ApiProperty({ enum: ['User', 'Organization'] })
+  type: 'User' | 'Organization';
+
+  @ApiPropertyOptional({ description: 'CDN avatar URL surfaced by GitHub.' })
+  avatarUrl?: string;
+}
+
+export class McpInstallationDto {
+  @ApiProperty({ description: 'Numeric installation id from GitHub.' })
+  id: number;
+
+  @ApiProperty({ type: McpInstallationAccountDto })
+  account: McpInstallationAccountDto;
+
+  @ApiProperty({ enum: ['all', 'selected'] })
+  repositorySelection: 'all' | 'selected';
+
+  @ApiPropertyOptional({ description: 'Endpoint to list the repositories included in this installation.' })
+  repositoriesUrl?: string;
+
+  @ApiProperty({ description: 'Deep link to manage the installation (add/remove repos) on github.com.' })
+  manageUrl: string;
+}
+
+/**
+ * Live installations the subscriber's GitHub-App token can act on. Status
+ * field surfaces token-side failures (e.g. `expired`) so the dashboard can
+ * prompt re-authorization without inventing a new wire shape.
+ */
+export class ListMcpInstallationsResponseDto {
+  @ApiProperty({ type: [McpInstallationDto] })
+  data: McpInstallationDto[];
+
+  @ApiProperty({ enum: McpConnectionStatusEnum })
+  connectionStatus: McpConnectionStatusEnum;
+}

--- a/apps/api/src/app/agents/e2e/agent-mcp-servers.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-mcp-servers.e2e.ts
@@ -577,6 +577,7 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
     const previousFlag = process.env.IS_MCP_NOVU_APP_ENABLED;
     const previousClientId = process.env.NOVU_GITHUB_MCP_APP_CLIENT_ID;
     const previousClientSecret = process.env.NOVU_GITHUB_MCP_APP_CLIENT_SECRET;
+    const previousAppSlug = process.env.NOVU_GITHUB_MCP_APP_SLUG;
     const previousApiRootUrl = process.env.API_ROOT_URL;
 
     let safeJsonStub: sinon.SinonStub;
@@ -603,6 +604,10 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
       process.env.IS_MCP_NOVU_APP_ENABLED = 'true';
       process.env.NOVU_GITHUB_MCP_APP_CLIENT_ID = 'Iv23livefakeclientid';
       process.env.NOVU_GITHUB_MCP_APP_CLIENT_SECRET = 'ghs_fakeclientsecret';
+      // GitHub catalog entry declares an `installation.appSlugEnv` so a slug
+      // env var is now required for authorize-URL generation. Match the
+      // shape used in production but use a fake slug here.
+      process.env.NOVU_GITHUB_MCP_APP_SLUG = 'novu-mcp-test';
       process.env.API_ROOT_URL = 'https://api.example.test';
 
       // PRM probe attempt is non-fatal; default to a 401 with no usable
@@ -635,6 +640,11 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
         delete process.env.NOVU_GITHUB_MCP_APP_CLIENT_SECRET;
       } else {
         process.env.NOVU_GITHUB_MCP_APP_CLIENT_SECRET = previousClientSecret;
+      }
+      if (previousAppSlug === undefined) {
+        delete process.env.NOVU_GITHUB_MCP_APP_SLUG;
+      } else {
+        process.env.NOVU_GITHUB_MCP_APP_SLUG = previousAppSlug;
       }
       if (previousApiRootUrl === undefined) {
         delete process.env.API_ROOT_URL;
@@ -688,7 +698,7 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
       expect(res.status).to.equal(404);
     });
 
-    it('generates an authorize URL with pinned catalog scopes, resource, PKCE, and persists novu-app state', async () => {
+    it('generates a GitHub App install-and-authorize URL with PKCE + resource, and persists novu-app state', async () => {
       const { identifier } = await createManagedAgent();
       await enableGithub(identifier);
 
@@ -698,7 +708,9 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
 
       expect(res.status, `oauth/url failed: ${JSON.stringify(res.body)}`).to.equal(200);
       const url = new URL(res.body.data.authorizeUrl);
-      expect(`${url.origin}${url.pathname}`).to.equal('https://github.com/login/oauth/authorize');
+      // GitHub App + Installation flow: authorize URL is the install URL
+      // for the configured App slug, NOT the classic OAuth authorize.
+      expect(`${url.origin}${url.pathname}`).to.equal('https://github.com/apps/novu-mcp-test/installations/new');
       expect(url.searchParams.get('client_id')).to.equal('Iv23livefakeclientid');
       expect(url.searchParams.get('response_type')).to.equal('code');
       expect(url.searchParams.get('code_challenge_method')).to.equal('S256');
@@ -707,10 +719,9 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
       // PRM probe failed; falls back to catalog. `resource` defaults to the
       // catalog URL when PRM produced no `resource` value.
       expect(url.searchParams.get('resource')).to.equal('https://api.githubcopilot.com/mcp/');
-      // Scopes mirror the catalog (no PRM challenge_scopes here).
-      expect(url.searchParams.get('scope')).to.equal(
-        'repo read:org read:user user:email read:packages write:packages read:project project gist notifications workflow codespace'
-      );
+      // GitHub Apps ignore the `scope=` parameter — Novu must NOT send one
+      // on the install URL or GitHub silently downgrades / 400s.
+      expect(url.searchParams.get('scope')).to.equal(null);
 
       const enablement = await agentMcpServerRepository.findOne(
         {
@@ -736,11 +747,15 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
       expect(connection!.oauthClient, 'oauthClient must NOT be persisted for novu-app').to.equal(undefined);
       expect(connection!.oauthState!.expectedIssuer).to.equal('https://github.com');
       expect(connection!.oauthState!.tokenEndpoint).to.equal('https://github.com/login/oauth/access_token');
-      expect(connection!.oauthState!.authorizationEndpoint).to.equal('https://github.com/login/oauth/authorize');
+      // `authorizationEndpoint` on oauthState records the install URL so
+      // the callback can rebuild the ephemeral oauthClient for vault push.
+      expect(connection!.oauthState!.authorizationEndpoint).to.equal(
+        'https://github.com/apps/novu-mcp-test/installations/new'
+      );
       expect(connection!.oauthState!.pkceVerifier).to.have.length.greaterThan(0);
     });
 
-    it('returns 422 with mcp_novu_app_credentials_missing when env vars are unset', async () => {
+    it('returns 422 with mcp_novu_app_credentials_missing when client_id / client_secret env vars are unset', async () => {
       delete process.env.NOVU_GITHUB_MCP_APP_CLIENT_ID;
       delete process.env.NOVU_GITHUB_MCP_APP_CLIENT_SECRET;
       const { identifier } = await createManagedAgent();
@@ -752,6 +767,25 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
 
       expect(res.status).to.equal(422);
       expect(res.body.error ?? res.body.data?.error).to.equal('mcp_novu_app_credentials_missing');
+    });
+
+    it('returns 422 with mcp_novu_app_credentials_missing when the app slug env var is unset', async () => {
+      // GitHub catalog declares `installation.appSlugEnv` — without the env
+      // var resolved the install URL would be malformed
+      // (`/apps/undefined/installations/new`), so this MUST surface the same
+      // 422 path as a missing client_id rather than crashing later in
+      // `resolveServerEndpointsForNovuApp`.
+      delete process.env.NOVU_GITHUB_MCP_APP_SLUG;
+      const { identifier } = await createManagedAgent();
+      await enableGithub(identifier);
+
+      const res = await session.testAgent
+        .post(`/v1/agents/${encodeURIComponent(identifier)}/mcp-servers/github/oauth/url`)
+        .send({ subscriberId: session.subscriberId });
+
+      expect(res.status).to.equal(422);
+      expect(res.body.error ?? res.body.data?.error).to.equal('mcp_novu_app_credentials_missing');
+      expect(res.body.message ?? res.body.data?.message).to.contain('NOVU_GITHUB_MCP_APP_SLUG');
     });
 
     /**
@@ -780,10 +814,25 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
       return { identifier, agentId, state: state as string };
     }
 
-    function routeJsonStub(perEndpoint: { tokenEndpoint?: unknown }) {
+    function routeJsonStub(perEndpoint: {
+      tokenEndpoint?: unknown;
+      userInstallationsSingle?: unknown;
+      userInstallationsList?: unknown;
+    }) {
       safeJsonStub.callsFake((args: { url: string }) => {
         if (args.url.includes('/login/oauth/access_token') && perEndpoint.tokenEndpoint) {
           return Promise.resolve(perEndpoint.tokenEndpoint);
+        }
+        // The callback fetches `/user/installations/{id}` to capture a
+        // single-installation snapshot at OAuth-callback time. The list-
+        // installations usecase fetches `/user/installations` (no trailing
+        // id) at view time. Route on path shape, since both URLs share the
+        // same prefix.
+        if (perEndpoint.userInstallationsSingle && /\/user\/installations\/\d+/.test(args.url)) {
+          return Promise.resolve(perEndpoint.userInstallationsSingle);
+        }
+        if (perEndpoint.userInstallationsList && args.url.endsWith('/user/installations')) {
+          return Promise.resolve(perEndpoint.userInstallationsList);
         }
         if (args.url.includes('/.well-known/oauth-protected-resource')) {
           return Promise.resolve({
@@ -993,6 +1042,276 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
       expect(bodyParams.get('code')).to.equal('fake-auth-code');
       expect(bodyParams.get('code_verifier')).to.match(/^[A-Za-z0-9_-]{43}$/);
       expect(bodyParams.get('resource')).to.equal('https://api.githubcopilot.com/mcp/');
+    });
+
+    /**
+     * GitHub App + Installation flow — the install URL redirect carries
+     * `installation_id` and `setup_action` alongside `code`. The callback
+     * has to:
+     *   1. Exchange `code` for a user-to-server token (existing path).
+     *   2. Fetch `/user/installations/{id}` to capture a display snapshot.
+     *   3. When `setup_action=request`, mark `Connected` but ALSO write a
+     *      `mcp_github_pending_org_approval` lastError so the dashboard
+     *      can render a "waiting for org owner" banner without inventing
+     *      a new connection status enum.
+     */
+    describe('install + authorize redirect (installation_id / setup_action)', () => {
+      it('captures installation snapshot from /user/installations/{id} on the connection row', async () => {
+        const { agentId, state } = await authorizeAndCaptureState();
+
+        routeJsonStub({
+          tokenEndpoint: {
+            statusCode: 200,
+            statusMessage: 'OK',
+            headers: { 'content-type': 'application/json' },
+            body: {
+              access_token: 'gho_fake-access',
+              refresh_token: 'ghr_fake-refresh',
+              expires_in: 28_800,
+              token_type: 'bearer',
+            },
+          },
+          userInstallationsSingle: {
+            statusCode: 200,
+            statusMessage: 'OK',
+            headers: { 'content-type': 'application/json' },
+            body: {
+              id: 9876543,
+              account: { login: 'novuhq', type: 'Organization', avatar_url: 'https://avatars.githubusercontent.com/x' },
+              repository_selection: 'selected',
+            },
+          },
+        });
+
+        const cb = await session.testAgent.get(
+          `/v1/agents/mcp/oauth/callback?state=${encodeURIComponent(state)}` +
+            `&code=fake-auth-code&installation_id=9876543&setup_action=install`
+        );
+        expect([200, 302]).to.include(cb.status);
+
+        const conn = await findGithubConnection(agentId);
+        expect(conn!.status).to.equal(McpConnectionStatusEnum.Connected);
+        expect(conn!.installation, 'installation snapshot should be persisted').to.exist;
+        expect(conn!.installation!.id).to.equal(9876543);
+        expect(conn!.installation!.account).to.equal('novuhq');
+        expect(conn!.installation!.accountType).to.equal('Organization');
+        expect(conn!.installation!.repositorySelection).to.equal('selected');
+        // Pending-approval lastError must NOT be set for the happy install
+        // path — the dashboard relies on its absence to mean "all good".
+        expect(conn!.lastError).to.equal(undefined);
+      });
+
+      it('marks Connected + mcp_github_pending_org_approval lastError when setup_action=request', async () => {
+        const { agentId, state } = await authorizeAndCaptureState();
+
+        routeJsonStub({
+          tokenEndpoint: {
+            statusCode: 200,
+            statusMessage: 'OK',
+            headers: { 'content-type': 'application/json' },
+            body: {
+              access_token: 'gho_fake-access',
+              token_type: 'bearer',
+            },
+          },
+          userInstallationsSingle: {
+            statusCode: 200,
+            statusMessage: 'OK',
+            headers: { 'content-type': 'application/json' },
+            body: {
+              id: 4242,
+              account: { login: 'novuhq', type: 'Organization' },
+              repository_selection: 'selected',
+            },
+          },
+        });
+
+        const cb = await session.testAgent.get(
+          `/v1/agents/mcp/oauth/callback?state=${encodeURIComponent(state)}` +
+            `&code=fake-auth-code&installation_id=4242&setup_action=request`
+        );
+        expect([200, 302]).to.include(cb.status);
+
+        const conn = await findGithubConnection(agentId);
+        expect(conn!.status).to.equal(McpConnectionStatusEnum.Connected);
+        expect(conn!.lastError?.code).to.equal('mcp_github_pending_org_approval');
+        // installation snapshot still captured — the org just hasn't
+        // approved the install yet, but we record what we know.
+        expect(conn!.installation!.id).to.equal(4242);
+      });
+
+      it('falls back to a minimal installation snapshot when /user/installations/{id} fails (non-blocking)', async () => {
+        const { agentId, state } = await authorizeAndCaptureState();
+
+        routeJsonStub({
+          tokenEndpoint: {
+            statusCode: 200,
+            statusMessage: 'OK',
+            headers: { 'content-type': 'application/json' },
+            body: { access_token: 'gho_fake-access', token_type: 'bearer' },
+          },
+          userInstallationsSingle: {
+            statusCode: 404,
+            statusMessage: 'Not Found',
+            headers: { 'content-type': 'application/json' },
+            body: { message: 'Not Found' },
+          },
+        });
+
+        const cb = await session.testAgent.get(
+          `/v1/agents/mcp/oauth/callback?state=${encodeURIComponent(state)}` +
+            `&code=fake-auth-code&installation_id=999`
+        );
+        expect([200, 302]).to.include(cb.status);
+
+        const conn = await findGithubConnection(agentId);
+        expect(conn!.status).to.equal(McpConnectionStatusEnum.Connected);
+        // Lookup failed but the connection still landed — display "unknown"
+        // until the dashboard re-fetches via `GET /user/installations`.
+        expect(conn!.installation!.id).to.equal(999);
+        expect(conn!.installation!.account).to.equal('unknown');
+      });
+
+      it('skips installation snapshot when installation_id is absent (classic OAuth fallback path)', async () => {
+        // Defence-in-depth: if a GitHub-App callback ever loses
+        // installation_id (misconfigured App, weird redirect), the
+        // connection still completes — just without a snapshot.
+        const { agentId, state } = await authorizeAndCaptureState();
+
+        routeJsonStub({
+          tokenEndpoint: {
+            statusCode: 200,
+            statusMessage: 'OK',
+            headers: { 'content-type': 'application/json' },
+            body: { access_token: 'gho_fake-access', token_type: 'bearer' },
+          },
+        });
+
+        const cb = await session.testAgent.get(
+          `/v1/agents/mcp/oauth/callback?state=${encodeURIComponent(state)}&code=fake-auth-code`
+        );
+        expect([200, 302]).to.include(cb.status);
+
+        const conn = await findGithubConnection(agentId);
+        expect(conn!.status).to.equal(McpConnectionStatusEnum.Connected);
+        expect(conn!.installation).to.equal(undefined);
+      });
+    });
+
+    /**
+     * `GET /v1/agents/:identifier/mcp-servers/github/installations` — live
+     * list backed by `/user/installations` upstream. Connection must be
+     * Connected and `installation` flow opt-in; otherwise the response
+     * carries the actual status with an empty list.
+     */
+    describe('GET /mcp-servers/:mcpId/installations', () => {
+      async function completeConnect(): Promise<{ identifier: string; agentId: string }> {
+        const { identifier, agentId, state } = await authorizeAndCaptureState();
+        routeJsonStub({
+          tokenEndpoint: {
+            statusCode: 200,
+            statusMessage: 'OK',
+            headers: { 'content-type': 'application/json' },
+            body: { access_token: 'gho_user_to_server_token', token_type: 'bearer' },
+          },
+          userInstallationsSingle: {
+            statusCode: 200,
+            statusMessage: 'OK',
+            headers: { 'content-type': 'application/json' },
+            body: {
+              id: 111,
+              account: { login: 'me', type: 'User' },
+              repository_selection: 'all',
+            },
+          },
+        });
+        const cb = await session.testAgent.get(
+          `/v1/agents/mcp/oauth/callback?state=${encodeURIComponent(state)}` +
+            `&code=fake-auth-code&installation_id=111&setup_action=install`
+        );
+        expect([200, 302]).to.include(cb.status);
+
+        return { identifier, agentId };
+      }
+
+      it('returns the live installation list from GitHub with manage deep links', async () => {
+        const { identifier } = await completeConnect();
+
+        // Re-program the stub to return a multi-installation list for the
+        // /user/installations call (no trailing id).
+        routeJsonStub({
+          userInstallationsList: {
+            statusCode: 200,
+            statusMessage: 'OK',
+            headers: { 'content-type': 'application/json' },
+            body: {
+              installations: [
+                {
+                  id: 111,
+                  account: { login: 'me', type: 'User', avatar_url: 'https://avatars.githubusercontent.com/u/1' },
+                  repository_selection: 'all',
+                  repositories_url: 'https://api.github.com/user/installations/111/repositories',
+                  html_url: 'https://github.com/settings/installations/111',
+                },
+                {
+                  id: 222,
+                  account: {
+                    login: 'novuhq',
+                    type: 'Organization',
+                    avatar_url: 'https://avatars.githubusercontent.com/u/2',
+                  },
+                  repository_selection: 'selected',
+                  repositories_url: 'https://api.github.com/user/installations/222/repositories',
+                  html_url: 'https://github.com/organizations/novuhq/settings/installations/222',
+                },
+              ],
+            },
+          },
+        });
+
+        const res = await session.testAgent.get(
+          `/v1/agents/${encodeURIComponent(identifier)}/mcp-servers/github/installations?subscriberId=${encodeURIComponent(
+            session.subscriberId
+          )}`
+        );
+        expect(res.status, `installations endpoint failed: ${JSON.stringify(res.body)}`).to.equal(200);
+        expect(res.body.data).to.be.an('array').with.lengthOf(2);
+        expect(res.body.data[0].id).to.equal(111);
+        expect(res.body.data[0].account.login).to.equal('me');
+        expect(res.body.data[0].account.type).to.equal('User');
+        expect(res.body.data[0].repositorySelection).to.equal('all');
+        expect(res.body.data[0].manageUrl).to.equal('https://github.com/settings/installations/111');
+        expect(res.body.data[1].account.type).to.equal('Organization');
+        expect(res.body.data[1].manageUrl).to.contain('organizations/novuhq');
+        expect(res.body.connectionStatus).to.equal(McpConnectionStatusEnum.Connected);
+      });
+
+      it('flips the connection to expired when GitHub returns 401 (token revoked upstream)', async () => {
+        const { identifier, agentId } = await completeConnect();
+
+        routeJsonStub({
+          userInstallationsList: {
+            statusCode: 401,
+            statusMessage: 'Unauthorized',
+            headers: { 'content-type': 'application/json' },
+            body: { message: 'Bad credentials' },
+          },
+        });
+
+        const res = await session.testAgent.get(
+          `/v1/agents/${encodeURIComponent(identifier)}/mcp-servers/github/installations?subscriberId=${encodeURIComponent(
+            session.subscriberId
+          )}`
+        );
+        expect(res.status).to.equal(200);
+        expect(res.body.data).to.be.an('array').with.lengthOf(0);
+        expect(res.body.connectionStatus).to.equal(McpConnectionStatusEnum.Expired);
+
+        const conn = await findGithubConnection(agentId);
+        expect(conn!.status, 'connection should be flipped to expired so dashboard prompts re-auth').to.equal(
+          McpConnectionStatusEnum.Expired
+        );
+      });
     });
   });
 });

--- a/apps/api/src/app/agents/services/mcp-oauth-discovery.service.ts
+++ b/apps/api/src/app/agents/services/mcp-oauth-discovery.service.ts
@@ -54,7 +54,14 @@ export type McpOAuthErrorCode =
   /** OAuth standard: the user clicked "Cancel" on the consent screen. */
   | 'mcp_user_denied'
   /** GitHub App: the target org has not approved/installed the Novu App. */
-  | 'mcp_app_not_installed';
+  | 'mcp_app_not_installed'
+  /**
+   * GitHub App: install completed but `setup_action=request` (user picked an
+   * org they don't admin). The OAuth grant is empty until an org owner
+   * approves the install; the dashboard renders a banner pointing at the
+   * install's manage URL so the user can wait + nudge the owner.
+   */
+  | 'mcp_github_pending_org_approval';
 
 export class McpOAuthDiscoveryError extends Error {
   readonly code: McpOAuthErrorCode;

--- a/apps/api/src/app/agents/usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase.ts
+++ b/apps/api/src/app/agents/usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase.ts
@@ -247,6 +247,17 @@ export class GenerateMcpOAuthUrl {
         let credentials: NovuAppCredentials;
         try {
           credentials = this.getNovuAppCredentials.execute(command.mcpId);
+          // Catalog opted into the GitHub-App install flow — resolve the
+          // slug now so a missing env var surfaces the same 422 path as a
+          // missing client_id, instead of crashing later inside
+          // `resolveServerEndpointsForNovuApp` after the connection row
+          // has already been mutated.
+          if (entry.installation) {
+            credentials = {
+              ...credentials,
+              appSlug: this.getNovuAppCredentials.executeAppSlug(command.mcpId),
+            };
+          }
         } catch (err) {
           if (err instanceof McpOAuthDiscoveryError) {
             throw new UnprocessableEntityException({
@@ -302,6 +313,12 @@ export class GenerateMcpOAuthUrl {
    * metadata discovery is skipped entirely because non-DCR upstreams
    * (e.g. GitHub) publish neither `.well-known/oauth-authorization-server`
    * nor a registration endpoint.
+   *
+   * When the catalog declares an `installation` block (GitHub App flow),
+   * the returned `authorizationEndpoint` is swapped to the App's install
+   * URL (`https://github.com/apps/<slug>/installations/new`) so the user
+   * installs the App and grants OAuth in one redirect. Scope list is
+   * forced to `[]` because GitHub Apps ignore the OAuth `scope=` param.
    */
   private async resolveServerEndpointsForNovuApp(
     catalog: McpServer,
@@ -326,6 +343,35 @@ export class GenerateMcpOAuthUrl {
         authorizationServers: [oauthConfig.catalog.issuer],
         scopesSupported: [],
         challengeScopes: undefined,
+      };
+    }
+
+    // GitHub-App "install + authorize in one redirect" path. The token
+    // endpoint stays the same as classic OAuth (`/login/oauth/access_token`),
+    // so only the user-facing redirect changes. `appSlug` is resolved
+    // upfront in `resolveOAuthConfig`, so by the time we get here it's
+    // guaranteed to be set whenever the catalog declares `installation`.
+    if (oauthConfig.catalog.installation) {
+      const slug = oauthConfig.credentials.appSlug;
+      if (!slug) {
+        // Should be unreachable — `resolveOAuthConfig` populates it before
+        // we get here. Throw a 500-ish error rather than constructing a
+        // malformed URL like `…/apps/undefined/installations/new`.
+        throw new Error(
+          `Resolved novu-app credentials for "${catalog.id}" missing app slug despite catalog installation block.`
+        );
+      }
+      const installAuthorizeUrl = `${oauthConfig.catalog.issuer}/apps/${encodeURIComponent(slug)}/installations/new`;
+
+      return {
+        issuer: oauthConfig.catalog.issuer,
+        authorizationEndpoint: installAuthorizeUrl,
+        tokenEndpoint: oauthConfig.catalog.tokenEndpoint,
+        resource: prm.resource ?? catalog.url,
+        // GitHub Apps reject / silently downgrade requests that include a
+        // `scope=` parameter on the install URL — permissions are declared
+        // on the App settings page, not via OAuth scopes.
+        scopes: [],
       };
     }
 

--- a/apps/api/src/app/agents/usecases/get-mcp-novu-app-credentials/get-mcp-novu-app-credentials.usecase.ts
+++ b/apps/api/src/app/agents/usecases/get-mcp-novu-app-credentials/get-mcp-novu-app-credentials.usecase.ts
@@ -1,10 +1,17 @@
 import { Injectable } from '@nestjs/common';
+import { MCP_SERVERS, McpConnectionAuthModeEnum } from '@novu/shared';
 
 import { McpOAuthDiscoveryError } from '../../services/mcp-oauth-discovery.service';
 
 export interface NovuAppCredentials {
   clientId: string;
   clientSecret: string;
+  /**
+   * Public GitHub App slug (e.g. `novu-mcp`) resolved when the catalog
+   * declares an `installation.appSlugEnv`. Absent for novu-app entries
+   * that use the classic OAuth-app flow without installation gating.
+   */
+  appSlug?: string;
 }
 
 /**
@@ -17,6 +24,11 @@ export interface NovuAppCredentials {
  * values surface as `mcp_novu_app_credentials_missing` on the connection's
  * `lastError.code` so the dashboard can render "Coming soon" copy instead
  * of silently 500-ing the picker.
+ *
+ * Some entries also use the catalog `installation` block to declare an
+ * `appSlugEnv` that resolves to a GitHub-App slug; that env var is read by
+ * `executeAppSlug` below, NOT this map (the slug isn't a secret, lives on
+ * the catalog as a contract, and only its VALUE is environment-specific).
  */
 const CRED_ENV_MAP: Record<string, { clientIdEnv: string; clientSecretEnv: string }> = {
   github: {
@@ -32,8 +44,9 @@ const CRED_ENV_MAP: Record<string, { clientIdEnv: string; clientSecretEnv: strin
  * the documented env vars without code changes.
  *
  * Throws `McpOAuthDiscoveryError('mcp_novu_app_credentials_missing', …)`
- * when either env var is unset or empty so the caller can map it onto
- * `mcp_connection.lastError.code` instead of leaking a 500.
+ * when either the env vars or the catalog-declared app slug are unset or
+ * empty so the caller can map it onto `mcp_connection.lastError.code`
+ * instead of leaking a 500.
  */
 @Injectable()
 export class GetMcpNovuAppCredentials {
@@ -65,5 +78,44 @@ export class GetMcpNovuAppCredentials {
     }
 
     return { clientId, clientSecret };
+  }
+
+  /**
+   * Resolve the GitHub App public slug (e.g. `novu-mcp`) for a catalog
+   * entry that uses the "App + Installation" flow. The env-var NAME is
+   * declared on the catalog's `oauth.installation.appSlugEnv`; only its
+   * VALUE is environment-specific so self-hosters can BYO App.
+   *
+   * Throws `McpOAuthDiscoveryError('mcp_novu_app_credentials_missing', ...)`
+   * when either the catalog entry doesn't declare an installation block or
+   * the named env var is unset/empty. Same error code as the client_id
+   * /secret path so the existing dashboard mapping renders uniform copy.
+   */
+  executeAppSlug(mcpId: string): string {
+    const catalog = MCP_SERVERS.find((entry) => entry.id === mcpId);
+    if (!catalog?.oauth || catalog.oauth.mode !== McpConnectionAuthModeEnum.NovuApp) {
+      throw new McpOAuthDiscoveryError(
+        'mcp_novu_app_credentials_missing',
+        `MCP "${mcpId}" is not a novu-app entry; no app slug to resolve.`
+      );
+    }
+
+    const slugEnvName = catalog.oauth.installation?.appSlugEnv;
+    if (!slugEnvName) {
+      throw new McpOAuthDiscoveryError(
+        'mcp_novu_app_credentials_missing',
+        `MCP "${mcpId}" novu-app entry does not declare an installation block; no app slug to resolve.`
+      );
+    }
+
+    const slug = process.env[slugEnvName]?.trim();
+    if (!slug) {
+      throw new McpOAuthDiscoveryError(
+        'mcp_novu_app_credentials_missing',
+        `Novu OAuth app slug missing for MCP "${mcpId}": ${slugEnvName}.`
+      );
+    }
+
+    return slug;
   }
 }

--- a/apps/api/src/app/agents/usecases/index.ts
+++ b/apps/api/src/app/agents/usecases/index.ts
@@ -25,6 +25,7 @@ import { ListAgentEmoji } from './list-agent-emoji/list-agent-emoji.usecase';
 import { ListAgentIntegrations } from './list-agent-integrations/list-agent-integrations.usecase';
 import { ListAgentMcpServers } from './list-agent-mcp-servers/list-agent-mcp-servers.usecase';
 import { ListAgents } from './list-agents/list-agents.usecase';
+import { ListMcpInstallations } from './list-mcp-installations/list-mcp-installations.usecase';
 import { McpOAuthCallback } from './mcp-oauth-callback/mcp-oauth-callback.usecase';
 import { MigrateAgentRuntime } from './migrate-agent-runtime/migrate-agent-runtime.usecase';
 import { ProvisionManagedAgent } from './provision-managed-agent/provision-managed-agent.usecase';
@@ -88,6 +89,7 @@ export const USE_CASES = [
   EnableAgentMcpServer,
   DisableAgentMcpServer,
   ListAgentMcpServers,
+  ListMcpInstallations,
   GenerateMcpOAuthUrl,
   McpOAuthCallback,
   GetMcpConnectionStatus,

--- a/apps/api/src/app/agents/usecases/list-mcp-installations/list-mcp-installations.command.ts
+++ b/apps/api/src/app/agents/usecases/list-mcp-installations/list-mcp-installations.command.ts
@@ -1,0 +1,18 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class ListMcpInstallationsCommand extends EnvironmentWithUserCommand {
+  @IsString()
+  @IsNotEmpty()
+  agentIdentifier: string;
+
+  @IsString()
+  @IsNotEmpty()
+  mcpId: string;
+
+  /** External subscriberId — converted to Mongo `Subscriber._id`. */
+  @IsString()
+  @IsNotEmpty()
+  subscriberId: string;
+}

--- a/apps/api/src/app/agents/usecases/list-mcp-installations/list-mcp-installations.usecase.ts
+++ b/apps/api/src/app/agents/usecases/list-mcp-installations/list-mcp-installations.usecase.ts
@@ -1,0 +1,215 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  decryptMcpConnectionAuth,
+  PinoLogger,
+  SsrfBlockedError,
+  safeOutboundJsonRequest,
+} from '@novu/application-generic';
+import { AgentMcpServerRepository, AgentRepository, McpConnectionRepository, SubscriberRepository } from '@novu/dal';
+import { MCP_SERVERS, McpConnectionAuthModeEnum, McpConnectionStatusEnum } from '@novu/shared';
+
+import { ListMcpInstallationsResponseDto, type McpInstallationDto } from '../../dtos/mcp-server.dto';
+import { ListMcpInstallationsCommand } from './list-mcp-installations.command';
+
+interface GithubInstallationRaw {
+  id: unknown;
+  account?: {
+    login?: unknown;
+    type?: unknown;
+    avatar_url?: unknown;
+  };
+  repository_selection?: unknown;
+  repositories_url?: unknown;
+  html_url?: unknown;
+}
+
+/**
+ * Fetch the live list of GitHub-App installations the subscriber's token
+ * can act on for an MCP that uses the App + Installation flow (currently
+ * only `github`).
+ *
+ * The mongo row carries a single-installation snapshot (the most recent
+ * one captured at callback time), but a GitHub user-to-server token
+ * implicitly grants access to **every** installation the user has
+ * consented to across their personal account and every org. This usecase
+ * is the authoritative read — the snapshot is just a display fallback for
+ * when GitHub is briefly unreachable.
+ *
+ * Token-side failures are mapped onto the connection's `status` and
+ * returned in the response so the caller doesn't have to make a second
+ * call to discover that re-auth is needed:
+ *  - 401 → flip connection to `expired`, return empty list + status.
+ *  - everything else → 502 (BadRequest) with sanitized message.
+ */
+@Injectable()
+export class ListMcpInstallations {
+  constructor(
+    private readonly agentRepository: AgentRepository,
+    private readonly agentMcpServerRepository: AgentMcpServerRepository,
+    private readonly mcpConnectionRepository: McpConnectionRepository,
+    private readonly subscriberRepository: SubscriberRepository,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(ListMcpInstallations.name);
+  }
+
+  async execute(command: ListMcpInstallationsCommand): Promise<ListMcpInstallationsResponseDto> {
+    const catalog = MCP_SERVERS.find((entry) => entry.id === command.mcpId);
+    if (!catalog) {
+      throw new NotFoundException(`Unknown MCP "${command.mcpId}".`);
+    }
+    if (!catalog.oauth) {
+      throw new BadRequestException(`MCP "${command.mcpId}" does not have OAuth connectivity configured.`);
+    }
+    if (catalog.oauth.mode !== McpConnectionAuthModeEnum.NovuApp || !catalog.oauth.installation) {
+      throw new BadRequestException(`MCP "${command.mcpId}" does not use the GitHub App + Installation flow.`);
+    }
+
+    const agent = await this.agentRepository.findOne(
+      {
+        identifier: command.agentIdentifier,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      },
+      ['_id']
+    );
+    if (!agent) {
+      throw new NotFoundException(`Agent "${command.agentIdentifier}" not found.`);
+    }
+
+    const enablement = await this.agentMcpServerRepository.findByAgentAndMcpId({
+      organizationId: command.organizationId,
+      environmentId: command.environmentId,
+      agentId: agent._id,
+      mcpId: command.mcpId,
+    });
+    if (!enablement) {
+      throw new NotFoundException(`MCP "${command.mcpId}" is not enabled on agent "${command.agentIdentifier}".`);
+    }
+
+    const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
+    if (!subscriber) {
+      throw new NotFoundException(`Subscriber "${command.subscriberId}" not found in this environment.`);
+    }
+
+    const connection = await this.mcpConnectionRepository.findSubscriberConnection({
+      organizationId: command.organizationId,
+      environmentId: command.environmentId,
+      agentMcpServerId: enablement._id,
+      subscriberId: subscriber._id,
+    });
+    if (!connection) {
+      return { data: [], connectionStatus: McpConnectionStatusEnum.PendingOAuth };
+    }
+    if (connection.status !== McpConnectionStatusEnum.Connected) {
+      return { data: [], connectionStatus: connection.status as McpConnectionStatusEnum };
+    }
+    if (!connection.auth?.accessToken) {
+      return { data: [], connectionStatus: McpConnectionStatusEnum.Error };
+    }
+
+    const decrypted = decryptMcpConnectionAuth({ accessToken: connection.auth.accessToken });
+    const accessToken = decrypted.accessToken;
+    if (!accessToken) {
+      return { data: [], connectionStatus: McpConnectionStatusEnum.Error };
+    }
+
+    try {
+      const response = await safeOutboundJsonRequest<{ installations?: unknown }>({
+        url: 'https://api.github.com/user/installations',
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          accept: 'application/vnd.github+json',
+          'x-github-api-version': '2022-11-28',
+        },
+        timeoutMs: 10_000,
+      });
+
+      if (response.statusCode === 401) {
+        // Token was revoked or rotated upstream. Flip the connection to
+        // `expired` so the dashboard can prompt re-auth. We do NOT touch
+        // `auth` itself — that's owned by the OAuth callback and the
+        // refresh path; just the status enum.
+        await this.mcpConnectionRepository.update(
+          {
+            _id: connection._id,
+            _environmentId: command.environmentId,
+            _organizationId: command.organizationId,
+          },
+          { $set: { status: McpConnectionStatusEnum.Expired } }
+        );
+
+        return { data: [], connectionStatus: McpConnectionStatusEnum.Expired };
+      }
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        this.logger.warn(
+          { mcpId: command.mcpId, status: response.statusCode },
+          'GitHub /user/installations returned non-2xx; surfacing empty list'
+        );
+
+        return { data: [], connectionStatus: connection.status as McpConnectionStatusEnum };
+      }
+
+      const rawList = Array.isArray(response.body?.installations) ? (response.body.installations as unknown[]) : [];
+      const data = rawList
+        .map((entry): McpInstallationDto | null => buildInstallationDto(entry))
+        .filter((entry): entry is McpInstallationDto => entry !== null);
+
+      return { data, connectionStatus: McpConnectionStatusEnum.Connected };
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        // SSRF block is a server-side policy decision, never bubble the
+        // upstream URL or reason directly. Return empty + Connected so
+        // the dashboard renders "no installations to manage" rather than
+        // a scary banner.
+        this.logger.warn(
+          { mcpId: command.mcpId, reason: err.reason },
+          'GitHub /user/installations blocked by SSRF policy'
+        );
+
+        return { data: [], connectionStatus: McpConnectionStatusEnum.Connected };
+      }
+      this.logger.warn(
+        { mcpId: command.mcpId, err: err instanceof Error ? err.message : String(err) },
+        'GitHub /user/installations fetch failed'
+      );
+      throw new BadRequestException('Failed to fetch GitHub installations.');
+    }
+  }
+}
+
+function buildInstallationDto(entry: unknown): McpInstallationDto | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const raw = entry as GithubInstallationRaw;
+
+  const id = typeof raw.id === 'number' && Number.isFinite(raw.id) ? raw.id : null;
+  if (id === null) return null;
+
+  const accountLogin = typeof raw.account?.login === 'string' ? raw.account.login : 'unknown';
+  const accountType: 'User' | 'Organization' = raw.account?.type === 'Organization' ? 'Organization' : 'User';
+  const avatarUrl = typeof raw.account?.avatar_url === 'string' ? raw.account.avatar_url : undefined;
+  const repositorySelection: 'all' | 'selected' = raw.repository_selection === 'all' ? 'all' : 'selected';
+  const repositoriesUrl = typeof raw.repositories_url === 'string' ? raw.repositories_url : undefined;
+
+  // Build a stable "Manage on GitHub" deep link. Org installations live
+  // under the org's settings; user installations live under the user's
+  // settings. `html_url` from the API is the canonical settings URL when
+  // present, so we trust it; otherwise we fall back to the well-known
+  // shape used by github.com.
+  const manageUrl =
+    typeof raw.html_url === 'string' && raw.html_url.length > 0
+      ? raw.html_url
+      : accountType === 'Organization'
+        ? `https://github.com/organizations/${encodeURIComponent(accountLogin)}/settings/installations/${id}`
+        : `https://github.com/settings/installations/${id}`;
+
+  return {
+    id,
+    account: { login: accountLogin, type: accountType, avatarUrl },
+    repositorySelection,
+    repositoriesUrl,
+    manageUrl,
+  };
+}

--- a/apps/api/src/app/agents/usecases/mcp-oauth-callback/mcp-oauth-callback.command.ts
+++ b/apps/api/src/app/agents/usecases/mcp-oauth-callback/mcp-oauth-callback.command.ts
@@ -1,5 +1,18 @@
 import { BaseCommand } from '@novu/application-generic';
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+/**
+ * `setup_action` values that GitHub returns on the install-and-authorize
+ * redirect. Other values are rejected at the controller boundary so a
+ * malformed redirect can't widen this union accidentally.
+ *
+ * - `install` — fresh installation just created.
+ * - `update`  — existing installation had its repo selection updated.
+ * - `request` — user picked an org they don't admin; install is pending
+ *               an org-owner approval. Token still gets issued but the
+ *               grant is effectively empty until approval lands.
+ */
+export type McpOAuthSetupAction = 'install' | 'update' | 'request';
 
 export class McpOAuthCallbackCommand extends BaseCommand {
   @IsNotEmpty()
@@ -23,6 +36,24 @@ export class McpOAuthCallbackCommand extends BaseCommand {
   @IsOptional()
   @IsString()
   iss?: string;
+
+  /**
+   * GitHub-App-only: numeric installation id returned alongside `code` when
+   * the catalog entry uses the install-and-authorize redirect. Carried as a
+   * string off the querystring; the callback parses it to a number before
+   * persisting to keep the entity field strict.
+   */
+  @IsOptional()
+  @IsString()
+  installationId?: string;
+
+  /**
+   * GitHub-App-only: `setup_action` returned alongside `code`. Whitelisted
+   * here so an unrecognised value is rejected before the callback runs.
+   */
+  @IsOptional()
+  @IsIn(['install', 'update', 'request'])
+  setupAction?: McpOAuthSetupAction;
 }
 
 export type McpOAuthCallbackResult = {

--- a/apps/api/src/app/agents/usecases/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
+++ b/apps/api/src/app/agents/usecases/mcp-oauth-callback/mcp-oauth-callback.usecase.ts
@@ -16,6 +16,7 @@ import {
   EnvironmentRepository,
   IntegrationRepository,
   McpConnectionEntity,
+  type McpConnectionInstallation,
   McpConnectionOAuthClient,
   McpConnectionRepository,
 } from '@novu/dal';
@@ -241,6 +242,32 @@ export class McpOAuthCallback {
       scopes: plainAuth.scopes,
     });
 
+    // GitHub-App "install + authorize" flow returns an `installation_id`
+    // alongside `code`. Fetch the metadata while we still have a fresh
+    // access token in memory and persist a snapshot for dashboard display.
+    // Falls back to a minimal snapshot (id + syncedAt) when the lookup
+    // fails — the connection itself is still valid; the dashboard will
+    // re-fetch via `GET /user/installations` at view time.
+    const installation = await this.captureInstallationSnapshotIfApplicable({
+      oauthConfig,
+      installationId: command.installationId,
+      accessToken: plainAuth.accessToken,
+    });
+
+    // `setup_action=request` means the user picked an org they don't admin;
+    // the install is pending an owner approval. Token still came back, so
+    // the row lands `Connected`, but we surface the pending state via
+    // `lastError` so the dashboard can render a banner without inventing
+    // a new status enum value (deferred per plan).
+    const pendingApprovalError =
+      command.setupAction === 'request'
+        ? {
+            code: 'mcp_github_pending_org_approval' as const,
+            message: 'Installation is pending approval from an organization owner.',
+            at: new Date(),
+          }
+        : undefined;
+
     await this.mcpConnectionRepository.update(
       {
         _id: claimed._id,
@@ -253,8 +280,14 @@ export class McpOAuthCallback {
           status: McpConnectionStatusEnum.Connected,
           auth,
           connectedAt: new Date(),
+          ...(installation && { installation }),
+          ...(pendingApprovalError && { lastError: pendingApprovalError }),
         },
-        $unset: { oauthState: 1, lastError: 1 },
+        // Only clear `lastError` when we're NOT writing a fresh
+        // pending-approval signal. Otherwise the same statement would
+        // both set and unset it (Mongo rejects). When pending approval
+        // applies we still want to drop `oauthState`, just not `lastError`.
+        $unset: pendingApprovalError ? { oauthState: 1 } : { oauthState: 1, lastError: 1 },
       }
     );
 
@@ -501,6 +534,96 @@ export class McpOAuthCallback {
       scopesGranted,
       registeredAt: new Date(claimed.createdAt),
     };
+  }
+
+  /**
+   * Resolve the GitHub-App installation metadata for the redirect we're
+   * processing. Only fires when:
+   *   - the catalog declares an `installation` block (i.e. App + Install flow), AND
+   *   - the redirect actually carried an `installation_id`.
+   *
+   * Returns `undefined` (no-op) for classic OAuth flows and for the rare
+   * case where the catalog uses the install flow but GitHub didn't return
+   * an installation_id — the connection itself is still valid; the
+   * dashboard will fetch installations fresh via `GET /user/installations`.
+   *
+   * GitHub call failures are logged but NEVER block the connection from
+   * landing `Connected`. A token without a snapshot is strictly better
+   * than failing the consent flow because we couldn't render a label.
+   */
+  private async captureInstallationSnapshotIfApplicable(args: {
+    oauthConfig: McpOAuthCatalogEntry;
+    installationId: string | undefined;
+    accessToken: string;
+  }): Promise<McpConnectionInstallation | undefined> {
+    const { oauthConfig, installationId, accessToken } = args;
+
+    if (oauthConfig.mode !== McpConnectionAuthModeEnum.NovuApp) {
+      return undefined;
+    }
+    if (!oauthConfig.installation) {
+      return undefined;
+    }
+    if (!installationId) {
+      return undefined;
+    }
+
+    const id = Number.parseInt(installationId, 10);
+    if (!Number.isInteger(id) || id <= 0) {
+      this.logger.warn(
+        { installationId },
+        'GitHub callback installation_id is not a positive integer; skipping snapshot'
+      );
+
+      return undefined;
+    }
+
+    try {
+      const response = await safeOutboundJsonRequest<Record<string, unknown>>({
+        url: `https://api.github.com/user/installations/${id}`,
+        method: 'GET',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          accept: 'application/vnd.github+json',
+          'x-github-api-version': '2022-11-28',
+        },
+        timeoutMs: 10_000,
+      });
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        this.logger.warn(
+          { installationId: id, status: response.statusCode },
+          'GitHub /user/installations/{id} returned non-2xx; storing minimal snapshot'
+        );
+
+        return {
+          id,
+          account: 'unknown',
+          accountType: 'User',
+          repositorySelection: 'selected',
+          syncedAt: new Date(),
+        };
+      }
+
+      return parseInstallationSnapshot(id, response.body);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        // SSRF policy ALWAYS wins; never bypass. We still don't fail the
+        // connection — just skip the snapshot.
+        this.logger.warn(
+          { installationId: id, reason: err.reason },
+          'GitHub /user/installations/{id} blocked by SSRF policy'
+        );
+
+        return undefined;
+      }
+      this.logger.warn(
+        { installationId: id, err: err instanceof Error ? err.message : String(err) },
+        'GitHub /user/installations/{id} fetch failed; skipping snapshot'
+      );
+
+      return undefined;
+    }
   }
 
   private async validateIssuer(
@@ -889,6 +1012,48 @@ function pickProviderErrorCode(body: unknown): string | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Build a `McpConnectionInstallation` snapshot from the JSON body of
+ * `GET /user/installations/{id}`. Tolerant of missing fields — returns a
+ * minimal snapshot rather than throwing, because failing the OAuth flow on
+ * a display-only field is worse UX than rendering "unknown" once.
+ *
+ * Reference: https://docs.github.com/en/rest/apps/installations
+ */
+function parseInstallationSnapshot(id: number, body: unknown): McpConnectionInstallation {
+  if (!body || typeof body !== 'object') {
+    return { id, account: 'unknown', accountType: 'User', repositorySelection: 'selected', syncedAt: new Date() };
+  }
+
+  const data = body as Record<string, unknown>;
+  const accountRaw = data.account;
+  let accountLogin = 'unknown';
+  let accountTypeRaw = 'User';
+  if (accountRaw && typeof accountRaw === 'object') {
+    const accountObj = accountRaw as Record<string, unknown>;
+    if (typeof accountObj.login === 'string' && accountObj.login.length > 0) {
+      accountLogin = accountObj.login;
+    }
+    if (typeof accountObj.type === 'string' && accountObj.type.length > 0) {
+      accountTypeRaw = accountObj.type;
+    }
+  }
+  const accountType: McpConnectionInstallation['accountType'] =
+    accountTypeRaw === 'Organization' ? 'Organization' : 'User';
+
+  const repoSelRaw = data.repository_selection;
+  const repositorySelection: McpConnectionInstallation['repositorySelection'] =
+    repoSelRaw === 'all' ? 'all' : 'selected';
+
+  return {
+    id,
+    account: accountLogin,
+    accountType,
+    repositorySelection,
+    syncedAt: new Date(),
+  };
 }
 
 /**

--- a/apps/dashboard/src/api/agents.ts
+++ b/apps/dashboard/src/api/agents.ts
@@ -550,6 +550,71 @@ export function disableAgentMcpServer(
   });
 }
 
+const MCP_INSTALLATIONS_QUERY_KEY = 'fetchMcpInstallations' as const;
+
+export function getMcpInstallationsQueryKey(
+  environmentId: string | undefined,
+  agentIdentifier: string | undefined,
+  mcpId: string,
+  subscriberId: string | undefined
+) {
+  return [MCP_INSTALLATIONS_QUERY_KEY, environmentId, agentIdentifier, mcpId, subscriberId] as const;
+}
+
+export type McpInstallation = {
+  id: number;
+  account: {
+    login: string;
+    type: 'User' | 'Organization';
+    avatarUrl?: string;
+  };
+  repositorySelection: 'all' | 'selected';
+  repositoriesUrl?: string;
+  manageUrl: string;
+};
+
+/**
+ * Connection status mirrors the api-service `McpConnectionStatusEnum`. We
+ * intentionally do NOT import the enum from `@novu/shared` here — the wire
+ * type would force a circular dependency for what is effectively five
+ * literal strings. Keep this in lock-step with the backend.
+ */
+export type McpConnectionStatus = 'pending_oauth' | 'connected' | 'expired' | 'revoked' | 'error';
+
+export type ListMcpInstallationsResponse = {
+  data: McpInstallation[];
+  connectionStatus: McpConnectionStatus;
+};
+
+export async function listMcpInstallations(
+  environment: IEnvironment,
+  agentIdentifier: string,
+  mcpId: string,
+  subscriberId: string,
+  signal?: AbortSignal
+): Promise<ListMcpInstallationsResponse> {
+  const response = await get<{ data: ListMcpInstallationsResponse }>(
+    `/agents/${encodeURIComponent(agentIdentifier)}/mcp-servers/${encodeURIComponent(mcpId)}/installations?subscriberId=${encodeURIComponent(subscriberId)}`,
+    { environment, signal }
+  );
+
+  return response.data;
+}
+
+export async function generateMcpOAuthUrl(
+  environment: IEnvironment,
+  agentIdentifier: string,
+  mcpId: string,
+  subscriberId: string
+): Promise<{ authorizeUrl: string }> {
+  const response = await post<{ data: { authorizeUrl: string } }>(
+    `/agents/${encodeURIComponent(agentIdentifier)}/mcp-servers/${encodeURIComponent(mcpId)}/oauth/url`,
+    { environment, body: { subscriberId } }
+  );
+
+  return response.data;
+}
+
 type AgentIntegrationResponseEnvelope = { data: AgentIntegrationLink };
 
 /** Enable or disable the Novu shared inbox for a single agent. */

--- a/apps/dashboard/src/components/agents/github-installations-list.tsx
+++ b/apps/dashboard/src/components/agents/github-installations-list.tsx
@@ -1,0 +1,169 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { RiAddLine, RiArrowRightUpLine, RiErrorWarningLine } from 'react-icons/ri';
+import {
+  generateMcpOAuthUrl,
+  getMcpInstallationsQueryKey,
+  listMcpInstallations,
+  type McpInstallation,
+} from '@/api/agents';
+import { NovuApiError } from '@/api/api.client';
+import { useConnectSubscriber } from '@/components/connect/connect-subscriber-provider';
+import { Button } from '@/components/primitives/button';
+import { showErrorToast } from '@/components/primitives/sonner-helpers';
+import { useEnvironment } from '@/context/environment/hooks';
+
+type GithubInstallationsListProps = {
+  agentIdentifier: string;
+  /** Catalog mcpId — always `github` today, but typed for future App+Install integrations. */
+  mcpId: string;
+};
+
+/**
+ * Render the live list of GitHub-App installations the current
+ * subscriber's stored token can act on, with deep links to manage repos
+ * on github.com and a button to install on additional accounts.
+ *
+ * Self-contained: renders nothing when the connection is not `connected`,
+ * because the only thing we could show without a token is "you're not
+ * connected yet", and that copy lives in the parent row's enable/auth UX.
+ *
+ * Triggers re-fetch on subscriber/environment change. Polling is NOT
+ * automatic — users add accounts by clicking the button, which generates
+ * a fresh OAuth URL and pops it in a new tab; we'll re-render once the
+ * callback fires and the query is invalidated.
+ */
+export function GithubInstallationsList({ agentIdentifier, mcpId }: GithubInstallationsListProps) {
+  const { currentEnvironment } = useEnvironment();
+  const { subscriberId, isReady } = useConnectSubscriber();
+
+  const installationsQuery = useQuery({
+    queryKey: getMcpInstallationsQueryKey(currentEnvironment?._id, agentIdentifier, mcpId, subscriberId),
+    queryFn: ({ signal }) => {
+      if (!currentEnvironment) {
+        throw new Error('No environment selected');
+      }
+
+      return listMcpInstallations(currentEnvironment, agentIdentifier, mcpId, subscriberId, signal);
+    },
+    enabled: Boolean(currentEnvironment && agentIdentifier && isReady && subscriberId),
+    // Stale time matches the backend SSRF cache rough lifecycle — the
+    // upstream call is cheap (single REST), but a tighter window would
+    // re-fetch on every sheet open with no UX benefit.
+    staleTime: 60_000,
+  });
+
+  const connectMutation = useMutation({
+    mutationFn: () => {
+      if (!currentEnvironment) {
+        throw new Error('No environment selected');
+      }
+
+      return generateMcpOAuthUrl(currentEnvironment, agentIdentifier, mcpId, subscriberId);
+    },
+    onSuccess: ({ authorizeUrl }) => {
+      // Pop the install URL in a new tab; the callback will redirect back
+      // to the dashboard's OAuth-result page, which invalidates the query.
+      window.open(authorizeUrl, '_blank', 'noopener,noreferrer');
+    },
+    onError: (err: Error) => {
+      const message = err instanceof NovuApiError ? err.message : 'Could not start the install flow.';
+      showErrorToast(message, 'Install failed');
+    },
+  });
+
+  if (!isReady) {
+    return null;
+  }
+
+  if (installationsQuery.isLoading) {
+    return <div className="text-text-soft text-label-xs px-3 py-2">Loading installations…</div>;
+  }
+
+  if (installationsQuery.isError) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 text-label-xs text-text-soft">
+        <RiErrorWarningLine className="size-4 shrink-0" aria-hidden />
+        <span>Could not load GitHub installations. Try again later.</span>
+      </div>
+    );
+  }
+
+  const data = installationsQuery.data;
+  if (!data) {
+    return null;
+  }
+
+  // Pending OAuth / not-yet-connected statuses are owned by the parent
+  // row's enable + authorize CTA. Render nothing here so we don't
+  // duplicate UX copy across two surfaces.
+  if (data.connectionStatus !== 'connected') {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col">
+      {data.data.length === 0 ? (
+        <div className="text-text-soft text-label-xs px-3 py-2">
+          No installations on your account yet. Install the GitHub App to grant repo access.
+        </div>
+      ) : (
+        <ul className="flex flex-col">
+          {data.data.map((installation) => (
+            <InstallationRow key={installation.id} installation={installation} />
+          ))}
+        </ul>
+      )}
+
+      <div className="px-3 pb-2">
+        <Button
+          type="button"
+          variant="secondary"
+          mode="outline"
+          size="xs"
+          trailingIcon={RiAddLine}
+          isLoading={connectMutation.isPending}
+          disabled={connectMutation.isPending}
+          onClick={() => connectMutation.mutate()}
+          className="border-stroke-soft w-full justify-center"
+        >
+          Install on another account
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function InstallationRow({ installation }: { installation: McpInstallation }) {
+  const { account, repositorySelection, manageUrl } = installation;
+  const repoSummary = repositorySelection === 'all' ? 'All repositories' : 'Selected repositories';
+
+  return (
+    <li className="flex items-center gap-3 px-3 py-2 not-last:border-b border-stroke-soft/60">
+      {account.avatarUrl ? (
+        <img
+          src={account.avatarUrl}
+          alt=""
+          className="size-5 rounded-full shrink-0"
+          referrerPolicy="no-referrer"
+          aria-hidden
+        />
+      ) : (
+        <span className="size-5 rounded-full bg-bg-weak shrink-0" aria-hidden />
+      )}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="text-text-strong text-label-xs font-medium truncate">{account.login}</span>
+        <span className="text-text-soft text-paragraph-xs leading-3 truncate">{repoSummary}</span>
+      </div>
+      <a
+        href={manageUrl}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="text-text-sub hover:text-text-strong inline-flex shrink-0 items-center gap-0.5 text-label-xs font-medium transition-colors"
+        aria-label={`Manage installation for ${account.login}`}
+      >
+        Manage
+        <RiArrowRightUpLine className="size-3.5" />
+      </a>
+    </li>
+  );
+}

--- a/apps/dashboard/src/components/agents/mcps-section.tsx
+++ b/apps/dashboard/src/components/agents/mcps-section.tsx
@@ -18,7 +18,17 @@ import { Skeleton } from '@/components/primitives/skeleton';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { Switch } from '@/components/primitives/switch';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
+import { GithubInstallationsList } from './github-installations-list';
 import { McpsSheet } from './mcps-sheet';
+
+/**
+ * Catalog ids whose `oauth.installation` block is set; these surface an
+ * additional installations list below the toggle row. Kept as a literal
+ * set rather than derived from `MCP_SERVERS` so the dashboard bundle
+ * doesn't pull the entire catalog into the component tree just for one
+ * conditional render.
+ */
+const MCPS_WITH_INSTALLATIONS_LIST = new Set(['github']);
 
 type McpsSectionProps = {
   agent: AgentResponse;
@@ -142,17 +152,25 @@ export function McpsSection({ agent }: McpsSectionProps) {
               const catalog = MCP_CATALOG_BY_ID.get(enablement.mcpId);
               const displayName = catalog?.name ?? enablement.mcpId;
               const Icon = getMcpIcon(catalog?.id ?? enablement.mcpId);
+              const hasInstallations = MCPS_WITH_INSTALLATIONS_LIST.has(enablement.mcpId);
 
               return (
-                <li key={enablement.id} className="flex items-center gap-3 p-3 not-last:border-b border-stroke-soft/60">
-                  <Switch
-                    checked
-                    disabled={!canEdit || isMutating}
-                    onCheckedChange={() => disableMcp.mutate(enablement.mcpId)}
-                    aria-label={`Disconnect ${displayName}`}
-                  />
-                  {Icon ? <Icon className="size-5 shrink-0 -mr-2" aria-hidden /> : null}
-                  <span className="text-text-sub text-label-sm min-w-0 flex-1 truncate font-medium">{displayName}</span>
+                <li key={enablement.id} className="flex flex-col not-last:border-b border-stroke-soft/60">
+                  <div className="flex items-center gap-3 p-3">
+                    <Switch
+                      checked
+                      disabled={!canEdit || isMutating}
+                      onCheckedChange={() => disableMcp.mutate(enablement.mcpId)}
+                      aria-label={`Disconnect ${displayName}`}
+                    />
+                    {Icon ? <Icon className="size-5 shrink-0 -mr-2" aria-hidden /> : null}
+                    <span className="text-text-sub text-label-sm min-w-0 flex-1 truncate font-medium">
+                      {displayName}
+                    </span>
+                  </div>
+                  {hasInstallations ? (
+                    <GithubInstallationsList agentIdentifier={agent.identifier} mcpId={enablement.mcpId} />
+                  ) : null}
                 </li>
               );
             })}

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.entity.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.entity.ts
@@ -132,6 +132,33 @@ export interface McpConnectionLastError {
 }
 
 /**
+ * Snapshot of the GitHub-App installation captured at OAuth-callback time
+ * for `novu-app` rows whose catalog declares an `installation` block.
+ *
+ * GitHub App user-to-server tokens cover EVERY installation the user has
+ * consented to — not just the one returned in the redirect. This row only
+ * records the most recent one for display continuity (e.g. when the dashboard
+ * loads but GitHub is briefly unreachable). The live list of installations
+ * the token can actually act on comes from `GET /user/installations` at
+ * view time; this snapshot exists purely as a hint, not a source of truth.
+ *
+ * Absent for rows whose catalog entry doesn't use the App + Installation
+ * flow, and for legacy connections persisted before the field was added.
+ */
+export interface McpConnectionInstallation {
+  /** Numeric installation id from GitHub's redirect `installation_id` param. */
+  id: number;
+  /** `login` of the account the App was installed on (user handle or org slug). */
+  account: string;
+  /** Account type — drives the "Manage" deep link path on github.com. */
+  accountType: 'User' | 'Organization';
+  /** `all` = every repo on the account; `selected` = a hand-picked list. */
+  repositorySelection: 'all' | 'selected';
+  /** When this snapshot was refreshed against GitHub. */
+  syncedAt: Date;
+}
+
+/**
  * OAuth state for a (scope, mcp, owner) tuple.
  *
  * `auth` is populated when `status === 'connected'` — the access/refresh
@@ -183,6 +210,14 @@ export class McpConnectionEntity {
    * from env vars / per-org config at request time instead.
    */
   oauthClient?: McpConnectionOAuthClient;
+
+  /**
+   * GitHub-App installation snapshot. Populated only for `novu-app` rows
+   * whose catalog declares an `installation` block (currently only `github`).
+   * Display hint — the dashboard's authoritative installation list comes
+   * from `GET /user/installations` at view time.
+   */
+  installation?: McpConnectionInstallation;
 
   lastError?: McpConnectionLastError;
 

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.schema.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.schema.ts
@@ -153,6 +153,34 @@ const lastErrorSchema = new Schema(
   { _id: false }
 );
 
+const installationSchema = new Schema(
+  {
+    id: {
+      type: Schema.Types.Number,
+      required: true,
+    },
+    account: {
+      type: Schema.Types.String,
+      required: true,
+    },
+    accountType: {
+      type: Schema.Types.String,
+      required: true,
+      enum: ['User', 'Organization'],
+    },
+    repositorySelection: {
+      type: Schema.Types.String,
+      required: true,
+      enum: ['all', 'selected'],
+    },
+    syncedAt: {
+      type: Schema.Types.Date,
+      required: true,
+    },
+  },
+  { _id: false }
+);
+
 const mcpConnectionSchema = new Schema<McpConnectionDBModel>(
   {
     _organizationId: {
@@ -229,6 +257,10 @@ const mcpConnectionSchema = new Schema<McpConnectionDBModel>(
     },
     oauthClient: {
       type: oauthClientSchema,
+      required: false,
+    },
+    installation: {
+      type: installationSchema,
       required: false,
     },
     lastError: {

--- a/packages/shared/src/consts/providers/mcp-servers.ts
+++ b/packages/shared/src/consts/providers/mcp-servers.ts
@@ -51,6 +51,29 @@ export type NovuAppOAuthCatalogEntry = {
   authorizationEndpoint: string;
   tokenEndpoint: string;
   scopes: string[];
+  /**
+   * Optional "GitHub App + Installation" flow. When present, `GenerateMcpOAuthUrl`
+   * redirects the user through `https://github.com/apps/<slug>/installations/new`
+   * instead of the classic `authorizationEndpoint`, so installing the App on a
+   * user/org and consenting to OAuth happen in a single click. The redirect
+   * returns BOTH `?code=...` and `?installation_id=...` to Novu's callback,
+   * which exchanges the code as usual and persists the installation snapshot
+   * for dashboard visibility.
+   *
+   * Requires the GitHub App settings to have "Request user authorization
+   * (OAuth) during installation" enabled, otherwise the install URL returns
+   * only `installation_id` and the token exchange fails. Without this block,
+   * `authorizationEndpoint` is used verbatim and `scopes` is sent on the URL
+   * (classic OAuth-App flow).
+   *
+   * `appSlugEnv` names the env var that resolves to the App's public slug
+   * (e.g. `novu-mcp` for `https://github.com/apps/novu-mcp`). Read at request
+   * time by `GetMcpNovuAppCredentials.executeAppSlug` so self-hosters can
+   * BYO App without forking the catalog.
+   */
+  installation?: {
+    appSlugEnv: string;
+  };
 };
 
 export type UserAppOAuthCatalogEntry = {
@@ -157,28 +180,40 @@ export const MCP_SERVERS: McpServer[] = [
     popular: true,
     // GitHub does NOT advertise RFC 8414 AS metadata or RFC 7591 DCR, so the
     // catalog pins the authorize/token endpoints and Novu uses its single
-    // pre-registered GitHub App (env-loaded `NOVU_GITHUB_MCP_APP_CLIENT_*`).
-    // Scopes mirror Anthropic's Claude GitHub connector verbatim so users
-    // see a familiar permission set on the consent screen.
+    // pre-registered **GitHub App** (env-loaded `NOVU_GITHUB_MCP_APP_*`).
+    //
+    // GitHub Apps differ from classic OAuth Apps in a critical way: access
+    // to a repo requires BOTH the user to consent via OAuth AND the App to
+    // be **installed** on the target account (user or org), with the repo
+    // included in the install's selection. Without an install, the user's
+    // token comes back valid but every REST call against a repo returns
+    // `403 Resource not accessible by integration`.
+    //
+    // The `installation` block below points the authorize redirect at
+    // `https://github.com/apps/<slug>/installations/new` (instead of the
+    // classic `authorizationEndpoint`) so the user installs the App AND
+    // grants OAuth in a single click. The callback receives `code` +
+    // `installation_id` and persists both.
+    //
+    // GitHub App settings checklist (required for the install-and-authorize
+    // redirect to return a `code`):
+    //   - "Where can this GitHub App be installed?" → Any account
+    //   - "Request user authorization (OAuth) during installation" → ON
+    //   - "Expire user authorization tokens" → ON (refresh-token issuance)
+    //   - "Callback URL" → `{FRONT_BASE_URL}/v1/agents/mcp/oauth/callback`
+    //
+    // `scopes: []` is intentional. GitHub Apps silently ignore the OAuth
+    // `scope=` parameter on the authorize URL; permissions are declared on
+    // the App's settings page instead (e.g. `Issues: Read and write`).
     oauth: {
       mode: McpConnectionAuthModeEnum.NovuApp,
       issuer: 'https://github.com',
       authorizationEndpoint: 'https://github.com/login/oauth/authorize',
       tokenEndpoint: 'https://github.com/login/oauth/access_token',
-      scopes: [
-        'repo',
-        'read:org',
-        'read:user',
-        'user:email',
-        'read:packages',
-        'write:packages',
-        'read:project',
-        'project',
-        'gist',
-        'notifications',
-        'workflow',
-        'codespace',
-      ],
+      scopes: [],
+      installation: {
+        appSlugEnv: 'NOVU_GITHUB_MCP_APP_SLUG',
+      },
     },
   },
   {


### PR DESCRIPTION
## What

Stitches GitHub App installation into the consent redirect so completing OAuth atomically grants access to specific repos.

Previously the token came back valid but every API call returned `403 Resource not accessible by integration` because no installation existed on the target account. GitHub Apps require **both** OAuth consent (`code`) and an installation on the account (`installation_id`) to act on a repo; the classic OAuth-authorize URL only delivers the first half.

> Linear ticket: **`NV-TBD`** — update the title before merge once a ticket is filed.

## Why

GitHub's permission model for Apps is two-axis: permissions define *what kinds of resources* the App can touch, installations define *which accounts/repos* it can touch them on. Without an installation on the target repo, every REST call returns `403 Resource not accessible by integration`. Today's flow lands a `Connected` token but no installation, so the very first agent action against `novuhq/novu` (or any repo) fails. This PR makes the consent flow always install the App on at least one account the user owns, returns both `code` + `installation_id` in a single callback, and exposes the live installation list in the dashboard with deep links to `https://github.com/settings/installations/<id>` so users can manage repos without re-running OAuth.

## How

```mermaid
sequenceDiagram
    participant User
    participant Dashboard
    participant NovuApi as Novu API
    participant GitHub
    User->>Dashboard: Click "Connect GitHub"
    Dashboard->>NovuApi: POST /agents/.../mcp/github/oauth/url
    NovuApi-->>Dashboard: { authorizeUrl: github.com/apps/SLUG/installations/new?... }
    Dashboard->>GitHub: Redirect
    User->>GitHub: Pick account + repo selection
    GitHub->>NovuApi: GET callback?code&installation_id&setup_action&state
    NovuApi->>GitHub: POST /login/oauth/access_token
    GitHub-->>NovuApi: user-to-server token
    NovuApi->>GitHub: GET /user/installations/{id}
    GitHub-->>NovuApi: account, repository_selection
    NovuApi-->>Dashboard: Connected (+ installation snapshot)
```

### Catalog + types (`packages/shared`)
- New optional `installation?: { appSlugEnv: string }` on `NovuAppOAuthCatalogEntry`.
- GitHub entry now declares `installation: { appSlugEnv: 'NOVU_GITHUB_MCP_APP_SLUG' }`, drops the 12 OAuth scopes (GitHub Apps ignore them; permissions live on the App settings page), and ships an inline App-settings configuration checklist.

### Authorize URL builder (`generate-mcp-oauth-url.usecase.ts`)
- When the catalog declares `installation`, the authorize URL becomes `https://github.com/apps/<slug>/installations/new` and `scope=` is omitted.
- `appSlug` is resolved in `resolveOAuthConfig` so a missing env var surfaces the same `mcp_novu_app_credentials_missing` 422 path as a missing client id.

### Callback (`mcp-oauth-callback.usecase.ts`)
- New `installationId` + `setupAction` on the command, parsed from the callback querystring with a controller-side whitelist.
- After token exchange the callback fetches `/user/installations/{id}` for a display snapshot and persists it on the connection row.
- `setup_action=request` (user picked an org they don't admin) lands `Connected` and writes a `mcp_github_pending_org_approval` lastError so the dashboard can render a "waiting for org owner" banner without a new status enum.
- Installation lookup failures are non-fatal — connection lands `Connected` with a minimal `{ id, account: 'unknown' }` snapshot.

### Entity + schema (`libs/dal`)
- New `McpConnectionInstallation` interface + `installation?` field on `McpConnectionEntity` + mongoose subdocument schema.

### New endpoint
- `GET /v1/agents/:identifier/mcp-servers/:mcpId/installations` calls `/user/installations` with the decrypted subscriber token, returns the live list with `manageUrl` deep links, and flips the connection to `expired` when GitHub returns 401 (token revoked upstream).

### Dashboard (`apps/dashboard`)
- New `GithubInstallationsList` component renders inline under the GitHub MCP row with one entry per installation (avatar, account, repo-selection summary, "Manage" deep link) and an "Install on another account" button.
- New `listMcpInstallations` + `generateMcpOAuthUrl` API client functions.

## Configuration (operators)

Three env vars now needed for GitHub MCP, documented in `apps/api/src/.example.env`:
- `NOVU_GITHUB_MCP_APP_CLIENT_ID` — GitHub App client id
- `NOVU_GITHUB_MCP_APP_CLIENT_SECRET` — GitHub App client secret
- **`NOVU_GITHUB_MCP_APP_SLUG`** — public slug from the App URL (e.g. `novu-mcp` for `https://github.com/apps/novu-mcp`)

GitHub App settings checklist (required):
- "Where can this GitHub App be installed?" → **Any account**
- "Request user authorization (OAuth) during installation" → **ON**
- "Expire user authorization tokens" → **ON**
- "Callback URL" → `{FRONT_BASE_URL}/v1/agents/mcp/oauth/callback`

## Breaking changes

None for production — the feature is still in development. The GitHub catalog entry's `scopes` array was changed from 12 entries to `[]` (GitHub Apps ignore OAuth scopes), and the authorize endpoint URL shape changed for GitHub specifically. Any in-flight `pending_oauth` rows from before this change should be re-initiated; existing `connected` rows keep working since the token endpoint URL is unchanged.

## Test plan

- [x] API service builds (`pnpm --filter @novu/api-service build`)
- [x] Dashboard typechecks (`tsc --noEmit -p tsconfig.app.json`)
- [x] E2E (`agent-mcp-servers.e2e.ts`): 27 passing
  - existing GitHub novu-app branch tests updated for new authorize URL + absent `scope` param
  - new `install + authorize redirect` describe block (4 tests: happy path, pending-approval, fallback, classic-OAuth fallback)
  - new `GET /mcp-servers/:mcpId/installations` describe block (2 tests: live list with manage links, 401 → expired status flip)
- [x] Biome lint clean on all touched files
- [ ] Reviewer: deploy to a staging environment with the App settings checklist applied, open the dashboard, toggle GitHub MCP on, complete the install flow against a personal repo, verify the installation appears under the GitHub row with a working "Manage" link.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The GitHub MCP OAuth flow was refactored to complete App installation and authorization in a single redirect. Instead of a traditional OAuth consent screen, users are now directed to `https://github.com/apps/<slug>/installations/new` where they authorize the app and select repositories. On callback, the system captures the `installation_id`, fetches an installation snapshot from GitHub, and persists it on the connection record so the dashboard can immediately display accessible repositories.

## Affected areas

**API** — OAuth callback handler now accepts and validates `installation_id` and `setup_action` parameters; new `ListMcpInstallations` use case fetches live installation data from GitHub's API and returns a list with connection status; updated `GenerateMcpOAuthUrl` to construct the GitHub App install URL instead of a traditional OAuth authorize URL; new endpoint `GET /agents/:identifier/mcp-servers/:mcpId/installations`.

**Dashboard** — New `GithubInstallationsList` component displays authenticated installations with account avatars, repository access levels, and manage links; added API client functions `listMcpInstallations()` and `generateMcpOAuthUrl()`; MCP section now conditionally renders the installations list for configured servers.

**DAL** — Added `McpConnectionInstallation` interface and optional `installation` field to `McpConnectionEntity` with corresponding Mongoose subdocument schema to store GitHub installation snapshots.

**Shared** — Updated `NovuAppOAuthCatalogEntry` type to support optional `installation` configuration block with `appSlugEnv`; GitHub MCP catalog entry switched from classic OAuth scopes to installation-based flow.

## Key technical decisions

- Installation lookup failures are non-fatal; missing or invalid snapshots return minimal data instead of blocking connection.
- When `setup_action=request` (pending org approval), connection is marked Connected but `mcp_github_pending_org_approval` is written as `lastError`.
- Connection status flips to Expired on upstream 401; otherwise, existing status is preserved on fetch failures.
- Three required environment variables: `NOVU_GITHUB_MCP_APP_CLIENT_ID`, `NOVU_GITHUB_MCP_APP_CLIENT_SECRET`, `NOVU_GITHUB_MCP_APP_SLUG`.

## Testing

E2E tests were expanded (27 passing) to cover the new install flow, installation snapshot persistence, pending approval handling, and the new `/installations` endpoint. Manual verification on staging is required to confirm the install redirect and dashboard listing work end-to-end.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->