### PR TITLE
ci(root): use Blacksmith Docker layer caching fixes NV-7899

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -340,7 +340,7 @@ jobs:
   build:
     needs: [prepare-matrix, run-clickhouse-migrations]
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     environment: ${{ fromJson(needs.prepare-matrix.outputs.env_matrix).environment[0] }}
     permissions:
       contents: read
@@ -374,9 +374,7 @@ jobs:
         run: pnpm ci
 
       - name: Set Up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-        with:
-          driver-opts: "image=moby/buildkit:v0.13.1"
+        uses: useblacksmith/setup-docker-builder@a592b831ebb20e68f7cf47329cf2c3c67b8a7655 # v1
 
       - name: Prepare Variables
         run: echo "BULL_MQ_PRO_NPM_TOKEN=${{ secrets.BULL_MQ_PRO_NPM_TOKEN }}" >> $GITHUB_ENV


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Speed up cloud deploy Docker builds by switching the `build` job in `.github/workflows/deploy.yml` to Blacksmith runners with persistent Docker layer caching.

## Changes

- Run the `build` job on `blacksmith-8vcpu-ubuntu-2404` instead of `ubuntu-latest`
- Replace `docker/setup-buildx-action` with `useblacksmith/setup-docker-builder@v1` (pinned to commit SHA)

Per [Blacksmith Docker caching docs](https://docs.blacksmith.sh/blacksmith-caching/docker-builds), the setup action hydrates BuildKit with cached layers from prior runs. Because this workflow already invokes `docker buildx build` via `pnpm run docker:build`, only the setup action is required — no migration to `useblacksmith/build-push-action` is needed.

## Unchanged

All other deploy workflow jobs remain on `ubuntu-latest`:

- `prepare-matrix`
- `run-clickhouse-migrations`
- `deploy`
- `sentry_release`
- `new_relic_release`
- `sync_novu_state`
- `webhook_notification`
- `linear_release_cloud`

The build/push/tag flow, AWS ECR login, matrix strategy, and ECS deploy steps are unchanged.

## Verification

- `python3 .github/workflows/scripts/check-workflow-security.py` passes (no unpinned actions or AWS credential regressions)

## Notes

- First deploy after merge will be an uncached run; subsequent builds should reuse Docker layers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6862693f-7652-4391-952c-06b1bb6aadf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6862693f-7652-4391-952c-06b1bb6aadf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `build` job in the deploy workflow now runs on `blacksmith-8vcpu-ubuntu-2404` instead of `ubuntu-latest`, and the Docker Buildx setup action was replaced with `useblacksmith/setup-docker-builder@v1`. These changes enable persistent Docker layer caching via Blacksmith's infrastructure, reducing build times for subsequent Docker image builds. The workflow's build/push/tag flow, AWS ECR login, and ECS deploy steps remain unchanged.

## Affected areas

**CI/Deployment**: The `.github/workflows/deploy.yml` file was updated to use Blacksmith for the build job runner and Docker layer caching, while all other jobs (`prepare-matrix`, `run-clickhouse-migrations`, `deploy`, `sentry_release`, `new_relic_release`, `sync_novu_state`, `webhook_notification`, `linear_release_cloud`) continue running on `ubuntu-latest`.

## Key technical decisions

- Only the Docker setup action was replaced; the `useblacksmith/build-push-action` was not adopted because the workflow invokes Docker builds through `pnpm run docker:build`, requiring only the setup step.
- The first deploy after merge will have no cached layers; subsequent builds will reuse Docker layers stored in Blacksmith's persistent cache.
- The action is pinned to a specific commit SHA rather than a semver tag for security.

## Testing

The change was verified using the existing `.github/workflows/scripts/check-workflow-security.py` script to ensure no unpinned actions or AWS credential regressions were introduced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the `build` job in the deploy workflow from `ubuntu-latest` to Blacksmith's `blacksmith-8vcpu-ubuntu-2404` runner and swaps `docker/setup-buildx-action` for `useblacksmith/setup-docker-builder@v1` to enable persistent Docker layer caching across runs.

- The Blacksmith setup action is pinned to a specific commit SHA (`a592b831ebb20e68f7cf47329cf2c3c67b8a7655`) rather than a mutable tag, which follows security best practices and matches Blacksmith's own recommendation for production environments.
- Per Blacksmith documentation, using `setup-docker-builder` (instead of the full `useblacksmith/build-push-action`) is the correct integration path when Docker commands are invoked directly (here via `pnpm run docker:build`), so no further migration is required.
- All other jobs (`prepare-matrix`, `run-clickhouse-migrations`, `deploy`, `sentry_release`, etc.) remain on `ubuntu-latest`, and the AWS ECR login, matrix strategy, and ECS deploy steps are untouched.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the build runner and Docker setup action, with no modifications to build logic, credentials handling, or deploy steps.

Only two lines are changed: the runner label and the Docker setup action. The Blacksmith action is a legitimate, documented integration for workflows that invoke Docker directly rather than through build-push-action. It is pinned to a commit SHA (recommended for production). The first post-merge build will be uncached, but subsequent runs will benefit from layer reuse. No correctness, security, or reliability concerns were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy.yml | Switches the `build` job runner to `blacksmith-8vcpu-ubuntu-2404` and replaces `docker/setup-buildx-action` with `useblacksmith/setup-docker-builder@v1` (pinned to commit SHA) for persistent Docker layer caching; all other jobs and build steps are unchanged. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant BS as Blacksmith Runner<br/>(blacksmith-8vcpu-ubuntu-2404)
    participant BK as BuildKit Cache<br/>(Blacksmith Persistent)
    participant ECR as Amazon ECR

    GH->>BS: Trigger build job (matrix per service)
    BS->>BK: setup-docker-builder hydrates BuildKit with cached layers from prior runs
    BS->>BS: pnpm ci (install deps)
    BS->>BK: docker buildx build (via pnpm run docker:build) reuses cached layers
    BK-->>BS: Cache hit: only changed layers rebuilt
    BS->>ECR: docker push (latest + SHA tag)
    BS->>BK: Commit updated layer cache for next run
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;next&#39; into cursor/deploy-b..."](https://github.com/novuhq/novu/commit/c066d54b05d537d869066f3b242bb72339ecb56e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34368279)</sub>

<!-- /greptile_comment -->