### PR TITLE
fix(dashboard): persist CLI auth session before org picker redirect fixes NV-7895

### DIFF
--- a/apps/dashboard/src/context/auth/auth-provider.tsx
+++ b/apps/dashboard/src/context/auth/auth-provider.tsx
@@ -5,7 +5,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { OnboardingProvisioningOverlay } from '@/components/auth/connect-provisioning-overlay';
 import { IS_NOVU_CONNECT } from '@/config';
 import { isPublicAuthPath } from '@/utils/auth-routes';
-import { readPendingCliAuth } from '@/utils/cli-auth-pending';
+import { readPendingCliAuth, storePendingCliAuthFromPath } from '@/utils/cli-auth-pending';
 import { buildConnectProvisionOrgListPath } from '@/utils/connect';
 import { isActiveConnectWorkspace, isConnectWorkspace } from '@/utils/connect';
 import { ROUTES } from '@/utils/routes';
@@ -125,6 +125,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       void clerk.setActive({ organization: null });
     }
 
+    // CliAuthPage never mounts here — `shouldBlockChildren` hides it while we redirect to the
+    // org picker — so persist the device session before leaving `/cli/auth`.
+    storePendingCliAuthFromPath(pathname, location.search);
+
     const pendingCliAuth = readPendingCliAuth();
     const orgListPath =
       pendingCliAuth && IS_NOVU_CONNECT
@@ -132,7 +136,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         : ROUTES.SIGNUP_ORGANIZATION_LIST;
 
     void navigate(orgListPath, { replace: true });
-  }, [shouldHandleResolution, clerkOrganization, clerk, redirectTo, navigate]);
+  }, [shouldHandleResolution, clerkOrganization, clerk, redirectTo, navigate, pathname, location.search]);
 
   const currentUser = useMemo(
     () => (clerkUser ? toUserEntity(clerkUser as unknown as UserResource) : undefined),

--- a/apps/dashboard/src/utils/cli-auth-pending.ts
+++ b/apps/dashboard/src/utils/cli-auth-pending.ts
@@ -66,6 +66,22 @@ export function parseCliAuthFromUrl(url: string): Pick<PendingCliAuth, 'deviceCo
   }
 }
 
+export function storePendingCliAuthFromPath(pathname: string, search = ''): boolean {
+  if (!isCliAuthPath(pathname)) {
+    return false;
+  }
+
+  const parsed = parseCliAuthFromUrl(`${pathname}${search}`);
+
+  if (!parsed) {
+    return false;
+  }
+
+  storePendingCliAuth(parsed.deviceCode, parsed.name);
+
+  return true;
+}
+
 export function storePendingCliAuth(
   deviceCode: string,
   name: string | null,


### PR DESCRIPTION
### What changed? Why was the change needed?

Follow-up to NV-7893: logged-in users without an active org who opened `/cli/auth` were sent to the org picker, but after selecting an org they landed on `/env` instead of returning to `/cli/auth`.

`AuthProvider` blocks `CliAuthPage` from mounting while org resolution is pending (`shouldBlockChildren`), so the pending device session was never written to sessionStorage before the redirect to `/auth/organization-list`.

- Added `storePendingCliAuthFromPath()` to parse and persist CLI auth params from the current URL
- `AuthProvider` now stores the pending session before navigating to the org picker when leaving `/cli/auth`

Related: [NV-7895](https://linear.app/novu/issue/NV-7895/cli-auth-resume-after-org-selection-for-logged-in-users), [NV-7893](https://linear.app/novu/issue/NV-7893/resume-cli-auth-after-sign-in-and-org-setup), [NV-7888](https://linear.app/novu/issue/NV-7888/replace-cli-loopback-auth-with-api-device-sessions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added `storePendingCliAuthFromPath()` helper to the dashboard's CLI auth utilities, which parses and persists CLI auth session parameters from the current URL. `AuthProvider` now invokes this function before navigating to the organization picker during its organization-resolution flow, ensuring the pending device session survives the org selection process and the user can resume `/cli/auth` after choosing an organization.

## Affected areas

**dashboard**: Fixed the CLI auth redirect flow by persisting pending CLI auth state before the org picker navigation, preventing loss of device session data during organization selection.

## Testing

No tests were added. The fix addresses a specific regression in the auth flow where organization resolution logic was blocking the CLI auth page from mounting. The change is defensive—storing session data before a navigation to ensure state persistence—and the existing CLI auth and auth provider test infrastructure covers related functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots

N/A — redirect/auth flow changes only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

```mermaid
sequenceDiagram
  participant User
  participant AuthProvider
  participant OrgPicker as Org picker
  participant CliAuth as /cli/auth

  User->>CliAuth: open /cli/auth?device_code=... (logged in, no org)
  AuthProvider->>AuthProvider: store pending session from URL
  AuthProvider->>OrgPicker: redirect to /auth/organization-list
  User->>OrgPicker: select organization
  OrgPicker->>CliAuth: resume pending session
  CliAuth->>User: authorize CLI
```

</details>

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CLI auth resume bug where a logged-in user with no active org visiting `/cli/auth` was redirected to the org picker but dropped back to `/env` instead of `/cli/auth` after selecting an org, because `AuthProvider`'s `shouldBlockChildren` gate prevented `CliAuthPage` from mounting and persisting the device session.

- Adds `storePendingCliAuthFromPath(pathname, search)` in `cli-auth-pending.ts`, which writes the device session to `sessionStorage` only when the pathname is exactly `/cli/auth` and a valid `device_code` is present — a no-op otherwise.
- `AuthProvider` now calls this helper before navigating to the org picker, and adds `pathname` and `location.search` to the effect's dependency array so the stored value always reflects the current URL.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is minimal, well-guarded, and touches only the CLI auth redirect path.

Both changed files are clean. `storePendingCliAuthFromPath` short-circuits on non-CLI-auth paths and on missing/invalid device codes, so it is a no-op in every other flow. The `useEffect` dependency array addition is correct: the new deps are already used inside the effect body, and `shouldHandleResolution` still gates all the navigation logic, preventing any unintended redirects or loops.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/utils/cli-auth-pending.ts | Adds `storePendingCliAuthFromPath` helper that safely parses and persists CLI auth params from a pathname+search pair, guarded by path and device-code validation. |
| apps/dashboard/src/context/auth/auth-provider.tsx | Calls `storePendingCliAuthFromPath` before the org-picker redirect inside the `shouldHandleResolution` effect; adds `pathname` and `location.search` to the dependency array accordingly. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[User visits /cli/auth logged in, no active org] --> B{AuthProvider: shouldHandleResolution?}
  B -- false --> C[CliAuthPage mounts normally]
  B -- true --> D[shouldBlockChildren = true, CliAuthPage blocked]
  D --> E[storePendingCliAuthFromPath writes device session to sessionStorage]
  E --> F{pathname is /cli/auth AND valid device_code?}
  F -- no --> G[no-op, existing session preserved]
  F -- yes --> H[session stored in sessionStorage]
  G --> I[readPendingCliAuth]
  H --> I
  I --> J[navigate to org picker]
  J --> K[User selects org]
  K --> L[resolvePendingCliAuthReturnUrl reads stored session]
  L --> M[redirect back to /cli/auth with stored params]
  M --> C
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): persist CLI auth session..."](https://github.com/novuhq/novu/commit/2265c012fcc23cb2d2d10089261049eda77b4673) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34337522)</sub>

<!-- /greptile_comment -->