### PR TITLE
fix(dashboard): hide existing-agent flow for Novu demo Claude provider fixes NV-7807

### DIFF
--- a/apps/dashboard/src/components/agents/agent-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-steps.tsx
@@ -106,7 +106,7 @@ function ConnectPhaseRecap({
   summary: ConnectSummary;
   integrations: IIntegration[] | undefined;
 }) {
-  const display = deriveConnectSummaryDisplay(summary);
+  const display = deriveConnectSummaryDisplay(summary, integrations);
 
   return (
     <div className="flex flex-col gap-10">

--- a/apps/dashboard/src/components/agents/connectors/claude-managed-integrations.ts
+++ b/apps/dashboard/src/components/agents/connectors/claude-managed-integrations.ts
@@ -1,4 +1,5 @@
 import { AgentRuntimeProviderIdEnum, type IIntegration, IntegrationKindEnum } from '@novu/shared';
+import { isDemoIntegration } from '@/components/integrations/components/utils/helpers';
 
 const CLAUDE_MANAGED_PROVIDER_IDS: ReadonlySet<string> = new Set([
   AgentRuntimeProviderIdEnum.NovuAnthropic,
@@ -58,6 +59,23 @@ export function getPreferredClaudeManagedIntegration(
   providerId?: AgentRuntimeProviderIdEnum
 ): IIntegration | undefined {
   return getClaudeManagedAgentIntegrations(integrations, providerId)[0];
+}
+
+export function isDemoManagedClaudeIntegrationSelected(
+  integrations: IIntegration[] | undefined,
+  selectedIntegrationId: string | undefined
+): boolean {
+  if (!selectedIntegrationId) {
+    return false;
+  }
+
+  const integration = (integrations ?? []).find((item) => item._id === selectedIntegrationId);
+
+  if (!integration) {
+    return false;
+  }
+
+  return isDemoIntegration(integration.providerId);
 }
 
 export function resolveClaudeManagedProviderId(integration: IIntegration | undefined): AgentRuntimeProviderIdEnum {

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -37,6 +37,7 @@ import { PromptInput } from '../onboarding/connect-agent/prompt-input';
 import {
   getClaudeManagedAgentIntegrations,
   getPreferredClaudeManagedIntegration,
+  isDemoManagedClaudeIntegrationSelected,
 } from './connectors/claude-managed-integrations';
 import {
   ConnectorIntegrationDropdown,
@@ -204,8 +205,9 @@ export function CreateAgentDialog({
   // Custom Scaffold generation only produces name/identifier/systemPrompt and never touches any
   // Anthropic-managed infrastructure, so it has no reason to depend on the managed flag.
   const useAiGeneration = isManagedClaudeConnector ? isManagedEnabled : isScratchRuntime;
+  const isDemoProviderSelected = isDemoManagedClaudeIntegrationSelected(integrations, selectedIntegrationId);
   const scope: 'create' | 'existing' = generationMode === 'existing' ? 'existing' : 'create';
-  const showScopeTabs = isManagedClaudeConnector;
+  const showScopeTabs = isManagedClaudeConnector && !isDemoProviderSelected;
   const showManagedOptions = isManagedEnabled;
 
   // Hide managed connectors when the feature flag is off — the dropdown still lists them visually,
@@ -417,6 +419,17 @@ export function CreateAgentDialog({
     }
   };
 
+  // Demo Novu-managed Claude credentials cannot adopt an existing provider agent.
+  useEffect(() => {
+    if (!open) return;
+    if (!isDemoProviderSelected) return;
+    if (generationMode !== 'existing') return;
+
+    setGenerationMode('prompt');
+    setExternalAgentId('');
+    setExternalEnvironmentId('');
+  }, [open, isDemoProviderSelected, generationMode]);
+
   const handleGenerationModeChange = useCallback((next: AgentGenerationMode) => {
     setGenerationMode(next);
     if (next === 'prompt' || next === 'manual') {
@@ -541,7 +554,7 @@ export function CreateAgentDialog({
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
 
-    const isExistingMode = runtime === 'claude' && generationMode === 'existing';
+    const isExistingMode = runtime === 'claude' && !isDemoProviderSelected && generationMode === 'existing';
     const isPromptGenerationMode = useAiGeneration && generationMode === 'prompt';
 
     let generated: GeneratedManagedAgent | null = null;

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
@@ -5,7 +5,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RiArrowRightSLine } from 'react-icons/ri';
 import type { AgentResponse, GeneratedManagedAgent } from '@/api/agents';
 import { NovuApiError } from '@/api/api.client';
-import { getClaudeManagedAgentIntegrations } from '@/components/agents/connectors/claude-managed-integrations';
+import {
+  getClaudeManagedAgentIntegrations,
+  isDemoManagedClaudeIntegrationSelected,
+} from '@/components/agents/connectors/claude-managed-integrations';
 import { type ConnectorIntegrationStatus } from '@/components/agents/connectors/connector-integration-dropdown';
 import { type ConnectorOption } from '@/components/agents/connectors/connector-options';
 import {
@@ -161,11 +164,14 @@ export function ConnectAgentStep({ onAgentCreated, onRuntimeChange, isManagedEna
   // Custom Scaffold generation only produces name/identifier/systemPrompt — it does not touch
   // any Anthropic-managed infrastructure — so it has no reason to depend on that flag.
   const useAiGeneration = isClaudeSelected ? isManagedEnabled : isScratchRuntime;
+  const isDemoProviderSelected = isDemoManagedClaudeIntegrationSelected(integrations, selectedIntegrationId);
   const isExistingMode =
-    isClaudeSelected && (useAiGeneration ? generationMode === 'existing' : templateSelection.kind === 'existing');
+    isClaudeSelected &&
+    !isDemoProviderSelected &&
+    (useAiGeneration ? generationMode === 'existing' : templateSelection.kind === 'existing');
   const isScratchMode =
     (useAiGeneration && generationMode === 'manual') || (!useAiGeneration && templateSelection.kind === 'scratch');
-  const showExistingOption = isClaudeSelected;
+  const showExistingOption = isClaudeSelected && !isDemoProviderSelected;
   const existingOptionIcon = isClaudeSelected ? (
     <div className="bg-primary-base/10 text-primary-base flex size-4 items-center justify-center rounded-full">
       <ClaudeIcon className="size-3" />

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-summary.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-summary.tsx
@@ -1,5 +1,7 @@
 import type { RuntimeType } from '@/components/agents/create-agent-fields';
+import { isDemoManagedClaudeIntegrationSelected } from '@/components/agents/connectors/claude-managed-integrations';
 import { ClaudeIcon } from '@/components/icons/claude';
+import type { IIntegration } from '@novu/shared';
 import { type ConnectorId, getConnectorById } from './connector-options';
 import type { TemplateSelection } from './template-dropdown';
 
@@ -40,12 +42,17 @@ function resolveRuntime(connectorId: ConnectorId): RuntimeType {
  * Derives the display-only flags that `ConnectAgentForm` needs from a `ConnectSummary`.
  * Keeps the recap rendering in `AgentSetupSteps` in sync with the editable form's logic.
  */
-export function deriveConnectSummaryDisplay(summary: ConnectSummary) {
+export function deriveConnectSummaryDisplay(summary: ConnectSummary, integrations?: IIntegration[]) {
   const runtime = resolveRuntime(summary.connectorId);
   const isClaudeSelected = runtime === 'claude';
-  const isExistingMode = isClaudeSelected && summary.templateSelection.kind === 'existing';
+  const isDemoProviderSelected = isDemoManagedClaudeIntegrationSelected(
+    integrations,
+    summary.selectedIntegrationId
+  );
+  const isExistingMode =
+    isClaudeSelected && !isDemoProviderSelected && summary.templateSelection.kind === 'existing';
   const isScratchMode = summary.templateSelection.kind === 'scratch';
-  const showExistingOption = isClaudeSelected;
+  const showExistingOption = isClaudeSelected && !isDemoProviderSelected;
   const existingOptionIcon = isClaudeSelected ? (
     <div className="bg-primary-base/10 text-primary-base flex size-4 items-center justify-center rounded-full">
       <ClaudeIcon className="size-3" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hides the "Connect existing agent" / adopt flow in agent creation and onboarding when the user has selected the Novu-managed Claude demo integration (`novu-anthropic`). The API already rejects adopting external agents on demo credentials; this aligns the dashboard with that behavior.

## Changes

- Added `isDemoManagedClaudeIntegrationSelected()` helper to detect when the selected managed integration is a demo provider.
- **Create agent dialog**: scope tabs and existing-agent fields are hidden when demo is selected; switching to demo collapses active existing mode.
- **Connect agent onboarding step**: same hiding for template dropdown, scope tabs, and existing-agent fields.
- **Setup recap**: `deriveConnectSummaryDisplay()` respects demo selection via `selectedIntegrationId`.

## Testing

- Dashboard `tsc --noEmit` passes locally.
- Manual: open Add agent → select Novu demo Claude integration → confirm "Connect existing agent" tab/option is not shown; switch to a non-demo Anthropic integration → option returns.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0545f665-50ad-457d-92bb-55ebc5d52607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0545f665-50ad-457d-92bb-55ebc5d52607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Added UI-level controls to hide the "Connect existing agent" / adopt flow in agent creation and onboarding when the Novu-managed Claude demo provider is selected. This aligns the dashboard behavior with the backend, which already rejects external agent adoption on demo credentials. A new helper function detects demo provider selection, and multiple components now conditionally disable related UI elements and automatically reset form state when switching between demo and non-demo providers.

## Affected areas

**dashboard**: Agent creation dialog and onboarding flow now hide existing-agent tabs, scope tabs, and template selection when the demo-managed Claude integration is active; the setup recap display logic updated to accept integration data for proper demo status evaluation.

## Key technical decisions

- Centralized demo provider detection via `isDemoManagedClaudeIntegrationSelected()` to avoid duplication and ensure consistent logic across components.
- Form state automatically resets when switching to demo provider while in existing mode to prevent invalid submissions.

## Testing

Manual verification confirmed that selecting the Novu demo Claude integration hides the "Connect existing agent" option, while non-demo integrations restore it. Dashboard TypeScript compilation (`tsc --noEmit`) passes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->