### PR TITLE
feat(api-service): show flow-complete page after MCP/Connect OAuth instead of dashboard redirect or blank tab

### DIFF
--- a/apps/api/src/app/agents/e2e/agent-mcp-servers.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-mcp-servers.e2e.ts
@@ -1016,9 +1016,10 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
       const cb = await session.testAgent.get(
         `/v1/agents/mcp/oauth/callback?state=${encodeURIComponent(state)}&code=fake-auth-code`
       );
-      // 200 HTML fallback (no DASHBOARD_URL) OR 302 redirect — both are
-      // success-side responses; the assertion that matters is the row state.
-      expect([200, 302], `unexpected callback status (body=${JSON.stringify(cb.body)})`).to.include(cb.status);
+      // The callback always renders a self-contained "flow complete" HTML page
+      // (no dashboard redirect); the assertion that matters is the row state.
+      expect(cb.status, `unexpected callback status (body=${JSON.stringify(cb.body)})`).to.equal(200);
+      expect(cb.text, 'callback should render the success page').to.include("You're all set");
 
       const conn = await findGithubConnection(agentId);
       expect(conn, 'mcp_connection row should exist').to.exist;
@@ -1099,7 +1100,8 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
       const cb = await session.testAgent.get(
         `/v1/agents/mcp/oauth/callback?state=${encodeURIComponent(state)}&error=access_denied&error_description=${encodeURIComponent('The user cancelled the consent')}`
       );
-      expect([200, 302]).to.include(cb.status);
+      expect(cb.status).to.equal(200);
+      expect(cb.text, 'callback should render the error page').to.include('Connection failed');
 
       const conn = await findGithubConnection(agentId);
       expect(conn!.status).to.equal(McpConnectionStatusEnum.Error);
@@ -1153,7 +1155,7 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
       const cb = await session.testAgent.get(
         `/v1/agents/mcp/oauth/callback?state=${encodeURIComponent(state)}&code=fake-auth-code`
       );
-      expect([200, 302]).to.include(cb.status);
+      expect(cb.status).to.equal(200);
 
       const tokenCall = safeJsonStub
         .getCalls()

