### PR TITLE
feat(dashboard): improve cross-origin navigation and session synchronization with Clerk 

### DIFF
--- a/apps/dashboard/.example.env
+++ b/apps/dashboard/.example.env
@@ -13,11 +13,9 @@ VITE_NOVU_ENTERPRISE=false
 # Novu Connect hostname split — Platform is the Clerk primary, Connect is the satellite.
 # Leave both empty to disable Connect (self-hosted / community builds).
 # Local dev: Platform at http://localhost:4201, Connect at http://connect.localhost:4201.
+# Production Connect: add DNS CNAME `clerk.<connect-domain>` → frontend-api.clerk.services.
 VITE_NOVU_PLATFORM_HOSTNAME=
 VITE_NOVU_CONNECT_HOSTNAME=
-# Connect satellite only — Clerk FAPI CNAME (clerk.<connect-domain> → frontend-api.clerk.services).
-# Defaults to https://clerk.${VITE_NOVU_CONNECT_HOSTNAME} when unset; override if your CNAME differs.
-VITE_CLERK_PROXY_URL=
 
 # Multi-Region Configuration
 # List of region codes (comma-separated). FIRST region is the base/default region.

--- a/apps/dashboard/src/components/auth/organization-picker.tsx
+++ b/apps/dashboard/src/components/auth/organization-picker.tsx
@@ -501,7 +501,7 @@ export function OrganizationPicker({
 
       if (otherProductUrl && clerk.loaded) {
         clearInvitationAcceptPending();
-        navigateWithClerkSessionIfCrossOrigin(clerk, otherProductUrl);
+        void navigateWithClerkSessionIfCrossOrigin(clerk, otherProductUrl);
 
         return;
       }

--- a/apps/dashboard/src/components/dashboard-shell/cross-app-link.tsx
+++ b/apps/dashboard/src/components/dashboard-shell/cross-app-link.tsx
@@ -1,6 +1,9 @@
+import { useAuth, useClerk } from '@clerk/react';
 import { type MouseEvent, type ReactNode } from 'react';
 import { IS_HOSTNAME_SPLIT_ENABLED } from '@/config';
 import { isAbsoluteUrl, isSafeNavigationHref } from '@/utils/apps';
+import { navigateWithClerkSessionIfCrossOrigin } from '@/utils/connect/clerk-cross-origin-auth';
+import { isConnectHostnameUrl } from '@/utils/product-auth-urls';
 
 type CrossAppLinkProps = {
   href: string;
@@ -11,11 +14,11 @@ type CrossAppLinkProps = {
   children: ReactNode;
 };
 
-// Hands off to the browser for cross-origin hrefs; Clerk satellite sync picks up the session.
 export function CrossAppLink({ href, openInNewTab, className, onClick, children, ...rest }: CrossAppLinkProps) {
+  const { isSignedIn, isLoaded } = useAuth();
+  const clerk = useClerk();
   const isHrefSafe = isSafeNavigationHref(href);
   const isCrossOrigin = isHrefSafe && IS_HOSTNAME_SPLIT_ENABLED && isAbsoluteUrl(href);
-  // Anchor href degrades to `#` for non-http(s) targets so a click can never execute `javascript:` etc.
   const safeAnchorHref = isHrefSafe ? href : '#';
 
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
@@ -39,6 +42,14 @@ export function CrossAppLink({ href, openInNewTab, className, onClick, children,
 
     if (openInNewTab) {
       window.open(href, '_blank', 'noopener,noreferrer');
+
+      return;
+    }
+
+    const shouldSyncClerkSession = isConnectHostnameUrl(href) && isLoaded && isSignedIn && clerk.loaded;
+
+    if (shouldSyncClerkSession) {
+      void navigateWithClerkSessionIfCrossOrigin(clerk, href);
 
       return;
     }

--- a/apps/dashboard/src/config/index.ts
+++ b/apps/dashboard/src/config/index.ts
@@ -53,21 +53,7 @@ function getHostnameWithoutPort(host: string): string {
   return normalizeAppHost(host).split(':')[0];
 }
 
-/** Clerk proxy CNAME only exists on deployed Connect domains — not localhost dev hosts. */
-function shouldUseDefaultClerkProxy(connectHostname: string): boolean {
-  const hostname = getHostnameWithoutPort(connectHostname);
-
-  return hostname !== 'localhost' && !hostname.endsWith('.localhost');
-}
-
-// Clerk FAPI proxy on the Connect satellite (CNAME `clerk.<connect-domain>` → frontend-api.clerk.services).
-// Auto-default on deployed hosts only; set VITE_CLERK_PROXY_URL explicitly when needed.
-export const CLERK_PROXY_URL =
-  window._env_?.VITE_CLERK_PROXY_URL ||
-  import.meta.env.VITE_CLERK_PROXY_URL ||
-  (NOVU_CONNECT_HOSTNAME && shouldUseDefaultClerkProxy(NOVU_CONNECT_HOSTNAME)
-    ? `https://clerk.${getHostnameWithoutPort(NOVU_CONNECT_HOSTNAME)}`
-    : '');
+export { getHostnameWithoutPort };
 
 // Fail fast when the hostname split is half-configured. Without `NOVU_PLATFORM_HOSTNAME`,
 // satellite → primary handoffs (Clerk sign-in, cross-product redirects) silently break.

--- a/apps/dashboard/src/context/ee-auth-provider.tsx
+++ b/apps/dashboard/src/context/ee-auth-provider.tsx
@@ -1,19 +1,18 @@
 import { buttonVariants } from '@/components/primitives/button';
 import {
   CLERK_PUBLISHABLE_KEY,
-  CLERK_PROXY_URL,
   EE_AUTH_PROVIDER,
+  getHostnameWithoutPort,
   IS_ENTERPRISE,
   IS_HOSTNAME_SPLIT_ENABLED,
   IS_NOVU_CONNECT,
   IS_SELF_HOSTED,
-  normalizeAppHost,
   NOVU_CONNECT_HOSTNAME,
-  NOVU_PLATFORM_HOSTNAME,
 } from '@/config';
 import { isAbsoluteUrl } from '@/utils/apps';
 import { buildAfterSignOutUrl } from '@/utils/cross-product-sign-out';
 import {
+  buildClerkAllowedRedirectOrigins,
   buildPrimarySignInUrl,
   buildPrimarySignUpUrl,
   CONNECT_PRODUCT_VALUE,
@@ -88,21 +87,11 @@ export const EEAuthProvider = (props: EEAuthProviderProps) => {
   const satelliteProps = isSatellite
     ? {
         isSatellite: true as const,
-        domain: normalizeAppHost(NOVU_CONNECT_HOSTNAME).split(':')[0],
-        ...(CLERK_PROXY_URL ? { proxyUrl: CLERK_PROXY_URL } : {}),
+        domain: getHostnameWithoutPort(NOVU_CONNECT_HOSTNAME),
       }
     : {};
 
-  const allowedRedirectOrigins: Array<string | RegExp> = [
-    'http://localhost:*',
-    ...(typeof window !== 'undefined' ? [window.location.origin] : []),
-    ...(IS_HOSTNAME_SPLIT_ENABLED && NOVU_PLATFORM_HOSTNAME
-      ? [`https://${normalizeAppHost(NOVU_PLATFORM_HOSTNAME).split(':')[0]}`]
-      : []),
-    ...(IS_HOSTNAME_SPLIT_ENABLED && NOVU_CONNECT_HOSTNAME
-      ? [`https://${normalizeAppHost(NOVU_CONNECT_HOSTNAME).split(':')[0]}`]
-      : []),
-  ];
+  const allowedRedirectOrigins = buildClerkAllowedRedirectOrigins();
 
   return (
     <_ClerkProvider

--- a/apps/dashboard/src/hooks/use-cross-app-navigation.ts
+++ b/apps/dashboard/src/hooks/use-cross-app-navigation.ts
@@ -1,19 +1,37 @@
 import { useCallback } from 'react';
+import { useAuth, useClerk } from '@clerk/react';
+import { IS_HOSTNAME_SPLIT_ENABLED } from '@/config';
 import { isSafeNavigationHref } from '@/utils/apps';
+import { navigateWithClerkSessionIfCrossOrigin } from '@/utils/connect/clerk-cross-origin-auth';
+import { isConnectHostnameUrl } from '@/utils/product-auth-urls';
 
 export function useCrossAppNavigation() {
-  return useCallback((href: string, openInNewTab = false) => {
-    // Whitelist http(s) / relative hrefs so callers can't smuggle `javascript:` / `data:` URLs in.
-    if (!isSafeNavigationHref(href)) {
-      return;
-    }
+  const { isSignedIn, isLoaded } = useAuth();
+  const clerk = useClerk();
 
-    if (openInNewTab) {
-      window.open(href, '_blank', 'noopener,noreferrer');
+  return useCallback(
+    (href: string, openInNewTab = false) => {
+      if (!isSafeNavigationHref(href)) {
+        return;
+      }
 
-      return;
-    }
+      if (openInNewTab) {
+        window.open(href, '_blank', 'noopener,noreferrer');
 
-    window.location.assign(href);
-  }, []);
+        return;
+      }
+
+      const shouldSyncClerkSession =
+        IS_HOSTNAME_SPLIT_ENABLED && isConnectHostnameUrl(href) && isLoaded && isSignedIn && clerk.loaded;
+
+      if (shouldSyncClerkSession) {
+        void navigateWithClerkSessionIfCrossOrigin(clerk, href);
+
+        return;
+      }
+
+      window.location.assign(href);
+    },
+    [clerk, isLoaded, isSignedIn]
+  );
 }

--- a/apps/dashboard/src/pages/sign-in.tsx
+++ b/apps/dashboard/src/pages/sign-in.tsx
@@ -80,6 +80,8 @@ export const SignInPage = () => {
     });
   }, []);
 
+  // Primary → Connect after auth: Clerk redirectWithAuth syncs the session to the satellite.
+  // Do not set forceRedirectUrl to a cross-origin Connect URL — that skips the handshake.
   useEffect(() => {
     if (!isLoaded || !isSignedIn || IS_NOVU_CONNECT || !clerk.loaded || hasRedirectedToConnectRef.current) {
       return;
@@ -94,7 +96,7 @@ export const SignInPage = () => {
         beginConnectProvisioning();
       }
 
-      navigateToConnectWithClerkSession(clerk, destination);
+      void navigateToConnectWithClerkSession(clerk, destination);
 
       return;
     }
@@ -112,8 +114,6 @@ export const SignInPage = () => {
     clerk,
     navigate,
   ]);
-
-  const connectProvisionRedirect = useMemo(() => connectDefaultDestination, [connectDefaultDestination]);
 
   // Preserve `?product=connect` across the Clerk sign-in ↔ sign-up link so branding survives.
   const signUpUrlWithProduct = isConnectSignIn
@@ -138,7 +138,6 @@ export const SignInPage = () => {
             path={ROUTES.SIGN_IN}
             signUpUrl={signUpUrlWithProduct}
             appearance={clerkSignupAppearance}
-            forceRedirectUrl={isConnectSignIn ? connectProvisionRedirect : undefined}
           />
           {!IS_SELF_HOSTED && !isConnectSignIn && <RegionPicker />}
         </div>

--- a/apps/dashboard/src/pages/sign-up.tsx
+++ b/apps/dashboard/src/pages/sign-up.tsx
@@ -78,6 +78,7 @@ export const SignUpPage = () => {
     });
   }, []);
 
+  // Primary → Connect after auth: Clerk redirectWithAuth syncs the session to the satellite.
   useEffect(() => {
     if (!isLoaded || !isSignedIn || IS_NOVU_CONNECT || !clerk.loaded || hasRedirectedToConnectRef.current) {
       return;
@@ -95,10 +96,8 @@ export const SignUpPage = () => {
       beginConnectProvisioning();
     }
 
-    navigateToConnectWithClerkSession(clerk, destination);
+    void navigateToConnectWithClerkSession(clerk, destination);
   }, [isLoaded, isSignedIn, isConnectSignUp, connectSatelliteReturnUrl, connectDefaultDestination, clerk]);
-
-  const connectProvisionRedirect = useMemo(() => connectDefaultDestination, [connectDefaultDestination]);
 
   const signInUrlWithProduct = isConnectSignUp
     ? `${ROUTES.SIGN_IN}?${PRODUCT_QUERY_PARAM}=${CONNECT_PRODUCT_VALUE}`
@@ -120,7 +119,7 @@ export const SignUpPage = () => {
             path={ROUTES.SIGN_UP}
             signInUrl={signInUrlWithProduct}
             appearance={clerkSignupAppearance}
-            forceRedirectUrl={isConnectSignUp ? connectProvisionRedirect : ROUTES.SIGNUP_ORGANIZATION_LIST}
+            forceRedirectUrl={isConnectSignUp ? undefined : ROUTES.SIGNUP_ORGANIZATION_LIST}
           />
           {!IS_SELF_HOSTED && !isConnectSignUp && <RegionPicker />}
         </div>

--- a/apps/dashboard/src/routes/hostname-guard.tsx
+++ b/apps/dashboard/src/routes/hostname-guard.tsx
@@ -1,9 +1,12 @@
+import { useAuth, useClerk } from '@clerk/react';
+import { ReactNode, useEffect } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
 import { IS_HOSTNAME_SPLIT_ENABLED, IS_NOVU_CONNECT, NOVU_CONNECT_HOSTNAME } from '@/config';
 import { useEnvironment } from '@/context/environment/hooks';
 import { LEGACY_CONNECT_PATH_REGEX } from '@/utils/apps';
+import { navigateWithClerkSessionIfCrossOrigin } from '@/utils/connect/clerk-cross-origin-auth';
+import { isConnectHostnameUrl } from '@/utils/product-auth-urls';
 import { buildRoute, ROUTES } from '@/utils/routes';
-import { ReactNode, useEffect } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
 
 type HostnameGuardProps = {
   children: ReactNode;
@@ -14,6 +17,8 @@ type HostnameGuardProps = {
 export function HostnameGuard({ children }: HostnameGuardProps) {
   const location = useLocation();
   const { currentEnvironment } = useEnvironment();
+  const { isSignedIn, isLoaded } = useAuth();
+  const clerk = useClerk();
 
   const isConnectPath = LEGACY_CONNECT_PATH_REGEX.test(location.pathname);
   const isEnvScopedPath = location.pathname.startsWith('/env/');
@@ -21,11 +26,36 @@ export function HostnameGuard({ children }: HostnameGuardProps) {
   const shouldRedirectCrossOrigin = IS_HOSTNAME_SPLIT_ENABLED && !IS_NOVU_CONNECT && isConnectPath;
 
   useEffect(() => {
-    if (shouldRedirectCrossOrigin && typeof window !== 'undefined') {
-      const url = `${window.location.protocol}//${NOVU_CONNECT_HOSTNAME}${location.pathname}${location.search}${location.hash}`;
-      window.location.replace(url);
+    if (!shouldRedirectCrossOrigin || typeof window === 'undefined') {
+      return;
     }
-  }, [shouldRedirectCrossOrigin, location.pathname, location.search, location.hash]);
+
+    const url = `${window.location.protocol}//${NOVU_CONNECT_HOSTNAME}${location.pathname}${location.search}${location.hash}`;
+
+    if (!isConnectHostnameUrl(url)) {
+      window.location.replace(url);
+
+      return;
+    }
+
+    const shouldSyncClerkSession = isLoaded && isSignedIn && clerk.loaded;
+
+    if (shouldSyncClerkSession) {
+      void navigateWithClerkSessionIfCrossOrigin(clerk, url);
+
+      return;
+    }
+
+    window.location.replace(url);
+  }, [
+    shouldRedirectCrossOrigin,
+    location.pathname,
+    location.search,
+    location.hash,
+    isLoaded,
+    isSignedIn,
+    clerk,
+  ]);
 
   if (!IS_HOSTNAME_SPLIT_ENABLED) {
     return <>{children}</>;

--- a/apps/dashboard/src/utils/connect/clerk-cross-origin-auth.ts
+++ b/apps/dashboard/src/utils/connect/clerk-cross-origin-auth.ts
@@ -1,63 +1,27 @@
 import { isConnectHostnameUrl } from '@/utils/product-auth-urls';
 
-// Clerk + Netlify: CDN can cache handshake redirects and cause infinite auth loops.
-const CLERK_NETLIFY_CACHE_BUST_PARAM = '__clerk_netlify_cache_bust';
-
-function isLocalDevRuntime(): boolean {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  const hostname = window.location.hostname;
-
-  return hostname === 'localhost' || hostname.endsWith('.localhost');
-}
-
 type ClerkCrossOriginAuth = {
   loaded: boolean;
   redirectWithAuth: (to: string) => Promise<unknown>;
-  buildUrlWithAuth: (to: string) => string;
   buildSignInUrl: (opts?: { signInForceRedirectUrl?: string | null }) => string;
   buildSignUpUrl: (opts?: { signUpForceRedirectUrl?: string | null }) => string;
 };
 
-function withNetlifyHandshakeCacheBust(url: string): string {
-  if (isLocalDevRuntime()) {
-    return url;
-  }
-
-  try {
-    const parsed = new URL(url);
-
-    if (parsed.searchParams.has('__clerk_handshake')) {
-      return url;
-    }
-
-    if (!parsed.searchParams.has(CLERK_NETLIFY_CACHE_BUST_PARAM)) {
-      parsed.searchParams.set(CLERK_NETLIFY_CACHE_BUST_PARAM, Date.now().toString());
-    }
-
-    return parsed.toString();
-  } catch {
-    return url;
-  }
-}
-
-function navigateWithDecoratedAuthUrl(clerk: ClerkCrossOriginAuth, destination: string): void {
-  const authedUrl = withNetlifyHandshakeCacheBust(clerk.buildUrlWithAuth(destination));
-
-  window.location.assign(authedUrl);
-}
-
-/** Primary → Connect handoff: decorates the URL so Clerk propagates the session to the satellite. */
-export function navigateToConnectWithClerkSession(clerk: ClerkCrossOriginAuth, destination: string): void {
-  navigateWithDecoratedAuthUrl(clerk, destination);
+/** Primary → Connect handoff: Clerk syncs the session to the satellite domain. */
+export async function navigateToConnectWithClerkSession(
+  clerk: ClerkCrossOriginAuth,
+  destination: string
+): Promise<void> {
+  await clerk.redirectWithAuth(destination);
 }
 
 /** Cross-product navigation — Connect targets must go through Clerk session sync. */
-export function navigateWithClerkSessionIfCrossOrigin(clerk: ClerkCrossOriginAuth, destination: string): void {
+export async function navigateWithClerkSessionIfCrossOrigin(
+  clerk: ClerkCrossOriginAuth,
+  destination: string
+): Promise<void> {
   if (isConnectHostnameUrl(destination)) {
-    navigateToConnectWithClerkSession(clerk, destination);
+    await navigateToConnectWithClerkSession(clerk, destination);
 
     return;
   }
@@ -71,7 +35,7 @@ export function redirectSatelliteToPrimarySignIn(clerk: ClerkCrossOriginAuth, re
     returnUrl ? { signInForceRedirectUrl: returnUrl } : undefined
   );
 
-  window.location.replace(withNetlifyHandshakeCacheBust(primarySignInUrl));
+  window.location.replace(primarySignInUrl);
 }
 
 /** Connect satellite → primary sign-up with optional post-auth return to Connect. */
@@ -80,5 +44,5 @@ export function redirectSatelliteToPrimarySignUp(clerk: ClerkCrossOriginAuth, re
     returnUrl ? { signUpForceRedirectUrl: returnUrl } : undefined
   );
 
-  window.location.replace(withNetlifyHandshakeCacheBust(primarySignUpUrl));
+  window.location.replace(primarySignUpUrl);
 }

--- a/apps/dashboard/src/utils/product-auth-urls.ts
+++ b/apps/dashboard/src/utils/product-auth-urls.ts
@@ -1,4 +1,5 @@
 import {
+  getHostnameWithoutPort,
   IS_HOSTNAME_SPLIT_ENABLED,
   normalizeAppHost,
   NOVU_CONNECT_HOSTNAME,
@@ -64,6 +65,41 @@ export function buildPrimarySignUpUrl(options?: PrimaryAuthUrlOptions): string {
   return buildAbsolutePlatformUrl(appendProductParam(ROUTES.SIGN_UP, options?.product));
 }
 
+function buildAppOrigin(hostname: string): string {
+  if (!hostname || typeof window === 'undefined') {
+    return '';
+  }
+
+  return `${window.location.protocol}//${normalizeAppHost(hostname)}`;
+}
+
+/** Primary ClerkProvider allowlist — satellite origins must be listed for redirectWithAuth. */
+export function buildClerkAllowedRedirectOrigins(): Array<string | RegExp> {
+  const origins: Array<string | RegExp> = ['http://localhost:*'];
+
+  if (typeof window === 'undefined') {
+    return origins;
+  }
+
+  origins.push(window.location.origin);
+
+  if (!IS_HOSTNAME_SPLIT_ENABLED) {
+    return origins;
+  }
+
+  if (NOVU_CONNECT_HOSTNAME) {
+    origins.push(buildAppOrigin(NOVU_CONNECT_HOSTNAME));
+    origins.push(`https://${getHostnameWithoutPort(NOVU_CONNECT_HOSTNAME)}`);
+  }
+
+  if (NOVU_PLATFORM_HOSTNAME) {
+    origins.push(buildAppOrigin(NOVU_PLATFORM_HOSTNAME));
+    origins.push(`https://${getHostnameWithoutPort(NOVU_PLATFORM_HOSTNAME)}`);
+  }
+
+  return [...new Set(origins)];
+}
+
 export function isConnectHostnameUrl(url: string): boolean {
   if (!IS_HOSTNAME_SPLIT_ENABLED || !NOVU_CONNECT_HOSTNAME || typeof window === 'undefined') {
     return false;
@@ -115,6 +151,21 @@ export function readClerkRedirectUrlParam(searchParams?: URLSearchParams): strin
   return readClerkAuthParamFromLocation('redirect_url', searchParams);
 }
 
+/** Strip handshake params that can accumulate across redirect loops. */
+function sanitizeConnectSatelliteReturnUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.searchParams.delete('__clerk_netlify_cache_bust');
+    parsed.searchParams.delete('__clerk_synced');
+    parsed.searchParams.delete('__clerk_sync');
+    parsed.searchParams.delete('__clerk_handshake');
+
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
 /** Clerk's satellite handshake return URL — must be honored so Connect receives the synced session. */
 export function readConnectSatelliteReturnUrl(searchParams?: URLSearchParams): string | null {
   const redirectUrl = readClerkRedirectUrlParam(searchParams);
@@ -123,24 +174,24 @@ export function readConnectSatelliteReturnUrl(searchParams?: URLSearchParams): s
     return null;
   }
 
-  return redirectUrl;
+  return sanitizeConnectSatelliteReturnUrl(redirectUrl);
 }
 
-function isConnectAuthPath(url: string): boolean {
+function isConnectPrimaryAuthPath(url: string): boolean {
   try {
     const pathname = new URL(url, typeof window !== 'undefined' ? window.location.origin : 'http://local').pathname;
 
-    return pathname.startsWith('/auth/');
+    return pathname === ROUTES.SIGN_IN || pathname === ROUTES.SIGN_UP;
   } catch {
     return false;
   }
 }
 
-/** Return URL to send back to Connect after primary auth — skips auth pages that would re-bounce. */
+/** Return URL to send back to Connect after primary auth — skip sign-in/sign-up pages that re-bounce. */
 export function resolveConnectSatelliteReturnUrl(searchParams: URLSearchParams): string | null {
   const fromQuery = readConnectSatelliteReturnUrl(searchParams);
 
-  if (fromQuery && !isConnectAuthPath(fromQuery)) {
+  if (fromQuery && !isConnectPrimaryAuthPath(fromQuery)) {
     return fromQuery;
   }
 
@@ -150,8 +201,8 @@ export function resolveConnectSatelliteReturnUrl(searchParams: URLSearchParams):
 
   const currentLocation = window.location.href;
 
-  if (isConnectHostnameUrl(currentLocation) && !isConnectAuthPath(currentLocation)) {
-    return currentLocation;
+  if (isConnectHostnameUrl(currentLocation) && !isConnectPrimaryAuthPath(currentLocation)) {
+    return sanitizeConnectSatelliteReturnUrl(currentLocation);
   }
 
   return null;


### PR DESCRIPTION


- Updated environment configuration to remove deprecated Clerk proxy URL.
- Enhanced `CrossAppLink` and `useCrossAppNavigation` hooks to support session synchronization for cross-origin links.
- Refactored `navigateWithClerkSessionIfCrossOrigin` to use async/await for better handling of navigation.
- Improved `HostnameGuard` to ensure proper session syncing during redirects.
- Added utility functions for building allowed redirect origins and sanitizing URLs to prevent handshake parameter accumulation.

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The PR enhances cross-origin navigation in the dashboard by replacing deprecated Clerk proxy URL patterns with direct Clerk session synchronization. Navigation functions now use Clerk's async `redirectWithAuth()` method instead of manual URL decoration. New utilities were added to build allowed redirect origins and sanitize URLs of handshake parameters, improving session handling across origin boundaries.

## Affected areas

**dashboard**: Cross-origin navigation hooks (`useCrossAppNavigation`, `CrossAppLink`) and routes (`HostnameGuard`) now integrate Clerk auth state for session synchronization. Core utilities (`clerk-cross-origin-auth`, `product-auth-urls`) refactored to use async Clerk redirects. Auth flow pages (`sign-in`, `sign-up`) simplified by removing forced redirect URL handling. Clerk redirect allowlisting centralized via new `buildClerkAllowedRedirectOrigins()` helper. Environment configuration removed deprecated `VITE_CLERK_PROXY_URL`.

## Key technical decisions

- Navigation functions converted to async/await pattern using `clerk.redirectWithAuth()` instead of synchronous `window.location.assign()` with decorated URLs
- Removed Netlify handshake cache-busting URL parameters (`withNetlifyHandshakeCacheBust` helper deleted)
- Added `buildClerkAllowedRedirectOrigins()` and `sanitizeConnectSatelliteReturnUrl()` utilities for centralized redirect handling
- Clerk session sync only triggered conditionally when cross-origin navigation detected, user signed in, and Clerk loaded
- Exported `getHostnameWithoutPort` utility for reuse across modules

## Testing

No tests were added. Changes are primarily integration-level refactoring of existing cross-origin navigation paths with improved session handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
