### PR TITLE
fix(providers): Add SSRF protection to email webhook and SMS providers fixes NV-7918

### DIFF
--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
@@ -1,34 +1,24 @@
 import * as dns from 'node:dns';
 import * as http from 'node:http';
-import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { EmailWebhookProvider } from './email-webhook.provider';
 
 const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
-beforeAll(() => {
-  process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
-  const realLookup = dns.promises.lookup.bind(dns.promises);
-  vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
-    if (hostname === 'test-email-webhook.invalid') {
-      const result = [{ address: '127.0.0.1', family: 4 }];
-
-      return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
-    }
-
-    return realLookup(hostname as string, opts as dns.LookupOptions);
-  }) as typeof dns.promises.lookup);
-});
-afterAll(() => {
-  vi.restoreAllMocks();
-  if (ORIGINAL_ALLOW === undefined) {
-    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
-  } else {
-    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
-  }
-});
+const ORIGINAL_ENTERPRISE = process.env.NOVU_ENTERPRISE;
+const ORIGINAL_SELF_HOSTED = process.env.IS_SELF_HOSTED;
 
 let server: http.Server;
 let serverUrl: string;
+let directServerUrl: string;
 let lastRequest: { url: string; method: string; headers: http.IncomingHttpHeaders; body: string } | null = null;
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
 
 beforeEach(async () => {
   lastRequest = null;
@@ -50,6 +40,7 @@ beforeEach(async () => {
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
   const addr = server.address();
   if (!addr || typeof addr === 'string') throw new Error('listen failed');
+  directServerUrl = `http://127.0.0.1:${addr.port}/webhook`;
   serverUrl = `http://test-email-webhook.invalid:${addr.port}/webhook`;
 });
 
@@ -57,106 +48,163 @@ afterEach(async () => {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
-test('should trigger email-webhook-provider library correctly', async () => {
-  const provider = new EmailWebhookProvider({
-    webhookUrl: serverUrl,
-    hmacSecretKey: 'super-secret-key',
-    retryDelay: 1,
-    retryCount: 1,
+describe('with SSRF protection (enterprise cloud)', () => {
+  beforeAll(() => {
+    process.env.NOVU_ENTERPRISE = 'true';
+    process.env.IS_SELF_HOSTED = 'false';
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+    const realLookup = dns.promises.lookup.bind(dns.promises);
+    vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
+      if (hostname === 'test-email-webhook.invalid') {
+        const result = [{ address: '127.0.0.1', family: 4 }];
+
+        return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
+      }
+
+      return realLookup(hostname as string, opts as dns.LookupOptions);
+    }) as typeof dns.promises.lookup);
   });
 
-  const testTo = 'johndoe@example.com';
-  const testFrom = 'janedoe@example.com';
-
-  const payload = {
-    to: [testTo],
-    from: testFrom,
-    subject: 'test',
-    html: '<h1>test</h1>',
-    text: 'test',
-  };
-
-  await provider.sendMessage(payload);
-
-  expect(lastRequest).not.toBeNull();
-  expect(lastRequest!.method).toBe('POST');
-  expect(lastRequest!.body).toBe(
-    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test","html":"<h1>test</h1>","text":"test"}'
-  );
-  expect(lastRequest!.headers['x-novu-signature']).toBe(
-    'd1e94cd19eeceec2e0717e36f7edacaa93612b311bde8756ee35b89d4a994767'
-  );
-});
-
-test('should trigger email-webhook-provider library correctly with _passthrough', async () => {
-  const provider = new EmailWebhookProvider({
-    webhookUrl: serverUrl,
-    hmacSecretKey: 'super-secret-key',
-    retryDelay: 1,
-    retryCount: 1,
+  afterAll(() => {
+    vi.restoreAllMocks();
+    restoreEnv('NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS', ORIGINAL_ALLOW);
+    restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
+    restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
   });
 
-  const testTo = 'johndoe@example.com';
-  const testFrom = 'janedoe@example.com';
+  test('should trigger email-webhook-provider library correctly', async () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: serverUrl,
+      hmacSecretKey: 'super-secret-key',
+      retryDelay: 1,
+      retryCount: 1,
+    });
 
-  const payload = {
-    to: [testTo],
-    from: testFrom,
-    subject: 'test',
-    html: '<h1>test</h1>',
-    text: 'test',
-  };
+    const testTo = 'johndoe@example.com';
+    const testFrom = 'janedoe@example.com';
 
-  await provider.sendMessage(payload, {
-    _passthrough: {
-      body: {
-        subject: 'test _passthrough',
+    const payload = {
+      to: [testTo],
+      from: testFrom,
+      subject: 'test',
+      html: '<h1>test</h1>',
+      text: 'test',
+    };
+
+    await provider.sendMessage(payload);
+
+    expect(lastRequest).not.toBeNull();
+    expect(lastRequest?.method).toBe('POST');
+    expect(lastRequest?.body).toBe(
+      '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test","html":"<h1>test</h1>","text":"test"}'
+    );
+    expect(lastRequest?.headers['x-novu-signature']).toBe(
+      'd1e94cd19eeceec2e0717e36f7edacaa93612b311bde8756ee35b89d4a994767'
+    );
+  });
+
+  test('should trigger email-webhook-provider library correctly with _passthrough', async () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: serverUrl,
+      hmacSecretKey: 'super-secret-key',
+      retryDelay: 1,
+      retryCount: 1,
+    });
+
+    const testTo = 'johndoe@example.com';
+    const testFrom = 'janedoe@example.com';
+
+    const payload = {
+      to: [testTo],
+      from: testFrom,
+      subject: 'test',
+      html: '<h1>test</h1>',
+      text: 'test',
+    };
+
+    await provider.sendMessage(payload, {
+      _passthrough: {
+        body: {
+          subject: 'test _passthrough',
+        },
       },
-    },
+    });
+
+    expect(lastRequest?.body).toBe(
+      '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test _passthrough","html":"<h1>test</h1>","text":"test"}'
+    );
+    expect(lastRequest?.headers['x-novu-signature']).toBe(
+      'b0bfe55e55cfc925891858e6a7a77d1da5e3917321ae4f440e1e81843b2f5fa7'
+    );
   });
 
-  expect(lastRequest!.body).toBe(
-    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test _passthrough","html":"<h1>test</h1>","text":"test"}'
-  );
-  expect(lastRequest!.headers['x-novu-signature']).toBe(
-    'b0bfe55e55cfc925891858e6a7a77d1da5e3917321ae4f440e1e81843b2f5fa7'
-  );
+  test('should reject the request when the URL resolves to a private IP', async () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: 'http://127.0.0.2:8080/webhook',
+      hmacSecretKey: 'super-secret-key',
+      retryDelay: 1,
+      retryCount: 1,
+    });
+
+    await expect(
+      provider.sendMessage({
+        to: ['johndoe@example.com'],
+        from: 'janedoe@example.com',
+        subject: 'test',
+        html: '<h1>test</h1>',
+        text: 'test',
+      })
+    ).rejects.toThrow(/Email webhook URL blocked/);
+  });
+
+  test('should reject non-http schemes', async () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: 'file:///etc/passwd',
+      hmacSecretKey: 'super-secret-key',
+      retryDelay: 1,
+      retryCount: 1,
+    });
+
+    await expect(
+      provider.sendMessage({
+        to: ['johndoe@example.com'],
+        from: 'janedoe@example.com',
+        subject: 'test',
+        html: '<h1>test</h1>',
+        text: 'test',
+      })
+    ).rejects.toThrow(/Invalid URL format|Email webhook URL blocked/);
+  });
 });
 
