### PR TITLE
fix(shared): default managed-agent MCP toolsets to always_allow fixes NV-7809

### DIFF
--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.spec.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.spec.ts
@@ -145,6 +145,9 @@ interface AgentToolsetPayloadEntry {
   type: string;
   configs?: AgentToolsetConfigEntry[];
   mcp_server_name?: string;
+  default_config?: {
+    permission_policy: { type: string };
+  };
 }
 
 function installUpdateConfigMockClient(
@@ -566,5 +569,11 @@ describe('AnthropicAgentRuntimeProvider.updateConfig', () => {
     const enabledNames = toolset?.configs?.filter((c) => c.enabled).map((c) => c.name) ?? [];
     expect(enabledNames).to.include.members(['bash', 'web_search']);
     expect(enabledNames).to.not.include('read');
+
+    const mcpToolset = (updatePayload as { tools?: AgentToolsetPayloadEntry[] }).tools?.find(
+      (t) => t.type === 'mcp_toolset'
+    );
+    expect(mcpToolset?.mcp_server_name).to.equal('Slack');
+    expect(mcpToolset?.default_config?.permission_policy).to.deep.equal({ type: 'always_allow' });
   });
 });

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.spec.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.spec.ts
@@ -1,5 +1,10 @@
+import { CLAUDE_BUILTIN_TOOLS } from '@novu/shared';
 import { expect } from 'chai';
-import { mapToolset } from './anthropic-runtime.helpers';
+import {
+  buildToolsPayload,
+  MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG,
+  mapToolset,
+} from './anthropic-runtime.helpers';
 
 describe('mapToolset', () => {
   it('maps enabled builtin toolset configs to AgentToolDto entries', () => {
@@ -25,5 +30,34 @@ describe('mapToolset', () => {
     });
 
     expect(tools).to.deep.equal([]);
+  });
+});
+
+describe('buildToolsPayload', () => {
+  it('sets always_allow on the agent toolset default_config', () => {
+    const payload = buildToolsPayload(['bash'], undefined);
+    const toolset = payload[0] as {
+      type: string;
+      default_config: typeof MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG;
+      configs: Array<{ name: string; enabled: boolean }>;
+    };
+
+    expect(toolset.type).to.equal('agent_toolset_20260401');
+    expect(toolset.default_config).to.deep.equal(MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG);
+    expect(toolset.configs).to.have.lengthOf(CLAUDE_BUILTIN_TOOLS.length);
+
+    const bashConfig = toolset.configs.find((c) => c.name === 'bash');
+    expect(bashConfig?.enabled).to.equal(true);
+  });
+
+  it('sets always_allow on each mcp_toolset default_config', () => {
+    const payload = buildToolsPayload(undefined, [{ name: 'GitHub', url: 'https://mcp.example.com/github' }]);
+    const mcpToolset = payload.find((entry) => entry.type === 'mcp_toolset');
+
+    expect(mcpToolset).to.deep.equal({
+      type: 'mcp_toolset',
+      mcp_server_name: 'GitHub',
+      default_config: MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG,
+    });
   });
 });

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
@@ -193,6 +193,18 @@ export function mapMcpServer(raw: Record<string, unknown>): AgentMcpServerDto {
 }
 
 /**
+ * Default permission policy for managed-agent toolsets we provision.
+ * Builtin tools default to `always_allow` when omitted, but MCP toolsets
+ * default to `always_ask` — we set this explicitly on both so Novu-created
+ * agents do not pause for approval on every tool invocation.
+ *
+ * @see https://platform.claude.com/docs/en/managed-agents/permission-policies
+ */
+export const MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG = {
+  permission_policy: { type: 'always_allow' },
+} as const;
+
+/**
  * The agent response `tools` array contains toolset objects, not plain tool entries.
  * Flatten builtin toolset configs into individual AgentToolDto entries.
  *
@@ -241,12 +253,17 @@ export function buildToolsPayload(
 
   payload.push({
     type: 'agent_toolset_20260401',
+    default_config: MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG,
     configs: allToolNames.map((name) => ({ name, enabled: enabledSet.has(name) })),
   });
 
   if (mcpServers) {
     for (const server of mcpServers) {
-      payload.push({ type: 'mcp_toolset', mcp_server_name: server.name });
+      payload.push({
+        type: 'mcp_toolset',
+        mcp_server_name: server.name,
+        default_config: MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG,
+      });
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When Novu provisions or syncs Claude managed agents, MCP servers are registered via `mcp_toolset` entries in the Anthropic `tools` payload. Anthropic defaults MCP toolsets to `always_ask`, which pauses every MCP tool invocation until the user approves it.

This change sets `default_config.permission_policy` to `always_allow` on both:

- `agent_toolset_20260401` (builtin tools)
- `mcp_toolset` (per enabled MCP server)

so agents created through the managed-agent flow (create agent, enable MCP, sync) run tools without requiring confirmation on each call.

## Implementation

- Added `MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG` in `anthropic-runtime.helpers.ts`
- Applied it in `buildToolsPayload`, which is used by `createAgent` and `updateConfig` on the Anthropic runtime provider

## References

- [Anthropic permission policies](https://platform.claude.com/docs/en/managed-agents/permission-policies)

## Testing

- `pnpm build` in `libs/application-generic` (TypeScript compile)
- Unit tests added/updated in `anthropic-runtime.helpers.spec.ts` and `anthropic-agent-runtime.provider.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db476703-3dbc-4f41-a8fc-06cbfa459467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db476703-3dbc-4f41-a8fc-06cbfa459467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

When Novu provisions or syncs Anthropic-managed agents, MCP servers now default to `always_allow` permission policy instead of `always_ask`. This prevents MCP tool invocations from pausing for user approval on each call. A new constant `MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG` was introduced and applied to both builtin agent toolsets and per-enabled MCP server payloads in the `buildToolsPayload` function.

## Affected areas

**shared**: Updated Anthropic agent runtime to include default permission policy configuration for both builtin tools (`agent_toolset_20260401`) and MCP toolsets. The `buildToolsPayload` function now sets `default_config.permission_policy` to `always_allow` on all toolset entries sent to the Anthropic API.

## Key technical decisions

- Introduced a centralized constant `MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG` to maintain consistency across all managed-agent toolsets and simplify future updates to permission policies.

## Testing

Unit tests were added and updated in `anthropic-runtime.helpers.spec.ts` and `anthropic-agent-runtime.provider.spec.ts` to verify that `buildToolsPayload` correctly sets the `default_config` structure on both agent toolsets and MCP toolsets. TypeScript compilation was verified via `pnpm build` in `libs/application-generic`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->