### PR TITLE
fix(api-service): bootstrap managed-agent sessions with labeled context fixes NV-7826

### DIFF
--- a/apps/api/src/app/agents/services/managed-agent-session-bootstrap.spec.ts
+++ b/apps/api/src/app/agents/services/managed-agent-session-bootstrap.spec.ts
@@ -1,0 +1,90 @@
+import { ConversationActivitySenderTypeEnum, ConversationActivityTypeEnum } from '@novu/dal';
+import { MessageRole } from '@novu/thalamus';
+import { expect } from 'chai';
+import { buildSessionBootstrapMessages, SESSION_RECOVERY_CONTEXT_HEADER } from './managed-agent-session-bootstrap';
+
+function activity(
+  partial: Partial<{
+    senderType: ConversationActivitySenderTypeEnum;
+    content: string;
+    platformMessageId: string;
+    createdAt: string;
+  }> = {}
+) {
+  return {
+    type: ConversationActivityTypeEnum.MESSAGE,
+    senderType: partial.senderType ?? ConversationActivitySenderTypeEnum.SUBSCRIBER,
+    content: partial.content ?? '',
+    platformMessageId: partial.platformMessageId,
+    createdAt: partial.createdAt ?? '2026-05-26T12:00:00.000Z',
+  } as never;
+}
+
+describe('buildSessionBootstrapMessages', () => {
+  it('returns only the current user line when there is no prior context', () => {
+    const messages = buildSessionBootstrapMessages({
+      activities: [activity({ content: 'Hello', platformMessageId: 'msg-1' })],
+      currentPlatformMessageId: 'msg-1',
+      currentText: 'Hello',
+    });
+
+    expect(messages).to.deep.equal([{ role: MessageRole.USER, content: 'Hello' }]);
+  });
+
+  it('packs prior assistant turns into a labeled context user message before the current line', () => {
+    const messages = buildSessionBootstrapMessages({
+      activities: [
+        activity({
+          senderType: ConversationActivitySenderTypeEnum.AGENT,
+          content: 'Your Slack app is connected! Send me a message to try it out.',
+          platformMessageId: 'welcome-1',
+          createdAt: '2026-05-26T12:48:38.000Z',
+        }),
+        activity({
+          content: 'Hello',
+          platformMessageId: 'msg-hello',
+          createdAt: '2026-05-26T12:48:49.000Z',
+        }),
+      ],
+      currentPlatformMessageId: 'msg-hello',
+      currentText: 'Hello',
+    });
+
+    expect(messages).to.have.length(2);
+    expect(messages[0].role).to.equal(MessageRole.USER);
+    expect(messages[0].content).to.equal(
+      `${SESSION_RECOVERY_CONTEXT_HEADER}Assistant: Your Slack app is connected! Send me a message to try it out.`
+    );
+    expect(messages[1]).to.deep.equal({ role: MessageRole.USER, content: 'Hello' });
+  });
+
+  it('includes prior user and assistant turns in the context block for session recovery', () => {
+    const messages = buildSessionBootstrapMessages({
+      activities: [
+        activity({
+          senderType: ConversationActivitySenderTypeEnum.AGENT,
+          content: 'Hi there',
+          platformMessageId: 'a1',
+          createdAt: '2026-05-26T12:00:00.000Z',
+        }),
+        activity({ content: 'Question one', platformMessageId: 'u1', createdAt: '2026-05-26T12:01:00.000Z' }),
+        activity({
+          senderType: ConversationActivitySenderTypeEnum.AGENT,
+          content: 'Answer one',
+          platformMessageId: 'a2',
+          createdAt: '2026-05-26T12:02:00.000Z',
+        }),
+        activity({ content: 'Follow up', platformMessageId: 'u2', createdAt: '2026-05-26T12:03:00.000Z' }),
+      ],
+      currentPlatformMessageId: 'u2',
+      currentText: 'Follow up',
+    });
+
+    expect(messages).to.have.length(2);
+    expect(messages[0].content).to.contain('Assistant: Hi there');
+    expect(messages[0].content).to.contain('User: Question one');
+    expect(messages[0].content).to.contain('Assistant: Answer one');
+    expect(messages[0].content).not.to.contain('Follow up');
+    expect(messages[1].content).to.equal('Follow up');
+  });
+});

