### PR TITLE
fix(api-service): allow inline styles in connection-result page CSP fixes NV-7926

### DIFF
--- a/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
@@ -56,9 +56,9 @@ export class AgentsMcpOAuthController {
     );
 
     // Render a self-contained "flow complete" page instead of redirecting to the
-    // dashboard. The shared renderer already shows a "Close this tab" action, so
-    // the message stays short and avoids repeating it. A best-effort postMessage
-    // lets any same-origin opener (e.g. a popup-based flow) auto-detect the outcome.
+    // dashboard. The shared renderer already shows a "Close this tab" action,
+    // so the message stays short and avoids repeating it. Openers detect the
+    // outcome via popup-close detection / status polling, not from this page.
     const isConnected = result.status === 'connected';
     const page = isConnected
       ? renderConnectionResultPage({
@@ -66,14 +66,12 @@ export class AgentsMcpOAuthController {
           title: 'Connection complete',
           heading: "You're all set",
           message: 'Your MCP server is connected and ready to use.',
-          postMessagePayload: { type: 'novu-mcp-oauth-result', status: 'connected' },
         })
       : renderConnectionResultPage({
           status: 'error',
           title: 'Connection failed',
           heading: "We couldn't connect",
           message: 'Something went wrong while connecting your MCP server. Please go back and try again.',
-          postMessagePayload: { type: 'novu-mcp-oauth-result', status: 'error', reason: result.message },
         });
 
     res.setHeader('Content-Type', 'text/html');

--- a/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
+++ b/apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts
@@ -4,7 +4,7 @@ import { ApiRateLimitCategoryEnum } from '@novu/shared';
 import { Response } from 'express';
 
 import { ThrottlerCategory } from '../../../rate-limiting/guards';
-import { renderConnectionResultPage } from '../../../shared/html/connection-result-page';
+import { CONNECTION_RESULT_CSP, renderConnectionResultPage } from '../../../shared/html/connection-result-page';
 import { McpOAuthCallbackCommand } from './mcp-oauth-callback/mcp-oauth-callback.command';
 import { McpOAuthCallback } from './mcp-oauth-callback/mcp-oauth-callback.usecase';
 
@@ -77,7 +77,7 @@ export class AgentsMcpOAuthController {
         });
 
     res.setHeader('Content-Type', 'text/html');
-    res.setHeader('Content-Security-Policy', "default-src 'self'; script-src 'self' 'unsafe-inline'");
+    res.setHeader('Content-Security-Policy', CONNECTION_RESULT_CSP);
     res.send(page);
   }
 }

--- a/apps/api/src/app/integrations/integrations.controller.ts
+++ b/apps/api/src/app/integrations/integrations.controller.ts
@@ -50,6 +50,7 @@ import {
 } from '../shared/framework/response.decorator';
 import { SdkGroupName, SdkMethodName } from '../shared/framework/swagger/sdk.decorators';
 import { UserSession } from '../shared/framework/user.decorator';
+import { CONNECTION_RESULT_CSP } from '../shared/html/connection-result-page';
 import { AutoConfigureIntegrationResponseDto } from './dtos/auto-configure-integration-response.dto';
 import { CreateIntegrationRequestDto } from './dtos/create-integration-request.dto';
 import { GenerateChatOauthUrlRequestDto } from './dtos/generate-chat-oauth-url.dto';
