### PR TITLE
fix(dashboard): scope connect session init to agents onboarding only fixes NV-7902

### DIFF
--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -174,7 +174,11 @@ const router = createBrowserRouter([
           },
           {
             path: ROUTES.AGENTS_SETUP,
-            element: <AgentsSetupPage />,
+            element: (
+              <ConnectSubscriberProvider>
+                <AgentsSetupPage />
+              </ConnectSubscriberProvider>
+            ),
           },
           {
             path: ROUTES.INBOX_USECASE,

--- a/apps/dashboard/src/routes/onboarding.tsx
+++ b/apps/dashboard/src/routes/onboarding.tsx
@@ -1,6 +1,5 @@
 import { Show } from '@clerk/react';
 import { AnimatedOutlet } from '@/components/animated-outlet';
-import { ConnectSubscriberProvider } from '@/components/connect/connect-subscriber-provider';
 import { AuthLayout } from '../components/auth-layout';
 import { EnvironmentProvider } from '../context/environment/environment-provider';
 
@@ -8,11 +7,9 @@ export const OnboardingParentRoute = () => {
   return (
     <Show when="signed-in">
       <EnvironmentProvider>
-        <ConnectSubscriberProvider>
-          <AuthLayout>
-            <AnimatedOutlet />
-          </AuthLayout>
-        </ConnectSubscriberProvider>
+        <AuthLayout>
+          <AnimatedOutlet />
+        </AuthLayout>
       </EnvironmentProvider>
     </Show>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In product onboarding at `/onboarding/inbox`, the test inbox preview was initialized against a `connect:<userId>` subscriber, but the **Send test notification** trigger fired on the bare `<userId>` (no prefix). The triggered notification therefore never appeared in the test inbox.

## Root cause

`OnboardingParentRoute` (`apps/dashboard/src/routes/onboarding.tsx`) wrapped **every** onboarding page in `ConnectSubscriberProvider`, which mounts a `@novu/react` `NovuProvider` using `subscriberId = connect:<userId>`.

`@novu/react`'s `<Inbox>` calls `useUnsafeNovu()` and, when an ambient `NovuProvider` is present, reuses that instance instead of the `subscriberId` prop it is given:

```
// packages/react/src/components/Inbox.tsx
const novu = useUnsafeNovu();
if (novu) {
  return <InboxChild ... subscriber={subscriber} />; // ambient connect:<userId> wins
}
```

So the inbox preview ended up subscribed as `connect:<userId>` while the onboarding trigger in `inbox-playground.tsx` targeted `<userId>` — a guaranteed mismatch. The connect session was being initialized even on non-connect onboarding flows (inbox / platform), which it should not.

## Fix

- Remove `ConnectSubscriberProvider` from the shared `OnboardingParentRoute`.
- Scope it to only the agents setup route (`/onboarding/agents/setup`), which is the sole onboarding page that consumes the connect subscriber (Slack / Teams / WhatsApp setup guides via `useConnectSubscriber`).

With the ambient connect provider gone from the inbox route, `<Inbox>` builds its own provider from the `subscriberId` prop (`user.externalId`, which equals `currentUser._id` per `context/auth/mappers.ts`), matching the trigger target. No connect session is initialized for inbox/platform onboarding.

```mermaid
flowchart TD
    A[/onboarding parent route/] --> B{which page?}
    B -->|inbox / usecase| C[No ConnectSubscriberProvider\nInbox builds own NovuProvider with userId]
    B -->|agents/setup| D[ConnectSubscriberProvider\nNovuProvider with connect:userId]
```

## Scope

Only the two routing files change; no behavior change for the agents flow. The connect subscriber context remains available exactly where it is consumed.

## Testing

- ✅ `npx tsc -b` (dashboard type-check)
- ✅ `npx biome lint src/main.tsx src/routes/onboarding.tsx`

Full UI end-to-end testing of the onboarding flow could not be completed in the cloud agent environment: the dashboard runs in `better-auth` enterprise mode and the organization-selection page (`/auth/organization-list`) renders blank because the better-auth `useOrganizationList` shim does not implement the Clerk membership API (`revalidate`/`hasNextPage`/`isFetching`) that `AutoCreateConnectOrganization` depends on, so it never gets past org selection into onboarding. The better-auth backend itself is healthy (verified `sign-in/email` → 200 and `organization/list` → returns the seeded org via curl). These are pre-existing environment/shim issues unrelated to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6638da19-8da2-4fd9-8c91-e309a9e8f08f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6638da19-8da2-4fd9-8c91-e309a9e8f08f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed
Moved `ConnectSubscriberProvider` from being a global wrapper around all onboarding pages to only wrapping the agents setup route (`/onboarding/agents/setup`). This eliminates a subscriber mismatch where the test inbox preview was initialized with `connect:<userId>` while the "Send test notification" trigger targeted the bare `<userId>`, preventing test notifications from appearing.

## Affected areas
**dashboard**: Removed `ConnectSubscriberProvider` from the shared `OnboardingParentRoute` component and scoped it specifically to the agents setup route in main routing configuration.

## Testing
Type-checking (`npx tsc -b`) and linting (`npx biome lint`) passed. Full E2E testing could not be completed due to pre-existing auth organization-selection issues unrelated to this change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an onboarding inbox preview bug where the test notification was sent to `<userId>` but the `<Inbox>` component was subscribed under `connect:<userId>` because `ConnectSubscriberProvider` was mounted in the shared `OnboardingParentRoute`. The provider is now scoped exclusively to the `/onboarding/agents/setup` route, the only onboarding page whose components (`slack-setup-guide`, `teams-setup-guide`, `whatsapp-setup-guide`) consume `useConnectSubscriber`.

- **`routes/onboarding.tsx`**: `ConnectSubscriberProvider` removed from `OnboardingParentRoute`; inbox and usecase onboarding pages now build their own `NovuProvider` from the correct `subscriberId` prop.
- **`main.tsx`**: `ConnectSubscriberProvider` added as a wrapper specifically around `<AgentsSetupPage />` in the route config, preserving its behavior only where it is actually consumed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, surgical re-scoping of a provider with no impact on the agents flow and a clear fix for the inbox onboarding mismatch.

Both changed files touch only route configuration. `useConnectSubscriber` is consumed exclusively in the three agent setup-guide components (Slack, Teams, WhatsApp), all of which live under `AgentsSetupPage`, so wrapping only that route with `ConnectSubscriberProvider` is correct. Inbox and platform onboarding pages never called the hook and now correctly build their own `NovuProvider` from the `subscriberId` prop. No data flow, API calls, or authentication logic is modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/routes/onboarding.tsx | Removes ConnectSubscriberProvider from the shared OnboardingParentRoute so inbox/platform onboarding pages no longer get a connect:<userId> NovuProvider injected above them. |
| apps/dashboard/src/main.tsx | Wraps only the AGENTS_SETUP child route with ConnectSubscriberProvider; all other onboarding and dashboard routes are unaffected. The import remains valid as the provider is still used here and in the CONNECT_HOME route. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/onboarding (OnboardingParentRoute)"] --> B{Route}
    B -->|USECASE_SELECT| C["UsecaseSelectPage\n(no ConnectSubscriberProvider)"]
    B -->|AGENTS_USECASE| D["AgentsUsecasePage\n(no ConnectSubscriberProvider)"]
    B -->|AGENTS_SETUP| E["ConnectSubscriberProvider\n↳ AgentsSetupPage\n(connect:userId subscriber)"]
    B -->|INBOX_USECASE| F["InboxUsecasePage\nBuilds own NovuProvider\nwith userId"]
    B -->|INBOX_EMBED| G["InboxEmbedPage\n(no ConnectSubscriberProvider)"]
    B -->|INBOX_EMBED_SUCCESS| H["InboxEmbedSuccessPage\n(no ConnectSubscriberProvider)"]

    style E fill:#d4edda,stroke:#28a745
    style F fill:#d4edda,stroke:#28a745
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): scope connect session in..."](https://github.com/novuhq/novu/commit/4031a15664fef1a603fa36f864c689d343de19a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34530620)</sub>

<!-- /greptile_comment -->