### PR TITLE
chore(novu): update Connect staging domain and runtime picker copy fixes NV-7901

### DIFF
--- a/packages/novu/package.json
+++ b/packages/novu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novu",
-  "version": "2.8.1-rc.12",
+  "version": "2.8.1-rc.13",
   "description": "Novu CLI. Run Novu Studio and sync workflows with Novu Cloud",
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/novu/src/commands/connect/ui/phase-content.tsx
+++ b/packages/novu/src/commands/connect/ui/phase-content.tsx
@@ -56,8 +56,10 @@ export function PhaseContent({
     case 'pick-runtime':
       return (
         <Box flexDirection="column" gap={1}>
-          <Text bold>Where do you want the agent to run?</Text>
-          <Text dimColor>Choose the agent runtime. Novu connects it to Slack, email, and more.</Text>
+          <Box flexDirection="column">
+            <Text bold>Where do you want the agent to run?</Text>
+            <Text dimColor>Choose the agent runtime. Novu connects it to Slack, email, and more.</Text>
+          </Box>
           <RuntimeSelect onChange={(value) => phase.resolve(value)} />
         </Box>
       );

--- a/packages/novu/src/commands/connect/ui/phase-content.tsx
+++ b/packages/novu/src/commands/connect/ui/phase-content.tsx
@@ -362,9 +362,9 @@ function RuntimeSelect({
   onChange: (value: AgentRuntimeChoice) => void;
 }): React.ReactElement {
   const options: Array<{ value: AgentRuntimeChoice; title: string; detail?: string }> = [
-    { value: 'demo', title: 'Novu Demo Agent', detail: '10 conversations per month' },
-    { value: 'claude', title: 'Claude Managed Agents - BYOK' },
-    { value: 'claude-aws', title: 'Claude Managed Agents on AWS' },
+    { value: 'demo', title: 'Demo Credentials', detail: '10 conversations per month' },
+    { value: 'claude', title: 'Claude Managed Agents' },
+    { value: 'claude-aws', title: 'AWS Claude Managed Agents' },
   ];
   const [idx, setIdx] = React.useState(0);
 

--- a/packages/novu/src/commands/dev/enums.ts
+++ b/packages/novu/src/commands/dev/enums.ts
@@ -20,7 +20,7 @@ export enum ApiUrlEnum {
 /** Browser-auth surface for `novu connect` (distinct from the main dashboard). */
 export enum ConnectDashboardUrlEnum {
   PROD = 'https://connect.novu.co',
-  STAGING = 'https://devconnect.novu.co',
+  STAGING = 'https://connect.novu-staging.co',
 }
 
 export const LOCAL_API_URL = 'https://api.novu.localhost';

--- a/packages/novu/src/commands/dev/resolve-region-urls.spec.ts
+++ b/packages/novu/src/commands/dev/resolve-region-urls.spec.ts
@@ -16,7 +16,7 @@ describe('resolveRegionUrls', () => {
 
     expect(urls.apiUrl).toBe('https://api.novu-staging.co');
     expect(urls.dashboardUrl).toBe('https://dashboard.novu-staging.co');
-    expect(urls.connectDashboardUrl).toBe('https://devconnect.novu.co');
+    expect(urls.connectDashboardUrl).toBe('https://connect.novu-staging.co');
   });
 
   it('maps local region to local dev URLs with connect dashboard matching dashboard', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Novu Connect CLI for staging and refreshes the interactive runtime picker copy.

## Changes

- **Staging Connect URL**: `devconnect.novu.co` → `connect.novu-staging.co` in `ConnectDashboardUrlEnum` and its unit test
- **`npx novu connect` runtime options** (Where do you want the agent to run?):
  - Demo Credentials
  - Claude Managed Agents
  - AWS Claude Managed Agents

## Testing

- `pnpm exec vitest run src/commands/dev/resolve-region-urls.spec.ts` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccf62442-cea4-4ebe-987b-5bc81f148997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccf62442-cea4-4ebe-987b-5bc81f148997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Updated the Novu Connect CLI staging configuration and improved the interactive runtime picker copy and layout. The staging Connect dashboard URL was changed from devconnect.novu.co to connect.novu-staging.co to point CLI flows at the correct staging endpoint, and runtime options in the interactive picker were relabeled to "Demo Credentials", "Claude Managed Agents", and "AWS Claude Managed Agents" for clearer UX. The package version was bumped and minor UI spacing was fixed.

## Affected areas

**js** — Updated the Connect CLI implementation and onboarding UI: the staging dashboard URL enum value and its unit test were updated, the runtime picker UI structure and labels were adjusted for better copy and spacing, and the package version in packages/novu was bumped.

## Testing

Existing unit tests were updated and run: `pnpm exec vitest run src/commands/dev/resolve-region-urls.spec.ts` passed. No new external dependencies or schema/API changes were introduced; manual verification of CLI picker copy was applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Novu Connect CLI staging domain and refreshes the interactive runtime picker labels. All changes are localized to the `packages/novu` CLI package with a corresponding version bump.

- **Staging URL**: `ConnectDashboardUrlEnum.STAGING` updated from `devconnect.novu.co` to `connect.novu-staging.co`; the old domain no longer appears anywhere in the codebase and the unit test is kept in sync.
- **Runtime picker copy**: Labels renamed to "Demo Credentials", "Claude Managed Agents", and "AWS Claude Managed Agents"; `Text` elements for the picker header are wrapped in a `Box` for layout consistency.
- **Version**: Bumped to `2.8.1-rc.13` to publish the updated CLI.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are a URL string swap with matching test update and copy-only label renames.

The staging domain update is simple and fully covered by the existing unit test. The runtime picker label changes are display-only with no impact on the underlying AgentRuntimeChoice values passed through the system. No logic paths were altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/package.json | Routine version bump from 2.8.1-rc.12 to 2.8.1-rc.13 to publish the updated CLI. |
| packages/novu/src/commands/dev/enums.ts | Staging ConnectDashboardUrl updated from devconnect.novu.co to connect.novu-staging.co; old domain is no longer referenced anywhere in the codebase. |
| packages/novu/src/commands/dev/resolve-region-urls.spec.ts | Test expectation updated to match new staging URL; test continues to pass. |
| packages/novu/src/commands/connect/ui/phase-content.tsx | Runtime picker labels refreshed and Text elements wrapped in a Box for layout consistency; no logic changes. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npx novu connect] --> B{pick-runtime phase}
    B --> C[Demo Credentials\n10 conversations/month]
    B --> D[Claude Managed Agents]
    B --> E[AWS Claude Managed Agents]
    C --> F{resolveRegionUrls}
    D --> F
    E --> F
    F -->|staging| G[connect.novu-staging.co]
    F -->|prod| H[connect.novu.co]
```

<sub>Reviews (3): Last reviewed commit: ["fix(novu): remove gap between runtime pi..."](https://github.com/novuhq/novu/commit/7a2ca99387597b2f5f9ff0d599d502c464f7c084) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34517856)</sub>

<!-- /greptile_comment -->