### PR TITLE
feat(root): Enforce org-specific MFA for enterprise Clerk tenants fixes NV-7886

### DIFF
--- a/apps/api/src/app/auth/e2e/clerk.strategy.spec.ts
+++ b/apps/api/src/app/auth/e2e/clerk.strategy.spec.ts
@@ -111,5 +111,29 @@ describe('ClerkStrategy', () => {
         expect(err.message).to.equal('Cannot find environment');
       }
     });
+
+    it('should throw UnauthorizedException when MFA is required but not enabled', async () => {
+      try {
+        await strategy.validate(mockRequest, {
+          ...mockPayload,
+          requireMfa: true,
+          isMfaEnabled: false,
+        });
+        expect.fail('Should have thrown an error');
+      } catch (err) {
+        expect(err).to.be.instanceOf(UnauthorizedException);
+        expect(err.message).to.equal('Multi-factor authentication is required for this organization');
+      }
+    });
+
+    it('should allow access when MFA is required and enabled', async () => {
+      const result = await strategy.validate(mockRequest, {
+        ...mockPayload,
+        requireMfa: true,
+        isMfaEnabled: true,
+      });
+
+      expect(result._id).to.equal('internal-user-123');
+    });
   });
 });

--- a/apps/dashboard/src/api/clerk-organization.ts
+++ b/apps/dashboard/src/api/clerk-organization.ts
@@ -1,0 +1,6 @@
+import type { SetOrgMfaRequirementDto } from '@novu/shared';
+import { post } from './api.client';
+
+export async function setOrgMfaRequirement(body: SetOrgMfaRequirementDto): Promise<{ id: string }> {
+  return post('/clerk/organization/mfa-requirement', { body });
+}

--- a/apps/dashboard/src/context/mfa-enforcement-provider.tsx
+++ b/apps/dashboard/src/context/mfa-enforcement-provider.tsx
@@ -1,0 +1,60 @@
+import { useAuth, useOrganization, useUser } from '@clerk/react';
+import { resolveMfaEnforcementState } from '@novu/shared';
+import { ReactNode, useEffect, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { EE_AUTH_PROVIDER, IS_ENTERPRISE, IS_SELF_HOSTED } from '@/config';
+import { isPublicAuthPath } from '@/utils/auth-routes';
+import { ROUTES } from '@/utils/routes';
+
+const MFA_SETUP_ROUTE = ROUTES.SETTINGS_ACCOUNT;
+
+function isMfaSetupPath(pathname: string): boolean {
+  return pathname === MFA_SETUP_ROUTE || pathname.startsWith(`${MFA_SETUP_ROUTE}/`);
+}
+
+export function MfaEnforcementProvider({ children }: { children: ReactNode }) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { isLoaded: isAuthLoaded, sessionClaims } = useAuth();
+  const { isLoaded: isUserLoaded, user } = useUser();
+  const { isLoaded: isOrganizationLoaded, organization } = useOrganization();
+
+  const isEnforcementEnabled = IS_ENTERPRISE && !IS_SELF_HOSTED && EE_AUTH_PROVIDER === 'clerk';
+
+  const enforcementState = useMemo(() => {
+    if (!isEnforcementEnabled) {
+      return { isBlocked: false };
+    }
+
+    return resolveMfaEnforcementState({
+      sessionClaims: sessionClaims as Record<string, unknown> | undefined,
+      organizationPublicMetadata: organization?.publicMetadata,
+      userTwoFactorEnabled: user?.twoFactorEnabled,
+    });
+  }, [isEnforcementEnabled, sessionClaims, organization?.publicMetadata, user?.twoFactorEnabled]);
+
+  const isReady = isAuthLoaded && isUserLoaded && isOrganizationLoaded;
+  const pathname = location.pathname;
+  const canAccessCurrentRoute = isPublicAuthPath(pathname) || isMfaSetupPath(pathname);
+  const shouldBlockChildren = isEnforcementEnabled && isReady && enforcementState.isBlocked && !canAccessCurrentRoute;
+
+  useEffect(() => {
+    if (!shouldBlockChildren) {
+      return;
+    }
+
+    if (!isMfaSetupPath(pathname)) {
+      void navigate(MFA_SETUP_ROUTE, { replace: true });
+    }
+  }, [shouldBlockChildren, pathname, navigate]);
+
+  if (!isReady && isEnforcementEnabled) {
+    return null;
+  }
+
+  if (shouldBlockChildren) {
+    return null;
+  }
+
+  return children;
+}

