### PR TITLE
feat(dal): add createdBy field to agent entity fixes NV-7920

### DIFF
--- a/apps/api/src/app/agents/e2e/agents.e2e.ts
+++ b/apps/api/src/app/agents/e2e/agents.e2e.ts
@@ -31,6 +31,7 @@ describe('Agents API - /agents #novu-v2', () => {
     expect(createRes.body.data.identifier).to.equal(identifier);
     expect(createRes.body.data.description).to.equal('e2e description');
     expect(createRes.body.data._id).to.be.a('string');
+    expect(createRes.body.data.createdBy).to.equal(session.user._id);
 
     const listRes = await session.testAgent.get('/v1/agents');
 

--- a/apps/api/src/app/agents/management/usecases/create-agent/create-agent.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/create-agent/create-agent.usecase.ts
@@ -82,6 +82,7 @@ export class CreateAgent {
               identifier: tempIdentifier,
               description: command.description,
               active: command.active ?? true,
+              createdBy: command.userId,
               _environmentId: command.environmentId,
               _organizationId: command.organizationId,
             },
@@ -159,6 +160,7 @@ export class CreateAgent {
           identifier: identifier ?? '',
           description: command.description,
           active: command.active ?? true,
+          createdBy: command.userId,
           _environmentId: command.environmentId,
           _organizationId: command.organizationId,
         });

--- a/apps/api/src/app/agents/management/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
@@ -55,6 +55,7 @@ export class SyncAgentToEnvironment {
         description: sourceAgent.description,
         behavior: sourceAgent.behavior,
         active: false,
+        createdBy: sourceAgent.createdBy ?? command.userId,
         _environmentId: targetEnvironmentId,
         _organizationId: organizationId,
       });

--- a/apps/api/src/app/agents/management/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
+++ b/apps/api/src/app/agents/management/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts
@@ -55,7 +55,7 @@ export class SyncAgentToEnvironment {
         description: sourceAgent.description,
         behavior: sourceAgent.behavior,
         active: false,
-        createdBy: sourceAgent.createdBy ?? command.userId,
+        createdBy: sourceAgent.createdBy,
         _environmentId: targetEnvironmentId,
         _organizationId: organizationId,
       });

--- a/apps/api/src/app/agents/shared/dtos/agent-response.dto.ts
+++ b/apps/api/src/app/agents/shared/dtos/agent-response.dto.ts
@@ -81,6 +81,9 @@ export class AgentResponseDto {
   @ApiProperty()
   _organizationId: string;
 
+  @ApiPropertyOptional({ description: 'Mongo user id of the user who created the agent' })
+  createdBy?: string;
+
   @ApiProperty()
   createdAt: string;
 

--- a/apps/api/src/app/agents/shared/mappers/agent-response.mapper.ts
+++ b/apps/api/src/app/agents/shared/mappers/agent-response.mapper.ts
@@ -86,6 +86,7 @@ export function toAgentResponse(agent: AgentEntity, hydration?: ManagedRuntimeHy
     managedRuntime,
     _environmentId: agent._environmentId,
     _organizationId: agent._organizationId,
+    createdBy: agent.createdBy,
     createdAt: agent.createdAt,
     updatedAt: agent.updatedAt,
   };

--- a/libs/dal/src/repositories/agent/agent.entity.ts
+++ b/libs/dal/src/repositories/agent/agent.entity.ts
@@ -53,9 +53,14 @@ export class AgentEntity {
 
   _organizationId: OrganizationId;
 
+  createdBy?: string;
+
   createdAt: string;
 
   updatedAt: string;
 }
 
-export type AgentDBModel = ChangePropsValueType<AgentEntity, '_environmentId' | '_organizationId'>;
+export type AgentDBModel = ChangePropsValueType<
+  AgentEntity,
+  '_environmentId' | '_organizationId' | 'createdBy'
+>;

--- a/libs/dal/src/repositories/agent/agent.schema.ts
+++ b/libs/dal/src/repositories/agent/agent.schema.ts
@@ -49,6 +49,10 @@ const agentSchema = new Schema<AgentDBModel>(
       type: Schema.Types.ObjectId,
       ref: 'Environment',
     },
+    createdBy: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+    },
   },
   schemaOptions
 );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The agent entity did not track who created an agent. This adds an optional `createdBy` field that stores the creating user's Mongo ObjectId.

