### PR TITLE
fix(dashboard): move to cookie based auth from satellite based handshake 

### DIFF
--- a/apps/dashboard/.example.env
+++ b/apps/dashboard/.example.env
@@ -10,10 +10,10 @@ VITE_SELF_HOSTED=
 VITE_PLAIN_SUPPORT_CHAT_APP_ID=
 VITE_NOVU_ENTERPRISE=false
 
-# Novu Connect hostname split — Platform is the Clerk primary; Connect runs as a same-registrable-
-# domain subdomain (NOT a Clerk satellite). Both hosts must share an eTLD+1 (e.g. *.novu.co) so
-# Clerk's session cookies (Domain=<root>) are visible on both. Add the Connect host to the Clerk
-# instance's "Allowed subdomains" list so its origin can call the primary Frontend API.
+# Novu Connect hostname split — Platform is the Clerk primary; Connect runs as a sibling
+# subdomain. Both hosts must share an eTLD+1 (e.g. *.novu.co) so Clerk's session cookies
+# (Domain=<root>) are visible on both. Add the Connect host to the Clerk instance's "Allowed
+# subdomains" list so its origin can call the primary Frontend API.
 # Leave both empty to disable Connect (self-hosted / community builds).
 # Local dev: Platform at http://localhost:4201, Connect at http://connect.localhost:4201.
 VITE_NOVU_PLATFORM_HOSTNAME=

--- a/apps/dashboard/.example.env
+++ b/apps/dashboard/.example.env
@@ -10,10 +10,12 @@ VITE_SELF_HOSTED=
 VITE_PLAIN_SUPPORT_CHAT_APP_ID=
 VITE_NOVU_ENTERPRISE=false
 
-# Novu Connect hostname split — Platform is the Clerk primary, Connect is the satellite.
+# Novu Connect hostname split — Platform is the Clerk primary; Connect runs as a same-registrable-
+# domain subdomain (NOT a Clerk satellite). Both hosts must share an eTLD+1 (e.g. *.novu.co) so
+# Clerk's session cookies (Domain=<root>) are visible on both. Add the Connect host to the Clerk
+# instance's "Allowed subdomains" list so its origin can call the primary Frontend API.
 # Leave both empty to disable Connect (self-hosted / community builds).
 # Local dev: Platform at http://localhost:4201, Connect at http://connect.localhost:4201.
-# Production Connect: add DNS CNAME `clerk.<connect-domain>` → frontend-api.clerk.services.
 VITE_NOVU_PLATFORM_HOSTNAME=
 VITE_NOVU_CONNECT_HOSTNAME=
 

--- a/apps/dashboard/.example.env
+++ b/apps/dashboard/.example.env
@@ -12,8 +12,7 @@ VITE_NOVU_ENTERPRISE=false
 
 # Novu Connect hostname split — Platform is the Clerk primary; Connect runs as a sibling
 # subdomain. Both hosts must share an eTLD+1 (e.g. *.novu.co) so Clerk's session cookies
-# (Domain=<root>) are visible on both. Add the Connect host to the Clerk instance's "Allowed
-# subdomains" list so its origin can call the primary Frontend API.
+# (Domain=<root>) are visible on both — that's the whole mechanism, no Clerk-side config needed.
 # Leave both empty to disable Connect (self-hosted / community builds).
 # Local dev: Platform at http://localhost:4201, Connect at http://connect.localhost:4201.
 VITE_NOVU_PLATFORM_HOSTNAME=

--- a/apps/dashboard/netlify.toml
+++ b/apps/dashboard/netlify.toml
@@ -18,8 +18,8 @@
   to = "/index.html"
   status = 200
 
-# Clerk satellite handshakes redirect through /auth/* — prevent Netlify CDN from caching
-# stale 200/index.html responses during cross-domain session sync (known Clerk + Netlify issue).
+# Auth pages must never be cached by the Netlify CDN. Clerk's React SDK uses hash routing for
+# multi-step flows, and stale 200/index.html responses can leak prior auth state across users.
 [[headers]]
   for = "/auth/*"
   [headers.values]

