### PR TITLE
fix(dashboard): add Clerk v6 exports to community self-hosted shim fixes NV-7908

### DIFF
--- a/apps/dashboard/src/utils/self-hosted/auth.resource.tsx
+++ b/apps/dashboard/src/utils/self-hosted/auth.resource.tsx
@@ -1,10 +1,21 @@
+import { MemberRoleEnum, PermissionsEnum } from '@novu/shared';
 import React from 'react';
 import { createContextHook } from '../context';
 import { DecodedJwt } from '.';
 import { getJwtToken, isJwtValid } from './jwt-manager';
-import { createUserFromJwt } from './user.types';
+import { createUserFromJwt, SelfHostedUser } from './user.types';
 
-export const AuthContext = React.createContext({});
+export type SelfHostedAuthContextValue = {
+  currentUser: SelfHostedUser | null;
+  has: (params: { permission: PermissionsEnum } | { role: MemberRoleEnum }) => boolean;
+};
+
+const defaultAuthContextValue: SelfHostedAuthContextValue = {
+  currentUser: null,
+  has: () => true,
+};
+
+export const AuthContext = React.createContext<SelfHostedAuthContextValue>(defaultAuthContextValue);
 
 export function AuthContextProvider({ children }: any) {
   const jwt = getJwtToken();

--- a/apps/dashboard/src/utils/self-hosted/auth.resource.tsx
+++ b/apps/dashboard/src/utils/self-hosted/auth.resource.tsx
@@ -18,4 +18,4 @@ export function AuthContextProvider({ children }: any) {
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
-export const useAuth = createContextHook(AuthContext);
+export const useAuthContext = createContextHook(AuthContext);

--- a/apps/dashboard/src/utils/self-hosted/clerk-loaded.tsx
+++ b/apps/dashboard/src/utils/self-hosted/clerk-loaded.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useAuth } from './use-auth';
+
+type ClerkLoadedProps = {
+  children: React.ReactNode;
+};
+
+export function ClerkLoaded({ children }: ClerkLoadedProps) {
+  const { isLoaded } = useAuth();
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/dashboard/src/utils/self-hosted/index.tsx
+++ b/apps/dashboard/src/utils/self-hosted/index.tsx
@@ -40,8 +40,10 @@ export {
 export { useAuth, useOrganization, useUser };
 
 export const useClerk = () => {
+  const { isLoaded } = useAuth();
+
   return {
-    loaded: true,
+    loaded: isLoaded,
     setActive: async () => {
       console.warn('Clerk.setActive is not available in self-hosted mode');
     },

--- a/apps/dashboard/src/utils/self-hosted/index.tsx
+++ b/apps/dashboard/src/utils/self-hosted/index.tsx
@@ -1,6 +1,9 @@
 import { IOrganizationEntity } from '@novu/shared';
 import React from 'react';
-import { AuthContextProvider, useAuth } from './auth.resource';
+import { AuthContextProvider } from './auth.resource';
+import { ClerkLoaded } from './clerk-loaded';
+import { Show } from './show';
+import { useAuth } from './use-auth';
 import {
   OrganizationList,
   OrganizationProfile,
@@ -19,11 +22,13 @@ import { UserButton } from './user-button';
 
 export {
   AuthContextProvider,
+  ClerkLoaded,
   OrganizationContextProvider,
   OrganizationList,
   OrganizationProfile,
   OrganizationSwitcher,
   RedirectToSignIn,
+  Show,
   SignedIn,
   SignedOut,
   SignIn,
@@ -36,6 +41,7 @@ export { useAuth, useOrganization, useUser };
 
 export const useClerk = () => {
   return {
+    loaded: true,
     setActive: async () => {
       console.warn('Clerk.setActive is not available in self-hosted mode');
     },

--- a/apps/dashboard/src/utils/self-hosted/show.tsx
+++ b/apps/dashboard/src/utils/self-hosted/show.tsx
@@ -1,0 +1,70 @@
+import type { CheckAuthorizationWithCustomPermissions, ShowWhenCondition } from '@clerk/shared/types';
+import { MemberRoleEnum, PermissionsEnum } from '@novu/shared';
+import React from 'react';
+import { useAuth } from './use-auth';
+
+type ShowProps = {
+  when: ShowWhenCondition;
+  fallback?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+function toClerkHas(
+  has: (params: { permission: PermissionsEnum } | { role: MemberRoleEnum }) => boolean
+): CheckAuthorizationWithCustomPermissions {
+  return (params) => {
+    if ('permission' in params && params.permission !== undefined) {
+      return has({ permission: params.permission as PermissionsEnum });
+    }
+
+    if ('role' in params && params.role !== undefined) {
+      return has({ role: params.role as MemberRoleEnum });
+    }
+
+    return false;
+  };
+}
+
+function evaluateShowCondition(
+  when: ShowWhenCondition,
+  has: (params: { permission: PermissionsEnum } | { role: MemberRoleEnum }) => boolean,
+  isSignedIn: boolean
+): boolean {
+  if (when === 'signed-in') {
+    return isSignedIn;
+  }
+
+  if (when === 'signed-out') {
+    return !isSignedIn;
+  }
+
+  if (typeof when === 'function') {
+    return when(toClerkHas(has));
+  }
+
+  if ('permission' in when && when.permission !== undefined) {
+    return has({ permission: when.permission as PermissionsEnum });
+  }
+
+  if ('role' in when && when.role !== undefined) {
+    return has({ role: when.role as MemberRoleEnum });
+  }
+
+  return false;
+}
+
+export function Show({ when, fallback, children }: ShowProps) {
+  const { isLoaded, isSignedIn, has } = useAuth();
+
+  if (!isLoaded) {
+    return null;
+  }
+
+  const shouldShow = evaluateShowCondition(when, has, isSignedIn);
+
+  if (!shouldShow) {
+    return fallback ? <>{fallback}</> : null;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/dashboard/src/utils/self-hosted/use-auth.ts
+++ b/apps/dashboard/src/utils/self-hosted/use-auth.ts
@@ -4,9 +4,15 @@ import { getJwtToken, isJwtValid } from './jwt-manager';
 import { useOrganization } from './organization.resource';
 import { useUser } from './user.resource';
 
+function denyPermissionCheck(
+  _params: { permission: PermissionsEnum } | { role: MemberRoleEnum }
+): boolean {
+  return false;
+}
+
 export function useAuth() {
-  const { currentUser, has } = useAuthContext();
-  const { user, isLoaded: isUserLoaded } = useUser();
+  const { currentUser } = useAuthContext();
+  const { isLoaded: isUserLoaded } = useUser();
   const { organization, isLoaded: isOrgLoaded } = useOrganization() as {
     organization?: { _id?: string; externalOrgId?: string };
     isLoaded: boolean;
@@ -14,13 +20,13 @@ export function useAuth() {
 
   const hasToken = isJwtValid(getJwtToken());
   const isLoaded = isUserLoaded && (hasToken ? isOrgLoaded : true);
-  const isSignedIn = !!currentUser || !!user;
+  const isSignedIn = !!currentUser;
 
   return {
     isLoaded,
     isSignedIn,
-    userId: currentUser?.externalId ?? user?.externalId,
+    userId: currentUser?.externalId,
     orgId: organization?.externalOrgId ?? organization?._id,
-    has: has as (params: { permission: PermissionsEnum } | { role: MemberRoleEnum }) => boolean,
+    has: denyPermissionCheck,
   };
 }

--- a/apps/dashboard/src/utils/self-hosted/use-auth.ts
+++ b/apps/dashboard/src/utils/self-hosted/use-auth.ts
@@ -1,25 +1,18 @@
-import { MemberRoleEnum, PermissionsEnum } from '@novu/shared';
 import { useAuthContext } from './auth.resource';
 import { getJwtToken, isJwtValid } from './jwt-manager';
 import { useOrganization } from './organization.resource';
 import { useUser } from './user.resource';
 
-function denyPermissionCheck(
-  _params: { permission: PermissionsEnum } | { role: MemberRoleEnum }
-): boolean {
-  return false;
-}
-
 export function useAuth() {
-  const { currentUser } = useAuthContext();
-  const { isLoaded: isUserLoaded } = useUser();
+  const { currentUser, has } = useAuthContext();
+  useUser();
   const { organization, isLoaded: isOrgLoaded } = useOrganization() as {
     organization?: { _id?: string; externalOrgId?: string };
     isLoaded: boolean;
   };
 
   const hasToken = isJwtValid(getJwtToken());
-  const isLoaded = isUserLoaded && (hasToken ? isOrgLoaded : true);
+  const isLoaded = hasToken ? isOrgLoaded : true;
   const isSignedIn = !!currentUser;
 
   return {
@@ -27,6 +20,6 @@ export function useAuth() {
     isSignedIn,
     userId: currentUser?.externalId,
     orgId: organization?.externalOrgId ?? organization?._id,
-    has: denyPermissionCheck,
+    has,
   };
 }

--- a/apps/dashboard/src/utils/self-hosted/use-auth.ts
+++ b/apps/dashboard/src/utils/self-hosted/use-auth.ts
@@ -1,0 +1,26 @@
+import { MemberRoleEnum, PermissionsEnum } from '@novu/shared';
+import { useAuthContext } from './auth.resource';
+import { getJwtToken, isJwtValid } from './jwt-manager';
+import { useOrganization } from './organization.resource';
+import { useUser } from './user.resource';
+
+export function useAuth() {
+  const { currentUser, has } = useAuthContext();
+  const { user, isLoaded: isUserLoaded } = useUser();
+  const { organization, isLoaded: isOrgLoaded } = useOrganization() as {
+    organization?: { _id?: string; externalOrgId?: string };
+    isLoaded: boolean;
+  };
+
+  const hasToken = isJwtValid(getJwtToken());
+  const isLoaded = isUserLoaded && (hasToken ? isOrgLoaded : true);
+  const isSignedIn = !!currentUser || !!user;
+
+  return {
+    isLoaded,
+    isSignedIn,
+    userId: currentUser?.externalId ?? user?.externalId,
+    orgId: organization?.externalOrgId ?? organization?._id,
+    has: has as (params: { permission: PermissionsEnum } | { role: MemberRoleEnum }) => boolean,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Clerk v6 upgrade added `Show`, `ClerkLoaded`, and `useAuth().isLoaded` usage across the dashboard, but the community self-hosted `@clerk/react` shim was not updated. This broke bundling and caused a blank screen after a manual stub (because `isLoaded` was always falsy).

## Changes

- **`Show`** — mirrors the better-auth implementation for `signed-in` / `signed-out` and RBAC-style conditions
- **`ClerkLoaded`** — gates the app tree until auth state is settled (user + organization contexts)
- **`useAuth()`** — returns `isLoaded`, `isSignedIn`, `userId`, `orgId`, and `has` by composing user, organization, and JWT auth contexts
- **`useClerk()`** — adds `loaded: true` for `ProtectedAuthRoute`

## Verification

Built the dashboard with community self-hosted aliases:

```bash
VITE_SELF_HOSTED=true VITE_NOVU_ENTERPRISE=false pnpm exec vite build
```

Build completes successfully (no missing export errors).

## Scope

Only `apps/dashboard/src/utils/self-hosted/` — cloud Clerk and enterprise better-auth shims are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7908](https://linear.app/novu/issue/NV-7908/bug-report-community-self-hosted-dashboard-fails-to-bundle-renders)

<div><a href="https://cursor.com/agents/bc-0d165bbe-8516-4da4-a6f7-53e1ba103a16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d165bbe-8516-4da4-a6f7-53e1ba103a16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
The dashboard's community self-hosted Clerk shim was extended to restore compatibility with Clerk v6. New exports and utilities were added: a Show component for conditional rendering, a ClerkLoaded gate to defer rendering until auth contexts settle, and a composite useAuth() hook exposing isLoaded, isSignedIn, userId, orgId and permission checks. useClerk() now includes a loaded flag. The existing auth context hook was renamed to useAuthContext and the AuthContext was typed to fix TypeScript build errors and prevent blank-screen bundling failures.

## Affected areas
- **dashboard**: Updated self-hosted Clerk shim under apps/dashboard/src/utils/self-hosted/ — added Show, ClerkLoaded, useAuth(), typed AuthContext (useAuth → useAuthContext), and adjusted useClerk() to expose load state so the dashboard builds and runs with Clerk v6-compatible imports.

## Key technical decisions
- Added ClerkLoaded to delay app render until user and organization auth contexts are ready, avoiding blank screens caused by premature gating.
- Composite useAuth() composes user, organization and JWT contexts and computes isLoaded conditionally (organization loading required only when a valid JWT exists) to balance correctness and permissiveness.
- Renamed existing useAuth to useAuthContext to avoid naming collisions and preserve the underlying context API.
- AuthContext now has a typed default value (including a permissive has() fallback) to satisfy TypeScript and keep self-hosted behavior aligned with cloud/enterprise shims.

## Testing
Manual verification: built the dashboard with self-hosted aliases (VITE_SELF_HOSTED=true VITE_NOVU_ENTERPRISE=false pnpm exec vite build) confirming the build completes without missing export or TypeScript errors; no new unit tests were added since changes fill API gaps in the shim.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fills the missing Clerk v6 API surface in the community self-hosted `@clerk/react` shim so the dashboard bundles and boots correctly without a blank screen. The previous shim was missing `Show`, `ClerkLoaded`, and a compliant `useAuth()` hook.

- **`useAuth`** — new hook (`use-auth.ts`) composing `useAuthContext`, `useOrganization`, and `useUser`; computes `isLoaded` by gating on the org-query completion only when a valid JWT is present, which correctly unblocks unauthenticated visitors immediately.
- **`ClerkLoaded`** and **`Show`** — new gate components that read `isLoaded`/`isSignedIn` from the new hook and replace the Clerk v6 components that were previously unresolved in the self-hosted bundle.
- **`useClerk`** — now exposes `loaded: isLoaded`, satisfying the `ProtectedAuthRoute` guard (`!clerk.loaded`) that previously kept the route permanently hidden.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are scoped entirely to the community self-hosted shim and correctly fill the missing Clerk v6 exports without affecting cloud or enterprise auth paths.

The new components and hook are straightforward shims: isLoaded logic correctly handles the no-token, valid-token, and expired-token cases; isSignedIn is derived solely from currentUser (which requires a valid JWT), so the previous false-positive issue is resolved. The only finding is a dead useUser() call that has no effect on behavior.

No files require special attention; all changes are in apps/dashboard/src/utils/self-hosted/.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/utils/self-hosted/use-auth.ts | New useAuth hook composing auth, org, and user contexts; isLoaded logic is sound but contains one dead-code useUser() call. |
| apps/dashboard/src/utils/self-hosted/auth.resource.tsx | Adds typed context value and renames useAuth to useAuthContext to avoid naming conflict with new public hook; no issues found. |
| apps/dashboard/src/utils/self-hosted/clerk-loaded.tsx | New gate component that suppresses rendering until useAuth().isLoaded is true; straightforward and correct. |
| apps/dashboard/src/utils/self-hosted/show.tsx | New Show component implementing signed-in/signed-out and RBAC-style condition evaluation; type imports from @clerk/shared/types are erased at build time so they are safe in the self-hosted bundle. |
| apps/dashboard/src/utils/self-hosted/index.tsx | Re-exports new symbols (ClerkLoaded, Show, useAuth) and adds loaded flag to useClerk(); wiring looks correct. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant ClerkProvider
    participant ClerkLoaded
    participant useAuth
    participant AuthContextProvider
    participant OrganizationContextProvider

    App->>ClerkProvider: render
    ClerkProvider->>AuthContextProvider: wrap (reads JWT, sets currentUser)
    ClerkProvider->>OrganizationContextProvider: wrap (fires /organizations/me query)
    App->>ClerkLoaded: render children?
    ClerkLoaded->>useAuth: isLoaded?
    useAuth->>AuthContextProvider: currentUser, has
    useAuth->>OrganizationContextProvider: organization, isOrgLoaded
    useAuth-->>ClerkLoaded: "isLoaded = hasValidToken ? isOrgLoaded : true"
    ClerkLoaded-->>App: "render children once isLoaded=true"
    App->>Show: "when="signed-in" or "signed-out""
    Show->>useAuth: isSignedIn, has
    Show-->>App: render children or fallback
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdashboard%2Fsrc%2Futils%2Fself-hosted%2Fuse-auth.ts%3A7-9%0AThe%20%60useUser%28%29%60%20call%20discards%20its%20return%20value%20and%20has%20no%20observable%20effect.%20%60UserContextProvider%60%20always%20sets%20%60isLoaded%3A%20true%60%20synchronously%20%28reads%20directly%20from%20%60localStorage%60%29%2C%20so%20neither%20the%20%60user%60%20nor%20the%20%60isLoaded%60%20fields%20it%20returns%20contribute%20anything%20to%20this%20hook's%20output.%20Removing%20the%20call%20eliminates%20a%20confusing%20dead-code%20invocation.%0A%0A%60%60%60suggestion%0A%20%20const%20%7B%20currentUser%2C%20has%20%7D%20%3D%20useAuthContext%28%29%3B%0A%20%20const%20%7B%20organization%2C%20isLoaded%3A%20isOrgLoaded%20%7D%20%3D%20useOrganization%28%29%20as%20%7B%0A%60%60%60%0A%0A&pr=11367&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/dashboard/src/utils/self-hosted/use-auth.ts:7-9
The `useUser()` call discards its return value and has no observable effect. `UserContextProvider` always sets `isLoaded: true` synchronously (reads directly from `localStorage`), so neither the `user` nor the `isLoaded` fields it returns contribute anything to this hook's output. Removing the call eliminates a confusing dead-code invocation.

```suggestion
  const { currentUser, has } = useAuthContext();
  const { organization, isLoaded: isOrgLoaded } = useOrganization() as {
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(dashboard): type self-hosted AuthCon..."](https://github.com/novuhq/novu/commit/866535cde15ce9db6d33c44ca307bd1e93824bfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34778427)</sub>

<!-- /greptile_comment -->