--- a/apps/api/src/app/agents/e2e/agent-mcp-servers.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agent-mcp-servers.e2e.ts
@@ -1019,7 +1019,7 @@ describe('Agent MCP Server endpoints #novu-v2', () => {
       // The callback always renders a self-contained "flow complete" HTML page
       // (no dashboard redirect); the assertion that matters is the row state.
       expect(cb.status, `unexpected callback status (body=${JSON.stringify(cb.body)})`).to.equal(200);
-      expect(cb.text, 'callback should render the success page').to.include("You're all set");
+      expect(cb.text, 'callback should render the success page').to.include('Connection complete');
 
       const conn = await findGithubConnection(agentId);
       expect(conn, 'mcp_connection row should exist').to.exist;

--- a/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
@@ -56,26 +56,23 @@ export class AgentsMcpOAuthController {
     );
 
     // Render a self-contained "flow complete" page instead of redirecting to the
-    // dashboard. The user reached this tab from a third-party OAuth provider, so
-    // we tell them the flow is finished, the tab can be closed, and they can
-    // return to wherever they started. A best-effort postMessage lets any
-    // same-origin opener (e.g. a popup-based flow) auto-detect the outcome.
+    // dashboard. The shared renderer already shows a "Close this tab" action, so
+    // the message stays short and avoids repeating it. A best-effort postMessage
+    // lets any same-origin opener (e.g. a popup-based flow) auto-detect the outcome.
     const isConnected = result.status === 'connected';
     const page = isConnected
       ? renderConnectionResultPage({
           status: 'success',
           title: 'Connection complete',
           heading: "You're all set",
-          message: 'Your MCP server is connected. You can safely close this tab and return to where you started.',
-          footerNote: 'You can now return to where you started.',
+          message: 'Your MCP server is connected and ready to use.',
           postMessagePayload: { type: 'novu-mcp-oauth-result', status: 'connected' },
         })
       : renderConnectionResultPage({
           status: 'error',
           title: 'Connection failed',
-          heading: 'Connection failed',
-          message: "We couldn't complete the connection. You can close this tab and try again from where you started.",
-          footerNote: 'You can now return to where you started.',
+          heading: "We couldn't connect",
+          message: 'Something went wrong while connecting your MCP server. Please go back and try again.',
           postMessagePayload: { type: 'novu-mcp-oauth-result', status: 'error', reason: result.message },
         });
 

--- a/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
@@ -4,11 +4,9 @@ import { ApiRateLimitCategoryEnum } from '@novu/shared';
 import { Response } from 'express';
 
 import { ThrottlerCategory } from '../../../rate-limiting/guards';
+import { renderConnectionResultPage } from '../../../shared/html/connection-result-page';
 import { McpOAuthCallbackCommand } from './mcp-oauth-callback/mcp-oauth-callback.command';
 import { McpOAuthCallback } from './mcp-oauth-callback/mcp-oauth-callback.usecase';
-
-const SUCCESS_FALLBACK_HTML = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Connection complete</title></head><body><p>Connection complete. You can close this window.</p><script>window.close();</script></body></html>`;
-const ERROR_FALLBACK_HTML = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Connection failed</title></head><body><p>Connection failed. You can close this window and try again.</p><script>window.close();</script></body></html>`;
 
 /**
  * Public-facing controller for the Novu-managed MCP OAuth callback.
@@ -57,30 +55,32 @@ export class AgentsMcpOAuthController {
       })
     );
 
-    const redirect = buildPostCallbackRedirect(result.status, result.message);
+    // Render a self-contained "flow complete" page instead of redirecting to the
+    // dashboard. The user reached this tab from a third-party OAuth provider, so
+    // we tell them the flow is finished, the tab can be closed, and they can
+    // return to wherever they started. A best-effort postMessage lets any
+    // same-origin opener (e.g. a popup-based flow) auto-detect the outcome.
+    const isConnected = result.status === 'connected';
+    const page = isConnected
+      ? renderConnectionResultPage({
+          status: 'success',
+          title: 'Connection complete',
+          heading: "You're all set",
+          message: 'Your MCP server is connected. You can safely close this tab and return to where you started.',
+          footerNote: 'You can now return to where you started.',
+          postMessagePayload: { type: 'novu-mcp-oauth-result', status: 'connected' },
+        })
+      : renderConnectionResultPage({
+          status: 'error',
+          title: 'Connection failed',
+          heading: 'Connection failed',
+          message: "We couldn't complete the connection. You can close this tab and try again from where you started.",
+          footerNote: 'You can now return to where you started.',
+          postMessagePayload: { type: 'novu-mcp-oauth-result', status: 'error', reason: result.message },
+        });
 
-    if (redirect) {
-      res.redirect(redirect);
-
-      return;
-    }
-
-    // No dashboard redirect URL configured — fall back to a tab-close page
-    // that signals success/failure visually.
     res.setHeader('Content-Type', 'text/html');
     res.setHeader('Content-Security-Policy', "default-src 'self'; script-src 'self' 'unsafe-inline'");
-    res.send(result.status === 'connected' ? SUCCESS_FALLBACK_HTML : ERROR_FALLBACK_HTML);
+    res.send(page);
   }
-}
-
-function buildPostCallbackRedirect(status: 'connected' | 'error', message?: string): string | undefined {
-  const base = process.env.DASHBOARD_URL?.replace(/\/$/, '');
-  if (!base) return undefined;
-
-  const params = new URLSearchParams({ status });
-  if (status === 'error' && message) {
-    params.set('reason', message);
-  }
-
-  return `${base}/agents/mcp/oauth/result?${params.toString()}`;
 }

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.spec.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.spec.ts
@@ -208,7 +208,7 @@ describe('MsTeamsOauthCallback', () => {
       const result = await usecase.execute(command);
 
       expect(generateMsTeamsOauthUrl.execute.called).to.be.false;
-      expect(result.result).to.include('window.close()');
+      expect(result.result).to.include("You're all set");
     });
 
     it('should fall through to close-tab when autoLinkUser=false even if subscriberId is present', async () => {
@@ -232,7 +232,7 @@ describe('MsTeamsOauthCallback', () => {
       const result = await usecase.execute(command);
 
       expect(generateMsTeamsOauthUrl.execute.called).to.be.false;
-      expect(result.result).to.include('window.close()');
+      expect(result.result).to.include("You're all set");
     });
 
     it('should fall through to close-tab when autoLinkUser is absent (raw API callers default to false)', async () => {
@@ -255,7 +255,7 @@ describe('MsTeamsOauthCallback', () => {
       const result = await usecase.execute(command);
 
       expect(generateMsTeamsOauthUrl.execute.called).to.be.false;
-      expect(result.result).to.include('window.close()');
+      expect(result.result).to.include("You're all set");
     });
 
     it('should fall through to close-tab and not throw when link_user chaining fails', async () => {
@@ -279,7 +279,7 @@ describe('MsTeamsOauthCallback', () => {
 
       const result = await usecase.execute(command);
 
-      expect(result.result).to.include('window.close()');
+      expect(result.result).to.include("You're all set");
     });
 
     it('should throw if tenant is missing', async () => {

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.spec.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.spec.ts
@@ -208,7 +208,7 @@ describe('MsTeamsOauthCallback', () => {
       const result = await usecase.execute(command);
 
       expect(generateMsTeamsOauthUrl.execute.called).to.be.false;
-      expect(result.result).to.include("You're all set");
+      expect(result.result).to.include('Microsoft Teams is connected');
     });
 
     it('should fall through to close-tab when autoLinkUser=false even if subscriberId is present', async () => {
@@ -232,7 +232,7 @@ describe('MsTeamsOauthCallback', () => {
       const result = await usecase.execute(command);
 
       expect(generateMsTeamsOauthUrl.execute.called).to.be.false;
-      expect(result.result).to.include("You're all set");
+      expect(result.result).to.include('Microsoft Teams is connected');
     });
 
     it('should fall through to close-tab when autoLinkUser is absent (raw API callers default to false)', async () => {
@@ -255,7 +255,7 @@ describe('MsTeamsOauthCallback', () => {
       const result = await usecase.execute(command);
 
       expect(generateMsTeamsOauthUrl.execute.called).to.be.false;
-      expect(result.result).to.include("You're all set");
+      expect(result.result).to.include('Microsoft Teams is connected');
     });
 
     it('should fall through to close-tab and not throw when link_user chaining fails', async () => {
@@ -279,7 +279,7 @@ describe('MsTeamsOauthCallback', () => {
 
       const result = await usecase.execute(command);
 
-      expect(result.result).to.include("You're all set");
+      expect(result.result).to.include('Microsoft Teams is connected');
     });
 
     it('should throw if tenant is missing', async () => {

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
@@ -306,6 +306,12 @@ export class MsTeamsOauthCallback {
     }
   }
 
+  /**
+   * Bot-install failures during link_user OAuth. Uses the shared connection-result
+   * page (same card as MCP/Slack success paths) instead of bespoke HTML so terminal
+   * pages stay visually consistent. Permission-related errors keep the Azure
+   * propagation hint in `footerNote`.
+   */
   private buildErrorHtml(message: string): string {
     const isPermissionError =
       message.includes('TeamsAppInstallation.ReadWriteSelfForUser.All') || message.includes('AppCatalog.Read.All');

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
@@ -114,8 +114,7 @@ export class MsTeamsOauthCallback {
         status: 'success',
         title: 'Connection complete',
         heading: "You're all set",
-        message: 'Microsoft Teams is connected. You can safely close this tab and return to where you started.',
-        footerNote: 'You can now return to where you started.',
+        message: 'Microsoft Teams is connected and ready to use.',
       }),
     };
   }
