### PR TITLE
feat(dashboard): Redirect Connect overview conversation clicks to Conversations page fixes NV-7806

### DIFF
--- a/apps/dashboard/src/components/connect/dashboard/recent-conversations-section.tsx
+++ b/apps/dashboard/src/components/connect/dashboard/recent-conversations-section.tsx
@@ -9,7 +9,7 @@ export function RecentConversationsSection() {
   const { currentEnvironment } = useEnvironment();
 
   const conversationsPath = currentEnvironment?.slug
-    ? buildRoute(ROUTES.ACTIVITY_CONVERSATIONS, { environmentSlug: currentEnvironment.slug })
+    ? buildRoute(ROUTES.CONNECT_CONVERSATIONS, { environmentSlug: currentEnvironment.slug })
     : undefined;
 
   return (
@@ -28,7 +28,11 @@ export function RecentConversationsSection() {
           </Link>
         ) : null}
       </div>
-      <ConversationsContent className="border-stroke-soft rounded-lg border bg-bg-white" contentHeight="h-[420px]" />
+      <ConversationsContent
+        className="border-stroke-soft rounded-lg border bg-bg-white"
+        contentHeight="h-[420px]"
+        redirectConversationSelectionTo={conversationsPath}
+      />
     </div>
   );
 }

--- a/apps/dashboard/src/components/conversations/conversations-content.tsx
+++ b/apps/dashboard/src/components/conversations/conversations-content.tsx
@@ -2,6 +2,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { conversationQueryKeys } from '@/components/conversations/conversation-query-keys';
 import { ConversationFilters } from '@/components/conversations/conversations-filters';
 import { ConversationsTable } from '@/components/conversations/conversations-table';
@@ -19,11 +20,14 @@ import { ConversationDetail } from './conversation-detail';
 type ConversationsContentProps = {
   className?: string;
   contentHeight?: string;
+  /** When set, row clicks navigate here with `conversationItemId` instead of opening the inline detail panel. */
+  redirectConversationSelectionTo?: string;
 };
 
 export function ConversationsContent({
   className,
   contentHeight = 'h-[calc(100vh-140px)]',
+  redirectConversationSelectionTo,
 }: ConversationsContentProps) {
   if (IS_SELF_HOSTED && !IS_ENTERPRISE) {
     return (
@@ -37,17 +41,51 @@ export function ConversationsContent({
     );
   }
 
-  return <EnterpriseConversationsContent className={className} contentHeight={contentHeight} />;
+  return (
+    <EnterpriseConversationsContent
+      className={className}
+      contentHeight={contentHeight}
+      redirectConversationSelectionTo={redirectConversationSelectionTo}
+    />
+  );
 }
 
 function EnterpriseConversationsContent({
   className,
   contentHeight = 'h-[calc(100vh-140px)]',
+  redirectConversationSelectionTo,
 }: ConversationsContentProps) {
+  const navigate = useNavigate();
   const { conversationItemId, filters, filterValues, handleConversationSelect, handleFiltersChange } =
     useConversationUrlState();
+  const redirectsOnSelect = Boolean(redirectConversationSelectionTo);
   const [showDetailPanel, setShowDetailPanel] = useState(false);
-  const onListStateChange = useCallback((hasConversations: boolean) => setShowDetailPanel(hasConversations), []);
+  const onListStateChange = useCallback(
+    (hasConversations: boolean) => {
+      if (!redirectsOnSelect) {
+        setShowDetailPanel(hasConversations);
+      }
+    },
+    [redirectsOnSelect]
+  );
+
+  const handleConversationSelectWithRedirect = useCallback(
+    (newConversationItemId: string) => {
+      if (!redirectConversationSelectionTo || !newConversationItemId) {
+        return;
+      }
+
+      const params = new URLSearchParams();
+      params.set('conversationItemId', newConversationItemId);
+      navigate(`${redirectConversationSelectionTo}?${params.toString()}`);
+    },
+    [navigate, redirectConversationSelectionTo]
+  );
+
+  const onConversationSelect = redirectsOnSelect
+    ? handleConversationSelectWithRedirect
+    : handleConversationSelect;
+  const selectedConversationId = redirectsOnSelect ? null : conversationItemId;
 
   const queryClient = useQueryClient();
   const { currentEnvironment } = useEnvironment();
@@ -111,8 +149,8 @@ function EnterpriseConversationsContent({
             id="conversations-table-panel"
           >
             <ConversationsTable
-              selectedConversationId={conversationItemId}
-              onConversationSelect={handleConversationSelect}
+              selectedConversationId={selectedConversationId}
+              onConversationSelect={onConversationSelect}
               filters={filters}
               hasActiveFilters={hasActiveFilters}
               onClearFilters={handleClearFilters}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the Connect Overview dashboard, clicking a row in the recent conversations table now navigates to the Connect Conversations page with that conversation preselected and the detail panel open, instead of opening details inline on the overview.

## Changes

- Added optional `redirectConversationSelectionTo` prop to `ConversationsContent` for table-only embeds that navigate on row click with `conversationItemId` in the query string.
- Wired Connect Overview `RecentConversationsSection` to redirect to `CONNECT_CONVERSATIONS` and fixed the "View all activity" link to use the Connect Conversations route (was Activity Feed conversations).

## Testing

- Dashboard TypeScript check passes (`tsc --noEmit`).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7806](https://linear.app/novu/issue/NV-7806/connect-overview-conversations-table-should-redirect-to-the)

<div><a href="https://cursor.com/agents/bc-31ac489b-9264-4104-8802-8647a981d810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31ac489b-9264-4104-8802-8647a981d810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Conversation row clicks on the Connect Overview dashboard now navigate to the dedicated Conversations page with the selected conversation preselected and the detail panel open, instead of expanding inline. This required adding navigation capability to the ConversationsContent component and rewiring the recent conversations section to use the correct route.

## Affected areas

- **dashboard**: Added an optional `redirectConversationSelectionTo` prop to `ConversationsContent` component that enables navigation to a specified route with the conversation ID as a query parameter when provided. Updated `RecentConversationsSection` to redirect to the Connect Conversations route instead of the Activity Feed route, and fixed the "View all activity" link to use the Connect Conversations route.

## Testing

Dashboard TypeScript check passes. No new unit or e2e tests were added, as this is a UI navigation change that requires manual verification of the redirect behavior on the Connect Overview dashboard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



https://github.com/user-attachments/assets/c650ff6f-d177-4021-b5c7-8f585ef05884

