### PR TITLE
fix(api-service): point MCP OAuth DCR logo_uri to /images/novu.svg fixes NV-7823

### DIFF
--- a/apps/api/src/app/agents/usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase.ts
+++ b/apps/api/src/app/agents/usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase.ts
@@ -447,7 +447,7 @@ export class GenerateMcpOAuthUrl {
         token_endpoint_auth_method: 'client_secret_post',
         scope: scopes.length > 0 ? scopes.join(' ') : undefined,
         client_uri: frontBase,
-        logo_uri: frontBase ? `${frontBase}/static/novu-logo.png` : undefined,
+        logo_uri: frontBase ? `${frontBase}/images/novu.svg` : undefined,
         software_id: oauthConfig.softwareId ?? DEFAULT_SOFTWARE_ID,
         software_version: SOFTWARE_VERSION,
       });


### PR DESCRIPTION
## Summary

- Fix the `logo_uri` sent during MCP OAuth Dynamic Client Registration to use `/images/novu.svg` instead of the non-existent `/static/novu-logo.png`.
- Aligns with the dashboard public asset at `apps/dashboard/public/images/novu.svg`.

Fixes [NV-7823](https://linear.app/novu/issue/NV-7823/fix-mcp-oauth-dcr-logo-uri-path-to-imagesnovusvg)

## Test plan

- [ ] Connect an MCP server that uses DCR OAuth and confirm the authorization server receives `logo_uri` pointing to `{DASHBOARD_URL}/images/novu.svg`
- [ ] Verify the logo URL resolves in a browser (e.g. `https://dashboard.novu.co/images/novu.svg`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR fixes the `logo_uri` path sent during MCP OAuth Dynamic Client Registration (DCR). The `logo_uri` now points to `/images/novu.svg` (the actual asset location in the dashboard public directory) instead of the non-existent `/static/novu-logo.png`. This ensures authorization servers receive a valid, resolvable logo URI during client registration.

## Affected areas

**api**: Updated the MCP OAuth DCR client registration method to use the correct `logo_uri` path pointing to the existing dashboard asset.

## Testing

Manual verification is required: connect an MCP server using DCR OAuth and confirm the authorization server receives `logo_uri` pointing to `{DASHBOARD_URL}/images/novu.svg`, then verify the URL resolves in a browser. No automated tests were added as this is a straightforward configuration fix in an existing usecase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->