### PR TITLE
fix(api-service): sequential MCP tool approval and observer pause delivery fixes NV-7841

### DIFF
--- a/apps/api/src/app/agents/usecases/handle-plan-progress/handle-plan-progress.command.ts
+++ b/apps/api/src/app/agents/usecases/handle-plan-progress/handle-plan-progress.command.ts
@@ -8,6 +8,7 @@ export interface ToolProgressPayload {
   toolName?: string;
   mcpServerName?: string;
   status?: 'running' | 'complete' | 'error';
+  details?: string;
   toolInput?: Record<string, unknown>;
 }
 

--- a/apps/api/src/app/agents/usecases/handle-plan-progress/handle-plan-progress.usecase.ts
+++ b/apps/api/src/app/agents/usecases/handle-plan-progress/handle-plan-progress.usecase.ts
@@ -81,7 +81,7 @@ export class HandlePlanProgress {
     const toolName = toolProgress.toolName || existing?.toolName || 'Tool';
     const mcpServerName = toolProgress.mcpServerName || existing?.mcpServerName;
     const status: PlanTaskStatus = toolProgress.status === 'running' ? 'in_progress' : toolProgress.status;
-    const details = formatToolInputSummary(toolProgress.toolInput) || existing?.details;
+    const details = toolProgress.details || formatToolInputSummary(toolProgress.toolInput) || existing?.details;
 
     tasks.set(toolProgress.toolUseId, { toolUseId: toolProgress.toolUseId, toolName, mcpServerName, status, details });
 
@@ -136,13 +136,8 @@ export class HandlePlanProgress {
       return;
     }
 
-    const finalStatus: PlanTaskStatus = toolProgress.action === 'fail' ? 'error' : 'complete';
     const title = toolProgress.action === 'fail' ? 'Something went wrong' : 'Finished thinking';
-
     const tasks = this.collectTasks(existingActivities);
-    for (const task of tasks.values()) {
-      task.status = finalStatus;
-    }
 
     await this.postOrEditPlan(command, planMessageId, this.toModel(title, tasks, true));
   }

--- a/apps/api/src/app/agents/usecases/tool-approval/approval-card.builder.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/approval-card.builder.ts
@@ -84,27 +84,19 @@ export function extractPendingToolApprovals(response: ThalamusResponse): Pending
 }
 
 function formatToolLabel(t: PendingToolApproval): string {
-  const name = t.mcpServerName ? `${t.toolName} from ${t.mcpServerName}` : t.toolName;
   const input = t.input ? `: ${summariseInput(t.input)}` : '';
 
-  return `${name}${input}`;
+  if (t.mcpServerName) {
+    return `${t.mcpServerName} -> ${t.toolName}${input}`;
+  }
+
+  return `${t.toolName}${input}`;
 }
 