## Changes

- Add `createdBy` to `AgentEntity` and the Mongo schema (`ObjectId` ref to `User`)
- Set `createdBy` from `command.userId` in `CreateAgent`
- Preserve the source agent's `createdBy` when syncing agents across environments (omit when unknown on pre-migration agents)
- Expose `createdBy` on `AgentResponseDto`
- Assert the field in agents e2e coverage

## Testing

- `pnpm --filter @novu/dal build`
- `apps/api` agents e2e suite (`agents.e2e.ts`) — 19 passing
- `sync-agent-to-environment.spec.ts` — 7 passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a3d4434-e204-49c7-abd9-6a5add983ffd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a3d4434-e204-49c7-abd9-6a5add983ffd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

Added an optional createdBy field to Agent to record who created an agent; it is persisted in the DB from the creating request's user ID, surfaced in agent API responses, and preserved when agents are synced to other environments (pre-migration agents keep createdBy unset rather than attributing the syncing user). This enables attribution/auditing of agent creation without misattributing legacy records.

## Affected areas

**dal**: AgentEntity and Mongoose schema now include createdBy as an ObjectId ref to User so creator IDs are persisted.  
**api**: CreateAgent now sets createdBy from command.userId (managed and non-managed flows); SyncAgentToEnvironment sets createdBy from the source agent when creating target agents and no longer falls back to the syncing user for pre-migration agents; AgentResponseDto and the response mapper expose createdBy.  
**tests / e2e**: Agents e2e tests were updated to assert createdBy equals the creating session user ID.

## Key technical decisions

- createdBy is stored as a Mongo ObjectId referencing the User model to allow direct lookups.  
- Sync behavior preserves sourceAgent.createdBy when copying agents and deliberately omits attribution for pre-migration agents instead of defaulting to the sync user.

## Testing

End-to-end tests were updated (agents e2e) to assert createdBy is set on create; relevant e2e suites passed locally as noted in the PR (agents suite and sync spec).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `createdBy` field to the `AgentEntity` and its Mongoose schema, storing the creating user's ObjectId. Agent creation sets the field from `command.userId`; environment sync propagates it from the source agent (leaving it absent for pre-migration agents).

- **DAL layer**: `createdBy?: string` added to `AgentEntity` and `AgentDBModel`; Mongoose schema gains an `ObjectId` ref to `User`.
- **API layer**: Both create-agent code paths set `createdBy: command.userId`; the sync usecase passes `sourceAgent.createdBy` through; `AgentResponseDto` exposes the field as optional.
- **Tests**: E2e assertion confirms `createdBy` equals the session user ID on agent creation.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the DB model type — all runtime paths behave correctly, but the type definition for `AgentDBModel` needs a one-line adjustment before it can be trusted by future callers.

The implementation is correct at runtime: `createdBy` is written, propagated, and serialized properly. The one structural concern is in `agent.entity.ts` where including the optional `createdBy` field in `ChangePropsValueType` strips its `?` modifier, making `AgentDBModel.createdBy` a required `Types.ObjectId`. Pre-migration documents will have `undefined` for that field at runtime, so any future code that accesses `agentDbModel.createdBy` directly and trusts the type will encounter an unexpected `undefined`.

