### PR TITLE
fix(api-service): stabilize combined workflow runs filter e2e test fixes NV-7891

### DIFF
--- a/apps/api/src/app/activity/e2e/get-workflow-runs.e2e.ts
+++ b/apps/api/src/app/activity/e2e/get-workflow-runs.e2e.ts
@@ -50,6 +50,7 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
     transactionId?: string;
     status?: WorkflowRunStatusEnum;
     channels?: StepTypeEnum[];
+    workflow?: NotificationTemplateEntity;
   }) {
     const {
       count,
@@ -58,6 +59,7 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
       transactionId,
       status = WorkflowRunStatusEnum.COMPLETED,
       channels = [StepTypeEnum.EMAIL],
+      workflow = template,
     } = options;
 
     const promises: Promise<void>[] = [];
@@ -68,7 +70,7 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
       // Create a mock NotificationEntity
       const mockNotification: NotificationEntity = {
         _id: NotificationRepository.createObjectId(),
-        _templateId: template._id,
+        _templateId: workflow._id,
         _environmentId: session.environment._id,
         _organizationId: session.organization._id,
         _subscriberId: subscriber._id,
@@ -83,7 +85,7 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
       };
 
       promises.push(
-        workflowRunRepository.create(mockNotification, template, {
+        workflowRunRepository.create(mockNotification, workflow, {
           status,
           userId: session.user._id,
           externalSubscriberId: subscriberId[0],
@@ -583,20 +585,19 @@ describe('Workflow Runs Filtering & Pagination - GET /v1/activity/workflow-runs 
   });
 
   it('should support combining multiple filters', async () => {
-    await novuClient.trigger({
-      workflowId: inAppWorkflow.triggers[0].identifier,
-      to: subscriber.subscriberId,
-      payload: { firstName: 'John' },
+    await createMultipleWorkflowRunsByDb({
+      count: 1,
+      subscriberId: [subscriber.subscriberId],
+      workflow: inAppWorkflow,
+      status: WorkflowRunStatusEnum.COMPLETED,
+      channels: [StepTypeEnum.IN_APP],
     });
-
-    await session.waitForWorkflowQueueCompletion();
-    await session.waitForSubscriberQueueCompletion();
 
     const { body } = await session.testAgent
       .get('/v1/activity/workflow-runs')
       .query({
         workflowIds: [inAppWorkflow._id],
-        subscriberIds: subscriber.subscriberId,
+        subscriberIds: [subscriber.subscriberId],
         statuses: [WorkflowRunStatusDtoEnum.COMPLETED],
         limit: 10,
       })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a flaky e2e test in the workflow runs activity suite: `should support combining multiple filters`.

The test previously triggered a real in-app workflow and immediately queried with `statuses: [COMPLETED]`. That races ClickHouse ReplacingMergeTree updates—queue completion does not guarantee the latest row is `COMPLETED`, so the combined filter sometimes returned zero rows.

## Changes

- Seed a known workflow run via `createMultipleWorkflowRunsByDb` with `inAppWorkflow`, `COMPLETED` status, and `IN_APP` channel (same pattern as the status filter test).
- Allow `createMultipleWorkflowRunsByDb` to accept an optional `workflow` template.
- Normalize `subscriberIds` query param to array form.

## Verification

Ran `should support combining multiple filters` three times locally—all passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c13c521d-d4a0-4338-be78-f4c088e76c9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c13c521d-d4a0-4338-be78-f4c088e76c9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
Fixed a flaky end-to-end test (`should support combining multiple filters`) in the workflow runs activity suite that was intermittently failing due to a race condition. The test was triggering a real in-app workflow and immediately querying with a status filter before ClickHouse's ReplacingMergeTree had completed its updates, causing the query to return zero results. The fix replaces the live workflow trigger with direct database seeding of a known completed workflow run, eliminating the race condition.

## Affected areas

**api**: Updated the `createMultipleWorkflowRunsByDb` helper function to accept an optional `workflow` parameter that allows tests to create workflow runs for a specified template instead of always using the default template. Modified the `"should support combining multiple filters"` test to seed workflow runs directly into the database with known `COMPLETED` status and `IN_APP` channel, rather than triggering them through the Novu client. Also normalized the `subscriberIds` query parameter to ensure it's always in array form.

## Testing

The `"should support combining multiple filters"` test was run three times locally after the fix and passed consistently, confirming that the flakiness has been resolved. No additional unit tests were needed since this is primarily a test stabilization fix that removes the race condition from the existing test setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a flaky e2e test in the workflow-runs activity suite. The race condition occurred because the original test triggered a real workflow and queried ClickHouse for `COMPLETED` rows before ReplacingMergeTree had a chance to deduplicate the intermediate status rows (PENDING → RUNNING → COMPLETED).

- The flaky test now seeds data directly via `createMultipleWorkflowRunsByDb` with an explicit `status: COMPLETED` and the `inAppWorkflow` template, bypassing the queue entirely and eliminating the ClickHouse timing race.
- The `createMultipleWorkflowRunsByDb` helper gains an optional `workflow` parameter (defaulting to the outer `template`) so callers can specify which workflow template to seed.
- The `subscriberIds` query parameter in the combined-filter test is normalized from a bare string to array form, matching the pattern used in every other test in the file.

<h3>Confidence Score: 4/5</h3>

Test-only change that removes a real queue trigger in favour of direct DB seeding; no production code is touched and the fix directly addresses the documented ClickHouse race condition.

All changes are confined to a single e2e test file. The direct-insert approach correctly eliminates the ReplacingMergeTree deduplication race because only one row is ever written for the run. The workflow parameter defaulting to the outer template preserves every existing call site. The subscriberIds array normalisation aligns with the pattern used across all other tests in the file.

No files require special attention; the single changed file is an e2e test helper and test case.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/activity/e2e/get-workflow-runs.e2e.ts | Stabilizes the 'should support combining multiple filters' test by replacing async queue-based seeding with direct DB insertion via createMultipleWorkflowRunsByDb, adds optional workflow parameter to that helper, and fixes subscriberIds from a bare string to array form in the query. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant Queue as Workflow Queue
    participant CH as ClickHouse (ReplacingMergeTree)
    rect rgb(255, 230, 230)
        Note over Test,CH: BEFORE (flaky)
        Test->>Queue: novuClient.trigger(inAppWorkflow)
        Queue->>CH: "INSERT row status=PENDING"
        Queue->>CH: "INSERT row status=RUNNING"
        Queue->>CH: "INSERT row status=COMPLETED"
        Test->>Test: waitForWorkflowQueueCompletion()
        Test->>CH: "SELECT WHERE status=COMPLETED"
        Note over CH: Merge not yet run - 0 rows returned
    end
    rect rgb(230, 255, 230)
        Note over Test,CH: AFTER (stable)
        Test->>CH: "workflowRunRepository.create(status=COMPLETED)"
        Note over CH: Single INSERT immediately visible
        Test->>CH: "SELECT WHERE status=COMPLETED"
        CH-->>Test: 1 row returned
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): stabilize combined wor..."](https://github.com/novuhq/novu/commit/abdc18f0b507c54f136e02acdeef6041f80fce54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34326560)</sub>

<!-- /greptile_comment -->