@@ -316,17 +315,14 @@ export class MsTeamsOauthCallback {
     const isPermissionError =
       message.includes('TeamsAppInstallation.ReadWriteSelfForUser.All') || message.includes('AppCatalog.Read.All');
 
-    const permissionFooter =
-      'Azure permission changes may take time to propagate. If you have already granted the required permissions, Azure AD can take up to 60 minutes to apply the changes. Wait a few minutes and try Link Teams Identity again.';
-
     return renderConnectionResultPage({
       status: 'error',
-      title: 'MS Teams setup error',
-      heading: 'MS Teams bot installation failed',
+      title: 'Setup error',
+      heading: "We couldn't set up Microsoft Teams",
       message,
       footerNote: isPermissionError
-        ? `${permissionFooter} You can now return to where you started.`
-        : 'You can now return to where you started.',
+        ? 'Azure permission changes can take up to 60 minutes to take effect. If you just granted the required permissions, wait a few minutes and try again.'
+        : undefined,
     });
   }
 

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
@@ -9,6 +9,7 @@ import {
 } from '@novu/dal';
 import { ChatProviderIdEnum, ENDPOINT_TYPES } from '@novu/shared';
 import axios from 'axios';
+import { renderConnectionResultPage } from '../../../../shared/html/connection-result-page';
 import { CreateChannelConnectionCommand } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.command';
 import { CreateChannelConnection } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
 import { CreateChannelEndpointCommand } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
