### PR TITLE
fix(api): steer agent generation toward concise replies

### DIFF
--- a/apps/api/src/app/agents/usecases/generate-managed-agent/generate-managed-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/generate-managed-agent/generate-managed-agent.usecase.ts
@@ -81,6 +81,8 @@ function buildSkillCatalog(): string {
   return CLAUDE_ANTHROPIC_SKILLS.map((skill) => `- ${skill.skillId} (${skill.name}): ${skill.description}`).join('\n');
 }
 
+const GENERATED_AGENT_RESPONSE_STYLE = `Include guidance that the agent should match reply length to each message: concise and direct when a short answer suffices; more thorough only when the user asks for analysis, reports, or step-by-step work. Avoid filler, repetition, and default verbosity — write like a helpful colleague. Do not impose fixed character or token limits; scale naturally with the ask.`;
+
 function buildSelfHostedSystemPrompt(): string {
   return `You are an expert AI agent architect for Novu. The user will describe — in plain English — what they want an agent to do. Your job is to scaffold the bare-bones agent metadata that Novu will use to provision a self-hosted agent runtime (AI SDK, LangChain, custom code, etc.). The user wires up their own tools, MCP servers and integrations — do NOT pick any of those.
 
@@ -88,6 +90,7 @@ Pick a clear human name, derive a kebab-case identifier, and write a system prom
 
 ## System prompt
 The \`systemPrompt\` is sent verbatim to the agent. Address the agent in second person ("You are a…"), describe its role, scope, tone, and the workflow it should follow when invoked. Do not reference Anthropic-specific tools, MCPs or skills — the runtime is custom.
+${GENERATED_AGENT_RESPONSE_STYLE}
 
 Return a JSON object matching the provided schema. Do not include any commentary outside the schema.`;
 }
@@ -121,6 +124,7 @@ You MUST select Claude built-in tools, MCP servers, and Anthropic Skills ONLY fr
 
 ## System prompt
 The \`systemPrompt\` is sent verbatim to Claude. Address the agent in second person ("You are a…"), describe its role, scope, tone, and the workflow it should follow when invoked. Do not enumerate the tool/MCP/skill IDs in the systemPrompt — Anthropic wires them in automatically.
+${GENERATED_AGENT_RESPONSE_STYLE}
 
 ## Identifier
 The \`identifier\` MUST be a kebab-case slug of the \`name\` (lowercase, hyphen-separated, ASCII only).
@@ -145,7 +149,7 @@ function buildUserPrompt(prompt: string): string {
 ${prompt.trim()}
 """
 
-Generate the complete agent configuration JSON. Pick a clear human name, derive a matching kebab-case identifier, write the systemPrompt as if instructing the agent, and select only the tools, MCP servers, and skills this agent actually needs — leave any array empty when its domain does not call for it.`;
+Generate the complete agent configuration JSON. Pick a clear human name, derive a matching kebab-case identifier, write the systemPrompt as if instructing the agent (with response-length guidance that scales to each message — not uniformly verbose), and select only the tools, MCP servers, and skills this agent actually needs — leave any array empty when its domain does not call for it.`;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adjusts the LLM prompts used by `POST /agents/generate` so generated agent `systemPrompt` values instruct the runtime to scale response length to each message instead of defaulting to long, verbose replies.

## Context

From #proj-conversations: generated agents tended to produce overly verbose responses. The goal is natural, request-appropriate length — concise for simple asks, more detailed when the user needs analysis or step-by-step work — without hard output character limits. Channel-specific tuning (e.g. WhatsApp vs email) is deferred to a future iteration.

## Changes

- Added shared `GENERATED_AGENT_RESPONSE_STYLE` guidance to both managed and self-hosted generation system prompts
- Reinforced the same expectation in the user prompt sent to the architect model

## Testing

- Prompt-only change; no runtime behavior change beyond generation output quality
- No new automated tests (generation is LLM-backed)

## Linear

Linear ticket to be linked — created from Slack thread in #proj-conversations (concise agent responses).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0AQDQ4J6UU/p1779772515997219?thread_ts=1779772515.997219&cid=C0AQDQ4J6UU)

<div><a href="https://cursor.com/agents/bc-3d9f9065-bb98-5ddd-a803-8d2580e522d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d9f9065-bb98-5ddd-a803-8d2580e522d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Modified the LLM prompts used by the agent generation endpoint (POST /agents/generate) to steer generated agents toward concise, request-appropriate replies. Added a shared `GENERATED_AGENT_RESPONSE_STYLE` prompt snippet that instructs agents to scale response length to each message—concise for simple asks, more thorough for analysis or step-by-step work—without imposing fixed character limits. This guidance was injected into both the managed agent and self-hosted agent generation prompts.

## Affected areas

**api**: The managed agent generation use case now includes response-length scaling guidance in both the system prompts (for managed and self-hosted runtimes) and the user prompt sent to the architect model, ensuring generated agents produce natural, context-appropriate responses instead of defaulting to verbose replies.

## Testing

This is a prompt-only change affecting LLM-based generation. No automated tests were added because the output depends on LLM behavior. Manual verification of generated agent system prompts would demonstrate the expected guidance is correctly embedded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->