### PR TITLE
fix(dashboard): remove Book demo from agent onboarding fixes NV-7808

### DIFF
--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -2,12 +2,11 @@ import { useOrganization, useUser } from '@clerk/react';
 import { FeatureFlagsKeysEnum } from '@novu/shared';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { RiArrowLeftSLine, RiArrowRightSLine, RiCalendarEventLine } from 'react-icons/ri';
+import { RiArrowLeftSLine, RiArrowRightSLine } from 'react-icons/ri';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import type { AgentResponse } from '@/api/agents';
 import { AgentSetupSteps } from '@/components/agents/agent-setup-steps';
 import type { RuntimeType } from '@/components/agents/create-agent-fields';
-import { BOOK_DEMO_URL } from '@/components/header-navigation/support-drawer-constants';
 import {
   AgentFlowIllustration,
   type AgentFlowRuntime,
@@ -99,19 +98,6 @@ function SkipBanner({ onSkip }: SkipBannerProps) {
         <span className="text-text-strong">Not the right time?</span> Skip for now and finish setup later.
       </p>
       <div className="flex items-center gap-2">
-        <a
-          href={BOOK_DEMO_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="border-stroke-soft text-text-sub inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium shadow-[0px_1px_3px_0px_rgba(14,18,27,0.12),0px_0px_0px_1px_#e1e4ea]"
-          style={{
-            backgroundImage:
-              'linear-gradient(180deg, transparent 30%, rgba(0,0,0,0.02) 100%), linear-gradient(90deg, #fff 0%, #fff 100%)',
-          }}
-        >
-          <RiCalendarEventLine className="size-4" />
-          Book a demo
-        </a>
         <button
           type="button"
           onClick={onSkip}

--- a/apps/dashboard/src/pages/agents-usecase-page.tsx
+++ b/apps/dashboard/src/pages/agents-usecase-page.tsx
@@ -1,11 +1,10 @@
 import { FeatureFlagsKeysEnum } from '@novu/shared';
-import { CalendarDays, Mail } from 'lucide-react';
+import { Mail } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { RiArrowLeftSLine, RiArrowRightSLine } from 'react-icons/ri';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { SetupStep } from '@/components/agents/setup-guide-primitives';
 import type { StepStatus } from '@/components/agents/setup-guide-step-utils';
-import { BOOK_DEMO_URL } from '@/components/header-navigation/support-drawer-constants';
 import { AgentFlowIllustration } from '@/components/onboarding/agent-flow-illustration';
 import { OnboardingShell } from '@/components/onboarding/onboarding-shell';
 import { PageMeta } from '@/components/page-meta';
@@ -234,18 +233,6 @@ export function AgentsUsecasePage() {
         </Button>
       </div>
 
-      <div className="text-text-sub mt-4 flex items-center gap-2 text-xs">
-        <span>Have questions?</span>
-        <a
-          href={BOOK_DEMO_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-text-strong inline-flex items-center gap-1 text-xs font-medium hover:underline"
-        >
-          <CalendarDays className="size-4" />
-          Book a demo
-        </a>
-      </div>
     </>
   );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the "Book a demo" CTA from agent onboarding screens.

## Changes

- **Agent setup** (`/onboarding/agents/setup`): Removed the Book a demo link from the skip banner; "Skip setup" remains.
- **Agents usecase** (`/onboarding/agents`): Removed the "Have questions? Book a demo" footer.

The support drawer Book a demo link is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cdc1aa4-aca7-4525-a4fd-6606efd7c66b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cdc1aa4-aca7-4525-a4fd-6606efd7c66b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Removed "Book a demo" calls-to-action from the agent onboarding flow. This simplifies the onboarding experience by eliminating marketing links and allowing users to focus on the core setup and usecase selection tasks.

## Affected areas

**dashboard**: Removed "Book a demo" CTA from the agent setup page's skip banner and from the agents usecase page's footer, along with their associated icon imports and `BOOK_DEMO_URL` constant.

## Testing

This is a straightforward UI change removing elements and unused imports. Manual verification of the agent onboarding pages should confirm the CTAs are properly removed and the remaining UI elements (Skip setup button, navigation buttons) function correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->