### PR TITLE
fix(dashboard): re-enable satelliteAutoSync for Connect (Clerk v6 default flip)

### DIFF
--- a/apps/dashboard/src/context/ee-auth-provider.tsx
+++ b/apps/dashboard/src/context/ee-auth-provider.tsx
@@ -88,6 +88,13 @@ export const EEAuthProvider = (props: EEAuthProviderProps) => {
     ? {
         isSatellite: true as const,
         domain: getHostnameWithoutPort(NOVU_CONNECT_HOSTNAME),
+        // Clerk v6 / Core 3 flipped the satellite default from auto-sync ON to OFF (#7597), so
+        // Connect now treats every first page load as anonymous unless cookies are already
+        // present — primary's sign-in then bounces back to a still-anonymous satellite and we
+        // loop. We rely on the Core 2 behavior (auto-handshake with primary on first load) so
+        // an already-signed-in user on Platform is recognized on Connect without re-auth.
+        // See https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3
+        satelliteAutoSync: true,
       }
     : {};
 


### PR DESCRIPTION
## Root cause

Clerk v6 / Core 3 changed the satellite default from `satelliteAutoSync: true` to `satelliteAutoSync: false` ([clerk/javascript#7597](https://github.com/clerk/javascript/pull/7597), [Core 3 upgrade guide](https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3)). Our Connect ClerkProvider doesn't pass the prop, so it now picks up the new default — that's the actual driver of the Platform ↔ Connect redirect loop that's been chased through #11286, #11288, #11291, and #11293.

Verified flow that produced the loop the user was seeing (\`https://devconnect.novu.co/auth/organization-list?provision=1\` ↔ \`https://dashboard.novu-staging.co/auth/sign-in?product=connect#/?redirect_url=...&__clerk_synced=false\`):

1. User hits a protected Connect URL without satellite cookies.
2. With auto-sync OFF, the satellite SDK skips the primary handshake and bounces to `signInUrl` with `redirect_url=<connect>&__clerk_synced=false`.
3. Primary sees `isSignedIn = true` and sends the user back via `forceRedirectUrl` / `window.location.assign(connectProvisionRedirect)`.
4. Connect still has no session — auto-sync is still OFF — so step 2 repeats forever.

"Yesterday it worked" because users had warm cookies on Connect; once they expired or were cleared, the loop kicked in. None of the previous follow-ups addressed this — they kept patching the React-side navigation while Clerk itself was refusing to perform the handshake.

## Change

\`\`\`tsx
const satelliteProps = isSatellite
  ? {
      isSatellite: true as const,
      domain: getHostnameWithoutPort(NOVU_CONNECT_HOSTNAME),
      satelliteAutoSync: true, // <-- restore the Core 2 default
    }
  : {};
\`\`\`

Opt back into Core 2 behavior on the Connect satellite ClerkProvider — first satellite page load handshakes with primary and picks up the existing session. Performance trade-off (one extra redirect on first Connect visit) is acceptable for the hostname-split deploy because there's no scenario where an anonymous user lands on Connect without intending to auth anyway.

## Test plan

- [ ] Fresh browser (or clear satellite cookies): visit \`https://devconnect.novu.co\` → satellite handshakes with primary → if signed in on Platform, lands on Connect's `/auth/organization-list` with valid session; no loop.
- [ ] Sign-in flow: Connect `/auth/sign-in` → Platform sign-in → back to Connect `?provision=1` → AutoCreate proceeds without bouncing.
- [ ] Sign-up flow: same as sign-in, with new account.
- [ ] Platform tile click on Connect → Platform org list.
- [ ] Direct Connect URL while having Platform org active: `AuthProvider` clears the org and lands on Connect picker (already merged in #11293).
- [ ] No `__clerk_synced=false` URLs in the browser history after these flows.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The EEAuthProvider's satellite (Connect) Clerk configuration now explicitly sets `satelliteAutoSync: true`. Clerk v6 / Core 3 changed the satellite auto-sync default to OFF, which caused Connect to treat first-time page loads as anonymous. This triggered an infinite redirect loop between Platform (signed in) and Connect (unsigned) when cookies were absent or expired. Re-enabling auto-sync restores the handshake behavior so Platform users are recognized on Connect without re-authentication.

## Affected areas

**dashboard**: The Clerk provider configuration for Connect (satellite mode) now includes `satelliteAutoSync: true` to match Core 2 behavior and prevent anonymous redirect loops on first load.

## Key technical decisions

- **Satellite auto-sync re-enabled**: Explicitly set `satelliteAutoSync: true` in satellite configuration alongside `isSatellite` and `domain` props to restore the handshake behavior that picks up existing sessions on first Connect visit.

## Testing

Manual verification is needed to confirm: fresh browser / cleared satellite cookies can handshake and land on Connect with a valid session when signed in on Platform; sign-in/sign-up flows return to Connect without bouncing; no __clerk_synced=false URLs remain in browser history after flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->