@@ -26,7 +27,6 @@ const MS_GRAPH_BASE_URL = 'https://graph.microsoft.com/v1.0';
 
 @Injectable()
 export class MsTeamsOauthCallback {
-  private readonly SCRIPT_CLOSE_TAB = '<script>window.close();</script>';
   private readonly MS_TEAMS_TOKEN_URL = 'https://login.microsoftonline.com';
 
   constructor(
@@ -110,7 +110,13 @@ export class MsTeamsOauthCallback {
 
     return {
       type: ResponseTypeEnum.HTML,
-      result: this.SCRIPT_CLOSE_TAB,
+      result: renderConnectionResultPage({
+        status: 'success',
+        title: 'Connection complete',
+        heading: "You're all set",
+        message: 'Microsoft Teams is connected. You can safely close this tab and return to where you started.',
+        footerNote: 'You can now return to where you started.',
+      }),
     };
   }
 

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
@@ -307,43 +307,21 @@ export class MsTeamsOauthCallback {
   }
 
   private buildErrorHtml(message: string): string {
-    const escaped = message
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-
     const isPermissionError =
       message.includes('TeamsAppInstallation.ReadWriteSelfForUser.All') || message.includes('AppCatalog.Read.All');
-    const cachingNote = isPermissionError
-      ? `
-  <div class="cache-note">
-    <strong>Azure permission changes may take time to propagate.</strong>
-    If you have already granted the required permissions, Azure AD can take up to <strong>60 minutes</strong> to apply the changes. Wait a few minutes and then try to <strong>Link Teams Identity</strong> again.
-  </div>`
-      : '';
 
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>MS Teams Setup Error</title>
-  <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; padding: 2rem; color: #1a1a1a; }
-    .error-box { background: #fff3f3; border: 1px solid #f5c6c6; border-radius: 8px; padding: 1.5rem; max-width: 560px; }
-    h2 { margin: 0 0 0.75rem; color: #c0392b; font-size: 1.1rem; }
-    p { margin: 0; line-height: 1.5; }
-    .cache-note { margin-top: 1rem; padding: 0.75rem 1rem; background: #fffbe6; border: 1px solid #ffe58f; border-radius: 6px; font-size: 0.9rem; line-height: 1.5; color: #7a5c00; }
-  </style>
-</head>
-<body>
-  <div class="error-box">
-    <h2>MS Teams Bot Installation Failed</h2>
-    <p>${escaped}</p>${cachingNote}
-  </div>
-</body>
-</html>`;
+    const permissionFooter =
+      'Azure permission changes may take time to propagate. If you have already granted the required permissions, Azure AD can take up to 60 minutes to apply the changes. Wait a few minutes and try Link Teams Identity again.';
+
+    return renderConnectionResultPage({
+      status: 'error',
+      title: 'MS Teams setup error',
+      heading: 'MS Teams bot installation failed',
+      message,
+      footerNote: isPermissionError
+        ? `${permissionFooter} You can now return to where you started.`
+        : 'You can now return to where you started.',
+    });
   }
 
   private async exchangeCodeForAadObjectId(code: string, credentials: ICredentialsEntity): Promise<string> {

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
@@ -9,11 +9,11 @@ import {
 } from '@novu/dal';
 import { ChatProviderIdEnum, ENDPOINT_TYPES } from '@novu/shared';
 import axios from 'axios';
-import { renderConnectionResultPage } from '../../../../shared/html/connection-result-page';
 import { CreateChannelConnectionCommand } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.command';
 import { CreateChannelConnection } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
 import { CreateChannelEndpointCommand } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
 import { CreateChannelEndpoint } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
+import { renderConnectionResultPage } from '../../../../shared/html/connection-result-page';
 import { peekOAuthStatePayload } from '../../generate-chat-oath-url/chat-oauth-state.util';
 import { GenerateMsTeamsOauthUrlCommand } from '../../generate-chat-oath-url/generate-msteams-oath-url/generate-msteams-oauth-url.command';
 import {

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
@@ -13,11 +13,11 @@ import {
 } from '@novu/dal';
 import { ChatProviderIdEnum, ENDPOINT_TYPES } from '@novu/shared';
 import axios from 'axios';
-import { renderConnectionResultPage } from '../../../../shared/html/connection-result-page';
 import { CreateChannelConnectionCommand } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.command';
 import { CreateChannelConnection } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
 import { CreateChannelEndpointCommand } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
 import { CreateChannelEndpoint } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.usecase';
+import { renderConnectionResultPage } from '../../../../shared/html/connection-result-page';
 import { peekOAuthStatePayload } from '../../generate-chat-oath-url/chat-oauth-state.util';
 import {
   GenerateSlackOauthUrl,

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
@@ -107,8 +107,7 @@ export class SlackOauthCallback {
         status: 'success',
         title: 'Connection complete',
         heading: "You're all set",
-        message: 'Your Slack workspace is connected. You can safely close this tab and return to where you started.',
-        footerNote: 'You can now return to where you started.',
+        message: 'Your Slack workspace is connected and ready to use.',
       }),
     };
   }

--- a/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
+++ b/apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts
@@ -13,6 +13,7 @@ import {
 } from '@novu/dal';
 import { ChatProviderIdEnum, ENDPOINT_TYPES } from '@novu/shared';
 import axios from 'axios';
+import { renderConnectionResultPage } from '../../../../shared/html/connection-result-page';
 import { CreateChannelConnectionCommand } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.command';
 import { CreateChannelConnection } from '../../../../channel-connections/usecases/create-channel-connection/create-channel-connection.usecase';
 import { CreateChannelEndpointCommand } from '../../../../channel-endpoints/usecases/create-channel-endpoint/create-channel-endpoint.command';
@@ -28,7 +29,6 @@ import { SlackOauthCallbackCommand } from './slack-oauth-callback.command';
 @Injectable()
 export class SlackOauthCallback {
   private readonly SLACK_ACCESS_URL = 'https://slack.com/api/oauth.v2.access';
-  private readonly SCRIPT_CLOSE_TAB = '<script>window.close();</script>';
 
   constructor(
     private integrationRepository: IntegrationRepository,
@@ -103,7 +103,13 @@ export class SlackOauthCallback {
 
     return {
       type: ResponseTypeEnum.HTML,
-      result: this.SCRIPT_CLOSE_TAB,
+      result: renderConnectionResultPage({
+        status: 'success',
+        title: 'Connection complete',
+        heading: "You're all set",
+        message: 'Your Slack workspace is connected. You can safely close this tab and return to where you started.',
+        footerNote: 'You can now return to where you started.',
+      }),
     };
   }
 

--- a/apps/api/src/app/shared/html/connection-result-page.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.ts
@@ -1,0 +1,212 @@
+/**
+ * Shared, self-contained HTML renderer for the terminal page shown after a user
+ * completes (or fails) an OAuth/Connect flow in a browser tab that was opened by
+ * another app (e.g. the agent MCP OAuth flow, or the React `Connect` button).
+ *
+ * The design intentionally mirrors the agent email action-button landing pages
+ * (`agent-email-actions.controller.ts`): a centered card, system font stack,
+ * light/dark via `prefers-color-scheme`, and an animated success check. The copy
+ * tells the user the flow is finished, the tab can be closed, and they can return
+ * to wherever they started.
+ *
+ * These are pure functions with no DI so any controller/use-case can render the
+ * same page without wiring.
+ */
+
+export type ConnectionResultStatus = 'success' | 'error';
+
+export interface ConnectionResultPageOptions {
+  status: ConnectionResultStatus;
+  /** `<title>` text. */
+  title: string;
+  /** Main `<h1>` heading. */
+  heading: string;
+  /** Supporting paragraph under the heading. */
+  message: string;
+  /** Optional small footer note (e.g. "You can now return to where you started."). */
+  footerNote?: string;
+  /**
+   * When provided, a best-effort `window.opener?.postMessage(payload, '*')` is
+   * emitted so a same-origin opener can auto-detect the outcome. Cross-origin
+   * openers that pin `event.origin` will ignore it — it is a convenience, never
+   * relied upon (the canonical flows use polling / popup-close detection).
+   */
+  postMessagePayload?: Record<string, unknown>;
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const PAGE_STYLES = `
+  *,*::before,*::after { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    background: #f7f7f8;
+    color: #18181b;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    -webkit-font-smoothing: antialiased;
+  }
+  .card {
+    background: #ffffff;
+    border: 1px solid #e4e4e7;
+    border-radius: 16px;
+    padding: 32px;
+    width: 100%;
+    max-width: 440px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 8px 24px rgba(0,0,0,0.06);
+    text-align: center;
+    animation: fadeIn 240ms ease-out both;
+  }
+  h1.message-heading { margin: 0 0 8px; font-size: 20px; font-weight: 600; color: #18181b; }
+  p.intro { margin: 0 0 8px; color: #52525b; font-size: 14px; line-height: 1.5; }
+  a.secondary,
+  button.secondary {
+    appearance: none;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    color: #71717a;
+    font-size: 13px;
+    font-weight: 500;
+    margin-top: 14px;
+    padding: 4px 8px;
+    text-decoration: none;
+    display: inline-block;
+    border-radius: 6px;
+    transition: color 120ms ease, background 120ms ease;
+    font-family: inherit;
+  }
+  a.secondary:hover, button.secondary:hover { color: #18181b; background: #f4f4f5; }
+  .footer {
+    margin-top: 24px;
+    padding-top: 16px;
+    border-top: 1px solid #f4f4f5;
+    font-size: 12px;
+    color: #a1a1aa;
+  }
+  .check {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 20px;
+    border-radius: 50%;
+    background: #ecfdf5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: pop 360ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  .check svg { width: 32px; height: 32px; }
+  .check svg path {
+    stroke: #059669;
+    stroke-width: 3;
+    fill: none;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-dasharray: 48;
+    stroke-dashoffset: 48;
+    animation: stroke 420ms 200ms ease-out forwards;
+  }
+  .info-icon {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 20px;
+    border-radius: 50%;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 28px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .cancel-hint {
+    display: none;
+    margin-top: 12px;
+    font-size: 12px;
+    color: #71717a;
+  }
+  @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+  @keyframes pop { 0% { transform: scale(0.6); opacity: 0; } 60% { transform: scale(1.06); opacity: 1; } 100% { transform: scale(1); opacity: 1; } }
+  @keyframes stroke { to { stroke-dashoffset: 0; } }
+
+  @media (prefers-color-scheme: dark) {
+    body { background: #0a0a0a; color: #fafafa; }
+    .card { background: #18181b; border-color: #27272a; box-shadow: 0 1px 2px rgba(0,0,0,0.4), 0 8px 24px rgba(0,0,0,0.4); }
+    h1.message-heading { color: #fafafa; }
+    p.intro { color: #a1a1aa; }
+    a.secondary, button.secondary { color: #a1a1aa; }
+    a.secondary:hover, button.secondary:hover { color: #fafafa; background: #27272a; }
+    .footer { color: #71717a; border-top-color: #27272a; }
+    .check { background: #052e16; }
+    .check svg path { stroke: #34d399; }
+    .info-icon { background: #450a0a; color: #fca5a5; }
+    .cancel-hint { color: #a1a1aa; }
+  }
+`;
+
+function pageShell(title: string, body: string, inlineScript?: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex,nofollow" />
+<meta name="referrer" content="no-referrer" />
+<meta name="color-scheme" content="light dark" />
+<title>${escapeHtml(title)}</title>
+<style>${PAGE_STYLES}</style>
+</head>
+<body>${body}${inlineScript ? `<script>${inlineScript}</script>` : ''}</body>
+</html>`;
+}
+
+const SUCCESS_ICON = `<div class="check">
+    <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12.5l4.5 4.5L19 7" /></svg>
+  </div>`;
+
+const ERROR_ICON = `<div class="info-icon" aria-hidden="true">!</div>`;
+
+/**
+ * Inline close-tab link. `window.close()` only works on tabs opened by script, so
+ * we attempt it and, if the tab is still here a moment later, reveal a manual hint.
+ * The handler is inlined so it works even when the markup is injected without
+ * executing `<script>` blocks.
+ */
+const CLOSE_LINK = `<a class="secondary" href="javascript:void(0)" onclick="try{window.close();}catch(e){}var h=this.nextElementSibling;setTimeout(function(){if(!document.hidden&&h){h.style.display='block';}},150);return false;">Close this tab</a>
+  <div class="cancel-hint">You can close this tab manually.</div>`;
+
+function buildPostMessageScript(payload: Record<string, unknown>): string {
+  // JSON.stringify keeps the payload safe to embed in a script context here
+  // because it only ever contains server-controlled primitive values.
+  return `try{if(window.opener){window.opener.postMessage(${JSON.stringify(payload)},'*');}}catch(e){}`;
+}
+
+export function renderConnectionResultPage(options: ConnectionResultPageOptions): string {
+  const { status, title, heading, message, footerNote, postMessagePayload } = options;
+  const icon = status === 'success' ? SUCCESS_ICON : ERROR_ICON;
+  const footer = footerNote ? `<div class="footer">${escapeHtml(footerNote)}</div>` : '';
+
+  const body = `
+<div class="card" data-state="${status}">
+  ${icon}
+  <h1 class="message-heading">${escapeHtml(heading)}</h1>
+  <p class="intro">${escapeHtml(message)}</p>
+  ${CLOSE_LINK}
+  ${footer}
+</div>`;
+
+  const inlineScript = postMessagePayload ? buildPostMessageScript(postMessagePayload) : undefined;
+
+  return pageShell(title, body, inlineScript);
+}

--- a/apps/api/src/app/shared/html/connection-result-page.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.ts
@@ -186,10 +186,16 @@ const ERROR_ICON = `<div class="info-icon" aria-hidden="true">!</div>`;
 const CLOSE_LINK = `<a class="secondary" href="javascript:void(0)" onclick="try{window.close();}catch(e){}var h=this.nextElementSibling;setTimeout(function(){if(!document.hidden&&h){h.style.display='block';}},150);return false;">Close this tab</a>
   <div class="cancel-hint">You can close this tab manually.</div>`;
 
+/**
+ * Embeds a postMessage call for same-origin openers (e.g. MCP OAuth popup).
+ *
+ * Security: `JSON.stringify` is not enough inside `<script>` — the HTML parser
+ * still recognizes `</script>` inside string literals and closes the block early.
+ * MCP error payloads include `reason` from OAuth `error_description`, which is
+ * provider-controlled. We replace `<` with `\u003c` in the serialized JSON so
+ * the tokenizer never sees a breakout sequence; JS decodes it identically at runtime.
+ */
 function buildPostMessageScript(payload: Record<string, unknown>): string {
-  // Replace < with \u003c so the HTML parser cannot close the script block early.
-  // JSON.stringify alone does not escape </, which would let </script> in any
-  // string value (e.g. OAuth error_description) break out of the <script> tag.
   const json = JSON.stringify(payload).replace(/</g, '\\u003c');
 
   return `try{if(window.opener){window.opener.postMessage(${json},'*');}}catch(e){}`;

--- a/apps/api/src/app/shared/html/connection-result-page.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.ts
@@ -187,9 +187,12 @@ const CLOSE_LINK = `<a class="secondary" href="javascript:void(0)" onclick="try{
   <div class="cancel-hint">You can close this tab manually.</div>`;
 
 function buildPostMessageScript(payload: Record<string, unknown>): string {
-  // JSON.stringify keeps the payload safe to embed in a script context here
-  // because it only ever contains server-controlled primitive values.
-  return `try{if(window.opener){window.opener.postMessage(${JSON.stringify(payload)},'*');}}catch(e){}`;
+  // Replace < with \u003c so the HTML parser cannot close the script block early.
+  // JSON.stringify alone does not escape </, which would let </script> in any
+  // string value (e.g. OAuth error_description) break out of the <script> tag.
+  const json = JSON.stringify(payload).replace(/</g, '\\u003c');
+
+  return `try{if(window.opener){window.opener.postMessage(${json},'*');}}catch(e){}`;
 }
 
 export function renderConnectionResultPage(options: ConnectionResultPageOptions): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

Two server-rendered OAuth endings produced poor terminal pages:

- **Agent MCP OAuth** redirected to `${DASHBOARD_URL}/agents/mcp/oauth/result` — a dashboard route that is not implemented (and otherwise fell back to a bare `window.close()` page).
- **React `Connect` flow** (Slack / MS Teams) returned `<script>window.close();</script>`, which renders as a blank tab.

Both now render a shared **"flow complete"** HTML page styled after the agent email action-button landing pages.

---

### Review fixes (Greptile) — commit `f5eaa3aa37`

- **XSS:** `buildPostMessageScript` replaces `<` with `\u003c` in serialized JSON so `</script>` in OAuth `error_description` cannot break out of the inline script. ([discussion](https://github.com/novuhq/novu/pull/11372#discussion_r3330021086))
- **Consistency:** MS Teams `buildErrorHtml` now uses `renderConnectionResultPage`.

### Copy pass — commit `4623360838`

Removed duplicated text (message + footer both said "return to where you started") and softened tone. Each page now shows a heading + a single concise message; the "Close this tab" link is the only CTA.

| State | Heading | Message |
| --- | --- | --- |
| Success (MCP/Slack/Teams) | You're all set | Your MCP server / Slack workspace / Microsoft Teams is connected and ready to use. |
| MCP error | We couldn't connect | Something went wrong while connecting your MCP server. Please go back and try again. |
| Teams setup error | We couldn't set up Microsoft Teams | <technical reason> (+ Azure-propagation footer when relevant) |

---

### Screenshots

MCP success:
![MCP OAuth success page](https://cursor.com/artifacts/c/art-bed4676f-4c83-4d1d-91e7-39ddf5298924)

MCP error:
![MCP OAuth error page](https://cursor.com/artifacts/c/art-028a5adc-059c-4e6c-9335-fd27b61e5a73)

Slack Connect success:
![Slack Connect success page](https://cursor.com/artifacts/c/art-b6d5801d-f8b4-4e40-b564-845bc8c0d124)

MS Teams setup error (shared renderer):
![MS Teams setup error page](https://cursor.com/artifacts/c/art-b9ffbbd8-ab33-4248-8c11-f1e98a59e665)

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Special notes for your reviewer

`msteams-oauth-callback.usecase.spec.ts` — 13 passing. Inline code comments document the postMessage escaping and `buildErrorHtml` migration. Existing e2e/spec assertions still match (titles `Connection complete` / `Connection failed` and the Teams success string are preserved).

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e891faa-5e67-40ca-850e-46f8b5f59e9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e891faa-5e67-40ca-850e-46f8b5f59e9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

OAuth terminal flows for Agent MCP, Slack Connect, and Microsoft Teams now render a shared, styled "connection result" HTML page (HTTP 200) that shows success or error messaging and a clear "Close this tab" action. This replaces prior redirects to an unimplemented dashboard route or bare window.close() scripts that produced blank tabs, improving end-user UX and providing a reliable way for clients to detect OAuth outcomes.

## Affected areas

**api**: MCP, Slack, and MS Teams OAuth callback handlers now return the server-rendered connection result page and, for MCP, attempt a best-effort novuhq-mcp-oauth-result postMessage to same-origin openers; MS Teams error rendering was migrated to the shared renderer while preserving an Azure permission-propagation footer for specific permission errors.

**shared**: Added apps/api/src/app/shared/html/connection-result-page.ts which exposes renderConnectionResultPage(), types, and helpers to generate the self-contained HTML (icons, dark-mode CSS, close handler, and optional postMessage script). All user-facing strings are escaped and the postMessage payload is JSON-escaped to prevent </script>-injection XSS.

**tests**: Updated unit/usecase and E2E tests to assert HTTP 200 responses and validate the rendered page content (MCP e2e and MS Teams/Slack callback specs) instead of expecting redirects or raw close-tab scripts.

## Key technical decisions

- Use a single server-rendered HTML page for all OAuth terminal states to unify UX and reduce duplicated fallback logic.  
- Deliver outcome signals to same-origin openers via postMessage with JSON-escaping to mitigate script-injection XSS.

## Testing

Updated automated tests include modified usecase specs and E2E assertions that check status 200 and rendered page contents; manual browser verification of close-tab behavior and postMessage receipt is recommended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces two broken OAuth terminal flows — an MCP redirect to an unimplemented dashboard route and a bare `window.close()` script tab — with a shared, styled "connection result" HTML page rendered by the new `renderConnectionResultPage()` helper. It also addresses two previously flagged issues: XSS in the postMessage payload serialization and the inconsistent bespoke `buildErrorHtml` template in the MS Teams callback.

- **`connection-result-page.ts`** (new): self-contained HTML renderer with full `escapeHtml()` coverage for all user-visible fields, animated success/error card, dark-mode CSS, and a `buildPostMessageScript()` that escapes `<` → `\\u003c` to prevent `</script>` injection in provider-controlled `error_description` values.
- **MCP, Slack, MS Teams callbacks**: `SCRIPT_CLOSE_TAB` / redirect logic removed; all three now delegate to `renderConnectionResultPage()`. MS Teams' `buildErrorHtml` migrated to the shared renderer, preserving the Azure permission-propagation footer note.
- **Tests**: E2E and usecase specs updated to assert HTTP 200 and presence of expected heading text instead of redirect codes or raw `window.close()` strings.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all dynamic content is HTML-escaped, the </script> injection vector is properly mitigated, and both previously flagged issues are resolved.

The change introduces a single new pure-function renderer where every user-supplied string passes through escapeHtml() before entering the HTML body, and JSON.stringify output is further sanitised with the \u003c substitution before being embedded in script blocks. The two issues raised in prior review rounds are addressed. Tests verify both success and error paths with explicit body-content assertions.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/api/src/app/shared/html/connection-result-page.ts | New shared renderer; all dynamic content is properly HTML-escaped, XSS via </script> is fixed by replacing < with \u003c in JSON before embedding in script tags. |
| apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts | Replaced redirect/fallback with renderConnectionResultPage(); user-visible message is hardcoded, provider error only flows into the postMessage payload where it is safely escaped. |
| apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts | Migrated SCRIPT_CLOSE_TAB and buildErrorHtml to the shared renderer; message passed to renderConnectionResultPage is HTML-escaped inside the renderer. |
| apps/api/src/app/integrations/usecases/chat-oauth-callback/slack-oauth-callback/slack-oauth-callback.usecase.ts | Replaced SCRIPT_CLOSE_TAB with renderConnectionResultPage() on the success path; no functional change other than the improved terminal page. |
| apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.spec.ts | Spec assertions updated to match the new HTML output; all four close-tab scenarios now check for 'Microsoft Teams is connected' heading text. |
| apps/api/src/app/agents/e2e/agent-mcp-servers.e2e.ts | E2E assertions tightened from [200, 302] to strict 200 plus HTML body content checks; accurately reflects the new always-200 contract. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OAuth Provider Redirect] --> B{Which flow?}
    B -->|MCP /oauth/callback| C[AgentsMcpOAuthController]
    B -->|Slack Connect| D[SlackOauthCallback]
    B -->|MS Teams Connect| E[MsTeamsOauthCallback]
    C --> F[McpOAuthCallback usecase]
    F -->|status = connected| G[renderConnectionResultPage status: success + postMessagePayload]
    F -->|status = error| H[renderConnectionResultPage status: error + postMessagePayload with reason]
    D -->|success| I[renderConnectionResultPage status: success]
    E -->|success| J[renderConnectionResultPage status: success]
    E -->|bot-install error| K[buildErrorHtml → renderConnectionResultPage status: error ± Azure footerNote]
    G --> L[HTTP 200 HTML page Close-tab action buildPostMessageScript < escaped to u003c]
    H --> L
    I --> M[HTTP 200 HTML page Close-tab action]
    J --> M
    K --> M
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts`, line 309-347 ([link](https://github.com/novuhq/novu/blob/5c84b09a624528167e90bcd5df727238e9ea925c/apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts#L309-L347)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`buildErrorHtml` not migrated to the shared renderer**

   The PR introduces `renderConnectionResultPage` as the canonical shared HTML renderer and migrates the close-tab responses, but `buildErrorHtml` still generates its own bespoke HTML with separate styles. The error page will now look visually inconsistent with every other terminal page returned by this service. Consider wrapping the permission-error content in `renderConnectionResultPage` (status `'error'`) with the `footerNote` field carrying the Azure-propagation hint, or at minimum make `buildErrorHtml` reuse the exported `escapeHtml` helper to avoid duplicated escaping logic.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/api/src/app/integrations/usecases/chat-oauth-callback/msteams-oauth-callback/msteams-oauth-callback.usecase.ts
   Line: 309-347

   Comment:
   **`buildErrorHtml` not migrated to the shared renderer**

   The PR introduces `renderConnectionResultPage` as the canonical shared HTML renderer and migrates the close-tab responses, but `buildErrorHtml` still generates its own bespoke HTML with separate styles. The error page will now look visually inconsistent with every other terminal page returned by this service. Consider wrapping the permission-error content in `renderConnectionResultPage` (status `'error'`) with the `footerNote` field carrying the Azure-propagation hint, or at minimum make `buildErrorHtml` reuse the exported `escapeHtml` helper to avoid duplicated escaping logic.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fapi%2Fsrc%2Fapp%2Fintegrations%2Fusecases%2Fchat-oauth-callback%2Fmsteams-oauth-callback%2Fmsteams-oauth-callback.usecase.ts%0ALine%3A%20309-347%0A%0AComment%3A%0A**%60buildErrorHtml%60%20not%20migrated%20to%20the%20shared%20renderer**%0A%0AThe%20PR%20introduces%20%60renderConnectionResultPage%60%20as%20the%20canonical%20shared%20HTML%20renderer%20and%20migrates%20the%20close-tab%20responses%2C%20but%20%60buildErrorHtml%60%20still%20generates%20its%20own%20bespoke%20HTML%20with%20separate%20styles.%20The%20error%20page%20will%20now%20look%20visually%20inconsistent%20with%20every%20other%20terminal%20page%20returned%20by%20this%20service.%20Consider%20wrapping%20the%20permission-error%20content%20in%20%60renderConnectionResultPage%60%20%28status%20%60'error'%60%29%20with%20the%20%60footerNote%60%20field%20carrying%20the%20Azure-propagation%20hint%2C%20or%20at%20minimum%20make%20%60buildErrorHtml%60%20reuse%20the%20exported%20%60escapeHtml%60%20helper%20to%20avoid%20duplicated%20escaping%20logic.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11372&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["refactor(api): tighten OAuth flow-comple..."](https://github.com/novuhq/novu/commit/4623360838b4c60717671b9d3b9aee69f25b931e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34780739)</sub>

<!-- /greptile_comment -->