### PR TITLE
fix(dashboard): restore Create organization entry in Connect side-nav fixes NV-7828

### DIFF
--- a/apps/dashboard/src/components/side-navigation/organization-dropdown-clerk.tsx
+++ b/apps/dashboard/src/components/side-navigation/organization-dropdown-clerk.tsx
@@ -28,7 +28,6 @@ import {
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { DEFAULT_REGION, getRegionCodeFromAws, useRegion } from '@/context/region';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
-import { isManualOrgCreationAllowed } from '@/utils/connect';
 import { ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
 
@@ -255,20 +254,18 @@ export function OrganizationDropdown() {
           )}
         </div>
 
-        {isManualOrgCreationAllowed() && (
-          <DropdownMenuItem
-            className={cn(
-              'flex h-9 cursor-pointer items-center gap-2 rounded-none border-t border-neutral-200 px-2 text-sm transition-shadow focus:bg-accent hover:bg-accent',
-              isScrolled && 'shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]'
-            )}
-            onSelect={() => {
-              navigate(ROUTES.SIGNUP_ORGANIZATION_LIST);
-            }}
-          >
-            <RiAddCircleLine className="size-4 text-text-sub" />
-            <span className="text-text-sub">Create organization</span>
-          </DropdownMenuItem>
-        )}
+        <DropdownMenuItem
+          className={cn(
+            'flex h-9 cursor-pointer items-center gap-2 rounded-none border-t border-neutral-200 px-2 text-sm transition-shadow focus:bg-accent hover:bg-accent',
+            isScrolled && 'shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]'
+          )}
+          onSelect={() => {
+            navigate(ROUTES.SIGNUP_ORGANIZATION_LIST);
+          }}
+        >
+          <RiAddCircleLine className="size-4 text-text-sub" />
+          <span className="text-text-sub">Create organization</span>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/dashboard/src/utils/better-auth/components/organization-dropdown.tsx
+++ b/apps/dashboard/src/utils/better-auth/components/organization-dropdown.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/components/primitives/dropdown-menu';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { IS_NOVU_CONNECT } from '@/config';
-import { isConnectWorkspace, isManualOrgCreationAllowed } from '@/utils/connect';
+import { isConnectWorkspace } from '@/utils/connect';
 import { isPlatformWorkspace } from '@/utils/platform-workspace';
 import { ROUTES } from '@/utils/routes';
 import { cn } from '@/utils/ui';
@@ -227,20 +227,18 @@ export function OrganizationDropdown() {
           )}
         </div>
 
-        {isManualOrgCreationAllowed() && (
-          <DropdownMenuItem
-            className={cn(
-              'flex h-9 cursor-pointer items-center gap-2 rounded-none border-t border-stroke-100 px-2 text-sm transition-shadow focus:bg-accent hover:bg-accent',
-              isScrolled && 'shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]'
-            )}
-            onSelect={() => {
-              navigate(ROUTES.SIGNUP_ORGANIZATION_LIST);
-            }}
-          >
-            <RiAddCircleLine className="size-4 text-text-sub" />
-            <span className="text-text-sub">Create organization</span>
-          </DropdownMenuItem>
-        )}
+        <DropdownMenuItem
+          className={cn(
+            'flex h-9 cursor-pointer items-center gap-2 rounded-none border-t border-stroke-100 px-2 text-sm transition-shadow focus:bg-accent hover:bg-accent',
+            isScrolled && 'shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]'
+          )}
+          onSelect={() => {
+            navigate(ROUTES.SIGNUP_ORGANIZATION_LIST);
+          }}
+        >
+          <RiAddCircleLine className="size-4 text-text-sub" />
+          <span className="text-text-sub">Create organization</span>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
## Summary

Restores the **Create organization** item in the side-nav org dropdown for Novu Connect. Previously it was hidden by `isManualOrgCreationAllowed()`, which short-circuits to `false` when `IS_NOVU_CONNECT` is true, leaving Connect users without a path to create additional workspaces from the dashboard.

The destination — `ROUTES.SIGNUP_ORGANIZATION_LIST` — already renders `OrganizationPicker`, which is product-aware:
- filters memberships by `publicMetadata.productType` (Connect-only in Connect host),
- surfaces its own **Create organization** affordance that writes the Connect session guard (`writeConnectAutoCreateSessionGuard`) and submits with `provisioningVariant: 'connect'`.

So Connect now follows the same shape as Platform: dropdown entry -> picker page -> list existing orgs or create a new one.

## Changes

- `apps/dashboard/src/components/side-navigation/organization-dropdown-clerk.tsx` (the dropdown actually mounted in the side nav for both Platform and Connect): removed the `isManualOrgCreationAllowed()` gate around the menu item and dropped the now-unused import.
- `apps/dashboard/src/utils/better-auth/components/organization-dropdown.tsx`: mirrored the same change to keep the better-auth dropdown aligned.

`isManualOrgCreationAllowed()` itself is untouched — it still gates the direct create form fallback in the better-auth `organization-create.tsx` / `organization-list.tsx`, so the existing `AutoCreateConnectOrganization` provisioning flow is not affected.

## Test plan

- [x] Connect host (`IS_NOVU_CONNECT=true`): open the side-nav org dropdown -> **Create organization** is visible at the bottom.
- [x] Click it -> lands on `/auth/organization-list` showing only Connect memberships in the picker.
- [x] Click **Create organization** in the picker -> create form opens; submitting a new org provisions a Connect workspace (productType: connect) and redirects to the post-org-create route.
- [x] Platform host: regression check that the existing entry still works identically.
- [x] User with zero Connect orgs reaches the picker -> auto-switches to the create view (existing picker behavior, unchanged).

Closes [NV-7828](https://linear.app/novu/issue/NV-7828/creating-a-new-organization-is-not-possible-from-the-connect-ui)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The "Create organization" menu item in the organization dropdown is now always displayed instead of being conditionally hidden by the `isManualOrgCreationAllowed()` check. This restores the ability for Connect users to create additional workspaces from the dashboard, which was blocked when `IS_NOVU_CONNECT=true`. The menu item routes to `ROUTES.SIGNUP_ORGANIZATION_LIST`, which renders OrganizationPicker—a product-aware component that filters memberships and provides a Connect-specific organization creation flow with proper session guards.

## Affected areas

**dashboard**: Organization dropdown components (Clerk and better-auth variants) updated to remove the `isManualOrgCreationAllowed()` conditional. The "Create organization" menu item is now rendered unconditionally and navigates to the organization picker page.

## Testing

Manual verification on Connect hosts confirms that the org dropdown shows "Create organization" and properly provisions Connect workspaces. Existing behavior on Platform hosts remains unchanged. The `isManualOrgCreationAllowed()` gate continues to protect the direct create form fallback used elsewhere.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->