### PR TITLE
fix(dashboard): complete Connect CLI auth resume after org provisioning fixes NV-7895 NV-7896

### DIFF
--- a/apps/dashboard/src/components/auth/auto-create-connect-organization.tsx
+++ b/apps/dashboard/src/components/auth/auto-create-connect-organization.tsx
@@ -64,6 +64,9 @@ function navigateToPostConnectOrgResolution(navigate: NavigateFunction, fallback
   const pendingCliAuthReturnUrl = resolvePendingCliAuthReturnUrl();
 
   if (pendingCliAuthReturnUrl) {
+    // Leave the connect onboarding overlay behind — `/cli/auth` is outside that flow and the
+    // full-screen loader would otherwise stay mounted from sessionStorage after auto-provision.
+    clearConnectProvisioning();
     window.location.assign(pendingCliAuthReturnUrl);
 
     return;

--- a/apps/dashboard/src/context/auth/auth-provider.tsx
+++ b/apps/dashboard/src/context/auth/auth-provider.tsx
@@ -5,7 +5,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { OnboardingProvisioningOverlay } from '@/components/auth/connect-provisioning-overlay';
 import { IS_NOVU_CONNECT } from '@/config';
 import { isPublicAuthPath } from '@/utils/auth-routes';
-import { readPendingCliAuth } from '@/utils/cli-auth-pending';
+import { readPendingCliAuth, storePendingCliAuthFromPath } from '@/utils/cli-auth-pending';
 import { buildConnectProvisionOrgListPath } from '@/utils/connect';
 import { isActiveConnectWorkspace, isConnectWorkspace } from '@/utils/connect';
 import { ROUTES } from '@/utils/routes';
@@ -125,6 +125,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       void clerk.setActive({ organization: null });
     }
 
+    // CliAuthPage never mounts here — `shouldBlockChildren` hides it while we redirect to the
+    // org picker — so persist the device session before leaving `/cli/auth`.
+    storePendingCliAuthFromPath(pathname, location.search);
+
     const pendingCliAuth = readPendingCliAuth();
     const orgListPath =
       pendingCliAuth && IS_NOVU_CONNECT
@@ -132,7 +136,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         : ROUTES.SIGNUP_ORGANIZATION_LIST;
 
     void navigate(orgListPath, { replace: true });
-  }, [shouldHandleResolution, clerkOrganization, clerk, redirectTo, navigate]);
+  }, [shouldHandleResolution, clerkOrganization, clerk, redirectTo, navigate, pathname, location.search]);
 
   const currentUser = useMemo(
     () => (clerkUser ? toUserEntity(clerkUser as unknown as UserResource) : undefined),

--- a/apps/dashboard/src/pages/cli-auth.tsx
+++ b/apps/dashboard/src/pages/cli-auth.tsx
@@ -16,6 +16,7 @@ import { useFeatureFlag } from '@/hooks/use-feature-flag';
 import { useFetchApiKeys } from '@/hooks/use-fetch-api-keys';
 import { useHasPermission } from '@/hooks/use-has-permission';
 import { clearPendingCliAuth, storePendingCliAuth } from '@/utils/cli-auth-pending';
+import { clearConnectProvisioning } from '@/utils/connect';
 import { buildRoute, ROUTES } from '@/utils/routes';
 
 function isValidDeviceCode(deviceCode: string | null): deviceCode is string {
@@ -35,6 +36,10 @@ export const CliAuthPage = () => {
       storePendingCliAuth(deviceCode, callerName);
     }
   }, [deviceCode, callerName]);
+
+  useEffect(() => {
+    clearConnectProvisioning();
+  }, []);
 
   if (!isLoaded) {
     return null;

--- a/apps/dashboard/src/utils/cli-auth-pending.ts
+++ b/apps/dashboard/src/utils/cli-auth-pending.ts
@@ -66,6 +66,22 @@ export function parseCliAuthFromUrl(url: string): Pick<PendingCliAuth, 'deviceCo
   }
 }
 
