### PR TITLE
fix(shared): revert agent provider card order fixes NV-7822

### DIFF
--- a/packages/shared/src/consts/providers/conversational-providers.ts
+++ b/packages/shared/src/consts/providers/conversational-providers.ts
@@ -9,10 +9,10 @@ export type ConversationalProvider = {
 
 export const CONVERSATIONAL_PROVIDERS: ConversationalProvider[] = [
   { providerId: ChatProviderIdEnum.Slack, displayName: 'Slack' },
-  { providerId: ChatProviderIdEnum.MsTeams, displayName: 'MS Teams' },
-  { providerId: ChatProviderIdEnum.WhatsAppBusiness, displayName: 'WhatsApp Business' },
-  { providerId: EmailProviderIdEnum.NovuAgent, displayName: 'Novu Email', requiresBusinessTier: true },
   { providerId: ChatProviderIdEnum.Telegram, displayName: 'Telegram' },
+  { providerId: ChatProviderIdEnum.WhatsAppBusiness, displayName: 'WhatsApp Business' },
+  { providerId: ChatProviderIdEnum.MsTeams, displayName: 'MS Teams' },
+  { providerId: EmailProviderIdEnum.NovuAgent, displayName: 'Novu Email', requiresBusinessTier: true },
   { providerId: ChatProviderIdEnum.Discord, displayName: 'Discord', comingSoon: true },
   { providerId: 'google-chat', displayName: 'Google Chat', comingSoon: true },
   { providerId: 'linear', displayName: 'Linear', comingSoon: true },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores the conversational provider card order on the agent onboarding screen to:

1. Slack
2. Telegram
3. WhatsApp Business
4. MS Teams

The order is defined in `CONVERSATIONAL_PROVIDERS`, which drives the provider cards and dropdown in the dashboard.

## Test plan

- [ ] Open agent setup and confirm provider cards appear in the order above
- [ ] Verify provider dropdown uses the same order
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac06b0a5-3238-4947-8e27-88d5738537ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac06b0a5-3238-4947-8e27-88d5738537ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reordered provider list arrangement to optimize organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->