-export function buildToolApprovalCard(pendingTools: PendingToolApproval[], turnId: string): Record<string, unknown> {
-  const tool = pendingTools[0];
-  const serverLabel = tool.mcpServerName ? ` from ${tool.mcpServerName}` : '';
+export function buildToolApprovalCard(tool: PendingToolApproval, turnId: string): Record<string, unknown> {
   const toolLabel = formatToolLabel(tool);
-  const mcpDisplayName = tool.mcpServerName ?? 'MCP';
 
-  const inputSummary = tool.input ? summariseInput(tool.input) : '';
-  const description = inputSummary
-    ? `I'd like to call \`${tool.toolName}\`${serverLabel}:\n\`\`\`\n${inputSummary}\n\`\`\``
-    : `I'd like to call \`${tool.toolName}\`${serverLabel}.`;
-
-  const children: Record<string, unknown>[] = [{ type: 'text', content: description }];
-
-  children.push(
-    { type: 'divider' },
+  const children: Record<string, unknown>[] = [
     {
       type: 'actions',
       children: [
@@ -123,80 +115,47 @@ export function buildToolApprovalCard(pendingTools: PendingToolApproval[], turnI
           value: toolLabel,
         },
       ],
-    }
-  );
-
-  if (pendingTools.length === 1) {
-    children.push(
-      { type: 'divider' },
-      {
-        type: 'actions',
-        children: [
-          {
-            type: 'button',
-            id: buildPersistTrustActionId('approve-tool', tool, turnId),
-            label: `Approve & always allow ${tool.toolName}`,
-            style: 'default',
-            value: toolLabel,
-          },
-          {
-            type: 'button',
-            id: buildPersistTrustActionId('approve-server', tool, turnId),
-            label: `Approve & always allow all ${mcpDisplayName} tools`,
-            style: 'default',
-            value: toolLabel,
-          },
-        ],
-      }
-    );
-  }
-
-  if (pendingTools.length > 1) {
-    const allIds = pendingTools.map((t) => t.toolUseId).join(',');
-    const allLabels = pendingTools.map((t) => formatToolLabel(t)).join('\n');
-    children.push({
+    },
+    { type: 'divider' },
+    {
       type: 'actions',
       children: [
         {
           type: 'button',
-          id: `${TOOL_APPROVAL_ACTION_PREFIX}:approve:${allIds}:${turnId}`,
-          label: `Approve All (${pendingTools.length})`,
-          style: 'primary',
-          value: allLabels,
+          id: buildPersistTrustActionId('approve-tool', tool, turnId),
+          label: `Approve & Always allow ${tool.toolName}`,
+          style: 'default',
+          value: toolLabel,
         },
         {
           type: 'button',
-          id: `${TOOL_APPROVAL_ACTION_PREFIX}:deny:${allIds}:${turnId}`,
-          label: `Deny All (${pendingTools.length})`,
-          style: 'danger',
-          value: allLabels,
+          id: buildPersistTrustActionId('approve-server', tool, turnId),
+          label: `Approve & Always allow all from ${tool.mcpServerName}`,
+          style: 'default',
+          value: toolLabel,
         },
       ],
-    });
-  }
+    },
+  ];
 
   return {
     type: 'card',
     title: 'Tool Approval',
+    subtitle: toolLabel,
     children,
   };
 }
 
