### PR TITLE
fix(root): bind TesterArmy deploy jobs to GitHub environment secrets fixes NV-7904

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -603,6 +603,7 @@ jobs:
     name: TesterArmy Staging Regression
     needs: [deploy, prepare-matrix]
     runs-on: ubuntu-latest
+    environment: ${{ fromJson(needs.prepare-matrix.outputs.env_matrix).environment[0] }}
     if: |
       always() &&
       needs.deploy.result == 'success' &&
@@ -646,6 +647,7 @@ jobs:
     name: TesterArmy Production Regression
     needs: [deploy, prepare-matrix]
     runs-on: ubuntu-latest
+    environment: ${{ fromJson(needs.prepare-matrix.outputs.env_matrix).environment[0] }}
     if: |
       always() &&
       needs.deploy.result == 'success' &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The TesterArmy staging and production regression jobs in `deploy.yml` referenced `secrets.TESTERARMY_*` without declaring a GitHub `environment` on the job. Repository-level secrets were empty at runtime, so the shell guard treated `TESTERARMY_STAGING_WEBHOOK_URL` as unset and skipped the webhook trigger—even when the URL was configured as an **environment secret** (e.g. on `staging-eu`).

## Fix

Add `environment: ${{ fromJson(needs.prepare-matrix.outputs.env_matrix).environment[0] }}` to both `testerarmy_staging_regression` and `testerarmy_production_regression`, matching `sync_novu_state` and `webhook_notification`.

## Verification

After merge, run a staging deploy and confirm the TesterArmy job logs a successful HTTP 2xx response instead of "is not configured, skipping regression trigger."

**Note:** `TESTERARMY_STAGING_WEBHOOK_URL` must exist on the deployment GitHub environment (`staging-eu` or `staging-apse1`), not only on a separate `development` environment used by dev Netlify workflows.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fd6a1fd-db98-4506-af13-0cb32dd5280b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fd6a1fd-db98-4506-af13-0cb32dd5280b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The `testerarmy_staging_regression` and `testerarmy_production_regression` jobs in `.github/workflows/deploy.yml` now declare a GitHub environment assignment. Each job is bound to the first environment from the deployment matrix (`environment: ${{ fromJson(needs.prepare-matrix.outputs.env_matrix).environment[0] }}`), matching the pattern used by other deployment jobs like `sync_novu_state` and `webhook_notification`.

## Why this was needed

The TesterArmy regression jobs referenced `secrets.TESTERARMY_STAGING_WEBHOOK_URL` and `secrets.TESTERARMY_PRODUCTION_WEBHOOK_URL` without assigning a job environment, preventing access to environment-level secrets. Repository-level secrets were empty at runtime, causing shell guards to skip the webhook trigger even though these secrets existed on deployment environments (e.g., staging-eu or staging-apse1). This fix resolves issue NV-7904.

## Affected areas

**GitHub Actions workflows**: The deploy workflow now properly grants the TesterArmy regression jobs access to environment-specific secrets. This ensures webhook triggers for staging and production regression testing execute successfully.

## Testing

Manual verification required post-merge: run a staging deployment and confirm the TesterArmy job logs a successful HTTP 2xx response instead of "is not configured, skipping regression trigger." Ensure `TESTERARMY_STAGING_WEBHOOK_URL` is configured as a secret on the deployment environment (e.g., staging-eu or staging-apse1).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/novu/pull/11363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a secret-resolution failure in the `testerarmy_staging_regression` and `testerarmy_production_regression` jobs by adding an `environment:` binding so that environment-scoped secrets (like `TESTERARMY_STAGING_WEBHOOK_URL`) are available at runtime. Without the binding, GitHub only provides repository-level secrets, so the shell guard treated the URL as unset and skipped the webhook.

- Adds `environment: ${{ fromJson(needs.prepare-matrix.outputs.env_matrix).environment[0] }}` to both TesterArmy jobs, matching the pattern already used by `build`, `sync_novu_state`, and `webhook_notification`.
- The `[0]` index is an accepted trade-off for multi-environment deployments (`production-us-and-eu`, etc.), consistent with how other post-deploy jobs in this workflow resolve secrets.

<h3>Confidence Score: 5/5</h3>

Safe to merge — two-line addition that follows an identical pattern already used by four other jobs in the same workflow.

The change is minimal and directly mirrors the environment expression already on build, sync_novu_state, and webhook_notification. The root cause (secrets only available when an environment is declared) is well-understood and the fix is correct.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy.yml | Adds environment: bindings to both TesterArmy regression jobs using the same established environment[0] pattern already present in build, sync_novu_state, and webhook_notification. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant PM as prepare-matrix
    participant D as deploy
    participant TA_S as testerarmy_staging_regression
    participant TA_P as testerarmy_production_regression
    participant TesterArmy as TesterArmy Webhook

    GH->>PM: workflow_dispatch (environment input)
    PM-->>GH: env_matrix
    GH->>D: deploy
    D-->>GH: result: success

    Note over TA_S: NEW: environment binding
    GH->>TA_S: run (binds to staging-eu / staging-apse1)
    TA_S->>TesterArmy: POST $TESTERARMY_STAGING_WEBHOOK_URL

    Note over TA_P: NEW: environment binding
    GH->>TA_P: run (binds to prod-us / prod-eu / etc.)
    TA_P->>TesterArmy: POST $TESTERARMY_PROD_WEBHOOK_URL
```

<sub>Reviews (1): Last reviewed commit: ["ci(root): bind TesterArmy deploy hook to..."](https://github.com/novuhq/novu/commit/5155856468586cfaf9367beba147e554c4903f7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34709389)</sub>

<!-- /greptile_comment -->