### PR TITLE
refactor(dashboard): update onboarding provisioning logic and components

### DIFF
--- a/apps/dashboard/src/components/auth/connect-provisioning-overlay.tsx
+++ b/apps/dashboard/src/components/auth/connect-provisioning-overlay.tsx
@@ -1,32 +1,68 @@
 import { useEffect, useState } from 'react';
 import { OnboardingLoader } from '@/components/onboarding/onboarding-loader';
-import { isConnectProvisioningActive, subscribeConnectProvisioningChange } from '@/utils/connect';
+import type { OnboardingLoaderVariant } from '@/components/onboarding/onboarding-loader';
+import {
+  getOnboardingProvisioningStartedAt,
+  getOnboardingProvisioningVariant,
+  isOnboardingProvisioningActive,
+  subscribeOnboardingProvisioningChange,
+} from '@/utils/connect/onboarding-session';
 
-const AUTH_BACKGROUND_CLASS =
-  "bg-[url('/images/auth/background.svg')] bg-cover bg-no-repeat bg-center";
+const AUTH_BACKGROUND_CLASS = "bg-[url('/images/auth/background.svg')] bg-cover bg-no-repeat bg-center";
+
+type ProvisioningSession = {
+  variant: OnboardingLoaderVariant;
+  startedAt: number;
+};
+
+function readSession(): ProvisioningSession | null {
+  const variant = getOnboardingProvisioningVariant();
+  const startedAt = getOnboardingProvisioningStartedAt();
+
+  if (!variant) {
+    return null;
+  }
+
+  return { variant, startedAt: startedAt ?? Date.now() };
+}
 
 /**
- * Single full-screen Connect provisioning state ("Build and distribute agents") that stays
- * mounted across org-list → agent-setup so the background and loader never swap mid-flow.
+ * Single full-screen onboarding provisioning state that stays mounted across org-list → onboarding
+ * so the loader never remounts mid-flow. Shows the platform or connect variant based on session.
  */
