### PR TITLE
fix(dashboard): pre-select first managed integration on create agent fixes NV-7801

### DIFF
--- a/apps/dashboard/src/components/agents/connectors/connector-options.tsx
+++ b/apps/dashboard/src/components/agents/connectors/connector-options.tsx
@@ -117,3 +117,11 @@ export function getConnectorById(id: ConnectorId | undefined): ConnectorOption |
 
   return CONNECTOR_OPTIONS.find((o) => o.id === id);
 }
+
+export function getConnectorIdForProviderId(providerId: string): ConnectorId | undefined {
+  if (providerId === AgentRuntimeProviderIdEnum.NovuAnthropic) {
+    return 'claude';
+  }
+
+  return CONNECTOR_OPTIONS.find((option) => option.providerId === providerId)?.id;
+}

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -34,12 +34,20 @@ import { cn } from '@/utils/ui';
 import { AgentSuggestionPills } from '../onboarding/connect-agent/agent-suggestion-pills';
 import { GenerationStatus, type GenerationStep } from '../onboarding/connect-agent/generation-status';
 import { PromptInput } from '../onboarding/connect-agent/prompt-input';
-import { getClaudeManagedAgentIntegrations } from './connectors/claude-managed-integrations';
+import {
+  getClaudeManagedAgentIntegrations,
+  getPreferredClaudeManagedIntegration,
+} from './connectors/claude-managed-integrations';
 import {
   ConnectorIntegrationDropdown,
   type ConnectorIntegrationStatus,
 } from './connectors/connector-integration-dropdown';
-import { type ConnectorId, type ConnectorOption, getConnectorById } from './connectors/connector-options';
+import {
+  type ConnectorId,
+  type ConnectorOption,
+  getConnectorById,
+  getConnectorIdForProviderId,
+} from './connectors/connector-options';
 import {
   AGENT_TEMPLATES,
   type AgentTemplate,
@@ -177,6 +185,9 @@ export function CreateAgentDialog({
   // Holds the integration id from "Save integration" until it appears in the fetched list, so the
   // auto-select effect does not overwrite it or reopen the credentials section during refetch.
   const pinnedIntegrationIdRef = useRef<string | null>(null);
+  // On dialog open, prefer the first managed integration across provider types (e.g. AWS Claude
+  // when Anthropic has none). Cleared once the user picks a connector or a provider match is found.
+  const preferAnyManagedIntegrationRef = useRef(true);
 
   const {
     generate: generateManagedAgent,
@@ -247,12 +258,30 @@ export function CreateAgentDialog({
     }
 
     if (matchingAnthropicIntegrations.length > 0) {
+      preferAnyManagedIntegrationRef.current = false;
       setSelectedIntegrationId(matchingAnthropicIntegrations[0]._id);
-    } else {
-      setSelectedIntegrationId(undefined);
-      setCredentialsPanelVisible(true);
-      setCredentialsPanelExpanded(true);
+
+      return;
     }
+
+    if (preferAnyManagedIntegrationRef.current) {
+      const preferred = getPreferredClaudeManagedIntegration(integrations);
+      if (preferred) {
+        const connectorForPreferred = getConnectorIdForProviderId(preferred.providerId);
+        if (connectorForPreferred) {
+          setConnectorId(connectorForPreferred);
+        }
+        preferAnyManagedIntegrationRef.current = false;
+        setSelectedIntegrationId(preferred._id);
+
+        return;
+      }
+    }
+
+    preferAnyManagedIntegrationRef.current = false;
+    setSelectedIntegrationId(undefined);
+    setCredentialsPanelVisible(true);
+    setCredentialsPanelExpanded(true);
   }, [
     open,
     isSubmitting,
@@ -260,6 +289,7 @@ export function CreateAgentDialog({
     matchingAnthropicIntegrations,
     selectedIntegrationId,
     credentialsPanelVisible,
+    integrations,
   ]);
 
   // Default integration name = "<Provider> <next-index>"
@@ -309,6 +339,7 @@ export function CreateAgentDialog({
     setIsIdentifierTouched(false);
     setShowSavedBadge(false);
     pinnedIntegrationIdRef.current = null;
+    preferAnyManagedIntegrationRef.current = true;
     if (savedBadgeTimerRef.current) {
       clearTimeout(savedBadgeTimerRef.current);
       savedBadgeTimerRef.current = null;
@@ -367,6 +398,7 @@ export function CreateAgentDialog({
   );
 
   const handleSelectConnector = (id: ConnectorId) => {
+    preferAnyManagedIntegrationRef.current = false;
     setConnectorId(id);
 
     const next = getConnectorById(id);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When opening the **Add agent** dialog, the connector dropdown now pre-selects the first available managed runtime integration across provider types (Anthropic, AWS Claude, Novu demo, etc.) and aligns the connector to that provider. This avoids opening the new integration credentials form when only a non-default provider (e.g. AWS Claude) is configured.

## Behavior

- **On open:** If the default Claude connector has no integrations, fall back to `getPreferredClaudeManagedIntegration()` (any managed provider) and set the matching connector.
- **After manual connector change:** Only integrations for the selected provider are considered; cross-provider fallback is disabled so users can set up credentials for a specific provider.
- **Custom code:** Unchanged — connectors without `providerId` skip managed integration auto-select.

## Changes

- `connector-options.ts`: `getConnectorIdForProviderId()` maps provider ids (including `NovuAnthropic`) to connector ids.
- `create-agent-dialog.tsx`: `preferAnyManagedIntegrationRef` gates cross-provider pre-selection to initial open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-632f3fbe-75a1-49b6-8af8-374716980826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-632f3fbe-75a1-49b6-8af8-374716980826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The "Add agent" dialog now intelligently pre-selects the first available managed integration on open, preventing unnecessary credential setup flows when non-default providers (e.g., AWS Claude) are configured. A new `getConnectorIdForProviderId()` helper maps provider IDs to connector IDs, and a ref flag controls whether the dialog should pick any managed provider's integration or remain provider-specific after manual selection.

## Affected areas

**dashboard**: The create-agent dialog component updated its connector and integration auto-selection logic. On open, it now attempts to select the first available Claude managed integration for the current provider, or falls back to any managed provider integration and adjusts the connector accordingly. Manual connector changes disable cross-provider fallback, requiring users to explicitly set up credentials for their chosen provider.

## Key technical decisions

- A `useRef` flag (`preferAnyManagedIntegrationRef`) gates cross-provider pre-selection to the initial dialog open, resetting when the dialog closes and disabling once a connector is manually selected.
- The `getConnectorIdForProviderId()` function special-cases the `NovuAnthropic` provider ID to map to the `'claude'` connector, then searches `CONNECTOR_OPTIONS` for matching provider IDs.
- Connectors without a `providerId` (custom code) skip managed integration auto-select entirely.

## Testing

No test files exist for this agent creation functionality. This UI behavior change would benefit from manual verification of the pre-selection flow across different managed provider configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->