### PR TITLE
fix(dashboard): rename custom scaffold connector label fixes NV-7819

### DIFF
--- a/apps/dashboard/src/components/agents/connectors/connector-options.tsx
+++ b/apps/dashboard/src/components/agents/connectors/connector-options.tsx
@@ -104,7 +104,7 @@ export const CONNECTOR_OPTIONS: ConnectorOption[] = [
   },
   {
     id: 'custom-scaffold',
-    label: 'Custom scaffold [AI SDK, LangChain]',
+    label: 'Custom code (AI SDK, langchain, etc...)',
     group: 'custom',
     icon: CUSTOM_CODE_AVATAR,
     comingSoon: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renames the custom scaffold option in the Agent integration connector dropdown to **Custom code (AI SDK, langchain, etc...)** so the label better reflects self-hosted / bring-your-own-runtime setups.

## Changes

- Update `CONNECTOR_OPTIONS` label for `custom-scaffold` in `connector-options.tsx` (used by create-agent dialog, connector integration dropdown, and onboarding connect-agent flow).

## Testing

- Copy-only change; no logic updates.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779775267416449?thread_ts=1779775267.416449&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-98fc25ff-12f9-57d4-b7af-de9b685f3dba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98fc25ff-12f9-57d4-b7af-de9b685f3dba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Updated the display label for the custom scaffold connector option in the agent integration dropdown from "Custom scaffold [AI SDK, LangChain]" to "Custom code (AI SDK, langchain, etc...)". This label change better reflects the purpose of this self-hosted, bring-your-own-runtime setup option. The change is copy-only with no logic or behavioral modifications.

## Affected areas

**`@novu/dashboard`**: Updated the `CONNECTOR_OPTIONS` constant in the connector-options component to reflect the new label for the custom-scaffold connector, which appears in the agent creation dialog, connector integration dropdown, and onboarding flow.

## Testing

No tests added, as this is a UI label-only change with no logic modifications. Manual verification of the label update in the agent creation and onboarding flows is sufficient.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->