### PR TITLE
fix(api-service): use Redis cluster hash tags for telegram mobile link keys fixes NV-7914

### DIFF
--- a/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts
@@ -138,7 +138,7 @@ describe('TelegramMobileLinkTokenService', () => {
 
     expect(cacheService.set.calledOnce).to.equal(true);
     const setArgs = cacheService.set.firstCall.args;
-    expect(setArgs[0]).to.equal(`telegram_mobile_link:${token}`);
+    expect(setArgs[0]).to.equal(`telegram_mobile_link:{${token}}`);
     const parsed = JSON.parse(setArgs[1] as string);
     expect(parsed.payload.kind).to.equal('agent');
     expect(parsed.payload.env).to.equal('env-1');
@@ -175,7 +175,7 @@ describe('TelegramMobileLinkTokenService', () => {
     const claimed = await service.claim(token, 'agent');
     expect(claimed.payload.kind).to.equal('agent');
 
-    const usedKey = `telegram_mobile_link_used:${token}`;
+    const usedKey = `telegram_mobile_link_used:{${token}}`;
     expect(cacheStore.get(usedKey)).to.equal('1');
     const usedTtl = keyTtls.get(usedKey);
     expect(usedTtl).to.be.a('number');

--- a/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts
+++ b/apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts
@@ -8,6 +8,11 @@ export const TELEGRAM_MOBILE_LINK_TTL_SECONDS = 5 * 60;
 const CACHE_KEY_PREFIX = 'telegram_mobile_link:';
 const USED_KEY_PREFIX = 'telegram_mobile_link_used:';
 
+/** Wrap token in `{…}` so storage + used-marker keys share a Redis Cluster hash slot. */
+function clusterSlotTag(token: string): string {
+  return `{${token}}`;
+}
+
 /** 192 bits of entropy → 32 URL-safe base64url characters (compact QR payloads). */
 const TOKEN_BYTES = 24;
 
@@ -351,10 +356,10 @@ export class TelegramMobileLinkTokenService {
   }
 
   private storageKey(token: string): string {
-    return `${CACHE_KEY_PREFIX}${token}`;
+    return `${CACHE_KEY_PREFIX}${clusterSlotTag(token)}`;
   }
 
   private usedKey(token: string): string {
-    return `${USED_KEY_PREFIX}${token}`;
+    return `${USED_KEY_PREFIX}${clusterSlotTag(token)}`;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #11364. Telegram mobile link `claim()` / `release()` use Lua scripts that touch **two Redis keys** in one `EVAL`. On **Redis Cluster**, that raises:

`CROSSSLOT Keys in request don't hash to the same slot`

This was observed in production on `POST /v1/agents/public/telegram/mobile-configure`.

## Fix

Wrap the token in a Redis **hash tag** so storage and used-marker keys share a slot:

- `telegram_mobile_link:{token}`
- `telegram_mobile_link_used:{token}`

Only the `{…}` portion is used for slot assignment, so both keys route together and the atomic scripts work on Cluster.

## Notes

- Tokens issued before deploy under the old key format expire naturally within 5 minutes.
- No API or URL shape changes — only internal Redis key layout.

## Test plan

- [x] `pnpm test -- --grep TelegramMobileLinkTokenService` (8 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7095f143-89d1-4534-a09a-5f5611d022df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7095f143-89d1-4534-a09a-5f5611d022df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

Telegram mobile link token functions (`claim()` and `release()`) use Lua scripts that atomically operate on two Redis keys. On Redis Cluster, this triggered "CROSSSLOT Keys in request don't hash to the same slot" errors in production. The fix wraps tokens in Redis hash tags (`{token}`) so both the storage key and used-marker key route to the same cluster slot, enabling atomic script execution on Cluster deployments.

## Affected areas

**api**: Updated `TelegramMobileLinkTokenService` to wrap tokens in hash tags when generating Redis keys. Added a `clusterSlotTag()` helper and updated `storageKey()` and `usedKey()` methods to use it, ensuring both keys map to the same hash slot for atomic operations.

## Key technical decisions

- Hash tags follow Redis Cluster convention: only the `{...}` portion is used for slot assignment, making the wrapping transparent to key semantics.
- No API or URL changes — purely internal Redis key layout adjustment.
- Pre-deploy tokens expire naturally within 5 minutes, so no migration is needed.

## Testing

Existing unit tests for `TelegramMobileLinkTokenService` were updated to expect the new key format (8 tests passing). No breaking behavior changes — only key naming adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Redis Cluster `CROSSSLOT` error in `TelegramMobileLinkTokenService` by wrapping tokens in a hash tag (`{token}`) so the two related keys — `telegram_mobile_link:{token}` and `telegram_mobile_link_used:{token}` — always map to the same cluster slot and can be operated on atomically by the Lua `EVAL` scripts.

- Adds a private `clusterSlotTag(token)` helper and applies it in both `storageKey()` and `usedKey()`, so the only-varying part (`token`) drives slot assignment for both keys.
- Updates two spec assertions to match the new `{...}`-wrapped key format; all eight tests pass.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow, well-understood Redis key layout fix with no API surface changes.

Both `storageKey()` and `usedKey()` now wrap the token in `{...}` so the Lua scripts always operate on keys that land in the same cluster slot. The token format (`/^[A-Za-z0-9_-]{32}$/`) guarantees no nested braces can appear in the tag, making slot resolution deterministic. Tests cover all eight paths and were updated to match. Old-format keys expire within the 5-minute TTL with no manual cleanup needed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.ts | Adds `clusterSlotTag` helper and applies it in `storageKey()` and `usedKey()` so both keys share the same Redis Cluster hash slot; fix is minimal and correct. |
| apps/api/src/app/agents/channels/telegram-linking/telegram-mobile-link-token.service.spec.ts | Updates two key-format assertions to include the `{...}` hash-tag wrapper; test coverage remains complete across all 8 test cases. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Service as TelegramMobileLinkTokenService
    participant Redis as Redis Cluster

    Note over Service,Redis: issue()
    Service->>Redis: "SET telegram_mobile_link:{token} payload EX 300"
    Redis-->>Service: "OK (slot = hash(token))"

    Note over Service,Redis: claim() — both keys in same slot
    Service->>Redis: "EVAL CLAIM_SCRIPT KEYS[telegram_mobile_link:{token}, telegram_mobile_link_used:{token}]"
    Note right of Redis: GETDEL KEYS[1], SET KEYS[2] EX ttl
    Redis-->>Service: "M{payload}"

    Note over Service,Redis: release() — both keys in same slot
    Service->>Redis: "EVAL RELEASE_SCRIPT KEYS[telegram_mobile_link:{token}, telegram_mobile_link_used:{token}]"
    Note right of Redis: SET KEYS[1] EX ttl, DEL KEYS[2]
    Redis-->>Service: OK
```

<sub>Reviews (1): Last reviewed commit: ["fix(api-service): use Redis cluster hash..."](https://github.com/novuhq/novu/commit/aa97cf3034779fa5678486a9de46a4a448eb2baf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34778309)</sub>

<!-- /greptile_comment -->