### PR TITLE
fix(novu): skip duplicate Telegram webhook configure in connect flow fixes NV-7919

### DIFF
--- a/packages/novu/src/commands/connect/pipeline/channels/telegram.ts
+++ b/packages/novu/src/commands/connect/pipeline/channels/telegram.ts
@@ -1,12 +1,10 @@
 import { CONNECT_EVENTS } from '../../analytics/events';
 import {
-  configureTelegramAgentWebhook,
   getTelegramMobileLinkStatus,
   issueTelegramMobileLink,
   issueTelegramSubscriberLink,
 } from '../../api/agents';
 import type { ConnectApiClient } from '../../api/client';
-import { NovuApiError } from '../../api/client';
 import { createTelegramIntegration, type IntegrationRecord } from '../../api/integrations';
 import type { AgentSummary } from '../../types';
 import { renderQR } from '../../ui/qr';
@@ -71,16 +69,6 @@ export async function connectTelegramForAgent(
       `The bot token wasn't saved within ${Math.round(CHANNEL_POLL_TIMEOUT_MS / 1000)} seconds. ` +
         'Re-run `npx novu connect` to get a fresh setup link.'
     );
-  }
-
-  try {
-    await configureTelegramAgentWebhook(client, agent.identifier, integration._id);
-  } catch (err) {
-    if (err instanceof NovuApiError && (err.status === 400 || err.status === 409)) {
-      // Already configured by the consume endpoint — fine.
-    } else {
-      throw err;
-    }
   }
 
   const subscriberLink = await issueTelegramSubscriberLink(client, agent.identifier, integration._id, subscriberId);


### PR DESCRIPTION
## Summary

- Removes the redundant `telegram/configure` call from the `npx novu connect` Telegram pipeline after the mobile setup token is consumed.
- The mobile setup consume endpoint (`ConsumeTelegramMobileLink`) already saves the bot token and registers the webhook via `ConfigureTelegramAgentWebhook`.
- The CLI was calling configure again immediately afterward, duplicating Telegram `setWebhook` and triggering `429 Too Many Requests` (surfaced as a 502 in the CLI) even when setup had already succeeded.

```mermaid
sequenceDiagram
  participant CLI as novu connect CLI
  participant API as Novu API
  participant TG as Telegram API
  participant User as Mobile setup page

  CLI->>API: Issue mobile link + poll status
  User->>API: POST mobile-configure (paste token)
  API->>TG: setWebhook (success)
  Note over CLI: Before: configure again
  CLI->>API: POST telegram/configure
  API->>TG: setWebhook (429 rate limit)
  Note over CLI: After: skip configure, issue subscriber link only
  CLI->>API: POST telegram/subscriber-link
```

## Test plan

- [ ] Run `npx novu connect` with a Telegram agent
- [ ] Complete BotFather step, scan/open the mobile setup QR, paste BotFather message, click **Connect bot**
- [ ] Confirm CLI proceeds to the subscriber deep-link step without `Telegram rejected the webhook registration: Too Many Requests`
- [ ] Open the bot in Telegram, tap Start, confirm the CLI reports Telegram connected

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes a redundant `configureTelegramAgentWebhook` call from the CLI Telegram connect flow that was causing Telegram 429 rate-limit errors (surfaced as 502s in the CLI), because the server-side `ConsumeTelegramMobileLink` endpoint already calls `ConfigureTelegramAgentWebhook` when it processes the bot token.

- Deletes the `try/catch` block that called `POST telegram/configure` immediately after the mobile-setup token was consumed, along with the now-unused `configureTelegramAgentWebhook` and `NovuApiError` imports.
- The `configureTelegramAgentWebhook` export in `agents.ts` is intentionally preserved in case other callers need it.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted removal of a duplicate webhook registration call that was already handled server-side.

The only modified file deletes code that was provably redundant: the server's ConsumeTelegramMobileLink handler always calls ConfigureTelegramAgentWebhook when it processes the bot token, and the CLI was calling it again immediately after polling for the used state. The remaining flow is unchanged and all imports left behind are correctly cleaned up.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/novu/src/commands/connect/pipeline/channels/telegram.ts | Removes the duplicate configureTelegramAgentWebhook call and its associated imports; the remaining flow (poll → subscriber link → poll for /start) is logically intact and correct. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as novu connect CLI
    participant API as Novu API
    participant TG as Telegram API
    participant User as Mobile setup page

    CLI->>API: issueTelegramMobileLink (POST /telegram/mobile-link)
    CLI->>CLI: "pollUntil token status == "used""
    User->>API: POST /telegram/mobile-configure (paste bot token)
    API->>TG: setWebhook (success)
    Note over API: ConsumeTelegramMobileLink already called ConfigureTelegramAgentWebhook

    Note over CLI: BEFORE fix: CLI called configure again
    CLI--xAPI: POST /telegram/configure (removed)
    API--xTG: setWebhook → 429 Too Many Requests

    Note over CLI: AFTER fix: skip configure, go straight to subscriber link
    CLI->>API: issueTelegramSubscriberLink (POST /telegram/subscriber-link)
    CLI->>CLI: pollForAgentLinkConnected until /start received
```

<sub>Reviews (1): Last reviewed commit: ["fix(novu): skip duplicate Telegram webho..."](https://github.com/novuhq/novu/commit/eff2f2668d0e900775ccc861be98c0221faeee49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779781)</sub>

<!-- /greptile_comment -->