--- a/apps/api/src/app/agents/services/managed-agent-session-bootstrap.ts
+++ b/apps/api/src/app/agents/services/managed-agent-session-bootstrap.ts
@@ -1,0 +1,87 @@
+import {
+  type ConversationActivityEntity,
+  ConversationActivitySenderTypeEnum,
+  ConversationActivityTypeEnum,
+} from '@novu/dal';
+import { type Message, MessageRole } from '@novu/thalamus';
+
+export const SESSION_RECOVERY_CONTEXT_HEADER =
+  'The following is recovered conversation context from before this session. Messages labeled "Assistant" were sent by you; "User" messages were sent by the subscriber.\n\n';
+
+export type BuildSessionBootstrapMessagesParams = {
+  activities: ConversationActivityEntity[];
+  currentPlatformMessageId?: string;
+  currentText: string;
+};
+
+function formatContextLine(activity: ConversationActivityEntity): string | null {
+  const trimmed = activity.content?.trim() ?? '';
+
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  if (activity.senderType === ConversationActivitySenderTypeEnum.AGENT) {
+    return `Assistant: ${trimmed}`;
+  }
+
+  if (
+    activity.senderType === ConversationActivitySenderTypeEnum.SUBSCRIBER ||
+    activity.senderType === ConversationActivitySenderTypeEnum.PLATFORM_USER
+  ) {
+    return `User: ${trimmed}`;
+  }
+
+  return null;
+}
+
+function isCurrentInboundActivity(
+  activity: ConversationActivityEntity,
+  currentPlatformMessageId: string | undefined
+): boolean {
+  if (!currentPlatformMessageId) {
+    return false;
+  }
+
+  return activity.platformMessageId === currentPlatformMessageId;
+}
+
+/**
+ * Builds Thalamus messages when opening a new managed-agent session.
+ * Prior turns are packed into a labeled user context message; the current inbound
+ * line is sent as a separate user message (Anthropic sessions only accept user input).
+ */
+export function buildSessionBootstrapMessages(params: BuildSessionBootstrapMessagesParams): Message[] {
+  const chronological = params.activities
+    .filter((entry) => entry.type !== ConversationActivityTypeEnum.SIGNAL)
+    .slice()
+    .reverse();
+
+  const priorActivities = chronological.filter(
+    (entry) => !isCurrentInboundActivity(entry, params.currentPlatformMessageId)
+  );
+  const contextLines = priorActivities
+    .map((entry) => formatContextLine(entry))
+    .filter((line): line is string => line !== null);
+
+  const currentText = params.currentText.trim();
+
+  if (contextLines.length === 0) {
+    if (currentText.length === 0) {
+      return [];
+    }
+
+    return [{ role: MessageRole.USER, content: currentText }];
+  }
+
+  const contextMessage = SESSION_RECOVERY_CONTEXT_HEADER + contextLines.join('\n\n');
+
+  if (currentText.length === 0) {
+    return [{ role: MessageRole.USER, content: contextMessage }];
+  }
+
+  return [
+    { role: MessageRole.USER, content: contextMessage },
+    { role: MessageRole.USER, content: currentText },
+  ];
+}

--- a/apps/api/src/app/agents/services/managed-agent.service.ts
+++ b/apps/api/src/app/agents/services/managed-agent.service.ts
@@ -4,8 +4,6 @@ import {
   type AgentEntity,
   AgentRepository,
   ConversationActivityRepository,
-  ConversationActivitySenderTypeEnum,
-  ConversationActivityTypeEnum,
   ConversationRepository,
   SubscriberRepository,
 } from '@novu/dal';
@@ -17,6 +15,7 @@ import type { AgentExecutionParams } from './bridge-executor.service';
 import { DemoClaudeQuotaPolicy } from './demo-claude-quota-policy.service';
 import { ManagedAgentEventHandler } from './managed-agent-event-handler';
 import { ManagedAgentProviderFactory } from './managed-agent-provider-factory';
