### PR TITLE
fix(api): remove conversational agents flag guard from agents controller fixes NV-7900

### DIFF
--- a/apps/api/src/app/agents/agents-webhook.controller.ts
+++ b/apps/api/src/app/agents/agents-webhook.controller.ts
@@ -9,7 +9,6 @@ import {
   Post,
   Req,
   Res,
-  UseGuards,
 } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
 import { PinoLogger } from '@novu/application-generic';
@@ -21,7 +20,6 @@ import { ExternalApiAccessible } from '../auth/framework/external-api.decorator'
 import { UserSession } from '../shared/framework/user.decorator';
 import { AgentReplyPayloadDto } from './dtos/agent-reply-payload.dto';
 import { AgentInactiveException } from './exceptions/agent-inactive.exception';
-import { AgentConversationEnabledGuard } from './guards/agent-conversation-enabled.guard';
 import type { AgentConfigResolveSource } from './services/agent-config-resolver.service';
 import { ChatSdkService } from './services/chat-sdk.service';
 import { ManagedAgentService } from './services/managed-agent.service';
@@ -29,7 +27,6 @@ import { HandleAgentReplyCommand } from './usecases/handle-agent-reply/handle-ag
 import { HandleAgentReply } from './usecases/handle-agent-reply/handle-agent-reply.usecase';
 
 @Controller('/agents')
