### PR TITLE
fix(dashboard): redirect loop between connect and platform

### DIFF
--- a/apps/dashboard/src/components/auth/organization-picker.tsx
+++ b/apps/dashboard/src/components/auth/organization-picker.tsx
@@ -24,8 +24,12 @@ import { cn } from '@/utils/ui';
 
 const SLUG_MAX_LENGTH = 50;
 const SLUG_RETRY_LIMIT = 3;
-// ~6 rows tall (each row ≈ 56px). Past that the list scrolls and the Create CTA stays pinned.
-const ORG_LIST_MAX_HEIGHT = 'max-h-[336px]';
+// Row ≈ 56px (size-8 avatar + py-3). Cap visible rows at 6, past that the list scrolls.
+const ORG_LIST_VISIBLE_ROWS = 6;
+// Fixed height — Radix ScrollArea's Viewport uses h-full, which needs a definite parent
+// height to scroll. `max-h` alone leaves the Viewport auto-sized so content gets clipped
+// without a scrollbar appearing. Applied only when scrolling is actually needed.
+const ORG_LIST_SCROLL_HEIGHT = 'h-[336px]';
 // Clerk defaults to 10 per page — we override because the picker filters by `productType` and
 // needs the full list before it can decide whether to auto-switch to the create view. Bumping
 // to 100 (well under Clerk's 500 cap) puts virtually every real-world user on a single round trip.
