### PR TITLE
chore(dashboard): reuse existing claude creds when migrating demo agent fixes NV-7856

### DIFF
--- a/apps/dashboard/src/components/agents/connectors/integration-dropdown.tsx
+++ b/apps/dashboard/src/components/agents/connectors/integration-dropdown.tsx
@@ -1,0 +1,221 @@
+import { type IIntegration } from '@novu/shared';
+import { AnimatePresence, motion } from 'motion/react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { RiAddLine, RiAlertLine, RiCheckLine, RiExpandUpDownLine } from 'react-icons/ri';
+import {
+  DemoCredentialBadge,
+  DemoCredentialDropdownItem,
+} from '@/components/integrations/components/demo-credential-badge';
+import { isDemoIntegration } from '@/components/integrations/components/utils/helpers';
+import { Badge } from '@/components/primitives/badge';
+import { Command, CommandEmpty, CommandGroup, CommandItem, CommandList } from '@/components/primitives/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/primitives/popover';
+import { cn } from '@/utils/ui';
+import { getClaudeManagedAgentIntegrations } from './claude-managed-integrations';
+import type { ConnectorOption } from './connector-options';
+
+const GROUP_HEADING_CLASSNAME =
+  '**:[[cmdk-group-heading]]:text-text-soft **:[[cmdk-group-heading]]:text-label-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:leading-4 **:[[cmdk-group-heading]]:px-1 **:[[cmdk-group-heading]]:py-1';
+
+export type IntegrationDropdownStatus = 'idle' | 'valid' | 'missing';
+
+type IntegrationDropdownProps = {
+  connector: ConnectorOption;
+  selectedIntegrationId?: string;
+  integrations: IIntegration[] | undefined;
+  status?: IntegrationDropdownStatus;
+  showStatusBadge?: boolean;
+  disabled?: boolean;
+  setupLabel?: string;
+  emptyLabel?: string;
+  /** When true, demo credentials (e.g. `NovuAnthropic`) are hidden from the dropdown. */
+  excludeDemo?: boolean;
+  onSelectIntegration: (integration: IIntegration) => void;
+  onRequestSetupCredentials: () => void;
+};
+
+function StatusBadge({ status }: { status: IntegrationDropdownStatus }) {
+  if (status === 'valid') {
+    return (
+      <span className="bg-success-base flex size-3.5 items-center justify-center rounded-full">
+        <RiCheckLine className="text-static-white size-2.5" aria-hidden />
+      </span>
+    );
+  }
+
+  if (status === 'missing') {
+    return <RiAlertLine className="text-warning-base size-3.5" aria-hidden />;
+  }
+
+  return null;
+}
+
+function TriggerGlyph({ status, showBadge }: { status: IntegrationDropdownStatus; showBadge: boolean }) {
+  return (
+    <span className="flex shrink-0 items-center gap-1">
+      <AnimatePresence initial={false}>
+        {showBadge && status !== 'idle' ? (
+          <motion.span
+            key="status-badge"
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+            className="flex items-center"
+          >
+            <StatusBadge status={status} />
+          </motion.span>
+        ) : null}
+      </AnimatePresence>
+      <RiExpandUpDownLine className="text-text-soft size-3.5" aria-hidden />
+    </span>
+  );
+}
+
+export function IntegrationDropdown({
+  connector,
+  selectedIntegrationId,
+  integrations,
+  status = 'idle',
+  showStatusBadge = false,
+  disabled,
+  setupLabel,
+  emptyLabel = 'No integrations yet.',
+  excludeDemo = false,
+  onSelectIntegration,
+  onRequestSetupCredentials,
+}: IntegrationDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const prevOpenRef = useRef(false);
+
+  useEffect(() => {
+    prevOpenRef.current = open;
+  }, [open]);
+
+  const matchingIntegrations = useMemo(() => {
+    if (!connector.providerId) return [];
+
+    const all = getClaudeManagedAgentIntegrations(integrations, connector.providerId);
+
+    return excludeDemo ? all.filter((integration) => !isDemoIntegration(integration.providerId)) : all;
+  }, [integrations, connector.providerId, excludeDemo]);
+
+  const selectedIntegration = useMemo(
+    () => matchingIntegrations.find((i) => i._id === selectedIntegrationId),
+    [matchingIntegrations, selectedIntegrationId]
+  );
+
+  const setupItemLabel = setupLabel ?? `Setup ${connector.providerLabel ?? 'provider'} credentials`;
+
+  const renderTriggerSecondary = () => {
+    if (!selectedIntegration) {
+      return null;
+    }
+
+    if (isDemoIntegration(selectedIntegration.providerId)) {
+      return <DemoCredentialBadge className="min-w-0 max-w-full" />;
+    }
+
+    return (
+      <Badge
+        color="gray"
+        variant="lighter"
+        size="md"
+        className="border-stroke-weak bg-bg-weak min-w-0 max-w-full truncate rounded-sm border"
+      >
+        <span className="truncate">{selectedIntegration.name}</span>
+      </Badge>
+    );
+  };
+
+  return (
+    <Popover open={open} onOpenChange={disabled ? undefined : setOpen}>
+      <PopoverTrigger asChild disabled={disabled}>
+        <button
+          type="button"
+          disabled={disabled}
+          className="border-stroke-soft bg-bg-white flex h-8 w-full items-center justify-between overflow-hidden rounded-md border px-2 py-1 shadow-xs disabled:opacity-60"
+        >
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
+            {connector.icon}
+            <span className="text-text-strong text-label-xs shrink-0 font-medium leading-4">{connector.label}</span>
+            {renderTriggerSecondary()}
+          </div>
+          <TriggerGlyph status={status} showBadge={showStatusBadge} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        portal={false}
+        className="pointer-events-auto flex max-h-[min(360px,var(--radix-popover-content-available-height))] w-(--radix-popover-trigger-width) min-w-[320px] flex-col overflow-hidden p-0"
+      >
+        <Command shouldFilter={false} loop className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <CommandList className="min-h-0 flex-1 overflow-y-auto p-1">
+            <CommandEmpty className="text-text-soft text-label-xs py-4">{emptyLabel}</CommandEmpty>
+            <CommandGroup className="p-0">
+              <CommandItem
+                value={`__setup-${connector.id}`}
+                onSelect={() => {
+                  onRequestSetupCredentials();
+                  setOpen(false);
+                }}
+                className="flex cursor-pointer items-center gap-1.5 rounded-md p-1"
+              >
+                {connector.icon}
+                <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-medium leading-4">
+                  {setupItemLabel}
+                </span>
+                <RiAddLine className="text-text-soft size-3.5 shrink-0" aria-hidden />
+              </CommandItem>
+            </CommandGroup>
+
+            {matchingIntegrations.length > 0 ? (
+              <CommandGroup heading="Existing" className={GROUP_HEADING_CLASSNAME}>
+                {matchingIntegrations.map((integration) => {
+                  const isCurrent = integration._id === selectedIntegrationId;
+                  const isDemo = isDemoIntegration(integration.providerId);
+
+                  return (
+                    <CommandItem
+                      key={integration._id}
+                      value={`integration-${integration._id}`}
+                      onSelect={() => {
+                        onSelectIntegration(integration);
+                        setOpen(false);
+                      }}
+                      className="flex min-w-0 cursor-pointer p-0"
+                    >
+                      {isDemo ? (
+                        <DemoCredentialDropdownItem
+                          providerId={integration.providerId}
+                          providerDisplayName={integration.name}
+                          isSelected={isCurrent}
+                        />
+                      ) : (
+                        <div
+                          className={cn(
+                            'flex w-full min-w-0 items-center gap-1.5 break-normal p-1',
+                            isCurrent && 'bg-bg-muted'
+                          )}
+                        >
+                          {connector.icon}
+                          <span className="text-text-sub text-label-xs min-w-0 flex-1 truncate font-medium leading-4">
+                            {integration.name}
+                          </span>
+                          <span className="text-text-soft text-label-xs shrink-0 truncate font-mono">
+                            {integration.identifier}
+                          </span>
+                        </div>
+                      )}
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            ) : null}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/dashboard/src/components/agents/demo-claude-upgrade-panel.tsx
+++ b/apps/dashboard/src/components/agents/demo-claude-upgrade-panel.tsx
@@ -17,6 +17,7 @@ import {
 import { Button } from '@/components/primitives/button';
 import { CompactButton } from '@/components/primitives/button-compact';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from '@/components/primitives/dialog';
+import { Skeleton } from '@/components/primitives/skeleton';
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useCreateIntegration } from '@/hooks/use-create-integration';
@@ -49,7 +50,7 @@ function dropdownStatusFor(verify: VerifyStatus, hasUsableSelectedIntegration: b
 export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaudeUpgradePanelProps) {
   const { currentEnvironment } = useEnvironment();
   const queryClient = useQueryClient();
-  const { integrations } = useFetchIntegrations();
+  const { integrations, isLoading: isLoadingIntegrations, isFetched: areIntegrationsFetched } = useFetchIntegrations();
   const { mutateAsync: createIntegration } = useCreateIntegration();
   const verifyMutation = useVerifyManagedCredentials();
   const verifiedCredentialsRef = useRef<string | null>(null);
@@ -94,9 +95,12 @@ export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaude
 
   // When the dialog opens, pick the latest real Anthropic integration if one exists. Otherwise
   // fall back to the inline setup form so the user has somewhere to act immediately — there is
-  // nothing to "pick" yet.
+  // nothing to "pick" yet. Wait for the integrations query to resolve first; an empty list while
+  // still loading must not be treated as "no credentials" or we'd skip auto-selecting an existing
+  // integration once it arrives.
   useEffect(() => {
     if (!open) return;
+    if (!areIntegrationsFetched) return;
     if (selectedIntegrationId) return;
     if (credentialsPanelVisible) return;
 
@@ -110,7 +114,7 @@ export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaude
 
     setCredentialsPanelVisible(true);
     setCredentialsExpanded(true);
-  }, [open, selectedIntegrationId, credentialsPanelVisible, realAnthropicIntegrations]);
+  }, [open, areIntegrationsFetched, selectedIntegrationId, credentialsPanelVisible, realAnthropicIntegrations]);
 
   // Bump the default integration name when the integration list changes so a new credential gets
   // a unique "Anthropic N" name out of the box.
@@ -299,7 +303,9 @@ export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaude
         <div className="bg-background flex max-h-[70vh] flex-col gap-5 overflow-y-auto p-4 min-h-[200px]">
           <div className="flex flex-col gap-2">
             <span className="text-text-strong text-label-xs font-medium">Anthropic integration</span>
-            {ANTHROPIC_CONNECTOR ? (
+            {isLoadingIntegrations ? <Skeleton className="h-8 w-full rounded-md" /> : null}
+
+            {!isLoadingIntegrations && ANTHROPIC_CONNECTOR ? (
               <IntegrationDropdown
                 connector={ANTHROPIC_CONNECTOR}
                 selectedIntegrationId={selectedIntegrationId}

--- a/apps/dashboard/src/components/agents/demo-claude-upgrade-panel.tsx
+++ b/apps/dashboard/src/components/agents/demo-claude-upgrade-panel.tsx
@@ -1,7 +1,7 @@
-import { AgentRuntimeProviderIdEnum, IntegrationKindEnum } from '@novu/shared';
+import { AgentRuntimeProviderIdEnum, type IIntegration, IntegrationKindEnum } from '@novu/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
-import { RiArrowRightSLine, RiCloseLine } from 'react-icons/ri';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { RiArrowRightSLine, RiArrowRightUpLine, RiCloseLine } from 'react-icons/ri';
 import {
   type AgentResponse,
   getAgentDemoQuotaQueryKey,
@@ -20,8 +20,15 @@ import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } fr
 import { showErrorToast, showSuccessToast } from '@/components/primitives/sonner-helpers';
 import { requireEnvironment, useEnvironment } from '@/context/environment/hooks';
 import { useCreateIntegration } from '@/hooks/use-create-integration';
+import { useFetchIntegrations } from '@/hooks/use-fetch-integrations';
 import { useVerifyManagedCredentials } from '@/hooks/use-verify-managed-credentials';
+import { AGENTS_DOCS_OVERVIEW_URL } from '@/utils/agent-docs';
 import { QueryKeys } from '@/utils/query-keys';
+import { isDemoIntegration } from '../integrations/components/utils/helpers';
+import { GenerationStatus, type GenerationStep } from '../onboarding/connect-agent/generation-status';
+import { getClaudeManagedAgentIntegrations } from './connectors/claude-managed-integrations';
+import { getConnectorById } from './connectors/connector-options';
+import { IntegrationDropdown, type IntegrationDropdownStatus } from './connectors/integration-dropdown';
 
 type DemoClaudeUpgradePanelProps = {
   agent: AgentResponse;
@@ -29,15 +36,30 @@ type DemoClaudeUpgradePanelProps = {
   onOpenChange: (open: boolean) => void;
 };
 
+const ANTHROPIC_CONNECTOR = getConnectorById('claude');
 const DEFAULT_ANTHROPIC_INTEGRATION_NAME = 'Anthropic';
+// Matches the dialog footer button's height so the status sits inside the footer instead of
+// pushing it taller, mirroring the create-agent dialog pattern.
+const FOOTER_STATUS_HEIGHT = 56;
+
+function dropdownStatusFor(verify: VerifyStatus, hasUsableSelectedIntegration: boolean): IntegrationDropdownStatus {
+  if (hasUsableSelectedIntegration) return 'valid';
+  if (verify === 'valid') return 'valid';
+  if (verify === 'invalid') return 'missing';
+
+  return 'idle';
+}
 
 export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaudeUpgradePanelProps) {
   const { currentEnvironment } = useEnvironment();
   const queryClient = useQueryClient();
+  const { integrations } = useFetchIntegrations();
   const { mutateAsync: createIntegration } = useCreateIntegration();
   const verifyMutation = useVerifyManagedCredentials();
   const verifiedCredentialsRef = useRef<string | null>(null);
 
+  const [selectedIntegrationId, setSelectedIntegrationId] = useState<string | undefined>(undefined);
+  const [credentialsPanelVisible, setCredentialsPanelVisible] = useState(false);
   const [integrationName, setIntegrationName] = useState(DEFAULT_ANTHROPIC_INTEGRATION_NAME);
   const [apiKey, setApiKey] = useState('');
   const [externalWorkspaceId, setExternalWorkspaceId] = useState('');
@@ -46,7 +68,24 @@ export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaude
   const [verifyMessage, setVerifyMessage] = useState<string | undefined>();
   const [credentialsExpanded, setCredentialsExpanded] = useState(true);
 
+  const realAnthropicIntegrations = useMemo(
+    () =>
+      getClaudeManagedAgentIntegrations(integrations, AgentRuntimeProviderIdEnum.Anthropic).filter(
+        (integration) => !isDemoIntegration(integration.providerId)
+      ),
+    [integrations]
+  );
+
+  const selectedIntegration = useMemo(
+    () => realAnthropicIntegrations.find((integration) => integration._id === selectedIntegrationId),
+    [realAnthropicIntegrations, selectedIntegrationId]
+  );
+
+  const hasUsableSelectedIntegration = Boolean(selectedIntegration);
+
   const resetForm = () => {
+    setSelectedIntegrationId(undefined);
+    setCredentialsPanelVisible(false);
     setIntegrationName(DEFAULT_ANTHROPIC_INTEGRATION_NAME);
     setApiKey('');
     setExternalWorkspaceId('');
@@ -57,11 +96,35 @@ export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaude
     verifiedCredentialsRef.current = null;
   };
 
+  // When the dialog opens, pick the latest real Anthropic integration if one exists. Otherwise
+  // fall back to the inline setup form so the user has somewhere to act immediately — there is
+  // nothing to "pick" yet.
   useEffect(() => {
-    if (open) {
-      setIntegrationName(DEFAULT_ANTHROPIC_INTEGRATION_NAME);
+    if (!open) return;
+    if (selectedIntegrationId) return;
+    if (credentialsPanelVisible) return;
+
+    // `realAnthropicIntegrations` is sorted newest-first by Mongo `_id`, so [0] is the latest.
+    const latest = realAnthropicIntegrations[0];
+    if (latest) {
+      setSelectedIntegrationId(latest._id);
+
+      return;
     }
-  }, [open]);
+
+    setCredentialsPanelVisible(true);
+    setCredentialsExpanded(true);
+  }, [open, selectedIntegrationId, credentialsPanelVisible, realAnthropicIntegrations]);
+
+  // Bump the default integration name when the integration list changes so a new credential gets
+  // a unique "Anthropic N" name out of the box.
+  useEffect(() => {
+    if (!credentialsPanelVisible) return;
+    if (integrationName && integrationName !== DEFAULT_ANTHROPIC_INTEGRATION_NAME) return;
+
+    const nextIndex = realAnthropicIntegrations.length + 1;
+    setIntegrationName(`${DEFAULT_ANTHROPIC_INTEGRATION_NAME} ${nextIndex}`);
+  }, [credentialsPanelVisible, realAnthropicIntegrations, integrationName]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     onOpenChange(nextOpen);
@@ -119,9 +182,34 @@ export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaude
     setErrors((prev) => ({ ...prev, apiKey: undefined }));
   };
 
+  const handleSelectIntegration = (integration: IIntegration) => {
+    setSelectedIntegrationId(integration._id);
+    setCredentialsPanelVisible(false);
+    setApiKey('');
+    setExternalWorkspaceId('');
+    setVerifyStatus('idle');
+    setVerifyMessage(undefined);
+    verifiedCredentialsRef.current = null;
+    setErrors({});
+  };
+
+  const handleRequestSetupCredentials = () => {
+    setSelectedIntegrationId(undefined);
+    setCredentialsPanelVisible(true);
+    setCredentialsExpanded(true);
+    setIntegrationName(`${DEFAULT_ANTHROPIC_INTEGRATION_NAME} ${realAnthropicIntegrations.length + 1}`);
+  };
+
   const upgradeMutation = useMutation({
     mutationFn: async () => {
       const environment = requireEnvironment(currentEnvironment, 'No environment selected');
+
+      // Path A — reuse an already-configured Anthropic integration.
+      if (hasUsableSelectedIntegration && selectedIntegration) {
+        return migrateAgentRuntime(environment, agent.identifier, { integrationId: selectedIntegration._id });
+      }
+
+      // Path B — create a new Anthropic integration from the inline credentials form.
       const trimmedApiKey = apiKey.trim();
       const trimmedName = integrationName.trim();
       const trimmedWorkspaceId = externalWorkspaceId.trim();
@@ -172,7 +260,32 @@ export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaude
   });
 
   const isBusy = upgradeMutation.isPending || verifyMutation.isPending;
-  const canMigrate = integrationName.trim().length > 0 && apiKey.trim().length > 0 && !isBusy;
+  const isSetupCredentialsReady =
+    credentialsPanelVisible && integrationName.trim().length > 0 && apiKey.trim().length > 0;
+  const canMigrate = !isBusy && (hasUsableSelectedIntegration || isSetupCredentialsReady);
+  const dropdownStatus = dropdownStatusFor(verifyStatus, hasUsableSelectedIntegration);
+
+  const generationSteps = useMemo<GenerationStep[]>(
+    () => [
+      { id: 'sleeves', text: 'Rolling up my sleeves' },
+      { id: 'coffee', text: 'Sipping a little bit of coffee' },
+      {
+        id: 'preparing',
+        text: (
+          <>
+            Preparing to move the agent:{' '}
+            <span className="text-text-strong rounded-sm bg-bg-weak px-1 font-mono text-[11px] leading-4">
+              {agent.identifier}
+            </span>
+          </>
+        ),
+      },
+      { id: 'migrating', text: 'Migrating the agent to your account' },
+      { id: 'configurations', text: 'Laying out the agent configurations' },
+      { id: 'finalizing', text: 'One moment while we set this up' },
+    ],
+    [agent.identifier]
+  );
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -184,11 +297,19 @@ export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaude
           <div className="flex items-start gap-2">
             <div className="flex min-w-0 flex-1 flex-col gap-0.5">
               <DialogTitle className="text-text-strong text-[16px] font-medium leading-6 tracking-[-0.176px]">
-                Use your own Anthropic key
+                Migrate agent to your Anthropic account
               </DialogTitle>
               <DialogDescription className="text-text-soft text-label-xs leading-4">
-                Connect your Anthropic account to remove demo limits. Existing demo conversations stay read-only; new
-                traffic runs on your credentials.
+                Novu will replace this agent and create a new agent in your account and route future messages to it.{' '}
+                <a
+                  href={AGENTS_DOCS_OVERVIEW_URL}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="text-text-soft hover:text-text-sub inline-flex items-center gap-0.5 underline-offset-2 hover:underline"
+                >
+                  Learn more
+                  <RiArrowRightUpLine className="size-3.5 shrink-0" aria-hidden />
+                </a>
               </DialogDescription>
             </div>
             <DialogClose asChild>
@@ -201,50 +322,73 @@ export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaude
 
         <div className="border-stroke-soft border-y" />
 
-        <div className="bg-background flex max-h-[70vh] flex-col gap-5 overflow-y-auto p-4">
+        <div className="bg-background flex max-h-[70vh] flex-col gap-5 overflow-y-auto p-4 min-h-[200px]">
           <div className="flex flex-col gap-2">
-            <span className="text-text-strong text-label-xs font-medium">Anthropic credentials</span>
-            <ConfigureCredentialsSection
-              providerId={AgentRuntimeProviderIdEnum.Anthropic}
-              providerLabel="Anthropic"
-              integrationName={integrationName}
-              apiKey={apiKey}
-              externalWorkspaceId={externalWorkspaceId}
-              errors={errors}
-              disabled={isBusy}
-              status={verifyStatus}
-              statusMessage={verifyMessage}
-              expanded={credentialsExpanded}
-              showSaveButton={false}
-              onExpandedChange={setCredentialsExpanded}
-              onIntegrationNameChange={(next) => {
-                setIntegrationName(next);
-                setErrors((prev) => ({ ...prev, integrationName: undefined }));
-              }}
-              onApiKeyChange={handleApiKeyChange}
-              onExternalWorkspaceIdChange={(next) => {
-                setExternalWorkspaceId(next);
-                setVerifyStatus('idle');
-                setVerifyMessage(undefined);
-                verifiedCredentialsRef.current = null;
-              }}
-              onVerify={handleVerify}
-              onSave={() => undefined}
-            />
+            <span className="text-text-strong text-label-xs font-medium">Anthropic integration</span>
+            {ANTHROPIC_CONNECTOR ? (
+              <IntegrationDropdown
+                connector={ANTHROPIC_CONNECTOR}
+                selectedIntegrationId={selectedIntegrationId}
+                integrations={integrations}
+                status={dropdownStatus}
+                showStatusBadge={hasUsableSelectedIntegration}
+                disabled={isBusy}
+                setupLabel="Setup Anthropic credentials"
+                excludeDemo
+                onSelectIntegration={handleSelectIntegration}
+                onRequestSetupCredentials={handleRequestSetupCredentials}
+              />
+            ) : null}
+
+            {credentialsPanelVisible ? (
+              <ConfigureCredentialsSection
+                providerId={AgentRuntimeProviderIdEnum.Anthropic}
+                providerLabel="Anthropic"
+                integrationName={integrationName}
+                apiKey={apiKey}
+                externalWorkspaceId={externalWorkspaceId}
+                errors={errors}
+                disabled={isBusy}
+                status={verifyStatus}
+                statusMessage={verifyMessage}
+                expanded={credentialsExpanded}
+                showSaveButton={false}
+                onExpandedChange={setCredentialsExpanded}
+                onIntegrationNameChange={(next) => {
+                  setIntegrationName(next);
+                  setErrors((prev) => ({ ...prev, integrationName: undefined }));
+                }}
+                onApiKeyChange={handleApiKeyChange}
+                onExternalWorkspaceIdChange={(next) => {
+                  setExternalWorkspaceId(next);
+                  setVerifyStatus('idle');
+                  setVerifyMessage(undefined);
+                  verifiedCredentialsRef.current = null;
+                }}
+                onVerify={handleVerify}
+                onSave={() => undefined}
+              />
+            ) : null}
           </div>
         </div>
 
-        <div className="bg-bg-weak border-stroke-soft flex items-center justify-end border-t px-4 py-3">
+        <div className="bg-bg-weak border-stroke-soft flex items-center gap-3 border-t px-4 py-3">
+          {isBusy ? (
+            <div className="-my-3 flex h-14 min-w-0 flex-1 items-center">
+              <GenerationStatus steps={generationSteps} containerHeight={FOOTER_STATUS_HEIGHT} className="w-full" />
+            </div>
+          ) : null}
           <Button
             variant="secondary"
             mode="gradient"
             size="xs"
+            className={isBusy ? 'shrink-0' : 'ml-auto'}
             disabled={!canMigrate}
             isLoading={isBusy}
             trailingIcon={RiArrowRightSLine}
             onClick={() => upgradeMutation.mutate()}
           >
-            Connect and migrate
+            Setup agent
           </Button>
         </div>
       </DialogContent>

--- a/apps/dashboard/src/components/agents/demo-claude-upgrade-panel.tsx
+++ b/apps/dashboard/src/components/agents/demo-claude-upgrade-panel.tsx
@@ -25,7 +25,6 @@ import { useVerifyManagedCredentials } from '@/hooks/use-verify-managed-credenti
 import { AGENTS_DOCS_OVERVIEW_URL } from '@/utils/agent-docs';
 import { QueryKeys } from '@/utils/query-keys';
 import { isDemoIntegration } from '../integrations/components/utils/helpers';
-import { GenerationStatus, type GenerationStep } from '../onboarding/connect-agent/generation-status';
 import { getClaudeManagedAgentIntegrations } from './connectors/claude-managed-integrations';
 import { getConnectorById } from './connectors/connector-options';
 import { IntegrationDropdown, type IntegrationDropdownStatus } from './connectors/integration-dropdown';
@@ -38,9 +37,6 @@ type DemoClaudeUpgradePanelProps = {
 
 const ANTHROPIC_CONNECTOR = getConnectorById('claude');
 const DEFAULT_ANTHROPIC_INTEGRATION_NAME = 'Anthropic';
-// Matches the dialog footer button's height so the status sits inside the footer instead of
-// pushing it taller, mirroring the create-agent dialog pattern.
-const FOOTER_STATUS_HEIGHT = 56;
 
 function dropdownStatusFor(verify: VerifyStatus, hasUsableSelectedIntegration: boolean): IntegrationDropdownStatus {
   if (hasUsableSelectedIntegration) return 'valid';
@@ -265,28 +261,6 @@ export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaude
   const canMigrate = !isBusy && (hasUsableSelectedIntegration || isSetupCredentialsReady);
   const dropdownStatus = dropdownStatusFor(verifyStatus, hasUsableSelectedIntegration);
 
-  const generationSteps = useMemo<GenerationStep[]>(
-    () => [
-      { id: 'sleeves', text: 'Rolling up my sleeves' },
-      { id: 'coffee', text: 'Sipping a little bit of coffee' },
-      {
-        id: 'preparing',
-        text: (
-          <>
-            Preparing to move the agent:{' '}
-            <span className="text-text-strong rounded-sm bg-bg-weak px-1 font-mono text-[11px] leading-4">
-              {agent.identifier}
-            </span>
-          </>
-        ),
-      },
-      { id: 'migrating', text: 'Migrating the agent to your account' },
-      { id: 'configurations', text: 'Laying out the agent configurations' },
-      { id: 'finalizing', text: 'One moment while we set this up' },
-    ],
-    [agent.identifier]
-  );
-
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
@@ -373,11 +347,6 @@ export function DemoClaudeUpgradePanel({ agent, open, onOpenChange }: DemoClaude
         </div>
 
         <div className="bg-bg-weak border-stroke-soft flex items-center gap-3 border-t px-4 py-3">
-          {isBusy ? (
-            <div className="-my-3 flex h-14 min-w-0 flex-1 items-center">
-              <GenerationStatus steps={generationSteps} containerHeight={FOOTER_STATUS_HEIGHT} className="w-full" />
-            </div>
-          ) : null}
           <Button
             variant="secondary"
             mode="gradient"

--- a/apps/dashboard/src/components/onboarding/connect-agent/generation-status.tsx
+++ b/apps/dashboard/src/components/onboarding/connect-agent/generation-status.tsx
@@ -1,11 +1,11 @@
 import { motion } from 'motion/react';
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { RiCheckboxCircleFill, RiLoader3Line, RiLoader4Fill } from 'react-icons/ri';
 import { cn } from '@/utils/ui';
 
 export type GenerationStep = {
   id: string;
-  text: string;
+  text: ReactNode;
 };
 
 type GenerationStatusProps = {


### PR DESCRIPTION
### What changed? Why was the change needed?

Agents - Reuse existing Claude credentials when migrating an agent that used demo creds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
When migrating agents that previously used demo Claude (Anthropic) credentials, the UI now prefers reusing an existing real Anthropic integration instead of creating new demo/duplicate creds. A new IntegrationDropdown lets users pick a non-demo Anthropic integration; the DemoClaudeUpgradePanel then either migrates the agent using the selected integration ID or validates inline credentials, creates a new active AGENT integration, and migrates with that ID. This prevents credential duplication and simplifies migrating demo agents to users' own Anthropic accounts.

## Affected areas
**dashboard**: Added an IntegrationDropdown component to list and select existing (non-demo) integrations; updated DemoClaudeUpgradePanel to support two migration flows (reuse selected integration or create-from-inline credentials), adjusted dialog copy/flow and CTA labels, and added status/validation UI. Also broadened GenerationStep.text to ReactNode to allow richer onboarding status labels.

## Key technical decisions
- Prefer reusing an existing non-demo Anthropic integration ID when available; otherwise validate inputs and create an active AGENT integration before migration.
- The upgrade panel auto-selects the most recent usable Anthropic integration on open and only shows the inline credentials form when no real integration is available.

## Testing
No automated tests were added; manual verification is required for integration selection, credential validation, both migration paths, and the updated dialog flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots
 
https://github.com/user-attachments/assets/19be24af-7665-43d8-9cda-9928d84e118f

https://github.com/user-attachments/assets/cdd035b8-3205-4165-8bd2-f7207e524e62

