### PR TITLE
feat(dashboard): enhance Clerk integration for cross-origin session sync

### DIFF
--- a/apps/dashboard/.example.env
+++ b/apps/dashboard/.example.env
@@ -15,6 +15,9 @@ VITE_NOVU_ENTERPRISE=false
 # Local dev: Platform at http://localhost:4201, Connect at http://connect.localhost:4201.
 VITE_NOVU_PLATFORM_HOSTNAME=
 VITE_NOVU_CONNECT_HOSTNAME=
+# Connect satellite only — Clerk FAPI CNAME (clerk.<connect-domain> → frontend-api.clerk.services).
+# Defaults to https://clerk.${VITE_NOVU_CONNECT_HOSTNAME} when unset; override if your CNAME differs.
+VITE_CLERK_PROXY_URL=
 
 # Multi-Region Configuration
 # List of region codes (comma-separated). FIRST region is the base/default region.

--- a/apps/dashboard/netlify.toml
+++ b/apps/dashboard/netlify.toml
@@ -18,6 +18,19 @@
   to = "/index.html"
   status = 200
 
+# Clerk satellite handshakes redirect through /auth/* — prevent Netlify CDN from caching
+# stale 200/index.html responses during cross-domain session sync (known Clerk + Netlify issue).
+[[headers]]
+  for = "/auth/*"
+  [headers.values]
+    Cache-Control = "private, no-cache, no-store, must-revalidate"
+    Netlify-CDN-Cache-Control = "private, no-cache, no-store, must-revalidate"
+
+[[headers]]
+  for = "/index.html"
+  [headers.values]
+    Netlify-CDN-Cache-Control = "private, no-cache"
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/apps/dashboard/src/components/auth/organization-picker.tsx
+++ b/apps/dashboard/src/components/auth/organization-picker.tsx
@@ -1,4 +1,4 @@
-import { useOrganizationList, useUser } from '@clerk/react';
+import { useOrganizationList, useUser, useClerk } from '@clerk/react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { RiAddCircleLine, RiArrowRightSLine, RiLoader4Line } from 'react-icons/ri';
@@ -12,7 +12,7 @@ import { IS_NOVU_CONNECT } from '@/config';
 import { RegionSelector, useShouldShowRegionSelector } from '@/context/region';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { APP_IDS, type AppId } from '@/utils/apps';
