### PR TITLE
ci(root): trigger TesterArmy staging and production regression after deploy fixes NV-7904 NV-7905

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -598,3 +598,46 @@ jobs:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY_CLOUD_PROD }}
           name: ${{ steps.release_meta.outputs.name }}
           version: ${{ github.sha }}
+
+  testerarmy_staging_regression:
+    name: TesterArmy Staging Regression
+    needs: [deploy, prepare-matrix]
+    runs-on: ubuntu-latest
+    if: |
+      always() &&
+      needs.deploy.result == 'success' &&
+      (
+        github.event.inputs.environment == 'staging' ||
+        github.event.inputs.environment == 'staging-sg'
+      )
+    steps:
+      - name: Trigger TesterArmy staging regression tests
+        env:
+          TESTERARMY_STAGING_WEBHOOK_URL: ${{ secrets.TESTERARMY_STAGING_WEBHOOK_URL }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$TESTERARMY_STAGING_WEBHOOK_URL" ]; then
+            echo "TESTERARMY_STAGING_WEBHOOK_URL is not configured, skipping regression trigger."
+            exit 0
+          fi
+
+          payload=$(jq -n \
+            --arg commitSha "$COMMIT_SHA" \
+            --arg targetUrl "https://dashboard.novu-staging.co" \
+            --arg environment "staging" \
+            '{commitSha: $commitSha, targetUrl: $targetUrl, environment: $environment}')
+
+          response=$(curl -sS -w "\n%{http_code}" -X POST "$TESTERARMY_STAGING_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          echo "TesterArmy response (HTTP ${http_code}): ${body}"
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "Failed to trigger TesterArmy staging regression tests."
+            exit 1
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -641,3 +641,80 @@ jobs:
             echo "Failed to trigger TesterArmy staging regression tests."
             exit 1
           fi
+
+  testerarmy_production_regression:
+    name: TesterArmy Production Regression
+    needs: [deploy, prepare-matrix]
+    runs-on: ubuntu-latest
+    if: |
+      always() &&
+      needs.deploy.result == 'success' &&
+      (contains(github.event.inputs.environment, 'production'))
+    steps:
+      - name: Trigger TesterArmy US production regression tests
+        if: |
+          github.event.inputs.environment == 'production-us' ||
+          github.event.inputs.environment == 'production-us-and-eu'
+        env:
+          TESTERARMY_PROD_WEBHOOK_URL: ${{ secrets.TESTERARMY_PROD_WEBHOOK_URL }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$TESTERARMY_PROD_WEBHOOK_URL" ]; then
+            echo "TESTERARMY_PROD_WEBHOOK_URL is not configured, skipping US production regression trigger."
+            exit 0
+          fi
+
+          payload=$(jq -n \
+            --arg commitSha "$COMMIT_SHA" \
+            --arg targetUrl "https://dashboard.novu.co" \
+            --arg environment "production" \
+            '{commitSha: $commitSha, targetUrl: $targetUrl, environment: $environment}')
+
+          response=$(curl -sS -w "\n%{http_code}" -X POST "$TESTERARMY_PROD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          echo "TesterArmy US production response (HTTP ${http_code}): ${body}"
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "Failed to trigger TesterArmy US production regression tests."
+            exit 1
+          fi
+
+      - name: Trigger TesterArmy EU production regression tests
+        if: |
+          github.event.inputs.environment == 'production-eu' ||
+          github.event.inputs.environment == 'production-us-and-eu'
+        env:
+          TESTERARMY_PROD_WEBHOOK_URL: ${{ secrets.TESTERARMY_PROD_WEBHOOK_URL }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$TESTERARMY_PROD_WEBHOOK_URL" ]; then
+            echo "TESTERARMY_PROD_WEBHOOK_URL is not configured, skipping EU production regression trigger."
+            exit 0
+          fi
+
+          payload=$(jq -n \
+            --arg commitSha "$COMMIT_SHA" \
+            --arg targetUrl "https://eu.dashboard.novu.co" \
+            --arg environment "production" \
+            '{commitSha: $commitSha, targetUrl: $targetUrl, environment: $environment}')
+
+          response=$(curl -sS -w "\n%{http_code}" -X POST "$TESTERARMY_PROD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          echo "TesterArmy EU production response (HTTP ${http_code}): ${body}"
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "Failed to trigger TesterArmy EU production regression tests."
+            exit 1
+          fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Adds TesterArmy group webhook regression triggers at the end of the deploy workflow after successful deployments.

**Staging** (`testerarmy_staging_regression`):
- Runs for `staging` and `staging-sg`
- POSTs to `TESTERARMY_STAGING_WEBHOOK_URL`
- Targets `https://dashboard.novu-staging.co` with `environment: staging`

**Production** (`testerarmy_production_regression`):
- Runs for production deploy environments
- POSTs to `TESTERARMY_PROD_WEBHOOK_URL`
- Triggers **independently** per region (mirrors existing Bug0 prod webhook pattern):
  - **US** — `https://dashboard.novu.co` when deploying `production-us` or `production-us-and-eu`
  - **EU** — `https://eu.dashboard.novu.co` when deploying `production-eu` or `production-us-and-eu`
- Uses `environment: production`

Both jobs pass `commitSha` so TesterArmy can post GitHub check runs on the deployed commit.

This follows the [TesterArmy group webhooks](https://docs.tester.army/run/group-webhooks) and [custom infrastructure](https://docs.tester.army/integrations/custom-infrastructure) integration pattern.

**Setup required — repository secrets:**
- `TESTERARMY_STAGING_WEBHOOK_URL` — staging regression test group webhook URL
- `TESTERARMY_PROD_WEBHOOK_URL` — production regression test group webhook URL

If a secret is not configured, the corresponding job/step skips gracefully without failing the deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83fafdb8-272e-42c8-ab0d-47832c44e3eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83fafdb8-272e-42c8-ab0d-47832c44e3eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Added TesterArmy regression-triggering steps to the deploy workflow so staging and production deploys POST deployment metadata to TesterArmy webhooks after successful deploys; this automates post-deploy regression runs and surfaces failures via non-2xx webhook responses. The change ensures automated end-to-end regression triggers for both staging and multi-region production deployments.

## Affected areas
**CI/CD workflows**: .github/workflows/deploy.yml now includes two post-deploy jobs: a staging regression trigger that runs for `staging` and `staging-sg`, and a production regression trigger that fires per-region (US/EU) for production deploys; both send commit SHA and target dashboard URL to configured TesterArmy webhook secrets.

## Key technical decisions
- Webhook triggers are guarded by repository secrets (`TESTERARMY_STAGING_WEBHOOK_URL`, `TESTERARMY_PROD_WEBHOOK_URL`) and will skip gracefully if secrets are unset to avoid failing deployments.  
- Production triggers mirror existing per-region webhook patterns and invoke TesterArmy independently for US and EU regions when appropriate.  
- Webhook responses are validated; non-2xx responses cause the job to fail so the deployment team is alerted.  
- Note: a static `environment: "staging"` value in the staging payload was flagged (will be incorrect for `staging-sg`) and should be adjusted to reflect the actual staging region when the job runs.

## Testing
No unit tests were added; the workflow is exercised via normal CI/CD runs and manual verification of webhook deliveries once the required secrets are configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two new GitHub Actions jobs (`testerarmy_staging_regression`, `testerarmy_production_regression`) that POST webhook payloads to TesterArmy after successful deploys to trigger regression tests; both jobs gracefully skip when the webhook secret is absent.

- **Staging job** fires for `staging` and `staging-sg`, sending commit SHA, dashboard URL, and environment to `TESTERARMY_STAGING_WEBHOOK_URL`.
- **Production job** fires two independent steps (US and EU) based on the selected environment, using `TESTERARMY_PROD_WEBHOOK_URL`; however, the job-level condition matches all production environments while the step-level conditions only cover `production-us`, `production-eu`, and `production-us-and-eu`, leaving six other production variants (`production-sg`, `production-au`, `production-uk`, `production-jp`, `production-kr`, `production-sg-au-uk-jp-kr`) with no step to execute and no test triggered.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix needed: the production job silently does nothing for six valid production environments.

The production regression job's step-level conditions only cover US and EU regions, so deploying to Singapore, Australia, UK, Japan, Korea, or the combined SG/AU/UK/JP/KR environment triggers the job but exits with both steps skipped and no webhook fired. All other aspects of the change — secret-absent graceful skip, HTTP status validation, staging job logic — are correct.

.github/workflows/deploy.yml — specifically the step conditions inside `testerarmy_production_regression`

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy.yml | Adds testerarmy_staging_regression and testerarmy_production_regression jobs; production job silently skips webhook for non-US/EU regions (sg, au, uk, jp, kr, sg-au-uk-jp-kr) |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[workflow_dispatch] --> B[prepare-matrix]
    B --> C[deploy]
    C --> D{deploy succeeded?}
    D -- No --> Z[TesterArmy jobs skipped]
    D -- Yes --> E{environment?}
    E -- staging / staging-sg --> F[testerarmy_staging_regression]
    F --> G[POST to TESTERARMY_STAGING_WEBHOOK_URL]
    E -- production-us / production-us-and-eu --> H[testerarmy_production_regression]
    E -- production-eu / production-us-and-eu --> H
    E -- production-sg / production-au / production-uk / production-jp / production-kr / production-sg-au-uk-jp-kr --> I[testerarmy_production_regression - both steps SKIPPED]
    H --> J[POST US webhook - dashboard.novu.co]
    H --> K[POST EU webhook - eu.dashboard.novu.co]
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fdeploy.yml%3A645-652%0A**Production%20regression%20silently%20skipped%20for%20non-US%2FEU%20regions**%0A%0AThe%20job-level%20condition%20%60contains%28...%2C%20'production'%29%60%20matches%20every%20production%20environment%20%28%60production-sg%60%2C%20%60production-au%60%2C%20%60production-uk%60%2C%20%60production-jp%60%2C%20%60production-kr%60%2C%20%60production-sg-au-uk-jp-kr%60%29%2C%20but%20the%20two%20steps%20inside%20only%20fire%20on%20%60production-us%60%20%2F%20%60production-eu%60%20%2F%20%60production-us-and-eu%60.%20For%20any%20other%20production%20environment%20both%20steps%20are%20skipped%2C%20the%20job%20exits%20cleanly%20with%20a%20green%20checkmark%2C%20and%20TesterArmy%20is%20never%20triggered.%20Six%20of%20the%20eleven%20selectable%20environments%20hit%20this%20silent%20no-op%20path.%0A%0A&pr=11349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/deploy.yml:645-652
**Production regression silently skipped for non-US/EU regions**

The job-level condition `contains(..., 'production')` matches every production environment (`production-sg`, `production-au`, `production-uk`, `production-jp`, `production-kr`, `production-sg-au-uk-jp-kr`), but the two steps inside only fire on `production-us` / `production-eu` / `production-us-and-eu`. For any other production environment both steps are skipped, the job exits cleanly with a green checkmark, and TesterArmy is never triggered. Six of the eleven selectable environments hit this silent no-op path.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["ci(deploy): trigger TesterArmy productio..."](https://github.com/novuhq/novu/commit/fea522d6ef293a3264b3d14d55d507442320a610) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34541296)</sub>

<!-- /greptile_comment -->