### PR TITLE
feat(api-service): subscriber-scoped MCP tool trust approval fixes NV-7771

### DIFF
--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.spec.ts
@@ -64,7 +64,9 @@ describe('AgentInboundHandler', () => {
     };
     const managedAgentService = {
       dispatch: sinon.stub().resolves(undefined),
-      confirmToolApproval: sinon.stub().resolves(undefined),
+    };
+    const confirmToolApproval = {
+      execute: sinon.stub().resolves(undefined),
     };
     const chatSdkService = {
       registerInboundCallbacks: sinon.stub(),
@@ -92,12 +94,6 @@ describe('AgentInboundHandler', () => {
     const channelEndpointRepository = {
       findByPlatformIdentity: overrides.findTelegramEndpointByIdentity ?? sinon.stub().resolves(null),
     };
-    const handleAgentReply = {
-      execute: sinon.stub().resolves({ messageId: 'setup-card-1', platformThreadId: 'thread1' }),
-    };
-    const handlePlanProgress = {
-      execute: sinon.stub().resolves(undefined),
-    };
     const handleManagedAgentSetupInbound = {
       execute: overrides.managedAgentSetupHandleInbound ?? sinon.stub().resolves(false),
     };
@@ -107,6 +103,7 @@ describe('AgentInboundHandler', () => {
       conversationService as any,
       bridgeExecutor as any,
       managedAgentService as any,
+      confirmToolApproval as any,
       handleManagedAgentSetupInbound as any,
       chatSdkService as any,
       agentRepository as any,
@@ -116,9 +113,7 @@ describe('AgentInboundHandler', () => {
       attachmentStorage as any,
       startCodeService as any,
       channelEndpointRepository as any,
-      linkTelegramChatToSubscriber as any,
-      handleAgentReply as any,
-      handlePlanProgress as any
+      linkTelegramChatToSubscriber as any
     );
 
     return {

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -388,6 +388,8 @@ export class AgentInboundHandler implements OnModuleInit {
 
     const isManagedAgent = agent?.runtime === 'managed' && agent.managedRuntime;
 
+    // Subscriber still owes MCP OAuth: hold this message, show the setup card, skip dispatch.
+    // After OAuth completes, CompleteManagedAgentSetup replays the held message.
     if (isManagedAgent && subscriber && message.id) {
       const parked = await this.handleManagedAgentSetupInbound.execute(
         ManagedAgentSetupInboundCommand.create({

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -20,14 +20,13 @@ import type { CardChild, CardElement, EmojiValue, Message, Thread } from 'chat';
 import { trackAgentInboundAction, trackAgentInboundMessage, trackAgentInboundReaction } from '../agent-analytics';
 import { AgentEventEnum } from '../dtos/agent-event.enum';
 import { AgentPlatformEnum, PLATFORMS_WITH_TYPING_INDICATOR } from '../dtos/agent-platform.enum';
-import { HandleAgentReplyCommand } from '../usecases/handle-agent-reply/handle-agent-reply.command';
-import { HandleAgentReply } from '../usecases/handle-agent-reply/handle-agent-reply.usecase';
-import { HandlePlanProgressCommand } from '../usecases/handle-plan-progress/handle-plan-progress.command';
-import { HandlePlanProgress } from '../usecases/handle-plan-progress/handle-plan-progress.usecase';
 import { LinkTelegramChatToSubscriberCommand } from '../usecases/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.command';
 import { LinkTelegramChatToSubscriber } from '../usecases/link-telegram-chat-to-subscriber/link-telegram-chat-to-subscriber.usecase';
 import { HandleManagedAgentSetupInbound } from '../usecases/managed-agent-setup/handle-managed-agent-setup-inbound.usecase';
 import { ManagedAgentSetupInboundCommand } from '../usecases/managed-agent-setup/managed-agent-setup-inbound.command';
+import { isLinkButtonActionId, parseToolApprovalActionId } from '../usecases/tool-approval/approval-card.builder';
+import { ConfirmToolApprovalCommand } from '../usecases/tool-approval/confirm-tool-approval.command';
+import { ConfirmToolApproval } from '../usecases/tool-approval/confirm-tool-approval.usecase';
 import { captureAgentException, captureAgentWarning } from '../utils/capture-agent-sentry';
 import { AgentAttachmentStorage, type StoredAttachment } from './agent-attachment-storage.service';
 import { ResolvedAgentConfig } from './agent-config-resolver.service';
@@ -36,11 +35,6 @@ import { AgentSubscriberResolver } from './agent-subscriber-resolver.service';
 import { BridgeExecutorService, type BridgeReaction, NoBridgeUrlError } from './bridge-executor.service';
 import { ChatSdkService } from './chat-sdk.service';
 import { ManagedAgentService } from './managed-agent.service';
-import {
-  buildToolApprovalVerdictCard,
-  isLinkButtonActionId,
-  parseToolApprovalActionId,
-} from './managed-agent-event-handler';
 import { TelegramStartCodeService } from './telegram-start-code.service';
 
 /**
@@ -226,6 +220,7 @@ export class AgentInboundHandler implements OnModuleInit {
     private readonly conversationService: AgentConversationService,
     private readonly bridgeExecutor: BridgeExecutorService,
     private readonly managedAgentService: ManagedAgentService,
+    private readonly confirmToolApproval: ConfirmToolApproval,
     private readonly handleManagedAgentSetupInbound: HandleManagedAgentSetupInbound,
     private readonly chatSdkService: ChatSdkService,
     private readonly agentRepository: AgentRepository,
@@ -235,9 +230,7 @@ export class AgentInboundHandler implements OnModuleInit {
     private readonly attachmentStorage: AgentAttachmentStorage,
     private readonly startCodeService: TelegramStartCodeService,
     private readonly channelEndpointRepository: ChannelEndpointRepository,
-    private readonly linkTelegramChatToSubscriber: LinkTelegramChatToSubscriber,
-    private readonly handleAgentReply: HandleAgentReply,
-    private readonly handlePlanProgress: HandlePlanProgress
+    private readonly linkTelegramChatToSubscriber: LinkTelegramChatToSubscriber
   ) {
     this.logger.setContext(this.constructor.name);
   }
@@ -821,69 +814,27 @@ export class AgentInboundHandler implements OnModuleInit {
       actionId: action.id,
     });
 
-    // MCP tool-approval routing: `ManagedAgentService` owns the Cloudflare
-    // durable session (post-#11156) and renders Approve/Deny cards with
-    // action ids of the form `mcp-approval:<verdict>:<toolUseId>`. Intercept
-    // those clicks here so they call `confirmToolApproval` to resume the
-    // parked Anthropic session — they must NOT fall through to the bridge
-    // (the user-defined `onAction` shouldn't see provider-internal tool-use ids).
+    // MCP Approve/Deny buttons (ids starting with mcp-approval:*) are handled here.
+    // Return early so these clicks are not forwarded to bridgeExecutor below.
     const toolApproval = parseToolApprovalActionId(action.id);
 
     if (toolApproval) {
-      await this.managedAgentService.confirmToolApproval({
-        conversationId: conversation._id,
-        environmentId: config.environmentId,
-        organizationId: config.organizationId,
-        agentIdentifier: config.agentIdentifier,
-        integrationIdentifier: config.integrationIdentifier,
-        subscriberId: subscriberId ?? undefined,
-        platform: config.platform,
-        toolUseIds: toolApproval.toolUseIds,
-        approved: toolApproval.approved,
-        turnId: toolApproval.turnId,
-      });
-
-      if (action.sourceMessageId) {
-        const verdictCard = buildToolApprovalVerdictCard(
-          toolApproval.approved,
-          toolApproval.toolUseIds.length,
-          action.value
-        );
-        this.handleAgentReply
-          .execute(
-            HandleAgentReplyCommand.create({
-              userId: 'system',
-              environmentId: config.environmentId,
-              organizationId: config.organizationId,
-              conversationId: conversation._id,
-              agentIdentifier: config.agentIdentifier,
-              integrationIdentifier: config.integrationIdentifier,
-              edit: { messageId: action.sourceMessageId, content: { card: verdictCard } },
-            })
-          )
-          .catch((err) => {
-            this.logger.warn(err, `[agent:${agentId}] Failed to update tool approval card with verdict`);
-          });
-      }
-
-      this.handlePlanProgress
-        .execute(
-          HandlePlanProgressCommand.create({
-            userId: 'system',
-            environmentId: config.environmentId,
-            organizationId: config.organizationId,
-            conversationId: conversation._id,
-            agentIdentifier: config.agentIdentifier,
-            integrationIdentifier: config.integrationIdentifier,
-            toolProgress: {
-              turnId: toolApproval.turnId,
-              action: toolApproval.approved ? 'approved' : 'denied',
-            },
-          })
-        )
-        .catch((err) => {
-          this.logger.warn(err, `[agent:${agentId}] Failed to update plan card after tool approval verdict`);
-        });
+      await this.confirmToolApproval.execute(
+        ConfirmToolApprovalCommand.create({
+          userId: 'system',
+          environmentId: config.environmentId,
+          organizationId: config.organizationId,
+          conversationId: conversation._id,
+          agentIdentifier: config.agentIdentifier,
+          integrationIdentifier: config.integrationIdentifier,
+          agentId,
+          subscriberId: subscriberId ?? undefined,
+          platform: config.platform,
+          parsed: toolApproval,
+          sourceMessageId: action.sourceMessageId,
+          actionValue: action.value,
+        })
+      );
 
       return;
     }

--- a/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
+++ b/apps/api/src/app/agents/services/agent-inbound-handler.service.ts
@@ -388,14 +388,20 @@ export class AgentInboundHandler implements OnModuleInit {
 
     const isManagedAgent = agent?.runtime === 'managed' && agent.managedRuntime;
 
-    if (isManagedAgent) {
-      const parked = await this.tryParkForManagedSetup({
-        config,
-        conversationId: conversation._id,
-        agentId: agent._id,
-        subscriber,
-        platformMessageId: message.id,
-      });
+    if (isManagedAgent && subscriber && message.id) {
+      const parked = await this.handleManagedAgentSetupInbound.execute(
+        ManagedAgentSetupInboundCommand.create({
+          userId: 'system',
+          environmentId: config.environmentId,
+          organizationId: config.organizationId,
+          conversationId: conversation._id,
+          agentId: agent._id,
+          subscriberId: subscriber.subscriberId,
+          agentIdentifier: config.agentIdentifier,
+          integrationIdentifier: config.integrationIdentifier,
+          platformMessageId: message.id,
+        })
+      );
 
       if (parked) {
         return;
@@ -520,38 +526,6 @@ export class AgentInboundHandler implements OnModuleInit {
 
       throw err;
     }
-  }
-
-  /**
-   * When the subscriber still has required managed-agent setup, park the turn
-   * and post the setup card. Returns true when dispatch must not proceed.
-   */
-  private async tryParkForManagedSetup(params: {
-    config: ResolvedAgentConfig;
-    conversationId: string;
-    agentId: string;
-    subscriber: { subscriberId: string } | null;
-    platformMessageId: string | undefined;
-  }): Promise<boolean> {
-    const { config, conversationId, agentId, subscriber, platformMessageId } = params;
-
-    if (!subscriber || !platformMessageId) {
-      return false;
-    }
-
-    return this.handleManagedAgentSetupInbound.execute(
-      ManagedAgentSetupInboundCommand.create({
-        userId: 'system',
-        environmentId: config.environmentId,
-        organizationId: config.organizationId,
-        conversationId,
-        agentId,
-        subscriberId: subscriber.subscriberId,
-        agentIdentifier: config.agentIdentifier,
-        integrationIdentifier: config.integrationIdentifier,
-        platformMessageId,
-      })
-    );
   }
 
   /**

--- a/apps/api/src/app/agents/services/managed-agent-event-handler.ts
+++ b/apps/api/src/app/agents/services/managed-agent-event-handler.ts
@@ -1,9 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import type { PendingToolApproval } from '@novu/application-generic';
-import { type IAgentRuntimeProvider, PinoLogger } from '@novu/application-generic';
+import { PinoLogger } from '@novu/application-generic';
 import { ConversationRepository } from '@novu/dal';
 import {
-  type ActionRequired,
   CredentialExpiredError,
   McpServerError,
   type SessionEventContext,
@@ -15,11 +13,10 @@ import { HandleAgentReplyCommand } from '../usecases/handle-agent-reply/handle-a
 import { HandleAgentReply } from '../usecases/handle-agent-reply/handle-agent-reply.usecase';
 import { HandlePlanProgressCommand } from '../usecases/handle-plan-progress/handle-plan-progress.command';
 import { HandlePlanProgress } from '../usecases/handle-plan-progress/handle-plan-progress.usecase';
-import { captureAgentException, captureAgentWarning } from '../utils/capture-agent-sentry';
+import { HandlePendingToolApprovalsCommand } from '../usecases/tool-approval/handle-pending-tool-approvals.command';
+import { HandlePendingToolApprovals } from '../usecases/tool-approval/handle-pending-tool-approvals.usecase';
+import { captureAgentException } from '../utils/capture-agent-sentry';
 import { DemoClaudeQuotaPolicy } from './demo-claude-quota-policy.service';
-import { ManagedAgentProviderFactory } from './managed-agent-provider-factory';
-
-export const TOOL_APPROVAL_ACTION_PREFIX = 'mcp-approval' as const;
 
 interface BaseCommandFields {
   userId: string;
@@ -33,10 +30,10 @@ interface BaseCommandFields {
 @Injectable()
 export class ManagedAgentEventHandler {
   constructor(
-    private readonly providerFactory: ManagedAgentProviderFactory,
     private readonly conversationRepository: ConversationRepository,
     private readonly handleAgentReply: HandleAgentReply,
     private readonly handlePlanProgress: HandlePlanProgress,
+    private readonly handlePendingToolApprovals: HandlePendingToolApprovals,
     private readonly demoQuota: DemoClaudeQuotaPolicy,
     private readonly logger: PinoLogger
   ) {
@@ -143,24 +140,24 @@ export class ManagedAgentEventHandler {
       onFinish: async (event: { response: ThalamusResponse }) => {
         try {
           if (event.response.finishReason === 'requires-action') {
-            const runtimeProvider = await this.tryGetRuntimeProvider(metadata);
-            if (runtimeProvider) {
-              const delivered = await this.tryDeliverToolApprovalCard(
-                metadata,
+            const deliveryResult = await this.handlePendingToolApprovals.execute(
+              HandlePendingToolApprovalsCommand.create({
+                ...baseFields,
+                subscriberId: metadata.subscriberId,
+                platform: metadata.platform,
                 sessionId,
                 turnId,
-                runtimeProvider,
-                event.response
-              );
+                response: event.response,
+              })
+            );
 
-              if (delivered) {
-                await this.handlePlanProgress.execute(
-                  HandlePlanProgressCommand.create({
-                    ...baseFields,
-                    toolProgress: { turnId, action: 'awaiting-approval' },
-                  })
-                );
-              }
+            if (deliveryResult === 'card') {
+              await this.handlePlanProgress.execute(
+                HandlePlanProgressCommand.create({
+                  ...baseFields,
+                  toolProgress: { turnId, action: 'awaiting-approval' },
+                })
+              );
             }
 
             return;
@@ -247,217 +244,6 @@ export class ManagedAgentEventHandler {
       });
     }
   }
-
-  /**
-   * Deliver an approval card for the pending tools. Reads `actionsRequired`
-   * directly from the finish response (fast path). Falls back to querying
-   * the Anthropic session event log when the response lacks tool details
-   * (e.g. after a partial confirmation triggers a new observation).
-   */
-  private async tryDeliverToolApprovalCard(
-    metadata: Record<string, string>,
-    sessionId: string,
-    turnId: string,
-    runtimeProvider: IAgentRuntimeProvider,
-    response?: ThalamusResponse
-  ): Promise<boolean> {
-    let pendingTools: PendingToolApproval[] = response ? extractPendingToolApprovals(response) : [];
-
-    if (pendingTools.length === 0) {
-      try {
-        pendingTools = await runtimeProvider.getAllPendingToolApprovals(sessionId);
-      } catch (err) {
-        this.logger.warn(
-          { err: err instanceof Error ? err.message : String(err), sessionId },
-          'getAllPendingToolApprovals failed; cannot render Approve/Deny card'
-        );
-        captureAgentWarning(err, {
-          component: 'managed-agent-event-handler',
-          operation: 'get-all-pending-tool-approvals',
-          sessionId,
-        });
-
-        return false;
-      }
-    }
-
-    if (pendingTools.length === 0) {
-      this.logger.warn(
-        { sessionId, conversationId: metadata.conversationId },
-        'Session is parked on requires-action but no pending tool approvals were located'
-      );
-
-      return false;
-    }
-
-    try {
-      await this.handleAgentReply.execute(
-        HandleAgentReplyCommand.create({
-          userId: 'system',
-          organizationId: metadata.organizationId,
-          environmentId: metadata.environmentId,
-          conversationId: metadata.conversationId,
-          agentIdentifier: metadata.agentIdentifier ?? '',
-          integrationIdentifier: metadata.integrationIdentifier ?? '',
-          reply: { card: buildToolApprovalCard(pendingTools, turnId) },
-        })
-      );
-    } catch (err) {
-      this.logger.error(err, `Failed to deliver tool-approval card for session ${sessionId}`);
-      captureAgentException(err, {
-        component: 'managed-agent-event-handler',
-        operation: 'deliver-tool-approval-card',
-        sessionId,
-      });
-
-      return false;
-    }
-
-    return true;
-  }
-
-  private async tryGetRuntimeProvider(metadata: Record<string, string>): Promise<IAgentRuntimeProvider | null> {
-    if (!metadata.environmentId || !metadata.agentIdentifier) {
-      return null;
-    }
-
-    return this.providerFactory.tryGetByAgentIdentifier(metadata.agentIdentifier, metadata.environmentId);
-  }
-}
-
-export function parseToolApprovalActionId(
-  id: string | undefined
-): { approved: boolean; toolUseIds: string[]; turnId: string } | null {
-  if (!id) return null;
-  const parts = id.split(':');
-  if (parts.length !== 4 || parts[0] !== TOOL_APPROVAL_ACTION_PREFIX) return null;
-
-  const verdict = parts[1];
-  const toolUseIdsPart = parts[2];
-  const turnId = parts[3];
-  if ((verdict !== 'approve' && verdict !== 'deny') || !toolUseIdsPart || !turnId) return null;
-
-  const toolUseIds = toolUseIdsPart.split(',').filter(Boolean);
-  if (toolUseIds.length === 0) return null;
-
-  return { approved: verdict === 'approve', toolUseIds, turnId };
-}
-
-function extractPendingToolApprovals(response: ThalamusResponse): PendingToolApproval[] {
-  const actions = response.actionsRequired;
-  if (!Array.isArray(actions) || actions.length === 0) {
-    return [];
-  }
-
-  return actions.map((action: ActionRequired) => ({
-    toolUseId: action.toolUseId,
-    toolName: action.toolName,
-    mcpServerName: action.type === 'mcp-approval' ? action.serverName : undefined,
-    input: action.input,
-  }));
-}
-
-export function isLinkButtonActionId(id: string | undefined): boolean {
-  return typeof id === 'string' && id.startsWith('link-');
-}
-
-function formatToolLabel(t: PendingToolApproval): string {
-  const name = t.mcpServerName ? `${t.toolName} from ${t.mcpServerName}` : t.toolName;
-  const input = t.input ? `: ${summariseInput(t.input)}` : '';
-
-  return `${name}${input}`;
-}
-
-function buildToolApprovalCard(pendingTools: PendingToolApproval[], turnId: string): Record<string, unknown> {
-  const tool = pendingTools[0];
-  const serverLabel = tool.mcpServerName ? ` from ${tool.mcpServerName}` : '';
-  const toolLabel = formatToolLabel(tool);
-
-  const inputSummary = tool.input ? summariseInput(tool.input) : '';
-  const description = inputSummary
-    ? `I'd like to call \`${tool.toolName}\`${serverLabel}:\n\`\`\`\n${inputSummary}\n\`\`\``
-    : `I'd like to call \`${tool.toolName}\`${serverLabel}.`;
-
-  const children: Record<string, unknown>[] = [{ type: 'text', content: description }];
-
-  children.push(
-    { type: 'divider' },
-    {
-      type: 'actions',
-      children: [
-        {
-          type: 'button',
-          id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve:${tool.toolUseId}:${turnId}`,
-          label: 'Approve',
-          style: 'primary',
-          value: toolLabel,
-        },
-        {
-          type: 'button',
-          id: `${TOOL_APPROVAL_ACTION_PREFIX}:deny:${tool.toolUseId}:${turnId}`,
-          label: 'Deny',
-          style: 'danger',
-          value: toolLabel,
-        },
-      ],
-    }
-  );
-
-  if (pendingTools.length > 1) {
-    const allIds = pendingTools.map((t) => t.toolUseId).join(',');
-    const allLabels = pendingTools.map((t) => formatToolLabel(t)).join('\n');
-    children.push({
-      type: 'actions',
-      children: [
-        {
-          type: 'button',
-          id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve:${allIds}:${turnId}`,
-          label: `Approve All (${pendingTools.length})`,
-          style: 'primary',
-          value: allLabels,
-        },
-        {
-          type: 'button',
-          id: `${TOOL_APPROVAL_ACTION_PREFIX}:deny:${allIds}:${turnId}`,
-          label: `Deny All (${pendingTools.length})`,
-          style: 'danger',
-          value: allLabels,
-        },
-      ],
-    });
-  }
-
-  return {
-    type: 'card',
-    title: 'Tool Approval',
-    children,
-  };
-}
-
-export function buildToolApprovalVerdictCard(
-  approved: boolean,
-  toolCount: number,
-  toolDescription?: string
-): Record<string, unknown> {
-  const emoji = approved ? '✅' : '🚫';
-  const verb = approved ? 'Approved' : 'Denied';
-  const suffix = toolCount > 1 ? ` all ${toolCount} tools` : '';
-  const subtitle = toolDescription || undefined;
-
-  return {
-    type: 'card',
-    title: 'Tool Approval',
-    subtitle,
-    children: [{ type: 'text', content: `${emoji}  ${verb}${suffix}` }],
-  };
-}
-
-function summariseInput(input: Record<string, unknown>): string {
-  const firstValue = Object.values(input)[0];
-  if (firstValue === undefined) return '';
-  const text = typeof firstValue === 'string' ? firstValue : JSON.stringify(firstValue);
-
-  return text.length > 80 ? `${text.slice(0, 77)}...` : text;
 }
 
 function buildErrorMessage(err: unknown): string {

--- a/apps/api/src/app/agents/services/managed-agent-event-handler.ts
+++ b/apps/api/src/app/agents/services/managed-agent-event-handler.ts
@@ -140,7 +140,7 @@ export class ManagedAgentEventHandler {
       onFinish: async (event: { response: ThalamusResponse }) => {
         try {
           if (event.response.finishReason === 'requires-action') {
-            const deliveryResult = await this.handlePendingToolApprovals.execute(
+            await this.handlePendingToolApprovals.execute(
               HandlePendingToolApprovalsCommand.create({
                 ...baseFields,
                 subscriberId: metadata.subscriberId,
@@ -150,15 +150,6 @@ export class ManagedAgentEventHandler {
                 response: event.response,
               })
             );
-
-            if (deliveryResult === 'card') {
-              await this.handlePlanProgress.execute(
-                HandlePlanProgressCommand.create({
-                  ...baseFields,
-                  toolProgress: { turnId, action: 'awaiting-approval' },
-                })
-              );
-            }
 
             return;
           }

--- a/apps/api/src/app/agents/services/managed-agent.service.ts
+++ b/apps/api/src/app/agents/services/managed-agent.service.ts
@@ -146,7 +146,7 @@ export class ManagedAgentService implements OnModuleInit {
    * user's verdict back through the provider as `toolResults` entries.
    * Accepts one or more tool IDs (per-tool approval or batch Approve All).
    */
-  async confirmToolApproval(params: {
+  async resumeWithToolResults(params: {
     conversationId: string;
     environmentId: string;
     organizationId: string;

--- a/apps/api/src/app/agents/usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase.ts
+++ b/apps/api/src/app/agents/usecases/generate-mcp-oauth-url/generate-mcp-oauth-url.usecase.ts
@@ -795,7 +795,11 @@ function canReusePendingOAuthSession(existing: McpConnectionEntity | null): bool
   }
 
   if (existing.authMode === McpConnectionAuthModeEnum.Dcr) {
-    return Boolean(existing.oauthClient && oauthState.expectedIssuer && oauthState.resource);
+    return Boolean(
+      oauthState.expectedIssuer &&
+        oauthState.resource &&
+        pickReusableOAuthClient(existing.oauthClient, oauthState.expectedIssuer)
+    );
   }
 
   return false;

--- a/apps/api/src/app/agents/usecases/index.ts
+++ b/apps/api/src/app/agents/usecases/index.ts
@@ -37,6 +37,8 @@ import { SendWhatsAppTestTemplate } from './send-whatsapp-test-template/send-wha
 import { SetAgentMcpServers } from './set-agent-mcp-servers/set-agent-mcp-servers.usecase';
 import { SyncAgentMcpServers } from './sync-agent-mcp-servers/sync-agent-mcp-servers.usecase';
 import { SyncAgentToEnvironment } from './sync-agent-to-environment/sync-agent-to-environment.usecase';
+import { ConfirmToolApproval } from './tool-approval/confirm-tool-approval.usecase';
+import { HandlePendingToolApprovals } from './tool-approval/handle-pending-tool-approvals.usecase';
 import { UpdateAgent } from './update-agent/update-agent.usecase';
 import { UpdateAgentInboxShared } from './update-agent-inbox-shared/update-agent-inbox-shared.usecase';
 import { UpdateAgentIntegration } from './update-agent-integration/update-agent-integration.usecase';
@@ -99,4 +101,6 @@ export const USE_CASES = [
   GetMcpConnectionStatus,
   GetMcpNovuAppCredentials,
   VerifyManagedCredentials,
+  HandlePendingToolApprovals,
+  ConfirmToolApproval,
 ];

--- a/apps/api/src/app/agents/usecases/managed-agent-setup/complete-managed-agent-setup.usecase.ts
+++ b/apps/api/src/app/agents/usecases/managed-agent-setup/complete-managed-agent-setup.usecase.ts
@@ -124,6 +124,7 @@ export class CompleteManagedAgentSetup {
     );
 
     if (mcps.some(isOAuthMcpPending)) {
+      // Some MCPs still need OAuth — refresh the setup card in each waiting Slack thread.
       await this.refreshSetupCardsForPendingConversations({
         agentId: agent._id,
         config,
@@ -138,6 +139,7 @@ export class CompleteManagedAgentSetup {
       return;
     }
 
+    // All MCPs connected — show "setup complete" and re-run every held user message.
     await this.completeAndReplayForAllPendingConversations({
       agentId: agent._id,
       agent,

--- a/apps/api/src/app/agents/usecases/managed-agent-setup/complete-managed-agent-setup.usecase.ts
+++ b/apps/api/src/app/agents/usecases/managed-agent-setup/complete-managed-agent-setup.usecase.ts
@@ -237,14 +237,21 @@ export class CompleteManagedAgentSetup {
         continue;
       }
 
-      await this.completeAndReplay({
-        conversation,
-        pending,
-        agent,
-        config,
-        subscriber,
-        mcps,
-      });
+      try {
+        await this.completeAndReplay({
+          conversation,
+          pending,
+          agent,
+          config,
+          subscriber,
+          mcps,
+        });
+      } catch (err) {
+        this.logger.warn(
+          err,
+          `Failed to complete managed-agent setup replay for conversation ${conversation._id}; continuing batch`
+        );
+      }
     }
   }
 

--- a/apps/api/src/app/agents/usecases/managed-agent-setup/handle-managed-agent-setup-inbound.usecase.ts
+++ b/apps/api/src/app/agents/usecases/managed-agent-setup/handle-managed-agent-setup-inbound.usecase.ts
@@ -174,6 +174,12 @@ export class HandleManagedAgentSetupInbound {
     const setupMessageId = conversation.pendingManagedAgentSetup?.setupMessageId;
 
     if (!setupMessageId) {
+      await this.conversationRepository.clearPendingManagedAgentSetup(
+        command.environmentId,
+        command.organizationId,
+        command.conversationId
+      );
+
       return;
     }
 

--- a/apps/api/src/app/agents/usecases/tool-approval/approval-card.builder.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/approval-card.builder.ts
@@ -3,17 +3,23 @@ import type { ActionRequired, Response as ThalamusResponse } from '@novu/thalamu
 
 export const TOOL_APPROVAL_ACTION_PREFIX = 'mcp-approval' as const;
 
+// Slack button clicks include action.id (parsed below) and action.value (label text only).
+// Id: mcp-approval:{approve|deny|approve-tool|approve-server}:{toolUseIds}:{turnId}
+// "Always allow" buttons append :{toolName}:{mcpServerName} (URI-encoded) for trust storage.
 export type ParsedToolApprovalAction = {
   approved: boolean;
   toolUseIds: string[];
   turnId: string;
   persistScope?: 'tool' | 'server';
+  toolName?: string;
+  mcpServerName?: string;
 };
 
 export function parseToolApprovalActionId(id: string | undefined): ParsedToolApprovalAction | null {
   if (!id) return null;
   const parts = id.split(':');
-  if (parts.length !== 4 || parts[0] !== TOOL_APPROVAL_ACTION_PREFIX) return null;
+  if (parts[0] !== TOOL_APPROVAL_ACTION_PREFIX) return null;
+  if (parts.length !== 4 && parts.length !== 6) return null;
 
   const verdict = parts[1];
   const toolUseIdsPart = parts[2];
@@ -40,7 +46,23 @@ export function parseToolApprovalActionId(id: string | undefined): ParsedToolApp
     parsed.persistScope = 'server';
   }
 
+  if (parts.length === 6) {
+    parsed.toolName = decodeURIComponent(parts[4]) || undefined;
+    parsed.mcpServerName = decodeURIComponent(parts[5]) || undefined;
+  }
+
   return parsed;
+}
+
+function buildPersistTrustActionId(
+  verdict: 'approve-tool' | 'approve-server',
+  tool: PendingToolApproval,
+  turnId: string
+): string {
+  const toolName = encodeURIComponent(tool.toolName);
+  const mcpServerName = encodeURIComponent(tool.mcpServerName ?? '');
+
+  return `${TOOL_APPROVAL_ACTION_PREFIX}:${verdict}:${tool.toolUseId}:${turnId}:${toolName}:${mcpServerName}`;
 }
 
 export function isLinkButtonActionId(id: string | undefined): boolean {
@@ -112,14 +134,14 @@ export function buildToolApprovalCard(pendingTools: PendingToolApproval[], turnI
         children: [
           {
             type: 'button',
-            id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve-tool:${tool.toolUseId}:${turnId}`,
+            id: buildPersistTrustActionId('approve-tool', tool, turnId),
             label: `Approve & always allow ${tool.toolName}`,
             style: 'default',
             value: toolLabel,
           },
           {
             type: 'button',
-            id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve-server:${tool.toolUseId}:${turnId}`,
+            id: buildPersistTrustActionId('approve-server', tool, turnId),
             label: `Approve & always allow all ${mcpDisplayName} tools`,
             style: 'default',
             value: toolLabel,

--- a/apps/api/src/app/agents/usecases/tool-approval/approval-card.builder.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/approval-card.builder.ts
@@ -1,0 +1,187 @@
+import type { PendingToolApproval } from '@novu/application-generic';
+import type { ActionRequired, Response as ThalamusResponse } from '@novu/thalamus';
+
+export const TOOL_APPROVAL_ACTION_PREFIX = 'mcp-approval' as const;
+
+export type ParsedToolApprovalAction = {
+  approved: boolean;
+  toolUseIds: string[];
+  turnId: string;
+  persistScope?: 'tool' | 'server';
+};
+
+export function parseToolApprovalActionId(id: string | undefined): ParsedToolApprovalAction | null {
+  if (!id) return null;
+  const parts = id.split(':');
+  if (parts.length !== 4 || parts[0] !== TOOL_APPROVAL_ACTION_PREFIX) return null;
+
+  const verdict = parts[1];
+  const toolUseIdsPart = parts[2];
+  const turnId = parts[3];
+  const isApprove = verdict === 'approve' || verdict === 'approve-tool' || verdict === 'approve-server';
+  const isDeny = verdict === 'deny';
+
+  if ((!isApprove && !isDeny) || !toolUseIdsPart || !turnId) return null;
+
+  const toolUseIds = toolUseIdsPart.split(',').filter(Boolean);
+  if (toolUseIds.length === 0) return null;
+
+  const parsed: ParsedToolApprovalAction = {
+    approved: isApprove,
+    toolUseIds,
+    turnId,
+  };
+
+  if (verdict === 'approve-tool') {
+    parsed.persistScope = 'tool';
+  }
+
+  if (verdict === 'approve-server') {
+    parsed.persistScope = 'server';
+  }
+
+  return parsed;
+}
+
+export function isLinkButtonActionId(id: string | undefined): boolean {
+  return typeof id === 'string' && id.startsWith('link-');
+}
+
+export function extractPendingToolApprovals(response: ThalamusResponse): PendingToolApproval[] {
+  const actions = response.actionsRequired;
+  if (!Array.isArray(actions) || actions.length === 0) {
+    return [];
+  }
+
+  return actions.map((action: ActionRequired) => ({
+    toolUseId: action.toolUseId,
+    toolName: action.toolName,
+    mcpServerName: action.type === 'mcp-approval' ? action.serverName : undefined,
+    input: action.input,
+  }));
+}
+
+function formatToolLabel(t: PendingToolApproval): string {
+  const name = t.mcpServerName ? `${t.toolName} from ${t.mcpServerName}` : t.toolName;
+  const input = t.input ? `: ${summariseInput(t.input)}` : '';
+
+  return `${name}${input}`;
+}
+
+export function buildToolApprovalCard(pendingTools: PendingToolApproval[], turnId: string): Record<string, unknown> {
+  const tool = pendingTools[0];
+  const serverLabel = tool.mcpServerName ? ` from ${tool.mcpServerName}` : '';
+  const toolLabel = formatToolLabel(tool);
+  const mcpDisplayName = tool.mcpServerName ?? 'MCP';
+
+  const inputSummary = tool.input ? summariseInput(tool.input) : '';
+  const description = inputSummary
+    ? `I'd like to call \`${tool.toolName}\`${serverLabel}:\n\`\`\`\n${inputSummary}\n\`\`\``
+    : `I'd like to call \`${tool.toolName}\`${serverLabel}.`;
+
+  const children: Record<string, unknown>[] = [{ type: 'text', content: description }];
+
+  children.push(
+    { type: 'divider' },
+    {
+      type: 'actions',
+      children: [
+        {
+          type: 'button',
+          id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve:${tool.toolUseId}:${turnId}`,
+          label: 'Approve',
+          style: 'primary',
+          value: toolLabel,
+        },
+        {
+          type: 'button',
+          id: `${TOOL_APPROVAL_ACTION_PREFIX}:deny:${tool.toolUseId}:${turnId}`,
+          label: 'Deny',
+          style: 'danger',
+          value: toolLabel,
+        },
+      ],
+    }
+  );
+
+  if (pendingTools.length === 1) {
+    children.push(
+      { type: 'divider' },
+      {
+        type: 'actions',
+        children: [
+          {
+            type: 'button',
+            id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve-tool:${tool.toolUseId}:${turnId}`,
+            label: `Approve & always allow ${tool.toolName}`,
+            style: 'default',
+            value: toolLabel,
+          },
+          {
+            type: 'button',
+            id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve-server:${tool.toolUseId}:${turnId}`,
+            label: `Approve & always allow all ${mcpDisplayName} tools`,
+            style: 'default',
+            value: toolLabel,
+          },
+        ],
+      }
+    );
+  }
+
+  if (pendingTools.length > 1) {
+    const allIds = pendingTools.map((t) => t.toolUseId).join(',');
+    const allLabels = pendingTools.map((t) => formatToolLabel(t)).join('\n');
+    children.push({
+      type: 'actions',
+      children: [
+        {
+          type: 'button',
+          id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve:${allIds}:${turnId}`,
+          label: `Approve All (${pendingTools.length})`,
+          style: 'primary',
+          value: allLabels,
+        },
+        {
+          type: 'button',
+          id: `${TOOL_APPROVAL_ACTION_PREFIX}:deny:${allIds}:${turnId}`,
+          label: `Deny All (${pendingTools.length})`,
+          style: 'danger',
+          value: allLabels,
+        },
+      ],
+    });
+  }
+
+  return {
+    type: 'card',
+    title: 'Tool Approval',
+    children,
+  };
+}
+
+export function buildToolApprovalVerdictCard(
+  approved: boolean,
+  toolCount: number,
+  toolDescription?: string
+): Record<string, unknown> {
+  const emoji = approved ? '✅' : '🚫';
+  const verb = approved ? 'Approved' : 'Denied';
+  const suffix = toolCount > 1 ? ` all ${toolCount} tools` : '';
+  const subtitle = toolDescription || undefined;
+
+  return {
+    type: 'card',
+    title: 'Tool Approval',
+    subtitle,
+    children: [{ type: 'text', content: `${emoji}  ${verb}${suffix}` }],
+  };
+}
+
+function summariseInput(input: Record<string, unknown>): string {
+  const firstValue = Object.values(input)[0];
+  if (firstValue === undefined) return '';
+  const text = typeof firstValue === 'string' ? firstValue : JSON.stringify(firstValue);
+
+  return text.length > 80 ? `${text.slice(0, 77)}...` : text;
+}

--- a/apps/api/src/app/agents/usecases/tool-approval/confirm-tool-approval.command.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/confirm-tool-approval.command.ts
@@ -1,0 +1,39 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+import { AgentPlatformEnum } from '../../dtos/agent-platform.enum';
+import type { ParsedToolApprovalAction } from './approval-card.builder';
+
+export class ConfirmToolApprovalCommand extends EnvironmentWithUserCommand {
+  @IsString()
+  @IsNotEmpty()
+  conversationId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  agentIdentifier: string;
+
+  @IsString()
+  @IsNotEmpty()
+  integrationIdentifier: string;
+
+  @IsString()
+  @IsNotEmpty()
+  agentId: string;
+
+  @IsString()
+  @IsOptional()
+  subscriberId?: string;
+
+  platform?: AgentPlatformEnum;
+
+  parsed: ParsedToolApprovalAction;
+
+  @IsString()
+  @IsOptional()
+  sourceMessageId?: string;
+
+  @IsString()
+  @IsOptional()
+  actionValue?: string;
+}

--- a/apps/api/src/app/agents/usecases/tool-approval/confirm-tool-approval.usecase.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/confirm-tool-approval.usecase.ts
@@ -1,0 +1,132 @@
+import { Injectable } from '@nestjs/common';
+import { PinoLogger } from '@novu/application-generic';
+import { AgentMcpServerRepository, McpConnectionRepository, SubscriberRepository } from '@novu/dal';
+
+import { ManagedAgentService } from '../../services/managed-agent.service';
+import { HandleAgentReplyCommand } from '../handle-agent-reply/handle-agent-reply.command';
+import { HandleAgentReply } from '../handle-agent-reply/handle-agent-reply.usecase';
+import { HandlePlanProgressCommand } from '../handle-plan-progress/handle-plan-progress.command';
+import { HandlePlanProgress } from '../handle-plan-progress/handle-plan-progress.usecase';
+import { buildToolApprovalVerdictCard } from './approval-card.builder';
+import { ConfirmToolApprovalCommand } from './confirm-tool-approval.command';
+import {
+  extractMcpServerNameFromApprovalValue,
+  extractToolNameFromApprovalValue,
+  mergeToolTrustPatch,
+  resolveTrustForPendingTool,
+} from './tool-trust.helper';
+
+@Injectable()
+export class ConfirmToolApproval {
+  constructor(
+    private readonly subscriberRepository: SubscriberRepository,
+    private readonly agentMcpServerRepository: AgentMcpServerRepository,
+    private readonly mcpConnectionRepository: McpConnectionRepository,
+    private readonly managedAgentService: ManagedAgentService,
+    private readonly handleAgentReply: HandleAgentReply,
+    private readonly handlePlanProgress: HandlePlanProgress,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  async execute(command: ConfirmToolApprovalCommand): Promise<void> {
+    const { parsed } = command;
+    let persistTrust: { connectionId: string; toolName: string; scope: 'tool' | 'server' } | undefined;
+
+    if (parsed.approved && parsed.persistScope && command.subscriberId) {
+      const subscriber = await this.subscriberRepository.findBySubscriberId(
+        command.environmentId,
+        command.subscriberId
+      );
+      const toolName = extractToolNameFromApprovalValue(command.actionValue);
+      const mcpServerName = extractMcpServerNameFromApprovalValue(command.actionValue);
+
+      if (subscriber && toolName) {
+        const resolution = await resolveTrustForPendingTool({
+          findOAuthEnablementsForAgent: (params) => this.agentMcpServerRepository.findOAuthEnablementsForAgent(params),
+          findSubscriberConnection: (params) => this.mcpConnectionRepository.findSubscriberConnection(params),
+          params: {
+            environmentId: command.environmentId,
+            organizationId: command.organizationId,
+            agentId: command.agentId,
+            subscriberMongoId: subscriber._id,
+            mcpServerName,
+            toolName,
+          },
+        });
+
+        if (resolution) {
+          persistTrust = {
+            connectionId: resolution.connection._id,
+            toolName,
+            scope: parsed.persistScope,
+          };
+        }
+      }
+    }
+
+    if (parsed.approved && persistTrust) {
+      await this.mcpConnectionRepository.mergeToolTrust({
+        connectionId: persistTrust.connectionId,
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        patch: mergeToolTrustPatch({
+          scope: persistTrust.scope,
+          toolName: persistTrust.toolName,
+        }),
+      });
+    }
+
+    await this.managedAgentService.resumeWithToolResults({
+      conversationId: command.conversationId,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      agentIdentifier: command.agentIdentifier,
+      integrationIdentifier: command.integrationIdentifier,
+      subscriberId: command.subscriberId,
+      platform: command.platform,
+      toolUseIds: parsed.toolUseIds,
+      approved: parsed.approved,
+      turnId: parsed.turnId,
+    });
+
+    if (command.sourceMessageId) {
+      const verdictCard = buildToolApprovalVerdictCard(parsed.approved, parsed.toolUseIds.length, command.actionValue);
+      this.handleAgentReply
+        .execute(
+          HandleAgentReplyCommand.create({
+            userId: command.userId,
+            environmentId: command.environmentId,
+            organizationId: command.organizationId,
+            conversationId: command.conversationId,
+            agentIdentifier: command.agentIdentifier,
+            integrationIdentifier: command.integrationIdentifier,
+            edit: { messageId: command.sourceMessageId, content: { card: verdictCard } },
+          })
+        )
+        .catch((err) => {
+          this.logger.warn(err, 'Failed to update tool approval card with verdict');
+        });
+    }
+
+    this.handlePlanProgress
+      .execute(
+        HandlePlanProgressCommand.create({
+          userId: command.userId,
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+          conversationId: command.conversationId,
+          agentIdentifier: command.agentIdentifier,
+          integrationIdentifier: command.integrationIdentifier,
+          toolProgress: {
+            turnId: parsed.turnId,
+            action: parsed.approved ? 'approved' : 'denied',
+          },
+        })
+      )
+      .catch((err) => {
+        this.logger.warn(err, 'Failed to update plan card after tool approval verdict');
+      });
+  }
+}

--- a/apps/api/src/app/agents/usecases/tool-approval/confirm-tool-approval.usecase.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/confirm-tool-approval.usecase.ts
@@ -9,12 +9,7 @@ import { HandlePlanProgressCommand } from '../handle-plan-progress/handle-plan-p
 import { HandlePlanProgress } from '../handle-plan-progress/handle-plan-progress.usecase';
 import { buildToolApprovalVerdictCard } from './approval-card.builder';
 import { ConfirmToolApprovalCommand } from './confirm-tool-approval.command';
-import {
-  extractMcpServerNameFromApprovalValue,
-  extractToolNameFromApprovalValue,
-  mergeToolTrustPatch,
-  resolveTrustForPendingTool,
-} from './tool-trust.helper';
+import { mergeToolTrustPatch, resolveTrustForPendingTool } from './tool-trust.helper';
 
 @Injectable()
 export class ConfirmToolApproval {
@@ -34,15 +29,17 @@ export class ConfirmToolApproval {
     const { parsed } = command;
     let persistTrust: { connectionId: string; toolName: string; scope: 'tool' | 'server' } | undefined;
 
+    // "Approve & always allow …": save always_allow on the MCP connection (from action.id),
+    // then tell the runtime to continue the paused agent turn.
     if (parsed.approved && parsed.persistScope && command.subscriberId) {
       const subscriber = await this.subscriberRepository.findBySubscriberId(
         command.environmentId,
         command.subscriberId
       );
-      const toolName = extractToolNameFromApprovalValue(command.actionValue);
-      const mcpServerName = extractMcpServerNameFromApprovalValue(command.actionValue);
+      const toolName = parsed.toolName;
+      const mcpServerName = parsed.mcpServerName;
 
-      if (subscriber && toolName) {
+      if (subscriber && mcpServerName && toolName) {
         const resolution = await resolveTrustForPendingTool({
           findOAuthEnablementsForAgent: (params) => this.agentMcpServerRepository.findOAuthEnablementsForAgent(params),
           findSubscriberConnection: (params) => this.mcpConnectionRepository.findSubscriberConnection(params),

--- a/apps/api/src/app/agents/usecases/tool-approval/handle-pending-tool-approvals.command.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/handle-pending-tool-approvals.command.ts
@@ -1,0 +1,36 @@
+import type { Response as ThalamusResponse } from '@novu/thalamus';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+import { EnvironmentWithUserCommand } from '../../../shared/commands/project.command';
+
+export class HandlePendingToolApprovalsCommand extends EnvironmentWithUserCommand {
+  @IsString()
+  @IsNotEmpty()
+  conversationId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  agentIdentifier: string;
+
+  @IsString()
+  @IsNotEmpty()
+  integrationIdentifier: string;
+
+  @IsString()
+  @IsOptional()
+  subscriberId?: string;
+
+  @IsString()
+  @IsOptional()
+  platform?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  sessionId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  turnId: string;
+
+  response: ThalamusResponse;
+}

--- a/apps/api/src/app/agents/usecases/tool-approval/handle-pending-tool-approvals.usecase.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/handle-pending-tool-approvals.usecase.ts
@@ -13,11 +13,11 @@ import { ManagedAgentProviderFactory } from '../../services/managed-agent-provid
 import { captureAgentException, captureAgentWarning } from '../../utils/capture-agent-sentry';
 import { HandleAgentReplyCommand } from '../handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from '../handle-agent-reply/handle-agent-reply.usecase';
+import { HandlePlanProgressCommand } from '../handle-plan-progress/handle-plan-progress.command';
+import { HandlePlanProgress } from '../handle-plan-progress/handle-plan-progress.usecase';
 import { buildToolApprovalCard, extractPendingToolApprovals } from './approval-card.builder';
 import { HandlePendingToolApprovalsCommand } from './handle-pending-tool-approvals.command';
 import { resolveTrustForPendingTool } from './tool-trust.helper';
-
-type DeliveryResult = 'card' | 'auto-confirmed' | 'none';
 
 @Injectable()
 export class HandlePendingToolApprovals {
@@ -30,19 +30,20 @@ export class HandlePendingToolApprovals {
     @Inject(forwardRef(() => ManagedAgentService))
     private readonly managedAgentService: ManagedAgentService,
     private readonly handleAgentReply: HandleAgentReply,
+    private readonly handlePlanProgress: HandlePlanProgress,
     private readonly logger: PinoLogger
   ) {
     this.logger.setContext(this.constructor.name);
   }
 
-  async execute(command: HandlePendingToolApprovalsCommand): Promise<DeliveryResult> {
+  async execute(command: HandlePendingToolApprovalsCommand): Promise<void> {
     const runtimeProvider = await this.providerFactory.tryGetByAgentIdentifier(
       command.agentIdentifier,
       command.environmentId
     );
 
     if (!runtimeProvider) {
-      return 'none';
+      return;
     }
 
     // Which tools need approval?
@@ -65,7 +66,7 @@ export class HandlePendingToolApprovals {
           sessionId: command.sessionId,
         });
 
-        return 'none';
+        return;
       }
     }
 
@@ -75,7 +76,7 @@ export class HandlePendingToolApprovals {
         'Session is parked on requires-action but no pending tool approvals were located'
       );
 
-      return 'none';
+      return;
     }
 
     // Split by mcp_connection.toolTrust: auto-approve matches, card for the rest.
@@ -111,16 +112,18 @@ export class HandlePendingToolApprovals {
           sessionId: command.sessionId,
         });
 
-        return this.deliverCard(command, pendingTools);
+        await this.deliverCard(command, pendingTools);
+
+        return;
       }
     }
 
     if (needsPromptTools.length === 0) {
-      return 'auto-confirmed';
+      return;
     }
 
     // Untrusted (or mixed batch remainder): post Approve/Deny card to the thread.
-    return this.deliverCard(command, needsPromptTools);
+    await this.deliverCard(command, needsPromptTools);
   }
 
   private async partitionByTrust(
@@ -175,7 +178,7 @@ export class HandlePendingToolApprovals {
   private async deliverCard(
     command: HandlePendingToolApprovalsCommand,
     pendingTools: PendingToolApproval[]
-  ): Promise<DeliveryResult> {
+  ): Promise<void> {
     try {
       await this.handleAgentReply.execute(
         HandleAgentReplyCommand.create({
@@ -196,9 +199,19 @@ export class HandlePendingToolApprovals {
         sessionId: command.sessionId,
       });
 
-      return 'none';
+      return;
     }
 
-    return 'card';
+    await this.handlePlanProgress.execute(
+      HandlePlanProgressCommand.create({
+        userId: command.userId,
+        organizationId: command.organizationId,
+        environmentId: command.environmentId,
+        conversationId: command.conversationId,
+        agentIdentifier: command.agentIdentifier,
+        integrationIdentifier: command.integrationIdentifier,
+        toolProgress: { turnId: command.turnId, action: 'awaiting-approval' },
+      })
+    );
   }
 }

--- a/apps/api/src/app/agents/usecases/tool-approval/handle-pending-tool-approvals.usecase.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/handle-pending-tool-approvals.usecase.ts
@@ -1,0 +1,204 @@
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import type { PendingToolApproval } from '@novu/application-generic';
+import { PinoLogger } from '@novu/application-generic';
+import {
+  AgentMcpServerRepository,
+  ConversationRepository,
+  McpConnectionRepository,
+  SubscriberRepository,
+} from '@novu/dal';
+import { AgentPlatformEnum } from '../../dtos/agent-platform.enum';
+import { ManagedAgentService } from '../../services/managed-agent.service';
+import { ManagedAgentProviderFactory } from '../../services/managed-agent-provider-factory';
+import { captureAgentException, captureAgentWarning } from '../../utils/capture-agent-sentry';
+import { HandleAgentReplyCommand } from '../handle-agent-reply/handle-agent-reply.command';
+import { HandleAgentReply } from '../handle-agent-reply/handle-agent-reply.usecase';
+import { buildToolApprovalCard, extractPendingToolApprovals } from './approval-card.builder';
+import { HandlePendingToolApprovalsCommand } from './handle-pending-tool-approvals.command';
+import { resolveTrustForPendingTool } from './tool-trust.helper';
+
+type DeliveryResult = 'card' | 'auto-confirmed' | 'none';
+
+@Injectable()
+export class HandlePendingToolApprovals {
+  constructor(
+    private readonly providerFactory: ManagedAgentProviderFactory,
+    private readonly conversationRepository: ConversationRepository,
+    private readonly subscriberRepository: SubscriberRepository,
+    private readonly agentMcpServerRepository: AgentMcpServerRepository,
+    private readonly mcpConnectionRepository: McpConnectionRepository,
+    @Inject(forwardRef(() => ManagedAgentService))
+    private readonly managedAgentService: ManagedAgentService,
+    private readonly handleAgentReply: HandleAgentReply,
+    private readonly logger: PinoLogger
+  ) {
+    this.logger.setContext(this.constructor.name);
+  }
+
+  async execute(command: HandlePendingToolApprovalsCommand): Promise<DeliveryResult> {
+    const runtimeProvider = await this.providerFactory.tryGetByAgentIdentifier(
+      command.agentIdentifier,
+      command.environmentId
+    );
+
+    if (!runtimeProvider) {
+      return 'none';
+    }
+
+    // Which tools need approval?
+    // 1. extractPendingToolApprovals — read response.actionsRequired from this webhook (fast, no API call).
+    // 2. getAllPendingToolApprovals — fallback when the webhook says requires-action but omits tool details
+    //    (e.g. user already approved some tools in the same session and others are still waiting).
+    let pendingTools = extractPendingToolApprovals(command.response);
+
+    if (pendingTools.length === 0) {
+      try {
+        pendingTools = await runtimeProvider.getAllPendingToolApprovals(command.sessionId);
+      } catch (err) {
+        this.logger.warn(
+          { err: err instanceof Error ? err.message : String(err), sessionId: command.sessionId },
+          'getAllPendingToolApprovals failed; cannot render Approve/Deny card'
+        );
+        captureAgentWarning(err, {
+          component: 'handle-pending-tool-approvals',
+          operation: 'get-all-pending-tool-approvals',
+          sessionId: command.sessionId,
+        });
+
+        return 'none';
+      }
+    }
+
+    if (pendingTools.length === 0) {
+      this.logger.warn(
+        { sessionId: command.sessionId, conversationId: command.conversationId },
+        'Session is parked on requires-action but no pending tool approvals were located'
+      );
+
+      return 'none';
+    }
+
+    // Split by mcp_connection.toolTrust: auto-approve matches, card for the rest.
+    const { trustedTools, needsPromptTools } = await this.partitionByTrust(command, pendingTools);
+
+    // Trusted: tell Anthropic yes without posting anything to the chat thread.
+    if (trustedTools.length > 0) {
+      try {
+        await this.managedAgentService.resumeWithToolResults({
+          conversationId: command.conversationId,
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+          agentIdentifier: command.agentIdentifier,
+          integrationIdentifier: command.integrationIdentifier,
+          subscriberId: command.subscriberId,
+          platform: command.platform as AgentPlatformEnum | undefined,
+          toolUseIds: trustedTools.map((tool) => tool.toolUseId),
+          approved: true,
+          turnId: command.turnId,
+        });
+      } catch (err) {
+        this.logger.warn(
+          {
+            err: err instanceof Error ? err.message : String(err),
+            sessionId: command.sessionId,
+            toolUseIds: trustedTools.map((t) => t.toolUseId),
+          },
+          'Auto-confirm for trusted MCP tools failed; falling back to approval card'
+        );
+        captureAgentWarning(err, {
+          component: 'handle-pending-tool-approvals',
+          operation: 'auto-confirm-trusted-tools',
+          sessionId: command.sessionId,
+        });
+
+        return this.deliverCard(command, pendingTools);
+      }
+    }
+
+    if (needsPromptTools.length === 0) {
+      return 'auto-confirmed';
+    }
+
+    // Untrusted (or mixed batch remainder): post Approve/Deny card to the thread.
+    return this.deliverCard(command, needsPromptTools);
+  }
+
+  private async partitionByTrust(
+    command: HandlePendingToolApprovalsCommand,
+    pendingTools: PendingToolApproval[]
+  ): Promise<{ trustedTools: PendingToolApproval[]; needsPromptTools: PendingToolApproval[] }> {
+    const conversation = await this.conversationRepository.findOne(
+      {
+        _id: command.conversationId,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      },
+      ['_agentId']
+    );
+
+    if (!conversation) {
+      return { trustedTools: [], needsPromptTools: pendingTools };
+    }
+
+    const subscriberMongoId = command.subscriberId
+      ? (await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId))?._id
+      : undefined;
+
+    const trustedTools: PendingToolApproval[] = [];
+    const needsPromptTools: PendingToolApproval[] = [];
+
+    for (const tool of pendingTools) {
+      const resolution = await resolveTrustForPendingTool({
+        findOAuthEnablementsForAgent: (params) => this.agentMcpServerRepository.findOAuthEnablementsForAgent(params),
+        findSubscriberConnection: (params) => this.mcpConnectionRepository.findSubscriberConnection(params),
+        params: {
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+          agentId: conversation._agentId,
+          subscriberMongoId,
+          mcpServerName: tool.mcpServerName,
+          toolName: tool.toolName,
+        },
+      });
+
+      if (resolution?.trusted) {
+        trustedTools.push(tool);
+        continue;
+      }
+
+      needsPromptTools.push(tool);
+    }
+
+    return { trustedTools, needsPromptTools };
+  }
+
+  private async deliverCard(
+    command: HandlePendingToolApprovalsCommand,
+    pendingTools: PendingToolApproval[]
+  ): Promise<DeliveryResult> {
+    try {
+      await this.handleAgentReply.execute(
+        HandleAgentReplyCommand.create({
+          userId: command.userId,
+          organizationId: command.organizationId,
+          environmentId: command.environmentId,
+          conversationId: command.conversationId,
+          agentIdentifier: command.agentIdentifier,
+          integrationIdentifier: command.integrationIdentifier,
+          reply: { card: buildToolApprovalCard(pendingTools, command.turnId) },
+        })
+      );
+    } catch (err) {
+      this.logger.error(err, `Failed to deliver tool-approval card for session ${command.sessionId}`);
+      captureAgentException(err, {
+        component: 'handle-pending-tool-approvals',
+        operation: 'deliver-tool-approval-card',
+        sessionId: command.sessionId,
+      });
+
+      return 'none';
+    }
+
+    return 'card';
+  }
+}

--- a/apps/api/src/app/agents/usecases/tool-approval/tool-trust.helper.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/tool-trust.helper.ts
@@ -38,39 +38,6 @@ export function mergeToolTrustPatch(params: {
   return { tools: { [params.toolName]: 'always_allow' } };
 }
 
-export function extractToolNameFromApprovalValue(value: string | undefined): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  const trimmed = value.trim();
-  const fromIndex = trimmed.indexOf(' from ');
-
-  if (fromIndex === -1) {
-    const colonIndex = trimmed.indexOf(':');
-
-    return colonIndex === -1 ? trimmed : trimmed.slice(0, colonIndex).trim();
-  }
-
-  return trimmed.slice(0, fromIndex).trim();
-}
-
-export function extractMcpServerNameFromApprovalValue(value: string | undefined): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  const fromIndex = value.indexOf(' from ');
-  if (fromIndex === -1) {
-    return undefined;
-  }
-
-  const rest = value.slice(fromIndex + ' from '.length);
-  const colonIndex = rest.indexOf(':');
-
-  return colonIndex === -1 ? rest.trim() : rest.slice(0, colonIndex).trim();
-}
-
 function matchesMcpServerName(enablement: AgentMcpServerEntity, mcpServerName: string): boolean {
   if (enablement.externalProjection?.mcpServerName === mcpServerName) {
     return true;

--- a/apps/api/src/app/agents/usecases/tool-approval/tool-trust.helper.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/tool-trust.helper.ts
@@ -1,22 +1,26 @@
-import type { AgentMcpServerEntity, McpConnectionEntity, McpToolTrust } from '@novu/dal';
+import {
+  type AgentMcpServerEntity,
+  DEFAULT_MCP_TOOL_TRUST_POLICY,
+  type McpConnectionEntity,
+  type McpToolTrust,
+  type McpToolTrustPolicy,
+} from '@novu/dal';
 import { MCP_SERVERS } from '@novu/shared';
 
 export type ToolTrustPersistScope = 'tool' | 'server';
 
+export function resolveToolTrustPolicy(trust: McpToolTrust | undefined, toolName: string): McpToolTrustPolicy {
+  const toolPolicy = trust?.tools?.[toolName];
+
+  if (toolPolicy) {
+    return toolPolicy;
+  }
+
+  return trust?.serverDefault ?? DEFAULT_MCP_TOOL_TRUST_POLICY;
+}
+
 export function isToolTrusted(trust: McpToolTrust | undefined, toolName: string): boolean {
-  if (!trust) {
-    return false;
-  }
-
-  if (trust.tools?.[toolName] === 'always_allow') {
-    return true;
-  }
-
-  if (trust.serverDefault === 'always_allow') {
-    return true;
-  }
-
-  return false;
+  return resolveToolTrustPolicy(trust, toolName) === 'always_allow';
 }
 
 export function mergeToolTrustPatch(params: {

--- a/apps/api/src/app/agents/usecases/tool-approval/tool-trust.helper.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/tool-trust.helper.ts
@@ -1,0 +1,133 @@
+import type { AgentMcpServerEntity, McpConnectionEntity, McpToolTrust } from '@novu/dal';
+import { MCP_SERVERS } from '@novu/shared';
+
+export type ToolTrustPersistScope = 'tool' | 'server';
+
+export function isToolTrusted(trust: McpToolTrust | undefined, toolName: string): boolean {
+  if (!trust) {
+    return false;
+  }
+
+  if (trust.tools?.[toolName] === 'always_allow') {
+    return true;
+  }
+
+  if (trust.serverDefault === 'always_allow') {
+    return true;
+  }
+
+  return false;
+}
+
+export function mergeToolTrustPatch(params: {
+  scope: ToolTrustPersistScope;
+  toolName?: string;
+}): Partial<McpToolTrust> {
+  if (params.scope === 'server') {
+    return { serverDefault: 'always_allow' };
+  }
+
+  if (!params.toolName) {
+    throw new Error('toolName required for tool scope');
+  }
+
+  return { tools: { [params.toolName]: 'always_allow' } };
+}
+
+export function extractToolNameFromApprovalValue(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  const fromIndex = trimmed.indexOf(' from ');
+
+  if (fromIndex === -1) {
+    const colonIndex = trimmed.indexOf(':');
+
+    return colonIndex === -1 ? trimmed : trimmed.slice(0, colonIndex).trim();
+  }
+
+  return trimmed.slice(0, fromIndex).trim();
+}
+
+export function extractMcpServerNameFromApprovalValue(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const fromIndex = value.indexOf(' from ');
+  if (fromIndex === -1) {
+    return undefined;
+  }
+
+  const rest = value.slice(fromIndex + ' from '.length);
+  const colonIndex = rest.indexOf(':');
+
+  return colonIndex === -1 ? rest.trim() : rest.slice(0, colonIndex).trim();
+}
+
+function matchesMcpServerName(enablement: AgentMcpServerEntity, mcpServerName: string): boolean {
+  if (enablement.externalProjection?.mcpServerName === mcpServerName) {
+    return true;
+  }
+
+  const catalog = MCP_SERVERS.find((entry) => entry.id === enablement.mcpId);
+
+  return catalog?.name === mcpServerName;
+}
+
+export async function resolveTrustForPendingTool(deps: {
+  findOAuthEnablementsForAgent: (params: {
+    organizationId: string;
+    environmentId: string;
+    agentId: string;
+  }) => Promise<AgentMcpServerEntity[]>;
+  findSubscriberConnection: (params: {
+    organizationId: string;
+    environmentId: string;
+    agentMcpServerId: string;
+    subscriberId: string;
+  }) => Promise<McpConnectionEntity | null>;
+  params: {
+    environmentId: string;
+    organizationId: string;
+    agentId: string;
+    subscriberMongoId?: string;
+    mcpServerName?: string;
+    toolName: string;
+  };
+}): Promise<{ connection: McpConnectionEntity; trusted: boolean } | null> {
+  const { params } = deps;
+
+  if (!params.subscriberMongoId || !params.mcpServerName) {
+    return null;
+  }
+
+  const enablements = await deps.findOAuthEnablementsForAgent({
+    organizationId: params.organizationId,
+    environmentId: params.environmentId,
+    agentId: params.agentId,
+  });
+  const enablement = enablements.find((row) => matchesMcpServerName(row, params.mcpServerName!));
+
+  if (!enablement) {
+    return null;
+  }
+
+  const connection = await deps.findSubscriberConnection({
+    organizationId: params.organizationId,
+    environmentId: params.environmentId,
+    agentMcpServerId: enablement._id,
+    subscriberId: params.subscriberMongoId,
+  });
+
+  if (!connection) {
+    return null;
+  }
+
+  return {
+    connection,
+    trusted: isToolTrusted(connection.toolTrust, params.toolName),
+  };
+}

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.entity.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.entity.ts
@@ -131,6 +131,15 @@ export interface McpConnectionLastError {
   at: Date;
 }
 
+export type McpToolTrustPolicy = 'always_allow';
+
+export type McpToolTrust = {
+  /** Applies to all tools from this MCP server for this subscriber. */
+  serverDefault?: McpToolTrustPolicy;
+  /** Per-tool overrides keyed by MCP tool name (e.g. "list_issues"). */
+  tools?: Record<string, McpToolTrustPolicy>;
+};
+
 /**
  * OAuth state for a (scope, mcp, owner) tuple.
  *
@@ -185,6 +194,9 @@ export class McpConnectionEntity {
   oauthClient?: McpConnectionOAuthClient;
 
   lastError?: McpConnectionLastError;
+
+  /** Subscriber-scoped auto-approve prefs for MCP tool calls. */
+  toolTrust?: McpToolTrust;
 
   connectedAt?: string;
 

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.entity.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.entity.ts
@@ -131,7 +131,9 @@ export interface McpConnectionLastError {
   at: Date;
 }
 
-export type McpToolTrustPolicy = 'always_allow';
+export type McpToolTrustPolicy = 'always_ask' | 'always_allow';
+
+export const DEFAULT_MCP_TOOL_TRUST_POLICY: McpToolTrustPolicy = 'always_ask';
 
 export type McpToolTrust = {
   /** Applies to all tools from this MCP server for this subscriber. */

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.repository.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.repository.ts
@@ -212,7 +212,7 @@ export class McpConnectionRepository extends BaseRepositoryV2<
   }): Promise<void> {
     const $set: Record<string, unknown> = {};
 
-    if (params.patch.serverDefault) {
+    if (params.patch.serverDefault !== undefined) {
       $set['toolTrust.serverDefault'] = params.patch.serverDefault;
     }
 

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.repository.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.repository.ts
@@ -218,6 +218,7 @@ export class McpConnectionRepository extends BaseRepositoryV2<
 
     if (params.patch.tools) {
       for (const [toolName, policy] of Object.entries(params.patch.tools)) {
+        assertSafeMcpToolTrustKeySegment(toolName);
         $set[`toolTrust.tools.${toolName}`] = policy;
       }
     }
@@ -234,5 +235,12 @@ export class McpConnectionRepository extends BaseRepositoryV2<
       },
       { $set }
     );
+  }
+}
+
+function assertSafeMcpToolTrustKeySegment(name: string): void {
+  // Stored as toolTrust.tools.{name}; `.` and `$` would corrupt the Mongo update path.
+  if (name.includes('.') || name.includes('$') || name.includes('\0')) {
+    throw new Error(`Invalid MCP tool name for trust persistence: ${name}`);
   }
 }

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.repository.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.repository.ts
@@ -3,7 +3,7 @@ import { FilterQuery } from 'mongoose';
 
 import type { EnforceEnvOrOrgIds } from '../../types';
 import { BaseRepositoryV2 } from '../base-repository-v2';
-import { McpConnectionDBModel, McpConnectionEntity } from './mcp-connection.entity';
+import { McpConnectionDBModel, McpConnectionEntity, McpToolTrust } from './mcp-connection.entity';
 import { McpConnection } from './mcp-connection.schema';
 
 export class McpConnectionRepository extends BaseRepositoryV2<
@@ -202,5 +202,37 @@ export class McpConnectionRepository extends BaseRepositoryV2<
     );
 
     return result.modified > 0;
+  }
+
+  async mergeToolTrust(params: {
+    connectionId: string;
+    environmentId: string;
+    organizationId: string;
+    patch: Partial<McpToolTrust>;
+  }): Promise<void> {
+    const $set: Record<string, unknown> = {};
+
+    if (params.patch.serverDefault) {
+      $set['toolTrust.serverDefault'] = params.patch.serverDefault;
+    }
+
+    if (params.patch.tools) {
+      for (const [toolName, policy] of Object.entries(params.patch.tools)) {
+        $set[`toolTrust.tools.${toolName}`] = policy;
+      }
+    }
+
+    if (Object.keys($set).length === 0) {
+      return;
+    }
+
+    await this.update(
+      {
+        _id: params.connectionId,
+        _environmentId: params.environmentId,
+        _organizationId: params.organizationId,
+      },
+      { $set }
+    );
   }
 }

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.schema.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.schema.ts
@@ -140,13 +140,13 @@ const toolTrustSchema = new Schema(
     serverDefault: {
       type: Schema.Types.String,
       required: false,
-      enum: ['always_allow'],
+      enum: ['always_ask', 'always_allow'],
     },
     tools: {
       type: Schema.Types.Map,
       of: {
         type: Schema.Types.String,
-        enum: ['always_allow'],
+        enum: ['always_ask', 'always_allow'],
       },
       required: false,
     },

--- a/libs/dal/src/repositories/mcp-connection/mcp-connection.schema.ts
+++ b/libs/dal/src/repositories/mcp-connection/mcp-connection.schema.ts
@@ -135,6 +135,25 @@ const oauthClientSchema = new Schema(
   { _id: false }
 );
 
+const toolTrustSchema = new Schema(
+  {
+    serverDefault: {
+      type: Schema.Types.String,
+      required: false,
+      enum: ['always_allow'],
+    },
+    tools: {
+      type: Schema.Types.Map,
+      of: {
+        type: Schema.Types.String,
+        enum: ['always_allow'],
+      },
+      required: false,
+    },
+  },
+  { _id: false }
+);
+
 const lastErrorSchema = new Schema(
   {
     code: {
@@ -233,6 +252,10 @@ const mcpConnectionSchema = new Schema<McpConnectionDBModel>(
     },
     lastError: {
       type: lastErrorSchema,
+      required: false,
+    },
+    toolTrust: {
+      type: toolTrustSchema,
       required: false,
     },
     connectedAt: {


### PR DESCRIPTION
## Summary

- Add subscriber-scoped MCP tool trust on `mcp_connection` — trusted tools auto-confirm on `requires-action`; untrusted tools show an approval card with allow-once / allow-tool / allow-server options
- Default trust policy is `always_ask`; persist `always_allow` only when the subscriber opts in on the approval card
- Harden setup OAuth reuse (reject expired DCR clients), isolate batch replay failures per conversation, and clear stale pending setup state

Builds on the OAuth setup gate merged in #11327.

```mermaid
sequenceDiagram
  participant Webhook as Thalamus webhook
  participant Handler as ManagedAgentEventHandler
  participant Pending as HandlePendingToolApprovals
  participant Inbound as AgentInboundHandler
  participant Confirm as ConfirmToolApproval

  Webhook->>Handler: requires-action
  Handler->>Pending: partition by trust
  alt trusted tool
    Pending->>Pending: auto-confirm + resume
  else untrusted tool
    Pending->>Inbound: post approval card
    Inbound->>Confirm: button click
    Confirm->>Confirm: persist trust (optional) + resume
  end
```

## Test plan

- [ ] Trigger tool call requiring approval — card shows approve/deny and persist options
- [ ] Approve with "always allow tool/server" — subsequent calls skip approval card
- [ ] Deny tool call — agent receives rejection and continues gracefully
- [ ] DCR OAuth reuse with expired client secret falls back to fresh flow
- [ ] OAuth callback replays all pending conversations even if one fails


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-subscriber MCP tool trust added so tools can be auto-confirmed (always_allow) or remain always_ask; approval cards support single/multi-tool flows and verdict summaries.
* **Behavior Changes**
  * Tool-approval actions now follow dedicated approval workflows that persist trust decisions and resume paused agent conversations.
* **Bug Fixes**
  * OAuth client reuse tightened to avoid expired clients; managed-agent setup/replay made resilient and cleans stale setup state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->