### PR TITLE
fix(dashboard): shorten Telegram mobile success CTA label fixes NV-7922

### DIFF
--- a/apps/dashboard/src/pages/agent-telegram-mobile-setup-page.tsx
+++ b/apps/dashboard/src/pages/agent-telegram-mobile-setup-page.tsx
@@ -240,7 +240,7 @@ function SuccessCard({
         className="bg-text-strong text-static-white hover:bg-text-strong/90 mt-5 flex h-10 w-full items-center justify-center gap-2 rounded-10 px-3.5 text-label-sm transition"
       >
         <RiSendPlaneLine className="size-4" />
-        {hasStartLink ? `Connect & test @${botUsername}` : `Open @${botUsername}`}
+        {hasStartLink ? 'Connect & test' : `Open @${botUsername}`}
       </a>
 
       <p className="text-text-soft text-label-xs mt-3 text-center">You can safely close this tab.</p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the Telegram mobile setup page (paste BotFather message flow), the success screen CTA no longer appends the bot username. The button label is now **Connect & test** only; the connected bot is still shown in the heading (`@{botUsername} is connected`).

## Why

The bot name in the button duplicated information already visible in the title and made the CTA unnecessarily long on mobile.

## Changes

- `apps/dashboard/src/pages/agent-telegram-mobile-setup-page.tsx`: when `hasStartLink` is true, use a static `Connect & test` label instead of `Connect & test @{botUsername}`.

## Testing

- Dashboard-only string change; no build required per AGENTS.md.
- Manual: complete mobile Telegram setup and confirm success CTA reads **Connect & test** without `@botname`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6b5ace1-c4b6-4e87-9700-9ad68d8c44fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6b5ace1-c4b6-4e87-9700-9ad68d8c44fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR shortens the success-screen CTA label on the Telegram mobile setup page. When a `deepLinkUrl` (start link) is present, the button now reads **Connect & test** instead of **Connect & test `@{botUsername}`**, since the bot username is already shown in the `@{botUsername} is connected` heading directly above.

- Removes the redundant `@${botUsername}` suffix from the `hasStartLink` branch of the CTA button label in `SuccessCard`.
- The non-`hasStartLink` path (`Open @${botUsername}`) is unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single string literal is shortened; no logic, data flow, or state is affected.

The only change is removing @${botUsername} from one string literal in the hasStartLink branch. The heading immediately above the button still displays the bot username, the link href is untouched, and the alternate branch is unchanged. No regressions are possible from this edit.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dashboard/src/pages/agent-telegram-mobile-setup-page.tsx | Single-line label change: removes `@${botUsername}` from the "Connect & test" CTA when `hasStartLink` is true; bot username is still displayed in the heading above. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SuccessCard renders] --> B{hasStartLink?}
    B -- Yes --> C["Button: 'Connect and test'"]
    B -- No --> D["Button: 'Open at botUsername'"]
    C --> E[Link to deepLinkUrl]
    D --> F[Link to telegram bot profile]
    G["Heading: 'at botUsername is connected'"] --> A
```

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): shorten Telegram mobile ..."](https://github.com/novuhq/novu/commit/cf30d27c90ecaad51739330a130c583ace0b2a93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34787161)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

The success CTA label on the Telegram mobile setup page was shortened from "Connect & test @{botUsername}" to "Connect & test" to reduce unnecessary length on mobile devices. The bot username remains visible in the page heading, eliminating redundant information in the button text.

## Affected areas

**dashboard** — Updated the success-state CTA text in `AgentTelegramMobileSetupPage` to display "Connect & test" without the bot username when a deep link is available, addressing the mobile UX concern of oversized button labels.

## Testing

Manual verification on the mobile Telegram setup flow is sufficient for this dashboard-only string change. No unit or e2e tests are needed since the modification is purely cosmetic text content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->