### PR TITLE
fix(dashboard): agents custom code form fixes NV-7816

### DIFF
--- a/apps/dashboard/src/components/agents/agent-setup-steps.tsx
+++ b/apps/dashboard/src/components/agents/agent-setup-steps.tsx
@@ -113,6 +113,7 @@ function ConnectPhaseRecap({
       <ConnectAgentForm
         connectorId={summary.connectorId}
         isClaudeSelected={display.isClaudeSelected}
+        isScratchRuntime={display.isScratchRuntime}
         apiKey={summary.apiKey}
         externalWorkspaceId={summary.externalWorkspaceId}
         region={summary.region ?? ''}

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -56,10 +56,10 @@ import {
   buildVerifyCredentialsPayload,
   buildVerifyFingerprint,
   ConfigureCredentialsSection,
-  hasCompleteManagedCredentials,
   type CreateAgentForm,
   type CreateAgentFormErrors,
   ExistingAgentFields,
+  hasCompleteManagedCredentials,
   hasFormErrors,
   type ManagedAgentRuntimeOverrides,
   ScratchAgentFields,
@@ -199,12 +199,10 @@ export function CreateAgentDialog({
   const selectedConnector = getConnectorById(connectorId);
   const isManagedClaudeConnector = selectedConnector?.runtime === 'claude';
   const runtime = selectedConnector?.runtime ?? 'scratch';
-  const isScratchRuntime = runtime === 'scratch';
-  // The "Generate from prompt" surface is available for both managed Claude (when the
-  // managed-runtime flag is on) and for the self-hosted Custom Scaffold flow unconditionally —
-  // Custom Scaffold generation only produces name/identifier/systemPrompt and never touches any
-  // Anthropic-managed infrastructure, so it has no reason to depend on the managed flag.
-  const useAiGeneration = isManagedClaudeConnector ? isManagedEnabled : isScratchRuntime;
+  // The "Generate from prompt" surface is reserved for managed Claude (when the managed-runtime
+  // flag is on). The Custom Scaffold flow always renders the manual ScratchAgentFields form, so
+  // teams writing their own runtime see exactly the inputs they need to fill in.
+  const useAiGeneration = isManagedClaudeConnector && isManagedEnabled;
   const isDemoProviderSelected = isDemoManagedClaudeIntegrationSelected(integrations, selectedIntegrationId);
   const scope: 'create' | 'existing' = generationMode === 'existing' ? 'existing' : 'create';
   const showScopeTabs = isManagedClaudeConnector && !isDemoProviderSelected;
@@ -385,20 +383,6 @@ export function CreateAgentDialog({
     });
   }, []);
 
-  // Legacy fallback (AI generation unavailable): pre-fill the manual form fields directly.
-  const handleSelectTemplate = useCallback(
-    (template: AgentTemplate) => {
-      setName(template.name);
-      if (!isIdentifierTouched) {
-        setIdentifier(slugify(template.name));
-        setErrors((prev) => ({ ...prev, identifier: undefined }));
-      }
-      setInstructions(template.instructions);
-      setErrors((prev) => ({ ...prev, name: undefined }));
-    },
-    [isIdentifierTouched]
-  );
-
   const handleSelectConnector = (id: ConnectorId) => {
     preferAnyManagedIntegrationRef.current = false;
     setConnectorId(id);
@@ -488,19 +472,18 @@ export function CreateAgentDialog({
     setVerifyMessage(undefined);
 
     verifyMutation.mutate(buildVerifyCredentialsPayload(selectedConnector.providerId, fields), {
-        onSuccess: () => {
-          if (lastVerifiedKeyRef.current !== verifyKey) return;
-          setVerifyStatus('valid');
-          setVerifyMessage(undefined);
-          setErrors((prev) => ({ ...prev, apiKey: undefined }));
-        },
-        onError: (err) => {
-          if (lastVerifiedKeyRef.current !== verifyKey) return;
-          setVerifyStatus('invalid');
-          setVerifyMessage(err instanceof Error ? err.message : 'Invalid');
-        },
-      }
-    );
+      onSuccess: () => {
+        if (lastVerifiedKeyRef.current !== verifyKey) return;
+        setVerifyStatus('valid');
+        setVerifyMessage(undefined);
+        setErrors((prev) => ({ ...prev, apiKey: undefined }));
+      },
+      onError: (err) => {
+        if (lastVerifiedKeyRef.current !== verifyKey) return;
+        setVerifyStatus('invalid');
+        setVerifyMessage(err instanceof Error ? err.message : 'Invalid');
+      },
+    });
   };
 
   const handleApiKeyChange = (next: string) => {
@@ -896,28 +879,25 @@ export function CreateAgentDialog({
                 </AnimatePresence>
               </div>
             ) : (
-              <div className="flex flex-col gap-2">
-                <AgentSuggestionPills suggestions={AGENT_TEMPLATES} onSelect={handleSelectTemplate} />
-
-                <ScratchAgentFields
-                  name={name}
-                  identifier={identifier}
-                  instructions={instructions}
-                  errors={errors}
-                  isIdentifierTouched={isIdentifierTouched}
-                  isClaudeSelected={isManagedClaudeConnector}
-                  onNameChange={(next) => {
-                    setName(next);
-                    setErrors((prev) => ({ ...prev, name: undefined }));
-                  }}
-                  onIdentifierChange={(next) => {
-                    setIdentifier(next);
-                    setErrors((prev) => ({ ...prev, identifier: undefined }));
-                  }}
-                  onIdentifierTouched={() => setIsIdentifierTouched(true)}
-                  onInstructionsChange={setInstructions}
-                />
-              </div>
+              <ScratchAgentFields
+                name={name}
+                identifier={identifier}
+                instructions={instructions}
+                errors={errors}
+                isIdentifierTouched={isIdentifierTouched}
+                isClaudeSelected={isManagedClaudeConnector}
+                disabled={isSubmitBusy}
+                onNameChange={(next) => {
+                  setName(next);
+                  setErrors((prev) => ({ ...prev, name: undefined }));
+                }}
+                onIdentifierChange={(next) => {
+                  setIdentifier(next);
+                  setErrors((prev) => ({ ...prev, identifier: undefined }));
+                }}
+                onIdentifierTouched={() => setIsIdentifierTouched(true)}
+                onInstructionsChange={setInstructions}
+              />
             )}
           </div>
 

--- a/apps/dashboard/src/components/agents/create-agent-fields/scratch-agent-fields.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-fields/scratch-agent-fields.tsx
@@ -118,7 +118,7 @@ export function ScratchAgentFields({
       <div className="flex flex-col gap-1">
         <div className="flex items-center gap-1">
           <label htmlFor={instructionsId} className="text-text-strong text-label-xs font-medium">
-            Instructions
+            {showSystemPromptHelper ? 'Instructions' : 'Description'}
           </label>
           {showSystemPromptHelper && (
             <span className="text-text-soft text-paragraph-xs ml-auto">(Sent to Claude as the system prompt)</span>

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-form.tsx
@@ -47,16 +47,17 @@ export type AgentGenerationBindings = {
    * disabled. Use after the LLM call has settled and the agent is being provisioned.
    */
   isCancelDisabled?: boolean;
-  /**
-   * Marks the Custom Scaffold flow. Drives copy and tone: scratch agents only get a
-   * generated name/identifier/system prompt — no tools/MCPs/skills are attached.
-   */
-  isScratchRuntime?: boolean;
 };
 
 type ConnectAgentFormProps = {
   connectorId: ConnectorId;
   isClaudeSelected: boolean;
+  /**
+   * When true, the connector runs on the Custom Scaffold (self-hosted) runtime. We collapse the
+   * second setup step into a plain manual form (no AI prompt UI, no template dropdown, no
+   * suggestion pills) so teams writing their own runtime see exactly the inputs they need.
+   */
+  isScratchRuntime: boolean;
   apiKey: string;
   externalWorkspaceId: string;
   region: string;
@@ -201,6 +202,7 @@ function AgentScopeTabs({
 export function ConnectAgentForm({
   connectorId,
   isClaudeSelected,
+  isScratchRuntime,
   apiKey,
   externalWorkspaceId,
   region,
@@ -250,7 +252,6 @@ export function ConnectAgentForm({
   const selectedConnector = getConnectorById(connectorId);
   const showCredentialsSection = isClaudeSelected && credentialsPanelVisible && Boolean(selectedConnector?.providerId);
   const usePromptUi = Boolean(aiGeneration);
-  const isScratchRuntime = Boolean(aiGeneration?.isScratchRuntime);
   const aiMode = aiGeneration?.mode ?? 'prompt';
   const scope: AgentScope = aiMode === 'existing' ? 'existing' : 'create';
   // Total steps across the full onboarding flow:
@@ -265,14 +266,7 @@ export function ConnectAgentForm({
   // In `'existing'` scope the segmented tabs above replace it, so we omit it entirely.
   const header = aiMode === 'existing' ? null : RIGHT_HEADER_BY_MODE[aiMode];
   const showScopeTabs = usePromptUi && showExistingOption;
-  const promptStepDescription = isScratchRuntime
-    ? 'Pick a starter or describe what your agent should do — we generate the name, identifier, and system prompt. Wire up your own tools, MCPs, and integrations in code.'
-    : 'Pick a starter or describe what your agent should do — we configure the tools, MCPs, skills, and system prompt for you.';
-  const promptStepTitle = scope === 'existing' ? 'Connect your existing agent' : 'Start from a template';
-  const promptStepDescriptionResolved =
-    scope === 'existing'
-      ? 'Paste the Claude Agent ID and Environment ID of an existing managed agent and Novu will route conversations to it.'
-      : promptStepDescription;
+  const { stepTitle, stepDescription } = resolveStepCopy({ isScratchRuntime, usePromptUi, scope });
 
   return (
     <>
@@ -341,12 +335,8 @@ export function ConnectAgentForm({
       <SetupStep
         index={2}
         status="completed"
-        title={usePromptUi ? promptStepTitle : 'Start from a template'}
-        description={
-          usePromptUi
-            ? promptStepDescriptionResolved
-            : 'Create an agent and deploy it to Anthropic from the starter templates. You can also bring in existing agents later.'
-        }
+        title={stepTitle}
+        description={stepDescription}
         headerSlot={
           showScopeTabs && aiGeneration ? (
             <AgentScopeTabs
@@ -358,83 +348,316 @@ export function ConnectAgentForm({
         }
         rightContent={
           <div className="flex w-full flex-col gap-2.5">
-            {usePromptUi && aiGeneration ? (
-              <PromptModeContent
-                aiGeneration={aiGeneration}
-                header={header}
-                disabled={disabled}
-                isExistingMode={isExistingMode}
-                name={name}
-                identifier={identifier}
-                instructions={instructions}
-                isIdentifierTouched={isIdentifierTouched}
-                externalAgentId={externalAgentId}
-                externalEnvironmentId={externalEnvironmentId}
-                errors={errors}
-                onNameChange={onNameChange}
-                onIdentifierChange={onIdentifierChange}
-                onIdentifierTouched={onIdentifierTouched}
-                onInstructionsChange={onInstructionsChange}
-                onExternalAgentIdChange={onExternalAgentIdChange}
-                onExternalEnvironmentIdChange={onExternalEnvironmentIdChange}
-                submitSlot={submitSlot}
-              />
-            ) : (
-              <>
-                <TemplateDropdown
-                  selection={templateSelection}
-                  onSelect={onTemplateChange}
-                  showExistingOption={showExistingOption}
-                  existingOptionIcon={existingOptionIcon}
-                  disabled={disabled}
-                />
-                {isClaudeSelected && templateSelection.kind !== 'existing' && (
-                  <p className="text-text-soft text-label-xs font-normal leading-4 flex items-center gap-1">
-                    <RiInformation2Line className="size-3.5" aria-hidden /> Sent to Claude as the system prompt.
-                  </p>
-                )}
-              </>
-            )}
+            {renderRightColumn({
+              isScratchRuntime,
+              usePromptUi,
+              aiGeneration,
+              header,
+              disabled,
+              isClaudeSelected,
+              isExistingMode,
+              name,
+              identifier,
+              instructions,
+              isIdentifierTouched,
+              externalAgentId,
+              externalEnvironmentId,
+              errors,
+              templateSelection,
+              showExistingOption,
+              existingOptionIcon,
+              onTemplateChange,
+              onNameChange,
+              onIdentifierChange,
+              onIdentifierTouched,
+              onInstructionsChange,
+              onExternalAgentIdChange,
+              onExternalEnvironmentIdChange,
+              submitSlot,
+            })}
           </div>
         }
         extraContent={
-          <div className="flex flex-col gap-5">
-            {usePromptUi && aiGeneration && aiMode === 'prompt' ? (
-              <AgentSuggestionPills
-                suggestions={aiGeneration.suggestions}
-                onSelect={aiGeneration.onSelectSuggestion}
-                disabled={disabled}
-              />
-            ) : !usePromptUi && isExistingMode ? (
-              <ExistingAgentFields
-                externalAgentId={externalAgentId}
-                externalEnvironmentId={externalEnvironmentId}
-                errors={errors}
-                disabled={disabled}
-                onExternalAgentIdChange={onExternalAgentIdChange}
-                onExternalEnvironmentIdChange={onExternalEnvironmentIdChange}
-              />
-            ) : !usePromptUi && isScratchMode ? (
-              <ScratchAgentFields
-                isColumnsLayout
-                name={name}
-                identifier={identifier}
-                instructions={instructions}
-                errors={errors}
-                isIdentifierTouched={isIdentifierTouched}
-                isClaudeSelected={isClaudeSelected}
-                disabled={disabled}
-                onNameChange={onNameChange}
-                onIdentifierChange={onIdentifierChange}
-                onIdentifierTouched={onIdentifierTouched}
-                onInstructionsChange={onInstructionsChange}
-              />
-            ) : null}
-          </div>
+          isScratchRuntime ? null : (
+            <div className="flex flex-col gap-5">
+              {renderExtraContent({
+                usePromptUi,
+                aiMode,
+                aiGeneration,
+                disabled,
+                isClaudeSelected,
+                isExistingMode,
+                isScratchMode,
+                name,
+                identifier,
+                instructions,
+                isIdentifierTouched,
+                externalAgentId,
+                externalEnvironmentId,
+                errors,
+                onNameChange,
+                onIdentifierChange,
+                onIdentifierTouched,
+                onInstructionsChange,
+                onExternalAgentIdChange,
+                onExternalEnvironmentIdChange,
+              })}
+            </div>
+          )
         }
       />
     </>
   );
+}
+
+function resolveStepCopy({
+  isScratchRuntime,
+  usePromptUi,
+  scope,
+}: {
+  isScratchRuntime: boolean;
+  usePromptUi: boolean;
+  scope: AgentScope;
+}): { stepTitle: string; stepDescription: string } {
+  if (isScratchRuntime) {
+    return {
+      stepTitle: 'Configure your agent',
+      stepDescription:
+        'Give your agent a name, identifier, and description. Wire up your own tools, MCPs, and integrations in code.',
+    };
+  }
+
+  if (usePromptUi) {
+    if (scope === 'existing') {
+      return {
+        stepTitle: 'Connect your existing agent',
+        stepDescription:
+          'Paste the Claude Agent ID and Environment ID of an existing managed agent and Novu will route conversations to it.',
+      };
+    }
+
+    return {
+      stepTitle: 'Start from a template',
+      stepDescription:
+        'Pick a starter or describe what your agent should do — we configure the tools, MCPs, skills, and system prompt for you.',
+    };
+  }
+
+  return {
+    stepTitle: 'Start from a template',
+    stepDescription:
+      'Create an agent and deploy it to Anthropic from the starter templates. You can also bring in existing agents later.',
+  };
+}
+
+type RightColumnArgs = {
+  isScratchRuntime: boolean;
+  usePromptUi: boolean;
+  aiGeneration: AgentGenerationBindings | undefined;
+  header: RightHeader | null;
+  disabled?: boolean;
+  isClaudeSelected: boolean;
+  isExistingMode: boolean;
+  name: string;
+  identifier: string;
+  instructions: string;
+  isIdentifierTouched: boolean;
+  externalAgentId: string;
+  externalEnvironmentId: string;
+  errors: CreateAgentFormErrors;
+  templateSelection: TemplateSelection;
+  showExistingOption: boolean;
+  existingOptionIcon?: ReactNode;
+  onTemplateChange: (next: TemplateSelection) => void;
+  onNameChange: (next: string) => void;
+  onIdentifierChange: (next: string) => void;
+  onIdentifierTouched: () => void;
+  onInstructionsChange: (next: string) => void;
+  onExternalAgentIdChange: (next: string) => void;
+  onExternalEnvironmentIdChange: (next: string) => void;
+  submitSlot?: ReactNode;
+};
+
+function renderRightColumn({
+  isScratchRuntime,
+  usePromptUi,
+  aiGeneration,
+  header,
+  disabled,
+  isClaudeSelected,
+  isExistingMode,
+  name,
+  identifier,
+  instructions,
+  isIdentifierTouched,
+  externalAgentId,
+  externalEnvironmentId,
+  errors,
+  templateSelection,
+  showExistingOption,
+  existingOptionIcon,
+  onTemplateChange,
+  onNameChange,
+  onIdentifierChange,
+  onIdentifierTouched,
+  onInstructionsChange,
+  onExternalAgentIdChange,
+  onExternalEnvironmentIdChange,
+  submitSlot,
+}: RightColumnArgs) {
+  if (isScratchRuntime) {
+    return (
+      <>
+        <ScratchAgentFields
+          isColumnsLayout
+          name={name}
+          identifier={identifier}
+          instructions={instructions}
+          errors={errors}
+          isIdentifierTouched={isIdentifierTouched}
+          isClaudeSelected={false}
+          disabled={disabled}
+          onNameChange={onNameChange}
+          onIdentifierChange={onIdentifierChange}
+          onIdentifierTouched={onIdentifierTouched}
+          onInstructionsChange={onInstructionsChange}
+        />
+        {submitSlot}
+      </>
+    );
+  }
+
+  if (usePromptUi && aiGeneration) {
+    return (
+      <PromptModeContent
+        aiGeneration={aiGeneration}
+        header={header}
+        disabled={disabled}
+        isExistingMode={isExistingMode}
+        name={name}
+        identifier={identifier}
+        instructions={instructions}
+        isIdentifierTouched={isIdentifierTouched}
+        externalAgentId={externalAgentId}
+        externalEnvironmentId={externalEnvironmentId}
+        errors={errors}
+        onNameChange={onNameChange}
+        onIdentifierChange={onIdentifierChange}
+        onIdentifierTouched={onIdentifierTouched}
+        onInstructionsChange={onInstructionsChange}
+        onExternalAgentIdChange={onExternalAgentIdChange}
+        onExternalEnvironmentIdChange={onExternalEnvironmentIdChange}
+        submitSlot={submitSlot}
+      />
+    );
+  }
+
+  return (
+    <>
+      <TemplateDropdown
+        selection={templateSelection}
+        onSelect={onTemplateChange}
+        showExistingOption={showExistingOption}
+        existingOptionIcon={existingOptionIcon}
+        disabled={disabled}
+      />
+      {isClaudeSelected && templateSelection.kind !== 'existing' && (
+        <p className="text-text-soft text-label-xs font-normal leading-4 flex items-center gap-1">
+          <RiInformation2Line className="size-3.5" aria-hidden /> Sent to Claude as the system prompt.
+        </p>
+      )}
+    </>
+  );
+}
+
+type ExtraContentArgs = {
+  usePromptUi: boolean;
+  aiMode: AgentGenerationMode;
+  aiGeneration: AgentGenerationBindings | undefined;
+  disabled?: boolean;
+  isClaudeSelected: boolean;
+  isExistingMode: boolean;
+  isScratchMode: boolean;
+  name: string;
+  identifier: string;
+  instructions: string;
+  isIdentifierTouched: boolean;
+  externalAgentId: string;
+  externalEnvironmentId: string;
+  errors: CreateAgentFormErrors;
+  onNameChange: (next: string) => void;
+  onIdentifierChange: (next: string) => void;
+  onIdentifierTouched: () => void;
+  onInstructionsChange: (next: string) => void;
+  onExternalAgentIdChange: (next: string) => void;
+  onExternalEnvironmentIdChange: (next: string) => void;
+};
+
+function renderExtraContent({
+  usePromptUi,
+  aiMode,
+  aiGeneration,
+  disabled,
+  isClaudeSelected,
+  isExistingMode,
+  isScratchMode,
+  name,
+  identifier,
+  instructions,
+  isIdentifierTouched,
+  externalAgentId,
+  externalEnvironmentId,
+  errors,
+  onNameChange,
+  onIdentifierChange,
+  onIdentifierTouched,
+  onInstructionsChange,
+  onExternalAgentIdChange,
+  onExternalEnvironmentIdChange,
+}: ExtraContentArgs) {
+  if (usePromptUi && aiGeneration && aiMode === 'prompt') {
+    return (
+      <AgentSuggestionPills
+        suggestions={aiGeneration.suggestions}
+        onSelect={aiGeneration.onSelectSuggestion}
+        disabled={disabled}
+      />
+    );
+  }
+
+  if (!usePromptUi && isExistingMode) {
+    return (
+      <ExistingAgentFields
+        externalAgentId={externalAgentId}
+        externalEnvironmentId={externalEnvironmentId}
+        errors={errors}
+        disabled={disabled}
+        onExternalAgentIdChange={onExternalAgentIdChange}
+        onExternalEnvironmentIdChange={onExternalEnvironmentIdChange}
+      />
+    );
+  }
+
+  if (!usePromptUi && isScratchMode) {
+    return (
+      <ScratchAgentFields
+        isColumnsLayout
+        name={name}
+        identifier={identifier}
+        instructions={instructions}
+        errors={errors}
+        isIdentifierTouched={isIdentifierTouched}
+        isClaudeSelected={isClaudeSelected}
+        disabled={disabled}
+        onNameChange={onNameChange}
+        onIdentifierChange={onIdentifierChange}
+        onIdentifierTouched={onIdentifierTouched}
+        onInstructionsChange={onInstructionsChange}
+      />
+    );
+  }
+
+  return null;
 }
 
 type RightHeader = (typeof RIGHT_HEADER_BY_MODE)[Exclude<AgentGenerationMode, 'existing'>];

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-agent-step.tsx
@@ -34,9 +34,9 @@ import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner
 import { useEnvironment } from '@/context/environment/hooks';
 import { useCreateAgentMutation } from '@/hooks/use-create-agent-mutation';
 import { useCreateIntegration } from '@/hooks/use-create-integration';
-import { useManagedClaudeCredentialsFlow } from '@/hooks/use-managed-claude-credentials-flow';
 import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { GenerationCancelledError, useGenerateManagedAgent } from '@/hooks/use-generate-managed-agent';
+import { useManagedClaudeCredentialsFlow } from '@/hooks/use-managed-claude-credentials-flow';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { useVerifyManagedCredentials } from '@/hooks/use-verify-managed-credentials';
 import { QueryKeys } from '@/utils/query-keys';
@@ -159,18 +159,20 @@ export function ConnectAgentStep({ onAgentCreated, onRuntimeChange, isManagedEna
   const runtime = useMemo(() => resolveRuntime(connectorId), [connectorId]);
   const isClaudeSelected = runtime === 'claude';
   const isScratchRuntime = runtime === 'scratch';
-  // The AI "Generate from prompt" surface is available for both managed Claude (when the
-  // managed-runtime flag is on) and for the self-hosted Custom Scaffold flow unconditionally.
-  // Custom Scaffold generation only produces name/identifier/systemPrompt — it does not touch
-  // any Anthropic-managed infrastructure — so it has no reason to depend on that flag.
-  const useAiGeneration = isClaudeSelected ? isManagedEnabled : isScratchRuntime;
+  // The AI "Generate from prompt" surface is reserved for managed Claude (when the
+  // managed-runtime flag is on). The Custom Scaffold flow always renders the manual
+  // ScratchAgentFields form so teams writing their own runtime see exactly the inputs they
+  // need to fill in.
+  const useAiGeneration = isClaudeSelected && isManagedEnabled;
   const isDemoProviderSelected = isDemoManagedClaudeIntegrationSelected(integrations, selectedIntegrationId);
   const isExistingMode =
     isClaudeSelected &&
     !isDemoProviderSelected &&
     (useAiGeneration ? generationMode === 'existing' : templateSelection.kind === 'existing');
   const isScratchMode =
-    (useAiGeneration && generationMode === 'manual') || (!useAiGeneration && templateSelection.kind === 'scratch');
+    isScratchRuntime ||
+    (useAiGeneration && generationMode === 'manual') ||
+    (!useAiGeneration && templateSelection.kind === 'scratch');
   const showExistingOption = isClaudeSelected && !isDemoProviderSelected;
   const existingOptionIcon = isClaudeSelected ? (
     <div className="bg-primary-base/10 text-primary-base flex size-4 items-center justify-center rounded-full">
@@ -280,16 +282,19 @@ export function ConnectAgentStep({ onAgentCreated, onRuntimeChange, isManagedEna
     };
   }, []);
 
-  const handleConnectorChange = useCallback((id: ConnectorId) => {
-    setConnectorId(id);
+  const handleConnectorChange = useCallback(
+    (id: ConnectorId) => {
+      setConnectorId(id);
 
-    const next = getConnectorById(id);
-    if (!next?.providerId) {
-      setSelectedIntegrationId(undefined);
-      setCredentialsPanelVisible(false);
-      resetCredentials();
-    }
-  }, [resetCredentials]);
+      const next = getConnectorById(id);
+      if (!next?.providerId) {
+        setSelectedIntegrationId(undefined);
+        setCredentialsPanelVisible(false);
+        resetCredentials();
+      }
+    },
+    [resetCredentials]
+  );
 
   const handlePromptChange = useCallback((next: string) => {
     setPrompt(next);
@@ -413,35 +418,32 @@ export function ConnectAgentStep({ onAgentCreated, onRuntimeChange, isManagedEna
   );
 
   const handleVerify = useCallback(() => {
-      if (!selectedConnector?.providerId) return;
-      if (verifyMutation.isPending) return;
+    if (!selectedConnector?.providerId) return;
+    if (verifyMutation.isPending) return;
 
-      const fields = { apiKey, region, externalWorkspaceId };
-      const verifyKey = buildVerifyFingerprint(selectedConnector.providerId, fields);
+    const fields = { apiKey, region, externalWorkspaceId };
+    const verifyKey = buildVerifyFingerprint(selectedConnector.providerId, fields);
 
-      if (lastVerifiedKeyRef.current === verifyKey && verifyStatus === 'valid') return;
+    if (lastVerifiedKeyRef.current === verifyKey && verifyStatus === 'valid') return;
 
-      lastVerifiedKeyRef.current = verifyKey;
-      setVerifyStatus('verifying');
-      setVerifyMessage(undefined);
+    lastVerifiedKeyRef.current = verifyKey;
+    setVerifyStatus('verifying');
+    setVerifyMessage(undefined);
 
-      verifyMutation.mutate(buildVerifyCredentialsPayload(selectedConnector.providerId, fields), {
-          onSuccess: () => {
-            if (lastVerifiedKeyRef.current !== verifyKey) return;
-            setVerifyStatus('valid');
-            setVerifyMessage(undefined);
-            setErrors((prev) => ({ ...prev, apiKey: undefined }));
-          },
-          onError: (err) => {
-            if (lastVerifiedKeyRef.current !== verifyKey) return;
-            setVerifyStatus('invalid');
-            setVerifyMessage(err instanceof Error ? err.message : 'Invalid');
-          },
-        }
-      );
-    },
-    [selectedConnector?.providerId, apiKey, externalWorkspaceId, region, verifyMutation, verifyStatus]
-  );
+    verifyMutation.mutate(buildVerifyCredentialsPayload(selectedConnector.providerId, fields), {
+      onSuccess: () => {
+        if (lastVerifiedKeyRef.current !== verifyKey) return;
+        setVerifyStatus('valid');
+        setVerifyMessage(undefined);
+        setErrors((prev) => ({ ...prev, apiKey: undefined }));
+      },
+      onError: (err) => {
+        if (lastVerifiedKeyRef.current !== verifyKey) return;
+        setVerifyStatus('invalid');
+        setVerifyMessage(err instanceof Error ? err.message : 'Invalid');
+      },
+    });
+  }, [selectedConnector?.providerId, apiKey, externalWorkspaceId, region, verifyMutation, verifyStatus]);
 
   const handleSaveIntegration = useCallback(async () => {
     if (!selectedConnector?.providerId) return;
@@ -678,6 +680,7 @@ export function ConnectAgentStep({ onAgentCreated, onRuntimeChange, isManagedEna
       <ConnectAgentForm
         connectorId={connectorId}
         isClaudeSelected={isClaudeSelected}
+        isScratchRuntime={isScratchRuntime}
         apiKey={apiKey}
         externalWorkspaceId={externalWorkspaceId}
         region={region}
@@ -712,7 +715,6 @@ export function ConnectAgentStep({ onAgentCreated, onRuntimeChange, isManagedEna
                 // we are mid-provisioning at Anthropic and there is nothing to abort, so keep
                 // the button visible (avoids a layout shift) but disable it.
                 isCancelDisabled: !isGenerating,
-                isScratchRuntime,
               }
             : undefined
         }
@@ -758,10 +760,10 @@ export function ConnectAgentStep({ onAgentCreated, onRuntimeChange, isManagedEna
         }}
         onVerify={handleVerify}
         onSaveIntegration={handleSaveIntegration}
-        submitSlot={useAiGeneration ? submitButton : undefined}
+        submitSlot={useAiGeneration || isScratchRuntime ? submitButton : undefined}
       />
 
-      {!useAiGeneration && <div className="flex flex-col gap-2 pl-6">{submitButton}</div>}
+      {!useAiGeneration && !isScratchRuntime && <div className="flex flex-col gap-2 pl-6">{submitButton}</div>}
     </form>
   );
 }

--- a/apps/dashboard/src/components/onboarding/connect-agent/connect-summary.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/connect-summary.tsx
@@ -1,7 +1,7 @@
-import type { RuntimeType } from '@/components/agents/create-agent-fields';
-import { isDemoManagedClaudeIntegrationSelected } from '@/components/agents/connectors/claude-managed-integrations';
-import { ClaudeIcon } from '@/components/icons/claude';
 import type { IIntegration } from '@novu/shared';
+import { isDemoManagedClaudeIntegrationSelected } from '@/components/agents/connectors/claude-managed-integrations';
+import type { RuntimeType } from '@/components/agents/create-agent-fields';
+import { ClaudeIcon } from '@/components/icons/claude';
 import { type ConnectorId, getConnectorById } from './connector-options';
 import type { TemplateSelection } from './template-dropdown';
 
@@ -45,13 +45,10 @@ function resolveRuntime(connectorId: ConnectorId): RuntimeType {
 export function deriveConnectSummaryDisplay(summary: ConnectSummary, integrations?: IIntegration[]) {
   const runtime = resolveRuntime(summary.connectorId);
   const isClaudeSelected = runtime === 'claude';
-  const isDemoProviderSelected = isDemoManagedClaudeIntegrationSelected(
-    integrations,
-    summary.selectedIntegrationId
-  );
-  const isExistingMode =
-    isClaudeSelected && !isDemoProviderSelected && summary.templateSelection.kind === 'existing';
-  const isScratchMode = summary.templateSelection.kind === 'scratch';
+  const isScratchRuntime = runtime === 'scratch';
+  const isDemoProviderSelected = isDemoManagedClaudeIntegrationSelected(integrations, summary.selectedIntegrationId);
+  const isExistingMode = isClaudeSelected && !isDemoProviderSelected && summary.templateSelection.kind === 'existing';
+  const isScratchMode = isScratchRuntime || summary.templateSelection.kind === 'scratch';
   const showExistingOption = isClaudeSelected && !isDemoProviderSelected;
   const existingOptionIcon = isClaudeSelected ? (
     <div className="bg-primary-base/10 text-primary-base flex size-4 items-center justify-center rounded-full">
@@ -59,5 +56,12 @@ export function deriveConnectSummaryDisplay(summary: ConnectSummary, integration
     </div>
   ) : undefined;
 
-  return { isClaudeSelected, isExistingMode, isScratchMode, showExistingOption, existingOptionIcon };
+  return {
+    isClaudeSelected,
+    isScratchRuntime,
+    isExistingMode,
+    isScratchMode,
+    showExistingOption,
+    existingOptionIcon,
+  };
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed? Why was the change needed?

This PR fixes the dashboard agent creation flow so AI-generation UI is only shown for managed Claude connectors when the managed runtime feature flag is enabled. Scratch runtime no longer shows the prompt/template UI or suggestion pills; it renders the scratch-specific fields directly. The change prevents incorrect AI prompt surfaces from appearing for scratch providers and makes runtime mode explicit by passing `isScratchRuntime` as a top-level prop.

## Affected areas

**dashboard**: Agent onboarding and creation components were updated to separate managed-Claude AI generation from scratch runtime flows, refactor step UI rendering into helpers, and pass `isScratchRuntime` explicitly into connect-agent form components.

## Key technical decisions

- Require `isScratchRuntime` at the `ConnectAgentForm` boundary to make runtime mode explicit and avoid deriving it from nested aiGeneration state.
- Gate AI generation on both Claude connector selection and the managed runtime feature flag to prevent showing prompt UI for scratch runtimes.
- Extracted step copy and right/extra column rendering into helper functions to simplify conditional UI paths.

## Testing

No automated tests were added; manual verification across managed Claude and scratch runtime scenarios is recommended to validate the UI and submit flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots


https://github.com/user-attachments/assets/e4133185-ad01-4eef-b19d-c00b79339ffd


https://github.com/user-attachments/assets/5560026e-5d35-424a-a4b8-a5fde63ce095