-export function ConnectProvisioningOverlay() {
-  const [visible, setVisible] = useState(isConnectProvisioningActive);
+export function OnboardingProvisioningOverlay() {
+  const [session, setSession] = useState<ProvisioningSession | null>(readSession);
 
   useEffect(() => {
-    const sync = () => setVisible(isConnectProvisioningActive());
+    const sync = () => {
+      setSession((prev) => {
+        const next = readSession();
+
+        if (!next) {
+          return null;
+        }
+
+        // Keep the original start time so client-side navigation does not restart the animation.
+        if (prev?.variant === next.variant && prev.startedAt) {
+          return { variant: next.variant, startedAt: prev.startedAt };
+        }
+
+        return next;
+      });
+    };
 
     sync();
 
-    return subscribeConnectProvisioningChange(sync);
+    return subscribeOnboardingProvisioningChange(sync);
   }, []);
 
-  if (!visible) {
+  if (!session || !isOnboardingProvisioningActive()) {
     return null;
   }
 
   return (
     <div className={`fixed inset-0 z-[200] flex items-center justify-center ${AUTH_BACKGROUND_CLASS}`}>
-      <OnboardingLoader variant="connect" />
+      <OnboardingLoader variant={session.variant} startedAt={session.startedAt} />
     </div>
   );
 }

--- a/apps/dashboard/src/components/auth/organization-picker.tsx
+++ b/apps/dashboard/src/components/auth/organization-picker.tsx
@@ -2,6 +2,7 @@ import { useOrganizationList, useUser } from '@clerk/react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { RiAddCircleLine, RiArrowRightSLine, RiLoader4Line } from 'react-icons/ri';
+import { useNavigate } from 'react-router-dom';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/primitives/avatar';
 import { Button } from '@/components/primitives/button';
@@ -11,8 +12,13 @@ import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { IS_NOVU_CONNECT } from '@/config';
 import { RegionSelector, useShouldShowRegionSelector } from '@/context/region';
 import { useTelemetry } from '@/hooks/use-telemetry';
-import { APP_IDS, type AppId } from '@/utils/apps';
-import { isConnectWorkspace, writeConnectAutoCreateSessionGuard } from '@/utils/connect';
+import { APP_IDS, type AppId, isAbsoluteUrl } from '@/utils/apps';
+import {
+  beginOnboardingProvisioning,
+  clearOnboardingProvisioning,
+  isConnectWorkspace,
+  writeConnectAutoCreateSessionGuard,
+} from '@/utils/connect';
 import { isPlatformWorkspace } from '@/utils/platform-workspace';
 import { TelemetryEvent } from '@/utils/telemetry';
 import { cn } from '@/utils/ui';
@@ -375,6 +381,7 @@ export function OrganizationPicker({
 }: OrganizationPickerProps) {
   const track = useTelemetry();
   const { user } = useUser();
+  const navigate = useNavigate();
 
   const productFilter = useMemo(getProductFilter, []);
   const productAppId = useMemo(() => getProductAppId(productFilter), [productFilter]);
@@ -493,7 +500,10 @@ export function OrganizationPicker({
     async ({ name, slug }: { name: string; slug: string }) => {
       if (!createOrganization || !setActive) return;
 
+      const provisioningVariant = productFilter === 'connect' ? 'connect' : 'platform';
+
       setIsCreating(true);
+      beginOnboardingProvisioning(provisioningVariant);
 
       let createdOrg: Awaited<ReturnType<typeof createOrganization>> | null = null;
       let lastError: unknown = null;
@@ -514,6 +524,7 @@ export function OrganizationPicker({
       }
 
       if (!createdOrg) {
+        clearOnboardingProvisioning();
         const message = readClerkErrorMessage(lastError, 'Failed to create organization.');
         showErrorToast(message, 'Create organization failed');
         setIsCreating(false);
@@ -529,6 +540,7 @@ export function OrganizationPicker({
       try {
         await setActive({ organization: createdOrg.id });
       } catch (error) {
+        clearOnboardingProvisioning();
         const message = readClerkErrorMessage(error, 'Failed to activate the new organization.');
         showErrorToast(message, 'Activation failed');
         setIsCreating(false);
@@ -545,9 +557,15 @@ export function OrganizationPicker({
       });
       hasTrackedRef.current = true;
 
-      window.location.assign(afterCreateOrganizationUrl);
+      if (isAbsoluteUrl(afterCreateOrganizationUrl)) {
+        window.location.assign(afterCreateOrganizationUrl);
+
+        return;
+      }
+
+      void navigate(afterCreateOrganizationUrl);
     },
-    [createOrganization, setActive, afterCreateOrganizationUrl, productAppId, productFilter, track, user?.id]
+    [createOrganization, setActive, afterCreateOrganizationUrl, productAppId, productFilter, track, user?.id, navigate]
   );
 
   const handleCancel = useCallback(() => {

--- a/apps/dashboard/src/components/onboarding/onboarding-loader.tsx
+++ b/apps/dashboard/src/components/onboarding/onboarding-loader.tsx
@@ -6,7 +6,7 @@ import { RiCheckboxCircleFill, RiLoader3Line, RiLoader4Fill } from 'react-icons/
 
 type LoaderLogoComponent = ComponentType<{ className?: string }>;
 
-type OnboardingLoaderVariant = 'platform' | 'connect';
+export type OnboardingLoaderVariant = 'platform' | 'connect';
 
 type LoaderStep = { id: string; text: string };
 
@@ -44,13 +44,29 @@ const VARIANT_CONFIG: Record<
 const ITEM_HEIGHT = 20;
 const GAP = 12;
 const CONTAINER_HEIGHT = 140;
-const STEP_DELAY_MS = 1500;
+export const ONBOARDING_STEP_DELAY_MS = 1500;
+export const PLATFORM_STEP_COUNT = PLATFORM_STEPS.length;
+export const CONNECT_STEP_COUNT = CONNECT_STEPS.length;
+
+const STEP_DELAY_MS = ONBOARDING_STEP_DELAY_MS;
 
 type OnboardingLoaderProps = {
   variant?: OnboardingLoaderVariant;
+  /** When set, step progress resumes from elapsed time instead of restarting at step 0. */
+  startedAt?: number | null;
 };
 
 type StepStatus = 'success' | 'progress' | 'pending';
+
+function getInitialActiveIndex(stepCount: number, startedAt?: number | null): number {
+  if (!startedAt) {
+    return 0;
+  }
+
+  const index = Math.floor((Date.now() - startedAt) / STEP_DELAY_MS);
+
+  return Math.min(Math.max(0, index), stepCount - 1);
+}
 
 function getStepStatus(index: number, activeIndex: number): StepStatus {
   if (index < activeIndex) return 'success';
@@ -59,9 +75,10 @@ function getStepStatus(index: number, activeIndex: number): StepStatus {
   return 'pending';
 }
 
-export function OnboardingLoader({ variant = 'platform' }: OnboardingLoaderProps) {
+export function OnboardingLoader({ variant = 'platform', startedAt = null }: OnboardingLoaderProps) {
   const { steps: stepDefs, title, Logo } = VARIANT_CONFIG[variant];
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(() => getInitialActiveIndex(stepDefs.length, startedAt));
+  const isResuming = activeIndex > 0;
 
   // Keep `activeIndex` in range when the variant (and therefore `stepDefs.length`) changes — a
   // shorter steps list could leave a previously-valid index hanging off the end and the y-offset
@@ -90,7 +107,7 @@ export function OnboardingLoader({ variant = 'platform' }: OnboardingLoaderProps
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-6">
       <motion.div
-        initial={{ opacity: 0, scale: 0.8 }}
+        initial={isResuming ? false : { opacity: 0, scale: 0.8 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.4, ease: 'easeOut' }}
         className="flex flex-col items-center gap-4"
@@ -99,9 +116,9 @@ export function OnboardingLoader({ variant = 'platform' }: OnboardingLoaderProps
           <Logo className="size-10" />
         </motion.div>
         <motion.span
-          initial={{ opacity: 0, y: 8 }}
+          initial={isResuming ? false : { opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.2, duration: 0.4 }}
+          transition={{ delay: isResuming ? 0 : 0.2, duration: 0.4 }}
           className="text-label-md text-text-strong font-medium"
         >
           {title}

--- a/apps/dashboard/src/context/auth/auth-provider.tsx
+++ b/apps/dashboard/src/context/auth/auth-provider.tsx
@@ -2,7 +2,7 @@ import { useClerk, useOrganization, useUser } from '@clerk/react';
 import type { OrganizationResource, UserResource } from '@clerk/shared/types';
 import { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ConnectProvisioningOverlay } from '@/components/auth/connect-provisioning-overlay';
+import { OnboardingProvisioningOverlay } from '@/components/auth/connect-provisioning-overlay';
 import { IS_NOVU_CONNECT } from '@/config';
 import { isPublicAuthPath } from '@/utils/auth-routes';
 import { isActiveConnectWorkspace, isConnectWorkspace } from '@/utils/connect';
@@ -154,7 +154,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   return (
     <AuthContext.Provider value={value}>
-      {IS_NOVU_CONNECT ? <ConnectProvisioningOverlay /> : null}
+      <OnboardingProvisioningOverlay />
       {shouldBlockChildren ? null : children}
     </AuthContext.Provider>
   );

--- a/apps/dashboard/src/hooks/use-onboarding-provisioning.ts
+++ b/apps/dashboard/src/hooks/use-onboarding-provisioning.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import type { OnboardingLoaderVariant } from '@/components/onboarding/onboarding-loader';
+import {
+  clearOnboardingProvisioning,
+  getMinLoaderDurationMs,
+  getOnboardingProvisioningStartedAt,
+  getOnboardingProvisioningVariant,
+  isOnboardingProvisioningActive,
+  subscribeOnboardingProvisioningChange,
+} from '@/utils/connect/onboarding-session';
+
+export function useOnboardingProvisioningActive(): boolean {
+  const [active, setActive] = useState(isOnboardingProvisioningActive);
+
+  useEffect(() => {
+    const sync = () => setActive(isOnboardingProvisioningActive());
+
+    sync();
+
+    return subscribeOnboardingProvisioningChange(sync);
+  }, []);
+
+  return active;
+}
+
+/**
+ * Keeps the full-screen provisioning overlay visible until the step animation has had time
+ * to finish, even when backend setup completes earlier.
+ */
+export function useOnboardingProvisioningDismiss({
+  isReady,
+  fallbackVariant,
+}: {
+  isReady: boolean;
+  fallbackVariant: OnboardingLoaderVariant;
+}): void {
+  const provisioningActive = useOnboardingProvisioningActive();
+
+  useEffect(() => {
+    if (!isReady || !provisioningActive) {
+      return;
+    }
+
+    const variant = getOnboardingProvisioningVariant() ?? fallbackVariant;
+    const startedAt = getOnboardingProvisioningStartedAt() ?? Date.now();
+    const remaining = Math.max(0, getMinLoaderDurationMs(variant) - (Date.now() - startedAt));
+    const timer = setTimeout(() => clearOnboardingProvisioning(), remaining);
+
+    return () => clearTimeout(timer);
+  }, [isReady, provisioningActive, fallbackVariant]);
+}

--- a/apps/dashboard/src/pages/agents-setup-page.tsx
+++ b/apps/dashboard/src/pages/agents-setup-page.tsx
@@ -24,7 +24,7 @@ import { useAgentRoutes } from '@/hooks/use-agent-routes';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useTelemetry } from '@/hooks/use-telemetry';
 import { APP_IDS, isAbsoluteUrl } from '@/utils/apps';
-import { clearConnectProvisioning, isConnectProvisioningActive } from '@/utils/connect';
+import { useOnboardingProvisioningActive, useOnboardingProvisioningDismiss } from '@/hooks/use-onboarding-provisioning';
 import { getPostOnboardingRoute, resolveOnboardingAppId, withAppId } from '@/utils/onboarding-redirect';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -172,6 +172,13 @@ export function AgentsSetupPage() {
   });
 
   const loadingPhase = useAgentEnvLoading(currentOrganization?._id);
+  const provisioningActive = useOnboardingProvisioningActive();
+  const isDataReady = Boolean(currentEnvironment) && loadingPhase === 'ready';
+
+  useOnboardingProvisioningDismiss({
+    isReady: isDataReady,
+    fallbackVariant: isConnectHost ? 'connect' : 'platform',
+  });
 
   useEffect(() => {
     if (environments?.length) {
@@ -180,14 +187,6 @@ export function AgentsSetupPage() {
       setEnvLoaded(true);
     }
   }, [environments, user, organization]);
-
-  useEffect(() => {
-    if (!currentEnvironment || loadingPhase !== 'ready') {
-      return;
-    }
-
-    clearConnectProvisioning();
-  }, [currentEnvironment, loadingPhase]);
 
   useEffect(() => {
     telemetry(TelemetryEvent.AGENTS_SETUP_PAGE_VIEWED);
@@ -252,8 +251,8 @@ export function AgentsSetupPage() {
     return <Navigate to={isConnectFlow ? ROUTES.ROOT : ROUTES.INBOX_USECASE} replace />;
   }
 
-  if (!currentEnvironment || loadingPhase !== 'ready') {
-    if (isConnectHost && isConnectProvisioningActive()) {
+  if (!isDataReady || provisioningActive) {
+    if (provisioningActive) {
       return null;
     }
 

--- a/apps/dashboard/src/pages/inbox-usecase-page.tsx
+++ b/apps/dashboard/src/pages/inbox-usecase-page.tsx
@@ -1,15 +1,14 @@
 import { useOrganization, useUser } from '@clerk/react';
 import type { IEnvironment } from '@novu/shared';
-import { motion } from 'motion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { RiCheckboxCircleFill, RiLoader3Line, RiLoader4Fill } from 'react-icons/ri';
 import { AnimatedPage } from '@/components/onboarding/animated-page';
+import { OnboardingLoader } from '@/components/onboarding/onboarding-loader';
 import { AuthCard } from '../components/auth/auth-card';
 import { InboxPlayground } from '../components/auth/inbox-playground';
-import { LogoCircle } from '../components/icons/logo-circle';
 import { PageMeta } from '../components/page-meta';
 import { useAuth } from '../context/auth/hooks';
 import { useEnvironment, useFetchEnvironments } from '../context/environment/hooks';
+import { useOnboardingProvisioningActive, useOnboardingProvisioningDismiss } from '@/hooks/use-onboarding-provisioning';
 import { useTelemetry } from '../hooks/use-telemetry';
 import { TelemetryEvent } from '../utils/telemetry';
 import { sendGTMEvent } from '../utils/tracking';
@@ -20,98 +19,6 @@ interface RequiredData {
 }
 
 type LoadingPhase = 'initializing' | 'loading' | 'ready' | 'error';
-
-const STEP_DELAY_MS = 1500;
-
-const ONBOARDING_STEPS = [
-  { id: 'org', text: 'Preparing your organization' },
-  { id: 'env', text: 'Setting up your environment' },
-  { id: 'channels', text: 'Configuring notification channels' },
-  { id: 'inbox', text: 'Getting your inbox ready' },
-  { id: 'final', text: 'Almost there...' },
-] as const;
-
-const ITEM_HEIGHT = 20;
-const GAP = 12;
-const CONTAINER_HEIGHT = 140;
-
-function OnboardingLoader() {
-  const [activeIndex, setActiveIndex] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setActiveIndex((prev) => {
-        if (prev >= ONBOARDING_STEPS.length - 1) return prev;
-
-        return prev + 1;
-      });
-    }, STEP_DELAY_MS);
-
-    return () => clearInterval(interval);
-  }, []);
-
-  const steps = ONBOARDING_STEPS.map((step, index) => {
-    const status = index < activeIndex ? 'success' : index === activeIndex ? 'progress' : 'pending';
-
-    return { ...step, status };
-  });
-
-  return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-6">
-      <motion.div
-        initial={{ opacity: 0, scale: 0.8 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 0.4, ease: 'easeOut' }}
-        className="flex flex-col items-center gap-4"
-      >
-        <motion.div animate={{ scale: [1, 1.08, 1] }} transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}>
-          <LogoCircle className="size-10" />
-        </motion.div>
-        <motion.span
-          initial={{ opacity: 0, y: 8 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.2, duration: 0.4 }}
-          className="text-label-md text-text-strong font-medium"
-        >
-          Setting up your workspace
-        </motion.span>
-      </motion.div>
-
-      <div className="relative w-full max-w-xs overflow-hidden" style={{ height: CONTAINER_HEIGHT }}>
-        <div
-          className="absolute inset-0"
-          style={{
-            maskImage: 'linear-gradient(to bottom, transparent 0%, black 35%, black 65%, transparent 100%)',
-            WebkitMaskImage: 'linear-gradient(to bottom, transparent 0%, black 35%, black 65%, transparent 100%)',
-          }}
-        >
-          <motion.div
-            className="absolute left-0 right-0 flex flex-col items-center"
-            style={{ gap: GAP }}
-            initial={false}
-            animate={{ y: CONTAINER_HEIGHT / 2 - ITEM_HEIGHT / 2 - activeIndex * (ITEM_HEIGHT + GAP) }}
-            transition={{ type: 'tween', ease: 'easeInOut', duration: 0.4 }}
-          >
-            {steps.map((step, index) => (
-              <motion.div
-                key={step.id}
-                className="flex shrink-0 items-center gap-2"
-                style={{ height: ITEM_HEIGHT }}
-                animate={{ opacity: index === activeIndex ? 1 : 0.35 }}
-                transition={{ duration: 0.3 }}
-              >
-                {step.status === 'success' && <RiCheckboxCircleFill className="size-4 shrink-0 text-success" />}
-                {step.status === 'progress' && <RiLoader4Fill className="size-4 shrink-0 animate-spin text-text-sub" />}
-                {step.status === 'pending' && <RiLoader3Line className="size-4 shrink-0 text-text-sub" />}
-                <span className="text-label-sm text-text-sub">{step.text}</span>
-              </motion.div>
-            ))}
-          </motion.div>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 const useInboxLoading = (organizationId?: string) => {
   const [phase, setPhase] = useState<LoadingPhase>('initializing');
@@ -138,7 +45,7 @@ const useInboxLoading = (organizationId?: string) => {
   useEffect(() => {
     if (organizationId) {
       loadingTimeoutRef.current = setTimeout(() => {
-        initializeAndFetch();
+        void initializeAndFetch();
       }, 50);
     }
 
@@ -179,6 +86,13 @@ export function InboxUsecasePage() {
   const loadingPhase = useInboxLoading(currentOrganization?._id);
   const environment = envFromContext;
   const requiredData = getRequiredData(environment, currentUser?._id, currentOrganization?._id);
+  const provisioningActive = useOnboardingProvisioningActive();
+  const isDataReady = Boolean(requiredData) && loadingPhase === 'ready';
+
+  useOnboardingProvisioningDismiss({
+    isReady: isDataReady,
+    fallbackVariant: 'platform',
+  });
 
   useEffect(() => {
     sendGTMEvent('sign_up');
@@ -196,24 +110,28 @@ export function InboxUsecasePage() {
     }
   }, [environments, user, organization]);
 
-  const shouldShowLoading = !requiredData || loadingPhase !== 'ready';
+  if (!isDataReady || provisioningActive || !requiredData) {
+    if (provisioningActive) {
+      return null;
+    }
 
-  if (shouldShowLoading) {
     return (
       <AnimatedPage>
         <PageMeta title="Integrate with the Inbox component" />
         <AuthCard>
-          <OnboardingLoader />
+          <OnboardingLoader variant="platform" />
         </AuthCard>
       </AnimatedPage>
     );
   }
 
+  const { appId, subscriberId } = requiredData;
+
   return (
     <AnimatedPage>
       <PageMeta title="Integrate with the Inbox component" />
       <AuthCard>
-        <InboxPlayground appId={requiredData.appId} subscriberId={requiredData.subscriberId} />
+        <InboxPlayground appId={appId} subscriberId={subscriberId} />
       </AuthCard>
     </AnimatedPage>
   );

--- a/apps/dashboard/src/utils/connect/onboarding-session.ts
+++ b/apps/dashboard/src/utils/connect/onboarding-session.ts
@@ -1,15 +1,29 @@
+import {
+  CONNECT_STEP_COUNT,
+  ONBOARDING_STEP_DELAY_MS,
+  PLATFORM_STEP_COUNT,
+  type OnboardingLoaderVariant,
+} from '@/components/onboarding/onboarding-loader';
+
+export const ONBOARDING_PROVISIONING_KEY = 'novu.onboarding.provisioning';
+/** Legacy Connect-only flag — still read for in-flight sessions. */
 export const CONNECT_PROVISIONING_KEY = 'novu.connect.provisioning';
 export const CONNECT_PROVISION_QUERY = 'provision';
 
-const PROVISIONING_CHANGE_EVENT = 'novu.connect.provisioning-change';
+const PROVISIONING_CHANGE_EVENT = 'novu.onboarding.provisioning-change';
 
-export function notifyConnectProvisioningChange(): void {
+type ProvisioningPayload = {
+  variant: OnboardingLoaderVariant;
+  startedAt: number;
+};
+
+export function notifyOnboardingProvisioningChange(): void {
   if (typeof window === 'undefined') return;
 
   window.dispatchEvent(new Event(PROVISIONING_CHANGE_EVENT));
 }
 
-export function subscribeConnectProvisioningChange(listener: () => void): () => void {
+export function subscribeOnboardingProvisioningChange(listener: () => void): () => void {
   if (typeof window === 'undefined') {
     return () => undefined;
   }
@@ -19,33 +33,96 @@ export function subscribeConnectProvisioningChange(listener: () => void): () => 
   return () => window.removeEventListener(PROVISIONING_CHANGE_EVENT, listener);
 }
 
-export function beginConnectProvisioning(): void {
-  if (typeof window === 'undefined') return;
+/** @deprecated Use `subscribeOnboardingProvisioningChange`. */
+export const subscribeConnectProvisioningChange = subscribeOnboardingProvisioningChange;
+
+/** @deprecated Use `notifyOnboardingProvisioningChange`. */
+export const notifyConnectProvisioningChange = notifyOnboardingProvisioningChange;
+
+function readProvisioningPayload(): ProvisioningPayload | null {
+  if (typeof window === 'undefined') return null;
+
   try {
-    sessionStorage.setItem(CONNECT_PROVISIONING_KEY, '1');
-    notifyConnectProvisioningChange();
+    const raw = sessionStorage.getItem(ONBOARDING_PROVISIONING_KEY);
+
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<ProvisioningPayload>;
+
+      if (parsed.variant === 'platform' || parsed.variant === 'connect') {
+        return {
+          variant: parsed.variant,
+          startedAt: typeof parsed.startedAt === 'number' ? parsed.startedAt : Date.now(),
+        };
+      }
+    }
+
+    if (sessionStorage.getItem(CONNECT_PROVISIONING_KEY) === '1') {
+      return { variant: 'connect', startedAt: Date.now() };
+    }
+  } catch {
+    // sessionStorage unavailable or malformed payload
+  }
+
+  return null;
+}
+
+export function beginOnboardingProvisioning(variant: OnboardingLoaderVariant): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const payload: ProvisioningPayload = { variant, startedAt: Date.now() };
+    sessionStorage.setItem(ONBOARDING_PROVISIONING_KEY, JSON.stringify(payload));
+    sessionStorage.removeItem(CONNECT_PROVISIONING_KEY);
+    notifyOnboardingProvisioningChange();
   } catch {
     // sessionStorage unavailable
   }
 }
 
+export function beginConnectProvisioning(): void {
+  beginOnboardingProvisioning('connect');
+}
+
+export function beginPlatformProvisioning(): void {
+  beginOnboardingProvisioning('platform');
+}
+
+export function getOnboardingProvisioningVariant(): OnboardingLoaderVariant | null {
+  return readProvisioningPayload()?.variant ?? null;
+}
+
+export function getOnboardingProvisioningStartedAt(): number | null {
+  return readProvisioningPayload()?.startedAt ?? null;
+}
+
+export function isOnboardingProvisioningActive(): boolean {
+  return getOnboardingProvisioningVariant() !== null;
+}
+
 export function isConnectProvisioningActive(): boolean {
-  if (typeof window === 'undefined') return false;
+  return getOnboardingProvisioningVariant() === 'connect';
+}
+
+export function clearOnboardingProvisioning(): void {
+  if (typeof window === 'undefined') return;
+
   try {
-    return sessionStorage.getItem(CONNECT_PROVISIONING_KEY) === '1';
+    sessionStorage.removeItem(ONBOARDING_PROVISIONING_KEY);
+    sessionStorage.removeItem(CONNECT_PROVISIONING_KEY);
+    notifyOnboardingProvisioningChange();
   } catch {
-    return false;
+    // sessionStorage unavailable
   }
 }
 
 export function clearConnectProvisioning(): void {
-  if (typeof window === 'undefined') return;
-  try {
-    sessionStorage.removeItem(CONNECT_PROVISIONING_KEY);
-    notifyConnectProvisioningChange();
-  } catch {
-    // sessionStorage unavailable
-  }
+  clearOnboardingProvisioning();
+}
+
+export function getMinLoaderDurationMs(variant: OnboardingLoaderVariant): number {
+  const stepCount = variant === 'connect' ? CONNECT_STEP_COUNT : PLATFORM_STEP_COUNT;
+
+  return stepCount * ONBOARDING_STEP_DELAY_MS;
 }
 
 export function buildConnectProvisionOrgListPath(orgListPath: string): string {
@@ -55,8 +132,6 @@ export function buildConnectProvisionOrgListPath(orgListPath: string): string {
   return `${url.pathname}${url.search}`;
 }
 
-// Appends `?provision=1` to a relative path or absolute URL so the intent survives a
-// cross-origin handoff (sessionStorage is per-origin and not visible to the destination).
 export function withConnectProvisioningIntent(href: string): string {
   if (!href) return href;
 
@@ -96,15 +171,6 @@ export function consumeConnectProvisionIntentFromLocation(): boolean {
   return true;
 }
 
-/**
- * True when the current Connect visit was initiated by an explicit provisioning intent —
- * either the cross-origin `?provision=1` query param (Platform → Connect handoff) or the
- * same-origin sessionStorage flag set by the Connect-switch modal.
- *
- * Read SYNCHRONOUSLY during render so the org-list page can decide between auto-provisioning
- * (post-sign-up, post-modal) and rendering the regular picker (post-delete, manual nav from
- * Platform with existing Connect orgs). Side-effect free.
- */
 export function hasConnectProvisionIntent(): boolean {
   if (typeof window === 'undefined') {
     return false;


### PR DESCRIPTION

### What changed? Why was the change needed?
- Renamed ConnectProvisioningOverlay to OnboardingProvisioningOverlay for clarity.
- Introduced new hooks for managing onboarding provisioning state.
- Updated onboarding loader to support session-based animations.
- Refactored organization picker and agents setup page to utilize new onboarding provisioning functions.
- Enhanced session management for onboarding provisioning in utils.
- Improved overall code organization and readability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR refactors the onboarding provisioning system from a Connect-only implementation to a unified, variant-based model supporting both 'platform' and 'connect' flows. It renames `ConnectProvisioningOverlay` to `OnboardingProvisioningOverlay`, introduces hooks for managing provisioning state, and updates `OnboardingLoader` to resume animations mid-sequence based on a `startedAt` timestamp. The provisioning session is now centralized in sessionStorage with variant and startedAt, eliminating the need to recreate the loader on navigation.

## Affected areas

- **dashboard**: Refactored provisioning overlay to read session state from utilities and support animation resumption. Added `useOnboardingProvisioningActive` and `useOnboardingProvisioningDismiss` hooks to manage provisioning lifecycle. Updated `OnboardingLoader` to export variant type and timing constants, and accept a `startedAt` prop for mid-sequence resumption. Integrated provisioning tracking in organization creation, agents setup page, and inbox usecase page. Enhanced session utilities to support variant-based provisioning with deprecated Connect-specific APIs as aliases.

## Key technical decisions

- Unified provisioning state uses a variant-based key (`'platform' | 'connect'`) with startedAt timestamp stored in sessionStorage, replacing separate boolean flags.
- `OnboardingProvisioningOverlay` is rendered unconditionally and positioned above the auth guard, allowing it to display even when the provider blocks child rendering.
- Animation resumption computes the initial activeIndex from elapsed time, with conditional transition timing to skip entrance animations when mid-sequence.
- Minimum loader duration is enforced via `useOnboardingProvisioningDismiss`, which schedules clearing only after the loader meets its target animation duration.

## Testing

No new tests are mentioned; this refactoring requires manual verification of onboarding flows across organization creation, agents setup, and inbox playground variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