--- a/apps/dashboard/src/routes/root.tsx
+++ b/apps/dashboard/src/routes/root.tsx
@@ -59,17 +59,17 @@ const RootRouteInternal = () => {
                 <SnitcherProvider>
                   <AuthProvider>
                     <MfaEnforcementProvider>
-                    <RegionProvider>
-                      <IdentityProvider>
-                        <HelmetProvider>
-                          <TooltipProvider delayDuration={100}>
-                            <EscapeKeyManagerProvider>
-                              <Outlet />
-                            </EscapeKeyManagerProvider>
-                          </TooltipProvider>
-                        </HelmetProvider>
-                      </IdentityProvider>
-                    </RegionProvider>
+                      <RegionProvider>
+                        <IdentityProvider>
+                          <HelmetProvider>
+                            <TooltipProvider delayDuration={100}>
+                              <EscapeKeyManagerProvider>
+                                <Outlet />
+                              </EscapeKeyManagerProvider>
+                            </TooltipProvider>
+                          </HelmetProvider>
+                        </IdentityProvider>
+                      </RegionProvider>
                     </MfaEnforcementProvider>
                   </AuthProvider>
                 </SnitcherProvider>

--- a/apps/dashboard/src/routes/root.tsx
+++ b/apps/dashboard/src/routes/root.tsx
@@ -7,6 +7,7 @@ import { ToastIcon } from '@/components/primitives/sonner';
 import { showToast } from '@/components/primitives/sonner-helpers';
 import { TooltipProvider } from '@/components/primitives/tooltip';
 import { AuthProvider } from '@/context/auth/auth-provider';
+import { MfaEnforcementProvider } from '@/context/mfa-enforcement-provider';
 import { CustomerIoProvider } from '@/context/customer-io';
 import { EEAuthProvider as ClerkProvider } from '@/context/ee-auth-provider';
 import { EscapeKeyManagerProvider } from '@/context/escape-key-manager/escape-key-manager';
@@ -57,6 +58,7 @@ const RootRouteInternal = () => {
               <CustomerIoProvider>
                 <SnitcherProvider>
                   <AuthProvider>
+                    <MfaEnforcementProvider>
                     <RegionProvider>
                       <IdentityProvider>
                         <HelmetProvider>
@@ -68,6 +70,7 @@ const RootRouteInternal = () => {
                         </HelmetProvider>
                       </IdentityProvider>
                     </RegionProvider>
+                    </MfaEnforcementProvider>
                   </AuthProvider>
                 </SnitcherProvider>
               </CustomerIoProvider>

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+export {};
+
+declare global {
+  interface CustomJwtSessionClaims {
+    requireMfa?: boolean;
+    isMfaEnabled?: boolean;
+  }
+}

--- a/packages/shared/src/dto/organization/index.ts
+++ b/packages/shared/src/dto/organization/index.ts
@@ -1,4 +1,5 @@
 export * from './create-organization.dto';
 export * from './members/bulk-invite-members.dto';
 export * from './members/get-invite.dto';
+export * from './set-org-mfa-requirement.dto';
 export * from './update-external-organization.dto';

--- a/packages/shared/src/dto/organization/set-org-mfa-requirement.dto.ts
+++ b/packages/shared/src/dto/organization/set-org-mfa-requirement.dto.ts
@@ -1,0 +1,3 @@
+export type SetOrgMfaRequirementDto = {
+  requireMfa: boolean;
+};

--- a/packages/shared/src/types/organization.ts
+++ b/packages/shared/src/types/organization.ts
@@ -109,4 +109,6 @@ export type OrganizationPublicMetadata = {
   companySize?: string;
   industry?: IndustryEnum;
   productType?: OrganizationProductTypeEnum;
+  /** When true, all org members must enable MFA before using the dashboard or API. */
+  requireMfa?: boolean;
 };

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './data-filter';
 export * from './env';
 export * from './issues';
 export * from './locales';
+export * from './mfa-enforcement';
 export * from './managed-integration-credentials';
 export * from './normalizeEmail';
 export { safeJsonStringify } from './safe-json-stringify';

--- a/packages/shared/src/utils/mfa-enforcement.spec.ts
+++ b/packages/shared/src/utils/mfa-enforcement.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isMfaEnforcementBlocking,
+  readMfaEnforcementFromSessionClaims,
+  readOrgRequireMfa,
+  resolveMfaEnforcementState,
+} from './mfa-enforcement';
+
+describe('mfa-enforcement utils', () => {
+  describe('readOrgRequireMfa', () => {
+    it('returns false when metadata is missing', () => {
+      expect(readOrgRequireMfa(undefined)).toBe(false);
+    });
+
+    it('returns true when requireMfa is set', () => {
+      expect(readOrgRequireMfa({ requireMfa: true })).toBe(true);
+    });
+  });
+
+  describe('readMfaEnforcementFromSessionClaims', () => {
+    it('reads requireMfa and isMfaEnabled from session claims', () => {
+      expect(readMfaEnforcementFromSessionClaims({ requireMfa: true, isMfaEnabled: true })).toEqual({
+        requireMfa: true,
+        isMfaEnabled: true,
+      });
+    });
+  });
+
+  describe('isMfaEnforcementBlocking', () => {
+    it('blocks when MFA is required but not enabled', () => {
+      expect(isMfaEnforcementBlocking(true, false)).toBe(true);
+    });
+
+    it('does not block when MFA is not required', () => {
+      expect(isMfaEnforcementBlocking(false, false)).toBe(false);
+    });
+  });
+
+  describe('resolveMfaEnforcementState', () => {
+    it('falls back to organization metadata and user two-factor state', () => {
+      expect(
+        resolveMfaEnforcementState({
+          sessionClaims: {},
+          organizationPublicMetadata: { requireMfa: true },
+          userTwoFactorEnabled: false,
+        })
+      ).toEqual({
+        requireMfa: true,
+        isMfaEnabled: false,
+        isBlocked: true,
+      });
+    });
+  });
+});

--- a/packages/shared/src/utils/mfa-enforcement.ts
+++ b/packages/shared/src/utils/mfa-enforcement.ts
@@ -1,0 +1,51 @@
+import type { OrganizationPublicMetadata } from '../types';
+
+export type MfaEnforcementSessionClaims = {
+  requireMfa?: boolean;
+  isMfaEnabled?: boolean;
+};
+
+export function readOrgRequireMfa(metadata?: OrganizationPublicMetadata | Record<string, unknown> | null): boolean {
+  if (!metadata || typeof metadata !== 'object') {
+    return false;
+  }
+
+  return (metadata as OrganizationPublicMetadata).requireMfa === true;
+}
+
+export function readMfaEnforcementFromSessionClaims(
+  claims?: MfaEnforcementSessionClaims | Record<string, unknown> | null
+): { requireMfa: boolean; isMfaEnabled: boolean } {
+  if (!claims || typeof claims !== 'object') {
+    return { requireMfa: false, isMfaEnabled: false };
+  }
+
+  const requireMfa = claims.requireMfa === true;
+  const isMfaEnabled = claims.isMfaEnabled === true;
+
+  return { requireMfa, isMfaEnabled };
+}
+
+export function isMfaEnforcementBlocking(requireMfa: boolean, isMfaEnabled: boolean): boolean {
+  return requireMfa && !isMfaEnabled;
+}
+
+export function resolveMfaEnforcementState({
+  sessionClaims,
+  organizationPublicMetadata,
+  userTwoFactorEnabled,
+}: {
+  sessionClaims?: MfaEnforcementSessionClaims | Record<string, unknown> | null;
+  organizationPublicMetadata?: OrganizationPublicMetadata | Record<string, unknown> | null;
+  userTwoFactorEnabled?: boolean;
+}): { requireMfa: boolean; isMfaEnabled: boolean; isBlocked: boolean } {
+  const claims = readMfaEnforcementFromSessionClaims(sessionClaims);
+  const requireMfa = claims.requireMfa || readOrgRequireMfa(organizationPublicMetadata);
+  const isMfaEnabled = claims.isMfaEnabled || userTwoFactorEnabled === true;
+
+  return {
+    requireMfa,
+    isMfaEnabled,
+    isBlocked: isMfaEnforcementBlocking(requireMfa, isMfaEnabled),
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements per-organization MFA enforcement for enterprise customers using Clerk organization metadata and session JWT claims, as recommended by Clerk support (instance-wide MFA is not sufficient).

## How it works

```mermaid
sequenceDiagram
  participant Admin
  participant API
  participant Clerk
  participant Dashboard
  participant User

  Admin->>API: POST /clerk/organization/mfa-requirement
  API->>Clerk: publicMetadata.requireMfa = true
  User->>Dashboard: Sign in / use app
  Dashboard->>Dashboard: Read sessionClaims + org metadata
  alt MFA required and not enabled
    Dashboard->>User: Redirect to /settings/account (security)
  else MFA enabled
    Dashboard->>User: Allow app access
  end
  User->>API: Bearer JWT
  API->>API: ClerkStrategy validates requireMfa/isMfaEnabled
```

## Changes

### `@novu/shared`
- `OrganizationPublicMetadata.requireMfa` flag
- `SetOrgMfaRequirementDto` and MFA enforcement helpers

### `@novu/ee-auth` (packages-enterprise)
- `SetOrgMfaRequirement` use case + `POST /v1/clerk/organization/mfa-requirement`
- API rejects requests when MFA is required but not enabled on the JWT

**Enterprise PR (required first):** https://github.com/novuhq/packages-enterprise/compare/next...fix/org-specific-mfa-enforcement-e5e3

Branch `fix/org-specific-mfa-enforcement-e5e3` is pushed; open and merge the PR above before merging this PR.

### Dashboard
- `MfaEnforcementProvider` redirects users without MFA to account security settings when their org requires it (enterprise + Clerk only)

## CI: `validate-submodule-sync`

This check compares `.source` to the tip of `packages-enterprise` `next`. It **fails until the enterprise PR is merged**, because this PR points `.source` at commit `15edf8b` on the feature branch (not yet on `next`).

**Merge order:**
1. Open and merge https://github.com/novuhq/packages-enterprise/compare/next...fix/org-specific-mfa-enforcement-e5e3
2. Rebase this branch and update `.source` to the new `packages-enterprise` `next` tip (or let the enterprise `sync-submodule-to-novu` bot open a sync PR and merge it, then rebase)
3. `validate-submodule-sync` will pass

## Clerk configuration (required for production)

In Clerk Dashboard → **Sessions** → **Customize session token**, add:

```json
{
  "requireMfa": "{{org.public_metadata.requireMfa}}",
  "isMfaEnabled": "{{user.two_factor_enabled}}"
}
```

Until this is configured, the dashboard falls back to `organization.publicMetadata.requireMfa` and `user.twoFactorEnabled`.

## Enabling MFA for an organization

```http
POST /v1/clerk/organization/mfa-requirement
Authorization: Bearer <token>
Content-Type: application/json

{ "requireMfa": true }
```

Requires `org:metadata:write` permission.

## Testing

- `packages/shared`: vitest `mfa-enforcement.spec.ts`
- `apps/api`: ClerkStrategy MFA validation specs

Linear: NV-7886
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7886](https://linear.app/novu/issue/NV-7886/enable-org-specific-mfa-enforcement-for-enterprise-customers)

<div><a href="https://cursor.com/agents/bc-535a1c53-0450-4d34-bba5-dffcabb0e5e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-535a1c53-0450-4d34-bba5-dffcabb0e5e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR implements organization-level MFA enforcement for enterprise Clerk tenants. When an organization requires MFA, users without it enabled are blocked from accessing the dashboard and API. The feature integrates Clerk's session JWT claims with organization metadata, allowing admins to enforce MFA at the org level via a new endpoint.

## Affected areas

- **shared**: Added MFA enforcement utility functions (`readOrgRequireMfa`, `readMfaEnforcementFromSessionClaims`, `isMfaEnforcementBlocking`, `resolveMfaEnforcementState`), introduced `SetOrgMfaRequirementDto` type, and extended `OrganizationPublicMetadata` with optional `requireMfa` flag.

- **api**: Extended `ClerkStrategy` validation to check MFA enforcement state on incoming JWTs; requests are rejected with `UnauthorizedException` when MFA is required but not enabled.

- **dashboard**: Created `MfaEnforcementProvider` context component that blocks access to non-auth routes when org-level MFA is required and user hasn't enabled it, redirecting to account security settings. Added API helper `setOrgMfaRequirement` for admin configuration and integrated provider into root layout. Extended TypeScript environment declarations for custom JWT claims (`requireMfa`, `isMfaEnabled`).

## Key technical decisions

- MFA enforcement state is resolved from Clerk session claims first, with fallback to organization public metadata and user two-factor status when claims are absent.
- The dashboard provider renders nothing (blocks rendering) while enforcement is active and user is blocked, then redirects to MFA setup.
- Clerk session token must be customized to include `requireMfa` and `isMfaEnabled` claims in production.

## Testing

Added vitest unit tests for MFA enforcement utilities and ClerkStrategy MFA validation tests covering both blocking and allowed scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->