### PR TITLE
fix(dashboard): resume CLI auth after sign-in and org setup fixes NV-7893

### DIFF
--- a/apps/dashboard/src/components/auth/auto-create-connect-organization.tsx
+++ b/apps/dashboard/src/components/auth/auto-create-connect-organization.tsx
@@ -1,7 +1,7 @@
 import { useOrganization, useOrganizationList, useUser } from '@clerk/react';
 import { FeatureFlagsKeysEnum, OrganizationProductTypeEnum, tryReadOrganizationProductType } from '@novu/shared';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, type NavigateFunction } from 'react-router-dom';
 import { Button } from '@/components/primitives/button';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useTelemetry } from '@/hooks/use-telemetry';
@@ -17,6 +17,7 @@ import {
   resolveConnectOrgListAction,
   writeConnectAutoCreateSessionGuard,
 } from '@/utils/connect';
+import { resolvePendingCliAuthReturnUrl } from '@/utils/cli-auth-pending';
 import { getPostOrgCreateRoute } from '@/utils/onboarding-redirect';
 import { ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -57,6 +58,18 @@ function isSlugTakenError(error: unknown): boolean {
       entry?.meta?.paramName === 'slug' &&
       (entry.code === 'form_identifier_exists' || entry.code === 'form_param_value_invalid')
   );
+}
+
+function navigateToPostConnectOrgResolution(navigate: NavigateFunction, fallbackPath: string) {
+  const pendingCliAuthReturnUrl = resolvePendingCliAuthReturnUrl();
+
+  if (pendingCliAuthReturnUrl) {
+    window.location.assign(pendingCliAuthReturnUrl);
+
+    return;
+  }
+
+  void navigate(fallbackPath, { replace: true });
 }
 
 export function AutoCreateConnectOrganization() {
@@ -245,13 +258,13 @@ export function AutoCreateConnectOrganization() {
       });
 
       if (resolution.type === 'created') {
-        navigate(getPostOrgCreateRoute(APP_IDS.CONNECT, isAgentsEnabled), { replace: true });
+        navigateToPostConnectOrgResolution(navigate, getPostOrgCreateRoute(APP_IDS.CONNECT, isAgentsEnabled));
 
         return;
       }
 
       clearConnectProvisioning();