-export function buildToolApprovalVerdictCard(
-  approved: boolean,
-  toolCount: number,
-  toolDescription?: string
-): Record<string, unknown> {
+export function buildToolApprovalVerdictCard(approved: boolean, toolDescription?: string): Record<string, unknown> {
   const emoji = approved ? '✅' : '🚫';
   const verb = approved ? 'Approved' : 'Denied';
-  const suffix = toolCount > 1 ? ` all ${toolCount} tools` : '';
   const subtitle = toolDescription || undefined;
 
   return {
     type: 'card',
     title: 'Tool Approval',
     subtitle,
-    children: [{ type: 'text', content: `${emoji}  ${verb}${suffix}` }],
+    children: [{ type: 'text', content: `${emoji}  ${verb}` }],
   };
 }
 

--- a/apps/api/src/app/agents/usecases/tool-approval/confirm-tool-approval.usecase.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/confirm-tool-approval.usecase.ts
@@ -1,13 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { PinoLogger } from '@novu/application-generic';
-import { AgentMcpServerRepository, McpConnectionRepository, SubscriberRepository } from '@novu/dal';
+import {
+  AgentMcpServerRepository,
+  ConversationRepository,
+  McpConnectionRepository,
+  SubscriberRepository,
+} from '@novu/dal';
 
 import { ManagedAgentService } from '../../services/managed-agent.service';
+import { ManagedAgentProviderFactory } from '../../services/managed-agent-provider-factory';
 import { HandleAgentReplyCommand } from '../handle-agent-reply/handle-agent-reply.command';
 import { HandleAgentReply } from '../handle-agent-reply/handle-agent-reply.usecase';
 import { HandlePlanProgressCommand } from '../handle-plan-progress/handle-plan-progress.command';
 import { HandlePlanProgress } from '../handle-plan-progress/handle-plan-progress.usecase';
-import { buildToolApprovalVerdictCard } from './approval-card.builder';
+import { buildToolApprovalVerdictCard, type ParsedToolApprovalAction } from './approval-card.builder';
 import { ConfirmToolApprovalCommand } from './confirm-tool-approval.command';
 import { mergeToolTrustPatch, resolveTrustForPendingTool } from './tool-trust.helper';
 
@@ -17,6 +23,8 @@ export class ConfirmToolApproval {
     private readonly subscriberRepository: SubscriberRepository,
     private readonly agentMcpServerRepository: AgentMcpServerRepository,
     private readonly mcpConnectionRepository: McpConnectionRepository,
+    private readonly conversationRepository: ConversationRepository,
+    private readonly providerFactory: ManagedAgentProviderFactory,
     private readonly managedAgentService: ManagedAgentService,
     private readonly handleAgentReply: HandleAgentReply,
     private readonly handlePlanProgress: HandlePlanProgress,
@@ -27,53 +35,10 @@ export class ConfirmToolApproval {
 
   async execute(command: ConfirmToolApprovalCommand): Promise<void> {
     const { parsed } = command;
-    let persistTrust: { connectionId: string; toolName: string; scope: 'tool' | 'server' } | undefined;
 
-    // "Approve & always allow …": save always_allow on the MCP connection (from action.id),
-    // then tell the runtime to continue the paused agent turn.
-    if (parsed.approved && parsed.persistScope && command.subscriberId) {
-      const subscriber = await this.subscriberRepository.findBySubscriberId(
-        command.environmentId,
-        command.subscriberId
-      );
-      const toolName = parsed.toolName;
-      const mcpServerName = parsed.mcpServerName;
+    await this.persistTrustIfNeeded(command, parsed);
 
-      if (subscriber && mcpServerName && toolName) {
-        const resolution = await resolveTrustForPendingTool({
-          findOAuthEnablementsForAgent: (params) => this.agentMcpServerRepository.findOAuthEnablementsForAgent(params),
-          findSubscriberConnection: (params) => this.mcpConnectionRepository.findSubscriberConnection(params),
-          params: {
-            environmentId: command.environmentId,
-            organizationId: command.organizationId,
-            agentId: command.agentId,
-            subscriberMongoId: subscriber._id,
-            mcpServerName,
-            toolName,
-          },
-        });
-
-        if (resolution) {
-          persistTrust = {
-            connectionId: resolution.connection._id,
-            toolName,
-            scope: parsed.persistScope,
-          };
-        }
-      }
-    }
-
-    if (parsed.approved && persistTrust) {
-      await this.mcpConnectionRepository.mergeToolTrust({
-        connectionId: persistTrust.connectionId,
-        environmentId: command.environmentId,
-        organizationId: command.organizationId,
-        patch: mergeToolTrustPatch({
-          scope: persistTrust.scope,
-          toolName: persistTrust.toolName,
-        }),
-      });
-    }
+    const toolUseIds = await this.resolveConfirmationToolUseIds(command, parsed);
 
     await this.managedAgentService.resumeWithToolResults({
       conversationId: command.conversationId,
@@ -83,28 +48,169 @@ export class ConfirmToolApproval {
       integrationIdentifier: command.integrationIdentifier,
       subscriberId: command.subscriberId,
       platform: command.platform,
-      toolUseIds: parsed.toolUseIds,
+      toolUseIds,
       approved: parsed.approved,
       turnId: parsed.turnId,
     });
 
-    if (command.sourceMessageId) {
-      const verdictCard = buildToolApprovalVerdictCard(parsed.approved, parsed.toolUseIds.length, command.actionValue);
-      this.handleAgentReply
-        .execute(
-          HandleAgentReplyCommand.create({
-            userId: command.userId,
-            environmentId: command.environmentId,
-            organizationId: command.organizationId,
-            conversationId: command.conversationId,
-            agentIdentifier: command.agentIdentifier,
-            integrationIdentifier: command.integrationIdentifier,
-            edit: { messageId: command.sourceMessageId, content: { card: verdictCard } },
-          })
-        )
-        .catch((err) => {
-          this.logger.warn(err, 'Failed to update tool approval card with verdict');
-        });
+    this.updateCardWithVerdict(command, parsed.approved);
+    this.updatePlanProgress(command, parsed);
+  }
+
+  private async persistTrustIfNeeded(
+    command: ConfirmToolApprovalCommand,
+    parsed: ParsedToolApprovalAction
+  ): Promise<void> {
+    if (!parsed.approved || !parsed.persistScope || !command.subscriberId) {
+      return;
+    }
+
+    const toolName = parsed.toolName;
+    const mcpServerName = parsed.mcpServerName;
+
+    if (!toolName || !mcpServerName) {
+      return;
+    }
+
+    const subscriber = await this.subscriberRepository.findBySubscriberId(command.environmentId, command.subscriberId);
+
+    if (!subscriber) {
+      return;
+    }
+
+    const resolution = await resolveTrustForPendingTool({
+      findOAuthEnablementsForAgent: (params) => this.agentMcpServerRepository.findOAuthEnablementsForAgent(params),
+      findSubscriberConnection: (params) => this.mcpConnectionRepository.findSubscriberConnection(params),
+      params: {
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        agentId: command.agentId,
+        subscriberMongoId: subscriber._id,
+        mcpServerName,
+        toolName,
+      },
+    });
+
+    if (!resolution) {
+      return;
+    }
+
+    await this.mcpConnectionRepository.mergeToolTrust({
+      connectionId: resolution.connection._id,
+      environmentId: command.environmentId,
+      organizationId: command.organizationId,
+      patch: mergeToolTrustPatch({
+        scope: parsed.persistScope,
+        toolName,
+      }),
+    });
+  }
+
+  private async resolveConfirmationToolUseIds(
+    command: ConfirmToolApprovalCommand,
+    parsed: ParsedToolApprovalAction
+  ): Promise<string[]> {
+    if (parsed.persistScope !== 'server' || !parsed.mcpServerName) {
+      return parsed.toolUseIds;
+    }
+
+    const sessionId = await this.getExternalSessionId(command);
+
+    if (!sessionId) {
+      return parsed.toolUseIds;
+    }
+
+    const runtimeProvider = await this.providerFactory.tryGetByAgentIdentifier(
+      command.agentIdentifier,
+      command.environmentId
+    );
+
+    if (!runtimeProvider) {
+      return parsed.toolUseIds;
+    }
+
+    try {
+      const pendingTools = await runtimeProvider.getAllPendingToolApprovals(sessionId);
+      const mcpToolUseIds = pendingTools
+        .filter((tool) => tool.mcpServerName === parsed.mcpServerName)
+        .map((tool) => tool.toolUseId);
+
+      if (mcpToolUseIds.length > 0) {
+        return mcpToolUseIds;
+      }
+    } catch (err) {
+      this.logger.warn(
+        { err: err instanceof Error ? err.message : String(err), conversationId: command.conversationId },
+        'getAllPendingToolApprovals failed; confirming clicked tool only'
+      );
+    }
+
+    return parsed.toolUseIds;
+  }
+
+  private async getExternalSessionId(command: ConfirmToolApprovalCommand): Promise<string | undefined> {
+    const conversation = await this.conversationRepository.findOne(
+      {
+        _id: command.conversationId,
+        _environmentId: command.environmentId,
+        _organizationId: command.organizationId,
+      },
+      ['externalSessionId']
+    );
+
+    return conversation?.externalSessionId;
+  }
+
+  private updateCardWithVerdict(command: ConfirmToolApprovalCommand, approved: boolean): void {
+    if (!command.sourceMessageId) {
+      return;
+    }
+
+    const verdictCard = buildToolApprovalVerdictCard(approved, command.actionValue);
+    this.handleAgentReply
+      .execute(
+        HandleAgentReplyCommand.create({
+          userId: command.userId,
+          environmentId: command.environmentId,
+          organizationId: command.organizationId,
+          conversationId: command.conversationId,
+          agentIdentifier: command.agentIdentifier,
+          integrationIdentifier: command.integrationIdentifier,
+          edit: { messageId: command.sourceMessageId, content: { card: verdictCard } },
+        })
+      )
+      .catch((err) => {
+        this.logger.warn(err, 'Failed to update tool approval card with verdict');
+      });
+  }
+
+  private updatePlanProgress(command: ConfirmToolApprovalCommand, parsed: ParsedToolApprovalAction): void {
+    if (!parsed.approved) {
+      for (const toolUseId of parsed.toolUseIds) {
+        this.handlePlanProgress
+          .execute(
+            HandlePlanProgressCommand.create({
+              userId: command.userId,
+              environmentId: command.environmentId,
+              organizationId: command.organizationId,
+              conversationId: command.conversationId,
+              agentIdentifier: command.agentIdentifier,
+              integrationIdentifier: command.integrationIdentifier,
+              toolProgress: {
+                turnId: parsed.turnId,
+                action: 'tool-use',
+                toolUseId,
+                status: 'error',
+                details: 'Denied',
+              },
+            })
+          )
+          .catch((err) => {
+            this.logger.warn(err, 'Failed to update plan card after tool denial');
+          });
+      }
+
+      return;
     }
 
     this.handlePlanProgress
@@ -118,7 +224,7 @@ export class ConfirmToolApproval {
           integrationIdentifier: command.integrationIdentifier,
           toolProgress: {
             turnId: parsed.turnId,
-            action: parsed.approved ? 'approved' : 'denied',
+            action: 'approved',
           },
         })
       )

--- a/apps/api/src/app/agents/usecases/tool-approval/handle-pending-tool-approvals.usecase.ts
+++ b/apps/api/src/app/agents/usecases/tool-approval/handle-pending-tool-approvals.usecase.ts
@@ -1,5 +1,5 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import type { PendingToolApproval } from '@novu/application-generic';
+import type { IAgentRuntimeProvider, PendingToolApproval } from '@novu/application-generic';
 import { PinoLogger } from '@novu/application-generic';
 import {
   AgentMcpServerRepository,
@@ -46,29 +46,7 @@ export class HandlePendingToolApprovals {
       return;
     }
 
-    // Which tools need approval?
-    // 1. extractPendingToolApprovals — read response.actionsRequired from this webhook (fast, no API call).
-    // 2. getAllPendingToolApprovals — fallback when the webhook says requires-action but omits tool details
-    //    (e.g. user already approved some tools in the same session and others are still waiting).
-    let pendingTools = extractPendingToolApprovals(command.response);
-
-    if (pendingTools.length === 0) {
-      try {
-        pendingTools = await runtimeProvider.getAllPendingToolApprovals(command.sessionId);
-      } catch (err) {
-        this.logger.warn(
-          { err: err instanceof Error ? err.message : String(err), sessionId: command.sessionId },
-          'getAllPendingToolApprovals failed; cannot render Approve/Deny card'
-        );
-        captureAgentWarning(err, {
-          component: 'handle-pending-tool-approvals',
-          operation: 'get-all-pending-tool-approvals',
-          sessionId: command.sessionId,
-        });
-
-        return;
-      }
-    }
+    const pendingTools = await this.fetchPendingTools(command, runtimeProvider);
 
     if (pendingTools.length === 0) {
       this.logger.warn(
@@ -79,51 +57,128 @@ export class HandlePendingToolApprovals {
       return;
     }
 
-    // Split by mcp_connection.toolTrust: auto-approve matches, card for the rest.
     const { trustedTools, needsPromptTools } = await this.partitionByTrust(command, pendingTools);
 
-    // Trusted: tell Anthropic yes without posting anything to the chat thread.
     if (trustedTools.length > 0) {
       try {
-        await this.managedAgentService.resumeWithToolResults({
-          conversationId: command.conversationId,
-          environmentId: command.environmentId,
-          organizationId: command.organizationId,
-          agentIdentifier: command.agentIdentifier,
-          integrationIdentifier: command.integrationIdentifier,
-          subscriberId: command.subscriberId,
-          platform: command.platform as AgentPlatformEnum | undefined,
-          toolUseIds: trustedTools.map((tool) => tool.toolUseId),
-          approved: true,
-          turnId: command.turnId,
-        });
-      } catch (err) {
-        this.logger.warn(
-          {
-            err: err instanceof Error ? err.message : String(err),
-            sessionId: command.sessionId,
-            toolUseIds: trustedTools.map((t) => t.toolUseId),
-          },
-          'Auto-confirm for trusted MCP tools failed; falling back to approval card'
-        );
-        captureAgentWarning(err, {
-          component: 'handle-pending-tool-approvals',
-          operation: 'auto-confirm-trusted-tools',
-          sessionId: command.sessionId,
-        });
-
-        await this.deliverCard(command, pendingTools);
+        await this.autoConfirmTrustedTools(command, trustedTools);
+      } catch {
+        await this.deliverAutoConfirmFailure(command);
 
         return;
       }
-    }
 
-    if (needsPromptTools.length === 0) {
+      // Resume succeeded — the follow-up requires-action webhook will post the next card.
       return;
     }
 
-    // Untrusted (or mixed batch remainder): post Approve/Deny card to the thread.
-    await this.deliverCard(command, needsPromptTools);
+    const nextTool = needsPromptTools[0];
+
+    if (!nextTool) {
+      return;
+    }
+
+    // No trusted tools in this batch — prompt for the first one only (sequential approval).
+    await this.deliverApprovalCard(command, nextTool);
+  }
+
+  private async fetchPendingTools(
+    command: HandlePendingToolApprovalsCommand,
+    runtimeProvider: IAgentRuntimeProvider
+  ): Promise<PendingToolApproval[]> {
+    const fromResponse = extractPendingToolApprovals(command.response);
+
+    if (fromResponse.length > 0) {
+      return fromResponse;
+    }
+
+    try {
+      return await runtimeProvider.getAllPendingToolApprovals(command.sessionId);
+    } catch (err) {
+      this.logger.warn(
+        { err: err instanceof Error ? err.message : String(err), sessionId: command.sessionId },
+        'getAllPendingToolApprovals failed; cannot render Approve/Deny card'
+      );
+      captureAgentWarning(err, {
+        component: 'handle-pending-tool-approvals',
+        operation: 'get-all-pending-tool-approvals',
+        sessionId: command.sessionId,
+      });
+
+      return [];
+    }
+  }
+
+  private async autoConfirmTrustedTools(
+    command: HandlePendingToolApprovalsCommand,
+    trustedTools: PendingToolApproval[]
+  ): Promise<void> {
+    try {
+      await this.managedAgentService.resumeWithToolResults({
+        conversationId: command.conversationId,
+        environmentId: command.environmentId,
+        organizationId: command.organizationId,
+        agentIdentifier: command.agentIdentifier,
+        integrationIdentifier: command.integrationIdentifier,
+        subscriberId: command.subscriberId,
+        platform: command.platform as AgentPlatformEnum | undefined,
+        toolUseIds: trustedTools.map((tool) => tool.toolUseId),
+        approved: true,
+        turnId: command.turnId,
+      });
+    } catch (err) {
+      this.logger.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          sessionId: command.sessionId,
+          toolUseIds: trustedTools.map((t) => t.toolUseId),
+        },
+        'Auto-confirm for trusted MCP tools failed'
+      );
+      captureAgentWarning(err, {
+        component: 'handle-pending-tool-approvals',
+        operation: 'auto-confirm-trusted-tools',
+        sessionId: command.sessionId,
+      });
+
+      throw err;
+    }
+  }
+
+  private async deliverAutoConfirmFailure(command: HandlePendingToolApprovalsCommand): Promise<void> {
+    const message = 'The agent is temporarily unavailable. Please try again later.';
+
+    try {
+      await this.handleAgentReply.execute(
+        HandleAgentReplyCommand.create({
+          userId: command.userId,
+          organizationId: command.organizationId,
+          environmentId: command.environmentId,
+          conversationId: command.conversationId,
+          agentIdentifier: command.agentIdentifier,
+          integrationIdentifier: command.integrationIdentifier,
+          reply: { markdown: message },
+        })
+      );
+      await this.handlePlanProgress.execute(
+        HandlePlanProgressCommand.create({
+          userId: command.userId,
+          organizationId: command.organizationId,
+          environmentId: command.environmentId,
+          conversationId: command.conversationId,
+          agentIdentifier: command.agentIdentifier,
+          integrationIdentifier: command.integrationIdentifier,
+          toolProgress: { turnId: command.turnId, action: 'fail' },
+        })
+      );
+    } catch (deliveryErr) {
+      this.logger.error(deliveryErr, `Failed to deliver auto-confirm error for session ${command.sessionId}`);
+      captureAgentException(deliveryErr, {
+        component: 'handle-pending-tool-approvals',
+        operation: 'deliver-auto-confirm-failure',
+        sessionId: command.sessionId,
+      });
+    }
   }
 
   private async partitionByTrust(
@@ -175,9 +230,9 @@ export class HandlePendingToolApprovals {
     return { trustedTools, needsPromptTools };
   }
 
-  private async deliverCard(
+  private async deliverApprovalCard(
     command: HandlePendingToolApprovalsCommand,
-    pendingTools: PendingToolApproval[]
+    tool: PendingToolApproval
   ): Promise<void> {
     try {
       await this.handleAgentReply.execute(
@@ -188,7 +243,7 @@ export class HandlePendingToolApprovals {
           conversationId: command.conversationId,
           agentIdentifier: command.agentIdentifier,
           integrationIdentifier: command.integrationIdentifier,
-          reply: { card: buildToolApprovalCard(pendingTools, command.turnId) },
+          reply: { card: buildToolApprovalCard(tool, command.turnId) },
         })
       );
     } catch (err) {

--- a/enterprise/workers/thalamus-observer/src/index.ts
+++ b/enterprise/workers/thalamus-observer/src/index.ts
@@ -222,6 +222,7 @@ export class SessionObserver extends Agent<Env, State> {
 
     const acc = parser.createAccumulator();
     let sequence = this.getNextSequence(params.sessionId);
+    let pauseWebhookSent = false;
 
     for await (const sseEvent of eventStream) {
       if (signal.aborted) break;
@@ -244,35 +245,69 @@ export class SessionObserver extends Agent<Env, State> {
 
       if (acc.done) {
         if (acc.finishReason === 'requires-action') {
-          const content = this.reconstructContent(params.sessionId);
-          const intermediateFinish: StreamPart = {
-            type: 'finish',
-            response: { ...acc.toResponse(params.sessionId), content },
-          };
-          this.persistEvent(params.sessionId, sequence++, intermediateFinish);
-          this.triggerDelivery(params);
-          acc.done = false;
-          acc.finishReason = 'stop';
-          acc.actionsRequired = [];
-        } else {
-          break;
+          sequence = this.emitFinishWebhook(params, params.sessionId, sequence, acc);
+          pauseWebhookSent = true;
         }
+
+        // One requires-action webhook per observe run. User approval starts a fresh
+        // observe via startObserving(); continuing this SSE caused duplicate pause
+        // webhooks when Anthropic emitted multiple session.status_idle events.
+        break;
       }
     }
 
-    if (acc.done) {
-      const content = this.reconstructContent(params.sessionId);
-      const finish: StreamPart = {
-        type: 'finish',
-        response: { ...acc.toResponse(params.sessionId), content },
-      };
-      this.persistEvent(params.sessionId, sequence++, finish);
-      this.triggerDelivery(params);
+    // acc.done stays true after the break above — do not persist a second finish.
+    if (acc.done && !pauseWebhookSent) {
+      sequence = this.emitFinishWebhook(params, params.sessionId, sequence, acc);
+      this.finalizeObservation(params, signal, 'terminal-complete');
+    } else if (pauseWebhookSent) {
+      this.finalizeObservation(params, signal, 'pause-complete');
+    } else {
+      this.finalizeObservation(params, signal, 'stream-error');
+    }
+  }
+
+  private emitFinishWebhook(
+    params: ObservationParams,
+    sessionId: string,
+    sequence: number,
+    acc: EdgeAccumulator
+  ): number {
+    const content = this.reconstructContent(sessionId);
+    const finish: StreamPart = {
+      type: 'finish',
+      response: { ...acc.toResponse(sessionId), content },
+    };
+    this.persistEvent(sessionId, sequence, finish);
+    this.triggerDelivery(params);
+
+    return sequence + 1;
+  }
+
+  private finalizeObservation(
+    params: ObservationParams,
+    signal: AbortSignal,
+    endState: 'terminal-complete' | 'pause-complete' | 'stream-error'
+  ): void {
+    if (endState === 'terminal-complete') {
       this.updateObservation({
         ...this.state.observation!,
         status: 'completed',
       });
-    } else if (!signal.aborted) {
+
+      return;
+    }
+
+    if (endState === 'pause-complete') {
+      this.updateObservation({
+        ...(this.state.observation ?? params),
+        status: 'completed',
+      });
+
+      return;
+    }
+
+    if (!signal.aborted) {
       this.updateObservation({
         ...(this.state.observation ?? params),
         status: 'error',
@@ -407,9 +442,10 @@ export class SessionObserver extends Agent<Env, State> {
             return;
           }
           if (event.type === 'finish') {
-            const isIntermediate =
+            const isPauseWebhook =
               (event as { response?: { finishReason?: string } }).response?.finishReason === 'requires-action';
-            if (isIntermediate) {
+            if (isPauseWebhook) {
+              // Pause is not terminal — the next user approval starts a new observe run.
               this.markDelivered(row.id);
 
               continue;


### PR DESCRIPTION
## Summary

- **Sequential approval UX**: post one tool approval card at a time; the next card arrives on the following `requires-action` webhook after the user resolves the current tool.
- **Trust shortcuts**: card subtitle shows `{MCP} -> {tool}: {input}`; buttons for approve-once, always-allow tool, and always-allow all tools from an MCP server.
- **Approve-server batching**: confirming “always allow all from {MCP}” resumes with all pending tool IDs from that server in one call.
- **Auto-confirm path**: trusted tools auto-resume without posting a card; successful auto-confirm returns early so the follow-up webhook posts the next card (avoids duplicates).
- **Observer fix**: emit one `requires-action` finish webhook per observe run, then break the SSE loop — prevents duplicate approval cards when Anthropic emits multiple `session.status_idle` events on the same stream.

Addresses **NV-7841**, **NV-7846**, **NV-7865**, **NV-7857**, **NV-7836**.

```mermaid
sequenceDiagram
  participant User
  participant API
  participant Observer
  participant Anthropic

  User->>API: prompt
  API->>Observer: startObserving (run A)
  Observer->>Anthropic: SSE
  Anthropic-->>Observer: mcp_tool_use x N + status_idle
  Observer->>API: one requires-action webhook
  API->>User: one approval card
  Note over Observer: break SSE (no second webhook)

  User->>API: approve / always-allow
  API->>Anthropic: tool confirmation(s)
  API->>Observer: startObserving (run B)
  Observer->>API: one requires-action webhook
  API->>User: next approval card
```

## Enterprise note

Changes include `enterprise/workers/thalamus-observer`. **Validate Submodule Sync** may fail until a matching branch is opened in `novuhq/packages-enterprise` from `next` — expected for `.source` submodule workflow.

## Test plan

- [ ] Prompt agent with Linear + Notion MCPs to trigger multiple tool approvals in one turn
- [ ] Verify first card is a single tool (not a batch list / prose block)
- [ ] Approve with **Always allow all from Linear** — expect exactly one next card (not duplicate)
- [ ] Walk through remaining Notion tools one card at a time
- [ ] Confirm **Always allow {tool}** / **Always allow all from {MCP}** persist trust and skip future prompts for matching tools
- [ ] Restart thalamus-observer locally after pulling this branch


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

This PR implements sequential MCP tool approval delivery and fixes observer pause webhooks. Users now approve tools one at a time—each resolved approval triggers the next card instead of showing all pending tools upfront. Trusted tools auto-approve without user interaction. The observer emits a single pause webhook per run, preventing duplicate approval cards when Anthropic sends multiple idle events.

## Affected areas

**api**: Tool approval card building refactored to create single-tool cards instead of multi-tool batches. Updated button labels to show `{MCP} -> {tool}` relationships and added trust-shortcut buttons for approve-once, always-allow-tool, and always-allow-server actions. Approval confirmation now persists trust based on user selection, dynamically resolves pending tool IDs (including server-wide batching), and updates plan progress per-tool.

**api**: Plan progress handling updated to use tool-provided `details` when available and removed forced in-memory status overwrites; task statuses now derive from stored activities.

**enterprise**: The thalamus-observer worker now tracks whether a pause webhook has been emitted during an observe run. When a `requires-action` finish arrives, it emits the webhook, sets a flag, and breaks the SSE loop—preventing duplicate cards from multiple idle events on the same stream.

## Key technical decisions

- Sequential delivery requires per-tool card building and completion tracking per approval decision.
- Trust persistence logic integrated into confirmation handler with runtime-based tool ID resolution for server-wide approvals.
- Observer pause tracking prevents SSE loop continuation after terminal pause, eliminating duplicate webhooks.

## Testing

Manual verification recommended per the test plan: prompt agent with multiple MCPs, verify sequential card delivery, test trust-shortcut persistence, and confirm observer pause behavior. No new unit/e2e tests noted in the summary.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->