### PR TITLE
fix(dashboard): show Novu demo Claude in Anthropic connector dropdown fixes NV-7802

### DIFF
--- a/apps/dashboard/src/components/agents/connectors/claude-managed-integrations.ts
+++ b/apps/dashboard/src/components/agents/connectors/claude-managed-integrations.ts
@@ -14,8 +14,15 @@ export function isClaudeManagedAgentIntegration(
     return false;
   }
 
-  if (providerId && integration.providerId !== providerId) {
-    return false;
+  if (providerId) {
+    const matchesConnector =
+      integration.providerId === providerId ||
+      (providerId === AgentRuntimeProviderIdEnum.Anthropic &&
+        integration.providerId === AgentRuntimeProviderIdEnum.NovuAnthropic);
+
+    if (!matchesConnector) {
+      return false;
+    }
   }
 
   if (!CLAUDE_MANAGED_PROVIDER_IDS.has(integration.providerId)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores visibility of auto-provisioned **Novu Managed Claude** (`novu-anthropic`) demo credentials in the Claude Managed Agent connector integration dropdown.

## Root cause

NV-7788 added per-connector `providerId` filtering in `getClaudeManagedAgentIntegrations()`. The demo integration uses `novu-anthropic`, while the "Claude Managed Agent" connector passes `anthropic`, so the strict equality check excluded demo credentials from the list.

## Fix

When filtering for the `anthropic` connector, also include `novu-anthropic` integrations. AWS (`anthropic-aws`) filtering remains exact.

## Testing

- Verified filter logic: demo integration matches `Anthropic` connector filter, not `AnthropicAws`.
- No API/package changes; dashboard-only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6d6992f-59ce-43e0-9aeb-dc77cdc9c009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6d6992f-59ce-43e0-9aeb-dc77cdc9c009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR fixes visibility of Novu demo Claude credentials (`novu-anthropic`) in the "Claude Managed Agent" connector dropdown. Previously, the filtering logic used strict equality on provider IDs, causing the demo integration to be excluded when the connector passed `anthropic` as the provider ID. The fix adds a special case to accept `novu-anthropic` integrations when filtering for the `anthropic` connector, while keeping other provider ID filtering exact.

## Affected areas

**dashboard** — Updated `claude-managed-integrations.ts` to modify the `isClaudeManagedAgentIntegration` function. Added a `matchesConnector` condition (lines 18–21) that accepts either an exact provider ID match or, specifically for the `anthropic` connector, also matches `novu-anthropic` integrations.

## Testing

No new tests were added. The change is a dashboard-only filtering fix. Manual verification confirmed the demo integration now appears in the Anthropic connector dropdown and not in the AnthropicAws dropdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->