### PR TITLE
fix(api-service): stop duplicating first inbound message for managed agents fixes NV-7824

### DIFF
--- a/apps/api/src/app/agents/services/managed-agent.service.spec.ts
+++ b/apps/api/src/app/agents/services/managed-agent.service.spec.ts
@@ -1,58 +1,6 @@
-import { ConversationActivitySenderTypeEnum, ConversationActivityTypeEnum } from '@novu/dal';
-import { MessageRole } from '@novu/thalamus';
 import { expect } from 'chai';
-import sinon from 'sinon';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
-import { ManagedAgentService } from './managed-agent.service';
 import { buildAnonymousUserMcpMessage } from './managed-agent-event-handler';
-
-function makeLogger() {
-  return {
-    setContext: sinon.stub(),
-    warn: sinon.stub(),
-    error: sinon.stub(),
-    info: sinon.stub(),
-    debug: sinon.stub(),
-  };
-}
-
-describe('ManagedAgentService buildMessagesWithHistory', () => {
-  it('returns persisted activities only and does not duplicate the inbound message', async () => {
-    const findByConversation = sinon.stub().resolves([
-      {
-        type: ConversationActivityTypeEnum.MESSAGE,
-        senderType: ConversationActivitySenderTypeEnum.SUBSCRIBER,
-        content: 'Hello',
-        createdAt: '2026-05-26T12:00:00.000Z',
-      },
-    ]);
-    const service = new ManagedAgentService(
-      {} as never,
-      {} as never,
-      {} as never,
-      {} as never,
-      { findByConversation } as never,
-      {} as never,
-      {} as never,
-      {} as never,
-      makeLogger() as never
-    );
-    const context = {
-      config: { environmentId: 'env_1' },
-      conversation: { _id: 'conv_1' },
-      message: { text: 'Hello' },
-    };
-
-    const messages = await (
-      service as unknown as {
-        buildMessagesWithHistory(ctx: typeof context): Promise<{ role: MessageRole; content: string }[]>;
-      }
-    ).buildMessagesWithHistory(context);
-
-    expect(messages).to.deep.equal([{ role: MessageRole.USER, content: 'Hello' }]);
-    expect(findByConversation.calledOnceWith('env_1', 'conv_1', 50)).to.equal(true);
-  });
-});
 
 describe('buildAnonymousUserMcpMessage', () => {
   it('mentions the MCP server name and Slack when the platform is Slack', () => {

--- a/apps/api/src/app/agents/services/managed-agent.service.spec.ts
+++ b/apps/api/src/app/agents/services/managed-agent.service.spec.ts
@@ -1,6 +1,58 @@
+import { ConversationActivitySenderTypeEnum, ConversationActivityTypeEnum } from '@novu/dal';
+import { MessageRole } from '@novu/thalamus';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
-import { buildAnonymousUserMcpMessage } from './managed-agent.service';
+import { ManagedAgentService } from './managed-agent.service';
+import { buildAnonymousUserMcpMessage } from './managed-agent-event-handler';
+
+function makeLogger() {
+  return {
+    setContext: sinon.stub(),
+    warn: sinon.stub(),
+    error: sinon.stub(),
+    info: sinon.stub(),
+    debug: sinon.stub(),
+  };
+}
+
+describe('ManagedAgentService buildMessagesWithHistory', () => {
+  it('returns persisted activities only and does not duplicate the inbound message', async () => {
+    const findByConversation = sinon.stub().resolves([
+      {
+        type: ConversationActivityTypeEnum.MESSAGE,
+        senderType: ConversationActivitySenderTypeEnum.SUBSCRIBER,
+        content: 'Hello',
+        createdAt: '2026-05-26T12:00:00.000Z',
+      },
+    ]);
+    const service = new ManagedAgentService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      { findByConversation } as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      makeLogger() as never
+    );
+    const context = {
+      config: { environmentId: 'env_1' },
+      conversation: { _id: 'conv_1' },
+      message: { text: 'Hello' },
+    };
+
+    const messages = await (
+      service as unknown as {
+        buildMessagesWithHistory(ctx: typeof context): Promise<{ role: MessageRole; content: string }[]>;
+      }
+    ).buildMessagesWithHistory(context);
+
+    expect(messages).to.deep.equal([{ role: MessageRole.USER, content: 'Hello' }]);
+    expect(findByConversation.calledOnceWith('env_1', 'conv_1', 50)).to.equal(true);
+  });
+});
 
 describe('buildAnonymousUserMcpMessage', () => {
   it('mentions the MCP server name and Slack when the platform is Slack', () => {

--- a/apps/api/src/app/agents/services/managed-agent.service.ts
+++ b/apps/api/src/app/agents/services/managed-agent.service.ts
@@ -245,8 +245,6 @@ export class ManagedAgentService implements OnModuleInit {
         content: entry.content,
       }));
 
-    // Inbound handler persists the current message before dispatch; do not append context.message again.
-
     return messages;
   }
 

--- a/apps/api/src/app/agents/services/managed-agent.service.ts
+++ b/apps/api/src/app/agents/services/managed-agent.service.ts
@@ -245,7 +245,7 @@ export class ManagedAgentService implements OnModuleInit {
         content: entry.content,
       }));
 
-    messages.push({ role: MessageRole.USER, content: context.message?.text ?? '' });
+    // Inbound handler persists the current message before dispatch; do not append context.message again.
 
     return messages;
   }


### PR DESCRIPTION
## Summary

- Removes redundant `messages.push` in `ManagedAgentService.buildMessagesWithHistory` so the first managed-agent turn does not send the inbound user message twice to Thalamus.
- Adds a unit test asserting a single persisted inbound activity maps to one user message.
- Fixes `managed-agent.service.spec.ts` import for `buildAnonymousUserMcpMessage` (lives in `managed-agent-event-handler`).

## Context

`agent-inbound-handler` persists the inbound message before `managedAgentService.dispatch`. On the first turn (no `externalSessionId`), history already included the current message; appending `context.message.text` duplicated it (e.g. `"HelloHello"` in session summaries).

Linear: https://linear.app/novu/issue/NV-7824/managed-agent-duplicates-first-inbound-message-on-session-bootstrap

## Test plan

- [x] `cd apps/api && pnpm test -- --grep "buildMessagesWithHistory"`
- [ ] Start a new managed-agent Slack/Telegram thread; first user message appears once in model-reported history
- [ ] Second turn in same thread still works (session id path unchanged)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->