### PR TITLE
revert(api-service): Set managed agent default permission to always_ask

### DIFF
--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.spec.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-agent-runtime.provider.spec.ts
@@ -574,6 +574,6 @@ describe('AnthropicAgentRuntimeProvider.updateConfig', () => {
       (t) => t.type === 'mcp_toolset'
     );
     expect(mcpToolset?.mcp_server_name).to.equal('Slack');
-    expect(mcpToolset?.default_config?.permission_policy).to.deep.equal({ type: 'always_allow' });
+    expect(mcpToolset?.default_config?.permission_policy).to.deep.equal({ type: 'always_ask' });
   });
 });

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.spec.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.spec.ts
@@ -1,10 +1,6 @@
 import { CLAUDE_BUILTIN_TOOLS } from '@novu/shared';
 import { expect } from 'chai';
-import {
-  buildToolsPayload,
-  MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG,
-  mapToolset,
-} from './anthropic-runtime.helpers';
+import { buildToolsPayload, MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG, mapToolset } from './anthropic-runtime.helpers';
 
 describe('mapToolset', () => {
   it('maps enabled builtin toolset configs to AgentToolDto entries', () => {
@@ -38,12 +34,12 @@ describe('buildToolsPayload', () => {
     const payload = buildToolsPayload(['bash'], undefined);
     const toolset = payload[0] as {
       type: string;
-      default_config: typeof MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG;
+      default_config: typeof MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG;
       configs: Array<{ name: string; enabled: boolean }>;
     };
 
     expect(toolset.type).to.equal('agent_toolset_20260401');
-    expect(toolset.default_config).to.deep.equal(MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG);
+    expect(toolset.default_config).to.deep.equal(MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG);
     expect(toolset.configs).to.have.lengthOf(CLAUDE_BUILTIN_TOOLS.length);
 
     const bashConfig = toolset.configs.find((c) => c.name === 'bash');
@@ -57,7 +53,7 @@ describe('buildToolsPayload', () => {
     expect(mcpToolset).to.deep.equal({
       type: 'mcp_toolset',
       mcp_server_name: 'GitHub',
-      default_config: MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG,
+      default_config: MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG,
     });
   });
 });

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
@@ -194,9 +194,8 @@ export function mapMcpServer(raw: Record<string, unknown>): AgentMcpServerDto {
 
 /**
  * Default permission policy for managed-agent toolsets we provision.
- * Builtin tools default to `always_allow` when omitted, but MCP toolsets
- * default to `always_ask` — we set this explicitly on both so Novu-created
- * agents do not pause for approval on every tool invocation.
+ * Both builtin and MCP toolsets are set to `always_ask` so that every tool
+ * invocation requires explicit user approval before execution.
  *
  * @see https://platform.claude.com/docs/en/managed-agents/permission-policies
  */

--- a/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
+++ b/libs/application-generic/src/agent-runtimes/anthropic/anthropic-runtime.helpers.ts
@@ -200,8 +200,8 @@ export function mapMcpServer(raw: Record<string, unknown>): AgentMcpServerDto {
  *
  * @see https://platform.claude.com/docs/en/managed-agents/permission-policies
  */
-export const MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG = {
-  permission_policy: { type: 'always_allow' },
+export const MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG = {
+  permission_policy: { type: 'always_ask' },
 } as const;
 
 /**
@@ -253,7 +253,7 @@ export function buildToolsPayload(
 
   payload.push({
     type: 'agent_toolset_20260401',
-    default_config: MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG,
+    default_config: MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG,
     configs: allToolNames.map((name) => ({ name, enabled: enabledSet.has(name) })),
   });
 
@@ -262,7 +262,7 @@ export function buildToolsPayload(
       payload.push({
         type: 'mcp_toolset',
         mcp_server_name: server.name,
-        default_config: MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG,
+        default_config: MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG,
       });
     }
   }


### PR DESCRIPTION
Replace MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG with MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG and change the default permission_policy from 'always_allow' to 'always_ask'. Update usages in anthropic-runtime.helpers (buildToolsPayload and MCP toolset) and adjust unit tests (anthropic-runtime.helpers.spec.ts and anthropic-agent-runtime.provider.spec.ts) to expect the new constant and policy. This aligns default managed agent behavior with the updated permission policy semantics.

### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The PR changes the default managed agent permission policy for Anthropic runtime from "always_allow" to "always_ask" and renames the constant from MANAGED_AGENT_ALWAYS_ALLOW_DEFAULT_CONFIG to MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG. This aligns managed-agent defaults with updated permission semantics so both builtin and MCP toolsets prompt by default rather than automatically allowing actions.

## Affected areas

**application-generic** (agent-runtimes/anthropic): Replaced the old default-config constant with MANAGED_AGENT_DEFAULT_PERMISSION_CONFIG (permission_policy: { type: 'always_ask' }) and updated buildToolsPayload to use it for both builtin (agent_toolset_20260401) and MCP (mcp_toolset) payloads; updated unit tests to assert the new default policy.

## Testing

Unit tests were updated to expect permission_policy: { type: 'always_ask' } (anthropic-runtime.helpers.spec.ts and anthropic-agent-runtime.provider.spec.ts) to validate the new default behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