@@ -207,6 +211,7 @@ function OrganizationListView({
   isLoadingMore,
 }: OrganizationListViewProps) {
   const productLabel = productFilter === 'connect' ? 'Novu Connect' : 'Novu Cloud';
+  const shouldScroll = memberships.length > ORG_LIST_VISIBLE_ROWS || isLoadingMore;
 
   return (
     <div className="flex w-full flex-col gap-6">
@@ -216,7 +221,7 @@ function OrganizationListView({
       </div>
 
       <div className="flex min-h-0 flex-col">
-        <ScrollArea className={cn('w-full', ORG_LIST_MAX_HEIGHT)}>
+        <ScrollArea className={cn('w-full', shouldScroll && ORG_LIST_SCROLL_HEIGHT)}>
           {/* `pr-2` reserves room for the overlay scrollbar so the row chevron doesn't get clipped. */}
           <div className="flex flex-col pr-2">
             <AnimatePresence initial={false} mode="popLayout">

--- a/apps/dashboard/src/pages/sign-in.tsx
+++ b/apps/dashboard/src/pages/sign-in.tsx
@@ -9,10 +9,13 @@ import { clerkSignupAppearance } from '@/utils/clerk-appearance';
 import { beginConnectProvisioning, buildConnectProvisionOrgListPath, isActiveConnectWorkspace } from '@/utils/connect';
 import { markInvitationAcceptIfPresent } from '@/utils/invitation-accept-signal';
 import {
+  appendRedirectUrl,
   buildAbsoluteConnectUrl,
   buildPrimarySignInUrl,
   CONNECT_PRODUCT_VALUE,
   PRODUCT_QUERY_PARAM,
+  readConnectSatelliteReturnUrl,
+  resolveConnectSatelliteReturnUrl,
 } from '@/utils/product-auth-urls';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -34,12 +37,23 @@ export const SignInPage = () => {
     [searchParams]
   );
 
+  const connectSatelliteReturnUrl = useMemo(
+    () => readConnectSatelliteReturnUrl(searchParams),
+    [searchParams]
+  );
+
   // Sign-in only runs on the primary; satellite visitors bounce back with the Connect flag.
   useEffect(() => {
-    if (IS_NOVU_CONNECT) {
-      window.location.replace(buildPrimarySignInUrl({ product: CONNECT_PRODUCT_VALUE }));
+    if (!IS_NOVU_CONNECT) {
+      return;
     }
-  }, []);
+
+    const primarySignInUrl = buildPrimarySignInUrl({ product: CONNECT_PRODUCT_VALUE });
+    const returnUrl = resolveConnectSatelliteReturnUrl(searchParams);
+    const targetUrl = returnUrl ? appendRedirectUrl(primarySignInUrl, returnUrl) : primarySignInUrl;
+
+    window.location.replace(targetUrl);
+  }, [searchParams]);
 
   // Capture invite-link entry (`__clerk_ticket` in the URL) BEFORE Clerk consumes the ticket
   // during sign-in. The picker reads this signal later to decide whether to hop across products.
@@ -62,6 +76,13 @@ export const SignInPage = () => {
     if (IS_NOVU_CONNECT) return; // satellite is mid-redirect to primary; let it finish.
 
     if (isConnectSignIn) {
+      // Satellite handshake: return via Clerk's redirect_url so the Connect session syncs.
+      if (connectSatelliteReturnUrl) {
+        window.location.assign(connectSatelliteReturnUrl);
+
+        return;
+      }
+
       if (!isUserLoaded || !isOrganizationLoaded) return;
 
       if (
@@ -88,7 +109,17 @@ export const SignInPage = () => {
       buildAppHomeRoute(getCurrentAppId(), 'default') ?? buildRoute(ROUTES.WORKFLOWS, { environmentSlug: 'default' });
 
     navigate(home, { replace: true });
-  }, [isLoaded, isSignedIn, isUserLoaded, isOrganizationLoaded, organization, user?.id, isConnectSignIn, navigate]);
+  }, [
+    isLoaded,
+    isSignedIn,
+    isUserLoaded,
+    isOrganizationLoaded,
+    organization,
+    user?.id,
+    isConnectSignIn,
+    connectSatelliteReturnUrl,
+    navigate,
+  ]);
 
   const connectProvisionRedirect = useMemo(
     () => buildAbsoluteConnectUrl(buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST)),
@@ -100,8 +131,9 @@ export const SignInPage = () => {
     ? `${ROUTES.SIGN_UP}?${PRODUCT_QUERY_PARAM}=${CONNECT_PRODUCT_VALUE}`
     : ROUTES.SIGN_UP;
 
-  // Render nothing while the satellite redirects to the primary so we don't flash the form.
-  if (IS_NOVU_CONNECT) {
+  // Render nothing while redirecting — mounting <SignIn> while signed in makes Clerk bounce to the
+  // home URL and causes a Platform ↔ Connect redirect loop during the satellite handshake.
+  if (IS_NOVU_CONNECT || (isLoaded && isSignedIn)) {
     return null;
   }
 

--- a/apps/dashboard/src/pages/sign-up.tsx
+++ b/apps/dashboard/src/pages/sign-up.tsx
@@ -8,10 +8,13 @@ import { clerkSignupAppearance } from '@/utils/clerk-appearance';
 import { beginConnectProvisioning, buildConnectProvisionOrgListPath, isActiveConnectWorkspace } from '@/utils/connect';
 import { markInvitationAcceptIfPresent } from '@/utils/invitation-accept-signal';
 import {
+  appendRedirectUrl,
   buildAbsoluteConnectUrl,
   buildPrimarySignUpUrl,
   CONNECT_PRODUCT_VALUE,
   PRODUCT_QUERY_PARAM,
+  readConnectSatelliteReturnUrl,
+  resolveConnectSatelliteReturnUrl,
 } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -32,12 +35,23 @@ export const SignUpPage = () => {
     [searchParams]
   );
 
+  const connectSatelliteReturnUrl = useMemo(
+    () => readConnectSatelliteReturnUrl(searchParams),
+    [searchParams]
+  );
+
   // Sign-up flows are primary-only — bounce satellite visitors back with Connect branding.
   useEffect(() => {
-    if (IS_NOVU_CONNECT) {
-      window.location.replace(buildPrimarySignUpUrl({ product: CONNECT_PRODUCT_VALUE }));
+    if (!IS_NOVU_CONNECT) {
+      return;
     }
-  }, []);
+
+    const primarySignUpUrl = buildPrimarySignUpUrl({ product: CONNECT_PRODUCT_VALUE });
+    const returnUrl = resolveConnectSatelliteReturnUrl(searchParams);
+    const targetUrl = returnUrl ? appendRedirectUrl(primarySignUpUrl, returnUrl) : primarySignUpUrl;
+
+    window.location.replace(targetUrl);
+  }, [searchParams]);
 
   // Capture invite-link entry (`__clerk_ticket` in the URL) BEFORE Clerk consumes the ticket
   // during sign-up. The picker reads this signal later to decide whether to hop across products.
@@ -59,6 +73,13 @@ export const SignUpPage = () => {
     if (!isLoaded || !isSignedIn) return;
     if (IS_NOVU_CONNECT) return;
     if (!isConnectSignUp) return;
+
+    if (connectSatelliteReturnUrl) {
+      window.location.assign(connectSatelliteReturnUrl);
+
+      return;
+    }
+
     if (!isUserLoaded || !isOrganizationLoaded) return;
 
     if (
@@ -75,7 +96,16 @@ export const SignUpPage = () => {
 
     beginConnectProvisioning();
     window.location.assign(buildAbsoluteConnectUrl(buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST)));
-  }, [isLoaded, isSignedIn, isUserLoaded, isOrganizationLoaded, organization, user?.id, isConnectSignUp]);
+  }, [
+    isLoaded,
+    isSignedIn,
+    isUserLoaded,
+    isOrganizationLoaded,
+    organization,
+    user?.id,
+    isConnectSignUp,
+    connectSatelliteReturnUrl,
+  ]);
 
   const connectProvisionRedirect = useMemo(
     () => buildAbsoluteConnectUrl(buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST)),
@@ -85,6 +115,10 @@ export const SignUpPage = () => {
   const signInUrlWithProduct = isConnectSignUp
     ? `${ROUTES.SIGN_IN}?${PRODUCT_QUERY_PARAM}=${CONNECT_PRODUCT_VALUE}`
     : ROUTES.SIGN_IN;
+
+  if (IS_NOVU_CONNECT || (isLoaded && isSignedIn)) {
+    return null;
+  }
 
   return (
     <div className="flex min-h-screen w-full flex-col md:max-w-[1120px] md:flex-row md:gap-36">

--- a/apps/dashboard/src/utils/product-auth-urls.ts
+++ b/apps/dashboard/src/utils/product-auth-urls.ts
@@ -58,3 +58,72 @@ export function buildPrimarySignInUrl(options?: PrimaryAuthUrlOptions): string {
 export function buildPrimarySignUpUrl(options?: PrimaryAuthUrlOptions): string {
   return buildAbsolutePlatformUrl(appendProductParam(ROUTES.SIGN_UP, options?.product));
 }
+
+export function isConnectHostnameUrl(url: string): boolean {
+  if (!IS_HOSTNAME_SPLIT_ENABLED || !NOVU_CONNECT_HOSTNAME || typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    return new URL(url, window.location.origin).host === NOVU_CONNECT_HOSTNAME;
+  } catch {
+    return false;
+  }
+}
+
+/** Clerk's satellite handshake return URL — must be honored so Connect receives the synced session. */
+export function readConnectSatelliteReturnUrl(searchParams: URLSearchParams): string | null {
+  const redirectUrl = searchParams.get('redirect_url');
+
+  if (!redirectUrl || !isConnectHostnameUrl(redirectUrl)) {
+    return null;
+  }
+
+  return redirectUrl;
+}
+
+export function appendRedirectUrl(primaryAuthUrl: string, returnUrl: string): string {
+  if (typeof window === 'undefined') {
+    return primaryAuthUrl;
+  }
+
+  try {
+    const url = new URL(primaryAuthUrl, window.location.origin);
+    url.searchParams.set('redirect_url', returnUrl);
+
+    return url.toString();
+  } catch {
+    return primaryAuthUrl;
+  }
+}
+
+function isConnectAuthPath(url: string): boolean {
+  try {
+    const pathname = new URL(url, typeof window !== 'undefined' ? window.location.origin : 'http://local').pathname;
+
+    return pathname.startsWith('/auth/');
+  } catch {
+    return false;
+  }
+}
+
+/** Return URL to send back to Connect after primary auth — skips auth pages that would re-bounce. */
+export function resolveConnectSatelliteReturnUrl(searchParams: URLSearchParams): string | null {
+  const fromQuery = readConnectSatelliteReturnUrl(searchParams);
+
+  if (fromQuery && !isConnectAuthPath(fromQuery)) {
+    return fromQuery;
+  }
+
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const currentLocation = window.location.href;
+
+  if (isConnectHostnameUrl(currentLocation) && !isConnectAuthPath(currentLocation)) {
+    return currentLocation;
+  }
+
+  return null;
+}


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Fixed a redirect loop between Connect and platform by properly handling satellite return URLs in sign-in and sign-up flows. The implementation reads return URLs from query parameters, validates they target the Connect hostname, and ensures redirects occur at the right time during Clerk authentication handshakes. Also improved organization picker scrolling behavior to render conditional viewport heights only when necessary.

## Affected areas
**dashboard**: Enhanced sign-in (`sign-in.tsx`) and sign-up (`sign-up.tsx`) pages to detect and redirect to Connect satellite return URLs during authentication. Added new URL utility functions in `product-auth-urls.ts` to determine if URLs target the Connect hostname, extract valid redirect targets, and resolve the appropriate return URL after primary authentication. Refactored `organization-picker.tsx` to improve scrolling behavior by conditionally applying viewport height constraints based on list size.

## Key technical decisions
- Return URL validation is restricted to only those targeting the Connect hostname, preventing open redirect vulnerabilities.
- Redirects via `window.location.assign` occur early in the authentication flow before other Connect/workspace logic to prevent re-bouncing.
- The sign-in/sign-up forms now return `null` during redirects to prevent flashing the form while authentication handshakes complete.
- Auth paths (`/auth/…`) are excluded from redirect logic to prevent re-entering auth flows.

## Testing
No tests are mentioned in the provided summary; this fix likely requires manual verification of authentication flows between Connect and platform environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
