### PR TITLE
feat(api-service): use opaque Redis tokens for Telegram mobile setup QR links fixes NV-7914

### DIFF
--- a/apps/api/src/app/agents/agents.module.ts
+++ b/apps/api/src/app/agents/agents.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
 import {
   CalculateDemoClaudeQuota,
   CalculateLimitNovuIntegration,
@@ -67,9 +66,6 @@ import { USE_CASES } from './usecases';
     AuthModule,
     EventsModule,
     ChannelEndpointsModule,
-    JwtModule.register({
-      secret: process.env.JWT_SECRET,
-    }),
   ],
   controllers: [
     AgentsController,

--- a/apps/api/src/app/agents/channels/telegram-linking/agents-public.controller.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/agents-public.controller.ts
@@ -21,8 +21,8 @@ import {
  * Public, unauthenticated agent endpoints (no session). Add provider-specific
  * route groups under this controller — today only Telegram mobile configure.
  *
- * Telegram: authorization is a signed, single-use, short-lived JWT in the
- * request; the dashboard issues it via authed
+ * Telegram: authorization is an opaque, single-use, short-lived token stored in
+ * Redis; the dashboard issues it via authed
  * `POST /agents/:id/integrations/:iid/telegram/mobile-link`.
  *
  * Base path `/v1/agents/public` keeps these routes separate from authed
@@ -44,7 +44,7 @@ export class AgentsPublicController {
   @ApiOperation({
     summary: 'Check the status of a Telegram mobile setup link',
     description:
-      'Returns whether a signed Telegram mobile-setup token is still usable. Designed to be called from the ' +
+      'Returns whether a Telegram mobile-setup token is still usable. Designed to be called from the ' +
       'mobile landing page before showing the credentials form.',
   })
   async getStatus(@Query('token') token: string): Promise<GetTelegramMobileLinkStatusResult> {
@@ -59,7 +59,7 @@ export class AgentsPublicController {
   @ApiOperation({
     summary: 'Consume a Telegram mobile setup link',
     description:
-      'Validates the signed token, persists the supplied Bot Token onto the linked Telegram integration, ' +
+      'Validates the setup token, persists the supplied Bot Token onto the linked Telegram integration, ' +
       'and registers the webhook with Telegram. The token becomes invalid after a successful call.',
   })
   async consume(@Body() body: ConsumeTelegramMobileLinkRequestDto): Promise<ConsumeTelegramMobileLinkResponseDto> {

--- a/apps/api/src/app/agents/channels/telegram-linking/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase.ts
@@ -12,7 +12,11 @@ import { ConfigureTelegramAgentWebhookCommand } from '../../telegram/configure-t
 import { ConfigureTelegramAgentWebhook } from '../../telegram/configure-telegram-agent-webhook/configure-telegram-agent-webhook.usecase';
 import { IssueTelegramSubscriberLinkCommand } from '../issue-telegram-subscriber-link/issue-telegram-subscriber-link.command';
 import { IssueTelegramSubscriberLink } from '../issue-telegram-subscriber-link/issue-telegram-subscriber-link.usecase';
-import { InvalidTelegramMobileTokenError, TelegramMobileLinkTokenService } from '../telegram-mobile-link-token.service';
+import {
+  InvalidTelegramMobileTokenError,
+  TelegramMobileLinkTokenPayload,
+  TelegramMobileLinkTokenService,
+} from '../telegram-mobile-link-token.service';
 import { ConsumeTelegramMobileLinkCommand } from './consume-telegram-mobile-link.command';
 
 export interface ConsumeTelegramMobileLinkResult {
@@ -35,16 +39,8 @@ export class ConsumeTelegramMobileLink {
   }
 
   async execute(command: ConsumeTelegramMobileLinkCommand): Promise<ConsumeTelegramMobileLinkResult> {
-    const payload = this.verifyToken(command.token);
-
-    const claimed = await this.tokenService.claimJti(payload.jti);
-
-    if (!claimed) {
-      throw new ConflictException({
-        code: 'token_already_used',
-        message: 'This setup link has already been used. Generate a new one from your dashboard.',
-      });
-    }
+    const claimed = await this.claimToken(command.token);
+    const payload = claimed.payload as TelegramMobileLinkTokenPayload;
 
     try {
       const integration = await this.integrationRepository.findOne(
@@ -112,17 +108,24 @@ export class ConsumeTelegramMobileLink {
         deepLinkUrl,
       };
     } catch (err) {
-      await this.tokenService.releaseJti(payload.jti);
-      this.logger.warn(`Telegram mobile setup consume failed for jti=${payload.jti}: ${(err as Error).message}`);
+      await this.tokenService.release(command.token, claimed);
+      this.logger.warn(`Telegram mobile setup consume failed: ${(err as Error).message}`);
       throw err;
     }
   }
 
-  private verifyToken(token: string) {
+  private async claimToken(token: string) {
     try {
-      return this.tokenService.verify(token);
+      return await this.tokenService.claim(token, 'agent');
     } catch (err) {
       if (err instanceof InvalidTelegramMobileTokenError) {
+        if (err.reason === 'used') {
+          throw new ConflictException({
+            code: 'token_already_used',
+            message: 'This setup link has already been used. Generate a new one from your dashboard.',
+          });
+        }
+
         throw new UnauthorizedException({
           code: err.reason === 'expired' ? 'token_expired' : 'token_invalid',
           message:

--- a/apps/api/src/app/agents/channels/telegram-linking/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase.ts
@@ -108,7 +108,11 @@ export class ConsumeTelegramMobileLink {
         deepLinkUrl,
       };
     } catch (err) {
-      await this.tokenService.release(command.token, claimed);
+      try {
+        await this.tokenService.release(command.token, claimed);
+      } catch (releaseErr) {
+        this.logger.error(`Telegram mobile setup token rollback failed: ${(releaseErr as Error).message}`);
+      }
       this.logger.warn(`Telegram mobile setup consume failed: ${(err as Error).message}`);
       throw err;
     }

--- a/apps/api/src/app/agents/channels/telegram-linking/get-telegram-mobile-link-status/get-telegram-mobile-link-status.usecase.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/get-telegram-mobile-link-status/get-telegram-mobile-link-status.usecase.ts
@@ -18,18 +18,14 @@ export class GetTelegramMobileLinkStatus {
   ) {}
 
   async execute(command: GetTelegramMobileLinkStatusCommand): Promise<GetTelegramMobileLinkStatusResult> {
-    let payload: ReturnType<TelegramMobileLinkTokenService['verify']>;
+    let payload: Awaited<ReturnType<TelegramMobileLinkTokenService['verify']>>;
     try {
-      payload = this.tokenService.verify(command.token);
+      payload = await this.tokenService.verify(command.token);
     } catch (err) {
       if (err instanceof InvalidTelegramMobileTokenError) {
         return { valid: false, reason: err.reason };
       }
       return { valid: false, reason: 'invalid' };
-    }
-
-    if (await this.tokenService.isJtiUsed(payload.jti)) {
-      return { valid: false, reason: 'used' };
     }
 
     const integration = await this.integrationRepository.findOne(

--- a/apps/api/src/app/agents/channels/telegram-linking/get-telegram-mobile-link-status/get-telegram-mobile-link-status.usecase.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/get-telegram-mobile-link-status/get-telegram-mobile-link-status.usecase.ts
@@ -25,7 +25,8 @@ export class GetTelegramMobileLinkStatus {
       if (err instanceof InvalidTelegramMobileTokenError) {
         return { valid: false, reason: err.reason };
       }
-      return { valid: false, reason: 'invalid' };
+
+      throw err;
     }
 
     const integration = await this.integrationRepository.findOne(

--- a/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts
@@ -1,0 +1,152 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import {
+  InvalidTelegramMobileTokenError,
+  TELEGRAM_MOBILE_LINK_TTL_SECONDS,
+  TelegramMobileLinkTokenService,
+} from './telegram-mobile-link-token.service';
+
+describe('TelegramMobileLinkTokenService', () => {
+  function makeService() {
+    const cacheStore = new Map<string, string>();
+    const client = {
+      getdel: sinon.stub().callsFake(async (key: string) => {
+        const value = cacheStore.get(key) ?? null;
+        if (value != null) {
+          cacheStore.delete(key);
+        }
+
+        return value;
+      }),
+    };
+    const cacheService = {
+      cacheEnabled: () => true,
+      client,
+      set: sinon.stub().callsFake(async (key: string, value: string) => {
+        cacheStore.set(key, value);
+
+        return 'OK';
+      }),
+      get: sinon.stub().callsFake(async (key: string) => cacheStore.get(key) ?? null),
+      del: sinon.stub().callsFake(async (key: string) => {
+        cacheStore.delete(key);
+      }),
+    };
+    const logger = {
+      setContext: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      debug: sinon.stub(),
+      info: sinon.stub(),
+    };
+
+    const service = new TelegramMobileLinkTokenService(cacheService as any, logger as any);
+
+    return { service, cacheService, cacheStore, client };
+  }
+
+  it('issues a 32-char opaque token and stores the payload in Redis', async () => {
+    const { service, cacheService } = makeService();
+
+    const { token, expiresAt } = await service.issue({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      agentIdentifier: 'agent-1',
+      integrationId: 'int-1',
+      subscriberId: 'sub-1',
+    });
+
+    expect(token).to.have.length(32);
+    expect(token).to.match(/^[A-Za-z0-9_-]+$/);
+
+    const expiresAtMs = Date.parse(expiresAt);
+    const expectedExpiresAtMs = Date.now() + TELEGRAM_MOBILE_LINK_TTL_SECONDS * 1000;
+    expect(Math.abs(expiresAtMs - expectedExpiresAtMs)).to.be.below(1500);
+
+    expect(cacheService.set.calledOnce).to.equal(true);
+    const setArgs = cacheService.set.firstCall.args;
+    expect(setArgs[0]).to.equal(`telegram_mobile_link:${token}`);
+    const parsed = JSON.parse(setArgs[1] as string);
+    expect(parsed.payload.kind).to.equal('agent');
+    expect(parsed.payload.env).to.equal('env-1');
+    expect(parsed.payload.sid).to.equal('sub-1');
+    expect(setArgs[2]).to.deep.equal({ ttl: TELEGRAM_MOBILE_LINK_TTL_SECONDS });
+  });
+
+  it('peek verifies without consuming', async () => {
+    const { service } = makeService();
+    const { token } = await service.issue({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      agentIdentifier: 'agent-1',
+      integrationId: 'int-1',
+    });
+
+    const payload = await service.verify(token);
+    expect(payload.kind).to.equal('agent');
+    expect(payload.aid).to.equal('agent-1');
+
+    const payloadAgain = await service.verify(token);
+    expect(payloadAgain.aid).to.equal('agent-1');
+  });
+
+  it('claim is single-use and marks the token as used', async () => {
+    const { service } = makeService();
+    const { token } = await service.issue({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      agentIdentifier: 'agent-1',
+      integrationId: 'int-1',
+    });
+
+    const claimed = await service.claim(token, 'agent');
+    expect(claimed.payload.kind).to.equal('agent');
+
+    try {
+      await service.claim(token, 'agent');
+      expect.fail('expected second claim to fail');
+    } catch (err) {
+      expect(err).to.be.instanceOf(InvalidTelegramMobileTokenError);
+      expect((err as InvalidTelegramMobileTokenError).reason).to.equal('used');
+    }
+
+    try {
+      await service.verify(token);
+      expect.fail('expected verify after claim to fail');
+    } catch (err) {
+      expect((err as InvalidTelegramMobileTokenError).reason).to.equal('used');
+    }
+  });
+
+  it('release restores a claimed token for retry', async () => {
+    const { service } = makeService();
+    const { token } = await service.issue({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      agentIdentifier: 'agent-1',
+      integrationId: 'int-1',
+    });
+
+    const claimed = await service.claim(token, 'agent');
+    await service.release(token, claimed);
+
+    const payload = await service.verify(token);
+    expect(payload.iid).to.equal('int-1');
+  });
+
+  it('rejects tokens with unexpected kind', async () => {
+    const { service } = makeService();
+    const { token } = await service.issueForIntegrationStore({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+    });
+
+    try {
+      await service.verify(token);
+      expect.fail('expected agent verify to reject integration-store token');
+    } catch (err) {
+      expect((err as InvalidTelegramMobileTokenError).reason).to.equal('invalid');
+    }
+  });
+});

--- a/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts
@@ -4,33 +4,73 @@ import sinon from 'sinon';
 import {
   InvalidTelegramMobileTokenError,
   TELEGRAM_MOBILE_LINK_TTL_SECONDS,
+  TelegramMobileLinkCacheUnavailableError,
   TelegramMobileLinkTokenService,
 } from './telegram-mobile-link-token.service';
 
 describe('TelegramMobileLinkTokenService', () => {
+  function runClaimScript(
+    cacheStore: Map<string, string>,
+    keyTtls: Map<string, number>,
+    keys: string[],
+    args: (string | number | Buffer)[]
+  ) {
+    const storageKey = keys[0];
+    const usedKey = keys[1];
+    const now = Number(args[0]);
+    const raw = cacheStore.get(storageKey) ?? null;
+
+    if (!raw) {
+      if (cacheStore.has(usedKey)) {
+        return 'U';
+      }
+
+      return '';
+    }
+
+    cacheStore.delete(storageKey);
+
+    let parsed: { expiresAt?: number };
+    try {
+      parsed = JSON.parse(raw) as { expiresAt?: number };
+    } catch {
+      return 'I';
+    }
+
+    if (!parsed.expiresAt) {
+      return 'I';
+    }
+
+    const ttl = Math.max(1, parsed.expiresAt - now);
+    cacheStore.set(usedKey, '1');
+    keyTtls.set(usedKey, ttl);
+
+    return `M${raw}`;
+  }
+
   function makeService() {
     const cacheStore = new Map<string, string>();
-    const client = {
-      getdel: sinon.stub().callsFake(async (key: string) => {
-        const value = cacheStore.get(key) ?? null;
-        if (value != null) {
-          cacheStore.delete(key);
-        }
-
-        return value;
-      }),
-    };
+    const keyTtls = new Map<string, number>();
     const cacheService = {
       cacheEnabled: () => true,
-      client,
-      set: sinon.stub().callsFake(async (key: string, value: string) => {
+      client: {},
+      set: sinon.stub().callsFake(async (key: string, value: string, options?: { ttl?: number }) => {
         cacheStore.set(key, value);
+        if (options?.ttl != null) {
+          keyTtls.set(key, options.ttl);
+        } else {
+          keyTtls.delete(key);
+        }
 
         return 'OK';
       }),
       get: sinon.stub().callsFake(async (key: string) => cacheStore.get(key) ?? null),
       del: sinon.stub().callsFake(async (key: string) => {
         cacheStore.delete(key);
+        keyTtls.delete(key);
+      }),
+      eval: sinon.stub().callsFake(async (_script: string, keys: string[], args: (string | number | Buffer)[]) => {
+        return runClaimScript(cacheStore, keyTtls, keys, args);
       }),
     };
     const logger = {
@@ -43,7 +83,7 @@ describe('TelegramMobileLinkTokenService', () => {
 
     const service = new TelegramMobileLinkTokenService(cacheService as any, logger as any);
 
-    return { service, cacheService, cacheStore, client };
+    return { service, cacheService, cacheStore, keyTtls };
   }
 
   it('issues a 32-char opaque token and stores the payload in Redis', async () => {
@@ -91,8 +131,8 @@ describe('TelegramMobileLinkTokenService', () => {
     expect(payloadAgain.aid).to.equal('agent-1');
   });
 
-  it('claim is single-use and marks the token as used', async () => {
-    const { service } = makeService();
+  it('claim is single-use and marks the token as used with remaining TTL', async () => {
+    const { service, cacheStore, keyTtls } = makeService();
     const { token } = await service.issue({
       environmentId: 'env-1',
       organizationId: 'org-1',
@@ -102,6 +142,13 @@ describe('TelegramMobileLinkTokenService', () => {
 
     const claimed = await service.claim(token, 'agent');
     expect(claimed.payload.kind).to.equal('agent');
+
+    const usedKey = `telegram_mobile_link_used:${token}`;
+    expect(cacheStore.get(usedKey)).to.equal('1');
+    const usedTtl = keyTtls.get(usedKey);
+    expect(usedTtl).to.be.a('number');
+    const remaining = claimed.expiresAt - Math.floor(Date.now() / 1000);
+    expect(usedTtl!).to.equal(Math.max(1, remaining));
 
     try {
       await service.claim(token, 'agent');
@@ -135,6 +182,24 @@ describe('TelegramMobileLinkTokenService', () => {
     expect(payload.iid).to.equal('int-1');
   });
 
+  it('release is a no-op when the natural expiry has passed', async () => {
+    const { service, cacheService } = makeService();
+    const { token } = await service.issue({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+      agentIdentifier: 'agent-1',
+      integrationId: 'int-1',
+    });
+
+    const claimed = await service.claim(token, 'agent');
+    const expiredClaim = { ...claimed, expiresAt: Math.floor(Date.now() / 1000) - 1 };
+    const setCallsBefore = cacheService.set.callCount;
+
+    await service.release(token, expiredClaim);
+
+    expect(cacheService.set.callCount).to.equal(setCallsBefore);
+  });
+
   it('rejects tokens with unexpected kind', async () => {
     const { service } = makeService();
     const { token } = await service.issueForIntegrationStore({
@@ -147,6 +212,18 @@ describe('TelegramMobileLinkTokenService', () => {
       expect.fail('expected agent verify to reject integration-store token');
     } catch (err) {
       expect((err as InvalidTelegramMobileTokenError).reason).to.equal('invalid');
+    }
+  });
+
+  it('surfaces cache failures from isTokenUsed', async () => {
+    const { service, cacheService } = makeService();
+    cacheService.get.rejects(new Error('redis down'));
+
+    try {
+      await service.isTokenUsed('abcdefghijklmnopqrstuvwxyz123456');
+      expect.fail('expected cache failure');
+    } catch (err) {
+      expect(err).to.be.instanceOf(TelegramMobileLinkCacheUnavailableError);
     }
   });
 });

--- a/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts
@@ -18,6 +18,7 @@ describe('TelegramMobileLinkTokenService', () => {
     const storageKey = keys[0];
     const usedKey = keys[1];
     const now = Number(args[0]);
+    const expectedKind = args[1] as string | undefined;
     const raw = cacheStore.get(storageKey) ?? null;
 
     if (!raw) {
@@ -30,15 +31,23 @@ describe('TelegramMobileLinkTokenService', () => {
 
     cacheStore.delete(storageKey);
 
-    let parsed: { expiresAt?: number };
+    let parsed: { expiresAt?: number; payload?: { kind?: string } };
     try {
-      parsed = JSON.parse(raw) as { expiresAt?: number };
+      parsed = JSON.parse(raw) as { expiresAt?: number; payload?: { kind?: string } };
     } catch {
       return 'I';
     }
 
-    if (!parsed.expiresAt) {
+    if (!parsed.expiresAt || !parsed.payload?.kind) {
       return 'I';
+    }
+
+    if (expectedKind && parsed.payload.kind !== expectedKind) {
+      const ttl = Math.max(1, parsed.expiresAt - now);
+      cacheStore.set(storageKey, raw);
+      keyTtls.set(storageKey, ttl);
+
+      return 'K';
     }
 
     const ttl = Math.max(1, parsed.expiresAt - now);
@@ -46,6 +55,23 @@ describe('TelegramMobileLinkTokenService', () => {
     keyTtls.set(usedKey, ttl);
 
     return `M${raw}`;
+  }
+
+  function runReleaseScript(
+    cacheStore: Map<string, string>,
+    keyTtls: Map<string, number>,
+    keys: string[],
+    args: (string | number | Buffer)[]
+  ) {
+    const storageKey = keys[0];
+    const usedKey = keys[1];
+    const value = String(args[0]);
+    const ttl = Number(args[1]);
+
+    cacheStore.set(storageKey, value);
+    keyTtls.set(storageKey, ttl);
+    cacheStore.delete(usedKey);
+    keyTtls.delete(usedKey);
   }
 
   function makeService() {
@@ -69,7 +95,13 @@ describe('TelegramMobileLinkTokenService', () => {
         cacheStore.delete(key);
         keyTtls.delete(key);
       }),
-      eval: sinon.stub().callsFake(async (_script: string, keys: string[], args: (string | number | Buffer)[]) => {
+      eval: sinon.stub().callsFake(async (script: string, keys: string[], args: (string | number | Buffer)[]) => {
+        if (script.includes("redis.call('DEL', KEYS[2])")) {
+          runReleaseScript(cacheStore, keyTtls, keys, args);
+
+          return null;
+        }
+
         return runClaimScript(cacheStore, keyTtls, keys, args);
       }),
     };
@@ -148,7 +180,8 @@ describe('TelegramMobileLinkTokenService', () => {
     const usedTtl = keyTtls.get(usedKey);
     expect(usedTtl).to.be.a('number');
     const remaining = claimed.expiresAt - Math.floor(Date.now() / 1000);
-    expect(usedTtl!).to.equal(Math.max(1, remaining));
+    const expectedTtl = Math.max(1, remaining);
+    expect(usedTtl!).to.be.within(expectedTtl, expectedTtl + 1);
 
     try {
       await service.claim(token, 'agent');
@@ -166,8 +199,8 @@ describe('TelegramMobileLinkTokenService', () => {
     }
   });
 
-  it('release restores a claimed token for retry', async () => {
-    const { service } = makeService();
+  it('release restores a claimed token for retry via atomic script', async () => {
+    const { service, cacheService } = makeService();
     const { token } = await service.issue({
       environmentId: 'env-1',
       organizationId: 'org-1',
@@ -178,6 +211,7 @@ describe('TelegramMobileLinkTokenService', () => {
     const claimed = await service.claim(token, 'agent');
     await service.release(token, claimed);
 
+    expect(cacheService.eval.callCount).to.be.at.least(2);
     const payload = await service.verify(token);
     expect(payload.iid).to.equal('int-1');
   });
@@ -200,7 +234,7 @@ describe('TelegramMobileLinkTokenService', () => {
     expect(cacheService.set.callCount).to.equal(setCallsBefore);
   });
 
-  it('rejects tokens with unexpected kind', async () => {
+  it('rejects tokens with unexpected kind on peek', async () => {
     const { service } = makeService();
     const { token } = await service.issueForIntegrationStore({
       environmentId: 'env-1',
@@ -213,6 +247,24 @@ describe('TelegramMobileLinkTokenService', () => {
     } catch (err) {
       expect((err as InvalidTelegramMobileTokenError).reason).to.equal('invalid');
     }
+  });
+
+  it('claim with wrong kind does not burn the token', async () => {
+    const { service } = makeService();
+    const { token } = await service.issueForIntegrationStore({
+      environmentId: 'env-1',
+      organizationId: 'org-1',
+    });
+
+    try {
+      await service.claim(token, 'agent');
+      expect.fail('expected agent claim to reject integration-store token');
+    } catch (err) {
+      expect((err as InvalidTelegramMobileTokenError).reason).to.equal('invalid');
+    }
+
+    const payload = await service.verifyIntegrationStore(token);
+    expect(payload.kind).to.equal('integration-store');
   });
 
   it('surfaces cache failures from isTokenUsed', async () => {

--- a/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts
@@ -13,6 +13,29 @@ const TOKEN_BYTES = 24;
 
 const TOKEN_FORMAT = /^[A-Za-z0-9_-]{32}$/;
 
+/**
+ * Atomically GETDEL the session payload and set the used-marker with matching TTL.
+ * Returns '' (missing), 'U' (already used), 'I' (corrupt payload), or 'M' + JSON body.
+ */
+const CLAIM_ATOMIC_SCRIPT = `
+local raw = redis.call('GETDEL', KEYS[1])
+if not raw then
+  if redis.call('GET', KEYS[2]) then
+    return 'U'
+  end
+  return ''
+end
+local ok, parsed = pcall(cjson.decode, raw)
+if not ok or not parsed.expiresAt then
+  return 'I'
+end
+local now = tonumber(ARGV[1])
+local ttl = parsed.expiresAt - now
+if ttl < 1 then ttl = 1 end
+redis.call('SET', KEYS[2], '1', 'EX', ttl)
+return 'M' .. raw
+`;
+
 export type TelegramMobileLinkKind = 'agent' | 'integration-store';
 
 export interface TelegramMobileLinkTokenPayload {
@@ -133,13 +156,18 @@ export class TelegramMobileLinkTokenService {
       return false;
     }
 
-    const value = await this.cacheService.get(this.usedKey(token));
+    let value: string | null | undefined;
+    try {
+      value = await this.cacheService.get(this.usedKey(token));
+    } catch (err) {
+      throw new TelegramMobileLinkCacheUnavailableError('isTokenUsed', err);
+    }
 
     return value != null;
   }
 
   /**
-   * Atomically claims a token for single-use consumption (GETDEL).
+   * Atomically claims a token for single-use consumption (GETDEL + used marker).
    * Returns the stored entry, or throws {@link InvalidTelegramMobileTokenError}.
    */
   async claim(token: string, expectedKind: TelegramMobileLinkKind): Promise<ClaimedTelegramMobileLink> {
@@ -153,38 +181,32 @@ export class TelegramMobileLinkTokenService {
       throw new InvalidTelegramMobileTokenError('used');
     }
 
-    const client = this.cacheService.client;
-    if (!client) {
-      throw new TelegramMobileLinkCacheUnavailableError('claim');
-    }
-
-    let raw: string | null;
+    let raw: string;
     try {
-      raw = await client.getdel(this.storageKey(token));
+      raw = await this.cacheService.eval<string>(
+        CLAIM_ATOMIC_SCRIPT,
+        [this.storageKey(token), this.usedKey(token)],
+        [Math.floor(Date.now() / 1000)]
+      );
     } catch (err) {
       throw new TelegramMobileLinkCacheUnavailableError('claim', err);
     }
 
-    if (!raw) {
-      if (await this.isTokenUsed(token)) {
-        throw new InvalidTelegramMobileTokenError('used');
-      }
-
-      throw new InvalidTelegramMobileTokenError('expired');
+    if (raw === 'U') {
+      throw new InvalidTelegramMobileTokenError('used');
     }
 
-    const entry = this.parseEntry(raw);
-    if (!entry || entry.payload.kind !== expectedKind) {
+    if (!raw || raw === 'I') {
+      throw new InvalidTelegramMobileTokenError(raw === 'I' ? 'invalid' : 'expired');
+    }
+
+    if (raw.charAt(0) !== 'M') {
       throw new InvalidTelegramMobileTokenError('invalid');
     }
 
-    const remaining = entry.expiresAt - Math.floor(Date.now() / 1000);
-    const usedTtl = Math.max(1, remaining);
-
-    try {
-      await this.cacheService.set(this.usedKey(token), '1', { ttl: usedTtl });
-    } catch (err) {
-      throw new TelegramMobileLinkCacheUnavailableError('claim', err);
+    const entry = this.parseEntry(raw.slice(1));
+    if (!entry || entry.payload.kind !== expectedKind) {
+      throw new InvalidTelegramMobileTokenError('invalid');
     }
 
     return entry;
@@ -212,7 +234,11 @@ export class TelegramMobileLinkTokenService {
       await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), { ttl: remaining });
       await this.cacheService.del(this.usedKey(token));
     } catch (err) {
-      this.logger.warn(`Failed to release telegram mobile link token: ${(err as Error).message}`);
+      this.logger.warn(
+        { err, token, storageKey: this.storageKey(token), usedKey: this.usedKey(token) },
+        'Failed to release telegram mobile link token'
+      );
+      throw new TelegramMobileLinkCacheUnavailableError('release', err);
     }
   }
 

--- a/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts
@@ -1,21 +1,22 @@
-import { randomUUID } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 import { Injectable } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
 import { CacheService, PinoLogger } from '@novu/application-generic';
 
 /** Lifetime of an issued mobile setup token (seconds). */
 export const TELEGRAM_MOBILE_LINK_TTL_SECONDS = 5 * 60;
 
-/** Cache TTL for the used-jti blocklist. Slightly larger than the JWT TTL to outlive clock skew. */
-const USED_JTI_TTL_SECONDS = TELEGRAM_MOBILE_LINK_TTL_SECONDS + 60;
+const CACHE_KEY_PREFIX = 'telegram_mobile_link:';
+const USED_KEY_PREFIX = 'telegram_mobile_link_used:';
 
-const JWT_AUDIENCE = 'telegram-mobile-setup';
-const JWT_AUDIENCE_INTEGRATION_STORE = 'telegram-integration-mobile-setup';
-const JWT_ISSUER = 'novu';
+/** 192 bits of entropy → 32 URL-safe base64url characters (compact QR payloads). */
+const TOKEN_BYTES = 24;
 
-const USED_JTI_KEY_PREFIX = 'telegram_mobile_jti:';
+const TOKEN_FORMAT = /^[A-Za-z0-9_-]{32}$/;
+
+export type TelegramMobileLinkKind = 'agent' | 'integration-store';
 
 export interface TelegramMobileLinkTokenPayload {
+  kind: 'agent';
   /** Environment id. */
   env: string;
   /** Organization id. */
@@ -26,14 +27,6 @@ export interface TelegramMobileLinkTokenPayload {
   iid: string;
   /** Subscriber to link via `/start` deep link after mobile setup (optional). */
   sid?: string;
-  /** Unique token id used for single-use enforcement. */
-  jti: string;
-  /** Issued-at (seconds since epoch). */
-  iat?: number;
-  /** Expiry (seconds since epoch). */
-  exp?: number;
-  aud?: string;
-  iss?: string;
 }
 
 /**
@@ -42,13 +35,17 @@ export interface TelegramMobileLinkTokenPayload {
  * known at issue time.
  */
 export interface IntegrationStoreTelegramMobileLinkPayload {
+  kind: 'integration-store';
   env: string;
   org: string;
-  jti: string;
-  iat?: number;
-  exp?: number;
-  aud?: string;
-  iss?: string;
+}
+
+type StoredPayload = TelegramMobileLinkTokenPayload | IntegrationStoreTelegramMobileLinkPayload;
+
+interface StoredEntry {
+  payload: StoredPayload;
+  /** Epoch seconds when this entry naturally expires. */
+  expiresAt: number;
 }
 
 export interface IssuedTelegramMobileLink {
@@ -57,16 +54,30 @@ export interface IssuedTelegramMobileLink {
   expiresAt: string;
 }
 
+export interface ClaimedTelegramMobileLink {
+  payload: StoredPayload;
+  expiresAt: number;
+}
+
 export class InvalidTelegramMobileTokenError extends Error {
   constructor(public readonly reason: 'invalid' | 'expired' | 'used') {
     super(`Telegram mobile token is ${reason}`);
   }
 }
 
+export class TelegramMobileLinkCacheUnavailableError extends Error {
+  constructor(operation: string, cause?: unknown) {
+    super(`Telegram mobile link cache unavailable during ${operation}`);
+    this.name = 'TelegramMobileLinkCacheUnavailableError';
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
 @Injectable()
 export class TelegramMobileLinkTokenService {
   constructor(
-    private readonly jwtService: JwtService,
     private readonly cacheService: CacheService,
     private readonly logger: PinoLogger
   ) {
@@ -80,150 +91,224 @@ export class TelegramMobileLinkTokenService {
     integrationId: string;
     subscriberId?: string;
   }): Promise<IssuedTelegramMobileLink> {
-    const jti = randomUUID();
-
     const payload: TelegramMobileLinkTokenPayload = {
+      kind: 'agent',
       env: params.environmentId,
       org: params.organizationId,
       aid: params.agentIdentifier,
       iid: params.integrationId,
-      jti,
       ...(params.subscriberId ? { sid: params.subscriberId } : {}),
     };
 
-    const token = this.jwtService.sign(payload, {
-      expiresIn: TELEGRAM_MOBILE_LINK_TTL_SECONDS,
-      audience: JWT_AUDIENCE,
-      issuer: JWT_ISSUER,
-    });
-
-    const expiresAt = new Date(Date.now() + TELEGRAM_MOBILE_LINK_TTL_SECONDS * 1000).toISOString();
-
-    return { token, expiresAt };
-  }
-
-  /**
-   * Verifies the JWT signature, audience, issuer and expiry.
-   * Returns the decoded payload, or throws {@link InvalidTelegramMobileTokenError}.
-   */
-  verify(token: string): TelegramMobileLinkTokenPayload {
-    if (!token || typeof token !== 'string') {
-      throw new InvalidTelegramMobileTokenError('invalid');
-    }
-
-    try {
-      const payload = this.jwtService.verify<TelegramMobileLinkTokenPayload>(token, {
-        audience: JWT_AUDIENCE,
-        issuer: JWT_ISSUER,
-      });
-
-      if (!payload?.env || !payload?.org || !payload?.aid || !payload?.iid || !payload?.jti) {
-        throw new InvalidTelegramMobileTokenError('invalid');
-      }
-
-      return payload;
-    } catch (err) {
-      if (err instanceof InvalidTelegramMobileTokenError) throw err;
-      const isExpired =
-        typeof err === 'object' &&
-        err !== null &&
-        'name' in err &&
-        (err as { name?: string }).name === 'TokenExpiredError';
-      throw new InvalidTelegramMobileTokenError(isExpired ? 'expired' : 'invalid');
-    }
+    return this.mint(payload);
   }
 
   async issueForIntegrationStore(params: {
     environmentId: string;
     organizationId: string;
   }): Promise<IssuedTelegramMobileLink> {
-    const jti = randomUUID();
-
     const payload: IntegrationStoreTelegramMobileLinkPayload = {
+      kind: 'integration-store',
       env: params.environmentId,
       org: params.organizationId,
-      jti,
     };
 
-    const token = this.jwtService.sign(payload, {
-      expiresIn: TELEGRAM_MOBILE_LINK_TTL_SECONDS,
-      audience: JWT_AUDIENCE_INTEGRATION_STORE,
-      issuer: JWT_ISSUER,
-    });
-
-    const expiresAt = new Date(Date.now() + TELEGRAM_MOBILE_LINK_TTL_SECONDS * 1000).toISOString();
-
-    return { token, expiresAt };
-  }
-
-  verifyIntegrationStore(token: string): IntegrationStoreTelegramMobileLinkPayload {
-    if (!token || typeof token !== 'string') {
-      throw new InvalidTelegramMobileTokenError('invalid');
-    }
-
-    try {
-      const payload = this.jwtService.verify<IntegrationStoreTelegramMobileLinkPayload>(token, {
-        audience: JWT_AUDIENCE_INTEGRATION_STORE,
-        issuer: JWT_ISSUER,
-      });
-
-      if (!payload?.env || !payload?.org || !payload?.jti) {
-        throw new InvalidTelegramMobileTokenError('invalid');
-      }
-
-      return payload;
-    } catch (err) {
-      if (err instanceof InvalidTelegramMobileTokenError) throw err;
-      const isExpired =
-        typeof err === 'object' &&
-        err !== null &&
-        'name' in err &&
-        (err as { name?: string }).name === 'TokenExpiredError';
-      throw new InvalidTelegramMobileTokenError(isExpired ? 'expired' : 'invalid');
-    }
+    return this.mint(payload);
   }
 
   /**
-   * Atomically claim a `jti` as used.
-   * Returns `true` if this caller is the first to claim, `false` if already used.
-   * Falls back to allow-by-default if the cache layer is unavailable so that the
-   * primary auth check (the signed JWT) still gates access.
+   * Reads the stored payload without consuming the token (safe for status/prefetch).
    */
-  async claimJti(jti: string): Promise<boolean> {
-    if (!this.cacheService.cacheEnabled()) {
-      this.logger.warn('Cache unavailable for telegram mobile jti tracking');
-
-      return true;
-    }
-
-    const result = await this.cacheService.setIfNotExist(this.jtiKey(jti), '1', {
-      ttl: USED_JTI_TTL_SECONDS,
-    });
-
-    return result !== null;
+  async verify(token: string): Promise<TelegramMobileLinkTokenPayload> {
+    return this.peek(token, 'agent') as Promise<TelegramMobileLinkTokenPayload>;
   }
 
-  /** Check (without claiming) whether a jti has already been used. */
-  async isJtiUsed(jti: string): Promise<boolean> {
-    if (!this.cacheService.cacheEnabled()) return false;
+  async verifyIntegrationStore(token: string): Promise<IntegrationStoreTelegramMobileLinkPayload> {
+    return this.peek(token, 'integration-store') as Promise<IntegrationStoreTelegramMobileLinkPayload>;
+  }
 
-    const value = await this.cacheService.get(this.jtiKey(jti));
+  /** Returns whether a token was already consumed (used marker present). */
+  async isTokenUsed(token: string): Promise<boolean> {
+    if (!this.isTokenFormatValid(token) || !this.cacheService.cacheEnabled()) {
+      return false;
+    }
+
+    const value = await this.cacheService.get(this.usedKey(token));
 
     return value != null;
   }
 
-  /** Release a previously-claimed jti — used to roll back when post-claim work fails. */
-  async releaseJti(jti: string): Promise<void> {
-    if (!this.cacheService.cacheEnabled()) return;
+  /**
+   * Atomically claims a token for single-use consumption (GETDEL).
+   * Returns the stored entry, or throws {@link InvalidTelegramMobileTokenError}.
+   */
+  async claim(token: string, expectedKind: TelegramMobileLinkKind): Promise<ClaimedTelegramMobileLink> {
+    this.assertCacheAvailable('claim');
+
+    if (!this.isTokenFormatValid(token)) {
+      throw new InvalidTelegramMobileTokenError('invalid');
+    }
+
+    if (await this.isTokenUsed(token)) {
+      throw new InvalidTelegramMobileTokenError('used');
+    }
+
+    const client = this.cacheService.client;
+    if (!client) {
+      throw new TelegramMobileLinkCacheUnavailableError('claim');
+    }
+
+    let raw: string | null;
+    try {
+      raw = await client.getdel(this.storageKey(token));
+    } catch (err) {
+      throw new TelegramMobileLinkCacheUnavailableError('claim', err);
+    }
+
+    if (!raw) {
+      if (await this.isTokenUsed(token)) {
+        throw new InvalidTelegramMobileTokenError('used');
+      }
+
+      throw new InvalidTelegramMobileTokenError('expired');
+    }
+
+    const entry = this.parseEntry(raw);
+    if (!entry || entry.payload.kind !== expectedKind) {
+      throw new InvalidTelegramMobileTokenError('invalid');
+    }
+
+    const remaining = entry.expiresAt - Math.floor(Date.now() / 1000);
+    const usedTtl = Math.max(1, remaining);
 
     try {
-      await this.cacheService.del(this.jtiKey(jti));
+      await this.cacheService.set(this.usedKey(token), '1', { ttl: usedTtl });
     } catch (err) {
-      this.logger.warn(`Failed to release telegram mobile jti ${jti}: ${(err as Error).message}`);
+      throw new TelegramMobileLinkCacheUnavailableError('claim', err);
+    }
+
+    return entry;
+  }
+
+  /**
+   * Re-stores a token after a failed consume so the visitor can retry the same link.
+   */
+  async release(token: string, claimed: ClaimedTelegramMobileLink): Promise<void> {
+    if (!this.isTokenFormatValid(token) || !this.cacheService.cacheEnabled()) {
+      return;
+    }
+
+    const remaining = claimed.expiresAt - Math.floor(Date.now() / 1000);
+    if (remaining <= 0) {
+      return;
+    }
+
+    const entry: StoredEntry = {
+      payload: claimed.payload,
+      expiresAt: claimed.expiresAt,
+    };
+
+    try {
+      await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), { ttl: remaining });
+      await this.cacheService.del(this.usedKey(token));
+    } catch (err) {
+      this.logger.warn(`Failed to release telegram mobile link token: ${(err as Error).message}`);
     }
   }
 
-  private jtiKey(jti: string): string {
-    return `${USED_JTI_KEY_PREFIX}${jti}`;
+  private async mint(payload: StoredPayload): Promise<IssuedTelegramMobileLink> {
+    this.assertCacheAvailable('issue');
+
+    const token = randomBytes(TOKEN_BYTES).toString('base64url');
+    const mintedAt = Math.floor(Date.now() / 1000);
+    const expiresAtEpoch = mintedAt + TELEGRAM_MOBILE_LINK_TTL_SECONDS;
+    const entry: StoredEntry = { payload, expiresAt: expiresAtEpoch };
+
+    await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), {
+      ttl: TELEGRAM_MOBILE_LINK_TTL_SECONDS,
+    });
+
+    const expiresAt = new Date(expiresAtEpoch * 1000).toISOString();
+
+    return { token, expiresAt };
+  }
+
+  private async peek(token: string, expectedKind: TelegramMobileLinkKind): Promise<StoredPayload> {
+    if (!this.isTokenFormatValid(token)) {
+      throw new InvalidTelegramMobileTokenError('invalid');
+    }
+
+    if (!this.cacheService.cacheEnabled()) {
+      throw new TelegramMobileLinkCacheUnavailableError('peek');
+    }
+
+    if (await this.isTokenUsed(token)) {
+      throw new InvalidTelegramMobileTokenError('used');
+    }
+
+    let raw: string | null | undefined;
+    try {
+      raw = await this.cacheService.get(this.storageKey(token));
+    } catch (err) {
+      throw new TelegramMobileLinkCacheUnavailableError('peek', err);
+    }
+
+    if (!raw) {
+      throw new InvalidTelegramMobileTokenError('expired');
+    }
+
+    const entry = this.parseEntry(raw);
+    if (!entry || entry.payload.kind !== expectedKind) {
+      throw new InvalidTelegramMobileTokenError('invalid');
+    }
+
+    if (entry.payload.kind === 'agent') {
+      const agentPayload = entry.payload;
+      if (!agentPayload.env || !agentPayload.org || !agentPayload.aid || !agentPayload.iid) {
+        throw new InvalidTelegramMobileTokenError('invalid');
+      }
+    } else if (!entry.payload.env || !entry.payload.org) {
+      throw new InvalidTelegramMobileTokenError('invalid');
+    }
+
+    return entry.payload;
+  }
+
+  private parseEntry(raw: string): ClaimedTelegramMobileLink | null {
+    try {
+      const parsed = JSON.parse(raw) as Partial<StoredEntry>;
+      if (!parsed?.payload || typeof parsed.expiresAt !== 'number') {
+        return null;
+      }
+
+      const payload = parsed.payload;
+      if (payload.kind !== 'agent' && payload.kind !== 'integration-store') {
+        return null;
+      }
+
+      return { payload, expiresAt: parsed.expiresAt };
+    } catch {
+      return null;
+    }
+  }
+
+  private isTokenFormatValid(token: string): boolean {
+    return typeof token === 'string' && TOKEN_FORMAT.test(token);
+  }
+
+  private assertCacheAvailable(operation: string): void {
+    if (!this.cacheService.cacheEnabled()) {
+      this.logger.warn(`Cache unavailable for telegram mobile link ${operation}`);
+
+      throw new TelegramMobileLinkCacheUnavailableError(operation);
+    }
+  }
+
+  private storageKey(token: string): string {
+    return `${CACHE_KEY_PREFIX}${token}`;
+  }
+
+  private usedKey(token: string): string {
+    return `${USED_KEY_PREFIX}${token}`;
   }
 }

--- a/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts
@@ -15,7 +15,8 @@ const TOKEN_FORMAT = /^[A-Za-z0-9_-]{32}$/;
 
 /**
  * Atomically GETDEL the session payload and set the used-marker with matching TTL.
- * Returns '' (missing), 'U' (already used), 'I' (corrupt payload), or 'M' + JSON body.
+ * Returns '' (missing), 'U' (already used), 'I' (corrupt payload), 'K' (kind mismatch;
+ * entry restored), or 'M' + JSON body.
  */
 const CLAIM_ATOMIC_SCRIPT = `
 local raw = redis.call('GETDEL', KEYS[1])
@@ -26,14 +27,27 @@ if not raw then
   return ''
 end
 local ok, parsed = pcall(cjson.decode, raw)
-if not ok or not parsed.expiresAt then
+if not ok or not parsed.expiresAt or not parsed.payload or not parsed.payload.kind then
   return 'I'
+end
+if parsed.payload.kind ~= ARGV[2] then
+  local now = tonumber(ARGV[1])
+  local ttl = parsed.expiresAt - now
+  if ttl < 1 then ttl = 1 end
+  redis.call('SET', KEYS[1], raw, 'EX', ttl)
+  return 'K'
 end
 local now = tonumber(ARGV[1])
 local ttl = parsed.expiresAt - now
 if ttl < 1 then ttl = 1 end
 redis.call('SET', KEYS[2], '1', 'EX', ttl)
 return 'M' .. raw
+`;
+
+/** Atomically restore the session payload and clear the used-marker. */
+const RELEASE_ATOMIC_SCRIPT = `
+redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[2]))
+redis.call('DEL', KEYS[2])
 `;
 
 export type TelegramMobileLinkKind = 'agent' | 'integration-store';
@@ -186,7 +200,7 @@ export class TelegramMobileLinkTokenService {
       raw = await this.cacheService.eval<string>(
         CLAIM_ATOMIC_SCRIPT,
         [this.storageKey(token), this.usedKey(token)],
-        [Math.floor(Date.now() / 1000)]
+        [Math.floor(Date.now() / 1000), expectedKind]
       );
     } catch (err) {
       throw new TelegramMobileLinkCacheUnavailableError('claim', err);
@@ -196,8 +210,12 @@ export class TelegramMobileLinkTokenService {
       throw new InvalidTelegramMobileTokenError('used');
     }
 
-    if (!raw || raw === 'I') {
-      throw new InvalidTelegramMobileTokenError(raw === 'I' ? 'invalid' : 'expired');
+    if (raw === 'K' || raw === 'I') {
+      throw new InvalidTelegramMobileTokenError('invalid');
+    }
+
+    if (!raw) {
+      throw new InvalidTelegramMobileTokenError('expired');
     }
 
     if (raw.charAt(0) !== 'M') {
@@ -231,8 +249,10 @@ export class TelegramMobileLinkTokenService {
     };
 
     try {
-      await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), { ttl: remaining });
-      await this.cacheService.del(this.usedKey(token));
+      await this.cacheService.eval(RELEASE_ATOMIC_SCRIPT, [this.storageKey(token), this.usedKey(token)], [
+        JSON.stringify(entry),
+        remaining,
+      ]);
     } catch (err) {
       this.logger.warn(
         { err, token, storageKey: this.storageKey(token), usedKey: this.usedKey(token) },

--- a/apps/api/src/app/agents/shared/dtos/issue-telegram-mobile-link-response.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/issue-telegram-mobile-link-response.dto.ts
@@ -1,7 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class IssueTelegramMobileLinkResponseDto {
-  @ApiProperty({ type: String, description: 'Signed, single-use JWT identifying this Telegram mobile-setup session' })
+  @ApiProperty({
+    type: String,
+    description: 'Opaque, single-use token identifying this Telegram mobile-setup session',
+  })
   token: string;
 
   @ApiProperty({

--- a/apps/api/src/app/integrations/dtos/issue-integration-store-telegram-mobile-link-response.dto.ts
+++ b/apps/api/src/app/integrations/dtos/issue-integration-store-telegram-mobile-link-response.dto.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class IssueIntegrationStoreTelegramMobileLinkResponseDto {
   @ApiProperty({
     type: String,
-    description: 'Signed, single-use JWT identifying this Telegram mobile-setup session',
+    description: 'Opaque, single-use token identifying this Telegram mobile-setup session',
   })
   token: string;
 

--- a/apps/api/src/app/integrations/integrations-public.controller.ts
+++ b/apps/api/src/app/integrations/integrations-public.controller.ts
@@ -21,8 +21,8 @@ import {
  * Public, unauthenticated endpoints for the integration-store Telegram mobile
  * setup landing page.
  *
- * Authorization is carried entirely by a signed, single-use, short-lived JWT
- * embedded in the request body / query — the dashboard issues these tokens
+ * Authorization is carried entirely by an opaque, single-use, short-lived token
+ * stored in Redis and embedded in the request body / query — the dashboard issues these tokens
  * through the authed `POST /v1/integrations/telegram/mobile-link` endpoint.
  *
  * Unlike {@link AgentsPublicController}, this flow has no agent or

--- a/apps/api/src/app/integrations/integrations-public.controller.ts
+++ b/apps/api/src/app/integrations/integrations-public.controller.ts
@@ -45,7 +45,7 @@ export class IntegrationsPublicController {
   @ApiOperation({
     summary: 'Check the status of a Telegram integration-store mobile setup link',
     description:
-      'Returns whether a signed Telegram mobile-setup token is still usable. Designed to be called from the ' +
+      'Returns whether an opaque Telegram mobile-setup token is still usable. Designed to be called from the ' +
       'mobile landing page before showing the credentials form.',
   })
   async getStatus(@Query('token') token: string): Promise<GetIntegrationStoreTelegramMobileLinkStatusResult> {
@@ -60,7 +60,7 @@ export class IntegrationsPublicController {
   @ApiOperation({
     summary: 'Consume a Telegram integration-store mobile setup link',
     description:
-      'Validates the signed token, calls Telegram getMe to verify the supplied BotFather token, and creates a ' +
+      'Validates the setup token, calls Telegram getMe to verify the supplied BotFather token, and creates a ' +
       'new Telegram integration in the issuing environment with the bot token stored on its credentials. ' +
       'The token becomes invalid after a successful call.',
   })

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -816,7 +816,7 @@ export class IntegrationsController {
   @ApiOperation({
     summary: 'Issue a short-lived Telegram mobile setup link for the integration store',
     description:
-      'Returns a signed, single-use, short-lived JWT plus a mobile URL. The visitor pastes the BotFather token on the linked landing page and the consume endpoint creates a brand-new Telegram integration in the current environment.',
+      'Returns an opaque, single-use, short-lived setup token plus a mobile URL. The visitor pastes the BotFather token on the linked landing page and the consume endpoint creates a brand-new Telegram integration in the current environment.',
   })
   @ApiExcludeEndpoint()
   @RequireAuthentication()

--- a/apps/api/src/app/integrations/integrations.module.ts
+++ b/apps/api/src/app/integrations/integrations.module.ts
@@ -1,5 +1,4 @@
 import { forwardRef, Module } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
 import {
   CalculateLimitNovuIntegration,
   ChannelFactory,
@@ -31,12 +30,6 @@ const PROVIDERS = [
     forwardRef(() => AuthModule),
     ChannelConnectionsModule,
     ChannelEndpointsModule,
-    // Local JwtModule mirroring AgentsModule's registration. Importing AgentsModule
-    // here would form a cycle (IntegrationModule → AgentsModule → EventsModule →
-    // IntegrationModule) that needs forwardRef on every edge; registering the
-    // token service locally is simpler and safe since it is stateless and the
-    // JTI cache is shared via Redis.
-    JwtModule.register({ secret: process.env.JWT_SECRET }),
   ],
   controllers: [IntegrationsController, IntegrationsPublicController],
   providers: [

--- a/apps/api/src/app/integrations/usecases/consume-integration-store-telegram-mobile-link/consume-integration-store-telegram-mobile-link.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/consume-integration-store-telegram-mobile-link/consume-integration-store-telegram-mobile-link.usecase.ts
@@ -5,6 +5,7 @@ import Axios from 'axios';
 import shortid from 'shortid';
 
 import {
+  IntegrationStoreTelegramMobileLinkPayload,
   InvalidTelegramMobileTokenError,
   TelegramMobileLinkTokenService,
 } from '../../../agents/channels/telegram-linking/telegram-mobile-link-token.service';
@@ -37,7 +38,7 @@ export interface ConsumeIntegrationStoreTelegramMobileLinkResult {
 /**
  * Consumes a single-use Telegram mobile-setup token issued from the
  * Integration Store create flow. The visitor is unauthenticated; trust comes
- * from the JWT signature + JTI cache. On success, creates a brand-new
+ * from the opaque Redis-backed setup token. On success, creates a brand-new
  * Telegram integration in the issuing environment using the BotFather token
  * supplied from the mobile device.
  *
@@ -57,17 +58,8 @@ export class ConsumeIntegrationStoreTelegramMobileLink {
   async execute(
     command: ConsumeIntegrationStoreTelegramMobileLinkCommand
   ): Promise<ConsumeIntegrationStoreTelegramMobileLinkResult> {
-    const payload = this.verifyToken(command.token);
-
-    // Single-use enforcement happens BEFORE we touch Telegram so retried submits
-    // don't ping the bot API repeatedly.
-    const claimed = await this.tokenService.claimJti(payload.jti);
-    if (!claimed) {
-      throw new ConflictException({
-        code: 'token_already_used',
-        message: 'This setup link has already been used. Generate a new one from your dashboard.',
-      });
-    }
+    const claimed = await this.claimToken(command.token);
+    const payload = claimed.payload as IntegrationStoreTelegramMobileLinkPayload;
 
     try {
       const botUsername = await this.callGetMe(command.botToken);
@@ -97,27 +89,29 @@ export class ConsumeIntegrationStoreTelegramMobileLink {
       };
     } catch (err) {
       try {
-        await this.tokenService.releaseJti(payload.jti);
+        await this.tokenService.release(command.token, claimed);
       } catch (releaseErr) {
-        this.logger.error(
-          { err: releaseErr, jti: payload.jti },
-          'Failed to release JTI during Telegram integration-store consume rollback'
-        );
+        this.logger.error({ err: releaseErr }, 'Failed to release token during Telegram integration-store rollback');
       }
 
-      this.logger.warn(
-        `Telegram integration-store mobile setup consume failed for jti=${payload.jti}: ${(err as Error).message}`
-      );
+      this.logger.warn(`Telegram integration-store mobile setup consume failed: ${(err as Error).message}`);
 
       throw err;
     }
   }
 
-  private verifyToken(token: string) {
+  private async claimToken(token: string) {
     try {
-      return this.tokenService.verifyIntegrationStore(token);
+      return await this.tokenService.claim(token, 'integration-store');
     } catch (err) {
       if (err instanceof InvalidTelegramMobileTokenError) {
+        if (err.reason === 'used') {
+          throw new ConflictException({
+            code: 'token_already_used',
+            message: 'This setup link has already been used. Generate a new one from your dashboard.',
+          });
+        }
+
         throw new UnauthorizedException({
           code: err.reason === 'expired' ? 'token_expired' : 'token_invalid',
           message:

--- a/apps/api/src/app/integrations/usecases/get-integration-store-telegram-mobile-link-status/get-integration-store-telegram-mobile-link-status.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/get-integration-store-telegram-mobile-link-status/get-integration-store-telegram-mobile-link-status.usecase.ts
@@ -34,7 +34,7 @@ export class GetIntegrationStoreTelegramMobileLinkStatus {
         return { valid: false, reason: err.reason };
       }
 
-      return { valid: false, reason: 'invalid' };
+      throw err;
     }
 
     return { valid: true, providerName: 'telegram' };

--- a/apps/api/src/app/integrations/usecases/get-integration-store-telegram-mobile-link-status/get-integration-store-telegram-mobile-link-status.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/get-integration-store-telegram-mobile-link-status/get-integration-store-telegram-mobile-link-status.usecase.ts
@@ -27,19 +27,14 @@ export class GetIntegrationStoreTelegramMobileLinkStatus {
   async execute(
     command: GetIntegrationStoreTelegramMobileLinkStatusCommand
   ): Promise<GetIntegrationStoreTelegramMobileLinkStatusResult> {
-    let payload: ReturnType<TelegramMobileLinkTokenService['verifyIntegrationStore']>;
     try {
-      payload = this.tokenService.verifyIntegrationStore(command.token);
+      await this.tokenService.verifyIntegrationStore(command.token);
     } catch (err) {
       if (err instanceof InvalidTelegramMobileTokenError) {
         return { valid: false, reason: err.reason };
       }
 
       return { valid: false, reason: 'invalid' };
-    }
-
-    if (await this.tokenService.isJtiUsed(payload.jti)) {
-      return { valid: false, reason: 'used' };
     }
 
     return { valid: true, providerName: 'telegram' };

--- a/apps/api/src/app/integrations/usecases/issue-integration-store-telegram-mobile-link/issue-integration-store-telegram-mobile-link.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/issue-integration-store-telegram-mobile-link/issue-integration-store-telegram-mobile-link.usecase.ts
@@ -14,7 +14,7 @@ export interface IssueIntegrationStoreTelegramMobileLinkResult {
 const MOBILE_PATH = '/integrations/telegram/connect';
 
 /**
- * Issues a signed, single-use, short-lived JWT that lets an unauthenticated
+ * Issues an opaque, single-use, short-lived token (stored in Redis) that lets an unauthenticated
  * mobile visitor create a Telegram integration in the issuing environment.
  *
  * Unlike the agent-scoped issuer ({@link IssueTelegramMobileLink}), this flow

--- a/apps/dashboard/src/api/integrations.ts
+++ b/apps/dashboard/src/api/integrations.ts
@@ -158,7 +158,7 @@ export type IntegrationStoreTelegramMobileLink = {
 type IntegrationStoreTelegramMobileLinkEnvelope = { data: IntegrationStoreTelegramMobileLink };
 
 /**
- * Issues a signed, single-use, short-lived JWT that lets an unauthenticated
+ * Issues an opaque, single-use, short-lived setup token that lets an unauthenticated
  * mobile visitor create a Telegram integration from the Integration Store
  * create flow. The integration is created server-side on submit.
  */

--- a/apps/dashboard/src/components/integrations/components/telegram-credentials-paste.tsx
+++ b/apps/dashboard/src/components/integrations/components/telegram-credentials-paste.tsx
@@ -34,7 +34,7 @@ type TelegramCredentialsPasteProps = {
    * field so the user can finish configuration from their phone. The QR card
    * is hidden the moment the form has an `apiToken` value (typed, pasted, or
    * pre-filled from an existing integration), which also unmounts the link
-   * `useQuery` and stops generating JWTs.
+   * `useQuery` and stops issuing setup links.
    */
   mobileSetup?: TelegramCredentialsPasteMobileSetup;
 };

--- a/packages/novu/src/commands/connect/api/agents.ts
+++ b/packages/novu/src/commands/connect/api/agents.ts
@@ -215,9 +215,10 @@ export interface TelegramMobileLinkStatus {
 /**
  * Public endpoint — needs no auth header (the opaque setup token in the query string
  * authenticates the request). We're polling this to detect when the user
- * has finished pasting their BotFather token on the mobile setup page; the
- * server consumes the token and subsequent status checks
- * return `{ valid: false, reason: 'used' }`.
+ * has finished pasting their BotFather token on the mobile setup page. This
+ * endpoint does not consume the token; it only checks status. Once the mobile
+ * setup page consumes the token, subsequent status checks return
+ * `{ valid: false, reason: 'used' }`.
  *
  * Why this and not `GET /v1/integrations`: ApiKey-authed callers never get
  * decrypted credentials back from the integration list endpoint (intentional

--- a/packages/novu/src/commands/connect/api/agents.ts
+++ b/packages/novu/src/commands/connect/api/agents.ts
@@ -160,7 +160,7 @@ export interface TelegramConfigureResult {
 }
 
 export interface TelegramMobileLinkResult {
-  /** Signed JWT identifying this mobile-setup session. */
+  /** Opaque setup token identifying this mobile-setup session. */
   token: string;
   /** Absolute URL the user opens on their phone to paste the BotFather token. */
   url: string;
@@ -213,10 +213,10 @@ export interface TelegramMobileLinkStatus {
 }
 
 /**
- * Public endpoint — needs no auth header (the signed JWT in the query string
+ * Public endpoint — needs no auth header (the opaque setup token in the query string
  * authenticates the request). We're polling this to detect when the user
  * has finished pasting their BotFather token on the mobile setup page; the
- * server marks the token's jti as consumed and subsequent status checks
+ * server consumes the token and subsequent status checks
  * return `{ valid: false, reason: 'used' }`.
  *
  * Why this and not `GET /v1/integrations`: ApiKey-authed callers never get


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Telegram agent onboarding (and integration-store mobile setup) previously put a signed JWT in the mobile URL path, which made QR codes unnecessarily dense. This change switches to **32-character opaque tokens** with the full session context stored in Redis — the same approach as `TelegramStartCodeService` and `AgentEmailActionTokenService`.

## What changed

- **`TelegramMobileLinkTokenService`**: mints `randomBytes(24)` base64url tokens; stores env/org/agent/integration (or integration-store) payload in Redis with a 5-minute TTL
- **Status checks** use `GET` (peek) without consuming the token
- **Consume** uses atomic `GETDEL` for single-use enforcement, plus a short-lived `used` marker so the landing page can distinguish *used* vs *expired*
- **Rollback** on transient failures via `release()` restores the token for retry
- Removed `JwtModule` registration from `AgentsModule` and `IntegrationModule` for this flow
- Added unit tests for the token service

## Security properties (unchanged intent)

| Property | Mechanism |
|----------|-----------|
| Short-lived | Redis TTL (5 min) |
| Single-use | `GETDEL` on consume + used marker |
| Opaque | No env/org/agent IDs in the URL |
| High entropy | 192-bit random token |
| Cache required | Issue fails if Redis is unavailable |

## Breaking changes

None for API consumers — response shape (`token`, `url`, `expiresAt`) is unchanged. **Previously issued JWT links will no longer work** after deploy (expected; links are short-lived).

## Flow

```mermaid
sequenceDiagram
  participant Dashboard
  participant API
  participant Redis
  participant Mobile

  Dashboard->>API: POST mobile-link (authed)
  API->>Redis: SET telegram_mobile_link:{token}
  API-->>Dashboard: url with 32-char token
  Mobile->>API: GET status?token=
  API->>Redis: GET (peek)
  Mobile->>API: POST mobile-configure
  API->>Redis: GETDEL + SET used marker
  API-->>Mobile: success
```

## Test plan

- [x] `pnpm test -- --grep TelegramMobileLinkTokenService` (5 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7095f143-89d1-4534-a09a-5f5611d022df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7095f143-89d1-4534-a09a-5f5611d022df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
Telegram mobile setup links now use opaque 32-character base64url tokens (192-bit entropy) stored in Redis instead of signed JWTs. The full session context (env/org/agent/integration or integration-store) is persisted with a 5-minute TTL; status checks peek the cache non-destructively, claim() atomically consumes a token and sets a used-marker to enforce single-use, and release() can restore tokens on rollback. This removes JWT handling for the flow and prevents sensitive identifiers from appearing in URLs.

## Affected areas
- api: Replaced JWT/JTI-based mobile-link flow with a Redis-backed opaque token implementation (TelegramMobileLinkTokenService), updated consume/status use-cases to call claim()/verify(), removed JwtModule registrations from AgentsModule and IntegrationsModule, adjusted DTOs/Swagger text, and added cache-related errors/types.
- dashboard: Updated docs/comments and a UI prop JSDoc to describe opaque Redis-backed setup tokens instead of JWTs.
- js: Updated inline docs in the Telegram agent setup command to reference opaque tokens.

## Key technical decisions
- Token format: 24 random bytes → base64url → 32-char opaque token (192 bits entropy).
- Single-use: atomic Redis Lua script does GETDEL of the token entry and SET of a used-marker with remaining-TTL to distinguish consumed vs expired tokens.
- TTL: 5-minute token lifetime; used-marker TTL derived from remaining lifetime.
- Rollback: release() uses an atomic Lua eval to restore entries and clear used-markers when appropriate.
- Operational dependency: Redis must be available; cache outages surface as TelegramMobileLinkCacheUnavailableError.
- Error mapping: InvalidTelegramMobileTokenError reasons (used/expired/invalid) are consistently mapped to HTTP responses.

## Testing
Added unit tests for TelegramMobileLinkTokenService covering issuance, TTL tolerance, non-consuming status/peek, single-use claim semantics, kind-mismatch handling, release/rollback via eval, and cache error propagation (test suite passes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces signed JWTs in Telegram mobile QR links with 32-character opaque tokens (192-bit entropy) backed by Redis, making QR codes smaller and removing sensitive identifiers from URLs. The implementation uses atomic Lua scripts for claim (`GETDEL` + used-marker) and release (`SET` + `DEL`) operations, with unit tests covering the full token lifecycle.

- **New `TelegramMobileLinkTokenService`** replaces the `JwtService`-based flow: `mint()` stores full session payload in Redis, `claim()` atomically consumes via a Lua script, and `release()` restores on rollback — also atomically.
- **Both consume use-cases** (agent and integration-store) are updated to call `claim()`/`release()`, and both status use-cases now call `verify()` asynchronously via a non-destructive `GET` peek.
- `JwtModule` registrations are removed from `AgentsModule` and `IntegrationsModule`, and all Swagger/JSDoc descriptions are updated to reflect the new token format.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the opaque-token flow is well-implemented with atomic Lua scripts and the previous JWT approach is cleanly removed.

The atomic claim and release scripts correctly address the partial-failure scenarios flagged in earlier reviews. The two observations here are minor inconsistencies — missing error wrapping in `mint()` and a Redis 6.2 command used where a version-agnostic Lua equivalent would work just as well — neither affects correctness or data integrity.

`telegram-mobile-link-token.service.ts` — specifically the `mint()` method and `CLAIM_ATOMIC_SCRIPT` sections noted above.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts | Core service rewrite: JWT replaced with opaque token + Redis. Atomic Lua scripts for claim/release are well-designed; `mint()` is the only Redis call without a try/catch wrapper. |
| apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts | New unit tests cover issuance, single-use enforcement, kind mismatch, release rollback, and cache failure paths via an in-process Lua interpreter mock. |
| apps/api/src/app/agents/channels/telegram-linking/consume-telegram-mobile-link/consume-telegram-mobile-link.usecase.ts | Correctly updated to use claim()/release() with proper error mapping for used/expired/invalid reasons. |
| apps/api/src/app/agents/channels/telegram-linking/get-telegram-mobile-link-status/get-telegram-mobile-link-status.usecase.ts | Correctly updated to async verify(); now propagates Redis errors as 500 instead of silently returning { valid: false, reason: 'invalid' }. |
| apps/api/src/app/integrations/usecases/consume-integration-store-telegram-mobile-link/consume-integration-store-telegram-mobile-link.usecase.ts | Parallel update to agent consume use-case; mirrors the same claim/release/error-mapping pattern correctly. |
| apps/api/src/app/integrations/usecases/get-integration-store-telegram-mobile-link-status/get-integration-store-telegram-mobile-link-status.usecase.ts | Correctly removes the isJtiUsed check and delegates to async verifyIntegrationStore(); non-InvalidTelegramMobileTokenError errors now propagate properly. |
| apps/api/src/app/agents/agents.module.ts | JwtModule removed cleanly; no other dependencies affected. |
| apps/api/src/app/integrations/integrations.module.ts | JwtModule removed; comment explaining the previous workaround correctly deleted as no longer relevant. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Dashboard
  participant API
  participant Redis
  participant Mobile

  Dashboard->>API: POST mobile-link (authed)
  API->>API: mint() — assertCacheAvailable
  API->>Redis: "SET telegram_mobile_link:{token} (TTL 5 min)"
  API-->>Dashboard: "{ token, url, expiresAt }"

  Mobile->>API: "GET status?token="
  API->>Redis: "GET telegram_mobile_link_used:{token} (isTokenUsed)"
  Redis-->>API: null (not used)
  API->>Redis: "GET telegram_mobile_link:{token} (peek)"
  Redis-->>API: JSON payload
  API-->>Mobile: "{ valid: true }"

  Mobile->>API: POST mobile-configure (botToken + token)
  API->>Redis: EVAL CLAIM_ATOMIC_SCRIPT (GETDEL + SET used-marker)
  Redis-->>API: M + JSON payload
  API->>API: configure integration, set webhook
  alt Success
    API-->>Mobile: "{ success, botUsername, webhookUrl }"
  else Error
    API->>Redis: EVAL RELEASE_ATOMIC_SCRIPT (SET storage + DEL used-marker)
    API-->>Mobile: error (token restored for retry)
  end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts`, line 174-185 ([link](https://github.com/novuhq/novu/blob/bfd9be8ef4927f2e95fbf42badb89d5f739cf35b/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts#L174-L185)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Test mock silently drops TTL options**

   The `set` stub in `makeService()` ignores the `{ ttl }` option entirely. This means the TTL-related logic in `claim()` — specifically the `usedTtl = Math.max(1, remaining)` calculation and the `remaining <= 0` guard in `release()` — is never exercised. A test that verifies the used-marker TTL matches the remaining lifetime, or that `release()` is a no-op when the token has already expired, would catch regressions here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts
   Line: 174-185

   Comment:
   **Test mock silently drops TTL options**

   The `set` stub in `makeService()` ignores the `{ ttl }` option entirely. This means the TTL-related logic in `claim()` — specifically the `usedTtl = Math.max(1, remaining)` calculation and the `remaining <= 0` guard in `release()` — is never exercised. A test that verifies the used-marker TTL matches the remaining lifetime, or that `release()` is a no-op when the token has already expired, would catch regressions here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fchannels%2Ftelegram-linking%2Ftelegram-mobile-link-token.service.spec.ts%0ALine%3A%20174-185%0A%0AComment%3A%0A**Test%20mock%20silently%20drops%20TTL%20options**%0A%0AThe%20%60set%60%20stub%20in%20%60makeService%28%29%60%20ignores%20the%20%60%7B%20ttl%20%7D%60%20option%20entirely.%20This%20means%20the%20TTL-related%20logic%20in%20%60claim%28%29%60%20%E2%80%94%20specifically%20the%20%60usedTtl%20%3D%20Math.max%281%2C%20remaining%29%60%20calculation%20and%20the%20%60remaining%20%3C%3D%200%60%20guard%20in%20%60release%28%29%60%20%E2%80%94%20is%20never%20exercised.%20A%20test%20that%20verifies%20the%20used-marker%20TTL%20matches%20the%20remaining%20lifetime%2C%20or%20that%20%60release%28%29%60%20is%20a%20no-op%20when%20the%20token%20has%20already%20expired%2C%20would%20catch%20regressions%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fchannels%2Ftelegram-linking%2Ftelegram-mobile-link-token.service.ts%3A273-277%0A%60mint%28%29%60%20is%20the%20only%20Redis%20call%20in%20this%20service%20without%20a%20try%2Fcatch.%20Every%20other%20Redis%20operation%20%28%60claim%60%2C%20%60peek%60%2C%20%60isTokenUsed%60%2C%20%60release%60%29%20wraps%20the%20call%20and%20throws%20%60TelegramMobileLinkCacheUnavailableError%60%20on%20failure.%20If%20%60cacheService.set%60%20throws%20here%20%E2%80%94%20e.g.%2C%20a%20transient%20Redis%20error%20after%20%60assertCacheAvailable%60%20already%20passed%20%E2%80%94%20the%20raw%20driver%20error%20propagates%20to%20callers%20instead%20of%20the%20typed%20error%20they%20can%20reason%20about.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20await%20this.cacheService.set%28this.storageKey%28token%29%2C%20JSON.stringify%28entry%29%2C%20%7B%0A%20%20%20%20%20%20%20%20ttl%3A%20TELEGRAM_MOBILE_LINK_TTL_SECONDS%2C%0A%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20%20%20throw%20new%20TelegramMobileLinkCacheUnavailableError%28'issue'%2C%20err%29%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20const%20expiresAt%20%3D%20new%20Date%28expiresAtEpoch%20*%201000%29.toISOString%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fapi%2Fsrc%2Fapp%2Fagents%2Fchannels%2Ftelegram-linking%2Ftelegram-mobile-link-token.service.ts%3A22%0A%60GETDEL%60%20was%20introduced%20in%20Redis%206.2.%20Since%20this%20Lua%20script%20runs%20inside%20%60redis.call%60%2C%20a%20cluster%20on%20Redis%20%E2%89%A4%206.1%20will%20throw%20%60ERR%20unknown%20command%20'getdel'%60%2C%20causing%20every%20%60claim%28%29%60%20to%20fail%20with%20%60TelegramMobileLinkCacheUnavailableError%60.%20Because%20the%20Lua%20script%20is%20already%20atomic%20%28Redis%20single-threads%20script%20execution%29%2C%20%60GET%60%20%2B%20conditional%20%60DEL%60%20inside%20the%20script%20would%20be%20equally%20atomic%20and%20Redis-version%20agnostic%20%E2%80%94%20%60GETDEL%60%20adds%20no%20extra%20safety%20here.%0A%0A&pr=11364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts:273-277
`mint()` is the only Redis call in this service without a try/catch. Every other Redis operation (`claim`, `peek`, `isTokenUsed`, `release`) wraps the call and throws `TelegramMobileLinkCacheUnavailableError` on failure. If `cacheService.set` throws here — e.g., a transient Redis error after `assertCacheAvailable` already passed — the raw driver error propagates to callers instead of the typed error they can reason about.

```suggestion
    try {
      await this.cacheService.set(this.storageKey(token), JSON.stringify(entry), {
        ttl: TELEGRAM_MOBILE_LINK_TTL_SECONDS,
      });
    } catch (err) {
      throw new TelegramMobileLinkCacheUnavailableError('issue', err);
    }

    const expiresAt = new Date(expiresAtEpoch * 1000).toISOString();
```

### Issue 2 of 2
apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts:22
`GETDEL` was introduced in Redis 6.2. Since this Lua script runs inside `redis.call`, a cluster on Redis ≤ 6.1 will throw `ERR unknown command 'getdel'`, causing every `claim()` to fail with `TelegramMobileLinkCacheUnavailableError`. Because the Lua script is already atomic (Redis single-threads script execution), `GET` + conditional `DEL` inside the script would be equally atomic and Redis-version agnostic — `GETDEL` adds no extra safety here.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(api-service): atomic release and kin..."](https://github.com/novuhq/novu/commit/72e08eaf06f7906e14f58cc396281d9517773c0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34770721)</sub>

<!-- /greptile_comment -->