@@ -777,7 +778,7 @@ export class IntegrationsController {
 
     if (result.type === ResponseTypeEnum.HTML) {
       res.setHeader('Content-Type', 'text/html');
-      res.setHeader('Content-Security-Policy', "default-src 'self'; script-src 'self' 'unsafe-inline'");
+      res.setHeader('Content-Security-Policy', CONNECTION_RESULT_CSP);
       res.send(result.result);
 
       return;

--- a/apps/api/src/app/shared/html/connection-result-page.spec.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.spec.ts
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+import {
+  CONNECTION_RESULT_CSP,
+  renderConnectionResultPage,
+} from './connection-result-page';
+
+describe('connection-result-page', () => {
+  describe('CONNECTION_RESULT_CSP', () => {
+    it('allows inline styles so the embedded <style> block is not blocked', () => {
+      expect(CONNECTION_RESULT_CSP).to.match(/style-src[^;]*'unsafe-inline'/);
+    });
+
+    it('allows inline scripts so the postMessage shim and onclick handler are not blocked', () => {
+      expect(CONNECTION_RESULT_CSP).to.match(/script-src[^;]*'unsafe-inline'/);
+    });
+
+    it("keeps default-src locked down to 'self'", () => {
+      expect(CONNECTION_RESULT_CSP).to.match(/default-src 'self'/);
+    });
+  });
+
+  describe('renderConnectionResultPage', () => {
+    it('emits an inline <style> block that requires style-src unsafe-inline', () => {
+      const html = renderConnectionResultPage({
+        status: 'success',
+        title: 'Connection complete',
+        heading: "You're all set",
+        message: 'Your workspace is connected and ready to use.',
+      });
+
+      expect(html).to.include('<style>');
+      expect(html).to.include('</style>');
+    });
+
+    it('escapes user-controlled copy in heading and message', () => {
+      const html = renderConnectionResultPage({
+        status: 'error',
+        title: 'Failed',
+        heading: '<img src=x onerror=alert(1)>',
+        message: '"oops" & <bad>',
+      });
+
+      expect(html).to.not.include('<img src=x onerror=alert(1)>');
+      expect(html).to.include('&lt;img src=x onerror=alert(1)&gt;');
+      expect(html).to.include('&quot;oops&quot; &amp; &lt;bad&gt;');
+    });
+
+    it('embeds a postMessage shim only when a payload is provided', () => {
+      const withPayload = renderConnectionResultPage({
+        status: 'success',
+        title: 't',
+        heading: 'h',
+        message: 'm',
+        postMessagePayload: { type: 'novu-mcp-oauth-result', status: 'connected' },
+      });
+      const withoutPayload = renderConnectionResultPage({
+        status: 'success',
+        title: 't',
+        heading: 'h',
+        message: 'm',
+      });
+
+      expect(withPayload).to.include('window.opener.postMessage(');
+      expect(withoutPayload).to.not.include('window.opener.postMessage(');
+    });
+
+    it('escapes </script> breakout sequences inside the postMessage JSON payload', () => {
+      const html = renderConnectionResultPage({
+        status: 'error',
+        title: 't',
+        heading: 'h',
+        message: 'm',
+        postMessagePayload: { reason: '</script><script>alert(1)</script>' },
+      });
+
+      expect(html).to.not.include('</script><script>alert(1)</script>');
+      expect(html).to.include('\\u003c/script>');
+    });
+  });
+});

--- a/apps/api/src/app/shared/html/connection-result-page.spec.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.spec.ts
@@ -10,7 +10,7 @@ describe('connection-result-page', () => {
       expect(CONNECTION_RESULT_CSP).to.match(/style-src[^;]*'unsafe-inline'/);
     });
 
-    it('allows inline scripts so the postMessage shim and onclick handler are not blocked', () => {
+    it('allows inline scripts so the close-tab onclick handler is not blocked', () => {
       expect(CONNECTION_RESULT_CSP).to.match(/script-src[^;]*'unsafe-inline'/);
     });
 
@@ -45,36 +45,17 @@ describe('connection-result-page', () => {
       expect(html).to.include('&quot;oops&quot; &amp; &lt;bad&gt;');
     });
 
-    it('embeds a postMessage shim only when a payload is provided', () => {
-      const withPayload = renderConnectionResultPage({
-        status: 'success',
-        title: 't',
-        heading: 'h',
-        message: 'm',
-        postMessagePayload: { type: 'novu-mcp-oauth-result', status: 'connected' },
-      });
-      const withoutPayload = renderConnectionResultPage({
-        status: 'success',
-        title: 't',
-        heading: 'h',
-        message: 'm',
-      });
-
-      expect(withPayload).to.include('window.opener.postMessage(');
-      expect(withoutPayload).to.not.include('window.opener.postMessage(');
-    });
-
-    it('escapes </script> breakout sequences inside the postMessage JSON payload', () => {
+    it('does not emit a window.opener.postMessage shim', () => {
       const html = renderConnectionResultPage({
-        status: 'error',
+        status: 'success',
         title: 't',
         heading: 'h',
         message: 'm',
-        postMessagePayload: { reason: '</script><script>alert(1)</script>' },
       });
 
-      expect(html).to.not.include('</script><script>alert(1)</script>');
-      expect(html).to.include('\\u003c/script>');
+      expect(html).to.not.include('window.opener');
+      expect(html).to.not.include('postMessage(');
+      expect(html).to.not.include('<script>');
     });
   });
 });

--- a/apps/api/src/app/shared/html/connection-result-page.spec.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.spec.ts
@@ -45,6 +45,20 @@ describe('connection-result-page', () => {
       expect(html).to.include('&quot;oops&quot; &amp; &lt;bad&gt;');
     });
 
+    it('escapes user-controlled copy in title and footerNote', () => {
+      const html = renderConnectionResultPage({
+        status: 'success',
+        title: '<script>alert(1)</script>',
+        heading: 'h',
+        message: 'm',
+        footerNote: '"footer" & <note>',
+      });
+
+      expect(html).to.not.include('<script>alert(1)</script>');
+      expect(html).to.include('&lt;script&gt;alert(1)&lt;/script&gt;');
+      expect(html).to.include('&quot;footer&quot; &amp; &lt;note&gt;');
+    });
+
     it('does not emit a window.opener.postMessage shim', () => {
       const html = renderConnectionResultPage({
         status: 'success',

--- a/apps/api/src/app/shared/html/connection-result-page.spec.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.spec.ts
@@ -6,12 +6,15 @@ import {
 
 describe('connection-result-page', () => {
   describe('CONNECTION_RESULT_CSP', () => {
+    // Anchor the directive name to a `^`/`;` boundary so neither assertion can
+    // pass via `script-src-attr` / `style-src-elem` if the bare directive ever
+    // regresses.
     it('allows inline styles so the embedded <style> block is not blocked', () => {
-      expect(CONNECTION_RESULT_CSP).to.match(/style-src[^;]*'unsafe-inline'/);
+      expect(CONNECTION_RESULT_CSP).to.match(/(?:^|;\s*)style-src\s+[^;]*'unsafe-inline'/);
     });
 
     it('allows inline scripts so the close-tab onclick handler is not blocked', () => {
-      expect(CONNECTION_RESULT_CSP).to.match(/script-src[^;]*'unsafe-inline'/);
+      expect(CONNECTION_RESULT_CSP).to.match(/(?:^|;\s*)script-src\s+[^;]*'unsafe-inline'/);
     });
 
     it("keeps default-src locked down to 'self'", () => {

--- a/apps/api/src/app/shared/html/connection-result-page.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.ts
@@ -15,6 +15,19 @@
 
 export type ConnectionResultStatus = 'success' | 'error';
 
+/**
+ * CSP header value that matches what {@link renderConnectionResultPage} emits:
+ * the page ships an inline `<style>` block and (optionally) an inline `<script>`
+ * with a `postMessage` shim, plus an `onclick` handler on the close-tab link.
+ *
+ * `script-src` covers both `<script>` and inline event handlers (CSP3 falls
+ * `script-src-attr` back to `script-src`). Same goes for `style-src` and
+ * `style-src-attr`. We keep `default-src 'self'` so nothing else (network,
+ * images, fonts, frames) is silently allowed.
+ */
+export const CONNECTION_RESULT_CSP =
+  "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
+
 export interface ConnectionResultPageOptions {
   status: ConnectionResultStatus;
   /** `<title>` text. */

--- a/apps/api/src/app/shared/html/connection-result-page.ts
+++ b/apps/api/src/app/shared/html/connection-result-page.ts
@@ -17,13 +17,10 @@ export type ConnectionResultStatus = 'success' | 'error';
 
 /**
  * CSP header value that matches what {@link renderConnectionResultPage} emits:
- * the page ships an inline `<style>` block and (optionally) an inline `<script>`
- * with a `postMessage` shim, plus an `onclick` handler on the close-tab link.
- *
- * `script-src` covers both `<script>` and inline event handlers (CSP3 falls
- * `script-src-attr` back to `script-src`). Same goes for `style-src` and
- * `style-src-attr`. We keep `default-src 'self'` so nothing else (network,
- * images, fonts, frames) is silently allowed.
+ * the page ships an inline `<style>` block and an `onclick` handler on the
+ * close-tab link. `script-src 'unsafe-inline'` covers the event handler via
+ * the CSP3 `script-src-attr` fallback; `style-src 'unsafe-inline'` covers the
+ * inline stylesheet. `default-src 'self'` keeps everything else locked down.
  */
 export const CONNECTION_RESULT_CSP =
   "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
@@ -38,13 +35,6 @@ export interface ConnectionResultPageOptions {
   message: string;
   /** Optional small footer note (e.g. "You can now return to where you started."). */
   footerNote?: string;
-  /**
-   * When provided, a best-effort `window.opener?.postMessage(payload, '*')` is
-   * emitted so a same-origin opener can auto-detect the outcome. Cross-origin
-   * openers that pin `event.origin` will ignore it — it is a convenience, never
-   * relied upon (the canonical flows use polling / popup-close detection).
-   */
-  postMessagePayload?: Record<string, unknown>;
 }
 
 export function escapeHtml(value: string): string {
@@ -168,7 +158,7 @@ const PAGE_STYLES = `
   }
 `;
 
-function pageShell(title: string, body: string, inlineScript?: string): string {
+function pageShell(title: string, body: string): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -180,7 +170,7 @@ function pageShell(title: string, body: string, inlineScript?: string): string {
 <title>${escapeHtml(title)}</title>
 <style>${PAGE_STYLES}</style>
 </head>
-<body>${body}${inlineScript ? `<script>${inlineScript}</script>` : ''}</body>
+<body>${body}</body>
 </html>`;
 }
 
@@ -199,23 +189,8 @@ const ERROR_ICON = `<div class="info-icon" aria-hidden="true">!</div>`;
 const CLOSE_LINK = `<a class="secondary" href="javascript:void(0)" onclick="try{window.close();}catch(e){}var h=this.nextElementSibling;setTimeout(function(){if(!document.hidden&&h){h.style.display='block';}},150);return false;">Close this tab</a>
   <div class="cancel-hint">You can close this tab manually.</div>`;
 
-/**
- * Embeds a postMessage call for same-origin openers (e.g. MCP OAuth popup).
- *
- * Security: `JSON.stringify` is not enough inside `<script>` — the HTML parser
- * still recognizes `</script>` inside string literals and closes the block early.
- * MCP error payloads include `reason` from OAuth `error_description`, which is
- * provider-controlled. We replace `<` with `\u003c` in the serialized JSON so
- * the tokenizer never sees a breakout sequence; JS decodes it identically at runtime.
- */
-function buildPostMessageScript(payload: Record<string, unknown>): string {
-  const json = JSON.stringify(payload).replace(/</g, '\\u003c');
-
-  return `try{if(window.opener){window.opener.postMessage(${json},'*');}}catch(e){}`;
-}
-
 export function renderConnectionResultPage(options: ConnectionResultPageOptions): string {
-  const { status, title, heading, message, footerNote, postMessagePayload } = options;
+  const { status, title, heading, message, footerNote } = options;
   const icon = status === 'success' ? SUCCESS_ICON : ERROR_ICON;
   const footer = footerNote ? `<div class="footer">${escapeHtml(footerNote)}</div>` : '';
 
@@ -228,7 +203,5 @@ export function renderConnectionResultPage(options: ConnectionResultPageOptions)
   ${footer}
 </div>`;
 
-  const inlineScript = postMessagePayload ? buildPostMessageScript(postMessagePayload) : undefined;
-
-  return pageShell(title, body, inlineScript);
+  return pageShell(title, body);
 }

--- a/playground/nextjs/src/app/agents-mcp/components/flow-simulator.tsx
+++ b/playground/nextjs/src/app/agents-mcp/components/flow-simulator.tsx
@@ -86,12 +86,6 @@ function stateToStepId(state: SimulatorState): string | null {
   }
 }
 
-type OAuthResultMessage = {
-  type: 'novu-mcp-oauth-result';
-  status: 'connected' | 'error';
-  reason?: string;
-};
-
 export function FlowSimulator({
   credentials,
   agent,
@@ -107,10 +101,8 @@ export function FlowSimulator({
   const [branch, setBranch] = useState<FlowBranch | undefined>(undefined);
   const [completedStepIds, setCompletedStepIds] = useState<ReadonlySet<string>>(new Set());
 
-  // Refs to support cancellation + ignoring stale popup messages from prior runs.
   const runIdRef = useRef(0);
   const popupRef = useRef<Window | null>(null);
-  const oauthResolverRef = useRef<((status: 'connected' | 'error', reason?: string) => void) | null>(null);
 
   const storage = useStorageDescriptor(agent);
 
@@ -121,7 +113,6 @@ export function FlowSimulator({
 
   const reset = useCallback(() => {
     runIdRef.current += 1; // cancels any in-flight simulation
-    oauthResolverRef.current = null;
     if (popupRef.current && !popupRef.current.closed) {
       popupRef.current.close();
     }
@@ -129,22 +120,6 @@ export function FlowSimulator({
     setState({ kind: 'idle' });
     setBranch(undefined);
     setCompletedStepIds(new Set());
-  }, []);
-
-  // Listen for postMessage from the OAuth result page. We accept the message
-  // when an OAuth round-trip is in flight; otherwise it's a stale event.
-  useEffect(() => {
-    function onMessage(event: MessageEvent) {
-      if (event.origin !== window.location.origin) return;
-      const data = event.data as OAuthResultMessage | undefined;
-      if (!data || data.type !== 'novu-mcp-oauth-result') return;
-      const resolve = oauthResolverRef.current;
-      if (!resolve) return;
-      resolve(data.status, data.reason);
-    }
-    window.addEventListener('message', onMessage);
-
-    return () => window.removeEventListener('message', onMessage);
   }, []);
 
   // Reset the simulator when the selection changes — stale state across MCPs
@@ -160,7 +135,6 @@ export function FlowSimulator({
     if (!ready || !agent || !enablement) return;
 
     const runId = ++runIdRef.current;
-    oauthResolverRef.current = null;
     setCompletedStepIds(new Set());
     setBranch(undefined);
 
@@ -268,10 +242,6 @@ export function FlowSimulator({
       }
       if (isCanceled()) return;
 
-      // Intentionally omit `noopener`: the same-origin OAuth result page calls
-      // `window.opener.postMessage(...)` to deliver the outcome, which requires
-      // opener access. The `noopener=no` form is ambiguous across browsers — an
-      // omitted feature is the unambiguous "opener access allowed" signal.
       const popup = window.open(authorizeUrl, 'novu-mcp-oauth-flow', 'width=520,height=720,scrollbars=yes');
       if (!popup) {
         failAt('Browser blocked the OAuth popup. Allow popups for this origin and re-run the simulation.', 'novu-dcr');
@@ -282,46 +252,23 @@ export function FlowSimulator({
 
       await advance({ kind: 'user-authorizes' }, 'novu-dcr');
 
-      // ── Wait for postMessage from oauth/result page (or popup close) ─────
-      const oauthOutcome = await new Promise<{ status: 'connected' | 'error'; reason?: string }>((resolve) => {
-        // Defensive: if the user closes the popup without completing OAuth,
-        // detect via polling and treat as an error. Cleared in every resolver
-        // path (postMessage, popup-closed, cancel) to avoid a leaked timer.
+      // ── Wait for the popup to close, then status-poll for the outcome ────
+      // The OAuth result page closes itself; we use that close event as the
+      // completion signal and ask the API whether the token actually landed.
+      await new Promise<void>((resolve) => {
         const interval = setInterval(() => {
-          if (isCanceled()) {
+          if (isCanceled() || popupRef.current?.closed) {
             clearInterval(interval);
-
-            return;
-          }
-          if (popupRef.current?.closed) {
-            clearInterval(interval);
-            if (oauthResolverRef.current) {
-              const r = oauthResolverRef.current;
-              oauthResolverRef.current = null;
-              r('error', 'OAuth popup was closed before completion.');
-            }
+            resolve();
           }
         }, 600);
-
-        oauthResolverRef.current = (status, reason) => {
-          clearInterval(interval);
-          oauthResolverRef.current = null;
-          resolve({ status, reason });
-        };
       });
 
       if (isCanceled()) return;
       popupRef.current = null;
 
-      if (oauthOutcome.status === 'error') {
-        failAt(`OAuth did not complete: ${oauthOutcome.reason ?? 'unknown reason'}`, 'user-authorizes');
-
-        return;
-      }
-
       await advance({ kind: 'novu-stores-token' }, 'user-authorizes');
 
-      // ── Real call: confirm the connection actually landed ────────────────
       try {
         const confirm = await getMcpConnectionStatus(
           credentials,
@@ -331,7 +278,7 @@ export function FlowSimulator({
         );
         if (confirm?.status !== 'connected') {
           failAt(
-            `Connection status is "${confirm?.status ?? 'missing'}" after OAuth callback; expected "connected".`,
+            `Connection status is "${confirm?.status ?? 'missing'}" after OAuth callback; expected "connected". Did the popup close before authorisation completed?`,
             'novu-stores-token'
           );
 

--- a/playground/nextjs/src/app/agents-mcp/page.tsx
+++ b/playground/nextjs/src/app/agents-mcp/page.tsx
@@ -43,11 +43,7 @@ import {
 const SELECTED_AGENT_STORAGE_KEY = 'novu-mcp-playground-selected-agent';
 const SUBSCRIBER_STORAGE_KEY = 'novu-mcp-playground-subscriber-id';
 
-type OAuthResultMessage = {
-  type: 'novu-mcp-oauth-result';
-  status: 'connected' | 'error';
-  reason?: string;
-};
+type OAuthResultBanner = { status: 'connected' | 'error'; reason?: string };
 
 export default function AgentsMcpPlaygroundPage() {
   return (
@@ -775,7 +771,15 @@ function OAuthPanel({
   const [authorizing, setAuthorizing] = useState(false);
   const [authorizeError, setAuthorizeError] = useState<string | null>(null);
   const [authorizePopup, setAuthorizePopup] = useState<Window | null>(null);
-  const [lastResultBanner, setLastResultBanner] = useState<OAuthResultMessage | null>(null);
+  const [lastResultBanner, setLastResultBanner] = useState<OAuthResultBanner | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    if (!enablement || !subscriberId.trim()) {
+      return null;
+    }
+
+    return getMcpConnectionStatus(credentials, agentIdentifier, enablement.mcpId, subscriberId.trim());
+  }, [credentials, agentIdentifier, enablement, subscriberId]);
 
   const refreshStatus = useCallback(async () => {
     if (!enablement || !subscriberId.trim()) {
@@ -787,14 +791,14 @@ function OAuthPanel({
     setStatusLoading(true);
     setStatusError(null);
     try {
-      const next = await getMcpConnectionStatus(credentials, agentIdentifier, enablement.mcpId, subscriberId.trim());
+      const next = await fetchStatus();
       setConnection(next);
     } catch (err) {
       setStatusError(toErrorMessage(err));
     } finally {
       setStatusLoading(false);
     }
-  }, [credentials, agentIdentifier, enablement, subscriberId]);
+  }, [fetchStatus, enablement, subscriberId]);
 
   useEffect(() => {
     setConnection(null);
@@ -807,33 +811,40 @@ function OAuthPanel({
     refreshStatus();
   }, [refreshStatus]);
 
-  useEffect(() => {
-    function onMessage(event: MessageEvent) {
-      if (event.origin !== window.location.origin) return;
-      const data = event.data as OAuthResultMessage | undefined;
-      if (!data || data.type !== 'novu-mcp-oauth-result') return;
-      setLastResultBanner(data);
-      refreshStatus();
-    }
-
-    window.addEventListener('message', onMessage);
-
-    return () => window.removeEventListener('message', onMessage);
-  }, [refreshStatus]);
-
+  // When the OAuth popup closes, refresh the connection status and derive a
+  // result banner from it. The popup itself can't notify us (the callback
+  // page no longer ships a postMessage shim), so this is the single source
+  // of truth for "did OAuth land?".
   useEffect(() => {
     if (!authorizePopup) return;
 
-    const interval = setInterval(() => {
-      if (authorizePopup.closed) {
-        clearInterval(interval);
-        setAuthorizePopup(null);
-        refreshStatus();
+    const interval = setInterval(async () => {
+      if (!authorizePopup.closed) return;
+      clearInterval(interval);
+      setAuthorizePopup(null);
+
+      try {
+        const next = await fetchStatus();
+        setConnection(next);
+        if (next?.status === 'connected') {
+          setLastResultBanner({ status: 'connected' });
+        } else {
+          setLastResultBanner({
+            status: 'error',
+            reason:
+              next?.status === undefined
+                ? 'Popup closed before a connection was created.'
+                : `Connection status is "${next.status}" after the popup closed; expected "connected".`,
+          });
+        }
+      } catch (err) {
+        setStatusError(toErrorMessage(err));
+        setLastResultBanner({ status: 'error', reason: toErrorMessage(err) });
       }
     }, 600);
 
     return () => clearInterval(interval);
-  }, [authorizePopup, refreshStatus]);
+  }, [authorizePopup, fetchStatus]);
 
   const handleAuthorize = useCallback(async () => {
     if (!enablement || !subscriberId.trim()) return;
@@ -845,9 +856,6 @@ function OAuthPanel({
       const { authorizeUrl } = await generateMcpOAuthUrl(credentials, agentIdentifier, enablement.mcpId, {
         subscriberId: subscriberId.trim(),
       });
-      // Intentionally omit `noopener`: the same-origin OAuth result page calls
-      // `window.opener.postMessage(...)` to deliver the outcome, which requires
-      // opener access.
       const popup = window.open(authorizeUrl, 'novu-mcp-oauth', 'width=520,height=720,scrollbars=yes');
       if (!popup) {
         setAuthorizeError('Browser blocked the popup. Allow popups for this site and retry.');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What changed? Why was the change needed?

@coderabbitai summary

Two related changes to the post-OAuth flow-complete page introduced in #11372, plus a follow-up that keeps the playground demo working after the shim removal:

**1. Fix the broken UI (CSP regression).** `renderConnectionResultPage` ships an inline `<style>` block, but the CSP set on its responses was `default-src 'self'; script-src 'self' 'unsafe-inline'`. With no `style-src` directive, browsers fall back to `default-src 'self'` for styles and refuse to apply the inline stylesheet — so the post-OAuth Slack/Teams/MCP terminal tab rendered as unstyled markup.

Reported error matches exactly:

> Refused to apply inline style because it violates the following Content Security Policy directive: "default-src 'self'". … Note also that 'style-src' was not explicitly set, so 'default-src' is used as a fallback.

Fix:

- Export `CONNECTION_RESULT_CSP` from `apps/api/src/app/shared/html/connection-result-page.ts` so the CSP and the rendered HTML live in one place.
- Use it in the two callers that render the page: `apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts` and `apps/api/src/app/integrations/integrations.controller.ts` (the Slack/Teams `/chat/oauth/callback` HTML branch).

**2. Drop the unused `window.opener.postMessage` shim.** The shim was only consumed by the playground demo (`playground/nextjs/src/app/agents-mcp`); the dashboard's real OAuth flow detects completion via popup-close detection and status polling, so the producer added no value in production. Removed `postMessagePayload` from `ConnectionResultPageOptions`, `buildPostMessageScript`, the optional `<script>` block emitted by `pageShell`, and the corresponding spec. The page now ships zero `<script>` tags — only the inline `<style>` block and the close-tab `onclick` handler remain.

**3. Migrate the playground to popup-close + status-poll.** Removing the postMessage producer would have left the agents-mcp playground broken — the simulator's only success-detection path was the postMessage event, so successful OAuth would resolve as `error` after the popup closed. Replaced the postMessage listener and resolver ref in `flow-simulator.tsx` with a popup-close wait followed by the existing `getMcpConnectionStatus` confirm step. Did the same for `page.tsx` so the result banner is now derived from the post-close status fetch.

CSP is unchanged because the `onclick` attribute still falls under `script-src 'unsafe-inline'` via the CSP3 `script-src-attr` fallback. The two unrelated CSP-emitting endpoints (`integrations` Azure Quick Setup popup, `subscribersV1` legacy chat OAuth callback) keep their existing tighter CSP — their HTML doesn't carry inline styles.

Locked the contract with `connection-result-page.spec.ts`: the CSP allows inline styles + scripts (regexes anchored to a directive boundary so the assertion can't pass via `script-src-attr` / `style-src-elem`), HTML escapes user-controlled copy in all four fields (`title`, `heading`, `message`, `footerNote`), and the rendered output emits no `<script>` tag or `postMessage` shim.

```mermaid
sequenceDiagram
  autonumber
  participant Browser
  participant API as Novu API
  Browser->>API: GET /v1/integrations/chat/oauth/callback?code=...&state=...
  API->>API: SlackOauthCallback / MsTeamsOauthCallback usecase
  API->>API: renderConnectionResultPage({ ... })
  Note over API: Sets Content-Security-Policy: CONNECTION_RESULT_CSP<br/>(default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline')
  API-->>Browser: 200 text/html (inline <style> + close-tab onclick)
  Browser->>Browser: Apply inline styles, render styled card, close tab
```

### Screenshots

Reproduction of the bug (before the fix) on the left, fixed page on the right:

![Broken page with the original CSP — unstyled checkmark and CSP violation in console](https://cursor.com/artifacts/c/art-4f313aff-0df6-4ad4-9802-26481722af84)

![Page rendered correctly with the fixed CSP — centered styled card, clean console](https://cursor.com/artifacts/c/art-db44db5c-0f55-4732-8d2d-2ca16dbd805b)

End-to-end demo (loads `/old` then `/new` against a tiny verifier serving the real `renderConnectionResultPage` output with the old vs new CSP header):

<a href="https://cursor.com/agents/bc-12402d1e-70d4-4141-95dc-a15429c867f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcsp_fix_before_after_demo.mp4"><img src="https://cursor.com/artifacts/c/art-f7d96773-dfba-411c-b83d-89462a3e4768" alt="csp_fix_before_after_demo.mp4" /></a>

<details>
<summary><strong>Expand for optional sections</strong></summary>

### Related enterprise PR

N/A — change is contained to `apps/api` and the agents-mcp playground.

### Special notes for your reviewer

- Specs run via `cd apps/api && pnpm test` (Mocha + chai, matches existing API conventions). 7 specs in `connection-result-page.spec.ts` plus the unchanged 18 in `MsTeamsOauthCallback`/`SlackOauthCallback`.
- I deliberately did not touch the CSP on `subscribersV1.controller.ts` and the Azure Quick Setup popup branch in `integrations.controller.ts` — they don't render `renderConnectionResultPage`, so adding `style-src 'unsafe-inline'` there would be a needless permission widening.
- After the postMessage removal, `flow-simulator.tsx` and `page.tsx` could no longer rely on `'message'` events and would have spuriously reported failure on a successful OAuth. Both were migrated to popup-close + `getMcpConnectionStatus` confirm; the existing post-close confirm step in the simulator is now the single source of truth.

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12402d1e-70d4-4141-95dc-a15429c867f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12402d1e-70d4-4141-95dc-a15429c867f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CSP regression introduced in #11372 where the connection-result page's inline `<style>` block was blocked by browsers because `style-src` was never declared — causing `default-src 'self'` to serve as the fallback and reject inline styles. It also removes the `window.opener.postMessage` shim that was only consumed by the playground demo, replacing it with popup-close detection + status polling.

- **CSP fix**: Exports `CONNECTION_RESULT_CSP` (adds `style-src 'self' 'unsafe-inline'`) from the renderer module so the policy and the HTML it covers are co-located; both the MCP OAuth and chat integration callback controllers now reference the constant instead of an inline string.
- **postMessage removal**: Strips `postMessagePayload`, `buildPostMessageScript`, and the conditional `<script>` injection from the renderer — the page now emits zero script tags, with the `onclick` close-tab handler remaining as an inline event attribute covered by `script-src 'unsafe-inline'`.
- **Playground update**: `flow-simulator.tsx` and `OAuthPanel` in `page.tsx` drop their `window.message` listeners and derive OAuth outcome by calling `getMcpConnectionStatus` after detecting popup close.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted CSP header correction backed by new unit tests, and the postMessage removal is cleanly reflected across all call sites.

The CSP constant is co-located with the renderer it covers, both controllers are updated, HTML escaping is unchanged and exercised by the spec, and the playground correctly switches to popup-close + status-poll detection. No data path or auth boundary is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/api/src/app/shared/html/connection-result-page.ts | Exports CONNECTION_RESULT_CSP alongside the renderer; removes postMessagePayload option, buildPostMessageScript, and the optional script injection — page now emits zero script tags. |
| apps/api/src/app/shared/html/connection-result-page.spec.ts | New test suite validates CSP directives, inline style presence, XSS escaping for all four user-controlled fields, and absence of postMessage shim. |
| apps/api/src/app/agents/mcp/oauth/agents-mcp-oauth.controller.ts | Swaps hardcoded CSP string for the exported CONNECTION_RESULT_CSP constant and drops postMessagePayload from both renderConnectionResultPage call sites. |
| apps/api/src/app/integrations/integrations.controller.ts | Applies CONNECTION_RESULT_CSP only to the ResponseTypeEnum.HTML branch of the chat OAuth callback; other CSP-emitting paths in this controller are untouched. |
| playground/nextjs/src/app/agents-mcp/components/flow-simulator.tsx | Removes postMessage listener and OAuthResultMessage type; popup-close detection resolves the promise and the simulation proceeds to status-polling for the outcome. |
| playground/nextjs/src/app/agents-mcp/page.tsx | OAuthPanel drops its window.message listener; popup-close setInterval now calls fetchStatus() asynchronously and derives the result banner from the API response. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  autonumber
  participant Browser
  participant Controller as MCP/Integration Controller
  participant Renderer as renderConnectionResultPage

  Browser->>Controller: "GET /oauth/callback?code=..."
  Controller->>Renderer: renderConnectionResultPage(options)
  Note over Renderer: Emits inline style block and onclick handler only
  Renderer-->>Controller: HTML string (no script tags)
  Controller->>Controller: Set Content-Security-Policy to CONNECTION_RESULT_CSP
  Note over Controller: style-src unsafe-inline now included
  Controller-->>Browser: 200 text/html
  Browser->>Browser: Inline styles applied successfully
  Browser->>Browser: User clicks Close this tab
  Browser->>Browser: Popup closes
  Browser->>Controller: GET /mcp/connection/status (polling)
  Controller-->>Browser: status connected
```

<sub>Reviews (4): Last reviewed commit: ["test(api-service): anchor CSP directive ..."](https://github.com/novuhq/novu/commit/6f3559d0fb6db9059f65c80393397813e13339a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34794554)</sub>

<!-- /greptile_comment -->