### PR TITLE
docs(root): refactor README provider list into collapsible tables fixes DOC-335

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,6 @@ With Novu, you can create custom workflows and define conditions for each channe
 - [Getting Started](https://github.com/novuhq/novu#-getting-started)
 - [Embeddable Inbox and Preferences](https://github.com/novuhq/novu#embeddable-notification-center)
 - [Providers](https://github.com/novuhq/novu#providers)
-  - [Email](https://github.com/novuhq/novu#-email)
-  - [SMS](https://github.com/novuhq/novu#-sms)
-  - [Push](https://github.com/novuhq/novu#-push)
-  - [Chat](https://github.com/novuhq/novu#-chat)
-  - [In-App](https://github.com/novuhq/novu#-in-app)
-  - [Others](https://github.com/novuhq/novu#other-coming-soon)
 - [Need Help?](https://github.com/novuhq/novu#-need-help)
 - [Links](https://github.com/novuhq/novu#-links)
 - [License](https://github.com/novuhq/novu#%EF%B8%8F-license)
@@ -109,64 +103,134 @@ Read more about how to add a [notification center Inbox](https://docs.novu.co/in
 
 ## Providers
 
-Novu provides a single API to manage providers across multiple channels with a simple-to-use API and UI interface.
+Novu provides a single API to manage providers across multiple channels with a simple-to-use API and UI interface. Each integration links to its implementation in [`packages/providers`](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib).
 
-#### 💌 Email
+| Channel | Integrations |
+| --- | ---: |
+| 💌 Email | 19 |
+| 📞 SMS | 37 |
+| 📱 Push | 8 |
+| 💬 Chat | 12 |
+| 📥 In-App | 1 |
 
-- [x] [Sendgrid](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/sendgrid)
-- [x] [Netcore](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/netcore)
-- [x] [Mailgun](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/mailgun)
-- [x] [SES](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/ses)
-- [x] [Postmark](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/postmark)
-- [x] [Custom SMTP](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/nodemailer)
-- [x] [Mailjet](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/mailjet)
-- [x] [Mandrill](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/mandrill)
-- [x] [Brevo (formerly SendinBlue)](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/brevo)
-- [x] [MailerSend](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/mailersend)
-- [x] [Infobip](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/infobip)
-- [x] [Resend](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/resend)
-- [x] [SparkPost](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/sparkpost)
-- [x] [Outlook 365](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/outlook365)
+Expand a channel below to browse supported providers.
 
-#### 📞 SMS
+<details>
+<summary><strong>💌 Email</strong> (19 providers)</summary>
 
-- [x] [Twilio](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/twilio)
-- [x] [Plivo](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/plivo)
-- [x] [SNS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/sns)
-- [x] [Nexmo - Vonage](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/nexmo)
-- [x] [Sms77](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/sms77)
-- [x] [Telnyx](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/telnyx)
-- [x] [Termii](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/termii)
-- [x] [Gupshup](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/gupshup)
-- [x] [SMS Central](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/sms-central)
-- [x] [Maqsam](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/maqsam)
-- [x] [46elks](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/forty-six-elks)
-- [x] [Clickatell](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/clickatell)
-- [x] [Burst SMS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/burst-sms)
-- [x] [Firetext](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/firetext)
-- [x] [Infobip](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/infobip)
-- [ ] Bandwidth
-- [ ] RingCentral
+| Provider |
+| --- |
+| [Amazon SES](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/ses) |
+| [Braze](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/braze) |
+| [Brevo](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/brevo) |
+| [Custom SMTP](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/nodemailer) |
+| [Email Webhook](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/email-webhook) |
+| [Email.js](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/emailjs) |
+| [Infobip](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/infobip) |
+| [MailerSend](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/mailersend) |
+| [Mailgun](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/mailgun) |
+| [Mailjet](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/mailjet) |
+| [Mailtrap](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/mailtrap) |
+| [Mandrill](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/mandrill) |
+| [Netcore](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/netcore) |
+| [Outlook 365](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/outlook365) |
+| [Plunk](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/plunk) |
+| [Postmark](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/postmark) |
+| [Resend](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/resend) |
+| [SendGrid](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/sendgrid) |
+| [SparkPost](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/email/sparkpost) |
 
-#### 📱 Push
+</details>
 
-- [x] [FCM](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/fcm)
-- [x] [Expo](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/expo)
-- [x] [APNS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/apns)
-- [x] [OneSignal](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/one-signal)
-- [x] [Pushpad](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/pushpad)
-- [ ] Pushwoosh
+<details>
+<summary><strong>📞 SMS</strong> (37 providers)</summary>
 
-#### 👇 Chat
+| Provider |
+| --- |
+| [46elks](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/forty-six-elks) |
+| [Africa's Talking](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/africas-talking) |
+| [Afro SMS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/afro-sms) |
+| [Amazon SNS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/sns) |
+| [Azure SMS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/azure-sms) |
+| [Bandwidth](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/bandwidth) |
+| [Brevo SMS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/brevo-sms) |
+| [Bulk SMS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/bulk-sms) |
+| [Burst SMS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/burst-sms) |
+| [Clickatell](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/clickatell) |
+| [ClickSend](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/clicksend) |
+| [CM Telecom](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/cm-telecom) |
+| [Eazy SMS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/eazy-sms) |
+| [Firetext](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/firetext) |
+| [Generic SMS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/generic-sms) |
+| [Gupshup](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/gupshup) |
+| [iMedia](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/imedia) |
+| [Infobip](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/infobip) |
+| [iSend SMS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/isend-sms) |
+| [iSendPro SMS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/isendpro-sms) |
+| [Kannel](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/kannel) |
+| [Maqsam](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/maqsam) |
+| [MessageBird](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/messagebird) |
+| [Mobishastra](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/mobishastra) |
+| [Plivo](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/plivo) |
+| [RingCentral](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/ring-central) |
+| [Sendchamp](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/sendchamp) |
+| [SimpleTexting](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/simpletexting) |
+| [Sinch](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/sinch) |
+| [SMS Central](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/sms-central) |
+| [SMS77](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/sms77) |
+| [SMSMode](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/smsmode) |
+| [Telnyx](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/telnyx) |
+| [Termii](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/termii) |
+| [Twilio](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/twilio) |
+| [Unifonic](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/unifonic) |
+| [Vonage](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/sms/nexmo) |
 
-- [x] [Slack](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/slack)
-- [x] [Discord](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/discord)
-- [x] [MS Teams](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/msTeams)
-- [x] [Mattermost](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/mattermost)
+</details>
 
-#### 📱 In-App
+<details>
+<summary><strong>📱 Push</strong> (8 providers)</summary>
 
-- [x] [Novu](https://docs.novu.co/inbox/react/get-started?utm_source=github&utm_medium=repository&utm_campaign=inbox-channel-link)
+| Provider |
+| --- |
+| [APNS](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/apns) |
+| [App.io](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/appio) |
+| [Expo](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/expo) |
+| [FCM](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/fcm) |
+| [OneSignal](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/one-signal) |
+| [Push Webhook](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/push-webhook) |
+| [Pusher Beams](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/pusher-beams) |
+| [Pushpad](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/push/pushpad) |
+
+</details>
+
+<details>
+<summary><strong>💬 Chat</strong> (12 providers)</summary>
+
+| Provider |
+| --- |
+| [Chat Webhook](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/chat-webhook) |
+| [Discord](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/discord) |
+| [GetStream](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/getstream) |
+| [Grafana OnCall](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/grafana-on-call) |
+| [Mattermost](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/mattermost) |
+| [Microsoft Teams](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/msTeams) |
+| [Rocket.Chat](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/rocket-chat) |
+| [Ryver](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/ryver) |
+| [Slack](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/slack) |
+| [Telegram](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/telegram) |
+| [WhatsApp Business](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/whatsapp-business) |
+| [Zulip](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib/chat/zulip) |
+
+</details>
+
+<details>
+<summary><strong>📥 In-App</strong> (1 provider)</summary>
+
+| Provider |
+| --- |
+| [Novu Inbox](https://docs.novu.co/inbox/react/get-started?utm_source=github&utm_medium=repository&utm_campaign=inbox-channel-link) |
+
+</details>
 
 ## 📋 Read Our Code Of Conduct
 

--- a/README.md
+++ b/README.md
@@ -103,15 +103,7 @@ Read more about how to add a [notification center Inbox](https://docs.novu.co/in
 
 ## Providers
 
-Novu provides a single API to manage providers across multiple channels with a simple-to-use API and UI interface. Each integration links to its implementation in [`packages/providers`](https://github.com/novuhq/novu/tree/next/packages/providers/src/lib).
-
-| Channel | Integrations |
-| --- | ---: |
-| 💌 Email | 19 |
-| 📞 SMS | 37 |
-| 📱 Push | 8 |
-| 💬 Chat | 12 |
-| 📥 In-App | 1 |
+Novu provides a single API to manage providers across multiple channels with a simple-to-use API and UI interface.
 
 Expand a channel below to browse supported providers.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors the root README **Providers** section, which had grown into a long, outdated checklist.

## Changes

- Adds a **channel summary table** (Email, SMS, Push, Chat, In-App) with integration counts
- Replaces checkbox lists with **collapsible `<details>` sections** containing per-channel provider tables
- Syncs the list with current implementations in `packages/providers` (76 integrations + Novu Inbox)
- Adds previously missing providers (e.g. Braze, Mailtrap, Bandwidth, RingCentral, WhatsApp Business, webhooks)
- Removes stale "coming soon" entries that are already implemented

## Why

The old format was hard to scan on GitHub and no longer matched the codebase. Collapsible tables keep the README compact while still exposing the full list on demand.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1779779189296779?thread_ts=1779779189.296779&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-a1127f15-73f6-510c-8c9f-c5a4fe67f445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1127f15-73f6-510c-8c9f-c5a4fe67f445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The root README's Providers section has been refactored from an outdated checkbox-style list to a more maintainable format. A new channel summary table was added (Email, SMS, Push, Chat, In-App) showing integration counts, followed by collapsible `<details>` sections per channel containing provider tables. The list now reflects 76 current integrations plus the Novu Inbox, with previously missing providers added (e.g., Braze, Mailtrap, Bandwidth, RingCentral, WhatsApp Business) and stale "coming soon" entries removed.

## Affected areas
**Documentation** – The README.md Providers section was restructured. The Table of Contents no longer references individual provider-category entries, instead jumping directly from "Embeddable Inbox and Preferences" to support sections. Provider information is now presented via collapsible details blocks with markdown tables, making the README more scannable while keeping it compact on GitHub's web interface.

## Testing
Manual verification was performed to ensure the collapsible tables render correctly on GitHub and that all listed providers are accurate and link to their implementations in `packages/providers`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->