-test('should reject the request when the URL resolves to a private IP', async () => {
-  const provider = new EmailWebhookProvider({
-    webhookUrl: 'http://127.0.0.2:8080/webhook',
-    hmacSecretKey: 'super-secret-key',
-    retryDelay: 1,
-    retryCount: 1,
+describe('without SSRF protection (self-hosted)', () => {
+  beforeAll(() => {
+    process.env.NOVU_ENTERPRISE = 'true';
+    process.env.IS_SELF_HOSTED = 'true';
   });
 
-  await expect(
-    provider.sendMessage({
+  afterAll(() => {
+    restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
+    restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
+  });
+
+  test('should allow requests to private IPs via axios', async () => {
+    const provider = new EmailWebhookProvider({
+      webhookUrl: directServerUrl,
+      hmacSecretKey: 'super-secret-key',
+      retryDelay: 1,
+      retryCount: 1,
+    });
+
+    await provider.sendMessage({
       to: ['johndoe@example.com'],
       from: 'janedoe@example.com',
       subject: 'test',
       html: '<h1>test</h1>',
       text: 'test',
-    })
-  ).rejects.toThrow(/Email webhook URL blocked/);
-});
+    });
 
-test('should reject non-http schemes', async () => {
-  const provider = new EmailWebhookProvider({
-    webhookUrl: 'file:///etc/passwd',
-    hmacSecretKey: 'super-secret-key',
-    retryDelay: 1,
-    retryCount: 1,
+    expect(lastRequest).not.toBeNull();
+    expect(lastRequest?.method).toBe('POST');
   });
-
-  await expect(
-    provider.sendMessage({
-      to: ['johndoe@example.com'],
-      from: 'janedoe@example.com',
-      subject: 'test',
-      html: '<h1>test</h1>',
-      text: 'test',
-    })
-  ).rejects.toThrow(/Invalid URL format|Email webhook URL blocked/);
 });

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts
@@ -1,15 +1,65 @@
-import axios from 'axios';
-import { expect, test } from 'vitest';
-import { axiosSpy } from '../../../utils/test/spy-axios';
+import * as dns from 'node:dns';
+import * as http from 'node:http';
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { EmailWebhookProvider } from './email-webhook.provider';
 
-test('should trigger email-webhook-provider library correctly', async () => {
-  const { mockPost } = axiosSpy({
-    data: true,
+const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+beforeAll(() => {
+  process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+  const realLookup = dns.promises.lookup.bind(dns.promises);
+  vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
+    if (hostname === 'test-email-webhook.invalid') {
+      const result = [{ address: '127.0.0.1', family: 4 }];
+
+      return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
+    }
+
+    return realLookup(hostname as string, opts as dns.LookupOptions);
+  }) as typeof dns.promises.lookup);
+});
+afterAll(() => {
+  vi.restoreAllMocks();
+  if (ORIGINAL_ALLOW === undefined) {
+    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+  } else {
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
+  }
+});
+
+let server: http.Server;
+let serverUrl: string;
+let lastRequest: { url: string; method: string; headers: http.IncomingHttpHeaders; body: string } | null = null;
+
+beforeEach(async () => {
+  lastRequest = null;
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      lastRequest = {
+        url: req.url ?? '',
+        method: req.method ?? 'GET',
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      };
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ id: 'ok' }));
+    });
   });
 
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('listen failed');
+  serverUrl = `http://test-email-webhook.invalid:${addr.port}/webhook`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+test('should trigger email-webhook-provider library correctly', async () => {
   const provider = new EmailWebhookProvider({
-    webhookUrl: 'http://127.0.0.1:8080/webhook',
+    webhookUrl: serverUrl,
     hmacSecretKey: 'super-secret-key',
     retryDelay: 1,
     retryCount: 1,
@@ -28,26 +78,19 @@ test('should trigger email-webhook-provider library correctly', async () => {
 
   await provider.sendMessage(payload);
 
-  expect(mockPost).toHaveBeenCalled();
-  expect(mockPost).toHaveBeenCalledWith(
-    'http://127.0.0.1:8080/webhook',
-    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test","html":"<h1>test</h1>","text":"test"}',
-    {
-      headers: {
-        'content-type': 'application/json',
-        'X-Novu-Signature': 'd1e94cd19eeceec2e0717e36f7edacaa93612b311bde8756ee35b89d4a994767',
-      },
-    }
+  expect(lastRequest).not.toBeNull();
+  expect(lastRequest!.method).toBe('POST');
+  expect(lastRequest!.body).toBe(
+    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test","html":"<h1>test</h1>","text":"test"}'
+  );
+  expect(lastRequest!.headers['x-novu-signature']).toBe(
+    'd1e94cd19eeceec2e0717e36f7edacaa93612b311bde8756ee35b89d4a994767'
   );
 });
 
 test('should trigger email-webhook-provider library correctly with _passthrough', async () => {
-  const { mockPost } = axiosSpy({
-    data: true,
-  });
-
   const provider = new EmailWebhookProvider({
-    webhookUrl: 'http://127.0.0.1:8080/webhook',
+    webhookUrl: serverUrl,
     hmacSecretKey: 'super-secret-key',
     retryDelay: 1,
     retryCount: 1,
@@ -72,15 +115,48 @@ test('should trigger email-webhook-provider library correctly with _passthrough'
     },
   });
 
-  expect(mockPost).toHaveBeenCalled();
-  expect(mockPost).toHaveBeenCalledWith(
-    'http://127.0.0.1:8080/webhook',
-    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test _passthrough","html":"<h1>test</h1>","text":"test"}',
-    {
-      headers: {
-        'content-type': 'application/json',
-        'X-Novu-Signature': 'b0bfe55e55cfc925891858e6a7a77d1da5e3917321ae4f440e1e81843b2f5fa7',
-      },
-    }
+  expect(lastRequest!.body).toBe(
+    '{"to":["johndoe@example.com"],"from":"janedoe@example.com","subject":"test _passthrough","html":"<h1>test</h1>","text":"test"}'
   );
+  expect(lastRequest!.headers['x-novu-signature']).toBe(
+    'b0bfe55e55cfc925891858e6a7a77d1da5e3917321ae4f440e1e81843b2f5fa7'
+  );
+});
+
+test('should reject the request when the URL resolves to a private IP', async () => {
+  const provider = new EmailWebhookProvider({
+    webhookUrl: 'http://127.0.0.2:8080/webhook',
+    hmacSecretKey: 'super-secret-key',
+    retryDelay: 1,
+    retryCount: 1,
+  });
+
+  await expect(
+    provider.sendMessage({
+      to: ['johndoe@example.com'],
+      from: 'janedoe@example.com',
+      subject: 'test',
+      html: '<h1>test</h1>',
+      text: 'test',
+    })
+  ).rejects.toThrow(/Email webhook URL blocked/);
+});
+
+test('should reject non-http schemes', async () => {
+  const provider = new EmailWebhookProvider({
+    webhookUrl: 'file:///etc/passwd',
+    hmacSecretKey: 'super-secret-key',
+    retryDelay: 1,
+    retryCount: 1,
+  });
+
+  await expect(
+    provider.sendMessage({
+      to: ['johndoe@example.com'],
+      from: 'janedoe@example.com',
+      subject: 'test',
+      html: '<h1>test</h1>',
+      text: 'test',
+    })
+  ).rejects.toThrow(/Invalid URL format|Email webhook URL blocked/);
 });

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto';
-import { EmailProviderIdEnum } from '@novu/shared';
+import { EmailProviderIdEnum, isOutboundSsrfProtectionEnabled } from '@novu/shared';
 import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
 import {
   assertSafeOutboundUrl,
@@ -14,6 +14,7 @@ import {
   IEmailProvider,
   ISendMessageSuccessResponse,
 } from '@novu/stateless';
+import axios from 'axios';
 import { setTimeout } from 'node:timers/promises';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
@@ -36,7 +37,7 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
     this.config.retryCount ??= 3;
   }
 
-  async checkIntegration(options: IEmailOptions): Promise<ICheckIntegrationResponse> {
+  async checkIntegration(_options: IEmailOptions): Promise<ICheckIntegrationResponse> {
     return {
       success: true,
       message: 'Integrated successfully!',
@@ -49,6 +50,46 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ): Promise<ISendMessageSuccessResponse> {
     const transformedData = this.transform(bridgeProviderData, options);
+    const bodyData = this.createBody(transformedData.body);
+    const hmacValue = this.computeHmac(bodyData);
+    const requestHeaders = {
+      'content-type': 'application/json',
+      'X-Novu-Signature': hmacValue,
+      ...transformedData.headers,
+    };
+
+    if (isOutboundSsrfProtectionEnabled()) {
+      await this.sendWithSsrfProtection(bodyData, requestHeaders);
+    } else {
+      await this.sendWithAxios(bodyData, requestHeaders);
+    }
+
+    return {
+      id: options.id,
+      date: new Date().toDateString(),
+    };
+  }
+
+  private async sendWithAxios(bodyData: string, requestHeaders: Record<string, string>): Promise<void> {
+    let sent = false;
+
+    for (let retries = 0; !sent && retries < this.config.retryCount; retries += 1) {
+      try {
+        await axios.create().post(this.config.webhookUrl, bodyData, {
+          headers: requestHeaders,
+        });
+        sent = true;
+      } catch {
+        await setTimeout(this.config.retryDelay);
+      }
+    }
+
+    if (!sent) {
+      throw new Error('webhook send failed !');
+    }
+  }
+
+  private async sendWithSsrfProtection(bodyData: string, requestHeaders: Record<string, string>): Promise<void> {
     const webhookUrl = normalizeOutboundHttpUrl(this.config.webhookUrl);
 
     if (!webhookUrl) {
@@ -64,8 +105,6 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
       throw err;
     }
 
-    const bodyData = this.createBody(transformedData.body);
-    const hmacValue = this.computeHmac(bodyData);
     let sent = false;
 
     for (let retries = 0; !sent && retries < this.config.retryCount; retries += 1) {
@@ -73,11 +112,7 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
         const response = await safeOutboundJsonRequest({
           url: webhookUrl,
           method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-            'X-Novu-Signature': hmacValue,
-            ...transformedData.headers,
-          },
+          headers: requestHeaders,
           body: bodyData,
         }).catch((err: unknown) => {
           if (err instanceof SsrfBlockedError) {
@@ -98,14 +133,10 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
         await setTimeout(this.config.retryDelay);
       }
     }
+
     if (!sent) {
       throw new Error('webhook send failed !');
     }
-
-    return {
-      id: options.id,
-      date: new Date().toDateString(),
-    };
   }
 
   createBody(options: WithPassthrough<Record<string, unknown>>): string {

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
@@ -70,7 +70,7 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
 
     for (let retries = 0; !sent && retries < this.config.retryCount; retries += 1) {
       try {
-        await safeOutboundJsonRequest({
+        const response = await safeOutboundJsonRequest({
           url: webhookUrl,
           method: 'POST',
           headers: {
@@ -85,6 +85,11 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
           }
           throw err;
         });
+
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          throw new Error(`webhook send failed with status ${response.statusCode}`);
+        }
+
         sent = true;
       } catch (error) {
         if (error instanceof Error && error.message.startsWith('Email webhook URL blocked')) {

--- a/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
+++ b/packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts
@@ -1,4 +1,11 @@
+import crypto from 'node:crypto';
 import { EmailProviderIdEnum } from '@novu/shared';
+import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
+import {
+  assertSafeOutboundUrl,
+  normalizeOutboundHttpUrl,
+  SsrfBlockedError,
+} from '@novu/shared/utils/ssrf-url-validation';
 import {
   ChannelTypeEnum,
   CheckIntegrationResponseEnum,
@@ -7,9 +14,7 @@ import {
   IEmailProvider,
   ISendMessageSuccessResponse,
 } from '@novu/stateless';
-import axios from 'axios';
-import crypto from 'crypto';
-import { setTimeout } from 'timers/promises';
+import { setTimeout } from 'node:timers/promises';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
 
@@ -44,21 +49,47 @@ export class EmailWebhookProvider extends BaseProvider implements IEmailProvider
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
   ): Promise<ISendMessageSuccessResponse> {
     const transformedData = this.transform(bridgeProviderData, options);
+    const webhookUrl = normalizeOutboundHttpUrl(this.config.webhookUrl);
+
+    if (!webhookUrl) {
+      throw new Error('Email webhook URL blocked: Invalid URL format.');
+    }
+
+    try {
+      assertSafeOutboundUrl(webhookUrl);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(`Email webhook URL blocked: ${err.message}`);
+      }
+      throw err;
+    }
+
     const bodyData = this.createBody(transformedData.body);
     const hmacValue = this.computeHmac(bodyData);
     let sent = false;
 
     for (let retries = 0; !sent && retries < this.config.retryCount; retries += 1) {
       try {
-        await axios.create().post(this.config.webhookUrl, bodyData, {
+        await safeOutboundJsonRequest({
+          url: webhookUrl,
+          method: 'POST',
           headers: {
             'content-type': 'application/json',
             'X-Novu-Signature': hmacValue,
             ...transformedData.headers,
           },
+          body: bodyData,
+        }).catch((err: unknown) => {
+          if (err instanceof SsrfBlockedError) {
+            throw new Error(`Email webhook URL blocked: ${err.message}`);
+          }
+          throw err;
         });
         sent = true;
       } catch (error) {
+        if (error instanceof Error && error.message.startsWith('Email webhook URL blocked')) {
+          throw error;
+        }
         await setTimeout(this.config.retryDelay);
       }
     }

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts
@@ -1,35 +1,25 @@
 import crypto from 'node:crypto';
 import * as dns from 'node:dns';
 import * as http from 'node:http';
-import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { GenericSmsProvider } from './generic-sms.provider';
 
 const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
-beforeAll(() => {
-  process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
-  const realLookup = dns.promises.lookup.bind(dns.promises);
-  vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
-    if (hostname === 'test-generic-sms.invalid') {
-      const result = [{ address: '127.0.0.1', family: 4 }];
-
-      return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
-    }
-
-    return realLookup(hostname as string, opts as dns.LookupOptions);
-  }) as typeof dns.promises.lookup);
-});
-afterAll(() => {
-  vi.restoreAllMocks();
-  if (ORIGINAL_ALLOW === undefined) {
-    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
-  } else {
-    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
-  }
-});
+const ORIGINAL_ENTERPRISE = process.env.NOVU_ENTERPRISE;
+const ORIGINAL_SELF_HOSTED = process.env.IS_SELF_HOSTED;
 
 let server: http.Server;
 let serverUrl: string;
+let directServerUrl: string;
 let lastRequest: { url: string; method: string; headers: http.IncomingHttpHeaders; body: string } | null = null;
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
 
 beforeEach(async () => {
   lastRequest = null;
@@ -60,6 +50,7 @@ beforeEach(async () => {
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
   const addr = server.address();
   if (!addr || typeof addr === 'string') throw new Error('listen failed');
+  directServerUrl = `http://127.0.0.1:${addr.port}/`;
   serverUrl = `http://test-generic-sms.invalid:${addr.port}/`;
 });
 
@@ -67,92 +58,148 @@ afterEach(async () => {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
-test('should trigger generic-sms library correctly', async () => {
-  const provider = new GenericSmsProvider({
-    baseUrl: serverUrl,
-    apiKeyRequestHeader: 'apiKey',
-    apiKey: '123456',
-    from: 'sender-id',
-    idPath: 'message.id',
-    datePath: 'message.date',
+describe('with SSRF protection (enterprise cloud)', () => {
+  beforeAll(() => {
+    process.env.NOVU_ENTERPRISE = 'true';
+    process.env.IS_SELF_HOSTED = 'false';
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+    const realLookup = dns.promises.lookup.bind(dns.promises);
+    vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
+      if (hostname === 'test-generic-sms.invalid') {
+        const result = [{ address: '127.0.0.1', family: 4 }];
+
+        return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
+      }
+
+      return realLookup(hostname as string, opts as dns.LookupOptions);
+    }) as typeof dns.promises.lookup);
   });
 
-  const result = await provider.sendMessage({
-    to: '+1234567890',
-    content: 'SMS Content form Generic SMS Provider',
+  afterAll(() => {
+    vi.restoreAllMocks();
+    restoreEnv('NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS', ORIGINAL_ALLOW);
+    restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
+    restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
   });
 
-  expect(lastRequest).not.toBeNull();
-  expect(lastRequest!.method).toBe('POST');
-  expect(JSON.parse(lastRequest!.body)).toEqual({
-    to: '+1234567890',
-    content: 'SMS Content form Generic SMS Provider',
-    sender: 'sender-id',
-  });
-  expect(lastRequest!.headers.apikey).toBe('123456');
-  expect(result.id).toBeDefined();
-  expect(result.date).toBeDefined();
-});
+  test('should trigger generic-sms library correctly', async () => {
+    const provider = new GenericSmsProvider({
+      baseUrl: serverUrl,
+      apiKeyRequestHeader: 'apiKey',
+      apiKey: '123456',
+      from: 'sender-id',
+      idPath: 'message.id',
+      datePath: 'message.date',
+    });
 
-test('should trigger generic-sms library correctly with _passthrough', async () => {
-  const provider = new GenericSmsProvider({
-    baseUrl: serverUrl,
-    apiKeyRequestHeader: 'apiKey',
-    apiKey: '123456',
-    from: 'sender-id',
-    idPath: 'message.id',
-    datePath: 'message.date',
-  });
-
-  await provider.sendMessage(
-    {
+    const result = await provider.sendMessage({
       to: '+1234567890',
       content: 'SMS Content form Generic SMS Provider',
-    },
-    {
-      _passthrough: {
-        body: {
-          to: '+2234567890',
-        },
+    });
+
+    expect(lastRequest).not.toBeNull();
+    expect(lastRequest?.method).toBe('POST');
+    expect(JSON.parse(lastRequest?.body ?? '{}')).toEqual({
+      to: '+1234567890',
+      content: 'SMS Content form Generic SMS Provider',
+      sender: 'sender-id',
+    });
+    expect(lastRequest?.headers.apikey).toBe('123456');
+    expect(result.id).toBeDefined();
+    expect(result.date).toBeDefined();
+  });
+
+  test('should trigger generic-sms library correctly with _passthrough', async () => {
+    const provider = new GenericSmsProvider({
+      baseUrl: serverUrl,
+      apiKeyRequestHeader: 'apiKey',
+      apiKey: '123456',
+      from: 'sender-id',
+      idPath: 'message.id',
+      datePath: 'message.date',
+    });
+
+    await provider.sendMessage(
+      {
+        to: '+1234567890',
+        content: 'SMS Content form Generic SMS Provider',
       },
-    }
-  );
+      {
+        _passthrough: {
+          body: {
+            to: '+2234567890',
+          },
+        },
+      }
+    );
 
-  expect(JSON.parse(lastRequest!.body)).toEqual({
-    to: '+2234567890',
-    content: 'SMS Content form Generic SMS Provider',
-    sender: 'sender-id',
+    expect(JSON.parse(lastRequest?.body ?? '{}')).toEqual({
+      to: '+2234567890',
+      content: 'SMS Content form Generic SMS Provider',
+      sender: 'sender-id',
+    });
+  });
+
+  test('should reject the request when the URL resolves to a private IP', async () => {
+    const provider = new GenericSmsProvider({
+      baseUrl: 'http://127.0.0.2:8080/',
+      apiKeyRequestHeader: 'apiKey',
+      apiKey: '123456',
+      from: 'sender-id',
+    });
+
+    await expect(
+      provider.sendMessage({
+        to: '+1234567890',
+        content: 'SMS Content form Generic SMS Provider',
+      })
+    ).rejects.toThrow(/Generic SMS URL blocked/);
+  });
+
+  test('should reject non-http schemes', async () => {
+    const provider = new GenericSmsProvider({
+      baseUrl: 'file:///etc/passwd',
+      apiKeyRequestHeader: 'apiKey',
+      apiKey: '123456',
+      from: 'sender-id',
+    });
+
+    await expect(
+      provider.sendMessage({
+        to: '+1234567890',
+        content: 'SMS Content form Generic SMS Provider',
+      })
+    ).rejects.toThrow(/Invalid URL format|Generic SMS URL blocked/);
   });
 });
 
-test('should reject the request when the URL resolves to a private IP', async () => {
-  const provider = new GenericSmsProvider({
-    baseUrl: 'http://127.0.0.2:8080/',
-    apiKeyRequestHeader: 'apiKey',
-    apiKey: '123456',
-    from: 'sender-id',
+describe('without SSRF protection (self-hosted)', () => {
+  beforeAll(() => {
+    process.env.NOVU_ENTERPRISE = 'true';
+    process.env.IS_SELF_HOSTED = 'true';
   });
 
-  await expect(
-    provider.sendMessage({
-      to: '+1234567890',
-      content: 'SMS Content form Generic SMS Provider',
-    })
-  ).rejects.toThrow(/Generic SMS URL blocked/);
-});
-
-test('should reject non-http schemes', async () => {
-  const provider = new GenericSmsProvider({
-    baseUrl: 'file:///etc/passwd',
-    apiKeyRequestHeader: 'apiKey',
-    apiKey: '123456',
-    from: 'sender-id',
+  afterAll(() => {
+    restoreEnv('NOVU_ENTERPRISE', ORIGINAL_ENTERPRISE);
+    restoreEnv('IS_SELF_HOSTED', ORIGINAL_SELF_HOSTED);
   });
 
-  await expect(
-    provider.sendMessage({
+  test('should allow requests to private IPs via axios', async () => {
+    const provider = new GenericSmsProvider({
+      baseUrl: directServerUrl,
+      apiKeyRequestHeader: 'apiKey',
+      apiKey: '123456',
+      from: 'sender-id',
+      idPath: 'message.id',
+      datePath: 'message.date',
+    });
+
+    const result = await provider.sendMessage({
       to: '+1234567890',
       content: 'SMS Content form Generic SMS Provider',
-    })
-  ).rejects.toThrow(/Invalid URL format|Generic SMS URL blocked/);
+    });
+
+    expect(lastRequest).not.toBeNull();
+    expect(result.id).toBeDefined();
+  });
 });

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts
@@ -1,20 +1,75 @@
-import crypto from 'crypto';
-import { expect, test } from 'vitest';
-import { axiosSpy } from '../../../utils/test/spy-axios';
+import crypto from 'node:crypto';
+import * as dns from 'node:dns';
+import * as http from 'node:http';
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { GenericSmsProvider } from './generic-sms.provider';
 
-test('should trigger generic-sms library correctly', async () => {
-  const { mockRequest: spy } = axiosSpy({
-    data: {
-      message: {
-        id: crypto.randomUUID(),
-        date: new Date().toISOString(),
-      },
-    },
+const ORIGINAL_ALLOW = process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+beforeAll(() => {
+  process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = '127.0.0.1';
+  const realLookup = dns.promises.lookup.bind(dns.promises);
+  vi.spyOn(dns.promises, 'lookup').mockImplementation(((hostname: string, opts: unknown): unknown => {
+    if (hostname === 'test-generic-sms.invalid') {
+      const result = [{ address: '127.0.0.1', family: 4 }];
+
+      return Promise.resolve(opts && typeof opts === 'object' && opts !== null && 'all' in opts ? result : result[0]);
+    }
+
+    return realLookup(hostname as string, opts as dns.LookupOptions);
+  }) as typeof dns.promises.lookup);
+});
+afterAll(() => {
+  vi.restoreAllMocks();
+  if (ORIGINAL_ALLOW === undefined) {
+    delete process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS;
+  } else {
+    process.env.NOVU_SAFE_OUTBOUND_TEST_ALLOW_IPS = ORIGINAL_ALLOW;
+  }
+});
+
+let server: http.Server;
+let serverUrl: string;
+let lastRequest: { url: string; method: string; headers: http.IncomingHttpHeaders; body: string } | null = null;
+
+beforeEach(async () => {
+  lastRequest = null;
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      lastRequest = {
+        url: req.url ?? '',
+        method: req.method ?? 'GET',
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      };
+      const messageId = crypto.randomUUID();
+      const messageDate = new Date().toISOString();
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          message: {
+            id: messageId,
+            date: messageDate,
+          },
+        })
+      );
+    });
   });
 
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('listen failed');
+  serverUrl = `http://test-generic-sms.invalid:${addr.port}/`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+test('should trigger generic-sms library correctly', async () => {
   const provider = new GenericSmsProvider({
-    baseUrl: 'https://api.generic-sms-provider.com',
+    baseUrl: serverUrl,
     apiKeyRequestHeader: 'apiKey',
     apiKey: '123456',
     from: 'sender-id',
@@ -22,34 +77,26 @@ test('should trigger generic-sms library correctly', async () => {
     datePath: 'message.date',
   });
 
-  await provider.sendMessage({
+  const result = await provider.sendMessage({
     to: '+1234567890',
     content: 'SMS Content form Generic SMS Provider',
   });
 
-  expect(spy).toHaveBeenCalled();
-  expect(spy).toHaveBeenCalledWith({
-    method: 'POST',
-    data: {
-      to: '+1234567890',
-      content: 'SMS Content form Generic SMS Provider',
-      sender: 'sender-id',
-    },
+  expect(lastRequest).not.toBeNull();
+  expect(lastRequest!.method).toBe('POST');
+  expect(JSON.parse(lastRequest!.body)).toEqual({
+    to: '+1234567890',
+    content: 'SMS Content form Generic SMS Provider',
+    sender: 'sender-id',
   });
+  expect(lastRequest!.headers.apikey).toBe('123456');
+  expect(result.id).toBeDefined();
+  expect(result.date).toBeDefined();
 });
 
 test('should trigger generic-sms library correctly with _passthrough', async () => {
-  const { mockRequest: spy } = axiosSpy({
-    data: {
-      message: {
-        id: crypto.randomUUID(),
-        date: new Date().toISOString(),
-      },
-    },
-  });
-
   const provider = new GenericSmsProvider({
-    baseUrl: 'https://api.generic-sms-provider.com',
+    baseUrl: serverUrl,
     apiKeyRequestHeader: 'apiKey',
     apiKey: '123456',
     from: 'sender-id',
@@ -71,13 +118,41 @@ test('should trigger generic-sms library correctly with _passthrough', async () 
     }
   );
 
-  expect(spy).toHaveBeenCalled();
-  expect(spy).toHaveBeenCalledWith({
-    method: 'POST',
-    data: {
-      to: '+2234567890',
-      content: 'SMS Content form Generic SMS Provider',
-      sender: 'sender-id',
-    },
+  expect(JSON.parse(lastRequest!.body)).toEqual({
+    to: '+2234567890',
+    content: 'SMS Content form Generic SMS Provider',
+    sender: 'sender-id',
   });
+});
+
+test('should reject the request when the URL resolves to a private IP', async () => {
+  const provider = new GenericSmsProvider({
+    baseUrl: 'http://127.0.0.2:8080/',
+    apiKeyRequestHeader: 'apiKey',
+    apiKey: '123456',
+    from: 'sender-id',
+  });
+
+  await expect(
+    provider.sendMessage({
+      to: '+1234567890',
+      content: 'SMS Content form Generic SMS Provider',
+    })
+  ).rejects.toThrow(/Generic SMS URL blocked/);
+});
+
+test('should reject non-http schemes', async () => {
+  const provider = new GenericSmsProvider({
+    baseUrl: 'file:///etc/passwd',
+    apiKeyRequestHeader: 'apiKey',
+    apiKey: '123456',
+    from: 'sender-id',
+  });
+
+  await expect(
+    provider.sendMessage({
+      to: '+1234567890',
+      content: 'SMS Content form Generic SMS Provider',
+    })
+  ).rejects.toThrow(/Invalid URL format|Generic SMS URL blocked/);
 });

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
@@ -63,14 +63,22 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
       const tokenResponse = await this.safeJsonRequest(domainUrl, {
         method: 'POST',
         headers: requestHeaders,
+        blockedPrefix: 'Generic SMS auth URL blocked',
       });
+
+      this.assertSuccessStatus(tokenResponse.statusCode, 'Generic SMS auth request failed');
 
       const tokenBody = tokenResponse.body as { data?: Record<string, string> };
       const token = tokenBody?.data?.[authTokenKey];
 
+      if (!token) {
+        throw new Error('Generic SMS auth request failed: authentication token missing from response.');
+      }
+
       requestHeaders = {
-        [authTokenKey]: token,
+        ...this.headers,
         ...data.headers,
+        [authTokenKey]: token,
       };
     }
 
@@ -80,12 +88,15 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
       method: 'POST',
       headers: requestHeaders,
       body: data.body,
+      blockedPrefix: 'Generic SMS URL blocked',
     });
 
-    const responseData = response.body;
+    this.assertSuccessStatus(response.statusCode, 'Generic SMS request failed');
+
+    const responseData = this.asResponseRecord(response.body);
 
     return {
-      id: this.getResponseValue(this.config.idPath || 'id', responseData),
+      id: this.getResponseValue(this.config.idPath || 'id', responseData) ?? '',
       date: this.getResponseValue(this.config.datePath || 'date', responseData) || new Date().toISOString(),
     };
   }
@@ -109,7 +120,23 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     return url;
   }
 
-  private safeJsonRequest(url: string, options: { method: 'POST'; headers: Record<string, string>; body?: unknown }) {
+  private assertSuccessStatus(statusCode: number, message: string): void {
+    if (statusCode < 200 || statusCode >= 300) {
+      throw new Error(`${message} with status ${statusCode}`);
+    }
+  }
+
+  private safeJsonRequest(
+    url: string,
+    options: {
+      method: 'POST';
+      headers: Record<string, string>;
+      body?: Record<string, unknown>;
+      blockedPrefix?: string;
+    }
+  ) {
+    const blockedPrefix = options.blockedPrefix ?? 'Generic SMS URL blocked';
+
     return safeOutboundJsonRequest({
       url,
       method: options.method,
@@ -117,15 +144,38 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
       body: options.body,
     }).catch((err: unknown) => {
       if (err instanceof SsrfBlockedError) {
-        throw new Error(`Generic SMS URL blocked: ${err.message}`);
+        throw new Error(`${blockedPrefix}: ${err.message}`);
       }
       throw err;
     });
   }
 
-  private getResponseValue(path: string, data: Record<string, unknown>) {
-    const pathArray = path.split('.');
+  private asResponseRecord(body: unknown): Record<string, unknown> {
+    if (body && typeof body === 'object' && !Array.isArray(body)) {
+      return body as Record<string, unknown>;
+    }
 
-    return pathArray.reduce<unknown>((acc, curr) => (acc as Record<string, unknown>)[curr], data);
+    return {};
+  }
+
+  private getResponseValue(path: string, data: Record<string, unknown>): string | undefined {
+    let current: unknown = data;
+
+    for (const segment of path.split('.')) {
+      if (current === null || current === undefined || typeof current !== 'object') {
+        return undefined;
+      }
+      current = (current as Record<string, unknown>)[segment];
+    }
+
+    if (typeof current === 'string') {
+      return current;
+    }
+
+    if (current === undefined || current === null) {
+      return undefined;
+    }
+
+    return String(current);
   }
 }

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
@@ -1,4 +1,4 @@
-import { SmsProviderIdEnum } from '@novu/shared';
+import { isOutboundSsrfProtectionEnabled, SmsProviderIdEnum } from '@novu/shared';
 import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
 import {
   assertSafeOutboundUrl,
@@ -7,6 +7,7 @@ import {
 } from '@novu/shared/utils/ssrf-url-validation';
 import { ChannelTypeEnum, ISendMessageSuccessResponse, ISmsOptions, ISmsProvider } from '@novu/stateless';
 
+import axios, { AxiosInstance } from 'axios';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
 
@@ -14,6 +15,7 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
   id = SmsProviderIdEnum.GenericSms;
   channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
   protected casing = CasingEnum.CAMEL_CASE;
+  axiosInstance?: AxiosInstance;
   headers: Record<string, string>;
 
   constructor(
@@ -39,11 +41,69 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     if (this.config?.secretKeyRequestHeader && this.config?.secretKey) {
       this.headers[this.config?.secretKeyRequestHeader] = config.secretKey;
     }
+
+    if (!this.config?.authenticateByToken) {
+      this.axiosInstance = axios.create({
+        baseURL: config.baseUrl,
+        headers: this.headers,
+      });
+    }
   }
 
   async sendMessage(
     options: ISmsOptions,
     bridgeProviderData: WithPassthrough<Record<string, unknown>> = {}
+  ): Promise<ISendMessageSuccessResponse> {
+    if (isOutboundSsrfProtectionEnabled()) {
+      return this.sendMessageWithSsrfProtection(options, bridgeProviderData);
+    }
+
+    return this.sendMessageWithAxios(options, bridgeProviderData);
+  }
+
+  private async sendMessageWithAxios(
+    options: ISmsOptions,
+    bridgeProviderData: WithPassthrough<Record<string, unknown>>
+  ): Promise<ISendMessageSuccessResponse> {
+    const data = this.transform(bridgeProviderData, {
+      ...options,
+      sender: options.from || this.config.from,
+    });
+
+    if (this.config?.authenticateByToken) {
+      const tokenAxiosInstance = await axios.request({
+        method: 'POST',
+        baseURL: this.config.domain,
+        headers: this.headers,
+      });
+
+      const token = tokenAxiosInstance.data.data[this.config.authenticationTokenKey!];
+
+      this.axiosInstance = axios.create({
+        baseURL: this.config.baseUrl,
+        headers: {
+          [this.config.authenticationTokenKey!]: token,
+          ...data.headers,
+        },
+      });
+    }
+
+    const response = await this.axiosInstance!.request({
+      method: 'POST',
+      data: data.body,
+    });
+
+    const responseData = response.data as Record<string, unknown>;
+
+    return {
+      id: this.getResponseValue(this.config.idPath || 'id', responseData) ?? '',
+      date: this.getResponseValue(this.config.datePath || 'date', responseData) || new Date().toISOString(),
+    };
+  }
+
+  private async sendMessageWithSsrfProtection(
+    options: ISmsOptions,
+    bridgeProviderData: WithPassthrough<Record<string, unknown>>
   ): Promise<ISendMessageSuccessResponse> {
     const data = this.transform(bridgeProviderData, {
       ...options,
@@ -87,7 +147,7 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     const response = await this.safeJsonRequest(baseUrl, {
       method: 'POST',
       headers: requestHeaders,
-      body: data.body,
+      body: data.body as Record<string, unknown>,
       blockedPrefix: 'Generic SMS URL blocked',
     });
 

--- a/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
+++ b/packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts
@@ -1,7 +1,12 @@
 import { SmsProviderIdEnum } from '@novu/shared';
+import { safeOutboundJsonRequest } from '@novu/shared/utils/safe-outbound-http';
+import {
+  assertSafeOutboundUrl,
+  normalizeOutboundHttpUrl,
+  SsrfBlockedError,
+} from '@novu/shared/utils/ssrf-url-validation';
 import { ChannelTypeEnum, ISendMessageSuccessResponse, ISmsOptions, ISmsProvider } from '@novu/stateless';
 
-import axios, { AxiosInstance } from 'axios';
 import { BaseProvider, CasingEnum } from '../../../base.provider';
 import { WithPassthrough } from '../../../utils/types';
 
@@ -9,7 +14,6 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
   id = SmsProviderIdEnum.GenericSms;
   channelType = ChannelTypeEnum.SMS as ChannelTypeEnum.SMS;
   protected casing = CasingEnum.CAMEL_CASE;
-  axiosInstance: AxiosInstance;
   headers: Record<string, string>;
 
   constructor(
@@ -35,13 +39,6 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     if (this.config?.secretKeyRequestHeader && this.config?.secretKey) {
       this.headers[this.config?.secretKeyRequestHeader] = config.secretKey;
     }
-
-    if (!this.config?.authenticateByToken) {
-      this.axiosInstance = axios.create({
-        baseURL: config.baseUrl,
-        headers: this.headers,
-      });
-    }
   }
 
   async sendMessage(
@@ -52,30 +49,40 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
       ...options,
       sender: options.from || this.config.from,
     });
+
+    let requestHeaders: Record<string, string> = { ...this.headers, ...data.headers };
+
     if (this.config?.authenticateByToken) {
-      const tokenAxiosInstance = await axios.request({
+      const authTokenKey = this.config.authenticationTokenKey;
+      if (!authTokenKey) {
+        throw new Error('Generic SMS auth URL blocked: authenticationTokenKey is required.');
+      }
+
+      const domainUrl = this.assertSafeSmsUrl(this.config.domain, 'Generic SMS auth URL blocked');
+
+      const tokenResponse = await this.safeJsonRequest(domainUrl, {
         method: 'POST',
-        baseURL: this.config.domain,
-        headers: this.headers,
+        headers: requestHeaders,
       });
 
-      const token = tokenAxiosInstance.data.data[this.config.authenticationTokenKey];
+      const tokenBody = tokenResponse.body as { data?: Record<string, string> };
+      const token = tokenBody?.data?.[authTokenKey];
 
-      this.axiosInstance = axios.create({
-        baseURL: this.config.baseUrl,
-        headers: {
-          [this.config.authenticationTokenKey]: token,
-          ...data.headers,
-        },
-      });
+      requestHeaders = {
+        [authTokenKey]: token,
+        ...data.headers,
+      };
     }
 
-    const response = await this.axiosInstance.request({
+    const baseUrl = this.assertSafeSmsUrl(this.config.baseUrl, 'Generic SMS URL blocked');
+
+    const response = await this.safeJsonRequest(baseUrl, {
       method: 'POST',
-      data: data.body,
+      headers: requestHeaders,
+      body: data.body,
     });
 
-    const responseData = response.data;
+    const responseData = response.body;
 
     return {
       id: this.getResponseValue(this.config.idPath || 'id', responseData),
@@ -83,9 +90,42 @@ export class GenericSmsProvider extends BaseProvider implements ISmsProvider {
     };
   }
 
-  private getResponseValue(path: string, data: any) {
+  private assertSafeSmsUrl(urlRaw: string | undefined, blockedPrefix: string): string {
+    const url = normalizeOutboundHttpUrl(urlRaw ?? '');
+
+    if (!url) {
+      throw new Error(`${blockedPrefix}: Invalid URL format.`);
+    }
+
+    try {
+      assertSafeOutboundUrl(url);
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(`${blockedPrefix}: ${err.message}`);
+      }
+      throw err;
+    }
+
+    return url;
+  }
+
+  private safeJsonRequest(url: string, options: { method: 'POST'; headers: Record<string, string>; body?: unknown }) {
+    return safeOutboundJsonRequest({
+      url,
+      method: options.method,
+      headers: options.headers,
+      body: options.body,
+    }).catch((err: unknown) => {
+      if (err instanceof SsrfBlockedError) {
+        throw new Error(`Generic SMS URL blocked: ${err.message}`);
+      }
+      throw err;
+    });
+  }
+
+  private getResponseValue(path: string, data: Record<string, unknown>) {
     const pathArray = path.split('.');
 
-    return pathArray.reduce((acc, curr) => acc[curr], data);
+    return pathArray.reduce<unknown>((acc, curr) => (acc as Record<string, unknown>)[curr], data);
   }
 }

--- a/packages/shared/src/utils/env.spec.ts
+++ b/packages/shared/src/utils/env.spec.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { isOutboundSsrfProtectionEnabled } from './env';
+
+const NOVU_ENTERPRISE_KEY = 'NOVU_ENTERPRISE';
+const IS_SELF_HOSTED_KEY = 'IS_SELF_HOSTED';
+const CI_EE_TEST_KEY = 'CI_EE_TEST';
+
+function withEnv(env: Record<string, string | undefined>, fn: () => void) {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of [NOVU_ENTERPRISE_KEY, IS_SELF_HOSTED_KEY, CI_EE_TEST_KEY]) {
+    previous[key] = process.env[key];
+    const value = env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    fn();
+  } finally {
+    for (const key of [NOVU_ENTERPRISE_KEY, IS_SELF_HOSTED_KEY, CI_EE_TEST_KEY]) {
+      const value = previous[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+describe('isOutboundSsrfProtectionEnabled', () => {
+  afterEach(() => {
+    delete process.env[NOVU_ENTERPRISE_KEY];
+    delete process.env[IS_SELF_HOSTED_KEY];
+    delete process.env[CI_EE_TEST_KEY];
+  });
+
+  test('returns true for enterprise cloud', () => {
+    withEnv({ [NOVU_ENTERPRISE_KEY]: 'true', [IS_SELF_HOSTED_KEY]: 'false' }, () => {
+      expect(isOutboundSsrfProtectionEnabled()).toBe(true);
+    });
+  });
+
+  test('returns false for community cloud', () => {
+    withEnv({ [NOVU_ENTERPRISE_KEY]: 'false', [IS_SELF_HOSTED_KEY]: 'false' }, () => {
+      expect(isOutboundSsrfProtectionEnabled()).toBe(false);
+    });
+  });
+
+  test('returns false for enterprise self-hosted', () => {
+    withEnv({ [NOVU_ENTERPRISE_KEY]: 'true', [IS_SELF_HOSTED_KEY]: 'true' }, () => {
+      expect(isOutboundSsrfProtectionEnabled()).toBe(false);
+    });
+  });
+
+  test('returns true when CI_EE_TEST is enabled on cloud', () => {
+    withEnv({ [CI_EE_TEST_KEY]: 'true', [IS_SELF_HOSTED_KEY]: 'false' }, () => {
+      expect(isOutboundSsrfProtectionEnabled()).toBe(true);
+    });
+  });
+});

--- a/packages/shared/src/utils/env.ts
+++ b/packages/shared/src/utils/env.ts
@@ -67,3 +67,14 @@ export const getEEAuthProvider = (): EEAuthProvider => {
 export const isClerkEnabled = () => isEEAuthEnabled() && getEEAuthProvider() === 'clerk';
 
 export const isBetterAuthEnabled = () => isEEAuthEnabled() && getEEAuthProvider() === 'better-auth';
+
+/**
+ * Outbound SSRF pinning applies only on Novu Cloud Enterprise builds.
+ * Self-hosted and community deployments may intentionally target internal URLs.
+ */
+export const isOutboundSsrfProtectionEnabled = (): boolean => {
+  const isEnterprise = process.env.NOVU_ENTERPRISE === 'true' || process.env.CI_EE_TEST === 'true';
+  const isSelfHosted = process.env.IS_SELF_HOSTED === 'true';
+
+  return isEnterprise && !isSelfHosted;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`EmailWebhookProvider` and `GenericSmsProvider` now route outbound HTTP through SSRF-safe helpers on **Novu Cloud Enterprise only** (`NOVU_ENTERPRISE=true` and `IS_SELF_HOSTED≠true`). Self-hosted and community deployments keep the legacy axios path so admins can target internal services on their own network.

## Changes

- **`isOutboundSsrfProtectionEnabled()`** in `@novu/shared` — central gate matching the enterprise cloud pattern used elsewhere (e.g. agent shared inbox).
- **Email webhook**: SSRF validation + `safeOutboundJsonRequest` on enterprise cloud; axios with retry on self-hosted/community.
- **Generic SMS**: Same conditional split — SSRF-safe path vs restored axios instance.
- **Tests**: Split into enterprise cloud (SSRF enforced) and self-hosted (private IPs allowed) suites.

## Security properties (enterprise cloud only)

- HTTP/HTTPS only, no embedded credentials
- DNS resolution rejects private/reserved addresses before connect
- Connection pinning + redirect re-validation via `safeOutboundJsonRequest`
- Non-2xx responses treated as failures (preserves axios retry semantics)

## Testing

```bash
cd packages/shared && pnpm exec vitest run src/utils/env.spec.ts
cd packages/providers && pnpm exec vitest run \
  src/lib/email/email-webhook/email-webhook.provider.spec.ts \
  src/lib/sms/generic-sms/generic-sms.provider.spec.ts
```

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NV-7918](https://linear.app/novu/issue/NV-7918/add-ssrf-protection-to-email-webhook-and-sms-providers)

<div><a href="https://cursor.com/agents/bc-356bc970-2913-4c49-98a4-9168c26e5774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-356bc970-2913-4c49-98a4-9168c26e5774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed
EmailWebhookProvider and GenericSmsProvider now validate, normalize and pin outbound HTTP(S) destinations and route all external calls through shared SSRF-safe helpers (normalizeOutboundHttpUrl, assertSafeOutboundUrl, safeOutboundJsonRequest). This prevents SSRF by rejecting non-HTTP schemes, embedded credentials, and private/reserved IPs before connect, while preserving provider semantics (signing, retries, passthrough). SSRF protection is gated to Novu Cloud Enterprise deployments.

## Affected areas
**providers**: Email webhook and Generic SMS providers were updated to use shared safe-outbound HTTP helpers, replace raw axios flows for SSRF-protected paths, and surface clearer provider-specific block errors; Generic SMS now validates both domain and baseUrl for token auth and consolidates headers/passthrough handling. Tests for both providers were rewritten from axios spies to in-process HTTP server integration tests with mocked dns.promises.lookup to assert request method, body, headers, and negative blocking cases.

**shared**: Added/updated env utilities to gate SSRF behavior via isOutboundSsrfProtectionEnabled(), and providers now import shared SSRF URL validation and safe-outbound request helpers.

## Key technical decisions
- Gate SSRF protections to Enterprise cloud only (isOutboundSsrfProtectionEnabled) to avoid breaking self-hosted/community use cases.  
- Reuse existing shared SSRF helpers for consistent connection pinning, redirect re-validation, and DNS-based private/reserved IP blocking across providers.  
- Map SsrfBlockedError to provider-specific error messages to make failures actionable while preserving existing signing and retry semantics.

## Testing
Added/rewrote unit/integration tests for both providers using an in-process node HTTP server and mocked DNS resolution; negative tests cover private/reserved IP and non-HTTP-scheme rejection; self-hosted behavior is validated by toggling env flags. No new npm dependencies introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds SSRF protection to `EmailWebhookProvider` and `GenericSmsProvider` by routing outbound HTTP calls through the shared `safeOutboundJsonRequest` helper (connection-pinned, redirect-revalidating) when `isOutboundSsrfProtectionEnabled()` is true, while keeping the original `axios` path for self-hosted deployments. A new `isOutboundSsrfProtectionEnabled()` utility is added to `@novu/shared` and covered by dedicated unit tests.

- **Email webhook**: the SSRF-protected path normalizes and pre-validates the URL, then uses a status-code-aware retry loop that correctly rethrows SSRF blocks without consuming a retry slot.
- **Generic SMS (SSRF path)**: `baseUrl` and `domain` are separately validated; the token-auth flow fetches a token via `safeJsonRequest` before making the SMS request. However, `requestHeaders` passed to the auth endpoint includes `data.headers`, inadvertently forwarding passthrough headers intended only for the SMS endpoint to the token-auth server.
- **Tests**: rewritten from axios spies to real HTTP server + mocked DNS; cover private-IP and non-HTTP scheme rejection, but do not cover the `authenticateByToken` flow under SSRF protection.

<h3>Confidence Score: 4/5</h3>

Safe to merge for enterprise-cloud deployments if the authenticateByToken flow is not in active use; the passthrough-header leak to the auth server needs a fix before enabling that code path in production.

The email-webhook provider is clean and the shared SSRF utilities are well-implemented. The generic-SMS provider has a concrete behavioral regression in the authenticateByToken branch: passthrough headers from bridgeProviderData are sent to the token-auth server instead of only the base credential headers, which could disclose per-request headers to the wrong third-party endpoint.

packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts — specifically the sendMessageWithSsrfProtection method's requestHeaders construction before the token-auth call.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts | Adds SSRF-protected send path; passthrough headers from bridgeProviderData are incorrectly forwarded to the token-auth endpoint (domain), leaking headers intended for the SMS endpoint to the wrong server. |
| packages/providers/src/lib/email/email-webhook/email-webhook.provider.ts | Adds SSRF-protected send path with pre-flight URL check, status-code-aware retry loop, and SSRF-error rethrow; non-SSRF path unchanged. |
| packages/providers/src/lib/sms/generic-sms/generic-sms.provider.spec.ts | Tests rewritten to use real HTTP server; covers SSRF rejection and passthrough. No test covers the authenticateByToken flow under SSRF protection, so the passthrough-headers regression is untested. |
| packages/providers/src/lib/email/email-webhook/email-webhook.provider.spec.ts | Tests rewritten from axios spy to real HTTP server + DNS mock; covers SSRF protection, passthrough, private-IP rejection, and non-HTTP scheme rejection for both enterprise and self-hosted modes. |
| packages/shared/src/utils/env.ts | Adds isOutboundSsrfProtectionEnabled(): enabled for enterprise cloud, disabled for self-hosted and community; logic is clean and well-documented. |
| packages/shared/src/utils/env.spec.ts | New tests for isOutboundSsrfProtectionEnabled() covering enterprise-cloud, community-cloud, self-hosted, and CI_EE_TEST combinations; env isolation is correct. |

</details>

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fproviders%2Fsrc%2Flib%2Fsms%2Fgeneric-sms%2Fgeneric-sms.provider.ts%3A113-127%0A**Passthrough%20headers%20sent%20to%20token-auth%20endpoint**%0A%0A%60requestHeaders%60%20is%20constructed%20as%20%60%7B%20...this.headers%2C%20...data.headers%20%7D%60%20before%20the%20token-auth%20branch.%20%60data.headers%60%20contains%20any%20headers%20from%20the%20%60bridgeProviderData%60%20transform%20%E2%80%94%20i.e.%2C%20operator%2Fuser-supplied%20passthrough%20headers%20intended%20for%20the%20SMS%20endpoint.%20These%20are%20now%20forwarded%20verbatim%20to%20%60this.config.domain%60%20%28the%20auth%20server%29%2C%20whereas%20the%20original%20%60sendMessageWithAxios%60%20path%20only%20sent%20%60this.headers%60%20%28the%20API%20key%20and%20optional%20secret%20key%29%20to%20the%20auth%20endpoint.%20Any%20sensitive%20headers%20in%20%60data.headers%60%20%28e.g.%2C%20custom%20%60Authorization%60%20values%20or%20per-user%20tokens%29%20will%20be%20disclosed%20to%20the%20wrong%20server.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fproviders%2Fsrc%2Flib%2Fsms%2Fgeneric-sms%2Fgeneric-sms.provider.ts%3A143-152%0A**%60baseUrl%60%20validated%20only%20after%20token-auth%20request%20fires**%0A%0AWhen%20%60authenticateByToken%60%20is%20%60true%60%20and%20%60baseUrl%60%20is%20SSRF-blocked%20or%20malformed%2C%20the%20code%20validates%20and%20fetches%20a%20token%20from%20%60domain%60%20first%2C%20then%20rejects%20%60baseUrl%60%20afterward.%20The%20token%20request%20to%20the%20auth%20server%20fires%20unnecessarily.%20Validating%20both%20%60baseUrl%60%20and%20%60domain%60%20before%20making%20any%20network%20call%20would%20eliminate%20this%20spurious%20request%20and%20surface%20the%20error%20faster.%0A%0A&pr=11370&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts:113-127
**Passthrough headers sent to token-auth endpoint**

`requestHeaders` is constructed as `{ ...this.headers, ...data.headers }` before the token-auth branch. `data.headers` contains any headers from the `bridgeProviderData` transform — i.e., operator/user-supplied passthrough headers intended for the SMS endpoint. These are now forwarded verbatim to `this.config.domain` (the auth server), whereas the original `sendMessageWithAxios` path only sent `this.headers` (the API key and optional secret key) to the auth endpoint. Any sensitive headers in `data.headers` (e.g., custom `Authorization` values or per-user tokens) will be disclosed to the wrong server.

### Issue 2 of 2
packages/providers/src/lib/sms/generic-sms/generic-sms.provider.ts:143-152
**`baseUrl` validated only after token-auth request fires**

When `authenticateByToken` is `true` and `baseUrl` is SSRF-blocked or malformed, the code validates and fetches a token from `domain` first, then rejects `baseUrl` afterward. The token request to the auth server fires unnecessarily. Validating both `baseUrl` and `domain` before making any network call would eliminate this spurious request and surface the error faster.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(providers): gate SSRF protection to ..."](https://github.com/novuhq/novu/commit/35ed6d310f1885d88e56e25ca3d148f0016f1587) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779649)</sub>

<!-- /greptile_comment -->