### PR TITLE
feat(worker): add workflow name to New Relic custom attributes fixes NV-7911

### DIFF
--- a/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
+++ b/apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts
@@ -169,6 +169,10 @@ export class RunJob {
         job.payload?.__source
       );
 
+      nr.addCustomAttributes({
+        workflow: workflow.name,
+      });
+
       const schedule = await this.getSubscriberSchedule.execute(
         GetSubscriberScheduleCommand.create({
           environmentId: job._environmentId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a New Relic custom attribute `workflow` in the worker `RunJob` use case, set to the workflow name returned by `getWorkflow`.

This complements the existing NR attributes (`transactionId`, `environmentId`, `organizationId`, `jobId`, `jobType`) so job execution traces can be filtered and grouped by workflow name in New Relic.

## Changes

- After fetching the workflow via `getWorkflow`, call `nr.addCustomAttributes({ workflow: workflow.name })`.

## Testing

- No behavior change to job execution logic; observability-only update.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0d0990d-f33f-4b10-8fad-c3358dee6719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0d0990d-f33f-4b10-8fad-c3358dee6719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single New Relic custom attribute — `workflow: workflow.name` — to the `RunJob` use case, complementing the existing `transactionId`, `environmentId`, `organizationId`, `jobId`, and `jobType` attributes so job traces can be grouped and filtered by workflow name.

- The attribute is placed inside the `try` block immediately after `getWorkflow` succeeds, so it is guaranteed non-null at that point and has no impact on job execution logic.
- Unlike the five pre-existing attributes (set unconditionally before the `try`), the new `workflow` attribute is skipped for error paths that throw before reaching it (e.g. notification not found), creating a minor gap in NR trace completeness on those failure paths.

<h3>Confidence Score: 4/5</h3>

Observability-only change with no impact on job execution; safe to merge.

The change is minimal and correct — `workflow` is guaranteed non-null at the call site. The only concern is that the new attribute is placed inside the `try` block while the other five NR attributes are set before it, so traces for jobs that fail on the notification lookup won't carry the `workflow` attribute, which is a minor observability gap rather than a functional defect.

No files require special attention; the single changed file has only a minor observability placement concern.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts | Adds `nr.addCustomAttributes({ workflow: workflow.name })` inside the try block, after `getWorkflow` succeeds; the attribute is skipped on error paths that throw before reaching it (e.g. notification-not-found), unlike the existing NR attributes set unconditionally before the try block. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Worker
    participant NR as New Relic
    participant DB as Repositories

    Worker->>NR: addCustomAttributes(transactionId, environmentId, organizationId, jobId, jobType)
    Worker->>DB: notificationRepository.findOne(notificationId)
    DB-->>Worker: notification
    Worker->>DB: getWorkflow(templateId, environmentId)
    DB-->>Worker: workflow
    Worker->>NR: "addCustomAttributes({ workflow: workflow.name })"
    Note over Worker,NR: NEW — added by this PR
    Worker->>Worker: continue job execution...
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fworker%2Fsrc%2Fapp%2Fworkflow%2Fusecases%2Frun-job%2Frun-job.usecase.ts%3A172-174%0A**Workflow%20attribute%20absent%20in%20notification-not-found%20error%20paths**%0A%0AThe%20new%20%60workflow%60%20attribute%20is%20set%20inside%20the%20%60try%60%20block%2C%20after%20both%20the%20notification%20lookup%20and%20%60getWorkflow%60.%20The%20five%20existing%20attributes%20%28%60transactionId%60%2C%20%60environmentId%60%2C%20%60organizationId%60%2C%20%60jobId%60%2C%20%60jobType%60%29%20are%20set%20unconditionally%20before%20the%20%60try%60.%20This%20means%20any%20NR%20trace%20for%20a%20run%20that%20throws%20on%20the%20notification%20lookup%20at%20line%20162%20will%20carry%20the%20existing%20attributes%20but%20have%20no%20%60workflow%60%20attribute%2C%20making%20it%20harder%20to%20group%2Ffilter%20those%20failure%20traces%20by%20workflow%20in%20New%20Relic.%0A%0A&pr=11359&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/worker/src/app/workflow/usecases/run-job/run-job.usecase.ts:172-174
**Workflow attribute absent in notification-not-found error paths**

The new `workflow` attribute is set inside the `try` block, after both the notification lookup and `getWorkflow`. The five existing attributes (`transactionId`, `environmentId`, `organizationId`, `jobId`, `jobType`) are set unconditionally before the `try`. This means any NR trace for a run that throws on the notification lookup at line 162 will carry the existing attributes but have no `workflow` attribute, making it harder to group/filter those failure traces by workflow in New Relic.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(worker): add workflow name to New R..."](https://github.com/novuhq/novu/commit/a63b44d91a3b4213f6210294ca7031521646f533) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34600693)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->