-      navigate(ROUTES.ENV, { replace: true });
+      navigateToPostConnectOrgResolution(navigate, ROUTES.ENV);
     } catch (error) {
       clearConnectProvisioning();
       setStatus('error');
@@ -266,7 +279,7 @@ export function AutoCreateConnectOrganization() {
     if (isCurrentOrgConnect) {
       hasStartedRef.current = true;
       clearConnectProvisioning();
-      navigate(ROUTES.ENV, { replace: true });
+      navigateToPostConnectOrgResolution(navigate, ROUTES.ENV);
 
       return;
     }

--- a/apps/dashboard/src/components/auth/create-organization.tsx
+++ b/apps/dashboard/src/components/auth/create-organization.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'react-router-dom';
 import { OrganizationPicker } from '@/components/auth/organization-picker';
 import { showErrorToast } from '@/components/primitives/sonner-helpers';
 import { buildAfterSignOutUrl } from '@/utils/cross-product-sign-out';
+import { resolvePendingCliAuthReturnUrl } from '@/utils/cli-auth-pending';
 import { useFeatureFlag } from '../../hooks/use-feature-flag';
 import {
   getOnboardingAppId,
@@ -57,8 +58,10 @@ function OrganizationForm() {
 
   // Only forward `?appId=` when it was set explicitly — hostname detection covers the rest.
   const explicitAppId = useMemo(() => getOnboardingAppId(searchParams), [searchParams]);
-  const afterCreateUrl = withAppId(getPostOrgCreateRoute(appId, isAgentsEnabled), explicitAppId);
-  const afterSelectUrl = withAppId(ROUTES.ENV, explicitAppId);
+  const pendingCliAuthReturnUrl = useMemo(() => resolvePendingCliAuthReturnUrl(), []);
+  const afterCreateUrl =
+    pendingCliAuthReturnUrl ?? withAppId(getPostOrgCreateRoute(appId, isAgentsEnabled), explicitAppId);
+  const afterSelectUrl = pendingCliAuthReturnUrl ?? withAppId(ROUTES.ENV, explicitAppId);
 
   const handleSignOut = useCallback(async () => {
     const fallbackUrl = buildAfterSignOutUrl();

--- a/apps/dashboard/src/context/auth/auth-provider.tsx
+++ b/apps/dashboard/src/context/auth/auth-provider.tsx
@@ -5,6 +5,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { OnboardingProvisioningOverlay } from '@/components/auth/connect-provisioning-overlay';
 import { IS_NOVU_CONNECT } from '@/config';
 import { isPublicAuthPath } from '@/utils/auth-routes';
+import { readPendingCliAuth } from '@/utils/cli-auth-pending';
+import { buildConnectProvisionOrgListPath } from '@/utils/connect';
 import { isActiveConnectWorkspace, isConnectWorkspace } from '@/utils/connect';
 import { ROUTES } from '@/utils/routes';
 import { AuthContext } from './auth-context';
@@ -123,7 +125,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       void clerk.setActive({ organization: null });
     }
 
-    void navigate(ROUTES.SIGNUP_ORGANIZATION_LIST, { replace: true });
+    const pendingCliAuth = readPendingCliAuth();
+    const orgListPath =
+      pendingCliAuth && IS_NOVU_CONNECT
+        ? buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST)
+        : ROUTES.SIGNUP_ORGANIZATION_LIST;
+
+    void navigate(orgListPath, { replace: true });
   }, [shouldHandleResolution, clerkOrganization, clerk, redirectTo, navigate]);
 
   const currentUser = useMemo(

--- a/apps/dashboard/src/pages/cli-auth.tsx
+++ b/apps/dashboard/src/pages/cli-auth.tsx
@@ -15,6 +15,7 @@ import { useEnvironment } from '@/context/environment/hooks';
 import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchApiKeys } from '@/hooks/use-fetch-api-keys';
 import { useHasPermission } from '@/hooks/use-has-permission';
+import { clearPendingCliAuth, storePendingCliAuth } from '@/utils/cli-auth-pending';
 import { buildRoute, ROUTES } from '@/utils/routes';
 
 function isValidDeviceCode(deviceCode: string | null): deviceCode is string {
@@ -25,6 +26,15 @@ function isValidDeviceCode(deviceCode: string | null): deviceCode is string {
 
 export const CliAuthPage = () => {
   const { isLoaded, isSignedIn } = useClerkAuth();
+  const [searchParams] = useSearchParams();
+  const deviceCode = searchParams.get('device_code');
+  const callerName = searchParams.get('name');
+
+  useEffect(() => {
+    if (isValidDeviceCode(deviceCode)) {
+      storePendingCliAuth(deviceCode, callerName);
+    }
+  }, [deviceCode, callerName]);
 
   if (!isLoaded) {
     return null;
@@ -94,6 +104,7 @@ function CliAuthContent() {
         environmentId: currentEnvironment._id,
       });
 
+      clearPendingCliAuth();
       setDidAuthorize(true);
       showSuccessToast('Novu CLI authorized. You can return to your terminal.');
     } catch (error) {

--- a/apps/dashboard/src/pages/sign-in.tsx
+++ b/apps/dashboard/src/pages/sign-in.tsx
@@ -12,8 +12,10 @@ import { clerkSignupAppearance } from '@/utils/clerk-appearance';
 import { buildConnectProvisionOrgListPath } from '@/utils/connect';
 import {
   appendRedirectUrlParam,
-  readCliAuthReturnUrl,
+  buildCliAuthReturnUrlFromSearchParams,
+  parseCliAuthReturnFromSearchParams,
   resolvePendingCliAuthReturnUrl,
+  storePendingCliAuth,
 } from '@/utils/cli-auth-pending';
 import {
   buildAbsoluteConnectUrl,
@@ -47,10 +49,18 @@ export const SignInPage = () => {
 
   const cliAuthReturnUrl = useMemo(
     () =>
-      readCliAuthReturnUrl(searchParams, { preferConnectHost: isConnectSignIn }) ??
+      buildCliAuthReturnUrlFromSearchParams(searchParams, { preferConnectHost: isConnectSignIn }) ??
       resolvePendingCliAuthReturnUrl(),
     [searchParams, isConnectSignIn]
   );
+
+  useEffect(() => {
+    const pending = parseCliAuthReturnFromSearchParams(searchParams, { preferConnectHost: isConnectSignIn });
+
+    if (pending) {
+      storePendingCliAuth(pending.deviceCode, pending.name, pending.returnHost);
+    }
+  }, [searchParams, isConnectSignIn]);
 
   // Sign-in only runs on the primary; satellite visitors bounce back with the Connect flag.
   useEffect(() => {

--- a/apps/dashboard/src/pages/sign-in.tsx
+++ b/apps/dashboard/src/pages/sign-in.tsx
@@ -11,10 +11,16 @@ import { buildAppHomeRoute, getCurrentAppId } from '@/utils/apps';
 import { clerkSignupAppearance } from '@/utils/clerk-appearance';
 import { buildConnectProvisionOrgListPath } from '@/utils/connect';
 import {
+  appendRedirectUrlParam,
+  readCliAuthReturnUrl,
+  resolvePendingCliAuthReturnUrl,
+} from '@/utils/cli-auth-pending';
+import {
   buildAbsoluteConnectUrl,
   buildPrimarySignInUrl,
   CONNECT_PRODUCT_VALUE,
   PRODUCT_QUERY_PARAM,
+  readClerkRedirectUrlParam,
 } from '@/utils/product-auth-urls';
 import { buildRoute, ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -39,12 +45,26 @@ export const SignInPage = () => {
     []
   );
 
+  const cliAuthReturnUrl = useMemo(
+    () =>
+      readCliAuthReturnUrl(searchParams, { preferConnectHost: isConnectSignIn }) ??
+      resolvePendingCliAuthReturnUrl(),
+    [searchParams, isConnectSignIn]
+  );
+
   // Sign-in only runs on the primary; satellite visitors bounce back with the Connect flag.
   useEffect(() => {
     if (IS_NOVU_CONNECT) {
-      window.location.replace(buildPrimarySignInUrl({ product: CONNECT_PRODUCT_VALUE }));
+      const redirectUrl = readClerkRedirectUrlParam(searchParams);
+      let primaryUrl = buildPrimarySignInUrl({ product: CONNECT_PRODUCT_VALUE });
+
+      if (redirectUrl) {
+        primaryUrl = appendRedirectUrlParam(primaryUrl, redirectUrl);
+      }
+
+      window.location.replace(primaryUrl);
     }
-  }, []);
+  }, [searchParams]);
 
   useEffect(() => {
     const utmParams = getUtmParams();
@@ -63,12 +83,19 @@ export const SignInPage = () => {
   // `?__clerk_synced=false` Connect URL) and always go to the clean provision entry point —
   // Clerk's satellite SDK syncs the session on arrival. Honoring the stale return URL is what
   // caused the Platform ↔ Connect redirect loop after the post-PR-11281 follow-ups.
+  // CLI auth is the exception: the device session must resume on `/cli/auth` after sign-in.
   useEffect(() => {
     if (!isLoaded || !isSignedIn || IS_NOVU_CONNECT || hasRedirectedRef.current) {
       return;
     }
 
     hasRedirectedRef.current = true;
+
+    if (cliAuthReturnUrl) {
+      window.location.assign(cliAuthReturnUrl);
+
+      return;
+    }
 
     if (isConnectSignIn) {
       window.location.assign(connectProvisionRedirect);
@@ -80,12 +107,20 @@ export const SignInPage = () => {
       buildAppHomeRoute(getCurrentAppId(), 'default') ?? buildRoute(ROUTES.WORKFLOWS, { environmentSlug: 'default' });
 
     void navigate(home, { replace: true });
-  }, [isLoaded, isSignedIn, isConnectSignIn, connectProvisionRedirect, navigate]);
+  }, [isLoaded, isSignedIn, isConnectSignIn, connectProvisionRedirect, cliAuthReturnUrl, navigate]);
 
-  // Preserve `?product=connect` across the Clerk sign-in ↔ sign-up link so branding survives.
-  const signUpUrlWithProduct = isConnectSignIn
-    ? `${ROUTES.SIGN_UP}?${PRODUCT_QUERY_PARAM}=${CONNECT_PRODUCT_VALUE}`
-    : ROUTES.SIGN_UP;
+  const signUpUrlWithProduct = useMemo(() => {
+    const redirectUrl = readClerkRedirectUrlParam(searchParams);
+    let url = isConnectSignIn
+      ? `${ROUTES.SIGN_UP}?${PRODUCT_QUERY_PARAM}=${CONNECT_PRODUCT_VALUE}`
+      : ROUTES.SIGN_UP;
+
+    if (redirectUrl) {
+      url = appendRedirectUrlParam(url, redirectUrl);
+    }
+
+    return url;
+  }, [searchParams, isConnectSignIn]);
 
   // Render nothing while redirecting:
   //   - On the satellite (`IS_NOVU_CONNECT`) the page is mid-replace to primary.
@@ -107,7 +142,7 @@ export const SignInPage = () => {
             path={ROUTES.SIGN_IN}
             signUpUrl={signUpUrlWithProduct}
             appearance={clerkSignupAppearance}
-            forceRedirectUrl={isConnectSignIn ? connectProvisionRedirect : undefined}
+            forceRedirectUrl={cliAuthReturnUrl ?? (isConnectSignIn ? connectProvisionRedirect : undefined)}
           />
           {!IS_SELF_HOSTED && !isConnectSignIn && <RegionPicker />}
         </div>

--- a/apps/dashboard/src/pages/sign-up.tsx
+++ b/apps/dashboard/src/pages/sign-up.tsx
@@ -9,11 +9,13 @@ import { IS_NOVU_CONNECT, IS_SELF_HOSTED } from '@/config';
 import { useSegment } from '@/context/segment';
 import { clerkSignupAppearance } from '@/utils/clerk-appearance';
 import { buildConnectProvisionOrgListPath } from '@/utils/connect';
+import { appendRedirectUrlParam, readCliAuthReturnUrl } from '@/utils/cli-auth-pending';
 import {
   buildAbsoluteConnectUrl,
   buildPrimarySignUpUrl,
   CONNECT_PRODUCT_VALUE,
   PRODUCT_QUERY_PARAM,
+  readClerkRedirectUrlParam,
 } from '@/utils/product-auth-urls';
 import { ROUTES } from '@/utils/routes';
 import { TelemetryEvent } from '@/utils/telemetry';
@@ -37,12 +39,24 @@ export const SignUpPage = () => {
     []
   );
 
+  // Persist pending CLI auth from inbound redirect_url; org creation still runs first.
+  useEffect(() => {
+    readCliAuthReturnUrl(searchParams, { preferConnectHost: isConnectSignUp });
+  }, [searchParams, isConnectSignUp]);
+
   // Sign-up flows are primary-only — bounce satellite visitors back with Connect branding.
   useEffect(() => {
     if (IS_NOVU_CONNECT) {
-      window.location.replace(buildPrimarySignUpUrl({ product: CONNECT_PRODUCT_VALUE }));
+      const redirectUrl = readClerkRedirectUrlParam(searchParams);
+      let primaryUrl = buildPrimarySignUpUrl({ product: CONNECT_PRODUCT_VALUE });
+
+      if (redirectUrl) {
+        primaryUrl = appendRedirectUrlParam(primaryUrl, redirectUrl);
+      }
+
+      window.location.replace(primaryUrl);
     }
-  }, []);
+  }, [searchParams]);
 
   useEffect(() => {
     const utmParams = getUtmParams();
@@ -58,6 +72,7 @@ export const SignUpPage = () => {
   // immediately. We deliberately drop any inbound `redirect_url` (e.g. a stale `?__clerk_synced=false`
   // Connect URL) and always go to the clean provision entry point — Clerk's satellite SDK syncs
   // the session on arrival. Honoring the stale return URL is what caused the redirect loop.
+  // CLI auth resumes through pending session storage after org provisioning completes.
   useEffect(() => {
     if (!isLoaded || !isSignedIn || IS_NOVU_CONNECT || hasRedirectedRef.current) {
       return;
@@ -71,9 +86,18 @@ export const SignUpPage = () => {
     window.location.assign(connectProvisionRedirect);
   }, [isLoaded, isSignedIn, isConnectSignUp, connectProvisionRedirect]);
 
-  const signInUrlWithProduct = isConnectSignUp
-    ? `${ROUTES.SIGN_IN}?${PRODUCT_QUERY_PARAM}=${CONNECT_PRODUCT_VALUE}`
-    : ROUTES.SIGN_IN;
+  const signInUrlWithProduct = useMemo(() => {
+    const redirectUrl = readClerkRedirectUrlParam(searchParams);
+    let url = isConnectSignUp
+      ? `${ROUTES.SIGN_IN}?${PRODUCT_QUERY_PARAM}=${CONNECT_PRODUCT_VALUE}`
+      : ROUTES.SIGN_IN;
+
+    if (redirectUrl) {
+      url = appendRedirectUrlParam(url, redirectUrl);
+    }
+
+    return url;
+  }, [searchParams, isConnectSignUp]);
 
   // Render nothing while redirecting:
   //   - On the satellite (`IS_NOVU_CONNECT`) the page is mid-replace to primary.

--- a/apps/dashboard/src/utils/cli-auth-pending.ts
+++ b/apps/dashboard/src/utils/cli-auth-pending.ts
@@ -151,10 +151,10 @@ type ReadCliAuthReturnUrlOptions = {
   preferConnectHost?: boolean;
 };
 
-export function readCliAuthReturnUrl(
+export function parseCliAuthReturnFromSearchParams(
   searchParams?: URLSearchParams,
   options?: ReadCliAuthReturnUrlOptions
-): string | null {
+): PendingCliAuth | null {
   const redirectUrl = readClerkRedirectUrlParam(searchParams);
 
   if (!redirectUrl || !isCliAuthReturnUrl(redirectUrl)) {
@@ -170,13 +170,39 @@ export function readCliAuthReturnUrl(
   const returnHost =
     options?.preferConnectHost || isConnectHostnameUrl(redirectUrl) ? 'connect' : detectReturnHost();
 
-  storePendingCliAuth(parsed.deviceCode, parsed.name, returnHost);
-
-  return buildCliAuthUrl({
+  return {
     deviceCode: parsed.deviceCode,
     name: parsed.name,
     returnHost,
-  });
+  };
+}
+
+export function buildCliAuthReturnUrlFromSearchParams(
+  searchParams?: URLSearchParams,
+  options?: ReadCliAuthReturnUrlOptions
+): string | null {
+  const pending = parseCliAuthReturnFromSearchParams(searchParams, options);
+
+  if (!pending) {
+    return null;
+  }
+
+  return buildCliAuthUrl(pending);
+}
+
+export function readCliAuthReturnUrl(
+  searchParams?: URLSearchParams,
+  options?: ReadCliAuthReturnUrlOptions
+): string | null {
+  const pending = parseCliAuthReturnFromSearchParams(searchParams, options);
+
+  if (!pending) {
+    return null;
+  }
+
+  storePendingCliAuth(pending.deviceCode, pending.name, pending.returnHost);
+
+  return buildCliAuthUrl(pending);
 }
 
 export function appendRedirectUrlParam(url: string, redirectUrl: string): string {

--- a/apps/dashboard/src/utils/cli-auth-pending.ts
+++ b/apps/dashboard/src/utils/cli-auth-pending.ts
@@ -1,0 +1,187 @@
+import { IS_NOVU_CONNECT } from '@/config';
+import {
+  buildAbsoluteConnectUrl,
+  buildAbsolutePlatformUrl,
+  isConnectHostnameUrl,
+  readClerkRedirectUrlParam,
+} from '@/utils/product-auth-urls';
+import { ROUTES } from '@/utils/routes';
+
+const STORAGE_KEY = 'pendingCliAuth';
+
+const DEVICE_CODE_PATTERN = /^[A-Za-z0-9_-]{16,128}$/;
+
+export type PendingCliAuth = {
+  deviceCode: string;
+  name: string | null;
+  returnHost: 'connect' | 'platform';
+};
+
+function detectReturnHost(): PendingCliAuth['returnHost'] {
+  return IS_NOVU_CONNECT ? 'connect' : 'platform';
+}
+
+function isValidDeviceCode(deviceCode: string | null | undefined): deviceCode is string {
+  if (!deviceCode) {
+    return false;
+  }
+
+  return DEVICE_CODE_PATTERN.test(deviceCode);
+}
+
+export function isCliAuthPath(pathname: string): boolean {
+  return pathname === ROUTES.CLI_AUTH;
+}
+
+export function isCliAuthReturnUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url, typeof window !== 'undefined' ? window.location.origin : 'http://local');
+
+    return isCliAuthPath(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
+export function parseCliAuthFromUrl(url: string): Pick<PendingCliAuth, 'deviceCode' | 'name'> | null {
+  try {
+    const parsed = new URL(url, typeof window !== 'undefined' ? window.location.origin : 'http://local');
+
+    if (!isCliAuthPath(parsed.pathname)) {
+      return null;
+    }
+
+    const deviceCode = parsed.searchParams.get('device_code');
+
+    if (!isValidDeviceCode(deviceCode)) {
+      return null;
+    }
+
+    return {
+      deviceCode,
+      name: parsed.searchParams.get('name'),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function storePendingCliAuth(
+  deviceCode: string,
+  name: string | null,
+  returnHost: PendingCliAuth['returnHost'] = detectReturnHost()
+): void {
+  if (typeof window === 'undefined' || !isValidDeviceCode(deviceCode)) {
+    return;
+  }
+
+  const pending: PendingCliAuth = {
+    deviceCode,
+    name,
+    returnHost,
+  };
+
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(pending));
+}
+
+export function readPendingCliAuth(): PendingCliAuth | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<PendingCliAuth>;
+
+    if (!isValidDeviceCode(parsed.deviceCode)) {
+      return null;
+    }
+
+    return {
+      deviceCode: parsed.deviceCode,
+      name: typeof parsed.name === 'string' ? parsed.name : null,
+      returnHost: parsed.returnHost === 'connect' ? 'connect' : 'platform',
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingCliAuth(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  sessionStorage.removeItem(STORAGE_KEY);
+}
+
+export function buildCliAuthUrl(pending: PendingCliAuth): string {
+  const params = new URLSearchParams();
+  params.set('device_code', pending.deviceCode);
+
+  if (pending.name) {
+    params.set('name', pending.name);
+  }
+
+  const path = `${ROUTES.CLI_AUTH}?${params.toString()}`;
+
+  if (pending.returnHost === 'connect') {
+    return buildAbsoluteConnectUrl(path);
+  }
+
+  return buildAbsolutePlatformUrl(path);
+}
+
+export function resolvePendingCliAuthReturnUrl(): string | null {
+  const pending = readPendingCliAuth();
+
+  if (!pending) {
+    return null;
+  }
+
+  return buildCliAuthUrl(pending);
+}
+
+type ReadCliAuthReturnUrlOptions = {
+  preferConnectHost?: boolean;
+};
+
+export function readCliAuthReturnUrl(
+  searchParams?: URLSearchParams,
+  options?: ReadCliAuthReturnUrlOptions
+): string | null {
+  const redirectUrl = readClerkRedirectUrlParam(searchParams);
+
+  if (!redirectUrl || !isCliAuthReturnUrl(redirectUrl)) {
+    return null;
+  }
+
+  const parsed = parseCliAuthFromUrl(redirectUrl);
+
+  if (!parsed) {
+    return null;
+  }
+
+  const returnHost =
+    options?.preferConnectHost || isConnectHostnameUrl(redirectUrl) ? 'connect' : detectReturnHost();
+
+  storePendingCliAuth(parsed.deviceCode, parsed.name, returnHost);
+
+  return buildCliAuthUrl({
+    deviceCode: parsed.deviceCode,
+    name: parsed.name,
+    returnHost,
+  });
+}
+
+export function appendRedirectUrlParam(url: string, redirectUrl: string): string {
+  const parsed = new URL(url, typeof window !== 'undefined' ? window.location.origin : 'http://local');
+  parsed.searchParams.set('redirect_url', redirectUrl);
+
+  return parsed.toString();
+}


### PR DESCRIPTION
### What changed? Why was the change needed?

Follow-up to NV-7888: the device-session CLI auth flow worked for signed-in users with an org, but signed-out users, new users, and Connect (`connect.novu.co`) redirects lost the pending device session and fell into dashboard onboarding instead of returning to `/cli/auth`.

This change persists pending CLI device sessions across auth and org setup, and resumes authorization after sign-in/sign-up and org provisioning (skipping dashboard onboarding where the CLI owns setup).

- Added `cli-auth-pending` session storage for `device_code`, caller name, and return host
- `/cli/auth` stores pending session on load and clears it after successful authorize
- Sign-in/sign-up preserve `redirect_url` across Connect satellite → Platform handoffs
- Org create/select and Connect auto-provision redirect back to `/cli/auth` when a pending session exists
- Connect users without an org route through auto-provision (`?provision=1`) before returning to authorize

Related: [NV-7893](https://linear.app/novu/issue/NV-7893/resume-cli-auth-after-sign-in-and-org-setup), [NV-7888](https://linear.app/novu/issue/NV-7888/replace-cli-loopback-auth-with-api-device-sessions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR fixes a regression where CLI device sessions were lost during sign-in/sign-up, org creation/selection, and Connect satellite→Platform handoffs, causing users to land in dashboard onboarding instead of returning to /cli/auth. It persists pending CLI authorization (device_code, caller name, return host) across these flows, restores the CLI auth flow after credential entry or org provisioning, and prioritizes resuming CLI authorization over normal post-org routes to ensure the CLI receives the final authorize response.

## Affected areas

**dashboard**: Added a new cli-auth-pending utility to parse, validate, store (sessionStorage), read, clear, and resolve pending CLI auth return URLs; updated sign-in, sign-up, and cli auth pages to preserve/attach Clerk redirect parameters and store pending state; changed auth provider, organization create/select, and Connect auto-provisioning flows to detect pending CLI sessions and route either with react-router or perform full-page redirects (window.location.assign/replace) back to the appropriate CLI /cli/auth host; auto-provisioning now appends ?provision=1 for Connect users without an org before returning to authorize.

## Key technical decisions

- Persist pending CLI auth in sessionStorage under a single utility to centralize validation, URL building, and host selection (Connect vs Platform).  
- Prefer full-page navigation (window.location.assign/replace) for cross-origin return URLs and react-router navigation for same-origin flows to reliably resume CLI auth across host handoffs.  
- CLI auth return URLs take precedence over standard post-org routes so authorization completes immediately after provisioning/selecting an org.

## Testing

No automated tests were added; changes are redirect/session-persistence focused and validated by manual flow checks (sign-in → org create/select/provision → return to /cli/auth across both Connect satellite and Platform).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots

N/A — redirect/auth flow changes only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

```mermaid
sequenceDiagram
  participant CLI
  participant Browser
  participant Auth as Sign-in / Sign-up
  participant Org as Org setup
  participant CliAuth as /cli/auth

  CLI->>Browser: open /cli/auth?device_code=...
  Browser->>Browser: store pending session
  alt signed out
    Browser->>Auth: redirect with redirect_url
    Auth->>Org: create/select org (skip onboarding)
  end
  Org->>CliAuth: resume pending session
  CliAuth->>CLI: approve device session
```

</details>

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression where CLI device auth sessions were lost during sign-in/sign-up, org creation/selection, and Connect satellite→Platform handoffs, causing users to land in dashboard onboarding instead of resuming `/cli/auth`. It introduces a `cli-auth-pending` sessionStorage utility to persist the `device_code`, caller name, and return host across these flows.

- **New `cli-auth-pending.ts` utility** centralises storage, validation, URL building, and host selection (`connect` vs `platform`) for pending CLI auth sessions; called at load in `/cli/auth`, cleared on successful authorize.
- **Sign-in and sign-up pages** now preserve `redirect_url` across Connect satellite→Platform bounces and correctly split sessionStorage writes to `useEffect` / reads to `useMemo`.
- **Org creation/selection and Connect auto-provision** inspect the pending session and use `window.location.assign` or react-router navigation to return to `/cli/auth` after an org is provisioned, skipping normal onboarding.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all redirect paths are well-guarded and the sessionStorage utility is read-only or write-in-effect, with no new cross-origin data exposure.

The core flows — Platform CLI auth, Connect CLI auth, sign-in, sign-up, org creation, and auto-provisioning — all correctly thread the pending session through sessionStorage and navigate back to /cli/auth. The one local copy of isValidDeviceCode in cli-auth.tsx that should import from the shared utility is the only concrete gap, and it is non-breaking since both copies use the same regex today.

cli-auth.tsx has a duplicated isValidDeviceCode that should be removed in favour of the exported utility in cli-auth-pending.ts.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/utils/cli-auth-pending.ts | New utility centralizing sessionStorage persistence, URL building, and search-param parsing for CLI device auth sessions; validation, read/write/clear, and host resolution logic are well-structured and safe. |
| apps/dashboard/src/pages/cli-auth.tsx | Adds storePendingCliAuth on mount and clearPendingCliAuth on successful authorize; isValidDeviceCode is duplicated from cli-auth-pending.ts and should be imported instead. |
| apps/dashboard/src/pages/sign-in.tsx | Correctly splits sessionStorage write into useEffect and read into useMemo; sets forceRedirectUrl and post-sign-in redirect to cliAuthReturnUrl to skip onboarding for CLI flows. |
| apps/dashboard/src/pages/sign-up.tsx | Correctly moves sessionStorage write to useEffect; preserves redirect_url across Connect satellite bounce; CLI auth resume for non-Connect sign-up relies on sessionStorage surviving to the org-list page (same tab only). |
| apps/dashboard/src/components/auth/create-organization.tsx | Reads pending CLI auth at mount (read-only sessionStorage in useMemo is idempotent and safe); afterCreateUrl/afterSelectUrl correctly prefer the CLI auth URL when present. |
| apps/dashboard/src/components/auth/auto-create-connect-organization.tsx | New navigateToPostConnectOrgResolution helper correctly prefers window.location.assign for cross-origin CLI auth redirects and falls through to react-router for same-origin flows. |
| apps/dashboard/src/context/auth/auth-provider.tsx | Adds ?provision=1 to org-list path for Connect users with a pending CLI session, ensuring auto-provision runs before returning to /cli/auth. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[CLI opens cli-auth page] --> B[storePendingCliAuth in sessionStorage]
  B --> C{Signed in?}
  C -- No --> D[Redirect to Sign-in or Sign-up]
  D --> E[Re-store pending in useEffect]
  C -- Yes --> F{Has org?}
  E --> G{Sign-in or Sign-up?}
  G -- Sign-in --> H[forceRedirectUrl = cliAuthReturnUrl]
  G -- Sign-up --> I[forceRedirectUrl = org list]
  H --> F
  I --> J[Org create and select page]
  F -- No --> J
  F -- Yes --> K[cli-auth authorize screen]
  J --> L[resolvePendingCliAuthReturnUrl]
  L --> K
  K --> M[clearPendingCliAuth and approve session]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/pages/cli-auth.tsx`, line 118-120 ([link](https://github.com/novuhq/novu/blob/ad145cac9480e10cc050e8e91d4b3ebb7526640c/apps/dashboard/src/pages/cli-auth.tsx#L118-L120)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale pending session after cancel**

   `handleCancel` navigates away without calling `clearPendingCliAuth()`, leaving the `pendingCliAuth` entry in `sessionStorage`. If the user later visits the org-creation or org-selection pages, `resolvePendingCliAuthReturnUrl()` / `afterCreateUrl` / `afterSelectUrl` will redirect them straight back to `/cli/auth` with the now-expired (or still-live) device code — potentially triggering an unwanted authorization or a confusing "authorization failed" error. All explicit cancel paths should clear the pending session.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/dashboard/src/pages/cli-auth.tsx
   Line: 118-120

   Comment:
   **Stale pending session after cancel**

   `handleCancel` navigates away without calling `clearPendingCliAuth()`, leaving the `pendingCliAuth` entry in `sessionStorage`. If the user later visits the org-creation or org-selection pages, `resolvePendingCliAuthReturnUrl()` / `afterCreateUrl` / `afterSelectUrl` will redirect them straight back to `/cli/auth` with the now-expired (or still-live) device code — potentially triggering an unwanted authorization or a confusing "authorization failed" error. All explicit cancel paths should clear the pending session.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdashboard%2Fsrc%2Fpages%2Fcli-auth.tsx%0ALine%3A%20118-120%0A%0AComment%3A%0A**Stale%20pending%20session%20after%20cancel**%0A%0A%60handleCancel%60%20navigates%20away%20without%20calling%20%60clearPendingCliAuth%28%29%60%2C%20leaving%20the%20%60pendingCliAuth%60%20entry%20in%20%60sessionStorage%60.%20If%20the%20user%20later%20visits%20the%20org-creation%20or%20org-selection%20pages%2C%20%60resolvePendingCliAuthReturnUrl%28%29%60%20%2F%20%60afterCreateUrl%60%20%2F%20%60afterSelectUrl%60%20will%20redirect%20them%20straight%20back%20to%20%60%2Fcli%2Fauth%60%20with%20the%20now-expired%20%28or%20still-live%29%20device%20code%20%E2%80%94%20potentially%20triggering%20an%20unwanted%20authorization%20or%20a%20confusing%20%22authorization%20failed%22%20error.%20All%20explicit%20cancel%20paths%20should%20clear%20the%20pending%20session.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11326&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fdashboard%2Fsrc%2Fpages%2Fcli-auth.tsx%3A21-25%0A%60isValidDeviceCode%60%20is%20already%20exported%20from%20%60%40%2Futils%2Fcli-auth-pending%60%20%28with%20the%20same%20regex%29%20and%20is%20imported%20in%20the%20same%20file.%20This%20local%20duplicate%20can%20silently%20diverge%20if%20the%20pattern%20in%20%60cli-auth-pending.ts%60%20ever%20changes%20%E2%80%94%20the%20two%20would%20no%20longer%20agree%20on%20what%20constitutes%20a%20valid%20code.%20Remove%20the%20local%20copy%20and%20import%20the%20shared%20one.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20clearPendingCliAuth%2C%20isValidDeviceCode%20as%20isValidDeviceCodeUtil%2C%20storePendingCliAuth%20%7D%20from%20'%40%2Futils%2Fcli-auth-pending'%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fdashboard%2Fsrc%2Fpages%2Fcli-auth.tsx%3A73%0A%60isValidDeviceCode%60%20is%20also%20used%20internally%20by%20the%20component%20%28%60deviceCodeOk%20%3D%20isValidDeviceCode%28deviceCode%29%60%29.%20This%20reference%20should%20also%20point%20to%20the%20exported%20utility%20once%20the%20duplicate%20is%20removed.%0A%0A%60%60%60suggestion%0A%20%20const%20deviceCodeOk%20%3D%20isValidDeviceCodeUtil%28deviceCode%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fdashboard%2Fsrc%2Fpages%2Fsign-up.tsx%3A117-122%0A**Non-Connect%20sign-up%20doesn't%20set%20%60forceRedirectUrl%60%20to%20the%20CLI%20auth%20URL**%0A%0AUnlike%20sign-in%20%28where%20%60forceRedirectUrl%60%20is%20set%20to%20%60cliAuthReturnUrl%60%20directly%29%2C%20sign-up%20always%20routes%20through%20%60ROUTES.SIGNUP_ORGANIZATION_LIST%60%20first.%20The%20CLI%20auth%20flow%20relies%20on%20sessionStorage%20being%20intact%20when%20%60create-organization.tsx%60%20mounts%20on%20the%20org-list%20page%20and%20calls%20%60resolvePendingCliAuthReturnUrl%28%29%60.%20This%20works%20as%20long%20as%20the%20user%20stays%20in%20the%20same%20browser%20tab%2C%20but%20if%20Clerk%20opens%20a%20new%20tab%20or%20the%20user%20duplicates%20the%20tab%20mid-flow%2C%20the%20Platform-origin%20sessionStorage%20won't%20carry%20over%20and%20the%20pending%20session%20will%20silently%20be%20lost.%20Worth%20documenting%20the%20assumption%20in%20a%20comment%20%28the%20Connect%20path%20already%20has%20one%29.%0A%0A&pr=11326&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/dashboard/src/pages/cli-auth.tsx:21-25
`isValidDeviceCode` is already exported from `@/utils/cli-auth-pending` (with the same regex) and is imported in the same file. This local duplicate can silently diverge if the pattern in `cli-auth-pending.ts` ever changes — the two would no longer agree on what constitutes a valid code. Remove the local copy and import the shared one.

```suggestion
import { clearPendingCliAuth, isValidDeviceCode as isValidDeviceCodeUtil, storePendingCliAuth } from '@/utils/cli-auth-pending';
```

### Issue 2 of 3
apps/dashboard/src/pages/cli-auth.tsx:73
`isValidDeviceCode` is also used internally by the component (`deviceCodeOk = isValidDeviceCode(deviceCode)`). This reference should also point to the exported utility once the duplicate is removed.

```suggestion
  const deviceCodeOk = isValidDeviceCodeUtil(deviceCode);
```

### Issue 3 of 3
apps/dashboard/src/pages/sign-up.tsx:117-122
**Non-Connect sign-up doesn't set `forceRedirectUrl` to the CLI auth URL**

Unlike sign-in (where `forceRedirectUrl` is set to `cliAuthReturnUrl` directly), sign-up always routes through `ROUTES.SIGNUP_ORGANIZATION_LIST` first. The CLI auth flow relies on sessionStorage being intact when `create-organization.tsx` mounts on the org-list page and calls `resolvePendingCliAuthReturnUrl()`. This works as long as the user stays in the same browser tab, but if Clerk opens a new tab or the user duplicates the tab mid-flow, the Platform-origin sessionStorage won't carry over and the pending session will silently be lost. Worth documenting the assumption in a comment (the Connect path already has one).


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(dashboard): keep CLI auth redirect d..."](https://github.com/novuhq/novu/commit/578db7a5cccf47b8acedd61724ba8ce9a3dbfdd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34327527)</sub>

<!-- /greptile_comment -->