libs/dal/src/repositories/agent/agent.entity.ts — the `AgentDBModel` type definition needs `createdBy` handled outside `ChangePropsValueType` to preserve optionality.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/dal/src/repositories/agent/agent.entity.ts | Adds optional `createdBy` field to entity, but includes it in `ChangePropsValueType` which strips the optional modifier — making `AgentDBModel.createdBy` a required `Types.ObjectId` even though it can be absent on pre-migration documents. |
| libs/dal/src/repositories/agent/agent.schema.ts | Adds optional `createdBy: ObjectId ref User` to the Mongoose schema — straightforward and correct. |
| apps/api/src/app/agents/management/usecases/create-agent/create-agent.usecase.ts | Sets `createdBy: command.userId` in both the transactional managed-runtime path and the simple self-hosted path — consistent and correct. |
| apps/api/src/app/agents/management/usecases/sync-agent-to-environment/sync-agent-to-environment.usecase.ts | Preserves `sourceAgent.createdBy` (which is `undefined` for pre-migration agents) when creating a new target-env agent; the update path for already-synced agents correctly leaves existing `createdBy` untouched. |
| apps/api/src/app/agents/shared/dtos/agent-response.dto.ts | Adds `@ApiPropertyOptional` `createdBy?: string` field — correctly marked optional to accommodate pre-migration agents. |
| apps/api/src/app/agents/shared/mappers/agent-response.mapper.ts | Passes `agent.createdBy` through to the response DTO — straightforward mapping. |
| apps/api/src/app/agents/e2e/agents.e2e.ts | Adds assertion that `createdBy` equals the session user ID after agent creation — covers the primary happy-path case. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant CreateAgent
    participant AgentRepository
    participant SyncAgent

    Client->>CreateAgent: execute(command)
    Note over CreateAgent: createdBy = command.userId
    CreateAgent->>AgentRepository: "create({ ..., createdBy })"
    AgentRepository-->>CreateAgent: AgentEntity (createdBy set)
    CreateAgent-->>Client: AgentResponseDto (createdBy: string)

    Client->>SyncAgent: execute(command)
    SyncAgent->>AgentRepository: findOne(sourceAgent)
    AgentRepository-->>SyncAgent: sourceAgent (createdBy may be undefined)
    Note over SyncAgent: targetAgent absent?
    alt New target agent
        SyncAgent->>AgentRepository: "create({ ..., createdBy: sourceAgent.createdBy })"
    else Existing target agent
        SyncAgent->>AgentRepository: update($set name/description/behavior only)
        Note over SyncAgent: createdBy unchanged on existing target
    end
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Fdal%2Fsrc%2Frepositories%2Fagent%2Fagent.entity.ts%3A63-66%0A**%60createdBy%60%20loses%20its%20optional%20modifier%20in%20%60AgentDBModel%60**%0A%0A%60ChangePropsValueType%60%20expands%20to%20%60Omit%3CT%2C%20K%3E%20%26%20%7B%20%5BP%20in%20K%5D%3A%20V%20%7D%60%20%E2%80%94%20the%20mapped%20type%20%60%7B%20%5BP%20in%20K%5D%3A%20V%20%7D%60%20is%20non-optional%2C%20so%20%60createdBy%3F%3A%20string%60%20on%20the%20entity%20becomes%20%60createdBy%3A%20Types.ObjectId%60%20%28required%29%20in%20the%20DB%20model.%20For%20every%20document%20written%20before%20this%20migration%2C%20Mongoose%20will%20return%20%60undefined%60%20for%20that%20field%2C%20but%20TypeScript%20will%20tell%20callers%20it%20is%20always%20a%20%60Types.ObjectId%60.%20Any%20code%20that%20relies%20on%20the%20DB-model%20type%20and%20accesses%20%60createdBy%60%20directly%20%28e.g.%20%60.toString%28%29%60%29%20will%20throw%20at%20runtime%20on%20pre-migration%20documents.%20To%20preserve%20optionality%2C%20exclude%20%60createdBy%60%20from%20the%20%60ChangePropsValueType%60%20spread%20and%20intersect%20the%20optional%20ObjectId%20type%20separately.%0A%0A&pr=11373&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
libs/dal/src/repositories/agent/agent.entity.ts:63-66
**`createdBy` loses its optional modifier in `AgentDBModel`**

`ChangePropsValueType` expands to `Omit<T, K> & { [P in K]: V }` — the mapped type `{ [P in K]: V }` is non-optional, so `createdBy?: string` on the entity becomes `createdBy: Types.ObjectId` (required) in the DB model. For every document written before this migration, Mongoose will return `undefined` for that field, but TypeScript will tell callers it is always a `Types.ObjectId`. Any code that relies on the DB-model type and accesses `createdBy` directly (e.g. `.toString()`) will throw at runtime on pre-migration documents. To preserve optionality, exclude `createdBy` from the `ChangePropsValueType` spread and intersect the optional ObjectId type separately.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api-service): preserve source create..."](https://github.com/novuhq/novu/commit/2d0fe59f040149dcaa81455e6abf847a0232031a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34786969)</sub>

<!-- /greptile_comment -->