-import { isConnectWorkspace, writeConnectAutoCreateSessionGuard } from '@/utils/connect';
+import { isConnectWorkspace, navigateWithClerkSessionIfCrossOrigin, writeConnectAutoCreateSessionGuard } from '@/utils/connect';
 import { buildOtherProductOrgListUrl } from '@/utils/cross-product-redirect';
 import {
   clearInvitationAcceptPending,
@@ -395,6 +395,7 @@ export function OrganizationPicker({
 }: OrganizationPickerProps) {
   const track = useTelemetry();
   const { user } = useUser();
+  const clerk = useClerk();
 
   const productFilter = useMemo(getProductFilter, []);
   const productAppId = useMemo(() => getProductAppId(productFilter), [productFilter]);
@@ -498,9 +499,9 @@ export function OrganizationPicker({
     if (isInvitationAcceptPending() && hasCrossProductMembership(allMemberships, productFilter)) {
       const otherProductUrl = buildOtherProductOrgListUrl(productFilter);
 
-      if (otherProductUrl) {
+      if (otherProductUrl && clerk.loaded) {
         clearInvitationAcceptPending();
-        window.location.assign(otherProductUrl);
+        navigateWithClerkSessionIfCrossOrigin(clerk, otherProductUrl);
 
         return;
       }
@@ -508,7 +509,7 @@ export function OrganizationPicker({
 
     clearInvitationAcceptPending();
     setView('create');
-  }, [isFullListLoaded, filteredMemberships.length, allMemberships, productFilter]);
+  }, [isFullListLoaded, filteredMemberships.length, allMemberships, productFilter, clerk.loaded, clerk]);
 
   const handleSelect = useCallback(
     async (organizationId: string) => {

--- a/apps/dashboard/src/config/index.ts
+++ b/apps/dashboard/src/config/index.ts
@@ -49,12 +49,25 @@ export function normalizeAppHost(host: string): string {
   return host.trim().toLowerCase();
 }
 
+function getHostnameWithoutPort(host: string): string {
+  return normalizeAppHost(host).split(':')[0];
+}
+
+/** Clerk proxy CNAME only exists on deployed Connect domains — not localhost dev hosts. */
+function shouldUseDefaultClerkProxy(connectHostname: string): boolean {
+  const hostname = getHostnameWithoutPort(connectHostname);
+
+  return hostname !== 'localhost' && !hostname.endsWith('.localhost');
+}
+
 // Clerk FAPI proxy on the Connect satellite (CNAME `clerk.<connect-domain>` → frontend-api.clerk.services).
-// Required for reliable satellite session sync on static hosts (Netlify); optional locally.
+// Auto-default on deployed hosts only; set VITE_CLERK_PROXY_URL explicitly when needed.
 export const CLERK_PROXY_URL =
   window._env_?.VITE_CLERK_PROXY_URL ||
   import.meta.env.VITE_CLERK_PROXY_URL ||
-  (NOVU_CONNECT_HOSTNAME ? `https://clerk.${normalizeAppHost(NOVU_CONNECT_HOSTNAME).split(':')[0]}` : '');
+  (NOVU_CONNECT_HOSTNAME && shouldUseDefaultClerkProxy(NOVU_CONNECT_HOSTNAME)
+    ? `https://clerk.${getHostnameWithoutPort(NOVU_CONNECT_HOSTNAME)}`
+    : '');
 
 // Fail fast when the hostname split is half-configured. Without `NOVU_PLATFORM_HOSTNAME`,
 // satellite → primary handoffs (Clerk sign-in, cross-product redirects) silently break.

--- a/apps/dashboard/src/config/index.ts
+++ b/apps/dashboard/src/config/index.ts
@@ -44,6 +44,18 @@ export const NOVU_CONNECT_HOSTNAME =
 export const NOVU_PLATFORM_HOSTNAME =
   window._env_?.VITE_NOVU_PLATFORM_HOSTNAME || import.meta.env.VITE_NOVU_PLATFORM_HOSTNAME || '';
 
+/** Lowercase host comparison — env may omit port locally while `location.host` includes it. */
+export function normalizeAppHost(host: string): string {
+  return host.trim().toLowerCase();
+}
+
+// Clerk FAPI proxy on the Connect satellite (CNAME `clerk.<connect-domain>` → frontend-api.clerk.services).
+// Required for reliable satellite session sync on static hosts (Netlify); optional locally.
+export const CLERK_PROXY_URL =
+  window._env_?.VITE_CLERK_PROXY_URL ||
+  import.meta.env.VITE_CLERK_PROXY_URL ||
+  (NOVU_CONNECT_HOSTNAME ? `https://clerk.${normalizeAppHost(NOVU_CONNECT_HOSTNAME).split(':')[0]}` : '');
+
 // Fail fast when the hostname split is half-configured. Without `NOVU_PLATFORM_HOSTNAME`,
 // satellite → primary handoffs (Clerk sign-in, cross-product redirects) silently break.
 if (NOVU_CONNECT_HOSTNAME && !NOVU_PLATFORM_HOSTNAME) {
@@ -58,7 +70,7 @@ export const IS_HOSTNAME_SPLIT_ENABLED = NOVU_CONNECT_HOSTNAME.length > 0;
 export const IS_NOVU_CONNECT =
   IS_HOSTNAME_SPLIT_ENABLED &&
   typeof window !== 'undefined' &&
-  window.location.host === NOVU_CONNECT_HOSTNAME;
+  normalizeAppHost(window.location.host) === normalizeAppHost(NOVU_CONNECT_HOSTNAME);
 
 // True when the hostname split is disabled (single-host deploys) AND when the split is enabled
 // but the current host does not match `NOVU_CONNECT_HOSTNAME`. Mirrors `IS_NOVU_CONNECT` /

--- a/apps/dashboard/src/context/ee-auth-provider.tsx
+++ b/apps/dashboard/src/context/ee-auth-provider.tsx
@@ -1,11 +1,13 @@
 import { buttonVariants } from '@/components/primitives/button';
 import {
   CLERK_PUBLISHABLE_KEY,
+  CLERK_PROXY_URL,
   EE_AUTH_PROVIDER,
   IS_ENTERPRISE,
   IS_HOSTNAME_SPLIT_ENABLED,
   IS_NOVU_CONNECT,
   IS_SELF_HOSTED,
+  normalizeAppHost,
   NOVU_CONNECT_HOSTNAME,
   NOVU_PLATFORM_HOSTNAME,
 } from '@/config';
@@ -86,18 +88,19 @@ export const EEAuthProvider = (props: EEAuthProviderProps) => {
   const satelliteProps = isSatellite
     ? {
         isSatellite: true as const,
-        domain: NOVU_CONNECT_HOSTNAME,
+        domain: normalizeAppHost(NOVU_CONNECT_HOSTNAME).split(':')[0],
+        ...(CLERK_PROXY_URL ? { proxyUrl: CLERK_PROXY_URL } : {}),
       }
     : {};
 
   const allowedRedirectOrigins: Array<string | RegExp> = [
     'http://localhost:*',
     ...(typeof window !== 'undefined' ? [window.location.origin] : []),
-    ...(IS_HOSTNAME_SPLIT_ENABLED && NOVU_PLATFORM_HOSTNAME && typeof window !== 'undefined'
-      ? [`${window.location.protocol}//${NOVU_PLATFORM_HOSTNAME}`]
+    ...(IS_HOSTNAME_SPLIT_ENABLED && NOVU_PLATFORM_HOSTNAME
+      ? [`https://${normalizeAppHost(NOVU_PLATFORM_HOSTNAME).split(':')[0]}`]
       : []),
-    ...(IS_HOSTNAME_SPLIT_ENABLED && NOVU_CONNECT_HOSTNAME && typeof window !== 'undefined'
-      ? [`${window.location.protocol}//${NOVU_CONNECT_HOSTNAME}`]
+    ...(IS_HOSTNAME_SPLIT_ENABLED && NOVU_CONNECT_HOSTNAME
+      ? [`https://${normalizeAppHost(NOVU_CONNECT_HOSTNAME).split(':')[0]}`]
       : []),
   ];
 

--- a/apps/dashboard/src/pages/sign-in.tsx
+++ b/apps/dashboard/src/pages/sign-in.tsx
@@ -6,12 +6,15 @@ import { IS_NOVU_CONNECT, IS_SELF_HOSTED } from '@/config';
 import { useSegment } from '@/context/segment';
 import { buildAppHomeRoute, getCurrentAppId } from '@/utils/apps';
 import { clerkSignupAppearance } from '@/utils/clerk-appearance';
-import { beginConnectProvisioning, buildConnectProvisionOrgListPath, isActiveConnectWorkspace } from '@/utils/connect';
+import {
+  beginConnectProvisioning,
+  buildConnectProvisionOrgListPath,
+  navigateToConnectWithClerkSession,
+  redirectSatelliteToPrimarySignIn,
+} from '@/utils/connect';
 import { markInvitationAcceptIfPresent } from '@/utils/invitation-accept-signal';
 import {
-  appendRedirectUrl,
   buildAbsoluteConnectUrl,
-  buildPrimarySignInUrl,
   CONNECT_PRODUCT_VALUE,
   PRODUCT_QUERY_PARAM,
   readConnectSatelliteReturnUrl,
@@ -20,17 +23,19 @@ import {
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { getReferrer, getUtmParams } from '@/utils/tracking';
-import { SignIn as SignInForm, useAuth, useOrganization, useUser } from '@clerk/react';
-import { useEffect, useMemo } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { SignIn as SignInForm, useAuth, useClerk } from '@clerk/react';
+import { useEffect, useMemo, useRef } from 'react';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 export const SignInPage = () => {
   const segment = useSegment();
   const { isSignedIn, isLoaded } = useAuth();
-  const { user, isLoaded: isUserLoaded } = useUser();
-  const { organization, isLoaded: isOrganizationLoaded } = useOrganization();
+  const clerk = useClerk();
   const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
+  const hasRedirectedToPrimaryRef = useRef(false);
+  const hasRedirectedToConnectRef = useRef(false);
 
   const isConnectSignIn = useMemo(
     () => searchParams.get(PRODUCT_QUERY_PARAM) === CONNECT_PRODUCT_VALUE || IS_NOVU_CONNECT,
@@ -39,21 +44,25 @@ export const SignInPage = () => {
 
   const connectSatelliteReturnUrl = useMemo(
     () => readConnectSatelliteReturnUrl(searchParams),
-    [searchParams]
+    [searchParams, location.hash, location.search]
   );
 
-  // Sign-in only runs on the primary; satellite visitors bounce back with the Connect flag.
+  const connectDefaultDestination = useMemo(
+    () => buildAbsoluteConnectUrl(buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST)),
+    []
+  );
+
+  // Sign-in only runs on the primary; satellite visitors bounce via Clerk.buildSignInUrl (sync params).
   useEffect(() => {
-    if (!IS_NOVU_CONNECT) {
+    if (!IS_NOVU_CONNECT || !clerk.loaded || hasRedirectedToPrimaryRef.current) {
       return;
     }
 
-    const primarySignInUrl = buildPrimarySignInUrl({ product: CONNECT_PRODUCT_VALUE });
+    hasRedirectedToPrimaryRef.current = true;
     const returnUrl = resolveConnectSatelliteReturnUrl(searchParams);
-    const targetUrl = returnUrl ? appendRedirectUrl(primarySignInUrl, returnUrl) : primarySignInUrl;
 
-    window.location.replace(targetUrl);
-  }, [searchParams]);
+    redirectSatelliteToPrimarySignIn(clerk, returnUrl);
+  }, [searchParams, location.hash, location.search, clerk.loaded, clerk]);
 
   // Capture invite-link entry (`__clerk_ticket` in the URL) BEFORE Clerk consumes the ticket
   // during sign-in. The picker reads this signal later to decide whether to hop across products.
@@ -72,35 +81,20 @@ export const SignInPage = () => {
   }, []);
 
   useEffect(() => {
-    if (!isLoaded || !isSignedIn) return;
-    if (IS_NOVU_CONNECT) return; // satellite is mid-redirect to primary; let it finish.
+    if (!isLoaded || !isSignedIn || IS_NOVU_CONNECT || !clerk.loaded || hasRedirectedToConnectRef.current) {
+      return;
+    }
 
     if (isConnectSignIn) {
-      // Satellite handshake: return via Clerk's redirect_url so the Connect session syncs.
-      if (connectSatelliteReturnUrl) {
-        window.location.assign(connectSatelliteReturnUrl);
+      hasRedirectedToConnectRef.current = true;
 
-        return;
+      const destination = connectSatelliteReturnUrl ?? connectDefaultDestination;
+
+      if (!connectSatelliteReturnUrl) {
+        beginConnectProvisioning();
       }
 
-      if (!isUserLoaded || !isOrganizationLoaded) return;
-
-      if (
-        organization &&
-        isActiveConnectWorkspace(organization.publicMetadata, {
-          userId: user?.id,
-          organizationId: organization.id,
-        })
-      ) {
-        window.location.assign(buildAbsoluteConnectUrl(ROUTES.ENV));
-
-        return;
-      }
-
-      beginConnectProvisioning();
-      window.location.assign(
-        buildAbsoluteConnectUrl(buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST))
-      );
+      navigateToConnectWithClerkSession(clerk, destination);
 
       return;
     }
@@ -112,19 +106,14 @@ export const SignInPage = () => {
   }, [
     isLoaded,
     isSignedIn,
-    isUserLoaded,
-    isOrganizationLoaded,
-    organization,
-    user?.id,
     isConnectSignIn,
     connectSatelliteReturnUrl,
+    connectDefaultDestination,
+    clerk,
     navigate,
   ]);
 
-  const connectProvisionRedirect = useMemo(
-    () => buildAbsoluteConnectUrl(buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST)),
-    []
-  );
+  const connectProvisionRedirect = useMemo(() => connectDefaultDestination, [connectDefaultDestination]);
 
   // Preserve `?product=connect` across the Clerk sign-in ↔ sign-up link so branding survives.
   const signUpUrlWithProduct = isConnectSignIn

--- a/apps/dashboard/src/pages/sign-up.tsx
+++ b/apps/dashboard/src/pages/sign-up.tsx
@@ -5,12 +5,15 @@ import { PageMeta } from '@/components/page-meta';
 import { IS_NOVU_CONNECT, IS_SELF_HOSTED } from '@/config';
 import { useSegment } from '@/context/segment';
 import { clerkSignupAppearance } from '@/utils/clerk-appearance';
-import { beginConnectProvisioning, buildConnectProvisionOrgListPath, isActiveConnectWorkspace } from '@/utils/connect';
+import {
+  beginConnectProvisioning,
+  buildConnectProvisionOrgListPath,
+  navigateToConnectWithClerkSession,
+  redirectSatelliteToPrimarySignUp,
+} from '@/utils/connect';
 import { markInvitationAcceptIfPresent } from '@/utils/invitation-accept-signal';
 import {
-  appendRedirectUrl,
   buildAbsoluteConnectUrl,
-  buildPrimarySignUpUrl,
   CONNECT_PRODUCT_VALUE,
   PRODUCT_QUERY_PARAM,
   readConnectSatelliteReturnUrl,
@@ -19,16 +22,18 @@ import {
 import { ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { getReferrer, getUtmParams } from '@/utils/tracking';
-import { SignUp as SignUpForm, useAuth, useOrganization, useUser } from '@clerk/react';
-import { useEffect, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { SignUp as SignUpForm, useAuth, useClerk } from '@clerk/react';
+import { useEffect, useMemo, useRef } from 'react';
+import { useLocation, useSearchParams } from 'react-router-dom';
 
 export const SignUpPage = () => {
   const segment = useSegment();
   const { isSignedIn, isLoaded } = useAuth();
-  const { user, isLoaded: isUserLoaded } = useUser();
-  const { organization, isLoaded: isOrganizationLoaded } = useOrganization();
+  const clerk = useClerk();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
+  const hasRedirectedToPrimaryRef = useRef(false);
+  const hasRedirectedToConnectRef = useRef(false);
 
   const isConnectSignUp = useMemo(
     () => searchParams.get(PRODUCT_QUERY_PARAM) === CONNECT_PRODUCT_VALUE || IS_NOVU_CONNECT,
@@ -37,21 +42,25 @@ export const SignUpPage = () => {
 
   const connectSatelliteReturnUrl = useMemo(
     () => readConnectSatelliteReturnUrl(searchParams),
-    [searchParams]
+    [searchParams, location.hash, location.search]
   );
 
-  // Sign-up flows are primary-only — bounce satellite visitors back with Connect branding.
+  const connectDefaultDestination = useMemo(
+    () => buildAbsoluteConnectUrl(buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST)),
+    []
+  );
+
+  // Sign-up flows are primary-only — bounce satellite visitors via Clerk.buildSignUpUrl (sync params).
   useEffect(() => {
-    if (!IS_NOVU_CONNECT) {
+    if (!IS_NOVU_CONNECT || !clerk.loaded || hasRedirectedToPrimaryRef.current) {
       return;
     }
 
-    const primarySignUpUrl = buildPrimarySignUpUrl({ product: CONNECT_PRODUCT_VALUE });
+    hasRedirectedToPrimaryRef.current = true;
     const returnUrl = resolveConnectSatelliteReturnUrl(searchParams);
-    const targetUrl = returnUrl ? appendRedirectUrl(primarySignUpUrl, returnUrl) : primarySignUpUrl;
 
-    window.location.replace(targetUrl);
-  }, [searchParams]);
+    redirectSatelliteToPrimarySignUp(clerk, returnUrl);
+  }, [searchParams, location.hash, location.search, clerk.loaded, clerk]);
 
   // Capture invite-link entry (`__clerk_ticket` in the URL) BEFORE Clerk consumes the ticket
   // during sign-up. The picker reads this signal later to decide whether to hop across products.
@@ -70,47 +79,26 @@ export const SignUpPage = () => {
   }, []);
 
   useEffect(() => {
-    if (!isLoaded || !isSignedIn) return;
-    if (IS_NOVU_CONNECT) return;
-    if (!isConnectSignUp) return;
-
-    if (connectSatelliteReturnUrl) {
-      window.location.assign(connectSatelliteReturnUrl);
-
+    if (!isLoaded || !isSignedIn || IS_NOVU_CONNECT || !clerk.loaded || hasRedirectedToConnectRef.current) {
       return;
     }
 
-    if (!isUserLoaded || !isOrganizationLoaded) return;
-
-    if (
-      organization &&
-      isActiveConnectWorkspace(organization.publicMetadata, {
-        userId: user?.id,
-        organizationId: organization.id,
-      })
-    ) {
-      window.location.assign(buildAbsoluteConnectUrl(ROUTES.ENV));
-
+    if (!isConnectSignUp) {
       return;
     }
 
-    beginConnectProvisioning();
-    window.location.assign(buildAbsoluteConnectUrl(buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST)));
-  }, [
-    isLoaded,
-    isSignedIn,
-    isUserLoaded,
-    isOrganizationLoaded,
-    organization,
-    user?.id,
-    isConnectSignUp,
-    connectSatelliteReturnUrl,
-  ]);
+    hasRedirectedToConnectRef.current = true;
 
-  const connectProvisionRedirect = useMemo(
-    () => buildAbsoluteConnectUrl(buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST)),
-    []
-  );
+    const destination = connectSatelliteReturnUrl ?? connectDefaultDestination;
+
+    if (!connectSatelliteReturnUrl) {
+      beginConnectProvisioning();
+    }
+
+    navigateToConnectWithClerkSession(clerk, destination);
+  }, [isLoaded, isSignedIn, isConnectSignUp, connectSatelliteReturnUrl, connectDefaultDestination, clerk]);
+
+  const connectProvisionRedirect = useMemo(() => connectDefaultDestination, [connectDefaultDestination]);
 
   const signInUrlWithProduct = isConnectSignUp
     ? `${ROUTES.SIGN_IN}?${PRODUCT_QUERY_PARAM}=${CONNECT_PRODUCT_VALUE}`

--- a/apps/dashboard/src/utils/connect/clerk-cross-origin-auth.ts
+++ b/apps/dashboard/src/utils/connect/clerk-cross-origin-auth.ts
@@ -1,7 +1,17 @@
 import { isConnectHostnameUrl } from '@/utils/product-auth-urls';
 
-// Clerk + Netlify: CDN can cache handshake redirects and cause infinite auth loops (dev + some prod configs).
+// Clerk + Netlify: CDN can cache handshake redirects and cause infinite auth loops.
 const CLERK_NETLIFY_CACHE_BUST_PARAM = '__clerk_netlify_cache_bust';
+
+function isLocalDevRuntime(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const hostname = window.location.hostname;
+
+  return hostname === 'localhost' || hostname.endsWith('.localhost');
+}
 
 type ClerkCrossOriginAuth = {
   loaded: boolean;
@@ -12,6 +22,10 @@ type ClerkCrossOriginAuth = {
 };
 
 function withNetlifyHandshakeCacheBust(url: string): string {
+  if (isLocalDevRuntime()) {
+    return url;
+  }
+
   try {
     const parsed = new URL(url);
 

--- a/apps/dashboard/src/utils/connect/clerk-cross-origin-auth.ts
+++ b/apps/dashboard/src/utils/connect/clerk-cross-origin-auth.ts
@@ -1,0 +1,70 @@
+import { isConnectHostnameUrl } from '@/utils/product-auth-urls';
+
+// Clerk + Netlify: CDN can cache handshake redirects and cause infinite auth loops (dev + some prod configs).
+const CLERK_NETLIFY_CACHE_BUST_PARAM = '__clerk_netlify_cache_bust';
+
+type ClerkCrossOriginAuth = {
+  loaded: boolean;
+  redirectWithAuth: (to: string) => Promise<unknown>;
+  buildUrlWithAuth: (to: string) => string;
+  buildSignInUrl: (opts?: { signInForceRedirectUrl?: string | null }) => string;
+  buildSignUpUrl: (opts?: { signUpForceRedirectUrl?: string | null }) => string;
+};
+
+function withNetlifyHandshakeCacheBust(url: string): string {
+  try {
+    const parsed = new URL(url);
+
+    if (parsed.searchParams.has('__clerk_handshake')) {
+      return url;
+    }
+
+    if (!parsed.searchParams.has(CLERK_NETLIFY_CACHE_BUST_PARAM)) {
+      parsed.searchParams.set(CLERK_NETLIFY_CACHE_BUST_PARAM, Date.now().toString());
+    }
+
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+function navigateWithDecoratedAuthUrl(clerk: ClerkCrossOriginAuth, destination: string): void {
+  const authedUrl = withNetlifyHandshakeCacheBust(clerk.buildUrlWithAuth(destination));
+
+  window.location.assign(authedUrl);
+}
+
+/** Primary → Connect handoff: decorates the URL so Clerk propagates the session to the satellite. */
+export function navigateToConnectWithClerkSession(clerk: ClerkCrossOriginAuth, destination: string): void {
+  navigateWithDecoratedAuthUrl(clerk, destination);
+}
+
+/** Cross-product navigation — Connect targets must go through Clerk session sync. */
+export function navigateWithClerkSessionIfCrossOrigin(clerk: ClerkCrossOriginAuth, destination: string): void {
+  if (isConnectHostnameUrl(destination)) {
+    navigateToConnectWithClerkSession(clerk, destination);
+
+    return;
+  }
+
+  window.location.assign(destination);
+}
+
+/** Connect satellite → primary sign-in with optional post-auth return to Connect. */
+export function redirectSatelliteToPrimarySignIn(clerk: ClerkCrossOriginAuth, returnUrl: string | null): void {
+  const primarySignInUrl = clerk.buildSignInUrl(
+    returnUrl ? { signInForceRedirectUrl: returnUrl } : undefined
+  );
+
+  window.location.replace(withNetlifyHandshakeCacheBust(primarySignInUrl));
+}
+
+/** Connect satellite → primary sign-up with optional post-auth return to Connect. */
+export function redirectSatelliteToPrimarySignUp(clerk: ClerkCrossOriginAuth, returnUrl: string | null): void {
+  const primarySignUpUrl = clerk.buildSignUpUrl(
+    returnUrl ? { signUpForceRedirectUrl: returnUrl } : undefined
+  );
+
+  window.location.replace(withNetlifyHandshakeCacheBust(primarySignUpUrl));
+}

--- a/apps/dashboard/src/utils/connect/index.ts
+++ b/apps/dashboard/src/utils/connect/index.ts
@@ -1,3 +1,4 @@
+export * from './clerk-cross-origin-auth';
 export * from './onboarding-session';
 export * from './org-departure';
 export * from './organization';

--- a/apps/dashboard/src/utils/invitation-accept-signal.ts
+++ b/apps/dashboard/src/utils/invitation-accept-signal.ts
@@ -9,13 +9,18 @@
  * only Connect workspace would bounce them off Connect entirely.
  */
 
+import { readClerkAuthParamFromLocation } from '@/utils/product-auth-urls';
+
 const CLERK_TICKET_PARAM = '__clerk_ticket';
 const FLAG_KEY = 'novu.inviteAcceptPending';
 const FLAG_VALUE = '1';
 
 export function markInvitationAcceptIfPresent(searchParams: URLSearchParams): void {
   if (typeof window === 'undefined') return;
-  if (!searchParams.has(CLERK_TICKET_PARAM)) return;
+
+  if (!readClerkAuthParamFromLocation(CLERK_TICKET_PARAM, searchParams)) {
+    return;
+  }
 
   try {
     window.sessionStorage.setItem(FLAG_KEY, FLAG_VALUE);

--- a/apps/dashboard/src/utils/product-auth-urls.ts
+++ b/apps/dashboard/src/utils/product-auth-urls.ts
@@ -1,4 +1,9 @@
-import { IS_HOSTNAME_SPLIT_ENABLED, NOVU_CONNECT_HOSTNAME, NOVU_PLATFORM_HOSTNAME } from '@/config';
+import {
+  IS_HOSTNAME_SPLIT_ENABLED,
+  normalizeAppHost,
+  NOVU_CONNECT_HOSTNAME,
+  NOVU_PLATFORM_HOSTNAME,
+} from '@/config';
 import { ROUTES } from '@/utils/routes';
 
 // Set when a Connect visitor is sent to Platform sign-in so the primary renders Connect branding.
@@ -65,36 +70,60 @@ export function isConnectHostnameUrl(url: string): boolean {
   }
 
   try {
-    return new URL(url, window.location.origin).host === NOVU_CONNECT_HOSTNAME;
+    return normalizeAppHost(new URL(url, window.location.origin).host) === normalizeAppHost(NOVU_CONNECT_HOSTNAME);
   } catch {
     return false;
   }
 }
 
+/** Clerk may put auth params in the query string or inside hash routing (#/?param=). */
+export function readClerkAuthParamFromLocation(param: string, searchParams?: URLSearchParams): string | null {
+  const fromPassedSearch = searchParams?.get(param);
+
+  if (fromPassedSearch) {
+    return fromPassedSearch;
+  }
+
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const fromWindowSearch = new URLSearchParams(window.location.search).get(param);
+
+  if (fromWindowSearch) {
+    return fromWindowSearch;
+  }
+
+  const hash = window.location.hash;
+
+  if (!hash || hash.length <= 1) {
+    return null;
+  }
+
+  const hashBody = hash.startsWith('#') ? hash.slice(1) : hash;
+  const queryIndex = hashBody.indexOf('?');
+
+  if (queryIndex === -1) {
+    return null;
+  }
+
+  return new URLSearchParams(hashBody.slice(queryIndex + 1)).get(param);
+}
+
+/** Clerk may put redirect_url in the query string or inside hash routing (#/?redirect_url=). */
+export function readClerkRedirectUrlParam(searchParams?: URLSearchParams): string | null {
+  return readClerkAuthParamFromLocation('redirect_url', searchParams);
+}
+
 /** Clerk's satellite handshake return URL — must be honored so Connect receives the synced session. */
-export function readConnectSatelliteReturnUrl(searchParams: URLSearchParams): string | null {
-  const redirectUrl = searchParams.get('redirect_url');
+export function readConnectSatelliteReturnUrl(searchParams?: URLSearchParams): string | null {
+  const redirectUrl = readClerkRedirectUrlParam(searchParams);
 
   if (!redirectUrl || !isConnectHostnameUrl(redirectUrl)) {
     return null;
   }
 
   return redirectUrl;
-}
-
-export function appendRedirectUrl(primaryAuthUrl: string, returnUrl: string): string {
-  if (typeof window === 'undefined') {
-    return primaryAuthUrl;
-  }
-
-  try {
-    const url = new URL(primaryAuthUrl, window.location.origin);
-    url.searchParams.set('redirect_url', returnUrl);
-
-    return url.toString();
-  } catch {
-    return primaryAuthUrl;
-  }
 }
 
 function isConnectAuthPath(url: string): boolean {


### PR DESCRIPTION

### What changed? Why was the change needed?
- Added VITE_CLERK_PROXY_URL to .example.env for Clerk FAPI CNAME configuration.
- Updated netlify.toml to prevent caching of authentication redirects.
- Refactored OrganizationPicker, SignInPage, and SignUpPage components to utilize new Clerk session navigation functions for cross-origin redirects.
- Introduced utility functions for handling Clerk's satellite handshake and session synchronization.
- Improved handling of redirect URLs in product-auth-urls utility.

@coderabbitai summary

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
