### PR TITLE
fix(api-service): reply with no-access when managed agent has unresolved subscriber fixes NV-7916

### DIFF
--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -1,3 +1,4 @@
+import { UNRESOLVED_SUBSCRIBER_ACCESS_REPLY } from '../../shared/util/agent-inbound-replies';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ManagedRuntime } from '../../managed-runtime/managed.runtime';
@@ -358,6 +359,28 @@ describe('AgentInboundHandler', () => {
       expect(thread.startTyping.calledOnceWith('Thinking...')).to.equal(true);
       expect(setupInbound.calledOnce).to.equal(true);
       expect(managedAgentService.dispatch.called).to.equal(false);
+    });
+
+    it('should reply with no-access message for managed agents when subscriber is unresolved', async () => {
+      const { handler, managedAgentService, outboundGateway } = makeHandler({
+        subscriberResolve: sinon.stub().resolves(null),
+        subscriberFindById: sinon.stub().resolves(null),
+        agentFindOne: sinon.stub().resolves({
+          _id: 'agent1',
+          runtime: 'managed',
+          managedRuntime: { providerId: 'anthropic', _integrationId: 'int1', externalAgentId: 'ext1' },
+        }),
+      });
+      const thread = makeSlackDmThread();
+      const message = makeSlackDmMessage();
+
+      await handler.handle('agent1', config as any, thread as any, message as any, AgentEventEnum.ON_MESSAGE);
+
+      expect(managedAgentService.dispatch.called).to.equal(false);
+      expect(outboundGateway.replyOnThread.calledOnce).to.equal(true);
+      expect(outboundGateway.replyOnThread.firstCall.args[1]).to.deep.equal({
+        markdown: UNRESOLVED_SUBSCRIBER_ACCESS_REPLY,
+      });
     });
   });
 

--- a/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
+++ b/apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts
@@ -1,6 +1,6 @@
-import { UNRESOLVED_SUBSCRIBER_ACCESS_REPLY } from '../../shared/util/agent-inbound-replies';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { UNRESOLVED_SUBSCRIBER_ACCESS_REPLY } from '../../shared/util/agent-inbound-replies';
 import { ManagedRuntime } from '../../managed-runtime/managed.runtime';
 import { AgentEventEnum } from '../../shared/enums/agent-event.enum';
 import { AgentPlatformEnum } from '../../shared/enums/agent-platform.enum';

--- a/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
@@ -45,7 +45,7 @@ export class ManagedRuntime implements AgentRuntime {
       return;
     }
 