-@UseGuards(AgentConversationEnabledGuard)
 @ApiExcludeController()
 export class AgentsWebhookController {
   constructor(

--- a/apps/api/src/app/agents/agents.controller.ts
+++ b/apps/api/src/app/agents/agents.controller.ts
@@ -13,7 +13,6 @@ import {
   Query,
   Req,
   UseFilters,
-  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiExcludeController, ApiExcludeEndpoint, ApiOperation } from '@nestjs/swagger';
@@ -81,7 +80,6 @@ import {
   SendWhatsAppTestTemplateResponseDto,
 } from './dtos/send-whatsapp-test-template.dto';
 import { AgentRuntimeExceptionFilter } from './filters/agent-runtime-exception.filter';
-import { AgentConversationEnabledGuard } from './guards/agent-conversation-enabled.guard';
 import { AddAgentIntegrationCommand } from './usecases/add-agent-integration/add-agent-integration.command';
 import { AddAgentIntegration } from './usecases/add-agent-integration/add-agent-integration.usecase';
 import { ConfigureTelegramAgentWebhookCommand } from './usecases/configure-telegram-agent-webhook/configure-telegram-agent-webhook.command';
@@ -148,7 +146,6 @@ import { VerifyManagedCredentials } from './usecases/verify-managed-credentials/
 @ApiCommonResponses()
 @Controller('/agents')
 @UseInterceptors(ClassSerializerInterceptor)
-@UseGuards(AgentConversationEnabledGuard)
 @ApiExcludeController()
 @RequireAuthentication()
 export class AgentsController {

--- a/apps/api/src/app/agents/services/agent-config-resolver.service.ts
+++ b/apps/api/src/app/agents/services/agent-config-resolver.service.ts
@@ -3,7 +3,6 @@ import {
   AnalyticsService,
   decryptChannelConnectionAuth,
   decryptCredentials,
-  FeatureFlagsService,
   PinoLogger,
 } from '@novu/application-generic';
 import {
@@ -13,7 +12,7 @@ import {
   ICredentialsEntity,
   IntegrationRepository,
 } from '@novu/dal';
-import { EmailProviderIdEnum, FeatureFlagsKeysEnum } from '@novu/shared';
+import { EmailProviderIdEnum } from '@novu/shared';
 import type { WellKnownEmoji } from 'chat';
 import { trackAgentIntegrationFirstWebhook } from '../agent-analytics';
 import { AgentPlatformEnum } from '../dtos/agent-platform.enum';
@@ -86,7 +85,6 @@ async function resolveReaction(
 @Injectable()
 export class AgentConfigResolver {
   constructor(
-    private readonly featureFlagsService: FeatureFlagsService,
     private readonly agentRepository: AgentRepository,
     private readonly agentIntegrationRepository: AgentIntegrationRepository,
     private readonly integrationRepository: IntegrationRepository,
@@ -112,16 +110,6 @@ export class AgentConfigResolver {
     }
 
     const { _environmentId: environmentId, _organizationId: organizationId } = agent;
-
-    const isEnabled = await this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED,
-      defaultValue: false,
-      environment: { _id: environmentId },
-      organization: { _id: organizationId },
-    });
-    if (!isEnabled) {
-      throw new NotFoundException();
-    }
 
     const integration = await this.integrationRepository.findOne({
       _environmentId: environmentId,

--- a/apps/api/src/app/agents/usecases/generate-managed-agent/generate-managed-agent.usecase.ts
+++ b/apps/api/src/app/agents/usecases/generate-managed-agent/generate-managed-agent.usecase.ts
@@ -1,11 +1,10 @@
-import { ForbiddenException, Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import { AnalyticsService, FeatureFlagsService, InstrumentUsecase, PinoLogger } from '@novu/application-generic';
+import { AnalyticsService, InstrumentUsecase, PinoLogger } from '@novu/application-generic';
 import {
   CLAUDE_ANTHROPIC_SKILLS,
   CLAUDE_BUILTIN_TOOLS,
   CLAUDE_DEFAULT_TOOL_TYPES,
-  FeatureFlagsKeysEnum,
   MCP_SERVERS,
 } from '@novu/shared';
 
@@ -177,7 +176,6 @@ function ensureDefaultTools(tools: string[]): string[] {
 export class GenerateManagedAgent {
   constructor(
     private readonly moduleRef: ModuleRef,
-    private readonly featureFlagsService: FeatureFlagsService,
     private readonly analyticsService: AnalyticsService,
     private readonly logger: PinoLogger
   ) {}
@@ -187,22 +185,6 @@ export class GenerateManagedAgent {
     const { user, prompt } = command;
     const runtime = command.runtime ?? 'managed';
     const { organizationId, environmentId, _id: userId } = user;
-
-    // Self-hosted scaffolding does not provision anything on Anthropic Managed Agents — it just
-    // emits name/identifier/systemPrompt for the caller's own runtime. There is therefore no
-    // reason to gate it on IS_MANAGED_AGENT_RUNTIME_ENABLED. Managed generation still requires
-    // the flag because the resulting agent will be provisioned on Anthropic.
-    if (runtime === 'managed') {
-      const isEnabled = await this.featureFlagsService.getFlag({
-        key: FeatureFlagsKeysEnum.IS_MANAGED_AGENT_RUNTIME_ENABLED,
-        defaultValue: false,
-        organization: { _id: organizationId },
-      });
-
-      if (!isEnabled) {
-        throw new ForbiddenException('Managed agent generation is not enabled for this organization');
-      }
-    }
 
     const eeAi = this.loadEeAi();
     const llmService = this.moduleRef.get(eeAi.LlmService, { strict: false });

--- a/apps/api/src/app/environments-v2/usecases/sync-strategies/agent-sync.strategy.ts
+++ b/apps/api/src/app/environments-v2/usecases/sync-strategies/agent-sync.strategy.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { FeatureFlagsService, PinoLogger } from '@novu/application-generic';
-import { FeatureFlagsKeysEnum, UserSessionData } from '@novu/shared';
+import { PinoLogger } from '@novu/application-generic';
+import { UserSessionData } from '@novu/shared';
 
 import { IDiffResult, ISyncContext, ISyncResult, ResourceTypeEnum } from '../../types/sync.types';
 import { BaseSyncStrategy } from './base/base-sync.strategy';
@@ -12,8 +12,7 @@ export class AgentSyncStrategy extends BaseSyncStrategy {
   constructor(
     logger: PinoLogger,
     private agentSyncOperation: AgentSyncOperation,
-    private agentDiffOperation: AgentDiffOperation,
-    private featureFlagsService: FeatureFlagsService
+    private agentDiffOperation: AgentDiffOperation
   ) {
     super(logger);
   }
@@ -23,12 +22,6 @@ export class AgentSyncStrategy extends BaseSyncStrategy {
   }
 
   async execute(context: ISyncContext): Promise<ISyncResult> {
-    const isEnabled = await this.isFeatureEnabled(context.user.organizationId, context.sourceEnvironmentId);
-
-    if (!isEnabled) {
-      return { resourceType: ResourceTypeEnum.AGENT, successful: [], failed: [], skipped: [], totalProcessed: 0 };
-    }
-
     return this.agentSyncOperation.execute(context);
   }
 
@@ -38,31 +31,10 @@ export class AgentSyncStrategy extends BaseSyncStrategy {
     organizationId: string,
     userContext: UserSessionData
   ): Promise<IDiffResult[]> {
-    const isEnabled = await this.isFeatureEnabled(organizationId, sourceEnvId);
-
-    if (!isEnabled) {
-      return [];
-    }
-
     return this.agentDiffOperation.execute(sourceEnvId, targetEnvId, organizationId, userContext);
   }
 
   async getAvailableResourceIds(sourceEnvironmentId: string, organizationId: string): Promise<string[]> {
-    const isEnabled = await this.isFeatureEnabled(organizationId, sourceEnvironmentId);
-
-    if (!isEnabled) {
-      return [];
-    }
-
     return this.agentSyncOperation.getAvailableResourceIds(sourceEnvironmentId, organizationId);
-  }
-
-  private async isFeatureEnabled(organizationId: string, environmentId: string): Promise<boolean> {
-    return this.featureFlagsService.getFlag({
-      key: FeatureFlagsKeysEnum.IS_CONVERSATIONAL_AGENTS_ENABLED,
-      defaultValue: false,
-      organization: { _id: organizationId },
-      environment: { _id: environmentId },
-    });
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes agent-related LaunchDarkly feature flag gates from the API so rollout control stays on the dashboard UI. Authenticated agent management, webhooks, config resolution, environment sync, and managed agent generation no longer depend on these flags server-side.

## Changes

- **`agents.controller.ts`** — removed `AgentConversationEnabledGuard` (`IS_CONVERSATIONAL_AGENTS_ENABLED`)
- **`agents-webhook.controller.ts`** — removed the same guard from inbound webhook/reply routes
- **`agent-config-resolver.service.ts`** — removed `IS_CONVERSATIONAL_AGENTS_ENABLED` check during agent config resolution
- **`agent-sync.strategy.ts`** — removed flag gating on agent diff/sync during environment publish
- **`generate-managed-agent.usecase.ts`** — removed `IS_MANAGED_AGENT_RUNTIME_ENABLED` check for managed generation

## Unchanged (still gated)

| Flag | Location |
|------|----------|
| `IS_CONVERSATIONAL_AGENTS_ENABLED` | Dashboard UI (navigation, pages, queries) |
| `IS_CONVERSATIONAL_AGENTS_ENABLED` | EE `conversations.controller.ts` |
| `IS_MCP_NOVU_APP_ENABLED` | `assert-mcp-novu-app-flag-enabled.ts` |
| `AGENT_EMAIL_INTEGRATION` | Product/tier feature on email inbox endpoints |

## Testing

- Lint: no new issues in touched files.
- Existing agent e2e suites should continue to pass; they already enable flags in setup where needed for unrelated paths.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9aa30866-3b75-44b8-b56b-c2406db58ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9aa30866-3b75-44b8-b56b-c2406db58ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Server-side LaunchDarkly guards that blocked agent-related API flows were removed so the API no longer enforces conversational-agent feature flags. The change centralizes rollout control to the dashboard UI and prevents the backend from returning NotFound/Forbidden for agent operations when the dashboard wants to surface agent features. Endpoint signatures and runtime behavior remain the same aside from removing the flag checks.

## Affected areas

**api**: Removed server-side feature-flag guards from agent controllers, inbound webhook routes, agent config resolution, agent sync/publish strategy, and managed-agent generation so these APIs no longer throw when conversational/managed-agent flags are off. Dashboard UI flag checks, EE conversations controller, and product/tier guards (e.g., email inbox) remain unchanged.

## Key technical decisions

- Move rollout control exclusively to the frontend by removing server-side gating while keeping API contracts unchanged.  
- No database/schema or new dependency changes; lazy-loaded EE AI usage and existing runtime branching were preserved.

## Testing

Lint passed for touched files; existing agent e2e suites are expected to continue passing because tests set required flags in setup. No new tests were added since this is removal of guards rather than new feature logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strips server-side LaunchDarkly feature flag guards (`IS_CONVERSATIONAL_AGENTS_ENABLED`, `IS_MANAGED_AGENT_RUNTIME_ENABLED`) from five agent-related files, moving rollout control exclusively to the dashboard UI layer while keeping the API endpoints always available to authenticated callers.

- **`agents.controller.ts` / `agents-webhook.controller.ts`**: `AgentConversationEnabledGuard` class-level decorator removed from both controllers; authentication (`@RequireAuthentication()`) and product-feature guards remain unchanged.
- **`agent-config-resolver.service.ts` / `generate-managed-agent.usecase.ts`**: Inline flag checks and their `FeatureFlagsService` dependencies removed; the resolvers now run unconditionally on every authenticated request.
- **`agent-sync.strategy.ts`**: Flag checks guarding `execute`, `diff`, and `getAvailableResourceIds` removed; `isFeatureEnabled` helper and its constructor injection cleaned up, NestJS DI handles the reduced constructor correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive in terms of API availability; authenticated endpoints gain access regardless of flag state, which is the stated intent.

All five files perform straightforward removals of flag-check code paths with no new logic introduced. Authentication guards on the main controller and the reply endpoint remain intact. The NestJS DI container handles the reduced constructor signatures in AgentSyncStrategy and GenerateManagedAgent correctly via existing module declarations. Inbound webhook endpoints were already unauthenticated by design prior to this PR. No data mutations or schema changes are involved.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/agents.controller.ts | Removed AgentConversationEnabledGuard class-level decorator; authentication via @RequireAuthentication() remains intact. |
| apps/api/src/app/agents/agents-webhook.controller.ts | Removed AgentConversationEnabledGuard from the webhook controller; inbound webhook endpoints were already unauthenticated by design (external platform delivery), and handleAgentReply retains its per-method @RequireAuthentication(). |
| apps/api/src/app/agents/services/agent-config-resolver.service.ts | Removed IS_CONVERSATIONAL_AGENTS_ENABLED flag check and its FeatureFlagsService dependency; NotFoundException on disabled flag is gone, config resolution proceeds unconditionally. |
| apps/api/src/app/agents/usecases/generate-managed-agent/generate-managed-agent.usecase.ts | Removed IS_MANAGED_AGENT_RUNTIME_ENABLED flag check for managed runtime generation; ForbiddenException on disabled flag and FeatureFlagsService dependency removed cleanly. |
| apps/api/src/app/environments-v2/usecases/sync-strategies/agent-sync.strategy.ts | Removed flag gating from execute, diff, and getAvailableResourceIds; FeatureFlagsService constructor parameter and private isFeatureEnabled helper removed; NestJS DI handles the reduced constructor correctly. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before this PR"]
        A1[Authenticated Request] --> B1{AgentConversationEnabledGuard}
        B1 -->|Flag OFF| C1[403 Forbidden / 404 Not Found]
        B1 -->|Flag ON| D1[Agent Logic]
        E1[Managed Gen Request] --> F1{IS_MANAGED_AGENT_RUNTIME_ENABLED}
        F1 -->|Flag OFF| G1[403 Forbidden]
        F1 -->|Flag ON| H1[Generate Agent]
        I1[Env Sync/Diff] --> J1{IS_CONVERSATIONAL_AGENTS_ENABLED}
        J1 -->|Flag OFF| K1[Return empty / skip]
        J1 -->|Flag ON| L1[Run Sync/Diff]
    end

    subgraph After["After this PR"]
        A2[Authenticated Request] --> D2[Agent Logic]
        E2[Managed Gen Request] --> H2[Generate Agent]
        I2[Env Sync/Diff] --> L2[Run Sync/Diff]
        M2[Dashboard UI] --> N2{IS_CONVERSATIONAL_AGENTS_ENABLED in React}
        N2 -->|Flag OFF| O2[Hide navigation/pages]
        N2 -->|Flag ON| P2[Show agent features]
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix(api): remove remaining agent feature..."](https://github.com/novuhq/novu/commit/33f34abf21ba7e31f840757c21838e9e78962ba7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34511036)</sub>

<!-- /greptile_comment -->