+export function storePendingCliAuthFromPath(pathname: string, search = ''): boolean {
+  if (!isCliAuthPath(pathname)) {
+    return false;
+  }
+
+  const parsed = parseCliAuthFromUrl(`${pathname}${search}`);
+
+  if (!parsed) {
+    return false;
+  }
+
+  storePendingCliAuth(parsed.deviceCode, parsed.name);
+
+  return true;
+}
+
 export function storePendingCliAuth(
   deviceCode: string,
   name: string | null,


### PR DESCRIPTION
### What changed? Why was the change needed?

Two follow-up fixes for the Connect CLI auth flow (`novu connect`):

**NV-7895 — Logged-in users without an org never returned to `/cli/auth` after org selection**
- `AuthProvider` blocked `CliAuthPage` from mounting while org resolution was pending, so the pending device session was never stored before redirecting to the org picker
- Added `storePendingCliAuthFromPath()` and persist the session from the current URL before leaving `/cli/auth`

**NV-7896 — Connect auto-provision stuck on the onboarding loader after redirect**
- Auto-provision kept the full-screen connect onboarding overlay in `sessionStorage` after redirecting to `/cli/auth`, leaving users on "Almost there..." instead of the authorize screen
- Clear connect provisioning before CLI auth redirect and on `/cli/auth` mount as a safety net

Related: [NV-7896](https://linear.app/novu/issue/NV-7896/dismiss-connect-provisioning-loader-before-cli-auth-redirect), [NV-7895](https://linear.app/novu/issue/NV-7895/cli-auth-resume-after-org-selection-for-logged-in-users), [NV-7893](https://linear.app/novu/issue/NV-7893/resume-cli-auth-after-sign-in-and-org-setup), [NV-7888](https://linear.app/novu/issue/NV-7888/replace-cli-loopback-auth-with-api-device-sessions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

The CLI auth resume flow now correctly handles the org selection redirect by persisting pending device sessions before navigation, and clears the Connect onboarding overlay that was left in `sessionStorage` after auto-provisioning. When a user without an organization selects or auto-creates one, they now return to the authorize screen at `/cli/auth` instead of being redirected away or stuck on the onboarding loader.

## Affected areas

**dashboard**: Added `storePendingCliAuthFromPath()` utility to persist pending CLI auth state before org selection redirects; modified `AuthProvider` to call this utility before computing the org list route; updated `cli-auth` page to clear Connect provisioning state on mount as a safety net; modified `auto-create-connect-organization` to clear provisioning before returning to the CLI auth URL.

## Key technical decisions

- Pending CLI auth state is stored to `sessionStorage` before the org selection redirect, allowing it to be retrieved after the user returns to `/cli/auth`.
- Connect provisioning overlay is cleared at two points (auth provider redirect and CLI auth mount) to guarantee the onboarding loader doesn't persist.

## Testing

No new tests were added; the fixes address edge cases in the authentication redirect flow that require manual verification of the complete `novu connect` flow (device code entry → org selection → auto-provisioning → auth screen).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots

N/A — redirect/auth flow changes only.

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A

### Special notes for your reviewer

```mermaid
sequenceDiagram
  participant CLI as novu connect
  participant CliAuth as /cli/auth
  participant AuthProvider
  participant OrgList as org list + auto-provision
  participant Authorize as CLI authorize UI

  CLI->>CliAuth: open with device_code
  AuthProvider->>AuthProvider: store pending session from URL
  AuthProvider->>OrgList: redirect with provision=1
  OrgList->>OrgList: auto-create first Connect org
  OrgList->>CliAuth: redirect (clear provisioning overlay)
  CliAuth->>Authorize: show authorize screen
```

</details>

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Two targeted fixes for the `novu connect` CLI auth flow: persisting the device session before `AuthProvider` redirects a logged-in, org-less user away from `/cli/auth`, and dismissing the connect onboarding overlay before and after the auto-provision redirect so users reach the authorize screen instead of being stuck on "Almost there...".

- **NV-7895**: `storePendingCliAuthFromPath` is called inside the `AuthProvider` resolution effect (before the org-list navigate) because `CliAuthPage` is blocked by `shouldBlockChildren` and its own `storePendingCliAuth` effect never fires. `pathname` and `location.search` are added to the dep array so the effect has the correct URL data.
- **NV-7896**: `clearConnectProvisioning()` is called in `auto-create-connect-organization.tsx` immediately before the `window.location.assign` redirect to `/cli/auth`, and again as a defensive no-op in `CliAuthPage`'s mount effect.

<h3>Confidence Score: 4/5</h3>

The changes are narrowly scoped redirect/sessionStorage fixes that address specific broken paths in the CLI auth flow; no auth tokens or API calls are modified.

Both fixes are correct and logically consistent with the existing patterns: the read-after-write to sessionStorage is synchronous and safe, the new effect deps are precise primitives that fire exactly when expected, and `clearConnectProvisioning` is idempotent so the double-call safety net carries no risk. The one minor flag is a style inconsistency in the dependency array (`location.search` inline vs. the already-extracted `pathname` const).

apps/dashboard/src/context/auth/auth-provider.tsx — worth a second read to confirm the expanded dependency array doesn't cause unexpected re-runs in other org-resolution scenarios.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/dashboard/src/utils/cli-auth-pending.ts | Adds `storePendingCliAuthFromPath(pathname, search)` helper — validates the path, parses and validates the device code, then delegates to the existing `storePendingCliAuth`; correctly returns early for non-CLI paths and invalid device codes. |
| apps/dashboard/src/context/auth/auth-provider.tsx | Calls `storePendingCliAuthFromPath` before navigating away from `/cli/auth` to persist the device session when `CliAuthPage` is blocked; also adds `pathname` and `location.search` to the resolution effect's dependency array. Functionally correct; minor consistency note on using `location.search` inline vs. extracting it to a named const like `pathname`. |
| apps/dashboard/src/pages/cli-auth.tsx | Adds a mount-time `useEffect` that calls `clearConnectProvisioning()` as a safety net to dismiss the full-screen onboarding overlay when landing on the CLI auth page. |
| apps/dashboard/src/components/auth/auto-create-connect-organization.tsx | Adds `clearConnectProvisioning()` before the `window.location.assign` redirect to `/cli/auth` so the connect onboarding overlay is dismissed before the CLI authorize screen appears. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant CLI as novu-connect CLI
  participant CliAuth as cli-auth page
  participant AP as AuthProvider effect
  participant OrgList as org-list auto-provision
  participant Store as sessionStorage

  CLI->>CliAuth: open with device param
  Note over AP: shouldHandleResolution=true
  AP->>Store: storePendingCliAuthFromPath
  AP->>Store: readPendingCliAuth
  AP->>OrgList: navigate to provision org-list
  OrgList->>OrgList: create or switch Connect org
  OrgList->>Store: clearConnectProvisioning
  OrgList->>CliAuth: assign return URL
  Note over CliAuth: mount effect clears provisioning
  CliAuth->>CliAuth: show Authorize screen
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dashboard/src/context/auth/auth-provider.tsx`, line 59 ([link](https://github.com/novuhq/novu/blob/513a2115233ef0fc03276187a68ecf31bbaa42fc/apps/dashboard/src/context/auth/auth-provider.tsx#L59)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> For consistency with how `pathname` is handled (extracted to a named const), consider pulling `location.search` out too. It keeps the effect body and dependency array both free of property-access chains and makes the symmetry explicit.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/dashboard/src/context/auth/auth-provider.tsx
   Line: 59

   Comment:
   For consistency with how `pathname` is handled (extracted to a named const), consider pulling `location.search` out too. It keeps the effect body and dependency array both free of property-access chains and makes the symmetry explicit.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdashboard%2Fsrc%2Fcontext%2Fauth%2Fauth-provider.tsx%0ALine%3A%2059%0A%0AComment%3A%0AFor%20consistency%20with%20how%20%60pathname%60%20is%20handled%20%28extracted%20to%20a%20named%20const%29%2C%20consider%20pulling%20%60location.search%60%20out%20too.%20It%20keeps%20the%20effect%20body%20and%20dependency%20array%20both%20free%20of%20property-access%20chains%20and%20makes%20the%20symmetry%20explicit.%0A%0A%60%60%60suggestion%0A%20%20const%20pathname%20%3D%20location.pathname%3B%0A%20%20const%20search%20%3D%20location.search%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11332&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Fcontext%2Fauth%2Fauth-provider.tsx%3A59%0AFor%20consistency%20with%20how%20%60pathname%60%20is%20handled%20%28extracted%20to%20a%20named%20const%29%2C%20consider%20pulling%20%60location.search%60%20out%20too.%20It%20keeps%20the%20effect%20body%20and%20dependency%20array%20both%20free%20of%20property-access%20chains%20and%20makes%20the%20symmetry%20explicit.%0A%0A%60%60%60suggestion%0A%20%20const%20pathname%20%3D%20location.pathname%3B%0A%20%20const%20search%20%3D%20location.search%3B%0A%60%60%60%0A%0A&pr=11332&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/context/auth/auth-provider.tsx:59
For consistency with how `pathname` is handled (extracted to a named const), consider pulling `location.search` out too. It keeps the effect body and dependency array both free of property-access chains and makes the symmetry explicit.

```suggestion
  const pathname = location.pathname;
  const search = location.search;
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): dismiss connect loader b..."](https://github.com/novuhq/novu/commit/513a2115233ef0fc03276187a68ecf31bbaa42fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34340770)</sub>

<!-- /greptile_comment -->