--- a/apps/dashboard/src/components/auth/auto-create-connect-organization.tsx
+++ b/apps/dashboard/src/components/auth/auto-create-connect-organization.tsx
@@ -174,7 +174,7 @@ export function AutoCreateConnectOrganization() {
       } catch (error) {
         // The cached membership was tombstoned (e.g. deleted in another tab). Treat as manual create
         // so we never leave the session pointing at an id Clerk has already removed — otherwise the
-        // satellite handshake redirects to Platform's sign-in URL.
+        // Connect host's auth guard would bounce the user to Platform's sign-in URL.
         if (isMissingOrganizationError(error)) {
           return { type: 'manual' };
         }

--- a/apps/dashboard/src/components/dashboard-shell/cross-app-link.tsx
+++ b/apps/dashboard/src/components/dashboard-shell/cross-app-link.tsx
@@ -11,10 +11,10 @@ type CrossAppLinkProps = {
   children: ReactNode;
 };
 
-// Hands off to the browser for cross-origin hrefs; Clerk's satellite domain SDK picks up the
-// session sync via its built-in handshake when the satellite page loads. Avoid `clerk.redirectWithAuth`
-// here — it short-circuits the satellite SDK's handshake and produced a `__clerk_synced=false`
-// redirect loop between Platform and Connect.
+// Hands off to the browser for cross-origin hrefs. Primary and Connect share Clerk session
+// cookies via the registrable domain, so the destination page picks up the session natively —
+// no SDK handshake involved. Avoid `clerk.redirectWithAuth` here (it short-circuits the cookie
+// scope and produced a `__clerk_synced=false` redirect loop in earlier satellite-mode setups).
 export function CrossAppLink({ href, openInNewTab, className, onClick, children, ...rest }: CrossAppLinkProps) {
   const isHrefSafe = isSafeNavigationHref(href);
   const isCrossOrigin = isHrefSafe && IS_HOSTNAME_SPLIT_ENABLED && isAbsoluteUrl(href);

--- a/apps/dashboard/src/components/dashboard-shell/cross-app-link.tsx
+++ b/apps/dashboard/src/components/dashboard-shell/cross-app-link.tsx
@@ -12,9 +12,8 @@ type CrossAppLinkProps = {
 };
 
 // Hands off to the browser for cross-origin hrefs. Primary and Connect share Clerk session
-// cookies via the registrable domain, so the destination page picks up the session natively —
-// no SDK handshake involved. Avoid `clerk.redirectWithAuth` here (it short-circuits the cookie
-// scope and produced a `__clerk_synced=false` redirect loop in earlier satellite-mode setups).
+// cookies via the registrable domain, so the destination page picks up the session natively
+// from a plain navigation.
 export function CrossAppLink({ href, openInNewTab, className, onClick, children, ...rest }: CrossAppLinkProps) {
   const isHrefSafe = isSafeNavigationHref(href);
   const isCrossOrigin = isHrefSafe && IS_HOSTNAME_SPLIT_ENABLED && isAbsoluteUrl(href);

--- a/apps/dashboard/src/components/settings/organization-settings.tsx
+++ b/apps/dashboard/src/components/settings/organization-settings.tsx
@@ -13,7 +13,7 @@ import { ROUTES } from '@/utils/routes';
 import { NovuBrandingSwitch } from './novu-branding-switch';
 
 // After deleting (or leaving) an org, Clerk falls back to `<ClerkProvider signInUrl>` when this
-// prop is unset. On the Connect satellite that points to Platform's sign-in, which kicks the
+// prop is unset. On the Connect host that points to Platform's sign-in, which kicks the
 // user out of Connect entirely — they'd land on Platform's picker even when they still have
 // Connect work to do. Pinning it to the local `/auth/organization-list` keeps them on the
 // current product; `AuthProvider` then clears any cross-product org Clerk auto-activates and

--- a/apps/dashboard/src/components/settings/settings-tabs.tsx
+++ b/apps/dashboard/src/components/settings/settings-tabs.tsx
@@ -25,7 +25,7 @@ import { UserProfile as BetterAuthUserProfile } from '@/utils/better-auth/index'
 import { ROUTES } from '@/utils/routes';
 
 // Pin Clerk's post-leave/delete redirect to the local `/auth/organization-list`. Without this,
-// Clerk falls back to `<ClerkProvider signInUrl>`, which on the Connect satellite points at
+// Clerk falls back to `<ClerkProvider signInUrl>`, which on the Connect host points at
 // Platform's sign-in — so deleting a Connect org would kick the user out of Connect even when
 // they still have Connect work to do. Keeping it same-host lets `AuthProvider` clear any cross-
 // product org Clerk auto-activates and lets the picker render this product's empty state.

--- a/apps/dashboard/src/config/index.ts
+++ b/apps/dashboard/src/config/index.ts
@@ -36,7 +36,8 @@ export const LEGACY_DASHBOARD_URL =
 
 export const DASHBOARD_URL = window._env_?.VITE_DASHBOARD_URL || import.meta.env.VITE_DASHBOARD_URL;
 
-// Connect satellite hostname. Empty when Connect is not deployed (self-hosted/dev).
+// Connect host. Must share registrable domain with `NOVU_PLATFORM_HOSTNAME` so Clerk session
+// cookies (Domain=<root>) are visible on both. Empty when Connect is not deployed (self-hosted/dev).
 export const NOVU_CONNECT_HOSTNAME =
   window._env_?.VITE_NOVU_CONNECT_HOSTNAME || import.meta.env.VITE_NOVU_CONNECT_HOSTNAME || '';
 
@@ -56,7 +57,7 @@ function getHostnameWithoutPort(host: string): string {
 export { getHostnameWithoutPort };
 
 // Fail fast when the hostname split is half-configured. Without `NOVU_PLATFORM_HOSTNAME`,
-// satellite → primary handoffs (Clerk sign-in, cross-product redirects) silently break.
+// Connect → Platform handoffs (Clerk sign-in, cross-product redirects) silently break.
 if (NOVU_CONNECT_HOSTNAME && !NOVU_PLATFORM_HOSTNAME) {
   throw new Error(
     'NOVU_PLATFORM_HOSTNAME is required when NOVU_CONNECT_HOSTNAME is set. ' +

--- a/apps/dashboard/src/context/ee-auth-provider.tsx
+++ b/apps/dashboard/src/context/ee-auth-provider.tsx
@@ -73,9 +73,8 @@ export const EEAuthProvider = (props: EEAuthProviderProps) => {
   };
 
   // Sign-in/up only renders on the primary; the Connect host bounces visitors there. Primary
-  // writes Clerk session cookies on `Domain=<registrable-root>` so both hosts read the same
-  // session natively — the Connect host just needs to be listed under "Allowed subdomains" in
-  // the Clerk instance config.
+  // writes Clerk session cookies on `Domain=<registrable-root>`, so both hosts read the same
+  // session natively from a plain navigation — no Clerk-side configuration needed.
   const isCrossProductHost = IS_HOSTNAME_SPLIT_ENABLED && IS_NOVU_CONNECT;
 
   const signInUrl = isCrossProductHost

--- a/apps/dashboard/src/context/ee-auth-provider.tsx
+++ b/apps/dashboard/src/context/ee-auth-provider.tsx
@@ -2,12 +2,10 @@ import { buttonVariants } from '@/components/primitives/button';
 import {
   CLERK_PUBLISHABLE_KEY,
   EE_AUTH_PROVIDER,
-  getHostnameWithoutPort,
   IS_ENTERPRISE,
   IS_HOSTNAME_SPLIT_ENABLED,
   IS_NOVU_CONNECT,
   IS_SELF_HOSTED,
-  NOVU_CONNECT_HOSTNAME,
 } from '@/config';
 import { isAbsoluteUrl } from '@/utils/apps';
 import { buildAfterSignOutUrl } from '@/utils/cross-product-sign-out';
@@ -74,35 +72,28 @@ export const EEAuthProvider = (props: EEAuthProviderProps) => {
     }
   };
 
-  // Sign-in flows are only allowed on the primary; satellite must point `signInUrl`/`signUpUrl`
-  // back to it. Primary lists the Connect origin in `allowedRedirectOrigins` for post-auth bounce.
-  const isSatellite = IS_HOSTNAME_SPLIT_ENABLED && IS_NOVU_CONNECT;
+  // Sign-in/up forms only render on the primary; the Connect host bounces visitors back to it.
+  // We deliberately do NOT use Clerk's satellite-domain mode (`isSatellite` / `satelliteAutoSync`).
+  // Satellite mode runs a cross-domain handshake whose `__client_uat_<HASH>` cookies get scoped
+  // to the shared registrable domain — when primary and satellite live under the same root, the
+  // satellite Frontend API's response clobbers the primary's session cookie and produces a
+  // sign-in ↔ Connect redirect loop. Instead, we rely on Clerk's recommended "same root domain"
+  // setup: primary writes session cookies on `Domain=<root>` and the Connect host reads them
+  // natively. Cross-product CORS is granted by adding the Connect host under "Allowed subdomains"
+  // in the Clerk instance config.
+  const isCrossProductHost = IS_HOSTNAME_SPLIT_ENABLED && IS_NOVU_CONNECT;
 
-  const satelliteSignInUrl = buildPrimarySignInUrl({ product: CONNECT_PRODUCT_VALUE });
-  const satelliteSignUpUrl = buildPrimarySignUpUrl({ product: CONNECT_PRODUCT_VALUE });
-
-  const signInUrl = isSatellite ? satelliteSignInUrl : ROUTES.SIGN_IN;
-  const signUpUrl = isSatellite ? satelliteSignUpUrl : ROUTES.SIGN_UP;
-
-  const satelliteProps = isSatellite
-    ? {
-        isSatellite: true as const,
-        domain: getHostnameWithoutPort(NOVU_CONNECT_HOSTNAME),
-        // Clerk v6 / Core 3 flipped the satellite default from auto-sync ON to OFF (#7597), so
-        // Connect now treats every first page load as anonymous unless cookies are already
-        // present — primary's sign-in then bounces back to a still-anonymous satellite and we
-        // loop. We rely on the Core 2 behavior (auto-handshake with primary on first load) so
-        // an already-signed-in user on Platform is recognized on Connect without re-auth.
-        // See https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3
-        satelliteAutoSync: true,
-      }
-    : {};
+  const signInUrl = isCrossProductHost
+    ? buildPrimarySignInUrl({ product: CONNECT_PRODUCT_VALUE })
+    : ROUTES.SIGN_IN;
+  const signUpUrl = isCrossProductHost
+    ? buildPrimarySignUpUrl({ product: CONNECT_PRODUCT_VALUE })
+    : ROUTES.SIGN_UP;
 
   const allowedRedirectOrigins = buildClerkAllowedRedirectOrigins();
 
   return (
     <_ClerkProvider
-      {...satelliteProps}
       routerPush={(to) => navigateClerk(to)}
       routerReplace={(to) => navigateClerk(to, true)}
       publishableKey={CLERK_PUBLISHABLE_KEY}

--- a/apps/dashboard/src/context/ee-auth-provider.tsx
+++ b/apps/dashboard/src/context/ee-auth-provider.tsx
@@ -72,15 +72,10 @@ export const EEAuthProvider = (props: EEAuthProviderProps) => {
     }
   };
 
-  // Sign-in/up forms only render on the primary; the Connect host bounces visitors back to it.
-  // We deliberately do NOT use Clerk's satellite-domain mode (`isSatellite` / `satelliteAutoSync`).
-  // Satellite mode runs a cross-domain handshake whose `__client_uat_<HASH>` cookies get scoped
-  // to the shared registrable domain — when primary and satellite live under the same root, the
-  // satellite Frontend API's response clobbers the primary's session cookie and produces a
-  // sign-in ↔ Connect redirect loop. Instead, we rely on Clerk's recommended "same root domain"
-  // setup: primary writes session cookies on `Domain=<root>` and the Connect host reads them
-  // natively. Cross-product CORS is granted by adding the Connect host under "Allowed subdomains"
-  // in the Clerk instance config.
+  // Sign-in/up only renders on the primary; the Connect host bounces visitors there. Primary
+  // writes Clerk session cookies on `Domain=<registrable-root>` so both hosts read the same
+  // session natively — the Connect host just needs to be listed under "Allowed subdomains" in
+  // the Clerk instance config.
   const isCrossProductHost = IS_HOSTNAME_SPLIT_ENABLED && IS_NOVU_CONNECT;
 
   const signInUrl = isCrossProductHost

--- a/apps/dashboard/src/hooks/use-cross-app-navigation.ts
+++ b/apps/dashboard/src/hooks/use-cross-app-navigation.ts
@@ -2,9 +2,8 @@ import { useCallback } from 'react';
 import { isSafeNavigationHref } from '@/utils/apps';
 
 // Plain cross-origin navigation. Primary and Connect share session cookies via the registrable
-// domain, so the destination page reads the existing Clerk session natively — no SDK handshake
-// involved. Avoid `clerk.redirectWithAuth` here (it short-circuits the cookie scope and produced
-// a `__clerk_synced=false` redirect loop in earlier satellite-mode iterations).
+// domain, so the destination page reads the existing Clerk session natively from a normal
+// browser navigation.
 export function useCrossAppNavigation() {
   return useCallback((href: string, openInNewTab = false) => {
     // Whitelist http(s) / relative hrefs so callers can't smuggle `javascript:` / `data:` URLs in.

--- a/apps/dashboard/src/hooks/use-cross-app-navigation.ts
+++ b/apps/dashboard/src/hooks/use-cross-app-navigation.ts
@@ -1,9 +1,10 @@
 import { useCallback } from 'react';
 import { isSafeNavigationHref } from '@/utils/apps';
 
-// Plain cross-origin navigation. The Connect satellite Clerk SDK handles session sync via its
-// built-in handshake on the destination page — wrapping with `clerk.redirectWithAuth` here caused
-// a `__clerk_synced=false` redirect loop with Platform.
+// Plain cross-origin navigation. Primary and Connect share session cookies via the registrable
+// domain, so the destination page reads the existing Clerk session natively — no SDK handshake
+// involved. Avoid `clerk.redirectWithAuth` here (it short-circuits the cookie scope and produced
+// a `__clerk_synced=false` redirect loop in earlier satellite-mode iterations).
 export function useCrossAppNavigation() {
   return useCallback((href: string, openInNewTab = false) => {
     // Whitelist http(s) / relative hrefs so callers can't smuggle `javascript:` / `data:` URLs in.

--- a/apps/dashboard/src/pages/sign-in.tsx
+++ b/apps/dashboard/src/pages/sign-in.tsx
@@ -40,8 +40,8 @@ export const SignInPage = () => {
     [searchParams]
   );
 
-  // Clean Connect provisioning entry point. Always the same URL — Clerk's satellite domain SDK
-  // performs the session-sync handshake natively when the destination page loads.
+  // Clean Connect provisioning entry point. Always the same URL — primary's session cookies
+  // live on the shared registrable domain, so the Connect host loads signed-in immediately.
   const connectProvisionRedirect = useMemo(
     () => buildAbsoluteConnectUrl(buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST)),
     []
@@ -62,7 +62,7 @@ export const SignInPage = () => {
     }
   }, [searchParams, isConnectSignIn]);
 
-  // Sign-in only runs on the primary; satellite visitors bounce back with the Connect flag.
+  // Sign-in only runs on the primary; Connect-host visitors bounce back with the Connect flag.
   useEffect(() => {
     if (IS_NOVU_CONNECT) {
       const redirectUrl = readClerkRedirectUrlParam(searchParams);
@@ -89,10 +89,11 @@ export const SignInPage = () => {
   // Already-signed-in user landing on `/auth/sign-in` — bounce to the right home before the
   // <SignIn/> form mounts and starts its own redirect (which would race this effect).
   //
-  // For Connect flows we deliberately drop any inbound `redirect_url` (e.g. a stale
-  // `?__clerk_synced=false` Connect URL) and always go to the clean provision entry point —
-  // Clerk's satellite SDK syncs the session on arrival. Honoring the stale return URL is what
-  // caused the Platform ↔ Connect redirect loop after the post-PR-11281 follow-ups.
+  // For Connect flows we deliberately drop any inbound `redirect_url` and always go to the
+  // clean provision entry point. The Connect host shares Clerk session cookies with primary
+  // via the registrable domain, so it loads signed-in directly — no handshake params to
+  // forward. Honoring a stale return URL is what caused the Platform ↔ Connect redirect loop
+  // after the post-PR-11281 follow-ups, so we keep it stripped.
   // CLI auth is the exception: the device session must resume on `/cli/auth` after sign-in.
   useEffect(() => {
     if (!isLoaded || !isSignedIn || IS_NOVU_CONNECT || hasRedirectedRef.current) {
@@ -133,7 +134,7 @@ export const SignInPage = () => {
   }, [searchParams, isConnectSignIn]);
 
   // Render nothing while redirecting:
-  //   - On the satellite (`IS_NOVU_CONNECT`) the page is mid-replace to primary.
+  //   - On the Connect host (`IS_NOVU_CONNECT`) the page is mid-replace to primary.
   //   - On the primary when the user is already signed in the effect above is handling the bounce;
   //     mounting <SignIn> here would also try to navigate via `forceRedirectUrl`, creating a race.
   if (IS_NOVU_CONNECT || (isLoaded && isSignedIn)) {

--- a/apps/dashboard/src/pages/sign-in.tsx
+++ b/apps/dashboard/src/pages/sign-in.tsx
@@ -89,11 +89,10 @@ export const SignInPage = () => {
   // Already-signed-in user landing on `/auth/sign-in` — bounce to the right home before the
   // <SignIn/> form mounts and starts its own redirect (which would race this effect).
   //
-  // For Connect flows we deliberately drop any inbound `redirect_url` and always go to the
-  // clean provision entry point. The Connect host shares Clerk session cookies with primary
-  // via the registrable domain, so it loads signed-in directly — no handshake params to
-  // forward. Honoring a stale return URL is what caused the Platform ↔ Connect redirect loop
-  // after the post-PR-11281 follow-ups, so we keep it stripped.
+  // For Connect flows we always go to the clean provision entry point. The Connect host shares
+  // Clerk session cookies with primary via the registrable domain, so it loads signed-in from a
+  // plain navigation. Inbound `redirect_url` is dropped so a stale return URL can't strand the
+  // user.
   // CLI auth is the exception: the device session must resume on `/cli/auth` after sign-in.
   useEffect(() => {
     if (!isLoaded || !isSignedIn || IS_NOVU_CONNECT || hasRedirectedRef.current) {

--- a/apps/dashboard/src/pages/sign-up.tsx
+++ b/apps/dashboard/src/pages/sign-up.tsx
@@ -69,10 +69,9 @@ export const SignUpPage = () => {
   }, []);
 
   // Already-signed-in user landing on `/auth/sign-up` with Connect intent — hand off to Connect
-  // immediately. We deliberately drop any inbound `redirect_url` and always go to the clean
-  // provision entry point. The Connect host shares Clerk session cookies with primary via the
-  // registrable domain, so it loads signed-in directly — no handshake params to forward.
-  // Honoring a stale return URL is what caused the redirect loop in earlier iterations.
+  // immediately. The Connect host shares Clerk session cookies with primary via the registrable
+  // domain, so it loads signed-in from a plain navigation. Inbound `redirect_url` is dropped and
+  // we always go to the clean provision entry point so a stale return URL can't strand the user.
   // CLI auth resumes through pending session storage after org provisioning completes.
   useEffect(() => {
     if (!isLoaded || !isSignedIn || IS_NOVU_CONNECT || hasRedirectedRef.current) {

--- a/apps/dashboard/src/pages/sign-up.tsx
+++ b/apps/dashboard/src/pages/sign-up.tsx
@@ -32,8 +32,8 @@ export const SignUpPage = () => {
     [searchParams]
   );
 
-  // Clean Connect provisioning entry point. Always the same URL — Clerk's satellite domain SDK
-  // performs the session-sync handshake natively when the destination page loads.
+  // Clean Connect provisioning entry point. Always the same URL — primary's session cookies
+  // live on the shared registrable domain, so the Connect host loads signed-in immediately.
   const connectProvisionRedirect = useMemo(
     () => buildAbsoluteConnectUrl(buildConnectProvisionOrgListPath(ROUTES.SIGNUP_ORGANIZATION_LIST)),
     []
@@ -44,7 +44,7 @@ export const SignUpPage = () => {
     readCliAuthReturnUrl(searchParams, { preferConnectHost: isConnectSignUp });
   }, [searchParams, isConnectSignUp]);
 
-  // Sign-up flows are primary-only — bounce satellite visitors back with Connect branding.
+  // Sign-up flows are primary-only — bounce Connect-host visitors back with Connect branding.
   useEffect(() => {
     if (IS_NOVU_CONNECT) {
       const redirectUrl = readClerkRedirectUrlParam(searchParams);
@@ -69,9 +69,10 @@ export const SignUpPage = () => {
   }, []);
 
   // Already-signed-in user landing on `/auth/sign-up` with Connect intent — hand off to Connect
-  // immediately. We deliberately drop any inbound `redirect_url` (e.g. a stale `?__clerk_synced=false`
-  // Connect URL) and always go to the clean provision entry point — Clerk's satellite SDK syncs
-  // the session on arrival. Honoring the stale return URL is what caused the redirect loop.
+  // immediately. We deliberately drop any inbound `redirect_url` and always go to the clean
+  // provision entry point. The Connect host shares Clerk session cookies with primary via the
+  // registrable domain, so it loads signed-in directly — no handshake params to forward.
+  // Honoring a stale return URL is what caused the redirect loop in earlier iterations.
   // CLI auth resumes through pending session storage after org provisioning completes.
   useEffect(() => {
     if (!isLoaded || !isSignedIn || IS_NOVU_CONNECT || hasRedirectedRef.current) {
@@ -100,7 +101,7 @@ export const SignUpPage = () => {
   }, [searchParams, isConnectSignUp]);
 
   // Render nothing while redirecting:
-  //   - On the satellite (`IS_NOVU_CONNECT`) the page is mid-replace to primary.
+  //   - On the Connect host (`IS_NOVU_CONNECT`) the page is mid-replace to primary.
   //   - On the primary when the user is already signed in the effect above is handling the bounce.
   if (IS_NOVU_CONNECT || (isLoaded && isSignedIn)) {
     return null;

--- a/apps/dashboard/src/routes/hostname-guard.tsx
+++ b/apps/dashboard/src/routes/hostname-guard.tsx
@@ -10,7 +10,7 @@ type HostnameGuardProps = {
 };
 
 // Connect host: collapses non-Connect `/env/:slug/*` paths to Connect home.
-// Platform host: cross-origin redirects stale `/env/:slug/connect/*` bookmarks to the satellite.
+// Platform host: cross-origin redirects stale `/env/:slug/connect/*` bookmarks to the Connect host.
 export function HostnameGuard({ children }: HostnameGuardProps) {
   const location = useLocation();
   const { currentEnvironment } = useEnvironment();
@@ -27,7 +27,8 @@ export function HostnameGuard({ children }: HostnameGuardProps) {
 
     const url = `${window.location.protocol}//${NOVU_CONNECT_HOSTNAME}${location.pathname}${location.search}${location.hash}`;
 
-    // Plain cross-origin replace — Clerk's satellite SDK runs its handshake on the destination page.
+    // Plain cross-origin replace — Clerk session cookies are scoped to the shared registrable
+    // domain, so the destination page reads the existing session natively (no handshake needed).
     window.location.replace(url);
   }, [shouldRedirectCrossOrigin, location.pathname, location.search, location.hash]);
 

--- a/apps/dashboard/src/routes/hostname-guard.tsx
+++ b/apps/dashboard/src/routes/hostname-guard.tsx
@@ -28,7 +28,7 @@ export function HostnameGuard({ children }: HostnameGuardProps) {
     const url = `${window.location.protocol}//${NOVU_CONNECT_HOSTNAME}${location.pathname}${location.search}${location.hash}`;
 
     // Plain cross-origin replace — Clerk session cookies are scoped to the shared registrable
-    // domain, so the destination page reads the existing session natively (no handshake needed).
+    // domain, so the destination page reads the existing session natively.
     window.location.replace(url);
   }, [shouldRedirectCrossOrigin, location.pathname, location.search, location.hash]);
 

--- a/apps/dashboard/src/routes/root.tsx
+++ b/apps/dashboard/src/routes/root.tsx
@@ -51,7 +51,7 @@ const RootRouteInternal = () => {
     <ErrorBoundary fallback={({ error, eventId }) => <RootRouteErrorFallback error={error} eventId={eventId} />}>
       <QueryClientProvider client={queryClient}>
         <ClerkProvider>
-          {/* Hold rendering until Clerk bootstraps to avoid a flash during satellite handshake. */}
+          {/* Hold rendering until Clerk bootstraps so route guards see a settled auth state. */}
           <ClerkLoaded>
             <SegmentProvider>
               <CustomerIoProvider>

--- a/apps/dashboard/src/utils/product-auth-urls.ts
+++ b/apps/dashboard/src/utils/product-auth-urls.ts
@@ -73,7 +73,7 @@ function buildAppOrigin(hostname: string): string {
   return `${window.location.protocol}//${normalizeAppHost(hostname)}`;
 }
 
-/** Primary ClerkProvider allowlist — satellite origins must be listed for redirectWithAuth. */
+/** Primary ClerkProvider allowlist — Connect host origin must be listed so post-auth navigation back from primary is honored. */
 export function buildClerkAllowedRedirectOrigins(): Array<string | RegExp> {
   const origins: Array<string | RegExp> = ['http://localhost:*'];
 
@@ -149,61 +149,4 @@ export function readClerkAuthParamFromLocation(param: string, searchParams?: URL
 /** Clerk may put redirect_url in the query string or inside hash routing (#/?redirect_url=). */
 export function readClerkRedirectUrlParam(searchParams?: URLSearchParams): string | null {
   return readClerkAuthParamFromLocation('redirect_url', searchParams);
-}
-
-/** Strip handshake params that can accumulate across redirect loops. */
-function sanitizeConnectSatelliteReturnUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    parsed.searchParams.delete('__clerk_netlify_cache_bust');
-    parsed.searchParams.delete('__clerk_synced');
-    parsed.searchParams.delete('__clerk_sync');
-    parsed.searchParams.delete('__clerk_handshake');
-
-    return parsed.toString();
-  } catch {
-    return url;
-  }
-}
-
-/** Clerk's satellite handshake return URL — must be honored so Connect receives the synced session. */
-export function readConnectSatelliteReturnUrl(searchParams?: URLSearchParams): string | null {
-  const redirectUrl = readClerkRedirectUrlParam(searchParams);
-
-  if (!redirectUrl || !isConnectHostnameUrl(redirectUrl)) {
-    return null;
-  }
-
-  return sanitizeConnectSatelliteReturnUrl(redirectUrl);
-}
-
-function isConnectPrimaryAuthPath(url: string): boolean {
-  try {
-    const pathname = new URL(url, typeof window !== 'undefined' ? window.location.origin : 'http://local').pathname;
-
-    return pathname === ROUTES.SIGN_IN || pathname === ROUTES.SIGN_UP;
-  } catch {
-    return false;
-  }
-}
-
-/** Return URL to send back to Connect after primary auth — skip sign-in/sign-up pages that re-bounce. */
-export function resolveConnectSatelliteReturnUrl(searchParams: URLSearchParams): string | null {
-  const fromQuery = readConnectSatelliteReturnUrl(searchParams);
-
-  if (fromQuery && !isConnectPrimaryAuthPath(fromQuery)) {
-    return fromQuery;
-  }
-
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  const currentLocation = window.location.href;
-
-  if (isConnectHostnameUrl(currentLocation) && !isConnectPrimaryAuthPath(currentLocation)) {
-    return sanitizeConnectSatelliteReturnUrl(currentLocation);
-  }
-
-  return null;
 }


### PR DESCRIPTION
### What changed? Why was the change needed?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

This PR moves the dashboard from a Clerk "satellite" handshake model to cookie-based auth for Connect by documenting and aligning code to a primary same-registrable-domain host model. Comments, environment guidance, and some auth utilities were removed or refactored so Connect and the primary product share Clerk session cookies (eTLD+1), avoiding SDK handshake/return-URL mechanics and reducing cross-origin redirect complexity.

## Affected areas

**dashboard**: Comments, env docs, and auth-related logic were updated to reflect the primary same-root-domain model; Netlify caching guidance was clarified to avoid stale auth pages.  
**dashboard (enterprise)**: EEAuthProvider was refactored to drop satellite variables, compute `isCrossProductHost`, and route sign-in/sign-up to primary auth URLs when appropriate.  
**dashboard/hooks & components**: Inline docs updated in cross-app navigation, CrossAppLink, HostnameGuard, SignIn/SignUp pages, settings, and other auth-adjacent components; removed satellite-specific return-URL utilities from product-auth-urls.ts.  
**config / env**: `.example.env` guidance adjusted to require shared eTLD+1 for cookie visibility and to instruct adding Connect hosts to Clerk allowed subdomains.

## Key technical decisions

- Rely on shared registrable-domain (eTLD+1) Clerk session cookies for cross-product auth instead of a satellite SDK handshake or CNAME-based satellite mapping.  
- Remove satellite return-URL utilities and simplify auth routing by using `isCrossProductHost` in EEAuthProvider to choose primary auth routes.

## Testing

No automated tests were added; changes are primarily comments, env guidance, and small auth-routing refactors with no API/schema changes. Recommend manual integration verification (sign-in/sign-up, cross-origin navigation between Connect and primary, and Netlify cache behavior) in an environment where Connect and Primary share the same registrable domain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Also include any relevant links, such as Linear tickets, Slack discussions, or design documents. -->

### Screenshots

<!-- If the changes are visual, include screenshots or screencasts. -->

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

<!-- A link to a dependent pull request  -->

### Special notes for your reviewer

<!-- Specific instructions or considerations you want to highlight for the reviewer. -->

</details>