+import { buildSessionBootstrapMessages } from './managed-agent-session-bootstrap';
 import { McpConnectionVaultService } from './mcp-connection-vault.service';
 
 type WebhookSessionMetadata = {
@@ -67,7 +66,7 @@ export class ManagedAgentService implements OnModuleInit {
 
     const messages = sessionId
       ? [{ role: MessageRole.USER, content: context.message?.text ?? '' }]
-      : await this.buildMessagesWithHistory(context);
+      : await this.buildSessionBootstrapMessages(context);
 
     const { sessionId: newSessionId } = await provider.send({
       messages,
@@ -230,22 +229,18 @@ export class ManagedAgentService implements OnModuleInit {
     });
   }
 
-  private async buildMessagesWithHistory(context: AgentExecutionParams): Promise<Message[]> {
-    const history = await this.conversationActivityRepository.findByConversation(
+  private async buildSessionBootstrapMessages(context: AgentExecutionParams): Promise<Message[]> {
+    const activities = await this.conversationActivityRepository.findByConversation(
       context.config.environmentId,
       String(context.conversation._id),
       50
     );
 
-    const messages: Message[] = history
-      .filter((entry) => entry.type !== ConversationActivityTypeEnum.SIGNAL)
-      .reverse()
-      .map((entry) => ({
-        role: entry.senderType === ConversationActivitySenderTypeEnum.AGENT ? MessageRole.ASSISTANT : MessageRole.USER,
-        content: entry.content,
-      }));
-
-    return messages;
+    return buildSessionBootstrapMessages({
+      activities,
+      currentPlatformMessageId: context.message?.id,
+      currentText: context.message?.text ?? '',
+    });
   }
 
   private async resolveVaultIdsForTurn(


### PR DESCRIPTION
## Summary

- When opening a new managed-agent session (`!externalSessionId`), pack prior conversation activities into a labeled **recovery context** user message, then send the current inbound line as a separate user message.
- Replaces role-mapped `buildMessagesWithHistory` (assistant rows were dropped or merged incorrectly by Thalamus).
- Pairs with [novuhq/thalamus#9](https://github.com/novuhq/thalamus/pull/9), which emits one `user.message` per user turn.

## Context

Mongo stores onboarding welcome as `agent` and inbound text as `subscriber` correctly. Anthropic sessions only accept user input, so assistant history must be embedded explicitly—not concatenated silently.

Linear: https://linear.app/novu/issue/NV-7826

## Test plan

- [x] `cd apps/api && pnpm test -- --grep "buildSessionBootstrapMessages"`
- [ ] Merge/publish Thalamus #9 and bump `@novu/thalamus` in Novu before release
- [ ] New Slack DM after onboarding: agent sees welcome in context block, not as user speech
- [ ] Session recovery after `externalSessionId` cleared: prior user + assistant turns in context, current message separate


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
When opening a new managed-agent session without prior context, the API now bootstraps the session by packing prior conversation activities (both assistant and user turns) into a labeled "recovery context" user message sent separately from the current inbound message. This replaces the previous `buildMessagesWithHistory` approach, which dropped or merged assistant rows incorrectly. The change ensures Anthropic-compatible message formatting since Anthropic sessions only accept user input, requiring assistant history to be embedded explicitly as labeled context rather than concatenated silently.

## Affected areas

**api**: Introduced new session bootstrap message construction logic (`buildSessionBootstrapMessages`) to format conversation history into labeled context blocks, and updated `ManagedAgentService` to use this helper instead of the legacy `buildMessagesWithHistory` when initializing sessions without prior context.

## Key technical decisions

- Session recovery context uses a labeled "Assistant:" / "User:" format to preserve conversation turn structure within a single user message, avoiding silent merging of assistant roles.
- Current inbound activity is excluded from recovery context and sent as a separate user message to maintain separation between historical and active turns.
- Integration depends on thalamus#9 emitting one `user.message` per user turn; requires bumping `@novu/thalamus` dependency.

## Testing

Unit tests added in `managed-agent-session-bootstrap.spec.ts` covering three scenarios: no prior context, prior assistant turns only, and mixed prior user/assistant turns. Tests verified via `pnpm test -- --grep "buildSessionBootstrapMessages"`. End-to-end verification of Slack DM onboarding and session recovery behavior pending thalamus#9 merge and dependency update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->