### PR TITLE
refactor(worker): remove organization existence check from workflow worker fixes NV-7910

### DIFF
--- a/apps/worker/src/app/workflow/services/workflow.worker.spec.ts
+++ b/apps/worker/src/app/workflow/services/workflow.worker.spec.ts
@@ -47,13 +47,11 @@ describe('Workflow Worker', () => {
     const workflowInMemoryProviderService = moduleRef.get<WorkflowInMemoryProviderService>(
       WorkflowInMemoryProviderService
     );
-    const organizationRepository = moduleRef.get<CommunityOrganizationRepository>(CommunityOrganizationRepository);
     const featureFlagsService = moduleRef.get<FeatureFlagsService>(FeatureFlagsService);
 
     workflowWorker = new WorkflowWorker(
       triggerEventUseCase,
       workflowInMemoryProviderService,
-      organizationRepository,
       mockSqsService,
       new PinoLogger({}),
       featureFlagsService

--- a/apps/worker/src/app/workflow/services/workflow.worker.ts
+++ b/apps/worker/src/app/workflow/services/workflow.worker.ts
@@ -15,7 +15,6 @@ import {
   WorkflowInMemoryProviderService,
   WorkflowWorkerService,
 } from '@novu/application-generic';
-import { CommunityOrganizationRepository } from '@novu/dal';
 import { FeatureFlagsKeysEnum, ObservabilityBackgroundTransactionEnum } from '@novu/shared';
 
 const nr = require('newrelic');
@@ -27,7 +26,6 @@ export class WorkflowWorker extends WorkflowWorkerService {
   constructor(
     private triggerEventUsecase: TriggerEvent,
     public workflowInMemoryProviderService: WorkflowInMemoryProviderService,
-    private organizationRepository: CommunityOrganizationRepository,
     sqsService: SqsService,
     protected logger: PinoLogger,
     private featureFlagsService: FeatureFlagsService
@@ -92,14 +90,6 @@ export class WorkflowWorker extends WorkflowWorkerService {
         return;
       }
 
-      const organizationExists = await this.organizationExist(data);
-
-      if (!organizationExists) {
-        this.logger.warn(`Organization not found for organizationId ${data.organizationId}. Skipping job.`);
-
-        return;
-      }
-
       return await new Promise((resolve, reject) => {
         const _this = this;
 
@@ -127,12 +117,5 @@ export class WorkflowWorker extends WorkflowWorkerService {
         );
       });
     };
-  }
-
-  private async organizationExist(data: IWorkflowDataDto): Promise<boolean> {
-    const { organizationId } = data;
-    const organization = await this.organizationRepository.findOne({ _id: organizationId });
-
-    return !!organization;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the redundant `organizationExist` MongoDB lookup from the workflow worker job processor. Trigger jobs no longer skip processing when the organization document is missing at this stage.

## Changes

- Removed the pre-processing organization existence check and early return in `WorkflowWorker`
- Removed the private `organizationExist` helper and `CommunityOrganizationRepository` dependency
- Updated `workflow.worker.spec.ts` constructor call to match the new signature

## Why

The organization existence query is no longer needed before processing workflow trigger jobs.

## Testing

- Verified changed files pass Biome check
- No behavior change expected beyond removing the skip-on-missing-org path
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e63dacf-cfe0-431c-b842-f48d2f68458b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e63dacf-cfe0-431c-b842-f48d2f68458b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `organizationExist` MongoDB lookup and early-return guard from `WorkflowWorker`, eliminating the `CommunityOrganizationRepository` dependency from the constructor entirely. The intent is to treat any downstream failure (including a missing org) as a non-retryable error handled by the existing at-most-once `setSqsFailedHandler`, rather than a pre-checked silent skip.

- **`workflow.worker.ts`**: Drops `CommunityOrganizationRepository` import/injection, removes the org-existence guard and its helper method. Jobs that previously silently acked on a missing org now proceed to `triggerEventUsecase.execute()`.
- **`workflow.worker.spec.ts`**: Updates the `WorkflowWorker` constructor call to the new 5-argument signature. `mockOrganizationRepository` and the `CommunityOrganizationRepository` import are intentionally kept since `WorkflowQueueService` still requires them.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the refactor is minimal and intentional, with the main trade-off being that jobs for missing organizations now fail loudly rather than being silently skipped.

The deletion is clean and self-contained. The key behavioral shift is that a job whose organization no longer exists will now reach triggerEventUsecase.execute() and, if it throws, be permanently dropped by the at-most-once setSqsFailedHandler rather than silently skipped upfront. Whether this is fully safe depends on whether the use-case handles a missing org gracefully — that path is not exercised by the updated tests.

workflow.worker.spec.ts has no test covering the scenario where triggerEventUsecase.execute is called with a non-existent organization, so the new error path is untested.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/services/workflow.worker.ts | Removes CommunityOrganizationRepository dependency, org-existence pre-check, and helper method. Clean deletion; the behavioral change (missing-org jobs now reach the use-case instead of being silently skipped) is intentional per the PR description. |
| apps/worker/src/app/workflow/services/workflow.worker.spec.ts | Constructor call updated to match new 5-argument signature. mockOrganizationRepository and CommunityOrganizationRepository import are correctly retained for WorkflowQueueService usage. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SQS / BullMQ Job Received] --> B{Kill switch enabled?}
    B -- Yes --> C[Log warn, skip job]
    B -- No --> D[triggerEventUsecase.execute]
    D -- Success --> E[Job acked / complete]
    D -- Throws --> F[setSqsFailedHandler]
    F --> G[Log warning, drop job at-most-once]
    style C fill:#ffd700,color:#000
    style G fill:#ff6b6b,color:#fff
    subgraph REMOVED [Removed in this PR]
        R1{organizationExist?}
        R2[Log warn, skip job]
        R1 -- No --> R2
    end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fservices%2Fworkflow.worker.ts%3A93-119%0A**Missing-org%20path%20now%20silently%20drops%20jobs%20without%20a%20dedicated%20test**%0A%0APreviously%2C%20a%20missing%20organization%20caused%20an%20explicit%20early%20return%20with%20a%20clear%20log%20message.%20Now%2C%20if%20%60triggerEventUsecase.execute%28data%29%60%20throws%20because%20the%20organization%20doesn't%20exist%2C%20the%20job%20is%20swallowed%20by%20%60setSqsFailedHandler%60%20and%20permanently%20dropped%20%28at-most-once%29.%20The%20spec%20has%20no%20test%20for%20this%20failure%20path%20%E2%80%94%20if%20the%20use-case%20doesn't%20handle%20a%20missing%20org%20gracefully%20and%20throws%20an%20unexpected%20error%20type%2C%20the%20failure%20will%20be%20invisible%20beyond%20the%20generic%20%60setSqsFailedHandler%60%20warning.%20Worth%20adding%20a%20test%20that%20stubs%20%60triggerEventUsecase.execute%60%20to%20throw%20and%20verifies%20the%20job%20is%20dropped%20%28not%20retried%29.%0A%0A&pr=11357&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/worker/src/app/workflow/services/workflow.worker.ts:93-119
**Missing-org path now silently drops jobs without a dedicated test**

Previously, a missing organization caused an explicit early return with a clear log message. Now, if `triggerEventUsecase.execute(data)` throws because the organization doesn't exist, the job is swallowed by `setSqsFailedHandler` and permanently dropped (at-most-once). The spec has no test for this failure path — if the use-case doesn't handle a missing org gracefully and throws an unexpected error type, the failure will be invisible beyond the generic `setSqsFailedHandler` warning. Worth adding a test that stubs `triggerEventUsecase.execute` to throw and verifies the job is dropped (not retried).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(worker): remove organization ex..."](https://github.com/novuhq/novu/commit/09d06fbf6014df8733ea8dcf6dd7ff709bacfa14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34590569)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The PR removes a redundant organization existence check from the workflow worker job processor. Previously, the worker would skip processing trigger jobs if the organization document wasn't found in MongoDB. This check has been eliminated along with the `organizationRepository` dependency, allowing jobs to proceed directly to execution after the kill-switch check.

## Affected areas

- `worker`: Removed the `organizationRepository` dependency and `organizationExist` method from `WorkflowWorker`, eliminating the pre-processing organization check that was skipping job execution when the organization was missing.

## Testing

The test file was updated to match the new `WorkflowWorker` constructor signature. Existing test logic for queue draining and worker lifecycle assertions remains unchanged. The PR was verified to pass Biome checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->