### PR TITLE
fix(api-service): use timing-safe HMAC digest comparison fixes NV-7917

### DIFF
--- a/apps/api/src/app/shared/helpers/is-valid-hmac.ts
+++ b/apps/api/src/app/shared/helpers/is-valid-hmac.ts
@@ -1,5 +1,21 @@
 import { createContextHash, createHash, decryptApiKey } from '@novu/application-generic';
 import { ContextPayload } from '@novu/shared';
+import { timingSafeEqual } from 'node:crypto';
+
+function areHexDigestsEqual(expected: string, provided: string): boolean {
+  if (expected.length !== provided.length) {
+    return false;
+  }
+
+  const expectedBuffer = Buffer.from(expected, 'hex');
+  const providedBuffer = Buffer.from(provided, 'hex');
+
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, providedBuffer);
+}
 
 export function isHmacValid(secretKey: string, subscriberId: string, hmacHash: string | undefined) {
   if (!hmacHash) {
@@ -9,7 +25,11 @@ export function isHmacValid(secretKey: string, subscriberId: string, hmacHash: s
   const key = decryptApiKey(secretKey);
   const computedHmacHash = createHash(key, subscriberId);
 
-  return computedHmacHash === hmacHash;
+  if (!computedHmacHash) {
+    return false;
+  }
+
+  return areHexDigestsEqual(computedHmacHash, hmacHash);
 }
 
 export function isContextHmacValid(
@@ -24,5 +44,9 @@ export function isContextHmacValid(
   const key = decryptApiKey(secretKey);
   const computedContextHash = createContextHash(key, context);
 
-  return computedContextHash === contextHash;
+  if (!computedContextHash) {
+    return false;
+  }
+
+  return areHexDigestsEqual(computedContextHash, contextHash);
 }

--- a/apps/api/src/app/shared/helpers/is-valid-hmac.ts
+++ b/apps/api/src/app/shared/helpers/is-valid-hmac.ts
@@ -2,7 +2,7 @@ import { createContextHash, createHash, decryptApiKey } from '@novu/application-
 import { ContextPayload } from '@novu/shared';
 import { timingSafeEqual } from 'node:crypto';
 
-function areHexDigestsEqual(expected: string, provided: string): boolean {
+export function areHexDigestsEqual(expected: string, provided: string): boolean {
   if (expected.length !== provided.length) {
     return false;
   }

--- a/apps/api/src/app/support/guards/plain-cards.guard.ts
+++ b/apps/api/src/app/support/guards/plain-cards.guard.ts
@@ -1,6 +1,7 @@
-import crypto, { timingSafeEqual } from 'node:crypto';
+import crypto from 'node:crypto';
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { Observable } from 'rxjs';
+import { areHexDigestsEqual } from '../../shared/helpers/is-valid-hmac';
 
 @Injectable()
 export class PlainCardsGuard implements CanActivate {
@@ -13,17 +14,6 @@ export class PlainCardsGuard implements CanActivate {
     if (!incomingSignature) throw new UnauthorizedException('Plain request signature is missing');
     const expectedSignature = crypto.createHmac('sha-256', plainCardsHMACSecretKey).update(requestBody).digest('hex');
 
-    if (incomingSignature.length !== expectedSignature.length) {
-      return false;
-    }
-
-    const incomingBuffer = Buffer.from(incomingSignature, 'hex');
-    const expectedBuffer = Buffer.from(expectedSignature, 'hex');
-
-    if (incomingBuffer.length !== expectedBuffer.length) {
-      return false;
-    }
-
-    return timingSafeEqual(incomingBuffer, expectedBuffer);
+    return areHexDigestsEqual(expectedSignature, incomingSignature);
   }
 }

--- a/apps/api/src/app/support/guards/plain-cards.guard.ts
+++ b/apps/api/src/app/support/guards/plain-cards.guard.ts
@@ -1,4 +1,4 @@
-import crypto from 'node:crypto';
+import crypto, { timingSafeEqual } from 'node:crypto';
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { Observable } from 'rxjs';
 
@@ -13,6 +13,17 @@ export class PlainCardsGuard implements CanActivate {
     if (!incomingSignature) throw new UnauthorizedException('Plain request signature is missing');
     const expectedSignature = crypto.createHmac('sha-256', plainCardsHMACSecretKey).update(requestBody).digest('hex');
 
-    return incomingSignature === expectedSignature;
+    if (incomingSignature.length !== expectedSignature.length) {
+      return false;
+    }
+
+    const incomingBuffer = Buffer.from(incomingSignature, 'hex');
+    const expectedBuffer = Buffer.from(expectedSignature, 'hex');
+
+    if (incomingBuffer.length !== expectedBuffer.length) {
+      return false;
+    }
+
+    return timingSafeEqual(incomingBuffer, expectedBuffer);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces timing-unsafe `===` HMAC digest comparisons with `crypto.timingSafeEqual` in subscriber authentication and Plain Cards webhook verification.

## Changes

- **`is-valid-hmac.ts`**: Added `areHexDigestsEqual()` helper that checks hex string length, decodes to buffers, verifies equal buffer lengths, then compares with `timingSafeEqual`. Used by `isHmacValid()` and `isContextHmacValid()`. Also returns `false` when computed hashes are null.
- **`plain-cards.guard.ts`**: Same pattern for incoming vs expected Plain Cards request signatures.

## Security

Mitigates timing side-channel attacks that could allow an attacker to recover subscriber HMAC digests byte-by-byte in inbox/widget session flows.

## Testing

- No behavior change for valid/invalid signatures with correct hex encoding.
- Manual verification: logic mirrors `packages/chat-adapter-email` webhook HMAC validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7917](https://linear.app/novu/issue/NV-7917/use-timing-safe-comparison-for-subscriber-hmac-verification)

<div><a href="https://cursor.com/agents/bc-d962f95c-bf79-4bb7-a241-6f8773190cb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d962f95c-bf79-4bb7-a241-6f8773190cb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces timing-unsafe `===` HMAC digest comparisons with `crypto.timingSafeEqual` in subscriber auth (`is-valid-hmac.ts`) and the Plain Cards webhook guard (`plain-cards.guard.ts`), mitigating a byte-by-byte timing side-channel attack.

- `areHexDigestsEqual` checks string length equality, decodes both hex strings to `Buffer`, re-checks buffer length equality (catching invalid/partial hex input), then delegates to `timingSafeEqual` — all three guards are necessary and correctly ordered.
- `isHmacValid` and `isContextHmacValid` now also short-circuit with `false` when `createHash`/`createContextHash` returns a falsy value, which is a small correctness improvement bundled with the security fix.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a well-scoped security hardening change with no behavior change for valid inputs.

The areHexDigestsEqual helper is correctly implemented: string length is checked first, both hex strings are decoded to Buffer, buffer lengths are re-validated (which also catches non-hex characters in attacker-supplied input), and timingSafeEqual performs the constant-time comparison. Because HMAC-SHA256 always produces fixed-length (64-char, even-length) hex digests, the edge cases around odd-length hex strings cannot be triggered on the computed side. The null guard additions for computedHmacHash are a small correctness improvement with no risk of regression.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/shared/helpers/is-valid-hmac.ts | Added areHexDigestsEqual helper using crypto.timingSafeEqual for constant-time HMAC digest comparison; updated isHmacValid and isContextHmacValid to use it and to guard against null computed hashes. |
| apps/api/src/app/support/guards/plain-cards.guard.ts | Replaced direct === string comparison with the shared areHexDigestsEqual helper for Plain Cards webhook signature verification. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming request with HMAC/signature header] --> B{Header present?}
    B -- No --> C[Return false / UnauthorizedException]
    B -- Yes --> D[Compute expected digest via HMAC-SHA256]
    D --> E{computedHash null?}
    E -- Yes --> C
    E -- No --> F[areHexDigestsEqual]
    F --> G{String lengths equal?}
    G -- No --> C
    G -- Yes --> H[Decode both hex strings to Buffer]
    H --> I{Buffer lengths equal?}
    I -- No --> C
    I -- Yes --> J[crypto.timingSafeEqual]
    J --> K{Buffers match?}
    K -- No --> C
    K -- Yes --> L[Return true / Allow request]
```

<sub>Reviews (2): Last reviewed commit: ["refactor(api-service): reuse areHexDiges..."](https://github.com/novuhq/novu/commit/88f067485a49a2b746cb2d37a512601e0cf4e74b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779513)</sub>

<!-- /greptile_comment -->