-    if (turn.subscriber && turn.message?.id) {
+    if (turn.message?.id) {
       const parked = await this.handleManagedAgentSetupInbound.execute(
         ManagedAgentSetupInboundCommand.create({
           userId: 'system',

--- a/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
+++ b/apps/api/src/app/agents/managed-runtime/managed.runtime.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { DEMO_QUOTA_EXHAUSTED_REPLY, DemoQuotaExhaustedError, PinoLogger } from '@novu/application-generic';
+import { UNRESOLVED_SUBSCRIBER_ACCESS_REPLY } from '../shared/util/agent-inbound-replies';
 import { AgentConversationService } from '../conversation-runtime/conversation/agent-conversation.service';
 import { OutboundGateway } from '../conversation-runtime/egress/outbound.gateway';
 import type { AgentRuntime } from '../conversation-runtime/runtime/agent-runtime.port';
@@ -35,6 +36,12 @@ export class ManagedRuntime implements AgentRuntime {
 
     // Managed agents otherwise only act on inbound messages (reactions are bridge-only today).
     if (turn.event !== AgentEventEnum.ON_MESSAGE) {
+      return;
+    }
+
+    if (!turn.subscriber) {
+      await this.replyUnresolvedSubscriberAccess(turn);
+
       return;
     }
 
@@ -120,6 +127,24 @@ export class ManagedRuntime implements AgentRuntime {
           channel: this.conversationService.getPrimaryChannel(turn.conversation),
           agentIdentifier: turn.config.agentIdentifier,
           content: DEMO_QUOTA_EXHAUSTED_REPLY,
+          environmentId: turn.config.environmentId,
+          organizationId: turn.config.organizationId,
+        },
+      }
+    );
+  }
+
+  private async replyUnresolvedSubscriberAccess(turn: ConversationTurn): Promise<void> {
+    applyPlatformThreadIdToThread(turn.thread, turn.platformThreadId);
+    await this.outboundGateway.replyOnThread(
+      turn.thread,
+      { markdown: UNRESOLVED_SUBSCRIBER_ACCESS_REPLY },
+      {
+        persist: {
+          conversationId: turn.conversation._id,
+          channel: this.conversationService.getPrimaryChannel(turn.conversation),
+          agentIdentifier: turn.config.agentIdentifier,
+          content: UNRESOLVED_SUBSCRIBER_ACCESS_REPLY,
           environmentId: turn.config.environmentId,
           organizationId: turn.config.organizationId,
         },

--- a/apps/api/src/app/agents/shared/util/agent-inbound-replies.ts
+++ b/apps/api/src/app/agents/shared/util/agent-inbound-replies.ts
@@ -1,0 +1,3 @@
+/** Shown when an inbound turn cannot be mapped to a Novu subscriber (e.g. unknown email sender). */
+export const UNRESOLVED_SUBSCRIBER_ACCESS_REPLY =
+  "You don't have access to message this agent. Connect your account through your application to continue.";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When someone emails a managed agent but Novu cannot resolve them to a subscriber (unknown email address), the managed runtime was still dispatching to Thalamus. That path often failed and surfaced the generic fallback: "The agent is temporarily unavailable. Please try again later."

This change short-circuits managed-agent inbound turns when `subscriber` is null and replies with a clear no-access message instead.

## Changes

- Added `UNRESOLVED_SUBSCRIBER_ACCESS_REPLY` in `apps/api/src/app/agents/shared/util/agent-inbound-replies.ts`
- `ManagedRuntime.dispatch` returns early for unresolved subscribers and posts the no-access reply (persisted like other automated agent replies)
- Unit test covers managed agents with unresolved subscriber identity

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Unknown email → managed agent | "The agent is temporarily unavailable…" | "You don't have access to message this agent. Connect your account through your application to continue." |
| Unknown user → self-hosted bridge agent | Bridge still receives `subscriber: null` (unchanged) | Unchanged |

## Testing

- Added unit test: `should reply with no-access message for managed agents when subscriber is unresolved`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7916](https://linear.app/novu/issue/NV-7916/when-a-subscriber-that-was-not-found-is-sending-an-email-error)

<div><a href="https://cursor.com/agents/bc-81781ef8-213c-46d3-947a-2ff419875d1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81781ef8-213c-46d3-947a-2ff419875d1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Inbound email turns destined for managed agents that cannot be resolved to a Novu subscriber (unknown sender) now receive a persisted "no-access" reply and the managed-agent dispatch is short-circuited for ON_MESSAGE turns. This replaces the previous behavior that dispatched to Thalamus and often produced a generic fallback error, giving a clearer, actionable response when the sender has not connected their account.

## Affected areas

**api**: Managed runtime now detects unresolved subscribers during inbound ON_MESSAGE turns and returns early after sending a persisted `UNRESOLVED_SUBSCRIBER_ACCESS_REPLY` via the outbound gateway; the reply constant was added to the shared agent inbound replies util. Unit test coverage for the inbound handler was added to assert the no-access reply is sent when subscriber resolution fails. Self-hosted bridge/ON_ACTION behavior is unchanged (bridge still receives subscriber: null, ON_ACTION retains existing dispatch flow).

## Testing

Added a unit test in the inbound-turn handler spec asserting that when subscriber resolution returns null, the handler sends a single `replyOnThread` with the no-access message and does not proceed with managed-agent dispatch. No DB/schema or dependency changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This fix short-circuits `ManagedRuntime.dispatch` when the inbound turn's subscriber is null, posting a clear "no-access" reply instead of falling through to the managed agent service and surfacing a generic failure message.

- A new `UNRESOLVED_SUBSCRIBER_ACCESS_REPLY` constant is introduced in a shared replies module and consumed in `ManagedRuntime`, following the same `persist`-aware reply pattern already used by `replyDemoQuotaExhausted`.
- The `ON_MESSAGE` guard is restructured from `if (turn.subscriber && turn.message?.id)` into two separate checks; the subscriber null-check returns early with the reply, and the message-id check proceeds as before for verified subscribers.
- A unit test covers the new path by stubbing both subscriber resolution methods to return null and asserting that `managedAgentService.dispatch` is never called and `replyOnThread` receives the no-access message.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-scoped early return that mirrors the existing quota-exhausted reply pattern and leaves all other dispatch paths untouched.

The null-subscriber guard is correctly placed after the ON_ACTION branch (which uses optional chaining and is unaffected), persistence options match the established pattern from replyDemoQuotaExhausted, the previous dead-code issue is resolved, and the new unit test exercises the exact failure scenario the PR targets.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/agents/managed-runtime/managed.runtime.ts | Adds early-return guard in dispatch() for null subscribers on ON_MESSAGE turns, posting a no-access reply via outboundGateway with full persistence options, consistent with the existing replyDemoQuotaExhausted pattern. |
| apps/api/src/app/agents/shared/util/agent-inbound-replies.ts | New file exporting UNRESOLVED_SUBSCRIBER_ACCESS_REPLY constant with a clear user-facing message for unknown email senders. |
| apps/api/src/app/agents/conversation-runtime/ingress/inbound-turn.handler.spec.ts | Adds a unit test verifying that the no-access reply is sent and dispatch is skipped when both subscriber resolution methods return null for a managed agent. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ManagedRuntime.dispatch] --> B{turn.event == ON_ACTION?}
    B -- Yes --> C[handleAction]
    B -- No --> D{turn.event == ON_MESSAGE?}
    D -- No --> E[return no-op]
    D -- Yes --> F{turn.subscriber == null?}
    F -- Yes --> G[replyUnresolvedSubscriberAccess\n+ persist to conversation]
    F -- No --> H{turn.message?.id?}
    H -- Yes --> I[handleManagedAgentSetupInbound]
    I --> J{parked?}
    J -- Yes --> K[return early]
    J -- No --> L[managedAgentService.dispatch]
    H -- No --> L
    L --> M{DemoQuotaExhaustedError?}
    M -- Yes --> N[replyDemoQuotaExhausted]
    M -- No --> O[rethrow]
```

<sub>Reviews (2): Last reviewed commit: ["fix(api): address PR review — remove dea..."](https://github.com/novuhq/novu/commit/cafe050c3eed92460be30b38f60df209f5e0300b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779550)</sub>

<!-- /greptile_comment -->