### PR TITLE
feat(dashboard): move add-agent loading state to dialog footer fixes NV-7811

### DIFF
--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -6,7 +6,6 @@ import {
   slugify,
 } from '@novu/shared';
 import { useQueryClient } from '@tanstack/react-query';
-import { AnimatePresence, motion } from 'motion/react';
 import type { FormEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RiArrowRightSLine, RiArrowRightUpLine, RiCloseLine } from 'react-icons/ri';
@@ -800,11 +799,8 @@ export function CreateAgentDialog({
                   )}
 
                   {generationMode === 'prompt' && (
-                    // We intentionally don't forward `generationSteps`/`onCancelGeneration` to
-                    // `PromptInput` here so the textarea stays compact. The Cancel button and the
-                    // animation are rendered as siblings below the suggestion pills instead, which
-                    // keeps the pills anchored directly under the textarea and stops them from
-                    // shifting whenever a generation kicks off.
+                    // Generation status and Cancel live in the dialog footer so the body height
+                    // stays stable while the agent is being created from a prompt.
                     <PromptInput
                       value={prompt}
                       onChange={handlePromptChange}
@@ -845,38 +841,6 @@ export function CreateAgentDialog({
                     disabled={isSubmitBusy}
                   />
                 )}
-
-                <AnimatePresence initial={false}>
-                  {isSubmitBusy && generationMode === 'prompt' && (
-                    <motion.div
-                      key="prompt-generation-status"
-                      initial={{ height: 0, opacity: 0, y: -4 }}
-                      animate={{ height: 'auto', opacity: 1, y: 0 }}
-                      exit={{ height: 0, opacity: 0, y: -4 }}
-                      transition={{ duration: 0.2, ease: 'easeInOut' }}
-                      className="overflow-hidden"
-                    >
-                      <div className="flex flex-col gap-3">
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          mode="outline"
-                          size="2xs"
-                          className="w-fit gap-1"
-                          onClick={handleCancelGeneration}
-                          // Cancel is only meaningful while the LLM call is in flight; once it
-                          // returns we are mid-provisioning at Anthropic and there is nothing to
-                          // abort, so keep the button visible (avoids a layout shift) but disable it.
-                          disabled={!isGenerating}
-                          trailingIcon={RiCloseLine}
-                        >
-                          Cancel
-                        </Button>
-                        <GenerationStatus steps={GENERATION_STEPS} />
-                      </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
               </div>
             ) : (
               <ScratchAgentFields
@@ -901,17 +865,41 @@ export function CreateAgentDialog({
             )}
           </div>
 
-          <div className="bg-bg-weak border-stroke-soft flex items-center justify-end border-t px-4 py-3">
-            <Button
-              variant="secondary"
-              mode="gradient"
-              size="xs"
-              type="submit"
-              isLoading={isSubmitBusy}
-              trailingIcon={RiArrowRightSLine}
-            >
-              Setup agent
-            </Button>
+          <div className="bg-bg-weak border-stroke-soft flex items-center gap-3 border-t px-4 py-3">
+            {isSubmitBusy && generationMode === 'prompt' ? (
+              <>
+                <div className="min-w-0 flex-1">
+                  <GenerationStatus steps={GENERATION_STEPS} />
+                </div>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  mode="outline"
+                  size="xs"
+                  className="shrink-0 gap-1"
+                  onClick={handleCancelGeneration}
+                  // Cancel is only meaningful while the LLM call is in flight; once it
+                  // returns we are mid-provisioning at Anthropic and there is nothing to
+                  // abort, so keep the button visible (avoids a layout shift) but disable it.
+                  disabled={!isGenerating}
+                  trailingIcon={RiCloseLine}
+                >
+                  Cancel
+                </Button>
+              </>
+            ) : (
+              <Button
+                variant="secondary"
+                mode="gradient"
+                size="xs"
+                type="submit"
+                className="ml-auto"
+                isLoading={isSubmitBusy}
+                trailingIcon={RiArrowRightSLine}
+              >
+                Setup agent
+              </Button>
+            )}
           </div>
         </form>
       </DialogContent>

--- a/apps/dashboard/src/components/agents/create-agent-dialog.tsx
+++ b/apps/dashboard/src/components/agents/create-agent-dialog.tsx
@@ -101,6 +101,10 @@ const GENERATION_STEPS: ReadonlyArray<GenerationStep> = [
 
 const MIN_PROMPT_LENGTH = 8;
 
+// Matches the dialog footer button's `h-14` (56px) so the animated status sits inside the footer
+// instead of stretching it taller while the agent is being generated.
+const FOOTER_STATUS_HEIGHT = 56;
+
 const PROMPT_HEADER: Record<
   Exclude<AgentGenerationMode, 'existing'>,
   { label: string; toggleLabel: string; toggleTo: Exclude<AgentGenerationMode, 'existing'>; toggleIcon?: 'sparkles' }
@@ -868,8 +872,12 @@ export function CreateAgentDialog({
           <div className="bg-bg-weak border-stroke-soft flex items-center gap-3 border-t px-4 py-3">
             {isSubmitBusy && generationMode === 'prompt' ? (
               <>
-                <div className="min-w-0 flex-1">
-                  <GenerationStatus steps={GENERATION_STEPS} />
+                <div className="flex h-14 -mt-3 -mb-3 min-w-0 flex-1 items-center">
+                  <GenerationStatus
+                    steps={GENERATION_STEPS}
+                    containerHeight={FOOTER_STATUS_HEIGHT}
+                    className="w-full"
+                  />
                 </div>
                 <Button
                   type="button"

--- a/apps/dashboard/src/components/onboarding/connect-agent/generation-status.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/generation-status.tsx
@@ -12,14 +12,25 @@ type GenerationStatusProps = {
   steps: ReadonlyArray<GenerationStep>;
   stepDelayMs?: number;
   className?: string;
+  /**
+   * Height of the scrolling viewport in pixels. Lower this when embedding the status inside a
+   * fixed-height region (e.g. a dialog footer) so the container does not push the parent taller.
+   * The fade mask scales with this value, so very small heights effectively show a single row.
+   */
+  containerHeight?: number;
 };
 
 const DEFAULT_STEP_DELAY_MS = 2000;
 const ITEM_HEIGHT = 16;
 const GAP = 8;
-const CONTAINER_HEIGHT = 80;
+const DEFAULT_CONTAINER_HEIGHT = 80;
 
-export function GenerationStatus({ steps, stepDelayMs = DEFAULT_STEP_DELAY_MS, className }: GenerationStatusProps) {
+export function GenerationStatus({
+  steps,
+  stepDelayMs = DEFAULT_STEP_DELAY_MS,
+  className,
+  containerHeight = DEFAULT_CONTAINER_HEIGHT,
+}: GenerationStatusProps) {
   const [activeIndex, setActiveIndex] = useState(0);
 
   useEffect(() => {
@@ -33,7 +44,7 @@ export function GenerationStatus({ steps, stepDelayMs = DEFAULT_STEP_DELAY_MS, c
   }, [steps.length, stepDelayMs]);
 
   return (
-    <div className={cn('relative flex flex-col overflow-hidden', className)} style={{ minHeight: CONTAINER_HEIGHT }}>
+    <div className={cn('relative flex flex-col overflow-hidden', className)} style={{ height: containerHeight }}>
       <div
         className="absolute inset-0 overflow-hidden"
         style={{
@@ -45,7 +56,7 @@ export function GenerationStatus({ steps, stepDelayMs = DEFAULT_STEP_DELAY_MS, c
           className="absolute left-0 right-0 flex flex-col"
           style={{ gap: GAP }}
           initial={false}
-          animate={{ y: CONTAINER_HEIGHT / 2 - ITEM_HEIGHT / 2 - activeIndex * (ITEM_HEIGHT + GAP) }}
+          animate={{ y: containerHeight / 2 - ITEM_HEIGHT / 2 - activeIndex * (ITEM_HEIGHT + GAP) }}
           transition={{ type: 'tween', ease: 'easeInOut' }}
         >
           {steps.map((step, index) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When creating an agent from a prompt in the Add agent dialog, the generation status animation and Cancel control now live in the dialog footer instead of the scrollable body. This keeps the dialog body height stable while generation runs and replaces the Setup agent submit button with Cancel for the duration of prompt-based creation.

## Changes

- Removed the animated generation status block from the dialog body (below suggestion pills).
- Footer shows `GenerationStatus` on the left and a Cancel button on the right while prompt-mode submission is in progress.
- Setup agent remains the footer action when idle or when using manual / existing flows (with loading spinner on submit when applicable).

## Testing

- [x] Dashboard TypeScript check (`tsc --noEmit`)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7811](https://linear.app/novu/issue/NV-7811/add-agent-modal-move-the-loading-state-to-the-dialog-footer-and)

<div><a href="https://cursor.com/agents/bc-24cd2c63-7efd-4af9-9a1a-8bf73b10e77e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24cd2c63-7efd-4af9-9a1a-8bf73b10e77e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The add-agent dialog now keeps the prompt-generation UI stable by moving the animated GenerationStatus and the Cancel control out of the scrollable dialog body and into the dialog footer while a prompt-based creation is in progress. This prevents layout shifts during generation and replaces the Setup agent submit action with Cancel for the duration of the LLM-driven flow; normal manual/existing flows and their submit behavior remain unchanged.

## Affected areas
**dashboard**: Updated the CreateAgentDialog and GenerationStatus components so prompt-mode generation renders a fixed-height status block in the dialog footer (with a Cancel button) rather than an animated block inside the scrollable body.

## Key technical decisions
- GenerationStatus now accepts a containerHeight prop (defaulted) so it can be embedded in fixed-height regions like the footer without changing parent layout.  
- The animated in-body presence/AnimatePresence usage was removed from the dialog body and replaced by footer rendering using a FOOTER_STATUS_HEIGHT constant.

## Testing
TypeScript checked with tsc --noEmit; no new unit or e2e tests were added and changes require manual/visual verification of dialog layout and prompt-generation flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

https://github.com/user-attachments/assets/aa1b4bfc-4f6a-49ff-a0a9-6f95b053d518


